### PR TITLE
feat: add @zuke/jsr tool wrapper

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -186,6 +186,14 @@
         { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
       ]
     },
+    "packages/jsr": {
+      "component": "jsr",
+      "release-as": "0.1.0",
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+      ]
+    },
     "packages/tsx": {
       "component": "tsx",
       "release-as": "0.1.0",

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -23,6 +23,7 @@
   "packages/tsup": "0.0.0",
   "packages/turbo": "0.0.0",
   "packages/nx": "0.0.0",
+  "packages/jsr": "0.0.0",
   "packages/tsx": "0.1.0",
   "packages/tsgo": "0.1.0",
   "packages/dprint": "0.1.0",

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ order. Inspired by [NUKE](https://nuke.build/) for .NET.
   `jsr:@zuke/oxlint`, `jsr:@zuke/eslint`, `jsr:@zuke/biome`, `jsr:@zuke/knip`,
   `jsr:@zuke/cspell`, `jsr:@zuke/jest`, `jsr:@zuke/vitest`,
   `jsr:@zuke/playwright`, `jsr:@zuke/cypress`, `jsr:@zuke/vite`,
-  `jsr:@zuke/tsup`, `jsr:@zuke/turbo`, `jsr:@zuke/nx`, `jsr:@zuke/tsx`,
-  `jsr:@zuke/tsgo`, `jsr:@zuke/dprint`,
+  `jsr:@zuke/tsup`, `jsr:@zuke/turbo`, `jsr:@zuke/nx`, `jsr:@zuke/jsr`,
+  `jsr:@zuke/tsx`, `jsr:@zuke/tsgo`, `jsr:@zuke/dprint`,
   `jsr:@zuke/gcloud`, `jsr:@zuke/git`, `jsr:@zuke/gh`, `jsr:@zuke/terraform`,
   `jsr:@zuke/tofu`, `jsr:@zuke/security`, `jsr:@zuke/cmd` (raw shell via
   `jsr:@zuke/core/shell`)

--- a/deno.json
+++ b/deno.json
@@ -20,6 +20,7 @@
     "packages/cypress",
     "packages/biome",
     "packages/knip",
+    "packages/jsr",
     "packages/vite",
     "packages/tsup",
     "packages/turbo",

--- a/deno.lock
+++ b/deno.lock
@@ -627,6 +627,11 @@
           "jsr:@zuke/core@0"
         ]
       },
