### PR TITLE
chore: prepare @zuke/core for a 1.0.0 release

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -8,6 +8,7 @@
     "packages/core": {
       "component": "core",
       "changelog-path": "CHANGELOG.md",
+      "release-as": "1.0.0",
       "extra-files": [
         {
           "type": "json",

--- a/README.md
+++ b/README.md
@@ -16,11 +16,6 @@
   <a href="./CONTRIBUTING.md"><img alt="PRs welcome" src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" /></a>
 </p>
 
-> [!WARNING]
-> **Under heavy development — not production ready.** Zuke is pre-1.0 and
-> evolving fast. APIs across all `@zuke/*` packages can change without notice
-> within `0.x`. Pin exact versions and expect breakage until a `1.0` release.
-
 > [!NOTE]
 > **Largely AI-written.** Much of this project — code, tests, and docs — was
 > generated with AI assistance. Take it with a grain of salt: review before you

--- a/deno.lock
+++ b/deno.lock
@@ -559,182 +559,182 @@
     "members": {
       "packages/biome": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/bun": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/cmd": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/cspell": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/cypress": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/deno": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/docker": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/docker-compose": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/dpdm": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/dprint": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/eslint": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/gcloud": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/gh": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/git": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/helm": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/jest": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/jsr": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/knip": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/kubectl": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/kustomize": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/npm": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/nx": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/oxlint": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/playwright": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/pnpm": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/release-please": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/security": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/terraform": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/tofu": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/tsgo": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/tsup": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/tsx": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/turbo": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/vite": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/vitest": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       },
       "packages/yarn": {
         "dependencies": [
-          "jsr:@zuke/core@0"
+          "jsr:@zuke/core@*"
         ]
       }
     }

--- a/packages/biome/deno.json
+++ b/packages/biome/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/bun/deno.json
+++ b/packages/bun/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/cmd/deno.json
+++ b/packages/cmd/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/cspell/deno.json
+++ b/packages/cspell/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/cypress/deno.json
+++ b/packages/cypress/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/deno/deno.json
+++ b/packages/deno/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/docker-compose/deno.json
+++ b/packages/docker-compose/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/docker/deno.json
+++ b/packages/docker/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/dpdm/deno.json
+++ b/packages/dpdm/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/dprint/deno.json
+++ b/packages/dprint/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/eslint/deno.json
+++ b/packages/eslint/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/gcloud/deno.json
+++ b/packages/gcloud/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/gh/deno.json
+++ b/packages/gh/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/git/deno.json
+++ b/packages/git/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/helm/deno.json
+++ b/packages/helm/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/jest/deno.json
+++ b/packages/jest/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/jsr/deno.json
+++ b/packages/jsr/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/knip/deno.json
+++ b/packages/knip/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/kubectl/deno.json
+++ b/packages/kubectl/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/kustomize/deno.json
+++ b/packages/kustomize/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/npm/deno.json
+++ b/packages/npm/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/nx/deno.json
+++ b/packages/nx/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/oxlint/deno.json
+++ b/packages/oxlint/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/playwright/deno.json
+++ b/packages/playwright/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/pnpm/deno.json
+++ b/packages/pnpm/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/release-please/deno.json
+++ b/packages/release-please/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/security/deno.json
+++ b/packages/security/deno.json
@@ -5,7 +5,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/terraform/deno.json
+++ b/packages/terraform/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/tofu/deno.json
+++ b/packages/tofu/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/tsgo/deno.json
+++ b/packages/tsgo/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/tsup/deno.json
+++ b/packages/tsup/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/tsx/deno.json
+++ b/packages/tsx/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/turbo/deno.json
+++ b/packages/turbo/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/vite/deno.json
+++ b/packages/vite/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/vitest/deno.json
+++ b/packages/vitest/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [

--- a/packages/yarn/deno.json
+++ b/packages/yarn/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0"
+    "@zuke/core": "jsr:@zuke/core@*"
   },
   "publish": {
     "exclude": [


### PR DESCRIPTION
Prepare `@zuke/core` to go public at `1.0.0`, and fix the dependency constraints so the `0 → 1` transition doesn't break.

## Changes
- **Pin core to `release-as: 1.0.0`** in `.release-please-config.json` (only `packages/core`; others stay on `0.x`).
- **Remove the "under heavy development" warning** from the root `README.md`.
- **Bridge every `@zuke/core` dependent** (36 `deno.json` files) from `jsr:@zuke/core@^0` to `jsr:@zuke/core@*`, plus the matching `deno.lock` update.

## Why the wildcard (and not `^0 || ^1` or `^1`)
- `^0` means `>=0.0.0 <1.0.0`, so it **excludes** core `1.0.0`. When core's local version flips to `1.0.0`, every `^0` dependent fails to resolve it — which would break the core `1.0.0` **release PR's own CI**.
- Deno's `jsr:` specifiers **don't support union ranges** — `^0 || ^1`, `^0||^1`, and `>=0.14.0 <2` are all rejected (verified).
- `^1` **can't be applied yet** — local core is `0.14.0`, which doesn't satisfy `^1`, so resolution fails today.
- `*` is the only form that resolves core `0.14.0` now **and** will accept `1.0.0` later.

**`*` never reaches JSR:** merging this doesn't republish those packages (it's a `chore`), so their published constraints are untouched. The wildcard is an in-repo bridge only.

## Release sequence
1. Merge this PR.
2. Cut core `1.0.0` (next core-scoped `feat:`/`fix:`, or `release.yml` via workflow_dispatch). The release PR's CI now passes because dependents accept `1.0.0` via `*`.
3. **Follow-up (after `1.0.0` is on JSR):** tighten all dependents `* → ^1` **and** remove the `release-as: 1.0.0` pin. Ping me and I'll open it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)