### PR TITLE
feat(core): cacheKey, always, secrets, artifacts, host detection, interactive params

### DIFF
--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -19,7 +19,12 @@ body, which is required before the target can run.
 | `.onlyWhen(condition)`   | `(c: () => boolean \| Promise<boolean>) => this` | Run only when the condition holds, else skip.    |
 | `.requires(...params)`   | `(...p: Parameter[]) => this`               | Fail the target unless these parameters are set.       |
 | `.proceedAfterFailure()` | `() => this`                                | Keep the build going if this target fails.             |
+| `.always()`              | `() => this`                                | Run for cleanup even after the build has failed.       |
 | `.unlisted()`            | `() => this`                                | Hide the target from `--list`/`--help`.                |
+| `.cacheKey(fn)`          | `(fn: () => string \| Promise<string>) => this` | Extra (non-file) input to the cache fingerprint. |
+| `.produces(...paths)`    | `(...p: PathLike[]) => this`                | Declare artifact paths this target produces.           |
+| `.consumes(...targets)`  | `(...t: Target[]) => this`                  | Depend on targets and use their `produces` artifacts.  |
+| `.whenSkipped(behavior)` | `("run-dependencies" \| "skip-dependencies") => this` | On skip, also skip exclusive deps.    |
 
 `dependsOn` pulls targets into the plan; `before`/`after` only reorder targets
 that are _already_ in the plan — they never pull new targets in.
@@ -110,8 +115,23 @@ deploy = target()
 - **`.proceedAfterFailure()`** — if this target fails, keep running the rest of
   the build instead of aborting. The build still reports failure, and this
   target's own dependents are skipped.
+- **`.always()`** — run even after the build has already failed, for
+  cleanup/teardown. It still waits for its own dependencies to complete.
 - **`.unlisted()`** — hide a helper target from `--list`/`--help`; it can still
   be run by name or depended on.
