### PR TITLE
feat: document AbsolutePath support across the tool-wrapper packages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,13 @@ zuke.ts                   # Zuke's own build (runnable example)
   (imperative mood; explain the *why*). Keep PRs reviewable.
 - **Conventional, semantic versioning** for releases; keep a changelog as the
   project grows.
+- **Keep code snippets out of commit message bodies.** release-please parses
+  every merged commit with a strict conventional-commits parser, and a code
+  fragment containing parentheses (e.g. an arrow function) makes it fail to
+  parse the whole commit — which silently drops it from the release, so no
+  version is bumped. The repo squash-merges, so the squash body comes from the
+  PR description/commits: put illustrative code in the PR discussion, and keep
+  commit bodies to prose. See [`RELEASING.md`](RELEASING.md).
 - **Update docs with code.** If behaviour changes, update `README.md`, JSDoc,
   and the spec/acceptance criteria in the same PR.
 - **No secrets or machine-specific paths** in the repo or commits. Don't commit

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -38,6 +38,15 @@ pull request.
 So the steady-state flow is: merge conventional commits → merge the release PR
 → the packages publish themselves.
 
+> [!IMPORTANT]
+> **Keep code snippets out of commit message bodies.** release-please parses
+> each merged commit with a strict conventional-commits parser, and code
+> fragments containing parentheses (for example an arrow-function example) make
+> it fail to parse the whole commit — which silently drops it from the release,
+> so no version is bumped. Because the repo squash-merges, the squash body is
+> built from the PR description/commits, so keep illustrative code in the PR
+> *discussion*, not in the commit body. Describe the change in prose instead.
+
 ## First release (one-time bootstrap)
 
 The four JSR packages start empty, so the very first release is bootstrapped to

--- a/packages/cmd/README.md
+++ b/packages/cmd/README.md
@@ -9,3 +9,8 @@ import { CmdTasks } from "jsr:@zuke/cmd";
 
 await CmdTasks.exec("git", (s) => s.args("rev-parse", "HEAD"));
 ```
+
+## Paths
+
+Every path argument accepts either a string or an `AbsolutePath` from
+`@zuke/core`, so a path built with `absolutePath` can be passed in directly.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -20,3 +20,9 @@ Also exports `jsr:@zuke/core/shell` (the injection-safe `$` runner) and
 `jsr:@zuke/core/tooling` (the base for typed tool wrappers).
 
 See [Zuke](https://github.com/zuke-build/zuke#readme) for the full guide.
+
+## Paths
+
+`@zuke/core` exports `absolutePath` and the `PathLike` type. Across the Zuke
+tool-wrapper packages, every path argument accepts either a string or an
+`AbsolutePath`.

--- a/packages/cspell/README.md
+++ b/packages/cspell/README.md
@@ -12,3 +12,8 @@ await CspellTasks.lint((s) =>
   s.files("**").config("cspell.json").noProgress().showSuggestions()
 );
 ```
+
+## Paths
+
+Every path argument accepts either a string or an `AbsolutePath` from
+`@zuke/core`, so a path built with `absolutePath` can be passed in directly.

--- a/packages/deno/README.md
+++ b/packages/deno/README.md
@@ -11,3 +11,8 @@ import { DenoTasks } from "jsr:@zuke/deno";
 await DenoTasks.test((s) => s.allowAll().coverage("cov_profile"));
 await DenoTasks.fmt((s) => s.check());
 ```
+
+## Paths
+
+Every path argument accepts either a string or an `AbsolutePath` from
+`@zuke/core`, so a path built with `absolutePath` can be passed in directly.

--- a/packages/docker-compose/README.md
+++ b/packages/docker-compose/README.md
@@ -19,3 +19,8 @@ await DockerComposeTasks.up((s) => s.file("compose.yml").detach().build());
 await DockerComposeTasks.logs((s) => s.follow().tail(100));
 await DockerComposeTasks.down((s) => s.volumes());
 ```
+
+## Paths
+
+Every path argument accepts either a string or an `AbsolutePath` from
+`@zuke/core`, so a path built with `absolutePath` can be passed in directly.

