### PR TITLE
docs: add per-package READMEs and republish as 0.1.1

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -8,7 +8,6 @@
     "packages/core": {
       "component": "core",
       "changelog-path": "CHANGELOG.md",
-      "release-as": "0.1.1",
       "extra-files": [
         { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
       ]
@@ -16,7 +15,6 @@
     "packages/deno": {
       "component": "deno",
       "changelog-path": "CHANGELOG.md",
-      "release-as": "0.1.1",
       "extra-files": [
         { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
       ]
@@ -24,7 +22,6 @@
     "packages/npm": {
       "component": "npm",
       "changelog-path": "CHANGELOG.md",
-      "release-as": "0.1.1",
       "extra-files": [
         { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
       ]
@@ -32,7 +29,6 @@
     "packages/cmd": {
       "component": "cmd",
       "changelog-path": "CHANGELOG.md",
-      "release-as": "0.1.1",
       "extra-files": [
         { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
       ]
@@ -40,7 +36,6 @@
     "packages/cli": {
       "component": "cli",
       "changelog-path": "CHANGELOG.md",
-      "release-as": "0.1.1",
       "extra-files": [
         { "type": "json", "path": "deno.json", "jsonpath": "$.version" },
         "src/version.ts"

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,9 @@
+# @zuke/cli
+
+The `zuke` command-line tool — scaffold
+[Zuke](https://github.com/zuke-build/zuke#readme) into any project.
+
+```sh
+deno install -A -g -n zuke jsr:@zuke/cli
+zuke setup
+```

--- a/packages/cmd/README.md
+++ b/packages/cmd/README.md
@@ -1,0 +1,11 @@
+# @zuke/cmd
+
+Run any external command as a [Zuke](https://github.com/zuke-build/zuke#readme)
+task — a generic, injection-safe tool wrapper for tools without a dedicated
+package.
+
+```ts
+import { CmdTasks } from "jsr:@zuke/cmd";
+
+await CmdTasks.exec("git", (s) => s.args("rev-parse", "HEAD"));
+```

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,22 @@
+# @zuke/core
+
+Code-first, strongly-typed build automation for Deno. Define builds as
+TypeScript classes; each target is a field wired to others by reference, forming
+a dependency graph that Zuke sorts and runs.
+
+```ts
+import { Build, run, target } from "jsr:@zuke/core";
+
+class MyBuild extends Build {
+  hello = target()
+    .description("Say hello")
+    .executes(() => console.log("Hello from Zuke!"));
+}
+
+if (import.meta.main) await run(MyBuild);
+```
+
+Also exports `jsr:@zuke/core/shell` (the injection-safe `$` runner) and
+`jsr:@zuke/core/tooling` (the base for typed tool wrappers).
+
+See [Zuke](https://github.com/zuke-build/zuke#readme) for the full guide.

--- a/packages/deno/README.md
+++ b/packages/deno/README.md
@@ -1,0 +1,13 @@
+# @zuke/deno
+
+Typed `deno` CLI task wrappers for
+[Zuke](https://github.com/zuke-build/zuke#readme) builds — `fmt`, `lint`,
+`check`, `test`, `coverage`, `cache`, `run`, and `task` in a fluent
+settings-lambda API.
+
+```ts
+import { DenoTasks } from "jsr:@zuke/deno";
+
+await DenoTasks.test((s) => s.allowAll().coverage("cov_profile"));
+await DenoTasks.fmt((s) => s.check());
+```

--- a/packages/npm/README.md
+++ b/packages/npm/README.md
@@ -1,0 +1,12 @@
+# @zuke/npm
+
+Typed `npm` CLI task wrappers for
+[Zuke](https://github.com/zuke-build/zuke#readme) builds — `install`, `ci`,
+`run`, `exec`, `publish`, and `version`.
+
+```ts
+import { NpmTasks } from "jsr:@zuke/npm";
+
+await NpmTasks.ci();
+await NpmTasks.run((s) => s.script("build"));
+```


### PR DESCRIPTION
## Why the last attempt did nothing

PR #16 bumped the `release-as` pins to `0.1.1`, but the release run produced an empty release set:

```
✔ Building strategies by path
❯ packages/core: simple ... packages/cli: simple
[]
```

`release-as` only sets the *version* of a release that's already happening — it can't *start* one. Nothing since `0.1.0` was a `feat`/`fix` (only `ci:`/`docs:`/`chore:`), so release-please had nothing to release.

## What this does

- Adds a short **README** (description + usage example) to each of the five packages. JSR renders it on the package's Overview tab and credits it for the "readme or module doc" score check. This is the genuine change that touches all five package paths.
- Carries a **`Release-As: 0.1.1` trailer** — the documented way to force release-please to cut a release without a feat/fix. Merging this should open a combined `0.1.1` release PR for all five; merging *that* republishes them with the module docs (from #15) and provenance.
- Removes the now-spent `release-as` config pins (they don't trigger and just confuse).

**Please squash-merge** so the trailer reaches `master` in the merge commit.

Verified locally with Deno 2.8.2: fmt, lint, type-check, tests, coverage (99.4%/97.4%), and cspell all pass.

https://claude.ai/code/session_01VRn8gL34mdDPRg4ZTVzGAz

Release-As: 0.1.1

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRn8gL34mdDPRg4ZTVzGAz)_