### PR TITLE
feat(git): add gitInfo() for repository metadata

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -54,7 +54,7 @@ raises a `ToolNotFoundError` that names the tool and the fix.
 | `@zuke/tsgo`           | `tsgo`                                                                                                               |
 | `@zuke/dprint`         | `fmt`, `check`                                                                                                      |
 | `@zuke/gcloud`         | `run` (any command)                                                                                                 |
-| `@zuke/git`            | `init`, `clone`, `add`, `commit`, `status`, `checkout`, `branch`, `tag`, `push`, `pull`, `fetch`, `run`             |
+| `@zuke/git`            | `init`, `clone`, `add`, `commit`, `status`, `checkout`, `branch`, `tag`, `push`, `pull`, `fetch`, `run` (+ `gitInfo()` helper) |
 | `@zuke/gh`             | `run` (any command)                                                                                                 |
 | `@zuke/terraform`      | `init`, `validate`, `plan`, `apply`, `destroy`, `fmt`, `output`                                                      |
 | `@zuke/tofu`           | `init`, `validate`, `plan`, `apply`, `destroy`, `fmt`, `output`                                                      |

--- a/packages/git/README.md
+++ b/packages/git/README.md
@@ -22,6 +22,20 @@ await GitTasks.run((s) => s.command("rev-parse", "--short", "HEAD"));
 Tasks: `init`, `clone`, `add`, `commit`, `status`, `checkout`, `branch`, `tag`,
 `push`, `pull`, `fetch`, and `run`.
 
+## Repository info — `gitInfo()`
+
+`gitInfo()` resolves the current repository's metadata for versioning and
+conditional steps: `branch`, `commit`/`shortCommit`, nearest `tag`, `dirty`
+flag, and `remoteUrl`. It throws outside a git repository; optional fields are
+`undefined` when absent. Pass `{ cwd }` to inspect another directory.
+
+```ts
+import { gitInfo } from "jsr:@zuke/git";
+
+const git = await gitInfo();
+console.log(`${git.branch} @ ${git.shortCommit}${git.dirty ? " (dirty)" : ""}`);
+```
+
 ## Paths
 
 Every path argument accepts either a string or an `AbsolutePath` from

--- a/packages/git/mod.ts
+++ b/packages/git/mod.ts
@@ -6,11 +6,16 @@
  * `GitTasks.run` with `.command(...)` for anything else.
  *
  * ```ts
- * import { GitTasks } from "jsr:@zuke/git";
+ * import { GitTasks, gitInfo } from "jsr:@zuke/git";
  * await GitTasks.commit((s) => s.all().message("ci: release"));
+ * const { branch, shortCommit } = await gitInfo();
  * ```
+ *
+ * The `gitInfo()` helper resolves repository metadata (branch, commit, tag,
+ * dirty state, remote) for versioning and conditional steps.
  *
  * @module
  */
 
 export * from "./src/git.ts";
+export * from "./src/git_info.ts";

