### PR TITLE
chore(release): drop the 0.1.0 release-as pins for docker packages

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -43,7 +43,6 @@
     },
     "packages/docker": {
       "component": "docker",
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
@@ -51,7 +50,6 @@
     },
     "packages/docker-compose": {
       "component": "docker-compose",
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         { "type": "json", "path": "deno.json", "jsonpath": "$.version" }


### PR DESCRIPTION
## Summary

`@zuke/docker` and `@zuke/docker-compose` have now published their first
release at **0.1.0** (release PR #24). The one-shot `release-as: "0.1.0"` pins
on both packages have served their purpose, so this removes them.

`release-as` is applied on **every** release-please run, so leaving the pins in
would force each package back to `0.1.0` on its next release and conflict with
the already-published tag. Removing them lets future releases bump normally
(e.g. a `feat` → 0.2.0, a `fix` → 0.1.1).

No code or version changes — only the two pin lines are deleted from
`.release-please-config.json`. The release config test still passes.

https://claude.ai/code/session_01VRn8gL34mdDPRg4ZTVzGAz

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRn8gL34mdDPRg4ZTVzGAz)_