### PR TITLE
chore: drop one-time release-as pins from released packages

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -9,59 +9,88 @@
       "component": "core",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/deno": {
       "component": "deno",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/npm": {
       "component": "npm",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/bun": {
       "component": "bun",
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/pnpm": {
       "component": "pnpm",
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/yarn": {
       "component": "yarn",
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/cmd": {
       "component": "cmd",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/cli": {
       "component": "cli",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" },
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        },
         "src/version.ts"
       ]
     },
@@ -69,97 +98,143 @@
       "component": "docker",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/docker-compose": {
       "component": "docker-compose",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/kubectl": {
       "component": "kubectl",
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/helm": {
       "component": "helm",
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/kustomize": {
       "component": "kustomize",
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/oxlint": {
       "component": "oxlint",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/eslint": {
       "component": "eslint",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/cspell": {
       "component": "cspell",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/jest": {
       "component": "jest",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/vitest": {
       "component": "vitest",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/playwright": {
       "component": "playwright",
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/biome": {
       "component": "biome",
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/knip": {
       "component": "knip",
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/dpdm": {
@@ -167,126 +242,176 @@
       "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/cypress": {
       "component": "cypress",
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/vite": {
       "component": "vite",
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/tsup": {
       "component": "tsup",
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/turbo": {
       "component": "turbo",
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/nx": {
       "component": "nx",
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/jsr": {
       "component": "jsr",
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/tsx": {
       "component": "tsx",
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/tsgo": {
       "component": "tsgo",
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/dprint": {
       "component": "dprint",
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/gcloud": {
       "component": "gcloud",
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/git": {
       "component": "git",
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/gh": {
       "component": "gh",
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/terraform": {
       "component": "terraform",
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/tofu": {
       "component": "tofu",
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     },
     "packages/security": {
       "component": "security",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "json", "path": "deno.json", "jsonpath": "$.version" }
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
       ]
     }
   }


### PR DESCRIPTION
## Summary

Fixes the phantom `git: 0.1.0` entry in the release-please PR (#83).

### Root cause

It's **not** related to the dpdm change — the release PR aggregates *all* unreleased commits across the workspace. git is in it because of the unreleased `gitInfo()` feature (#76), and it's **stuck** because `.release-please-config.json` still pins `"release-as": "0.1.0"` on git.

`release-as` is a one-time bootstrap to cut a package's *first* release at `0.1.0`. As `RELEASING.md` says, it must be deleted afterwards — otherwise it forces every future release back to `0.1.0` and breaks automatic versioning. With the pin still in place, the `feat(git): gitInfo` that should have bumped git `0.1.0 → 0.2.0` was forced back to `0.1.0`; re-releasing an existing version is a no-op, so the feature never cleared and git re-appeared in every release PR as a `git-v0.1.0...git-v0.1.0` entry.

### Change

Removed `release-as` from every package that **already has a `v0.1.0` tag** (23 packages — verified against `git tag`), keeping it only on **`dpdm`**, whose `0.1.0` hasn't been cut yet (it's still in the pending release PR #83).

### Effect

After this merges, the next release-please run will:
- bump **git → 0.2.0** for `gitInfo()` (and clear the phantom entry),
- still cut **dpdm → 0.1.0** via its remaining pin,
- resume normal semver bumps for all other packages on their next feat/fix.

`dpdm`'s pin should be removed in a follow-up once its `0.1.0` is tagged/published.

## Checks

`deno task ci` is green; `release_config_test` still passes (package set, simple release type, and manifest↔deno.json versions all unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtqHmRRvtT6qkQKaPzrWhT

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtqHmRRvtT6qkQKaPzrWhT)_