### PR TITLE
feat: add oxlint, eslint, cspell, jest, and vitest tool wrappers

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -54,6 +54,46 @@
       "extra-files": [
         { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
       ]
+    },
+    "packages/oxlint": {
+      "component": "oxlint",
+      "release-as": "0.1.0",
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+      ]
+    },
+    "packages/eslint": {
+      "component": "eslint",
+      "release-as": "0.1.0",
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+      ]
+    },
+    "packages/cspell": {
+      "component": "cspell",
+      "release-as": "0.1.0",
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+      ]
+    },
+    "packages/jest": {
+      "component": "jest",
+      "release-as": "0.1.0",
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+      ]
+    },
+    "packages/vitest": {
+      "component": "vitest",
+      "release-as": "0.1.0",
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+      ]
     }
   }
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -5,5 +5,10 @@
   "packages/cmd": "0.1.1",
   "packages/cli": "0.1.1",
   "packages/docker": "0.1.0",
-  "packages/docker-compose": "0.1.0"
+  "packages/docker-compose": "0.1.0",
+  "packages/oxlint": "0.0.0",
+  "packages/eslint": "0.0.0",
+  "packages/cspell": "0.0.0",
+  "packages/jest": "0.0.0",
+  "packages/vitest": "0.0.0"
 }

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ order. Inspired by [NUKE](https://nuke.build/) for .NET.
 - **Runtime:** Deno
 - **Packages:** `jsr:@zuke/core` plus typed tool wrappers `jsr:@zuke/deno`,
   `jsr:@zuke/npm`, `jsr:@zuke/docker`, `jsr:@zuke/docker-compose`,
-  `jsr:@zuke/cmd` (raw shell via `jsr:@zuke/core/shell`)
+  `jsr:@zuke/oxlint`, `jsr:@zuke/eslint`, `jsr:@zuke/cspell`, `jsr:@zuke/jest`,
+  `jsr:@zuke/vitest`, `jsr:@zuke/cmd` (raw shell via `jsr:@zuke/core/shell`)
 - **Build file:** `zuke.ts` in your project root
 - **Zero runtime dependencies**
 
@@ -83,10 +84,11 @@ Zuke is imported straight from JSR.
 
 > [!NOTE]
 > All packages — `@zuke/core`, `@zuke/deno`, `@zuke/npm`, `@zuke/docker`,
-> `@zuke/docker-compose`, `@zuke/cmd`, and the `@zuke/cli` command — publish to
-> [JSR](https://jsr.io/@zuke) from CI via release-please and OIDC (see
-> [`RELEASING.md`](./RELEASING.md)). The npm scope `@zuke` is not controlled by
-> this project — install from JSR, not npm.
+> `@zuke/docker-compose`, `@zuke/oxlint`, `@zuke/eslint`, `@zuke/cspell`,
+> `@zuke/jest`, `@zuke/vitest`, `@zuke/cmd`, and the `@zuke/cli` command —
+> publish to [JSR](https://jsr.io/@zuke) from CI via release-please and OIDC
+> (see [`RELEASING.md`](./RELEASING.md)). The npm scope `@zuke` is not
+> controlled by this project — install from JSR, not npm.
 
 ### Scaffold a project with `zuke setup`
 
@@ -367,6 +369,11 @@ raises a `ToolNotFoundError` that names the tool and the fix.
 | `@zuke/npm`            | `install`, `ci`, `run`, `exec`, `publish`, `version`                                                                 |
 | `@zuke/docker`         | `build`, `run`, `exec`, `push`, `pull`, `tag`, `login`, `images`, `ps`, `stop`, `start`, `rm`, `rmi`, `save`, `load` |
 | `@zuke/docker-compose` | `up`, `down`, `build`, `pull`, `push`, `run`, `exec`, `logs`, `ps`, `config`, `start`, `stop`, `restart`, `rm`       |
+| `@zuke/oxlint`         | `lint`                                                                                                               |
+| `@zuke/eslint`         | `lint`                                                                                                               |
+| `@zuke/cspell`         | `lint`                                                                                                               |
+| `@zuke/jest`           | `run`                                                                                                                |
+| `@zuke/vitest`         | `run`                                                                                                                |
 | `@zuke/cmd`            | `exec` (any tool)                                                                                                    |
 
 ## Using Zuke in a Node/npm project

--- a/cspell.json
+++ b/cspell.json
@@ -11,6 +11,8 @@
     "jsonpath",
     "OIDC",
     "mytool",
+    "oxlint",
+    "oxlintrc",
     "spawnable",
     "topo",
     "unconfigured",

--- a/deno.json
+++ b/deno.json
@@ -6,7 +6,12 @@
     "packages/npm",
     "packages/cli",
     "packages/docker",
-    "packages/docker-compose"
+    "packages/docker-compose",
+    "packages/oxlint",
+    "packages/eslint",
+    "packages/cspell",
+    "packages/jest",
+    "packages/vitest"
   ],
   "tasks": {
     "zuke": "deno run -A zuke.ts",

--- a/deno.lock
+++ b/deno.lock
@@ -562,6 +562,11 @@
           "jsr:@zuke/core@0"
         ]
       },
+      "packages/cspell": {
+        "dependencies": [
+          "jsr:@zuke/core@0"
+        ]
+      },
       "packages/deno": {
         "dependencies": [
           "jsr:@zuke/core@0"
@@ -577,7 +582,27 @@
           "jsr:@zuke/core@0"
         ]
       },
+      "packages/eslint": {
+        "dependencies": [
+          "jsr:@zuke/core@0"
+        ]
+      },
+      "packages/jest": {
+        "dependencies": [
+          "jsr:@zuke/core@0"
+        ]
+      },
       "packages/npm": {
+        "dependencies": [
+          "jsr:@zuke/core@0"
+        ]
+      },
+      "packages/oxlint": {
+        "dependencies": [
+          "jsr:@zuke/core@0"
+        ]
+      },
+      "packages/vitest": {
         "dependencies": [
           "jsr:@zuke/core@0"
         ]

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/cli",
   "version": "0.1.1",
+  "description": "The zuke command-line tool — scaffold a Zuke project with `zuke setup`, including a starter build, launchers, and tasks.",
   "exports": {
     ".": "./mod.ts"
   },

--- a/packages/cmd/deno.json
+++ b/packages/cmd/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/cmd",
   "version": "0.1.1",
+  "description": "Generic command task wrapper for Zuke builds — run any CLI tool through a typed, injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"
   },

--- a/packages/core/deno.json
+++ b/packages/core/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/core",
   "version": "0.2.0",
