### PR TITLE
chore: drop the release-as pin from dpdm

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -239,7 +239,6 @@
     },
     "packages/dpdm": {
       "component": "dpdm",
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         {


### PR DESCRIPTION
## Summary

Follow-up to #84: removes the last `release-as: "0.1.0"` bootstrap pin, now that **dpdm's `0.1.0` has been cut** (the release-please manifest records `packages/dpdm: 0.1.0`, and git advanced to `0.2.0` in the same merged release — confirming a real release ran).

With dpdm's first release done, the pin has served its purpose; leaving it would force every future dpdm release back to `0.1.0`. Removing it lets dpdm bump normally (e.g. `0.1.0 → 0.2.0` on the next feature).

**No `release-as` pins remain in `.release-please-config.json`** — automatic versioning is fully restored across the workspace.

## Checks

`deno task ci` is green; `release_config_test` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtqHmRRvtT6qkQKaPzrWhT

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtqHmRRvtT6qkQKaPzrWhT)_