### PR TITLE
feat(core): typed build parameters from flags and environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Full documentation lives in [`docs/`](./docs/):
   launcher, and a first build.
 - [Core concepts](./docs/concepts.md) — the build/target/graph model and
   execution semantics.
+- [Parameters](./docs/parameters.md) — typed build inputs from flags and env
+  vars (`parameter()`, `this.x.value`).
 - [Authoring API](./docs/authoring.md) — `target()`, `Build`, `run()`, and
   gotchas.
 - [Shell wrapper (`$`)](./docs/shell.md) — ergonomic, injection-safe process
@@ -118,7 +120,6 @@ CI runs `deno task ci` on every push and pull request (see
 
 Post-v0, for context:
 
-- Parameter & environment injection (`this.configuration`, `--configuration`).
 - Parallel execution of independent targets.
 - A `zuke` standalone binary + `zuke init` scaffolding.
 - Caching / incremental targets.

--- a/cspell.json
+++ b/cspell.json
@@ -43,6 +43,7 @@
     "vulns",
     "unconfigured",
     "unparseable",
+    "unsupplied",
     "xdg",
     "zizmor",
     "zuck",

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -1,0 +1,86 @@
+# Parameters
+
+Parameters are typed inputs to a build. You declare them as class fields — just
+like targets — and read the resolved value inside a target. The execution
+engine resolves every parameter **before any target runs**, from (in order of
+precedence):
+
+1. a command-line flag — `--environment production` or `--environment=production`
+2. an environment variable — `ENVIRONMENT`
+3. the declared default
+
+```ts
+import { Build, parameter, run, target } from "jsr:@zuke/core";
+
+class Deploy extends Build {
+  environment = parameter("Target environment")
+    .options("dev", "staging", "production")
+    .required();
+
+  workers = parameter("Parallel upload workers").number().default(4);
+
+  dryRun = parameter("Print actions without performing them").boolean();
+
+  deploy = target().executes(() => {
+    if (this.dryRun.value) console.log("(dry run)");
+    console.log(`Deploying to ${this.environment.value} with ${this.workers.value} workers`);
+  });
+}
+
+if (import.meta.main) await run(Deploy);
+```
+
+```sh
+./zuke deploy --environment production --workers 8 --dry-run
+ENVIRONMENT=staging ./zuke deploy        # value from the environment
+```
+
+## Declaring
+
+`parameter(description?)` starts a **string** parameter. Configure it fluently;
+each call refines the value type, so `value` is exactly as strong as the
+declaration:
+
+| Method | Effect | `value` type |
+| --- | --- | --- |
+| `parameter("…")` | optional string | `string \| undefined` |
+| `.number()` | parse as a number | `number \| undefined` |
+| `.boolean()` | a flag; defaults to `false` | `boolean` |
+| `.options("a", "b")` | restrict a string to choices | unchanged |
+| `.default(v)` | provide a default | non-optional (`T`) |
+| `.required()` | must be supplied | non-optional (`T`) |
+| `.env("NAME")` | override the env var name | unchanged |
+
+`.number()` and `.boolean()` come first (they change the kind); `.options()`
+applies to strings. A required parameter with no value (and no default) fails
+the build before any target runs, with a message naming the flag and env var.
+
+## Reading
+
+Read a parameter inside a target body via `this.<name>.value`. The value is
+fully typed: a `.required()` or `.default()` parameter is non-optional, while a
+plain optional parameter is `T | undefined`. Reading `.value` before the build
+has resolved parameters (e.g. at construction time) throws.
+
+## Naming
+
+The flag and environment variable are derived from the property name:
+`environment` → `--environment` / `ENVIRONMENT`; a camelCase name like
+`targetEnv` → `--target-env` / `TARGET_ENV`. Override the environment variable
+with `.env("NAME")`.
+
+## Without the CLI
+
+Resolution lives in the execution engine, not the CLI, so a programmatic
+[`execute`](./programmatic-api.md) call resolves parameters too — pass raw
+values via `params` and/or rely on environment variables:
+
+```ts
+import { discoverTargets, execute } from "jsr:@zuke/core";
+
+const build = new Deploy();
+const deploy = discoverTargets(build).get("deploy");
+if (deploy) {
+  await execute(build, deploy, { params: { environment: "production" } });
+}
+```

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -36,6 +36,14 @@ export { execute, type ExecuteOptions, type Reporter } from "./src/executor.ts";
 export { type AbsolutePath, absolutePath, type PathLike } from "./src/path.ts";
 export { CONFIG_FILE, repoRoot } from "./src/config.ts";
 export {
+  type AnyParameter,
+  discoverParameters,
+  Parameter,
+  parameter,
+  ParameterError,
+  type ParamValue,
+} from "./src/params.ts";
+export {
   executionSet,
   findCycle,
   GraphError,

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -11,6 +11,7 @@ import {
   graphCommand,
   type GraphHost,
 } from "./graph_view.ts";
+import { type AnyParameter, discoverParameters, flagName } from "./params.ts";
 import type { TargetBuilder } from "./target.ts";
 
 /** Convention: a target literally named `default` runs when none is requested. */
@@ -27,6 +28,16 @@ function parseOutput(value: string): GraphOutput {
   return value === "html" ? "html" : "text";
 }
 
+/** A declared parameter's CLI flag and whether it is a value-less boolean. */
+export interface ParamFlag {
+  /** The parameter's property name. */
+  name: string;
+  /** The CLI flag (without leading dashes). */
+  flag: string;
+  /** Whether the parameter is a boolean (its flag takes no value). */
+  boolean: boolean;
+}
+
 /** Parsed command-line arguments. */
 export interface ParsedArgs {
   /** The requested target, if a positional argument was given. */
@@ -40,55 +51,64 @@ export interface ParsedArgs {
   output: GraphOutput;
   /** Open the HTML graph in a browser (default true; `--no-open` clears). */
   open: boolean;
+  /** Raw parameter values from declared flags, keyed by property name. */
+  values: Record<string, string>;
   help: boolean;
 }
 
-/** Parse `zuke` arguments. Unknown flags are reported by the caller. */
-export function parseArgs(args: string[]): ParsedArgs {
+/**
+ * Parse `zuke` arguments. Built-in flags are recognised first; `paramFlags`
+ * lets the caller pass the build's declared parameter flags so their values are
+ * collected. Unknown flags are ignored.
+ */
+export function parseArgs(
+  args: string[],
+  paramFlags: ParamFlag[] = [],
+): ParsedArgs {
   const parsed: ParsedArgs = {
     skip: [],
     list: false,
     graph: false,
     output: "text",
     open: true,
+    values: {},
     help: false,
   };
+  const byFlag = new Map<string, ParamFlag>();
+  for (const pf of paramFlags) byFlag.set(pf.flag, pf);
+
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
-    if (arg.startsWith("--output=")) {
+    if (arg === "--list" || arg === "-l") {
+      parsed.list = true;
+    } else if (arg === "--no-open") {
+      parsed.open = false;
+    } else if (arg === "--help" || arg === "-h") {
+      parsed.help = true;
+    } else if (arg === "--skip") {
+      const dep = args[++i];
+      if (dep) parsed.skip.push(dep);
+    } else if (arg === "--output") {
+      const value = args[++i];
+      if (value) parsed.output = parseOutput(value);
+    } else if (arg.startsWith("--output=")) {
       parsed.output = parseOutput(arg.slice("--output=".length));
-      continue;
-    }
-    switch (arg) {
-      case "--list":
-      case "-l":
-        parsed.list = true;
-        break;
-      case "--output": {
-        const value = args[++i];
-        if (value) parsed.output = parseOutput(value);
-        break;
-      }
-      case "--no-open":
-        parsed.open = false;
-        break;
-      case "--help":
-      case "-h":
-        parsed.help = true;
-        break;
-      case "--skip": {
-        const dep = args[++i];
-        if (dep) parsed.skip.push(dep);
-        break;
-      }
-      default:
-        if (
-          !arg.startsWith("-") && parsed.target === undefined && !parsed.graph
-        ) {
-          if (arg === GRAPH_COMMAND) parsed.graph = true;
-          else parsed.target = arg;
+    } else if (arg.startsWith("--")) {
+      const eq = arg.indexOf("=");
+      const flag = eq === -1 ? arg.slice(2) : arg.slice(2, eq);
+      const pf = byFlag.get(flag);
+      if (pf !== undefined) {
+        if (eq !== -1) parsed.values[pf.name] = arg.slice(eq + 1);
+        else if (pf.boolean) parsed.values[pf.name] = "true";
+        else {
+          const value = args[++i];
+          if (value !== undefined) parsed.values[pf.name] = value;
         }
-        break;
+      }
+      // Unknown flags are ignored.
+    } else if (parsed.target === undefined && !parsed.graph) {
+      if (arg === GRAPH_COMMAND) parsed.graph = true;
+      else parsed.target = arg;
     }
   }
   return parsed;
@@ -115,16 +135,31 @@ Options:
                     page to .zuke/ and opens it in a browser.
   --output <fmt>    Graph output format: text (default) or html.
   --no-open         With --output=html, do not open a browser.
+  --<param> <val>   Set a declared build parameter (see Parameters below).
   --help, -h        Show this help.`;
 
-/** Render `--help`, including the available targets. */
-export function formatHelp(targets: Map<string, TargetBuilder>): string {
-  return `${USAGE}\n\n${formatList(targets)}`;
+/** Render `--help`, including the available targets and parameters. */
+export function formatHelp(
+  targets: Map<string, TargetBuilder>,
+  params: Map<string, AnyParameter> = new Map(),
+): string {
+  return `${USAGE}\n\n${formatList(targets, params)}`;
 }
 
-/** Render `--list`: each target with its description and dependencies. */
-export function formatList(targets: Map<string, TargetBuilder>): string {
-  if (targets.size === 0) return "No targets defined.";
+/** Render `--list`: each target with its description and dependencies, then parameters. */
+export function formatList(
+  targets: Map<string, TargetBuilder>,
+  params: Map<string, AnyParameter> = new Map(),
+): string {
+  const targetText = targets.size === 0
+    ? "No targets defined."
+    : renderTargets(targets);
+  const paramText = formatParameters(params);
+  return paramText === "" ? targetText : `${targetText}\n\n${paramText}`;
+}
+
+/** Render the target listing (non-empty). */
+function renderTargets(targets: Map<string, TargetBuilder>): string {
   const width = Math.max(...[...targets.keys()].map((n) => n.length));
   const lines = ["Targets:"];
   for (const [name, t] of targets) {
@@ -132,6 +167,25 @@ export function formatList(targets: Map<string, TargetBuilder>): string {
     const desc = t.description_ ?? "";
     const suffix = deps.length ? `  (depends on: ${deps.join(", ")})` : "";
     lines.push(`  ${name.padEnd(width)}  ${desc}${suffix}`);
+  }
+  return lines.join("\n");
+}
+
+/** Render the parameters section, or `""` when no parameters are declared. */
+function formatParameters(params: Map<string, AnyParameter>): string {
+  if (params.size === 0) return "";
+  const flags = [...params.keys()].map(flagName);
+  const width = Math.max(...flags.map((f) => f.length));
+  const lines = ["Parameters:"];
+  for (const [name, p] of params) {
+    const bits: string[] = [];
+    if (p.required_) bits.push("required");
+    if (p.options_ && p.options_.length > 0) {
+      bits.push(`one of: ${p.options_.join(", ")}`);
+    }
+    const meta = bits.length > 0 ? `  (${bits.join("; ")})` : "";
+    const desc = p.description_ ?? "";
+    lines.push(`  --${flagName(name).padEnd(width)}  ${desc}${meta}`);
   }
   return lines.join("\n");
 }
@@ -159,10 +213,16 @@ export async function main(
 ): Promise<number> {
   const build = new BuildClass();
   const targets = discoverTargets(build);
-  const parsed = parseArgs(args);
+  const params = discoverParameters(build);
+  const paramFlags: ParamFlag[] = [...params.entries()].map(([name, p]) => ({
+    name,
+    flag: flagName(name),
+    boolean: p.kind_ === "boolean",
+  }));
+  const parsed = parseArgs(args, paramFlags);
 
   if (parsed.help) {
-    console.log(formatHelp(targets));
+    console.log(formatHelp(targets, params));
     return 0;
   }
 
@@ -177,7 +237,7 @@ export async function main(
   }
 
   if (parsed.list) {
-    console.log(formatList(targets));
+    console.log(formatList(targets, params));
     return 0;
   }
   if (parsed.graph) {
@@ -193,7 +253,7 @@ export async function main(
     if (targets.has(DEFAULT_TARGET)) {
       name = DEFAULT_TARGET;
     } else {
-      console.log(formatList(targets));
+      console.log(formatList(targets, params));
       return 0;
     }
   }
@@ -201,11 +261,14 @@ export async function main(
   const root = targets.get(name);
   if (!root) {
     console.error(`Unknown target: ${name}\n`);
-    console.error(formatList(targets));
+    console.error(formatList(targets, params));
     return 1;
   }
 
-  const result = await execute(build, root, { skip: parsed.skip });
+  const result = await execute(build, root, {
+    skip: parsed.skip,
+    params: parsed.values,
+  });
   return result.ok ? 0 : 1;
 }
 

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -18,6 +18,11 @@
 
 import type { Build, BuildResult } from "./build.ts";
 import { plan } from "./graph.ts";
+import {
+  discoverParameters,
+  ParameterError,
+  resolveParameters,
+} from "./params.ts";
 import type { TargetBuilder } from "./target.ts";
 
 /** Sink for executor output, defaulting to the console. Overridable in tests. */
@@ -41,6 +46,18 @@ export interface ExecuteOptions {
   reporter?: Reporter;
   /** Target names to skip even if they appear in the plan (CLI `--skip`). */
   skip?: string[];
+  /**
+   * Raw parameter values from the command line, keyed by parameter (property)
+   * name. Each declared {@link Parameter} is resolved from this map, then the
+   * environment, then its declared default before any target runs.
+   */
+  params?: Record<string, string>;
+  /**
+   * Reads an environment variable as a parameter fallback. Defaults to
+   * `Deno.env.get` (returning `undefined` when env access is unavailable);
+   * overridable so parameter resolution can be tested hermetically.
+   */
+  readEnv?: (name: string) => string | undefined;
   /**
    * Force GitHub Actions output formatting on or off. Auto-detected from the
    * `GITHUB_ACTIONS` environment variable when omitted.
@@ -95,6 +112,15 @@ function inGitHubActions(): boolean {
     return Deno.env.get("GITHUB_ACTIONS") === "true";
   } catch {
     return false;
+  }
+}
+
+/** Read an environment variable, treating missing env access as unset. */
+function defaultReadEnv(name: string): string | undefined {
+  try {
+    return Deno.env.get(name);
+  } catch {
+    return undefined;
   }
 }
 
@@ -262,6 +288,24 @@ export async function execute(
   const github = options.github ?? inGitHubActions();
   const style = resolveStyle(options, github);
   const skip = new Set(options.skip ?? []);
+
+  // Resolve declared parameters (CLI value → environment → default) before any
+  // target runs, so a target body can read `this.param.value`. A missing
+  // required parameter or an invalid value fails the build before it starts.
+  const paramErrors = resolveParameters(
+    discoverParameters(build),
+    options.params ?? {},
+    options.readEnv ?? defaultReadEnv,
+  );
+  if (paramErrors.length > 0) {
+    reporter.error("Invalid or missing parameters:");
+    for (const message of paramErrors) reporter.error(`  ${message}`);
+    return {
+      ok: false,
+      executed: [],
+      error: new ParameterError(paramErrors.join("; ")),
+    };
+  }
 
   const order = plan(root);
   const reports: TargetReport[] = [];

--- a/packages/core/src/params.ts
+++ b/packages/core/src/params.ts
@@ -1,0 +1,347 @@
+/**
+ * Build parameters: typed, injectable inputs resolved from CLI flags and
+ * environment variables before targets run.
+ *
+ * Parameters are declared as class fields, exactly like targets — the framework
+ * discovers them by introspection (see {@link discoverParameters}) and resolves
+ * each value before the build executes. Declaration is fully type-safe: the
+ * fluent builder narrows the value type as you configure it, so a target reads
+ * a resolved value off `this`.
+ *
+ * ```ts
+ * import { Build, parameter, target } from "jsr:@zuke/core";
+ *
+ * class Deploy extends Build {
+ *   environment = parameter("Target environment")
+ *     .options("dev", "staging", "production")
+ *     .required();
+ *
+ *   deploy = target().executes(() => {
+ *     console.log(`Deploying to ${this.environment.value}`); // string
+ *   });
+ * }
+ * ```
+ *
+ * A value comes from `--environment <v>` (or `--environment=<v>`), else the
+ * `ENVIRONMENT` environment variable, else the declared default; the CLI wins
+ * over the environment, which wins over the default.
+ *
+ * @module
+ */
+
+/** The value kinds a parameter can hold. */
+export type ParamValue = string | number | boolean;
+
+/** A parameter's runtime kind tag. */
+type ParamKind = "string" | "number" | "boolean";
+
+/** Internal resolved state: a value is present only once `ok` is true. */
+type Resolved<T> = { readonly ok: true; readonly value: T } | {
+  readonly ok: false;
+};
+
+/** Internal fallback (declared default): present only when `has` is true. */
+type Fallback<T> = { readonly has: true; readonly value: T } | {
+  readonly has: false;
+};
+
+/** Raised when a parameter value is invalid or read before resolution. */
+export class ParameterError extends Error {
+  override name = "ParameterError";
+}
+
+/** Parse a raw string as a finite number, or throw {@link ParameterError}. */
+function parseNumber(raw: string): number {
+  const value = Number(raw);
+  if (raw.trim() === "" || !Number.isFinite(value)) {
+    throw new ParameterError(`expected a number, got "${raw}"`);
+  }
+  return value;
+}
+
+/** Parse a raw string as a boolean, or throw {@link ParameterError}. */
+function parseBoolean(raw: string): boolean {
+  const value = raw.toLowerCase();
+  if (value === "true" || value === "1" || value === "yes") return true;
+  if (value === "false" || value === "0" || value === "no") return false;
+  throw new ParameterError(`expected a boolean, got "${raw}"`);
+}
+
+/** Build a string parser that optionally enforces a fixed set of choices. */
+function makeStringParser(
+  options?: readonly string[],
+): (raw: string) => string {
+  return (raw: string): string => {
+    if (options !== undefined && !options.includes(raw)) {
+      throw new ParameterError(
+        `expected one of ${options.join(", ")}, got "${raw}"`,
+      );
+    }
+    return raw;
+  };
+}
+
+/** The non-generic view of a parameter, used by discovery and resolution. */
+export interface AnyParameter {
+  /** Property name, assigned during discovery. Undefined until then. */
+  name_?: string;
+  /** Human-readable description shown in `--help`/`--list`. */
+  readonly description_?: string;
+  /** The runtime value kind. */
+  readonly kind_: ParamKind;
+  /** Whether a value must be supplied (no default). */
+  readonly required_: boolean;
+  /** The allowed string choices, if restricted with {@link Parameter.options}. */
+  readonly options_?: readonly string[];
+  /** An explicit environment variable name override. */
+  readonly envName_?: string;
+  /** Whether the parameter has a declared default value. */
+  readonly hasFallback_: boolean;
+  /** Resolve from a raw input (or `undefined` when none was supplied). */
+  resolve_(raw: string | undefined): void;
+}
+
+/** The constructor spec for a {@link Parameter}. */
+interface ParamSpec<K extends ParamValue, T extends K | undefined> {
+  description?: string;
+  kind: ParamKind;
+  required: boolean;
+  options?: readonly string[];
+  envName?: string;
+  parse: (raw: string) => T;
+  fallback: Fallback<T>;
+}
+
+/**
+ * A typed build parameter. Declare one with {@link parameter} and configure it
+ * with the fluent methods; each method returns a new parameter whose `value`
+ * type reflects the configuration (`string`, `number`, `boolean`, and whether
+ * it can be `undefined`).
+ *
+ * `K` is the underlying value kind; `T` is the exposed `value` type, which is
+ * `K` for required/defaulted parameters and `K | undefined` for optional ones.
+ */
+export class Parameter<
+  K extends ParamValue = ParamValue,
+  T extends K | undefined = K | undefined,
+> implements AnyParameter {
+  name_?: string;
+  readonly description_?: string;
+  readonly kind_: ParamKind;
+  readonly required_: boolean;
+  readonly options_?: readonly string[];
+  readonly envName_?: string;
+  readonly hasFallback_: boolean;
+  readonly #parse: (raw: string) => T;
+  readonly #fallback: Fallback<T>;
+  #state: Resolved<T> = { ok: false };
+
+  /**
+   * Wrap this parameter's parser to return a definitely-present value. The
+   * parsers never yield `undefined` (they return a value or throw), so the
+   * guard only narrows the type — it lets `.default()`/`.required()` produce a
+   * `(raw) => K` parser from this `(raw) => T` one without a cast.
+   */
+  #definiteParse(): (raw: string) => K {
+    const parse = this.#parse;
+    return (raw: string): K => {
+      const value = parse(raw);
+      if (value === undefined) {
+        throw new ParameterError("internal: parser produced no value");
+      }
+      return value;
+    };
+  }
+
+  constructor(spec: ParamSpec<K, T>) {
+    this.description_ = spec.description;
+    this.kind_ = spec.kind;
+    this.required_ = spec.required;
+    this.options_ = spec.options;
+    this.envName_ = spec.envName;
+    this.#parse = spec.parse;
+    this.#fallback = spec.fallback;
+    this.hasFallback_ = spec.fallback.has;
+  }
+
+  /** The resolved value. Throws if read before the build resolves parameters. */
+  get value(): T {
+    if (!this.#state.ok) {
+      throw new ParameterError(
+        `Parameter "${this.name_ ?? "(unnamed)"}" was read before it was ` +
+          `resolved. Read parameters inside a target body, not at construction.`,
+      );
+    }
+    return this.#state.value;
+  }
+
+  /** Parse the value as a number (e.g. `--workers 4`). */
+  number(
+    this: Parameter<string, string | undefined>,
+  ): Parameter<number, number | undefined> {
+    return new Parameter<number, number | undefined>({
+      description: this.description_,
+      kind: "number",
+      required: false,
+      envName: this.envName_,
+      parse: parseNumber,
+      fallback: { has: true, value: undefined },
+    });
+  }
+
+  /** Treat the parameter as a boolean flag (e.g. `--verbose`); defaults to false. */
+  boolean(
+    this: Parameter<string, string | undefined>,
+  ): Parameter<boolean, boolean> {
+    return new Parameter<boolean, boolean>({
+      description: this.description_,
+      kind: "boolean",
+      required: false,
+      envName: this.envName_,
+      parse: parseBoolean,
+      fallback: { has: true, value: false },
+    });
+  }
+
+  /** Restrict a string parameter to a fixed set of choices. */
+  options(
+    this: Parameter<string, string | undefined>,
+    ...values: string[]
+  ): Parameter<string, string | undefined> {
+    return new Parameter<string, string | undefined>({
+      description: this.description_,
+      kind: "string",
+      required: this.required_,
+      options: values,
+      envName: this.envName_,
+      parse: makeStringParser(values),
+      fallback: this.#fallback,
+    });
+  }
+
+  /** Provide a default, making `value` non-optional (`K`). */
+  default(value: K): Parameter<K, K> {
+    return new Parameter<K, K>({
+      description: this.description_,
+      kind: this.kind_,
+      required: false,
+      options: this.options_,
+      envName: this.envName_,
+      parse: this.#definiteParse(),
+      fallback: { has: true, value },
+    });
+  }
+
+  /** Require a value, making `value` non-optional (`K`); errors if unsupplied. */
+  required(): Parameter<K, K> {
+    return new Parameter<K, K>({
+      description: this.description_,
+      kind: this.kind_,
+      required: true,
+      options: this.options_,
+      envName: this.envName_,
+      parse: this.#definiteParse(),
+      fallback: { has: false },
+    });
+  }
+
+  /** Override the environment variable read as a fallback for this parameter. */
+  env(name: string): Parameter<K, T> {
+    return new Parameter<K, T>({
+      description: this.description_,
+      kind: this.kind_,
+      required: this.required_,
+      options: this.options_,
+      envName: name,
+      parse: this.#parse,
+      fallback: this.#fallback,
+    });
+  }
+
+  resolve_(raw: string | undefined): void {
+    if (raw !== undefined) {
+      this.#state = { ok: true, value: this.#parse(raw) };
+      return;
+    }
+    if (this.#fallback.has) {
+      this.#state = { ok: true, value: this.#fallback.value };
+    }
+    // Otherwise leave unresolved; resolveParameters reports a missing required.
+  }
+}
+
+/**
+ * Create a new build parameter (a `string` by default). Configure it fluently:
+ * `.number()`/`.boolean()` change the kind, `.options(...)` restricts a string,
+ * `.default(v)`/`.required()` set optionality, and `.env(name)` overrides the
+ * environment variable.
+ */
+export function parameter(
+  description?: string,
+): Parameter<string, string | undefined> {
+  return new Parameter<string, string | undefined>({
+    description,
+    kind: "string",
+    required: false,
+    parse: makeStringParser(),
+    fallback: { has: true, value: undefined },
+  });
+}
+
+/**
+ * Discover all parameters declared on a build instance: scan its own enumerable
+ * properties for {@link Parameter} values, bind each its property name, and
+ * return a name → parameter map preserving declaration order.
+ */
+export function discoverParameters(build: object): Map<string, AnyParameter> {
+  const params = new Map<string, AnyParameter>();
+  for (const [key, value] of Object.entries(build)) {
+    if (value instanceof Parameter) {
+      value.name_ = key;
+      params.set(key, value);
+    }
+  }
+  return params;
+}
+
+/** The CLI flag for a parameter: its property name in kebab-case. */
+export function flagName(name: string): string {
+  return name.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
+}
+
+/** The environment variable for a parameter: its name in SCREAMING_SNAKE_CASE. */
+export function envVarName(name: string): string {
+  return name.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toUpperCase();
+}
+
+/**
+ * Resolve every parameter from CLI values (keyed by property name) and the
+ * environment, applying defaults. Returns a list of human-readable errors for
+ * missing-required or invalid values; empty means success.
+ *
+ * @param params Discovered parameters.
+ * @param cliValues Raw values parsed from the command line, keyed by name.
+ * @param readEnv Reads an environment variable by name.
+ */
+export function resolveParameters(
+  params: Map<string, AnyParameter>,
+  cliValues: Record<string, string>,
+  readEnv: (name: string) => string | undefined,
+): string[] {
+  const errors: string[] = [];
+  for (const [name, param] of params) {
+    const envName = param.envName_ ?? envVarName(name);
+    const raw = name in cliValues ? cliValues[name] : readEnv(envName);
+    try {
+      param.resolve_(raw);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      errors.push(`--${flagName(name)}: ${message}`);
+      continue;
+    }
+    if (raw === undefined && param.required_ && !param.hasFallback_) {
+      errors.push(`--${flagName(name)} is required (or set ${envName}).`);
+    }
+  }
+  return errors;
+}

--- a/packages/core/tests/cli_test.ts
+++ b/packages/core/tests/cli_test.ts
@@ -11,6 +11,22 @@ import {
 import { discoverTargets } from "../src/build.ts";
 import { FakeGraphHost } from "./_fakes.ts";
 import { CONFIG_FILE } from "../src/config.ts";
+import { parameter } from "../src/params.ts";
+
+/** A build with declared parameters, for the parameter-aware CLI tests. */
+class Parameterised extends Build {
+  environment = parameter("Target environment").options("dev", "prod")
+    .required();
+  verbose = parameter("Verbose logging").boolean();
+  greet = target().executes(() => {
+    console.log(`env=${this.environment.value} verbose=${this.verbose.value}`);
+  });
+}
+
+const greetFlags = [
+  { name: "environment", flag: "environment", boolean: false },
+  { name: "verbose", flag: "verbose", boolean: true },
+];
 
 /** Run `fn` with `console.log`/`console.error` captured instead of printed. */
 async function capture(
@@ -76,6 +92,21 @@ Deno.test("parseArgs defaults graph to false, output to text, open to true", () 
   ]);
 });
 
+Deno.test("parseArgs collects declared parameter flags", () => {
+  const valued = parseArgs(
+    ["greet", "--environment", "prod", "--verbose"],
+    greetFlags,
+  );
+  assertEquals(valued.target, "greet");
+  assertEquals(valued.values, { environment: "prod", verbose: "true" });
+
+  const inline = parseArgs(["--environment=dev"], greetFlags);
+  assertEquals(inline.values, { environment: "dev" });
+
+  // Unknown flags are ignored, not treated as parameters.
+  assertEquals(parseArgs(["--nope", "x"], greetFlags).values, {});
+});
+
 Deno.test("parseArgs collects repeatable --skip and keeps first positional", () => {
   const parsed = parseArgs([
     "build",
@@ -133,6 +164,36 @@ Deno.test("main graph --output=html renders HTML via the injected host", async (
   assertEquals(code, 0);
   assertEquals(host.files.has("/repo/.zuke/graph.html"), true);
   assertEquals(host.opened, []);
+});
+
+Deno.test("main lists declared parameters under --help and --list", async () => {
+  const help = await capture(() => main(Parameterised, ["--help"]));
+  const text = help.out.join("\n");
+  assertEquals(text.includes("Parameters:"), true);
+  assertEquals(text.includes("--environment"), true);
+  assertEquals(text.includes("required"), true);
+  assertEquals(text.includes("one of: dev, prod"), true);
+});
+
+Deno.test("main resolves a parameter flag and runs the target", async () => {
+  const { code, out } = await capture(() =>
+    main(Parameterised, ["greet", "--environment", "dev", "--verbose"])
+  );
+  assertEquals(code, 0);
+  assertEquals(out.join("\n").includes("env=dev verbose=true"), true);
+});
+
+Deno.test("main fails with exit 1 when a required parameter is missing", async () => {
+  // Ensure the value can't leak in from the ambient environment.
+  const saved = Deno.env.get("ENVIRONMENT");
+  Deno.env.delete("ENVIRONMENT");
+  try {
+    const { code, err } = await capture(() => main(Parameterised, ["greet"]));
+    assertEquals(code, 1);
+    assertEquals(err.join("\n").includes("--environment is required"), true);
+  } finally {
+    if (saved !== undefined) Deno.env.set("ENVIRONMENT", saved);
+  }
 });
 
 Deno.test("main runs a target and its dependencies, returning 0", async () => {

--- a/packages/core/tests/params_test.ts
+++ b/packages/core/tests/params_test.ts
@@ -1,0 +1,199 @@
+import { assertEquals, assertThrows } from "./_assert.ts";
+import { Build, target } from "../mod.ts";
+import { discoverTargets } from "../src/build.ts";
+import { execute } from "../src/executor.ts";
+import {
+  type AnyParameter,
+  discoverParameters,
+  envVarName,
+  flagName,
+  Parameter,
+  parameter,
+  ParameterError,
+  resolveParameters,
+} from "../src/params.ts";
+
+Deno.test("a fresh parameter is an optional string", () => {
+  const p = parameter("desc");
+  p.resolve_(undefined);
+  assertEquals(p.value, undefined);
+  p.resolve_("hello");
+  assertEquals(p.value, "hello");
+});
+
+Deno.test("reading a value before resolution throws", () => {
+  assertThrows(
+    () => parameter("x").value,
+    ParameterError,
+    "before it was resolved",
+  );
+});
+
+Deno.test("default makes the value definite", () => {
+  const p = parameter("desc").default("Debug");
+  p.resolve_(undefined);
+  assertEquals(p.value, "Debug");
+  p.resolve_("Release");
+  assertEquals(p.value, "Release");
+  assertEquals(p.required_, false);
+  assertEquals(p.hasFallback_, true);
+});
+
+Deno.test("required has no fallback and stays unresolved without input", () => {
+  const p = parameter("desc").required();
+  assertEquals([p.required_, p.hasFallback_], [true, false]);
+  p.resolve_(undefined);
+  assertThrows(() => p.value, ParameterError);
+});
+
+Deno.test("number parses and rejects non-numbers", () => {
+  const p = parameter().number().default(1);
+  p.resolve_("42");
+  assertEquals(p.value, 42);
+  assertThrows(() => p.resolve_("abc"), ParameterError, "expected a number");
+  assertThrows(() => p.resolve_(""), ParameterError, "expected a number");
+});
+
+Deno.test("boolean parses truthy/falsy spellings and defaults to false", () => {
+  const flag = parameter().boolean();
+  flag.resolve_(undefined);
+  assertEquals(flag.value, false);
+  for (const yes of ["true", "1", "yes"]) {
+    const p = parameter().boolean();
+    p.resolve_(yes);
+    assertEquals(p.value, true);
+  }
+  for (const no of ["false", "0", "no"]) {
+    const p = parameter().boolean();
+    p.resolve_(no);
+    assertEquals(p.value, false);
+  }
+  assertThrows(
+    () => parameter().boolean().resolve_("maybe"),
+    ParameterError,
+    "expected a boolean",
+  );
+});
+
+Deno.test("options restrict a string to a fixed set", () => {
+  const p = parameter("env").options("dev", "prod");
+  assertEquals(p.options_, ["dev", "prod"]);
+  p.resolve_("dev");
+  assertEquals(p.value, "dev");
+  assertThrows(() => p.resolve_("staging"), ParameterError, "expected one of");
+});
+
+Deno.test("env overrides the environment variable name", () => {
+  const p = parameter("token").env("CI_TOKEN");
+  assertEquals(p.envName_, "CI_TOKEN");
+});
+
+Deno.test("flagName and envVarName convert camelCase", () => {
+  assertEquals(flagName("environment"), "environment");
+  assertEquals(flagName("targetEnv"), "target-env");
+  assertEquals(envVarName("environment"), "ENVIRONMENT");
+  assertEquals(envVarName("targetEnv"), "TARGET_ENV");
+});
+
+class Demo extends Build {
+  environment = parameter("Target environment").options("dev", "prod")
+    .required();
+  workers = parameter("Worker count").number().default(2);
+  verbose = parameter("Verbose logging").boolean();
+}
+
+Deno.test("discoverParameters names and collects parameters", () => {
+  const params = discoverParameters(new Demo());
+  assertEquals([...params.keys()], ["environment", "workers", "verbose"]);
+  assertEquals(params.get("environment")?.name_, "environment");
+});
+
+Deno.test("resolveParameters: CLI beats env beats default", () => {
+  const params = discoverParameters(new Demo());
+  const env = (name: string) => (name === "WORKERS" ? "8" : undefined);
+  const errors = resolveParameters(params, { environment: "prod" }, env);
+  assertEquals(errors, []);
+  const get = (n: string): AnyParameter => {
+    const p = params.get(n);
+    if (!p) throw new Error(`missing ${n}`);
+    return p;
+  };
+  // value is typed on Parameter; narrow via the concrete class.
+  const env_ = get("environment");
+  if (env_ instanceof Parameter) assertEquals(env_.value, "prod");
+  const workers = get("workers");
+  if (workers instanceof Parameter) assertEquals(workers.value, 8); // env
+  const verbose = get("verbose");
+  if (verbose instanceof Parameter) assertEquals(verbose.value, false); // default
+});
+
+Deno.test("resolveParameters reports missing required and invalid values", () => {
+  const params = discoverParameters(new Demo());
+  const errors = resolveParameters(
+    params,
+    { workers: "lots" },
+    () => undefined,
+  );
+  assertEquals(errors.length, 2);
+  assertEquals(
+    errors.some((e) => e.includes("--environment is required")),
+    true,
+  );
+  assertEquals(
+    errors.some((e) => e.includes("--workers: expected a number")),
+    true,
+  );
+});
+
+Deno.test("execute resolves parameters from the params map before running", async () => {
+  const seen: string[] = [];
+  class Deploy extends Build {
+    environment = parameter("env").required();
+    deploy = target().executes(() => void seen.push(this.environment.value));
+  }
+  const build = new Deploy();
+  const root = discoverTargets(build).get("deploy");
+  if (!root) throw new Error("no deploy target");
+  const result = await execute(build, root, {
+    silent: true,
+    params: { environment: "production" },
+    readEnv: () => undefined,
+  });
+  assertEquals(result.ok, true);
+  assertEquals(seen, ["production"]);
+});
+
+Deno.test("execute resolves parameters from the environment", async () => {
+  const seen: string[] = [];
+  class Deploy extends Build {
+    environment = parameter("env").required();
+    deploy = target().executes(() => void seen.push(this.environment.value));
+  }
+  const build = new Deploy();
+  const root = discoverTargets(build).get("deploy");
+  if (!root) throw new Error("no deploy target");
+  const result = await execute(build, root, {
+    silent: true,
+    readEnv: (name) => (name === "ENVIRONMENT" ? "staging" : undefined),
+  });
+  assertEquals(result.ok, true);
+  assertEquals(seen, ["staging"]);
+});
+
+Deno.test("execute fails before running when a required parameter is missing", async () => {
+  let ran = false;
+  class Deploy extends Build {
+    environment = parameter("env").required();
+    deploy = target().executes(() => void (ran = true));
+  }
+  const build = new Deploy();
+  const root = discoverTargets(build).get("deploy");
+  if (!root) throw new Error("no deploy target");
+  const result = await execute(build, root, {
+    silent: true,
+    readEnv: () => undefined,
+  });
+  assertEquals(result.ok, false);
+  assertEquals(ran, false);
+  assertEquals(result.error instanceof ParameterError, true);
+});


### PR DESCRIPTION
## Summary

Implements the roadmap's **parameter & environment injection**. Builds can declare typed parameters as class fields (mirroring `target()`), and the **execution engine** resolves each one before any target runs. Green under `deno task ci` (fmt, lint, spell, check, 95% coverage gate; new code fully covered).

```ts
class Deploy extends Build {
  environment = parameter("Target environment").options("dev", "prod").required();
  workers      = parameter("Workers").number().default(4);
  dryRun       = parameter("Dry run").boolean();

  deploy = target().executes(() => {
    console.log(`${this.environment.value} x ${this.workers.value}`); // string x number
  });
}
```

### Declaration — `parameter()` builder
- Fluent refinement: `.number()` / `.boolean()` / `.options(...)` / `.default(v)` / `.required()` / `.env("NAME")`.
- `value` is exactly as strong as the declaration: required/defaulted parameters are non-optional, plain ones are `T | undefined`. Implemented with **no `as` and no `!`** — the definite forms narrow via control flow.
- Reading `.value` before resolution (e.g. at construction) throws.

### Resolution — in the engine, not the CLI
- `execute()` discovers a build's parameters and resolves each from **CLI value → environment variable → declared default**, before any target runs.
- So programmatic `execute(build, target, { params })` (or relying on env vars) gets parameter/environment injection too — not only runs that go through the command line.
- A missing-required or invalid value fails the build **before it starts**, with a message naming the flag and env var.

### CLI
- Collects declared parameter flags: `--name value`, `--name=value`, and bare `--flag` for booleans.
- `--help` / `--list` gain a **Parameters** section.
- Flag and env names derive from the property name: `environment` → `--environment` / `ENVIRONMENT`; `targetEnv` → `--target-env` / `TARGET_ENV`. Env vars are intentionally **unprefixed** (NUKE-style); override with `.env("NAME")`.

## Public API additions (`@zuke/core`)
`parameter`, `Parameter`, `ParameterError`, `ParamValue`, `AnyParameter`, `discoverParameters`; `ExecuteOptions` gains `params` and `readEnv`.

## Docs
New `docs/parameters.md`, linked from the README; dropped the now-shipped roadmap entry.

## Notes for reviewers
- One intentionally-uncovered defensive branch in `params.ts` (`#definiteParse`): the kind parsers never return `undefined`, so the guard exists only to narrow `(raw) => T` to `(raw) => K` without a cast.
- Env vars unprefixed by design (confirmed); collision risk (e.g. a `path` param reading `PATH`) is mitigated by `.env()`.

https://claude.ai/code/session_01PtqHmRRvtT6qkQKaPzrWhT

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtqHmRRvtT6qkQKaPzrWhT)_