### PR TITLE
feat(core): incremental caching, conditions, and more target methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ CI runs `deno task ci` on every push and pull request (see
 Post-v0, for context:
 
 - A `zuke` standalone binary + `zuke init` scaffolding.
-- Caching / incremental targets.
 - More tool wrapper packages — see [Tools](./docs/tools.md) for what ships today.
 
 ## Security

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -12,6 +12,9 @@ body, which is required before the target can run.
 | `.executes(fn)`          | `(fn: () => void \| Promise<void>) => this` | The body. May be async.                                |
 | `.before(...targets)`    | `(...t: Target[]) => this`                  | Soft ordering: run before these _if both are planned_. |
 | `.after(...targets)`     | `(...t: Target[]) => this`                  | Soft ordering: run after these _if both are planned_.  |
+| `.inputs(...paths)`      | `(...p: PathLike[]) => this`                | Cache inputs: skip the target when these are unchanged. |
+| `.outputs(...paths)`     | `(...p: PathLike[]) => this`                | Cache outputs: a hit also requires these to still exist. |
+| `.onlyWhen(condition)`   | `(c: () => boolean \| Promise<boolean>) => this` | Run only when the condition holds, else skip.    |
 
 `dependsOn` pulls targets into the plan; `before`/`after` only reorder targets
 that are _already_ in the plan — they never pull new targets in.
@@ -52,6 +55,41 @@ Here `clean` runs first (all three depend on it), then `lint`/`format`/
 so they batch whenever they run — no `--parallel` flag needed. Ungrouped
 targets stay serialized unless you opt the whole build into `--parallel`.
 Declare the group field above the targets that join it.
+
+### Incremental caching — `.inputs()` / `.outputs()`
+
+A target that declares **inputs** becomes incremental: Zuke fingerprints those
+files/directories (SHA-256 of their contents, directories hashed recursively)
+and **skips** the target — reporting it `cached` — when the fingerprint is
+unchanged since the last successful run and every declared **output** still
+exists. Otherwise it runs and refreshes the fingerprint.
+
+```ts
+compile = target()
+  .inputs("src", "deno.json") // re-run only when these change…
+  .outputs("dist") // …or when dist is missing
+  .executes(async () => {
+    await DenoTasks.run((s) => s.script("build.ts"));
+  });
+```
+
+Fingerprints live in `<repo root>/.zuke/cache.json` (git-ignored). A target with
+no inputs always runs. Pass `--no-cache` (or `execute(..., { cache: false })`)
+to ignore the cache and rebuild everything. A skipped/cached target counts as
+satisfied, so its dependents still run.
+
+### Conditional execution — `.onlyWhen()`
+
+`.onlyWhen(condition)` runs the target only when the condition holds; otherwise
+it is skipped (and its dependents still run). The predicate may be async and can
+read resolved [parameters](./parameters.md) or the environment. Repeatable — all
+conditions must hold.
+
+```ts
+deploy = target()
+  .onlyWhen(() => this.environment.value === "production")
+  .executes(/* ... */);
+```
 
 ### `Build`
 

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -12,9 +12,14 @@ body, which is required before the target can run.
 | `.executes(fn)`          | `(fn: () => void \| Promise<void>) => this` | The body. May be async.                                |
 | `.before(...targets)`    | `(...t: Target[]) => this`                  | Soft ordering: run before these _if both are planned_. |
 | `.after(...targets)`     | `(...t: Target[]) => this`                  | Soft ordering: run after these _if both are planned_.  |
+| `.triggers(...targets)`  | `(...t: Target[]) => this`                  | Pull these into the plan and run them _after_ this.    |
+| `.dependentFor(...targets)` | `(...t: Target[]) => this`               | Reverse of `dependsOn`: run this _before_ those.       |
 | `.inputs(...paths)`      | `(...p: PathLike[]) => this`                | Cache inputs: skip the target when these are unchanged. |
 | `.outputs(...paths)`     | `(...p: PathLike[]) => this`                | Cache outputs: a hit also requires these to still exist. |
 | `.onlyWhen(condition)`   | `(c: () => boolean \| Promise<boolean>) => this` | Run only when the condition holds, else skip.    |
+| `.requires(...params)`   | `(...p: Parameter[]) => this`               | Fail the target unless these parameters are set.       |
+| `.proceedAfterFailure()` | `() => this`                                | Keep the build going if this target fails.             |
+| `.unlisted()`            | `() => this`                                | Hide the target from `--list`/`--help`.                |
 
 `dependsOn` pulls targets into the plan; `before`/`after` only reorder targets
 that are _already_ in the plan — they never pull new targets in.
@@ -90,6 +95,23 @@ deploy = target()
   .onlyWhen(() => this.environment.value === "production")
   .executes(/* ... */);
 ```
+
+### More target options
+
+- **`.triggers(...targets)`** — the inverse of `dependsOn`: running this target
+  pulls the listed targets into the plan and runs them _after_ it (e.g. a
+  `notify` target triggered by `deploy`).
+- **`.dependentFor(...targets)`** — declare this target as a prerequisite of
+  others without editing them: each listed target gains this one as a
+  dependency. Declare the listed targets above this one.
+- **`.requires(...params)`** — fail the target (with a message naming the
+  parameter) unless each listed [parameter](./parameters.md) resolved to a
+  value. Use it for a parameter that is optional build-wide but mandatory here.
+- **`.proceedAfterFailure()`** — if this target fails, keep running the rest of
+  the build instead of aborting. The build still reports failure, and this
+  target's own dependents are skipped.
+- **`.unlisted()`** — hide a helper target from `--list`/`--help`; it can still
+  be run by name or depended on.
 
 ### `Build`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -5,6 +5,7 @@
 | `zuke <target>`              | Run the target and all its transitive dependencies, in order. |
 | `zuke <target> --skip <dep>` | Run the target but skip the named dependency (repeatable).    |
 | `zuke <target> --parallel`   | Run independent targets concurrently (`--parallel=N` caps it). |
+| `zuke <target> --no-cache`   | Ignore the incremental cache; re-run every target.            |
 | `zuke --list` / `-l`         | List all targets with descriptions and dependencies.          |
 | `zuke graph`                 | Print the dependency graph (`target → deps`).                 |
 | `zuke graph --output=html`   | Render an interactive HTML graph into `.zuke/` and open it.   |
@@ -57,3 +58,11 @@ Programmatic callers get the same behaviour via `execute(build, target, { parall
 For parallelism scoped to specific targets rather than the whole build, put
 them in a [`group()`](./authoring.md#group-and-partof) with `.partOf(...)` — the
 group's members run concurrently even without `--parallel`.
+
+## Incremental builds
+
+Targets that declare [`.inputs()`](./authoring.md#incremental-caching-inputs--outputs)
+are cached: Zuke skips one (showing it `cached` in the summary) when its inputs
+are unchanged since the last successful run and its outputs still exist.
+Fingerprints live in `.zuke/cache.json`. `--no-cache` ignores the cache and
+re-runs everything.

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -26,6 +26,7 @@
 
 export { Build, type BuildResult, discoverTargets } from "./src/build.ts";
 export {
+  type Condition,
   Group,
   group,
   type Target,
@@ -35,6 +36,7 @@ export {
 } from "./src/target.ts";
 export { run } from "./src/cli.ts";
 export { execute, type ExecuteOptions, type Reporter } from "./src/executor.ts";
+export type { BuildCache } from "./src/cache.ts";
 export { type AbsolutePath, absolutePath, type PathLike } from "./src/path.ts";
 export { CONFIG_FILE, repoRoot } from "./src/config.ts";
 export {

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -1,0 +1,212 @@
+/**
+ * Incremental-build cache: fingerprints a target's declared {@link
+ * TargetBuilder.inputs} and lets the executor skip it when nothing has changed
+ * since the last successful run and its {@link TargetBuilder.outputs} still
+ * exist.
+ *
+ * The fingerprint is a SHA-256 over the contents of every input (directories
+ * hashed recursively), computed with the built-in Web Crypto API — no
+ * dependency. Fingerprints persist in `<repo root>/.zuke/cache.json`. All
+ * filesystem effects go through an injectable {@link CacheHost} so the logic
+ * stays unit-testable.
+ *
+ * @module
+ */
+
+import type { TargetBuilder } from "./target.ts";
+
+/** The cache store file name within the `.zuke/` artifact directory. */
+export const CACHE_FILE = "cache.json";
+
+/** Injected filesystem effects, so {@link openCache} is unit-testable. */
+export interface CacheHost {
+  /** File contents, or `null` if the path does not exist. */
+  readFile(path: string): Promise<Uint8Array | null>;
+  /** Whether a path exists and is a directory, or `null` if it is missing. */
+  stat(path: string): Promise<{ isDirectory: boolean } | null>;
+  /** The entry names within a directory. */
+  readDir(path: string): Promise<string[]>;
+  /** The cache store text, or `null` if it does not exist yet. */
+  readStore(path: string): Promise<string | null>;
+  /** Write the cache store text, creating parent directories. */
+  writeStore(path: string, content: string): Promise<void>;
+}
+
+/** The real, `Deno`-backed {@link CacheHost}. */
+export const defaultCacheHost: CacheHost = {
+  async readFile(path: string): Promise<Uint8Array | null> {
+    try {
+      return await Deno.readFile(path);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) return null;
+      throw error;
+    }
+  },
+  async stat(path: string): Promise<{ isDirectory: boolean } | null> {
+    try {
+      const info = await Deno.stat(path);
+      return { isDirectory: info.isDirectory };
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) return null;
+      throw error;
+    }
+  },
+  async readDir(path: string): Promise<string[]> {
+    const names: string[] = [];
+    for await (const entry of Deno.readDir(path)) names.push(entry.name);
+    return names;
+  },
+  async readStore(path: string): Promise<string | null> {
+    try {
+      return await Deno.readTextFile(path);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) return null;
+      throw error;
+    }
+  },
+  async writeStore(path: string, content: string): Promise<void> {
+    const slash = path.replace(/\\/g, "/").lastIndexOf("/");
+    if (slash > 0) await Deno.mkdir(path.slice(0, slash), { recursive: true });
+    await Deno.writeTextFile(path, content);
+  },
+};
+
+const encoder = new TextEncoder();
+
+/** Hex SHA-256 of raw bytes. */
+async function hashBytes(bytes: Uint8Array): Promise<string> {
+  // Copy into a fresh ArrayBuffer-backed view so the digest input type is
+  // unambiguous regardless of the source buffer (e.g. a SharedArrayBuffer).
+  const digest = await crypto.subtle.digest("SHA-256", new Uint8Array(bytes));
+  return Array.from(
+    new Uint8Array(digest),
+    (b) => b.toString(16).padStart(2, "0"),
+  ).join("");
+}
+
+/** Hex SHA-256 of a UTF-8 string. */
+function hashText(text: string): Promise<string> {
+  return hashBytes(encoder.encode(text));
+}
+
+/**
+ * Fingerprint a file or directory: the file's content hash, or — for a
+ * directory — a hash of its sorted `name:hash` entries (recursively). A missing
+ * path hashes to a sentinel so its appearance or removal changes the result.
+ */
+async function hashPath(path: string, host: CacheHost): Promise<string> {
+  const info = await host.stat(path);
+  if (info === null) return "∅"; // missing
+  if (!info.isDirectory) {
+    const bytes = await host.readFile(path);
+    return bytes === null ? "∅" : await hashBytes(bytes);
+  }
+  const names = (await host.readDir(path)).slice().sort();
+  const parts: string[] = [];
+  for (const name of names) {
+    parts.push(`${name}:${await hashPath(`${path}/${name}`, host)}`);
+  }
+  return hashText(parts.join("\n"));
+}
+
+/** The combined fingerprint of a target's declared inputs, in declaration order. */
+export async function fingerprint(
+  target: TargetBuilder,
+  host: CacheHost,
+): Promise<string> {
+  const parts: string[] = [];
+  for (const input of target.inputs_) {
+    parts.push(`${input}:${await hashPath(input, host)}`);
+  }
+  return hashText(parts.join("\n"));
+}
+
+/** The incremental cache used by the executor to skip up-to-date targets. */
+export interface BuildCache {
+  /**
+   * Whether `target` is up-to-date: it declares inputs, their fingerprint
+   * matches the last successful run, and every declared output still exists.
+   */
+  upToDate(target: TargetBuilder): Promise<boolean>;
+  /** Record `target`'s current fingerprint after a successful run. */
+  record(target: TargetBuilder): Promise<void>;
+  /** Persist the store if anything changed. */
+  save(): Promise<void>;
+}
+
+/** Parse the cache store JSON into a flat name → fingerprint record. */
+function parseStore(text: string | null): Record<string, string> {
+  if (text === null) return {};
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (typeof parsed !== "object" || parsed === null) return {};
+    const store: Record<string, string> = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (typeof value === "string") store[key] = value;
+    }
+    return store;
+  } catch {
+    return {}; // a corrupt store just means everything rebuilds
+  }
+}
+
+/** Filesystem-backed {@link BuildCache}. */
+class FsCache implements BuildCache {
+  readonly #host: CacheHost;
+  readonly #storePath: string;
+  readonly #store: Record<string, string>;
+  readonly #computed = new Map<TargetBuilder, string>();
+  #dirty = false;
+
+  constructor(
+    host: CacheHost,
+    storePath: string,
+    store: Record<string, string>,
+  ) {
+    this.#host = host;
+    this.#storePath = storePath;
+    this.#store = store;
+  }
+
+  async upToDate(target: TargetBuilder): Promise<boolean> {
+    if (target.inputs_.length === 0) return false;
+    const fp = await fingerprint(target, this.#host);
+    this.#computed.set(target, fp);
+    if (this.#store[target.name_ ?? ""] !== fp) return false;
+    for (const output of target.outputs_) {
+      if (await this.#host.stat(output) === null) return false;
+    }
+    return true;
+  }
+
+  async record(target: TargetBuilder): Promise<void> {
+    if (target.inputs_.length === 0) return;
+    const name = target.name_ ?? "";
+    const fp = this.#computed.get(target) ??
+      await fingerprint(target, this.#host);
+    if (this.#store[name] !== fp) {
+      this.#store[name] = fp;
+      this.#dirty = true;
+    }
+  }
+
+  async save(): Promise<void> {
+    if (!this.#dirty) return;
+    await this.#host.writeStore(
+      this.#storePath,
+      `${JSON.stringify(this.#store, null, 2)}\n`,
+    );
+  }
+}
+
+/**
+ * Open the incremental cache stored at `storePath`, loading any existing
+ * fingerprints. Filesystem access goes through `host`.
+ */
+export async function openCache(
+  storePath: string,
+  host: CacheHost = defaultCacheHost,
+): Promise<BuildCache> {
+  const store = parseStore(await host.readStore(storePath));
+  return new FsCache(host, storePath, store);
+}

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -53,6 +53,8 @@ export interface ParsedArgs {
   open: boolean;
   /** Run independent targets concurrently (`--parallel[=N]`). */
   parallel?: boolean | number;
+  /** Disable the incremental cache (`--no-cache`); undefined leaves it on. */
+  cache?: boolean;
   /** Raw parameter values from declared flags, keyed by property name. */
   values: Record<string, string>;
   help: boolean;
@@ -92,6 +94,8 @@ export function parseArgs(
       parsed.list = true;
     } else if (arg === "--no-open") {
       parsed.open = false;
+    } else if (arg === "--no-cache") {
+      parsed.cache = false;
     } else if (arg === "--parallel") {
       parsed.parallel = true;
     } else if (arg.startsWith("--parallel=")) {
@@ -144,6 +148,7 @@ Options:
   --skip <dep>      Skip the named dependency (repeatable).
   --parallel[=N]    Run independent targets concurrently (N = max in flight,
                     default = CPU count).
+  --no-cache        Ignore the incremental cache; re-run every target.
   --list, -l        List all targets with descriptions and dependencies.
   graph             Show the dependency graph. Default output is the terminal
                     adjacency listing; --output=html writes an interactive
@@ -284,6 +289,7 @@ export async function main(
     skip: parsed.skip,
     params: parsed.values,
     parallel: parsed.parallel,
+    cache: parsed.cache,
   });
   return result.ok ? 0 : 1;
 }

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -171,9 +171,13 @@ export function formatList(
   targets: Map<string, TargetBuilder>,
   params: Map<string, AnyParameter> = new Map(),
 ): string {
-  const targetText = targets.size === 0
+  // `unlisted` targets stay runnable by name but are hidden from the listing.
+  const listed = new Map(
+    [...targets].filter(([, t]) => !t.unlisted_),
+  );
+  const targetText = listed.size === 0
     ? "No targets defined."
-    : renderTargets(targets);
+    : renderTargets(listed);
   const paramText = formatParameters(params);
   return paramText === "" ? targetText : `${targetText}\n\n${paramText}`;
 }

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -23,7 +23,18 @@ import {
   ParameterError,
   resolveParameters,
 } from "./params.ts";
+import {
+  type BuildCache,
+  CACHE_FILE,
+  defaultCacheHost,
+  openCache,
+} from "./cache.ts";
+import { findConfigDir, pathExists } from "./config.ts";
+import { absolutePath } from "./path.ts";
 import type { TargetBuilder } from "./target.ts";
+
+/** The artifact directory (under the repo root) for the cache store. */
+const ARTIFACT_DIR = ".zuke";
 
 /** Sink for executor output, defaulting to the console. Overridable in tests. */
 export interface Reporter {
@@ -53,6 +64,13 @@ export interface ExecuteOptions {
    */
   parallel?: boolean | number;
   /**
+   * Incremental caching: skip targets whose declared {@link TargetBuilder.inputs}
+   * are unchanged since the last successful run (and whose outputs still exist).
+   * Defaults to on; pass `false` to disable (CLI `--no-cache`). A {@link
+   * BuildCache} may be supplied directly (used in tests).
+   */
+  cache?: boolean | BuildCache;
+  /**
    * Raw parameter values from the command line, keyed by parameter (property)
    * name. Each declared {@link Parameter} is resolved from this map, then the
    * environment, then its declared default before any target runs.
@@ -77,7 +95,7 @@ export interface ExecuteOptions {
 }
 
 /** A target's outcome, collected for the end-of-build summary. */
-type TargetStatus = "passed" | "failed" | "skipped";
+type TargetStatus = "passed" | "failed" | "skipped" | "cached";
 
 interface TargetReport {
   name: string;
@@ -89,6 +107,7 @@ const ICON: Record<TargetStatus, string> = {
   passed: "✔",
   failed: "✘",
   skipped: "⊘",
+  cached: "⊙",
 };
 
 /** ANSI select-graphic-rendition codes used for terminal colour. */
@@ -210,6 +229,7 @@ const ROW_COLOR: Record<TargetStatus, string> = {
   passed: SGR.green,
   failed: SGR.red,
   skipped: SGR.dim,
+  cached: SGR.cyan,
 };
 
 /** Render the end-of-build summary block. */
@@ -222,15 +242,18 @@ function summaryBlock(
   const width = reports.reduce((w, x) => Math.max(w, x.name.length), 0);
   const rows = reports.map((x) => {
     const icon = paint(style.color, ROW_COLOR[x.status], ICON[x.status]);
-    const right = x.status === "skipped" ? "skipped" : formatDuration(x.ms);
+    const ran = x.status === "passed" || x.status === "failed";
+    const right = ran ? formatDuration(x.ms) : x.status;
     return `  ${icon} ${x.name.padEnd(width)}  ${right}`;
   });
-  const passed = reports.filter((x) => x.status === "passed").length;
+  const succeeded =
+    reports.filter((x) => x.status === "passed" || x.status === "cached")
+      .length;
   const banner = paint(
     style.color,
     SGR.bold + (ok ? SGR.green : SGR.red),
     `${ok ? ICON.passed : ICON.failed} ${ok ? "SUCCESS" : "FAILED"} — ` +
-      `${passed}/${reports.length} targets in ${formatDuration(totalMs)}`,
+      `${succeeded}/${reports.length} targets in ${formatDuration(totalMs)}`,
   );
   return [
     "",
@@ -256,13 +279,16 @@ function writeJobSummary(
   }
   if (path === undefined || path === "") return;
 
-  const passed = reports.filter((x) => x.status === "passed").length;
+  const succeeded =
+    reports.filter((x) => x.status === "passed" || x.status === "cached")
+      .length;
   const rows = reports.map((x) => {
-    const time = x.status === "skipped" ? "—" : formatDuration(x.ms);
+    const ran = x.status === "passed" || x.status === "failed";
+    const time = ran ? formatDuration(x.ms) : "—";
     return `| ${x.name} | ${ICON[x.status]} ${x.status} | ${time} |`;
   });
   const markdown = [
-    `## ${ok ? "✅" : "❌"} Zuke build — ${passed}/${reports.length} ` +
+    `## ${ok ? "✅" : "❌"} Zuke build — ${succeeded}/${reports.length} ` +
     `targets in ${formatDuration(totalMs)}`,
     "",
     "| Target | Result | Time |",
@@ -292,14 +318,28 @@ interface RunOutcome {
   aborted: boolean;
 }
 
-/** Run one target: open its section, run its body, report pass/fail. */
+/**
+ * Run one target: honour its `onlyWhen` conditions and the incremental cache,
+ * then (if it must run) open its section, run its body, and report pass/fail.
+ * A condition that fails yields `skipped`; an up-to-date target yields `cached`
+ * — both unblock dependents without executing the body.
+ */
 async function runTarget(
   reporter: Reporter,
   style: Style,
   t: TargetBuilder,
   opened: number,
+  cache: BuildCache | undefined,
 ): Promise<TargetOutcome> {
   const name = t.name_ ?? "<unnamed>";
+
+  for (const condition of t.onlyWhen_) {
+    if (!(await condition())) return { status: "skipped", ms: 0 };
+  }
+  if (cache !== undefined && await cache.upToDate(t)) {
+    return { status: "cached", ms: 0 };
+  }
+
   openTarget(reporter, style, name, opened);
   const start = performance.now();
 
@@ -314,6 +354,7 @@ async function runTarget(
   try {
     await t.fn_();
     const ms = performance.now() - start;
+    if (cache !== undefined) await cache.record(t);
     passTarget(reporter, style, name, ms);
     return { status: "passed", ms };
   } catch (error) {
@@ -362,6 +403,7 @@ async function runSequential(
   reporter: Reporter,
   style: Style,
   skip: Set<string>,
+  cache: BuildCache | undefined,
 ): Promise<RunOutcome> {
   const reports: TargetReport[] = [];
   const executed: string[] = [];
@@ -375,11 +417,11 @@ async function runSequential(
       reports.push({ name, status: "skipped", ms: 0 });
       continue;
     }
-    const outcome = await runTarget(reporter, style, t, opened);
-    opened++;
+    const outcome = await runTarget(reporter, style, t, opened, cache);
+    if (outcome.status === "passed" || outcome.status === "failed") opened++;
     reports.push({ name, status: outcome.status, ms: outcome.ms });
     if (outcome.status === "passed") executed.push(name);
-    else {
+    else if (outcome.status === "failed") {
       failure = outcome.error;
       aborted = true;
     }
@@ -405,6 +447,7 @@ async function runScheduled(
   skip: Set<string>,
   limit: number,
   canOverlap: (a: TargetBuilder, b: TargetBuilder) => boolean,
+  cache: BuildCache | undefined,
 ): Promise<RunOutcome> {
   const outcomes = new Map<TargetBuilder, TargetOutcome>();
   const done = new Set<TargetBuilder>(); // passed or skipped → unblocks dependents
@@ -437,19 +480,27 @@ async function runScheduled(
           started.add(t);
           runningSet.add(t);
           const buffer = bufferReporter();
-          runTarget(buffer.reporter, style, t, flushed).then((outcome) => {
-            if (!style.github && flushed > 0) reporter.info("");
-            buffer.flush(reporter);
-            flushed++;
-            outcomes.set(t, outcome);
-            runningSet.delete(t);
-            if (outcome.status === "passed") done.add(t);
-            else {
-              aborted = true;
-              failure = outcome.error;
-            }
-            pump();
-          });
+          runTarget(buffer.reporter, style, t, flushed, cache).then(
+            (outcome) => {
+              // Only an executed target prints a block worth separating.
+              const printed = outcome.status === "passed" ||
+                outcome.status === "failed";
+              if (printed) {
+                if (!style.github && flushed > 0) reporter.info("");
+                buffer.flush(reporter);
+                flushed++;
+              }
+              outcomes.set(t, outcome);
+              runningSet.delete(t);
+              if (outcome.status === "failed") {
+                aborted = true;
+                failure = outcome.error;
+              } else {
+                done.add(t); // passed, cached, or condition-skipped
+              }
+              pump();
+            },
+          );
         }
       }
       if (runningSet.size === 0) {
@@ -518,13 +569,14 @@ export async function execute(
   const limit = resolveConcurrency(options.parallel);
   const globalParallel = limit > 1;
   const grouped = order.some((t) => t.group_ !== undefined);
+  const cache = await resolveCache(options.cache, order);
   const overallStart = performance.now();
 
   await build.onStart();
 
   let run: RunOutcome;
   if (!globalParallel && !grouped) {
-    run = await runSequential(order, reporter, style, skip);
+    run = await runSequential(order, reporter, style, skip, cache);
   } else {
     // With `--parallel`, anything independent may overlap up to `limit`.
     // Otherwise only same-group members overlap (the rest stay serialized),
@@ -542,8 +594,10 @@ export async function execute(
       skip,
       effectiveLimit,
       canOverlap,
+      cache,
     );
   }
+  if (cache !== undefined) await cache.save();
 
   const result: BuildResult = run.aborted
     ? { ok: false, executed: run.executed, error: run.failure }
@@ -554,4 +608,21 @@ export async function execute(
   if (style.github) writeJobSummary(run.reports, totalMs, result.ok);
   await build.onFinish(result);
   return result;
+}
+
+/**
+ * Resolve the incremental cache for a run: `false` disables it, a supplied
+ * {@link BuildCache} is used directly, and otherwise a `.zuke/cache.json`-backed
+ * cache is opened — but only when at least one target declares inputs.
+ */
+async function resolveCache(
+  option: boolean | BuildCache | undefined,
+  order: TargetBuilder[],
+): Promise<BuildCache | undefined> {
+  if (option === false) return undefined;
+  if (typeof option === "object") return option;
+  if (!order.some((t) => t.inputs_.length > 0)) return undefined;
+  const root = findConfigDir(Deno.cwd(), pathExists) ?? Deno.cwd();
+  const storePath = absolutePath(root)(ARTIFACT_DIR, CACHE_FILE).path;
+  return await openCache(storePath, defaultCacheHost);
 }

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -336,6 +336,18 @@ async function runTarget(
   for (const condition of t.onlyWhen_) {
     if (!(await condition())) return { status: "skipped", ms: 0 };
   }
+
+  const missing = t.requires_.filter((p) => !p.isSet_());
+  if (missing.length > 0) {
+    const names = missing.map((p) => `"${p.name_ ?? "(unnamed)"}"`).join(", ");
+    const error = new Error(
+      `Target "${name}" requires parameter(s) that are not set: ${names}.`,
+    );
+    openTarget(reporter, style, name, opened);
+    failTarget(reporter, style, name, 0, error);
+    return { status: "failed", ms: 0, error };
+  }
+
   if (cache !== undefined && await cache.upToDate(t)) {
     return { status: "cached", ms: 0 };
   }
@@ -450,11 +462,12 @@ async function runScheduled(
   cache: BuildCache | undefined,
 ): Promise<RunOutcome> {
   const outcomes = new Map<TargetBuilder, TargetOutcome>();
-  const done = new Set<TargetBuilder>(); // passed or skipped → unblocks dependents
+  const done = new Set<TargetBuilder>(); // passed/cached/skipped → unblocks dependents
   const started = new Set<TargetBuilder>();
   const runningSet = new Set<TargetBuilder>();
   let failure: unknown;
-  let aborted = false;
+  let anyFailed = false; // a failure occurred → the build fails
+  let halted = false; // a non-lenient failure → stop launching new targets
   let flushed = 0;
 
   // `--skip` targets count as completed so their dependents can still run.
@@ -473,7 +486,7 @@ async function runScheduled(
 
   await new Promise<void>((resolve) => {
     const pump = () => {
-      if (!aborted) {
+      if (!halted) {
         for (const t of order) {
           if (runningSet.size >= limit) break;
           if (started.has(t) || !ready(t) || !overlaps(t)) continue;
@@ -493,8 +506,11 @@ async function runScheduled(
               outcomes.set(t, outcome);
               runningSet.delete(t);
               if (outcome.status === "failed") {
-                aborted = true;
-                failure = outcome.error;
+                anyFailed = true;
+                failure ??= outcome.error;
+                // A lenient failure lets independent targets keep going; its
+                // own dependents stay blocked (never added to `done`).
+                if (!t.proceedAfterFailure_) halted = true;
               } else {
                 done.add(t); // passed, cached, or condition-skipped
               }
@@ -524,7 +540,7 @@ async function runScheduled(
     reports.push({ name, status: outcome.status, ms: outcome.ms });
     if (outcome.status === "passed") executed.push(name);
   }
-  return { reports, executed, failure, aborted };
+  return { reports, executed, failure, aborted: anyFailed };
 }
 
 /**
@@ -569,13 +585,16 @@ export async function execute(
   const limit = resolveConcurrency(options.parallel);
   const globalParallel = limit > 1;
   const grouped = order.some((t) => t.group_ !== undefined);
+  // `proceedAfterFailure` needs the scheduler's per-target skip-on-failure, so
+  // the simple sequential loop is only used when none of these features apply.
+  const lenient = order.some((t) => t.proceedAfterFailure_);
   const cache = await resolveCache(options.cache, order);
   const overallStart = performance.now();
 
   await build.onStart();
 
   let run: RunOutcome;
-  if (!globalParallel && !grouped) {
+  if (!globalParallel && !grouped && !lenient) {
     run = await runSequential(order, reporter, style, skip, cache);
   } else {
     // With `--parallel`, anything independent may overlap up to `limit`.

--- a/packages/core/src/graph.ts
+++ b/packages/core/src/graph.ts
@@ -35,24 +35,32 @@ export function validateReferences(
   targets: Map<string, TargetBuilder>,
 ): void {
   const known = new Set(targets.values());
-  for (const [name, t] of targets) {
-    for (const dep of t.dependsOn_) {
-      if (dep === undefined) {
+  const check = (
+    name: string,
+    refs: ReadonlyArray<TargetBuilder>,
+    verb: string,
+  ) => {
+    for (const ref of refs) {
+      if (ref === undefined) {
         throw new GraphError(
-          `Target "${name}" has an undefined dependency. This usually means it ` +
+          `Target "${name}" ${verb} an undefined target. This usually means it ` +
             `references a sibling via this.x that is declared *after* it — ` +
-            `class fields initialise top-to-bottom, so dependencies must be ` +
-            `declared before the targets that depend on them.`,
+            `class fields initialise top-to-bottom, so referenced targets must ` +
+            `be declared before the targets that reference them.`,
         );
       }
-      if (!known.has(dep)) {
+      if (!known.has(ref)) {
         throw new GraphError(
-          `Target "${name}" depends on a target that was not discovered ` +
-            `(${label(dep)}). Dependencies must reference sibling targets ` +
+          `Target "${name}" ${verb} a target that was not discovered ` +
+            `(${label(ref)}). References must point at sibling targets ` +
             `declared as properties of the build.`,
         );
       }
     }
+  };
+  for (const [name, t] of targets) {
+    check(name, t.dependsOn_, "depends on");
+    check(name, t.triggers_, "triggers");
   }
 }
 
@@ -124,6 +132,7 @@ export function executionSet(root: TargetBuilder): Set<TargetBuilder> {
     if (set.has(node)) return;
     set.add(node);
     for (const dep of node.dependsOn_) walk(dep);
+    for (const trigger of node.triggers_) walk(trigger);
   };
   walk(root);
   return set;
@@ -149,6 +158,7 @@ function planEdges(
     for (const dep of node.dependsOn_) addEdge(dep, node); // dep before node
     for (const b of node.before_) addEdge(node, b); // node before b
     for (const a of node.after_) addEdge(a, node); // a before node
+    for (const t of node.triggers_) addEdge(node, t); // node before trigger
   }
   return { set, edges };
 }

--- a/packages/core/src/params.ts
+++ b/packages/core/src/params.ts
@@ -99,6 +99,8 @@ export interface AnyParameter {
   readonly hasFallback_: boolean;
   /** Resolve from a raw input (or `undefined` when none was supplied). */
   resolve_(raw: string | undefined): void;
+  /** Whether the parameter resolved to a defined value (used by `.requires()`). */
+  isSet_(): boolean;
 }
 
 /** The constructor spec for a {@link Parameter}. */
@@ -173,6 +175,10 @@ export class Parameter<
       );
     }
     return this.#state.value;
+  }
+
+  isSet_(): boolean {
+    return this.#state.ok && this.#state.value !== undefined;
   }
 
   /** Parse the value as a number (e.g. `--workers 4`). */

--- a/packages/core/src/target.ts
+++ b/packages/core/src/target.ts
@@ -27,8 +27,13 @@
  * ```
  */
 
+import type { PathLike } from "./path.ts";
+
 /** The executable body of a target. May be synchronous or asynchronous. */
 export type TargetFn = () => void | Promise<void>;
+
+/** A predicate gating whether a target runs; may be synchronous or async. */
+export type Condition = () => boolean | Promise<boolean>;
 
 /**
  * A parallel batch of targets, created with {@link group}. Targets join it via
@@ -62,6 +67,12 @@ export class TargetBuilder {
   name_?: string;
   /** The parallel batch this target belongs to, if any (set by {@link partOf}). */
   group_?: Group;
+  /** Input files/directories whose contents key the cache (set by {@link inputs}). */
+  readonly inputs_: string[] = [];
+  /** Output files/directories that must exist for a cache hit (set by {@link outputs}). */
+  readonly outputs_: string[] = [];
+  /** Conditions gating execution; all must hold or the target is skipped. */
+  readonly onlyWhen_: Condition[] = [];
 
   /** Set the human-readable description shown in `zuke --list`. */
   description(text: string): this {
@@ -94,6 +105,42 @@ export class TargetBuilder {
       this.group_ = group;
       group.members_.push(this);
     }
+    return this;
+  }
+
+  /**
+   * Declare input files or directories (directories are hashed recursively).
+   * A target with inputs is *incremental*: it is skipped (reported `cached`)
+   * when its inputs are unchanged since the last successful run and all its
+   * {@link outputs} still exist. Repeatable.
+   */
+  inputs(...paths: PathLike[]): this {
+    this.inputs_.push(...paths.map(String));
+    return this;
+  }
+
+  /**
+   * Declare output files or directories. A cache hit also requires every output
+   * to still exist, so deleting an output forces a rebuild. Repeatable.
+   */
+  outputs(...paths: PathLike[]): this {
+    this.outputs_.push(...paths.map(String));
+    return this;
+  }
+
+  /**
+   * Run only when `condition` holds; otherwise the target is skipped (and its
+   * dependents still run). The predicate may be async and can read resolved
+   * parameters or the environment. Repeatable — all conditions must hold.
+   *
+   * ```ts
+   * deploy = target()
+   *   .onlyWhen(() => this.environment.value === "production")
+   *   .executes(...);
+   * ```
+   */
+  onlyWhen(condition: Condition): this {
+    this.onlyWhen_.push(condition);
     return this;
   }
 

--- a/packages/core/src/target.ts
+++ b/packages/core/src/target.ts
@@ -28,6 +28,7 @@
  */
 
 import type { PathLike } from "./path.ts";
+import type { AnyParameter } from "./params.ts";
 
 /** The executable body of a target. May be synchronous or asynchronous. */
 export type TargetFn = () => void | Promise<void>;
@@ -73,6 +74,14 @@ export class TargetBuilder {
   readonly outputs_: string[] = [];
   /** Conditions gating execution; all must hold or the target is skipped. */
   readonly onlyWhen_: Condition[] = [];
+  /** Targets pulled in and run after this one (set by {@link triggers}). */
+  readonly triggers_: TargetBuilder[] = [];
+  /** Parameters that must be set for this target (set by {@link requires}). */
+  readonly requires_: AnyParameter[] = [];
+  /** Continue the build if this target fails (set by {@link proceedAfterFailure}). */
+  proceedAfterFailure_ = false;
+  /** Hide this target from `--list`/`--help` (set by {@link unlisted}). */
+  unlisted_ = false;
 
   /** Set the human-readable description shown in `zuke --list`. */
   description(text: string): this {
@@ -159,6 +168,50 @@ export class TargetBuilder {
   /** Run after the listed targets if both are in the plan (soft ordering). */
   after(...targets: TargetBuilder[]): this {
     this.after_.push(...targets);
+    return this;
+  }
+
+  /**
+   * Pull the listed targets into the plan and run them *after* this one. The
+   * inverse of {@link dependsOn}: running this target triggers the others.
+   */
+  triggers(...targets: TargetBuilder[]): this {
+    this.triggers_.push(...targets);
+    return this;
+  }
+
+  /**
+   * Declare this target as a prerequisite of the listed targets — the reverse
+   * of {@link dependsOn}: each listed target gains this one as a dependency,
+   * so this runs before them. Declare the listed targets above this one.
+   */
+  dependentFor(...targets: TargetBuilder[]): this {
+    for (const t of targets) if (t !== undefined) t.dependsOn_.push(this);
+    return this;
+  }
+
+  /**
+   * Require that the given parameters resolve to a value before this target
+   * runs; otherwise the target fails with a message naming the missing one.
+   * Use it when a target needs a parameter that is optional build-wide.
+   */
+  requires(...params: AnyParameter[]): this {
+    this.requires_.push(...params);
+    return this;
+  }
+
+  /**
+   * Keep running the rest of the build even if this target fails. The build
+   * still reports failure, and this target's own dependents are skipped.
+   */
+  proceedAfterFailure(): this {
+    this.proceedAfterFailure_ = true;
+    return this;
+  }
+
+  /** Hide this target from `--list` and `--help` (it can still be run by name). */
+  unlisted(): this {
+    this.unlisted_ = true;
     return this;
   }
 }

--- a/packages/core/tests/cache_test.ts
+++ b/packages/core/tests/cache_test.ts
@@ -1,0 +1,137 @@
+import { assertEquals } from "./_assert.ts";
+import { target } from "../src/target.ts";
+import {
+  type CacheHost,
+  defaultCacheHost,
+  fingerprint,
+  openCache,
+} from "../src/cache.ts";
+
+const enc = (text: string) => new TextEncoder().encode(text);
+
+/** An in-memory {@link CacheHost} for hermetic cache tests. */
+class MemHost implements CacheHost {
+  readonly files = new Map<string, Uint8Array>();
+  readonly dirs = new Map<string, string[]>();
+  readonly stores = new Map<string, string>();
+
+  readFile(path: string): Promise<Uint8Array | null> {
+    return Promise.resolve(this.files.get(path) ?? null);
+  }
+  stat(path: string): Promise<{ isDirectory: boolean } | null> {
+    if (this.dirs.has(path)) return Promise.resolve({ isDirectory: true });
+    if (this.files.has(path)) return Promise.resolve({ isDirectory: false });
+    return Promise.resolve(null);
+  }
+  readDir(path: string): Promise<string[]> {
+    return Promise.resolve(this.dirs.get(path) ?? []);
+  }
+  readStore(path: string): Promise<string | null> {
+    return Promise.resolve(this.stores.get(path) ?? null);
+  }
+  writeStore(path: string, content: string): Promise<void> {
+    this.stores.set(path, content);
+    return Promise.resolve();
+  }
+}
+
+const STORE = "/repo/.zuke/cache.json";
+
+Deno.test("fingerprint changes with file content and with missing files", async () => {
+  const host = new MemHost();
+  host.files.set("a.txt", enc("one"));
+  const t = target().inputs("a.txt");
+  const first = await fingerprint(t, host);
+  host.files.set("a.txt", enc("two"));
+  const second = await fingerprint(t, host);
+  assertEquals(first === second, false);
+
+  const missing = target().inputs("gone.txt");
+  const a = await fingerprint(missing, host);
+  host.files.set("gone.txt", enc("now here"));
+  const b = await fingerprint(missing, host);
+  assertEquals(a === b, false); // appearance of the file changes the fingerprint
+});
+
+Deno.test("fingerprint hashes directories recursively", async () => {
+  const host = new MemHost();
+  host.dirs.set("src", ["a.ts", "b.ts"]);
+  host.files.set("src/a.ts", enc("a"));
+  host.files.set("src/b.ts", enc("b"));
+  const t = target().inputs("src");
+  const before = await fingerprint(t, host);
+  host.files.set("src/b.ts", enc("b changed"));
+  const after = await fingerprint(t, host);
+  assertEquals(before === after, false);
+});
+
+Deno.test("a cache round-trip skips an unchanged target", async () => {
+  const host = new MemHost();
+  host.files.set("in.txt", enc("v1"));
+  const make = () => {
+    const t = target().inputs("in.txt").outputs("out.txt");
+    t.name_ = "build";
+    return t;
+  };
+
+  const cache = await openCache(STORE, host);
+  assertEquals(await cache.upToDate(make()), false); // nothing stored yet
+  await cache.record(make());
+  await cache.save();
+  assertEquals(host.stores.has(STORE), true);
+
+  // Reopen: inputs unchanged but the declared output is missing → must rebuild.
+  const reopened = await openCache(STORE, host);
+  assertEquals(await reopened.upToDate(make()), false);
+  host.files.set("out.txt", enc("output"));
+  assertEquals(await reopened.upToDate(make()), true); // now a hit
+
+  // Change the input → stale again.
+  host.files.set("in.txt", enc("v2"));
+  assertEquals(await reopened.upToDate(make()), false);
+});
+
+Deno.test("a target without inputs is never cached", async () => {
+  const host = new MemHost();
+  const cache = await openCache(STORE, host);
+  const t = target();
+  t.name_ = "nocache";
+  assertEquals(await cache.upToDate(t), false);
+  await cache.record(t); // no-op
+  await cache.save(); // nothing dirty → no write
+  assertEquals(host.stores.has(STORE), false);
+});
+
+Deno.test("defaultCacheHost hashes a real directory and tolerates missing paths", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    await Deno.mkdir(`${dir}/src`);
+    await Deno.writeTextFile(`${dir}/src/a.ts`, "a");
+    const t = target().inputs(`${dir}/src`, `${dir}/missing.ts`);
+    const before = await fingerprint(t, defaultCacheHost);
+    await Deno.writeTextFile(`${dir}/src/a.ts`, "changed");
+    const after = await fingerprint(t, defaultCacheHost);
+    assertEquals(before === after, false);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("a corrupt or non-object store is treated as empty", async () => {
+  const host = new MemHost();
+  host.files.set("in.txt", enc("v1"));
+  host.stores.set(STORE, "not json {");
+  const corrupt = await openCache(STORE, host);
+  const t = target().inputs("in.txt");
+  t.name_ = "build";
+  assertEquals(await corrupt.upToDate(t), false);
+
+  host.stores.set(STORE, '"a string, not an object"');
+  const wrong = await openCache(STORE, host);
+  assertEquals(await wrong.upToDate(t), false);
+
+  // Non-string entries are ignored when parsing the store.
+  host.stores.set(STORE, '{"build": 42}');
+  const mixed = await openCache(STORE, host);
+  assertEquals(await mixed.upToDate(t), false);
+});

--- a/packages/core/tests/cli_test.ts
+++ b/packages/core/tests/cli_test.ts
@@ -140,6 +140,16 @@ Deno.test("formatGraph renders adjacency, formatHelp includes usage", () => {
   assertEquals(formatHelp(targets).includes("Usage:"), true);
 });
 
+Deno.test("formatList hides unlisted targets but keeps the rest", () => {
+  class B extends Build {
+    visible = target().description("Shown").executes(() => {});
+    helper = target().unlisted().executes(() => {});
+  }
+  const list = formatList(discoverTargets(new B()));
+  assertEquals(list.includes("visible"), true);
+  assertEquals(list.includes("helper"), false);
+});
+
 Deno.test("formatList/formatGraph handle an empty build", () => {
   class Empty extends Build {}
   const targets = discoverTargets(new Empty());

--- a/packages/core/tests/executor_test.ts
+++ b/packages/core/tests/executor_test.ts
@@ -769,6 +769,77 @@ Deno.test("execute caches incrementally via the default .zuke store", async () =
   }
 });
 
+Deno.test("triggers run the triggered target after this one", async () => {
+  const order: string[] = [];
+  class B extends Build {
+    notify = target().executes(() => void order.push("notify"));
+    build = target().triggers(this.notify).executes(() =>
+      void order.push("build")
+    );
+  }
+  const b = new B();
+  discoverTargets(b);
+  const result = await execute(b, b.build, { silent: true });
+  assertEquals(result.ok, true);
+  assertEquals(order, ["build", "notify"]);
+});
+
+Deno.test("proceedAfterFailure keeps the build going but still fails", async () => {
+  const ran: string[] = [];
+  class B extends Build {
+    flaky = target().proceedAfterFailure().executes(() => {
+      throw new Error("flaked");
+    });
+    afterFlaky = target().dependsOn(this.flaky).executes(() =>
+      void ran.push("afterFlaky")
+    );
+    independent = target().executes(() => void ran.push("independent"));
+    all = target()
+      .dependsOn(this.afterFlaky, this.independent)
+      .executes(() => void ran.push("all"));
+  }
+  const b = new B();
+  discoverTargets(b);
+  const result = await execute(b, b.all, { silent: true });
+  assertEquals(result.ok, false); // a failure still fails the build
+  assertEquals(ran.includes("independent"), true); // kept going
+  assertEquals(ran.includes("afterFlaky"), false); // dependent of the failure
+  assertEquals(ran.includes("all"), false); // transitively blocked
+});
+
+Deno.test("requires fails a target whose parameter is unset", async () => {
+  class B extends Build {
+    token = parameter("API token");
+    publish = target().requires(this.token).executes(() => {});
+  }
+  const b = new B();
+  discoverTargets(b);
+  const result = await execute(b, b.publish, {
+    silent: true,
+    readEnv: () => undefined,
+  });
+  assertEquals(result.ok, false);
+  assertEquals(messageOf(result.error).includes("requires parameter"), true);
+});
+
+Deno.test("requires passes once the parameter is set", async () => {
+  const ran: string[] = [];
+  class B extends Build {
+    token = parameter("API token");
+    publish = target().requires(this.token).executes(() =>
+      void ran.push("publish")
+    );
+  }
+  const b = new B();
+  discoverTargets(b);
+  const result = await execute(b, b.publish, {
+    silent: true,
+    params: { token: "secret" },
+  });
+  assertEquals(result.ok, true);
+  assertEquals(ran, ["publish"]);
+});
+
 Deno.test("an unwritable job-summary file never fails the build", async () => {
   const dir = await Deno.makeTempDir(); // a directory is not writable as a file
   const { reporter } = recorder();

--- a/packages/core/tests/executor_test.ts
+++ b/packages/core/tests/executor_test.ts
@@ -1,6 +1,26 @@
 import { assertEquals, messageOf } from "./_assert.ts";
 import { Build, type BuildResult, discoverTargets } from "../src/build.ts";
 import { group, target } from "../src/target.ts";
+import type { BuildCache } from "../src/cache.ts";
+import { parameter } from "../src/params.ts";
+
+/** An in-memory {@link BuildCache} for executor caching tests. */
+class FakeCache implements BuildCache {
+  readonly fresh = new Set<string>();
+  readonly recorded: string[] = [];
+  saved = false;
+  upToDate(t: { name_?: string }): Promise<boolean> {
+    return Promise.resolve(this.fresh.has(t.name_ ?? ""));
+  }
+  record(t: { name_?: string }): Promise<void> {
+    this.recorded.push(t.name_ ?? "");
+    return Promise.resolve();
+  }
+  save(): Promise<void> {
+    this.saved = true;
+    return Promise.resolve();
+  }
+}
 import {
   execute,
   type ExecuteOptions,
@@ -627,6 +647,126 @@ Deno.test("a failing group member skips the group's dependents", async () => {
   const result = await execute(b, b.deploy, { silent: true });
   assertEquals(result.ok, false);
   assertEquals(ran.includes("deploy"), false); // group member failed
+});
+
+Deno.test("onlyWhen=false skips the target but its dependents still run", async () => {
+  const ran: string[] = [];
+  class B extends Build {
+    gated = target().onlyWhen(() => false).executes(() =>
+      void ran.push("gated")
+    );
+    after = target().dependsOn(this.gated).executes(() =>
+      void ran.push("after")
+    );
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  const result = await execute(b, b.after, { silent: true });
+  assertEquals(result.ok, true);
+  assertEquals(ran, ["after"]); // gated skipped, dependent still ran
+});
+
+Deno.test("onlyWhen can gate on a resolved parameter", async () => {
+  const ran: string[] = [];
+  class B extends Build {
+    env = parameter("env").default("dev");
+    deploy = target()
+      .onlyWhen(() => this.env.value === "prod")
+      .executes(() => void ran.push("deploy"));
+  }
+  const dev = new B();
+  discoverTargets(dev);
+  await execute(dev, dev.deploy, { silent: true, params: { env: "dev" } });
+  assertEquals(ran, []); // dev → skipped
+
+  const prod = new B();
+  discoverTargets(prod);
+  await execute(prod, prod.deploy, { silent: true, params: { env: "prod" } });
+  assertEquals(ran, ["deploy"]);
+});
+
+Deno.test("a cached target is skipped and counted as succeeded", async () => {
+  const { lines, reporter } = recorder();
+  const ran: string[] = [];
+  class B extends Build {
+    build = target().inputs("x").executes(() => void ran.push("build"));
+  }
+  const b = new B();
+  discoverTargets(b);
+  const cache = new FakeCache();
+  cache.fresh.add("build");
+
+  const result = await execute(b, b.build, {
+    reporter,
+    github: false,
+    cache,
+  });
+  assertEquals(result.ok, true);
+  assertEquals(ran, []); // body not run
+  assertEquals(cache.saved, true);
+  const summary = lines[lines.length - 1];
+  assertEquals(summary.includes("⊙ build"), true);
+  assertEquals(summary.includes("cached"), true);
+  assertEquals(summary.includes("1/1 targets"), true);
+});
+
+Deno.test("a stale target runs and records its fingerprint", async () => {
+  const ran: string[] = [];
+  class B extends Build {
+    build = target().inputs("x").executes(() => void ran.push("build"));
+  }
+  const b = new B();
+  discoverTargets(b);
+  const cache = new FakeCache(); // nothing fresh → must run
+
+  await execute(b, b.build, { silent: true, cache });
+  assertEquals(ran, ["build"]);
+  assertEquals(cache.recorded, ["build"]);
+});
+
+Deno.test("cache:false runs cacheable targets without touching the cache", async () => {
+  const ran: string[] = [];
+  class B extends Build {
+    build = target().inputs("x").executes(() => void ran.push("build"));
+  }
+  const b = new B();
+  discoverTargets(b);
+  const result = await execute(b, b.build, { silent: true, cache: false });
+  assertEquals(result.ok, true);
+  assertEquals(ran, ["build"]);
+});
+
+Deno.test("execute caches incrementally via the default .zuke store", async () => {
+  const dir = await Deno.makeTempDir();
+  const original = Deno.cwd();
+  try {
+    await Deno.writeTextFile(`${dir}/zuke.json`, "{}\n");
+    await Deno.writeTextFile(`${dir}/input.txt`, "v1");
+    Deno.chdir(dir);
+    let runs = 0;
+    class B extends Build {
+      build = target().inputs("input.txt").executes(() => void runs++);
+    }
+    const first = new B();
+    discoverTargets(first);
+    await execute(first, first.build, { silent: true });
+    assertEquals(runs, 1);
+
+    const second = new B(); // unchanged input → cached
+    discoverTargets(second);
+    await execute(second, second.build, { silent: true });
+    assertEquals(runs, 1);
+
+    await Deno.writeTextFile(`${dir}/input.txt`, "v2"); // changed → rebuild
+    const third = new B();
+    discoverTargets(third);
+    await execute(third, third.build, { silent: true });
+    assertEquals(runs, 2);
+  } finally {
+    Deno.chdir(original);
+    await Deno.remove(dir, { recursive: true });
+  }
 });
 
 Deno.test("an unwritable job-summary file never fails the build", async () => {

--- a/packages/core/tests/graph_test.ts
+++ b/packages/core/tests/graph_test.ts
@@ -54,6 +54,30 @@ Deno.test("planGraph detects cycles", () => {
   assertThrows(() => planGraph(b.a), GraphError, "cycle");
 });
 
+Deno.test("triggers pull targets into the plan and run them after", () => {
+  class B extends Build {
+    cleanup = target().executes(() => {});
+    main = target().triggers(this.cleanup).executes(() => {});
+  }
+  const b = new B();
+  discover(b);
+  const order = plan(b.main).map((t) => t.name_);
+  assertEquals(order.includes("cleanup"), true); // pulled into the plan
+  assertEquals(order.indexOf("main") < order.indexOf("cleanup"), true);
+});
+
+Deno.test("validateReferences rejects an undefined trigger", () => {
+  const main = target();
+  main.name_ = "main";
+  // @ts-expect-error simulate a forward-referenced (unbound) trigger
+  main.triggers(undefined);
+  assertThrows(
+    () => validateReferences(new Map([["main", main]])),
+    GraphError,
+    "undefined target",
+  );
+});
+
 Deno.test("topological order respects dependencies", () => {
   class B extends Build {
     clean = target().executes(() => {});
@@ -162,7 +186,7 @@ Deno.test("validateReferences rejects an undefined (forward-referenced) dep", ()
   assertThrows(
     () => validateReferences(discover(new B())),
     GraphError,
-    "undefined dependency",
+    "undefined target",
   );
 });
 

--- a/packages/core/tests/target_test.ts
+++ b/packages/core/tests/target_test.ts
@@ -1,6 +1,30 @@
 import { assertEquals, assertThrows } from "./_assert.ts";
 import { Build, discoverTargets } from "../src/build.ts";
 import { Group, group, target, TargetBuilder } from "../src/target.ts";
+import { parameter } from "../src/params.ts";
+
+Deno.test("triggers, dependentFor, requires, proceedAfterFailure, unlisted record config", () => {
+  class B extends Build {
+    before = target().executes(() => {});
+    after = target().executes(() => {});
+    token = parameter("token");
+    main = target()
+      .triggers(this.after)
+      .dependentFor(this.before)
+      .requires(this.token)
+      .proceedAfterFailure()
+      .unlisted()
+      .executes(() => {});
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  assertEquals(b.main.triggers_.map((t) => t.name_), ["after"]);
+  assertEquals(b.before.dependsOn_.map((t) => t.name_), ["main"]); // dependentFor
+  assertEquals(b.main.requires_.length, 1);
+  assertEquals(b.main.proceedAfterFailure_, true);
+  assertEquals(b.main.unlisted_, true);
+});
 
 Deno.test("partOf joins a group; dependsOn(group) expands to its members", () => {
   class B extends Build {

--- a/packages/core/tests/target_test.ts
+++ b/packages/core/tests/target_test.ts
@@ -21,6 +21,21 @@ Deno.test("partOf joins a group; dependsOn(group) expands to its members", () =>
   assertEquals(b.d.dependsOn_.map((t) => t.name_), ["a", "b", "c"]);
 });
 
+Deno.test("inputs, outputs, and onlyWhen record their configuration", () => {
+  let allow = false;
+  const t = target()
+    .inputs("src", "deno.json")
+    .outputs("dist")
+    .onlyWhen(() => allow)
+    .executes(() => {});
+  assertEquals(t.inputs_, ["src", "deno.json"]);
+  assertEquals(t.outputs_, ["dist"]);
+  assertEquals(t.onlyWhen_.length, 1);
+  assertEquals(t.onlyWhen_[0](), false);
+  allow = true;
+  assertEquals(t.onlyWhen_[0](), true);
+});
+
 Deno.test("partOf ignores an undefined (forward-referenced) group", () => {
   const t = target();
   // @ts-expect-error exercising the runtime guard against an unbound reference


### PR DESCRIPTION
## Summary

Adds incremental caching and a batch of NUKE-style target capabilities. Opt-in and backwards-compatible. Green under `deno task ci` (fmt, lint, spell, check, 95% coverage gate).

### Incremental caching — `.inputs()` / `.outputs()`
```ts
compile = target().inputs("src", "deno.json").outputs("dist").executes(/* … */);
```
A target with declared inputs is skipped (reported `cached`) when their SHA-256 fingerprint is unchanged since the last successful run and its outputs still exist; otherwise it runs and refreshes the fingerprint. Directories are hashed recursively via built-in Web Crypto — no dependency. Fingerprints persist in `<root>/.zuke/cache.json`; `--no-cache` (or `execute(…, { cache: false })`) bypasses it. Filesystem access is behind an injectable `CacheHost`.

### Conditional execution — `.onlyWhen(condition)`
```ts
deploy = target().onlyWhen(() => this.environment.value === "production").executes(/* … */);
```
Runs only when the (possibly async) predicate holds — can read resolved parameters or env; otherwise skipped. Repeatable.

### More target methods
- **`.triggers(...targets)`** — inverse of `dependsOn`: pull targets into the plan and run them *after* this one (graph execution-set/edges + `validateReferences` follow triggers).
- **`.dependentFor(...targets)`** — declare this as a prerequisite of others without editing them.
- **`.requires(...params)`** — fail the target (naming the parameter) unless each listed parameter resolved to a value; for inputs optional build-wide but mandatory for one target.
- **`.proceedAfterFailure()`** — keep the build running past this target's failure (the build still fails; the target's own dependents are skipped). The executor now separates "a failure occurred" from "stop launching", so a lenient failure doesn't abort independent work.
- **`.unlisted()`** — hide a helper target from `--list`/`--help` (still runnable by name).

### Engine / API
- Cached and condition-skipped targets count as satisfied, so dependents still run; the summary gains a `⊙ cached` status.
- New exports (`@zuke/core`): `Condition`, `BuildCache`; `ExecuteOptions.cache`; CLI `--no-cache`. `Parameter` gains an internal set-check for `.requires()`.

### Verified
End-to-end: cache miss → hit → `--no-cache` rebuild; `onlyWhen` gating on a parameter; `triggers` running after; `proceedAfterFailure` continuing then failing; `requires` failing/passing; `unlisted` hidden from `--list`.

## Docs
`docs/authoring.md` (method table + sections for caching, conditions, and the new methods), `docs/cli.md` (`--no-cache`, incremental builds). Roadmap "Caching / incremental targets" entry dropped.

## Notes
- Caching keys on declared file inputs (+ output existence); it does not yet factor in parameter values or the target's command — easy to extend later via a `.cacheKey()` escape hatch if wanted.

https://claude.ai/code/session_01PtqHmRRvtT6qkQKaPzrWhT

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtqHmRRvtT6qkQKaPzrWhT)_