### PR TITLE
Fix release: use the `simple` release-please type instead of unknown `deno`

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "deno",
+  "release-type": "simple",
   "tag-separator": "-v",
   "separate-pull-requests": true,
   "bump-minor-pre-major": true,
@@ -8,28 +8,43 @@
     "packages/core": {
       "component": "core",
       "changelog-path": "CHANGELOG.md",
-      "release-as": "0.1.0"
+      "release-as": "0.1.0",
+      "extra-files": [
+        { "type": "json", "path": "packages/core/deno.json", "jsonpath": "$.version" }
+      ]
     },
     "packages/deno": {
       "component": "deno",
       "changelog-path": "CHANGELOG.md",
-      "release-as": "0.1.0"
+      "release-as": "0.1.0",
+      "extra-files": [
+        { "type": "json", "path": "packages/deno/deno.json", "jsonpath": "$.version" }
+      ]
     },
     "packages/npm": {
       "component": "npm",
       "changelog-path": "CHANGELOG.md",
-      "release-as": "0.1.0"
+      "release-as": "0.1.0",
+      "extra-files": [
+        { "type": "json", "path": "packages/npm/deno.json", "jsonpath": "$.version" }
+      ]
     },
     "packages/cmd": {
       "component": "cmd",
       "changelog-path": "CHANGELOG.md",
-      "release-as": "0.1.0"
+      "release-as": "0.1.0",
+      "extra-files": [
+        { "type": "json", "path": "packages/cmd/deno.json", "jsonpath": "$.version" }
+      ]
     },
     "packages/cli": {
       "component": "cli",
       "changelog-path": "CHANGELOG.md",
       "release-as": "0.1.0",
-      "extra-files": ["src/version.ts"]
+      "extra-files": [
+        { "type": "json", "path": "packages/cli/deno.json", "jsonpath": "$.version" },
+        "packages/cli/src/version.ts"
+      ]
     }
   }
 }

--- a/cspell.json
+++ b/cspell.json
@@ -7,6 +7,7 @@
     "chmods",
     "cowsay",
     "Interpolatable",
+    "jsonpath",
     "OIDC",
     "mytool",
     "spawnable",

--- a/tests/release_config_test.ts
+++ b/tests/release_config_test.ts
@@ -23,11 +23,11 @@ Deno.test("release-please config matches the workspace packages", async () => {
   assertEquals(Object.keys(packages).sort(), [...PACKAGES].sort());
 });
 
-Deno.test("the config uses the deno release type", async () => {
-  // The version source of truth is each package's deno.json, so the releaser
-  // must be "deno" (not "node" — there is no package.json in this repo).
+Deno.test("the config uses the simple release type", async () => {
+  // release-please has no "deno" releaser; the version lives in each package's
+  // deno.json, bumped via the simple releaser plus a json extra-files updater.
   const config = await readJson(CONFIG);
-  assertEquals(config["release-type"], "deno");
+  assertEquals(config["release-type"], "simple");
 });
 
 Deno.test("manifest versions match each package deno.json", async () => {


### PR DESCRIPTION
The Release workflow failed on `master` after #5 merged:

```
ConfigurationError: core (zuke-build/zuke): Unknown release type: deno
    at buildStrategy (.../release-please/16.18.0/build/src/factory.js:135:11)
```

## Cause

`release-please` has **no `deno` release type** — its valid `--release-type`
values are `node`, `simple`, `rust`, `python`, `go`, … but not `deno`. Our
`.release-please-config.json` has used `"release-type": "deno"` since before #5
(every prior `release.yml` run on `master` failed too); enabling the workflow in
#5 just surfaced it. The release job got all the way through the launcher and
into release-please before erroring, so the rest of the pipeline is fine.

## Fix

A Deno monorepo keeps each package's version in its `deno.json` (there is no
`package.json`), so this uses the **`simple`** release type and bumps the
version with a generic JSON updater:

- `.release-please-config.json`: `release-type` `deno` → `simple`; each package
  gets an `extra-files` entry
  `{ "type": "json", "path": "packages/<pkg>/deno.json", "jsonpath": "$.version" }`.
  The `cli` package keeps its `version.ts` updater, now with a repo-root path.
- `tests/release_config_test.ts`: assert the `simple` release type.
- `cspell.json`: allow `jsonpath`.

The bootstrap is unchanged: manifest seeded at `0.0.0`, `release-as: 0.1.0` pins
for the first release, `bump-minor-pre-major` to stay in `0.x`.

## Note

I couldn't run release-please in the dev container (it blocks `deno.land`), so
the residual unknown is the `extra-files` path base (repo-root vs
package-relative) and whether `simple` needs a `version.txt`. I used the
documented repo-root + JSON-updater form. If the next release *tags* but doesn't
*bump* `deno.json`, the path base is the knob to flip — and because `zuke
publish` is idempotent (it only publishes a version not already on JSR), a
misfire no-ops rather than mis-publishing.

https://claude.ai/code/session_01VRn8gL34mdDPRg4ZTVzGAz

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRn8gL34mdDPRg4ZTVzGAz)_