+      "packages/jsr": {
+        "dependencies": [
+          "jsr:@zuke/core@0"
+        ]
+      },
       "packages/knip": {
         "dependencies": [
           "jsr:@zuke/core@0"

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -47,6 +47,7 @@ raises a `ToolNotFoundError` that names the tool and the fix.
 | `@zuke/tsup`           | `build`                                                                                                              |
 | `@zuke/turbo`          | `run`, `prune`                                                                                                       |
 | `@zuke/nx`             | `run`, `runMany`, `affected`                                                                                         |
+| `@zuke/jsr`            | `publish`, `add`, `remove`                                                                                           |
 | `@zuke/tsx`            | `tsx`, `watch`                                                                                                       |
 | `@zuke/tsgo`           | `tsgo`                                                                                                               |
 | `@zuke/dprint`         | `fmt`, `check`                                                                                                      |

--- a/packages/jsr/README.md
+++ b/packages/jsr/README.md
@@ -1,0 +1,12 @@
+# @zuke/jsr
+
+Typed [JSR](https://jsr.io) CLI task wrappers for
+[Zuke](https://github.com/zuke-build/zuke#readme) builds — `publish`, `add`, and
+`remove`.
+
+```ts
+import { JsrTasks } from "jsr:@zuke/jsr";
+
+await JsrTasks.publish((s) => s.dryRun().allowSlowTypes());
+await JsrTasks.add((s) => s.packages("@std/assert"));
+```

--- a/packages/jsr/deno.json
+++ b/packages/jsr/deno.json
@@ -1,0 +1,16 @@
+{
+  "name": "@zuke/jsr",
+  "version": "0.0.0",
+  "description": "Typed JSR CLI task wrappers for Zuke builds — publish, add, and remove via an injection-free settings-lambda API.",
+  "exports": {
+    ".": "./mod.ts"
+  },
+  "imports": {
+    "@zuke/core": "jsr:@zuke/core@^0"
+  },
+  "publish": {
+    "exclude": [
+      "tests/"
+    ]
+  }
+}

--- a/packages/jsr/mod.ts
+++ b/packages/jsr/mod.ts
@@ -1,0 +1,21 @@
+/**
+ * `@zuke/jsr` — typed `JsrTasks` wrappers for the [JSR](https://jsr.io) CLI, for
+ * use in Zuke builds (publishing and managing JSR dependencies).
+ *
+ * ```ts
+ * import { JsrTasks } from "jsr:@zuke/jsr";
+ *
+ * await JsrTasks.publish((s) => s.dryRun());
+ * await JsrTasks.add((s) => s.packages("@std/assert"));
+ * ```
+ *
+ * @module
+ */
+
+export {
+  JsrAddSettings,
+  JsrPublishSettings,
+  JsrRemoveSettings,
+  JsrTasks,
+  type JsrTasksApi,
+} from "./src/jsr.ts";

--- a/packages/jsr/src/jsr.ts
+++ b/packages/jsr/src/jsr.ts
@@ -1,0 +1,155 @@
+/**
+ * `JsrTasks` — typed task functions for the [JSR](https://jsr.io) CLI, in the
+ * settings-lambda style: configure a fluent settings object in a lambda, and
+ * the task function builds the command line and executes it.
+ *
+ * ```ts
+ * import { JsrTasks } from "jsr:@zuke/jsr";
+ * await JsrTasks.publish((s) => s.dryRun().allowSlowTypes());
+ * await JsrTasks.add((s) => s.packages("@std/assert"));
+ * ```
+ *
+ * The binary is `jsr` from PATH. Arguments stay a discrete argv array
+ * end-to-end — never a concatenated shell string — so command construction is
+ * injection-free.
+ *
+ * @module
+ */
+
+import { type Configure, runSettings, ToolSettings } from "@zuke/core/tooling";
+import type { CommandOutput } from "@zuke/core/shell";
+
+/** Base for all `jsr` subcommand settings: the binary is `jsr`. */
+abstract class JsrSettings extends ToolSettings {
+  protected override defaultTool(): string {
+    return "jsr";
+  }
+}
+
+/** Settings for `jsr publish`. */
+export class JsrPublishSettings extends JsrSettings {
+  #dryRun = false;
+  #allowSlowTypes = false;
+  #allowDirty = false;
+  #noCheck = false;
+  #provenance = false;
+  #token?: string;
+
+  /** Validate without publishing (`--dry-run`). */
+  dryRun(): this {
+    this.#dryRun = true;
+    return this;
+  }
+
+  /** Permit slow types in the published package (`--allow-slow-types`). */
+  allowSlowTypes(): this {
+    this.#allowSlowTypes = true;
+    return this;
+  }
+
+  /** Publish even with an uncommitted working tree (`--allow-dirty`). */
+  allowDirty(): this {
+    this.#allowDirty = true;
+    return this;
+  }
+
+  /** Skip type-checking before publishing (`--no-check`). */
+  noCheck(): this {
+    this.#noCheck = true;
+    return this;
+  }
+
+  /** Attach provenance attestation in CI (`--provenance`). */
+  provenance(): this {
+    this.#provenance = true;
+    return this;
+  }
+
+  /** Authenticate with a token instead of the interactive flow (`--token`). */
+  token(value: string): this {
+    this.#token = value;
+    return this;
+  }
+
+  protected override buildArgs(): string[] {
+    const argv = ["publish"];
+    if (this.#dryRun) argv.push("--dry-run");
+    if (this.#allowSlowTypes) argv.push("--allow-slow-types");
+    if (this.#allowDirty) argv.push("--allow-dirty");
+    if (this.#noCheck) argv.push("--no-check");
+    if (this.#provenance) argv.push("--provenance");
+    if (this.#token !== undefined) argv.push("--token", this.#token);
+    return argv;
+  }
+}
+
+/** Settings for `jsr add` (install a JSR dependency). */
+export class JsrAddSettings extends JsrSettings {
+  #packages: string[] = [];
+  #dev = false;
+
+  /** Package specs to add, e.g. `@std/assert` (required). */
+  packages(...specs: string[]): this {
+    this.#packages.push(...specs);
+    return this;
+  }
+
+  /** Add as a development dependency (`--save-dev`). */
+  dev(): this {
+    this.#dev = true;
+    return this;
+  }
+
+  protected override buildArgs(): string[] {
+    if (this.#packages.length === 0) {
+      throw new Error("JsrTasks.add: .packages() requires at least one spec.");
+    }
+    const argv = ["add"];
+    if (this.#dev) argv.push("--save-dev");
+    argv.push(...this.#packages);
+    return argv;
+  }
+}
+
+/** Settings for `jsr remove`. */
+export class JsrRemoveSettings extends JsrSettings {
+  #packages: string[] = [];
+
+  /** Package names to remove (required). */
+  packages(...names: string[]): this {
+    this.#packages.push(...names);
+    return this;
+  }
+
+  protected override buildArgs(): string[] {
+    if (this.#packages.length === 0) {
+      throw new Error(
+        "JsrTasks.remove: .packages() requires at least one name.",
+      );
+    }
+    return ["remove", ...this.#packages];
+  }
+}
+
+/** The shape of {@link JsrTasks}. */
+export interface JsrTasksApi {
+  /** Publish the package: `jsr publish`. */
+  publish(configure?: Configure<JsrPublishSettings>): Promise<CommandOutput>;
+  /** Add a JSR dependency: `jsr add`. */
+  add(configure?: Configure<JsrAddSettings>): Promise<CommandOutput>;
+  /** Remove a dependency: `jsr remove`. */
+  remove(configure?: Configure<JsrRemoveSettings>): Promise<CommandOutput>;
+}
+
+/** Typed task functions for the `jsr` CLI. */
+export const JsrTasks: JsrTasksApi = {
+  publish(configure?: Configure<JsrPublishSettings>): Promise<CommandOutput> {
+    return runSettings(new JsrPublishSettings(), configure);
+  },
+  add(configure?: Configure<JsrAddSettings>): Promise<CommandOutput> {
+    return runSettings(new JsrAddSettings(), configure);
+  },
+  remove(configure?: Configure<JsrRemoveSettings>): Promise<CommandOutput> {
+    return runSettings(new JsrRemoveSettings(), configure);
+  },
+};

--- a/packages/jsr/tests/jsr_test.ts
+++ b/packages/jsr/tests/jsr_test.ts
@@ -1,0 +1,85 @@
+import {
+  assertEquals,
+  assertRejects,
+  assertThrows,
+} from "../../core/tests/_assert.ts";
+import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import {
+  JsrAddSettings,
+  JsrPublishSettings,
+  JsrRemoveSettings,
+  JsrTasks,
+} from "../src/jsr.ts";
+
+Deno.test("the default binary is jsr", () => {
+  assertEquals(new JsrPublishSettings().argv()[0], "jsr");
+});
+
+Deno.test("publish: bare and all options", () => {
+  assertEquals(new JsrPublishSettings().argv().slice(1), ["publish"]);
+  assertEquals(
+    new JsrPublishSettings()
+      .dryRun()
+      .allowSlowTypes()
+      .allowDirty()
+      .noCheck()
+      .provenance()
+      .token("xyz")
+      .argv()
+      .slice(1),
+    [
+      "publish",
+      "--dry-run",
+      "--allow-slow-types",
+      "--allow-dirty",
+      "--no-check",
+      "--provenance",
+      "--token",
+      "xyz",
+    ],
+  );
+});
+
+Deno.test("add: packages required; --save-dev", () => {
+  assertThrows(
+    () => new JsrAddSettings().argv(),
+    Error,
+    "JsrTasks.add: .packages() requires at least one spec",
+  );
+  assertEquals(
+    new JsrAddSettings().dev().packages("@std/assert", "@std/path").argv()
+      .slice(
+        1,
+      ),
+    ["add", "--save-dev", "@std/assert", "@std/path"],
+  );
+});
+
+Deno.test("remove: names required", () => {
+  assertThrows(
+    () => new JsrRemoveSettings().argv(),
+    Error,
+    "JsrTasks.remove: .packages() requires at least one name",
+  );
+  assertEquals(
+    new JsrRemoveSettings().packages("@std/assert").argv().slice(1),
+    ["remove", "@std/assert"],
+  );
+});
+
+const missing = <S extends ToolSettings>(s: S): S => {
+  s.os_ = "linux";
+  return s.toolPath("zuke-no-such-jsr-xyz");
+};
+
+Deno.test("every JsrTasks function reaches execution", async () => {
+  await assertRejects(() => JsrTasks.publish(missing), ToolNotFoundError);
+  await assertRejects(
+    () => JsrTasks.add((s) => missing(s).packages("@std/assert")),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => JsrTasks.remove((s) => missing(s).packages("@std/assert")),
+    ToolNotFoundError,
+  );
+});

--- a/tests/release_config_test.ts
+++ b/tests/release_config_test.ts
@@ -25,6 +25,7 @@ const PACKAGES = [
   "packages/tsup",
   "packages/turbo",
   "packages/nx",
+  "packages/jsr",
   "packages/tsx",
   "packages/tsgo",
   "packages/dprint",

--- a/zuke.ts
+++ b/zuke.ts
@@ -39,6 +39,7 @@ const PACKAGES = [
   "cypress",
   "biome",
   "knip",
+  "jsr",
   "vite",
   "tsup",
   "turbo",


### PR DESCRIPTION
## Summary

A JSR CLI wrapper — dogfood-relevant, since this repo publishes to JSR.

| Package | `Tasks` | Commands |
| --- | --- | --- |
| `@zuke/jsr` | `JsrTasks` | `publish`, `add`, `remove` |

```ts
import { JsrTasks } from "jsr:@zuke/jsr";

await JsrTasks.publish((s) => s.dryRun().allowSlowTypes());
await JsrTasks.add((s) => s.packages("@std/assert"));
```

## Notes

- **publish**: `--dry-run`, `--allow-slow-types`, `--allow-dirty`, `--no-check`, `--provenance`, `--token`.
- **add/remove**: require at least one package, fail fast otherwise; `add` supports `--save-dev`.
- Pure `buildArgs()`; every task covered incl. the missing-binary path.

## Stacking

> 📚 **Stacked on [#69](https://github.com/zuke-build/zuke/pull/69)** → #68 → [#67](https://github.com/zuke-build/zuke/pull/67). Base is `claude/gracious-lovelace-5hsv7w-3`; merge the chain in order (bases auto-retarget).

## Checks

`deno task ci` green — package at 100% line/branch coverage; overall 96.3% lines / 98.5% branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtqHmRRvtT6qkQKaPzrWhT)_