### PR TITLE
feat(core): add assertion and control-flow helpers

### DIFF
--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -200,6 +200,23 @@ honouring `--skip` and `onlyWhen` conditions — without executing any body or
 touching the [cache](#incremental-caching-inputs--outputs). Use it to preview a
 plan before committing to it.
 
+### Assertions — `assert()` / `assertExists()` / `fail()`
+
+Fail a target fast with a clear message when an expectation does not hold.
+`assert(condition, message?)` throws when the condition is falsy;
+`assertExists(value, message?)` throws on `null`/`undefined` and returns the
+value narrowed to its non-nullable type; `fail(message)` always throws. The
+async `assertFileExists(path)` / `assertDirectoryExists(path)` check the
+filesystem. All throw an `AssertionError`.
+
+```ts
+import { assert, assertExists, assertFileExists } from "jsr:@zuke/core";
+
+const token = assertExists(Deno.env.get("TOKEN"), "TOKEN is required");
+assert(this.environment.value !== "", "environment must be set");
+await assertFileExists("dist/app.js");
+```
+
 ### Host detection — `isCI()` / `ciHost()`
 
 `isCI()` and `ciHost()` (e.g. `"github-actions"`, `"gitlab-ci"`, `"local"`) let

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -62,3 +62,11 @@ export {
   validateGraph,
 } from "./src/graph.ts";
 export { glob, type GlobOptions, globToRegExp } from "./src/glob.ts";
+export {
+  assert,
+  assertDirectoryExists,
+  assertExists,
+  assertFileExists,
+  AssertionError,
+  fail,
+} from "./src/assert.ts";

--- a/packages/core/src/assert.ts
+++ b/packages/core/src/assert.ts
@@ -1,0 +1,86 @@
+/**
+ * Assertions and control-flow helpers for build scripts — fail fast with a
+ * clear message when an expectation does not hold.
+ *
+ * ```ts
+ * import { assert, assertExists, fail } from "jsr:@zuke/core";
+ *
+ * assert(version !== "", "version must not be empty");
+ * const token = assertExists(Deno.env.get("TOKEN"), "TOKEN is required");
+ * if (broken) fail("refusing to deploy a broken build");
+ * ```
+ *
+ * The filesystem checks ({@link assertFileExists}, {@link assertDirectoryExists})
+ * are async; the rest are synchronous and narrow types where possible.
+ *
+ * @module
+ */
+
+import type { PathLike } from "./path.ts";
+
+/** Raised by the assertion helpers when an expectation fails. */
+export class AssertionError extends Error {
+  override name = "AssertionError";
+}
+
+/** Throw an {@link AssertionError} with `message`. Never returns. */
+export function fail(message: string): never {
+  throw new AssertionError(message);
+}
+
+/**
+ * Assert that `condition` is truthy, narrowing it for the rest of the scope.
+ * Throws an {@link AssertionError} with `message` otherwise.
+ */
+export function assert(
+  condition: unknown,
+  message = "Assertion failed",
+): asserts condition {
+  if (!condition) fail(message);
+}
+
+/**
+ * Assert that `value` is neither `null` nor `undefined`, returning it narrowed
+ * to its non-nullable type so it can be used inline.
+ *
+ * ```ts
+ * const token = assertExists(Deno.env.get("TOKEN"), "TOKEN is required");
+ * ```
+ */
+export function assertExists<T>(
+  value: T,
+  message = "Expected a value to be present",
+): NonNullable<T> {
+  if (value === null || value === undefined) fail(message);
+  return value;
+}
+
+/** Assert that `path` exists and is a file. Async (stats the filesystem). */
+export async function assertFileExists(path: PathLike): Promise<void> {
+  const target = String(path);
+  let isFile = false;
+  try {
+    isFile = (await Deno.stat(target)).isFile;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      fail(`Expected file to exist: ${target}`);
+    }
+    throw error;
+  }
+  if (!isFile) fail(`Expected a file (not a directory): ${target}`);
+}
+
+/** Assert that `path` exists and is a directory. Async (stats the filesystem). */
+export async function assertDirectoryExists(path: PathLike): Promise<void> {
+  const target = String(path);
+  let isDirectory = false;
+  try {
+    isDirectory = (await Deno.stat(target)).isDirectory;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      fail(`Expected directory to exist: ${target}`);
+    }
+    throw error;
+  }
+  if (!isDirectory) fail(`Expected a directory (not a file): ${target}`);
+}