+- **`.cacheKey(fn)`** — add a non-file value (a parameter, tool version, git
+  commit…) to the [cache](#incremental-caching-inputs--outputs) fingerprint, so
+  the target also rebuilds when that value changes. Repeatable; may be async.
+- **`.produces(...paths)`** / **`.consumes(...targets)`** — declare artifact
+  paths a target produces, and (on a consumer) depend on the producers.
+- **`.whenSkipped("skip-dependencies")`** — when this target is skipped by a
+  condition, also skip dependencies that no other target needs. Its condition is
+  evaluated up front, so it must not rely on state produced during the run.
+
+### Host detection — `isCI()` / `ciHost()`
+
+`isCI()` and `ciHost()` (e.g. `"github-actions"`, `"gitlab-ci"`, `"local"`) let
+a build branch on where it runs — e.g. `deploy.onlyWhen(() => isCI())`.
 
 ### `Build`
 

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -50,10 +50,27 @@ declaration:
 | `.default(v)` | provide a default | non-optional (`T`) |
 | `.required()` | must be supplied | non-optional (`T`) |
 | `.env("NAME")` | override the env var name | unchanged |
+| `.secret()` | mark the value sensitive | unchanged |
 
 `.number()` and `.boolean()` come first (they change the kind); `.options()`
 applies to strings. A required parameter with no value (and no default) fails
-the build before any target runs, with a message naming the flag and env var.
+the build before any target runs, with a message naming the flag and env var —
+unless it can be supplied interactively (below).
+
+## Secrets
+
+`.secret()` marks a value sensitive. Under GitHub Actions, Zuke emits an
+`::add-mask::` for the resolved value so it is redacted from the logs.
+
+```ts
+token = parameter("Deploy token").secret().required();
+```
+
+## Interactive input
+
+When a required parameter is missing and the build runs at an interactive
+terminal (a TTY, not CI), Zuke prompts for the value instead of failing. On CI
+or non-interactive runs it still errors, so automation stays deterministic.
 
 ## Reading
 

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -29,7 +29,9 @@ export {
   type BuildResult,
   discoverGroups,
   discoverTargets,
+  type TargetStatus,
 } from "./src/build.ts";
+export { ciHost, isCI } from "./src/host.ts";
 export {
   type Condition,
   Group,

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -9,6 +9,9 @@
 
 import { Group, TargetBuilder } from "./target.ts";
 
+/** The outcome of a single target, reported in the summary and lifecycle hooks. */
+export type TargetStatus = "passed" | "failed" | "skipped" | "cached";
+
 /** Result passed to the {@link Build.onFinish} lifecycle hook. */
 export interface BuildResult {
   /** Whether every executed target succeeded. */
@@ -29,6 +32,12 @@ export class Build {
 
   /** Called once after the run completes (success or failure). */
   onFinish(_result: BuildResult): void | Promise<void> {}
+
+  /** Called just before a target's body executes (not for skipped/cached). */
+  onTargetStart(_name: string): void | Promise<void> {}
+
+  /** Called after each target settles, with its final status. */
+  onTargetEnd(_name: string, _status: TargetStatus): void | Promise<void> {}
 }
 
 /**

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -118,7 +118,15 @@ export async function fingerprint(
   for (const input of target.inputs_) {
     parts.push(`${input}:${await hashPath(input, host)}`);
   }
+  for (const cacheKey of target.cacheKeys_) {
+    parts.push(`key:${await cacheKey()}`);
+  }
   return hashText(parts.join("\n"));
+}
+
+/** Whether a target participates in caching (declares inputs or cache keys). */
+export function isCacheable(target: TargetBuilder): boolean {
+  return target.inputs_.length > 0 || target.cacheKeys_.length > 0;
 }
 
 /** The incremental cache used by the executor to skip up-to-date targets. */
@@ -169,7 +177,7 @@ class FsCache implements BuildCache {
   }
 
   async upToDate(target: TargetBuilder): Promise<boolean> {
-    if (target.inputs_.length === 0) return false;
+    if (!isCacheable(target)) return false;
     const fp = await fingerprint(target, this.#host);
     this.#computed.set(target, fp);
     if (this.#store[target.name_ ?? ""] !== fp) return false;
@@ -180,7 +188,7 @@ class FsCache implements BuildCache {
   }
 
   async record(target: TargetBuilder): Promise<void> {
-    if (target.inputs_.length === 0) return;
+    if (!isCacheable(target)) return;
     const name = target.name_ ?? "";
     const fp = this.#computed.get(target) ??
       await fingerprint(target, this.#host);

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -16,7 +16,7 @@
  * their shared prerequisite a single time.
  */
 
-import type { Build, BuildResult } from "./build.ts";
+import type { Build, BuildResult, TargetStatus } from "./build.ts";
 import { planGraph } from "./graph.ts";
 import {
   discoverParameters,
@@ -27,9 +27,11 @@ import {
   type BuildCache,
   CACHE_FILE,
   defaultCacheHost,
+  isCacheable,
   openCache,
 } from "./cache.ts";
 import { findConfigDir, pathExists } from "./config.ts";
+import { isCI } from "./host.ts";
 import { absolutePath } from "./path.ts";
 import type { TargetBuilder } from "./target.ts";
 
@@ -83,6 +85,15 @@ export interface ExecuteOptions {
    */
   readEnv?: (name: string) => string | undefined;
   /**
+   * Prompt for a missing required parameter, returning the entered value (or
+   * `undefined` to leave it unset). Defaults to an interactive terminal prompt
+   * when stdin is a TTY and the build is not on CI; overridable for testing.
+   */
+  prompt?: (
+    flag: string,
+    description: string | undefined,
+  ) => string | undefined;
+  /**
    * Force GitHub Actions output formatting on or off. Auto-detected from the
    * `GITHUB_ACTIONS` environment variable when omitted.
    */
@@ -93,9 +104,6 @@ export interface ExecuteOptions {
    */
   color?: boolean;
 }
-
-/** A target's outcome, collected for the end-of-build summary. */
-type TargetStatus = "passed" | "failed" | "skipped" | "cached";
 
 interface TargetReport {
   name: string;
@@ -147,6 +155,63 @@ function defaultReadEnv(name: string): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+/** Prompt for a missing required parameter, only at an interactive (non-CI) TTY. */
+function defaultPrompt(
+  flag: string,
+  description: string | undefined,
+): string | undefined {
+  let interactive = false;
+  try {
+    interactive = Deno.stdin.isTerminal();
+  } catch {
+    interactive = false;
+  }
+  if (!interactive || isCI()) return undefined;
+  const label = description ? `--${flag} (${description})` : `--${flag}`;
+  return prompt(`${label}:`) ?? undefined;
+}
+
+/**
+ * Evaluate up-front conditions for `whenSkipped("skip-dependencies")` targets;
+ * return the names to skip — those targets plus any dependencies that no other
+ * target in the plan needs.
+ */
+async function conditionSkips(
+  root: TargetBuilder,
+  order: TargetBuilder[],
+): Promise<Set<string>> {
+  const pruned = new Set<TargetBuilder>();
+  for (const t of order) {
+    if (!t.skipDependencies_ || t.onlyWhen_.length === 0) continue;
+    let run = true;
+    for (const condition of t.onlyWhen_) {
+      if (!(await condition())) {
+        run = false;
+        break;
+      }
+    }
+    if (!run) pruned.add(t);
+  }
+  if (pruned.size === 0) return new Set();
+
+  // Everything still reachable from the root without pulling dependencies in
+  // *through* a pruned target.
+  const kept = new Set<TargetBuilder>();
+  const walk = (node: TargetBuilder) => {
+    if (node === undefined || kept.has(node)) return;
+    kept.add(node);
+    if (pruned.has(node)) return;
+    for (const dep of node.dependsOn_) walk(dep);
+    for (const trigger of node.triggers_) walk(trigger);
+  };
+  walk(root);
+
+  const names = new Set<string>();
+  for (const t of pruned) names.add(t.name_ ?? "");
+  for (const t of order) if (!kept.has(t)) names.add(t.name_ ?? "");
+  return names;
 }
 
 /** Whether terminal colour should be used (TTY, and `NO_COLOR` unset). */
@@ -325,6 +390,7 @@ interface RunOutcome {
  * — both unblock dependents without executing the body.
  */
 async function runTarget(
+  build: Build,
   reporter: Reporter,
   style: Style,
   t: TargetBuilder,
@@ -353,6 +419,7 @@ async function runTarget(
   }
 
   openTarget(reporter, style, name, opened);
+  await build.onTargetStart(name);
   const start = performance.now();
 
   if (!t.fn_) {
@@ -411,6 +478,7 @@ function bufferReporter(): {
 
 /** Sequentially run the plan, aborting (and skipping the rest) on first failure. */
 async function runSequential(
+  build: Build,
   order: TargetBuilder[],
   reporter: Reporter,
   style: Style,
@@ -429,7 +497,8 @@ async function runSequential(
       reports.push({ name, status: "skipped", ms: 0 });
       continue;
     }
-    const outcome = await runTarget(reporter, style, t, opened, cache);
+    const outcome = await runTarget(build, reporter, style, t, opened, cache);
+    await build.onTargetEnd(name, outcome.status);
     if (outcome.status === "passed" || outcome.status === "failed") opened++;
     reports.push({ name, status: outcome.status, ms: outcome.ms });
     if (outcome.status === "passed") executed.push(name);
@@ -452,6 +521,7 @@ async function runSequential(
  * stops new launches; in-flight targets settle and the rest are skipped.
  */
 async function runScheduled(
+  build: Build,
   order: TargetBuilder[],
   predecessors: Map<TargetBuilder, TargetBuilder[]>,
   reporter: Reporter,
@@ -486,38 +556,40 @@ async function runScheduled(
 
   await new Promise<void>((resolve) => {
     const pump = () => {
-      if (!halted) {
-        for (const t of order) {
-          if (runningSet.size >= limit) break;
-          if (started.has(t) || !ready(t) || !overlaps(t)) continue;
-          started.add(t);
-          runningSet.add(t);
-          const buffer = bufferReporter();
-          runTarget(buffer.reporter, style, t, flushed, cache).then(
-            (outcome) => {
-              // Only an executed target prints a block worth separating.
-              const printed = outcome.status === "passed" ||
-                outcome.status === "failed";
-              if (printed) {
-                if (!style.github && flushed > 0) reporter.info("");
-                buffer.flush(reporter);
-                flushed++;
-              }
-              outcomes.set(t, outcome);
-              runningSet.delete(t);
-              if (outcome.status === "failed") {
-                anyFailed = true;
-                failure ??= outcome.error;
-                // A lenient failure lets independent targets keep going; its
-                // own dependents stay blocked (never added to `done`).
-                if (!t.proceedAfterFailure_) halted = true;
-              } else {
-                done.add(t); // passed, cached, or condition-skipped
-              }
-              pump();
-            },
-          );
-        }
+      for (const t of order) {
+        if (runningSet.size >= limit) break;
+        if (started.has(t) || !ready(t) || !overlaps(t)) continue;
+        // After a fatal failure, stop launching — except `always` targets,
+        // which run for cleanup even when the build is failing.
+        if (halted && !t.always_) continue;
+        started.add(t);
+        runningSet.add(t);
+        const buffer = bufferReporter();
+        runTarget(build, buffer.reporter, style, t, flushed, cache).then(
+          async (outcome) => {
+            await build.onTargetEnd(t.name_ ?? "<unnamed>", outcome.status);
+            // Only an executed target prints a block worth separating.
+            const printed = outcome.status === "passed" ||
+              outcome.status === "failed";
+            if (printed) {
+              if (!style.github && flushed > 0) reporter.info("");
+              buffer.flush(reporter);
+              flushed++;
+            }
+            outcomes.set(t, outcome);
+            runningSet.delete(t);
+            if (outcome.status === "failed") {
+              anyFailed = true;
+              failure ??= outcome.error;
+              // A lenient failure lets independent targets keep going; its
+              // own dependents stay blocked (never added to `done`).
+              if (!t.proceedAfterFailure_) halted = true;
+            } else {
+              done.add(t); // passed, cached, or condition-skipped
+            }
+            pump();
+          },
+        );
       }
       if (runningSet.size === 0) {
         for (const t of order) {
@@ -566,10 +638,12 @@ export async function execute(
   // Resolve declared parameters (CLI value → environment → default) before any
   // target runs, so a target body can read `this.param.value`. A missing
   // required parameter or an invalid value fails the build before it starts.
+  const params = discoverParameters(build);
   const paramErrors = resolveParameters(
-    discoverParameters(build),
+    params,
     options.params ?? {},
     options.readEnv ?? defaultReadEnv,
+    options.prompt ?? defaultPrompt,
   );
   if (paramErrors.length > 0) {
     reporter.error("Invalid or missing parameters:");
@@ -580,22 +654,35 @@ export async function execute(
       error: new ParameterError(paramErrors.join("; ")),
     };
   }
+  // Under GitHub Actions, mask resolved secret values so they don't leak.
+  if (style.github) {
+    for (const p of params.values()) {
+      const value = p.secret_ ? p.stringValue_() : undefined;
+      if (value !== undefined && value !== "") {
+        reporter.info(`::add-mask::${value}`);
+      }
+    }
+  }
 
   const { order, predecessors } = planGraph(root);
+  // Evaluate up-front conditions for `whenSkipped("skip-dependencies")` targets
+  // and skip them plus any dependencies that nothing else needs.
+  for (const name of await conditionSkips(root, order)) skip.add(name);
+
   const limit = resolveConcurrency(options.parallel);
   const globalParallel = limit > 1;
   const grouped = order.some((t) => t.group_ !== undefined);
-  // `proceedAfterFailure` needs the scheduler's per-target skip-on-failure, so
-  // the simple sequential loop is only used when none of these features apply.
-  const lenient = order.some((t) => t.proceedAfterFailure_);
+  // `proceedAfterFailure` and `always` need the scheduler's per-target control,
+  // so the simple sequential loop is only used when none of these apply.
+  const scheduled = order.some((t) => t.proceedAfterFailure_ || t.always_);
   const cache = await resolveCache(options.cache, order);
   const overallStart = performance.now();
 
   await build.onStart();
 
   let run: RunOutcome;
-  if (!globalParallel && !grouped && !lenient) {
-    run = await runSequential(order, reporter, style, skip, cache);
+  if (!globalParallel && !grouped && !scheduled) {
+    run = await runSequential(build, order, reporter, style, skip, cache);
   } else {
     // With `--parallel`, anything independent may overlap up to `limit`.
     // Otherwise only same-group members overlap (the rest stay serialized),
@@ -606,6 +693,7 @@ export async function execute(
       : (a: TargetBuilder, b: TargetBuilder) =>
         a.group_ !== undefined && a.group_ === b.group_;
     run = await runScheduled(
+      build,
       order,
       predecessors,
       reporter,
@@ -640,7 +728,7 @@ async function resolveCache(
 ): Promise<BuildCache | undefined> {
   if (option === false) return undefined;
   if (typeof option === "object") return option;
-  if (!order.some((t) => t.inputs_.length > 0)) return undefined;
+  if (!order.some(isCacheable)) return undefined;
   const root = findConfigDir(Deno.cwd(), pathExists) ?? Deno.cwd();
   const storePath = absolutePath(root)(ARTIFACT_DIR, CACHE_FILE).path;
   return await openCache(storePath, defaultCacheHost);

--- a/packages/core/src/host.ts
+++ b/packages/core/src/host.ts
@@ -1,0 +1,37 @@
+/**
+ * Host / CI detection helpers for build scripts. A build can branch on where it
+ * runs — e.g. only deploy from CI, or pick coloured output locally.
+ *
+ * ```ts
+ * import { ciHost, isCI } from "jsr:@zuke/core";
+ * deploy = target().onlyWhen(() => isCI()).executes(...);
+ * ```
+ *
+ * @module
+ */
+
+/** Read an environment variable, treating missing env access as unset. */
+function env(name: string): string | undefined {
+  try {
+    return Deno.env.get(name);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * A short identifier for the detected CI host, or `"local"` when not on CI.
+ * Recognises GitHub Actions, GitLab CI, and the generic `CI` convention.
+ */
+export function ciHost(): string {
+  if (env("GITHUB_ACTIONS") === "true") return "github-actions";
+  if (env("GITLAB_CI") === "true") return "gitlab-ci";
+  const ci = env("CI");
+  if (ci !== undefined && ci !== "" && ci !== "false") return "ci";
+  return "local";
+}
+
+/** Whether the build appears to be running in a CI environment. */
+export function isCI(): boolean {
+  return ciHost() !== "local";
+}

--- a/packages/core/src/params.ts
+++ b/packages/core/src/params.ts
@@ -97,10 +97,14 @@ export interface AnyParameter {
   readonly envName_?: string;
   /** Whether the parameter has a declared default value. */
   readonly hasFallback_: boolean;
+  /** Whether the value is sensitive and should be masked in CI output. */
+  readonly secret_: boolean;
   /** Resolve from a raw input (or `undefined` when none was supplied). */
   resolve_(raw: string | undefined): void;
   /** Whether the parameter resolved to a defined value (used by `.requires()`). */
   isSet_(): boolean;
+  /** The resolved value as a string, or `undefined` if unset (for masking). */
+  stringValue_(): string | undefined;
 }
 
 /** The constructor spec for a {@link Parameter}. */
@@ -112,6 +116,7 @@ interface ParamSpec<K extends ParamValue, T extends K | undefined> {
   envName?: string;
   parse: (raw: string) => T;
   fallback: Fallback<T>;
+  secret?: boolean;
 }
 
 /**
@@ -134,6 +139,7 @@ export class Parameter<
   readonly options_?: readonly string[];
   readonly envName_?: string;
   readonly hasFallback_: boolean;
+  readonly secret_: boolean;
   readonly #parse: (raw: string) => T;
   readonly #fallback: Fallback<T>;
   #state: Resolved<T> = { ok: false };
@@ -164,6 +170,7 @@ export class Parameter<
     this.#parse = spec.parse;
     this.#fallback = spec.fallback;
     this.hasFallback_ = spec.fallback.has;
+    this.secret_ = spec.secret ?? false;
   }
 
   /** The resolved value. Throws if read before the build resolves parameters. */
@@ -181,6 +188,26 @@ export class Parameter<
     return this.#state.ok && this.#state.value !== undefined;
   }
 
+  stringValue_(): string | undefined {
+    return this.#state.ok && this.#state.value !== undefined
+      ? String(this.#state.value)
+      : undefined;
+  }
+
+  /** Mark the value as sensitive, so it is masked in CI output (`::add-mask::`). */
+  secret(): Parameter<K, T> {
+    return new Parameter<K, T>({
+      description: this.description_,
+      kind: this.kind_,
+      required: this.required_,
+      options: this.options_,
+      envName: this.envName_,
+      parse: this.#parse,
+      fallback: this.#fallback,
+      secret: true,
+    });
+  }
+
   /** Parse the value as a number (e.g. `--workers 4`). */
   number(
     this: Parameter<string, string | undefined>,
@@ -192,6 +219,7 @@ export class Parameter<
       envName: this.envName_,
       parse: parseNumber,
       fallback: { has: true, value: undefined },
+      secret: this.secret_,
     });
   }
 
@@ -206,6 +234,7 @@ export class Parameter<
       envName: this.envName_,
       parse: parseBoolean,
       fallback: { has: true, value: false },
+      secret: this.secret_,
     });
   }
 
@@ -222,6 +251,7 @@ export class Parameter<
       envName: this.envName_,
       parse: makeStringParser(values),
       fallback: this.#fallback,
+      secret: this.secret_,
     });
   }
 
@@ -235,6 +265,7 @@ export class Parameter<
       envName: this.envName_,
       parse: this.#definiteParse(),
       fallback: { has: true, value },
+      secret: this.secret_,
     });
   }
 
@@ -248,6 +279,7 @@ export class Parameter<
       envName: this.envName_,
       parse: this.#definiteParse(),
       fallback: { has: false },
+      secret: this.secret_,
     });
   }
 
@@ -261,6 +293,7 @@ export class Parameter<
       envName: name,
       parse: this.#parse,
       fallback: this.#fallback,
+      secret: this.secret_,
     });
   }
 
@@ -328,16 +361,26 @@ export function envVarName(name: string): string {
  * @param params Discovered parameters.
  * @param cliValues Raw values parsed from the command line, keyed by name.
  * @param readEnv Reads an environment variable by name.
+ * @param prompt Optional: ask for a missing required value (interactive input).
  */
 export function resolveParameters(
   params: Map<string, AnyParameter>,
   cliValues: Record<string, string>,
   readEnv: (name: string) => string | undefined,
+  prompt?: (
+    flag: string,
+    description: string | undefined,
+  ) => string | undefined,
 ): string[] {
   const errors: string[] = [];
   for (const [name, param] of params) {
     const envName = param.envName_ ?? envVarName(name);
-    const raw = name in cliValues ? cliValues[name] : readEnv(envName);
+    let raw = name in cliValues ? cliValues[name] : readEnv(envName);
+    // Prompt for a missing required value when an input source is available.
+    if (raw === undefined && param.required_ && !param.hasFallback_ && prompt) {
+      const answer = prompt(flagName(name), param.description_);
+      if (answer !== undefined && answer !== "") raw = answer;
+    }
     try {
       param.resolve_(raw);
     } catch (error) {

--- a/packages/core/src/target.ts
+++ b/packages/core/src/target.ts
@@ -82,8 +82,16 @@ export class TargetBuilder {
   readonly requires_: AnyParameter[] = [];
   /** Continue the build if this target fails (set by {@link proceedAfterFailure}). */
   proceedAfterFailure_ = false;
+  /** Run even after the build has failed (set by {@link always}). */
+  always_ = false;
   /** Hide this target from `--list`/`--help` (set by {@link unlisted}). */
   unlisted_ = false;
+  /** Extra cache-key contributors beyond input files (set by {@link cacheKey}). */
+  readonly cacheKeys_: Array<() => string | Promise<string>> = [];
+  /** Artifact paths this target produces (set by {@link produces}). */
+  readonly produces_: string[] = [];
+  /** When skipped by a condition, also skip dependencies (set by {@link whenSkipped}). */
+  skipDependencies_ = false;
 
   /** Set the human-readable description shown in `zuke --list`. */
   description(text: string): this {
@@ -214,6 +222,60 @@ export class TargetBuilder {
   /** Hide this target from `--list` and `--help` (it can still be run by name). */
   unlisted(): this {
     this.unlisted_ = true;
+    return this;
+  }
+
+  /**
+   * Run this target even after the build has failed — for cleanup/teardown that
+   * must happen regardless. It still waits for its own dependencies to complete;
+   * the build's overall result is unchanged. Repeatable conditions/inputs apply.
+   */
+  always(): this {
+    this.always_ = true;
+    return this;
+  }
+
+  /**
+   * Contribute an extra value to this target's cache fingerprint, beyond its
+   * input files — e.g. a parameter value, tool version, or git commit. The
+   * target is up-to-date only when its inputs *and* every cache key are
+   * unchanged. The function may be async. Repeatable.
+   *
+   * ```ts
+   * compile = target()
+   *   .inputs("src")
+   *   .cacheKey(() => this.configuration.value)
+   *   .executes(...);
+   * ```
+   */
+  cacheKey(fn: () => string | Promise<string>): this {
+    this.cacheKeys_.push(fn);
+    return this;
+  }
+
+  /** Declare artifact files/directories this target produces (metadata). */
+  produces(...paths: PathLike[]): this {
+    this.produces_.push(...paths.map(String));
+    return this;
+  }
+
+  /**
+   * Depend on the listed targets and consume their artifacts: equivalent to
+   * {@link dependsOn} for ordering, expressing that this target uses what they
+   * {@link produces}.
+   */
+  consumes(...targets: Array<TargetBuilder | Group>): this {
+    return this.dependsOn(...targets);
+  }
+
+  /**
+   * When this target is skipped by an {@link onlyWhen} condition, also skip its
+   * dependencies that no other planned target needs. Because the dependencies
+   * would otherwise run first, the condition is evaluated up front, so it must
+   * not depend on state produced by other targets during the run.
+   */
+  whenSkipped(behavior: "run-dependencies" | "skip-dependencies"): this {
+    this.skipDependencies_ = behavior === "skip-dependencies";
     return this;
   }
 }

--- a/packages/core/tests/cache_test.ts
+++ b/packages/core/tests/cache_test.ts
@@ -91,6 +91,28 @@ Deno.test("a cache round-trip skips an unchanged target", async () => {
   assertEquals(await reopened.upToDate(make()), false);
 });
 
+Deno.test("a cacheKey contributes to the fingerprint", async () => {
+  const host = new MemHost();
+  let key = "v1";
+  const t = target().cacheKey(() => key);
+  const first = await fingerprint(t, host);
+  key = "v2";
+  const second = await fingerprint(t, host);
+  assertEquals(first === second, false);
+
+  // A target with only a cacheKey (no inputs) is still cacheable.
+  t.name_ = "keyed";
+  const cache = await openCache(STORE, host);
+  key = "v1";
+  assertEquals(await cache.upToDate(t), false);
+  await cache.record(t);
+  await cache.save();
+  const reopened = await openCache(STORE, host);
+  assertEquals(await reopened.upToDate(t), true);
+  key = "v3";
+  assertEquals(await reopened.upToDate(t), false);
+});
+
 Deno.test("a target without inputs is never cached", async () => {
   const host = new MemHost();
   const cache = await openCache(STORE, host);

--- a/packages/core/tests/executor_test.ts
+++ b/packages/core/tests/executor_test.ts
@@ -1,5 +1,10 @@
 import { assertEquals, messageOf } from "./_assert.ts";
-import { Build, type BuildResult, discoverTargets } from "../src/build.ts";
+import {
+  Build,
+  type BuildResult,
+  discoverTargets,
+  type TargetStatus,
+} from "../src/build.ts";
 import { group, target } from "../src/target.ts";
 import type { BuildCache } from "../src/cache.ts";
 import { parameter } from "../src/params.ts";
@@ -838,6 +843,103 @@ Deno.test("requires passes once the parameter is set", async () => {
   });
   assertEquals(result.ok, true);
   assertEquals(ran, ["publish"]);
+});
+
+Deno.test("always targets run for cleanup even after a failure", async () => {
+  const ran: string[] = [];
+  class B extends Build {
+    boom = target().executes(() => {
+      throw new Error("boom");
+    });
+    cleanup = target().always().executes(() => void ran.push("cleanup"));
+    all = target()
+      .dependsOn(this.boom, this.cleanup)
+      .executes(() => void ran.push("all"));
+  }
+  const b = new B();
+  discoverTargets(b);
+  const result = await execute(b, b.all, { silent: true });
+  assertEquals(result.ok, false);
+  assertEquals(ran.includes("cleanup"), true); // ran despite the failure
+  assertEquals(ran.includes("all"), false); // blocked by the failed dep
+});
+
+Deno.test("whenSkipped(skip-dependencies) skips the target and its exclusive deps", async () => {
+  const ran: string[] = [];
+  class B extends Build {
+    onlyForDocs = target().executes(() => void ran.push("onlyForDocs"));
+    docs = target()
+      .dependsOn(this.onlyForDocs)
+      .onlyWhen(() => false)
+      .whenSkipped("skip-dependencies")
+      .executes(() => void ran.push("docs"));
+    site = target().dependsOn(this.docs).executes(() => void ran.push("site"));
+  }
+  const b = new B();
+  discoverTargets(b);
+  const result = await execute(b, b.site, { silent: true });
+  assertEquals(result.ok, true);
+  assertEquals(ran.includes("docs"), false); // condition false → skipped
+  assertEquals(ran.includes("onlyForDocs"), false); // exclusive dep skipped too
+  assertEquals(ran.includes("site"), true); // dependent still runs
+});
+
+Deno.test("onTargetStart and onTargetEnd fire around each target", async () => {
+  const events: string[] = [];
+  class B extends Build {
+    override onTargetStart(name: string) {
+      events.push(`start:${name}`);
+    }
+    override onTargetEnd(name: string, status: TargetStatus) {
+      events.push(`end:${name}:${status}`);
+    }
+    a = target().executes(() => {});
+    b = target().dependsOn(this.a).executes(() => {});
+  }
+  const b = new B();
+  discoverTargets(b);
+  await execute(b, b.b, { silent: true });
+  assertEquals(events, [
+    "start:a",
+    "end:a:passed",
+    "start:b",
+    "end:b:passed",
+  ]);
+});
+
+Deno.test("secret parameter values are masked under GitHub Actions", async () => {
+  const { lines, reporter } = recorder();
+  class B extends Build {
+    token = parameter("token").secret();
+    go = target().executes(() => {});
+  }
+  const b = new B();
+  discoverTargets(b);
+  await withEnv("GITHUB_STEP_SUMMARY", undefined, async () => {
+    await execute(b, b.go, {
+      reporter,
+      github: true,
+      params: { token: "s3cr3t" },
+    });
+  });
+  assertEquals(lines.includes("::add-mask::s3cr3t"), true);
+});
+
+Deno.test("execute prompts for a missing required parameter", async () => {
+  const seen: string[] = [];
+  class B extends Build {
+    token = parameter("token").required();
+    go = target().executes(() => void seen.push(this.token.value));
+  }
+  const b = new B();
+  discoverTargets(b);
+  const result = await execute(b, b.go, {
+    silent: true,
+    readEnv: () => undefined,
+    prompt: () => "prompted",
+  });
+  assertEquals(result.ok, true);
+  assertEquals(seen, ["prompted"]);
 });
 
 Deno.test("an unwritable job-summary file never fails the build", async () => {

--- a/packages/core/tests/host_test.ts
+++ b/packages/core/tests/host_test.ts
@@ -1,0 +1,53 @@
+import { assertEquals } from "./_assert.ts";
+import { ciHost, isCI } from "../src/host.ts";
+
+/** Run `fn` with several environment variables temporarily set/unset. */
+async function withEnv(
+  vars: Record<string, string | undefined>,
+  fn: () => void | Promise<void>,
+): Promise<void> {
+  const saved = new Map<string, string | undefined>();
+  for (const [key, value] of Object.entries(vars)) {
+    saved.set(key, Deno.env.get(key));
+    if (value === undefined) Deno.env.delete(key);
+    else Deno.env.set(key, value);
+  }
+  try {
+    await fn();
+  } finally {
+    for (const [key, value] of saved) {
+      if (value === undefined) Deno.env.delete(key);
+      else Deno.env.set(key, value);
+    }
+  }
+}
+
+Deno.test("ciHost detects the provider and isCI follows", async () => {
+  await withEnv(
+    { GITHUB_ACTIONS: "true", GITLAB_CI: undefined, CI: undefined },
+    () => {
+      assertEquals(ciHost(), "github-actions");
+      assertEquals(isCI(), true);
+    },
+  );
+  await withEnv(
+    { GITHUB_ACTIONS: undefined, GITLAB_CI: "true", CI: undefined },
+    () => {
+      assertEquals(ciHost(), "gitlab-ci");
+    },
+  );
+  await withEnv(
+    { GITHUB_ACTIONS: undefined, GITLAB_CI: undefined, CI: "true" },
+    () => {
+      assertEquals(ciHost(), "ci");
+      assertEquals(isCI(), true);
+    },
+  );
+  await withEnv(
+    { GITHUB_ACTIONS: undefined, GITLAB_CI: undefined, CI: undefined },
+    () => {
+      assertEquals(ciHost(), "local");
+      assertEquals(isCI(), false);
+    },
+  );
+});

--- a/packages/core/tests/params_test.ts
+++ b/packages/core/tests/params_test.ts
@@ -88,6 +88,38 @@ Deno.test("env overrides the environment variable name", () => {
   assertEquals(p.envName_, "CI_TOKEN");
 });
 
+Deno.test("secret survives chaining and stringValue exposes the value", () => {
+  const before = parameter("token").secret().required();
+  const after = parameter("token").required().secret();
+  assertEquals(before.secret_, true);
+  assertEquals(after.secret_, true);
+  assertEquals(parameter("plain").secret_, false);
+
+  before.resolve_("hunter2");
+  assertEquals(before.stringValue_(), "hunter2");
+  assertEquals(parameter("x").stringValue_(), undefined); // unresolved
+});
+
+Deno.test("resolveParameters prompts for a missing required value", () => {
+  class B extends Build {
+    token = parameter("API token").required();
+  }
+  const params = discoverParameters(new B());
+  const errors = resolveParameters(
+    params,
+    {},
+    () => undefined,
+    (flag, description) => {
+      assertEquals(flag, "token");
+      assertEquals(description, "API token");
+      return "from-prompt";
+    },
+  );
+  assertEquals(errors, []);
+  const p = params.get("token");
+  if (p instanceof Parameter) assertEquals(p.value, "from-prompt");
+});
+
 Deno.test("flagName and envVarName convert camelCase", () => {
   assertEquals(flagName("environment"), "environment");
   assertEquals(flagName("targetEnv"), "target-env");

--- a/packages/core/tests/target_test.ts
+++ b/packages/core/tests/target_test.ts
@@ -71,6 +71,27 @@ Deno.test("inputs, outputs, and onlyWhen record their configuration", () => {
   assertEquals(t.onlyWhen_[0](), true);
 });
 
+Deno.test("cacheKey, produces, consumes, always, whenSkipped record config", () => {
+  class B extends Build {
+    dep = target().executes(() => {});
+    main = target()
+      .inputs("src")
+      .cacheKey(() => "v1")
+      .produces("dist")
+      .consumes(this.dep)
+      .always()
+      .whenSkipped("skip-dependencies")
+      .executes(() => {});
+  }
+  const b = new B();
+  discoverTargets(b);
+  assertEquals(b.main.cacheKeys_.length, 1);
+  assertEquals(b.main.produces_, ["dist"]);
+  assertEquals(b.main.dependsOn_.map((t) => t.name_), ["dep"]); // consumes
+  assertEquals(b.main.always_, true);
+  assertEquals(b.main.skipDependencies_, true);
+});
+
 Deno.test("partOf ignores an undefined (forward-referenced) group", () => {
   const t = target();
   // @ts-expect-error exercising the runtime guard against an unbound reference


### PR DESCRIPTION
## Summary

Rounds out the NUKE-inspired target/parameter surface with the remaining concepts from both lists, plus interactive parameter input. Opt-in and backwards-compatible. Green under `deno task ci` (`target.ts`/`build.ts` at 100%).

| Concept | API |
|---|---|
| Non-file cache invalidation | `.cacheKey(() => string)` — folded into the SHA-256 fingerprint; a target with only cache keys (no inputs) is still cacheable |
| Finally / teardown targets | `.always()` — runs for cleanup even after the build has failed |
| Secret parameters | `parameter().secret()` — resolved value emitted as `::add-mask::` under GitHub Actions |
| Artifacts | `.produces(...paths)` / `.consumes(...targets)` |
| Skip-dependency behavior | `.whenSkipped("skip-dependencies")` — on a skipped condition, also skip dependencies nothing else needs (condition evaluated up front) |
| Interactive input | a missing required parameter is prompted for at a non-CI TTY; `resolveParameters` gains an injectable prompt |
| Per-target lifecycle hooks | `Build.onTargetStart(name)` / `onTargetEnd(name, status)` |
| Host / CI detection | `isCI()` / `ciHost()` (new `host.ts`) |

## Engine notes
- The executor now distinguishes "a failure occurred" from "stop launching", and keeps launching `.always()` targets after a halt; builds using `always`/`proceedAfterFailure` route through the scheduler.
- `whenSkipped` prunes the skipped target plus any dependency not reachable from the root except through it.
- `TargetStatus` moved to `build.ts` (shared by the new hooks).

## API additions (`@zuke/core`)
`TargetStatus`, `isCI`, `ciHost`; `TargetBuilder.cacheKey/produces/consumes/always/whenSkipped`; `Parameter.secret`; `ExecuteOptions.prompt`.

## Docs
`docs/authoring.md` (new method rows + sections, host detection) and `docs/parameters.md` (secrets, interactive input).

## Out of scope (planned separately)
Git/version injection → the upcoming `@zuke/git` package; partitioning left out as advanced/CI-coupled.

https://claude.ai/code/session_01PtqHmRRvtT6qkQKaPzrWhT

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtqHmRRvtT6qkQKaPzrWhT)_