### PR TITLE
chore: tighten core deps to ^1, drop the release-as pin, harden Deno bootstrap

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -8,7 +8,6 @@
     "packages/core": {
       "component": "core",
       "changelog-path": "CHANGELOG.md",
-      "release-as": "1.0.0",
       "extra-files": [
         {
           "type": "json",

--- a/deno.lock
+++ b/deno.lock
@@ -559,182 +559,182 @@
     "members": {
       "packages/biome": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/bun": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/cmd": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/cspell": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/cypress": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/deno": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/docker": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/docker-compose": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/dpdm": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/dprint": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/eslint": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/gcloud": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/gh": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/git": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/helm": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/jest": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/jsr": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/knip": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/kubectl": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/kustomize": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/npm": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/nx": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/oxlint": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/playwright": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/pnpm": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/release-please": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/security": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/terraform": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/tofu": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/tsgo": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/tsup": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/tsx": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/turbo": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/vite": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/vitest": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       },
       "packages/yarn": {
         "dependencies": [
-          "jsr:@zuke/core@*"
+          "jsr:@zuke/core@1"
         ]
       }
     }

--- a/packages/biome/deno.json
+++ b/packages/biome/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/bun/deno.json
+++ b/packages/bun/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/cmd/deno.json
+++ b/packages/cmd/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/cspell/deno.json
+++ b/packages/cspell/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/cypress/deno.json
+++ b/packages/cypress/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/deno/deno.json
+++ b/packages/deno/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/docker-compose/deno.json
+++ b/packages/docker-compose/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/docker/deno.json
+++ b/packages/docker/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/dpdm/deno.json
+++ b/packages/dpdm/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/dprint/deno.json
+++ b/packages/dprint/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/eslint/deno.json
+++ b/packages/eslint/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/gcloud/deno.json
+++ b/packages/gcloud/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/gh/deno.json
+++ b/packages/gh/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/git/deno.json
+++ b/packages/git/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/helm/deno.json
+++ b/packages/helm/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/jest/deno.json
+++ b/packages/jest/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/jsr/deno.json
+++ b/packages/jsr/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/knip/deno.json
+++ b/packages/knip/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/kubectl/deno.json
+++ b/packages/kubectl/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/kustomize/deno.json
+++ b/packages/kustomize/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/npm/deno.json
+++ b/packages/npm/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/nx/deno.json
+++ b/packages/nx/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/oxlint/deno.json
+++ b/packages/oxlint/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/playwright/deno.json
+++ b/packages/playwright/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/pnpm/deno.json
+++ b/packages/pnpm/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/release-please/deno.json
+++ b/packages/release-please/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/security/deno.json
+++ b/packages/security/deno.json
@@ -5,7 +5,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/terraform/deno.json
+++ b/packages/terraform/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/tofu/deno.json
+++ b/packages/tofu/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/tsgo/deno.json
+++ b/packages/tsgo/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/tsup/deno.json
+++ b/packages/tsup/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/tsx/deno.json
+++ b/packages/tsx/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/turbo/deno.json
+++ b/packages/turbo/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/vite/deno.json
+++ b/packages/vite/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/vitest/deno.json
+++ b/packages/vitest/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/packages/yarn/deno.json
+++ b/packages/yarn/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@*"
+    "@zuke/core": "jsr:@zuke/core@^1"
   },
   "publish": {
     "exclude": [

--- a/zuke
+++ b/zuke
@@ -39,16 +39,36 @@ else
   fi
   export DENO_INSTALL="$deno_install"
   deno_version="${DENO_VERSION:-$DEFAULT_DENO_VERSION}"
-  if [ "$deno_version" = "latest" ]; then
-    curl -fsSL https://deno.land/install.sh | sh >/dev/null
-  else
+  if [ "$deno_version" != "latest" ]; then
     # install.sh expects a leading "v"; accept either form from DENO_VERSION.
     case "$deno_version" in
       v*) ;;
       *) deno_version="v$deno_version" ;;
     esac
-    curl -fsSL https://deno.land/install.sh | sh -s "$deno_version" >/dev/null
   fi
+
+  # The install fetches over the network, which is occasionally flaky (e.g. a
+  # transient 5xx from the CDN). Retry a few times with backoff so a blip
+  # doesn't fail the whole run.
+  install_deno() {
+    if [ "$deno_version" = "latest" ]; then
+      curl -fsSL https://deno.land/install.sh | sh >/dev/null
+    else
+      curl -fsSL https://deno.land/install.sh | sh -s "$deno_version" >/dev/null
+    fi
+  }
+  attempt=1
+  max_attempts=4
+  until install_deno; do
+    if [ "$attempt" -ge "$max_attempts" ]; then
+      echo "zuke: failed to install Deno after $max_attempts attempts." >&2
+      exit 1
+    fi
+    delay=$((attempt * 3))
+    echo "zuke: Deno install failed (attempt $attempt/$max_attempts); retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+  done
   deno_bin="$deno_install/bin/deno"
 fi
 

--- a/zuke.ps1
+++ b/zuke.ps1
@@ -45,7 +45,23 @@ if (-not $deno) {
     # install.ps1 reads $v as the version, without a leading "v".
     $v = ($denoVersion -replace '^v', '')
   }
-  Invoke-RestMethod https://deno.land/install.ps1 | Invoke-Expression
+  # The install fetches over the network, which is occasionally flaky (e.g. a
+  # transient 5xx from the CDN). Retry a few times with backoff so a blip
+  # doesn't fail the whole run.
+  $maxAttempts = 4
+  for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+    try {
+      Invoke-RestMethod https://deno.land/install.ps1 | Invoke-Expression
+      break
+    } catch {
+      if ($attempt -ge $maxAttempts) {
+        throw "zuke: failed to install Deno after $maxAttempts attempts: $_"
+      }
+      $delay = $attempt * 3
+      Write-Host "zuke: Deno install failed (attempt $attempt/$maxAttempts); retrying in ${delay}s..."
+      Start-Sleep -Seconds $delay
+    }
+  }
   $deno = Join-Path $env:DENO_INSTALL "bin\deno.exe"
 }
 


