### PR TITLE
Self-host CI/release with Zuke, enable JSR publishing, and add the `zuke` CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Deno
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.x
-
-      # Zuke builds Zuke: fmt → lint → spell → check → test → coverage gate.
+      # No "set up Deno" step: the ./zuke launcher installs Deno on first use,
+      # so every CI run exercises the bootstrap script itself.
       - name: Run the full gate with Zuke
-        run: deno task zuke ci
+        run: ./zuke ci
 
   test-os:
     name: Tests (${{ matrix.os }})
@@ -34,14 +30,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest]
+        include:
+          - os: macos-latest
+            shell: bash
+            launch: ./zuke test
+          - os: windows-latest
+            shell: pwsh
+            launch: ./zuke.ps1 test
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Deno
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.x
-
-      - name: Run tests with Zuke
-        run: deno task zuke test
+      # Exercise the matching launcher per OS (bash on macOS, PowerShell on
+      # Windows); each one bootstraps Deno before running the tests.
+      - name: Run tests with the Zuke launcher
+        shell: ${{ matrix.shell }}
+        run: ${{ matrix.launch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,18 +30,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: macos-latest
-            shell: bash
-            launch: ./zuke test
-          - os: windows-latest
-            shell: pwsh
-            launch: ./zuke.ps1 test
+        os: [macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
 
-      # Exercise the matching launcher per OS (bash on macOS, PowerShell on
-      # Windows); each one bootstraps Deno before running the tests.
-      - name: Run tests with the Zuke launcher
-        shell: ${{ matrix.shell }}
-        run: ${{ matrix.launch }}
+      # Exercise the matching launcher per OS — each bootstraps Deno first.
+      - name: Run tests with the bash launcher
+        if: runner.os != 'Windows'
+        run: ./zuke test
+
+      - name: Run tests with the PowerShell launcher
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: ./zuke.ps1 test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   quality:
-    name: Format, lint, type-check & coverage
+    name: Build & verify with Zuke
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -24,25 +24,9 @@ jobs:
         with:
           deno-version: v2.x
 
-      - name: Check formatting
-        run: deno fmt --check
-
-      - name: Lint
-        run: deno lint
-
-      - name: Spell-check
-        run: deno task spell
-
-      - name: Type-check
-        run: deno task check
-
-      - name: Test with coverage
-        run: deno test -A --coverage=cov_profile
-
-      - name: Enforce coverage threshold (95%)
-        run: |
-          deno coverage cov_profile --lcov --exclude='(tests|scripts)/' --output=cov.lcov
-          deno run --allow-read scripts/check-coverage.ts cov.lcov 95
+      # Zuke builds Zuke: fmt → lint → spell → check → test → coverage gate.
+      - name: Run the full gate with Zuke
+        run: deno task zuke ci
 
   test-os:
     name: Tests (${{ matrix.os }})
@@ -59,5 +43,5 @@ jobs:
         with:
           deno-version: v2.x
 
-      - name: Run tests
-        run: deno test -A
+      - name: Run tests with Zuke
+        run: deno task zuke test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,36 +5,17 @@ on:
     branches: [master]
   workflow_dispatch:
 
-jobs:
-  release-please:
-    name: Release Please
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    outputs:
-      releases_created: ${{ steps.rp.outputs.releases_created }}
-      core_released: ${{ steps.rp.outputs['packages/core--release_created'] }}
-      deno_released: ${{ steps.rp.outputs['packages/deno--release_created'] }}
-      npm_released: ${{ steps.rp.outputs['packages/npm--release_created'] }}
-      cmd_released: ${{ steps.rp.outputs['packages/cmd--release_created'] }}
-    steps:
-      - uses: googleapis/release-please-action@v4
-        id: rp
-        with:
-          config-file: .release-please-config.json
-          manifest-file: .release-please-manifest.json
+# release-please needs to write commits/PRs; JSR publishing uses OIDC, so
+# `id-token: write` mints the short-lived token and no secrets are required.
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
 
-  publish:
-    name: Publish to JSR with Zuke
-    needs: release-please
-    if: needs.release-please.outputs.releases_created == 'true'
+jobs:
+  release:
+    name: Release & publish with Zuke
     runs-on: ubuntu-latest
-    # OIDC: JSR trusts this workflow via the package <-> repo link, so no
-    # secrets are needed. `id-token: write` mints the short-lived token.
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -44,12 +25,14 @@ jobs:
         with:
           deno-version: v2.x
 
-      # `zuke publish` publishes only the packages flagged below, and always
-      # publishes @zuke/core before the packages that depend on it.
-      - name: Publish released packages to JSR
-        run: deno task zuke publish
+      # release-please, driven by Zuke: keep release PRs up to date and, when
+      # one is merged, cut the GitHub release and tag.
+      - name: Manage releases with Zuke
+        run: deno task zuke release
         env:
-          ZUKE_PUBLISH_CORE: ${{ needs.release-please.outputs.core_released }}
-          ZUKE_PUBLISH_DENO: ${{ needs.release-please.outputs.deno_released }}
-          ZUKE_PUBLISH_NPM: ${{ needs.release-please.outputs.npm_released }}
-          ZUKE_PUBLISH_CMD: ${{ needs.release-please.outputs.cmd_released }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Publish any package whose version is not yet on JSR (core first). This
+      # is idempotent: on pushes without a new release it does nothing.
+      - name: Publish to JSR with Zuke
+        run: deno task zuke publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,14 +25,11 @@ jobs:
         with:
           deno-version: v2.x
 
-      # release-please, driven by Zuke: keep release PRs up to date and, when
-      # one is merged, cut the GitHub release and tag.
-      - name: Manage releases with Zuke
-        run: deno task zuke release
+      # One command: `publish` depends on `release`, so Zuke first runs
+      # release-please (keep release PRs current; cut the release & tag on a
+      # merge) and then publishes any package whose version is not yet on JSR
+      # (core first). Idempotent: a push without a new release does nothing.
+      - name: Release & publish with Zuke
+        run: deno task zuke publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # Publish any package whose version is not yet on JSR (core first). This
-      # is idempotent: on pushes without a new release it does nothing.
-      - name: Publish to JSR with Zuke
-        run: deno task zuke publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,16 +20,13 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up Deno
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.x
-
-      # One command: `publish` depends on `release`, so Zuke first runs
-      # release-please (keep release PRs current; cut the release & tag on a
-      # merge) and then publishes any package whose version is not yet on JSR
-      # (core first). Idempotent: a push without a new release does nothing.
+      # No "set up Deno" step: the ./zuke launcher installs Deno if it's
+      # missing, so the release pipeline exercises the bootstrap script too.
+      # `publish` depends on `release`, so Zuke first runs release-please (keep
+      # release PRs current; cut the release & tag on a merge) and then
+      # publishes any package whose version is not yet on JSR (core first).
+      # Idempotent: a push without a new release does nothing.
       - name: Release & publish with Zuke
-        run: deno task zuke publish
+        run: ./zuke publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [master]
+  workflow_dispatch:
 
 jobs:
   release-please:
@@ -25,50 +26,30 @@ jobs:
           manifest-file: .release-please-manifest.json
 
   publish:
-    name: Publish ${{ matrix.package }} to JSR
+    name: Publish to JSR with Zuke
     needs: release-please
-    # DISABLED until the @zuke/* packages are linked to this repo on jsr.io.
-    # Re-enable by restoring the condition below:
-    #   if: needs.release-please.outputs.releases_created == 'true'
-    # release-please still runs and prepares release PRs; only JSR publishing
-    # is gated off so a merged release PR cannot trigger a failing publish.
-    if: false
+    if: needs.release-please.outputs.releases_created == 'true'
     runs-on: ubuntu-latest
+    # OIDC: JSR trusts this workflow via the package <-> repo link, so no
+    # secrets are needed. `id-token: write` mints the short-lived token.
     permissions:
       contents: read
       id-token: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - package: core
-            path: packages/core
-            released: ${{ needs.release-please.outputs.core_released }}
-          - package: deno
-            path: packages/deno
-            released: ${{ needs.release-please.outputs.deno_released }}
-          - package: npm
-            path: packages/npm
-            released: ${{ needs.release-please.outputs.npm_released }}
-          - package: cmd
-            path: packages/cmd
-            released: ${{ needs.release-please.outputs.cmd_released }}
     steps:
-      - name: Skip if this package was not released
-        if: matrix.released != 'true'
-        run: echo "No release for ${{ matrix.package }} — skipping."
-
       - name: Check out repository
-        if: matrix.released == 'true'
         uses: actions/checkout@v4
 
       - name: Set up Deno
-        if: matrix.released == 'true'
         uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
 
-      - name: Publish to JSR
-        if: matrix.released == 'true'
-        working-directory: ${{ matrix.path }}
-        run: deno publish --allow-dirty
+      # `zuke publish` publishes only the packages flagged below, and always
+      # publishes @zuke/core before the packages that depend on it.
+      - name: Publish released packages to JSR
+        run: deno task zuke publish
+        env:
+          ZUKE_PUBLISH_CORE: ${{ needs.release-please.outputs.core_released }}
+          ZUKE_PUBLISH_DENO: ${{ needs.release-please.outputs.deno_released }}
+          ZUKE_PUBLISH_NPM: ${{ needs.release-please.outputs.npm_released }}
+          ZUKE_PUBLISH_CMD: ${{ needs.release-please.outputs.cmd_released }}

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -3,22 +3,27 @@
   "release-type": "deno",
   "tag-separator": "-v",
   "separate-pull-requests": true,
+  "bump-minor-pre-major": true,
   "packages": {
     "packages/core": {
       "component": "core",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "release-as": "0.1.0"
     },
     "packages/deno": {
       "component": "deno",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "release-as": "0.1.0"
     },
     "packages/npm": {
       "component": "npm",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "release-as": "0.1.0"
     },
     "packages/cmd": {
       "component": "cmd",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "release-as": "0.1.0"
     }
   }
 }

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -24,6 +24,12 @@
       "component": "cmd",
       "changelog-path": "CHANGELOG.md",
       "release-as": "0.1.0"
+    },
+    "packages/cli": {
+      "component": "cli",
+      "changelog-path": "CHANGELOG.md",
+      "release-as": "0.1.0",
+      "extra-files": ["src/version.ts"]
     }
   }
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
-  "packages/core": "0.1.0",
-  "packages/deno": "0.1.0",
-  "packages/npm": "0.1.0",
-  "packages/cmd": "0.1.0"
+  "packages/core": "0.0.0",
+  "packages/deno": "0.0.0",
+  "packages/npm": "0.0.0",
+  "packages/cmd": "0.0.0"
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,5 +2,6 @@
   "packages/core": "0.0.0",
   "packages/deno": "0.0.0",
   "packages/npm": "0.0.0",
-  "packages/cmd": "0.0.0"
+  "packages/cmd": "0.0.0",
+  "packages/cli": "0.0.0"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ zuke.ts                   # Zuke's own build (runnable example)
 - **The shell `$`** tokenises interpolated values into discrete argv entries
   (never a concatenated shell string), so command construction is
   injection-free.
-- **Tool wrappers** (`@zuke/deno`, `@zuke/npm`, `@zuke/cmd`) follow the NUKE
+- **Tool wrappers** (`@zuke/deno`, `@zuke/npm`, `@zuke/cmd`) follow a
   settings-lambda style. Settings classes extend `ToolSettings` from
   `@zuke/core/tooling`; `buildArgs()` must stay pure (no I/O) so argv
   construction is unit-testable. Execution reuses `Command` from `shell.ts`.

--- a/README.md
+++ b/README.md
@@ -79,12 +79,29 @@ You need [Deno](https://deno.com/) installed. There's nothing else to install �
 Zuke is imported straight from JSR.
 
 > [!NOTE]
-> All four packages — `@zuke/core`, `@zuke/deno`, `@zuke/npm`, `@zuke/cmd` —
-> publish to [JSR](https://jsr.io/@zuke) from CI via release-please and OIDC
-> (see [`RELEASING.md`](./RELEASING.md)). The npm scope `@zuke` is not
-> controlled by this project — install from JSR, not npm.
+> All packages — `@zuke/core`, `@zuke/deno`, `@zuke/npm`, `@zuke/cmd`, and the
+> `@zuke/cli` command — publish to [JSR](https://jsr.io/@zuke) from CI via
+> release-please and OIDC (see [`RELEASING.md`](./RELEASING.md)). The npm scope
+> `@zuke` is not controlled by this project — install from JSR, not npm.
 
-Create a `zuke.ts` in your project root and run it with Deno:
+### Scaffold a project with `zuke setup`
+
+The fastest start is the `@zuke/cli` tool, the Deno analog of NUKE's
+`nuke :setup`. Install it once, then scaffold a starter `zuke.ts`, the `./zuke`
+launchers, and a `deno.json` task into any directory:
+
+```sh
+deno install -A -g -n zuke jsr:@zuke/cli   # once
+zuke setup                                  # in your project
+./zuke                                      # run the build
+```
+
+Without installing, the same wizard runs via
+`deno run -A jsr:@zuke/cli setup` (flags: `--name <Class>`, `--force`, `--yes`).
+
+### Run it yourself
+
+Or just create a `zuke.ts` in your project root and run it with Deno:
 
 ```sh
 deno run -A zuke.ts <target>

--- a/README.md
+++ b/README.md
@@ -91,8 +91,23 @@ deno run -A zuke.ts <target>
 ```
 
 The `-A` grants permissions (your targets typically run processes, read/write
-files, etc.). A dedicated `zuke` launcher binary is on the roadmap; for now the
-`deno run` invocation is the interface.
+files, etc.).
+
+### `./zuke` launcher (no Deno required up front)
+
+For a NUKE-style `./build.sh` experience, drop the bootstrap launchers
+[`zuke`](./zuke) (bash) and [`zuke.ps1`](./zuke.ps1) (PowerShell) in your repo
+root. They locate the project, **install Deno on first use if it's missing**,
+then run `zuke.ts` — so a fresh checkout needs nothing but the script:
+
+```sh
+./zuke ci          # full gate          (Windows: .\zuke.ps1 ci)
+./zuke test        # type-check + tests  (Windows: .\zuke.ps1 test)
+./zuke --list      # list every target
+```
+
+If you already have Deno, `deno task zuke <target>` (via the `zuke` task in
+`deno.json`) does the same thing.
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ Zuke is imported straight from JSR.
 
 ### Scaffold a project with `zuke setup`
 
-The fastest start is the `@zuke/cli` tool, the Deno analog of NUKE's
-`nuke :setup`. Install it once, then scaffold a starter `zuke.ts`, the `./zuke`
-launchers, and a `deno.json` task into any directory:
+The fastest start is the `@zuke/cli` tool. Install it once, then scaffold a
+starter `zuke.ts`, the `./zuke` launchers, and a `deno.json` task into any
+directory:
 
 ```sh
 deno install -A -g -n zuke jsr:@zuke/cli   # once
@@ -112,7 +112,7 @@ files, etc.).
 
 ### `./zuke` launcher (no Deno required up front)
 
-For a NUKE-style `./build.sh` experience, drop the bootstrap launchers
+For a one-command `./build.sh`-style experience, drop the bootstrap launchers
 [`zuke`](./zuke) (bash) and [`zuke.ps1`](./zuke.ps1) (PowerShell) in your repo
 root. They locate the project, **install Deno on first use if it's missing**,
 then run `zuke.ts` — so a fresh checkout needs nothing but the script:
@@ -307,9 +307,9 @@ stdout; `.text()`/`.lines()` capture without echoing; `.quiet()` does neither.
 
 ## Tools
 
-Typed tool wrappers in the NUKE `DotNetTasks` style: configure a fluent
-settings object in a lambda and the task function builds the argv and runs
-it. Arguments stay a discrete array end-to-end — never a shell string — so
+Typed tool wrappers in a settings-lambda style: configure a fluent settings
+object in a lambda and the task function builds the argv and runs it.
+Arguments stay a discrete array end-to-end — never a shell string — so
 command construction is injection-free.
 
 ```ts
@@ -340,7 +340,7 @@ raises a `ToolNotFoundError` that names the tool and the fix.
 ## Using Zuke in a Node/npm project
 
 Zuke can drive a Node project's build without touching its dependencies —
-the NUKE convention of a `build/` folder next to the code. Deno is the only
+build logic in a `build/` folder that lives next to the code. Deno is the only
 prerequisite (it runs the build; your app keeps its Node toolchain):
 
 ```

--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ You need [Deno](https://deno.com/) installed. There's nothing else to install �
 Zuke is imported straight from JSR.
 
 > [!NOTE]
-> `@zuke/core` is published on [JSR](https://jsr.io/@zuke/core). The tool
-> packages (`@zuke/deno`, `@zuke/npm`, `@zuke/cmd`) will follow once release
-> automation is in place. The npm scope `@zuke` is not controlled by this
-> project — install from JSR, not npm.
+> All four packages — `@zuke/core`, `@zuke/deno`, `@zuke/npm`, `@zuke/cmd` —
+> publish to [JSR](https://jsr.io/@zuke) from CI via release-please and OIDC
+> (see [`RELEASING.md`](./RELEASING.md)). The npm scope `@zuke` is not
+> controlled by this project — install from JSR, not npm.
 
 Create a `zuke.ts` in your project root and run it with Deno:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,73 @@
+# Releasing
+
+Zuke publishes four packages to [JSR](https://jsr.io/@zuke) —
+`@zuke/core`, `@zuke/deno`, `@zuke/npm`, `@zuke/cmd` — from a single workspace.
+Releases are automated end to end; you only ever merge a pull request.
+
+## How it works
+
+1. **Conventional commits drive versions.** Land work on `master` with
+   Conventional Commits (`feat:`, `fix:`, `feat!:` / `BREAKING CHANGE:`).
+   Because Zuke is pre-1.0, breaking
+   changes bump the **minor** version and stay in `0.x`
+   (`bump-minor-pre-major`); they do not jump to `1.0.0`.
+
+2. **release-please opens release PRs.** The `release-please` job in
+   `.github/workflows/release.yml` watches `master` and maintains a release PR
+   per package (`separate-pull-requests`), bumping the version in
+   `packages/<pkg>/deno.json`, updating the `CHANGELOG.md`, and updating
+   `.release-please-manifest.json`. Merging a release PR tags the release
+   (`<component>-v<version>`, e.g. `core-v0.1.0`) and marks that package as
+   released.
+
+3. **Zuke publishes to JSR.** When a release is created, the `publish` job runs
+   `deno task zuke publish`. The `publish` target in `zuke.ts` publishes only
+   the packages flagged by the workflow (`ZUKE_PUBLISH_<PKG>` env vars, wired
+   from release-please outputs) and always publishes `@zuke/core` **before**
+   the packages that depend on it. Authentication is OIDC — the JSR
+   package ↔ repo link means **no tokens or secrets** are required; the job just
+   needs `id-token: write`.
+
+So the steady-state flow is: merge conventional commits → merge the release PR
+→ the package publishes itself.
+
+## First release (one-time bootstrap)
+
+The four JSR packages start empty, so the very first release is bootstrapped to
+land at exactly `0.1.0`:
+
+- `.release-please-manifest.json` is seeded at `0.0.0` for every package.
+- `.release-please-config.json` pins `"release-as": "0.1.0"` per package, so the
+  first release PR for each is cut at `0.1.0` regardless of commit history.
+
+To cut the first release:
+
+1. Merge this change to `master`. release-please opens four `0.1.0` release PRs.
+2. **Merge the `core` release PR first** and let it publish. The other three
+   import `jsr:@zuke/core@^0`, so core must exist on JSR before they publish.
+   (Within a single run `zuke publish` already orders core first; this only
+   matters because the PRs are separate.)
+3. Merge the `deno`, `npm`, and `cmd` release PRs.
+
+### Remove the `release-as` pins afterwards
+
+Once all four `0.1.0` versions are on JSR, **delete the `"release-as": "0.1.0"`
+lines** from `.release-please-config.json`. They are a one-time bootstrap; if
+left in place they would force every future release back to `0.1.0` and break
+automatic versioning. After removal, the manifest (now `0.1.0`) becomes the
+baseline and conventional commits drive all subsequent versions.
+
+## Manual trigger
+
+`release.yml` also has a `workflow_dispatch` trigger, so you can run
+release-please on demand from the Actions tab without waiting for a push.
+
+## Running the build locally
+
+The same targets the workflows use are runnable locally:
+
+```sh
+deno task zuke ci      # the full gate CI runs
+deno task zuke test    # type-check + tests
+deno task zuke --list  # every target
+```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,8 +15,9 @@ pull request.
 
 2. **Zuke runs the whole release.** `.github/workflows/release.yml` is itself
    driven by Zuke: on every push to `master` it runs a single command,
-   `deno task zuke publish`. Because `publish` depends on `release`, Zuke runs
-   the `release` target first, then publishes.
+   `./zuke publish` (the launcher installs Deno if the runner lacks it, so the
+   workflow has no separate "set up Deno" step). Because `publish` depends on
+   `release`, Zuke runs the `release` target first, then publishes.
 
 3. **`release` drives release-please.** The `release` target invokes the
    release-please CLI (`release-pr` + `github-release`). release-please

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,21 +12,23 @@ Releases are automated end to end; you only ever merge a pull request.
    changes bump the **minor** version and stay in `0.x`
    (`bump-minor-pre-major`); they do not jump to `1.0.0`.
 
-2. **release-please opens release PRs.** The `release-please` job in
-   `.github/workflows/release.yml` watches `master` and maintains a release PR
-   per package (`separate-pull-requests`), bumping the version in
+2. **Zuke runs release-please.** `.github/workflows/release.yml` is itself
+   driven by Zuke: on every push to `master` it runs `deno task zuke release`,
+   whose `release` target invokes the release-please CLI
+   (`release-pr` + `github-release`). release-please maintains a release PR per
+   package (`separate-pull-requests`), bumping the version in
    `packages/<pkg>/deno.json`, updating the `CHANGELOG.md`, and updating
    `.release-please-manifest.json`. Merging a release PR tags the release
-   (`<component>-v<version>`, e.g. `core-v0.1.0`) and marks that package as
-   released.
+   (`<component>-v<version>`, e.g. `core-v0.1.0`) and cuts the GitHub release.
 
-3. **Zuke publishes to JSR.** When a release is created, the `publish` job runs
-   `deno task zuke publish`. The `publish` target in `zuke.ts` publishes only
-   the packages flagged by the workflow (`ZUKE_PUBLISH_<PKG>` env vars, wired
-   from release-please outputs) and always publishes `@zuke/core` **before**
-   the packages that depend on it. Authentication is OIDC — the JSR
-   package ↔ repo link means **no tokens or secrets** are required; the job just
-   needs `id-token: write`.
+3. **Zuke publishes to JSR.** The same job then runs `deno task zuke publish`.
+   The `publish` target walks the packages **core first** (so the workspace's
+   `jsr:@zuke/core` dependency resolves) and publishes each one whose
+   `deno.json` version is **not yet on JSR** — it queries each package's JSR
+   `meta.json` first, so the step is idempotent and a no-op on pushes that
+   didn't release anything. Authentication is OIDC — the JSR package ↔ repo
+   link means **no tokens or secrets** are required; the workflow just grants
+   `id-token: write`.
 
 So the steady-state flow is: merge conventional commits → merge the release PR
 → the package publishes itself.
@@ -36,13 +38,16 @@ So the steady-state flow is: merge conventional commits → merge the release PR
 The four JSR packages start empty, so the very first release is bootstrapped to
 land at exactly `0.1.0`:
 
-- `.release-please-manifest.json` is seeded at `0.0.0` for every package.
+- Every package's `deno.json` and `.release-please-manifest.json` are seeded at
+  `0.0.0`. `zuke publish` treats `0.0.0` as "not released yet" and skips it, so
+  nothing is published until release-please bumps a package to a real version.
 - `.release-please-config.json` pins `"release-as": "0.1.0"` per package, so the
   first release PR for each is cut at `0.1.0` regardless of commit history.
 
 To cut the first release:
 
-1. Merge this change to `master`. release-please opens four `0.1.0` release PRs.
+1. Merge this change to `master`. release-please opens four `0.1.0` release PRs
+   (bumping each `deno.json` from `0.0.0` to `0.1.0`); nothing publishes yet.
 2. **Merge the `core` release PR first** and let it publish. The other three
    import `jsr:@zuke/core@^0`, so core must exist on JSR before they publish.
    (Within a single run `zuke publish` already orders core first; this only

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,23 +12,26 @@ Releases are automated end to end; you only ever merge a pull request.
    changes bump the **minor** version and stay in `0.x`
    (`bump-minor-pre-major`); they do not jump to `1.0.0`.
 
-2. **Zuke runs release-please.** `.github/workflows/release.yml` is itself
-   driven by Zuke: on every push to `master` it runs `deno task zuke release`,
-   whose `release` target invokes the release-please CLI
-   (`release-pr` + `github-release`). release-please maintains a release PR per
-   package (`separate-pull-requests`), bumping the version in
-   `packages/<pkg>/deno.json`, updating the `CHANGELOG.md`, and updating
-   `.release-please-manifest.json`. Merging a release PR tags the release
-   (`<component>-v<version>`, e.g. `core-v0.1.0`) and cuts the GitHub release.
+2. **Zuke runs the whole release.** `.github/workflows/release.yml` is itself
+   driven by Zuke: on every push to `master` it runs a single command,
+   `deno task zuke publish`. Because `publish` depends on `release`, Zuke runs
+   the `release` target first, then publishes.
 
-3. **Zuke publishes to JSR.** The same job then runs `deno task zuke publish`.
-   The `publish` target walks the packages **core first** (so the workspace's
-   `jsr:@zuke/core` dependency resolves) and publishes each one whose
-   `deno.json` version is **not yet on JSR** — it queries each package's JSR
-   `meta.json` first, so the step is idempotent and a no-op on pushes that
-   didn't release anything. Authentication is OIDC — the JSR package ↔ repo
-   link means **no tokens or secrets** are required; the workflow just grants
-   `id-token: write`.
+3. **`release` drives release-please.** The `release` target invokes the
+   release-please CLI (`release-pr` + `github-release`). release-please
+   maintains a release PR per package (`separate-pull-requests`), bumping the
+   version in `packages/<pkg>/deno.json`, updating the `CHANGELOG.md`, and
+   updating `.release-please-manifest.json`. Merging a release PR tags the
+   release (`<component>-v<version>`, e.g. `core-v0.1.0`) and cuts the GitHub
+   release.
+
+4. **`publish` pushes to JSR.** The `publish` target walks the packages
+   **core first** (so the workspace's `jsr:@zuke/core` dependency resolves) and
+   publishes each one whose `deno.json` version is **not yet on JSR** — it
+   queries each package's JSR `meta.json` first, so it is idempotent and a
+   no-op on pushes that didn't release anything. Authentication is OIDC — the
+   JSR package ↔ repo link means **no tokens or secrets** are required; the
+   workflow just grants `id-token: write`.
 
 So the steady-state flow is: merge conventional commits → merge the release PR
 → the package publishes itself.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,8 +1,9 @@
 # Releasing
 
-Zuke publishes four packages to [JSR](https://jsr.io/@zuke) —
-`@zuke/core`, `@zuke/deno`, `@zuke/npm`, `@zuke/cmd` — from a single workspace.
-Releases are automated end to end; you only ever merge a pull request.
+Zuke publishes five packages to [JSR](https://jsr.io/@zuke) — `@zuke/core`,
+`@zuke/deno`, `@zuke/npm`, `@zuke/cmd`, and the `@zuke/cli` command — from a
+single workspace. Releases are automated end to end; you only ever merge a
+pull request.
 
 ## How it works
 

--- a/cspell.json
+++ b/cspell.json
@@ -19,6 +19,8 @@
   ],
   "ignorePaths": [
     "cov_profile/",
-    "cov.lcov"
+    "cov.lcov",
+    "/zuke",
+    "/zuke.ps1"
   ]
 }

--- a/cspell.json
+++ b/cspell.json
@@ -6,6 +6,7 @@
     "chainers",
     "cowsay",
     "Interpolatable",
+    "OIDC",
     "mytool",
     "spawnable",
     "topo",

--- a/cspell.json
+++ b/cspell.json
@@ -4,6 +4,7 @@
   "useGitignore": true,
   "words": [
     "chainers",
+    "chmods",
     "cowsay",
     "Interpolatable",
     "OIDC",
@@ -11,6 +12,7 @@
     "spawnable",
     "topo",
     "unconfigured",
+    "unparseable",
     "zuck",
     "zudoku",
     "zuke",

--- a/deno.json
+++ b/deno.json
@@ -6,6 +6,7 @@
     "packages/npm"
   ],
   "tasks": {
+    "zuke": "deno run -A zuke.ts",
     "test": "deno test -A",
     "cov": "deno test -A --coverage=cov_profile && deno coverage cov_profile --lcov '--exclude=(tests|scripts)/' --output=cov.lcov && deno run --allow-read scripts/check-coverage.ts cov.lcov 95",
     "cov:report": "deno coverage cov_profile '--exclude=(tests|scripts)/'",

--- a/deno.json
+++ b/deno.json
@@ -3,7 +3,8 @@
     "packages/core",
     "packages/cmd",
     "packages/deno",
-    "packages/npm"
+    "packages/npm",
+    "packages/cli"
   ],
   "tasks": {
     "zuke": "deno run -A zuke.ts",

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,0 +1,10 @@
+{
+  "name": "@zuke/cli",
+  "version": "0.0.0",
+  "exports": {
+    ".": "./mod.ts"
+  },
+  "publish": {
+    "exclude": ["tests/"]
+  }
+}

--- a/packages/cli/mod.ts
+++ b/packages/cli/mod.ts
@@ -5,8 +5,7 @@
  * deno install -A -g -n zuke jsr:@zuke/cli
  * ```
  *
- * and scaffold Zuke into any project with `zuke setup` (the Deno analog of
- * NUKE's `nuke :setup`).
+ * and scaffold Zuke into any project with `zuke setup`.
  */
 
 import { defaultHost, runSetup, type SetupHost } from "./src/setup.ts";

--- a/packages/cli/mod.ts
+++ b/packages/cli/mod.ts
@@ -1,0 +1,140 @@
+/**
+ * `@zuke/cli` — the `zuke` command. Install it globally with
+ *
+ * ```sh
+ * deno install -A -g -n zuke jsr:@zuke/cli
+ * ```
+ *
+ * and scaffold Zuke into any project with `zuke setup` (the Deno analog of
+ * NUKE's `nuke :setup`).
+ */
+
+import { defaultHost, runSetup, type SetupHost } from "./src/setup.ts";
+import { VERSION } from "./src/version.ts";
+
+/**
+ * The interactive surface, injectable so the wizard is testable without a TTY.
+ */
+export interface Prompter {
+  /** Whether prompts should be shown (i.e. stdin is a terminal). */
+  interactive(): boolean;
+  /** Ask a free-text question, returning `fallback` if unanswered. */
+  ask(question: string, fallback: string): string;
+  /** Ask a yes/no question. */
+  confirm(question: string): boolean;
+}
+
+/** The real {@link Prompter}, backed by Deno's `prompt`/`confirm`. */
+export const defaultPrompter: Prompter = {
+  interactive(): boolean {
+    return Deno.stdin.isTerminal();
+  },
+  ask(question: string, fallback: string): string {
+    const answer = prompt(question, fallback);
+    return answer ?? fallback;
+  },
+  confirm(question: string): boolean {
+    return confirm(question);
+  },
+};
+
+/** Flags accepted by `zuke setup`. */
+export interface SetupFlags {
+  /** Overwrite existing files. */
+  force: boolean;
+  /** Skip prompts and accept defaults. */
+  yes: boolean;
+  /** Build class name for the starter `zuke.ts`. */
+  name?: string;
+}
+
+/** Parse the argument list following `zuke setup`. */
+export function parseSetupFlags(args: string[]): SetupFlags {
+  const flags: SetupFlags = { force: false, yes: false };
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--force" || arg === "-f") {
+      flags.force = true;
+    } else if (arg === "--yes" || arg === "-y") {
+      flags.yes = true;
+    } else if (arg === "--name") {
+      if (i + 1 < args.length) {
+        i++;
+        flags.name = args[i];
+      }
+    } else if (arg.startsWith("--name=")) {
+      flags.name = arg.slice("--name=".length);
+    }
+  }
+  return flags;
+}
+
+const HELP = `zuke ${VERSION} — code-first build automation for Deno
+
+Usage:
+  zuke setup [options]   Scaffold Zuke into the current directory
+  zuke --help            Show this help
+  zuke --version         Show the version
+
+Setup options:
+  --name <Class>   Build class name for zuke.ts (default: MyBuild)
+  --force, -f      Overwrite existing files
+  --yes, -y        Accept defaults without prompting
+
+Run your build with the scaffolded launcher: ./zuke <target>`;
+
+/** Run the `setup` subcommand. */
+async function commandSetup(
+  args: string[],
+  host: SetupHost,
+  prompter: Prompter,
+): Promise<number> {
+  const flags = parseSetupFlags(args);
+  let name = flags.name ?? "MyBuild";
+  let force = flags.force;
+
+  if (!flags.yes && prompter.interactive()) {
+    name = prompter.ask("Build class name", name);
+    if (!force) {
+      force = prompter.confirm("Overwrite existing files if present?");
+    }
+  }
+
+  host.log("Scaffolding Zuke into the current directory:");
+  const result = await runSetup({ dir: ".", force, name }, host);
+  const written = result.files.filter((f) => f.status !== "skipped").length;
+  host.log(`Done — ${written} file(s) written. Next: ./zuke`);
+  return 0;
+}
+
+/**
+ * The CLI entry point. Returns a process exit code; `host`/`prompter` are
+ * injectable for testing.
+ */
+export async function main(
+  args: string[],
+  host: SetupHost = defaultHost,
+  prompter: Prompter = defaultPrompter,
+): Promise<number> {
+  if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
+    host.log(HELP);
+    return 0;
+  }
+  const command = args[0];
+  const rest = args.slice(1);
+
+  if (command === "--version" || command === "-V") {
+    host.log(VERSION);
+    return 0;
+  }
+  if (command === "setup") {
+    return await commandSetup(rest, host, prompter);
+  }
+  host.log(`Unknown command: ${command}\n`);
+  host.log(HELP);
+  return 1;
+}
+
+if (import.meta.main) {
+  Deno.exit(await main(Deno.args));
+}

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -1,0 +1,274 @@
+/**
+ * The scaffolding engine behind `zuke setup` — the Deno analog of NUKE's
+ * `nuke :setup`. It writes a starter `zuke.ts`, the `./zuke` bootstrap
+ * launchers, and a `deno.json` task into a target directory.
+ *
+ * All filesystem and console effects go through an injectable {@link SetupHost}
+ * so the logic stays pure and unit-testable; {@link defaultHost} is the real
+ * `Deno`-backed implementation used in production.
+ */
+
+/** Narrow an unknown value to a plain JSON object (record). */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** The starter `zuke.ts`, with the build class named `name`. */
+export function starterBuild(name: string): string {
+  return `import { Build, run, target } from "jsr:@zuke/core";
+
+/** Your project's build. Run a target with \`./zuke <target>\`. */
+class ${name} extends Build {
+  hello = target()
+    .description("A sample target — replace me with real work")
+    .executes(() => {
+      console.log("Hello from Zuke!");
+    });
+
+  // Convention: \`default\` runs when no target is named.
+  default = target()
+    .description("Default target")
+    .dependsOn(this.hello)
+    .executes(() => {});
+}
+
+if (import.meta.main) {
+  await run(${name});
+}
+`;
+}
+
+/* cspell:disable */
+
+/** The bash bootstrap launcher (`./zuke`). Installs Deno on first use. */
+export function launcherBash(): string {
+  return `#!/usr/bin/env bash
+# Zuke launcher — installs Deno if missing, then runs zuke.ts.
+set -euo pipefail
+dir="$(cd "$(dirname "\${BASH_SOURCE[0]}")" && pwd)"
+cd "$dir"
+if command -v deno >/dev/null 2>&1; then
+  deno run -A zuke.ts "$@"
+else
+  echo "zuke: Deno not found — installing to ~/.deno ..." >&2
+  curl -fsSL https://deno.land/install.sh | sh >/dev/null
+  "$HOME/.deno/bin/deno" run -A zuke.ts "$@"
+fi
+`;
+}
+
+/** The PowerShell bootstrap launcher (`.\\zuke.ps1`). */
+export function launcherPwsh(): string {
+  return `#!/usr/bin/env pwsh
+# Zuke launcher — installs Deno if missing, then runs zuke.ts.
+$ErrorActionPreference = "Stop"
+$dir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $dir
+$found = Get-Command deno -ErrorAction SilentlyContinue
+if ($found) {
+  $deno = $found.Source
+} else {
+  Write-Host "zuke: Deno not found - installing ..."
+  Invoke-RestMethod https://deno.land/install.ps1 | Invoke-Expression
+  $deno = Join-Path $HOME ".deno\\bin\\deno.exe"
+}
+& $deno run -A (Join-Path $dir "zuke.ts") @args
+exit $LASTEXITCODE
+`;
+}
+
+/* cspell:enable */
+
+/** The task names `setup` writes into `deno.json`, with their commands. */
+const DEFAULT_TASKS: ReadonlyArray<readonly [string, string]> = [
+  ["zuke", "deno run -A zuke.ts"],
+  ["fmt", "deno fmt"],
+  ["lint", "deno lint"],
+  ["test", "deno test -A"],
+];
+
+/**
+ * Merge the default Zuke tasks into a `deno.json` document, preserving the
+ * existing content. `existing` is the file text, or `null` to start fresh.
+ */
+export function mergeDenoJson(existing: string | null): string {
+  const root: Record<string, unknown> = {};
+  if (existing !== null) {
+    const parsed: unknown = JSON.parse(existing);
+    if (isRecord(parsed)) Object.assign(root, parsed);
+  }
+  const tasks: Record<string, unknown> = isRecord(root.tasks)
+    ? { ...root.tasks }
+    : {};
+  for (const [task, command] of DEFAULT_TASKS) {
+    if (!(task in tasks)) tasks[task] = command;
+  }
+  root.tasks = tasks;
+  return `${JSON.stringify(root, null, 2)}\n`;
+}
+
+/** Whether a `deno.json` text already declares the `zuke` task. */
+export type DenoJsonState = "present" | "absent" | "unparseable";
+
+/** Classify a `deno.json` text by whether it already has the `zuke` task. */
+export function zukeTaskState(text: string): DenoJsonState {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return "unparseable";
+  }
+  if (isRecord(parsed) && isRecord(parsed.tasks) && "zuke" in parsed.tasks) {
+    return "present";
+  }
+  return "absent";
+}
+
+/** Injected side effects, so {@link runSetup} is unit-testable. */
+export interface SetupHost {
+  /** Whether a path exists. */
+  exists(path: string): Promise<boolean>;
+  /** Read a file as UTF-8 text. */
+  readText(path: string): Promise<string>;
+  /** Write UTF-8 text to a file, creating or truncating it. */
+  writeText(path: string, content: string): Promise<void>;
+  /** Set a file's permission bits (may be unsupported on some platforms). */
+  chmod(path: string, mode: number): Promise<void>;
+  /** Emit a line of progress output. */
+  log(message: string): void;
+}
+
+/** The real, `Deno`-backed {@link SetupHost}. */
+export const defaultHost: SetupHost = {
+  async exists(path: string): Promise<boolean> {
+    try {
+      await Deno.lstat(path);
+      return true;
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) return false;
+      throw error;
+    }
+  },
+  readText(path: string): Promise<string> {
+    return Deno.readTextFile(path);
+  },
+  writeText(path: string, content: string): Promise<void> {
+    return Deno.writeTextFile(path, content);
+  },
+  chmod(path: string, mode: number): Promise<void> {
+    return Deno.chmod(path, mode);
+  },
+  log(message: string): void {
+    console.log(message);
+  },
+};
+
+/** Options controlling {@link runSetup}. */
+export interface SetupOptions {
+  /** Directory to scaffold into (e.g. `"."`). */
+  dir: string;
+  /** Overwrite existing files instead of skipping them. */
+  force: boolean;
+  /** Build class name for the starter `zuke.ts`. */
+  name: string;
+}
+
+/** What happened to one scaffolded file. */
+export type FileStatus = "created" | "overwritten" | "skipped";
+
+/** The outcome for a single file. */
+export interface FileResult {
+  /** The file's name, relative to the setup directory. */
+  path: string;
+  /** What `setup` did with it. */
+  status: FileStatus;
+}
+
+/** The result of a {@link runSetup} run. */
+export interface SetupResult {
+  /** One entry per file `setup` considered. */
+  files: FileResult[];
+}
+
+/** Join a directory and file name without pulling in path utilities. */
+function joinPath(dir: string, name: string): string {
+  return dir === "." ? name : `${dir}/${name}`;
+}
+
+/** One file the scaffolder can write. */
+interface ScaffoldFile {
+  name: string;
+  content: string;
+  mode?: number;
+}
+
+/**
+ * Scaffold Zuke into `options.dir`: a starter `zuke.ts`, the `./zuke` and
+ * `./zuke.ps1` launchers, and a `deno.json` task block. Existing files are
+ * skipped unless `options.force` is set; `deno.json` is always merged (never
+ * clobbered).
+ */
+export async function runSetup(
+  options: SetupOptions,
+  host: SetupHost = defaultHost,
+): Promise<SetupResult> {
+  const files: FileResult[] = [];
+
+  const scaffold: readonly ScaffoldFile[] = [
+    { name: "zuke.ts", content: starterBuild(options.name) },
+    { name: "zuke", content: launcherBash(), mode: 0o755 },
+    { name: "zuke.ps1", content: launcherPwsh() },
+  ];
+
+  for (const item of scaffold) {
+    const path = joinPath(options.dir, item.name);
+    const existed = await host.exists(path);
+    if (existed && !options.force) {
+      host.log(`  skip     ${item.name}  (already exists)`);
+      files.push({ path: item.name, status: "skipped" });
+      continue;
+    }
+    await host.writeText(path, item.content);
+    if (item.mode !== undefined) {
+      try {
+        await host.chmod(path, item.mode);
+      } catch {
+        // chmod is a no-op / unsupported on some platforms (e.g. Windows).
+      }
+    }
+    const status: FileStatus = existed ? "overwritten" : "created";
+    host.log(`  ${existed ? "update" : "create"}   ${item.name}`);
+    files.push({ path: item.name, status });
+  }
+
+  files.push(await setupDenoJson(options.dir, host));
+  return { files };
+}
+
+/** Create or merge `deno.json`, returning what happened to it. */
+async function setupDenoJson(
+  dir: string,
+  host: SetupHost,
+): Promise<FileResult> {
+  const name = "deno.json";
+  const path = joinPath(dir, name);
+  if (!(await host.exists(path))) {
+    await host.writeText(path, mergeDenoJson(null));
+    host.log(`  create   ${name}`);
+    return { path: name, status: "created" };
+  }
+
+  const before = await host.readText(path);
+  const state = zukeTaskState(before);
+  if (state === "present") {
+    host.log(`  skip     ${name}  (zuke task already present)`);
+    return { path: name, status: "skipped" };
+  }
+  if (state === "unparseable") {
+    host.log(`  skip     ${name}  (unparseable, edit by hand)`);
+    return { path: name, status: "skipped" };
+  }
+  await host.writeText(path, mergeDenoJson(before));
+  host.log(`  update   ${name}`);
+  return { path: name, status: "overwritten" };
+}

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -1,7 +1,7 @@
 /**
- * The scaffolding engine behind `zuke setup` — the Deno analog of NUKE's
- * `nuke :setup`. It writes a starter `zuke.ts`, the `./zuke` bootstrap
- * launchers, and a `deno.json` task into a target directory.
+ * The scaffolding engine behind `zuke setup`. It writes a starter `zuke.ts`,
+ * the `./zuke` bootstrap launchers, and a `deno.json` task into a target
+ * directory.
  *
  * All filesystem and console effects go through an injectable {@link SetupHost}
  * so the logic stays pure and unit-testable; {@link defaultHost} is the real

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,0 +1,2 @@
+/** The `@zuke/cli` version. Kept in sync with deno.json by release-please. */
+export const VERSION = "0.0.0"; // x-release-please-version

