### PR TITLE
docs(core): document semantic-versioning stability for 1.0.0

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -21,6 +21,11 @@ Also exports `jsr:@zuke/core/shell` (the injection-safe `$` runner) and
 
 See [Zuke](https://github.com/zuke-build/zuke#readme) for the full guide.
 
+## Stability
+
+From `1.0.0`, `@zuke/core` follows semantic versioning: breaking changes to the
+public API bump the major version, so you can depend on `^1` with confidence.
+
 ## Paths
 
 `@zuke/core` exports `absolutePath` and the `PathLike` type. Across the Zuke


### PR DESCRIPTION
Force the first stable release of `@zuke/core`.

PR #90 added the `release-as: 1.0.0` pin, but as a `chore` that did not touch `packages/core/` it did not trigger a core release — so `1.0.0` is not cut yet and the last release run opened no release PR. This PR makes a real core-scoped change — a short stability note in the core README — and carries a `Release-As: 1.0.0` trailer so release-please opens the core `1.0.0` release PR.

When you squash-merge, please keep the `Release-As: 1.0.0` line in the commit body so release-please picks it up. The body is deliberately free of parentheses, which would otherwise break the conventional-commits parser and silently drop the release.

After `1.0.0` is on JSR: drop the `release-as` pin and tighten the temporary `@zuke/core@*` dependency bridges to `^1`. I will open that follow-up on your go-ahead.

🤖 Generated with Claude Code — https://claude.com/claude-code

Release-As: 1.0.0

---
_Generated by [Claude Code](https://claude.ai/code/session_018M3JEtwN7jaUco8K5Xctth)_