### PR TITLE
docs: remove disabled Discussions links and fix LinkedIn badge icon

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,8 @@ By participating, you agree to abide by our
 
 > [!NOTE]
 > Zuke is pre-1.0 and evolving fast. APIs can change within `0.x`. If you are
-> planning a large change, please open an issue or discussion first so we can
-> agree on the direction before you invest the effort.
+> planning a large change, please open an issue first so we can agree on the
+> direction before you invest the effort.
 
 ## Prerequisites
 
@@ -94,8 +94,8 @@ the squash commit that [release-please](./RELEASING.md) parses.
 - Search [existing issues](https://github.com/zuke-build/zuke/issues) first.
 - For bugs, include a minimal reproduction, the Deno version, and what you
   expected versus what happened.
-- For ideas and open-ended questions, start a
-  [discussion](https://github.com/zuke-build/zuke/discussions).
+- For ideas and open-ended questions, open an
+  [issue](https://github.com/zuke-build/zuke/issues) with the relevant label.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -226,15 +226,14 @@ Zuke stands on the shoulders of giants:
 
 ## Community & contact
 
-Questions, ideas, or just want to say hi? Open a
-[discussion](https://github.com/zuke-build/zuke/discussions) or an
+Questions, ideas, or just want to say hi? Open an
 [issue](https://github.com/zuke-build/zuke/issues), or reach out:
 
 <p align="center">
   <a href="mailto:contact@zuke.build"><img alt="Email" src="https://img.shields.io/badge/email-contact@zuke.build-8B89CC?style=for-the-badge&logo=protonmail&logoColor=white" /></a>
   <a href="https://todorov.bg"><img alt="Blog" src="https://img.shields.io/badge/Blog-todorov.bg-000000?style=for-the-badge&logo=rss&logoColor=white" /></a>
   <a href="https://twitter.com/totollygeek"><img alt="X" src="https://img.shields.io/badge/@totollygeek-000000?style=for-the-badge&logo=x&logoColor=white" /></a>
-  <a href="https://www.linkedin.com/in/totollygeek"><img alt="LinkedIn" src="https://img.shields.io/badge/totollygeek-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white" /></a>
+  <a href="https://www.linkedin.com/in/totollygeek"><img alt="LinkedIn" src="https://custom-icon-badges.demolab.com/badge/totollygeek-0A66C2?style=for-the-badge&logo=linkedin-white&logoColor=white" /></a>
   <a href="https://infosec.exchange/@totollygeek"><img alt="Mastodon" src="https://img.shields.io/badge/@totollygeek-6364FF?style=for-the-badge&logo=mastodon&logoColor=white" /></a>
   <a href="https://www.threads.net/@totollygeek"><img alt="Threads" src="https://img.shields.io/badge/@totollygeek-000000?style=for-the-badge&logo=threads&logoColor=white" /></a>
   <a href="https://bsky.app/profile/totollygeek.com"><img alt="Bluesky" src="https://img.shields.io/badge/totollygeek.com-0285FF?style=for-the-badge&logo=bluesky&logoColor=white" /></a>
@@ -253,6 +252,8 @@ If Zuke is useful to you, consider **starring the repo** — it helps others fin
 the project. ⭐
 
 ### Contributors
+
+Thanks goes to these wonderful people:
 
 <a href="https://github.com/zuke-build/zuke/graphs/contributors">
   <img alt="Contributors" src="https://contrib.rocks/image?repo=zuke-build/zuke" />

--- a/cspell.json
+++ b/cspell.json
@@ -92,6 +92,7 @@
     "mastodon",
     "protonmail",
     "linkedin",
+    "demolab",
     "rss",
     "socio",
     "mailto",


### PR DESCRIPTION
Follow-up to #86.

## What
- **Remove Discussions links.** Discussions are disabled on the repo, so the links in the README contact section and in `CONTRIBUTING.md` pointed nowhere. They now direct people to Issues instead.
- **Fix the LinkedIn contact badge.** simple-icons (which shields.io uses) no longer ships the LinkedIn glyph, so `logo=linkedin` rendered with no icon. The LinkedIn badge is now served from `custom-icon-badges.demolab.com`, which still provides the icon (same color and label). Other badges are unchanged.
- Added `demolab` to the cspell dictionary for the new badge URL.

## Files
- `README.md` — drop Discussions link; swap LinkedIn badge host
- `CONTRIBUTING.md` — replace two Discussions references with Issues
- `cspell.json` — allow `demolab`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qy1s1ZhKafrsb4fUvNE45W)_