--- a/packages/docker/README.md
+++ b/packages/docker/README.md
@@ -14,3 +14,8 @@ await DockerTasks.build((s) =>
 );
 await DockerTasks.push((s) => s.image("app:1.0"));
 ```
+
+## Paths
+
+Every path argument accepts either a string or an `AbsolutePath` from
+`@zuke/core`, so a path built with `absolutePath` can be passed in directly.

--- a/packages/eslint/README.md
+++ b/packages/eslint/README.md
@@ -12,3 +12,8 @@ await EslintTasks.lint((s) =>
   s.paths("src").ext(".ts", ".tsx").fix().maxWarnings(0)
 );
 ```
+
+## Paths
+
+Every path argument accepts either a string or an `AbsolutePath` from
+`@zuke/core`, so a path built with `absolutePath` can be passed in directly.

--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -10,3 +10,8 @@ import { JestTasks } from "jsr:@zuke/jest";
 
 await JestTasks.run((s) => s.ci().coverage().maxWorkers("50%").bail());
 ```
+
+## Paths
+
+Every path argument accepts either a string or an `AbsolutePath` from
+`@zuke/core`, so a path built with `absolutePath` can be passed in directly.

--- a/packages/oxlint/README.md
+++ b/packages/oxlint/README.md
@@ -12,3 +12,8 @@ await OxlintTasks.lint((s) =>
   s.paths("src").config(".oxlintrc.json").fix().denyWarnings()
 );
 ```
+
+## Paths
+
+Every path argument accepts either a string or an `AbsolutePath` from
+`@zuke/core`, so a path built with `absolutePath` can be passed in directly.

--- a/packages/security/README.md
+++ b/packages/security/README.md
@@ -33,3 +33,8 @@ await SecurityTasks.gitleaks((s) =>
   s.source(".").reportFormat("sarif").reportPath("gitleaks.sarif").redact()
 );
 ```
+
+## Paths
+
+Every path argument accepts either a string or an `AbsolutePath` from
+`@zuke/core`, so a path built with `absolutePath` can be passed in directly.

--- a/packages/vitest/README.md
+++ b/packages/vitest/README.md
@@ -14,3 +14,8 @@ import { VitestTasks } from "jsr:@zuke/vitest";
 
 await VitestTasks.run((s) => s.coverage().reporter("dot").bail(1));
 ```
+
+## Paths
+
+Every path argument accepts either a string or an `AbsolutePath` from
+`@zuke/core`, so a path built with `absolutePath` can be passed in directly.


### PR DESCRIPTION
## Root cause (why the unpin alone didn't help)

I pulled the release-please log from the run after the unpin (#35) merged. Removing the `release-as` pins was a real fix for those packages' *future* releases, but it wasn't the blocker. The blocker is this, logged for nearly every package:

```
❯ commit could not be parsed: 576c2528… feat: accept AbsolutePath wherever tool wrappers take a path (#34)
❯ error message: Error: unexpected token '(' at 18:16, valid tokens [)]
❯ commits: 0
✔ No commits for path: packages/…, skipping
```

release-please parses each merged commit with a strict conventional-commits parser. **PR #34's squash-commit body contained a code snippet with nested parentheses** (an arrow-function example), which made the parser fail on the *entire* commit — so it counted **zero** commits for every package and proposed no release. That commit is immutable on master, so it will never be counted; the packages need a fresh, cleanly-worded commit to be released.

## What this does

Adds a short, genuine **"## Paths"** note to the README of every package that #34 changed — `core`, `deno`, `cmd`, `docker`, `docker-compose`, `eslint`, `oxlint`, `jest`, `vitest`, `cspell`, `security` — documenting that path arguments accept a string **or** an `AbsolutePath`. This is real user-facing docs for the shipped-but-unreleased feature, and the cleanly parseable commit lets release-please finally bump and publish those packages.

The commit message body is **prose only** (no code snippets) so it parses cleanly.

Also adds a caution to `RELEASING.md`: keep code snippets out of commit message bodies, or release-please silently drops the commit. (Because the repo squash-merges, the squash body is built from the PR description/commits — so illustrative code belongs in the PR discussion, not the commit body.)

## On merge

release-please will open a release PR bumping the 11 packages above (minor, since these are `feat`s pre-1.0). `npm` and `cli` are intentionally excluded — #34 didn't touch them.

## Verification

- `deno task ci` green (99.4% lines / 97.8% branches); cspell clean over all package READMEs.

https://claude.ai/code/session_01D95HNhZEJrnSpDyznbmLXd

---
_Generated by [Claude Code](https://claude.ai/code/session_01D95HNhZEJrnSpDyznbmLXd)_