### PR TITLE
chore(release): cut 0.1.1 to publish module docs and provenance

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -8,7 +8,7 @@
     "packages/core": {
       "component": "core",
       "changelog-path": "CHANGELOG.md",
-      "release-as": "0.1.0",
+      "release-as": "0.1.1",
       "extra-files": [
         { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
       ]
@@ -16,7 +16,7 @@
     "packages/deno": {
       "component": "deno",
       "changelog-path": "CHANGELOG.md",
-      "release-as": "0.1.0",
+      "release-as": "0.1.1",
       "extra-files": [
         { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
       ]
@@ -24,7 +24,7 @@
     "packages/npm": {
       "component": "npm",
       "changelog-path": "CHANGELOG.md",
-      "release-as": "0.1.0",
+      "release-as": "0.1.1",
       "extra-files": [
         { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
       ]
@@ -32,7 +32,7 @@
     "packages/cmd": {
       "component": "cmd",
       "changelog-path": "CHANGELOG.md",
-      "release-as": "0.1.0",
+      "release-as": "0.1.1",
       "extra-files": [
         { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
       ]
@@ -40,7 +40,7 @@
     "packages/cli": {
       "component": "cli",
       "changelog-path": "CHANGELOG.md",
-      "release-as": "0.1.0",
+      "release-as": "0.1.1",
       "extra-files": [
         { "type": "json", "path": "deno.json", "jsonpath": "$.version" },
         "src/version.ts"


### PR DESCRIPTION
## Why

The published `0.1.0` predates the `@module` docs merged in #15, so the JSR score's doc checks ("readme/module doc", "examples", "module docs in all entrypoints") still read 0. And `deno`/`cmd`/`cli`'s `0.1.0` was published before their provenance step (those runs stalled), so they lack provenance too. Both only count on a *new* published version.

## What

Bump the five `release-as` pins from `0.1.0` → `0.1.1`. release-please will cut **one combined `0.1.1` release PR**; merging that republishes all five packages with:

- the module docs + examples (now in source), and
- provenance, via the now stall-proof publish step (per-package timeout from #15).

Together with setting each package's **Description** + **Deno runtime** in JSR Settings, this should push every package into the ~90s.

## Verified locally

Ran the full gate with Deno 2.8.2: `fmt`, `lint`, type-check, tests, and coverage (99.4% lines / 97.4% branches) all pass.

## Follow-up

Once `0.1.1` is published, I'll remove the `release-as` pins entirely so future versions are commit-driven.

https://claude.ai/code/session_01VRn8gL34mdDPRg4ZTVzGAz

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRn8gL34mdDPRg4ZTVzGAz)_