--- a/packages/core/tests/assert_test.ts
+++ b/packages/core/tests/assert_test.ts
@@ -1,0 +1,82 @@
+import { assertEquals, assertRejects, assertThrows } from "./_assert.ts";
+import {
+  assert,
+  assertDirectoryExists,
+  assertExists,
+  assertFileExists,
+  AssertionError,
+  fail,
+} from "../src/assert.ts";
+
+Deno.test("fail always throws an AssertionError with the message", () => {
+  assertThrows(() => fail("nope"), AssertionError, "nope");
+});
+
+Deno.test("assert passes on truthy, throws on falsy", () => {
+  assert(1 === 1); // no throw
+  assert("x", "should pass");
+  assertThrows(() => assert(false, "bad"), AssertionError, "bad");
+  // Default message when none supplied.
+  assertThrows(() => assert(0), AssertionError, "Assertion failed");
+});
+
+Deno.test("assertExists returns the value and narrows it", () => {
+  assertEquals(assertExists("hello"), "hello");
+  assertEquals(assertExists(0), 0); // 0 is present, not nullish
+  assertEquals(assertExists(false), false);
+  assertThrows(
+    () => assertExists(null, "missing"),
+    AssertionError,
+    "missing",
+  );
+  assertThrows(() => assertExists(undefined), AssertionError, "present");
+});
+
+Deno.test("assertFileExists: passes for a file, fails for missing or a dir", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const file = `${dir}/a.txt`;
+    await Deno.writeTextFile(file, "hi");
+    await assertFileExists(file); // no throw
+    await assertRejects(
+      () => assertFileExists(`${dir}/missing.txt`),
+      AssertionError,
+      "Expected file to exist",
+    );
+    await assertRejects(
+      () => assertFileExists(dir),
+      AssertionError,
+      "Expected a file",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("filesystem asserts rethrow non-NotFound stat errors", async () => {
+  // A NUL byte makes Deno.stat reject with a TypeError, not NotFound, which
+  // must propagate rather than be reported as a missing path.
+  await assertRejects(() => assertFileExists("bad\0path"), TypeError);
+  await assertRejects(() => assertDirectoryExists("bad\0path"), TypeError);
+});
+
+Deno.test("assertDirectoryExists: passes for a dir, fails for missing or a file", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    await assertDirectoryExists(dir); // no throw
+    const file = `${dir}/a.txt`;
+    await Deno.writeTextFile(file, "hi");
+    await assertRejects(
+      () => assertDirectoryExists(`${dir}/missing`),
+      AssertionError,
+      "Expected directory to exist",
+    );
+    await assertRejects(
+      () => assertDirectoryExists(file),
+      AssertionError,
+      "Expected a directory",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary

First of the core features — NUKE/Fallout-style **assertions / control-flow** in `@zuke/core`, for failing a target fast with a clear message.

```ts
import { assert, assertExists, assertFileExists, fail } from "jsr:@zuke/core";

const token = assertExists(Deno.env.get("TOKEN"), "TOKEN is required"); // narrows to string
assert(this.environment.value !== "", "environment must be set");
await assertFileExists("dist/app.js");
if (broken) fail("refusing to deploy a broken build");
```

## API

- `assert(condition, message?)` — `asserts condition`; throws on falsy.
- `assertExists(value, message?)` — returns `NonNullable<T>`; throws on `null`/`undefined`.
- `fail(message)` — `never`.
- `assertFileExists(path)` / `assertDirectoryExists(path)` — async filesystem checks.
- `AssertionError` — the thrown type.

All exported from `mod.ts`, documented in `docs/authoring.md`.

## Stacking

> 📚 **Stacked on [#71](https://github.com/zuke-build/zuke/pull/71)** (the tail of the tool-wrapper chain). This kicks off the **core-feature** PRs: assertions → http → compression → git-info → tool-install → defineTool → CI-gen → plugin contract.

## Checks

`deno task ci` green — `assert.ts` at 100% line/branch (incl. the non-NotFound stat rethrow paths); overall 96.5% lines / 98.6% branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtqHmRRvtT6qkQKaPzrWhT)_