### PR TITLE
feat: add helm and kustomize tool wrappers

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -87,6 +87,22 @@
         { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
       ]
     },
+    "packages/helm": {
+      "component": "helm",
+      "release-as": "0.1.0",
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+      ]
+    },
+    "packages/kustomize": {
+      "component": "kustomize",
+      "release-as": "0.1.0",
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+      ]
+    },
     "packages/oxlint": {
       "component": "oxlint",
       "changelog-path": "CHANGELOG.md",

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -10,6 +10,8 @@
   "packages/docker": "0.3.0",
   "packages/docker-compose": "0.3.0",
   "packages/kubectl": "0.0.0",
+  "packages/helm": "0.0.0",
+  "packages/kustomize": "0.0.0",
   "packages/oxlint": "0.2.0",
   "packages/eslint": "0.2.0",
   "packages/cspell": "0.2.0",

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ order. Inspired by [NUKE](https://nuke.build/) for .NET.
 - **Packages:** `jsr:@zuke/core` plus typed tool wrappers `jsr:@zuke/deno`,
   `jsr:@zuke/npm`, `jsr:@zuke/bun`, `jsr:@zuke/pnpm`, `jsr:@zuke/yarn`,
   `jsr:@zuke/docker`, `jsr:@zuke/docker-compose`, `jsr:@zuke/kubectl`,
-  `jsr:@zuke/oxlint`, `jsr:@zuke/eslint`, `jsr:@zuke/biome`, `jsr:@zuke/knip`,
+  `jsr:@zuke/helm`, `jsr:@zuke/kustomize`, `jsr:@zuke/oxlint`, `jsr:@zuke/eslint`, `jsr:@zuke/biome`, `jsr:@zuke/knip`,
   `jsr:@zuke/cspell`, `jsr:@zuke/jest`, `jsr:@zuke/vitest`,
   `jsr:@zuke/playwright`, `jsr:@zuke/cypress`, `jsr:@zuke/vite`,
   `jsr:@zuke/tsup`, `jsr:@zuke/turbo`, `jsr:@zuke/nx`, `jsr:@zuke/jsr`,

--- a/deno.json
+++ b/deno.json
@@ -11,6 +11,8 @@
     "packages/docker",
     "packages/docker-compose",
     "packages/kubectl",
+    "packages/helm",
+    "packages/kustomize",
     "packages/oxlint",
     "packages/eslint",
     "packages/cspell",

--- a/deno.lock
+++ b/deno.lock
@@ -622,6 +622,11 @@
           "jsr:@zuke/core@0"
         ]
       },
