### PR TITLE
feat(core): add HTTP download/text/json helpers

### DIFF
--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -217,6 +217,23 @@ assert(this.environment.value !== "", "environment must be set");
 await assertFileExists("dist/app.js");
 ```
 
+### HTTP — `httpDownload()` / `httpText()` / `httpJson()`
+
+Fetch over HTTP from a build script, built on the platform `fetch`.
+`httpDownload(url, dest)` streams a URL to a file; `httpText(url)` and
+`httpJson(url)` return the body. All accept `{ headers, fetch }` (the `fetch`
+seam makes them unit-testable) and throw an `HttpError` (carrying `.status`) on
+a non-2xx response.
+
+```ts
+import { httpDownload, httpJson } from "jsr:@zuke/core";
+
+await httpDownload("https://example.com/tool.tar.gz", ".zuke/tool.tar.gz");
+const release = await httpJson<{ tag_name: string }>(
+  "https://api.github.com/repos/zuke-build/zuke/releases/latest",
+);
+```
+
 ### Host detection — `isCI()` / `ciHost()`
 
 `isCI()` and `ciHost()` (e.g. `"github-actions"`, `"gitlab-ci"`, `"local"`) let

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -70,3 +70,10 @@ export {
   AssertionError,
   fail,
 } from "./src/assert.ts";
+export {
+  httpDownload,
+  HttpError,
+  httpJson,
+  type HttpOptions,
+  httpText,
+} from "./src/http.ts";

--- a/packages/core/src/http.ts
+++ b/packages/core/src/http.ts
@@ -1,0 +1,96 @@
+/**
+ * HTTP helpers for build scripts: download a URL to a file, or fetch its body
+ * as text or JSON. Built on the platform `fetch`, with an injectable `fetch`
+ * seam so they can be unit-tested without network access.
+ *
+ * ```ts
+ * import { httpDownload, httpJson } from "jsr:@zuke/core";
+ *
+ * await httpDownload("https://example.com/tool.tar.gz", ".zuke/tool.tar.gz");
+ * const release = await httpJson<{ tag_name: string }>(
+ *   "https://api.github.com/repos/zuke-build/zuke/releases/latest",
+ * );
+ * ```
+ *
+ * A non-2xx response throws an {@link HttpError} carrying the status.
+ *
+ * @module
+ */
+
+import type { PathLike } from "./path.ts";
+
+/** Raised when an HTTP request returns a non-2xx status. */
+export class HttpError extends Error {
+  override name = "HttpError";
+  constructor(
+    /** The HTTP status code of the failing response. */
+    readonly status: number,
+    /** The requested URL. */
+    readonly url: string,
+  ) {
+    super(`HTTP ${status} for ${url}`);
+  }
+}
+
+/** Options shared by the HTTP helpers. */
+export interface HttpOptions {
+  /** Extra request headers (e.g. an `Authorization` token). */
+  headers?: Record<string, string>;
+  /**
+   * The `fetch` implementation to use. Defaults to the global `fetch`;
+   * override it to unit-test without network access.
+   */
+  fetch?: typeof fetch;
+}
+
+/** Perform the request and return the response, throwing on a non-2xx status. */
+async function request(url: string, options: HttpOptions): Promise<Response> {
+  const doFetch = options.fetch ?? fetch;
+  const response = await doFetch(url, { headers: options.headers });
+  if (!response.ok) {
+    // Drain the body so the connection can be reused/closed.
+    await response.body?.cancel();
+    throw new HttpError(response.status, url);
+  }
+  return response;
+}
+
+/**
+ * Download `url` to `dest`, streaming the response body to the file. Creates or
+ * truncates `dest`. Throws {@link HttpError} on a non-2xx status.
+ */
+export async function httpDownload(
+  url: string,
+  dest: PathLike,
+  options: HttpOptions = {},
+): Promise<void> {
+  const response = await request(url, options);
+  const file = await Deno.open(String(dest), {
+    write: true,
+    create: true,
+    truncate: true,
+  });
+  if (response.body === null) {
+    file.close();
+    return;
+  }
+  await response.body.pipeTo(file.writable); // closes the file when done
+}
+
+/** Fetch `url` and return its body as text. Throws {@link HttpError} on non-2xx. */
+export async function httpText(
+  url: string,
+  options: HttpOptions = {},
+): Promise<string> {
+  const response = await request(url, options);
+  return await response.text();
+}
+
+/** Fetch `url` and parse its body as JSON. Throws {@link HttpError} on non-2xx. */
+export async function httpJson<T = unknown>(
+  url: string,
+  options: HttpOptions = {},
+): Promise<T> {
+  const response = await request(url, options);
+  return await response.json() as T;
+}

--- a/packages/core/tests/http_test.ts
+++ b/packages/core/tests/http_test.ts
@@ -1,0 +1,96 @@
+import { assertEquals, assertRejects } from "./_assert.ts";
+import {
+  httpDownload,
+  HttpError,
+  httpJson,
+  type HttpOptions,
+  httpText,
+} from "../src/http.ts";
+
+/** A fake `fetch` returning `body` with `status`, recording the call. */
+function fakeFetch(
+  body: string,
+  status = 200,
+): { fetch: typeof fetch; calls: Array<{ url: string; init?: RequestInit }> } {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const impl = ((input: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(input), init });
+    return Promise.resolve(new Response(body, { status }));
+  }) as typeof fetch;
+  return { fetch: impl, calls };
+}
+
+Deno.test("httpText returns the body and forwards headers", async () => {
+  const { fetch, calls } = fakeFetch("hello");
+  const options: HttpOptions = {
+    fetch,
+    headers: { Authorization: "Bearer x" },
+  };
+  assertEquals(await httpText("https://example.com/a", options), "hello");
+  assertEquals(calls[0].url, "https://example.com/a");
+  assertEquals(calls[0].init?.headers, { Authorization: "Bearer x" });
+});
+
+Deno.test("httpJson parses the body", async () => {
+  const { fetch } = fakeFetch('{"tag":"v1.2.3"}');
+  const data = await httpJson<{ tag: string }>("https://example.com/r", {
+    fetch,
+  });
+  assertEquals(data.tag, "v1.2.3");
+});
+
+Deno.test("a non-2xx status throws HttpError carrying the status", async () => {
+  const { fetch } = fakeFetch("nope", 404);
+  const error = await assertRejects(
+    () => httpText("https://example.com/missing", { fetch }),
+    HttpError,
+    "HTTP 404",
+  );
+  if (error instanceof HttpError) {
+    assertEquals(error.status, 404);
+    assertEquals(error.url, "https://example.com/missing");
+  }
+});
+
+Deno.test("httpDownload streams the body to a file", async () => {
+  const { fetch } = fakeFetch("file-contents");
+  const dir = await Deno.makeTempDir();
+  try {
+    const dest = `${dir}/out.txt`;
+    await httpDownload("https://example.com/f", dest, { fetch });
+    assertEquals(await Deno.readTextFile(dest), "file-contents");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("httpDownload of a non-2xx status throws before writing", async () => {
+  const { fetch } = fakeFetch("err", 500);
+  const dir = await Deno.makeTempDir();
+  try {
+    const dest = `${dir}/out.txt`;
+    await assertRejects(
+      () => httpDownload("https://example.com/f", dest, { fetch }),
+      HttpError,
+      "HTTP 500",
+    );
+    assertEquals(await Deno.stat(dest).catch(() => null), null); // not created
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("httpDownload handles an empty (null) body", async () => {
+  // A 204 response has a null body; the file is created but empty.
+  const impl =
+    (() =>
+      Promise.resolve(new Response(null, { status: 200 }))) as typeof fetch;
+  const dir = await Deno.makeTempDir();
+  try {
+    const dest = `${dir}/empty.bin`;
+    await httpDownload("https://example.com/empty", dest, { fetch: impl });
+    assertEquals((await Deno.stat(dest)).size, 0);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary

Second core feature — fetch-based **HTTP helpers** in `@zuke/core`, for build scripts (download a tool, read a release manifest, etc.).

```ts
import { httpDownload, httpJson, httpText } from "jsr:@zuke/core";

