### PR TITLE
feat(cli): add a --dir flag to scaffold into a chosen directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ zuke setup                                  # in your project
 ```
 
 Without installing, the same wizard runs via
-`deno run -A jsr:@zuke/cli setup` (flags: `--name <Class>`, `--force`, `--yes`).
+`deno run -A jsr:@zuke/cli setup` (flags: `--dir <path>`, `--name <Class>`,
+`--force`, `--yes`).
 
 ### Run it yourself
 

--- a/packages/cli/mod.ts
+++ b/packages/cli/mod.ts
@@ -45,6 +45,8 @@ export interface SetupFlags {
   yes: boolean;
   /** Build class name for the starter `zuke.ts`. */
   name?: string;
+  /** Directory to scaffold into (defaults to the current directory). */
+  dir?: string;
 }
 
 /** Parse the argument list following `zuke setup`. */
@@ -63,6 +65,13 @@ export function parseSetupFlags(args: string[]): SetupFlags {
       }
     } else if (arg.startsWith("--name=")) {
       flags.name = arg.slice("--name=".length);
+    } else if (arg === "--dir") {
+      if (i + 1 < args.length) {
+        i++;
+        flags.dir = args[i];
+      }
+    } else if (arg.startsWith("--dir=")) {
+      flags.dir = arg.slice("--dir=".length);
     }
   }
   return flags;
@@ -71,11 +80,12 @@ export function parseSetupFlags(args: string[]): SetupFlags {
 const HELP = `zuke ${VERSION} — code-first build automation for Deno
 
 Usage:
-  zuke setup [options]   Scaffold Zuke into the current directory
+  zuke setup [options]   Scaffold Zuke into a directory
   zuke --help            Show this help
   zuke --version         Show the version
 
 Setup options:
+  --dir <path>     Directory to scaffold into (default: .)
   --name <Class>   Build class name for zuke.ts (default: MyBuild)
   --force, -f      Overwrite existing files
   --yes, -y        Accept defaults without prompting
@@ -91,6 +101,7 @@ async function commandSetup(
   const flags = parseSetupFlags(args);
   let name = flags.name ?? "MyBuild";
   let force = flags.force;
+  const dir = flags.dir ?? ".";
 
   if (!flags.yes && prompter.interactive()) {
     name = prompter.ask("Build class name", name);
@@ -99,8 +110,9 @@ async function commandSetup(
     }
   }
 
-  host.log("Scaffolding Zuke into the current directory:");
-  const result = await runSetup({ dir: ".", force, name }, host);
+  const where = dir === "." ? "the current directory" : dir;
+  host.log(`Scaffolding Zuke into ${where}:`);
+  const result = await runSetup({ dir, force, name }, host);
   const written = result.files.filter((f) => f.status !== "skipped").length;
   host.log(`Done — ${written} file(s) written. Next: ./zuke`);
   return 0;

--- a/packages/cli/tests/cli_test.ts
+++ b/packages/cli/tests/cli_test.ts
@@ -12,7 +12,23 @@ Deno.test("parseSetupFlags reads every flag form", () => {
   assertEquals(parseSetupFlags(["--name", "Foo"]).name, "Foo");
   assertEquals(parseSetupFlags(["--name=Bar"]).name, "Bar");
   assertEquals(parseSetupFlags(["--name"]).name, undefined);
+  assertEquals(parseSetupFlags(["--dir", "app"]).dir, "app");
+  assertEquals(parseSetupFlags(["--dir=pkg"]).dir, "pkg");
+  assertEquals(parseSetupFlags(["--dir"]).dir, undefined);
   assertEquals(parseSetupFlags(["whatever"]).name, undefined);
+});
+
+Deno.test("main setup honours --dir", async () => {
+  const host = new FakeHost();
+  const code = await main(
+    ["setup", "--yes", "--dir", "sub", "--name", "Widget"],
+    host,
+    new FakePrompter(false),
+  );
+  assertEquals(code, 0);
+  assertEquals(host.files.get("sub/zuke.ts")?.includes("class Widget"), true);
+  assertEquals(host.files.has("sub/deno.json"), true);
+  assertEquals(host.logs[0].includes("into sub"), true);
 });
 
 Deno.test("main --version prints the version", async () => {


### PR DESCRIPTION
## Why

After the org PR-creation toggle was enabled, release-please opened release PRs for four of the five packages (`core`, `deno`, `npm`, `cmd`) but **not `@zuke/cli`**. release-please only cuts a release for a component that has at least one Conventional Commit on its path; `release-as` sets the version but won't manufacture a release from nothing. `@zuke/cli` was introduced solely by the squash-merge of #5, whose subject (`Self-host CI/release…`) isn't a Conventional Commit — so there was nothing releasable on `packages/cli/`.

## What

A small, real feature that doubles as the bootstrap commit:

- `zuke setup` gains a **`--dir <path>` / `--dir=<path>`** flag. `runSetup` already accepts a target directory; the CLI just hardcoded `"."`. Now you can scaffold into any directory, and the progress line reflects it.
- Help text and the README flag list updated; tests added for the new flag (parsing, the `--dir` path, and the message branch).

Because this is a `feat(cli):` commit touching `packages/cli/`, the next Release run will open the missing **`cli` 0.1.0** release PR.

> ⚠️ **Squash-merge with this PR's title** (`feat(cli): …`) so the commit subject stays a Conventional Commit — that's exactly what was missing for `cli` the first time.

https://claude.ai/code/session_01VRn8gL34mdDPRg4ZTVzGAz

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRn8gL34mdDPRg4ZTVzGAz)_