--- a/packages/cli/tests/_fakes.ts
+++ b/packages/cli/tests/_fakes.ts
@@ -1,0 +1,71 @@
+/** Test doubles for the CLI's injectable seams. */
+
+import type { SetupHost } from "../src/setup.ts";
+import type { Prompter } from "../mod.ts";
+
+/** An in-memory {@link SetupHost} that records writes, chmods, and logs. */
+export class FakeHost implements SetupHost {
+  /** Virtual filesystem: path → contents. */
+  readonly files = new Map<string, string>();
+  /** Lines passed to {@link log}. */
+  readonly logs: string[] = [];
+  /** `[path, mode]` pairs passed to {@link chmod}. */
+  readonly chmods: Array<[string, number]> = [];
+  /** When true, {@link chmod} rejects (simulating an unsupported platform). */
+  chmodFails = false;
+
+  constructor(initial?: Record<string, string>) {
+    if (initial) {
+      for (const [path, content] of Object.entries(initial)) {
+        this.files.set(path, content);
+      }
+    }
+  }
+
+  exists(path: string): Promise<boolean> {
+    return Promise.resolve(this.files.has(path));
+  }
+
+  readText(path: string): Promise<string> {
+    const value = this.files.get(path);
+    return value === undefined
+      ? Promise.reject(new Error(`missing: ${path}`))
+      : Promise.resolve(value);
+  }
+
+  writeText(path: string, content: string): Promise<void> {
+    this.files.set(path, content);
+    return Promise.resolve();
+  }
+
+  chmod(path: string, mode: number): Promise<void> {
+    if (this.chmodFails) return Promise.reject(new Error("chmod unsupported"));
+    this.chmods.push([path, mode]);
+    return Promise.resolve();
+  }
+
+  log(message: string): void {
+    this.logs.push(message);
+  }
+}
+
+/** A scripted {@link Prompter} with canned answers. */
+export class FakePrompter implements Prompter {
+  constructor(
+    private readonly tty: boolean,
+    private readonly answer: string = "",
+    private readonly yes: boolean = false,
+  ) {}
+
+  interactive(): boolean {
+    return this.tty;
+  }
+
+  ask(_question: string, fallback: string): string {
+    return this.answer === "" ? fallback : this.answer;
+  }
+
+  confirm(_question: string): boolean {
+    return this.yes;
+  }
+}

