### PR TITLE
feat: add turbo and nx tool wrappers

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -154,6 +154,22 @@
         { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
       ]
     },
+    "packages/turbo": {
+      "component": "turbo",
+      "release-as": "0.1.0",
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+      ]
+    },
+    "packages/nx": {
+      "component": "nx",
+      "release-as": "0.1.0",
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+      ]
+    },
     "packages/tsx": {
       "component": "tsx",
       "release-as": "0.1.0",

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -19,6 +19,8 @@
   "packages/biome": "0.0.0",
   "packages/vite": "0.0.0",
   "packages/tsup": "0.0.0",
+  "packages/turbo": "0.0.0",
+  "packages/nx": "0.0.0",
   "packages/tsx": "0.1.0",
   "packages/tsgo": "0.1.0",
   "packages/dprint": "0.1.0",

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ order. Inspired by [NUKE](https://nuke.build/) for .NET.
   `jsr:@zuke/docker`, `jsr:@zuke/docker-compose`, `jsr:@zuke/kubectl`,
   `jsr:@zuke/oxlint`, `jsr:@zuke/eslint`, `jsr:@zuke/biome`, `jsr:@zuke/cspell`,
   `jsr:@zuke/jest`, `jsr:@zuke/vitest`, `jsr:@zuke/playwright`, `jsr:@zuke/vite`,
-  `jsr:@zuke/tsup`, `jsr:@zuke/tsx`, `jsr:@zuke/tsgo`, `jsr:@zuke/dprint`,
+  `jsr:@zuke/tsup`, `jsr:@zuke/turbo`, `jsr:@zuke/nx`, `jsr:@zuke/tsx`,
+  `jsr:@zuke/tsgo`, `jsr:@zuke/dprint`,
   `jsr:@zuke/gcloud`, `jsr:@zuke/git`, `jsr:@zuke/gh`, `jsr:@zuke/terraform`,
   `jsr:@zuke/tofu`, `jsr:@zuke/security`, `jsr:@zuke/cmd` (raw shell via
   `jsr:@zuke/core/shell`)

--- a/deno.json
+++ b/deno.json
@@ -20,6 +20,8 @@
     "packages/biome",
     "packages/vite",
     "packages/tsup",
+    "packages/turbo",
+    "packages/nx",
     "packages/tsx",
     "packages/tsgo",
     "packages/dprint",

--- a/deno.lock
+++ b/deno.lock
@@ -632,6 +632,11 @@
           "jsr:@zuke/core@0"
         ]
       },