### PR DESCRIPTION
Follow-up after `@zuke/core@1.0.0` shipped. Three things:

### 1. Tighten core deps `*` → `^1`
Every package's `jsr:@zuke/core@*` is now `jsr:@zuke/core@^1`. The `*` was a one-release bridge across the `0.x → 1.0.0` boundary (Deno can't express `^0 || ^1`); `^1` is the durable constraint now that 1.0.0 is out.

### 2. Drop the `release-as: 1.0.0` pin
Removed from the core entry in `.release-please-config.json`. With 1.0.0 cut, leaving the pin would peg every future core release back to 1.0.0 and stall versioning. From here, conventional commits drive core's version.

### 3. Harden the Deno bootstrap (the actual CI failure)
The CI failures on #91 and the release PR were **not** code issues — the macOS `test-os` job hit a transient `curl: (56) ... error: 500` from the install CDN *while bootstrapping Deno*:
```
zuke: Deno not found — installing it now...
curl: (56) The requested URL returned error: 500
```
(That's why master went green again on its own.) The `zuke` and `zuke.ps1` launchers now retry the install up to 4 times with backoff, so a CDN blip rides out instead of failing the run — a win for every user, not just CI.

### Notes
- Kept as a **`chore:`** on purpose: the dependency-constraint bump touches 36 packages, and a `fix:`/`feat:` would make release-please mass-release all of them. As a chore, each package adopts `^1` on its *next* natural release (published packages keep working on core `0.x` until then — no break).
- `@zuke/cli`'s `setup.ts` scaffolds a *separate, simpler* launcher template that has the same flaky single-shot bootstrap. I left it out to keep this PR focused; happy to send a `fix(cli)` to add the same retry to the scaffolded launchers if you want.

Verified locally: `./zuke ci` green 8/8 (incl. `--frozen` check/test against the updated lock), bash launcher passes `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018M3JEtwN7jaUco8K5Xctth)_