### PR TITLE
feat(core): visualise parallel groups in the graph

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -27,6 +27,9 @@ everything it connects to — its transitive dependencies and dependents — and
 click the background (or **Reset**) to clear the selection. Mermaid loads from a
 pinned CDN, so the first view needs internet access.
 
+Targets in a [`group()`](./authoring.md#group-and-partof) are drawn inside a
+labelled box (a Mermaid subgraph); the text listing tags them `[group: name]`.
+
 | Option          | Behaviour                                                   |
 | --------------- | ----------------------------------------------------------- |
 | `--output=html` | Render the interactive HTML page instead of terminal text.  |

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -24,7 +24,12 @@
  * @module
  */
 
-export { Build, type BuildResult, discoverTargets } from "./src/build.ts";
+export {
+  Build,
+  type BuildResult,
+  discoverGroups,
+  discoverTargets,
+} from "./src/build.ts";
 export {
   type Condition,
   Group,

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -7,7 +7,7 @@
  * its property name.
  */
 
-import { TargetBuilder } from "./target.ts";
+import { Group, TargetBuilder } from "./target.ts";
 
 /** Result passed to the {@link Build.onFinish} lifecycle hook. */
 export interface BuildResult {
@@ -56,4 +56,20 @@ export function discoverTargets(build: Build): Map<string, TargetBuilder> {
     }
   }
   return targets;
+}
+
+/**
+ * Discover all parallel {@link Group} batches declared on a build instance,
+ * binding each its property name (for labelling, e.g. in the graph). Groups
+ * that are not assigned to a build property simply stay unnamed.
+ */
+export function discoverGroups(build: Build): Map<string, Group> {
+  const groups = new Map<string, Group>();
+  for (const [key, value] of Object.entries(build)) {
+    if (value instanceof Group) {
+      value.name_ = key;
+      groups.set(key, value);
+    }
+  }
+  return groups;
 }

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -3,7 +3,7 @@
  * {@link run} entry point that drives a build from `zuke.ts`.
  */
 
-import { type Build, discoverTargets } from "./build.ts";
+import { type Build, discoverGroups, discoverTargets } from "./build.ts";
 import { GraphError, validateGraph } from "./graph.ts";
 import { execute } from "./executor.ts";
 import {
@@ -220,7 +220,11 @@ export function formatGraph(targets: Map<string, TargetBuilder>): string {
   const lines = ["Dependency graph:"];
   for (const [name, t] of targets) {
     const deps = depNames(t);
-    lines.push(deps.length ? `  ${name} → ${deps.join(", ")}` : `  ${name}`);
+    const group = t.group_?.name_ !== undefined
+      ? `  [group: ${t.group_.name_}]`
+      : "";
+    const arrow = deps.length ? ` → ${deps.join(", ")}` : "";
+    lines.push(`  ${name}${arrow}${group}`);
   }
   return lines.join("\n");
 }
@@ -238,6 +242,7 @@ export async function main(
   const build = new BuildClass();
   const targets = discoverTargets(build);
   const params = discoverParameters(build);
+  discoverGroups(build); // names group batches so the graph can label them
   const paramFlags: ParamFlag[] = [...params.entries()].map(([name, p]) => ({
     name,
     flag: flagName(name),

--- a/packages/core/src/graph_html.ts
+++ b/packages/core/src/graph_html.ts
@@ -23,6 +23,8 @@ export interface GraphNode {
   name: string;
   /** The target's description, or `""` if none. */
   description: string;
+  /** The name of the parallel group this target belongs to, if any. */
+  group?: string;
 }
 
 /** The nodes and dependency edges of a build graph. */
@@ -41,7 +43,10 @@ export function graphData(targets: Map<string, TargetBuilder>): GraphData {
   const nodes: GraphNode[] = [];
   const edges: Array<[string, string]> = [];
   for (const [name, t] of targets) {
-    nodes.push({ name, description: t.description_ ?? "" });
+    const node: GraphNode = { name, description: t.description_ ?? "" };
+    const group = t.group_?.name_;
+    if (group !== undefined) node.group = group;
+    nodes.push(node);
     for (const dep of t.dependsOn_) {
       const depName = dep?.name_;
       if (depName !== undefined && targets.has(depName)) {
@@ -59,8 +64,9 @@ function mermaidLabel(text: string): string {
 
 /**
  * Render {@link GraphData} as Mermaid `flowchart TD` source. Each node gets a
- * synthetic id (`n0`, `n1`, …) so the markup is independent of target names; an
- * empty graph renders a single placeholder node.
+ * synthetic id (`n0`, `n1`, …) so the markup is independent of target names;
+ * targets that share a parallel {@link group} are wrapped in a Mermaid
+ * `subgraph`. An empty graph renders a single placeholder node.
  */
 export function toMermaid(data: GraphData): string {
   if (data.nodes.length === 0) {
@@ -70,10 +76,30 @@ export function toMermaid(data: GraphData): string {
   data.nodes.forEach((n, i) => {
     id[n.name] = `n${i}`;
   });
-  const lines = ["flowchart TD"];
+  const def = (n: GraphNode) => `${id[n.name]}["${mermaidLabel(n.name)}"]`;
+
+  // Bucket nodes by group (declaration order preserved); ungrouped stay flat.
+  const grouped = new Map<string, GraphNode[]>();
+  const ungrouped: GraphNode[] = [];
   for (const n of data.nodes) {
-    lines.push(`  ${id[n.name]}["${mermaidLabel(n.name)}"]`);
+    if (n.group !== undefined && n.group !== "") {
+      const members = grouped.get(n.group) ?? [];
+      members.push(n);
+      grouped.set(n.group, members);
+    } else {
+      ungrouped.push(n);
+    }
   }
+
+  const lines = ["flowchart TD"];
+  let g = 0;
+  for (const [name, members] of grouped) {
+    lines.push(`  subgraph g${g}["${mermaidLabel(name)}"]`);
+    for (const n of members) lines.push(`    ${def(n)}`);
+    lines.push("  end");
+    g++;
+  }
+  for (const n of ungrouped) lines.push(`  ${def(n)}`);
   for (const [from, to] of data.edges) {
     lines.push(`  ${id[from]} --> ${id[to]}`);
   }

--- a/packages/core/src/target.ts
+++ b/packages/core/src/target.ts
@@ -46,6 +46,8 @@ export type Condition = () => boolean | Promise<boolean>;
 export class Group {
   /** Members that declared themselves part of this group, in declaration order. */
   readonly members_: TargetBuilder[] = [];
+  /** Property name, assigned during discovery. Undefined until then. */
+  name_?: string;
 }
 
 /**

--- a/packages/core/tests/cli_test.ts
+++ b/packages/core/tests/cli_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "./_assert.ts";
-import { Build, target } from "../mod.ts";
+import { Build, group, target } from "../mod.ts";
 import {
   formatGraph,
   formatHelp,
@@ -8,7 +8,7 @@ import {
   parseArgs,
   run,
 } from "../src/cli.ts";
-import { discoverTargets } from "../src/build.ts";
+import { discoverGroups, discoverTargets } from "../src/build.ts";
 import { FakeGraphHost } from "./_fakes.ts";
 import { CONFIG_FILE } from "../src/config.ts";
 import { parameter } from "../src/params.ts";
@@ -138,6 +138,17 @@ Deno.test("formatGraph renders adjacency, formatHelp includes usage", () => {
   const targets = discoverTargets(new Demo());
   assertEquals(formatGraph(targets).includes("build → clean"), true);
   assertEquals(formatHelp(targets).includes("Usage:"), true);
+});
+
+Deno.test("formatGraph annotates group membership", () => {
+  class B extends Build {
+    checks = group();
+    lint = target().partOf(this.checks).executes(() => {});
+  }
+  const b = new B();
+  const targets = discoverTargets(b);
+  discoverGroups(b);
+  assertEquals(formatGraph(targets).includes("lint  [group: checks]"), true);
 });
 
 Deno.test("formatList hides unlisted targets but keeps the rest", () => {

--- a/packages/core/tests/graph_html_test.ts
+++ b/packages/core/tests/graph_html_test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from "./_assert.ts";
-import { Build, target } from "../mod.ts";
-import { discoverTargets } from "../src/build.ts";
+import { Build, group, target } from "../mod.ts";
+import { discoverGroups, discoverTargets } from "../src/build.ts";
 import { TargetBuilder } from "../src/target.ts";
 import {
   clientModel,
@@ -24,6 +24,30 @@ Deno.test("graphData yields a node per target and an edge per dependency", () =>
     { name: "build", description: "Build" },
   ]);
   assertEquals(data.edges, [["clean", "build"]]);
+});
+
+Deno.test("graphData records group membership and toMermaid wraps it in a subgraph", () => {
+  class Grouped extends Build {
+    checks = group();
+    clean = target().executes(() => {});
+    lint = target().dependsOn(this.clean).partOf(this.checks).executes(
+      () => {},
+    );
+    format = target().dependsOn(this.clean).partOf(this.checks).executes(
+      () => {},
+    );
+  }
+  const b = new Grouped();
+  discoverTargets(b);
+  discoverGroups(b); // names the group so it can be labelled
+
+  const data = graphData(discoverTargets(b));
+  assertEquals(data.nodes.find((n) => n.name === "lint")?.group, "checks");
+  assertEquals(data.nodes.find((n) => n.name === "clean")?.group, undefined);
+
+  const mermaid = toMermaid(data);
+  assertEquals(mermaid.includes('subgraph g0["checks"]'), true);
+  assertEquals(mermaid.includes("end"), true);
 });
 
 Deno.test("graphData skips edges to undiscovered or unnamed dependencies", () => {

--- a/packages/core/tests/target_test.ts
+++ b/packages/core/tests/target_test.ts
@@ -1,7 +1,18 @@
 import { assertEquals, assertThrows } from "./_assert.ts";
-import { Build, discoverTargets } from "../src/build.ts";
+import { Build, discoverGroups, discoverTargets } from "../src/build.ts";
 import { Group, group, target, TargetBuilder } from "../src/target.ts";
 import { parameter } from "../src/params.ts";
+
+Deno.test("discoverGroups binds each group to its property name", () => {
+  class B extends Build {
+    checks = group();
+    a = target().partOf(this.checks).executes(() => {});
+  }
+  const b = new B();
+  const groups = discoverGroups(b);
+  assertEquals([...groups.keys()], ["checks"]);
+  assertEquals(b.checks.name_, "checks");
+});
 
 Deno.test("triggers, dependentFor, requires, proceedAfterFailure, unlisted record config", () => {
   class B extends Build {


### PR DESCRIPTION
## Summary

Surfaces `group()` parallel batches in `zuke graph`, both output formats. Green under `deno task ci`.

- **HTML** (`--output=html`): a group's members are drawn inside a labelled **Mermaid subgraph** box (e.g. a `checks` box around `lint`/`format`/`typecheck`). Click-to-highlight still works.
- **Text** (`zuke graph`): grouped targets are tagged, e.g. `lint → clean  [group: checks]`.

## How

- Groups gain a name via a new `discoverGroups(build)` (introspects `checks = group()` build fields, mirroring target/parameter discovery). Exported from `@zuke/core`.
- `graphData` records each node's group name; `toMermaid` buckets grouped nodes into `subgraph` blocks (ungrouped stay flat). `formatGraph` annotates `[group: name]`. The CLI names groups before rendering.

## Docs
`docs/cli.md` graph section notes the subgraph/tag behaviour.

https://claude.ai/code/session_01PtqHmRRvtT6qkQKaPzrWhT

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtqHmRRvtT6qkQKaPzrWhT)_