### PR TITLE
feat: accept AbsolutePath wherever tool wrappers take a path

### DIFF
--- a/packages/cmd/src/cmd.ts
+++ b/packages/cmd/src/cmd.ts
@@ -9,17 +9,22 @@
  * ```
  */
 
-import { type Configure, runSettings, ToolSettings } from "@zuke/core/tooling";
+import {
+  type Configure,
+  type PathLike,
+  runSettings,
+  ToolSettings,
+} from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
 
 /** Settings for a generic command: the tool name plus raw arguments. */
 export class CmdSettings extends ToolSettings {
   #tool: string;
 
-  constructor(tool: string) {
+  constructor(tool: PathLike) {
     super();
     if (!tool) throw new Error("CmdTasks.exec: tool name is required.");
-    this.#tool = tool;
+    this.#tool = String(tool);
   }
 
   protected override defaultTool(): string {
@@ -35,7 +40,7 @@ export class CmdSettings extends ToolSettings {
 export interface CmdTasksApi {
   /** Run `tool` with the configured settings. */
   exec(
-    tool: string,
+    tool: PathLike,
     configure?: Configure<CmdSettings>,
   ): Promise<CommandOutput>;
 }
@@ -48,7 +53,7 @@ export const CmdTasks: CmdTasksApi = {
    * @example `await CmdTasks.exec("git", (s) => s.args("status", "-s"))`
    */
   exec(
-    tool: string,
+    tool: PathLike,
     configure?: Configure<CmdSettings>,
   ): Promise<CommandOutput> {
     return runSettings(new CmdSettings(tool), configure);

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -33,7 +33,7 @@ export {
 } from "./src/target.ts";
 export { run } from "./src/cli.ts";
 export { execute, type ExecuteOptions, type Reporter } from "./src/executor.ts";
-export { type AbsolutePath, absolutePath } from "./src/path.ts";
+export { type AbsolutePath, absolutePath, type PathLike } from "./src/path.ts";
 export {
   executionSet,
   findCycle,

--- a/packages/core/src/path.ts
+++ b/packages/core/src/path.ts
@@ -29,6 +29,13 @@
  * @module
  */
 
+/**
+ * A filesystem path accepted by Zuke APIs: either a plain string or an
+ * {@link AbsolutePath}. Anywhere a tool wrapper or build helper takes a path,
+ * it accepts a `PathLike` and coerces it to a string.
+ */
+export type PathLike = string | AbsolutePath;
+
 /** The separated form of a path: its root (`""` if relative) and clean parts. */
 interface PathParts {
   /** `"/"`, a drive root like `"C:/"`, or `""` for a relative path. */

--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -16,7 +16,7 @@
  * @module
  */
 
-import type { AbsolutePath } from "./path.ts";
+import type { AbsolutePath, PathLike } from "./path.ts";
 
 /** A value that may be interpolated into a `$` template. */
 export type Interpolatable =
@@ -121,8 +121,8 @@ export class Command implements PromiseLike<CommandOutput> {
   }
 
   /** Set the working directory for the process. */
-  cwd(path: string): this {
-    this.#cwd = path;
+  cwd(path: PathLike): this {
+    this.#cwd = String(path);
     return this;
   }
 

--- a/packages/core/src/tooling.ts
+++ b/packages/core/src/tooling.ts
@@ -20,7 +20,9 @@
  */
 
 import { Command, type CommandOutput } from "./shell.ts";
-import type { AbsolutePath } from "./path.ts";
+import type { AbsolutePath, PathLike } from "./path.ts";
+
+export type { PathLike };
 
 /** Raised when a tool's binary cannot be found on the system. */
 export class ToolNotFoundError extends Error {
@@ -95,8 +97,8 @@ export abstract class ToolSettings {
   }
 
   /** Set the working directory for the process. */
-  cwd(path: string): this {
-    this.#cwd = path;
+  cwd(path: PathLike): this {
+    this.#cwd = String(path);
     return this;
   }
 
@@ -113,8 +115,8 @@ export abstract class ToolSettings {
   }
 
   /** Override the binary to run (e.g. an absolute path to the tool). */
-  toolPath(path: string): this {
-    this.#toolPath = path;
+  toolPath(path: PathLike): this {
+    this.#toolPath = String(path);
     return this;
   }
 

--- a/packages/cspell/src/cspell.ts
+++ b/packages/cspell/src/cspell.ts
@@ -15,7 +15,12 @@
  * @module
  */
 
-import { type Configure, runSettings, ToolSettings } from "@zuke/core/tooling";
+import {
+  type Configure,
+  type PathLike,
+  runSettings,
+  ToolSettings,
+} from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
 
 /** Settings for a `cspell lint` run. */
@@ -40,14 +45,14 @@ export class CspellSettings extends ToolSettings {
   }
 
   /** Files or globs to check (positional); repeatable. */
-  files(...globs: string[]): this {
-    this.#files.push(...globs);
+  files(...globs: PathLike[]): this {
+    this.#files.push(...globs.map(String));
     return this;
   }
 
   /** Use an explicit config file (`-c`/`--config`). */
-  config(path: string): this {
-    this.#config = path;
+  config(path: PathLike): this {
+    this.#config = String(path);
     return this;
   }
 

--- a/packages/deno/src/deno.ts
+++ b/packages/deno/src/deno.ts
@@ -13,7 +13,12 @@
  * `.toolPath(...)`.
  */
 
-import { type Configure, runSettings, ToolSettings } from "@zuke/core/tooling";
+import {
+  type Configure,
+  type PathLike,
+  runSettings,
+  ToolSettings,
+} from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
 
 /** A Deno permission domain, as used by `--allow-*` flags. */
@@ -68,8 +73,8 @@ export class DenoRunSettings extends DenoPermissionSettings {
   #reload = false;
 
   /** The script to run (required). */
-  script(path: string): this {
-    this.#script = path;
+  script(path: PathLike): this {
+    this.#script = String(path);
     return this;
   }
 
@@ -80,8 +85,8 @@ export class DenoRunSettings extends DenoPermissionSettings {
   }
 
   /** Use an explicit config file (`--config`). */
-  config(path: string): this {
-    this.#config = path;
+  config(path: PathLike): this {
+    this.#config = String(path);
     return this;
   }
 
@@ -112,14 +117,14 @@ export class DenoTestSettings extends DenoPermissionSettings {
   #failFast = false;
 
   /** Restrict the run to specific test files or directories. */
-  paths(...paths: string[]): this {
-    this.#paths.push(...paths);
+  paths(...paths: PathLike[]): this {
+    this.#paths.push(...paths.map(String));
     return this;
   }
 
   /** Collect coverage into the given profile directory (`--coverage=`). */
-  coverage(dir: string): this {
-    this.#coverage = dir;
+  coverage(dir: PathLike): this {
+    this.#coverage = String(dir);
     return this;
   }
 
@@ -159,8 +164,8 @@ export class DenoCheckSettings extends DenoSettings {
   #paths: string[] = [];
 
   /** The files to type-check (at least one is required). */
-  paths(...paths: string[]): this {
-    this.#paths.push(...paths);
+  paths(...paths: PathLike[]): this {
+    this.#paths.push(...paths.map(String));
     return this;
   }
 
@@ -186,8 +191,8 @@ export class DenoFmtSettings extends DenoSettings {
   }
 
   /** Restrict formatting to specific files or directories. */
-  paths(...paths: string[]): this {
-    this.#paths.push(...paths);
+  paths(...paths: PathLike[]): this {
+    this.#paths.push(...paths.map(String));
     return this;
   }
 
@@ -211,8 +216,8 @@ export class DenoLintSettings extends DenoSettings {
   }
 
   /** Restrict linting to specific files or directories. */
-  paths(...paths: string[]): this {
-    this.#paths.push(...paths);
+  paths(...paths: PathLike[]): this {
+    this.#paths.push(...paths.map(String));
     return this;
   }
 
@@ -236,8 +241,8 @@ export class DenoCacheSettings extends DenoSettings {
   }
 
   /** The entry points to cache (at least one is required). */
-  paths(...paths: string[]): this {
-    this.#paths.push(...paths);
+  paths(...paths: PathLike[]): this {
+    this.#paths.push(...paths.map(String));
     return this;
   }
 
@@ -262,8 +267,8 @@ export class DenoCoverageSettings extends DenoSettings {
   #exclude?: string;
 
   /** The coverage profile directory to report on. */
-  dir(path: string): this {
-    this.#dir = path;
+  dir(path: PathLike): this {
+    this.#dir = String(path);
     return this;
   }
 
@@ -274,8 +279,8 @@ export class DenoCoverageSettings extends DenoSettings {
   }
 
   /** Write the report to a file (`--output=`). */
-  output(path: string): this {
-    this.#output = path;
+  output(path: PathLike): this {
+    this.#output = String(path);
     return this;
   }
 

--- a/packages/docker-compose/src/docker_compose.ts
+++ b/packages/docker-compose/src/docker_compose.ts
@@ -23,7 +23,12 @@
  * @module
  */
 
-import { type Configure, runSettings, ToolSettings } from "@zuke/core/tooling";
+import {
+  type Configure,
+  type PathLike,
+  runSettings,
+  ToolSettings,
+} from "@zuke/core/tooling";
 import { ToolNotFoundError } from "@zuke/core/tooling";
 import { Command, type CommandOutput } from "@zuke/core/shell";
 
@@ -111,8 +116,8 @@ export abstract class DockerComposeSettings extends ToolSettings {
   }
 
   /** Add a Compose file (`-f`); repeatable, order-significant. */
-  file(path: string): this {
-    this.#files.push("-f", path);
+  file(path: PathLike): this {
+    this.#files.push("-f", String(path));
     return this;
   }
 
@@ -129,14 +134,14 @@ export abstract class DockerComposeSettings extends ToolSettings {
   }
 
   /** Set the project working directory (`--project-directory`). */
-  projectDirectory(path: string): this {
-    this.#projectDirectory = path;
+  projectDirectory(path: PathLike): this {
+    this.#projectDirectory = String(path);
     return this;
   }
 
   /** Load environment from a file (`--env-file`). */
-  envFile(path: string): this {
-    this.#envFile = path;
+  envFile(path: PathLike): this {
+    this.#envFile = String(path);
     return this;
   }
 
@@ -477,8 +482,8 @@ export class DockerComposeExecSettings extends DockerComposeSettings {
   }
 
   /** Working directory inside the container (`-w`). */
-  workdir(path: string): this {
-    this.#workdir = path;
+  workdir(path: PathLike): this {
+    this.#workdir = String(path);
     return this;
   }
 

--- a/packages/docker/src/docker.ts
+++ b/packages/docker/src/docker.ts
@@ -16,7 +16,12 @@
  * @module
  */
 
-import { type Configure, runSettings, ToolSettings } from "@zuke/core/tooling";
+import {
+  type Configure,
+  type PathLike,
+  runSettings,
+  ToolSettings,
+} from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
 
 /** Base for all `docker` subcommand settings: the binary is `docker`. */
@@ -45,8 +50,8 @@ export class DockerBuildSettings extends DockerSettings {
   }
 
   /** Use an explicit Dockerfile (`-f`). */
-  file(path: string): this {
-    this.#file = path;
+  file(path: PathLike): this {
+    this.#file = String(path);
     return this;
   }
 
@@ -87,8 +92,8 @@ export class DockerBuildSettings extends DockerSettings {
   }
 
   /** The build context path or URL (default `.`). */
-  context(path: string): this {
-    this.#context = path;
+  context(path: PathLike): this {
+    this.#context = String(path);
     return this;
   }
 
@@ -170,8 +175,8 @@ export class DockerRunSettings extends DockerSettings {
   }
 
   /** Bind-mount or attach a volume (`-v source:target`). */
-  volume(source: string, target: string): this {
-    this.#volumes.push("-v", `${source}:${target}`);
+  volume(source: PathLike, target: PathLike): this {
+    this.#volumes.push("-v", `${String(source)}:${String(target)}`);
     return this;
   }
 
@@ -238,8 +243,8 @@ export class DockerExecSettings extends DockerSettings {
   }
 
   /** Working directory inside the container (`-w`). */
-  workdir(path: string): this {
-    this.#workdir = path;
+  workdir(path: PathLike): this {
+    this.#workdir = String(path);
     return this;
   }
 
@@ -599,8 +604,8 @@ export class DockerSaveSettings extends DockerSettings {
   }
 
   /** Write to a file instead of STDOUT (`-o`). */
-  output(path: string): this {
-    this.#output = path;
+  output(path: PathLike): this {
+    this.#output = String(path);
     return this;
   }
 
@@ -621,8 +626,8 @@ export class DockerLoadSettings extends DockerSettings {
   #quiet = false;
 
   /** Read from a tar archive instead of STDIN (`-i`). */
-  input(path: string): this {
-    this.#input = path;
+  input(path: PathLike): this {
+    this.#input = String(path);
     return this;
   }
 

--- a/packages/eslint/src/eslint.ts
+++ b/packages/eslint/src/eslint.ts
@@ -15,7 +15,12 @@
  * @module
  */
 
-import { type Configure, runSettings, ToolSettings } from "@zuke/core/tooling";
+import {
+  type Configure,
+  type PathLike,
+  runSettings,
+  ToolSettings,
+} from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
 
 /** Settings for an `eslint` run. */
@@ -43,14 +48,14 @@ export class EslintSettings extends ToolSettings {
   }
 
   /** Files, directories, or globs to lint (positional); repeatable. */
-  paths(...values: string[]): this {
-    this.#paths.push(...values);
+  paths(...values: PathLike[]): this {
+    this.#paths.push(...values.map(String));
     return this;
   }
 
   /** Use an explicit config file (`-c`/`--config`). */
-  config(path: string): this {
-    this.#config = path;
+  config(path: PathLike): this {
+    this.#config = String(path);
     return this;
   }
 
@@ -97,8 +102,8 @@ export class EslintSettings extends ToolSettings {
   }
 
   /** Write the report to a file (`-o`/`--output-file`). */
-  outputFile(path: string): this {
-    this.#outputFile = path;
+  outputFile(path: PathLike): this {
+    this.#outputFile = String(path);
     return this;
   }
 
@@ -109,14 +114,14 @@ export class EslintSettings extends ToolSettings {
   }
 
   /** Where to store the cache (`--cache-location`). */
-  cacheLocation(path: string): this {
-    this.#cacheLocation = path;
+  cacheLocation(path: PathLike): this {
+    this.#cacheLocation = String(path);
     return this;
   }
 
   /** Read ignore globs from a file (`--ignore-path`). */
-  ignorePath(path: string): this {
-    this.#ignorePath = path;
+  ignorePath(path: PathLike): this {
+    this.#ignorePath = String(path);
     return this;
   }
 

--- a/packages/jest/src/jest.ts
+++ b/packages/jest/src/jest.ts
@@ -15,7 +15,12 @@
  * @module
  */
 
-import { type Configure, runSettings, ToolSettings } from "@zuke/core/tooling";
+import {
+  type Configure,
+  type PathLike,
+  runSettings,
+  ToolSettings,
+} from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
 
 /** Settings for a `jest` run. */
@@ -44,14 +49,14 @@ export class JestSettings extends ToolSettings {
   }
 
   /** Regex patterns matched against test paths (positional); repeatable. */
-  paths(...values: string[]): this {
-    this.#patterns.push(...values);
+  paths(...values: PathLike[]): this {
+    this.#patterns.push(...values.map(String));
     return this;
   }
 
   /** Use an explicit config file (`-c`/`--config`). */
-  config(path: string): this {
-    this.#config = path;
+  config(path: PathLike): this {
+    this.#config = String(path);
     return this;
   }
 

--- a/packages/oxlint/src/oxlint.ts
+++ b/packages/oxlint/src/oxlint.ts
@@ -15,7 +15,12 @@
  * @module
  */
 
-import { type Configure, runSettings, ToolSettings } from "@zuke/core/tooling";
+import {
+  type Configure,
+  type PathLike,
+  runSettings,
+  ToolSettings,
+} from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
 
 /** Settings for an `oxlint` run. */
@@ -39,20 +44,20 @@ export class OxlintSettings extends ToolSettings {
   }
 
   /** Files or directories to lint (positional); repeatable. */
-  paths(...values: string[]): this {
-    this.#paths.push(...values);
+  paths(...values: PathLike[]): this {
+    this.#paths.push(...values.map(String));
     return this;
   }
 
   /** Use an explicit config file (`-c`/`--config`). */
-  config(path: string): this {
-    this.#config = path;
+  config(path: PathLike): this {
+    this.#config = String(path);
     return this;
   }
 
   /** Point at a `tsconfig.json` for type-aware rules (`--tsconfig`). */
-  tsconfig(path: string): this {
-    this.#tsconfig = path;
+  tsconfig(path: PathLike): this {
+    this.#tsconfig = String(path);
     return this;
   }
 
@@ -87,8 +92,8 @@ export class OxlintSettings extends ToolSettings {
   }
 
   /** Read ignore globs from a file (`--ignore-path`). */
-  ignorePath(path: string): this {
-    this.#ignorePath = path;
+  ignorePath(path: PathLike): this {
+    this.#ignorePath = String(path);
     return this;
   }
 

--- a/packages/security/src/security.ts
+++ b/packages/security/src/security.ts
@@ -30,7 +30,12 @@
  * @module
  */
 
-import { type Configure, runSettings, ToolSettings } from "@zuke/core/tooling";
+import {
+  type Configure,
+  type PathLike,
+  runSettings,
+  ToolSettings,
+} from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
 
 /**
@@ -51,14 +56,14 @@ export class ZizmorSettings extends ToolSettings {
   }
 
   /** Add a workflow file or directory to audit (positional); repeatable. */
-  paths(...inputs: string[]): this {
-    this.#paths.push(...inputs);
+  paths(...inputs: PathLike[]): this {
+    this.#paths.push(...inputs.map(String));
     return this;
   }
 
   /** Use an explicit zizmor config file (`--config`). */
-  config(path: string): this {
-    this.#config = path;
+  config(path: PathLike): this {
+    this.#config = String(path);
     return this;
   }
 
@@ -115,8 +120,8 @@ export class ActionlintSettings extends ToolSettings {
   }
 
   /** Add an explicit workflow file to lint (positional); repeatable. */
-  files(...paths: string[]): this {
-    this.#files.push(...paths);
+  files(...paths: PathLike[]): this {
+    this.#files.push(...paths.map(String));
     return this;
   }
 
@@ -166,14 +171,14 @@ export class GitleaksDetectSettings extends ToolSettings {
   }
 
   /** Path to scan (`--source`). */
-  source(path: string): this {
-    this.#source = path;
+  source(path: PathLike): this {
+    this.#source = String(path);
     return this;
   }
 
   /** Use an explicit gitleaks config (`--config`). */
-  config(path: string): this {
-    this.#config = path;
+  config(path: PathLike): this {
+    this.#config = String(path);
     return this;
   }
 
@@ -184,8 +189,8 @@ export class GitleaksDetectSettings extends ToolSettings {
   }
 
   /** Write the report to a file (`--report-path`). */
-  reportPath(path: string): this {
-    this.#reportPath = path;
+  reportPath(path: PathLike): this {
+    this.#reportPath = String(path);
     return this;
   }
 
@@ -240,14 +245,14 @@ export class OsvScannerSettings extends ToolSettings {
   }
 
   /** Scan an explicit lockfile (`--lockfile`); repeatable. */
-  lockfile(path: string): this {
-    this.#lockfiles.push(path);
+  lockfile(path: PathLike): this {
+    this.#lockfiles.push(String(path));
     return this;
   }
 
   /** Add a directory to scan (positional); repeatable. */
-  paths(...inputs: string[]): this {
-    this.#paths.push(...inputs);
+  paths(...inputs: PathLike[]): this {
+    this.#paths.push(...inputs.map(String));
     return this;
   }
 
@@ -258,8 +263,8 @@ export class OsvScannerSettings extends ToolSettings {
   }
 
   /** Write the report to a file (`--output`). */
-  output(path: string): this {
-    this.#output = path;
+  output(path: PathLike): this {
+    this.#output = String(path);
     return this;
   }
 
@@ -304,8 +309,8 @@ export class SemgrepScanSettings extends ToolSettings {
   }
 
   /** Add a path to scan (positional); repeatable. */
-  paths(...inputs: string[]): this {
-    this.#paths.push(...inputs);
+  paths(...inputs: PathLike[]): this {
+    this.#paths.push(...inputs.map(String));
     return this;
   }
 
@@ -322,8 +327,8 @@ export class SemgrepScanSettings extends ToolSettings {
   }
 
   /** Write output to a file (`--output`). */
-  output(path: string): this {
-    this.#output = path;
+  output(path: PathLike): this {
+    this.#output = String(path);
     return this;
   }
 
@@ -363,8 +368,8 @@ abstract class TrivyReportSettings extends ToolSettings {
   }
 
   /** Write the report to a file (`--output`). */
-  output(path: string): this {
-    this.#output = path;
+  output(path: PathLike): this {
+    this.#output = String(path);
     return this;
   }
 
@@ -404,8 +409,8 @@ export class TrivyFsSettings extends TrivyReportSettings {
   #scanners: string[] = [];
 
   /** The path to scan (default `.`). */
-  target(path: string): this {
-    this.#target = path;
+  target(path: PathLike): this {
+    this.#target = String(path);
     return this;
   }
 
@@ -435,8 +440,8 @@ export class TrivyConfigSettings extends TrivyReportSettings {
   #target = ".";
 
   /** The path to scan (default `.`). */
-  target(path: string): this {
-    this.#target = path;
+  target(path: PathLike): this {
+    this.#target = String(path);
     return this;
   }
 

--- a/packages/vitest/src/vitest.ts
+++ b/packages/vitest/src/vitest.ts
@@ -19,7 +19,12 @@
  * @module
  */
 
-import { type Configure, runSettings, ToolSettings } from "@zuke/core/tooling";
+import {
+  type Configure,
+  type PathLike,
+  runSettings,
+  ToolSettings,
+} from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
 
 /** Settings for a `vitest` run. */
@@ -61,20 +66,20 @@ export class VitestSettings extends ToolSettings {
   }
 
   /** Use an explicit config file (`-c`/`--config`). */
-  config(path: string): this {
-    this.#config = path;
+  config(path: PathLike): this {
+    this.#config = String(path);
     return this;
   }
 
   /** Project root (`--root`). */
-  root(path: string): this {
-    this.#root = path;
+  root(path: PathLike): this {
+    this.#root = String(path);
     return this;
   }
 
   /** Restrict the scanned directory (`--dir`). */
-  dir(path: string): this {
-    this.#dir = path;
+  dir(path: PathLike): this {
+    this.#dir = String(path);
     return this;
   }
 
@@ -127,8 +132,8 @@ export class VitestSettings extends ToolSettings {
   }
 
   /** Write report output to a file (`--outputFile`). */
-  outputFile(path: string): this {
-    this.#outputFile = path;
+  outputFile(path: PathLike): this {
+    this.#outputFile = String(path);
     return this;
   }
 


### PR DESCRIPTION
## Why

Follow-up to #32 (`absolutePath`): now that `@zuke/core` has an `AbsolutePath`, every tool wrapper and build helper that takes a path should accept one directly — no manual `String(...)` / `.path` at call sites.

## What

Adds `PathLike = string | AbsolutePath` to `@zuke/core` (re-exported from `@zuke/core/tooling`) and widens every path-accepting parameter to it, coercing to a string with `String(...)` at the boundary. Private fields stay `string`/`string[]`; **no `as`/casts**.

```ts
const root = absolutePath("/app");
await DenoTasks.run((s) => s.script(root("mod.ts")).cwd(root));
await DockerTasks.build((s) => s.file(root("Dockerfile")).context(root));
```

Widened across:

- **core** — `$`/`Command.cwd`, `ToolSettings.cwd` & `toolPath`
- **@zuke/deno** — `script`, `config`, `coverage`, `dir`, `output`, all `paths(...)`
- **@zuke/docker** — `file`, `context`, `volume` (both sides), `workdir`, `output`, `input`
- **@zuke/docker-compose** — `file`, `projectDirectory`, `envFile`, `workdir`
- **@zuke/eslint / oxlint / jest / vitest / cspell** — `paths`/`files`, `config`, `output`, `root`, `tsconfig`, `ignorePath`, `cacheLocation`, `outputFile`
- **@zuke/security** — zizmor/gitleaks/osv/semgrep/trivy path inputs
- **@zuke/cmd** — the tool name

Non-path options are intentionally left as `string` (formats, severities, image/container names, tags, env keys, and semgrep's `config` ruleset id like `auto`/`p/ci`).

## Verification

- `deno task ci` green — 214 tests pass; 99.4% lines / 97.8% branches.
- Type-only widening; the `String(...)` coercion paths are already exercised by the existing string-based wrapper tests.

## Note

Conventional-Commit title so release-please bumps the affected packages (core + wrappers) on squash-merge.

https://claude.ai/code/session_01D95HNhZEJrnSpDyznbmLXd

---
_Generated by [Claude Code](https://claude.ai/code/session_01D95HNhZEJrnSpDyznbmLXd)_