+      "packages/nx": {
+        "dependencies": [
+          "jsr:@zuke/core@0"
+        ]
+      },
       "packages/oxlint": {
         "dependencies": [
           "jsr:@zuke/core@0"
@@ -673,6 +678,11 @@
         ]
       },
       "packages/tsx": {
+        "dependencies": [
+          "jsr:@zuke/core@0"
+        ]
+      },
+      "packages/turbo": {
         "dependencies": [
           "jsr:@zuke/core@0"
         ]

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -43,6 +43,8 @@ raises a `ToolNotFoundError` that names the tool and the fix.
 | `@zuke/playwright`     | `test`, `install`, `showReport`, `codegen`                                                                           |
 | `@zuke/vite`           | `dev`, `build`, `preview`                                                                                            |
 | `@zuke/tsup`           | `build`                                                                                                              |
+| `@zuke/turbo`          | `run`, `prune`                                                                                                       |
+| `@zuke/nx`             | `run`, `runMany`, `affected`                                                                                         |
 | `@zuke/tsx`            | `tsx`, `watch`                                                                                                       |
 | `@zuke/tsgo`           | `tsgo`                                                                                                               |
 | `@zuke/dprint`         | `fmt`, `check`                                                                                                      |

--- a/packages/nx/README.md
+++ b/packages/nx/README.md
@@ -1,0 +1,15 @@
+# @zuke/nx
+
+Typed [Nx](https://nx.dev) CLI task wrappers for
+[Zuke](https://github.com/zuke-build/zuke#readme) builds — `run`, `runMany`, and
+`affected`.
+
+```ts
+import { NxTasks } from "jsr:@zuke/nx";
+
+await NxTasks.run((s) => s.target("web:build"));
+await NxTasks.runMany((s) =>
+  s.target("build").projects("web", "api").parallel(3)
+);
+await NxTasks.affected((s) => s.target("test").base("main"));
+```

--- a/packages/nx/deno.json
+++ b/packages/nx/deno.json
@@ -1,0 +1,16 @@
+{
+  "name": "@zuke/nx",
+  "version": "0.0.0",
+  "description": "Typed Nx CLI task wrappers for Zuke builds — run, run-many, and affected via an injection-free settings-lambda API.",
+  "exports": {
+    ".": "./mod.ts"
+  },
+  "imports": {
+    "@zuke/core": "jsr:@zuke/core@^0"
+  },
+  "publish": {
+    "exclude": [
+      "tests/"
+    ]
+  }
+}

--- a/packages/nx/mod.ts
+++ b/packages/nx/mod.ts
@@ -1,0 +1,21 @@
+/**
+ * `@zuke/nx` — typed `NxTasks` wrappers for the [Nx](https://nx.dev) CLI, for
+ * use in Zuke builds.
+ *
+ * ```ts
+ * import { NxTasks } from "jsr:@zuke/nx";
+ *
+ * await NxTasks.affected((s) => s.target("test").base("main"));
+ * await NxTasks.runMany((s) => s.target("build").projects("web", "api"));
+ * ```
+ *
+ * @module
+ */
+
+export {
+  NxAffectedSettings,
+  NxRunManySettings,
+  NxRunSettings,
+  NxTasks,
+  type NxTasksApi,
+} from "./src/nx.ts";

--- a/packages/nx/src/nx.ts
+++ b/packages/nx/src/nx.ts
@@ -1,0 +1,186 @@
+/**
+ * `NxTasks` — typed task functions for the [Nx](https://nx.dev) CLI, in the
+ * settings-lambda style: configure a fluent settings object in a lambda, and
+ * the task function builds the command line and executes it.
+ *
+ * ```ts
+ * import { NxTasks } from "jsr:@zuke/nx";
+ * await NxTasks.affected((s) => s.target("test").base("main").parallel(3));
+ * await NxTasks.runMany((s) => s.target("build").projects("web", "api"));
+ * ```
+ *
+ * Arguments stay a discrete argv array end-to-end — never a concatenated shell
+ * string — so command construction is injection-free.
+ *
+ * @module
+ */
+
+import { type Configure, runSettings, ToolSettings } from "@zuke/core/tooling";
+import type { CommandOutput } from "@zuke/core/shell";
+
+/** Base for all `nx` subcommand settings: the binary is `nx`. */
+abstract class NxSettings extends ToolSettings {
+  protected override defaultTool(): string {
+    return "nx";
+  }
+}
+
+/** Settings for `nx run` (a single `project:target`). */
+export class NxRunSettings extends NxSettings {
+  #target?: string;
+  #configuration?: string;
+
+  /** The `project:target` to run, e.g. `web:build` (required). */
+  target(spec: string): this {
+    this.#target = spec;
+    return this;
+  }
+
+  /** Use a named configuration (`--configuration`). */
+  configuration(name: string): this {
+    this.#configuration = name;
+    return this;
+  }
+
+  protected override buildArgs(): string[] {
+    if (this.#target === undefined) {
+      throw new Error("NxTasks.run: .target() is required.");
+    }
+    const argv = ["run", this.#target];
+    if (this.#configuration !== undefined) {
+      argv.push(`--configuration=${this.#configuration}`);
+    }
+    return argv;
+  }
+}
+
+/** Settings for `nx run-many`. */
+export class NxRunManySettings extends NxSettings {
+  #target?: string;
+  #projects: string[] = [];
+  #configuration?: string;
+  #parallel?: number;
+  #all = false;
+
+  /** The target to run across projects (required). */
+  target(name: string): this {
+    this.#target = name;
+    return this;
+  }
+
+  /** Limit to specific projects (`--projects`); repeatable. */
+  projects(...names: string[]): this {
+    this.#projects.push(...names);
+    return this;
+  }
+
+  /** Use a named configuration (`--configuration`). */
+  configuration(name: string): this {
+    this.#configuration = name;
+    return this;
+  }
+
+  /** Maximum number of tasks to run in parallel (`--parallel`). */
+  parallel(count: number): this {
+    this.#parallel = count;
+    return this;
+  }
+
+  /** Run for every project (`--all`). */
+  all(): this {
+    this.#all = true;
+    return this;
+  }
+
+  protected override buildArgs(): string[] {
+    if (this.#target === undefined) {
+      throw new Error("NxTasks.runMany: .target() is required.");
+    }
+    const argv = ["run-many", `--target=${this.#target}`];
+    if (this.#projects.length > 0) {
+      argv.push(`--projects=${this.#projects.join(",")}`);
+    }
+    if (this.#configuration !== undefined) {
+      argv.push(`--configuration=${this.#configuration}`);
+    }
+    if (this.#parallel !== undefined) argv.push(`--parallel=${this.#parallel}`);
+    if (this.#all) argv.push("--all");
+    return argv;
+  }
+}
+
+/** Settings for `nx affected`. */
+export class NxAffectedSettings extends NxSettings {
+  #target?: string;
+  #base?: string;
+  #head?: string;
+  #configuration?: string;
+  #parallel?: number;
+
+  /** The target to run on affected projects (required). */
+  target(name: string): this {
+    this.#target = name;
+    return this;
+  }
+
+  /** The base ref to diff against (`--base`). */
+  base(ref: string): this {
+    this.#base = ref;
+    return this;
+  }
+
+  /** The head ref to diff against (`--head`). */
+  head(ref: string): this {
+    this.#head = ref;
+    return this;
+  }
+
+  /** Use a named configuration (`--configuration`). */
+  configuration(name: string): this {
+    this.#configuration = name;
+    return this;
+  }
+
+  /** Maximum number of tasks to run in parallel (`--parallel`). */
+  parallel(count: number): this {
+    this.#parallel = count;
+    return this;
+  }
+
+  protected override buildArgs(): string[] {
+    if (this.#target === undefined) {
+      throw new Error("NxTasks.affected: .target() is required.");
+    }
+    const argv = ["affected", `--target=${this.#target}`];
+    if (this.#base !== undefined) argv.push(`--base=${this.#base}`);
+    if (this.#head !== undefined) argv.push(`--head=${this.#head}`);
+    if (this.#configuration !== undefined) {
+      argv.push(`--configuration=${this.#configuration}`);
+    }
+    if (this.#parallel !== undefined) argv.push(`--parallel=${this.#parallel}`);
+    return argv;
+  }
+}
+
+/** The shape of {@link NxTasks}. */
+export interface NxTasksApi {
+  /** Run a single `project:target`: `nx run`. */
+  run(configure?: Configure<NxRunSettings>): Promise<CommandOutput>;
+  /** Run a target across many projects: `nx run-many`. */
+  runMany(configure?: Configure<NxRunManySettings>): Promise<CommandOutput>;
+  /** Run a target on affected projects: `nx affected`. */
+  affected(configure?: Configure<NxAffectedSettings>): Promise<CommandOutput>;
+}
+
+/** Typed task functions for the `nx` CLI. */
+export const NxTasks: NxTasksApi = {
+  run(configure?: Configure<NxRunSettings>): Promise<CommandOutput> {
+    return runSettings(new NxRunSettings(), configure);
+  },
+  runMany(configure?: Configure<NxRunManySettings>): Promise<CommandOutput> {
+    return runSettings(new NxRunManySettings(), configure);
+  },
+  affected(configure?: Configure<NxAffectedSettings>): Promise<CommandOutput> {
+    return runSettings(new NxAffectedSettings(), configure);
+  },
+};

--- a/packages/nx/tests/nx_test.ts
+++ b/packages/nx/tests/nx_test.ts
@@ -1,0 +1,109 @@
+import {
+  assertEquals,
+  assertRejects,
+  assertThrows,
+} from "../../core/tests/_assert.ts";
+import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import {
+  NxAffectedSettings,
+  NxRunManySettings,
+  NxRunSettings,
+  NxTasks,
+} from "../src/nx.ts";
+
+Deno.test("the default binary is nx", () => {
+  assertEquals(new NxRunSettings().target("web:build").argv()[0], "nx");
+});
+
+Deno.test("run: requires a target; configuration", () => {
+  assertThrows(
+    () => new NxRunSettings().argv(),
+    Error,
+    "NxTasks.run: .target() is required",
+  );
+  assertEquals(new NxRunSettings().target("web:build").argv().slice(1), [
+    "run",
+    "web:build",
+  ]);
+  assertEquals(
+    new NxRunSettings().target("web:build").configuration("production").argv()
+      .slice(1),
+    ["run", "web:build", "--configuration=production"],
+  );
+});
+
+Deno.test("runMany: requires a target; projects, configuration, parallel, all", () => {
+  assertThrows(
+    () => new NxRunManySettings().argv(),
+    Error,
+    "NxTasks.runMany: .target() is required",
+  );
+  assertEquals(new NxRunManySettings().target("build").argv().slice(1), [
+    "run-many",
+    "--target=build",
+  ]);
+  assertEquals(
+    new NxRunManySettings()
+      .target("build")
+      .projects("web", "api")
+      .configuration("ci")
+      .parallel(3)
+      .all()
+      .argv()
+      .slice(1),
+    [
+      "run-many",
+      "--target=build",
+      "--projects=web,api",
+      "--configuration=ci",
+      "--parallel=3",
+      "--all",
+    ],
+  );
+});
+
+Deno.test("affected: requires a target; base, head, configuration, parallel", () => {
+  assertThrows(
+    () => new NxAffectedSettings().argv(),
+    Error,
+    "NxTasks.affected: .target() is required",
+  );
+  assertEquals(
+    new NxAffectedSettings()
+      .target("test")
+      .base("main")
+      .head("HEAD")
+      .configuration("ci")
+      .parallel(2)
+      .argv()
+      .slice(1),
+    [
+      "affected",
+      "--target=test",
+      "--base=main",
+      "--head=HEAD",
+      "--configuration=ci",
+      "--parallel=2",
+    ],
+  );
+});
+
+const missing = <S extends ToolSettings>(s: S): S => {
+  s.os_ = "linux";
+  return s.toolPath("zuke-no-such-nx-xyz");
+};
+
+Deno.test("every NxTasks function reaches execution", async () => {
+  await assertRejects(
+    () => NxTasks.run((s) => missing(s).target("web:build")),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => NxTasks.runMany((s) => missing(s).target("build")),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => NxTasks.affected((s) => missing(s).target("test")),
+    ToolNotFoundError,
+  );
+});

--- a/packages/turbo/README.md
+++ b/packages/turbo/README.md
@@ -1,0 +1,11 @@
+# @zuke/turbo
+
+Typed [Turborepo](https://turbo.build) CLI task wrappers for
+[Zuke](https://github.com/zuke-build/zuke#readme) builds — `run` and `prune`.
+
+```ts
+import { TurboTasks } from "jsr:@zuke/turbo";
+
+await TurboTasks.run((s) => s.tasks("build", "test").filter("web").parallel());
+await TurboTasks.prune((s) => s.package("web").docker().outDir("out"));
+```

--- a/packages/turbo/deno.json
+++ b/packages/turbo/deno.json
@@ -1,0 +1,16 @@
+{
+  "name": "@zuke/turbo",
+  "version": "0.0.0",
+  "description": "Typed Turborepo CLI task wrappers for Zuke builds — run and prune via an injection-free settings-lambda API.",
+  "exports": {
+    ".": "./mod.ts"
+  },
+  "imports": {
+    "@zuke/core": "jsr:@zuke/core@^0"
+  },
+  "publish": {
+    "exclude": [
+      "tests/"
+    ]
+  }
+}

--- a/packages/turbo/mod.ts
+++ b/packages/turbo/mod.ts
@@ -1,0 +1,19 @@
+/**
+ * `@zuke/turbo` — typed `TurboTasks` wrappers for the
+ * [Turborepo](https://turbo.build) CLI, for use in Zuke builds.
+ *
+ * ```ts
+ * import { TurboTasks } from "jsr:@zuke/turbo";
+ *
+ * await TurboTasks.run((s) => s.tasks("build", "test").filter("web"));
+ * ```
+ *
+ * @module
+ */
+
+export {
+  TurboPruneSettings,
+  TurboRunSettings,
+  TurboTasks,
+  type TurboTasksApi,
+} from "./src/turbo.ts";

--- a/packages/turbo/src/turbo.ts
+++ b/packages/turbo/src/turbo.ts
@@ -1,0 +1,172 @@
+/**
+ * `TurboTasks` — typed task functions for the [Turborepo](https://turbo.build)
+ * CLI, in the settings-lambda style: configure a fluent settings object in a
+ * lambda, and the task function builds the command line and executes it.
+ *
+ * ```ts
+ * import { TurboTasks } from "jsr:@zuke/turbo";
+ * await TurboTasks.run((s) => s.tasks("build", "test").filter("web").parallel());
+ * ```
+ *
+ * Arguments stay a discrete argv array end-to-end — never a concatenated shell
+ * string — so command construction is injection-free.
+ *
+ * @module
+ */
+
+import {
+  type Configure,
+  type PathLike,
+  runSettings,
+  ToolSettings,
+} from "@zuke/core/tooling";
+import type { CommandOutput } from "@zuke/core/shell";
+
+/** Base for all `turbo` subcommand settings: the binary is `turbo`. */
+abstract class TurboSettings extends ToolSettings {
+  protected override defaultTool(): string {
+    return "turbo";
+  }
+}
+
+/** Settings for `turbo run`. */
+export class TurboRunSettings extends TurboSettings {
+  #tasks: string[] = [];
+  #filters: string[] = [];
+  #parallel = false;
+  #concurrency?: string;
+  #force = false;
+  #noCache = false;
+  #continue = false;
+  #dryRun = false;
+  #outputLogs?: string;
+
+  /** The package.json task(s) to run (positional; at least one required). */
+  tasks(...names: string[]): this {
+    this.#tasks.push(...names);
+    return this;
+  }
+
+  /** Restrict to matching packages (`--filter`); repeatable. */
+  filter(pattern: string): this {
+    this.#filters.push(pattern);
+    return this;
+  }
+
+  /** Run tasks in parallel, ignoring dependencies (`--parallel`). */
+  parallel(): this {
+    this.#parallel = true;
+    return this;
+  }
+
+  /** Limit concurrency, e.g. `10` or `50%` (`--concurrency`). */
+  concurrency(value: string): this {
+    this.#concurrency = value;
+    return this;
+  }
+
+  /** Ignore cache hits and force execution (`--force`). */
+  force(): this {
+    this.#force = true;
+    return this;
+  }
+
+  /** Disable reading and writing the cache (`--no-cache`). */
+  noCache(): this {
+    this.#noCache = true;
+    return this;
+  }
+
+  /** Continue running tasks even after one fails (`--continue`). */
+  continue(): this {
+    this.#continue = true;
+    return this;
+  }
+
+  /** List what would run without executing (`--dry-run`). */
+  dryRun(): this {
+    this.#dryRun = true;
+    return this;
+  }
+
+  /** Output-log mode, e.g. `full`, `hash-only`, `errors-only` (`--output-logs`). */
+  outputLogs(mode: string): this {
+    this.#outputLogs = mode;
+    return this;
+  }
+
+  protected override buildArgs(): string[] {
+    if (this.#tasks.length === 0) {
+      throw new Error(
+        "TurboTasks.run: .tasks(...) requires at least one task.",
+      );
+    }
+    const argv = ["run", ...this.#tasks];
+    for (const f of this.#filters) argv.push(`--filter=${f}`);
+    if (this.#parallel) argv.push("--parallel");
+    if (this.#concurrency !== undefined) {
+      argv.push(`--concurrency=${this.#concurrency}`);
+    }
+    if (this.#force) argv.push("--force");
+    if (this.#noCache) argv.push("--no-cache");
+    if (this.#continue) argv.push("--continue");
+    if (this.#dryRun) argv.push("--dry-run");
+    if (this.#outputLogs !== undefined) {
+      argv.push(`--output-logs=${this.#outputLogs}`);
+    }
+    return argv;
+  }
+}
+
+/** Settings for `turbo prune`. */
+export class TurboPruneSettings extends TurboSettings {
+  #package?: string;
+  #docker = false;
+  #outDir?: string;
+
+  /** The package to prune the workspace down to (required). */
+  package(name: string): this {
+    this.#package = name;
+    return this;
+  }
+
+  /** Produce a Docker-friendly layout (`--docker`). */
+  docker(): this {
+    this.#docker = true;
+    return this;
+  }
+
+  /** Output directory (`--out-dir`). */
+  outDir(path: PathLike): this {
+    this.#outDir = String(path);
+    return this;
+  }
+
+  protected override buildArgs(): string[] {
+    if (this.#package === undefined) {
+      throw new Error("TurboTasks.prune: .package() is required.");
+    }
+    const argv = ["prune", this.#package];
+    if (this.#docker) argv.push("--docker");
+    if (this.#outDir !== undefined) argv.push(`--out-dir=${this.#outDir}`);
+    return argv;
+  }
+}
+
+/** The shape of {@link TurboTasks}. */
+export interface TurboTasksApi {
+  /** Run workspace tasks: `turbo run`. */
+  run(configure?: Configure<TurboRunSettings>): Promise<CommandOutput>;
+  /** Prune the workspace to a package: `turbo prune`. */
+  prune(configure?: Configure<TurboPruneSettings>): Promise<CommandOutput>;
+}
+
+/** Typed task functions for the `turbo` CLI. */
+export const TurboTasks: TurboTasksApi = {
+  run(configure?: Configure<TurboRunSettings>): Promise<CommandOutput> {
+    return runSettings(new TurboRunSettings(), configure);
+  },
+  prune(configure?: Configure<TurboPruneSettings>): Promise<CommandOutput> {
+    return runSettings(new TurboPruneSettings(), configure);
+  },
+};

--- a/packages/turbo/tests/turbo_test.ts
+++ b/packages/turbo/tests/turbo_test.ts
@@ -1,0 +1,86 @@
+import {
+  assertEquals,
+  assertRejects,
+  assertThrows,
+} from "../../core/tests/_assert.ts";
+import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import {
+  TurboPruneSettings,
+  TurboRunSettings,
+  TurboTasks,
+} from "../src/turbo.ts";
+
+Deno.test("the default binary is turbo", () => {
+  assertEquals(new TurboRunSettings().tasks("build").argv()[0], "turbo");
+});
+
+Deno.test("run: requires a task; tasks first, then flags", () => {
+  assertThrows(
+    () => new TurboRunSettings().argv(),
+    Error,
+    "TurboTasks.run: .tasks(...) requires at least one task",
+  );
+  assertEquals(new TurboRunSettings().tasks("build").argv().slice(1), [
+    "run",
+    "build",
+  ]);
+  assertEquals(
+    new TurboRunSettings()
+      .tasks("build", "test")
+      .filter("web")
+      .filter("docs")
+      .parallel()
+      .concurrency("50%")
+      .force()
+      .noCache()
+      .continue()
+      .dryRun()
+      .outputLogs("errors-only")
+      .argv()
+      .slice(1),
+    [
+      "run",
+      "build",
+      "test",
+      "--filter=web",
+      "--filter=docs",
+      "--parallel",
+      "--concurrency=50%",
+      "--force",
+      "--no-cache",
+      "--continue",
+      "--dry-run",
+      "--output-logs=errors-only",
+    ],
+  );
+});
+
+Deno.test("prune: requires a package; --docker and --out-dir", () => {
+  assertThrows(
+    () => new TurboPruneSettings().argv(),
+    Error,
+    "TurboTasks.prune: .package() is required",
+  );
+  assertEquals(
+    new TurboPruneSettings().package("web").docker().outDir("out").argv().slice(
+      1,
+    ),
+    ["prune", "web", "--docker", "--out-dir=out"],
+  );
+});
+
+const missing = <S extends ToolSettings>(s: S): S => {
+  s.os_ = "linux";
+  return s.toolPath("zuke-no-such-turbo-xyz");
+};
+
+Deno.test("every TurboTasks function reaches execution", async () => {
+  await assertRejects(
+    () => TurboTasks.run((s) => missing(s).tasks("build")),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => TurboTasks.prune((s) => missing(s).package("web")),
+    ToolNotFoundError,
+  );
+});

--- a/tests/release_config_test.ts
+++ b/tests/release_config_test.ts
@@ -21,6 +21,8 @@ const PACKAGES = [
   "packages/biome",
   "packages/vite",
   "packages/tsup",
+  "packages/turbo",
+  "packages/nx",
   "packages/tsx",
   "packages/tsgo",
   "packages/dprint",

--- a/zuke.ts
+++ b/zuke.ts
@@ -39,6 +39,8 @@ const PACKAGES = [
   "biome",
   "vite",
   "tsup",
+  "turbo",
+  "nx",
   "tsx",
   "tsgo",
   "dprint",


### PR DESCRIPTION
## Summary

JS monorepo task-runner wrappers, settings-lambda style, core-only dependency.

| Package | `Tasks` | Commands |
| --- | --- | --- |
| `@zuke/turbo` | `TurboTasks` | `run`, `prune` |
| `@zuke/nx` | `NxTasks` | `run`, `runMany`, `affected` |

```ts
import { TurboTasks } from "jsr:@zuke/turbo";
import { NxTasks } from "jsr:@zuke/nx";

await TurboTasks.run((s) => s.tasks("build", "test").filter("web").parallel());
await NxTasks.affected((s) => s.target("test").base("main").parallel(3));
```

## Notes

- **turbo** `run` takes tasks positionally then flags (`--filter` repeatable, `--parallel`, `--concurrency`, `--force`, `--no-cache`, `--continue`, `--dry-run`, `--output-logs`); `prune` needs a package and supports `--docker`/`--out-dir`.
- **nx** covers `run` (`project:target`), `run-many` (`--target`/`--projects`/`--parallel`/`--all`), and `affected` (`--base`/`--head`). All require a target and fail fast otherwise.
- Pure `buildArgs()`; every task covered incl. the missing-binary path.

## Stacking

> 📚 **Stacked on [#67](https://github.com/zuke-build/zuke/pull/67)** (biome/vite/tsup) — base branch is `claude/gracious-lovelace-5hsv7w`. It'll auto-retarget to `master` once #67 merges. Review #67 first.

## Checks

`deno task ci` green — both packages 100% line/branch coverage; overall 96.2% lines / 98.4% branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtqHmRRvtT6qkQKaPzrWhT)_