--- a/packages/git/src/git_info.ts
+++ b/packages/git/src/git_info.ts
@@ -1,0 +1,98 @@
+/**
+ * `gitInfo()` — resolve the current repository's branch, commit, nearest tag,
+ * dirty state, and origin URL. Useful for versioning and conditional build
+ * steps, e.g. `publish.onlyWhen(async () => (await gitInfo()).branch === "main")`.
+ *
+ * ```ts
+ * import { gitInfo } from "jsr:@zuke/git";
+ *
+ * const git = await gitInfo();
+ * console.log(`${git.branch} @ ${git.shortCommit}${git.dirty ? " (dirty)" : ""}`);
+ * ```
+ *
+ * The git invocations go through an injectable {@link GitRunner} (defaulting to
+ * spawning `git`), so the logic is unit-testable without a real repository.
+ *
+ * @module
+ */
+
+/** Resolved git repository information. */
+export interface GitInfo {
+  /** Current branch, or `"HEAD"` when detached. */
+  branch: string;
+  /** Full commit SHA of `HEAD`. */
+  commit: string;
+  /** Abbreviated commit SHA. */
+  shortCommit: string;
+  /** The nearest tag (`git describe --tags --abbrev=0`), if any. */
+  tag?: string;
+  /** Whether the working tree has uncommitted changes. */
+  dirty: boolean;
+  /** The `origin` remote URL, if configured. */
+  remoteUrl?: string;
+}
+
+/**
+ * Runs a `git` subcommand and resolves to its trimmed stdout, or `null` when
+ * the command fails (non-zero exit, or `git` unavailable).
+ */
+export type GitRunner = (args: string[]) => Promise<string | null>;
+
+/** Options for {@link gitInfo}. */
+export interface GitInfoOptions {
+  /** Directory to inspect (defaults to the current directory). */
+  cwd?: string;
+  /** Override how git is invoked (defaults to spawning `git`); for testing. */
+  run?: GitRunner;
+}
+
+/** A {@link GitRunner} that spawns the real `git` binary in `cwd`. */
+function defaultRunner(cwd?: string): GitRunner {
+  return async (args: string[]): Promise<string | null> => {
+    try {
+      const command = new Deno.Command("git", {
+        args,
+        cwd,
+        stdout: "piped",
+        stderr: "null",
+      });
+      const { code, stdout } = await command.output();
+      if (code !== 0) return null;
+      return new TextDecoder().decode(stdout).trim();
+    } catch {
+      return null; // git not installed, or no permission to run it
+    }
+  };
+}
+
+/** Normalize an empty/`null` runner result to `undefined`. */
+function optional(value: string | null): string | undefined {
+  return value === null || value === "" ? undefined : value;
+}
+
+/**
+ * Resolve {@link GitInfo} for the repository at `cwd`. Throws if `cwd` is not a
+ * git repository (or `git` is unavailable). Optional fields (`tag`, `remoteUrl`)
+ * are `undefined` when absent.
+ */
+export async function gitInfo(options: GitInfoOptions = {}): Promise<GitInfo> {
+  const run = options.run ?? defaultRunner(options.cwd);
+
+  const commit = await run(["rev-parse", "HEAD"]);
+  if (commit === null) {
+    throw new Error("gitInfo: not a git repository, or git is unavailable.");
+  }
+  const branch = await run(["rev-parse", "--abbrev-ref", "HEAD"]) ?? "HEAD";
+  const shortCommit = await run(["rev-parse", "--short", "HEAD"]) ??
+    commit.slice(0, 7);
+  const status = await run(["status", "--porcelain"]);
+
+  return {
+    branch,
+    commit,
+    shortCommit,
+    tag: optional(await run(["describe", "--tags", "--abbrev=0"])),
+    dirty: status !== null && status !== "",
+    remoteUrl: optional(await run(["config", "--get", "remote.origin.url"])),
+  };
+}