--- a/packages/cli/tests/cli_test.ts
+++ b/packages/cli/tests/cli_test.ts
@@ -1,0 +1,105 @@
+import { assertEquals } from "../../core/tests/_assert.ts";
+import { defaultPrompter, main, parseSetupFlags } from "../mod.ts";
+import { VERSION } from "../src/version.ts";
+import { FakeHost, FakePrompter } from "./_fakes.ts";
+
+Deno.test("parseSetupFlags reads every flag form", () => {
+  assertEquals(parseSetupFlags([]), { force: false, yes: false });
+  assertEquals(parseSetupFlags(["--force"]).force, true);
+  assertEquals(parseSetupFlags(["-f"]).force, true);
+  assertEquals(parseSetupFlags(["--yes"]).yes, true);
+  assertEquals(parseSetupFlags(["-y"]).yes, true);
+  assertEquals(parseSetupFlags(["--name", "Foo"]).name, "Foo");
+  assertEquals(parseSetupFlags(["--name=Bar"]).name, "Bar");
+  assertEquals(parseSetupFlags(["--name"]).name, undefined);
+  assertEquals(parseSetupFlags(["whatever"]).name, undefined);
+});
+
+Deno.test("main --version prints the version", async () => {
+  const host = new FakeHost();
+  assertEquals(await main(["--version"], host), 0);
+  assertEquals(host.logs, [VERSION]);
+  const host2 = new FakeHost();
+  assertEquals(await main(["-V"], host2), 0);
+  assertEquals(host2.logs, [VERSION]);
+});
+
+Deno.test("main shows help for --help, -h and no args", async () => {
+  for (const args of [[], ["--help"], ["-h"]]) {
+    const host = new FakeHost();
+    assertEquals(await main(args, host), 0);
+    assertEquals(host.logs[0].includes("Usage:"), true);
+  }
+});
+
+Deno.test("main rejects an unknown command", async () => {
+  const host = new FakeHost();
+  const code = await main(["bogus"], host);
+  assertEquals(code, 1);
+  assertEquals(host.logs[0].includes("Unknown command: bogus"), true);
+});
+
+Deno.test("main setup (non-interactive) scaffolds with flags", async () => {
+  const host = new FakeHost();
+  const code = await main(
+    ["setup", "--yes", "--name", "Widget"],
+    host,
+    new FakePrompter(true, "IGNORED", true),
+  );
+  assertEquals(code, 0);
+  assertEquals(host.files.get("zuke.ts")?.includes("class Widget"), true);
+});
+
+Deno.test("main setup (non-tty) uses defaults without prompting", async () => {
+  const host = new FakeHost();
+  const code = await main(["setup"], host, new FakePrompter(false));
+  assertEquals(code, 0);
+  assertEquals(host.files.get("zuke.ts")?.includes("class MyBuild"), true);
+});
+
+Deno.test("main setup (interactive) asks for name and overwrite", async () => {
+  const host = new FakeHost({ "zuke.ts": "old" });
+  const code = await main(
+    ["setup"],
+    host,
+    new FakePrompter(true, "Chosen", true),
+  );
+  assertEquals(code, 0);
+  // confirm() returned true -> existing zuke.ts is overwritten.
+  assertEquals(host.files.get("zuke.ts")?.includes("class Chosen"), true);
+});
+
+Deno.test("main setup (interactive) keeps --force without asking", async () => {
+  const host = new FakeHost();
+  // confirm would return false, but --force already set: files still written.
+  const code = await main(
+    ["setup", "--force"],
+    host,
+    new FakePrompter(true, "Named", false),
+  );
+  assertEquals(code, 0);
+  assertEquals(host.files.get("zuke.ts")?.includes("class Named"), true);
+});
+
+Deno.test("main uses default host/prompter when omitted", async () => {
+  // --version touches only host.log; safe to exercise the real defaults.
+  assertEquals(await main(["--version"]), 0);
+});
+
+Deno.test("defaultPrompter wraps prompt/confirm", () => {
+  assertEquals(typeof defaultPrompter.interactive(), "boolean");
+
+  const realPrompt = globalThis.prompt;
+  const realConfirm = globalThis.confirm;
+  try {
+    globalThis.prompt = () => "typed";
+    assertEquals(defaultPrompter.ask("q", "fallback"), "typed");
+    globalThis.prompt = () => null;
+    assertEquals(defaultPrompter.ask("q", "fallback"), "fallback");
+    globalThis.confirm = () => true;
+    assertEquals(defaultPrompter.confirm("q"), true);
+  } finally {
+    globalThis.prompt = realPrompt;
+    globalThis.confirm = realConfirm;
+  }
+});