+  "description": "Core of Zuke: a code-first, strongly-typed build-automation library for Deno & TypeScript with a typed target graph and an injection-free shell.",
   "exports": {
     ".": "./mod.ts",
     "./shell": "./src/shell.ts",

--- a/packages/cspell/README.md
+++ b/packages/cspell/README.md
@@ -1,0 +1,14 @@
+# @zuke/cspell
+
+Typed [`cspell`](https://cspell.org/) task wrappers for
+[Zuke](https://github.com/zuke-build/zuke#readme) builds, in a fluent
+settings-lambda API. Arguments stay a discrete argv array, so command
+construction is injection-free.
+
+```ts
+import { CspellTasks } from "jsr:@zuke/cspell";
+
+await CspellTasks.lint((s) =>
+  s.files("**").config("cspell.json").noProgress().showSuggestions()
+);
+```

--- a/packages/cspell/deno.json
+++ b/packages/cspell/deno.json
@@ -1,0 +1,13 @@
+{
+  "name": "@zuke/cspell",
+  "version": "0.0.0",
+  "exports": {
+    ".": "./mod.ts"
+  },
+  "imports": {
+    "@zuke/core": "jsr:@zuke/core@^0"
+  },
+  "publish": {
+    "exclude": ["tests/"]
+  }
+}

--- a/packages/cspell/deno.json
+++ b/packages/cspell/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/cspell",
   "version": "0.0.0",
+  "description": "Typed cspell task wrappers for Zuke builds — spell-check files and globs via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"
   },

--- a/packages/cspell/mod.ts
+++ b/packages/cspell/mod.ts
@@ -1,0 +1,15 @@
+/**
+ * `@zuke/cspell` — typed `cspell` task wrappers for Zuke builds.
+ *
+ * Configure a fluent settings object in a lambda; the task builds the argv and
+ * runs it.
+ *
+ * ```ts
+ * import { CspellTasks } from "jsr:@zuke/cspell";
+ * await CspellTasks.lint((s) => s.files("**").noProgress().showSuggestions());
+ * ```
+ *
+ * @module
+ */
+
+export * from "./src/cspell.ts";

--- a/packages/cspell/src/cspell.ts
+++ b/packages/cspell/src/cspell.ts
@@ -1,0 +1,159 @@
+/**
+ * `CspellTasks` — typed task functions for the `cspell` spell-checker, in the
+ * same settings-lambda style as the other Zuke tool wrappers: configure a
+ * fluent settings object in a lambda, and the task function builds the command
+ * line and executes it.
+ *
+ * ```ts
+ * import { CspellTasks } from "jsr:@zuke/cspell";
+ * await CspellTasks.lint((s) => s.files("**").noProgress().showSuggestions());
+ * ```
+ *
+ * Arguments stay a discrete argv array end-to-end — never a concatenated shell
+ * string — so command construction is injection-free.
+ *
+ * @module
+ */
+
+import { type Configure, runSettings, ToolSettings } from "@zuke/core/tooling";
+import type { CommandOutput } from "@zuke/core/shell";
+
+/** Settings for a `cspell lint` run. */
+export class CspellSettings extends ToolSettings {
+  #files: string[] = [];
+  #config?: string;
+  #noProgress = false;
+  #noSummary = false;
+  #showSuggestions = false;
+  #showContext = false;
+  #quietOutput = false;
+  #cache = false;
+  #dot = false;
+  #gitignore = false;
+  #unique = false;
+  #locale?: string;
+  #excludes: string[] = [];
+  #maxDuplicateProblems?: number;
+
+  protected override defaultTool(): string {
+    return "cspell";
+  }
+
+  /** Files or globs to check (positional); repeatable. */
+  files(...globs: string[]): this {
+    this.#files.push(...globs);
+    return this;
+  }
+
+  /** Use an explicit config file (`-c`/`--config`). */
+  config(path: string): this {
+    this.#config = path;
+    return this;
+  }
+
+  /** Suppress the progress output (`--no-progress`). */
+  noProgress(): this {
+    this.#noProgress = true;
+    return this;
+  }
+
+  /** Suppress the summary line (`--no-summary`). */
+  noSummary(): this {
+    this.#noSummary = true;
+    return this;
+  }
+
+  /** Print spelling suggestions for each issue (`--show-suggestions`). */
+  showSuggestions(): this {
+    this.#showSuggestions = true;
+    return this;
+  }
+
+  /** Print the surrounding line for each issue (`--show-context`). */
+  showContext(): this {
+    this.#showContext = true;
+    return this;
+  }
+
+  /** Only emit issues, hiding informational output (`--quiet`). */
+  quietOutput(): this {
+    this.#quietOutput = true;
+    return this;
+  }
+
+  /** Cache results between runs (`--cache`). */
+  cache(): this {
+    this.#cache = true;
+    return this;
+  }
+
+  /** Include dotfiles and dot-directories (`--dot`). */
+  dot(): this {
+    this.#dot = true;
+    return this;
+  }
+
+  /** Honour `.gitignore` files (`--gitignore`). */
+  gitignore(): this {
+    this.#gitignore = true;
+    return this;
+  }
+
+  /** Report each unique issue only once (`--unique`). */
+  unique(): this {
+    this.#unique = true;
+    return this;
+  }
+
+  /** Restrict to a locale, e.g. `en,en-GB` (`--locale`). */
+  locale(value: string): this {
+    this.#locale = value;
+    return this;
+  }
+
+  /** Exclude files matching a glob (`-e`/`--exclude`); repeatable. */
+  exclude(glob: string): this {
+    this.#excludes.push("-e", glob);
+    return this;
+  }
+
+  /** Cap the number of duplicate problems reported (`--max-duplicate-problems`). */
+  maxDuplicateProblems(count: number): this {
+    this.#maxDuplicateProblems = count;
+    return this;
+  }
+
+  protected override buildArgs(): string[] {
+    const argv = ["lint"];
+    if (this.#config !== undefined) argv.push("-c", this.#config);
+    if (this.#noProgress) argv.push("--no-progress");
+    if (this.#noSummary) argv.push("--no-summary");
+    if (this.#showSuggestions) argv.push("--show-suggestions");
+    if (this.#showContext) argv.push("--show-context");
+    if (this.#quietOutput) argv.push("--quiet");
+    if (this.#cache) argv.push("--cache");
+    if (this.#dot) argv.push("--dot");
+    if (this.#gitignore) argv.push("--gitignore");
+    if (this.#unique) argv.push("--unique");
+    if (this.#locale !== undefined) argv.push("--locale", this.#locale);
+    argv.push(...this.#excludes);
+    if (this.#maxDuplicateProblems !== undefined) {
+      argv.push("--max-duplicate-problems", String(this.#maxDuplicateProblems));
+    }
+    argv.push(...this.#files);
+    return argv;
+  }
+}
+
+/** The shape of {@link CspellTasks}. */
+export interface CspellTasksApi {
+  /** Spell-check with `cspell lint`. */
+  lint(configure?: Configure<CspellSettings>): Promise<CommandOutput>;
+}
+
+/** Typed task functions for the `cspell` spell-checker. */
+export const CspellTasks: CspellTasksApi = {
+  lint(configure?: Configure<CspellSettings>): Promise<CommandOutput> {
+    return runSettings(new CspellSettings(), configure);
+  },
+};

--- a/packages/cspell/tests/cspell_test.ts
+++ b/packages/cspell/tests/cspell_test.ts
@@ -1,0 +1,57 @@
+import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
+import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { CspellSettings, CspellTasks } from "../src/cspell.ts";
+
+Deno.test("the default invocation is cspell lint", () => {
+  assertEquals(new CspellSettings().argv(), ["cspell", "lint"]);
+});
+
+Deno.test("cspell: every option renders, files last", () => {
+  const argv = new CspellSettings()
+    .config("cspell.json").noProgress().noSummary().showSuggestions()
+    .showContext().quietOutput().cache().dot().gitignore().unique()
+    .locale("en,en-GB").exclude("dist/**").exclude("vendor/**")
+    .maxDuplicateProblems(5).files("**", "docs/**").argv();
+  assertEquals(argv, [
+    "cspell",
+    "lint",
+    "-c",
+    "cspell.json",
+    "--no-progress",
+    "--no-summary",
+    "--show-suggestions",
+    "--show-context",
+    "--quiet",
+    "--cache",
+    "--dot",
+    "--gitignore",
+    "--unique",
+    "--locale",
+    "en,en-GB",
+    "-e",
+    "dist/**",
+    "-e",
+    "vendor/**",
+    "--max-duplicate-problems",
+    "5",
+    "**",
+    "docs/**",
+  ]);
+});
+
+Deno.test("cspell: minimal checks just the given glob", () => {
+  assertEquals(new CspellSettings().files("**").argv(), [
+    "cspell",
+    "lint",
+    "**",
+  ]);
+});
+
+const missing = <S extends ToolSettings>(s: S): S => {
+  s.os_ = "linux";
+  return s.toolPath("zz-no-such-cspell-zz");
+};
+
+Deno.test("CspellTasks.lint reaches execution", async () => {
+  await assertRejects(() => CspellTasks.lint(missing), ToolNotFoundError);
+});

--- a/packages/deno/deno.json
+++ b/packages/deno/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/deno",
   "version": "0.1.1",
+  "description": "Typed deno CLI task wrappers for Zuke builds — run, test, check, fmt, lint, cache, coverage, and task via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"
   },

--- a/packages/docker-compose/deno.json
+++ b/packages/docker-compose/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/docker-compose",
   "version": "0.1.0",
+  "description": "Typed Docker Compose task wrappers for Zuke builds — auto-detects `docker compose` (v2) vs `docker-compose` (v1); up, down, build, logs, ps, and more.",
   "exports": {
     ".": "./mod.ts"
   },

--- a/packages/docker/deno.json
+++ b/packages/docker/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/docker",
   "version": "0.1.0",
+  "description": "Typed docker CLI task wrappers for Zuke builds — build, run, exec, push, pull, tag, login, images, ps, and more via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"
   },

--- a/packages/eslint/README.md
+++ b/packages/eslint/README.md
@@ -1,0 +1,14 @@
+# @zuke/eslint
+
+Typed [`eslint`](https://eslint.org/) task wrappers for
+[Zuke](https://github.com/zuke-build/zuke#readme) builds, in a fluent
+settings-lambda API. Arguments stay a discrete argv array, so command
+construction is injection-free.
+
+```ts
+import { EslintTasks } from "jsr:@zuke/eslint";
+
+await EslintTasks.lint((s) =>
+  s.paths("src").ext(".ts", ".tsx").fix().maxWarnings(0)
+);
+```

--- a/packages/eslint/deno.json
+++ b/packages/eslint/deno.json
@@ -1,0 +1,13 @@
+{
+  "name": "@zuke/eslint",
+  "version": "0.0.0",
+  "exports": {
+    ".": "./mod.ts"
+  },
+  "imports": {
+    "@zuke/core": "jsr:@zuke/core@^0"
+  },
+  "publish": {
+    "exclude": ["tests/"]
+  }
+}

--- a/packages/eslint/deno.json
+++ b/packages/eslint/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/eslint",
   "version": "0.0.0",
+  "description": "Typed eslint task wrappers for Zuke builds — lint, fix, caching, and reporters via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"
   },

--- a/packages/eslint/mod.ts
+++ b/packages/eslint/mod.ts
@@ -1,0 +1,15 @@
+/**
+ * `@zuke/eslint` — typed `eslint` task wrappers for Zuke builds.
+ *
+ * Configure a fluent settings object in a lambda; the task builds the argv and
+ * runs it.
+ *
+ * ```ts
+ * import { EslintTasks } from "jsr:@zuke/eslint";
+ * await EslintTasks.lint((s) => s.paths("src").ext(".ts", ".tsx").fix());
+ * ```
+ *
+ * @module
+ */
+
+export * from "./src/eslint.ts";

--- a/packages/eslint/src/eslint.ts
+++ b/packages/eslint/src/eslint.ts
@@ -1,0 +1,189 @@
+/**
+ * `EslintTasks` — typed task functions for the `eslint` linter, in the same
+ * settings-lambda style as the other Zuke tool wrappers: configure a fluent
+ * settings object in a lambda, and the task function builds the command line
+ * and executes it.
+ *
+ * ```ts
+ * import { EslintTasks } from "jsr:@zuke/eslint";
+ * await EslintTasks.lint((s) => s.paths("src").ext(".ts", ".tsx").fix());
+ * ```
+ *
+ * Arguments stay a discrete argv array end-to-end — never a concatenated shell
+ * string — so command construction is injection-free.
+ *
+ * @module
+ */
+
+import { type Configure, runSettings, ToolSettings } from "@zuke/core/tooling";
+import type { CommandOutput } from "@zuke/core/shell";
+
+/** Settings for an `eslint` run. */
+export class EslintSettings extends ToolSettings {
+  #paths: string[] = [];
+  #config?: string;
+  #exts: string[] = [];
+  #fix = false;
+  #fixDryRun = false;
+  #fixTypes: string[] = [];
+  #quietWarnings = false;
+  #maxWarnings?: number;
+  #format?: string;
+  #outputFile?: string;
+  #cache = false;
+  #cacheLocation?: string;
+  #ignorePath?: string;
+  #ignorePatterns: string[] = [];
+  #noIgnore = false;
+  #noConfigLookup = false;
+  #reportUnusedDisableDirectives = false;
+
+  protected override defaultTool(): string {
+    return "eslint";
+  }
+
+  /** Files, directories, or globs to lint (positional); repeatable. */
+  paths(...values: string[]): this {
+    this.#paths.push(...values);
+    return this;
+  }
+
+  /** Use an explicit config file (`-c`/`--config`). */
+  config(path: string): this {
+    this.#config = path;
+    return this;
+  }
+
+  /** Additional file extensions to lint (`--ext`); repeatable. */
+  ext(...extensions: string[]): this {
+    for (const extension of extensions) this.#exts.push("--ext", extension);
+    return this;
+  }
+
+  /** Apply automatic fixes (`--fix`). */
+  fix(): this {
+    this.#fix = true;
+    return this;
+  }
+
+  /** Compute fixes without writing them (`--fix-dry-run`). */
+  fixDryRun(): this {
+    this.#fixDryRun = true;
+    return this;
+  }
+
+  /** Restrict fixes to the given types (`--fix-type`); repeatable. */
+  fixType(...types: string[]): this {
+    for (const type of types) this.#fixTypes.push("--fix-type", type);
+    return this;
+  }
+
+  /** Report errors only, suppressing warnings (`--quiet`). */
+  quietWarnings(): this {
+    this.#quietWarnings = true;
+    return this;
+  }
+
+  /** Fail once this many warnings are reached (`--max-warnings`). */
+  maxWarnings(count: number): this {
+    this.#maxWarnings = count;
+    return this;
+  }
+
+  /** Output format, e.g. `stylish`, `json` (`-f`/`--format`). */
+  format(value: string): this {
+    this.#format = value;
+    return this;
+  }
+
+  /** Write the report to a file (`-o`/`--output-file`). */
+  outputFile(path: string): this {
+    this.#outputFile = path;
+    return this;
+  }
+
+  /** Cache results between runs (`--cache`). */
+  cache(): this {
+    this.#cache = true;
+    return this;
+  }
+
+  /** Where to store the cache (`--cache-location`). */
+  cacheLocation(path: string): this {
+    this.#cacheLocation = path;
+    return this;
+  }
+
+  /** Read ignore globs from a file (`--ignore-path`). */
+  ignorePath(path: string): this {
+    this.#ignorePath = path;
+    return this;
+  }
+
+  /** Ignore files matching a glob (`--ignore-pattern`); repeatable. */
+  ignorePattern(glob: string): this {
+    this.#ignorePatterns.push("--ignore-pattern", glob);
+    return this;
+  }
+
+  /** Disable all ignore handling (`--no-ignore`). */
+  noIgnore(): this {
+    this.#noIgnore = true;
+    return this;
+  }
+
+  /** Do not search for a config file (`--no-config-lookup`). */
+  noConfigLookup(): this {
+    this.#noConfigLookup = true;
+    return this;
+  }
+
+  /** Report unused `eslint-disable` directives (`--report-unused-disable-directives`). */
+  reportUnusedDisableDirectives(): this {
+    this.#reportUnusedDisableDirectives = true;
+    return this;
+  }
+
+  protected override buildArgs(): string[] {
+    const argv: string[] = [];
+    if (this.#config !== undefined) argv.push("-c", this.#config);
+    argv.push(...this.#exts);
+    if (this.#fix) argv.push("--fix");
+    if (this.#fixDryRun) argv.push("--fix-dry-run");
+    argv.push(...this.#fixTypes);
+    if (this.#quietWarnings) argv.push("--quiet");
+    if (this.#maxWarnings !== undefined) {
+      argv.push("--max-warnings", String(this.#maxWarnings));
+    }
+    if (this.#format !== undefined) argv.push("-f", this.#format);
+    if (this.#outputFile !== undefined) argv.push("-o", this.#outputFile);
+    if (this.#cache) argv.push("--cache");
+    if (this.#cacheLocation !== undefined) {
+      argv.push("--cache-location", this.#cacheLocation);
+    }
+    if (this.#ignorePath !== undefined) {
+      argv.push("--ignore-path", this.#ignorePath);
+    }
+    argv.push(...this.#ignorePatterns);
+    if (this.#noIgnore) argv.push("--no-ignore");
+    if (this.#noConfigLookup) argv.push("--no-config-lookup");
+    if (this.#reportUnusedDisableDirectives) {
+      argv.push("--report-unused-disable-directives");
+    }
+    argv.push(...this.#paths);
+    return argv;
+  }
+}
+
+/** The shape of {@link EslintTasks}. */
+export interface EslintTasksApi {
+  /** Lint with `eslint`. */
+  lint(configure?: Configure<EslintSettings>): Promise<CommandOutput>;
+}
+
+/** Typed task functions for the `eslint` linter. */
+export const EslintTasks: EslintTasksApi = {
+  lint(configure?: Configure<EslintSettings>): Promise<CommandOutput> {
+    return runSettings(new EslintSettings(), configure);
+  },
+};

--- a/packages/eslint/tests/eslint_test.ts
+++ b/packages/eslint/tests/eslint_test.ts
@@ -1,0 +1,64 @@
+import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
+import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { EslintSettings, EslintTasks } from "../src/eslint.ts";
+
+Deno.test("the default binary is eslint", () => {
+  assertEquals(new EslintSettings().argv(), ["eslint"]);
+});
+
+Deno.test("eslint: every option renders, paths last", () => {
+  const argv = new EslintSettings()
+    .config("eslint.config.js").ext(".ts", ".tsx").fix().fixDryRun()
+    .fixType("problem", "suggestion").quietWarnings().maxWarnings(0)
+    .format("json").outputFile("report.json").cache()
+    .cacheLocation(".eslintcache").ignorePath(".eslintignore")
+    .ignorePattern("dist/**").noIgnore().noConfigLookup()
+    .reportUnusedDisableDirectives().paths("src", "test").argv();
+  assertEquals(argv, [
+    "eslint",
+    "-c",
+    "eslint.config.js",
+    "--ext",
+    ".ts",
+    "--ext",
+    ".tsx",
+    "--fix",
+    "--fix-dry-run",
+    "--fix-type",
+    "problem",
+    "--fix-type",
+    "suggestion",
+    "--quiet",
+    "--max-warnings",
+    "0",
+    "-f",
+    "json",
+    "-o",
+    "report.json",
+    "--cache",
+    "--cache-location",
+    ".eslintcache",
+    "--ignore-path",
+    ".eslintignore",
+    "--ignore-pattern",
+    "dist/**",
+    "--no-ignore",
+    "--no-config-lookup",
+    "--report-unused-disable-directives",
+    "src",
+    "test",
+  ]);
+});
+
+Deno.test("eslint: minimal lints just the given path", () => {
+  assertEquals(new EslintSettings().paths("src").argv(), ["eslint", "src"]);
+});
+
+const missing = <S extends ToolSettings>(s: S): S => {
+  s.os_ = "linux";
+  return s.toolPath("zz-no-such-eslint-zz");
+};
+
+Deno.test("EslintTasks.lint reaches execution", async () => {
+  await assertRejects(() => EslintTasks.lint(missing), ToolNotFoundError);
+});

--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -1,0 +1,12 @@
+# @zuke/jest
+
+Typed [`jest`](https://jestjs.io/) task wrappers for
+[Zuke](https://github.com/zuke-build/zuke#readme) builds, in a fluent
+settings-lambda API. Arguments stay a discrete argv array, so command
+construction is injection-free.
+
+```ts
+import { JestTasks } from "jsr:@zuke/jest";
+
+await JestTasks.run((s) => s.ci().coverage().maxWorkers("50%").bail());
+```

--- a/packages/jest/deno.json
+++ b/packages/jest/deno.json
@@ -1,0 +1,13 @@
+{
+  "name": "@zuke/jest",
+  "version": "0.0.0",
+  "exports": {
+    ".": "./mod.ts"
+  },
+  "imports": {
+    "@zuke/core": "jsr:@zuke/core@^0"
+  },
+  "publish": {
+    "exclude": ["tests/"]
+  }
+}

--- a/packages/jest/deno.json
+++ b/packages/jest/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/jest",
   "version": "0.0.0",
+  "description": "Typed jest task wrappers for Zuke builds — coverage, CI mode, workers, snapshots, and reporters via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"
   },

--- a/packages/jest/mod.ts
+++ b/packages/jest/mod.ts
@@ -1,0 +1,15 @@
+/**
+ * `@zuke/jest` — typed `jest` task wrappers for Zuke builds.
+ *
+ * Configure a fluent settings object in a lambda; the task builds the argv and
+ * runs it.
+ *
+ * ```ts
+ * import { JestTasks } from "jsr:@zuke/jest";
+ * await JestTasks.run((s) => s.ci().coverage().maxWorkers(2));
+ * ```
+ *
+ * @module
+ */
+
+export * from "./src/jest.ts";

--- a/packages/jest/src/jest.ts
+++ b/packages/jest/src/jest.ts
@@ -1,0 +1,195 @@
+/**
+ * `JestTasks` — typed task functions for the `jest` test runner, in the same
+ * settings-lambda style as the other Zuke tool wrappers: configure a fluent
+ * settings object in a lambda, and the task function builds the command line
+ * and executes it.
+ *
+ * ```ts
+ * import { JestTasks } from "jsr:@zuke/jest";
+ * await JestTasks.run((s) => s.ci().coverage().maxWorkers(2));
+ * ```
+ *
+ * Arguments stay a discrete argv array end-to-end — never a concatenated shell
+ * string — so command construction is injection-free.
+ *
+ * @module
+ */
+
+import { type Configure, runSettings, ToolSettings } from "@zuke/core/tooling";
+import type { CommandOutput } from "@zuke/core/shell";
+
+/** Settings for a `jest` run. */
+export class JestSettings extends ToolSettings {
+  #patterns: string[] = [];
+  #config?: string;
+  #coverage = false;
+  #watch = false;
+  #watchAll = false;
+  #ci = false;
+  #runInBand = false;
+  #maxWorkers?: string;
+  #updateSnapshot = false;
+  #bail?: number;
+  #verbose = false;
+  #silent = false;
+  #testNamePattern?: string;
+  #onlyChanged = false;
+  #passWithNoTests = false;
+  #detectOpenHandles = false;
+  #selectProjects: string[] = [];
+  #reporters: string[] = [];
+
+  protected override defaultTool(): string {
+    return "jest";
+  }
+
+  /** Regex patterns matched against test paths (positional); repeatable. */
+  paths(...values: string[]): this {
+    this.#patterns.push(...values);
+    return this;
+  }
+
+  /** Use an explicit config file (`-c`/`--config`). */
+  config(path: string): this {
+    this.#config = path;
+    return this;
+  }
+
+  /** Collect test coverage (`--coverage`). */
+  coverage(): this {
+    this.#coverage = true;
+    return this;
+  }
+
+  /** Watch files related to changed files (`--watch`). */
+  watch(): this {
+    this.#watch = true;
+    return this;
+  }
+
+  /** Watch all files (`--watchAll`). */
+  watchAll(): this {
+    this.#watchAll = true;
+    return this;
+  }
+
+  /** Run in CI mode, failing on new snapshots (`--ci`). */
+  ci(): this {
+    this.#ci = true;
+    return this;
+  }
+
+  /** Run all tests serially in the current process (`-i`/`--runInBand`). */
+  runInBand(): this {
+    this.#runInBand = true;
+    return this;
+  }
+
+  /** Limit worker count, e.g. `2` or `50%` (`--maxWorkers`). */
+  maxWorkers(value: string | number): this {
+    this.#maxWorkers = String(value);
+    return this;
+  }
+
+  /** Re-record snapshots (`-u`/`--updateSnapshot`). */
+  updateSnapshot(): this {
+    this.#updateSnapshot = true;
+    return this;
+  }
+
+  /** Stop after N failing test suites (`--bail`). */
+  bail(suites = 1): this {
+    this.#bail = suites;
+    return this;
+  }
+
+  /** Report each individual test (`--verbose`). */
+  verbose(): this {
+    this.#verbose = true;
+    return this;
+  }
+
+  /** Prevent tests from printing to the console (`--silent`). */
+  silent(): this {
+    this.#silent = true;
+    return this;
+  }
+
+  /** Run only tests whose name matches the pattern (`-t`/`--testNamePattern`). */
+  testNamePattern(pattern: string): this {
+    this.#testNamePattern = pattern;
+    return this;
+  }
+
+  /** Run only tests affected by changed files (`-o`/`--onlyChanged`). */
+  onlyChanged(): this {
+    this.#onlyChanged = true;
+    return this;
+  }
+
+  /** Pass when no tests are found (`--passWithNoTests`). */
+  passWithNoTests(): this {
+    this.#passWithNoTests = true;
+    return this;
+  }
+
+  /** Detect handles keeping the process open (`--detectOpenHandles`). */
+  detectOpenHandles(): this {
+    this.#detectOpenHandles = true;
+    return this;
+  }
+
+  /** Restrict to named projects (`--selectProjects`); repeatable. */
+  selectProjects(...names: string[]): this {
+    this.#selectProjects.push(...names);
+    return this;
+  }
+
+  /** Use the named reporters (`--reporters`); repeatable. */
+  reporters(...names: string[]): this {
+    for (const name of names) this.#reporters.push("--reporters", name);
+    return this;
+  }
+
+  protected override buildArgs(): string[] {
+    const argv: string[] = [];
+    if (this.#config !== undefined) argv.push("-c", this.#config);
+    if (this.#coverage) argv.push("--coverage");
+    if (this.#watch) argv.push("--watch");
+    if (this.#watchAll) argv.push("--watchAll");
+    if (this.#ci) argv.push("--ci");
+    if (this.#runInBand) argv.push("-i");
+    if (this.#maxWorkers !== undefined) {
+      argv.push("--maxWorkers", this.#maxWorkers);
+    }
+    if (this.#updateSnapshot) argv.push("-u");
+    if (this.#bail !== undefined) argv.push("--bail", String(this.#bail));
+    if (this.#verbose) argv.push("--verbose");
+    if (this.#silent) argv.push("--silent");
+    if (this.#testNamePattern !== undefined) {
+      argv.push("-t", this.#testNamePattern);
+    }
+    if (this.#onlyChanged) argv.push("-o");
+    if (this.#passWithNoTests) argv.push("--passWithNoTests");
+    if (this.#detectOpenHandles) argv.push("--detectOpenHandles");
+    if (this.#selectProjects.length > 0) {
+      argv.push("--selectProjects", ...this.#selectProjects);
+    }
+    argv.push(...this.#reporters);
+    argv.push(...this.#patterns);
+    return argv;
+  }
+}
+
+/** The shape of {@link JestTasks}. */
+export interface JestTasksApi {
+  /** Run tests with `jest`. */
+  run(configure?: Configure<JestSettings>): Promise<CommandOutput>;
+}
+
+/** Typed task functions for the `jest` test runner. */
+export const JestTasks: JestTasksApi = {
+  run(configure?: Configure<JestSettings>): Promise<CommandOutput> {
+    return runSettings(new JestSettings(), configure);
+  },
+};

--- a/packages/jest/tests/jest_test.ts
+++ b/packages/jest/tests/jest_test.ts
@@ -1,0 +1,64 @@
+import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
+import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { JestSettings, JestTasks } from "../src/jest.ts";
+
+Deno.test("the default binary is jest", () => {
+  assertEquals(new JestSettings().argv(), ["jest"]);
+});
+
+Deno.test("jest: every option renders, patterns last", () => {
+  const argv = new JestSettings()
+    .config("jest.config.js").coverage().watch().watchAll().ci().runInBand()
+    .maxWorkers("50%").updateSnapshot().bail(2).verbose().silent()
+    .testNamePattern("renders").onlyChanged().passWithNoTests()
+    .detectOpenHandles().selectProjects("web", "api")
+    .reporters("default", "jest-junit").paths("src/", "test/").argv();
+  assertEquals(argv, [
+    "jest",
+    "-c",
+    "jest.config.js",
+    "--coverage",
+    "--watch",
+    "--watchAll",
+    "--ci",
+    "-i",
+    "--maxWorkers",
+    "50%",
+    "-u",
+    "--bail",
+    "2",
+    "--verbose",
+    "--silent",
+    "-t",
+    "renders",
+    "-o",
+    "--passWithNoTests",
+    "--detectOpenHandles",
+    "--selectProjects",
+    "web",
+    "api",
+    "--reporters",
+    "default",
+    "--reporters",
+    "jest-junit",
+    "src/",
+    "test/",
+  ]);
+});
+
+Deno.test("jest: bail defaults to one suite", () => {
+  assertEquals(new JestSettings().bail().argv(), ["jest", "--bail", "1"]);
+});
+
+Deno.test("jest: minimal invocation is bare", () => {
+  assertEquals(new JestSettings().argv(), ["jest"]);
+});
+
+const missing = <S extends ToolSettings>(s: S): S => {
+  s.os_ = "linux";
+  return s.toolPath("zz-no-such-jest-zz");
+};
+
+Deno.test("JestTasks.run reaches execution", async () => {
+  await assertRejects(() => JestTasks.run(missing), ToolNotFoundError);
+});

--- a/packages/npm/deno.json
+++ b/packages/npm/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/npm",
   "version": "0.1.1",
+  "description": "Typed npm CLI task wrappers for Zuke builds — install, ci, run, exec, publish, and version via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"
   },

--- a/packages/oxlint/README.md
+++ b/packages/oxlint/README.md
@@ -1,0 +1,14 @@
+# @zuke/oxlint
+
+Typed [`oxlint`](https://oxc.rs/docs/guide/usage/linter.html) task wrappers for
+[Zuke](https://github.com/zuke-build/zuke#readme) builds, in a fluent
+settings-lambda API. Arguments stay a discrete argv array, so command
+construction is injection-free.
+
+```ts
+import { OxlintTasks } from "jsr:@zuke/oxlint";
+
+await OxlintTasks.lint((s) =>
+  s.paths("src").config(".oxlintrc.json").fix().denyWarnings()
+);
+```

--- a/packages/oxlint/deno.json
+++ b/packages/oxlint/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/oxlint",
   "version": "0.0.0",
+  "description": "Typed oxlint task wrappers for Zuke builds — fast Rust-based linting via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"
   },

--- a/packages/oxlint/deno.json
+++ b/packages/oxlint/deno.json
@@ -1,0 +1,13 @@
+{
+  "name": "@zuke/oxlint",
+  "version": "0.0.0",
+  "exports": {
+    ".": "./mod.ts"
+  },
+  "imports": {
+    "@zuke/core": "jsr:@zuke/core@^0"
+  },
+  "publish": {
+    "exclude": ["tests/"]
+  }
+}

--- a/packages/oxlint/mod.ts
+++ b/packages/oxlint/mod.ts
@@ -1,0 +1,15 @@
+/**
+ * `@zuke/oxlint` — typed `oxlint` task wrappers for Zuke builds.
+ *
+ * Configure a fluent settings object in a lambda; the task builds the argv and
+ * runs it.
+ *
+ * ```ts
+ * import { OxlintTasks } from "jsr:@zuke/oxlint";
+ * await OxlintTasks.lint((s) => s.paths("src").fix().denyWarnings());
+ * ```
+ *
+ * @module
+ */
+
+export * from "./src/oxlint.ts";

--- a/packages/oxlint/src/oxlint.ts
+++ b/packages/oxlint/src/oxlint.ts
@@ -1,0 +1,167 @@
+/**
+ * `OxlintTasks` — typed task functions for the `oxlint` linter, in the same
+ * settings-lambda style as the other Zuke tool wrappers: configure a fluent
+ * settings object in a lambda, and the task function builds the command line
+ * and executes it.
+ *
+ * ```ts
+ * import { OxlintTasks } from "jsr:@zuke/oxlint";
+ * await OxlintTasks.lint((s) => s.paths("src").fix().denyWarnings());
+ * ```
+ *
+ * Arguments stay a discrete argv array end-to-end — never a concatenated shell
+ * string — so command construction is injection-free.
+ *
+ * @module
+ */
+
+import { type Configure, runSettings, ToolSettings } from "@zuke/core/tooling";
+import type { CommandOutput } from "@zuke/core/shell";
+
+/** Settings for an `oxlint` run. */
+export class OxlintSettings extends ToolSettings {
+  #paths: string[] = [];
+  #config?: string;
+  #tsconfig?: string;
+  #fix = false;
+  #fixSuggestions = false;
+  #rules: string[] = [];
+  #ignorePath?: string;
+  #ignorePatterns: string[] = [];
+  #maxWarnings?: number;
+  #quietWarnings = false;
+  #denyWarnings = false;
+  #format?: string;
+  #threads?: number;
+
+  protected override defaultTool(): string {
+    return "oxlint";
+  }
+
+  /** Files or directories to lint (positional); repeatable. */
+  paths(...values: string[]): this {
+    this.#paths.push(...values);
+    return this;
+  }
+
+  /** Use an explicit config file (`-c`/`--config`). */
+  config(path: string): this {
+    this.#config = path;
+    return this;
+  }
+
+  /** Point at a `tsconfig.json` for type-aware rules (`--tsconfig`). */
+  tsconfig(path: string): this {
+    this.#tsconfig = path;
+    return this;
+  }
+
+  /** Apply automatic fixes (`--fix`). */
+  fix(): this {
+    this.#fix = true;
+    return this;
+  }
+
+  /** Apply suggestion fixes too (`--fix-suggestions`). */
+  fixSuggestions(): this {
+    this.#fixSuggestions = true;
+    return this;
+  }
+
+  /** Raise a rule or category to error (`-D`/`--deny`); repeatable. */
+  deny(rule: string): this {
+    this.#rules.push("-D", rule);
+    return this;
+  }
+
+  /** Set a rule or category to warning (`-W`/`--warn`); repeatable. */
+  warn(rule: string): this {
+    this.#rules.push("-W", rule);
+    return this;
+  }
+
+  /** Turn a rule or category off (`-A`/`--allow`); repeatable. */
+  allow(rule: string): this {
+    this.#rules.push("-A", rule);
+    return this;
+  }
+
+  /** Read ignore globs from a file (`--ignore-path`). */
+  ignorePath(path: string): this {
+    this.#ignorePath = path;
+    return this;
+  }
+
+  /** Ignore files matching a glob (`--ignore-pattern`); repeatable. */
+  ignorePattern(glob: string): this {
+    this.#ignorePatterns.push("--ignore-pattern", glob);
+    return this;
+  }
+
+  /** Fail once this many warnings are reached (`--max-warnings`). */
+  maxWarnings(count: number): this {
+    this.#maxWarnings = count;
+    return this;
+  }
+
+  /** Report errors only, suppressing warnings (`--quiet`). */
+  quietWarnings(): this {
+    this.#quietWarnings = true;
+    return this;
+  }
+
+  /** Exit non-zero if any warnings are found (`--deny-warnings`). */
+  denyWarnings(): this {
+    this.#denyWarnings = true;
+    return this;
+  }
+
+  /** Output format, e.g. `default`, `json`, `github` (`-f`/`--format`). */
+  format(value: string): this {
+    this.#format = value;
+    return this;
+  }
+
+  /** Number of threads to use (`--threads`). */
+  threads(count: number): this {
+    this.#threads = count;
+    return this;
+  }
+
+  protected override buildArgs(): string[] {
+    const argv: string[] = [];
+    if (this.#config !== undefined) argv.push("-c", this.#config);
+    if (this.#tsconfig !== undefined) argv.push("--tsconfig", this.#tsconfig);
+    if (this.#fix) argv.push("--fix");
+    if (this.#fixSuggestions) argv.push("--fix-suggestions");
+    argv.push(...this.#rules);
+    if (this.#ignorePath !== undefined) {
+      argv.push("--ignore-path", this.#ignorePath);
+    }
+    argv.push(...this.#ignorePatterns);
+    if (this.#maxWarnings !== undefined) {
+      argv.push("--max-warnings", String(this.#maxWarnings));
+    }
+    if (this.#quietWarnings) argv.push("--quiet");
+    if (this.#denyWarnings) argv.push("--deny-warnings");
+    if (this.#format !== undefined) argv.push("-f", this.#format);
+    if (this.#threads !== undefined) {
+      argv.push("--threads", String(this.#threads));
+    }
+    argv.push(...this.#paths);
+    return argv;
+  }
+}
+
+/** The shape of {@link OxlintTasks}. */
+export interface OxlintTasksApi {
+  /** Lint with `oxlint`. */
+  lint(configure?: Configure<OxlintSettings>): Promise<CommandOutput>;
+}
+
+/** Typed task functions for the `oxlint` linter. */
+export const OxlintTasks: OxlintTasksApi = {
+  lint(configure?: Configure<OxlintSettings>): Promise<CommandOutput> {
+    return runSettings(new OxlintSettings(), configure);
+  },
+};

--- a/packages/oxlint/tests/oxlint_test.ts
+++ b/packages/oxlint/tests/oxlint_test.ts
@@ -1,0 +1,58 @@
+import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
+import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { OxlintSettings, OxlintTasks } from "../src/oxlint.ts";
+
+Deno.test("the default binary is oxlint", () => {
+  assertEquals(new OxlintSettings().argv(), ["oxlint"]);
+});
+
+Deno.test("oxlint: every option renders, paths last", () => {
+  const argv = new OxlintSettings()
+    .config(".oxlintrc.json").tsconfig("tsconfig.json").fix().fixSuggestions()
+    .deny("no-debugger").warn("eqeqeq").allow("no-console")
+    .ignorePath(".gitignore").ignorePattern("dist/**").maxWarnings(0)
+    .quietWarnings().denyWarnings().format("github").threads(4)
+    .paths("src", "test").argv();
+  assertEquals(argv, [
+    "oxlint",
+    "-c",
+    ".oxlintrc.json",
+    "--tsconfig",
+    "tsconfig.json",
+    "--fix",
+    "--fix-suggestions",
+    "-D",
+    "no-debugger",
+    "-W",
+    "eqeqeq",
+    "-A",
+    "no-console",
+    "--ignore-path",
+    ".gitignore",
+    "--ignore-pattern",
+    "dist/**",
+    "--max-warnings",
+    "0",
+    "--quiet",
+    "--deny-warnings",
+    "-f",
+    "github",
+    "--threads",
+    "4",
+    "src",
+    "test",
+  ]);
+});
+
+Deno.test("oxlint: minimal lints just the given path", () => {
+  assertEquals(new OxlintSettings().paths("src").argv(), ["oxlint", "src"]);
+});
+
+const missing = <S extends ToolSettings>(s: S): S => {
+  s.os_ = "linux";
+  return s.toolPath("zz-no-such-oxlint-zz");
+};
+
+Deno.test("OxlintTasks.lint reaches execution", async () => {
+  await assertRejects(() => OxlintTasks.lint(missing), ToolNotFoundError);
+});

--- a/packages/vitest/README.md
+++ b/packages/vitest/README.md
@@ -1,0 +1,16 @@
+# @zuke/vitest
+
+Typed [`vitest`](https://vitest.dev/) task wrappers for
+[Zuke](https://github.com/zuke-build/zuke#readme) builds, in a fluent
+settings-lambda API. Arguments stay a discrete argv array, so command
+construction is injection-free.
+
+Vitest defaults to watch mode when invoked bare; this wrapper emits the one-shot
+`run` subcommand by default (CI-friendly) and switches to `watch` with
+`.watch()`.
+
+```ts
+import { VitestTasks } from "jsr:@zuke/vitest";
+
+await VitestTasks.run((s) => s.coverage().reporter("dot").bail(1));
+```

--- a/packages/vitest/deno.json
+++ b/packages/vitest/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/vitest",
   "version": "0.0.0",
+  "description": "Typed vitest task wrappers for Zuke builds — one-shot run by default, plus coverage, reporters, and watch mode via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"
   },

--- a/packages/vitest/deno.json
+++ b/packages/vitest/deno.json
@@ -1,0 +1,13 @@
+{
+  "name": "@zuke/vitest",
+  "version": "0.0.0",
+  "exports": {
+    ".": "./mod.ts"
+  },
+  "imports": {
+    "@zuke/core": "jsr:@zuke/core@^0"
+  },
+  "publish": {
+    "exclude": ["tests/"]
+  }
+}

--- a/packages/vitest/mod.ts
+++ b/packages/vitest/mod.ts
@@ -1,0 +1,16 @@
+/**
+ * `@zuke/vitest` — typed `vitest` task wrappers for Zuke builds.
+ *
+ * Configure a fluent settings object in a lambda; the task builds the argv and
+ * runs it. The one-shot `run` subcommand is emitted by default; switch to
+ * watch mode with `.watch()`.
+ *
+ * ```ts
+ * import { VitestTasks } from "jsr:@zuke/vitest";
+ * await VitestTasks.run((s) => s.coverage().reporter("dot"));
+ * ```
+ *
+ * @module
+ */
+
+export * from "./src/vitest.ts";

--- a/packages/vitest/src/vitest.ts
+++ b/packages/vitest/src/vitest.ts
@@ -1,0 +1,206 @@
+/**
+ * `VitestTasks` — typed task functions for the `vitest` test runner, in the
+ * same settings-lambda style as the other Zuke tool wrappers: configure a
+ * fluent settings object in a lambda, and the task function builds the command
+ * line and executes it.
+ *
+ * Vitest defaults to watch mode when invoked bare; this wrapper emits the
+ * one-shot `run` subcommand by default (CI-friendly) and switches to `watch`
+ * via {@link VitestSettings.watch}.
+ *
+ * ```ts
+ * import { VitestTasks } from "jsr:@zuke/vitest";
+ * await VitestTasks.run((s) => s.coverage().reporter("dot"));
+ * ```
+ *
+ * Arguments stay a discrete argv array end-to-end — never a concatenated shell
+ * string — so command construction is injection-free.
+ *
+ * @module
+ */
+
+import { type Configure, runSettings, ToolSettings } from "@zuke/core/tooling";
+import type { CommandOutput } from "@zuke/core/shell";
+
+/** Settings for a `vitest` run. */
+export class VitestSettings extends ToolSettings {
+  #filters: string[] = [];
+  #watch = false;
+  #config?: string;
+  #root?: string;
+  #dir?: string;
+  #coverage = false;
+  #ui = false;
+  #update = false;
+  #run = false;
+  #bail?: number;
+  #retry?: number;
+  #shard?: string;
+  #reporters: string[] = [];
+  #outputFile?: string;
+  #testNamePattern?: string;
+  #environment?: string;
+  #globals = false;
+  #passWithNoTests = false;
+  #silent = false;
+
+  protected override defaultTool(): string {
+    return "vitest";
+  }
+
+  /** Filename filters matched against test files (positional); repeatable. */
+  filters(...values: string[]): this {
+    this.#filters.push(...values);
+    return this;
+  }
+
+  /** Use watch mode (`watch`) instead of the default one-shot `run`. */
+  watch(): this {
+    this.#watch = true;
+    return this;
+  }
+
+  /** Use an explicit config file (`-c`/`--config`). */
+  config(path: string): this {
+    this.#config = path;
+    return this;
+  }
+
+  /** Project root (`--root`). */
+  root(path: string): this {
+    this.#root = path;
+    return this;
+  }
+
+  /** Restrict the scanned directory (`--dir`). */
+  dir(path: string): this {
+    this.#dir = path;
+    return this;
+  }
+
+  /** Collect test coverage (`--coverage`). */
+  coverage(): this {
+    this.#coverage = true;
+    return this;
+  }
+
+  /** Open the Vitest UI (`--ui`). */
+  ui(): this {
+    this.#ui = true;
+    return this;
+  }
+
+  /** Update snapshots (`-u`/`--update`). */
+  update(): this {
+    this.#update = true;
+    return this;
+  }
+
+  /** Force one-shot mode even under watch (`--run`). */
+  forceRun(): this {
+    this.#run = true;
+    return this;
+  }
+
+  /** Stop after N failed tests (`--bail`). */
+  bail(count: number): this {
+    this.#bail = count;
+    return this;
+  }
+
+  /** Retry failed tests up to N times (`--retry`). */
+  retry(count: number): this {
+    this.#retry = count;
+    return this;
+  }
+
+  /** Run a shard of the suite, e.g. `1/4` (`--shard`). */
+  shard(value: string): this {
+    this.#shard = value;
+    return this;
+  }
+
+  /** Use the named reporters (`--reporter`); repeatable. */
+  reporter(...names: string[]): this {
+    for (const name of names) this.#reporters.push("--reporter", name);
+    return this;
+  }
+
+  /** Write report output to a file (`--outputFile`). */
+  outputFile(path: string): this {
+    this.#outputFile = path;
+    return this;
+  }
+
+  /** Run only tests whose name matches the pattern (`-t`/`--testNamePattern`). */
+  testNamePattern(pattern: string): this {
+    this.#testNamePattern = pattern;
+    return this;
+  }
+
+  /** Test environment, e.g. `jsdom`, `node` (`--environment`). */
+  environment(value: string): this {
+    this.#environment = value;
+    return this;
+  }
+
+  /** Enable global test APIs (`--globals`). */
+  globals(): this {
+    this.#globals = true;
+    return this;
+  }
+
+  /** Pass when no tests are found (`--passWithNoTests`). */
+  passWithNoTests(): this {
+    this.#passWithNoTests = true;
+    return this;
+  }
+
+  /** Suppress test console output (`--silent`). */
+  silent(): this {
+    this.#silent = true;
+    return this;
+  }
+
+  protected override buildArgs(): string[] {
+    const argv = [this.#watch ? "watch" : "run"];
+    if (this.#config !== undefined) argv.push("-c", this.#config);
+    if (this.#root !== undefined) argv.push("--root", this.#root);
+    if (this.#dir !== undefined) argv.push("--dir", this.#dir);
+    if (this.#coverage) argv.push("--coverage");
+    if (this.#ui) argv.push("--ui");
+    if (this.#update) argv.push("-u");
+    if (this.#run) argv.push("--run");
+    if (this.#bail !== undefined) argv.push("--bail", String(this.#bail));
+    if (this.#retry !== undefined) argv.push("--retry", String(this.#retry));
+    if (this.#shard !== undefined) argv.push("--shard", this.#shard);
+    argv.push(...this.#reporters);
+    if (this.#outputFile !== undefined) {
+      argv.push("--outputFile", this.#outputFile);
+    }
+    if (this.#testNamePattern !== undefined) {
+      argv.push("-t", this.#testNamePattern);
+    }
+    if (this.#environment !== undefined) {
+      argv.push("--environment", this.#environment);
+    }
+    if (this.#globals) argv.push("--globals");
+    if (this.#passWithNoTests) argv.push("--passWithNoTests");
+    if (this.#silent) argv.push("--silent");
+    argv.push(...this.#filters);
+    return argv;
+  }
+}
+
+/** The shape of {@link VitestTasks}. */
+export interface VitestTasksApi {
+  /** Run tests with `vitest` (one-shot `run` unless {@link VitestSettings.watch}). */
+  run(configure?: Configure<VitestSettings>): Promise<CommandOutput>;
+}
+
+/** Typed task functions for the `vitest` test runner. */
+export const VitestTasks: VitestTasksApi = {
+  run(configure?: Configure<VitestSettings>): Promise<CommandOutput> {
+    return runSettings(new VitestSettings(), configure);
+  },
+};

--- a/packages/vitest/tests/vitest_test.ts
+++ b/packages/vitest/tests/vitest_test.ts
@@ -1,0 +1,63 @@
+import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
+import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { VitestSettings, VitestTasks } from "../src/vitest.ts";
+
+Deno.test("the default invocation is a one-shot run", () => {
+  assertEquals(new VitestSettings().argv(), ["vitest", "run"]);
+});
+
+Deno.test("watch() switches to the watch subcommand", () => {
+  assertEquals(new VitestSettings().watch().argv(), ["vitest", "watch"]);
+});
+
+Deno.test("vitest: every option renders, filters last", () => {
+  const argv = new VitestSettings()
+    .config("vitest.config.ts").root(".").dir("src").coverage().ui().update()
+    .forceRun().bail(1).retry(2).shard("1/4").reporter("dot", "junit")
+    .outputFile("out.xml").testNamePattern("renders").environment("jsdom")
+    .globals().passWithNoTests().silent().filters("math", "string").argv();
+  assertEquals(argv, [
+    "vitest",
+    "run",
+    "-c",
+    "vitest.config.ts",
+    "--root",
+    ".",
+    "--dir",
+    "src",
+    "--coverage",
+    "--ui",
+    "-u",
+    "--run",
+    "--bail",
+    "1",
+    "--retry",
+    "2",
+    "--shard",
+    "1/4",
+    "--reporter",
+    "dot",
+    "--reporter",
+    "junit",
+    "--outputFile",
+    "out.xml",
+    "-t",
+    "renders",
+    "--environment",
+    "jsdom",
+    "--globals",
+    "--passWithNoTests",
+    "--silent",
+    "math",
+    "string",
+  ]);
+});
+
+const missing = <S extends ToolSettings>(s: S): S => {
+  s.os_ = "linux";
+  return s.toolPath("zz-no-such-vitest-zz");
+};
+
+Deno.test("VitestTasks.run reaches execution", async () => {
+  await assertRejects(() => VitestTasks.run(missing), ToolNotFoundError);
+});

--- a/tests/release_config_test.ts
+++ b/tests/release_config_test.ts
@@ -8,6 +8,11 @@ const PACKAGES = [
   "packages/cli",
   "packages/docker",
   "packages/docker-compose",
+  "packages/oxlint",
+  "packages/eslint",
+  "packages/cspell",
+  "packages/jest",
+  "packages/vitest",
 ];
 
 async function readJson(path: string): Promise<Record<string, unknown>> {

--- a/zuke.ts
+++ b/zuke.ts
@@ -25,6 +25,11 @@ const PACKAGES = [
   "cli",
   "docker",
   "docker-compose",
+  "oxlint",
+  "eslint",
+  "cspell",
+  "jest",
+  "vitest",
 ];
 
 /** The `version` field of a package's `deno.json`, validated as a string. */


### PR DESCRIPTION
## Summary

Adds five new typed tool-wrapper packages, all following the established
settings-lambda pattern (configure a fluent settings object in a lambda, the
task builds a pure argv array and runs it via the shell `Command`):

| Package | Task | Wraps |
| --- | --- | --- |
| `@zuke/oxlint` | `OxlintTasks.lint` | the `oxlint` linter |
| `@zuke/eslint` | `EslintTasks.lint` | the `eslint` linter |
| `@zuke/cspell` | `CspellTasks.lint` | the `cspell` spell-checker |
| `@zuke/jest` | `JestTasks.run` | the `jest` test runner |
| `@zuke/vitest` | `VitestTasks.run` | the `vitest` test runner |

```ts
import { OxlintTasks } from "jsr:@zuke/oxlint";
import { EslintTasks } from "jsr:@zuke/eslint";
import { CspellTasks } from "jsr:@zuke/cspell";
import { JestTasks } from "jsr:@zuke/jest";
import { VitestTasks } from "jsr:@zuke/vitest";

await OxlintTasks.lint((s) => s.paths("src").fix().denyWarnings());
await EslintTasks.lint((s) => s.paths("src").ext(".ts", ".tsx").maxWarnings(0));
await CspellTasks.lint((s) => s.files("**").noProgress());
await JestTasks.run((s) => s.ci().coverage().maxWorkers("50%"));
await VitestTasks.run((s) => s.coverage().reporter("dot"));
```

## Design notes

- **Broad coverage** of each tool's common flags; the long tail is still
  reachable through the base `.args()` escape hatch.
- `buildArgs()` stays pure (no I/O) so argv is fully unit-tested via `argv()`.
- The default binary is the tool name (e.g. `eslint`); `.toolPath()` overrides
  it, and the base `cmd /c` shim already covers Windows `.cmd` shims for these
  npm-distributed CLIs.
- A few flag setters are renamed to avoid colliding with `ToolSettings`:
  `quietWarnings()` (oxlint/eslint `--quiet`), `quietOutput()` (cspell
  `--quiet`), and `forceRun()` (vitest `--run`, since `run()` is the base
  executor). `cspell` emits the explicit `lint` subcommand; `vitest` emits the
  one-shot `run` subcommand by default and switches to `watch` via `.watch()`.

## Wiring

- Added all five to the workspace, the zuke build's publish order, and the
  release-please config + manifest.
- **Pinned each first release to `0.1.0`** via `release-as` (same as the docker
  packages) so they don't default to `1.0.0`. These pins should be removed once
  0.1.0 publishes — I can send that follow-up right after, as before.
- Listed them in the README tool table and package lists; added `oxlint` to the
  cspell dictionary.

## Checks

`deno task ci` is green locally — fmt, lint, spell, check, 196 tests, and the
95% coverage gate (aggregate 99.4% lines / 97.8% branches; all five source
files at 100%).

https://claude.ai/code/session_01VRn8gL34mdDPRg4ZTVzGAz

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRn8gL34mdDPRg4ZTVzGAz)_