await httpDownload("https://example.com/tool.tar.gz", ".zuke/tool.tar.gz");
const release = await httpJson<{ tag_name: string }>(
  "https://api.github.com/repos/zuke-build/zuke/releases/latest",
);
```

## API

- `httpDownload(url, dest, opts?)` — streams the response body to a file.
- `httpText(url, opts?)` / `httpJson<T>(url, opts?)` — body as text / parsed JSON.
- `HttpError` (carries `.status`, `.url`) — thrown on a non-2xx response.
- `HttpOptions { headers, fetch }` — the **`fetch` seam** keeps these hermetically testable (tests inject a fake `fetch`; no network).

Exported from `mod.ts`, documented in `docs/authoring.md`.

## Stacking

> 📚 **Stacked on [#72](https://github.com/zuke-build/zuke/pull/72)** (assertions) — base `claude/gracious-lovelace-5hsv7w-6`. Tail of the chain: #70 → #71 → #72 → **#this**. (I've already rebuilt #70–#72 onto current `master` after #68/#69 merged.)

## Checks

`deno task ci` green — `http.ts` 100% branch coverage (the one uncovered line is the `?? fetch` real-network fallback, which can't be exercised hermetically); overall 96.5% lines / 98.6% branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtqHmRRvtT6qkQKaPzrWhT)_