### PR TITLE
feat(core): add absolutePath, a fluent path type

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ class MyBuild extends Build {
   - [`Build`](#build)
   - [`run()`](#run)
 - [Shell wrapper (`$`)](#shell-wrapper-)
+- [Paths (`absolutePath`)](#paths-absolutepath)
 - [Tools](#tools)
 - [Using Zuke in a Node/npm project](#using-zuke-in-a-nodenpm-project)
 - [CLI reference](#cli-reference)
@@ -337,6 +338,34 @@ await $`echo ${dirty}`; // prints the literal string; runs nothing else
 
 By default a command streams its output live to your terminal and captures
 stdout; `.text()`/`.lines()` capture without echoing; `.quiet()` does neither.
+
+## Paths (`absolutePath`)
+
+NUKE overloads `/` so you can write `RootDirectory / "src" / "Project.csproj"`.
+TypeScript has no operator overloading, so `absolutePath` gets as close as the
+language allows: the returned `AbsolutePath` is **callable** (and has an
+equivalent `.join(...)`), so appending segments reads almost the same.
+
+```ts
+import { absolutePath } from "jsr:@zuke/core";
+
+const root = absolutePath("/app");
+const main = root("src", "main.ts"); // callable: /app/src/main.ts
+const test = root.join("tests", "x.ts"); // explicit: /app/tests/x.ts
+
+main.name; // "main.ts"
+main.stem; // "main"
+main.extension; // ".ts"
+main.parent(); // AbsolutePath → /app/src
+main.relativeTo(root); // "src/main.ts"
+main.equals("/app/lib/../src/main.ts"); // true
+
+await $`deno run ${main}`; // toString() → drops straight into $`` and args()
+```
+
+Paths are immutable and normalised (forward slashes, `.`/`..` resolved; a
+Windows `C:/…` drive prefix is preserved). The base must be absolute — start
+with `/` or a drive letter, or build from an absolute base.
 
 ## Tools
 

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -33,6 +33,7 @@ export {
 } from "./src/target.ts";
 export { run } from "./src/cli.ts";
 export { execute, type ExecuteOptions, type Reporter } from "./src/executor.ts";
+export { type AbsolutePath, absolutePath } from "./src/path.ts";
 export {
   executionSet,
   findCycle,

--- a/packages/core/src/path.ts
+++ b/packages/core/src/path.ts
@@ -1,0 +1,201 @@
+/**
+ * Ergonomic, immutable file paths for build scripts.
+ *
+ * TypeScript has no operator overloading, so Zuke cannot mimic NUKE's
+ * `RootDirectory / "src" / "Project.csproj"` literally. {@link absolutePath}
+ * gets as close as the language allows: the returned {@link AbsolutePath} is
+ * **callable**, so appending segments reads almost like the original — and a
+ * `.join(...)` method does the same thing explicitly.
+ *
+ * ```ts
+ * import { absolutePath } from "jsr:@zuke/core";
+ *
+ * const root = absolutePath("/app");
+ * const main = root("src", "main.ts");      // /app/src/main.ts  (callable)
+ * const test = root.join("tests", "x.ts");  // /app/tests/x.ts   (explicit)
+ *
+ * main.name;        // "main.ts"
+ * main.stem;        // "main"
+ * main.extension;   // ".ts"
+ * main.parent();    // AbsolutePath -> /app/src
+ * main.relativeTo(root); // "src/main.ts"
+ * `${main}`;        // "/app/src/main.ts" (toString — drops into $`` and args())
+ * ```
+ *
+ * Paths are normalised to forward slashes with `.`/`..` segments resolved; a
+ * Windows drive prefix (`C:/…`) is preserved. Instances are immutable: every
+ * operation returns a new {@link AbsolutePath}.
+ *
+ * @module
+ */
+
+/** The separated form of a path: its root (`""` if relative) and clean parts. */
+interface PathParts {
+  /** `"/"`, a drive root like `"C:/"`, or `""` for a relative path. */
+  root: string;
+  /** Path segments with `.`/empty removed and `..` resolved where possible. */
+  parts: string[];
+}
+
+/** Split a path string into its root and normalised segments. */
+function toParts(input: string): PathParts {
+  const slashed = input.replace(/\\/g, "/");
+  let root = "";
+  let rest = slashed;
+  if (slashed.startsWith("/")) {
+    root = "/";
+    rest = slashed.slice(1);
+  } else {
+    const drive = /^([A-Za-z]:)\/?/.exec(slashed);
+    if (drive !== null) {
+      root = `${drive[1]}/`;
+      rest = slashed.slice(drive[0].length);
+    }
+  }
+  const parts: string[] = [];
+  for (const segment of rest.split("/")) {
+    if (segment === "" || segment === ".") continue;
+    if (segment === "..") {
+      const top = parts[parts.length - 1];
+      if (parts.length > 0 && top !== "..") parts.pop();
+      else if (root === "") parts.push("..");
+      // An absolute path can't climb above its root: drop the "..".
+    } else {
+      parts.push(segment);
+    }
+  }
+  return { root, parts };
+}
+
+/** Re-render separated parts back into a path string. */
+function render({ root, parts }: PathParts): string {
+  if (root !== "") return root + parts.join("/");
+  return parts.length > 0 ? parts.join("/") : ".";
+}
+
+/** Normalise any path string (relative or absolute) to its canonical form. */
+function clean(input: string): string {
+  return render(toParts(input));
+}
+
+/** The base name (last segment) of a path, or `""` for a root. */
+function baseName(parts: string[]): string {
+  return parts.length > 0 ? parts[parts.length - 1] : "";
+}
+
+/** The extension of a base name including the dot, or `""` if none. */
+function extensionOf(name: string): string {
+  const dot = name.lastIndexOf(".");
+  return dot > 0 ? name.slice(dot) : "";
+}
+
+/**
+ * An immutable, absolute filesystem path with a fluent, NUKE-inspired API.
+ *
+ * Build one with {@link absolutePath}. The value itself is **callable** —
+ * `path(...segments)` returns a new path with those segments appended — and the
+ * equivalent {@link AbsolutePath.join} method does the same. `toString()`
+ * yields the path string, so an `AbsolutePath` can be interpolated into the
+ * `$` shell helper and passed straight to tool `args()`.
+ */
+export interface AbsolutePath {
+  /** Append path segments, returning a new path (the callable form of {@link join}). */
+  (...segments: string[]): AbsolutePath;
+  /** The normalised path string (forward slashes, `.`/`..` resolved). */
+  readonly path: string;
+  /** The final segment, e.g. `"main.ts"` (or `""` for a root). */
+  readonly name: string;
+  /** The final segment without its extension, e.g. `"main"` (`".gitignore"` has none). */
+  readonly stem: string;
+  /** The extension including the dot, e.g. `".ts"` (or `""` if none). */
+  readonly extension: string;
+  /** Whether this path is a filesystem root (`"/"`, `"C:/"`). */
+  readonly isRoot: boolean;
+  /** Append path segments, returning a new path. */
+  join(...segments: string[]): AbsolutePath;
+  /** The parent directory; a root is its own parent. */
+  parent(): AbsolutePath;
+  /** This path expressed relative to `base` (e.g. `"src/main.ts"`, `"../lib"`). */
+  relativeTo(base: AbsolutePath | string): string;
+  /** Whether `other` resolves to the same normalised path. */
+  equals(other: AbsolutePath | string): boolean;
+  /** The normalised path string. */
+  toString(): string;
+}
+
+/**
+ * Build an {@link AbsolutePath} from one or more segments. The first segment
+ * (after joining) must be absolute — start with `/` or a drive letter, or build
+ * from an absolute base — otherwise an error is thrown.
+ *
+ * ```ts
+ * const root = absolutePath("/app");
+ * root("src", "main.ts").path;       // "/app/src/main.ts"
+ * root.join("..", "shared").path;    // "/shared"
+ * absolutePath("C:\\repo", "x").path; // "C:/repo/x"
+ * ```
+ *
+ * @param first The first path segment; must make the result absolute.
+ * @param rest Additional segments to append.
+ */
+export function absolutePath(first: string, ...rest: string[]): AbsolutePath {
+  const joined = [first, ...rest].join("/");
+  const split = toParts(joined);
+  if (split.root === "") {
+    throw new Error(
+      `absolutePath: expected an absolute path, got "${joined}". ` +
+        `Start with "/" or a drive letter (e.g. "C:/"), or join onto an ` +
+        `absolute base.`,
+    );
+  }
+  const value = render(split);
+  const name = baseName(split.parts);
+  const extension = extensionOf(name);
+
+  const call = (...segments: string[]): AbsolutePath =>
+    absolutePath(value, ...segments);
+
+  // A function's own `name` is read-only; unlock it so the path's own `name`
+  // (the final segment) can shadow it via the assignment below.
+  Object.defineProperty(call, "name", { writable: true, configurable: true });
+
+  return Object.assign(call, {
+    path: value,
+    name,
+    stem: extension === "" ? name : name.slice(0, -extension.length),
+    extension,
+    isRoot: split.parts.length === 0,
+    join: (...segments: string[]): AbsolutePath =>
+      absolutePath(value, ...segments),
+    parent: (): AbsolutePath =>
+      absolutePath(
+        render({ root: split.root, parts: split.parts.slice(0, -1) }),
+      ),
+    relativeTo: (base: AbsolutePath | string): string => {
+      const from = toParts(String(base));
+      if (from.root !== split.root) {
+        throw new Error(
+          `relativeTo: cannot relate paths with different roots ` +
+            `("${from.root || "<relative>"}" vs "${split.root}").`,
+        );
+      }
+      let common = 0;
+      while (
+        common < from.parts.length &&
+        common < split.parts.length &&
+        from.parts[common] === split.parts[common]
+      ) {
+        common++;
+      }
+      const up = from.parts.length - common;
+      const segments = [
+        ...new Array<string>(up).fill(".."),
+        ...split.parts.slice(common),
+      ];
+      return segments.length > 0 ? segments.join("/") : ".";
+    },
+    equals: (other: AbsolutePath | string): boolean =>
+      value === clean(String(other)),
+    toString: (): string => value,
+  });
+}

--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -16,11 +16,14 @@
  * @module
  */
 
+import type { AbsolutePath } from "./path.ts";
+
 /** A value that may be interpolated into a `$` template. */
 export type Interpolatable =
   | string
   | number
-  | Array<string | number>;
+  | AbsolutePath
+  | Array<string | number | AbsolutePath>;
 
 /** Raised when a command exits non-zero and throwing was not suppressed. */
 export class CommandError extends Error {

--- a/packages/core/src/tooling.ts
+++ b/packages/core/src/tooling.ts
@@ -20,6 +20,7 @@
  */
 
 import { Command, type CommandOutput } from "./shell.ts";
+import type { AbsolutePath } from "./path.ts";
 
 /** Raised when a tool's binary cannot be found on the system. */
 export class ToolNotFoundError extends Error {
@@ -118,7 +119,7 @@ export abstract class ToolSettings {
   }
 
   /** Escape hatch: append raw arguments after all typed options. */
-  args(...extra: Array<string | number>): this {
+  args(...extra: Array<string | number | AbsolutePath>): this {
     this.#extraArgs.push(...extra.map(String));
     return this;
   }

--- a/packages/core/tests/path_test.ts
+++ b/packages/core/tests/path_test.ts
@@ -1,0 +1,114 @@
+import { assertEquals, assertThrows } from "./_assert.ts";
+import { absolutePath } from "../src/path.ts";
+import { tokenize } from "../src/shell.ts";
+
+Deno.test("joins segments via call and .join, and normalises", () => {
+  const root = absolutePath("/app");
+  assertEquals(root("src", "main.ts").path, "/app/src/main.ts");
+  assertEquals(root.join("src", "main.ts").path, "/app/src/main.ts");
+  assertEquals(root("src")("main.ts").path, "/app/src/main.ts");
+  // `.` and `..` resolve; duplicate and trailing slashes collapse.
+  assertEquals(absolutePath("/app/./src/").path, "/app/src");
+  assertEquals(absolutePath("/app/lib", "..", "src").path, "/app/src");
+  assertEquals(absolutePath("/a//b///c").path, "/a/b/c");
+});
+
+Deno.test("preserves a Windows drive root and normalises backslashes", () => {
+  assertEquals(absolutePath("C:\\repo", "x").path, "C:/repo/x");
+  assertEquals(absolutePath("C:").path, "C:/");
+  assertEquals(absolutePath("C:/repo").isRoot, false);
+});
+
+Deno.test("rejects a relative base", () => {
+  assertThrows(
+    () => absolutePath("src/main.ts"),
+    Error,
+    "expected an absolute path",
+  );
+  assertThrows(() => absolutePath(".."), Error, "expected an absolute path");
+});
+
+Deno.test("name, stem, and extension", () => {
+  const f = absolutePath("/app/src/main.ts");
+  assertEquals(f.name, "main.ts");
+  assertEquals(f.stem, "main");
+  assertEquals(f.extension, ".ts");
+
+  const archive = absolutePath("/d/archive.tar.gz");
+  assertEquals(archive.stem, "archive.tar");
+  assertEquals(archive.extension, ".gz");
+
+  const dotfile = absolutePath("/home/.gitignore");
+  assertEquals(dotfile.extension, ""); // leading dot is not an extension
+  assertEquals(dotfile.stem, ".gitignore");
+
+  const binary = absolutePath("/usr/bin/deno");
+  assertEquals(binary.extension, "");
+  assertEquals(binary.stem, "deno");
+});
+
+Deno.test("root has empty name and is its own parent", () => {
+  const root = absolutePath("/");
+  assertEquals(root.isRoot, true);
+  assertEquals(root.name, "");
+  assertEquals(root.stem, "");
+  assertEquals(root.extension, "");
+  assertEquals(root.parent().path, "/");
+  // climbing above the root is a no-op
+  assertEquals(absolutePath("/..").path, "/");
+  assertEquals(absolutePath("/a/../..").path, "/");
+});
+
+Deno.test("parent walks up the tree", () => {
+  assertEquals(absolutePath("/app/src/main.ts").parent().path, "/app/src");
+  assertEquals(absolutePath("/app").parent().path, "/");
+  assertEquals(absolutePath("/app").parent().isRoot, true);
+});
+
+Deno.test("relativeTo computes descendant, ancestor, and sibling paths", () => {
+  const base = absolutePath("/app");
+  assertEquals(
+    absolutePath("/app/src/main.ts").relativeTo(base),
+    "src/main.ts",
+  );
+  assertEquals(absolutePath("/app").relativeTo(base), ".");
+  assertEquals(
+    absolutePath("/app/a").relativeTo(absolutePath("/app/b/c")),
+    "../../a",
+  );
+  // accepts a plain string base too
+  assertEquals(absolutePath("/app/x").relativeTo("/app"), "x");
+});
+
+Deno.test("relativeTo rejects mismatched roots", () => {
+  assertThrows(
+    () => absolutePath("/app").relativeTo("C:/app"),
+    Error,
+    "different roots",
+  );
+});
+
+Deno.test("equals normalises both sides and accepts strings or paths", () => {
+  const f = absolutePath("/app/src");
+  assertEquals(f.equals("/app/lib/../src"), true);
+  assertEquals(f.equals(absolutePath("/app/src")), true);
+  assertEquals(f.equals("/app/other"), false);
+  // normalisation also covers relative inputs (which never match an absolute)
+  assertEquals(f.equals("../../x"), false);
+});
+
+Deno.test("toString lets a path interpolate into the $ tokenizer", () => {
+  const f = absolutePath("/app/src/main.ts");
+  assertEquals(`${f}`, "/app/src/main.ts");
+  assertEquals(String(f), "/app/src/main.ts");
+  // discrete argv entry — never re-split, even with an array of paths
+  assertEquals(tokenize(["deno run ", ""], [f]), [
+    "deno",
+    "run",
+    "/app/src/main.ts",
+  ]);
+  assertEquals(
+    tokenize(["fmt ", ""], [[absolutePath("/a"), absolutePath("/b")]]),
+    ["fmt", "/a", "/b"],
+  );
+});


### PR DESCRIPTION
## Why

A fluent, ergonomic path type for build scripts: build and manipulate filesystem paths without sprinkling string concatenation and `join()` calls everywhere. TypeScript has **no operator overloading**, so a literal `/` join (`root / "src"`) is impossible — it would coerce to `NaN`. This adds the closest ergonomic equivalent to `@zuke/core`.

## What

A new `absolutePath` factory returning an `AbsolutePath` that is **callable** (the chosen "both" API):

```ts
import { absolutePath } from "jsr:@zuke/core";

const root = absolutePath("/app");
root("src", "main.ts");      // callable → /app/src/main.ts
root.join("tests", "x.ts");  // explicit → /app/tests/x.ts
```

Plus `path`, `name`, `stem`, `extension`, `isRoot`, `parent()`, `relativeTo(base)`, `equals(other)`, and `toString()`.

- **Immutable & normalised** — forward slashes, `.`/`..` resolved, duplicate/trailing slashes collapsed; a Windows `C:/…` drive prefix is preserved.
- **Dependency-free** — no `@std/path`; pure string logic (keeps `@zuke/core`'s zero-dependency rule).
- **Absolute-only** — a relative base throws a friendly error.
- **Interop** — `toString()` returns the path, and `Interpolatable` (the `$` template) and `ToolSettings.args()` now accept `AbsolutePath`, so a path drops straight into `` $`deno run ${main}` `` and tool wrappers.

## Design notes

- Segment-appending is the **callable instance + `.join()`** API (TypeScript can't overload `/`).
- `parent()` is a **method** (not a getter property): the project bans `as`/type-forcing in `src/`, and a callable object with lazy getter properties can't be built without a cast. `parent` returns another path, so it must stay lazy — a method keeps it both lazy and fully type-safe. The scalar facts (`name`/`stem`/`extension`/`isRoot`) are eager properties as in the preview.

## Verification

- `deno task ci` green — `packages/core/src/path.ts` fully covered (lcov shows no unhit lines); overall 99.4% lines / 97.8% branches.
- 10 unit tests cover joining, normalisation, Windows drives, name/stem/extension edge cases (dotfiles, multi-dot), `parent`/root behaviour, `relativeTo` (descendant/ancestor/sibling + mismatched-root error), `equals`, the relative-base error, and `$`-tokenizer interop.

## Note

Conventional-Commit title (`feat(core): …`) so release-please picks it up on squash-merge and bumps `@zuke/core`.

https://claude.ai/code/session_01D95HNhZEJrnSpDyznbmLXd