### PR TITLE
feat(security): support a zizmor config file and cut the first release

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -97,6 +97,7 @@
     },
     "packages/security": {
       "component": "security",
+      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         { "type": "json", "path": "deno.json", "jsonpath": "$.version" }

--- a/packages/security/src/security.ts
+++ b/packages/security/src/security.ts
@@ -40,6 +40,7 @@ import type { CommandOutput } from "@zuke/core/shell";
  */
 export class ZizmorSettings extends ToolSettings {
   #paths: string[] = [];
+  #config?: string;
   #format?: string;
   #minSeverity?: string;
   #persona?: string;
@@ -52,6 +53,12 @@ export class ZizmorSettings extends ToolSettings {
   /** Add a workflow file or directory to audit (positional); repeatable. */
   paths(...inputs: string[]): this {
     this.#paths.push(...inputs);
+    return this;
+  }
+
+  /** Use an explicit zizmor config file (`--config`). */
+  config(path: string): this {
+    this.#config = path;
     return this;
   }
 
@@ -81,6 +88,7 @@ export class ZizmorSettings extends ToolSettings {
 
   protected override buildArgs(): string[] {
     const argv: string[] = [];
+    if (this.#config !== undefined) argv.push("--config", this.#config);
     if (this.#format !== undefined) argv.push("--format", this.#format);
     if (this.#minSeverity !== undefined) {
       argv.push("--min-severity", this.#minSeverity);

--- a/packages/security/tests/security_test.ts
+++ b/packages/security/tests/security_test.ts
@@ -14,10 +14,13 @@ import {
 Deno.test("zizmor: full and minimal argv", () => {
   assertEquals(
     new ZizmorSettings()
-      .format("sarif").minSeverity("medium").persona("auditor").offline()
+      .config("zizmor.yml").format("sarif").minSeverity("medium")
+      .persona("auditor").offline()
       .paths(".github/workflows", "extra.yml").argv(),
     [
       "zizmor",
+      "--config",
+      "zizmor.yml",
       "--format",
       "sarif",
       "--min-severity",


### PR DESCRIPTION
## Why

`@zuke/security` landed on `master` in #28, but no release PR appeared and it's still unpublished at `0.0.0`.

Root cause: #28 was **squash-merged** with a non–Conventional-Commit title ("Add @zuke/security package…"). release-please reads the squash commit's header to decide what to release, so it treated the merge as non-releasable. (The release workflow itself ran green — nothing failed.)

## What this does

- Adds `release-as: "0.1.0"` to the `packages/security` entry in `.release-please-config.json` — the same one-time bootstrap pin used for the other new wrapper packages (#26).
- Adds a genuine, correctly-typed `feat(security)` change that touches the package path so release-please attributes it: a `config(path)` option on `ZizmorSettings`, mapping to zizmor's `-c, --config <FILE>`.

On merge (with this PR's Conventional-Commit title), release-please opens the `@zuke/security@0.1.0` release PR; merging that publishes to JSR.

## Verification

- `deno task ci` green — `packages/security` stays at **100%** line/branch coverage; overall 99.4% lines / 98.0% branches.
- New `config()` option covered by the existing argv test.

## Note on squash merges

Because this repo squash-merges, the **PR title must be a Conventional Commit** or release-please will skip it — that's what happened with #28. Worth enforcing the convention (e.g. a PR-title lint), or switching merge strategy, to avoid a repeat.

https://claude.ai/code/session_01D95HNhZEJrnSpDyznbmLXd

---
_Generated by [Claude Code](https://claude.ai/code/session_01D95HNhZEJrnSpDyznbmLXd)_