### PR TITLE
fix(release): bump deno.json via package-relative extra-files (nothing was publishing)

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -10,7 +10,7 @@
       "changelog-path": "CHANGELOG.md",
       "release-as": "0.1.0",
       "extra-files": [
-        { "type": "json", "path": "packages/core/deno.json", "jsonpath": "$.version" }
+        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
       ]
     },
     "packages/deno": {
@@ -18,7 +18,7 @@
       "changelog-path": "CHANGELOG.md",
       "release-as": "0.1.0",
       "extra-files": [
-        { "type": "json", "path": "packages/deno/deno.json", "jsonpath": "$.version" }
+        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
       ]
     },
     "packages/npm": {
@@ -26,7 +26,7 @@
       "changelog-path": "CHANGELOG.md",
       "release-as": "0.1.0",
       "extra-files": [
-        { "type": "json", "path": "packages/npm/deno.json", "jsonpath": "$.version" }
+        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
       ]
     },
     "packages/cmd": {
@@ -34,7 +34,7 @@
       "changelog-path": "CHANGELOG.md",
       "release-as": "0.1.0",
       "extra-files": [
-        { "type": "json", "path": "packages/cmd/deno.json", "jsonpath": "$.version" }
+        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
       ]
     },
     "packages/cli": {
@@ -42,8 +42,8 @@
       "changelog-path": "CHANGELOG.md",
       "release-as": "0.1.0",
       "extra-files": [
-        { "type": "json", "path": "packages/cli/deno.json", "jsonpath": "$.version" },
-        "packages/cli/src/version.ts"
+        { "type": "json", "path": "deno.json", "jsonpath": "$.version" },
+        "src/version.ts"
       ]
     }
   }

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
-  "tag-separator": "-v",
-  "separate-pull-requests": true,
+  "tag-separator": "-",
+  "separate-pull-requests": false,
   "bump-minor-pre-major": true,
   "packages": {
     "packages/core": {

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,7 +1,7 @@
 {
   "packages/core": "0.0.0",
-  "packages/deno": "0.1.0",
+  "packages/deno": "0.0.0",
   "packages/npm": "0.0.0",
   "packages/cmd": "0.0.0",
-  "packages/cli": "0.1.0"
+  "packages/cli": "0.0.0"
 }

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -21,11 +21,11 @@ pull request.
 
 3. **`release` drives release-please.** The `release` target invokes the
    release-please CLI (`release-pr` + `github-release`). release-please
-   maintains a release PR per package (`separate-pull-requests`), bumping the
-   version in `packages/<pkg>/deno.json`, updating the `CHANGELOG.md`, and
-   updating `.release-please-manifest.json`. Merging a release PR tags the
-   release (`<component>-v<version>`, e.g. `core-v0.1.0`) and cuts the GitHub
-   release.
+   maintains a **single** release PR covering every package with pending
+   changes, bumping the version in each `packages/<pkg>/deno.json`, updating the
+   `CHANGELOG.md`s, and updating `.release-please-manifest.json`. Merging it tags
+   each release (`<component>-v<version>`, e.g. `core-v0.1.0`) and cuts the
+   GitHub releases.
 
 4. **`publish` pushes to JSR.** The `publish` target walks the packages
    **core first** (so the workspace's `jsr:@zuke/core` dependency resolves) and
@@ -36,7 +36,7 @@ pull request.
    workflow just grants `id-token: write`.
 
 So the steady-state flow is: merge conventional commits → merge the release PR
-→ the package publishes itself.
+→ the packages publish themselves.
 
 ## First release (one-time bootstrap)
 
@@ -47,17 +47,15 @@ land at exactly `0.1.0`:
   `0.0.0`. `zuke publish` treats `0.0.0` as "not released yet" and skips it, so
   nothing is published until release-please bumps a package to a real version.
 - `.release-please-config.json` pins `"release-as": "0.1.0"` per package, so the
-  first release PR for each is cut at `0.1.0` regardless of commit history.
+  first release is cut at `0.1.0` regardless of commit history.
 
 To cut the first release:
 
-1. Merge this change to `master`. release-please opens four `0.1.0` release PRs
-   (bumping each `deno.json` from `0.0.0` to `0.1.0`); nothing publishes yet.
-2. **Merge the `core` release PR first** and let it publish. The other three
-   import `jsr:@zuke/core@^0`, so core must exist on JSR before they publish.
-   (Within a single run `zuke publish` already orders core first; this only
-   matters because the PRs are separate.)
-3. Merge the `deno`, `npm`, and `cmd` release PRs.
+1. Merge this change to `master`. release-please opens a single `0.1.0` release
+   PR covering all packages (bumping each `deno.json` from `0.0.0` to `0.1.0`);
+   nothing publishes yet.
+2. Merge that release PR. `zuke publish` then publishes every package, **core
+   first**, in one run.
 
 ### Remove the `release-as` pins afterwards
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,8 +1,0 @@
-# Changelog
-
-## 0.1.0 (2026-06-08)
-
-
-### Features
-
-* **cli:** add a --dir flag to scaffold into a chosen directory ([#11](https://github.com/zuke-build/zuke/issues/11)) ([0524413](https://github.com/zuke-build/zuke/commit/05244136ff125f4304036b4397756a67104ef5bc))

--- a/packages/deno/CHANGELOG.md
+++ b/packages/deno/CHANGELOG.md
@@ -1,8 +1,0 @@
-# Changelog
-
-## 0.1.0 (2026-06-08)
-
-
-### Features
-
-* NUKE-style tool wrappers (@zuke/deno, @zuke/npm, @zuke/cmd) + workspace ([#2](https://github.com/zuke-build/zuke/issues/2)) ([c98c4a7](https://github.com/zuke-build/zuke/commit/c98c4a7bb7cc25cc727f98316efcc27025b9c9f5))


### PR DESCRIPTION
## The real problem: nothing is actually on JSR

CI on this PR caught it — the `manifest versions match each package deno.json` test failed because the manifest said `deno`/`cli` = `0.1.0` while every `deno.json` was still `0.0.0`.

**Root cause:** in **manifest mode**, release-please resolves `extra-files` paths **relative to each package directory**, but PR #6 set them to **repo-root** (`packages/core/deno.json`). They matched nothing, so the JSON updater never bumped the `deno.json` versions. release-please advanced its manifest and cut tags, but `zuke publish` keys off `deno.json` (where `0.0.0` = "unreleased"), so it **skipped every package**. The earlier "successful" `deno`/`cli` releases were **no-ops — JSR is still empty.**

## Fix + clean reset

- **`extra-files` → package-relative `deno.json`** (and restore `cli`'s `src/version.ts` to a package-relative path) so the version actually gets bumped.
- Since nothing was published, **reset the manifest + all `deno.json`/`version.ts` to `0.0.0`** so one combined release PR cuts a clean `0.1.0` for all five, publishing **core-first in a single run** (correct JSR dependency order).
- Delete the empty CHANGELOGs the no-op releases left behind.
- Keep: **`separate-pull-requests: false`** (one combined PR, no manifest conflicts) and **`tag-separator: "-"`** (no more `deno-vv0.1.0`).

## Safety net

The `manifest matches deno.json` test now guards this: if the package-relative `extra-files` path were *still* wrong, the **combined release PR's CI would fail** that test rather than silently no-op'ing the publish.

## After merge

1. release-please opens **one combined release PR** (all five at `0.1.0`); this merge itself publishes nothing.
2. Merge that PR → all five publish to JSR, core first.
3. Cleanup (cosmetic, optional): close the stale per-package PRs #7/#9/#10, and delete the orphaned `deno-vv0.1.0` / `cli-vv0.1.0` tags + releases. Then drop the `release-as` pins.

https://claude.ai/code/session_01VRn8gL34mdDPRg4ZTVzGAz