### PR TITLE
feat(core): parallel execution — `--parallel` flag and `group()` batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ CI runs `deno task ci` on every push and pull request (see
 
 Post-v0, for context:
 
-- Parallel execution of independent targets.
 - A `zuke` standalone binary + `zuke init` scaffolding.
 - Caching / incremental targets.
 - More tool wrapper packages — see [Tools](./docs/tools.md) for what ships today.

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -26,6 +26,31 @@ lint = target()
   });
 ```
 
+### `group()`
+
+`group(...targets)` bundles targets into a parallel **batch**: its members run
+concurrently with one another — even when the build is otherwise sequential —
+each still waiting for its own dependencies. Pass the group to `.dependsOn(...)`
+to depend on every member at once.
+
+```ts
+clean = target().executes(/* ... */);
+lint = target().dependsOn(this.clean).executes(/* ... */);
+format = target().dependsOn(this.clean).executes(/* ... */);
+typecheck = target().dependsOn(this.clean).executes(/* ... */);
+
+checks = group(this.lint, this.format, this.typecheck);
+
+deploy = target()
+  .dependsOn(this.checks) // waits for lint, format, and typecheck
+  .executes(/* ... */);
+```
+
+Here `clean` runs first (all three depend on it), then `lint`/`format`/
+`typecheck` run together, then `deploy`. Grouping is a property of the members,
+so they batch whenever they run — no `--parallel` flag needed. Ungrouped
+targets stay serialized unless you opt the whole build into `--parallel`.
+
 ### `Build`
 
 The base class your build extends. It contributes no targets of its own.

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -26,20 +26,21 @@ lint = target()
   });
 ```
 
-### `group()`
+### `group()` and `.partOf()`
 
-`group(...targets)` bundles targets into a parallel **batch**: its members run
-concurrently with one another — even when the build is otherwise sequential —
-each still waiting for its own dependencies. Pass the group to `.dependsOn(...)`
-to depend on every member at once.
+`group()` creates a parallel **batch**. A target joins it with `.partOf(group)`;
+members of the same group run concurrently with one another — even when the
+build is otherwise sequential — each still waiting for its own dependencies.
+Pass the group to another target's `.dependsOn(...)` to depend on every member
+at once.
 
 ```ts
-clean = target().executes(/* ... */);
-lint = target().dependsOn(this.clean).executes(/* ... */);
-format = target().dependsOn(this.clean).executes(/* ... */);
-typecheck = target().dependsOn(this.clean).executes(/* ... */);
+checks = group();
 
-checks = group(this.lint, this.format, this.typecheck);
+clean = target().executes(/* ... */);
+lint = target().dependsOn(this.clean).partOf(this.checks).executes(/* ... */);
+format = target().dependsOn(this.clean).partOf(this.checks).executes(/* ... */);
+typecheck = target().dependsOn(this.clean).partOf(this.checks).executes(/* ... */);
 
 deploy = target()
   .dependsOn(this.checks) // waits for lint, format, and typecheck
@@ -50,6 +51,7 @@ Here `clean` runs first (all three depend on it), then `lint`/`format`/
 `typecheck` run together, then `deploy`. Grouping is a property of the members,
 so they batch whenever they run — no `--parallel` flag needed. Ungrouped
 targets stay serialized unless you opt the whole build into `--parallel`.
+Declare the group field above the targets that join it.
 
 ### `Build`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -4,6 +4,7 @@
 | ---------------------------- | ------------------------------------------------------------- |
 | `zuke <target>`              | Run the target and all its transitive dependencies, in order. |
 | `zuke <target> --skip <dep>` | Run the target but skip the named dependency (repeatable).    |
+| `zuke <target> --parallel`   | Run independent targets concurrently (`--parallel=N` caps it). |
 | `zuke --list` / `-l`         | List all targets with descriptions and dependencies.          |
 | `zuke graph`                 | Print the dependency graph (`target → deps`).                 |
 | `zuke graph --output=html`   | Render an interactive HTML graph into `.zuke/` and open it.   |
@@ -38,3 +39,17 @@ name.
 exits `1`. A final summary lists every target's status and duration plus the
 total. Under GitHub Actions, targets become collapsible log groups, failures
 emit `::error::` annotations, and the summary is written to the job summary.
+
+## Parallel execution
+
+By default targets run one at a time in a deterministic order. `--parallel`
+runs independent targets concurrently while still completing every dependency
+before its dependents; `--parallel=N` caps the number in flight (the default is
+the host's CPU count). Each target's banner block is buffered and flushed as a
+unit, so concurrent runs don't interleave their headers (a target's own
+subprocess output may still interleave, as with `make -j`). The first failure
+stops new launches; targets already running finish, and the rest are reported
+as skipped. The build summary stays in declaration order regardless.
+
+Programmatic callers get the same behaviour via `execute(build, target, { parallel: true })`
+(or a number) — see the [programmatic API](./programmatic-api.md).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -54,6 +54,6 @@ as skipped. The build summary stays in declaration order regardless.
 Programmatic callers get the same behaviour via `execute(build, target, { parallel: true })`
 (or a number) — see the [programmatic API](./programmatic-api.md).
 
-For parallelism scoped to specific targets rather than the whole build, bundle
-them into a [`group()`](./authoring.md#group) — the group's members run
-concurrently even without `--parallel`.
+For parallelism scoped to specific targets rather than the whole build, put
+them in a [`group()`](./authoring.md#group-and-partof) with `.partOf(...)` — the
+group's members run concurrently even without `--parallel`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -53,3 +53,7 @@ as skipped. The build summary stays in declaration order regardless.
 
 Programmatic callers get the same behaviour via `execute(build, target, { parallel: true })`
 (or a number) — see the [programmatic API](./programmatic-api.md).
+
+For parallelism scoped to specific targets rather than the whole build, bundle
+them into a [`group()`](./authoring.md#group) — the group's members run
+concurrently even without `--parallel`.

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -26,6 +26,8 @@
 
 export { Build, type BuildResult, discoverTargets } from "./src/build.ts";
 export {
+  Group,
+  group,
   type Target,
   target,
   TargetBuilder,

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -51,9 +51,18 @@ export interface ParsedArgs {
   output: GraphOutput;
   /** Open the HTML graph in a browser (default true; `--no-open` clears). */
   open: boolean;
+  /** Run independent targets concurrently (`--parallel[=N]`). */
+  parallel?: boolean | number;
   /** Raw parameter values from declared flags, keyed by property name. */
   values: Record<string, string>;
   help: boolean;
+}
+
+/** Parse a `--parallel`/`--parallel=N` value: a positive count, or `true`. */
+function parseParallel(value: string | undefined): boolean | number {
+  if (value === undefined || value === "") return true;
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : true;
 }
 
 /**
@@ -83,6 +92,10 @@ export function parseArgs(
       parsed.list = true;
     } else if (arg === "--no-open") {
       parsed.open = false;
+    } else if (arg === "--parallel") {
+      parsed.parallel = true;
+    } else if (arg.startsWith("--parallel=")) {
+      parsed.parallel = parseParallel(arg.slice("--parallel=".length));
     } else if (arg === "--help" || arg === "-h") {
       parsed.help = true;
     } else if (arg === "--skip") {
@@ -122,13 +135,15 @@ function depNames(t: TargetBuilder): string[] {
 const USAGE = `zuke — code-first build automation
 
 Usage:
