### PR TITLE
docs: remove the Roadmap section from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,6 @@ CI runs `deno task ci` on every push and pull request (see
 - Add tests in the same change as the code they cover.
 - Keep commits small and descriptive; update docs when behaviour changes.
 
-## Roadmap
-
-Post-v0, for context:
-
-- A `zuke` standalone binary + `zuke init` scaffolding.
-- More tool wrapper packages — see [Tools](./docs/tools.md) for what ships today.
-
 ## Security
 
 As a build tool that runs in other people's pipelines, Zuke treats


### PR DESCRIPTION
## Summary

Removes the **Roadmap** section from the README. Its remaining items are either shipped (parameters, parallel execution, groups, caching, the NUKE-style target methods, the dprint/gcloud/git/gh wrappers) or declined (the standalone `zuke` binary / `zuke init`), so the section no longer reflects direction.

README-only change; `deno task fmt:check` clean.

https://claude.ai/code/session_01PtqHmRRvtT6qkQKaPzrWhT

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtqHmRRvtT6qkQKaPzrWhT)_