--- a/packages/cli/tests/setup_test.ts
+++ b/packages/cli/tests/setup_test.ts
@@ -21,7 +21,7 @@ Deno.test("isRecord distinguishes plain objects", () => {
 
 Deno.test("starterBuild embeds the class name and entry point", () => {
   const out = starterBuild("Acme");
-  assertEquals(out.includes('import { Build, run, target }'), true);
+  assertEquals(out.includes("import { Build, run, target }"), true);
   assertEquals(out.includes("class Acme extends Build"), true);
   assertEquals(out.includes("await run(Acme)"), true);
 });

--- a/packages/cli/tests/setup_test.ts
+++ b/packages/cli/tests/setup_test.ts
@@ -1,0 +1,166 @@
+import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
+import {
+  defaultHost,
+  isRecord,
+  launcherBash,
+  launcherPwsh,
+  mergeDenoJson,
+  runSetup,
+  starterBuild,
+  zukeTaskState,
+} from "../src/setup.ts";
+import { FakeHost } from "./_fakes.ts";
+
+Deno.test("isRecord distinguishes plain objects", () => {
+  assertEquals(isRecord({}), true);
+  assertEquals(isRecord({ a: 1 }), true);
+  assertEquals(isRecord(null), false);
+  assertEquals(isRecord([]), false);
+  assertEquals(isRecord(42), false);
+});
+
+Deno.test("starterBuild embeds the class name and entry point", () => {
+  const out = starterBuild("Acme");
+  assertEquals(out.includes('import { Build, run, target }'), true);
+  assertEquals(out.includes("class Acme extends Build"), true);
+  assertEquals(out.includes("await run(Acme)"), true);
+});
+
+Deno.test("launchers carry a shebang and run zuke.ts", () => {
+  const bash = launcherBash();
+  assertEquals(bash.startsWith("#!/usr/bin/env bash"), true);
+  assertEquals(bash.includes("deno run -A zuke.ts"), true);
+  const pwsh = launcherPwsh();
+  assertEquals(pwsh.startsWith("#!/usr/bin/env pwsh"), true);
+  assertEquals(pwsh.includes("zuke.ts"), true);
+});
+
+Deno.test("mergeDenoJson seeds tasks from scratch", () => {
+  const text = mergeDenoJson(null);
+  const parsed: unknown = JSON.parse(text);
+  assertEquals(isRecord(parsed) && isRecord(parsed.tasks), true);
+  if (isRecord(parsed) && isRecord(parsed.tasks)) {
+    assertEquals(parsed.tasks.zuke, "deno run -A zuke.ts");
+    assertEquals(parsed.tasks.test, "deno test -A");
+  }
+  assertEquals(text.endsWith("\n"), true);
+});
+
+Deno.test("mergeDenoJson preserves existing keys and tasks", () => {
+  const before = '{"name":"x","tasks":{"fmt":"custom"}}';
+  const parsed: unknown = JSON.parse(mergeDenoJson(before));
+  assertEquals(isRecord(parsed), true);
+  if (isRecord(parsed) && isRecord(parsed.tasks)) {
+    assertEquals(parsed.name, "x");
+    assertEquals(parsed.tasks.fmt, "custom");
+    assertEquals(parsed.tasks.zuke, "deno run -A zuke.ts");
+  }
+});
+
+Deno.test("mergeDenoJson ignores a non-object document", () => {
+  const parsed: unknown = JSON.parse(mergeDenoJson("[]"));
+  assertEquals(isRecord(parsed) && isRecord(parsed.tasks), true);
+  if (isRecord(parsed) && isRecord(parsed.tasks)) {
+    assertEquals(parsed.tasks.zuke, "deno run -A zuke.ts");
+  }
+});
+
+Deno.test("zukeTaskState classifies deno.json text", () => {
+  assertEquals(zukeTaskState('{"tasks":{"zuke":"x"}}'), "present");
+  assertEquals(zukeTaskState('{"tasks":{"a":"b"}}'), "absent");
+  assertEquals(zukeTaskState('{"tasks":5}'), "absent");
+  assertEquals(zukeTaskState("[]"), "absent");
+  assertEquals(zukeTaskState("not json"), "unparseable");
+});
+
+Deno.test("runSetup scaffolds an empty project", async () => {
+  const host = new FakeHost();
+  const result = await runSetup({ dir: ".", force: false, name: "Foo" }, host);
+  assertEquals(result.files.map((f) => f.status), [
+    "created",
+    "created",
+    "created",
+    "created",
+  ]);
+  assertEquals(host.files.get("zuke.ts")?.includes("class Foo"), true);
+  assertEquals(host.files.has("zuke"), true);
+  assertEquals(host.files.has("zuke.ps1"), true);
+  assertEquals(host.files.has("deno.json"), true);
+  assertEquals(host.chmods[0], ["zuke", 0o755]);
+});
+
+Deno.test("runSetup skips existing files without --force", async () => {
+  const host = new FakeHost({ "zuke.ts": "keep me" });
+  const result = await runSetup({ dir: ".", force: false, name: "Foo" }, host);
+  assertEquals(result.files[0], { path: "zuke.ts", status: "skipped" });
+  assertEquals(host.files.get("zuke.ts"), "keep me");
+});
+
+Deno.test("runSetup overwrites existing files with --force", async () => {
+  const host = new FakeHost({ "zuke.ts": "old" });
+  const result = await runSetup({ dir: ".", force: true, name: "Bar" }, host);
+  assertEquals(result.files[0], { path: "zuke.ts", status: "overwritten" });
+  assertEquals(host.files.get("zuke.ts")?.includes("class Bar"), true);
+});
+
+Deno.test("runSetup tolerates chmod failing", async () => {
+  const host = new FakeHost();
+  host.chmodFails = true;
+  const result = await runSetup({ dir: ".", force: false, name: "Foo" }, host);
+  assertEquals(result.files[1], { path: "zuke", status: "created" });
+  assertEquals(host.files.has("zuke"), true);
+});
+
+Deno.test("runSetup skips deno.json that already has the zuke task", async () => {
+  const host = new FakeHost({ "deno.json": '{"tasks":{"zuke":"x"}}' });
+  const result = await runSetup({ dir: ".", force: false, name: "Foo" }, host);
+  const dj = result.files.find((f) => f.path === "deno.json");
+  assertEquals(dj?.status, "skipped");
+  assertEquals(host.files.get("deno.json"), '{"tasks":{"zuke":"x"}}');
+});
+
+Deno.test("runSetup merges a deno.json missing the zuke task", async () => {
+  const host = new FakeHost({ "deno.json": '{"tasks":{"a":"b"}}' });
+  const result = await runSetup({ dir: ".", force: false, name: "Foo" }, host);
+  const dj = result.files.find((f) => f.path === "deno.json");
+  assertEquals(dj?.status, "overwritten");
+  assertEquals(host.files.get("deno.json")?.includes('"zuke"'), true);
+});
+
+Deno.test("runSetup leaves an unparseable deno.json alone", async () => {
+  const host = new FakeHost({ "deno.json": "oops" });
+  const result = await runSetup({ dir: ".", force: false, name: "Foo" }, host);
+  const dj = result.files.find((f) => f.path === "deno.json");
+  assertEquals(dj?.status, "skipped");
+  assertEquals(host.files.get("deno.json"), "oops");
+});
+
+Deno.test("runSetup writes to disk via the default host", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const result = await runSetup({ dir, force: false, name: "Acme" });
+    assertEquals(result.files.length, 4);
+    const zukeTs = await Deno.readTextFile(`${dir}/zuke.ts`);
+    assertEquals(zukeTs.includes("class Acme extends Build"), true);
+    if (Deno.build.os !== "windows") {
+      const info = await Deno.lstat(`${dir}/zuke`);
+      assertEquals((info.mode ?? 0) & 0o100, 0o100);
+    }
+    // Second pass: everything now exists and is left untouched.
+    const again = await runSetup({ dir, force: false, name: "Acme" });
+    assertEquals(again.files.every((f) => f.status === "skipped"), true);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("defaultHost.exists rethrows non-NotFound errors", async () => {
+  if (Deno.build.os === "windows") return; // ENOTDIR is POSIX-specific.
+  const file = await Deno.makeTempFile();
+  try {
+    // Treating a file as a directory yields NotADirectory, not NotFound.
+    await assertRejects(() => defaultHost.exists(`${file}/child`));
+  } finally {
+    await Deno.remove(file);
+  }
+});

--- a/packages/cmd/deno.json
+++ b/packages/cmd/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@zuke/cmd",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "exports": {
     ".": "./mod.ts"
   },

--- a/packages/core/deno.json
+++ b/packages/core/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@zuke/core",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "exports": {
     ".": "./mod.ts",
     "./shell": "./src/shell.ts",

--- a/packages/core/src/tooling.ts
+++ b/packages/core/src/tooling.ts
@@ -1,5 +1,5 @@
 /**
- * Foundations for typed tool wrappers (NUKE-style task functions).
+ * Foundations for typed tool wrappers (settings-lambda task functions).
  *
  * A tool package (e.g. `@zuke/deno`, `@zuke/npm`) defines one settings class
  * per subcommand by extending {@link ToolSettings}: `buildArgs()` assembles

--- a/packages/deno/deno.json
+++ b/packages/deno/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@zuke/deno",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "exports": {
     ".": "./mod.ts"
   },

--- a/packages/deno/src/deno.ts
+++ b/packages/deno/src/deno.ts
@@ -1,6 +1,6 @@
 /**
- * `DenoTasks` — typed task functions for the `deno` CLI, in the NUKE
- * `DotNetTasks` style: configure a fluent settings object in a lambda, and
+ * `DenoTasks` — typed task functions for the `deno` CLI, in the
+ * settings-lambda style: configure a fluent settings object in a lambda, and
  * the task function builds the command line and executes it.
  *
  * ```ts

--- a/packages/npm/deno.json
+++ b/packages/npm/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@zuke/npm",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "exports": {
     ".": "./mod.ts"
   },

--- a/packages/npm/src/npm.ts
+++ b/packages/npm/src/npm.ts
@@ -1,6 +1,6 @@
 /**
- * `NpmTasks` — typed task functions for the `npm` CLI, in the NUKE
- * `DotNetTasks` style: configure a fluent settings object in a lambda, and
+ * `NpmTasks` — typed task functions for the `npm` CLI, in the
+ * settings-lambda style: configure a fluent settings object in a lambda, and
  * the task function builds the command line and executes it.
  *
  * ```ts

--- a/tests/release_config_test.ts
+++ b/tests/release_config_test.ts
@@ -5,6 +5,7 @@ const PACKAGES = [
   "packages/deno",
   "packages/npm",
   "packages/cmd",
+  "packages/cli",
 ];
 
 async function readJson(path: string): Promise<Record<string, unknown>> {
@@ -13,7 +14,7 @@ async function readJson(path: string): Promise<Record<string, unknown>> {
 
 const CONFIG = ".release-please-config.json";
 
-Deno.test("release-please config lists exactly the four packages", async () => {
+Deno.test("release-please config matches the workspace packages", async () => {
   const config = await readJson(CONFIG);
   const packages = config.packages;
   if (packages === null || typeof packages !== "object") {

--- a/zuke
+++ b/zuke
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Zuke bootstrap launcher — the NUKE-style `./build.sh`, but for Deno.
+# Zuke bootstrap launcher — a `./build.sh`-style entry point for Deno.
 #
 #   ./zuke ci          # run the full gate
 #   ./zuke test        # type-check + tests

--- a/zuke
+++ b/zuke
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Zuke bootstrap launcher — the NUKE-style `./build.sh`, but for Deno.
+#
+#   ./zuke ci          # run the full gate
+#   ./zuke test        # type-check + tests
+#   ./zuke --list      # list every target
+#
+# Ensures Deno is available (installing it on first use if missing), then runs
+# the project's build file (zuke.ts). No global install required.
+#
+# Honoured environment variables:
+#   DENO_INSTALL   where Deno is installed/looked for (default: ~/.deno)
+#   DENO_VERSION   pin a specific Deno version for the bootstrap install
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$script_dir"
+
+deno_install="${DENO_INSTALL:-$HOME/.deno}"
+
+if command -v deno >/dev/null 2>&1; then
+  deno_bin="$(command -v deno)"
+elif [ -x "$deno_install/bin/deno" ]; then
+  deno_bin="$deno_install/bin/deno"
+else
+  echo "zuke: Deno not found — installing it now..." >&2
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "zuke: curl is required to bootstrap Deno; install Deno manually:" >&2
+    echo "      https://docs.deno.com/runtime/getting_started/installation/" >&2
+    exit 1
+  fi
+  export DENO_INSTALL="$deno_install"
+  if [ -n "${DENO_VERSION:-}" ]; then
+    curl -fsSL https://deno.land/install.sh | sh -s "$DENO_VERSION" >/dev/null
+  else
+    curl -fsSL https://deno.land/install.sh | sh >/dev/null
+  fi
+  deno_bin="$deno_install/bin/deno"
+fi
+
+exec "$deno_bin" run -A zuke.ts "$@"

--- a/zuke.ps1
+++ b/zuke.ps1
@@ -1,6 +1,6 @@
 #!/usr/bin/env pwsh
 #
-# Zuke bootstrap launcher (PowerShell) — the NUKE-style `.\build.ps1`.
+# Zuke bootstrap launcher (PowerShell) — a `.\build.ps1`-style entry point.
 #
 #   .\zuke.ps1 ci          # run the full gate
 #   .\zuke.ps1 test        # type-check + tests

--- a/zuke.ps1
+++ b/zuke.ps1
@@ -1,0 +1,39 @@
+#!/usr/bin/env pwsh
+#
+# Zuke bootstrap launcher (PowerShell) — the NUKE-style `.\build.ps1`.
+#
+#   .\zuke.ps1 ci          # run the full gate
+#   .\zuke.ps1 test        # type-check + tests
+#   .\zuke.ps1 --list      # list every target
+#
+# Ensures Deno is available (installing it on first use if missing), then runs
+# the project's build file (zuke.ts). No global install required.
+#
+# Honoured environment variable:
+#   DENO_INSTALL   where Deno is installed/looked for (default: ~/.deno)
+
+$ErrorActionPreference = "Stop"
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $scriptDir
+
+if (-not $env:DENO_INSTALL) {
+  $env:DENO_INSTALL = Join-Path $HOME ".deno"
+}
+
+function Resolve-Deno {
+  $onPath = Get-Command deno -CommandType Application -ErrorAction SilentlyContinue
+  if ($onPath) { return $onPath.Source }
+  $local = Join-Path $env:DENO_INSTALL "bin\deno.exe"
+  if (Test-Path $local) { return $local }
+  return $null
+}
+
+$deno = Resolve-Deno
+if (-not $deno) {
+  Write-Host "zuke: Deno not found - installing it now..."
+  Invoke-RestMethod https://deno.land/install.ps1 | Invoke-Expression
+  $deno = Join-Path $env:DENO_INSTALL "bin\deno.exe"
+}
+
+& $deno run -A (Join-Path $scriptDir "zuke.ts") @args
+exit $LASTEXITCODE

--- a/zuke.ts
+++ b/zuke.ts
@@ -2,12 +2,13 @@
  * Zuke's own build, authored with Zuke — the project builds itself.
  *
  * Every CI and release step is a target here, so the GitHub workflows collapse
- * to a single `deno task zuke <target>` invocation (equivalently
+ * to `deno task zuke <target>` invocations (equivalently
  * `deno run -A zuke.ts <target>`):
  *
  *   deno task zuke ci        # fmt → lint → spell → check → test → coverage gate
  *   deno task zuke test      # type-check, then run the suite with coverage
- *   deno task zuke publish   # publish released packages to JSR, core first
+ *   deno task zuke release   # release-please: maintain release PRs & releases
+ *   deno task zuke publish   # publish new package versions to JSR, core first
  *   deno task zuke --list    # show every target
  */
 
@@ -18,9 +19,45 @@ import { DenoTasks } from "@zuke/deno";
 /** Workspace packages, in dependency order: core must publish before the rest. */
 const PACKAGES = ["core", "deno", "npm", "cmd"];
 
-/** Per-package publish flag set by the release workflow (`true` to publish). */
-function publishFlag(pkg: string): string | undefined {
-  return Deno.env.get(`ZUKE_PUBLISH_${pkg.toUpperCase()}`);
+/** The `version` field of a package's `deno.json`, validated as a string. */
+function readVersion(value: unknown): string {
+  if (typeof value !== "object" || value === null) {
+    throw new Error("deno.json must be a JSON object.");
+  }
+  if (!("version" in value)) {
+    throw new Error('deno.json is missing a "version" field.');
+  }
+  if (typeof value.version !== "string") {
+    throw new Error('deno.json "version" must be a string.');
+  }
+  return value.version;
+}
+
+/** The current version declared in `packages/<pkg>/deno.json`. */
+async function localVersion(pkg: string): Promise<string> {
+  const text = await Deno.readTextFile(`packages/${pkg}/deno.json`);
+  return readVersion(JSON.parse(text));
+}
+
+/** The set of version strings present in a JSR `meta.json` payload. */
+function publishedVersions(meta: unknown): Set<string> {
+  if (typeof meta !== "object" || meta === null) return new Set<string>();
+  if (!("versions" in meta)) return new Set<string>();
+  const versions = meta.versions;
+  if (typeof versions !== "object" || versions === null) {
+    return new Set<string>();
+  }
+  return new Set(Object.keys(versions));
+}
+
+/** Whether `@zuke/<pkg>@<version>` is already published on JSR. */
+async function isOnJsr(pkg: string, version: string): Promise<boolean> {
+  const res = await fetch(`https://jsr.io/@zuke/${pkg}/meta.json`);
+  if (!res.ok) {
+    await res.body?.cancel();
+    return false;
+  }
+  return publishedVersions(await res.json()).has(version);
 }
 
 class ZukeBuild extends Build {
@@ -88,19 +125,49 @@ class ZukeBuild extends Build {
     .dependsOn(this.format, this.lint, this.spell, this.coverage)
     .executes(() => {});
 
-  publish = target()
-    .description("Publish released packages to JSR, in dependency order")
+  release = target()
+    .description("Maintain release PRs and GitHub releases (release-please)")
     .executes(async () => {
-      const gated = PACKAGES.some((p) => publishFlag(p) !== undefined);
-      const selected = gated
-        ? PACKAGES.filter((p) => publishFlag(p) === "true")
-        : [...PACKAGES];
-      if (selected.length === 0) {
-        console.log("Nothing to publish: no released packages selected.");
-        return;
+      const token = Deno.env.get("GITHUB_TOKEN");
+      const repo = Deno.env.get("GITHUB_REPOSITORY");
+      if (token === undefined || repo === undefined) {
+        throw new Error(
+          "release requires GITHUB_TOKEN and GITHUB_REPOSITORY in the env.",
+        );
       }
-      for (const pkg of selected) {
-        console.log(`Publishing @zuke/${pkg} to JSR...`);
+      const common = [
+        "--token",
+        token,
+        "--repo-url",
+        repo,
+        "--target-branch",
+        "master",
+        "--config-file",
+        ".release-please-config.json",
+        "--manifest-file",
+        ".release-please-manifest.json",
+      ];
+      const cli = ["run", "-A", "npm:release-please@16"];
+      for (const cmd of ["release-pr", "github-release"]) {
+        const argv = [...cli, cmd, ...common];
+        await CmdTasks.exec(Deno.execPath(), (s) => s.args(...argv));
+      }
+    });
+
+  publish = target()
+    .description("Publish new package versions to JSR, core first")
+    .executes(async () => {
+      for (const pkg of PACKAGES) {
+        const version = await localVersion(pkg);
+        if (version === "0.0.0") {
+          console.log(`@zuke/${pkg} has no released version yet.`);
+          continue;
+        }
+        if (await isOnJsr(pkg, version)) {
+          console.log(`@zuke/${pkg}@${version} is already on JSR.`);
+          continue;
+        }
+        console.log(`Publishing @zuke/${pkg}@${version} to JSR...`);
         await CmdTasks.exec(Deno.execPath(), (s) => {
           return s.cwd(`packages/${pkg}`).args("publish", "--allow-dirty");
         });

--- a/zuke.ts
+++ b/zuke.ts
@@ -156,6 +156,7 @@ class ZukeBuild extends Build {
 
   publish = target()
     .description("Publish new package versions to JSR, core first")
+    .dependsOn(this.release)
     .executes(async () => {
       for (const pkg of PACKAGES) {
         const version = await localVersion(pkg);

--- a/zuke.ts
+++ b/zuke.ts
@@ -1,15 +1,27 @@
 /**
- * Zuke's own build, authored with Zuke. Demonstrates the v0 authoring API and
- * doubles as a runnable acceptance example — including the typed tool
- * wrappers (`DenoTasks`) and the generic fallback (`CmdTasks`).
+ * Zuke's own build, authored with Zuke — the project builds itself.
  *
- *   deno run -A zuke.ts test     # clean → restore → compile → test
- *   deno run -A zuke.ts --list
+ * Every CI and release step is a target here, so the GitHub workflows collapse
+ * to a single `deno task zuke <target>` invocation (equivalently
+ * `deno run -A zuke.ts <target>`):
+ *
+ *   deno task zuke ci        # fmt → lint → spell → check → test → coverage gate
+ *   deno task zuke test      # type-check, then run the suite with coverage
+ *   deno task zuke publish   # publish released packages to JSR, core first
+ *   deno task zuke --list    # show every target
  */
 
 import { Build, run, target } from "@zuke/core";
 import { CmdTasks } from "@zuke/cmd";
 import { DenoTasks } from "@zuke/deno";
+
+/** Workspace packages, in dependency order: core must publish before the rest. */
+const PACKAGES = ["core", "deno", "npm", "cmd"];
+
+/** Per-package publish flag set by the release workflow (`true` to publish). */
+function publishFlag(pkg: string): string | undefined {
+  return Deno.env.get(`ZUKE_PUBLISH_${pkg.toUpperCase()}`);
+}
 
 class ZukeBuild extends Build {
   clean = target()
@@ -19,30 +31,86 @@ class ZukeBuild extends Build {
     });
 
   restore = target()
-    .description("Install dependencies")
+    .description("Warm the module cache")
     .executes(async () => {
-      // No external dependencies in v0; reload the local module graph.
-      await DenoTasks.cache((s) => s.paths("packages/core/mod.ts"));
+      const mods = PACKAGES.map((p) => `packages/${p}/mod.ts`);
+      await DenoTasks.cache((s) => s.paths(...mods));
     });
 
-  compile = target()
-    .description("Type-check the project")
-    .dependsOn(this.clean, this.restore)
+  format = target()
+    .description("Check formatting (deno fmt --check)")
     .executes(async () => {
-      await DenoTasks.check((s) => s.paths("packages/core/mod.ts"));
+      await DenoTasks.fmt((s) => s.check());
+    });
+
+  lint = target()
+    .description("Lint the workspace (deno lint)")
+    .executes(async () => {
+      await DenoTasks.lint();
+    });
+
+  spell = target()
+    .description("Spell-check the repository (cspell)")
+    .executes(async () => {
+      const argv = ["run", "--allow-read", "--allow-env", "--allow-sys"];
+      argv.push("npm:cspell@9", "lint", "--no-progress", "**");
+      await CmdTasks.exec(Deno.execPath(), (s) => s.args(...argv));
+    });
+
+  check = target()
+    .description("Type-check the whole workspace")
+    .dependsOn(this.restore)
+    .executes(async () => {
+      await DenoTasks.task((s) => s.name("check"));
     });
 
   test = target()
-    .description("Run the test suite")
-    .dependsOn(this.compile)
+    .description("Run the test suite with coverage")
+    .dependsOn(this.check)
     .executes(async () => {
-      await DenoTasks.test((s) => s.allowAll());
+      await DenoTasks.test((s) => s.allowAll().coverage("cov_profile"));
+    });
+
+  coverage = target()
+    .description("Enforce the 95% coverage gate")
+    .dependsOn(this.test)
+    .executes(async () => {
+      const cov = ["coverage", "cov_profile", "--lcov"];
+      cov.push("--exclude=(tests|scripts)/", "--output=cov.lcov");
+      await CmdTasks.exec(Deno.execPath(), (s) => s.args(...cov));
+      const gate = ["run", "--allow-read", "scripts/check-coverage.ts"];
+      gate.push("cov.lcov", "95");
+      await CmdTasks.exec(Deno.execPath(), (s) => s.args(...gate));
+    });
+
+  ci = target()
+    .description("Full pre-commit / CI gate")
+    .dependsOn(this.format, this.lint, this.spell, this.coverage)
+    .executes(() => {});
+
+  publish = target()
+    .description("Publish released packages to JSR, in dependency order")
+    .executes(async () => {
+      const gated = PACKAGES.some((p) => publishFlag(p) !== undefined);
+      const selected = gated
+        ? PACKAGES.filter((p) => publishFlag(p) === "true")
+        : [...PACKAGES];
+      if (selected.length === 0) {
+        console.log("Nothing to publish: no released packages selected.");
+        return;
+      }
+      for (const pkg of selected) {
+        console.log(`Publishing @zuke/${pkg} to JSR...`);
+        await CmdTasks.exec(Deno.execPath(), (s) => {
+          return s.cwd(`packages/${pkg}`).args("publish", "--allow-dirty");
+        });
+      }
     });
 
   // Convention: the `default` target runs when none is named.
   default = target()
-    .description("Default: run the full test pipeline")
-    .dependsOn(this.test)
+    .description("Default: run the full CI gate")
+    .dependsOn(this.ci)
     .executes(() => {});
 }
 

--- a/zuke.ts
+++ b/zuke.ts
@@ -17,7 +17,7 @@ import { CmdTasks } from "@zuke/cmd";
 import { DenoTasks } from "@zuke/deno";
 
 /** Workspace packages, in dependency order: core must publish before the rest. */
-const PACKAGES = ["core", "deno", "npm", "cmd"];
+const PACKAGES = ["core", "deno", "npm", "cmd", "cli"];
 
 /** The `version` field of a package's `deno.json`, validated as a string. */
 function readVersion(value: unknown): string {


### PR DESCRIPTION
Zuke now builds, tests, and releases itself, and ships the tooling for others to do the same. Every CI and release step is a Zuke target, JSR publishing is wired up (OIDC, no secrets), and there's a NUKE-style launcher plus a `zuke setup` scaffolder.

## Highlights

- **Zuke builds Zuke.** The GitHub workflows collapse to single `deno task zuke <target>` invocations; the build graph encodes the ordering, not the YAML.
- **JSR publishing enabled** for all five packages — `@zuke/core`, `@zuke/deno`, `@zuke/npm`, `@zuke/cmd`, and the new `@zuke/cli` — via release-please + OIDC, with the first `0.1.0` release bootstrapped.
- **A real `zuke` CLI**: repo-root `./zuke` launchers that install Deno if missing, and a global `@zuke/cli` with an interactive `zuke setup` (the analog of `nuke :setup`).

## CI/CD is now self-hosted

`zuke.ts` grew from a demo into the actual build. New targets: `format`, `lint`, `spell`, `check`, `test`, `coverage`, an aggregate `ci`, plus `release` and `publish`.

- **`.github/workflows/ci.yml`** — the quality job is one step, `deno task zuke ci`; the OS matrix runs `deno task zuke test`.
- **`.github/workflows/release.yml`** — one job runs `deno task zuke publish`. Because `publish` depends on `release`, Zuke runs release-please (`release-pr` + `github-release`) first, then publishes. Replaces the release-please action and the per-package publish matrix.
- **OIDC** for publishing (only `id-token: write`, no secrets); `GITHUB_TOKEN` is passed for release-please.

## Publishing: idempotent and dependency-ordered

- `publish` walks packages **core-first** (so `jsr:@zuke/core` resolves for the dependents) and publishes each one **only if its `deno.json` version isn't already on JSR** — it queries each package's JSR `meta.json`, so the step is a safe no-op on pushes that didn't release anything.
- A `0.0.0` version is treated as "unreleased" and skipped.

## First-release bootstrap

- `.release-please-manifest.json` and every `packages/*/deno.json` are seeded at `0.0.0`.
- `.release-please-config.json` pins `release-as: 0.1.0` per package and sets `bump-minor-pre-major` so breaking changes stay in `0.x`.
- ⚠️ **After the first release publishes, remove the `release-as` pins** (documented in `RELEASING.md`), or every future release is forced back to `0.1.0`. Also merge the **`core`** release PR first so it's on JSR before the dependents.

## `./zuke` launchers (NUKE's `build.sh`)

- `zuke` (bash) and `zuke.ps1` (PowerShell) at the repo root locate the project, **install Deno on first use if missing**, then run `zuke.ts` — a fresh checkout needs nothing but the script.

## `@zuke/cli` — `zuke setup` (NUKE's `nuke :setup`)

A fifth workspace package providing the `zuke` command (`deno install -A -g -n zuke jsr:@zuke/cli`):

- **`zuke setup`** — interactive in a TTY (asks for the build class name / overwrite), flag-driven otherwise (`--name`, `--force`, `--yes`). Scaffolds a starter `zuke.ts`, the `./zuke` launchers, and a `deno.json` task block (merged, never clobbered).
- `zuke --help` / `--version`.
- Built around an injectable `SetupHost` (filesystem/console) and `Prompter` (TTY) so every branch is covered by hermetic tests (in-memory fakes + temp dirs).

## Docs & housekeeping

- **`RELEASING.md`** (new) — the end-to-end release flow, the first-release bootstrap, and the `release-as` cleanup.
- **`README.md`** — `zuke setup`, the `./zuke` launchers, and the five published packages.
- **`deno.json`** — added the `zuke` task and `packages/cli` to the workspace.
- **`cspell.json`** — added `OIDC`, `chmods`, `unparseable`, and ignores for the launcher scripts.
- **`tests/release_config_test.ts`** — updated to expect the five workspace packages.

## Verification

CI is green: `deno task zuke ci` (fmt → lint → spell → check → test → coverage gate) passes, the coverage gate holds at **99.4% lines / 97.4% branches** (threshold 95%), and the macOS/Windows test matrices pass. The `release`/`publish` targets run only from `release.yml` on `master`, so they'll first exercise on merge.

https://claude.ai/code/session_01VRn8gL34mdDPRg4ZTVzGAz