### PR TITLE
chore: drop the one-time release-as 0.1.0 pins

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -57,7 +57,6 @@
     },
     "packages/oxlint": {
       "component": "oxlint",
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
@@ -65,7 +64,6 @@
     },
     "packages/eslint": {
       "component": "eslint",
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
@@ -73,7 +71,6 @@
     },
     "packages/cspell": {
       "component": "cspell",
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
@@ -81,7 +78,6 @@
     },
     "packages/jest": {
       "component": "jest",
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
@@ -89,7 +85,6 @@
     },
     "packages/vitest": {
       "component": "vitest",
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
@@ -97,7 +92,6 @@
     },
     "packages/security": {
       "component": "security",
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         { "type": "json", "path": "deno.json", "jsonpath": "$.version" }


### PR DESCRIPTION
## Why no packages were released after #34

#34 (`feat: accept AbsolutePath …`) modified `src/` in several wrapper packages — including **eslint, oxlint, jest, vitest, cspell, and security** — yet **no release PR was created** (manifest still shows `core` 0.4.0, `deno`/`docker` 0.2.0, etc.).

Root cause: those six packages still carry their **one-time `release-as: "0.1.0"` bootstrap pins** (added in #26 and #30). `0.1.0` is already tagged/released, so when #34 gave those packages new commits, release-please tried to re-cut an existing version. With `separate-pull-requests: false` that's one combined PR, and the conflict **aborts the entire release** — so `core`, `deno`, `docker`, `docker-compose`, and `cmd` got no bump either.

By contrast #32 only touched `packages/core` (no pinned package), so release PR #33 was created normally. That's the tell.

`RELEASING.md` already documents these pins as one-time:
> Once all the `0.1.0` versions are on JSR, **delete the `"release-as": "0.1.0"` lines** … if left in place they would force every future release back to `0.1.0` and break automatic versioning.

## What

Removes all six stale `release-as: "0.1.0"` lines from `.release-please-config.json`. No other change.

## What happens on merge

release-please re-evaluates every package against its last tag and opens a release PR bumping each package that has unreleased commits from #34 — expected: `core`, `deno`, `cmd`, `docker`, `docker-compose`, `eslint`, `oxlint`, `jest`, `vitest`, `cspell`, `security` (`npm`/`cli` were untouched, so no bump). Merging that publishes them to JSR.

## Verification

- `deno.json`/config parse valid; `deno task ci` green (99.4% lines / 97.8% branches).
- `release_config_test.ts` still passes (package set and manifest unchanged).

https://claude.ai/code/session_01D95HNhZEJrnSpDyznbmLXd

---
_Generated by [Claude Code](https://claude.ai/code/session_01D95HNhZEJrnSpDyznbmLXd)_