### PR TITLE
feat(core): plugin contract for extending Zuke without forking

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Full documentation lives in [`docs/`](./docs/):
   execution.
 - [Paths (`absolutePath`)](./docs/paths.md) — the fluent path type.
 - [Tools](./docs/tools.md) — the typed tool-wrapper packages and their tasks.
+- [Extending Zuke](./docs/extending.md) — the plugin contract: lifecycle
+  plugins, tool wrappers, and reusable target bundles.
 - [Using Zuke in a Node/npm project](./docs/node-projects.md) — drive a Node
   build with Deno.
 - [CLI reference](./docs/cli.md) — commands and flags.

--- a/cspell.json
+++ b/cspell.json
@@ -5,6 +5,7 @@
   "words": [
     "actionlint",
     "cicd",
+    "subclassing",
     "bunx",
     "chainers",
     "chmods",

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@
 - [Shell wrapper (`$`)](./shell.md) — ergonomic, injection-safe process execution.
 - [Paths (`absolutePath`)](./paths.md) — the fluent path type.
 - [Tools](./tools.md) — the typed tool-wrapper packages and their tasks.
+- [Extending Zuke](./extending.md) — the plugin contract: lifecycle plugins, tool wrappers, and reusable target bundles.
 - [Using Zuke in a Node/npm project](./node-projects.md) — drive a Node build with Deno.
 - [CLI reference](./cli.md) — commands and flags.
 - [Programmatic API](./programmatic-api.md) — drive Zuke from your own code.

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -372,13 +372,17 @@ is named on the command line.
 ### `run()`
 
 ```ts
-run(BuildClass: new () => Build, args?: string[]): Promise<void>
+run(
+  BuildClass: new () => Build,
+  options?: { args?: string[]; plugins?: Plugin[] },
+): Promise<void>
 ```
 
 Instantiates the build, discovers targets, validates the graph, parses CLI
-arguments (defaulting to `Deno.args`), dispatches to the executor, and calls
-`Deno.exit` with `0` on success or `1` on failure. This is the standard entry
-point at the bottom of `zuke.ts`.
+arguments (`options.args`, defaulting to `Deno.args`), dispatches to the executor
+with any registered `options.plugins`, and calls `Deno.exit` with `0` on success
+or `1` on failure. This is the standard entry point at the bottom of `zuke.ts`.
+See [Extending Zuke](./extending.md) for the plugin contract.
 
 ## Gotchas
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1,0 +1,124 @@
+# Extending Zuke
+
+Zuke is built to be extended **without forking**. There are three stable
+extension points, each a small public contract a third-party package can build
+against:
+
+1. **Plugins** — observe the build lifecycle (`Plugin`).
+2. **Tool wrappers** — add a typed CLI wrapper (`ToolSettings` / `defineTool`).
+3. **Components** — ship reusable bundles of targets (the bundle convention).
+
+## 1. Plugins — observe the lifecycle
+
+A **plugin** is a plain object implementing any of the lifecycle hooks. Register
+plugins by passing them to `run` (or `execute`); each hook runs alongside the
+build's own method, in registration order. Plugins **observe** — they report,
+time, or notify — they don't change the plan or a target's result.
+
+```ts
+import { type Plugin, run } from "jsr:@zuke/core";
+
+const timing: Plugin = {
+  name: "timing",
+  onTargetEnd: (target, status) => console.log(`${target}: ${status}`),
+  onFinish: (result) => console.log(`done: ${result.ok ? "ok" : "failed"}`),
+};
+
+if (import.meta.main) await run(MyBuild, { plugins: [timing] });
+```
+
+| Hook                       | When it runs                                          |
+| -------------------------- | ----------------------------------------------------- |
+| `onStart()`                | Once, before any target runs.                         |
+| `onTargetStart(target)`    | Before a target's body executes (not skipped/cached). |
+| `onTargetEnd(target, s)`   | After each target settles, with its status.           |
+| `onFinish(result)`         | Once, after the run (success or failure).             |
+
+Every hook is optional and may be async — the executor awaits each before
+continuing. Hooks mirror the `Build` lifecycle methods (`onStart`,
+`onTargetStart`, `onTargetEnd`, `onFinish`), so anything a build can observe by
+overriding those, a plugin can observe without subclassing — and several plugins
+can observe at once.
+
+A plugin is just a value, so a package can export a factory:
+
+```ts
+// @acme/zuke-slack
+export function slack(opts: { webhook: string }): Plugin {
+  return {
+    name: "slack",
+    onFinish: async (result) => {
+      if (!result.ok) await notify(opts.webhook, "build failed");
+    },
+  };
+}
+```
+
+## 2. Tool wrappers — typed CLI tasks
+
+Wrap a CLI as a typed, fluent task in the settings-lambda style. For a one-off,
+`defineTool` needs no class (see [Tools](./tools.md#define-your-own-tool)); a
+distributable package extends `ToolSettings` from `@zuke/core/tooling`.
+
+```ts
+import { type Configure, runSettings, ToolSettings } from "jsr:@zuke/core/tooling";
+
+class MyToolSettings extends ToolSettings {
+  #args: string[] = [];
+  fast(): this {
+    this.#args.push("--fast");
+    return this;
+  }
+  protected override defaultTool(): string {
+    return "mytool";
+  }
+  protected override buildArgs(): string[] {
+    return ["build", ...this.#args];
+  }
+}
+
+export const MyToolTasks = {
+  build: (configure?: Configure<MyToolSettings>) =>
+    runSettings(new MyToolSettings(), configure),
+};
+
+// → await MyToolTasks.build((s) => s.fast().cwd("app"));
+```
+
+`buildArgs()` must stay **pure** (no I/O) so argv construction is unit-testable;
+the base contributes the shared chainers (`env`, `cwd`, `noThrow`, `quiet`,
+`toolPath`, `args`) and runs the command through the injection-free shell. A
+wrapper package is a workspace sibling that depends only on `@zuke/core` — the
+existing `@zuke/*` wrappers are the template.
+
+## 3. Components — reusable target bundles
+
+A **component** is a function that returns an object of related targets.
+Assigned to a build field, discovery recurses into the bundle and names each
+target with a dotted path (`release.publish`), runnable as `zuke release.publish`
+and shown in the graph. Components compose, nest, and take options.
+
+```ts
+// @acme/zuke-release
+export function release(opts: { registry: string }) {
+  const pack = target().executes(/* … */);
+  const publish = target()
+    .dependsOn(pack)
+    .executes(async () => {
+      await $`npm publish --registry ${opts.registry}`;
+    });
+  return { pack, publish };
+}
+
+// In a build:
+class MyBuild extends Build {
+  release = release({ registry: "https://registry.npmjs.org" });
+  deploy = target().dependsOn(this.release.publish).executes(/* … */);
+}
+```
+
+Targets reference each other across components via the field
+(`this.release.publish`), so declare a component field above anything that
+depends on it. Components can also declare [parameters](./parameters.md) and
+nest other components — all discovered under the same dotted path. See
+[Authoring](./authoring.md#reusable-components) for the full convention.

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -41,7 +41,8 @@ export {
   TargetBuilder,
   type TargetFn,
 } from "./src/target.ts";
-export { run } from "./src/cli.ts";
+export { run, type RunOptions } from "./src/cli.ts";
+export type { Plugin } from "./src/plugin.ts";
 export { execute, type ExecuteOptions, type Reporter } from "./src/executor.ts";
 export type { BuildCache } from "./src/cache.ts";
 export { type AbsolutePath, absolutePath, type PathLike } from "./src/path.ts";

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -15,6 +15,7 @@ import {
 } from "./graph_view.ts";
 import { type AnyParameter, discoverParameters, flagName } from "./params.ts";
 import type { TargetBuilder } from "./target.ts";
+import type { Plugin } from "./plugin.ts";
 
 /** Convention: a target literally named `default` runs when none is requested. */
 const DEFAULT_TARGET = "default";
@@ -298,6 +299,14 @@ export async function syncCiConfig(
   return 0;
 }
 
+/** Optional inputs for {@link main} beyond the build class and argv. */
+export interface MainOptions {
+  /** Host used to render and open the HTML graph (injected in tests). */
+  graphHost?: GraphHost;
+  /** Lifecycle observers to run alongside the build's own hooks. */
+  plugins?: Plugin[];
+}
+
 /**
  * Drive a build to completion and resolve to a process exit code (0 success,
  * 1 failure). Does not call `Deno.exit`, so it is unit-testable; {@link run}
@@ -306,8 +315,9 @@ export async function syncCiConfig(
 export async function main(
   BuildClass: new () => Build,
   args: string[],
-  graphHost: GraphHost = defaultGraphHost,
+  options: MainOptions = {},
 ): Promise<number> {
+  const graphHost = options.graphHost ?? defaultGraphHost;
   const build = new BuildClass();
   const targets = discoverTargets(build);
   const params = discoverParameters(build);
@@ -384,22 +394,35 @@ export async function main(
     parallel: parsed.parallel,
     cache: parsed.cache,
     dryRun: parsed.dryRun,
+    plugins: options.plugins,
   });
   return result.ok ? 0 : 1;
 }
 
+/** Options for {@link run}. */
+export interface RunOptions {
+  /** Command-line arguments. Defaults to `Deno.args`. */
+  args?: string[];
+  /** Lifecycle observers to run alongside the build's own hooks. */
+  plugins?: Plugin[];
+}
+
 /**
- * Public entry point. Instantiate the build, parse `Deno.args`, run, and set the
+ * Public entry point. Instantiate the build, parse arguments, run, and set the
  * process exit code.
  *
  * ```ts
- * if (import.meta.main) { await run(MyBuild); }
+ * if (import.meta.main) await run(MyBuild);
+ * // …with plugins:
+ * if (import.meta.main) await run(MyBuild, { plugins: [timing] });
  * ```
  */
 export async function run(
   BuildClass: new () => Build,
-  args: string[] = Deno.args,
+  options: RunOptions = {},
 ): Promise<void> {
-  const code = await main(BuildClass, args);
+  const code = await main(BuildClass, options.args ?? Deno.args, {
+    plugins: options.plugins,
+  });
   Deno.exit(code);
 }

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -34,6 +34,7 @@ import { findConfigDir, pathExists } from "./config.ts";
 import { isCI } from "./host.ts";
 import { absolutePath } from "./path.ts";
 import type { TargetBuilder, TargetFn } from "./target.ts";
+import type { Plugin } from "./plugin.ts";
 
 /** The artifact directory (under the repo root) for the cache store. */
 const ARTIFACT_DIR = ".zuke";
@@ -57,6 +58,11 @@ export interface ExecuteOptions {
   silent?: boolean;
   /** Custom reporter; overrides `silent`. */
   reporter?: Reporter;
+  /**
+   * Lifecycle observers invoked alongside the build's own hooks, in order.
+   * Lets third-party packages report/time/notify without subclassing the build.
+   */
+  plugins?: Plugin[];
   /** Target names to skip even if they appear in the plan (CLI `--skip`). */
   skip?: string[];
   /**
@@ -389,6 +395,40 @@ interface RunOutcome {
   aborted: boolean;
 }
 
+/**
+ * The merged lifecycle: the build's own hooks plus any registered plugins,
+ * invoked in order (build first, then each plugin). The run functions call
+ * through this so they need not know about plugins.
+ */
+interface Lifecycle {
+  start(): Promise<void>;
+  targetStart(name: string): Promise<void>;
+  targetEnd(name: string, status: TargetStatus): Promise<void>;
+  finish(result: BuildResult): Promise<void>;
+}
+
+/** Compose a build and its plugins into one {@link Lifecycle}. */
+function makeLifecycle(build: Build, plugins: Plugin[]): Lifecycle {
+  return {
+    async start() {
+      await build.onStart();
+      for (const p of plugins) await p.onStart?.();
+    },
+    async targetStart(name) {
+      await build.onTargetStart(name);
+      for (const p of plugins) await p.onTargetStart?.(name);
+    },
+    async targetEnd(name, status) {
+      await build.onTargetEnd(name, status);
+      for (const p of plugins) await p.onTargetEnd?.(name, status);
+    },
+    async finish(result) {
+      await build.onFinish(result);
+      for (const p of plugins) await p.onFinish?.(result);
+    },
+  };
+}
+
 /** Resolve after `ms` milliseconds. */
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -452,7 +492,7 @@ async function runBody(t: TargetBuilder): Promise<void> {
  * that would run is reported without executing its body or touching the cache.
  */
 async function runTarget(
-  build: Build,
+  life: Lifecycle,
   reporter: Reporter,
   style: Style,
   t: TargetBuilder,
@@ -492,7 +532,7 @@ async function runTarget(
   }
 
   openTarget(reporter, style, name, opened);
-  await build.onTargetStart(name);
+  await life.targetStart(name);
   const start = performance.now();
 
   if (!t.fn_) {
@@ -551,7 +591,7 @@ function bufferReporter(): {
 
 /** Sequentially run the plan, aborting (and skipping the rest) on first failure. */
 async function runSequential(
-  build: Build,
+  life: Lifecycle,
   order: TargetBuilder[],
   reporter: Reporter,
   style: Style,
@@ -572,7 +612,7 @@ async function runSequential(
       continue;
     }
     const outcome = await runTarget(
-      build,
+      life,
       reporter,
       style,
       t,
@@ -580,7 +620,7 @@ async function runSequential(
       cache,
       dryRun,
     );
-    await build.onTargetEnd(name, outcome.status);
+    await life.targetEnd(name, outcome.status);
     if (outcome.status === "passed" || outcome.status === "failed") opened++;
     reports.push({ name, status: outcome.status, ms: outcome.ms });
     if (outcome.status === "passed") executed.push(name);
@@ -603,7 +643,7 @@ async function runSequential(
  * stops new launches; in-flight targets settle and the rest are skipped.
  */
 async function runScheduled(
-  build: Build,
+  life: Lifecycle,
   order: TargetBuilder[],
   predecessors: Map<TargetBuilder, TargetBuilder[]>,
   reporter: Reporter,
@@ -648,10 +688,10 @@ async function runScheduled(
         started.add(t);
         runningSet.add(t);
         const buffer = bufferReporter();
-        runTarget(build, buffer.reporter, style, t, flushed, cache, dryRun)
+        runTarget(life, buffer.reporter, style, t, flushed, cache, dryRun)
           .then(
             async (outcome) => {
-              await build.onTargetEnd(t.name_ ?? "<unnamed>", outcome.status);
+              await life.targetEnd(t.name_ ?? "<unnamed>", outcome.status);
               // Only an executed target prints a block worth separating.
               const printed = outcome.status === "passed" ||
                 outcome.status === "failed";
@@ -771,12 +811,13 @@ export async function execute(
   const cache = dryRun ? undefined : await resolveCache(options.cache, order);
   const overallStart = performance.now();
 
-  await build.onStart();
+  const life = makeLifecycle(build, options.plugins ?? []);
+  await life.start();
 
   let run: RunOutcome;
   if (!globalParallel && !grouped && !scheduled) {
     run = await runSequential(
-      build,
+      life,
       order,
       reporter,
       style,
@@ -794,7 +835,7 @@ export async function execute(
       : (a: TargetBuilder, b: TargetBuilder) =>
         a.group_ !== undefined && a.group_ === b.group_;
     run = await runScheduled(
-      build,
+      life,
       order,
       predecessors,
       reporter,
@@ -817,7 +858,7 @@ export async function execute(
   if (style.github && writesToConsole) {
     writeJobSummary(run.reports, totalMs, result.ok);
   }
-  await build.onFinish(result);
+  await life.finish(result);
   return result;
 }
 

--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -1,0 +1,42 @@
+/**
+ * The plugin contract: observe a build's lifecycle without subclassing
+ * {@link Build} or forking Zuke.
+ *
+ * A {@link Plugin} is a plain object with optional async hooks. Register one (or
+ * several) by passing them to {@link run} or {@link execute}; every hook a
+ * plugin implements is invoked alongside the build's own lifecycle methods, in
+ * registration order. Plugins observe — they report, time, or notify — they do
+ * not alter the plan or a target's result.
+ *
+ * ```ts
+ * import { type Plugin, run } from "jsr:@zuke/core";
+ *
+ * const timing: Plugin = {
+ *   name: "timing",
+ *   onTargetEnd: (target, status) => console.log(`${target}: ${status}`),
+ * };
+ *
+ * if (import.meta.main) await run(MyBuild, { plugins: [timing] });
+ * ```
+ *
+ * @module
+ */
+
+import type { BuildResult, TargetStatus } from "./build.ts";
+
+/**
+ * A lifecycle observer. Every hook is optional; implement only the ones you
+ * need. Hooks may be async — the executor awaits each before continuing.
+ */
+export interface Plugin {
+  /** A name for diagnostics (optional). */
+  name?: string;
+  /** Called once before any target runs. */
+  onStart?(): void | Promise<void>;
+  /** Called just before a target's body executes (not for skipped/cached). */
+  onTargetStart?(target: string): void | Promise<void>;
+  /** Called after each target settles, with its final status. */
+  onTargetEnd?(target: string, status: TargetStatus): void | Promise<void>;
+  /** Called once after the run completes (success or failure). */
+  onFinish?(result: BuildResult): void | Promise<void>;
+}

--- a/packages/core/tests/cli_test.ts
+++ b/packages/core/tests/cli_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals, assertStringIncludes } from "./_assert.ts";
-import { Build, cicd, group, target } from "../mod.ts";
+import { Build, cicd, group, type Plugin, target } from "../mod.ts";
 import {
   formatGraph,
   formatHelp,
@@ -203,7 +203,7 @@ Deno.test("main --list and graph (text) return 0", async () => {
 Deno.test("main graph --output=html renders HTML via the injected host", async () => {
   const host = new FakeGraphHost("/repo", [`/repo/${CONFIG_FILE}`]);
   const { code } = await capture(() =>
-    main(Demo, ["graph", "--output=html", "--no-open"], host)
+    main(Demo, ["graph", "--output=html", "--no-open"], { graphHost: host })
   );
   assertEquals(code, 0);
   assertEquals(host.files.has("/repo/.zuke/graph.html"), true);
@@ -328,7 +328,7 @@ Deno.test("run() drives main and sets the process exit code", async () => {
   const origLog = console.log;
   console.log = () => {};
   try {
-    await run(Demo, ["--list"]);
+    await run(Demo, { args: ["--list"] });
   } catch (e) {
     if (!(e instanceof ExitSignal)) throw e;
   } finally {
@@ -465,3 +465,42 @@ async function assertRejectsNotFound(path: string): Promise<void> {
   }
   assertEquals(missing, true);
 }
+
+// --- Plugins via the CLI entry points ---
+
+Deno.test("main forwards plugins to the build lifecycle", async () => {
+  const seen: string[] = [];
+  const plugin: Plugin = {
+    onTargetEnd: (name, status) => void seen.push(`${name}:${status}`),
+  };
+  // Demo: `build` depends on `clean`, so both targets are observed.
+  const { code } = await capture(() =>
+    main(Demo, ["build"], { plugins: [plugin] })
+  );
+  assertEquals(code, 0);
+  assertEquals(seen.includes("clean:passed"), true);
+  assertEquals(seen.includes("build:passed"), true);
+});
+
+Deno.test("run forwards args and plugins to main", async () => {
+  const seen: string[] = [];
+  const plugin: Plugin = { onFinish: () => void seen.push("finished") };
+  const origExit = Deno.exit;
+  const origLog = console.log;
+  let code: number | undefined;
+  Deno.exit = (c?: number): never => {
+    code = c;
+    throw new ExitSignal();
+  };
+  console.log = () => {};
+  try {
+    await run(Demo, { args: ["build"], plugins: [plugin] });
+  } catch (e) {
+    if (!(e instanceof ExitSignal)) throw e;
+  } finally {
+    Deno.exit = origExit;
+    console.log = origLog;
+  }
+  assertEquals(code, 0);
+  assertEquals(seen, ["finished"]);
+});

--- a/packages/core/tests/executor_test.ts
+++ b/packages/core/tests/executor_test.ts
@@ -31,6 +31,7 @@ import {
   type ExecuteOptions,
   type Reporter,
 } from "../src/executor.ts";
+import type { Plugin } from "../src/plugin.ts";
 
 const silent: ExecuteOptions = { silent: true };
 
@@ -1169,4 +1170,60 @@ Deno.test("retry gives up after the configured attempts (with delay)", async () 
   assertEquals(result.ok, false);
   assertEquals(attempts, 3); // 1 initial + 2 retries
   assertEquals(messageOf(result.error), "always fails");
+});
+
+// --- Plugins (lifecycle observers) ---
+
+Deno.test("execute runs plugin hooks alongside the build hooks, in order", async () => {
+  const events: string[] = [];
+  class B extends Build {
+    override onStart() {
+      events.push("build:start");
+    }
+    override onTargetStart(n: string) {
+      events.push(`build:ts:${n}`);
+    }
+    override onTargetEnd(n: string, s: TargetStatus) {
+      events.push(`build:te:${n}:${s}`);
+    }
+    override onFinish(r: BuildResult) {
+      events.push(`build:finish:${r.ok}`);
+    }
+    a = target().executes(() => {});
+  }
+  const plugin: Plugin = {
+    name: "spy",
+    onStart: () => void events.push("plugin:start"),
+    onTargetStart: (n) => void events.push(`plugin:ts:${n}`),
+    onTargetEnd: (n, s) => void events.push(`plugin:te:${n}:${s}`),
+    onFinish: (r) => void events.push(`plugin:finish:${r.ok}`),
+  };
+  const b = new B();
+  discoverTargets(b);
+  await execute(b, b.a, { silent: true, plugins: [plugin] });
+  assertEquals(events, [
+    "build:start",
+    "plugin:start",
+    "build:ts:a",
+    "plugin:ts:a",
+    "build:te:a:passed",
+    "plugin:te:a:passed",
+    "build:finish:true",
+    "plugin:finish:true",
+  ]);
+});
+
+Deno.test("execute supports multiple plugins and partial hook sets", async () => {
+  const calls: string[] = [];
+  class B extends Build {
+    a = target().executes(() => {});
+  }
+  // p1 implements only onTargetEnd; p2 only onFinish — the unimplemented hooks
+  // must be skipped without error.
+  const p1: Plugin = { onTargetEnd: (n, s) => void calls.push(`p1:${n}:${s}`) };
+  const p2: Plugin = { onFinish: () => void calls.push("p2:finish") };
+  const b = new B();
+  discoverTargets(b);
+  await execute(b, b.a, { silent: true, plugins: [p1, p2] });
+  assertEquals(calls, ["p1:a:passed", "p2:finish"]);
 });


### PR DESCRIPTION
## Summary

Formalizes Zuke's extension surface so third parties can extend it **without forking**, and fills the one real gap: lifecycle observation.

### New: `Plugin` — observe the lifecycle

A `Plugin` is a plain object of optional, possibly-async hooks. Register plugins by passing them to `run` (or `execute`); each hook runs alongside the build's own method, in registration order. Plugins **observe** (report/time/notify) — they don't change the plan or a target's result.

```ts
import { type Plugin, run } from "jsr:@zuke/core";

const timing: Plugin = {
  name: "timing",
  onTargetEnd: (target, status) => console.log(`${target}: ${status}`),
  onFinish: (result) => console.log(result.ok ? "ok" : "failed"),
};

if (import.meta.main) await run(MyBuild, { plugins: [timing] });
```

| Hook | When |
|---|---|
| `onStart()` | once, before any target |
| `onTargetStart(target)` | before a target's body (not skipped/cached) |
| `onTargetEnd(target, status)` | after each target settles |
| `onFinish(result)` | once, after the run |

These mirror the `Build` lifecycle methods — so anything a build could observe by overriding those, a plugin observes **without subclassing**, and several plugins can observe at once. The executor merges build + plugins into one internal lifecycle and invokes them in order.

### Docs: `docs/extending.md`

A new guide formalizing the three stable extension points as the plugin contract:

1. **Plugins** — lifecycle observers (above).
2. **Tool wrappers** — `defineTool` (one-off) or extend `ToolSettings` from `@zuke/core/tooling` (distributable package); `buildArgs()` stays pure.
3. **Components** — functions returning target bundles, discovered under dotted paths.

Linked from the README and `docs/` index.

## API changes

- New: `Plugin` (type), exported from `@zuke/core`.
- `execute(build, root, { plugins })` — `ExecuteOptions.plugins?: Plugin[]`.
- `run(BuildClass, options?)` — now takes `{ args?, plugins? }`. **The no-argument form `run(MyBuild)` is unchanged**; only the rare positional-args form (`run(B, args)`) becomes `run(B, { args })`.
- `main(BuildClass, args, { graphHost?, plugins? })` (internal entry; was a positional `graphHost`).

## Checks

`deno task ci` is green. New plugin lifecycle tests cover ordering, multiple plugins, and partial hook sets, plus `run`/`main` forwarding. Overall 99.2% lines / 97.1% branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtqHmRRvtT6qkQKaPzrWhT

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtqHmRRvtT6qkQKaPzrWhT)_