+      "packages/helm": {
+        "dependencies": [
+          "jsr:@zuke/core@0"
+        ]
+      },
       "packages/jest": {
         "dependencies": [
           "jsr:@zuke/core@0"
@@ -638,6 +643,11 @@
         ]
       },
       "packages/kubectl": {
+        "dependencies": [
+          "jsr:@zuke/core@0"
+        ]
+      },
+      "packages/kustomize": {
         "dependencies": [
           "jsr:@zuke/core@0"
         ]

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -34,6 +34,8 @@ raises a `ToolNotFoundError` that names the tool and the fix.
 | `@zuke/docker`         | `build`, `run`, `exec`, `push`, `pull`, `tag`, `login`, `images`, `ps`, `stop`, `start`, `rm`, `rmi`, `save`, `load` |
 | `@zuke/docker-compose` | `up`, `down`, `build`, `pull`, `push`, `run`, `exec`, `logs`, `ps`, `config`, `start`, `stop`, `restart`, `rm`       |
 | `@zuke/kubectl`        | `apply`, `create`, `delete`, `get`, `describe`, `logs`, `exec`, `rollout`, `scale`, `setImage`, `patch`, `portForward`, `wait`, `top` |
+| `@zuke/helm`           | `install`, `upgrade`, `uninstall`, `template`, `lint`, `dependencyUpdate`, `repoAdd`, `package`                      |
+| `@zuke/kustomize`      | `build`, `editSetImage`                                                                                              |
 | `@zuke/oxlint`         | `lint`                                                                                                               |
 | `@zuke/eslint`         | `lint`                                                                                                               |
 | `@zuke/biome`          | `check`, `format`, `lint`, `ci`                                                                                      |

--- a/packages/helm/README.md
+++ b/packages/helm/README.md
@@ -1,0 +1,19 @@
+# @zuke/helm
+
+Typed [Helm](https://helm.sh) CLI task wrappers for
+[Zuke](https://github.com/zuke-build/zuke#readme) builds — `install`, `upgrade`,
+`uninstall`, `template`, `lint`, `dependencyUpdate`, `repoAdd`, and `package`.
+
+```ts
+import { HelmTasks } from "jsr:@zuke/helm";
+
+await HelmTasks.upgrade((s) =>
+  s.release("api").chart("./charts/api").install().namespace("prod")
+    .set("image.tag", "1.4").wait()
+);
+```
+
+Every task shares the cluster-targeting flags `.namespace(...)`,
+`.kubeContext(...)`, and `.kubeconfig(...)`. Arguments stay a discrete argv
+array end-to-end — never a shell string — so command construction is
+injection-free.

--- a/packages/helm/deno.json
+++ b/packages/helm/deno.json
@@ -1,0 +1,16 @@
+{
+  "name": "@zuke/helm",
+  "version": "0.0.0",
+  "description": "Typed Helm CLI task wrappers for Zuke builds — install, upgrade, uninstall, template, lint, dependency update, repo add, and package via an injection-free settings-lambda API.",
+  "exports": {
+    ".": "./mod.ts"
+  },
+  "imports": {
+    "@zuke/core": "jsr:@zuke/core@^0"
+  },
+  "publish": {
+    "exclude": [
+      "tests/"
+    ]
+  }
+}

--- a/packages/helm/mod.ts
+++ b/packages/helm/mod.ts
@@ -1,0 +1,27 @@
+/**
+ * `@zuke/helm` — typed `HelmTasks` wrappers for the [Helm](https://helm.sh) CLI,
+ * for packaging and deploying to Kubernetes from a Zuke build.
+ *
+ * ```ts
+ * import { HelmTasks } from "jsr:@zuke/helm";
+ *
+ * await HelmTasks.upgrade((s) =>
+ *   s.release("api").chart("./charts/api").install().namespace("prod").wait()
+ * );
+ * ```
+ *
+ * @module
+ */
+
+export {
+  HelmDependencyUpdateSettings,
+  HelmInstallSettings,
+  HelmLintSettings,
+  HelmPackageSettings,
+  HelmRepoAddSettings,
+  HelmTasks,
+  type HelmTasksApi,
+  HelmTemplateSettings,
+  HelmUninstallSettings,
+  HelmUpgradeSettings,
+} from "./src/helm.ts";

--- a/packages/helm/src/helm.ts
+++ b/packages/helm/src/helm.ts
@@ -1,0 +1,508 @@
+/**
+ * `HelmTasks` — typed task functions for the [Helm](https://helm.sh) CLI, in
+ * the settings-lambda style: configure a fluent settings object in a lambda,
+ * and the task function builds the command line and executes it.
+ *
+ * ```ts
+ * import { HelmTasks } from "jsr:@zuke/helm";
+ *
+ * await HelmTasks.upgrade((s) =>
+ *   s.release("api").chart("./charts/api").install().namespace("prod")
+ *     .set("image.tag", "1.4").wait()
+ * );
+ * ```
+ *
+ * Every subcommand shares the cluster-targeting flags `--namespace`,
+ * `--kube-context`, and `--kubeconfig` (from the {@link HelmSettings} base).
+ * Arguments stay a discrete argv array end-to-end — never a concatenated shell
+ * string — so command construction is injection-free.
+ *
+ * @module
+ */
+
+import {
+  type Configure,
+  type PathLike,
+  runSettings,
+  ToolSettings,
+} from "@zuke/core/tooling";
+import type { CommandOutput } from "@zuke/core/shell";
+
+/**
+ * Base for all `helm` subcommand settings: the binary is `helm`, and the
+ * cluster-targeting flags (`--namespace`, `--kube-context`, `--kubeconfig`) are
+ * shared by every subcommand.
+ */
+abstract class HelmSettings extends ToolSettings {
+  #namespace?: string;
+  #kubeContext?: string;
+  #kubeconfig?: string;
+
+  protected override defaultTool(): string {
+    return "helm";
+  }
+
+  /** Target a namespace (`--namespace`). */
+  namespace(name: string): this {
+    this.#namespace = name;
+    return this;
+  }
+
+  /** Use a named kube context (`--kube-context`). */
+  kubeContext(name: string): this {
+    this.#kubeContext = name;
+    return this;
+  }
+
+  /** Use an explicit kubeconfig file (`--kubeconfig`). */
+  kubeconfig(path: PathLike): this {
+    this.#kubeconfig = String(path);
+    return this;
+  }
+
+  /** The cluster-targeting flags shared by every subcommand. */
+  protected globalArgs(): string[] {
+    const argv: string[] = [];
+    if (this.#namespace !== undefined) {
+      argv.push("--namespace", this.#namespace);
+    }
+    if (this.#kubeContext !== undefined) {
+      argv.push("--kube-context", this.#kubeContext);
+    }
+    if (this.#kubeconfig !== undefined) {
+      argv.push("--kubeconfig", this.#kubeconfig);
+    }
+    return argv;
+  }
+}
+
+/** Base for value-bearing commands (install/upgrade/template). */
+abstract class HelmValuesSettings extends HelmSettings {
+  #valueFiles: string[] = [];
+  #sets: Array<[string, string]> = [];
+  #version?: string;
+
+  /** Add a values file (`--values`/`-f`); repeatable. */
+  values(path: PathLike): this {
+    this.#valueFiles.push(String(path));
+    return this;
+  }
+
+  /** Override a single value (`--set name=value`); repeatable. */
+  set(name: string, value: string): this {
+    this.#sets.push([name, value]);
+    return this;
+  }
+
+  /** Pin the chart version (`--version`). */
+  version(value: string): this {
+    this.#version = value;
+    return this;
+  }
+
+  /** The shared value/version arguments. */
+  protected valueArgs(): string[] {
+    const argv: string[] = [];
+    for (const f of this.#valueFiles) argv.push("--values", f);
+    for (const [name, value] of this.#sets) {
+      argv.push("--set", `${name}=${value}`);
+    }
+    if (this.#version !== undefined) argv.push("--version", this.#version);
+    return argv;
+  }
+}
+
+/** Settings for `helm install`. */
+export class HelmInstallSettings extends HelmValuesSettings {
+  #release?: string;
+  #chart?: string;
+  #createNamespace = false;
+  #wait = false;
+  #atomic = false;
+  #timeout?: string;
+  #dryRun = false;
+
+  /** The release name (required). */
+  release(name: string): this {
+    this.#release = name;
+    return this;
+  }
+
+  /** The chart reference or path (required). */
+  chart(ref: string): this {
+    this.#chart = ref;
+    return this;
+  }
+
+  /** Create the release namespace if absent (`--create-namespace`). */
+  createNamespace(): this {
+    this.#createNamespace = true;
+    return this;
+  }
+
+  /** Wait until resources are ready (`--wait`). */
+  wait(): this {
+    this.#wait = true;
+    return this;
+  }
+
+  /** Roll back on failure (`--atomic`). */
+  atomic(): this {
+    this.#atomic = true;
+    return this;
+  }
+
+  /** Operation timeout, e.g. `5m` (`--timeout`). */
+  timeout(duration: string): this {
+    this.#timeout = duration;
+    return this;
+  }
+
+  /** Simulate the install (`--dry-run`). */
+  dryRun(): this {
+    this.#dryRun = true;
+    return this;
+  }
+
+  protected override buildArgs(): string[] {
+    if (this.#release === undefined || this.#chart === undefined) {
+      throw new Error(
+        "HelmTasks.install: .release() and .chart() are required.",
+      );
+    }
+    const argv = ["install", this.#release, this.#chart, ...this.globalArgs()];
+    argv.push(...this.valueArgs());
+    if (this.#createNamespace) argv.push("--create-namespace");
+    if (this.#wait) argv.push("--wait");
+    if (this.#atomic) argv.push("--atomic");
+    if (this.#timeout !== undefined) argv.push("--timeout", this.#timeout);
+    if (this.#dryRun) argv.push("--dry-run");
+    return argv;
+  }
+}
+
+/** Settings for `helm upgrade`. */
+export class HelmUpgradeSettings extends HelmValuesSettings {
+  #release?: string;
+  #chart?: string;
+  #install = false;
+  #createNamespace = false;
+  #wait = false;
+  #atomic = false;
+  #timeout?: string;
+
+  /** The release name (required). */
+  release(name: string): this {
+    this.#release = name;
+    return this;
+  }
+
+  /** The chart reference or path (required). */
+  chart(ref: string): this {
+    this.#chart = ref;
+    return this;
+  }
+
+  /** Install the release if it does not exist (`--install`). */
+  install(): this {
+    this.#install = true;
+    return this;
+  }
+
+  /** Create the release namespace if absent (`--create-namespace`). */
+  createNamespace(): this {
+    this.#createNamespace = true;
+    return this;
+  }
+
+  /** Wait until resources are ready (`--wait`). */
+  wait(): this {
+    this.#wait = true;
+    return this;
+  }
+
+  /** Roll back on failure (`--atomic`). */
+  atomic(): this {
+    this.#atomic = true;
+    return this;
+  }
+
+  /** Operation timeout, e.g. `5m` (`--timeout`). */
+  timeout(duration: string): this {
+    this.#timeout = duration;
+    return this;
+  }
+
+  protected override buildArgs(): string[] {
+    if (this.#release === undefined || this.#chart === undefined) {
+      throw new Error(
+        "HelmTasks.upgrade: .release() and .chart() are required.",
+      );
+    }
+    const argv = ["upgrade", this.#release, this.#chart, ...this.globalArgs()];
+    argv.push(...this.valueArgs());
+    if (this.#install) argv.push("--install");
+    if (this.#createNamespace) argv.push("--create-namespace");
+    if (this.#wait) argv.push("--wait");
+    if (this.#atomic) argv.push("--atomic");
+    if (this.#timeout !== undefined) argv.push("--timeout", this.#timeout);
+    return argv;
+  }
+}
+
+/** Settings for `helm uninstall`. */
+export class HelmUninstallSettings extends HelmSettings {
+  #release?: string;
+  #keepHistory = false;
+  #wait = false;
+
+  /** The release name to uninstall (required). */
+  release(name: string): this {
+    this.#release = name;
+    return this;
+  }
+
+  /** Retain release history (`--keep-history`). */
+  keepHistory(): this {
+    this.#keepHistory = true;
+    return this;
+  }
+
+  /** Wait until removal completes (`--wait`). */
+  wait(): this {
+    this.#wait = true;
+    return this;
+  }
+
+  protected override buildArgs(): string[] {
+    if (this.#release === undefined) {
+      throw new Error("HelmTasks.uninstall: .release() is required.");
+    }
+    const argv = ["uninstall", this.#release, ...this.globalArgs()];
+    if (this.#keepHistory) argv.push("--keep-history");
+    if (this.#wait) argv.push("--wait");
+    return argv;
+  }
+}
+
+/** Settings for `helm template` (render manifests locally). */
+export class HelmTemplateSettings extends HelmValuesSettings {
+  #release?: string;
+  #chart?: string;
+  #outputDir?: string;
+
+  /** The release name (required). */
+  release(name: string): this {
+    this.#release = name;
+    return this;
+  }
+
+  /** The chart reference or path (required). */
+  chart(ref: string): this {
+    this.#chart = ref;
+    return this;
+  }
+
+  /** Write rendered manifests to a directory (`--output-dir`). */
+  outputDir(path: PathLike): this {
+    this.#outputDir = String(path);
+    return this;
+  }
+
+  protected override buildArgs(): string[] {
+    if (this.#release === undefined || this.#chart === undefined) {
+      throw new Error(
+        "HelmTasks.template: .release() and .chart() are required.",
+      );
+    }
+    const argv = ["template", this.#release, this.#chart, ...this.globalArgs()];
+    argv.push(...this.valueArgs());
+    if (this.#outputDir !== undefined) {
+      argv.push("--output-dir", this.#outputDir);
+    }
+    return argv;
+  }
+}
+
+/** Settings for `helm lint`. */
+export class HelmLintSettings extends HelmSettings {
+  #chart?: string;
+  #valueFiles: string[] = [];
+  #strict = false;
+
+  /** The chart path to lint (required). */
+  chart(path: PathLike): this {
+    this.#chart = String(path);
+    return this;
+  }
+
+  /** Add a values file (`--values`); repeatable. */
+  values(path: PathLike): this {
+    this.#valueFiles.push(String(path));
+    return this;
+  }
+
+  /** Treat warnings as errors (`--strict`). */
+  strict(): this {
+    this.#strict = true;
+    return this;
+  }
+
+  protected override buildArgs(): string[] {
+    if (this.#chart === undefined) {
+      throw new Error("HelmTasks.lint: .chart() is required.");
+    }
+    const argv = ["lint", this.#chart, ...this.globalArgs()];
+    for (const f of this.#valueFiles) argv.push("--values", f);
+    if (this.#strict) argv.push("--strict");
+    return argv;
+  }
+}
+
+/** Settings for `helm dependency update`. */
+export class HelmDependencyUpdateSettings extends HelmSettings {
+  #chart?: string;
+
+  /** The chart path whose dependencies to update (required). */
+  chart(path: PathLike): this {
+    this.#chart = String(path);
+    return this;
+  }
+
+  protected override buildArgs(): string[] {
+    if (this.#chart === undefined) {
+      throw new Error("HelmTasks.dependencyUpdate: .chart() is required.");
+    }
+    return ["dependency", "update", this.#chart, ...this.globalArgs()];
+  }
+}
+
+/** Settings for `helm repo add`. */
+export class HelmRepoAddSettings extends HelmSettings {
+  #name?: string;
+  #url?: string;
+
+  /** The repository name (required). */
+  name(value: string): this {
+    this.#name = value;
+    return this;
+  }
+
+  /** The repository URL (required). */
+  url(value: string): this {
+    this.#url = value;
+    return this;
+  }
+
+  protected override buildArgs(): string[] {
+    if (this.#name === undefined || this.#url === undefined) {
+      throw new Error("HelmTasks.repoAdd: .name() and .url() are required.");
+    }
+    return ["repo", "add", this.#name, this.#url, ...this.globalArgs()];
+  }
+}
+
+/** Settings for `helm package`. */
+export class HelmPackageSettings extends HelmSettings {
+  #chart?: string;
+  #destination?: string;
+  #version?: string;
+  #appVersion?: string;
+
+  /** The chart path to package (required). */
+  chart(path: PathLike): this {
+    this.#chart = String(path);
+    return this;
+  }
+
+  /** Output directory for the packaged chart (`--destination`). */
+  destination(path: PathLike): this {
+    this.#destination = String(path);
+    return this;
+  }
+
+  /** Set the chart version (`--version`). */
+  version(value: string): this {
+    this.#version = value;
+    return this;
+  }
+
+  /** Set the chart appVersion (`--app-version`). */
+  appVersion(value: string): this {
+    this.#appVersion = value;
+    return this;
+  }
+
+  protected override buildArgs(): string[] {
+    if (this.#chart === undefined) {
+      throw new Error("HelmTasks.package: .chart() is required.");
+    }
+    const argv = ["package", this.#chart, ...this.globalArgs()];
+    if (this.#destination !== undefined) {
+      argv.push("--destination", this.#destination);
+    }
+    if (this.#version !== undefined) argv.push("--version", this.#version);
+    if (this.#appVersion !== undefined) {
+      argv.push("--app-version", this.#appVersion);
+    }
+    return argv;
+  }
+}
+
+/** The shape of {@link HelmTasks}. */
+export interface HelmTasksApi {
+  /** Install a chart: `helm install`. */
+  install(configure?: Configure<HelmInstallSettings>): Promise<CommandOutput>;
+  /** Upgrade (or install) a release: `helm upgrade`. */
+  upgrade(configure?: Configure<HelmUpgradeSettings>): Promise<CommandOutput>;
+  /** Uninstall a release: `helm uninstall`. */
+  uninstall(
+    configure?: Configure<HelmUninstallSettings>,
+  ): Promise<CommandOutput>;
+  /** Render manifests locally: `helm template`. */
+  template(configure?: Configure<HelmTemplateSettings>): Promise<CommandOutput>;
+  /** Lint a chart: `helm lint`. */
+  lint(configure?: Configure<HelmLintSettings>): Promise<CommandOutput>;
+  /** Update chart dependencies: `helm dependency update`. */
+  dependencyUpdate(
+    configure?: Configure<HelmDependencyUpdateSettings>,
+  ): Promise<CommandOutput>;
+  /** Add a chart repository: `helm repo add`. */
+  repoAdd(configure?: Configure<HelmRepoAddSettings>): Promise<CommandOutput>;
+  /** Package a chart: `helm package`. */
+  package(configure?: Configure<HelmPackageSettings>): Promise<CommandOutput>;
+}
+
+/** Typed task functions for the `helm` CLI. */
+export const HelmTasks: HelmTasksApi = {
+  install(configure?: Configure<HelmInstallSettings>): Promise<CommandOutput> {
+    return runSettings(new HelmInstallSettings(), configure);
+  },
+  upgrade(configure?: Configure<HelmUpgradeSettings>): Promise<CommandOutput> {
+    return runSettings(new HelmUpgradeSettings(), configure);
+  },
+  uninstall(
+    configure?: Configure<HelmUninstallSettings>,
+  ): Promise<CommandOutput> {
+    return runSettings(new HelmUninstallSettings(), configure);
+  },
+  template(
+    configure?: Configure<HelmTemplateSettings>,
+  ): Promise<CommandOutput> {
+    return runSettings(new HelmTemplateSettings(), configure);
+  },
+  lint(configure?: Configure<HelmLintSettings>): Promise<CommandOutput> {
+    return runSettings(new HelmLintSettings(), configure);
+  },
+  dependencyUpdate(
+    configure?: Configure<HelmDependencyUpdateSettings>,
+  ): Promise<CommandOutput> {
+    return runSettings(new HelmDependencyUpdateSettings(), configure);
+  },
+  repoAdd(configure?: Configure<HelmRepoAddSettings>): Promise<CommandOutput> {
+    return runSettings(new HelmRepoAddSettings(), configure);
+  },
+  package(configure?: Configure<HelmPackageSettings>): Promise<CommandOutput> {
+    return runSettings(new HelmPackageSettings(), configure);
+  },
+};

--- a/packages/helm/tests/helm_test.ts
+++ b/packages/helm/tests/helm_test.ts
@@ -1,0 +1,249 @@
+import {
+  assertEquals,
+  assertRejects,
+  assertThrows,
+} from "../../core/tests/_assert.ts";
+import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import {
+  HelmDependencyUpdateSettings,
+  HelmInstallSettings,
+  HelmLintSettings,
+  HelmPackageSettings,
+  HelmRepoAddSettings,
+  HelmTasks,
+  HelmTemplateSettings,
+  HelmUninstallSettings,
+  HelmUpgradeSettings,
+} from "../src/helm.ts";
+
+Deno.test("the default binary is helm", () => {
+  assertEquals(new HelmUninstallSettings().release("api").argv()[0], "helm");
+});
+
+Deno.test("install: requires release+chart; values, set, version, global, flags", () => {
+  assertThrows(
+    () => new HelmInstallSettings().release("api").argv(),
+    Error,
+    "HelmTasks.install: .release() and .chart() are required",
+  );
+  assertEquals(
+    new HelmInstallSettings()
+      .release("api")
+      .chart("./charts/api")
+      .namespace("prod")
+      .kubeContext("staging")
+      .kubeconfig("~/.kube/config")
+      .values("values.yaml")
+      .set("image.tag", "1.4")
+      .version("2.0.0")
+      .createNamespace()
+      .wait()
+      .atomic()
+      .timeout("5m")
+      .dryRun()
+      .argv()
+      .slice(1),
+    [
+      "install",
+      "api",
+      "./charts/api",
+      "--namespace",
+      "prod",
+      "--kube-context",
+      "staging",
+      "--kubeconfig",
+      "~/.kube/config",
+      "--values",
+      "values.yaml",
+      "--set",
+      "image.tag=1.4",
+      "--version",
+      "2.0.0",
+      "--create-namespace",
+      "--wait",
+      "--atomic",
+      "--timeout",
+      "5m",
+      "--dry-run",
+    ],
+  );
+});
+
+Deno.test("upgrade: requires release+chart; --install and flags", () => {
+  assertThrows(
+    () => new HelmUpgradeSettings().chart("c").argv(),
+    Error,
+    "HelmTasks.upgrade: .release() and .chart() are required",
+  );
+  assertEquals(
+    new HelmUpgradeSettings()
+      .release("api")
+      .chart("./charts/api")
+      .install()
+      .createNamespace()
+      .wait()
+      .atomic()
+      .timeout("3m")
+      .set("replicas", "2")
+      .argv()
+      .slice(1),
+    [
+      "upgrade",
+      "api",
+      "./charts/api",
+      "--set",
+      "replicas=2",
+      "--install",
+      "--create-namespace",
+      "--wait",
+      "--atomic",
+      "--timeout",
+      "3m",
+    ],
+  );
+});
+
+Deno.test("uninstall: requires release; --keep-history, --wait", () => {
+  assertThrows(
+    () => new HelmUninstallSettings().argv(),
+    Error,
+    "HelmTasks.uninstall: .release() is required",
+  );
+  assertEquals(
+    new HelmUninstallSettings().release("api").keepHistory().wait().argv()
+      .slice(1),
+    ["uninstall", "api", "--keep-history", "--wait"],
+  );
+});
+
+Deno.test("template: requires release+chart; --output-dir", () => {
+  assertThrows(
+    () => new HelmTemplateSettings().release("api").argv(),
+    Error,
+    "HelmTasks.template: .release() and .chart() are required",
+  );
+  assertEquals(
+    new HelmTemplateSettings()
+      .release("api")
+      .chart("./charts/api")
+      .values("values.yaml")
+      .outputDir("out")
+      .argv()
+      .slice(1),
+    [
+      "template",
+      "api",
+      "./charts/api",
+      "--values",
+      "values.yaml",
+      "--output-dir",
+      "out",
+    ],
+  );
+});
+
+Deno.test("lint: requires chart; values and --strict", () => {
+  assertThrows(
+    () => new HelmLintSettings().argv(),
+    Error,
+    "HelmTasks.lint: .chart() is required",
+  );
+  assertEquals(
+    new HelmLintSettings().chart("./charts/api").values("v.yaml").strict()
+      .argv()
+      .slice(1),
+    ["lint", "./charts/api", "--values", "v.yaml", "--strict"],
+  );
+});
+
+Deno.test("dependencyUpdate: requires chart", () => {
+  assertThrows(
+    () => new HelmDependencyUpdateSettings().argv(),
+    Error,
+    "HelmTasks.dependencyUpdate: .chart() is required",
+  );
+  assertEquals(
+    new HelmDependencyUpdateSettings().chart("./charts/api").argv().slice(1),
+    ["dependency", "update", "./charts/api"],
+  );
+});
+
+Deno.test("repoAdd: requires name and url", () => {
+  assertThrows(
+    () => new HelmRepoAddSettings().name("charts").argv(),
+    Error,
+    "HelmTasks.repoAdd: .name() and .url() are required",
+  );
+  assertEquals(
+    new HelmRepoAddSettings().name("charts").url("https://example.com/charts")
+      .argv().slice(1),
+    ["repo", "add", "charts", "https://example.com/charts"],
+  );
+});
+
+Deno.test("package: requires chart; destination, version, app-version", () => {
+  assertThrows(
+    () => new HelmPackageSettings().argv(),
+    Error,
+    "HelmTasks.package: .chart() is required",
+  );
+  assertEquals(
+    new HelmPackageSettings()
+      .chart("./charts/api")
+      .destination("dist")
+      .version("1.2.0")
+      .appVersion("1.4")
+      .argv()
+      .slice(1),
+    [
+      "package",
+      "./charts/api",
+      "--destination",
+      "dist",
+      "--version",
+      "1.2.0",
+      "--app-version",
+      "1.4",
+    ],
+  );
+});
+
+const missing = <S extends ToolSettings>(s: S): S => {
+  s.os_ = "linux";
+  return s.toolPath("zuke-no-such-helm-xyz");
+};
+
+Deno.test("every HelmTasks function reaches execution", async () => {
+  await assertRejects(
+    () => HelmTasks.install((s) => missing(s).release("a").chart("c")),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => HelmTasks.upgrade((s) => missing(s).release("a").chart("c")),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => HelmTasks.uninstall((s) => missing(s).release("a")),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => HelmTasks.template((s) => missing(s).release("a").chart("c")),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => HelmTasks.lint((s) => missing(s).chart("c")),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => HelmTasks.dependencyUpdate((s) => missing(s).chart("c")),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => HelmTasks.repoAdd((s) => missing(s).name("n").url("u")),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => HelmTasks.package((s) => missing(s).chart("c")),
+    ToolNotFoundError,
+  );
+});

--- a/packages/kustomize/README.md
+++ b/packages/kustomize/README.md
@@ -1,0 +1,12 @@
+# @zuke/kustomize
+
+Typed [Kustomize](https://kustomize.io) CLI task wrappers for
+[Zuke](https://github.com/zuke-build/zuke#readme) builds — `build` and
+`editSetImage`.
+
+```ts
+import { KustomizeTasks } from "jsr:@zuke/kustomize";
+
+await KustomizeTasks.build((s) => s.dir("overlays/prod").output("out.yaml"));
+await KustomizeTasks.editSetImage((s) => s.image("api", "api:1.4"));
+```

--- a/packages/kustomize/deno.json
+++ b/packages/kustomize/deno.json
@@ -1,0 +1,16 @@
+{
+  "name": "@zuke/kustomize",
+  "version": "0.0.0",
+  "description": "Typed Kustomize CLI task wrappers for Zuke builds — build and edit set image via an injection-free settings-lambda API.",
+  "exports": {
+    ".": "./mod.ts"
+  },
+  "imports": {
+    "@zuke/core": "jsr:@zuke/core@^0"
+  },
+  "publish": {
+    "exclude": [
+      "tests/"
+    ]
+  }
+}

--- a/packages/kustomize/mod.ts
+++ b/packages/kustomize/mod.ts
@@ -1,0 +1,20 @@
+/**
+ * `@zuke/kustomize` — typed `KustomizeTasks` wrappers for the
+ * [Kustomize](https://kustomize.io) CLI, for use in Zuke builds.
+ *
+ * ```ts
+ * import { KustomizeTasks } from "jsr:@zuke/kustomize";
+ *
+ * await KustomizeTasks.build((s) => s.dir("overlays/prod"));
+ * await KustomizeTasks.editSetImage((s) => s.image("api", "api:1.4"));
+ * ```
+ *
+ * @module
+ */
+
+export {
+  KustomizeBuildSettings,
+  KustomizeEditSetImageSettings,
+  KustomizeTasks,
+  type KustomizeTasksApi,
+} from "./src/kustomize.ts";

--- a/packages/kustomize/src/kustomize.ts
+++ b/packages/kustomize/src/kustomize.ts
@@ -1,0 +1,120 @@
+/**
+ * `KustomizeTasks` — typed task functions for the
+ * [Kustomize](https://kustomize.io) CLI, in the settings-lambda style:
+ * configure a fluent settings object in a lambda, and the task function builds
+ * the command line and executes it.
+ *
+ * ```ts
+ * import { KustomizeTasks } from "jsr:@zuke/kustomize";
+ * await KustomizeTasks.build((s) => s.dir("overlays/prod").output("out.yaml"));
+ * await KustomizeTasks.editSetImage((s) => s.image("api", "api:1.4"));
+ * ```
+ *
+ * Arguments stay a discrete argv array end-to-end — never a concatenated shell
+ * string — so command construction is injection-free.
+ *
+ * @module
+ */
+
+import {
+  type Configure,
+  type PathLike,
+  runSettings,
+  ToolSettings,
+} from "@zuke/core/tooling";
+import type { CommandOutput } from "@zuke/core/shell";
+
+/** Base for all `kustomize` subcommand settings: the binary is `kustomize`. */
+abstract class KustomizeSettings extends ToolSettings {
+  protected override defaultTool(): string {
+    return "kustomize";
+  }
+}
+
+/** Settings for `kustomize build`. */
+export class KustomizeBuildSettings extends KustomizeSettings {
+  #dir?: string;
+  #output?: string;
+  #enableHelm = false;
+  #loadRestrictor?: string;
+
+  /** The kustomization directory to build (defaults to the current directory). */
+  dir(path: PathLike): this {
+    this.#dir = String(path);
+    return this;
+  }
+
+  /** Write the rendered output to a file or directory (`--output`). */
+  output(path: PathLike): this {
+    this.#output = String(path);
+    return this;
+  }
+
+  /** Enable the Helm chart inflator (`--enable-helm`). */
+  enableHelm(): this {
+    this.#enableHelm = true;
+    return this;
+  }
+
+  /** Set the file-load restrictor, e.g. `LoadRestrictionsNone` (`--load-restrictor`). */
+  loadRestrictor(mode: string): this {
+    this.#loadRestrictor = mode;
+    return this;
+  }
+
+  protected override buildArgs(): string[] {
+    const argv = ["build"];
+    if (this.#dir !== undefined) argv.push(this.#dir);
+    if (this.#output !== undefined) argv.push("--output", this.#output);
+    if (this.#enableHelm) argv.push("--enable-helm");
+    if (this.#loadRestrictor !== undefined) {
+      argv.push("--load-restrictor", this.#loadRestrictor);
+    }
+    return argv;
+  }
+}
+
+/** Settings for `kustomize edit set image`. */
+export class KustomizeEditSetImageSettings extends KustomizeSettings {
+  #images: string[] = [];
+
+  /**
+   * Set an image override, e.g. `("api", "api:1.4")` → `api=api:1.4`; repeatable,
+   * at least one is required.
+   */
+  image(name: string, reference: string): this {
+    this.#images.push(`${name}=${reference}`);
+    return this;
+  }
+
+  protected override buildArgs(): string[] {
+    if (this.#images.length === 0) {
+      throw new Error(
+        "KustomizeTasks.editSetImage: at least one .image() is required.",
+      );
+    }
+    return ["edit", "set", "image", ...this.#images];
+  }
+}
+
+/** The shape of {@link KustomizeTasks}. */
+export interface KustomizeTasksApi {
+  /** Render a kustomization: `kustomize build`. */
+  build(configure?: Configure<KustomizeBuildSettings>): Promise<CommandOutput>;
+  /** Update image overrides: `kustomize edit set image`. */
+  editSetImage(
+    configure?: Configure<KustomizeEditSetImageSettings>,
+  ): Promise<CommandOutput>;
+}
+
+/** Typed task functions for the `kustomize` CLI. */
+export const KustomizeTasks: KustomizeTasksApi = {
+  build(configure?: Configure<KustomizeBuildSettings>): Promise<CommandOutput> {
+    return runSettings(new KustomizeBuildSettings(), configure);
+  },
+  editSetImage(
+    configure?: Configure<KustomizeEditSetImageSettings>,
+  ): Promise<CommandOutput> {
+    return runSettings(new KustomizeEditSetImageSettings(), configure);
+  },
+};

--- a/packages/kustomize/tests/kustomize_test.ts
+++ b/packages/kustomize/tests/kustomize_test.ts
@@ -1,0 +1,66 @@
+import {
+  assertEquals,
+  assertRejects,
+  assertThrows,
+} from "../../core/tests/_assert.ts";
+import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import {
+  KustomizeBuildSettings,
+  KustomizeEditSetImageSettings,
+  KustomizeTasks,
+} from "../src/kustomize.ts";
+
+Deno.test("the default binary is kustomize", () => {
+  assertEquals(new KustomizeBuildSettings().argv()[0], "kustomize");
+});
+
+Deno.test("build: bare and all options", () => {
+  assertEquals(new KustomizeBuildSettings().argv().slice(1), ["build"]);
+  assertEquals(
+    new KustomizeBuildSettings()
+      .dir("overlays/prod")
+      .output("out.yaml")
+      .enableHelm()
+      .loadRestrictor("LoadRestrictionsNone")
+      .argv()
+      .slice(1),
+    [
+      "build",
+      "overlays/prod",
+      "--output",
+      "out.yaml",
+      "--enable-helm",
+      "--load-restrictor",
+      "LoadRestrictionsNone",
+    ],
+  );
+});
+
+Deno.test("editSetImage: requires an image; renders name=ref pairs", () => {
+  assertThrows(
+    () => new KustomizeEditSetImageSettings().argv(),
+    Error,
+    "KustomizeTasks.editSetImage: at least one .image() is required",
+  );
+  assertEquals(
+    new KustomizeEditSetImageSettings()
+      .image("api", "api:1.4")
+      .image("web", "web:2")
+      .argv()
+      .slice(1),
+    ["edit", "set", "image", "api=api:1.4", "web=web:2"],
+  );
+});
+
+const missing = <S extends ToolSettings>(s: S): S => {
+  s.os_ = "linux";
+  return s.toolPath("zuke-no-such-kustomize-xyz");
+};
+
+Deno.test("every KustomizeTasks function reaches execution", async () => {
+  await assertRejects(() => KustomizeTasks.build(missing), ToolNotFoundError);
+  await assertRejects(
+    () => KustomizeTasks.editSetImage((s) => missing(s).image("api", "api:1")),
+    ToolNotFoundError,
+  );
+});

--- a/tests/release_config_test.ts
+++ b/tests/release_config_test.ts
@@ -12,6 +12,8 @@ const PACKAGES = [
   "packages/docker",
   "packages/docker-compose",
   "packages/kubectl",
+  "packages/helm",
+  "packages/kustomize",
   "packages/oxlint",
   "packages/eslint",
   "packages/cspell",

--- a/zuke.ts
+++ b/zuke.ts
@@ -30,6 +30,8 @@ const PACKAGES = [
   "docker",
   "docker-compose",
   "kubectl",
+  "helm",
+  "kustomize",
   "oxlint",
   "eslint",
   "cspell",


### PR DESCRIPTION
## Summary

Kubernetes-packaging wrappers — the companions to `@zuke/kubectl`.

| Package | `Tasks` | Commands |
| --- | --- | --- |
| `@zuke/helm` | `HelmTasks` | `install`, `upgrade`, `uninstall`, `template`, `lint`, `dependencyUpdate`, `repoAdd`, `package` |
| `@zuke/kustomize` | `KustomizeTasks` | `build`, `editSetImage` |

```ts
import { HelmTasks } from "jsr:@zuke/helm";
import { KustomizeTasks } from "jsr:@zuke/kustomize";

await HelmTasks.upgrade((s) =>
  s.release("api").chart("./charts/api").install().namespace("prod")
    .set("image.tag", "1.4").wait()
);
await KustomizeTasks.build((s) => s.dir("overlays/prod"));
```

## Notes

- **helm** shares cluster-targeting flags (`--namespace`/`--kube-context`/`--kubeconfig`) on every command via a base, and `--values`/`--set`/`--version` across the value-bearing commands (install/upgrade/template). Required inputs (release+chart, etc.) fail fast.
- **kustomize** focuses on `build` (`--output`/`--enable-helm`/`--load-restrictor`) and the common CD idiom `edit set image`.
- Pure `buildArgs()`; every task covered incl. the missing-binary path.

## Stacking

> 📚 **Stacked on [#70](https://github.com/zuke-build/zuke/pull/70)** → #69 → #68 → [#67](https://github.com/zuke-build/zuke/pull/67). This is the **last of the tool-wrapper batch**; the core features (compression/http/assertions/git-info/tool-install/custom-tool/CI-gen/plugin) come next. Merge the chain in order.

## Checks

`deno task ci` green — both packages 100% line/branch coverage; overall 96.5% lines / 98.6% branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtqHmRRvtT6qkQKaPzrWhT)_