### PR TITLE
feat(core): code-first CI config generation (GitHub, GitLab, Azure)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,22 +2,22 @@
 
 Guidance for working in this repository. Read this before making changes.
 
-Zuke is a code-first, strongly-typed build automation system for Deno/TypeScript
-(inspired by [NUKE](https://nuke.build/)).
+Zuke is a code-first, strongly-typed build automation system for
+Deno/TypeScript.
 
 ## Tech stack
 
-- **Runtime & toolchain:** [Deno](https://deno.com/) (2.x). All tooling —
-  test runner, formatter, linter, type-checker, coverage — is the built-in
-  `deno` CLI. No Node, npm, or external build tools.
+- **Runtime & toolchain:** [Deno](https://deno.com/) (2.x). All tooling — test
+  runner, formatter, linter, type-checker, coverage — is the built-in `deno`
+  CLI. No Node, npm, or external build tools.
 - **Language:** TypeScript, strict mode (Deno's default).
 - **Distribution:** [JSR](https://jsr.io/) as a workspace of four packages:
-  `@zuke/core` (exports `.`, `./shell`, `./tooling`), `@zuke/deno`,
-  `@zuke/npm`, `@zuke/cmd`. The npm org `@zuke-build` is reserved for future
-  npm distribution (1:1 name mapping).
-- **No runtime dependencies.** The library is dependency-free; tests use a
-  local assertion helper (`tests/_assert.ts`) rather than a third-party assert
-  library so the suite runs with zero network access.
+  `@zuke/core` (exports `.`, `./shell`, `./tooling`), `@zuke/deno`, `@zuke/npm`,
+  `@zuke/cmd`. The npm org `@zuke-build` is reserved for future npm distribution
+  (1:1 name mapping).
+- **No runtime dependencies.** The library is dependency-free; tests use a local
+  assertion helper (`tests/_assert.ts`) rather than a third-party assert library
+  so the suite runs with zero network access.
 
 ### TypeScript 7 / `tsgo`
 
@@ -44,11 +44,11 @@ update the `check` task and CI accordingly. Do not bolt on a parallel
    - The single sanctioned escape is a `// @ts-expect-error` **in a test** that
      deliberately exercises a runtime guard against type-unsafe input, with a
      comment explaining why. Do not use it in `src/`.
-2. **All linting, formatting, type-checking, and tests must always pass.**
-   Run `deno task ci` before committing; it must be green.
-3. **Keep test coverage at 95%+ (lines and branches) at all times.** Enforced
-   by `scripts/check-coverage.ts` in the `cov` task and in CI. New code needs
-   new tests in the same change.
+2. **All linting, formatting, type-checking, and tests must always pass.** Run
+   `deno task ci` before committing; it must be green.
+3. **Keep test coverage at 95%+ (lines and branches) at all times.** Enforced by
+   `scripts/check-coverage.ts` in the `cov` task and in CI. New code needs new
+   tests in the same change.
 4. **Document the public API.** Every exported symbol carries a JSDoc comment;
    match the existing density and tone when adding to it.
 5. **Tests are hermetic and fast.** No network, no reliance on ambient tools.
@@ -57,16 +57,16 @@ update the `check` task and CI accordingly. Do not bolt on a parallel
 
 ## Commands
 
-| Task | Command |
-|---|---|
-| Run tests | `deno task test` |
-| Coverage + gate (95%) | `deno task cov` |
-| Human-readable coverage table | `deno task cov:report` |
-| Type-check everything | `deno task check` |
-| Format / check formatting | `deno task fmt` / `deno task fmt:check` |
-| Lint | `deno task lint` |
-| Spell-check | `deno task spell` |
-| Full pre-commit / CI gate | `deno task ci` |
+| Task                          | Command                                 |
+| ----------------------------- | --------------------------------------- |
+| Run tests                     | `deno task test`                        |
+| Coverage + gate (95%)         | `deno task cov`                         |
+| Human-readable coverage table | `deno task cov:report`                  |
+| Type-check everything         | `deno task check`                       |
+| Format / check formatting     | `deno task fmt` / `deno task fmt:check` |
+| Lint                          | `deno task lint`                        |
+| Spell-check                   | `deno task spell`                       |
+| Full pre-commit / CI gate     | `deno task ci`                          |
 
 ## Repository layout
 
@@ -100,13 +100,13 @@ zuke.ts                   # Zuke's own build (runnable example)
 - **Tool wrappers** (`@zuke/deno`, `@zuke/npm`, `@zuke/cmd`) follow a
   settings-lambda style. Settings classes extend `ToolSettings` from
   `@zuke/core/tooling`; `buildArgs()` must stay pure (no I/O) so argv
-  construction is unit-testable. Execution reuses `Command` from `shell.ts`.
-  New wrapper packages are workspace siblings that depend only on core.
+  construction is unit-testable. Execution reuses `Command` from `shell.ts`. New
+  wrapper packages are workspace siblings that depend only on core.
 
 ## Good open-source practices to follow
 
-- **Small, focused changes** with clear, descriptive commit messages
-  (imperative mood; explain the *why*). Keep PRs reviewable.
+- **Small, focused changes** with clear, descriptive commit messages (imperative
+  mood; explain the _why_). Keep PRs reviewable.
 - **Conventional, semantic versioning** for releases; keep a changelog as the
   project grows.
 - **Keep code snippets out of commit message bodies.** release-please parses

--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ order. Inspired by [NUKE](https://nuke.build/) for .NET.
 - **Packages:** `jsr:@zuke/core` plus typed tool wrappers `jsr:@zuke/deno`,
   `jsr:@zuke/npm`, `jsr:@zuke/bun`, `jsr:@zuke/pnpm`, `jsr:@zuke/yarn`,
   `jsr:@zuke/docker`, `jsr:@zuke/docker-compose`, `jsr:@zuke/kubectl`,
-  `jsr:@zuke/helm`, `jsr:@zuke/kustomize`, `jsr:@zuke/oxlint`, `jsr:@zuke/eslint`, `jsr:@zuke/biome`, `jsr:@zuke/knip`,
-  `jsr:@zuke/cspell`, `jsr:@zuke/jest`, `jsr:@zuke/vitest`,
-  `jsr:@zuke/playwright`, `jsr:@zuke/cypress`, `jsr:@zuke/vite`,
-  `jsr:@zuke/tsup`, `jsr:@zuke/turbo`, `jsr:@zuke/nx`, `jsr:@zuke/jsr`,
-  `jsr:@zuke/tsx`, `jsr:@zuke/tsgo`, `jsr:@zuke/dprint`,
-  `jsr:@zuke/gcloud`, `jsr:@zuke/git`, `jsr:@zuke/gh`, `jsr:@zuke/terraform`,
-  `jsr:@zuke/tofu`, `jsr:@zuke/security`, `jsr:@zuke/cmd` (raw shell via
-  `jsr:@zuke/core/shell`)
+  `jsr:@zuke/helm`, `jsr:@zuke/kustomize`, `jsr:@zuke/oxlint`,
+  `jsr:@zuke/eslint`, `jsr:@zuke/biome`, `jsr:@zuke/knip`, `jsr:@zuke/cspell`,
+  `jsr:@zuke/jest`, `jsr:@zuke/vitest`, `jsr:@zuke/playwright`,
+  `jsr:@zuke/cypress`, `jsr:@zuke/vite`, `jsr:@zuke/tsup`, `jsr:@zuke/turbo`,
+  `jsr:@zuke/nx`, `jsr:@zuke/jsr`, `jsr:@zuke/tsx`, `jsr:@zuke/tsgo`,
+  `jsr:@zuke/dprint`, `jsr:@zuke/gcloud`, `jsr:@zuke/git`, `jsr:@zuke/gh`,
+  `jsr:@zuke/terraform`, `jsr:@zuke/tofu`, `jsr:@zuke/security`, `jsr:@zuke/cmd`
+  (raw shell via `jsr:@zuke/core/shell`)
 - **Build file:** `zuke.ts` in your project root
 - **Zero runtime dependencies**
 
@@ -56,6 +56,10 @@ class MyBuild extends Build {
   (throw on failure, capture output) and is injection-safe.
 - **Small and explicit.** A tiny core: discover targets, build a graph, sort,
   run. No magic, no plugins to learn (yet).
+- **Code-first CI.** Declare your pipeline in the build with `cicd()` — even
+  `cicd()` with no arguments produces a working workflow — and Zuke generates
+  GitHub Actions, GitLab CI, or Azure Pipelines YAML, regenerating it whenever
+  the build runs (and verifying it on CI).
 
 ## Install
 
@@ -87,8 +91,8 @@ Full documentation lives in [`docs/`](./docs/):
   execution semantics.
 - [Parameters](./docs/parameters.md) — typed build inputs from flags and env
   vars (`parameter()`, `this.x.value`).
-- [Authoring API](./docs/authoring.md) — `target()`, `Build`, `run()`, and
-  gotchas.
+- [Authoring API](./docs/authoring.md) — `target()`, `Build`, `run()`,
+  code-first CI generation (`cicd()`), and gotchas.
 - [Shell wrapper (`$`)](./docs/shell.md) — ergonomic, injection-safe process
   execution.
 - [Paths (`absolutePath`)](./docs/paths.md) — the fluent path type.
@@ -96,7 +100,8 @@ Full documentation lives in [`docs/`](./docs/):
 - [Using Zuke in a Node/npm project](./docs/node-projects.md) — drive a Node
   build with Deno.
 - [CLI reference](./docs/cli.md) — commands and flags.
-- [Programmatic API](./docs/programmatic-api.md) — drive Zuke from your own code.
+- [Programmatic API](./docs/programmatic-api.md) — drive Zuke from your own
+  code.
 
 ## Development
 
@@ -124,14 +129,15 @@ CI runs `deno task ci` on every push and pull request (see
 
 ## Security
 
-As a build tool that runs in other people's pipelines, Zuke treats
-supply-chain integrity as a first-class concern: zero runtime dependencies,
-injection-free `Deno.Command` execution, OIDC trusted publishing with
-provenance, least-privilege and SHA-pinned CI, a frozen lockfile, and
-continuous scanning. Scanning runs as a typed Zuke target — `deno task zuke
-security` drives zizmor, actionlint, and gitleaks through
-[`@zuke/security`](./packages/security) (which also wraps osv-scanner, semgrep,
-and Trivy) — alongside CodeQL and OpenSSF Scorecard for the Security tab.
+As a build tool that runs in other people's pipelines, Zuke treats supply-chain
+integrity as a first-class concern: zero runtime dependencies, injection-free
+`Deno.Command` execution, OIDC trusted publishing with provenance,
+least-privilege and SHA-pinned CI, a frozen lockfile, and continuous scanning.
+Scanning runs as a typed Zuke target — `deno task zuke
+security` drives zizmor,
+actionlint, and gitleaks through [`@zuke/security`](./packages/security) (which
+also wraps osv-scanner, semgrep, and Trivy) — alongside CodeQL and OpenSSF
+Scorecard for the Security tab.
 
 See [`SECURITY.md`](./SECURITY.md) for the full posture and how to report a
 vulnerability.

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ class MyBuild extends Build {
   (throw on failure, capture output) and is injection-safe.
 - **Small and explicit.** A tiny core: discover targets, build a graph, sort,
   run. No magic, no plugins to learn (yet).
-- **Code-first CI.** Declare your pipeline in the build with `cicd()` — even
-  `cicd()` with no arguments produces a working workflow — and Zuke generates
-  GitHub Actions, GitLab CI, or Azure Pipelines YAML, regenerating it whenever
-  the build runs (and verifying it on CI).
+- **Code-first CI.** Declare your pipeline in the build with
+  `cicd({ provider: "github" })` — the provider is the only required field — and
+  Zuke generates GitHub Actions, GitLab CI, or Azure Pipelines YAML,
+  regenerating it whenever the build runs (and verifying it on CI).
 
 ## Install
 

--- a/cspell.json
+++ b/cspell.json
@@ -4,6 +4,7 @@
   "useGitignore": true,
   "words": [
     "actionlint",
+    "cicd",
     "bunx",
     "chainers",
     "chmods",

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -332,10 +332,11 @@ elsewhere, since GitLab and Azure check out the repo automatically. `runsOn` is
 interpreted per provider (a runner label, a Docker image, or a `vmImage`); when
 a matrix defines `os`, GitHub runs on it automatically.
 
-For one-off rendering without the build wiring, `generateCi(pipeline, provider)`
-returns the YAML string directly. Either way the emitted YAML quotes any scalar
-that would otherwise be misread (a bare `on`, a numeric-looking version), so the
-output is paste-ready.
+For one-off rendering without the build wiring,
+`generateCi(pipeline?, provider?)` returns the YAML string directly
+(`generateCi()` yields the default GitHub workflow). Either way the emitted YAML
+quotes any scalar that would otherwise be misread (a bare `on`, a
+numeric-looking version), so the output is paste-ready.
 
 ### Host detection — `isCI()` / `ciHost()`
 

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -280,6 +280,41 @@ const bin = await installRelease({
 await CmdTasks.exec(String(bin), (s) => s.args("version"));
 ```
 
+### CI config generation — `generateCi()`
+
+Describe a pipeline once as a provider-agnostic `CiPipeline` — triggers, jobs,
+an optional `matrix`, and steps — then render it for GitHub Actions, GitLab CI,
+or Azure Pipelines. A `run` step (a shell command) maps to every provider; a
+`uses` step (a GitHub Action) renders only for GitHub and is skipped elsewhere,
+since GitLab and Azure check out the repo automatically. `runsOn` is interpreted
+per provider (a runner label, a Docker image, or a `vmImage`); when a matrix
+defines `os`, GitHub runs on it automatically.
+
+```ts
+import { type CiPipeline, generateCi } from "jsr:@zuke/core";
+
+const pipeline: CiPipeline = {
+  name: "CI",
+  triggers: { push: ["main"], pullRequest: ["main"] },
+  jobs: [{
+    id: "test",
+    matrix: { os: ["ubuntu-latest", "macos-latest"] },
+    steps: [
+      { uses: "denoland/setup-deno@v2", with: { "deno-version": "v2.x" } },
+      { name: "Test", run: "deno task ci" },
+    ],
+  }],
+};
+
+await Deno.writeTextFile(
+  ".github/workflows/ci.yml",
+  generateCi(pipeline, "github"), // or "gitlab" / "azure"
+);
+```
+
+The emitted YAML quotes any scalar that would otherwise be misread (a bare `on`,
+a numeric-looking version), so the output is paste-ready.
+
 ### Host detection — `isCI()` / `ciHost()`
 
 `isCI()` and `ciHost()` (e.g. `"github-actions"`, `"gitlab-ci"`, `"local"`) let

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -288,25 +288,26 @@ provider-agnostic `CiPipeline` to an output path. The file is then kept in sync
 with the definition: it is regenerated whenever you run the build, and
 `zuke generate-ci` writes it on demand.
 
-Everything is optional. `cicd()` with no arguments declares a GitHub workflow at
-`.github/workflows/ci.yml` that, on push/PR to `main`, runs a single `build` job
-whose one step invokes the build through the `./zuke` launcher (which bootstraps
-Deno itself — no separate setup step). Override only what you need:
+The provider is the only required field. `cicd({ provider: "github" })` declares
+a workflow at `.github/workflows/ci.yml` that, on push/PR to `main`, runs a
+single `build` job whose one step invokes the build through the `./zuke`
+launcher (which bootstraps Deno itself — no separate setup step). Override only
+what else you need:
 
 ```ts
 import { Build, cicd, target } from "jsr:@zuke/core";
 
 class MyBuild extends Build {
-  ci = cicd(); // the default workflow — runs ./zuke on push/PR to main
+  ci = cicd({ provider: "github" }); // runs ./zuke on push/PR to main
 
   test = target().executes(async () => {/* … */});
 }
 ```
 
-The defaults: `provider` is `github`, `path` follows the provider, the pipeline
-`name` is `CI`, `triggers` are push/PR on `main`, a job's `id` is `build`, its
-`runsOn` is `ubuntu-latest`, and its single step runs `./zuke`. Supply only the
-fields you want to change:
+The defaults: `path` follows the provider, the pipeline `name` is `CI`,
+`triggers` are push/PR on `main`, a job's `id` is `build`, its `runsOn` is
+`ubuntu-latest`, and its single step runs `./zuke`. Supply only the fields you
+want to change:
 
 ```ts
 ci = cicd({
@@ -332,10 +333,10 @@ elsewhere, since GitLab and Azure check out the repo automatically. `runsOn` is
 interpreted per provider (a runner label, a Docker image, or a `vmImage`); when
 a matrix defines `os`, GitHub runs on it automatically.
 
-For one-off rendering without the build wiring,
-`generateCi(pipeline?, provider?)` returns the YAML string directly
-(`generateCi()` yields the default GitHub workflow). Either way the emitted YAML
-quotes any scalar that would otherwise be misread (a bare `on`, a
+For one-off rendering without the build wiring, `generateCi(pipeline, provider)`
+returns the YAML string directly (pass an empty pipeline,
+`generateCi({}, "github")`, to accept every default). Either way the emitted
+YAML quotes any scalar that would otherwise be misread (a bare `on`, a
 numeric-looking version), so the output is paste-ready.
 
 ### Host detection — `isCI()` / `ciHost()`

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -286,34 +286,38 @@ Generate your CI configuration **from the build** instead of hand-maintaining
 YAML. Declare a pipeline as a build field with `cicd()`, binding a
 provider-agnostic `CiPipeline` to an output path. The file is then kept in sync
 with the definition: it is regenerated whenever you run the build, and
-`zuke generate-ci` writes it on demand. Almost every field has a sensible
-default — `provider` is `github`, `path` follows the provider, the pipeline
-`name` is `CI`, triggers default to push/PR on `main`, and a job's `id` is
-`build` — so a minimal definition is just a job with steps.
+`zuke generate-ci` writes it on demand.
+
+Everything is optional. `cicd()` with no arguments declares a GitHub workflow at
+`.github/workflows/ci.yml` that, on push/PR to `main`, runs a single `build` job
+whose one step invokes the build through the `./zuke` launcher (which bootstraps
+Deno itself — no separate setup step). Override only what you need:
 
 ```ts
 import { Build, cicd, target } from "jsr:@zuke/core";
 
 class MyBuild extends Build {
-  ci = cicd({
-    provider: "github", // or "gitlab" / "azure"
-    path: ".github/workflows/ci.yml",
-    pipeline: {
-      name: "CI",
-      triggers: { push: ["main"], pullRequest: ["main"] },
-      jobs: [{
-        id: "test",
-        matrix: { os: ["ubuntu-latest", "macos-latest"] },
-        steps: [
-          { uses: "denoland/setup-deno@v2", with: { "deno-version": "v2.x" } },
-          { name: "Test", run: "deno task ci" },
-        ],
-      }],
-    },
-  });
+  ci = cicd(); // the default workflow — runs ./zuke on push/PR to main
 
   test = target().executes(async () => {/* … */});
 }
+```
+
+The defaults: `provider` is `github`, `path` follows the provider, the pipeline
+`name` is `CI`, `triggers` are push/PR on `main`, a job's `id` is `build`, its
+`runsOn` is `ubuntu-latest`, and its single step runs `./zuke`. Supply only the
+fields you want to change:
+
+```ts
+ci = cicd({
+  provider: "github", // or "gitlab" / "azure"
+  pipeline: {
+    jobs: [{
+      matrix: { os: ["ubuntu-latest", "macos-latest"] },
+      steps: [{ name: "Test", run: "./zuke test" }],
+    }],
+  },
+});
 ```
 
 - **`zuke generate-ci`** writes every declared file (creating parent dirs).

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -280,40 +280,55 @@ const bin = await installRelease({
 await CmdTasks.exec(String(bin), (s) => s.args("version"));
 ```
 
-### CI config generation — `generateCi()`
+### CI config generation — `cicd()` and `generate-ci`
 
-Describe a pipeline once as a provider-agnostic `CiPipeline` — triggers, jobs,
-an optional `matrix`, and steps — then render it for GitHub Actions, GitLab CI,
-or Azure Pipelines. A `run` step (a shell command) maps to every provider; a
-`uses` step (a GitHub Action) renders only for GitHub and is skipped elsewhere,
-since GitLab and Azure check out the repo automatically. `runsOn` is interpreted
-per provider (a runner label, a Docker image, or a `vmImage`); when a matrix
-defines `os`, GitHub runs on it automatically.
+Generate your CI configuration **from the build** instead of hand-maintaining
+YAML — the way NUKE does. Declare a pipeline as a build field with `cicd()`,
+binding a provider-agnostic `CiPipeline` to an output path. The file is then
+kept in sync with the definition: it is regenerated whenever you run the build,
+and `zuke generate-ci` writes it on demand.
 
 ```ts
-import { type CiPipeline, generateCi } from "jsr:@zuke/core";
+import { Build, cicd, target } from "jsr:@zuke/core";
 
-const pipeline: CiPipeline = {
-  name: "CI",
-  triggers: { push: ["main"], pullRequest: ["main"] },
-  jobs: [{
-    id: "test",
-    matrix: { os: ["ubuntu-latest", "macos-latest"] },
-    steps: [
-      { uses: "denoland/setup-deno@v2", with: { "deno-version": "v2.x" } },
-      { name: "Test", run: "deno task ci" },
-    ],
-  }],
-};
+class MyBuild extends Build {
+  ci = cicd({
+    provider: "github", // or "gitlab" / "azure"
+    path: ".github/workflows/ci.yml",
+    pipeline: {
+      name: "CI",
+      triggers: { push: ["main"], pullRequest: ["main"] },
+      jobs: [{
+        id: "test",
+        matrix: { os: ["ubuntu-latest", "macos-latest"] },
+        steps: [
+          { uses: "denoland/setup-deno@v2", with: { "deno-version": "v2.x" } },
+          { name: "Test", run: "deno task ci" },
+        ],
+      }],
+    },
+  });
 
-await Deno.writeTextFile(
-  ".github/workflows/ci.yml",
-  generateCi(pipeline, "github"), // or "gitlab" / "azure"
-);
+  test = target().executes(async () => {/* … */});
+}
 ```
 
-The emitted YAML quotes any scalar that would otherwise be misread (a bare `on`,
-a numeric-looking version), so the output is paste-ready.
+- **`zuke generate-ci`** writes every declared file (creating parent dirs).
+- **Running any target** regenerates the files too, so you can't forget to — and
+  on CI (`isCI()`), the run instead _verifies_ the committed files are current
+  and fails if they have drifted (use `zuke generate-ci --check` for a dedicated
+  gate). `--dry-run` skips regeneration.
+
+The model is a portable subset: a `run` step (a shell command) maps to every
+provider; a `uses` step (a GitHub Action) renders only for GitHub and is skipped
+elsewhere, since GitLab and Azure check out the repo automatically. `runsOn` is
+interpreted per provider (a runner label, a Docker image, or a `vmImage`); when
+a matrix defines `os`, GitHub runs on it automatically.
+
+For one-off rendering without the build wiring, `generateCi(pipeline, provider)`
+returns the YAML string directly. Either way the emitted YAML quotes any scalar
+that would otherwise be misread (a bare `on`, a numeric-looking version), so the
+output is paste-ready.
 
 ### Host detection — `isCI()` / `ciHost()`
 

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -283,10 +283,13 @@ await CmdTasks.exec(String(bin), (s) => s.args("version"));
 ### CI config generation — `cicd()` and `generate-ci`
 
 Generate your CI configuration **from the build** instead of hand-maintaining
-YAML — the way NUKE does. Declare a pipeline as a build field with `cicd()`,
-binding a provider-agnostic `CiPipeline` to an output path. The file is then
-kept in sync with the definition: it is regenerated whenever you run the build,
-and `zuke generate-ci` writes it on demand.
+YAML. Declare a pipeline as a build field with `cicd()`, binding a
+provider-agnostic `CiPipeline` to an output path. The file is then kept in sync
+with the definition: it is regenerated whenever you run the build, and
+`zuke generate-ci` writes it on demand. Almost every field has a sensible
+default — `provider` is `github`, `path` follows the provider, the pipeline
+`name` is `CI`, triggers default to push/PR on `main`, and a job's `id` is
+`build` — so a minimal definition is just a job with steps.
 
 ```ts
 import { Build, cicd, target } from "jsr:@zuke/core";

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -93,3 +93,11 @@ export {
   installRelease,
   type InstallReleaseOptions,
 } from "./src/install.ts";
+export {
+  type CiJob,
+  type CiPipeline,
+  type CiProvider,
+  type CiStep,
+  type CiTriggers,
+  generateCi,
+} from "./src/ci.ts";

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -94,6 +94,9 @@ export {
   type InstallReleaseOptions,
 } from "./src/install.ts";
 export {
+  cicd,
+  CiFile,
+  type CiFileSpec,
   type CiJob,
   type CiPipeline,
   type CiProvider,

--- a/packages/core/src/ci.ts
+++ b/packages/core/src/ci.ts
@@ -106,9 +106,6 @@ const DEFAULT_NAME = "CI";
 /** The default job id when one is not given. */
 const DEFAULT_JOB_ID = "build";
 
-/** The default provider for {@link generateCi} and {@link cicd}. */
-const DEFAULT_PROVIDER: CiProvider = "github";
-
 /** Default triggers: push and pull request on `main`. */
 const DEFAULT_TRIGGERS: CiTriggers = { push: ["main"], pullRequest: ["main"] };
 
@@ -251,13 +248,13 @@ function azure(pipeline: CiPipeline): YamlValue {
 }
 
 /**
- * Render `pipeline` as the YAML configuration for `provider` (default
- * `"github"`): `.github/workflows/*.yml`, `.gitlab-ci.yml`, or
- * `azure-pipelines.yml`.
+ * Render `pipeline` as the YAML configuration for `provider`:
+ * `.github/workflows/*.yml`, `.gitlab-ci.yml`, or `azure-pipelines.yml`. The
+ * pipeline may be empty (`{}`) to accept every default.
  */
 export function generateCi(
-  pipeline: CiPipeline = {},
-  provider: CiProvider = DEFAULT_PROVIDER,
+  pipeline: CiPipeline,
+  provider: CiProvider,
 ): string {
   switch (provider) {
     case "github":
@@ -271,8 +268,8 @@ export function generateCi(
 
 /** A CI configuration file declared on a build: a pipeline bound to a path. */
 export interface CiFileSpec {
-  /** The provider to render for. Defaults to `"github"`. */
-  provider?: CiProvider;
+  /** The provider to render for — the one field you must choose. */
+  provider: CiProvider;
   /**
    * The output path (relative to the working directory). Defaults to the
    * provider's conventional location (`.github/workflows/ci.yml`,
@@ -295,8 +292,8 @@ export class CiFile {
   /** The pipeline this file renders. */
   readonly pipeline: CiPipeline;
 
-  constructor(spec: CiFileSpec = {}) {
-    this.provider = spec.provider ?? DEFAULT_PROVIDER;
+  constructor(spec: CiFileSpec) {
+    this.provider = spec.provider;
     this.path = spec.path ?? DEFAULT_PATHS[this.provider];
     this.pipeline = spec.pipeline ?? {};
   }
@@ -312,19 +309,19 @@ export class CiFile {
  * `generate-ci` command writes it on demand), so the committed configuration is
  * generated from code rather than hand-maintained.
  *
- * Everything is optional: `cicd()` declares a GitHub workflow at
- * `.github/workflows/ci.yml` that runs the build on push/PR to `main`. Override
- * only what you need.
+ * The provider is the only required field: `cicd({ provider: "github" })`
+ * declares a workflow at `.github/workflows/ci.yml` that runs the build on
+ * push/PR to `main`. Override only what else you need.
  *
  * ```ts
  * class MyBuild extends Build {
- *   ci = cicd(); // sensible default workflow
+ *   ci = cicd({ provider: "github" }); // sensible default workflow
  *   // …or customise:
  *   gitlab = cicd({ provider: "gitlab", pipeline: { jobs: [{ steps: [...] }] } });
  * }
  * ```
  */
-export function cicd(spec: CiFileSpec = {}): CiFile {
+export function cicd(spec: CiFileSpec): CiFile {
   return new CiFile(spec);
 }
 

--- a/packages/core/src/ci.ts
+++ b/packages/core/src/ci.ts
@@ -32,6 +32,7 @@
  */
 
 import { toYaml, type YamlValue } from "./yaml.ts";
+import { type Build, forEachField } from "./build.ts";
 
 /** The CI providers {@link generateCi} can target. */
 export type CiProvider = "github" | "gitlab" | "azure";
@@ -234,4 +235,133 @@ export function generateCi(
     case "azure":
       return toYaml(azure(pipeline));
   }
+}
+
+/** A CI configuration file declared on a build: a pipeline bound to a path. */
+export interface CiFileSpec {
+  /** The provider to render for. */
+  provider: CiProvider;
+  /**
+   * The output path (relative to the working directory), e.g.
+   * `.github/workflows/ci.yml`, `.gitlab-ci.yml`, or `azure-pipelines.yml`.
+   */
+  path: string;
+  /** The pipeline to render. */
+  pipeline: CiPipeline;
+}
+
+/**
+ * A declared CI file. Assign one (via {@link cicd}) to a build field and Zuke
+ * keeps the file on disk in sync with the definition when the build runs.
+ */
+export class CiFile {
+  constructor(
+    /** The provider, output path, and pipeline this file renders. */
+    readonly spec: CiFileSpec,
+  ) {}
+
+  /** The output path. */
+  get path(): string {
+    return this.spec.path;
+  }
+
+  /** Render the file's YAML content. */
+  render(): string {
+    return generateCi(this.spec.pipeline, this.spec.provider);
+  }
+}
+
+/**
+ * Declare a CI file as a build field. Running the build regenerates it (and the
+ * `generate-ci` command writes it on demand), so the committed configuration is
+ * generated from code rather than hand-maintained.
+ *
+ * ```ts
+ * class MyBuild extends Build {
+ *   ci = cicd({
+ *     provider: "github",
+ *     path: ".github/workflows/ci.yml",
+ *     pipeline: { name: "CI", triggers: { push: ["main"] }, jobs: [...] },
+ *   });
+ * }
+ * ```
+ */
+export function cicd(spec: CiFileSpec): CiFile {
+  return new CiFile(spec);
+}
+
+/** Find every {@link CiFile} declared on a build instance. */
+export function discoverCiFiles(build: Build): CiFile[] {
+  const files: CiFile[] = [];
+  forEachField(build, (_path, value) => {
+    if (value instanceof CiFile) files.push(value);
+  });
+  return files;
+}
+
+/** What {@link syncCiFiles} did to a file. */
+export type CiSyncStatus = "written" | "unchanged" | "stale";
+
+/** The outcome of syncing one {@link CiFile}. */
+export interface CiSyncResult {
+  /** The file's path. */
+  path: string;
+  /** Whether it was written, already current, or (in check mode) out of date. */
+  status: CiSyncStatus;
+}
+
+/** Filesystem seams for {@link syncCiFiles} (overridable for tests). */
+export interface CiSyncOptions {
+  /**
+   * Verify instead of write: report an out-of-date file as `stale` rather than
+   * overwriting it. Intended for CI, where committed config must match the build.
+   */
+  check?: boolean;
+  /** Read a file's contents, or `null` when it does not exist. */
+  read?: (path: string) => Promise<string | null>;
+  /** Write a file, creating parent directories as needed. */
+  write?: (path: string, content: string) => Promise<void>;
+}
+
+/** Default reader: the file's text, or `null` when it is absent. */
+async function readOrNull(path: string): Promise<string | null> {
+  try {
+    return await Deno.readTextFile(path);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return null;
+    throw error;
+  }
+}
+
+/** Default writer: create the parent directory, then write the file. */
+async function writeFile(path: string, content: string): Promise<void> {
+  const slash = path.replace(/\\/g, "/").lastIndexOf("/");
+  if (slash !== -1) await Deno.mkdir(path.slice(0, slash), { recursive: true });
+  await Deno.writeTextFile(path, content);
+}
+
+/**
+ * Bring each declared {@link CiFile} on disk in line with its definition. By
+ * default a changed file is rewritten; in `check` mode it is reported `stale`
+ * instead (so CI can fail when the committed config has drifted).
+ */
+export async function syncCiFiles(
+  files: readonly CiFile[],
+  options: CiSyncOptions = {},
+): Promise<CiSyncResult[]> {
+  const read = options.read ?? readOrNull;
+  const write = options.write ?? writeFile;
+  const results: CiSyncResult[] = [];
+  for (const file of files) {
+    const content = file.render();
+    if (await read(file.path) === content) {
+      results.push({ path: file.path, status: "unchanged" });
+    } else if (options.check) {
+      results.push({ path: file.path, status: "stale" });
+    } else {
+      await write(file.path, content);
+      results.push({ path: file.path, status: "written" });
+    }
+  }
+  return results;
 }

--- a/packages/core/src/ci.ts
+++ b/packages/core/src/ci.ts
@@ -1,0 +1,237 @@
+/**
+ * Generate CI pipeline configuration from a single typed, provider-agnostic
+ * model. Describe the pipeline once as a {@link CiPipeline} — triggers, jobs,
+ * an optional matrix, and steps — then render it for GitHub Actions, GitLab CI,
+ * or Azure Pipelines with {@link generateCi}.
+ *
+ * ```ts
+ * import { generateCi } from "jsr:@zuke/core";
+ *
+ * const pipeline = {
+ *   name: "CI",
+ *   triggers: { push: ["main"], pullRequest: ["main"] },
+ *   jobs: [{
+ *     id: "test",
+ *     matrix: { os: ["ubuntu-latest", "macos-latest"] },
+ *     steps: [
+ *       { uses: "denoland/setup-deno@v2" },
+ *       { name: "Test", run: "deno task ci" },
+ *     ],
+ *   }],
+ * };
+ * await Deno.writeTextFile(".github/workflows/ci.yml", generateCi(pipeline, "github"));
+ * ```
+ *
+ * The model is intentionally a portable subset. A `run` step (a shell command)
+ * maps to every provider; a `uses` step (a GitHub Action) only renders for
+ * GitHub and is skipped elsewhere, since GitLab and Azure check out the repo
+ * automatically and have no Action equivalent. `runsOn` is interpreted per
+ * provider (a runner label, a Docker image, or a `vmImage`).
+ *
+ * @module
+ */
+
+import { toYaml, type YamlValue } from "./yaml.ts";
+
+/** The CI providers {@link generateCi} can target. */
+export type CiProvider = "github" | "gitlab" | "azure";
+
+/** A single step in a job. */
+export interface CiStep {
+  /** Human-readable step name. */
+  name?: string;
+  /** A shell command to run. Portable across all providers. */
+  run?: string;
+  /**
+   * A GitHub Action reference (e.g. `actions/checkout@v4`). Rendered only for
+   * GitHub; skipped for GitLab and Azure.
+   */
+  uses?: string;
+  /** Inputs for a {@link uses} Action (GitHub only). */
+  with?: Record<string, string>;
+}
+
+/** A job: a named unit of work with steps, optionally fanned out by a matrix. */
+export interface CiJob {
+  /** Stable identifier, used as the job key and as a dependency target. */
+  id: string;
+  /** Human-readable job name. */
+  name?: string;
+  /**
+   * The runner. Interpreted per provider: a GitHub runner label and Azure
+   * `vmImage` (default `ubuntu-latest`), or a GitLab Docker image (runner
+   * default when omitted). Ignored when a matrix defines `os` on GitHub.
+   */
+  runsOn?: string;
+  /** Other jobs (by {@link id}) that must finish before this one. */
+  needs?: string[];
+  /** A build matrix: each key fans out over its values. */
+  matrix?: Record<string, Array<string | number>>;
+  /** Environment variables for the job. */
+  env?: Record<string, string>;
+  /** The steps to run, in order. */
+  steps: CiStep[];
+}
+
+/** When the pipeline runs. */
+export interface CiTriggers {
+  /** Branches whose pushes trigger the pipeline. */
+  push?: string[];
+  /** Branches whose pull/merge requests trigger the pipeline. */
+  pullRequest?: string[];
+  /** Allow manual runs (workflow dispatch / web). */
+  manual?: boolean;
+}
+
+/** A complete, provider-agnostic CI pipeline. */
+export interface CiPipeline {
+  /** The pipeline name. */
+  name: string;
+  /** When it runs. Omit for a pipeline triggered only by external means. */
+  triggers?: CiTriggers;
+  /** The jobs to run. */
+  jobs: CiJob[];
+}
+
+/** The default runner image used when a job does not set {@link CiJob.runsOn}. */
+const DEFAULT_RUNNER = "ubuntu-latest";
+
+/** Collect the shell commands of a job's `run` steps, in order. */
+function runCommands(steps: CiStep[]): string[] {
+  const commands: string[] = [];
+  for (const step of steps) {
+    if (step.run !== undefined) commands.push(step.run);
+  }
+  return commands;
+}
+
+/** Render a GitHub Actions workflow object. */
+function github(pipeline: CiPipeline): YamlValue {
+  const triggers = pipeline.triggers ?? {};
+  const on: Record<string, YamlValue> = {};
+  if (triggers.push) on.push = { branches: triggers.push };
+  if (triggers.pullRequest) {
+    on.pull_request = { branches: triggers.pullRequest };
+  }
+  if (triggers.manual) on.workflow_dispatch = {};
+
+  const jobs: Record<string, YamlValue> = {};
+  for (const job of pipeline.jobs) {
+    const matrixOs = job.matrix !== undefined && "os" in job.matrix;
+    const steps = job.steps.map((step): YamlValue => ({
+      name: step.name,
+      uses: step.uses,
+      with: step.with,
+      run: step.run,
+    }));
+    jobs[job.id] = {
+      name: job.name,
+      "runs-on": matrixOs ? "${{ matrix.os }}" : (job.runsOn ?? DEFAULT_RUNNER),
+      needs: job.needs,
+      strategy: job.matrix ? { matrix: job.matrix } : undefined,
+      env: job.env,
+      steps,
+    };
+  }
+  return { name: pipeline.name, on, jobs };
+}
+
+/** Render a GitLab CI configuration object. */
+function gitlab(pipeline: CiPipeline): YamlValue {
+  const triggers = pipeline.triggers ?? {};
+  const config: Record<string, YamlValue> = {};
+
+  const rules: YamlValue[] = [];
+  for (const branch of triggers.push ?? []) {
+    rules.push({ if: `$CI_COMMIT_BRANCH == "${branch}"` });
+  }
+  if (triggers.pullRequest) {
+    rules.push({ if: `$CI_PIPELINE_SOURCE == "merge_request_event"` });
+  }
+  if (triggers.manual) rules.push({ if: `$CI_PIPELINE_SOURCE == "web"` });
+  if (rules.length > 0) config.workflow = { rules };
+
+  config.stages = ["build"];
+  for (const job of pipeline.jobs) {
+    config[job.id] = {
+      stage: "build",
+      image: job.runsOn,
+      needs: job.needs,
+      variables: job.env,
+      parallel: job.matrix ? { matrix: [job.matrix] } : undefined,
+      script: runCommands(job.steps),
+    };
+  }
+  return config;
+}
+
+/** Expand a matrix into Azure's named-configuration form (cartesian product). */
+function azureMatrix(
+  matrix: Record<string, Array<string | number>>,
+): Record<string, YamlValue> {
+  let combos: Array<Record<string, string | number>> = [{}];
+  for (const key of Object.keys(matrix)) {
+    const expanded: Array<Record<string, string | number>> = [];
+    for (const combo of combos) {
+      for (const value of matrix[key]) {
+        expanded.push({ ...combo, [key]: value });
+      }
+    }
+    combos = expanded;
+  }
+  const configs: Record<string, YamlValue> = {};
+  for (const combo of combos) {
+    configs[Object.values(combo).map(String).join("_")] = combo;
+  }
+  return configs;
+}
+
+/** Render an Azure Pipelines object. */
+function azure(pipeline: CiPipeline): YamlValue {
+  const triggers = pipeline.triggers ?? {};
+  const config: Record<string, YamlValue> = {};
+  if (triggers.push) config.trigger = { branches: { include: triggers.push } };
+  else if (triggers.manual) config.trigger = "none";
+  if (triggers.pullRequest) {
+    config.pr = { branches: { include: triggers.pullRequest } };
+  }
+
+  const jobs: YamlValue[] = [];
+  for (const job of pipeline.jobs) {
+    const steps: YamlValue[] = [];
+    for (const step of job.steps) {
+      if (step.run !== undefined) {
+        steps.push({ script: step.run, displayName: step.name });
+      }
+    }
+    jobs.push({
+      job: job.id,
+      displayName: job.name,
+      pool: { vmImage: job.runsOn ?? DEFAULT_RUNNER },
+      dependsOn: job.needs,
+      strategy: job.matrix ? { matrix: azureMatrix(job.matrix) } : undefined,
+      variables: job.env,
+      steps,
+    });
+  }
+  config.jobs = jobs;
+  return config;
+}
+
+/**
+ * Render `pipeline` as the YAML configuration for `provider`
+ * (`.github/workflows/*.yml`, `.gitlab-ci.yml`, or `azure-pipelines.yml`).
+ */
+export function generateCi(
+  pipeline: CiPipeline,
+  provider: CiProvider,
+): string {
+  switch (provider) {
+    case "github":
+      return toYaml(github(pipeline));
+    case "gitlab":
+      return toYaml(gitlab(pipeline));
+    case "azure":
+      return toYaml(azure(pipeline));
+  }
+}

--- a/packages/core/src/ci.ts
+++ b/packages/core/src/ci.ts
@@ -70,8 +70,8 @@ export interface CiJob {
   matrix?: Record<string, Array<string | number>>;
   /** Environment variables for the job. */
   env?: Record<string, string>;
-  /** The steps to run, in order. */
-  steps: CiStep[];
+  /** The steps to run, in order. Defaults to a single step that runs the build. */
+  steps?: CiStep[];
 }
 
 /** When the pipeline runs. */
@@ -93,8 +93,8 @@ export interface CiPipeline {
    * object (`{}`) for a pipeline triggered only by external means.
    */
   triggers?: CiTriggers;
-  /** The jobs to run. */
-  jobs: CiJob[];
+  /** The jobs to run. Defaults to a single `build` job that runs the build. */
+  jobs?: CiJob[];
 }
 
 /** The default runner image used when a job does not set {@link CiJob.runsOn}. */
@@ -111,6 +111,15 @@ const DEFAULT_PROVIDER: CiProvider = "github";
 
 /** Default triggers: push and pull request on `main`. */
 const DEFAULT_TRIGGERS: CiTriggers = { push: ["main"], pullRequest: ["main"] };
+
+/**
+ * The default step: run the build through the `./zuke` launcher, which
+ * bootstraps Deno itself — so a single step needs no separate setup.
+ */
+const DEFAULT_STEPS: CiStep[] = [{ name: "Build", run: "./zuke" }];
+
+/** The default jobs: a single `build` job running the default steps. */
+const DEFAULT_JOBS: CiJob[] = [{ steps: DEFAULT_STEPS }];
 
 /** The conventional output path for each provider. */
 const DEFAULT_PATHS: Record<CiProvider, string> = {
@@ -139,9 +148,9 @@ function github(pipeline: CiPipeline): YamlValue {
   if (triggers.manual) on.workflow_dispatch = {};
 
   const jobs: Record<string, YamlValue> = {};
-  for (const job of pipeline.jobs) {
+  for (const job of pipeline.jobs ?? DEFAULT_JOBS) {
     const matrixOs = job.matrix !== undefined && "os" in job.matrix;
-    const steps = job.steps.map((step): YamlValue => ({
+    const steps = (job.steps ?? DEFAULT_STEPS).map((step): YamlValue => ({
       name: step.name,
       uses: step.uses,
       with: step.with,
@@ -175,14 +184,14 @@ function gitlab(pipeline: CiPipeline): YamlValue {
   if (rules.length > 0) config.workflow = { rules };
 
   config.stages = ["build"];
-  for (const job of pipeline.jobs) {
+  for (const job of pipeline.jobs ?? DEFAULT_JOBS) {
     config[job.id ?? DEFAULT_JOB_ID] = {
       stage: "build",
       image: job.runsOn,
       needs: job.needs,
       variables: job.env,
       parallel: job.matrix ? { matrix: [job.matrix] } : undefined,
-      script: runCommands(job.steps),
+      script: runCommands(job.steps ?? DEFAULT_STEPS),
     };
   }
   return config;
@@ -220,9 +229,9 @@ function azure(pipeline: CiPipeline): YamlValue {
   }
 
   const jobs: YamlValue[] = [];
-  for (const job of pipeline.jobs) {
+  for (const job of pipeline.jobs ?? DEFAULT_JOBS) {
     const steps: YamlValue[] = [];
-    for (const step of job.steps) {
+    for (const step of job.steps ?? DEFAULT_STEPS) {
       if (step.run !== undefined) {
         steps.push({ script: step.run, displayName: step.name });
       }
@@ -247,7 +256,7 @@ function azure(pipeline: CiPipeline): YamlValue {
  * `azure-pipelines.yml`.
  */
 export function generateCi(
-  pipeline: CiPipeline,
+  pipeline: CiPipeline = {},
   provider: CiProvider = DEFAULT_PROVIDER,
 ): string {
   switch (provider) {
@@ -270,8 +279,8 @@ export interface CiFileSpec {
    * `.gitlab-ci.yml`, or `azure-pipelines.yml`).
    */
   path?: string;
-  /** The pipeline to render. */
-  pipeline: CiPipeline;
+  /** The pipeline to render. Defaults to a single `build` job that runs the build. */
+  pipeline?: CiPipeline;
 }
 
 /**
@@ -286,10 +295,10 @@ export class CiFile {
   /** The pipeline this file renders. */
   readonly pipeline: CiPipeline;
 
-  constructor(spec: CiFileSpec) {
+  constructor(spec: CiFileSpec = {}) {
     this.provider = spec.provider ?? DEFAULT_PROVIDER;
     this.path = spec.path ?? DEFAULT_PATHS[this.provider];
-    this.pipeline = spec.pipeline;
+    this.pipeline = spec.pipeline ?? {};
   }
 
   /** Render the file's YAML content. */
@@ -303,17 +312,19 @@ export class CiFile {
  * `generate-ci` command writes it on demand), so the committed configuration is
  * generated from code rather than hand-maintained.
  *
+ * Everything is optional: `cicd()` declares a GitHub workflow at
+ * `.github/workflows/ci.yml` that runs the build on push/PR to `main`. Override
+ * only what you need.
+ *
  * ```ts
  * class MyBuild extends Build {
- *   ci = cicd({
- *     provider: "github",
- *     path: ".github/workflows/ci.yml",
- *     pipeline: { name: "CI", triggers: { push: ["main"] }, jobs: [...] },
- *   });
+ *   ci = cicd(); // sensible default workflow
+ *   // …or customise:
+ *   gitlab = cicd({ provider: "gitlab", pipeline: { jobs: [{ steps: [...] }] } });
  * }
  * ```
  */
-export function cicd(spec: CiFileSpec): CiFile {
+export function cicd(spec: CiFileSpec = {}): CiFile {
   return new CiFile(spec);
 }
 

--- a/packages/core/src/ci.ts
+++ b/packages/core/src/ci.ts
@@ -54,8 +54,8 @@ export interface CiStep {
 
 /** A job: a named unit of work with steps, optionally fanned out by a matrix. */
 export interface CiJob {
-  /** Stable identifier, used as the job key and as a dependency target. */
-  id: string;
+  /** Stable identifier, used as the job key and as a dependency target. Defaults to `"build"`. */
+  id?: string;
   /** Human-readable job name. */
   name?: string;
   /**
@@ -86,9 +86,12 @@ export interface CiTriggers {
 
 /** A complete, provider-agnostic CI pipeline. */
 export interface CiPipeline {
-  /** The pipeline name. */
-  name: string;
-  /** When it runs. Omit for a pipeline triggered only by external means. */
+  /** The pipeline name. Defaults to `"CI"`. */
+  name?: string;
+  /**
+   * When it runs. Defaults to push and pull request on `main`; pass an empty
+   * object (`{}`) for a pipeline triggered only by external means.
+   */
   triggers?: CiTriggers;
   /** The jobs to run. */
   jobs: CiJob[];
@@ -96,6 +99,25 @@ export interface CiPipeline {
 
 /** The default runner image used when a job does not set {@link CiJob.runsOn}. */
 const DEFAULT_RUNNER = "ubuntu-latest";
+
+/** The default pipeline name. */
+const DEFAULT_NAME = "CI";
+
+/** The default job id when one is not given. */
+const DEFAULT_JOB_ID = "build";
+
+/** The default provider for {@link generateCi} and {@link cicd}. */
+const DEFAULT_PROVIDER: CiProvider = "github";
+
+/** Default triggers: push and pull request on `main`. */
+const DEFAULT_TRIGGERS: CiTriggers = { push: ["main"], pullRequest: ["main"] };
+
+/** The conventional output path for each provider. */
+const DEFAULT_PATHS: Record<CiProvider, string> = {
+  github: ".github/workflows/ci.yml",
+  gitlab: ".gitlab-ci.yml",
+  azure: "azure-pipelines.yml",
+};
 
 /** Collect the shell commands of a job's `run` steps, in order. */
 function runCommands(steps: CiStep[]): string[] {
@@ -108,7 +130,7 @@ function runCommands(steps: CiStep[]): string[] {
 
 /** Render a GitHub Actions workflow object. */
 function github(pipeline: CiPipeline): YamlValue {
-  const triggers = pipeline.triggers ?? {};
+  const triggers = pipeline.triggers ?? DEFAULT_TRIGGERS;
   const on: Record<string, YamlValue> = {};
   if (triggers.push) on.push = { branches: triggers.push };
   if (triggers.pullRequest) {
@@ -125,7 +147,7 @@ function github(pipeline: CiPipeline): YamlValue {
       with: step.with,
       run: step.run,
     }));
-    jobs[job.id] = {
+    jobs[job.id ?? DEFAULT_JOB_ID] = {
       name: job.name,
       "runs-on": matrixOs ? "${{ matrix.os }}" : (job.runsOn ?? DEFAULT_RUNNER),
       needs: job.needs,
@@ -134,12 +156,12 @@ function github(pipeline: CiPipeline): YamlValue {
       steps,
     };
   }
-  return { name: pipeline.name, on, jobs };
+  return { name: pipeline.name ?? DEFAULT_NAME, on, jobs };
 }
 
 /** Render a GitLab CI configuration object. */
 function gitlab(pipeline: CiPipeline): YamlValue {
-  const triggers = pipeline.triggers ?? {};
+  const triggers = pipeline.triggers ?? DEFAULT_TRIGGERS;
   const config: Record<string, YamlValue> = {};
 
   const rules: YamlValue[] = [];
@@ -154,7 +176,7 @@ function gitlab(pipeline: CiPipeline): YamlValue {
 
   config.stages = ["build"];
   for (const job of pipeline.jobs) {
-    config[job.id] = {
+    config[job.id ?? DEFAULT_JOB_ID] = {
       stage: "build",
       image: job.runsOn,
       needs: job.needs,
@@ -189,7 +211,7 @@ function azureMatrix(
 
 /** Render an Azure Pipelines object. */
 function azure(pipeline: CiPipeline): YamlValue {
-  const triggers = pipeline.triggers ?? {};
+  const triggers = pipeline.triggers ?? DEFAULT_TRIGGERS;
   const config: Record<string, YamlValue> = {};
   if (triggers.push) config.trigger = { branches: { include: triggers.push } };
   else if (triggers.manual) config.trigger = "none";
@@ -206,7 +228,7 @@ function azure(pipeline: CiPipeline): YamlValue {
       }
     }
     jobs.push({
-      job: job.id,
+      job: job.id ?? DEFAULT_JOB_ID,
       displayName: job.name,
       pool: { vmImage: job.runsOn ?? DEFAULT_RUNNER },
       dependsOn: job.needs,
@@ -220,12 +242,13 @@ function azure(pipeline: CiPipeline): YamlValue {
 }
 
 /**
- * Render `pipeline` as the YAML configuration for `provider`
- * (`.github/workflows/*.yml`, `.gitlab-ci.yml`, or `azure-pipelines.yml`).
+ * Render `pipeline` as the YAML configuration for `provider` (default
+ * `"github"`): `.github/workflows/*.yml`, `.gitlab-ci.yml`, or
+ * `azure-pipelines.yml`.
  */
 export function generateCi(
   pipeline: CiPipeline,
-  provider: CiProvider,
+  provider: CiProvider = DEFAULT_PROVIDER,
 ): string {
   switch (provider) {
     case "github":
@@ -239,13 +262,14 @@ export function generateCi(
 
 /** A CI configuration file declared on a build: a pipeline bound to a path. */
 export interface CiFileSpec {
-  /** The provider to render for. */
-  provider: CiProvider;
+  /** The provider to render for. Defaults to `"github"`. */
+  provider?: CiProvider;
   /**
-   * The output path (relative to the working directory), e.g.
-   * `.github/workflows/ci.yml`, `.gitlab-ci.yml`, or `azure-pipelines.yml`.
+   * The output path (relative to the working directory). Defaults to the
+   * provider's conventional location (`.github/workflows/ci.yml`,
+   * `.gitlab-ci.yml`, or `azure-pipelines.yml`).
    */
-  path: string;
+  path?: string;
   /** The pipeline to render. */
   pipeline: CiPipeline;
 }
@@ -255,19 +279,22 @@ export interface CiFileSpec {
  * keeps the file on disk in sync with the definition when the build runs.
  */
 export class CiFile {
-  constructor(
-    /** The provider, output path, and pipeline this file renders. */
-    readonly spec: CiFileSpec,
-  ) {}
-
+  /** The provider this file renders for. */
+  readonly provider: CiProvider;
   /** The output path. */
-  get path(): string {
-    return this.spec.path;
+  readonly path: string;
+  /** The pipeline this file renders. */
+  readonly pipeline: CiPipeline;
+
+  constructor(spec: CiFileSpec) {
+    this.provider = spec.provider ?? DEFAULT_PROVIDER;
+    this.path = spec.path ?? DEFAULT_PATHS[this.provider];
+    this.pipeline = spec.pipeline;
   }
 
   /** Render the file's YAML content. */
   render(): string {
-    return generateCi(this.spec.pipeline, this.spec.provider);
+    return generateCi(this.pipeline, this.provider);
   }
 }
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -4,6 +4,8 @@
  */
 
 import { type Build, discoverGroups, discoverTargets } from "./build.ts";
+import { discoverCiFiles, syncCiFiles } from "./ci.ts";
+import { isCI } from "./host.ts";
 import { GraphError, validateGraph } from "./graph.ts";
 import { execute } from "./executor.ts";
 import {
@@ -19,6 +21,9 @@ const DEFAULT_TARGET = "default";
 
 /** The reserved positional command that renders the dependency graph. */
 const GRAPH_COMMAND = "graph";
+
+/** The reserved positional command that writes declared CI configuration. */
+const GENERATE_CI_COMMAND = "generate-ci";
 
 /** Output format for the `graph` command: a terminal listing or an HTML page. */
 export type GraphOutput = "text" | "html";
@@ -49,6 +54,10 @@ export interface ParsedArgs {
   list: boolean;
   /** The `graph` command was requested. */
   graph: boolean;
+  /** The `generate-ci` command was requested. */
+  generateCi: boolean;
+  /** Verify (rather than write) generated files (`--check`); fail if stale. */
+  check: boolean;
   /** Graph output format (`--output`); defaults to `text`. */
   output: GraphOutput;
   /** Open the HTML graph in a browser (default true; `--no-open` clears). */
@@ -84,6 +93,8 @@ export function parseArgs(
     skip: [],
     list: false,
     graph: false,
+    generateCi: false,
+    check: false,
     output: "text",
     open: true,
     values: {},
@@ -103,6 +114,8 @@ export function parseArgs(
       parsed.cache = false;
     } else if (arg === "--dry-run") {
       parsed.dryRun = true;
+    } else if (arg === "--check") {
+      parsed.check = true;
     } else if (arg === "--parallel") {
       parsed.parallel = true;
     } else if (arg.startsWith("--parallel=")) {
@@ -134,8 +147,11 @@ export function parseArgs(
         }
       }
       // Unknown flags are ignored.
-    } else if (parsed.target === undefined && !parsed.graph) {
+    } else if (
+      parsed.target === undefined && !parsed.graph && !parsed.generateCi
+    ) {
       if (arg === GRAPH_COMMAND) parsed.graph = true;
+      else if (arg === GENERATE_CI_COMMAND) parsed.generateCi = true;
       else parsed.target = arg;
     }
   }
@@ -153,6 +169,7 @@ Usage:
   deno run -A zuke.ts <target> [--skip <dep>] [--parallel[=N]]
   deno run -A zuke.ts --list
   deno run -A zuke.ts graph [--output=html] [--no-open]
+  deno run -A zuke.ts generate-ci [--check]
 
 Options:
   <target>          Run the target and its transitive dependencies.
@@ -165,6 +182,10 @@ Options:
   graph             Show the dependency graph. Default output is the terminal
                     adjacency listing; --output=html writes an interactive
                     page to .zuke/ and opens it in a browser.
+  generate-ci       Write the CI configuration files declared on the build
+                    (via cicd()). Running any target regenerates them too.
+  --check           With generate-ci, verify the files are current instead of
+                    writing them, failing if any has drifted (use on CI).
   --output <fmt>    Graph output format: text (default) or html.
   --no-open         With --output=html, do not open a browser.
   --<param> <val>   Set a declared build parameter (see Parameters below).
@@ -242,6 +263,42 @@ export function formatGraph(targets: Map<string, TargetBuilder>): string {
 }
 
 /**
+ * Generate (or, with `check`, verify) the CI files a build declares, logging
+ * what changed and returning a process exit code. This is the single code path
+ * shared by the `generate-ci` command and the automatic regeneration that runs
+ * with the build.
+ *
+ * @param quietWhenEmpty Stay silent when the build declares no CI files (used by
+ *   the implicit on-run hook); the explicit command reports it instead.
+ */
+export async function syncCiConfig(
+  build: Build,
+  options: { check?: boolean; quietWhenEmpty?: boolean } = {},
+): Promise<number> {
+  const files = discoverCiFiles(build);
+  if (files.length === 0) {
+    if (!options.quietWhenEmpty) {
+      console.log("No CI configuration is declared on this build.");
+    }
+    return 0;
+  }
+  const results = await syncCiFiles(files, { check: options.check });
+  const stale: string[] = [];
+  for (const { path, status } of results) {
+    if (status === "written") console.log(`Generated ${path}`);
+    else if (status === "stale") stale.push(path);
+  }
+  if (stale.length > 0) {
+    console.error(
+      `CI configuration is out of date: ${stale.join(", ")}.\n` +
+        `Run \`zuke generate-ci\` and commit the result.`,
+    );
+    return 1;
+  }
+  return 0;
+}
+
+/**
  * Drive a build to completion and resolve to a process exit code (0 success,
  * 1 failure). Does not call `Deno.exit`, so it is unit-testable; {@link run}
  * wraps it. Output goes through `console` unless `execute` options say otherwise.
@@ -289,6 +346,9 @@ export async function main(
     console.log(formatGraph(targets));
     return 0;
   }
+  if (parsed.generateCi) {
+    return await syncCiConfig(build, { check: parsed.check });
+  }
 
   let name = parsed.target;
   if (name === undefined) {
@@ -305,6 +365,17 @@ export async function main(
     console.error(`Unknown target: ${name}\n`);
     console.error(formatList(targets, params));
     return 1;
+  }
+
+  // Keep declared CI config in sync as part of running the build (NUKE-style):
+  // write changes locally, but only verify on CI so an ephemeral checkout is
+  // never dirtied — a drifted file fails the build there instead.
+  if (!parsed.dryRun) {
+    const ciCode = await syncCiConfig(build, {
+      check: isCI(),
+      quietWhenEmpty: true,
+    });
+    if (ciCode !== 0) return ciCode;
   }
 
   const result = await execute(build, root, {

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -367,9 +367,9 @@ export async function main(
     return 1;
   }
 
-  // Keep declared CI config in sync as part of running the build (NUKE-style):
-  // write changes locally, but only verify on CI so an ephemeral checkout is
-  // never dirtied — a drifted file fails the build there instead.
+  // Keep declared CI config in sync as part of running the build: write
+  // changes locally, but only verify on CI so an ephemeral checkout is never
+  // dirtied — a drifted file fails the build there instead.
   if (!parsed.dryRun) {
     const ciCode = await syncCiConfig(build, {
       check: isCI(),

--- a/packages/core/src/path.ts
+++ b/packages/core/src/path.ts
@@ -1,11 +1,11 @@
 /**
  * Ergonomic, immutable file paths for build scripts.
  *
- * TypeScript has no operator overloading, so Zuke cannot mimic NUKE's
- * `RootDirectory / "src" / "Project.csproj"` literally. {@link absolutePath}
- * gets as close as the language allows: the returned {@link AbsolutePath} is
- * **callable**, so appending segments reads almost like the original — and a
- * `.join(...)` method does the same thing explicitly.
+ * TypeScript has no operator overloading, so Zuke cannot offer a
+ * `RootDirectory / "src" / "Project.csproj"` path-join operator literally.
+ * {@link absolutePath} gets as close as the language allows: the returned
+ * {@link AbsolutePath} is **callable**, so appending segments reads almost like
+ * the original — and a `.join(...)` method does the same thing explicitly.
  *
  * ```ts
  * import { absolutePath } from "jsr:@zuke/core";
@@ -97,7 +97,7 @@ function extensionOf(name: string): string {
 }
 
 /**
- * An immutable, absolute filesystem path with a fluent, NUKE-inspired API.
+ * An immutable, absolute filesystem path with a fluent API.
  *
  * Build one with {@link absolutePath}. The value itself is **callable** —
  * `path(...segments)` returns a new path with those segments appended — and the

--- a/packages/core/src/yaml.ts
+++ b/packages/core/src/yaml.ts
@@ -1,0 +1,136 @@
+/**
+ * A tiny, dependency-free YAML emitter for the structured subset Zuke needs to
+ * generate CI configuration: mappings, sequences, and scalars (strings,
+ * numbers, booleans, null), with block-literal output for multi-line strings.
+ *
+ * It is deliberately minimal — there is no parser and no support for anchors,
+ * tags, or flow collections beyond empty `{}`/`[]`. Strings are emitted as plain
+ * scalars when unambiguous and double-quoted (JSON-escaped) otherwise, so YAML
+ * 1.1 pitfalls — a bare `on` or `no` becoming a boolean, a bare `1.20` becoming
+ * a number — are quoted away.
+ *
+ * @module
+ */
+
+/** A scalar value emittable as YAML. */
+export type YamlScalar = string | number | boolean | null;
+
+/** Any value emittable as YAML: a scalar, a sequence, or a mapping. */
+export type YamlValue =
+  | YamlScalar
+  | readonly YamlValue[]
+  | { readonly [key: string]: YamlValue | undefined };
+
+/** YAML 1.1 words a plain scalar would be misread as. */
+const RESERVED = new Set([
+  "true",
+  "false",
+  "null",
+  "yes",
+  "no",
+  "on",
+  "off",
+  "~",
+]);
+
+/** Whether `s` must be quoted to round-trip as the intended string. */
+function needsQuote(s: string): boolean {
+  if (s === "") return true;
+  if (s.trim() !== s) return true; // leading/trailing whitespace
+  if (RESERVED.has(s.toLowerCase())) return true;
+  if (/^[-+]?\d+(\.\d+)?$/.test(s)) return true; // would parse as a number
+  return !/^[A-Za-z0-9_./@][A-Za-z0-9_./@ -]*$/.test(s);
+}
+
+/** Render a string/key, quoting (JSON-escaped) only when necessary. */
+function quoted(s: string): string {
+  return needsQuote(s) ? JSON.stringify(s) : s;
+}
+
+/** Render an inline scalar token (used after `key:` and `- `). */
+function token(value: YamlScalar): string {
+  if (value === null) return "null";
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return quoted(value);
+}
+
+/** Type guard: a YAML sequence (works around `Array.isArray` + `readonly`). */
+function isSeq(value: YamlValue): value is readonly YamlValue[] {
+  return Array.isArray(value);
+}
+
+/** Type guard: a YAML mapping. */
+function isMap(
+  value: YamlValue,
+): value is { readonly [key: string]: YamlValue | undefined } {
+  return typeof value === "object" && value !== null && !isSeq(value);
+}
+
+const pad = (indent: number): string => "  ".repeat(indent);
+
+/** Render the lines of a mapping at the given indent level. */
+function renderMap(
+  map: { readonly [key: string]: YamlValue | undefined },
+  indent: number,
+): string[] {
+  const lines: string[] = [];
+  for (const [name, value] of Object.entries(map)) {
+    if (value === undefined) continue;
+    lines.push(...renderEntry(name, value, indent));
+  }
+  return lines;
+}
+
+/** Render a single `key: value` entry, recursing for containers. */
+function renderEntry(name: string, value: YamlValue, indent: number): string[] {
+  const prefix = `${pad(indent)}${quoted(name)}:`;
+  if (typeof value === "string" && value.includes("\n")) {
+    const child = pad(indent + 1);
+    const body = value.split("\n").map((l) => l === "" ? "" : child + l);
+    return [`${prefix} |`, ...body];
+  }
+  if (isSeq(value)) {
+    return value.length === 0
+      ? [`${prefix} []`]
+      : [prefix, ...renderSeq(value, indent + 1)];
+  }
+  if (isMap(value)) {
+    const inner = renderMap(value, indent + 1);
+    return inner.length === 0 ? [`${prefix} {}`] : [prefix, ...inner];
+  }
+  return [`${prefix} ${token(value)}`];
+}
+
+/** Render the lines of a sequence at the given indent level. */
+function renderSeq(seq: readonly YamlValue[], indent: number): string[] {
+  const lines: string[] = [];
+  for (const item of seq) {
+    if (isSeq(item)) {
+      lines.push(`${pad(indent)}-`, ...renderSeq(item, indent + 1));
+    } else if (isMap(item)) {
+      const block = renderMap(item, indent + 1);
+      if (block.length === 0) {
+        lines.push(`${pad(indent)}- {}`);
+      } else {
+        // Hang the first key off the dash: "- key: value".
+        block[0] = `${pad(indent)}- ${block[0].slice((indent + 1) * 2)}`;
+        lines.push(...block);
+      }
+    } else {
+      lines.push(`${pad(indent)}- ${token(item)}`);
+    }
+  }
+  return lines;
+}
+
+/** Serialize `value` to a YAML document string (trailing newline included). */
+export function toYaml(value: YamlValue): string {
+  const lines = isSeq(value)
+    ? renderSeq(value, 0)
+    : isMap(value)
+    ? renderMap(value, 0)
+    : [token(value)];
+  return lines.join("\n") + "\n";
+}

--- a/packages/core/tests/_assert.ts
+++ b/packages/core/tests/_assert.ts
@@ -41,6 +41,22 @@ export function assertEquals<T>(actual: T, expected: T, msg?: string): void {
   }
 }
 
+/** Assert that `haystack` contains the substring `needle`. */
+export function assertStringIncludes(
+  haystack: string,
+  needle: string,
+  msg?: string,
+): void {
+  if (!haystack.includes(needle)) {
+    throw new Error(
+      msg ??
+        `Expected string to contain substring.\n  substring: ${
+          JSON.stringify(needle)
+        }\n  actual:    ${JSON.stringify(haystack)}`,
+    );
+  }
+}
+
 /** Assert that `fn` throws; optionally check the error type and message. */
 export function assertThrows(
   fn: () => unknown,

--- a/packages/core/tests/ci_test.ts
+++ b/packages/core/tests/ci_test.ts
@@ -1,5 +1,13 @@
 import { assertEquals, assertStringIncludes } from "./_assert.ts";
-import { type CiPipeline, generateCi } from "../src/ci.ts";
+import {
+  cicd,
+  type CiPipeline,
+  discoverCiFiles,
+  generateCi,
+  syncCiFiles,
+} from "../src/ci.ts";
+import { Build } from "../src/build.ts";
+import { target } from "../src/target.ts";
 
 /** A small pipeline exercised across providers. */
 const pipeline: CiPipeline = {
@@ -130,4 +138,115 @@ Deno.test("a pipeline with no triggers renders without an on/trigger block", () 
   assertStringIncludes(generateCi(bare, "github"), `"on": {}`);
   assertEquals(generateCi(bare, "gitlab").includes("workflow:"), false);
   assertEquals(generateCi(bare, "azure").includes("trigger:"), false);
+});
+
+// --- Declarative CI files: cicd(), discovery, and on-disk sync ---
+
+const filePipeline: CiPipeline = {
+  name: "CI",
+  triggers: { push: ["main"] },
+  jobs: [{ id: "test", steps: [{ run: "deno task ci" }] }],
+};
+
+Deno.test("cicd: path and render reflect the spec", () => {
+  const file = cicd({
+    provider: "github",
+    path: ".github/workflows/ci.yml",
+    pipeline: filePipeline,
+  });
+  assertEquals(file.path, ".github/workflows/ci.yml");
+  assertStringIncludes(file.render(), "name: CI");
+});
+
+Deno.test("discoverCiFiles collects every declared CI file", () => {
+  class WithCi extends Build {
+    gh = cicd({
+      provider: "github",
+      path: ".github/workflows/ci.yml",
+      pipeline: filePipeline,
+    });
+    gl = cicd({
+      provider: "gitlab",
+      path: ".gitlab-ci.yml",
+      pipeline: filePipeline,
+    });
+    build = target().executes(() => {});
+  }
+  const paths = discoverCiFiles(new WithCi()).map((f) => f.path).sort();
+  assertEquals(paths, [".github/workflows/ci.yml", ".gitlab-ci.yml"]);
+});
+
+Deno.test("discoverCiFiles returns nothing for a build without CI", () => {
+  class Bare extends Build {
+    build = target().executes(() => {});
+  }
+  assertEquals(discoverCiFiles(new Bare()), []);
+});
+
+Deno.test("syncCiFiles writes a changed file, then leaves a current one", async () => {
+  const store = new Map<string, string>();
+  const file = cicd({
+    provider: "github",
+    path: "ci.yml",
+    pipeline: filePipeline,
+  });
+  const opts = {
+    read: (p: string) => Promise.resolve(store.get(p) ?? null),
+    write: (p: string, c: string) => {
+      store.set(p, c);
+      return Promise.resolve();
+    },
+  };
+  const first = await syncCiFiles([file], opts);
+  assertEquals(first[0].status, "written");
+  assertEquals(store.get("ci.yml"), file.render());
+  const second = await syncCiFiles([file], opts);
+  assertEquals(second[0].status, "unchanged");
+});
+
+Deno.test("syncCiFiles in check mode reports a stale file without writing", async () => {
+  const file = cicd({
+    provider: "github",
+    path: "ci.yml",
+    pipeline: filePipeline,
+  });
+  let wrote = false;
+  const results = await syncCiFiles([file], {
+    check: true,
+    read: () => Promise.resolve("old content"),
+    write: () => {
+      wrote = true;
+      return Promise.resolve();
+    },
+  });
+  assertEquals(results[0].status, "stale");
+  assertEquals(wrote, false);
+});
+
+Deno.test("syncCiFiles in check mode passes when content already matches", async () => {
+  const file = cicd({
+    provider: "github",
+    path: "ci.yml",
+    pipeline: filePipeline,
+  });
+  const results = await syncCiFiles([file], {
+    check: true,
+    read: () => Promise.resolve(file.render()),
+  });
+  assertEquals(results[0].status, "unchanged");
+});
+
+Deno.test("syncCiFiles uses the real filesystem by default", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const path = `${dir}/.github/workflows/ci.yml`;
+    const file = cicd({ provider: "github", path, pipeline: filePipeline });
+    const first = await syncCiFiles([file]); // creates parent dirs and writes
+    assertEquals(first[0].status, "written");
+    assertEquals(await Deno.readTextFile(path), file.render());
+    const second = await syncCiFiles([file]);
+    assertEquals(second[0].status, "unchanged");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
 });

--- a/packages/core/tests/ci_test.ts
+++ b/packages/core/tests/ci_test.ts
@@ -1,0 +1,133 @@
+import { assertEquals, assertStringIncludes } from "./_assert.ts";
+import { type CiPipeline, generateCi } from "../src/ci.ts";
+
+/** A small pipeline exercised across providers. */
+const pipeline: CiPipeline = {
+  name: "CI",
+  triggers: { push: ["main"], pullRequest: ["main"], manual: true },
+  jobs: [{
+    id: "test",
+    name: "Test suite",
+    needs: ["lint"],
+    matrix: { os: ["ubuntu-latest", "macos-latest"] },
+    env: { CI: "true" },
+    steps: [
+      { uses: "denoland/setup-deno@v2", with: { "deno-version": "v2.x" } },
+      { name: "Run tests", run: "deno task ci" },
+    ],
+  }, {
+    id: "lint",
+    steps: [{ run: "deno lint" }],
+  }],
+};
+
+Deno.test("github: triggers, matrix-driven runs-on, needs, uses and run steps", () => {
+  const yaml = generateCi(pipeline, "github");
+  assertStringIncludes(yaml, "name: CI");
+  // `on` is quoted so YAML doesn't read it as a boolean.
+  assertStringIncludes(yaml, `"on":`);
+  assertStringIncludes(yaml, "push:\n    branches:\n      - main");
+  assertStringIncludes(yaml, "pull_request:");
+  assertStringIncludes(yaml, "workflow_dispatch: {}");
+  // A job with an `os` matrix runs on the matrix value.
+  assertStringIncludes(yaml, `runs-on: "\${{ matrix.os }}"`);
+  assertStringIncludes(yaml, "strategy:\n      matrix:\n        os:");
+  assertStringIncludes(yaml, "needs:\n      - lint");
+  assertStringIncludes(yaml, "uses: denoland/setup-deno@v2");
+  assertStringIncludes(yaml, "deno-version: v2.x");
+  assertStringIncludes(yaml, "run: deno task ci");
+});
+
+Deno.test("github: a job without an os matrix uses runsOn or the default", () => {
+  const yaml = generateCi({
+    name: "CI",
+    jobs: [
+      { id: "a", runsOn: "windows-latest", steps: [{ run: "echo a" }] },
+      { id: "b", steps: [{ run: "echo b" }] },
+    ],
+  }, "github");
+  assertStringIncludes(yaml, "runs-on: windows-latest");
+  assertStringIncludes(yaml, "runs-on: ubuntu-latest");
+});
+
+Deno.test("gitlab: workflow rules, stages, image, parallel matrix, script", () => {
+  const yaml = generateCi(pipeline, "gitlab");
+  assertStringIncludes(yaml, "workflow:\n  rules:");
+  // The `if:` expressions contain `$` and quotes, so YAML double-quotes them;
+  // assert on the distinctive inner tokens rather than the escaped string.
+  assertStringIncludes(yaml, "CI_COMMIT_BRANCH");
+  assertStringIncludes(yaml, "merge_request_event");
+  assertStringIncludes(yaml, "CI_PIPELINE_SOURCE ==");
+  assertStringIncludes(yaml, "stages:\n  - build");
+  assertStringIncludes(yaml, "test:\n  stage: build");
+  // Only `run` steps become script lines; the `uses` step is dropped.
+  assertStringIncludes(yaml, "script:\n    - deno task ci");
+  assertEquals(yaml.includes("setup-deno"), false);
+  assertStringIncludes(yaml, "parallel:\n    matrix:\n      - os:");
+});
+
+Deno.test("gitlab: a job's runsOn becomes the image", () => {
+  const yaml = generateCi({
+    name: "CI",
+    jobs: [{ id: "a", runsOn: "denoland/deno:latest", steps: [{ run: "x" }] }],
+  }, "gitlab");
+  // A colon makes the image value a quoted scalar; assert the value substring.
+  assertStringIncludes(yaml, "denoland/deno:latest");
+});
+
+Deno.test("azure: trigger/pr branches, pool, dependsOn, matrix product, steps", () => {
+  const yaml = generateCi(pipeline, "azure");
+  assertStringIncludes(
+    yaml,
+    "trigger:\n  branches:\n    include:\n      - main",
+  );
+  assertStringIncludes(yaml, "pr:\n  branches:\n    include:\n      - main");
+  assertStringIncludes(yaml, "- job: test");
+  assertStringIncludes(yaml, "displayName: Test suite");
+  assertStringIncludes(yaml, "pool:\n      vmImage: ubuntu-latest");
+  assertStringIncludes(yaml, "dependsOn:\n      - lint");
+  // Single-dimension matrix yields one named config per value.
+  assertStringIncludes(
+    yaml,
+    "matrix:\n        ubuntu-latest:\n          os: ubuntu-latest",
+  );
+  assertStringIncludes(yaml, "script: deno task ci");
+  assertEquals(yaml.includes("setup-deno"), false);
+});
+
+Deno.test("azure: a multi-dimension matrix is expanded to the cartesian product", () => {
+  const yaml = generateCi({
+    name: "CI",
+    jobs: [{
+      id: "test",
+      matrix: { os: ["linux", "mac"], deno: ["1.0", "2.0"] },
+      steps: [{ run: "x" }],
+    }],
+  }, "azure");
+  // 2 x 2 = 4 named configurations, labelled by their joined values.
+  assertStringIncludes(yaml, "linux_1.0:");
+  assertStringIncludes(yaml, "linux_2.0:");
+  assertStringIncludes(yaml, "mac_1.0:");
+  assertStringIncludes(yaml, "mac_2.0:");
+  // Numeric-looking matrix values are quoted to stay strings.
+  assertStringIncludes(yaml, `deno: "2.0"`);
+});
+
+Deno.test("azure: a manual-only pipeline disables the CI trigger", () => {
+  const yaml = generateCi({
+    name: "CI",
+    triggers: { manual: true },
+    jobs: [{ id: "a", steps: [{ run: "x" }] }],
+  }, "azure");
+  assertStringIncludes(yaml, "trigger: none");
+});
+
+Deno.test("a pipeline with no triggers renders without an on/trigger block", () => {
+  const bare: CiPipeline = {
+    name: "CI",
+    jobs: [{ id: "a", steps: [{ run: "x" }] }],
+  };
+  assertStringIncludes(generateCi(bare, "github"), `"on": {}`);
+  assertEquals(generateCi(bare, "gitlab").includes("workflow:"), false);
+  assertEquals(generateCi(bare, "azure").includes("trigger:"), false);
+});

--- a/packages/core/tests/ci_test.ts
+++ b/packages/core/tests/ci_test.ts
@@ -141,14 +141,17 @@ Deno.test("explicit empty triggers render without an on/trigger block", () => {
   assertEquals(generateCi(bare, "azure").includes("trigger:"), false);
 });
 
-Deno.test("defaults: provider, name, triggers and job id fill in", () => {
+Deno.test("defaults: name, triggers and job id fill in", () => {
   // Only steps are given; everything else falls back to a meaningful default.
-  const yaml = generateCi({ jobs: [{ steps: [{ run: "deno task ci" }] }] });
+  const yaml = generateCi(
+    { jobs: [{ steps: [{ run: "deno task ci" }] }] },
+    "github",
+  );
   assertStringIncludes(yaml, "name: CI"); // default name
   assertStringIncludes(yaml, `"on":`); // default triggers present
   assertStringIncludes(yaml, "push:\n    branches:\n      - main"); // default branch
   assertStringIncludes(yaml, "pull_request:");
-  assertStringIncludes(yaml, "build:"); // default job id (github default provider)
+  assertStringIncludes(yaml, "build:"); // default job id
 });
 
 Deno.test("defaults: a default job id flows through every provider", () => {
@@ -163,7 +166,7 @@ Deno.test("defaults: a default job id flows through every provider", () => {
 
 Deno.test("defaults: jobs and steps fall back to a single build step", () => {
   // An empty pipeline still produces a complete, runnable workflow.
-  const yaml = generateCi();
+  const yaml = generateCi({}, "github");
   assertStringIncludes(yaml, "name: CI");
   assertStringIncludes(yaml, "build:"); // default job id
   assertStringIncludes(yaml, "run: ./zuke"); // default step runs the build
@@ -182,22 +185,28 @@ Deno.test("defaults: a job may omit steps and get the default step", () => {
   assertStringIncludes(yaml, "run: ./zuke");
 });
 
-Deno.test("cicd: with no spec declares the default workflow", () => {
-  const file = cicd();
+Deno.test("cicd: with only a provider declares the default workflow", () => {
+  const file = cicd({ provider: "github" });
   assertEquals(file.path, ".github/workflows/ci.yml");
   assertStringIncludes(file.render(), "run: ./zuke");
 });
 
-Deno.test("cicd: provider defaults to github and path follows the provider", () => {
+Deno.test("cicd: the path follows the provider unless overridden", () => {
   const pipeline: CiPipeline = { jobs: [{ steps: [{ run: "x" }] }] };
-  assertEquals(cicd({ pipeline }).path, ".github/workflows/ci.yml");
+  assertEquals(
+    cicd({ provider: "github", pipeline }).path,
+    ".github/workflows/ci.yml",
+  );
   assertEquals(cicd({ provider: "gitlab", pipeline }).path, ".gitlab-ci.yml");
   assertEquals(
     cicd({ provider: "azure", pipeline }).path,
     "azure-pipelines.yml",
   );
   // An explicit path overrides the convention.
-  assertEquals(cicd({ path: "custom.yml", pipeline }).path, "custom.yml");
+  assertEquals(
+    cicd({ provider: "github", path: "custom.yml", pipeline }).path,
+    "custom.yml",
+  );
 });
 
 // --- Declarative CI files: cicd(), discovery, and on-disk sync ---

--- a/packages/core/tests/ci_test.ts
+++ b/packages/core/tests/ci_test.ts
@@ -161,6 +161,33 @@ Deno.test("defaults: a default job id flows through every provider", () => {
   assertStringIncludes(generateCi(pipeline, "azure"), "- job: build");
 });
 
+Deno.test("defaults: jobs and steps fall back to a single build step", () => {
+  // An empty pipeline still produces a complete, runnable workflow.
+  const yaml = generateCi();
+  assertStringIncludes(yaml, "name: CI");
+  assertStringIncludes(yaml, "build:"); // default job id
+  assertStringIncludes(yaml, "run: ./zuke"); // default step runs the build
+});
+
+Deno.test("defaults: the default job/step flow through every provider", () => {
+  const empty: CiPipeline = { triggers: {} };
+  assertStringIncludes(generateCi(empty, "github"), "run: ./zuke");
+  assertStringIncludes(generateCi(empty, "gitlab"), "- ./zuke");
+  assertStringIncludes(generateCi(empty, "azure"), "script: ./zuke");
+});
+
+Deno.test("defaults: a job may omit steps and get the default step", () => {
+  const yaml = generateCi({ triggers: {}, jobs: [{ id: "verify" }] }, "github");
+  assertStringIncludes(yaml, "verify:");
+  assertStringIncludes(yaml, "run: ./zuke");
+});
+
+Deno.test("cicd: with no spec declares the default workflow", () => {
+  const file = cicd();
+  assertEquals(file.path, ".github/workflows/ci.yml");
+  assertStringIncludes(file.render(), "run: ./zuke");
+});
+
 Deno.test("cicd: provider defaults to github and path follows the provider", () => {
   const pipeline: CiPipeline = { jobs: [{ steps: [{ run: "x" }] }] };
   assertEquals(cicd({ pipeline }).path, ".github/workflows/ci.yml");

--- a/packages/core/tests/ci_test.ts
+++ b/packages/core/tests/ci_test.ts
@@ -130,14 +130,47 @@ Deno.test("azure: a manual-only pipeline disables the CI trigger", () => {
   assertStringIncludes(yaml, "trigger: none");
 });
 
-Deno.test("a pipeline with no triggers renders without an on/trigger block", () => {
+Deno.test("explicit empty triggers render without an on/trigger block", () => {
   const bare: CiPipeline = {
     name: "CI",
+    triggers: {},
     jobs: [{ id: "a", steps: [{ run: "x" }] }],
   };
   assertStringIncludes(generateCi(bare, "github"), `"on": {}`);
   assertEquals(generateCi(bare, "gitlab").includes("workflow:"), false);
   assertEquals(generateCi(bare, "azure").includes("trigger:"), false);
+});
+
+Deno.test("defaults: provider, name, triggers and job id fill in", () => {
+  // Only steps are given; everything else falls back to a meaningful default.
+  const yaml = generateCi({ jobs: [{ steps: [{ run: "deno task ci" }] }] });
+  assertStringIncludes(yaml, "name: CI"); // default name
+  assertStringIncludes(yaml, `"on":`); // default triggers present
+  assertStringIncludes(yaml, "push:\n    branches:\n      - main"); // default branch
+  assertStringIncludes(yaml, "pull_request:");
+  assertStringIncludes(yaml, "build:"); // default job id (github default provider)
+});
+
+Deno.test("defaults: a default job id flows through every provider", () => {
+  const pipeline: CiPipeline = {
+    triggers: {},
+    jobs: [{ steps: [{ run: "x" }] }],
+  };
+  assertStringIncludes(generateCi(pipeline, "github"), "build:");
+  assertStringIncludes(generateCi(pipeline, "gitlab"), "build:");
+  assertStringIncludes(generateCi(pipeline, "azure"), "- job: build");
+});
+
+Deno.test("cicd: provider defaults to github and path follows the provider", () => {
+  const pipeline: CiPipeline = { jobs: [{ steps: [{ run: "x" }] }] };
+  assertEquals(cicd({ pipeline }).path, ".github/workflows/ci.yml");
+  assertEquals(cicd({ provider: "gitlab", pipeline }).path, ".gitlab-ci.yml");
+  assertEquals(
+    cicd({ provider: "azure", pipeline }).path,
+    "azure-pipelines.yml",
+  );
+  // An explicit path overrides the convention.
+  assertEquals(cicd({ path: "custom.yml", pipeline }).path, "custom.yml");
 });
 
 // --- Declarative CI files: cicd(), discovery, and on-disk sync ---

--- a/packages/core/tests/cli_test.ts
+++ b/packages/core/tests/cli_test.ts
@@ -1,5 +1,5 @@
-import { assertEquals } from "./_assert.ts";
-import { Build, group, target } from "../mod.ts";
+import { assertEquals, assertStringIncludes } from "./_assert.ts";
+import { Build, cicd, group, target } from "../mod.ts";
 import {
   formatGraph,
   formatHelp,
@@ -350,3 +350,118 @@ Deno.test("main honours --skip", async () => {
   assertEquals(code, 0);
   assertEquals(log, ["go"]);
 });
+
+// --- CI config generation (generate-ci command + on-run regeneration) ---
+
+/** A build that declares a GitHub Actions workflow file. */
+class CiBuild extends Build {
+  ci = cicd({
+    provider: "github",
+    path: ".github/workflows/zuke.yml",
+    pipeline: {
+      name: "CI",
+      triggers: { push: ["main"] },
+      jobs: [{ id: "test", steps: [{ run: "deno task ci" }] }],
+    },
+  });
+  build = target().executes(() => {});
+}
+
+/** Run `fn` with the process cwd set to a fresh temp dir, then clean up. */
+async function inTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir();
+  const prev = Deno.cwd();
+  Deno.chdir(dir);
+  try {
+    await fn(dir);
+  } finally {
+    Deno.chdir(prev);
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+Deno.test("parseArgs recognises the generate-ci command and --check", () => {
+  const a = parseArgs(["generate-ci", "--check"]);
+  assertEquals(a.generateCi, true);
+  assertEquals(a.check, true);
+  assertEquals(a.target, undefined);
+});
+
+Deno.test("main: generate-ci writes the declared CI file", async () => {
+  await inTempDir(async (dir) => {
+    const { code, out } = await capture(() => main(CiBuild, ["generate-ci"]));
+    assertEquals(code, 0);
+    const content = await Deno.readTextFile(
+      `${dir}/.github/workflows/zuke.yml`,
+    );
+    assertStringIncludes(content, "name: CI");
+    assertEquals(out.some((l) => l.includes("Generated")), true);
+  });
+});
+
+Deno.test("main: generate-ci --check fails when the file is missing or stale", async () => {
+  await inTempDir(async () => {
+    const { code, err } = await capture(() =>
+      main(CiBuild, ["generate-ci", "--check"])
+    );
+    assertEquals(code, 1);
+    assertEquals(err.some((l) => l.includes("out of date")), true);
+  });
+});
+
+Deno.test("main: generate-ci reports when no CI config is declared", async () => {
+  const { code, out } = await capture(() => main(Demo, ["generate-ci"]));
+  assertEquals(code, 0);
+  assertEquals(out.some((l) => l.includes("No CI configuration")), true);
+});
+
+Deno.test("main: running a target keeps a current CI file in sync", async () => {
+  await inTempDir(async (dir) => {
+    // Pre-write the expected content so the on-run sync is a no-op regardless
+    // of whether the tests themselves run on CI (check) or locally (write).
+    const expected = new CiBuild().ci.render();
+    await Deno.mkdir(`${dir}/.github/workflows`, { recursive: true });
+    await Deno.writeTextFile(`${dir}/.github/workflows/zuke.yml`, expected);
+    const { code } = await capture(() => main(CiBuild, ["build"]));
+    assertEquals(code, 0);
+    assertEquals(
+      await Deno.readTextFile(`${dir}/.github/workflows/zuke.yml`),
+      expected,
+    );
+  });
+});
+
+Deno.test("main: running a target fails on CI when the CI file has drifted", async () => {
+  await inTempDir(async () => {
+    const prev = Deno.env.get("GITHUB_ACTIONS");
+    Deno.env.set("GITHUB_ACTIONS", "true"); // force isCI() → check mode
+    try {
+      const { code, err } = await capture(() => main(CiBuild, ["build"]));
+      assertEquals(code, 1); // file is missing → stale → build fails
+      assertEquals(err.some((l) => l.includes("out of date")), true);
+    } finally {
+      if (prev === undefined) Deno.env.delete("GITHUB_ACTIONS");
+      else Deno.env.set("GITHUB_ACTIONS", prev);
+    }
+  });
+});
+
+Deno.test("main: --dry-run does not regenerate CI files", async () => {
+  await inTempDir(async (dir) => {
+    const { code } = await capture(() => main(CiBuild, ["build", "--dry-run"]));
+    assertEquals(code, 0);
+    // Nothing was written: the workflow file does not exist.
+    await assertRejectsNotFound(`${dir}/.github/workflows/zuke.yml`);
+  });
+});
+
+/** Assert that reading `path` rejects because the file is absent. */
+async function assertRejectsNotFound(path: string): Promise<void> {
+  let missing = false;
+  try {
+    await Deno.readTextFile(path);
+  } catch (error) {
+    missing = error instanceof Deno.errors.NotFound;
+  }
+  assertEquals(missing, true);
+}

--- a/packages/core/tests/yaml_test.ts
+++ b/packages/core/tests/yaml_test.ts
@@ -1,0 +1,79 @@
+import { assertEquals } from "./_assert.ts";
+import { toYaml } from "../src/yaml.ts";
+
+Deno.test("toYaml renders scalars with type-correct tokens", () => {
+  assertEquals(toYaml("hello"), "hello\n");
+  assertEquals(toYaml(42), "42\n");
+  assertEquals(toYaml(true), "true\n");
+  assertEquals(toYaml(false), "false\n");
+  assertEquals(toYaml(null), "null\n");
+});
+
+Deno.test("toYaml quotes strings that would be misread", () => {
+  assertEquals(toYaml(""), `""\n`);
+  assertEquals(toYaml("on"), `"on"\n`);
+  assertEquals(toYaml("No"), `"No"\n`);
+  assertEquals(toYaml("123"), `"123"\n`);
+  assertEquals(toYaml("-1.5"), `"-1.5"\n`);
+  assertEquals(toYaml("a: b"), `"a: b"\n`);
+  assertEquals(toYaml(" trim "), `" trim "\n`);
+  assertEquals(toYaml("${{ matrix.os }}"), `"\${{ matrix.os }}"\n`);
+});
+
+Deno.test("toYaml leaves safe plain scalars unquoted", () => {
+  assertEquals(toYaml("ubuntu-latest"), "ubuntu-latest\n");
+  assertEquals(toYaml("deno task ci"), "deno task ci\n");
+  assertEquals(toYaml("actions/checkout@v4"), "actions/checkout@v4\n");
+});
+
+Deno.test("toYaml renders a mapping with nested maps and quoted keys", () => {
+  assertEquals(
+    toYaml({ name: "CI", "runs-on": "ubuntu-latest", env: { KEY: "v" } }),
+    "name: CI\nruns-on: ubuntu-latest\nenv:\n  KEY: v\n",
+  );
+  // A reserved key like `on` is quoted so it stays a string, not a boolean.
+  assertEquals(toYaml({ on: { push: "x" } }), `"on":\n  push: x\n`);
+});
+
+Deno.test("toYaml skips undefined entries", () => {
+  assertEquals(toYaml({ a: 1, b: undefined, c: 2 }), "a: 1\nc: 2\n");
+});
+
+Deno.test("toYaml renders empty collections inline", () => {
+  assertEquals(toYaml({ items: [], opts: {} }), "items: []\nopts: {}\n");
+});
+
+Deno.test("toYaml renders sequences of scalars under a key", () => {
+  assertEquals(
+    toYaml({ branches: ["main", "dev"] }),
+    "branches:\n  - main\n  - dev\n",
+  );
+});
+
+Deno.test("toYaml renders a sequence of maps with a hanging dash", () => {
+  assertEquals(
+    toYaml({ steps: [{ name: "a", run: "x" }, { uses: "u" }] }),
+    "steps:\n  - name: a\n    run: x\n  - uses: u\n",
+  );
+});
+
+Deno.test("toYaml renders a top-level sequence", () => {
+  assertEquals(toYaml(["a", "b"]), "- a\n- b\n");
+});
+
+Deno.test("toYaml renders an empty map item in a sequence", () => {
+  assertEquals(toYaml([{}, "x"]), "- {}\n- x\n");
+});
+
+Deno.test("toYaml renders nested sequences", () => {
+  assertEquals(toYaml([["a", "b"], ["c"]]), "-\n  - a\n  - b\n-\n  - c\n");
+});
+
+Deno.test("toYaml renders multi-line strings as block literals", () => {
+  assertEquals(
+    toYaml({ script: "line1\nline2" }),
+    "script: |\n  line1\n  line2\n",
+  );
+  // Blank interior lines stay blank (no trailing indentation).
+  assertEquals(toYaml({ script: "a\n\nb" }), "script: |\n  a\n\n  b\n");
+});


### PR DESCRIPTION
## Summary

Generate your CI configuration **from the build** instead of hand-maintaining YAML. Declare a pipeline as a build field with `cicd()`; Zuke keeps the file on disk in sync with the definition. The **provider is the only required field** — everything else has a sensible default:

```ts
import { Build, cicd, target } from "jsr:@zuke/core";

class MyBuild extends Build {
  ci = cicd({ provider: "github" }); // ← a complete GitHub workflow

  test = target().executes(async () => {/* … */});
}
```

`cicd({ provider: "github" })` declares a workflow at `.github/workflows/ci.yml` that, on push/PR to `main`, runs a single `build` job whose one step is `./zuke`. The `./zuke` launcher bootstraps Deno itself, so a single step needs no separate setup — the same way this repo's own CI runs.

Override only what you need:

```ts
ci = cicd({
  provider: "gitlab", // or "github" / "azure"
  pipeline: {
    jobs: [{
      matrix: { os: ["ubuntu-latest", "macos-latest"] },
      steps: [{ name: "Test", run: "./zuke test" }],
    }],
  },
});
```

## How it generates

- **`zuke generate-ci`** — explicit command; writes every declared file (creating parent dirs).
- **Running any target** regenerates the files too, so the committed config can't silently drift from the build definition.
- **On CI** (`isCI()`), the on-run step *verifies* the files are current and **fails on drift** instead of writing (so an ephemeral checkout is never dirtied). `zuke generate-ci --check` does the same explicitly — ideal as a dedicated CI gate.
- **`--dry-run`** skips regeneration.

Both the command and the on-run hook call the **same** `syncCiFiles` routine.

## Defaults

Only `provider` is required; everything else defaults:

| Field | Default |
|---|---|
| `provider` | **required** — `github` / `gitlab` / `azure` |
| `path` | provider's convention (`.github/workflows/ci.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`) |
| `pipeline` | one default job |
| `jobs` | a single `build` job |
| `steps` | one step: `run: ./zuke` (the launcher bootstraps Deno) |
| pipeline `name` | `CI` |
| `triggers` | push + pull request on `main` (pass `{}` for none) |
| job `id` | `build` |
| job `runsOn` | `ubuntu-latest` |

## Model & mapping

A provider-agnostic `CiPipeline` renders for all three providers:

- A **`run`** step (shell command) maps everywhere; a **`uses`** step (GitHub Action) renders for GitHub only (GitLab/Azure check out automatically).
- **`runsOn`** is interpreted per provider (runner label / Docker image / `vmImage`); a matrix `os` drives GitHub's `runs-on`.
- A matrix expands to GitLab's `parallel:matrix` and to the **cartesian product** of Azure's named configurations.
- Triggers map to `on:` (GitHub), `workflow:rules` (GitLab), `trigger:`/`pr:` (Azure).

For one-off rendering without the build wiring, **`generateCi(pipeline, provider)`** returns the YAML string directly (pass `{}` for the pipeline to accept every default).

## YAML emitter

Backed by a small **dependency-free** YAML emitter (`toYaml`, internal) that quotes any scalar that would otherwise be misread (a bare `on`, a numeric-looking `"2.0"`), so the output is paste-ready.

## API

- `cicd(spec)` → a `CiFile` build field; `generateCi(pipeline, provider): string`
- types: `CiFileSpec`, `CiPipeline`, `CiJob`, `CiStep`, `CiTriggers`, `CiProvider`
- CLI: `generate-ci` command and `--check` flag

## Checks

`deno task ci` is green. Overall 99.2% lines / 97.1% branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtqHmRRvtT6qkQKaPzrWhT