### PR TITLE
fix(core): only write the GitHub job summary on a default-console run

### DIFF
--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -715,6 +715,13 @@ export async function execute(
 ): Promise<BuildResult> {
   const reporter = options.reporter ??
     (options.silent ? silentReporter : consoleReporter);
+  // The GitHub job summary is a real-world output side effect (it appends to a
+  // shared file named by GITHUB_STEP_SUMMARY). Only write it when output goes to
+  // the default console — i.e. neither silenced nor redirected to a custom
+  // reporter. This keeps embedded/test runs (a build's own test suite calls
+  // `execute` with `silent`/a custom reporter) from polluting the workflow
+  // summary, while a normal CLI run still writes it.
+  const writesToConsole = options.reporter === undefined && !options.silent;
   const github = options.github ?? inGitHubActions();
   const style = resolveStyle(options, github);
   const skip = new Set(options.skip ?? []);
@@ -807,7 +814,9 @@ export async function execute(
 
   const totalMs = performance.now() - overallStart;
   reporter.info(summaryBlock(style, run.reports, totalMs, result.ok));
-  if (style.github) writeJobSummary(run.reports, totalMs, result.ok);
+  if (style.github && writesToConsole) {
+    writeJobSummary(run.reports, totalMs, result.ok);
+  }
   await build.onFinish(result);
   return result;
 }

--- a/packages/core/tests/executor_test.ts
+++ b/packages/core/tests/executor_test.ts
@@ -63,6 +63,23 @@ async function withEnv(
   }
 }
 
+/**
+ * Run `fn` with `console.log`/`console.error` silenced — for tests that drive
+ * the default console reporter (so the job summary is written) but don't want
+ * the banner output cluttering the test log.
+ */
+async function withSilencedConsole(fn: () => Promise<unknown>): Promise<void> {
+  const { log, error } = console;
+  console.log = () => {};
+  console.error = () => {};
+  try {
+    await fn();
+  } finally {
+    console.log = log;
+    console.error = error;
+  }
+}
+
 Deno.test("executes dependencies before dependents, in order", async () => {
   const log: string[] = [];
   class B extends Build {
@@ -315,9 +332,8 @@ Deno.test("auto-detects GitHub Actions from the environment", async () => {
   });
 });
 
-Deno.test("github mode appends a Markdown job summary", async () => {
+Deno.test("github mode appends a Markdown job summary (default console)", async () => {
   const tmp = await Deno.makeTempFile();
-  const { reporter } = recorder();
   class B extends Build {
     a = target().executes(() => {});
     b = target().dependsOn(this.a).executes(() => {});
@@ -326,8 +342,12 @@ Deno.test("github mode appends a Markdown job summary", async () => {
   discoverTargets(build);
 
   try {
+    // The summary is only written on a default-console run (no custom reporter,
+    // not silent); silence the console to keep the banner out of the test log.
     await withEnv("GITHUB_STEP_SUMMARY", tmp, async () => {
-      await execute(build, build.b, { reporter, github: true });
+      await withSilencedConsole(() =>
+        execute(build, build.b, { github: true })
+      );
     });
     const md = await Deno.readTextFile(tmp);
     assertEquals(md.includes("Zuke build"), true);
@@ -335,6 +355,28 @@ Deno.test("github mode appends a Markdown job summary", async () => {
     assertEquals(md.includes("| a | ✔ passed |"), true);
   } finally {
     await Deno.remove(tmp);
+  }
+});
+
+Deno.test("the job summary is NOT written when output is redirected or silent", async () => {
+  const { reporter } = recorder();
+  class B extends Build {
+    work = target().executes(() => {});
+  }
+  const build = new B();
+  discoverTargets(build);
+
+  for (const options of [{ reporter }, { silent: true }] as const) {
+    const tmp = await Deno.makeTempFile();
+    try {
+      await withEnv("GITHUB_STEP_SUMMARY", tmp, async () => {
+        await execute(build, build.work, { ...options, github: true });
+      });
+      // A redirected/silent run must not touch the shared summary file.
+      assertEquals(await Deno.readTextFile(tmp), "");
+    } finally {
+      await Deno.remove(tmp);
+    }
   }
 });
 
@@ -967,7 +1009,6 @@ Deno.test("targets from a reusable component run in dependency order", async () 
 
 Deno.test("an unwritable job-summary file never fails the build", async () => {
   const dir = await Deno.makeTempDir(); // a directory is not writable as a file
-  const { reporter } = recorder();
   class B extends Build {
     work = target().executes(() => {});
   }
@@ -976,8 +1017,12 @@ Deno.test("an unwritable job-summary file never fails the build", async () => {
 
   try {
     let result: BuildResult | undefined;
+    // Default-console run so the summary write is attempted (and fails on the
+    // directory path); console silenced to keep the banner quiet.
     await withEnv("GITHUB_STEP_SUMMARY", dir, async () => {
-      result = await execute(b, b.work, { reporter, github: true });
+      await withSilencedConsole(async () => {
+        result = await execute(b, b.work, { github: true });
+      });
     });
     assertEquals(result?.ok, true);
   } finally {


### PR DESCRIPTION
## The problem

The GitHub **job summary** for a Zuke build showed dozens of stray `Zuke build — N/M targets` tables with test-fixture target names (`boom`, `a/b/c`, `first/last`, …).

## Root cause

Under GitHub Actions (`GITHUB_ACTIONS=true`), the executor appends a Markdown block to the shared `GITHUB_STEP_SUMMARY` file whenever GitHub mode is active. A build's **own test suite** runs many real `execute()` calls (with `silent` or a custom reporter), so under CI each one appended a block. Reproduced: `executor_test.ts` alone wrote **41** blocks; after the fix, **0** (file not even created).

This is a **package-level** bug affecting every consumer — their build's tests would pollute their job summary too. A per-build workaround (blanking `GITHUB_STEP_SUMMARY` for the test process) wouldn't help users who don't know to do it, so the fix belongs in core.

## Fix

The job summary is a real **output** side effect, so only write it when output goes to the **default console** — i.e. neither `silent` nor a custom `reporter`:

```ts
const writesToConsole = options.reporter === undefined && !options.silent;
…
if (style.github && writesToConsole) writeJobSummary(...);
```

- Test runs and embedded use (`silent`/custom reporter) no longer touch the shared summary file — for **any** consumer.
- A normal CLI run (`run()` → default console reporter) still writes it.

The `::group::`/`::error::`/`::add-mask::` console output is unaffected (it already flows through the reporter).

Adds a regression test (redirected/silent runs write nothing) and updates the existing summary tests to drive the default console with output silenced.

## Checks

`deno task ci` green — the new gate is 100% branch-covered; overall 96.3% lines / 98.5% branches. No public API change.

> Independent of the feature stack — based on `master`, safe to merge anytime; touches only `executor.ts` + its test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)