### PR TITLE
feat(core): CI-aware, coloured build output with a per-target summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,28 @@ Example output:
 ▶ test
 ✔ test (2.4s)
 
+Build summary:
+  ✔ clean    0.0s
+  ✔ restore  0.3s
+  ✔ compile  1.1s
+  ✔ test     2.4s
+
 ✔ SUCCESS — 4/4 targets in 3.8s
 ```
+
+Every run ends with a summary listing each target's status (`✔` passed, `✘`
+failed, `⊘` skipped) and duration, plus the total.
+
+### GitHub Actions
+
+When Zuke detects it's running under GitHub Actions (`GITHUB_ACTIONS=true`), it
+switches to that runner's log conventions automatically — no configuration:
+
+- each target becomes a **collapsible log group**, so the workflow log is tidy
+  and every target is easy to find;
+- a failing target emits an **`::error::` annotation** (surfaced on the run and
+  in the diff); and
+- the per-target summary is also written to the **job summary** as a table.
 
 ## Core concepts
 
@@ -433,7 +453,9 @@ can do — no one has to learn Deno commands.
 
 **Output:** each target prints `▶ name` on start, then `✔ name (1.2s)` or
 `✘ name (0.4s)`. A failure prints the error, aborts the remaining targets, and
-exits `1`. A final summary reports targets run, total time, and overall status.
+exits `1`. A final summary lists every target's status and duration plus the
+total. Under GitHub Actions, targets become collapsible log groups, failures
+emit `::error::` annotations, and the summary is written to the job summary.
 
 ## Execution semantics
 

--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ Build summary:
 Every run ends with a summary listing each target's status (`✔` passed, `✘`
 failed, `⊘` skipped) and duration, plus the total.
 
+In a terminal, consecutive targets are separated by a blank line and the output
+is coloured (bold headers, green/red/dim status). Colour is used when stdout is
+a TTY and `NO_COLOR` is unset; piped output stays plain.
+
 ### GitHub Actions
 
 When Zuke detects it's running under GitHub Actions (`GITHUB_ACTIONS=true`), it

--- a/cspell.json
+++ b/cspell.json
@@ -5,6 +5,7 @@
   "words": [
     "chainers",
     "chmods",
+    "endgroup",
     "cowsay",
     "Interpolatable",
     "jsonpath",

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -2,6 +2,13 @@
  * The executor: resolves a plan, runs each target body in order, reports
  * pass/fail with timing, and aborts on the first failure.
  *
+ * Output adapts to where the build runs. Under GitHub Actions each target is
+ * wrapped in a collapsible log group (`::group::`/`::endgroup::`) with an
+ * `::error::` annotation on failure and a Markdown table appended to the job
+ * summary; in a terminal it prints plain banners. Either way a per-target
+ * summary — each target's status and duration, plus the total — is printed when
+ * the build finishes.
+ *
  * Sequencing and de-duplication are handled by {@link plan} — the returned
  * order already contains each target exactly once, so diamond dependencies run
  * their shared prerequisite a single time.
@@ -32,6 +39,35 @@ export interface ExecuteOptions {
   reporter?: Reporter;
   /** Target names to skip even if they appear in the plan (CLI `--skip`). */
   skip?: string[];
+  /**
+   * Force GitHub Actions output formatting on or off. Auto-detected from the
+   * `GITHUB_ACTIONS` environment variable when omitted.
+   */
+  github?: boolean;
+}
+
+/** A target's outcome, collected for the end-of-build summary. */
+type TargetStatus = "passed" | "failed" | "skipped";
+
+interface TargetReport {
+  name: string;
+  status: TargetStatus;
+  ms: number;
+}
+
+const ICON: Record<TargetStatus, string> = {
+  passed: "✔",
+  failed: "✘",
+  skipped: "⊘",
+};
+
+/** Whether the build is running inside a GitHub Actions runner. */
+function inGitHubActions(): boolean {
+  try {
+    return Deno.env.get("GITHUB_ACTIONS") === "true";
+  } catch {
+    return false;
+  }
 }
 
 /** Format a duration in milliseconds as `1.2s`. */
@@ -39,11 +75,98 @@ function formatDuration(ms: number): string {
   return `${(ms / 1000).toFixed(1)}s`;
 }
 
+/** Open a target's section — a collapsible group under GitHub Actions. */
+function openTarget(r: Reporter, github: boolean, name: string): void {
+  r.info(github ? `::group::${name}` : `▶ ${name}`);
+}
+
+/** Close a target's section after it succeeded. */
+function passTarget(
+  r: Reporter,
+  github: boolean,
+  name: string,
+  ms: number,
+): void {
+  r.info(`${ICON.passed} ${name} (${formatDuration(ms)})`);
+  if (github) r.info("::endgroup::");
+}
+
+/** Close a target's section after it failed and surface the error. */
+function failTarget(
+  r: Reporter,
+  github: boolean,
+  name: string,
+  ms: number,
+  error: unknown,
+): void {
+  const message = error instanceof Error ? error.message : String(error);
+  r.error(`${ICON.failed} ${name} (${formatDuration(ms)})`);
+  r.error(message);
+  if (github) {
+    r.info("::endgroup::");
+    r.error(`::error title=${name}::${name} failed: ${message}`);
+  }
+}
+
+/** Render the end-of-build summary block. */
+function summaryBlock(
+  reports: TargetReport[],
+  totalMs: number,
+  ok: boolean,
+): string {
+  const width = reports.reduce((w, x) => Math.max(w, x.name.length), 0);
+  const rows = reports.map((x) => {
+    const right = x.status === "skipped" ? "skipped" : formatDuration(x.ms);
+    return `  ${ICON[x.status]} ${x.name.padEnd(width)}  ${right}`;
+  });
+  const passed = reports.filter((x) => x.status === "passed").length;
+  const banner = `${ok ? ICON.passed : ICON.failed} ` +
+    `${ok ? "SUCCESS" : "FAILED"} — ${passed}/${reports.length} targets ` +
+    `in ${formatDuration(totalMs)}`;
+  return ["", "Build summary:", ...rows, "", banner].join("\n");
+}
+
+/** Append a Markdown summary to the GitHub Actions job-summary file, if set. */
+function writeJobSummary(
+  reports: TargetReport[],
+  totalMs: number,
+  ok: boolean,
+): void {
+  let path: string | undefined;
+  try {
+    path = Deno.env.get("GITHUB_STEP_SUMMARY");
+  } catch {
+    return;
+  }
+  if (path === undefined || path === "") return;
+
+  const passed = reports.filter((x) => x.status === "passed").length;
+  const rows = reports.map((x) => {
+    const time = x.status === "skipped" ? "—" : formatDuration(x.ms);
+    return `| ${x.name} | ${ICON[x.status]} ${x.status} | ${time} |`;
+  });
+  const markdown = [
+    `## ${ok ? "✅" : "❌"} Zuke build — ${passed}/${reports.length} ` +
+    `targets in ${formatDuration(totalMs)}`,
+    "",
+    "| Target | Result | Time |",
+    "| --- | --- | --- |",
+    ...rows,
+    "",
+  ].join("\n");
+  try {
+    Deno.writeTextFileSync(path, markdown, { append: true });
+  } catch {
+    // Best-effort: an unwritable summary file must never fail the build.
+  }
+}
+
 /**
  * Execute the requested target and its transitive dependencies.
  *
  * Runs the build's `onStart`/`onFinish` lifecycle hooks around the plan. Stops
- * at the first target that throws, reports it, and returns a failing result.
+ * at the first target that throws, reports it, marks the unreached targets as
+ * skipped, and returns a failing result.
  */
 export async function execute(
   build: Build,
@@ -52,70 +175,63 @@ export async function execute(
 ): Promise<BuildResult> {
   const reporter = options.reporter ??
     (options.silent ? silentReporter : consoleReporter);
-
+  const github = options.github ?? inGitHubActions();
   const skip = new Set(options.skip ?? []);
-  const order = plan(root).filter((t) => !skip.has(t.name_ ?? ""));
+
+  const order = plan(root);
+  const reports: TargetReport[] = [];
   const executed: string[] = [];
   const overallStart = performance.now();
 
   await build.onStart();
 
-  let result: BuildResult;
-  try {
-    for (const t of order) {
-      const name = t.name_ ?? "<unnamed>";
-      if (!t.fn_) {
-        throw new Error(
-          `Target "${name}" has no body — call .executes(...) before running.`,
-        );
-      }
+  let failure: unknown;
+  let aborted = false;
 
-      reporter.info(`▶ ${name}`);
-      const start = performance.now();
-      try {
-        await t.fn_();
-      } catch (error) {
-        const elapsed = formatDuration(performance.now() - start);
-        reporter.error(`✘ ${name} (${elapsed})`);
-        reporter.error(
-          error instanceof Error ? error.message : String(error),
-        );
-        result = { ok: false, executed, error };
-        return await finish(
-          build,
-          reporter,
-          result,
-          overallStart,
-          order.length,
-        );
-      }
-      const elapsed = formatDuration(performance.now() - start);
-      reporter.info(`✔ ${name} (${elapsed})`);
-      executed.push(name);
+  for (const t of order) {
+    const name = t.name_ ?? "<unnamed>";
+
+    if (skip.has(name) || aborted) {
+      reports.push({ name, status: "skipped", ms: 0 });
+      continue;
     }
-    result = { ok: true, executed };
-  } catch (error) {
-    // A pre-flight error (e.g. missing body) before/outside a target body.
-    result = { ok: false, executed, error };
+
+    openTarget(reporter, github, name);
+    const start = performance.now();
+
+    if (!t.fn_) {
+      const error = new Error(
+        `Target "${name}" has no body — call .executes(...) before running.`,
+      );
+      failTarget(reporter, github, name, 0, error);
+      reports.push({ name, status: "failed", ms: 0 });
+      failure = error;
+      aborted = true;
+      continue;
+    }
+
+    try {
+      await t.fn_();
+      const ms = performance.now() - start;
+      passTarget(reporter, github, name, ms);
+      reports.push({ name, status: "passed", ms });
+      executed.push(name);
+    } catch (error) {
+      const ms = performance.now() - start;
+      failTarget(reporter, github, name, ms, error);
+      reports.push({ name, status: "failed", ms });
+      failure = error;
+      aborted = true;
+    }
   }
 
-  return await finish(build, reporter, result, overallStart, order.length);
-}
+  const result: BuildResult = aborted
+    ? { ok: false, executed, error: failure }
+    : { ok: true, executed };
 
-/** Print the summary, run the finish hook, and return the result. */
-async function finish(
-  build: Build,
-  reporter: Reporter,
-  result: BuildResult,
-  overallStart: number,
-  planned: number,
-): Promise<BuildResult> {
-  const total = formatDuration(performance.now() - overallStart);
-  const status = result.ok ? "SUCCESS" : "FAILED";
-  reporter.info(
-    `\n${result.ok ? "✔" : "✘"} ${status} — ` +
-      `${result.executed.length}/${planned} targets in ${total}`,
-  );
+  const totalMs = performance.now() - overallStart;
+  reporter.info(summaryBlock(reports, totalMs, result.ok));
+  if (github) writeJobSummary(reports, totalMs, result.ok);
   await build.onFinish(result);
   return result;
 }

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -5,9 +5,11 @@
  * Output adapts to where the build runs. Under GitHub Actions each target is
  * wrapped in a collapsible log group (`::group::`/`::endgroup::`) with an
  * `::error::` annotation on failure and a Markdown table appended to the job
- * summary; in a terminal it prints plain banners. Either way a per-target
- * summary — each target's status and duration, plus the total — is printed when
- * the build finishes.
+ * summary. In a terminal, targets are separated by blank lines and coloured
+ * (bold headers, green/red/dim status) when stdout is a TTY and `NO_COLOR` is
+ * unset; piped output stays plain. Either way a per-target summary — each
+ * target's status and duration, plus the total — is printed when the build
+ * finishes.
  *
  * Sequencing and de-duplication are handled by {@link plan} — the returned
  * order already contains each target exactly once, so diamond dependencies run
@@ -44,6 +46,11 @@ export interface ExecuteOptions {
    * `GITHUB_ACTIONS` environment variable when omitted.
    */
   github?: boolean;
+  /**
+   * Force ANSI colour on or off. Auto-detected (a TTY with `NO_COLOR` unset,
+   * outside GitHub Actions) when omitted; off by default with a custom reporter.
+   */
+  color?: boolean;
 }
 
 /** A target's outcome, collected for the end-of-build summary. */
@@ -61,6 +68,27 @@ const ICON: Record<TargetStatus, string> = {
   skipped: "⊘",
 };
 
+/** ANSI select-graphic-rendition codes used for terminal colour. */
+const SGR = {
+  reset: "\x1b[0m",
+  bold: "\x1b[1m",
+  dim: "\x1b[2m",
+  red: "\x1b[31m",
+  green: "\x1b[32m",
+  cyan: "\x1b[36m",
+};
+
+/** How a run renders its output. */
+interface Style {
+  github: boolean;
+  color: boolean;
+}
+
+/** Wrap text in ANSI codes when colour is enabled, otherwise return it as-is. */
+function paint(color: boolean, codes: string, text: string): string {
+  return color ? `${codes}${text}${SGR.reset}` : text;
+}
+
 /** Whether the build is running inside a GitHub Actions runner. */
 function inGitHubActions(): boolean {
   try {
@@ -70,60 +98,116 @@ function inGitHubActions(): boolean {
   }
 }
 
+/** Whether terminal colour should be used (TTY, and `NO_COLOR` unset). */
+function autoColor(): boolean {
+  try {
+    if (Deno.env.get("NO_COLOR")) return false;
+  } catch {
+    return false;
+  }
+  return Deno.stdout.isTerminal();
+}
+
+/** Resolve the output style from the options and the detected environment. */
+function resolveStyle(options: ExecuteOptions, github: boolean): Style {
+  if (options.color !== undefined) return { github, color: options.color };
+  if (github || options.reporter !== undefined) return { github, color: false };
+  return { github, color: autoColor() };
+}
+
 /** Format a duration in milliseconds as `1.2s`. */
 function formatDuration(ms: number): string {
   return `${(ms / 1000).toFixed(1)}s`;
 }
 
-/** Open a target's section — a collapsible group under GitHub Actions. */
-function openTarget(r: Reporter, github: boolean, name: string): void {
-  r.info(github ? `::group::${name}` : `▶ ${name}`);
+/**
+ * Open a target's section — a collapsible group under GitHub Actions, or a
+ * blank-line-separated bold header in a terminal.
+ */
+function openTarget(
+  r: Reporter,
+  style: Style,
+  name: string,
+  opened: number,
+): void {
+  if (style.github) {
+    r.info(`::group::${name}`);
+    return;
+  }
+  if (opened > 0) r.info("");
+  r.info(paint(style.color, SGR.bold + SGR.cyan, `▶ ${name}`));
 }
 
 /** Close a target's section after it succeeded. */
 function passTarget(
   r: Reporter,
-  github: boolean,
+  style: Style,
   name: string,
   ms: number,
 ): void {
-  r.info(`${ICON.passed} ${name} (${formatDuration(ms)})`);
-  if (github) r.info("::endgroup::");
+  const icon = paint(style.color, SGR.green, ICON.passed);
+  const time = paint(style.color, SGR.dim, `(${formatDuration(ms)})`);
+  r.info(`${icon} ${name} ${time}`);
+  if (style.github) r.info("::endgroup::");
 }
 
 /** Close a target's section after it failed and surface the error. */
 function failTarget(
   r: Reporter,
-  github: boolean,
+  style: Style,
   name: string,
   ms: number,
   error: unknown,
 ): void {
   const message = error instanceof Error ? error.message : String(error);
-  r.error(`${ICON.failed} ${name} (${formatDuration(ms)})`);
-  r.error(message);
-  if (github) {
+  r.error(
+    paint(
+      style.color,
+      SGR.red,
+      `${ICON.failed} ${name} (${formatDuration(ms)})`,
+    ),
+  );
+  r.error(paint(style.color, SGR.red, message));
+  if (style.github) {
     r.info("::endgroup::");
     r.error(`::error title=${name}::${name} failed: ${message}`);
   }
 }
 
+const ROW_COLOR: Record<TargetStatus, string> = {
+  passed: SGR.green,
+  failed: SGR.red,
+  skipped: SGR.dim,
+};
+
 /** Render the end-of-build summary block. */
 function summaryBlock(
+  style: Style,
   reports: TargetReport[],
   totalMs: number,
   ok: boolean,
 ): string {
   const width = reports.reduce((w, x) => Math.max(w, x.name.length), 0);
   const rows = reports.map((x) => {
+    const icon = paint(style.color, ROW_COLOR[x.status], ICON[x.status]);
     const right = x.status === "skipped" ? "skipped" : formatDuration(x.ms);
-    return `  ${ICON[x.status]} ${x.name.padEnd(width)}  ${right}`;
+    return `  ${icon} ${x.name.padEnd(width)}  ${right}`;
   });
   const passed = reports.filter((x) => x.status === "passed").length;
-  const banner = `${ok ? ICON.passed : ICON.failed} ` +
-    `${ok ? "SUCCESS" : "FAILED"} — ${passed}/${reports.length} targets ` +
-    `in ${formatDuration(totalMs)}`;
-  return ["", "Build summary:", ...rows, "", banner].join("\n");
+  const banner = paint(
+    style.color,
+    SGR.bold + (ok ? SGR.green : SGR.red),
+    `${ok ? ICON.passed : ICON.failed} ${ok ? "SUCCESS" : "FAILED"} — ` +
+      `${passed}/${reports.length} targets in ${formatDuration(totalMs)}`,
+  );
+  return [
+    "",
+    paint(style.color, SGR.bold, "Build summary:"),
+    ...rows,
+    "",
+    banner,
+  ]
+    .join("\n");
 }
 
 /** Append a Markdown summary to the GitHub Actions job-summary file, if set. */
@@ -176,6 +260,7 @@ export async function execute(
   const reporter = options.reporter ??
     (options.silent ? silentReporter : consoleReporter);
   const github = options.github ?? inGitHubActions();
+  const style = resolveStyle(options, github);
   const skip = new Set(options.skip ?? []);
 
   const order = plan(root);
@@ -187,6 +272,7 @@ export async function execute(
 
   let failure: unknown;
   let aborted = false;
+  let opened = 0;
 
   for (const t of order) {
     const name = t.name_ ?? "<unnamed>";
@@ -196,14 +282,15 @@ export async function execute(
       continue;
     }
 
-    openTarget(reporter, github, name);
+    openTarget(reporter, style, name, opened);
+    opened++;
     const start = performance.now();
 
     if (!t.fn_) {
       const error = new Error(
         `Target "${name}" has no body — call .executes(...) before running.`,
       );
-      failTarget(reporter, github, name, 0, error);
+      failTarget(reporter, style, name, 0, error);
       reports.push({ name, status: "failed", ms: 0 });
       failure = error;
       aborted = true;
@@ -213,12 +300,12 @@ export async function execute(
     try {
       await t.fn_();
       const ms = performance.now() - start;
-      passTarget(reporter, github, name, ms);
+      passTarget(reporter, style, name, ms);
       reports.push({ name, status: "passed", ms });
       executed.push(name);
     } catch (error) {
       const ms = performance.now() - start;
-      failTarget(reporter, github, name, ms, error);
+      failTarget(reporter, style, name, ms, error);
       reports.push({ name, status: "failed", ms });
       failure = error;
       aborted = true;
@@ -230,8 +317,8 @@ export async function execute(
     : { ok: true, executed };
 
   const totalMs = performance.now() - overallStart;
-  reporter.info(summaryBlock(reports, totalMs, result.ok));
-  if (github) writeJobSummary(reports, totalMs, result.ok);
+  reporter.info(summaryBlock(style, reports, totalMs, result.ok));
+  if (style.github) writeJobSummary(reports, totalMs, result.ok);
   await build.onFinish(result);
   return result;
 }

--- a/packages/core/tests/executor_test.ts
+++ b/packages/core/tests/executor_test.ts
@@ -345,6 +345,34 @@ Deno.test("falls back to the console reporter when none is given", async () => {
   assertEquals(captured.some((l) => l.includes("FAILED")), true);
 });
 
+Deno.test("colour mode wraps output in ANSI codes", async () => {
+  const { lines, reporter } = recorder();
+  class B extends Build {
+    work = target().executes(() => {});
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  await execute(b, b.work, { reporter, github: false, color: true });
+  assertEquals(lines[0].includes("\x1b["), true);
+  assertEquals(lines[0].includes("▶ work"), true);
+  assertEquals(lines[lines.length - 1].includes("\x1b["), true);
+});
+
+Deno.test("plain mode separates consecutive targets with a blank line", async () => {
+  const { lines, reporter } = recorder();
+  class B extends Build {
+    a = target().executes(() => {});
+    b = target().dependsOn(this.a).executes(() => {});
+  }
+  const build = new B();
+  discoverTargets(build);
+
+  await execute(build, build.b, { reporter, github: false, color: false });
+  assertEquals(lines[0], "▶ a"); // no leading blank before the first target
+  assertEquals(lines[lines.indexOf("▶ b") - 1], ""); // blank before the second
+});
+
 Deno.test("an unwritable job-summary file never fails the build", async () => {
   const dir = await Deno.makeTempDir(); // a directory is not writable as a file
   const { reporter } = recorder();

--- a/packages/core/tests/executor_test.ts
+++ b/packages/core/tests/executor_test.ts
@@ -1,9 +1,42 @@
 import { assertEquals, messageOf } from "./_assert.ts";
 import { Build, type BuildResult, discoverTargets } from "../src/build.ts";
 import { target } from "../src/target.ts";
-import { execute, type ExecuteOptions } from "../src/executor.ts";
+import {
+  execute,
+  type ExecuteOptions,
+  type Reporter,
+} from "../src/executor.ts";
 
 const silent: ExecuteOptions = { silent: true };
+
+/** A reporter that records every line, for asserting output. */
+function recorder(): { lines: string[]; reporter: Reporter } {
+  const lines: string[] = [];
+  return {
+    lines,
+    reporter: {
+      info: (line) => void lines.push(line),
+      error: (line) => void lines.push(line),
+    },
+  };
+}
+
+/** Run `fn` with an environment variable temporarily set (or unset). */
+async function withEnv(
+  key: string,
+  value: string | undefined,
+  fn: () => Promise<void>,
+): Promise<void> {
+  const prev = Deno.env.get(key);
+  if (value === undefined) Deno.env.delete(key);
+  else Deno.env.set(key, value);
+  try {
+    await fn();
+  } finally {
+    if (prev === undefined) Deno.env.delete(key);
+    else Deno.env.set(key, prev);
+  }
+}
 
 Deno.test("executes dependencies before dependents, in order", async () => {
   const log: string[] = [];
@@ -112,31 +145,25 @@ Deno.test("a target without a body fails fast", async () => {
   assertEquals(messageOf(result.error).includes("no body"), true);
 });
 
-Deno.test("a custom reporter receives start/success banners and summary", async () => {
-  const lines: string[] = [];
-  const reporter = {
-    info: (line: string) => void lines.push(line),
-    error: (line: string) => void lines.push(line),
-  };
+Deno.test("plain mode prints start/success banners and a summary", async () => {
+  const { lines, reporter } = recorder();
   class B extends Build {
     work = target().executes(() => {});
   }
   const b = new B();
   discoverTargets(b);
 
-  await execute(b, b.work, { reporter });
+  await execute(b, b.work, { reporter, github: false });
   assertEquals(lines[0], "▶ work");
   assertEquals(lines[1].startsWith("✔ work ("), true);
-  assertEquals(lines[2].includes("SUCCESS"), true);
-  assertEquals(lines[2].includes("1/1 targets"), true);
+  const summary = lines[lines.length - 1];
+  assertEquals(summary.includes("Build summary:"), true);
+  assertEquals(summary.includes("SUCCESS"), true);
+  assertEquals(summary.includes("1/1 targets"), true);
 });
 
-Deno.test("failure banner and summary are reported", async () => {
-  const lines: string[] = [];
-  const reporter = {
-    info: (line: string) => void lines.push(line),
-    error: (line: string) => void lines.push(line),
-  };
+Deno.test("plain mode reports a failure banner and summary", async () => {
+  const { lines, reporter } = recorder();
   class B extends Build {
     boom = target().executes(() => {
       throw new Error("nope");
@@ -145,18 +172,14 @@ Deno.test("failure banner and summary are reported", async () => {
   const b = new B();
   discoverTargets(b);
 
-  await execute(b, b.boom, { reporter });
+  await execute(b, b.boom, { reporter, github: false });
   assertEquals(lines.some((l) => l.startsWith("✘ boom (")), true);
   assertEquals(lines.includes("nope"), true);
-  assertEquals(lines.some((l) => l.includes("FAILED")), true);
+  assertEquals(lines[lines.length - 1].includes("FAILED"), true);
 });
 
 Deno.test("a non-Error throw is reported via String coercion", async () => {
-  const lines: string[] = [];
-  const reporter = {
-    info: (line: string) => void lines.push(line),
-    error: (line: string) => void lines.push(line),
-  };
+  const { lines, reporter } = recorder();
   class B extends Build {
     boom = target().executes(() => {
       throw "string failure";
@@ -165,8 +188,179 @@ Deno.test("a non-Error throw is reported via String coercion", async () => {
   const b = new B();
   discoverTargets(b);
 
-  const result = await execute(b, b.boom, { reporter });
+  const result = await execute(b, b.boom, { reporter, github: false });
   assertEquals(result.ok, false);
   assertEquals(result.error, "string failure");
   assertEquals(lines.includes("string failure"), true);
+});
+
+Deno.test("github mode wraps each target in a collapsible group", async () => {
+  const { lines, reporter } = recorder();
+  class B extends Build {
+    work = target().executes(() => {});
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  await withEnv("GITHUB_STEP_SUMMARY", undefined, async () => {
+    await execute(b, b.work, { reporter, github: true });
+  });
+  assertEquals(lines[0], "::group::work");
+  assertEquals(lines.some((l) => l.startsWith("✔ work (")), true);
+  assertEquals(lines.includes("::endgroup::"), true);
+});
+
+Deno.test("github mode emits an ::error annotation on failure", async () => {
+  const { lines, reporter } = recorder();
+  class B extends Build {
+    boom = target().executes(() => {
+      throw new Error("nope");
+    });
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  await withEnv("GITHUB_STEP_SUMMARY", undefined, async () => {
+    await execute(b, b.boom, { reporter, github: true });
+  });
+  assertEquals(lines.includes("::endgroup::"), true);
+  assertEquals(
+    lines.some((l) => l.startsWith("::error title=boom::")),
+    true,
+  );
+  assertEquals(lines.some((l) => l.includes("boom failed: nope")), true);
+});
+
+Deno.test("summary lists skipped targets and counts", async () => {
+  const { lines, reporter } = recorder();
+  class B extends Build {
+    setup = target().executes(() => {});
+    main = target().dependsOn(this.setup).executes(() => {});
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  await execute(b, b.main, { reporter, github: false, skip: ["setup"] });
+  const summary = lines[lines.length - 1];
+  assertEquals(summary.includes("⊘ setup"), true);
+  assertEquals(summary.includes("skipped"), true);
+  assertEquals(summary.includes("✔ main"), true);
+  assertEquals(summary.includes("1/2 targets"), true);
+});
+
+Deno.test("targets after a failure are marked skipped in the summary", async () => {
+  const { lines, reporter } = recorder();
+  class B extends Build {
+    first = target().executes(() => {});
+    boom = target().dependsOn(this.first).executes(() => {
+      throw new Error("x");
+    });
+    last = target().dependsOn(this.boom).executes(() => {});
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  await execute(b, b.last, { reporter, github: false });
+  const summary = lines[lines.length - 1];
+  assertEquals(summary.includes("✔ first"), true);
+  assertEquals(summary.includes("✘ boom"), true);
+  assertEquals(summary.includes("⊘ last"), true);
+  assertEquals(summary.includes("FAILED"), true);
+});
+
+Deno.test("auto-detects GitHub Actions from the environment", async () => {
+  const { lines, reporter } = recorder();
+  class B extends Build {
+    work = target().executes(() => {});
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  await withEnv("GITHUB_STEP_SUMMARY", undefined, async () => {
+    await withEnv("GITHUB_ACTIONS", "true", async () => {
+      await execute(b, b.work, { reporter }); // no github option
+    });
+    assertEquals(lines[0], "::group::work");
+
+    lines.length = 0;
+    await withEnv("GITHUB_ACTIONS", undefined, async () => {
+      await execute(b, b.work, { reporter });
+    });
+    assertEquals(lines[0], "▶ work");
+  });
+});
+
+Deno.test("github mode appends a Markdown job summary", async () => {
+  const tmp = await Deno.makeTempFile();
+  const { reporter } = recorder();
+  class B extends Build {
+    a = target().executes(() => {});
+    b = target().dependsOn(this.a).executes(() => {});
+  }
+  const build = new B();
+  discoverTargets(build);
+
+  try {
+    await withEnv("GITHUB_STEP_SUMMARY", tmp, async () => {
+      await execute(build, build.b, { reporter, github: true });
+    });
+    const md = await Deno.readTextFile(tmp);
+    assertEquals(md.includes("Zuke build"), true);
+    assertEquals(md.includes("| Target | Result | Time |"), true);
+    assertEquals(md.includes("| a | ✔ passed |"), true);
+  } finally {
+    await Deno.remove(tmp);
+  }
+});
+
+Deno.test("falls back to the console reporter when none is given", async () => {
+  const realLog = console.log;
+  const realError = console.error;
+  const captured: string[] = [];
+  const sink = (...args: unknown[]) =>
+    void captured.push(args.map(String).join(" "));
+  class Ok extends Build {
+    work = target().executes(() => {});
+  }
+  class Bad extends Build {
+    boom = target().executes(() => {
+      throw new Error("x");
+    });
+  }
+  const ok = new Ok();
+  discoverTargets(ok);
+  const bad = new Bad();
+  discoverTargets(bad);
+
+  try {
+    console.log = sink;
+    console.error = sink;
+    await execute(ok, ok.work, { github: false });
+    await execute(bad, bad.boom, { github: false });
+  } finally {
+    console.log = realLog;
+    console.error = realError;
+  }
+  assertEquals(captured.some((l) => l.includes("SUCCESS")), true);
+  assertEquals(captured.some((l) => l.includes("FAILED")), true);
+});
+
+Deno.test("an unwritable job-summary file never fails the build", async () => {
+  const dir = await Deno.makeTempDir(); // a directory is not writable as a file
+  const { reporter } = recorder();
+  class B extends Build {
+    work = target().executes(() => {});
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  try {
+    let result: BuildResult | undefined;
+    await withEnv("GITHUB_STEP_SUMMARY", dir, async () => {
+      result = await execute(b, b.work, { reporter, github: true });
+    });
+    assertEquals(result?.ok, true);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
 });


### PR DESCRIPTION
## What

The executor now tailors its output to where the build runs, and always ends with a per-target summary.

### Terminal
- Consecutive targets are separated by a **blank line**, and the output is **coloured**: bold cyan target headers, green/dim success, red failure, and a bold green/red summary banner with per-status row colours.
- Colour is **auto-detected** — used when stdout is a TTY and `NO_COLOR` is unset — and can be forced with `ExecuteOptions.color`. It defaults off when a custom reporter is supplied, so captured/redirected output stays plain.

```
▶ clean
✔ clean (0.0s)

▶ restore
✔ restore (0.3s)

Build summary:
  ✔ clean    0.0s
  ✔ restore  0.3s

✔ SUCCESS — 2/2 targets in 0.3s
```

### GitHub Actions (auto-detected from `GITHUB_ACTIONS`)
- Each target is wrapped in a **collapsible log group** (`::group::` / `::endgroup::`).
- A failing target emits an **`::error::` annotation**.
- The summary is appended to the **job summary** (`$GITHUB_STEP_SUMMARY`) as a Markdown table.

### Always — end-of-build summary
Lists every target's status (`✔` passed, `✘` failed, `⊘` skipped) and duration plus the total. Targets not reached after a failure are reported as skipped.

## Design
- One detection point; `ExecuteOptions.github` / `.color` override it. Other CI providers can be added later the same way — GitHub only for now, as requested.
- `Reporter` (the `info`/`error` sink) is unchanged — additive, non-breaking.

## Verified locally (Deno 2.8.2)
fmt, lint, type-check, all tests, coverage (**98.8% lines / 96.6% branches** aggregate), and cspell all pass. The remaining uncovered lines in `executor.ts` are only the env-permission `catch` guards.

Note: this is a `feat`, so merging it will have release-please propose **`@zuke/core` 0.2.0** (other packages untouched).

https://claude.ai/code/session_01VRn8gL34mdDPRg4ZTVzGAz