--- a/packages/git/tests/git_info_test.ts
+++ b/packages/git/tests/git_info_test.ts
@@ -1,0 +1,93 @@
+import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
+import { gitInfo, type GitRunner } from "../src/git_info.ts";
+
+/** Build a fake {@link GitRunner} from a map of `git <args>` → output (or null). */
+function fakeRun(responses: Record<string, string | null>): GitRunner {
+  return (args) => Promise.resolve(responses[args.join(" ")] ?? null);
+}
+
+Deno.test("gitInfo resolves a full clean repository", async () => {
+  const info = await gitInfo({
+    run: fakeRun({
+      "rev-parse HEAD": "abcdef0123456789",
+      "rev-parse --abbrev-ref HEAD": "master",
+      "rev-parse --short HEAD": "abcdef0",
+      "status --porcelain": "",
+      "describe --tags --abbrev=0": "v1.2.3",
+      "config --get remote.origin.url": "git@github.com:zuke-build/zuke.git",
+    }),
+  });
+  assertEquals(info, {
+    branch: "master",
+    commit: "abcdef0123456789",
+    shortCommit: "abcdef0",
+    tag: "v1.2.3",
+    dirty: false,
+    remoteUrl: "git@github.com:zuke-build/zuke.git",
+  });
+});
+
+Deno.test("gitInfo reports a dirty tree", async () => {
+  const info = await gitInfo({
+    run: fakeRun({
+      "rev-parse HEAD": "9f01ab23",
+      "rev-parse --abbrev-ref HEAD": "feature",
+      "rev-parse --short HEAD": "9f01ab2",
+      "status --porcelain": " M src/a.ts\n?? new.ts",
+    }),
+  });
+  assertEquals(info.dirty, true);
+  assertEquals(info.tag, undefined); // no tag configured
+  assertEquals(info.remoteUrl, undefined); // no remote configured
+});
+
+Deno.test("gitInfo falls back when branch/short are unavailable (detached HEAD)", async () => {
+  const info = await gitInfo({
+    run: fakeRun({
+      "rev-parse HEAD": "0123456789abcdef",
+      "rev-parse --abbrev-ref HEAD": null,
+      "rev-parse --short HEAD": null,
+      "status --porcelain": "",
+    }),
+  });
+  assertEquals(info.branch, "HEAD");
+  assertEquals(info.shortCommit, "0123456"); // first 7 chars of the commit
+});
+
+Deno.test("gitInfo treats an empty tag/remote result as undefined", async () => {
+  const info = await gitInfo({
+    run: fakeRun({
+      "rev-parse HEAD": "abc1234",
+      "rev-parse --abbrev-ref HEAD": "main",
+      "rev-parse --short HEAD": "abc1234",
+      "status --porcelain": "",
+      "describe --tags --abbrev=0": "",
+      "config --get remote.origin.url": "",
+    }),
+  });
+  assertEquals(info.tag, undefined);
+  assertEquals(info.remoteUrl, undefined);
+});
+
+Deno.test("gitInfo throws when HEAD cannot be resolved", async () => {
+  await assertRejects(
+    () => gitInfo({ run: fakeRun({}) }),
+    Error,
+    "not a git repository",
+  );
+});
+
+Deno.test("gitInfo's default runner returns nothing outside a repository", async () => {
+  // Exercises the real spawning runner against a non-repo temp dir: whether git
+  // exits non-zero or is absent, HEAD resolves to null and gitInfo throws.
+  const dir = await Deno.makeTempDir();
+  try {
+    await assertRejects(
+      () => gitInfo({ cwd: dir }),
+      Error,
+      "not a git repository",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary

**`gitInfo()`** — resolve the current repository's metadata for versioning and conditional steps. Lives in **`@zuke/git`** (git-specific, so it belongs with the git wrapper rather than core).

```ts
import { gitInfo } from "jsr:@zuke/git";

const git = await gitInfo();
console.log(`${git.branch} @ ${git.shortCommit}${git.dirty ? " (dirty)" : ""}`);

publish.onlyWhen(async () => (await gitInfo()).branch === "master");
```

## API

```ts
interface GitInfo {
  branch: string;        // "HEAD" when detached
  commit: string;
  shortCommit: string;
  tag?: string;          // nearest tag, if any
  dirty: boolean;
  remoteUrl?: string;    // origin, if configured
}
gitInfo(options?: { cwd?: string; run?: GitRunner }): Promise<GitInfo>
```

- Throws outside a git repository (or when `git` is unavailable); optional fields are `undefined` when absent.
- git invocations go through an injectable **`GitRunner`** seam (default spawns `git`), so all parsing/fallback logic is **unit-tested without a real repo** (detached HEAD, dirty tree, missing tag/remote, empty results). A non-repo temp-dir test exercises the real spawning runner's failure path.

Exported from `@zuke/git`'s `mod.ts`; documented in the package README and `docs/tools.md`. Unblocks the planned GitVersion-style helper later.

## Stacking

> 📚 Based directly on `master`, standalone. Core/tooling-feature progress: assertions ✅ · http ✅ · compression ✅ · **git-info (#this, now in @zuke/git)**. Next: tool-install → `defineTool()` → CI-gen → plugin contract.

## Checks

`deno task ci` green — `git_info.ts` 100% branch coverage (the only uncovered lines are the real-`git` spawn success path, which can't run hermetically); overall 96.4% lines / 98.5% branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)