### PR TITLE
ci: stop running CI twice per pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,12 @@
 name: CI
 
 on:
+  # Run once per change: `pull_request` covers every PR branch, and `push`
+  # covers the post-merge commit on the default branch. Triggering `push` on
+  # all branches as well would double every PR run (a `push` and a
+  # `pull_request` job for the same commit) for no extra signal.
   push:
-    branches: ["**"]
+    branches: [master]
   pull_request:
 
 # Least privilege: CI only ever needs to read the repo. No secrets are used.


### PR DESCRIPTION
## Summary

The CI workflow triggered on `push` for **all** branches *and* on `pull_request`. When a branch has an open PR, GitHub fires both events, so every push ran the whole workflow twice — a `(push)` job and a `(pull_request)` job for the same commit — doubling CI minutes for no added signal. (The two runs don't dedupe via `concurrency` because `push` and `pull_request` have different `github.ref` values.)

This restricts `push` to the default branch:

```yaml
on:
  push:
    branches: [master]   # was ["**"]
  pull_request:
```

Now there's exactly **one** run per change: `pull_request` covers every PR branch, and `push` covers the post-merge commit on `master`.

## Notes

- This matches the trigger pattern already used by `security.yml` and `scorecard.yml` (`push: branches: [master]`), so CI is now consistent with the other workflows.
- No job in `ci.yml` is conditioned on the `push` event or on a non-`master` branch (the only `if:` conditions are OS-based), so nothing depended on the all-branches `push` trigger.
- Pushing a branch with no open PR will no longer start a CI run until a PR exists — the conventional behavior for this pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtqHmRRvtT6qkQKaPzrWhT

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtqHmRRvtT6qkQKaPzrWhT)_