### PR TITLE
Initial Zuke v0 implementation: code-first build automation for Deno

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Format, lint, type-check & coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Check formatting
+        run: deno fmt --check
+
+      - name: Lint
+        run: deno lint
+
+      - name: Type-check
+        run: deno task check
+
+      - name: Test with coverage
+        run: deno test -A --coverage=cov_profile
+
+      - name: Enforce coverage threshold (95%)
+        run: |
+          deno coverage cov_profile --lcov --exclude='(tests|scripts)/' --output=cov.lcov
+          deno run --allow-read scripts/check-coverage.ts cov.lcov 95
+
+  test-os:
+    name: Tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Run tests
+        run: deno test -A

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Coverage artifacts
+/cov_profile/
+/cov.lcov
+/html_cov/
+
+# Build output (example builds produce this)
+/dist/
+
+# Editor / OS noise
+.DS_Store
+*.swp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,111 @@
+# CLAUDE.md
+
+Guidance for working in this repository. Read this before making changes.
+
+Zuke is a code-first, strongly-typed build automation system for Deno/TypeScript
+(inspired by [NUKE](https://nuke.build/)). The full product spec lives in
+[`docs/zuke-spec-v0.md`](docs/zuke-spec-v0.md).
+
+## Tech stack
+
+- **Runtime & toolchain:** [Deno](https://deno.com/) (2.x). All tooling —
+  test runner, formatter, linter, type-checker, coverage — is the built-in
+  `deno` CLI. No Node, npm, or external build tools.
+- **Language:** TypeScript, strict mode (Deno's default).
+- **Distribution:** [JSR](https://jsr.io/) as `@zuke/core` (entry `mod.ts`,
+  shell submodule `@zuke/core/shell`).
+- **No runtime dependencies.** The library is dependency-free; tests use a
+  local assertion helper (`tests/_assert.ts`) rather than a third-party assert
+  library so the suite runs with zero network access.
+
+### TypeScript 7 / `tsgo`
+
+The request is to use `tsgo` (the native TypeScript port, a.k.a. TypeScript 7)
+**if Deno supports it.** As of the current toolchain it does **not**: Deno
+type-checks with its own embedded TypeScript via `deno check` and provides no
+hook to delegate checking to an external `tsc`/`tsgo` binary. `tsgo`
+(`@typescript/native-preview`) is a standalone preview that also does not
+understand Deno's module resolution (`jsr:`/`https:` specifiers, the `Deno`
+global) out of the box.
+
+**Therefore:** `deno check` is the authoritative type-checker for this repo.
+Adopt `tsgo`/TS7 only once Deno can use it as its checker — at that point,
+update the `check` task and CI accordingly. Do not bolt on a parallel
+`tsc`/`tsgo` pass that can't see Deno's module graph.
+
+## Coding guidelines (non-negotiable)
+
+1. **Strict, strongly-typed TypeScript.**
+   - Never use `any`. The `no-explicit-any` lint rule is enabled.
+   - Never use `as` to force a type or silence the compiler, and avoid the
+     non-null assertion `!`. Narrow with control flow and type guards instead
+     (e.g. `value instanceof Error ? value.message : String(value)`).
+   - The single sanctioned escape is a `// @ts-expect-error` **in a test** that
+     deliberately exercises a runtime guard against type-unsafe input, with a
+     comment explaining why. Do not use it in `src/`.
+2. **All linting, formatting, type-checking, and tests must always pass.**
+   Run `deno task ci` before committing; it must be green.
+3. **Keep test coverage at 95%+ (lines and branches) at all times.** Enforced
+   by `scripts/check-coverage.ts` in the `cov` task and in CI. New code needs
+   new tests in the same change.
+4. **Document the public API.** Every exported symbol carries a JSDoc comment;
+   match the existing density and tone when adding to it.
+5. **Tests are hermetic and fast.** No network, no reliance on ambient tools.
+   When a test needs a subprocess, invoke `Deno.execPath()` (the running
+   `deno`), which is always present and shell-free.
+
+## Commands
+
+| Task | Command |
+|---|---|
+| Run tests | `deno task test` |
+| Coverage + gate (95%) | `deno task cov` |
+| Human-readable coverage table | `deno task cov:report` |
+| Type-check everything | `deno task check` |
+| Format / check formatting | `deno task fmt` / `deno task fmt:check` |
+| Lint | `deno task lint` |
+| Full pre-commit / CI gate | `deno task ci` |
+
+## Repository layout
+
+```
+mod.ts                    # public API surface
+src/{target,build,graph,executor,cli,shell}.ts
+tests/*_test.ts           # one suite per module (+ _assert.ts helper)
+scripts/check-coverage.ts # coverage gate
+zuke.ts                   # Zuke's own build (runnable example)
+docs/zuke-spec-v0.md      # the spec
+.github/workflows/ci.yml  # PR checks
+```
+
+## Architecture notes
+
+- **Targets are class fields.** Dependencies are passed as `this.x` references,
+  not strings, for compile-time safety and rename support. Because class fields
+  initialise top-to-bottom, **a target may only depend on siblings declared
+  above it** — a forward reference is `undefined` and is reported as an error by
+  `validateReferences`.
+- **Naming** is recovered by `discoverTargets`, which introspects the instance's
+  own enumerable properties after construction.
+- **Ordering** is a DFS topological sort in `graph.ts` that also honours the
+  soft `before`/`after` hints and detects cycles (reporting the path).
+- **The shell `$`** tokenises interpolated values into discrete argv entries
+  (never a concatenated shell string), so command construction is
+  injection-free.
+
+## Good open-source practices to follow
+
+- **Small, focused changes** with clear, descriptive commit messages
+  (imperative mood; explain the *why*). Keep PRs reviewable.
+- **Conventional, semantic versioning** for releases; keep a changelog as the
+  project grows.
+- **Update docs with code.** If behaviour changes, update `README.md`, JSDoc,
+  and the spec/acceptance criteria in the same PR.
+- **No secrets or machine-specific paths** in the repo or commits. Don't commit
+  coverage artifacts (`cov_profile/`, `cov.lcov`) — they're git-ignored.
+- **Deterministic output.** Topological order is declaration-stable; keep it
+  that way so `--graph`/`--list` output doesn't churn.
+- **Friendly errors.** Validation failures should name the offending target and
+  explain the fix (see the cycle and forward-reference messages for the bar).
+- **Don't expand the public API casually.** Internal fields use a trailing
+  underscore (`name_`, `dependsOn_`); only add to `mod.ts` deliberately.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Zuke contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,118 @@
+# Zuke
+
+A code-first, strongly-typed build automation system for the Deno/TypeScript
+ecosystem. Inspired by [NUKE](https://nuke.build/). Builds are defined in
+TypeScript as a class; targets form a dependency graph; a CLI resolves and
+executes them.
+
+See [`docs/zuke-spec-v0.md`](docs/zuke-spec-v0.md) for the full v0 spec.
+
+## Quick start
+
+```ts
+// zuke.ts
+import { Build, run, target } from "jsr:@zuke/core";
+import { $ } from "jsr:@zuke/core/shell";
+
+class MyBuild extends Build {
+  clean = target()
+    .description("Remove build artifacts")
+    .executes(async () => {
+      await $`rm -rf dist`;
+    });
+
+  compile = target()
+    .description("Type-check and build")
+    .dependsOn(this.clean)
+    .executes(async () => {
+      await $`deno check mod.ts`;
+    });
+
+  test = target()
+    .description("Run the test suite")
+    .dependsOn(this.compile)
+    .executes(async () => {
+      await $`deno test -A`;
+    });
+}
+
+if (import.meta.main) {
+  await run(MyBuild);
+}
+```
+
+```sh
+deno run -A zuke.ts test     # clean → compile → test, in order
+deno run -A zuke.ts --list   # show targets, descriptions, dependencies
+deno run -A zuke.ts --graph  # print the dependency graph
+deno run -A zuke.ts --help   # usage
+```
+
+> **Declaration order matters.** Dependencies are referenced by `this.x`, and
+> class fields initialise top-to-bottom — so a target may only depend on
+> siblings declared *above* it. A forward reference is reported as an error.
+
+## Authoring API
+
+`target()` returns a chainable builder:
+
+| Method | Purpose |
+|---|---|
+| `.description(text)` | Summary shown in `--list`. |
+| `.dependsOn(...targets)` | Hard prerequisites (run first, transitively). |
+| `.executes(fn)` | The target body. May be `async`. |
+| `.before(...targets)` | Soft ordering: run before these, if both are planned. |
+| `.after(...targets)` | Soft ordering: run after these, if both are planned. |
+
+`Build` subclasses optionally override `onStart()` and `onFinish(result)`.
+A target literally named `default` runs when no target is requested.
+
+## Shell wrapper
+
+```ts
+import { $ } from "jsr:@zuke/core/shell";
+
+await $`deno test -A`;                              // throws on non-zero exit
+const sha = await $`git rev-parse HEAD`.text();     // trimmed stdout
+const files = await $`git diff --name-only`.lines(); // string[]
+const code = await $`flaky-cmd`.noThrow().code();    // exit code, no throw
+await $`build`.env({ NODE_ENV: "prod" }).cwd("./app").quiet();
+```
+
+Interpolated values become discrete argv entries (never spliced into a shell
+string), so command construction is injection-free. Arrays expand to multiple
+arguments.
+
+## Execution semantics
+
+1. Instantiate the build and discover targets by property introspection.
+2. Build the dependency graph from `.dependsOn(...)`.
+3. Validate: undefined/unknown references and cycles fail fast (exit 1).
+4. Compute the transitive closure of the requested target and topologically
+   sort it (v0 runs sequentially).
+5. Run each body once — diamond dependencies dedupe.
+6. On a thrown error, stop, report, and exit 1.
+
+## Project layout
+
+```
+mod.ts            # public API: Build, target, run, execute, graph helpers
+src/
+  build.ts        # Build base class + target discovery
+  target.ts       # TargetBuilder fluent API + Target type
+  graph.ts        # topo sort + cycle detection
+  executor.ts     # runs the plan, timing, reporting
+  cli.ts          # arg parsing, --list/--graph/--help, run()
+  shell.ts        # $ tagged-template wrapper
+tests/            # graph, target, executor, shell coverage
+zuke.ts           # Zuke's own build (runnable example)
+```
+
+## Development
+
+```sh
+deno task test    # run the suite
+deno task check   # type-check
+deno task fmt     # format
+deno task lint    # lint
+```

--- a/README.md
+++ b/README.md
@@ -1,11 +1,75 @@
 # Zuke
 
-A code-first, strongly-typed build automation system for the Deno/TypeScript
-ecosystem. Inspired by [NUKE](https://nuke.build/). Builds are defined in
-TypeScript as a class; targets form a dependency graph; a CLI resolves and
-executes them.
+> A code-first, strongly-typed build automation system for Deno & TypeScript.
 
-See [`docs/zuke-spec-v0.md`](docs/zuke-spec-v0.md) for the full v0 spec.
+Zuke lets you define builds as a **TypeScript class**. Each target is a class
+field declared with a fluent API; targets reference each other by `this.x`
+(not strings), forming a dependency graph that Zuke resolves and runs in
+topological order. Inspired by [NUKE](https://nuke.build/) for .NET.
+
+- **Runtime:** Deno
+- **Package:** `jsr:@zuke/core` (+ `jsr:@zuke/core/shell`)
+- **Build file:** `zuke.ts` in your project root
+- **Zero runtime dependencies**
+
+```ts
+class MyBuild extends Build {
+  compile = target()
+    .dependsOn(this.clean, this.restore)
+    .executes(async () => { await $`deno check mod.ts`; });
+}
+```
+
+---
+
+## Table of contents
+
+- [Why Zuke](#why-zuke)
+- [Install & run](#install--run)
+- [Quick start](#quick-start)
+- [Core concepts](#core-concepts)
+- [Authoring API](#authoring-api)
+  - [`target()`](#target)
+  - [`Build`](#build)
+  - [`run()`](#run)
+- [Shell wrapper (`$`)](#shell-wrapper-)
+- [CLI reference](#cli-reference)
+- [Execution semantics](#execution-semantics)
+- [Programmatic API](#programmatic-api)
+- [Gotchas](#gotchas)
+- [Development](#development)
+- [Contributing](#contributing)
+- [Roadmap](#roadmap)
+- [License](#license)
+
+---
+
+## Why Zuke
+
+- **Typed, refactor-safe dependencies.** You wire targets together with
+  `this.clean`, not `"clean"`. Rename a target and every reference moves with
+  it; a typo is a compile error, not a runtime surprise.
+- **Just TypeScript.** Your build logic is ordinary async functions with full
+  editor support — no YAML, no bespoke DSL.
+- **Ergonomic shell.** The `$` tagged template runs processes with sane
+  defaults (throw on failure, capture output) and is injection-safe.
+- **Small and explicit.** A tiny core: discover targets, build a graph, sort,
+  run. No magic, no plugins to learn (yet).
+
+## Install & run
+
+You need [Deno](https://deno.com/) installed. There's nothing else to install —
+Zuke is imported straight from JSR.
+
+Create a `zuke.ts` in your project root and run it with Deno:
+
+```sh
+deno run -A zuke.ts <target>
+```
+
+The `-A` grants permissions (your targets typically run processes, read/write
+files, etc.). A dedicated `zuke` launcher binary is on the roadmap; for now the
+`deno run` invocation is the interface.
 
 ## Quick start
 
@@ -21,9 +85,15 @@ class MyBuild extends Build {
       await $`rm -rf dist`;
     });
 
+  restore = target()
+    .description("Install dependencies")
+    .executes(async () => {
+      await $`deno install`;
+    });
+
   compile = target()
     .description("Type-check and build")
-    .dependsOn(this.clean)
+    .dependsOn(this.clean, this.restore)
     .executes(async () => {
       await $`deno check mod.ts`;
     });
@@ -34,6 +104,9 @@ class MyBuild extends Build {
     .executes(async () => {
       await $`deno test -A`;
     });
+
+  // Optional: runs when you invoke `zuke` with no target.
+  default = target().dependsOn(this.test).executes(() => {});
 }
 
 if (import.meta.main) {
@@ -42,77 +115,235 @@ if (import.meta.main) {
 ```
 
 ```sh
-deno run -A zuke.ts test     # clean → compile → test, in order
-deno run -A zuke.ts --list   # show targets, descriptions, dependencies
-deno run -A zuke.ts --graph  # print the dependency graph
-deno run -A zuke.ts --help   # usage
+deno run -A zuke.ts test     # clean → restore → compile → test
+deno run -A zuke.ts          # runs `default` (→ test)
+deno run -A zuke.ts --list   # show all targets
 ```
 
-> **Declaration order matters.** Dependencies are referenced by `this.x`, and
-> class fields initialise top-to-bottom — so a target may only depend on
-> siblings declared *above* it. A forward reference is reported as an error.
+Example output:
+
+```
+▶ clean
+✔ clean (0.0s)
+▶ restore
+✔ restore (0.3s)
+▶ compile
+✔ compile (1.1s)
+▶ test
+✔ test (2.4s)
+
+✔ SUCCESS — 4/4 targets in 3.8s
+```
+
+## Core concepts
+
+| Concept | Description |
+|---|---|
+| **Build** | A class extending `Build`. Each target is a field. |
+| **Target** | A named unit of work: a description, dependencies, and a body. |
+| **Dependency graph** | A DAG derived from `.dependsOn(...)`. Cycles are an error. |
+| **Plan** | The requested target's transitive dependencies, topologically sorted. |
+| **Executor** | Runs the plan sequentially, with timing and pass/fail reporting. |
 
 ## Authoring API
 
-`target()` returns a chainable builder:
+### `target()`
 
-| Method | Purpose |
-|---|---|
-| `.description(text)` | Summary shown in `--list`. |
-| `.dependsOn(...targets)` | Hard prerequisites (run first, transitively). |
-| `.executes(fn)` | The target body. May be `async`. |
-| `.before(...targets)` | Soft ordering: run before these, if both are planned. |
-| `.after(...targets)` | Soft ordering: run after these, if both are planned. |
+`target()` returns a chainable `TargetBuilder`. Everything is optional except a
+body, which is required before the target can run.
 
-`Build` subclasses optionally override `onStart()` and `onFinish(result)`.
-A target literally named `default` runs when no target is requested.
+| Method | Signature | Purpose |
+|---|---|---|
+| `.description(text)` | `(s: string) => this` | Summary shown in `--list`. |
+| `.dependsOn(...targets)` | `(...t: Target[]) => this` | Hard prerequisites; run first, transitively. |
+| `.executes(fn)` | `(fn: () => void \| Promise<void>) => this` | The body. May be async. |
+| `.before(...targets)` | `(...t: Target[]) => this` | Soft ordering: run before these *if both are planned*. |
+| `.after(...targets)` | `(...t: Target[]) => this` | Soft ordering: run after these *if both are planned*. |
 
-## Shell wrapper
+`dependsOn` pulls targets into the plan; `before`/`after` only reorder targets
+that are *already* in the plan — they never pull new targets in.
+
+```ts
+lint = target()
+  .description("Lint sources")
+  .after(this.restore)   // if restore is in the plan, run after it
+  .before(this.test)     // if test is in the plan, run before it
+  .executes(async () => { await $`deno lint`; });
+```
+
+### `Build`
+
+The base class your build extends. It contributes no targets of its own.
+
+- After construction, Zuke discovers targets by introspecting the instance's
+  own enumerable properties (the class fields).
+- Optional lifecycle hooks, overridable on your subclass:
+
+```ts
+class MyBuild extends Build {
+  override onStart() {
+    console.log("Build starting…");
+  }
+  override onFinish(result: BuildResult) {
+    console.log(result.ok ? "All good" : "Something failed");
+  }
+  // …targets…
+}
+```
+
+`BuildResult` is `{ ok: boolean; executed: string[]; error?: unknown }`.
+
+A field literally named `default` is the **default target**, run when no target
+is named on the command line.
+
+### `run()`
+
+```ts
+run(BuildClass: new () => Build, args?: string[]): Promise<void>
+```
+
+Instantiates the build, discovers targets, validates the graph, parses CLI
+arguments (defaulting to `Deno.args`), dispatches to the executor, and calls
+`Deno.exit` with `0` on success or `1` on failure. This is the standard entry
+point at the bottom of `zuke.ts`.
+
+## Shell wrapper (`$`)
+
+Ergonomic process execution built on `Deno.Command`, imported from the `shell`
+submodule:
 
 ```ts
 import { $ } from "jsr:@zuke/core/shell";
 
 await $`deno test -A`;                              // throws on non-zero exit
-const sha = await $`git rev-parse HEAD`.text();     // trimmed stdout
+const sha   = await $`git rev-parse HEAD`.text();   // trimmed stdout
 const files = await $`git diff --name-only`.lines(); // string[]
-const code = await $`flaky-cmd`.noThrow().code();    // exit code, no throw
+const code  = await $`flaky-cmd`.noThrow().code();   // exit code, never throws
 await $`build`.env({ NODE_ENV: "prod" }).cwd("./app").quiet();
 ```
 
-Interpolated values become discrete argv entries (never spliced into a shell
-string), so command construction is injection-free. Arrays expand to multiple
-arguments.
+| Member | Behaviour |
+|---|---|
+| `` $`…` `` | Builds a lazy command. Awaiting it runs the process and **throws `CommandError` on non-zero exit** by default. |
+| `.text()` | Run; resolve to trimmed stdout. Throws on non-zero (unless `.noThrow()`). |
+| `.lines()` | Run; resolve to `string[]` (stdout split on newlines; empty output → `[]`). |
+| `.code()` | Run; resolve to the numeric exit code. **Never throws** on non-zero. |
+| `.noThrow()` | Suppress throwing on non-zero exit. |
+| `.env(record)` | Merge environment variables. |
+| `.cwd(path)` | Set the working directory. |
+| `.quiet()` | Suppress live stdout/stderr streaming. |
+
+Awaiting a command resolves to a `CommandOutput` (`{ code, stdout, stderr }`,
+plus a `.text()` helper for trimmed stdout).
+
+**Safety:** interpolated values become **discrete argv entries** — they are
+never spliced into a shell string — so there is no injection surface. Arrays
+expand to multiple arguments:
+
+```ts
+const files = ["a.ts", "b.ts"];
+await $`deno fmt ${files}`;          // → ["deno", "fmt", "a.ts", "b.ts"]
+const dirty = "; rm -rf /";
+await $`echo ${dirty}`;              // prints the literal string; runs nothing else
+```
+
+By default a command streams its output live to your terminal and captures
+stdout; `.text()`/`.lines()` capture without echoing; `.quiet()` does neither.
+
+## CLI reference
+
+| Command | Behaviour |
+|---|---|
+| `zuke <target>` | Run the target and all its transitive dependencies, in order. |
+| `zuke <target> --skip <dep>` | Run the target but skip the named dependency (repeatable). |
+| `zuke --list` / `-l` | List all targets with descriptions and dependencies. |
+| `zuke --graph` | Print the dependency graph (`target → deps`). |
+| `zuke --help` / `-h` | Usage. |
+| `zuke` (no target) | Run the `default` target if defined, else print `--list`. |
+
+(Read `zuke` as `deno run -A zuke.ts` until the launcher binary ships.)
+
+**Output:** each target prints `▶ name` on start, then `✔ name (1.2s)` or
+`✘ name (0.4s)`. A failure prints the error, aborts the remaining targets, and
+exits `1`. A final summary reports targets run, total time, and overall status.
 
 ## Execution semantics
 
-1. Instantiate the build and discover targets by property introspection.
-2. Build the dependency graph from `.dependsOn(...)`.
-3. Validate: undefined/unknown references and cycles fail fast (exit 1).
-4. Compute the transitive closure of the requested target and topologically
-   sort it (v0 runs sequentially).
-5. Run each body once — diamond dependencies dedupe.
-6. On a thrown error, stop, report, and exit 1.
+1. Instantiate the build class.
+2. Discover targets by property introspection.
+3. Build the dependency graph from `.dependsOn(...)`.
+4. **Validate:** an undefined/unknown dependency or a cycle fails fast (with the
+   offending path) and exits `1`.
+5. Compute the requested target's transitive closure.
+6. **Topologically sort** (honouring `before`/`after`); v0 runs **sequentially**.
+7. Run each body. On throw, stop and report.
+8. Each target runs **at most once** per invocation — diamond dependencies
+   dedupe.
 
-## Project layout
+## Programmatic API
 
+Beyond authoring, `mod.ts` exports the building blocks if you want to drive Zuke
+yourself or test a build:
+
+```ts
+import {
+  discoverTargets, // (build) => Map<string, TargetBuilder>
+  execute,         // (build, rootTarget, options?) => Promise<BuildResult>
+  plan,            // (rootTarget) => TargetBuilder[]  (topological order)
+  validateGraph,   // (targets) => void  (throws GraphError)
+  findCycle,       // (targets) => string[] | null
+  executionSet,    // (rootTarget) => Set<TargetBuilder>
+  GraphError,
+} from "jsr:@zuke/core";
 ```
-mod.ts            # public API: Build, target, run, execute, graph helpers
-src/
-  build.ts        # Build base class + target discovery
-  target.ts       # TargetBuilder fluent API + Target type
-  graph.ts        # topo sort + cycle detection
-  executor.ts     # runs the plan, timing, reporting
-  cli.ts          # arg parsing, --list/--graph/--help, run()
-  shell.ts        # $ tagged-template wrapper
-tests/            # graph, target, executor, shell coverage
-zuke.ts           # Zuke's own build (runnable example)
-```
+
+`execute` accepts `{ silent?, reporter?, skip? }`. Provide a custom `reporter`
+(`{ info(line), error(line) }`) to capture or redirect output.
+
+## Gotchas
+
+- **Declaration order matters.** Because dependencies are `this.x` references
+  and class fields initialise top-to-bottom, a target can only depend on
+  siblings **declared above it**. A forward reference is `undefined` at runtime
+  and reported as an error. TypeScript also flags it (`TS2729`).
+- **A body is required.** Running a target whose `.executes(...)` was never set
+  fails fast with a clear message.
+- **`default` is a convention**, not a keyword — name a field `default` to opt
+  in.
 
 ## Development
 
 ```sh
-deno task test    # run the suite
-deno task check   # type-check
-deno task fmt     # format
-deno task lint    # lint
+deno task test        # run the suite
+deno task cov         # run with coverage + enforce the 95% gate
+deno task cov:report  # print a per-file coverage table
+deno task check       # type-check
+deno task fmt         # format (fmt:check to verify only)
+deno task lint        # lint
+deno task ci          # everything CI runs: fmt:check, lint, check, cov
 ```
+
+CI runs `deno task ci` on every push and pull request (see
+[`.github/workflows/ci.yml`](.github/workflows/ci.yml)).
+
+## Contributing
+
+- Read [`CLAUDE.md`](CLAUDE.md) for the coding standards (strict typing, no
+  `any`/`as`, 95%+ coverage, hermetic tests).
+- Run `deno task ci` before opening a PR — it must be green.
+- Add tests in the same change as the code they cover.
+- Keep commits small and descriptive; update docs when behaviour changes.
+
+## Roadmap
+
+Post-v0, for context (see [`docs/zuke-spec-v0.md`](docs/zuke-spec-v0.md)):
+
+- Parameter & environment injection (`this.configuration`, `--configuration`).
+- Parallel execution of independent targets.
+- A `zuke` standalone binary + `zuke init` scaffolding.
+- Caching / incremental targets.
+- Tool wrapper packages (git, deno, docker helpers).
+
+## License
+
+MIT — see [`LICENSE`](LICENSE).

--- a/deno.json
+++ b/deno.json
@@ -7,14 +7,22 @@
   },
   "tasks": {
     "test": "deno test -A",
-    "check": "deno check mod.ts src/*.ts",
+    "cov": "deno test -A --coverage=cov_profile && deno coverage cov_profile --lcov '--exclude=(tests|scripts)/' --output=cov.lcov && deno run --allow-read scripts/check-coverage.ts cov.lcov 95",
+    "cov:report": "deno coverage cov_profile '--exclude=(tests|scripts)/'",
+    "check": "deno check mod.ts src/*.ts tests/*.ts scripts/*.ts zuke.ts",
     "fmt": "deno fmt",
-    "lint": "deno lint"
+    "fmt:check": "deno fmt --check",
+    "lint": "deno lint",
+    "ci": "deno fmt --check && deno lint && deno task check && deno task cov"
   },
   "fmt": {
-    "include": ["mod.ts", "src/", "tests/"]
+    "include": ["mod.ts", "zuke.ts", "src/", "tests/", "scripts/"]
   },
   "lint": {
-    "include": ["mod.ts", "src/", "tests/"]
+    "include": ["mod.ts", "zuke.ts", "src/", "tests/", "scripts/"],
+    "rules": {
+      "tags": ["recommended"],
+      "include": ["no-explicit-any", "verbatim-module-syntax", "ban-untagged-todo"]
+    }
   }
 }

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,20 @@
+{
+  "name": "@zuke/core",
+  "version": "0.0.0",
+  "exports": {
+    ".": "./mod.ts",
+    "./shell": "./src/shell.ts"
+  },
+  "tasks": {
+    "test": "deno test -A",
+    "check": "deno check mod.ts src/*.ts",
+    "fmt": "deno fmt",
+    "lint": "deno lint"
+  },
+  "fmt": {
+    "include": ["mod.ts", "src/", "tests/"]
+  },
+  "lint": {
+    "include": ["mod.ts", "src/", "tests/"]
+  }
+}

--- a/mod.ts
+++ b/mod.ts
@@ -1,0 +1,40 @@
+/**
+ * Zuke — a code-first, strongly-typed build automation system for Deno.
+ *
+ * Public API. Define a build by extending {@link Build}, declare targets with
+ * the {@link target} fluent builder, and make the file runnable with
+ * {@link run}:
+ *
+ * ```ts
+ * import { Build, target, run } from "jsr:@zuke/core";
+ * import { $ } from "jsr:@zuke/core/shell";
+ *
+ * class MyBuild extends Build {
+ *   test = target()
+ *     .description("Run the test suite")
+ *     .executes(async () => { await $`deno test -A`; });
+ * }
+ *
+ * if (import.meta.main) { await run(MyBuild); }
+ * ```
+ *
+ * The shell helper `$` lives in the `./shell` submodule
+ * (`jsr:@zuke/core/shell`).
+ */
+
+export { Build, type BuildResult, discoverTargets } from "./src/build.ts";
+export {
+  type Target,
+  target,
+  TargetBuilder,
+  type TargetFn,
+} from "./src/target.ts";
+export { run } from "./src/cli.ts";
+export { execute, type ExecuteOptions, type Reporter } from "./src/executor.ts";
+export {
+  executionSet,
+  findCycle,
+  GraphError,
+  plan,
+  validateGraph,
+} from "./src/graph.ts";

--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env -S deno run --allow-read
+/**
+ * Coverage gate. Parses an LCOV report and fails (exit 1) if line or branch
+ * coverage falls below a threshold. `deno coverage` has no built-in fail-under
+ * flag, so we enforce it here and wire it into CI.
+ *
+ * Usage:
+ *   deno test -A --coverage=cov_profile
+ *   deno coverage cov_profile --lcov --exclude=tests/ --output=cov.lcov
+ *   deno run --allow-read scripts/check-coverage.ts [cov.lcov] [threshold]
+ */
+
+interface Totals {
+  linesFound: number;
+  linesHit: number;
+  branchesFound: number;
+  branchesHit: number;
+}
+
+/** Sum the LF/LH/BRF/BRH records across every file in an LCOV report. */
+function parseLcov(lcov: string): Totals {
+  const totals: Totals = {
+    linesFound: 0,
+    linesHit: 0,
+    branchesFound: 0,
+    branchesHit: 0,
+  };
+  for (const line of lcov.split("\n")) {
+    const [tag, value] = line.split(":", 2);
+    const n = Number(value);
+    if (Number.isNaN(n)) continue;
+    switch (tag) {
+      case "LF":
+        totals.linesFound += n;
+        break;
+      case "LH":
+        totals.linesHit += n;
+        break;
+      case "BRF":
+        totals.branchesFound += n;
+        break;
+      case "BRH":
+        totals.branchesHit += n;
+        break;
+    }
+  }
+  return totals;
+}
+
+/** Percentage hit/found; 100 when nothing was found (vacuously covered). */
+function pct(hit: number, found: number): number {
+  return found === 0 ? 100 : (hit / found) * 100;
+}
+
+function main(): number {
+  const path = Deno.args[0] ?? "cov.lcov";
+  const threshold = Number(Deno.args[1] ?? "95");
+
+  let lcov: string;
+  try {
+    lcov = Deno.readTextFileSync(path);
+  } catch {
+    console.error(`✘ coverage: could not read LCOV report at "${path}".`);
+    return 1;
+  }
+
+  const t = parseLcov(lcov);
+  const linePct = pct(t.linesHit, t.linesFound);
+  const branchPct = pct(t.branchesHit, t.branchesFound);
+
+  const fmt = (n: number) => n.toFixed(1);
+  console.log(
+    `Coverage — lines: ${fmt(linePct)}% (${t.linesHit}/${t.linesFound}), ` +
+      `branches: ${fmt(branchPct)}% (${t.branchesHit}/${t.branchesFound})`,
+  );
+
+  const failures: string[] = [];
+  if (linePct < threshold) {
+    failures.push(`line coverage ${fmt(linePct)}% < ${threshold}%`);
+  }
+  if (branchPct < threshold) {
+    failures.push(`branch coverage ${fmt(branchPct)}% < ${threshold}%`);
+  }
+
+  if (failures.length > 0) {
+    console.error(`✘ coverage gate failed: ${failures.join("; ")}`);
+    return 1;
+  }
+  console.log(`✔ coverage gate passed (threshold ${threshold}%)`);
+  return 0;
+}
+
+if (import.meta.main) {
+  Deno.exit(main());
+}
+
+export { parseLcov, pct };

--- a/src/build.ts
+++ b/src/build.ts
@@ -1,0 +1,59 @@
+/**
+ * The {@link Build} base class and target discovery.
+ *
+ * Users extend `Build` and declare targets as instance properties. After the
+ * subclass is constructed, {@link discoverTargets} introspects the instance's
+ * own enumerable properties to find every {@link TargetBuilder} and bind it to
+ * its property name.
+ */
+
+import { TargetBuilder } from "./target.ts";
+
+/** Result passed to the {@link Build.onFinish} lifecycle hook. */
+export interface BuildResult {
+  /** Whether every executed target succeeded. */
+  ok: boolean;
+  /** Names of the targets that ran, in execution order. */
+  executed: string[];
+  /** The error that aborted the run, if any. */
+  error?: unknown;
+}
+
+/**
+ * Base class for user-defined builds. Provides no targets of its own; subclasses
+ * declare targets as properties. Optionally override the lifecycle hooks.
+ */
+export class Build {
+  /** Called once before any target runs. */
+  onStart(): void | Promise<void> {}
+
+  /** Called once after the run completes (success or failure). */
+  onFinish(_result: BuildResult): void | Promise<void> {}
+}
+
+/**
+ * Discover all targets declared on a build instance.
+ *
+ * Scans the instance's own enumerable properties (the class fields) for
+ * {@link TargetBuilder} values, assigns each its property name, and returns a
+ * name → target map preserving declaration order.
+ *
+ * @throws if two properties somehow reference the same builder instance under
+ *   different names (a programming error that would corrupt naming).
+ */
+export function discoverTargets(build: Build): Map<string, TargetBuilder> {
+  const targets = new Map<string, TargetBuilder>();
+  for (const [key, value] of Object.entries(build)) {
+    if (value instanceof TargetBuilder) {
+      if (value.name_ !== undefined && value.name_ !== key) {
+        throw new Error(
+          `Target instance is bound to two names: "${value.name_}" and "${key}". ` +
+            `Each target() must be assigned to exactly one property.`,
+        );
+      }
+      value.name_ = key;
+      targets.set(key, value);
+    }
+  }
+  return targets;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,183 @@
+/**
+ * The CLI surface: argument parsing, `--list`/`--help`/`--graph`, and the
+ * public {@link run} entry point that drives a build from `zuke.ts`.
+ */
+
+import { type Build, discoverTargets } from "./build.ts";
+import { GraphError, validateGraph } from "./graph.ts";
+import { execute } from "./executor.ts";
+import type { TargetBuilder } from "./target.ts";
+
+/** Convention: a target literally named `default` runs when none is requested. */
+const DEFAULT_TARGET = "default";
+
+/** Parsed command-line arguments. */
+export interface ParsedArgs {
+  /** The requested target, if a positional argument was given. */
+  target?: string;
+  /** Dependencies to skip (`--skip <dep>`, repeatable). */
+  skip: string[];
+  list: boolean;
+  graph: boolean;
+  help: boolean;
+}
+
+/** Parse `zuke` arguments. Unknown flags are reported by the caller. */
+export function parseArgs(args: string[]): ParsedArgs {
+  const parsed: ParsedArgs = {
+    skip: [],
+    list: false,
+    graph: false,
+    help: false,
+  };
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    switch (arg) {
+      case "--list":
+      case "-l":
+        parsed.list = true;
+        break;
+      case "--graph":
+        parsed.graph = true;
+        break;
+      case "--help":
+      case "-h":
+        parsed.help = true;
+        break;
+      case "--skip": {
+        const dep = args[++i];
+        if (dep) parsed.skip.push(dep);
+        break;
+      }
+      default:
+        if (!arg.startsWith("-") && parsed.target === undefined) {
+          parsed.target = arg;
+        }
+        break;
+    }
+  }
+  return parsed;
+}
+
+/** Names of a target's direct dependencies, in declaration order. */
+function depNames(t: TargetBuilder): string[] {
+  return t.dependsOn_.map((d) => d.name_ ?? "?");
+}
+
+const USAGE = `zuke — code-first build automation
+
+Usage:
+  deno run -A zuke.ts <target> [--skip <dep>]
+  deno run -A zuke.ts --list
+  deno run -A zuke.ts --graph
+
+Options:
+  <target>        Run the target and its transitive dependencies.
+  --skip <dep>    Skip the named dependency (repeatable).
+  --list, -l      List all targets with descriptions and dependencies.
+  --graph         Print the dependency graph.
+  --help, -h      Show this help.`;
+
+/** Render `--help`, including the available targets. */
+export function formatHelp(targets: Map<string, TargetBuilder>): string {
+  return `${USAGE}\n\n${formatList(targets)}`;
+}
+
+/** Render `--list`: each target with its description and dependencies. */
+export function formatList(targets: Map<string, TargetBuilder>): string {
+  if (targets.size === 0) return "No targets defined.";
+  const width = Math.max(...[...targets.keys()].map((n) => n.length));
+  const lines = ["Targets:"];
+  for (const [name, t] of targets) {
+    const deps = depNames(t);
+    const desc = t.description_ ?? "";
+    const suffix = deps.length ? `  (depends on: ${deps.join(", ")})` : "";
+    lines.push(`  ${name.padEnd(width)}  ${desc}${suffix}`);
+  }
+  return lines.join("\n");
+}
+
+/** Render `--graph`: an adjacency listing of `target → dependencies`. */
+export function formatGraph(targets: Map<string, TargetBuilder>): string {
+  if (targets.size === 0) return "No targets defined.";
+  const lines = ["Dependency graph:"];
+  for (const [name, t] of targets) {
+    const deps = depNames(t);
+    lines.push(deps.length ? `  ${name} → ${deps.join(", ")}` : `  ${name}`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Drive a build to completion and resolve to a process exit code (0 success,
+ * 1 failure). Does not call `Deno.exit`, so it is unit-testable; {@link run}
+ * wraps it. Output goes through `console` unless `execute` options say otherwise.
+ */
+export async function main(
+  BuildClass: new () => Build,
+  args: string[],
+): Promise<number> {
+  const build = new BuildClass();
+  const targets = discoverTargets(build);
+  const parsed = parseArgs(args);
+
+  if (parsed.help) {
+    console.log(formatHelp(targets));
+    return 0;
+  }
+
+  try {
+    validateGraph(targets);
+  } catch (error) {
+    if (error instanceof GraphError) {
+      console.error(error.message);
+      return 1;
+    }
+    throw error;
+  }
+
+  if (parsed.list) {
+    console.log(formatList(targets));
+    return 0;
+  }
+  if (parsed.graph) {
+    console.log(formatGraph(targets));
+    return 0;
+  }
+
+  let name = parsed.target;
+  if (name === undefined) {
+    if (targets.has(DEFAULT_TARGET)) {
+      name = DEFAULT_TARGET;
+    } else {
+      console.log(formatList(targets));
+      return 0;
+    }
+  }
+
+  const root = targets.get(name);
+  if (!root) {
+    console.error(`Unknown target: ${name}\n`);
+    console.error(formatList(targets));
+    return 1;
+  }
+
+  const result = await execute(build, root, { skip: parsed.skip });
+  return result.ok ? 0 : 1;
+}
+
+/**
+ * Public entry point. Instantiate the build, parse `Deno.args`, run, and set the
+ * process exit code.
+ *
+ * ```ts
+ * if (import.meta.main) { await run(MyBuild); }
+ * ```
+ */
+export async function run(
+  BuildClass: new () => Build,
+  args: string[] = Deno.args,
+): Promise<void> {
+  const code = await main(BuildClass, args);
+  Deno.exit(code);
+}

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -1,0 +1,121 @@
+/**
+ * The executor: resolves a plan, runs each target body in order, reports
+ * pass/fail with timing, and aborts on the first failure.
+ *
+ * Sequencing and de-duplication are handled by {@link plan} — the returned
+ * order already contains each target exactly once, so diamond dependencies run
+ * their shared prerequisite a single time.
+ */
+
+import type { Build, BuildResult } from "./build.ts";
+import { plan } from "./graph.ts";
+import type { TargetBuilder } from "./target.ts";
+
+/** Sink for executor output, defaulting to the console. Overridable in tests. */
+export interface Reporter {
+  info(line: string): void;
+  error(line: string): void;
+}
+
+const consoleReporter: Reporter = {
+  info: (line) => console.log(line),
+  error: (line) => console.error(line),
+};
+
+const silentReporter: Reporter = { info: () => {}, error: () => {} };
+
+/** Options for {@link execute}. */
+export interface ExecuteOptions {
+  /** Suppress all banner/summary output (used by tests). */
+  silent?: boolean;
+  /** Custom reporter; overrides `silent`. */
+  reporter?: Reporter;
+  /** Target names to skip even if they appear in the plan (CLI `--skip`). */
+  skip?: string[];
+}
+
+/** Format a duration in milliseconds as `1.2s`. */
+function formatDuration(ms: number): string {
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+/**
+ * Execute the requested target and its transitive dependencies.
+ *
+ * Runs the build's `onStart`/`onFinish` lifecycle hooks around the plan. Stops
+ * at the first target that throws, reports it, and returns a failing result.
+ */
+export async function execute(
+  build: Build,
+  root: TargetBuilder,
+  options: ExecuteOptions = {},
+): Promise<BuildResult> {
+  const reporter = options.reporter ??
+    (options.silent ? silentReporter : consoleReporter);
+
+  const skip = new Set(options.skip ?? []);
+  const order = plan(root).filter((t) => !skip.has(t.name_ ?? ""));
+  const executed: string[] = [];
+  const overallStart = performance.now();
+
+  await build.onStart();
+
+  let result: BuildResult;
+  try {
+    for (const t of order) {
+      const name = t.name_ ?? "<unnamed>";
+      if (!t.fn_) {
+        throw new Error(
+          `Target "${name}" has no body — call .executes(...) before running.`,
+        );
+      }
+
+      reporter.info(`▶ ${name}`);
+      const start = performance.now();
+      try {
+        await t.fn_();
+      } catch (error) {
+        const elapsed = formatDuration(performance.now() - start);
+        reporter.error(`✘ ${name} (${elapsed})`);
+        reporter.error(
+          error instanceof Error ? error.message : String(error),
+        );
+        result = { ok: false, executed, error };
+        return await finish(
+          build,
+          reporter,
+          result,
+          overallStart,
+          order.length,
+        );
+      }
+      const elapsed = formatDuration(performance.now() - start);
+      reporter.info(`✔ ${name} (${elapsed})`);
+      executed.push(name);
+    }
+    result = { ok: true, executed };
+  } catch (error) {
+    // A pre-flight error (e.g. missing body) before/outside a target body.
+    result = { ok: false, executed, error };
+  }
+
+  return await finish(build, reporter, result, overallStart, order.length);
+}
+
+/** Print the summary, run the finish hook, and return the result. */
+async function finish(
+  build: Build,
+  reporter: Reporter,
+  result: BuildResult,
+  overallStart: number,
+  planned: number,
+): Promise<BuildResult> {
+  const total = formatDuration(performance.now() - overallStart);
+  const status = result.ok ? "SUCCESS" : "FAILED";
+  reporter.info(
+    `\n${result.ok ? "✔" : "✘"} ${status} — ` +
+      `${result.executed.length}/${planned} targets in ${total}`,
+  );
+  await build.onFinish(result);
+  return result;
+}

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -1,0 +1,191 @@
+/**
+ * Dependency-graph construction: validation, cycle detection, transitive
+ * closure, and topological sort.
+ *
+ * Edges come from three sources:
+ *   - `.dependsOn(D)` on N  → hard edge `D → N` (D runs before N). Determines
+ *     which targets are pulled into the execution set.
+ *   - `.after(A)` on N      → soft edge `A → N`, applied only when both are in
+ *     the plan. Does not pull A into the set.
+ *   - `.before(B)` on N     → soft edge `N → B`, applied only when both are in
+ *     the plan. Does not pull B into the set.
+ */
+
+import type { TargetBuilder } from "./target.ts";
+
+/** Raised when the build graph is invalid (cycle or unknown dependency). */
+export class GraphError extends Error {
+  override name = "GraphError";
+}
+
+/** Human label for a target, falling back to a placeholder if unbound. */
+function label(t: TargetBuilder | undefined): string {
+  return t?.name_ ?? "<unnamed target>";
+}
+
+/**
+ * Validate that every `.dependsOn(...)` reference is a discovered target.
+ *
+ * A reference is "unknown" if the builder was never assigned to a property of
+ * the build (so it has no name), or if it is not present in the discovered map.
+ *
+ * @throws {GraphError} on the first unknown dependency.
+ */
+export function validateReferences(
+  targets: Map<string, TargetBuilder>,
+): void {
+  const known = new Set(targets.values());
+  for (const [name, t] of targets) {
+    for (const dep of t.dependsOn_) {
+      if (dep === undefined) {
+        throw new GraphError(
+          `Target "${name}" has an undefined dependency. This usually means it ` +
+            `references a sibling via this.x that is declared *after* it — ` +
+            `class fields initialise top-to-bottom, so dependencies must be ` +
+            `declared before the targets that depend on them.`,
+        );
+      }
+      if (!known.has(dep)) {
+        throw new GraphError(
+          `Target "${name}" depends on a target that was not discovered ` +
+            `(${label(dep)}). Dependencies must reference sibling targets ` +
+            `declared as properties of the build.`,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Detect a cycle in the hard-dependency (`dependsOn`) graph across all targets.
+ *
+ * @returns the cycle as a path of names (e.g. `["a", "b", "a"]`) or `null`.
+ */
+export function findCycle(
+  targets: Map<string, TargetBuilder>,
+): string[] | null {
+  const WHITE = 0, GRAY = 1, BLACK = 2;
+  const color = new Map<TargetBuilder, number>();
+  const stack: TargetBuilder[] = [];
+
+  const visit = (node: TargetBuilder): string[] | null => {
+    color.set(node, GRAY);
+    stack.push(node);
+    for (const dep of node.dependsOn_) {
+      const c = color.get(dep) ?? WHITE;
+      if (c === GRAY) {
+        // Found a back-edge: extract the cycle from the stack.
+        const start = stack.indexOf(dep);
+        const cycle = stack.slice(start).map(label);
+        cycle.push(label(dep));
+        return cycle;
+      }
+      if (c === WHITE) {
+        const found = visit(dep);
+        if (found) return found;
+      }
+    }
+    stack.pop();
+    color.set(node, BLACK);
+    return null;
+  };
+
+  for (const t of targets.values()) {
+    if ((color.get(t) ?? WHITE) === WHITE) {
+      const cycle = visit(t);
+      if (cycle) return cycle;
+    }
+  }
+  return null;
+}
+
+/**
+ * Validate the whole graph: unknown references first, then cycles.
+ *
+ * @throws {GraphError} with a descriptive message including the cycle path.
+ */
+export function validateGraph(targets: Map<string, TargetBuilder>): void {
+  validateReferences(targets);
+  const cycle = findCycle(targets);
+  if (cycle) {
+    throw new GraphError(
+      `Dependency cycle detected: ${cycle.join(" → ")}`,
+    );
+  }
+}
+
+/**
+ * Compute the execution set for a requested target: the target plus the
+ * transitive closure of its hard dependencies.
+ */
+export function executionSet(root: TargetBuilder): Set<TargetBuilder> {
+  const set = new Set<TargetBuilder>();
+  const walk = (node: TargetBuilder) => {
+    if (set.has(node)) return;
+    set.add(node);
+    for (const dep of node.dependsOn_) walk(dep);
+  };
+  walk(root);
+  return set;
+}
+
+/**
+ * Topologically sort the execution set for `root`, honouring hard dependencies
+ * and the soft `before`/`after` ordering hints (the latter only between nodes
+ * that are both in the set).
+ *
+ * @returns target builders in a valid execution order.
+ * @throws {GraphError} if the planned graph contains a cycle (which can happen
+ *   via soft edges even when the hard graph is acyclic).
+ */
+export function plan(root: TargetBuilder): TargetBuilder[] {
+  const set = executionSet(root);
+
+  // Build the adjacency list of "must run before" edges within the set.
+  const edges = new Map<TargetBuilder, Set<TargetBuilder>>();
+  for (const node of set) edges.set(node, new Set());
+  const addEdge = (from: TargetBuilder, to: TargetBuilder) => {
+    if (set.has(from) && set.has(to)) edges.get(from)!.add(to);
+  };
+
+  for (const node of set) {
+    for (const dep of node.dependsOn_) addEdge(dep, node); // dep before node
+    for (const b of node.before_) addEdge(node, b); // node before b
+    for (const a of node.after_) addEdge(a, node); // a before node
+  }
+
+  // Deterministic DFS post-order topological sort. Iterate in declaration
+  // order (insertion order of `set`) so output is stable across runs.
+  const WHITE = 0, GRAY = 1, BLACK = 2;
+  const color = new Map<TargetBuilder, number>();
+  const order: TargetBuilder[] = [];
+  const stack: TargetBuilder[] = [];
+
+  const visit = (node: TargetBuilder) => {
+    color.set(node, GRAY);
+    stack.push(node);
+    for (const next of edges.get(node)!) {
+      const c = color.get(next) ?? WHITE;
+      if (c === GRAY) {
+        const start = stack.indexOf(next);
+        const cycle = stack.slice(start).map(label);
+        cycle.push(label(next));
+        throw new GraphError(
+          `Dependency cycle detected: ${cycle.join(" → ")}`,
+        );
+      }
+      if (c === WHITE) visit(next);
+    }
+    stack.pop();
+    color.set(node, BLACK);
+    order.push(node);
+  };
+
+  for (const node of set) {
+    if ((color.get(node) ?? WHITE) === WHITE) visit(node);
+  }
+  // Post-order DFS yields reverse topological order; flip it so that every
+  // "must run before" edge points forward.
+  order.reverse();
+  return order;
+}

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -145,7 +145,8 @@ export function plan(root: TargetBuilder): TargetBuilder[] {
   const edges = new Map<TargetBuilder, Set<TargetBuilder>>();
   for (const node of set) edges.set(node, new Set());
   const addEdge = (from: TargetBuilder, to: TargetBuilder) => {
-    if (set.has(from) && set.has(to)) edges.get(from)!.add(to);
+    const fromEdges = edges.get(from);
+    if (fromEdges && set.has(to)) fromEdges.add(to);
   };
 
   for (const node of set) {
@@ -164,7 +165,7 @@ export function plan(root: TargetBuilder): TargetBuilder[] {
   const visit = (node: TargetBuilder) => {
     color.set(node, GRAY);
     stack.push(node);
-    for (const next of edges.get(node)!) {
+    for (const next of edges.get(node) ?? []) {
       const c = color.get(next) ?? WHITE;
       if (c === GRAY) {
         const start = stack.indexOf(next);

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -1,0 +1,281 @@
+/**
+ * Ergonomic process execution built on `Deno.Command`, exposed as the `$`
+ * tagged template.
+ *
+ * ```ts
+ * await $`deno test -A`;                            // throws on non-zero exit
+ * const out = await $`git rev-parse HEAD`.text();   // trimmed stdout
+ * const code = await $`flaky-cmd`.noThrow().code();  // exit code, no throw
+ * await $`build`.env({ NODE_ENV: "prod" }).cwd("./app");
+ * ```
+ *
+ * Interpolated values become *discrete argv entries* — they are never spliced
+ * into a shell string — so there is no shell-injection surface. Arrays expand
+ * to multiple arguments.
+ */
+
+/** A value that may be interpolated into a `$` template. */
+export type Interpolatable =
+  | string
+  | number
+  | Array<string | number>;
+
+/** Raised when a command exits non-zero and throwing was not suppressed. */
+export class CommandError extends Error {
+  override name = "CommandError";
+  constructor(
+    /** The command line that failed (argv joined by spaces). */
+    readonly command: string,
+    /** The process exit code. */
+    readonly code: number,
+    /** Captured stderr, if any. */
+    readonly stderr: string,
+  ) {
+    super(
+      `Command failed (exit ${code}): ${command}` +
+        (stderr ? `\n${stderr.trimEnd()}` : ""),
+    );
+  }
+}
+
+/** The resolved result of a command, available when awaiting a {@link Command}. */
+export class CommandOutput {
+  constructor(
+    readonly code: number,
+    readonly stdout: string,
+    readonly stderr: string,
+  ) {}
+
+  /** Trimmed stdout. */
+  text(): string {
+    return this.stdout.trim();
+  }
+}
+
+interface RunResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+/** Concatenate byte chunks into one buffer and decode as UTF-8. */
+function decodeChunks(chunks: Uint8Array[]): string {
+  let total = 0;
+  for (const c of chunks) total += c.length;
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    merged.set(c, offset);
+    offset += c.length;
+  }
+  return new TextDecoder().decode(merged);
+}
+
+/** Drain a stream, optionally tee-ing each chunk to a live sink, and capture. */
+async function collect(
+  stream: ReadableStream<Uint8Array>,
+  sink: { writeSync(p: Uint8Array): number } | null,
+): Promise<string> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+      if (sink) sink.writeSync(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return decodeChunks(chunks);
+}
+
+/**
+ * A lazily-executed command. Built by the `$` tagged template. The process does
+ * not start until the command is awaited or a terminal method (`text`, `lines`,
+ * `code`) is called; the result is memoised so repeated reads are cheap.
+ */
+export class Command implements PromiseLike<CommandOutput> {
+  #argv: string[];
+  #env: Record<string, string> = {};
+  #cwd?: string;
+  #throwOnError = true;
+  #quiet = false;
+  #capturing = false;
+  #result?: Promise<RunResult>;
+
+  constructor(argv: string[]) {
+    this.#argv = argv;
+  }
+
+  /** Merge additional environment variables. */
+  env(record: Record<string, string>): this {
+    this.#env = { ...this.#env, ...record };
+    return this;
+  }
+
+  /** Set the working directory for the process. */
+  cwd(path: string): this {
+    this.#cwd = path;
+    return this;
+  }
+
+  /** Do not throw on a non-zero exit; combine with {@link code}. */
+  noThrow(): this {
+    this.#throwOnError = false;
+    return this;
+  }
+
+  /** Suppress live stdout/stderr streaming to the terminal. */
+  quiet(): this {
+    this.#quiet = true;
+    return this;
+  }
+
+  /** The command line, for diagnostics. */
+  get commandLine(): string {
+    return this.#argv.join(" ");
+  }
+
+  #run(): Promise<RunResult> {
+    if (!this.#result) this.#result = this.#spawn();
+    return this.#result;
+  }
+
+  async #spawn(): Promise<RunResult> {
+    const [cmd, ...args] = this.#argv;
+    if (!cmd) throw new Error("Cannot run an empty command.");
+
+    const child = new Deno.Command(cmd, {
+      args,
+      cwd: this.#cwd,
+      env: this.#env,
+      stdout: "piped",
+      stderr: "piped",
+    }).spawn();
+
+    // When capturing programmatically, don't echo stdout to the terminal.
+    const streamStdout = !this.#quiet && !this.#capturing;
+    const streamStderr = !this.#quiet;
+
+    const [stdout, stderr] = await Promise.all([
+      collect(child.stdout, streamStdout ? Deno.stdout : null),
+      collect(child.stderr, streamStderr ? Deno.stderr : null),
+    ]);
+    const status = await child.status;
+    return { code: status.code, stdout, stderr };
+  }
+
+  #maybeThrow(r: RunResult): void {
+    if (r.code !== 0 && this.#throwOnError) {
+      throw new CommandError(this.commandLine, r.code, r.stderr);
+    }
+  }
+
+  /** Await support: run the command and resolve to a {@link CommandOutput}. */
+  then<TResult1 = CommandOutput, TResult2 = never>(
+    onfulfilled?:
+      | ((value: CommandOutput) => TResult1 | PromiseLike<TResult1>)
+      | null,
+    onrejected?:
+      | ((reason: unknown) => TResult2 | PromiseLike<TResult2>)
+      | null,
+  ): PromiseLike<TResult1 | TResult2> {
+    return this.#output().then(onfulfilled, onrejected);
+  }
+
+  async #output(): Promise<CommandOutput> {
+    const r = await this.#run();
+    this.#maybeThrow(r);
+    return new CommandOutput(r.code, r.stdout, r.stderr);
+  }
+
+  /** Run and resolve to trimmed stdout. Throws on non-zero unless `noThrow`. */
+  async text(): Promise<string> {
+    this.#capturing = true;
+    const r = await this.#run();
+    this.#maybeThrow(r);
+    return r.stdout.trim();
+  }
+
+  /** Run and resolve to stdout split into lines (trailing blank dropped). */
+  async lines(): Promise<string[]> {
+    const text = await this.text();
+    return text.length === 0 ? [] : text.split("\n");
+  }
+
+  /** Run and resolve to the numeric exit code. Never throws on non-zero. */
+  async code(): Promise<number> {
+    const r = await this.#run();
+    return r.code;
+  }
+}
+
+/**
+ * Tokenise a tagged-template invocation into an argv array.
+ *
+ * Literal whitespace separates arguments; interpolated values are appended as
+ * atomic tokens (so `--flag=${x}` and `pre${x}` work), and arrays expand to one
+ * argument per element. Interpolated values are never re-split on whitespace,
+ * which is what keeps command construction injection-free.
+ */
+export function tokenize(
+  strings: ReadonlyArray<string>,
+  values: ReadonlyArray<Interpolatable>,
+): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let hasCurrent = false;
+
+  const append = (s: string) => {
+    current += s;
+    hasCurrent = true;
+  };
+  const flush = () => {
+    if (hasCurrent) {
+      tokens.push(current);
+      current = "";
+      hasCurrent = false;
+    }
+  };
+
+  for (let i = 0; i < strings.length; i++) {
+    let buf = "";
+    for (const ch of strings[i]) {
+      if (ch === " " || ch === "\t" || ch === "\n" || ch === "\r") {
+        if (buf) {
+          append(buf);
+          buf = "";
+        }
+        flush();
+      } else {
+        buf += ch;
+      }
+    }
+    if (buf) append(buf);
+
+    if (i < values.length) {
+      const v = values[i];
+      const arr = Array.isArray(v) ? v : [v];
+      for (let j = 0; j < arr.length; j++) {
+        if (j > 0) flush();
+        append(String(arr[j]));
+      }
+    }
+  }
+  flush();
+  return tokens;
+}
+
+/**
+ * Run an external command, ergonomically.
+ *
+ * @example `await $\`deno test -A\``
+ */
+export function $(
+  strings: TemplateStringsArray,
+  ...values: Interpolatable[]
+): Command {
+  return new Command(tokenize(strings, values));
+}

--- a/src/target.ts
+++ b/src/target.ts
@@ -1,0 +1,80 @@
+/**
+ * Target authoring API: the `target()` fluent builder and the `Target` type.
+ *
+ * A target is declared as a class property on a {@link Build} subclass:
+ *
+ * ```ts
+ * compile = target()
+ *   .description("Type-check and build")
+ *   .dependsOn(this.clean, this.restore)
+ *   .executes(async () => { await $`deno check mod.ts`; });
+ * ```
+ *
+ * Dependencies are declared by passing sibling target *references*
+ * (`this.clean`), not strings. The framework maps each builder back to its
+ * property name during discovery (see {@link Build}).
+ */
+
+/** The executable body of a target. May be synchronous or asynchronous. */
+export type TargetFn = () => void | Promise<void>;
+
+/**
+ * The fluent builder returned by {@link target}. All configuration methods are
+ * chainable and return `this`. A body (via {@link TargetBuilder.executes}) is
+ * required before a target can be executed.
+ */
+export class TargetBuilder {
+  /** Human-readable summary shown in `--list`. */
+  description_?: string;
+  /** Hard prerequisites: these run (transitively) before this target. */
+  readonly dependsOn_: TargetBuilder[] = [];
+  /** Soft ordering: this runs before the listed targets if both are planned. */
+  readonly before_: TargetBuilder[] = [];
+  /** Soft ordering: this runs after the listed targets if both are planned. */
+  readonly after_: TargetBuilder[] = [];
+  /** The target body. */
+  fn_?: TargetFn;
+  /** Property name, assigned during discovery. Undefined until then. */
+  name_?: string;
+
+  /** Set the human-readable description shown in `zuke --list`. */
+  description(text: string): this {
+    this.description_ = text;
+    return this;
+  }
+
+  /** Declare hard prerequisites. References sibling targets via `this.x`. */
+  dependsOn(...targets: TargetBuilder[]): this {
+    this.dependsOn_.push(...targets);
+    return this;
+  }
+
+  /** Set the target body. May be async. */
+  executes(fn: TargetFn): this {
+    this.fn_ = fn;
+    return this;
+  }
+
+  /** Run before the listed targets if both are in the plan (soft ordering). */
+  before(...targets: TargetBuilder[]): this {
+    this.before_.push(...targets);
+    return this;
+  }
+
+  /** Run after the listed targets if both are in the plan (soft ordering). */
+  after(...targets: TargetBuilder[]): this {
+    this.after_.push(...targets);
+    return this;
+  }
+}
+
+/**
+ * A configured target. Alias of {@link TargetBuilder} — the same object both
+ * builds and represents the target. Exposed as `Target` for use in signatures.
+ */
+export type Target = TargetBuilder;
+
+/** Create a new, empty target builder. */
+export function target(): TargetBuilder {
+  return new TargetBuilder();
+}

--- a/tests/_assert.ts
+++ b/tests/_assert.ts
@@ -3,6 +3,14 @@
  * dependencies (the sandbox blocks the JSR registry).
  */
 
+/** A constructor usable on the right of `instanceof` (e.g. `TypeError`). */
+type ErrorCtor = new (...args: never[]) => Error;
+
+/** Extract a message from an unknown thrown value without casting. */
+export function messageOf(value: unknown): string {
+  return value instanceof Error ? value.message : String(value);
+}
+
 /** Structural equality via JSON-ish deep comparison. */
 function deepEqual(a: unknown, b: unknown): boolean {
   if (a === b) return true;
@@ -36,8 +44,7 @@ export function assertEquals<T>(actual: T, expected: T, msg?: string): void {
 /** Assert that `fn` throws; optionally check the error type and message. */
 export function assertThrows(
   fn: () => unknown,
-  // deno-lint-ignore no-explicit-any
-  ErrorClass?: new (...args: any[]) => Error,
+  ErrorClass?: ErrorCtor,
   msgIncludes?: string,
 ): Error {
   let thrown: Error | undefined;
@@ -54,8 +61,7 @@ export function assertThrows(
 /** Assert that the promise returned by `fn` rejects. */
 export async function assertRejects(
   fn: () => PromiseLike<unknown>,
-  // deno-lint-ignore no-explicit-any
-  ErrorClass?: new (...args: any[]) => Error,
+  ErrorClass?: ErrorCtor,
   msgIncludes?: string,
 ): Promise<Error> {
   let thrown: Error | undefined;
@@ -71,8 +77,7 @@ export async function assertRejects(
 
 function check(
   error: Error,
-  // deno-lint-ignore no-explicit-any
-  ErrorClass?: new (...args: any[]) => Error,
+  ErrorClass?: ErrorCtor,
   msgIncludes?: string,
 ): void {
   const gotName = error.constructor?.name ?? "Error";

--- a/tests/_assert.ts
+++ b/tests/_assert.ts
@@ -1,0 +1,90 @@
+/**
+ * Minimal assertion helpers, kept local so the test suite has zero network
+ * dependencies (the sandbox blocks the JSR registry).
+ */
+
+/** Structural equality via JSON-ish deep comparison. */
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b || a === null || b === null) return false;
+  if (typeof a !== "object") return false;
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) {
+      return false;
+    }
+    return a.every((v, i) => deepEqual(v, b[i]));
+  }
+  const ao = a as Record<string, unknown>;
+  const bo = b as Record<string, unknown>;
+  const ak = Object.keys(ao);
+  const bk = Object.keys(bo);
+  if (ak.length !== bk.length) return false;
+  return ak.every((k) => deepEqual(ao[k], bo[k]));
+}
+
+/** Assert deep equality. */
+export function assertEquals<T>(actual: T, expected: T, msg?: string): void {
+  if (!deepEqual(actual, expected)) {
+    throw new Error(
+      msg ??
+        `Values not equal:\n  actual:   ${JSON.stringify(actual)}\n` +
+          `  expected: ${JSON.stringify(expected)}`,
+    );
+  }
+}
+
+/** Assert that `fn` throws; optionally check the error type and message. */
+export function assertThrows(
+  fn: () => unknown,
+  // deno-lint-ignore no-explicit-any
+  ErrorClass?: new (...args: any[]) => Error,
+  msgIncludes?: string,
+): Error {
+  let thrown: Error | undefined;
+  try {
+    fn();
+  } catch (e) {
+    thrown = e instanceof Error ? e : new Error(String(e));
+  }
+  if (!thrown) throw new Error("Expected function to throw, but it did not.");
+  check(thrown, ErrorClass, msgIncludes);
+  return thrown;
+}
+
+/** Assert that the promise returned by `fn` rejects. */
+export async function assertRejects(
+  fn: () => PromiseLike<unknown>,
+  // deno-lint-ignore no-explicit-any
+  ErrorClass?: new (...args: any[]) => Error,
+  msgIncludes?: string,
+): Promise<Error> {
+  let thrown: Error | undefined;
+  try {
+    await fn();
+  } catch (e) {
+    thrown = e instanceof Error ? e : new Error(String(e));
+  }
+  if (!thrown) throw new Error("Expected promise to reject, but it resolved.");
+  check(thrown, ErrorClass, msgIncludes);
+  return thrown;
+}
+
+function check(
+  error: Error,
+  // deno-lint-ignore no-explicit-any
+  ErrorClass?: new (...args: any[]) => Error,
+  msgIncludes?: string,
+): void {
+  const gotName = error.constructor?.name ?? "Error";
+  const message = error.message;
+  if (ErrorClass && !(error instanceof ErrorClass)) {
+    throw new Error(
+      `Expected error of type ${ErrorClass.name}, got ${gotName}: ${message}`,
+    );
+  }
+  if (msgIncludes && !message.includes(msgIncludes)) {
+    throw new Error(
+      `Expected error message to include "${msgIncludes}", got: ${message}`,
+    );
+  }
+}

--- a/tests/cli_test.ts
+++ b/tests/cli_test.ts
@@ -1,0 +1,194 @@
+import { assertEquals } from "./_assert.ts";
+import { Build, target } from "../mod.ts";
+import {
+  formatGraph,
+  formatHelp,
+  formatList,
+  main,
+  parseArgs,
+  run,
+} from "../src/cli.ts";
+import { discoverTargets } from "../src/build.ts";
+
+/** Run `fn` with `console.log`/`console.error` captured instead of printed. */
+async function capture(
+  fn: () => Promise<number> | number,
+): Promise<{ code: number; out: string[]; err: string[] }> {
+  const out: string[] = [];
+  const err: string[] = [];
+  const origLog = console.log;
+  const origErr = console.error;
+  console.log = (...args: unknown[]) => void out.push(args.join(" "));
+  console.error = (...args: unknown[]) => void err.push(args.join(" "));
+  try {
+    const code = await fn();
+    return { code, out, err };
+  } finally {
+    console.log = origLog;
+    console.error = origErr;
+  }
+}
+
+class Demo extends Build {
+  clean = target().description("Clean").executes(() => {});
+  build = target().description("Build").dependsOn(this.clean).executes(
+    () => {},
+  );
+}
+
+Deno.test("parseArgs reads a positional target", () => {
+  assertEquals(parseArgs(["build"]).target, "build");
+});
+
+Deno.test("parseArgs recognises flags and aliases", () => {
+  assertEquals(parseArgs(["--list"]).list, true);
+  assertEquals(parseArgs(["-l"]).list, true);
+  assertEquals(parseArgs(["--graph"]).graph, true);
+  assertEquals(parseArgs(["--help"]).help, true);
+  assertEquals(parseArgs(["-h"]).help, true);
+});
+
+Deno.test("parseArgs collects repeatable --skip and keeps first positional", () => {
+  const parsed = parseArgs([
+    "build",
+    "--skip",
+    "clean",
+    "--skip",
+    "restore",
+    "extra",
+  ]);
+  assertEquals(parsed.target, "build");
+  assertEquals(parsed.skip, ["clean", "restore"]);
+});
+
+Deno.test("formatList shows targets, descriptions and dependencies", () => {
+  const list = formatList(discoverTargets(new Demo()));
+  assertEquals(list.includes("clean"), true);
+  assertEquals(list.includes("Build"), true);
+  assertEquals(list.includes("(depends on: clean)"), true);
+});
+
+Deno.test("formatGraph renders adjacency, formatHelp includes usage", () => {
+  const targets = discoverTargets(new Demo());
+  assertEquals(formatGraph(targets).includes("build → clean"), true);
+  assertEquals(formatHelp(targets).includes("Usage:"), true);
+});
+
+Deno.test("formatList/formatGraph handle an empty build", () => {
+  class Empty extends Build {}
+  const targets = discoverTargets(new Empty());
+  assertEquals(formatList(targets), "No targets defined.");
+  assertEquals(formatGraph(targets), "No targets defined.");
+});
+
+Deno.test("main --help prints usage and returns 0", async () => {
+  const { code, out } = await capture(() => main(Demo, ["--help"]));
+  assertEquals(code, 0);
+  assertEquals(out.join("\n").includes("Usage:"), true);
+});
+
+Deno.test("main --list and --graph return 0", async () => {
+  const list = await capture(() => main(Demo, ["--list"]));
+  assertEquals(list.code, 0);
+  assertEquals(list.out.join("\n").includes("Targets:"), true);
+
+  const graph = await capture(() => main(Demo, ["--graph"]));
+  assertEquals(graph.code, 0);
+  assertEquals(graph.out.join("\n").includes("Dependency graph:"), true);
+});
+
+Deno.test("main runs a target and its dependencies, returning 0", async () => {
+  const log: string[] = [];
+  class Tracked extends Build {
+    a = target().executes(() => void log.push("a"));
+    b = target().dependsOn(this.a).executes(() => void log.push("b"));
+  }
+  const { code } = await capture(() => main(Tracked, ["b"]));
+  assertEquals(code, 0);
+  assertEquals(log, ["a", "b"]);
+});
+
+Deno.test("main runs the default target when none is named", async () => {
+  const log: string[] = [];
+  class WithDefault extends Build {
+    work = target().executes(() => void log.push("work"));
+    default = target().dependsOn(this.work).executes(() => {});
+  }
+  const { code } = await capture(() => main(WithDefault, []));
+  assertEquals(code, 0);
+  assertEquals(log, ["work"]);
+});
+
+Deno.test("main with no target and no default lists targets, returns 0", async () => {
+  const { code, out } = await capture(() => main(Demo, []));
+  assertEquals(code, 0);
+  assertEquals(out.join("\n").includes("Targets:"), true);
+});
+
+Deno.test("main reports an unknown target and returns 1", async () => {
+  const { code, err } = await capture(() => main(Demo, ["nope"]));
+  assertEquals(code, 1);
+  assertEquals(err.join("\n").includes("Unknown target: nope"), true);
+});
+
+Deno.test("main reports a dependency cycle and returns 1", async () => {
+  class Cyclic extends Build {
+    a = target().executes(() => {});
+    b = target().executes(() => {});
+    constructor() {
+      super();
+      this.a.dependsOn(this.b);
+      this.b.dependsOn(this.a);
+    }
+  }
+  const { code, err } = await capture(() => main(Cyclic, ["a"]));
+  assertEquals(code, 1);
+  assertEquals(err.join("\n").includes("cycle detected"), true);
+});
+
+Deno.test("main returns 1 when an executed target fails", async () => {
+  class Failing extends Build {
+    boom = target().executes(() => {
+      throw new Error("explode");
+    });
+  }
+  const { code, err } = await capture(() => main(Failing, ["boom"]));
+  assertEquals(code, 1);
+  assertEquals(err.join("\n").includes("explode"), true);
+});
+
+/** Sentinel thrown by the stubbed `Deno.exit` so control returns to the test. */
+class ExitSignal extends Error {}
+
+Deno.test("run() drives main and sets the process exit code", async () => {
+  const origExit = Deno.exit;
+  let captured: number | undefined;
+  Deno.exit = (code?: number): never => {
+    captured = code ?? 0;
+    throw new ExitSignal();
+  };
+  const origLog = console.log;
+  console.log = () => {};
+  try {
+    await run(Demo, ["--list"]);
+  } catch (e) {
+    if (!(e instanceof ExitSignal)) throw e;
+  } finally {
+    Deno.exit = origExit;
+    console.log = origLog;
+  }
+  assertEquals(captured, 0);
+});
+
+Deno.test("main honours --skip", async () => {
+  const log: string[] = [];
+  class Tracked extends Build {
+    setup = target().executes(() => void log.push("setup"));
+    go = target().dependsOn(this.setup).executes(() => void log.push("go"));
+  }
+  const { code } = await capture(() =>
+    main(Tracked, ["go", "--skip", "setup"])
+  );
+  assertEquals(code, 0);
+  assertEquals(log, ["go"]);
+});

--- a/tests/coverage_test.ts
+++ b/tests/coverage_test.ts
@@ -1,0 +1,33 @@
+import { assertEquals } from "./_assert.ts";
+import { parseLcov, pct } from "../scripts/check-coverage.ts";
+
+Deno.test("parseLcov sums LF/LH/BRF/BRH across files", () => {
+  const lcov = [
+    "SF:a.ts",
+    "FNF:2",
+    "FNH:2",
+    "BRF:4",
+    "BRH:3",
+    "LF:10",
+    "LH:9",
+    "end_of_record",
+    "SF:b.ts",
+    "BRF:6",
+    "BRH:6",
+    "LF:20",
+    "LH:20",
+    "end_of_record",
+  ].join("\n");
+
+  const totals = parseLcov(lcov);
+  assertEquals(totals.linesFound, 30);
+  assertEquals(totals.linesHit, 29);
+  assertEquals(totals.branchesFound, 10);
+  assertEquals(totals.branchesHit, 9);
+});
+
+Deno.test("pct computes percentages and treats zero-found as 100", () => {
+  assertEquals(pct(9, 10), 90);
+  assertEquals(pct(0, 0), 100);
+  assertEquals(pct(1, 4), 25);
+});

--- a/tests/executor_test.ts
+++ b/tests/executor_test.ts
@@ -1,0 +1,116 @@
+import { assertEquals } from "./_assert.ts";
+import { Build, type BuildResult, discoverTargets } from "../src/build.ts";
+import { target } from "../src/target.ts";
+import { execute } from "../src/executor.ts";
+
+const silent = { silent: true } as const;
+
+Deno.test("executes dependencies before dependents, in order", async () => {
+  const log: string[] = [];
+  class B extends Build {
+    clean = target().executes(() => void log.push("clean"));
+    restore = target().executes(() => void log.push("restore"));
+    compile = target()
+      .dependsOn(this.clean, this.restore)
+      .executes(() => void log.push("compile"));
+    test = target().dependsOn(this.compile).executes(() =>
+      void log.push("test")
+    );
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  const result = await execute(b, b.test, silent);
+  assertEquals(result.ok, true);
+  assertEquals(log[log.length - 1], "test");
+  assertEquals(log.indexOf("compile") < log.indexOf("test"), true);
+  assertEquals(log.indexOf("clean") < log.indexOf("compile"), true);
+});
+
+Deno.test("diamond shared target runs exactly once", async () => {
+  const log: string[] = [];
+  class B extends Build {
+    base = target().executes(() => void log.push("base"));
+    left = target().dependsOn(this.base).executes(() => void log.push("left"));
+    right = target().dependsOn(this.base).executes(() =>
+      void log.push("right")
+    );
+    top = target()
+      .dependsOn(this.left, this.right)
+      .executes(() => void log.push("top"));
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  await execute(b, b.top, silent);
+  assertEquals(log.filter((n) => n === "base").length, 1);
+});
+
+Deno.test("a failing target aborts the run", async () => {
+  const log: string[] = [];
+  class B extends Build {
+    first = target().executes(() => void log.push("first"));
+    boom = target()
+      .dependsOn(this.first)
+      .executes(() => {
+        throw new Error("kaboom");
+      });
+    last = target().dependsOn(this.boom).executes(() => void log.push("last"));
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  const result = await execute(b, b.last, silent);
+  assertEquals(result.ok, false);
+  assertEquals((result.error as Error).message, "kaboom");
+  assertEquals(log.includes("first"), true);
+  assertEquals(log.includes("last"), false); // aborted before reaching last
+  assertEquals(result.executed, ["first"]);
+});
+
+Deno.test("lifecycle hooks run around the plan", async () => {
+  const events: string[] = [];
+  class B extends Build {
+    override onStart() {
+      events.push("start");
+    }
+    override onFinish(r: BuildResult) {
+      events.push(`finish:${r.ok}`);
+    }
+    work = target().executes(() => void events.push("work"));
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  await execute(b, b.work, silent);
+  assertEquals(events, ["start", "work", "finish:true"]);
+});
+
+Deno.test("skip removes a target from the plan", async () => {
+  const log: string[] = [];
+  class B extends Build {
+    setup = target().executes(() => void log.push("setup"));
+    main = target().dependsOn(this.setup).executes(() => void log.push("main"));
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  const result = await execute(b, b.main, { silent: true, skip: ["setup"] });
+  assertEquals(result.ok, true);
+  assertEquals(log, ["main"]);
+});
+
+Deno.test("a target without a body fails fast", async () => {
+  class B extends Build {
+    incomplete = target().description("no body here");
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  const result = await execute(b, b.incomplete, silent);
+  assertEquals(result.ok, false);
+  assertEquals(
+    String((result.error as Error).message).includes("no body"),
+    true,
+  );
+});

--- a/tests/executor_test.ts
+++ b/tests/executor_test.ts
@@ -1,9 +1,9 @@
-import { assertEquals } from "./_assert.ts";
+import { assertEquals, messageOf } from "./_assert.ts";
 import { Build, type BuildResult, discoverTargets } from "../src/build.ts";
 import { target } from "../src/target.ts";
-import { execute } from "../src/executor.ts";
+import { execute, type ExecuteOptions } from "../src/executor.ts";
 
-const silent = { silent: true } as const;
+const silent: ExecuteOptions = { silent: true };
 
 Deno.test("executes dependencies before dependents, in order", async () => {
   const log: string[] = [];
@@ -62,7 +62,7 @@ Deno.test("a failing target aborts the run", async () => {
 
   const result = await execute(b, b.last, silent);
   assertEquals(result.ok, false);
-  assertEquals((result.error as Error).message, "kaboom");
+  assertEquals(messageOf(result.error), "kaboom");
   assertEquals(log.includes("first"), true);
   assertEquals(log.includes("last"), false); // aborted before reaching last
   assertEquals(result.executed, ["first"]);
@@ -109,8 +109,64 @@ Deno.test("a target without a body fails fast", async () => {
 
   const result = await execute(b, b.incomplete, silent);
   assertEquals(result.ok, false);
-  assertEquals(
-    String((result.error as Error).message).includes("no body"),
-    true,
-  );
+  assertEquals(messageOf(result.error).includes("no body"), true);
+});
+
+Deno.test("a custom reporter receives start/success banners and summary", async () => {
+  const lines: string[] = [];
+  const reporter = {
+    info: (line: string) => void lines.push(line),
+    error: (line: string) => void lines.push(line),
+  };
+  class B extends Build {
+    work = target().executes(() => {});
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  await execute(b, b.work, { reporter });
+  assertEquals(lines[0], "▶ work");
+  assertEquals(lines[1].startsWith("✔ work ("), true);
+  assertEquals(lines[2].includes("SUCCESS"), true);
+  assertEquals(lines[2].includes("1/1 targets"), true);
+});
+
+Deno.test("failure banner and summary are reported", async () => {
+  const lines: string[] = [];
+  const reporter = {
+    info: (line: string) => void lines.push(line),
+    error: (line: string) => void lines.push(line),
+  };
+  class B extends Build {
+    boom = target().executes(() => {
+      throw new Error("nope");
+    });
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  await execute(b, b.boom, { reporter });
+  assertEquals(lines.some((l) => l.startsWith("✘ boom (")), true);
+  assertEquals(lines.includes("nope"), true);
+  assertEquals(lines.some((l) => l.includes("FAILED")), true);
+});
+
+Deno.test("a non-Error throw is reported via String coercion", async () => {
+  const lines: string[] = [];
+  const reporter = {
+    info: (line: string) => void lines.push(line),
+    error: (line: string) => void lines.push(line),
+  };
+  class B extends Build {
+    boom = target().executes(() => {
+      throw "string failure";
+    });
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  const result = await execute(b, b.boom, { reporter });
+  assertEquals(result.ok, false);
+  assertEquals(result.error, "string failure");
+  assertEquals(lines.includes("string failure"), true);
 });

--- a/tests/graph_test.ts
+++ b/tests/graph_test.ts
@@ -77,9 +77,9 @@ Deno.test("findCycle reports the offending path", () => {
   discover(inst);
 
   const cycle = findCycle(discover(inst));
-  assertEquals(cycle !== null, true);
+  if (cycle === null) throw new Error("expected a cycle to be found");
   // The path starts and ends at the same node.
-  assertEquals(cycle![0], cycle![cycle!.length - 1]);
+  assertEquals(cycle[0], cycle[cycle.length - 1]);
 });
 
 Deno.test("validateGraph throws GraphError with the cycle path", () => {
@@ -107,6 +107,23 @@ Deno.test("validateReferences rejects a dependency on an undiscovered target", (
     () => validateReferences(discover(new B())),
     GraphError,
     "not discovered",
+  );
+});
+
+Deno.test("validateReferences rejects an undefined (forward-referenced) dep", () => {
+  class B extends Build {
+    // TypeScript catches this forward reference (TS2729); the suppression
+    // simulates a consumer that bypassed type-checking, exercising the runtime
+    // guard. Class fields initialise top-to-bottom, so `this.later` is undefined.
+    // @ts-expect-error -- deliberately forward-references a later field
+
+    early = target().dependsOn(this.later).executes(() => {});
+    later = target().executes(() => {});
+  }
+  assertThrows(
+    () => validateReferences(discover(new B())),
+    GraphError,
+    "undefined dependency",
   );
 });
 

--- a/tests/graph_test.ts
+++ b/tests/graph_test.ts
@@ -1,0 +1,146 @@
+import { assertEquals, assertThrows } from "./_assert.ts";
+import { Build, discoverTargets } from "../src/build.ts";
+import { target } from "../src/target.ts";
+import {
+  executionSet,
+  findCycle,
+  GraphError,
+  plan,
+  validateGraph,
+  validateReferences,
+} from "../src/graph.ts";
+
+/** Build a discovered-target map from a Build subclass instance. */
+function discover(b: Build) {
+  return discoverTargets(b);
+}
+
+Deno.test("topological order respects dependencies", () => {
+  class B extends Build {
+    clean = target().executes(() => {});
+    restore = target().executes(() => {});
+    compile = target().dependsOn(this.clean, this.restore).executes(() => {});
+    test = target().dependsOn(this.compile).executes(() => {});
+  }
+  const b = new B();
+  discover(b);
+  const order = plan(b.test).map((t) => t.name_);
+
+  // test last; compile before test; clean & restore before compile.
+  assertEquals(order[order.length - 1], "test");
+  const idx = (n: string) => order.indexOf(n);
+  assertEquals(idx("compile") < idx("test"), true);
+  assertEquals(idx("clean") < idx("compile"), true);
+  assertEquals(idx("restore") < idx("compile"), true);
+});
+
+Deno.test("diamond dependencies appear exactly once", () => {
+  class B extends Build {
+    base = target().executes(() => {});
+    left = target().dependsOn(this.base).executes(() => {});
+    right = target().dependsOn(this.base).executes(() => {});
+    top = target().dependsOn(this.left, this.right).executes(() => {});
+  }
+  const b = new B();
+  discover(b);
+  const order = plan(b.top).map((t) => t.name_);
+
+  assertEquals(order.filter((n) => n === "base").length, 1);
+  assertEquals(order.length, 4);
+  assertEquals(order[order.length - 1], "top");
+});
+
+Deno.test("execution set is the transitive closure of the root", () => {
+  class B extends Build {
+    a = target().executes(() => {});
+    b = target().dependsOn(this.a).executes(() => {});
+    c = target().dependsOn(this.b).executes(() => {});
+    unrelated = target().executes(() => {});
+  }
+  const inst = new B();
+  discover(inst);
+  const set = [...executionSet(inst.c)].map((t) => t.name_).sort();
+  assertEquals(set, ["a", "b", "c"]);
+});
+
+Deno.test("findCycle reports the offending path", () => {
+  class B extends Build {
+    a = target();
+    b = target();
+    c = target();
+  }
+  const inst = new B();
+  // a → b → c → a
+  inst.a.dependsOn(inst.b);
+  inst.b.dependsOn(inst.c);
+  inst.c.dependsOn(inst.a);
+  discover(inst);
+
+  const cycle = findCycle(discover(inst));
+  assertEquals(cycle !== null, true);
+  // The path starts and ends at the same node.
+  assertEquals(cycle![0], cycle![cycle!.length - 1]);
+});
+
+Deno.test("validateGraph throws GraphError with the cycle path", () => {
+  class B extends Build {
+    a = target();
+    b = target();
+  }
+  const inst = new B();
+  inst.a.dependsOn(inst.b);
+  inst.b.dependsOn(inst.a);
+
+  assertThrows(
+    () => validateGraph(discover(inst)),
+    GraphError,
+    "cycle detected",
+  );
+});
+
+Deno.test("validateReferences rejects a dependency on an undiscovered target", () => {
+  const orphan = target(); // never assigned to a property
+  class B extends Build {
+    a = target().dependsOn(orphan);
+  }
+  assertThrows(
+    () => validateReferences(discover(new B())),
+    GraphError,
+    "not discovered",
+  );
+});
+
+Deno.test("soft before/after hints order nodes within the plan", () => {
+  class B extends Build {
+    setup = target().executes(() => {});
+    work = target().dependsOn(this.setup).executes(() => {});
+    // `lint` has no hard dep but should run after setup when both are planned.
+    lint = target().after(this.setup).before(this.work).executes(() => {});
+  }
+  const b = new B();
+  discover(b);
+  // Pull lint into the plan by depending on it from a root.
+  const root = target().dependsOn(b.work, b.lint).executes(() => {});
+  root.name_ = "root";
+
+  const order = plan(root).map((t) => t.name_);
+  const idx = (n: string) => order.indexOf(n);
+  assertEquals(idx("setup") < idx("lint"), true);
+  assertEquals(idx("lint") < idx("work"), true);
+});
+
+Deno.test("plan detects a cycle introduced by soft edges", () => {
+  class B extends Build {
+    a = target().executes(() => {});
+    b = target().executes(() => {});
+  }
+  const inst = new B();
+  // a before b, and b before a → soft cycle.
+  inst.a.before(inst.b);
+  inst.b.before(inst.a);
+  discover(inst);
+  const root = target().dependsOn(inst.a, inst.b).executes(() => {});
+  root.name_ = "root";
+
+  assertThrows(() => plan(root), GraphError, "cycle detected");
+});

--- a/tests/shell_test.ts
+++ b/tests/shell_test.ts
@@ -1,0 +1,81 @@
+import { assertEquals, assertRejects } from "./_assert.ts";
+import { $, CommandError, tokenize } from "../src/shell.ts";
+
+// `deno` is guaranteed present (we are running under it) and shell-free, so it
+// makes a reliable, cross-platform subject for these tests.
+const DENO = Deno.execPath();
+
+Deno.test("tokenize splits literals on whitespace", () => {
+  assertEquals(tokenize(["deno  test   -A"], []), ["deno", "test", "-A"]);
+});
+
+Deno.test("tokenize keeps interpolated values as atomic args", () => {
+  // `cmd ${"a b"}` → two template strings, one value with a space inside.
+  assertEquals(tokenize(["cmd ", ""], ["a b"]), ["cmd", "a b"]);
+});
+
+Deno.test("tokenize attaches a value to an adjacent literal", () => {
+  // `--flag=${"v"}` → no whitespace boundary.
+  assertEquals(tokenize(["--flag=", ""], ["v"]), ["--flag=v"]);
+});
+
+Deno.test("tokenize expands arrays into multiple args", () => {
+  assertEquals(tokenize(["cmd ", ""], [["a", "b", "c"]]), [
+    "cmd",
+    "a",
+    "b",
+    "c",
+  ]);
+});
+
+Deno.test("$ captures trimmed stdout via .text()", async () => {
+  const out = await $`${DENO} eval ${"console.log('hello world')"}`.text();
+  assertEquals(out, "hello world");
+});
+
+Deno.test("$ .lines() splits stdout into lines", async () => {
+  const lines = await $`${DENO} eval ${"console.log('a');console.log('b')"}`
+    .lines();
+  assertEquals(lines, ["a", "b"]);
+});
+
+Deno.test("$ .code() returns the exit code without throwing", async () => {
+  const code = await $`${DENO} eval ${"Deno.exit(3)"}`.noThrow().code();
+  assertEquals(code, 3);
+});
+
+Deno.test("$ throws CommandError on non-zero exit by default", async () => {
+  const err = await assertRejects(
+    () => $`${DENO} eval ${"Deno.exit(2)"}`.quiet().then(),
+    CommandError,
+  );
+  assertEquals((err as CommandError).code, 2);
+});
+
+Deno.test("$ .noThrow() suppresses the throw", async () => {
+  const result = await $`${DENO} eval ${"Deno.exit(5)"}`.noThrow();
+  assertEquals(result.code, 5);
+});
+
+Deno.test("$ .env() injects environment variables", async () => {
+  const out = await $`${DENO} eval ${"console.log(Deno.env.get('ZUKE_T'))"}`
+    .env({ ZUKE_T: "present" })
+    .text();
+  assertEquals(out, "present");
+});
+
+Deno.test("$ .cwd() sets the working directory", async () => {
+  const dir = await Deno.makeTempDir();
+  const out = await $`${DENO} eval ${"console.log(Deno.cwd())"}`.cwd(dir)
+    .text();
+  // realPath collapses any symlinks (e.g. /tmp → /private/tmp) for comparison.
+  assertEquals(out, await Deno.realPath(dir));
+});
+
+Deno.test("$ interpolated values are not re-split (injection safe)", async () => {
+  // The whole string is one argv entry, printed verbatim — not run as a command.
+  const payload = "; rm -rf /";
+  const out = await $`${DENO} eval ${"console.log(Deno.args[0])"} ${payload}`
+    .text();
+  assertEquals(out, payload);
+});

--- a/tests/shell_test.ts
+++ b/tests/shell_test.ts
@@ -79,3 +79,33 @@ Deno.test("$ interpolated values are not re-split (injection safe)", async () =>
     .text();
   assertEquals(out, payload);
 });
+
+Deno.test("$ .text() throws on non-zero exit by default", async () => {
+  const err = await assertRejects(
+    () => $`${DENO} eval ${"console.log('x'); Deno.exit(1)"}`.text(),
+    CommandError,
+  );
+  assertEquals(err instanceof CommandError && err.code === 1, true);
+});
+
+Deno.test("$ .lines() on empty output is an empty array", async () => {
+  const lines = await $`${DENO} eval ${"// prints nothing"}`.lines();
+  assertEquals(lines, []);
+});
+
+Deno.test("$ .quiet() suppresses streaming but still captures", async () => {
+  const out = await $`${DENO} eval ${"console.log('quiet capture')"}`
+    .quiet()
+    .text();
+  assertEquals(out, "quiet capture");
+});
+
+Deno.test("$ awaited result exposes code/stdout and CommandOutput.text()", async () => {
+  const result = await $`${DENO} eval ${"console.log('  hi  ')"}`.quiet();
+  assertEquals(result.code, 0);
+  assertEquals(result.text(), "hi");
+});
+
+Deno.test("$ on an empty command rejects", async () => {
+  await assertRejects(() => $``.quiet(), Error, "empty command");
+});

--- a/tests/shell_test.ts
+++ b/tests/shell_test.ts
@@ -66,9 +66,13 @@ Deno.test("$ .env() injects environment variables", async () => {
 
 Deno.test("$ .cwd() sets the working directory", async () => {
   const dir = await Deno.makeTempDir();
-  const out = await $`${DENO} eval ${"console.log(Deno.cwd())"}`.cwd(dir)
-    .text();
-  // realPath collapses any symlinks (e.g. /tmp → /private/tmp) for comparison.
+  // Canonicalise inside the child too: on Windows `Deno.cwd()` can report the
+  // 8.3 short form (RUNNER~1) while the parent's realPath returns the long form;
+  // realPath on both sides also collapses symlinks (e.g. /tmp → /private/tmp).
+  const out =
+    await $`${DENO} eval ${"console.log(Deno.realPathSync(Deno.cwd()))"}`
+      .cwd(dir)
+      .text();
   assertEquals(out, await Deno.realPath(dir));
 });
 

--- a/tests/target_test.ts
+++ b/tests/target_test.ts
@@ -1,0 +1,56 @@
+import { assertEquals, assertThrows } from "./_assert.ts";
+import { Build, discoverTargets } from "../src/build.ts";
+import { target, TargetBuilder } from "../src/target.ts";
+
+Deno.test("target() builder is chainable and records configuration", () => {
+  const dep = target();
+  const t = target()
+    .description("compile things")
+    .dependsOn(dep)
+    .executes(() => {});
+
+  assertEquals(t instanceof TargetBuilder, true);
+  assertEquals(t.description_, "compile things");
+  assertEquals(t.dependsOn_, [dep]);
+  assertEquals(typeof t.fn_, "function");
+});
+
+Deno.test("before/after record soft ordering hints", () => {
+  const a = target();
+  const b = target();
+  const t = target().before(a).after(b);
+  assertEquals(t.before_, [a]);
+  assertEquals(t.after_, [b]);
+});
+
+Deno.test("discovery binds each target to its property name", () => {
+  class B extends Build {
+    clean = target().description("clean");
+    compile = target().dependsOn(this.clean);
+    notATarget = 42;
+  }
+  const b = new B();
+  const targets = discoverTargets(b);
+
+  assertEquals([...targets.keys()], ["clean", "compile"]);
+  assertEquals(targets.get("clean")!.name_, "clean");
+  assertEquals(targets.get("compile")!.name_, "compile");
+});
+
+Deno.test("discovery preserves declaration order", () => {
+  class B extends Build {
+    z = target();
+    a = target();
+    m = target();
+  }
+  assertEquals([...discoverTargets(new B()).keys()], ["z", "a", "m"]);
+});
+
+Deno.test("discovery rejects a target bound to two names", () => {
+  const shared = target();
+  class B extends Build {
+    one = shared;
+    two = shared;
+  }
+  assertThrows(() => discoverTargets(new B()), Error, "two names");
+});

--- a/zuke.ts
+++ b/zuke.ts
@@ -1,0 +1,49 @@
+/**
+ * Zuke's own build, authored with Zuke. Demonstrates the v0 authoring API and
+ * doubles as a runnable acceptance example.
+ *
+ *   deno run -A zuke.ts test     # clean → restore → compile → test
+ *   deno run -A zuke.ts --list
+ */
+
+import { Build, run, target } from "./mod.ts";
+import { $ } from "./src/shell.ts";
+
+class ZukeBuild extends Build {
+  clean = target()
+    .description("Remove build artifacts")
+    .executes(async () => {
+      await $`rm -rf dist`;
+    });
+
+  restore = target()
+    .description("Install dependencies")
+    .executes(async () => {
+      // No external dependencies in v0; reload the local module graph.
+      await $`${Deno.execPath()} cache mod.ts`;
+    });
+
+  compile = target()
+    .description("Type-check the project")
+    .dependsOn(this.clean, this.restore)
+    .executes(async () => {
+      await $`${Deno.execPath()} check mod.ts`;
+    });
+
+  test = target()
+    .description("Run the test suite")
+    .dependsOn(this.compile)
+    .executes(async () => {
+      await $`${Deno.execPath()} test -A`;
+    });
+
+  // Convention: the `default` target runs when none is named.
+  default = target()
+    .description("Default: run the full test pipeline")
+    .dependsOn(this.test)
+    .executes(() => {});
+}
+
+if (import.meta.main) {
+  await run(ZukeBuild);
+}


### PR DESCRIPTION
## Summary

This PR introduces Zuke v0, a code-first, strongly-typed build automation system for Deno and TypeScript. Users define builds as TypeScript classes with targets declared as fluent-API fields, forming a dependency graph that Zuke resolves and executes in topological order.

## Key Changes

- **Core build framework** (`src/build.ts`, `src/target.ts`): 
  - `Build` base class for user-defined builds with optional lifecycle hooks (`onStart`, `onFinish`)
  - `target()` fluent builder API with chainable methods: `.description()`, `.dependsOn()`, `.executes()`, `.before()`, `.after()`
  - Target discovery via instance property introspection

- **Dependency graph** (`src/graph.ts`):
  - Hard dependencies (`.dependsOn()`) pull targets into the execution plan
  - Soft ordering (`.before()`, `.after()`) reorder targets already in the plan without pulling new ones
  - Cycle detection and validation with descriptive error messages
  - Topological sort ensuring correct execution order and handling diamond dependencies

- **Executor** (`src/executor.ts`):
  - Sequential execution of the planned targets with timing and pass/fail reporting
  - Abort-on-first-failure semantics
  - Support for skipping targets via CLI `--skip` flag
  - Lifecycle hook integration

- **CLI** (`src/cli.ts`):
  - Argument parsing for target selection, `--list`, `--graph`, `--help`, and `--skip`
  - Formatted output for target listing, dependency graph visualization, and help text
  - Public `run()` entry point that instantiates the build, validates the graph, and drives execution

- **Shell wrapper** (`src/shell.ts`):
  - Ergonomic `$` tagged template for process execution built on `Deno.Command`
  - Injection-safe: interpolated values become discrete argv entries, never spliced into shell strings
  - Chainable API: `.text()`, `.lines()`, `.code()`, `.env()`, `.cwd()`, `.noThrow()`, `.quiet()`
  - Automatic throw on non-zero exit (suppressible with `.noThrow()`)
  - Output capture and live streaming to terminal

- **Public API** (`mod.ts`):
  - Exports `Build`, `BuildResult`, `discoverTargets`, `target`, and `run`
  - Shell submodule exports `$`, `Command`, `CommandError`, `CommandOutput`

- **Comprehensive test suite** (`tests/`):
  - Unit tests for target builder, graph validation, cycle detection, execution semantics, CLI parsing, and shell operations
  - Local assertion helpers (`tests/_assert.ts`) with zero external dependencies
  - Coverage enforcement script (`scripts/check-coverage.ts`) with 95% threshold

- **Documentation & examples**:
  - Extensive README with quick start, core concepts, API reference, and CLI usage
  - `CLAUDE.md` with development guidelines and tech stack notes
  - `zuke.ts`: Zuke's own build file demonstrating the v0 API

- **Project configuration**:
  - `deno.json` with JSR package metadata, task definitions, and linter/formatter config
  - GitHub Actions CI workflow for format, lint, type-check, test, and coverage validation
  - `.gitignore` for build artifacts and editor noise

## Notable Implementation Details

- **Type-safe dependencies**: Targets reference each other via `this.x` (not strings), making refactoring safe and typos compile errors
- **Zero runtime dependencies**: The library is completely self-contained; tests use local assertions rather than external packages
- **Strict TypeScript**: No `any`, no unsafe casts; control-flow narrowing throughout
- **Deno-native**: Uses Deno's built-in tooling (test runner, formatter, linter, type-checker) with no external build tools
- **Injection-safe shell**: The `$` template prevents shell injection by design—interpolated values are never parsed as shell syntax

https://claude.ai/code/session_01U5KKHriQcVYvNQREozZPhv