-  deno run -A zuke.ts <target> [--skip <dep>]
+  deno run -A zuke.ts <target> [--skip <dep>] [--parallel[=N]]
   deno run -A zuke.ts --list
   deno run -A zuke.ts graph [--output=html] [--no-open]
 
 Options:
   <target>          Run the target and its transitive dependencies.
   --skip <dep>      Skip the named dependency (repeatable).
+  --parallel[=N]    Run independent targets concurrently (N = max in flight,
+                    default = CPU count).
   --list, -l        List all targets with descriptions and dependencies.
   graph             Show the dependency graph. Default output is the terminal
                     adjacency listing; --output=html writes an interactive
@@ -268,6 +283,7 @@ export async function main(
   const result = await execute(build, root, {
     skip: parsed.skip,
     params: parsed.values,
+    parallel: parsed.parallel,
   });
   return result.ok ? 0 : 1;
 }

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -17,7 +17,7 @@
  */
 
 import type { Build, BuildResult } from "./build.ts";
-import { plan, planGraph } from "./graph.ts";
+import { planGraph } from "./graph.ts";
 import {
   discoverParameters,
   ParameterError,
@@ -326,11 +326,14 @@ async function runTarget(
 /** Resolve the concurrency limit; 1 means sequential. */
 function resolveConcurrency(option: boolean | number | undefined): number {
   if (option === undefined || option === false) return 1;
-  if (option === true) {
-    const cpus = navigator.hardwareConcurrency;
-    return cpus > 0 ? cpus : 4;
-  }
+  if (option === true) return cpuCount();
   return option > 1 ? Math.floor(option) : 1;
+}
+
+/** The host's CPU count, used as the default parallel/batch concurrency. */
+function cpuCount(): number {
+  const cpus = navigator.hardwareConcurrency;
+  return cpus > 0 ? cpus : 4;
 }
 
 /** A reporter that buffers lines so a target's block can flush atomically. */
@@ -355,12 +358,11 @@ function bufferReporter(): {
 
 /** Sequentially run the plan, aborting (and skipping the rest) on first failure. */
 async function runSequential(
-  root: TargetBuilder,
+  order: TargetBuilder[],
   reporter: Reporter,
   style: Style,
   skip: Set<string>,
 ): Promise<RunOutcome> {
-  const order = plan(root);
   const reports: TargetReport[] = [];
   const executed: string[] = [];
   let failure: unknown;
@@ -387,24 +389,29 @@ async function runSequential(
 
 /**
  * Run the plan with up to `limit` targets in flight, respecting dependencies.
+ * `canOverlap` decides which ready targets may run at the same time: with
+ * global parallelism it is always true; otherwise only members of the same
+ * {@link group} overlap, keeping ungrouped targets serialized.
+ *
  * Each target's framework output is buffered and flushed as a contiguous block
  * on completion, so concurrent runs don't interleave their banners. A failure
  * stops new launches; in-flight targets settle and the rest are skipped.
  */
-async function runParallel(
-  root: TargetBuilder,
+async function runScheduled(
+  order: TargetBuilder[],
+  predecessors: Map<TargetBuilder, TargetBuilder[]>,
   reporter: Reporter,
   style: Style,
   skip: Set<string>,
   limit: number,
+  canOverlap: (a: TargetBuilder, b: TargetBuilder) => boolean,
 ): Promise<RunOutcome> {
-  const { order, predecessors } = planGraph(root);
   const outcomes = new Map<TargetBuilder, TargetOutcome>();
   const done = new Set<TargetBuilder>(); // passed or skipped → unblocks dependents
   const started = new Set<TargetBuilder>();
+  const runningSet = new Set<TargetBuilder>();
   let failure: unknown;
   let aborted = false;
-  let running = 0;
   let flushed = 0;
 
   // `--skip` targets count as completed so their dependents can still run.
@@ -418,22 +425,24 @@ async function runParallel(
 
   const ready = (t: TargetBuilder): boolean =>
     (predecessors.get(t) ?? []).every((p) => done.has(p));
+  const overlaps = (t: TargetBuilder): boolean =>
+    [...runningSet].every((r) => canOverlap(t, r));
 
   await new Promise<void>((resolve) => {
     const pump = () => {
       if (!aborted) {
         for (const t of order) {
-          if (running >= limit) break;
-          if (started.has(t) || !ready(t)) continue;
+          if (runningSet.size >= limit) break;
+          if (started.has(t) || !ready(t) || !overlaps(t)) continue;
           started.add(t);
-          running++;
+          runningSet.add(t);
           const buffer = bufferReporter();
           runTarget(buffer.reporter, style, t, flushed).then((outcome) => {
             if (!style.github && flushed > 0) reporter.info("");
             buffer.flush(reporter);
             flushed++;
             outcomes.set(t, outcome);
-            running--;
+            runningSet.delete(t);
             if (outcome.status === "passed") done.add(t);
             else {
               aborted = true;
@@ -443,7 +452,7 @@ async function runParallel(
           });
         }
       }
-      if (running === 0) {
+      if (runningSet.size === 0) {
         for (const t of order) {
           if (!started.has(t)) {
             outcomes.set(t, { status: "skipped", ms: 0 });
@@ -505,14 +514,36 @@ export async function execute(
     };
   }
 
+  const { order, predecessors } = planGraph(root);
   const limit = resolveConcurrency(options.parallel);
+  const globalParallel = limit > 1;
+  const grouped = order.some((t) => t.group_ !== undefined);
   const overallStart = performance.now();
 
   await build.onStart();
 
-  const run = limit > 1
-    ? await runParallel(root, reporter, style, skip, limit)
-    : await runSequential(root, reporter, style, skip);
+  let run: RunOutcome;
+  if (!globalParallel && !grouped) {
+    run = await runSequential(order, reporter, style, skip);
+  } else {
+    // With `--parallel`, anything independent may overlap up to `limit`.
+    // Otherwise only same-group members overlap (the rest stay serialized),
+    // bounded by the CPU count.
+    const effectiveLimit = globalParallel ? limit : cpuCount();
+    const canOverlap = globalParallel
+      ? () => true
+      : (a: TargetBuilder, b: TargetBuilder) =>
+        a.group_ !== undefined && a.group_ === b.group_;
+    run = await runScheduled(
+      order,
+      predecessors,
+      reporter,
+      style,
+      skip,
+      effectiveLimit,
+      canOverlap,
+    );
+  }
 
   const result: BuildResult = run.aborted
     ? { ok: false, executed: run.executed, error: run.failure }

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -17,7 +17,7 @@
  */
 
 import type { Build, BuildResult } from "./build.ts";
-import { plan } from "./graph.ts";
+import { plan, planGraph } from "./graph.ts";
 import {
   discoverParameters,
   ParameterError,
@@ -46,6 +46,12 @@ export interface ExecuteOptions {
   reporter?: Reporter;
   /** Target names to skip even if they appear in the plan (CLI `--skip`). */
   skip?: string[];
+  /**
+   * Run independent targets concurrently. `false`/omitted runs sequentially in
+   * deterministic order; `true` uses the host's CPU count; a number sets the
+   * maximum concurrency. Dependencies still complete before their dependents.
+   */
+  parallel?: boolean | number;
   /**
    * Raw parameter values from the command line, keyed by parameter (property)
    * name. Each declared {@link Parameter} is resolved from this map, then the
@@ -271,12 +277,204 @@ function writeJobSummary(
   }
 }
 
+/** The result of one target, plus the framework error if it failed. */
+interface TargetOutcome {
+  status: TargetStatus;
+  ms: number;
+  error?: unknown;
+}
+
+/** What a run (sequential or parallel) produced, fed into the shared summary. */
+interface RunOutcome {
+  reports: TargetReport[];
+  executed: string[];
+  failure: unknown;
+  aborted: boolean;
+}
+
+/** Run one target: open its section, run its body, report pass/fail. */
+async function runTarget(
+  reporter: Reporter,
+  style: Style,
+  t: TargetBuilder,
+  opened: number,
+): Promise<TargetOutcome> {
+  const name = t.name_ ?? "<unnamed>";
+  openTarget(reporter, style, name, opened);
+  const start = performance.now();
+
+  if (!t.fn_) {
+    const error = new Error(
+      `Target "${name}" has no body — call .executes(...) before running.`,
+    );
+    failTarget(reporter, style, name, 0, error);
+    return { status: "failed", ms: 0, error };
+  }
+
+  try {
+    await t.fn_();
+    const ms = performance.now() - start;
+    passTarget(reporter, style, name, ms);
+    return { status: "passed", ms };
+  } catch (error) {
+    const ms = performance.now() - start;
+    failTarget(reporter, style, name, ms, error);
+    return { status: "failed", ms, error };
+  }
+}
+
+/** Resolve the concurrency limit; 1 means sequential. */
+function resolveConcurrency(option: boolean | number | undefined): number {
+  if (option === undefined || option === false) return 1;
+  if (option === true) {
+    const cpus = navigator.hardwareConcurrency;
+    return cpus > 0 ? cpus : 4;
+  }
+  return option > 1 ? Math.floor(option) : 1;
+}
+
+/** A reporter that buffers lines so a target's block can flush atomically. */
+function bufferReporter(): {
+  reporter: Reporter;
+  flush: (to: Reporter) => void;
+} {
+  const lines: Array<{ error: boolean; text: string }> = [];
+  return {
+    reporter: {
+      info: (text) => void lines.push({ error: false, text }),
+      error: (text) => void lines.push({ error: true, text }),
+    },
+    flush: (to) => {
+      for (const line of lines) {
+        if (line.error) to.error(line.text);
+        else to.info(line.text);
+      }
+    },
+  };
+}
+
+/** Sequentially run the plan, aborting (and skipping the rest) on first failure. */
+async function runSequential(
+  root: TargetBuilder,
+  reporter: Reporter,
+  style: Style,
+  skip: Set<string>,
+): Promise<RunOutcome> {
+  const order = plan(root);
+  const reports: TargetReport[] = [];
+  const executed: string[] = [];
+  let failure: unknown;
+  let aborted = false;
+  let opened = 0;
+
+  for (const t of order) {
+    const name = t.name_ ?? "<unnamed>";
+    if (skip.has(name) || aborted) {
+      reports.push({ name, status: "skipped", ms: 0 });
+      continue;
+    }
+    const outcome = await runTarget(reporter, style, t, opened);
+    opened++;
+    reports.push({ name, status: outcome.status, ms: outcome.ms });
+    if (outcome.status === "passed") executed.push(name);
+    else {
+      failure = outcome.error;
+      aborted = true;
+    }
+  }
+  return { reports, executed, failure, aborted };
+}
+
+/**
+ * Run the plan with up to `limit` targets in flight, respecting dependencies.
+ * Each target's framework output is buffered and flushed as a contiguous block
+ * on completion, so concurrent runs don't interleave their banners. A failure
+ * stops new launches; in-flight targets settle and the rest are skipped.
+ */
+async function runParallel(
+  root: TargetBuilder,
+  reporter: Reporter,
+  style: Style,
+  skip: Set<string>,
+  limit: number,
+): Promise<RunOutcome> {
+  const { order, predecessors } = planGraph(root);
+  const outcomes = new Map<TargetBuilder, TargetOutcome>();
+  const done = new Set<TargetBuilder>(); // passed or skipped → unblocks dependents
+  const started = new Set<TargetBuilder>();
+  let failure: unknown;
+  let aborted = false;
+  let running = 0;
+  let flushed = 0;
+
+  // `--skip` targets count as completed so their dependents can still run.
+  for (const t of order) {
+    if (skip.has(t.name_ ?? "<unnamed>")) {
+      outcomes.set(t, { status: "skipped", ms: 0 });
+      done.add(t);
+      started.add(t);
+    }
+  }
+
+  const ready = (t: TargetBuilder): boolean =>
+    (predecessors.get(t) ?? []).every((p) => done.has(p));
+
+  await new Promise<void>((resolve) => {
+    const pump = () => {
+      if (!aborted) {
+        for (const t of order) {
+          if (running >= limit) break;
+          if (started.has(t) || !ready(t)) continue;
+          started.add(t);
+          running++;
+          const buffer = bufferReporter();
+          runTarget(buffer.reporter, style, t, flushed).then((outcome) => {
+            if (!style.github && flushed > 0) reporter.info("");
+            buffer.flush(reporter);
+            flushed++;
+            outcomes.set(t, outcome);
+            running--;
+            if (outcome.status === "passed") done.add(t);
+            else {
+              aborted = true;
+              failure = outcome.error;
+            }
+            pump();
+          });
+        }
+      }
+      if (running === 0) {
+        for (const t of order) {
+          if (!started.has(t)) {
+            outcomes.set(t, { status: "skipped", ms: 0 });
+            started.add(t);
+          }
+        }
+        resolve();
+      }
+    };
+    pump();
+  });
+
+  const reports: TargetReport[] = [];
+  const executed: string[] = [];
+  for (const t of order) {
+    const name = t.name_ ?? "<unnamed>";
+    const outcome = outcomes.get(t) ?? { status: "skipped", ms: 0 };
+    reports.push({ name, status: outcome.status, ms: outcome.ms });
+    if (outcome.status === "passed") executed.push(name);
+  }
+  return { reports, executed, failure, aborted };
+}
+
 /**
  * Execute the requested target and its transitive dependencies.
  *
- * Runs the build's `onStart`/`onFinish` lifecycle hooks around the plan. Stops
- * at the first target that throws, reports it, marks the unreached targets as
- * skipped, and returns a failing result.
+ * Runs the build's `onStart`/`onFinish` lifecycle hooks around the plan. By
+ * default targets run sequentially in deterministic order; with `parallel`,
+ * independent targets run concurrently while dependencies still complete first.
+ * Stops launching after the first failure, marks unreached targets as skipped,
+ * and returns a failing result.
  */
 export async function execute(
   build: Build,
@@ -307,62 +505,22 @@ export async function execute(
     };
   }
 
-  const order = plan(root);
-  const reports: TargetReport[] = [];
-  const executed: string[] = [];
+  const limit = resolveConcurrency(options.parallel);
   const overallStart = performance.now();
 
   await build.onStart();
 
-  let failure: unknown;
-  let aborted = false;
-  let opened = 0;
+  const run = limit > 1
+    ? await runParallel(root, reporter, style, skip, limit)
+    : await runSequential(root, reporter, style, skip);
 
-  for (const t of order) {
-    const name = t.name_ ?? "<unnamed>";
-
-    if (skip.has(name) || aborted) {
-      reports.push({ name, status: "skipped", ms: 0 });
-      continue;
-    }
-
-    openTarget(reporter, style, name, opened);
-    opened++;
-    const start = performance.now();
-
-    if (!t.fn_) {
-      const error = new Error(
-        `Target "${name}" has no body — call .executes(...) before running.`,
-      );
-      failTarget(reporter, style, name, 0, error);
-      reports.push({ name, status: "failed", ms: 0 });
-      failure = error;
-      aborted = true;
-      continue;
-    }
-
-    try {
-      await t.fn_();
-      const ms = performance.now() - start;
-      passTarget(reporter, style, name, ms);
-      reports.push({ name, status: "passed", ms });
-      executed.push(name);
-    } catch (error) {
-      const ms = performance.now() - start;
-      failTarget(reporter, style, name, ms, error);
-      reports.push({ name, status: "failed", ms });
-      failure = error;
-      aborted = true;
-    }
-  }
-
-  const result: BuildResult = aborted
-    ? { ok: false, executed, error: failure }
-    : { ok: true, executed };
+  const result: BuildResult = run.aborted
+    ? { ok: false, executed: run.executed, error: run.failure }
+    : { ok: true, executed: run.executed };
 
   const totalMs = performance.now() - overallStart;
-  reporter.info(summaryBlock(style, reports, totalMs, result.ok));
-  if (style.github) writeJobSummary(reports, totalMs, result.ok);
+  reporter.info(summaryBlock(style, run.reports, totalMs, result.ok));
+  if (style.github) writeJobSummary(run.reports, totalMs, result.ok);
   await build.onFinish(result);
   return result;
 }

--- a/packages/core/src/graph.ts
+++ b/packages/core/src/graph.ts
@@ -130,18 +130,14 @@ export function executionSet(root: TargetBuilder): Set<TargetBuilder> {
 }
 
 /**
- * Topologically sort the execution set for `root`, honouring hard dependencies
- * and the soft `before`/`after` ordering hints (the latter only between nodes
- * that are both in the set).
- *
- * @returns target builders in a valid execution order.
- * @throws {GraphError} if the planned graph contains a cycle (which can happen
- *   via soft edges even when the hard graph is acyclic).
+ * Build the "must run before" edges within the execution set for `root`. An
+ * edge `from → to` means `from` runs before `to`. Shared by {@link plan} and
+ * {@link planGraph}.
  */
-export function plan(root: TargetBuilder): TargetBuilder[] {
+function planEdges(
+  root: TargetBuilder,
+): { set: Set<TargetBuilder>; edges: Map<TargetBuilder, Set<TargetBuilder>> } {
   const set = executionSet(root);
-
-  // Build the adjacency list of "must run before" edges within the set.
   const edges = new Map<TargetBuilder, Set<TargetBuilder>>();
   for (const node of set) edges.set(node, new Set());
   const addEdge = (from: TargetBuilder, to: TargetBuilder) => {
@@ -154,9 +150,19 @@ export function plan(root: TargetBuilder): TargetBuilder[] {
     for (const b of node.before_) addEdge(node, b); // node before b
     for (const a of node.after_) addEdge(a, node); // a before node
   }
+  return { set, edges };
+}
 
-  // Deterministic DFS post-order topological sort. Iterate in declaration
-  // order (insertion order of `set`) so output is stable across runs.
+/**
+ * Deterministic DFS post-order topological sort over the precomputed edges.
+ * Iterates in declaration order (insertion order of `set`) so output is stable.
+ *
+ * @throws {GraphError} if the planned graph contains a cycle.
+ */
+function topoOrder(
+  set: Set<TargetBuilder>,
+  edges: Map<TargetBuilder, Set<TargetBuilder>>,
+): TargetBuilder[] {
   const WHITE = 0, GRAY = 1, BLACK = 2;
   const color = new Map<TargetBuilder, number>();
   const order: TargetBuilder[] = [];
@@ -189,4 +195,48 @@ export function plan(root: TargetBuilder): TargetBuilder[] {
   // "must run before" edge points forward.
   order.reverse();
   return order;
+}
+
+/**
+ * Topologically sort the execution set for `root`, honouring hard dependencies
+ * and the soft `before`/`after` ordering hints (the latter only between nodes
+ * that are both in the set).
+ *
+ * @returns target builders in a valid execution order.
+ * @throws {GraphError} if the planned graph contains a cycle (which can happen
+ *   via soft edges even when the hard graph is acyclic).
+ */
+export function plan(root: TargetBuilder): TargetBuilder[] {
+  const { set, edges } = planEdges(root);
+  return topoOrder(set, edges);
+}
+
+/**
+ * A linearised plan plus, for each target, the targets that must finish before
+ * it may start. The predecessors drive parallel scheduling; the order gives a
+ * deterministic listing (e.g. for the build summary).
+ */
+export interface ExecutionPlan {
+  /** Targets in a valid, deterministic execution order. */
+  order: TargetBuilder[];
+  /** For each target, the targets that must complete before it can run. */
+  predecessors: Map<TargetBuilder, TargetBuilder[]>;
+}
+
+/**
+ * Plan the execution set for `root` for scheduling: the deterministic order
+ * plus each target's direct predecessors (hard dependencies and the applicable
+ * soft `before`/`after` edges).
+ *
+ * @throws {GraphError} if the planned graph contains a cycle.
+ */
+export function planGraph(root: TargetBuilder): ExecutionPlan {
+  const { set, edges } = planEdges(root);
+  const order = topoOrder(set, edges);
+  const predecessors = new Map<TargetBuilder, TargetBuilder[]>();
+  for (const node of set) predecessors.set(node, []);
+  for (const [from, tos] of edges) {
+    for (const to of tos) predecessors.get(to)?.push(from);
+  }
+  return { order, predecessors };
 }

--- a/packages/core/src/target.ts
+++ b/packages/core/src/target.ts
@@ -1,5 +1,6 @@
 /**
- * Target authoring API: the `target()` fluent builder and the `Target` type.
+ * Target authoring API: the `target()` fluent builder, the `group()` parallel
+ * batch, and the `Target` type.
  *
  * A target is declared as a class property on a {@link Build} subclass:
  *
@@ -13,10 +14,32 @@
  * Dependencies are declared by passing sibling target *references*
  * (`this.clean`), not strings. The framework maps each builder back to its
  * property name during discovery (see {@link Build}).
+ *
+ * Related targets can be bundled into a {@link group}: a batch that runs its
+ * members concurrently (even in an otherwise sequential build) and can be
+ * depended on as a unit.
+ *
+ * ```ts
+ * checks = group(this.lint, this.format, this.typecheck);
+ * deploy = target().dependsOn(this.checks).executes(...); // waits for all three
+ * ```
  */
 
 /** The executable body of a target. May be synchronous or asynchronous. */
 export type TargetFn = () => void | Promise<void>;
+
+/**
+ * A parallel batch of targets created with {@link group}. Its members run
+ * concurrently with one another (subject to their own dependencies) regardless
+ * of the global parallel setting, and the group can be passed to
+ * {@link TargetBuilder.dependsOn} to depend on every member at once.
+ */
+export class Group {
+  constructor(
+    /** The grouped targets, in declaration order. */
+    readonly members_: ReadonlyArray<TargetBuilder>,
+  ) {}
+}
 
 /**
  * The fluent builder returned by {@link target}. All configuration methods are
@@ -36,6 +59,8 @@ export class TargetBuilder {
   fn_?: TargetFn;
   /** Property name, assigned during discovery. Undefined until then. */
   name_?: string;
+  /** The parallel batch this target belongs to, if any (set by {@link group}). */
+  group_?: Group;
 
   /** Set the human-readable description shown in `zuke --list`. */
   description(text: string): this {
@@ -43,9 +68,15 @@ export class TargetBuilder {
     return this;
   }
 
-  /** Declare hard prerequisites. References sibling targets via `this.x`. */
-  dependsOn(...targets: TargetBuilder[]): this {
-    this.dependsOn_.push(...targets);
+  /**
+   * Declare hard prerequisites. References sibling targets via `this.x`, or a
+   * {@link group} (which expands to every member of the group).
+   */
+  dependsOn(...targets: Array<TargetBuilder | Group>): this {
+    for (const t of targets) {
+      if (t instanceof Group) this.dependsOn_.push(...t.members_);
+      else this.dependsOn_.push(t);
+    }
     return this;
   }
 
@@ -77,4 +108,24 @@ export type Target = TargetBuilder;
 /** Create a new, empty target builder. */
 export function target(): TargetBuilder {
   return new TargetBuilder();
+}
+
+/**
+ * Bundle targets into a parallel {@link Group}: a batch whose members run
+ * concurrently with each other — even when the build is otherwise sequential —
+ * each still waiting for its own dependencies. Pass the group to
+ * {@link TargetBuilder.dependsOn} to depend on all of its members at once.
+ *
+ * ```ts
+ * checks = group(this.lint, this.format, this.typecheck);
+ * deploy = target().dependsOn(this.checks).executes(...);
+ * ```
+ */
+export function group(...targets: TargetBuilder[]): Group {
+  const created = new Group(targets);
+  for (const t of targets) {
+    // A forward reference is `undefined` here; the graph reports it later.
+    if (t !== undefined) t.group_ = created;
+  }
+  return created;
 }

--- a/packages/core/src/target.ts
+++ b/packages/core/src/target.ts
@@ -15,13 +15,15 @@
  * (`this.clean`), not strings. The framework maps each builder back to its
  * property name during discovery (see {@link Build}).
  *
- * Related targets can be bundled into a {@link group}: a batch that runs its
- * members concurrently (even in an otherwise sequential build) and can be
- * depended on as a unit.
+ * Targets join a parallel batch with {@link TargetBuilder.partOf}; the
+ * {@link group} they belong to runs its members concurrently (even in a
+ * sequential build) and can itself be a dependency:
  *
  * ```ts
- * checks = group(this.lint, this.format, this.typecheck);
- * deploy = target().dependsOn(this.checks).executes(...); // waits for all three
+ * checks = group();
+ * lint = target().dependsOn(this.clean).partOf(this.checks).executes(...);
+ * format = target().dependsOn(this.clean).partOf(this.checks).executes(...);
+ * deploy = target().dependsOn(this.checks).executes(...); // waits for the batch
  * ```
  */
 
@@ -29,16 +31,15 @@
 export type TargetFn = () => void | Promise<void>;
 
 /**
- * A parallel batch of targets created with {@link group}. Its members run
- * concurrently with one another (subject to their own dependencies) regardless
- * of the global parallel setting, and the group can be passed to
- * {@link TargetBuilder.dependsOn} to depend on every member at once.
+ * A parallel batch of targets, created with {@link group}. Targets join it via
+ * {@link TargetBuilder.partOf}; its members run concurrently with one another
+ * (each still awaiting its own dependencies) regardless of the global parallel
+ * setting. Passing a group to {@link TargetBuilder.dependsOn} depends on every
+ * member at once.
  */
 export class Group {
-  constructor(
-    /** The grouped targets, in declaration order. */
-    readonly members_: ReadonlyArray<TargetBuilder>,
-  ) {}
+  /** Members that declared themselves part of this group, in declaration order. */
+  readonly members_: TargetBuilder[] = [];
 }
 
 /**
@@ -59,7 +60,7 @@ export class TargetBuilder {
   fn_?: TargetFn;
   /** Property name, assigned during discovery. Undefined until then. */
   name_?: string;
-  /** The parallel batch this target belongs to, if any (set by {@link group}). */
+  /** The parallel batch this target belongs to, if any (set by {@link partOf}). */
   group_?: Group;
 
   /** Set the human-readable description shown in `zuke --list`. */
@@ -70,12 +71,28 @@ export class TargetBuilder {
 
   /**
    * Declare hard prerequisites. References sibling targets via `this.x`, or a
-   * {@link group} (which expands to every member of the group).
+   * {@link group} (which expands to every member that has joined it).
    */
   dependsOn(...targets: Array<TargetBuilder | Group>): this {
     for (const t of targets) {
       if (t instanceof Group) this.dependsOn_.push(...t.members_);
       else this.dependsOn_.push(t);
+    }
+    return this;
+  }
+
+  /**
+   * Join a parallel {@link group}. Members of the same group run concurrently
+   * with one another (each still awaiting its own dependencies) even when the
+   * build is otherwise sequential. Declare the group before the targets that
+   * join it.
+   */
+  partOf(group: Group): this {
+    // A forward reference is `undefined` here; ignore it (the group field
+    // should be declared above the targets that join it).
+    if (group !== undefined) {
+      this.group_ = group;
+      group.members_.push(this);
     }
     return this;
   }
@@ -111,21 +128,17 @@ export function target(): TargetBuilder {
 }
 
 /**
- * Bundle targets into a parallel {@link Group}: a batch whose members run
- * concurrently with each other — even when the build is otherwise sequential —
- * each still waiting for its own dependencies. Pass the group to
- * {@link TargetBuilder.dependsOn} to depend on all of its members at once.
+ * Create a parallel {@link Group}. Targets join it with
+ * {@link TargetBuilder.partOf}, and a downstream target can depend on the whole
+ * batch by passing the group to {@link TargetBuilder.dependsOn}.
  *
  * ```ts
- * checks = group(this.lint, this.format, this.typecheck);
+ * checks = group();
+ * lint = target().partOf(this.checks).executes(...);
+ * format = target().partOf(this.checks).executes(...);
  * deploy = target().dependsOn(this.checks).executes(...);
  * ```
  */
-export function group(...targets: TargetBuilder[]): Group {
-  const created = new Group(targets);
-  for (const t of targets) {
-    // A forward reference is `undefined` here; the graph reports it later.
-    if (t !== undefined) t.group_ = created;
-  }
-  return created;
+export function group(): Group {
+  return new Group();
 }

--- a/packages/core/tests/cli_test.ts
+++ b/packages/core/tests/cli_test.ts
@@ -107,6 +107,13 @@ Deno.test("parseArgs collects declared parameter flags", () => {
   assertEquals(parseArgs(["--nope", "x"], greetFlags).values, {});
 });
 
+Deno.test("parseArgs reads the --parallel flag and count", () => {
+  assertEquals(parseArgs(["build", "--parallel"]).parallel, true);
+  assertEquals(parseArgs(["build", "--parallel=4"]).parallel, 4);
+  assertEquals(parseArgs(["build", "--parallel=bad"]).parallel, true);
+  assertEquals(parseArgs(["build"]).parallel, undefined);
+});
+
 Deno.test("parseArgs collects repeatable --skip and keeps first positional", () => {
   const parsed = parseArgs([
     "build",
@@ -205,6 +212,21 @@ Deno.test("main runs a target and its dependencies, returning 0", async () => {
   const { code } = await capture(() => main(Tracked, ["b"]));
   assertEquals(code, 0);
   assertEquals(log, ["a", "b"]);
+});
+
+Deno.test("main runs targets in parallel and returns 0", async () => {
+  const log: string[] = [];
+  class Par extends Build {
+    a = target().executes(() => void log.push("a"));
+    b = target().executes(() => void log.push("b"));
+    all = target().dependsOn(this.a, this.b).executes(() =>
+      void log.push("all")
+    );
+  }
+  const { code } = await capture(() => main(Par, ["all", "--parallel=2"]));
+  assertEquals(code, 0);
+  assertEquals(log[log.length - 1], "all"); // dependents still run last
+  assertEquals(log.includes("a") && log.includes("b"), true);
 });
 
 Deno.test("main runs the default target when none is named", async () => {

--- a/packages/core/tests/executor_test.ts
+++ b/packages/core/tests/executor_test.ts
@@ -556,11 +556,17 @@ Deno.test("a group runs its members in parallel without the --parallel flag", as
     active--;
   };
   class B extends Build {
+    checks = group();
     clean = target().executes(track("clean"));
-    lint = target().dependsOn(this.clean).executes(track("lint"));
-    format = target().dependsOn(this.clean).executes(track("format"));
-    typecheck = target().dependsOn(this.clean).executes(track("typecheck"));
-    checks = group(this.lint, this.format, this.typecheck);
+    lint = target().dependsOn(this.clean).partOf(this.checks).executes(
+      track("lint"),
+    );
+    format = target().dependsOn(this.clean).partOf(this.checks).executes(
+      track("format"),
+    );
+    typecheck = target().dependsOn(this.clean).partOf(this.checks).executes(
+      track("typecheck"),
+    );
     deploy = target().dependsOn(this.checks).executes(track("deploy"));
   }
   const b = new B();
@@ -584,13 +590,13 @@ Deno.test("ungrouped targets stay sequential while a group runs in parallel", as
     active--;
   };
   class B extends Build {
+    batch = group();
     // Two independent ungrouped targets — must NOT overlap each other.
     first = target().executes(track);
     second = target().executes(track);
     // A group whose members may overlap.
-    a = target().executes(track);
-    bb = target().executes(track);
-    batch = group(this.a, this.bb);
+    a = target().partOf(this.batch).executes(track);
+    bb = target().partOf(this.batch).executes(track);
     all = target()
       .dependsOn(this.first, this.second, this.batch)
       .executes(() => {});
@@ -606,11 +612,11 @@ Deno.test("ungrouped targets stay sequential while a group runs in parallel", as
 Deno.test("a failing group member skips the group's dependents", async () => {
   const ran: string[] = [];
   class B extends Build {
-    ok = target().executes(() => void ran.push("ok"));
-    boom = target().executes(() => {
+    checks = group();
+    ok = target().partOf(this.checks).executes(() => void ran.push("ok"));
+    boom = target().partOf(this.checks).executes(() => {
       throw new Error("boom");
     });
-    checks = group(this.ok, this.boom);
     deploy = target().dependsOn(this.checks).executes(() =>
       void ran.push("deploy")
     );

--- a/packages/core/tests/executor_test.ts
+++ b/packages/core/tests/executor_test.ts
@@ -1,6 +1,6 @@
 import { assertEquals, messageOf } from "./_assert.ts";
 import { Build, type BuildResult, discoverTargets } from "../src/build.ts";
-import { target } from "../src/target.ts";
+import { group, target } from "../src/target.ts";
 import {
   execute,
   type ExecuteOptions,
@@ -542,6 +542,85 @@ Deno.test("parallel buffers each target's block (plain and github)", async () =>
   assertEquals(open >= 0, true);
   assertEquals(gh.lines[open + 1].startsWith("✔ a ("), true);
   assertEquals(gh.lines[open + 2], "::endgroup::");
+});
+
+Deno.test("a group runs its members in parallel without the --parallel flag", async () => {
+  const order: string[] = [];
+  let active = 0;
+  let peak = 0;
+  const track = (name: string) => async () => {
+    order.push(name);
+    active++;
+    peak = Math.max(peak, active);
+    await delay(20);
+    active--;
+  };
+  class B extends Build {
+    clean = target().executes(track("clean"));
+    lint = target().dependsOn(this.clean).executes(track("lint"));
+    format = target().dependsOn(this.clean).executes(track("format"));
+    typecheck = target().dependsOn(this.clean).executes(track("typecheck"));
+    checks = group(this.lint, this.format, this.typecheck);
+    deploy = target().dependsOn(this.checks).executes(track("deploy"));
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  // No `parallel` option: only the group's members run concurrently.
+  const result = await execute(b, b.deploy, { silent: true });
+  assertEquals(result.ok, true);
+  assertEquals(peak, 3); // lint, format, typecheck overlapped
+  assertEquals(order[0], "clean"); // clean ran first (all depend on it)
+  assertEquals(order[order.length - 1], "deploy"); // deploy ran after the group
+});
+
+Deno.test("ungrouped targets stay sequential while a group runs in parallel", async () => {
+  let active = 0;
+  let peak = 0;
+  const track = async () => {
+    active++;
+    peak = Math.max(peak, active);
+    await delay(20);
+    active--;
+  };
+  class B extends Build {
+    // Two independent ungrouped targets — must NOT overlap each other.
+    first = target().executes(track);
+    second = target().executes(track);
+    // A group whose members may overlap.
+    a = target().executes(track);
+    bb = target().executes(track);
+    batch = group(this.a, this.bb);
+    all = target()
+      .dependsOn(this.first, this.second, this.batch)
+      .executes(() => {});
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  await execute(b, b.all, { silent: true });
+  // Peak 2 comes only from the group; first/second never overlap anything.
+  assertEquals(peak, 2);
+});
+
+Deno.test("a failing group member skips the group's dependents", async () => {
+  const ran: string[] = [];
+  class B extends Build {
+    ok = target().executes(() => void ran.push("ok"));
+    boom = target().executes(() => {
+      throw new Error("boom");
+    });
+    checks = group(this.ok, this.boom);
+    deploy = target().dependsOn(this.checks).executes(() =>
+      void ran.push("deploy")
+    );
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  const result = await execute(b, b.deploy, { silent: true });
+  assertEquals(result.ok, false);
+  assertEquals(ran.includes("deploy"), false); // group member failed
 });
 
 Deno.test("an unwritable job-summary file never fails the build", async () => {

--- a/packages/core/tests/executor_test.ts
+++ b/packages/core/tests/executor_test.ts
@@ -373,6 +373,177 @@ Deno.test("plain mode separates consecutive targets with a blank line", async ()
   assertEquals(lines[lines.indexOf("▶ b") - 1], ""); // blank before the second
 });
 
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+Deno.test("parallel runs independent targets concurrently", async () => {
+  let active = 0;
+  let peak = 0;
+  const track = async () => {
+    active++;
+    peak = Math.max(peak, active);
+    await delay(20);
+    active--;
+  };
+  class B extends Build {
+    a = target().executes(track);
+    b = target().executes(track);
+    c = target().executes(track);
+    all = target().dependsOn(this.a, this.b, this.c).executes(() => {});
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  const result = await execute(b, b.all, { silent: true, parallel: 3 });
+  assertEquals(result.ok, true);
+  assertEquals(peak, 3); // a, b, c all overlapped
+
+  peak = 0;
+  await execute(b, b.all, { silent: true }); // sequential: no overlap
+  assertEquals(peak, 1);
+});
+
+Deno.test("parallel still runs dependencies before dependents", async () => {
+  const order: string[] = [];
+  const rec = (name: string) => async () => {
+    await delay(5);
+    order.push(name);
+  };
+  class B extends Build {
+    base = target().executes(rec("base"));
+    mid = target().dependsOn(this.base).executes(rec("mid"));
+    top = target().dependsOn(this.mid).executes(rec("top"));
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  const result = await execute(b, b.top, { silent: true, parallel: 4 });
+  assertEquals(result.ok, true);
+  assertEquals(order, ["base", "mid", "top"]);
+});
+
+Deno.test("parallel diamond runs the shared dep once and overlaps the middle", async () => {
+  let active = 0;
+  let peak = 0;
+  const counts = new Map<string, number>();
+  const run = (name: string) => async () => {
+    counts.set(name, (counts.get(name) ?? 0) + 1);
+    active++;
+    peak = Math.max(peak, active);
+    await delay(20);
+    active--;
+  };
+  class B extends Build {
+    base = target().executes(run("base"));
+    left = target().dependsOn(this.base).executes(run("left"));
+    right = target().dependsOn(this.base).executes(run("right"));
+    top = target().dependsOn(this.left, this.right).executes(run("top"));
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  await execute(b, b.top, { silent: true, parallel: 4 });
+  assertEquals(counts.get("base"), 1);
+  assertEquals(peak, 2); // left and right overlap; base and top run alone
+});
+
+Deno.test("parallel skips dependents of a failed target but finishes peers", async () => {
+  const ran: string[] = [];
+  class B extends Build {
+    boom = target().executes(() => {
+      throw new Error("boom");
+    });
+    afterBoom = target().dependsOn(this.boom).executes(() =>
+      void ran.push("afterBoom")
+    );
+    independent = target().executes(() => void ran.push("independent"));
+    all = target()
+      .dependsOn(this.afterBoom, this.independent)
+      .executes(() => void ran.push("all"));
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  const result = await execute(b, b.all, { silent: true, parallel: 4 });
+  assertEquals(result.ok, false);
+  assertEquals(messageOf(result.error), "boom");
+  assertEquals(ran.includes("independent"), true); // launched alongside boom
+  assertEquals(ran.includes("afterBoom"), false); // dependency failed
+  assertEquals(ran.includes("all"), false); // transitively blocked
+});
+
+Deno.test("parallel treats --skip targets as satisfied dependencies", async () => {
+  const ran: string[] = [];
+  class B extends Build {
+    setup = target().executes(() => void ran.push("setup"));
+    main = target().dependsOn(this.setup).executes(() => void ran.push("main"));
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  const result = await execute(b, b.main, {
+    silent: true,
+    parallel: 4,
+    skip: ["setup"],
+  });
+  assertEquals(result.ok, true);
+  assertEquals(ran, ["main"]);
+});
+
+Deno.test("parallel=true uses the host CPU count and succeeds", async () => {
+  class B extends Build {
+    a = target().executes(() => {});
+    b = target().executes(() => {});
+  }
+  const build = new B();
+  discoverTargets(build);
+  // `b` has no deps on `a`; running `b` alone exercises the auto-limit path.
+  const result = await execute(build, build.b, {
+    silent: true,
+    parallel: true,
+  });
+  assertEquals(result.ok, true);
+});
+
+Deno.test("parallel buffers each target's block (plain and github)", async () => {
+  class B extends Build {
+    a = target().executes(() => {});
+    boom = target().executes(() => {
+      throw new Error("nope");
+    });
+    all = target().dependsOn(this.a, this.boom).executes(() => {});
+  }
+  const build = new B();
+  discoverTargets(build);
+
+  // Plain: each target's banner block flushes contiguously; blocks are
+  // separated by a blank line; the failure surfaces and the run fails.
+  const plain = recorder();
+  const result = await execute(build, build.all, {
+    reporter: plain.reporter,
+    github: false,
+    parallel: 4,
+  });
+  assertEquals(result.ok, false);
+  assertEquals(plain.lines.some((l) => l.startsWith("▶ a")), true);
+  assertEquals(plain.lines.includes("nope"), true);
+  assertEquals(plain.lines.includes(""), true); // blank separator between blocks
+  assertEquals(plain.lines[plain.lines.length - 1].includes("FAILED"), true);
+
+  // GitHub: buffering keeps each ::group:: contiguous with its body/endgroup.
+  const gh = recorder();
+  await withEnv("GITHUB_STEP_SUMMARY", undefined, async () => {
+    await execute(build, build.a, {
+      reporter: gh.reporter,
+      github: true,
+      parallel: 4,
+    });
+  });
+  const open = gh.lines.indexOf("::group::a");
+  assertEquals(open >= 0, true);
+  assertEquals(gh.lines[open + 1].startsWith("✔ a ("), true);
+  assertEquals(gh.lines[open + 2], "::endgroup::");
+});
+
 Deno.test("an unwritable job-summary file never fails the build", async () => {
   const dir = await Deno.makeTempDir(); // a directory is not writable as a file
   const { reporter } = recorder();

--- a/packages/core/tests/graph_test.ts
+++ b/packages/core/tests/graph_test.ts
@@ -6,6 +6,7 @@ import {
   findCycle,
   GraphError,
   plan,
+  planGraph,
   validateGraph,
   validateReferences,
 } from "../src/graph.ts";
@@ -14,6 +15,44 @@ import {
 function discover(b: Build) {
   return discoverTargets(b);
 }
+
+Deno.test("planGraph returns the order and each target's predecessors", () => {
+  class B extends Build {
+    base = target().executes(() => {});
+    left = target().dependsOn(this.base).executes(() => {});
+    right = target().dependsOn(this.base).executes(() => {});
+    top = target().dependsOn(this.left, this.right).executes(() => {});
+  }
+  const b = new B();
+  discover(b);
+  const { order, predecessors } = planGraph(b.top);
+
+  const names = order.map((t) => t.name_);
+  assertEquals(names[0], "base");
+  assertEquals(names[names.length - 1], "top");
+  assertEquals([...names].sort(), ["base", "left", "right", "top"]);
+  assertEquals(predecessors.get(b.base)?.map((t) => t.name_), []);
+  assertEquals(predecessors.get(b.left)?.map((t) => t.name_), ["base"]);
+  assertEquals(
+    predecessors.get(b.top)?.map((t) => t.name_),
+    ["left", "right"],
+  );
+});
+
+Deno.test("planGraph detects cycles", () => {
+  class B extends Build {
+    a = target().executes(() => {});
+    b = target().executes(() => {});
+    constructor() {
+      super();
+      this.a.dependsOn(this.b);
+      this.b.dependsOn(this.a);
+    }
+  }
+  const b = new B();
+  discover(b);
+  assertThrows(() => planGraph(b.a), GraphError, "cycle");
+});
 
 Deno.test("topological order respects dependencies", () => {
   class B extends Build {

--- a/packages/core/tests/target_test.ts
+++ b/packages/core/tests/target_test.ts
@@ -2,28 +2,30 @@ import { assertEquals, assertThrows } from "./_assert.ts";
 import { Build, discoverTargets } from "../src/build.ts";
 import { Group, group, target, TargetBuilder } from "../src/target.ts";
 
-Deno.test("group expands to its members in dependsOn and tags them", () => {
+Deno.test("partOf joins a group; dependsOn(group) expands to its members", () => {
   class B extends Build {
-    a = target().executes(() => {});
-    b = target().executes(() => {});
-    batch = group(this.a, this.b);
-    c = target().dependsOn(this.batch).executes(() => {});
-    d = target().dependsOn(this.batch, this.c).executes(() => {});
+    checks = group();
+    a = target().partOf(this.checks).executes(() => {});
+    b = target().partOf(this.checks).executes(() => {});
+    c = target().dependsOn(this.checks).executes(() => {});
+    d = target().dependsOn(this.checks, this.c).executes(() => {});
   }
   const b = new B();
   discoverTargets(b);
 
-  assertEquals(b.batch instanceof Group, true);
+  assertEquals(b.checks instanceof Group, true);
+  assertEquals(b.checks.members_.map((t) => t.name_), ["a", "b"]);
+  assertEquals(b.a.group_, b.checks);
+  assertEquals(b.a.group_ === b.b.group_, true);
   assertEquals(b.c.dependsOn_.map((t) => t.name_), ["a", "b"]);
   assertEquals(b.d.dependsOn_.map((t) => t.name_), ["a", "b", "c"]);
-  assertEquals(b.a.group_, b.batch);
-  assertEquals(b.a.group_ === b.b.group_, true);
 });
 
-Deno.test("group tolerates an undefined (forward-referenced) member", () => {
+Deno.test("partOf ignores an undefined (forward-referenced) group", () => {
+  const t = target();
   // @ts-expect-error exercising the runtime guard against an unbound reference
-  const g = group(undefined);
-  assertEquals(g.members_.length, 1);
+  t.partOf(undefined);
+  assertEquals(t.group_, undefined);
 });
 
 Deno.test("target() builder is chainable and records configuration", () => {

--- a/packages/core/tests/target_test.ts
+++ b/packages/core/tests/target_test.ts
@@ -1,6 +1,30 @@
 import { assertEquals, assertThrows } from "./_assert.ts";
 import { Build, discoverTargets } from "../src/build.ts";
-import { target, TargetBuilder } from "../src/target.ts";
+import { Group, group, target, TargetBuilder } from "../src/target.ts";
+
+Deno.test("group expands to its members in dependsOn and tags them", () => {
+  class B extends Build {
+    a = target().executes(() => {});
+    b = target().executes(() => {});
+    batch = group(this.a, this.b);
+    c = target().dependsOn(this.batch).executes(() => {});
+    d = target().dependsOn(this.batch, this.c).executes(() => {});
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  assertEquals(b.batch instanceof Group, true);
+  assertEquals(b.c.dependsOn_.map((t) => t.name_), ["a", "b"]);
+  assertEquals(b.d.dependsOn_.map((t) => t.name_), ["a", "b", "c"]);
+  assertEquals(b.a.group_, b.batch);
+  assertEquals(b.a.group_ === b.b.group_, true);
+});
+
+Deno.test("group tolerates an undefined (forward-referenced) member", () => {
+  // @ts-expect-error exercising the runtime guard against an unbound reference
+  const g = group(undefined);
+  assertEquals(g.members_.length, 1);
+});
 
 Deno.test("target() builder is chainable and records configuration", () => {
   const dep = target();


### PR DESCRIPTION
## Summary

Two complementary ways to run targets concurrently. Both opt-in, so plain builds stay sequential and deterministic. Green under `deno task ci` (fmt, lint, spell, check, 95% coverage gate).

### 1. `--parallel` — whole-build concurrency
- `execute(build, target, { parallel })`: `false`/omitted = sequential; `true` = host CPU count; a number = max concurrency. CLI: `--parallel` / `--parallel=N`.
- Independent targets run concurrently; every dependency still completes before its dependents. First failure stops new launches; in-flight targets settle and the rest are reported skipped.

### 2. `group()` + `.partOf()` — declarative parallel batches
- `group()` creates a batch. A target joins it with `.partOf(group)` in its chain; members of the same group run **concurrently even in a sequential build** (each still awaiting its own deps).
- Depending on a group (`.dependsOn(group)`) expands to every member that joined, so a downstream target waits for the whole batch:
  ```ts
  checks = group();

  clean     = target().executes(/* ... */);
  lint      = target().dependsOn(this.clean).partOf(this.checks).executes(/* ... */);
  format    = target().dependsOn(this.clean).partOf(this.checks).executes(/* ... */);
  typecheck = target().dependsOn(this.clean).partOf(this.checks).executes(/* ... */);

  deploy = target().dependsOn(this.checks).executes(/* ... */); // after all three
  ```
  Runs `clean`, then `lint`/`format`/`typecheck` together, then `deploy` — no `--parallel` needed. Declare the group field above the targets that join it (same rule as ordinary dependencies).

### Engine
- `graph.ts` gains `planGraph()` (execution order + each target's predecessors); `plan()` refactored onto a shared edge-builder + topo sort (no behaviour change).
- The executor plans once and routes through one scheduler whenever a group is present or `--parallel` is set, else the sequential fast path. The scheduler takes a `canOverlap` predicate: with `--parallel` anything independent overlaps; otherwise only same-group members do (ungrouped targets stay serialized). Per-target banners are buffered and flushed as contiguous blocks; the summary stays deterministic.

### API additions (`@zuke/core`)
`group`, `Group`, `TargetBuilder.partOf`; `ExecuteOptions.parallel`.

### Verified
- `--parallel`: 3×150 ms independent targets finish ~0.2 s (≈0.45 s serial); chains stay ordered; failed deps skip dependents.
- `group()`/`.partOf()`: `clean → {lint,format,typecheck} → deploy` batches the three (~0.2 s) with no flag; ungrouped targets don't overlap; a failed batch member skips the group's dependents.

## Docs
`docs/authoring.md` (`group()`/`.partOf()` section), `docs/cli.md` (parallel section + `--parallel` row), roadmap entry dropped.

## Notes
- Both are opt-in by design (determinism; protects builds relying on ordering/shared state).
- Membership is a property of the target, so a group's members batch whenever they run. A target's own subprocess output can still interleave under concurrency (like `make -j`); only framework banners are serialized.

https://claude.ai/code/session_01PtqHmRRvtT6qkQKaPzrWhT