### PR TITLE
feat(ai): generate the AI-review workflow for GitLab, Azure and Bitbucket too

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -27,6 +27,6 @@ jobs:
         run: ./zuke review
         env:
           OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}"
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           GEMINI_API_KEY: "${{ secrets.GEMINI_API_KEY }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           ZUKE_REVIEW_BASE: FETCH_HEAD

--- a/docs/ai-review.md
+++ b/docs/ai-review.md
@@ -227,26 +227,24 @@ from the workflow env (the generator can't infer a secret name).
 
 ### Multi-host
 
-`host` defaults to `"github"`; pass `"gitlab"` or `"azure"` to generate the
-equivalent for those providers — matching the cross-platform PR commenting
-above. Output shape per host:
+`host` defaults to `"github"`; pass `"gitlab"`, `"azure"`, or `"bitbucket"` to
+generate the equivalent for those providers — matching the cross-platform PR
+commenting above. Output shape per host:
 
 | `host` | Default path | What's generated |
 | --- | --- | --- |
 | `"github"` | `.github/workflows/ai-review.yml` | Full workflow — fork-gated, harden-runner + pinned checkout, base-branch fetch, `pull-requests: write` if any reviewer comments. |
 | `"gitlab"` | `.gitlab/ai-review.gitlab-ci.yml` | Merge-request-only job snippet on `denoland/deno:latest`. **Include from your `.gitlab-ci.yml`** (`include: { local: '.gitlab/ai-review.gitlab-ci.yml' }`). GitLab project-level CI variables flow into the job automatically — no `variables:` block emitted. |
 | `"azure"` | `pipelines/ai-review.azure-pipelines.yml` | PR-only job snippet. Each reviewer's secret is wired into the script step's `env:` block as `$(NAME)` (Azure doesn't expose pipeline secrets as env vars by default); `SYSTEM_ACCESSTOKEN` is added when any reviewer uses `.comment()`. **Use as a template** from your main pipeline. |
+| `"bitbucket"` | `bitbucket-pipelines.yml` | Pull-request-only step on `denoland/deno:latest`, written to the repo-root pipelines file Bitbucket expects (it has no `include` mechanism). Repository variables flow into the step automatically — no env block emitted; map your secrets as **secured** repository variables. |
 
 ```ts
 // Declare one per host you care about — they share the same reviewers.
 ghReview = aiReviewWorkflow({ reviewers: [this.security] });
 glReview = aiReviewWorkflow({ host: "gitlab", reviewers: [this.security] });
 azReview = aiReviewWorkflow({ host: "azure", reviewers: [this.security] });
+bbReview = aiReviewWorkflow({ host: "bitbucket", reviewers: [this.security] });
 ```
-
-Bitbucket Pipelines isn't generated yet (the core `CiProvider` model doesn't
-cover Bitbucket); for Bitbucket, write the workflow by hand and rely on
-`.comment()` for cross-platform commenting — which already supports it.
 
 ## Worked example: Zuke reviews itself
 

--- a/docs/ai-review.md
+++ b/docs/ai-review.md
@@ -221,9 +221,32 @@ class Pipeline extends Build {
 
 Override what you need: `target` (default `"review"`), `baseBranch` (default
 `"master"`), `name`, `path`, `timeoutMinutes`. A reviewer that uses
-`.githubToken(param)` swaps its parameter's env var in for the default
-`GITHUB_TOKEN`; a reviewer constructed with a literal-string `.apiKey("…")` is
-skipped from the workflow env (the generator can't infer a secret name).
+`.commentToken(param)` swaps its parameter's env var in for the host's default
+token; a reviewer constructed with a literal-string `.apiKey("…")` is skipped
+from the workflow env (the generator can't infer a secret name).
+
+### Multi-host
+
+`host` defaults to `"github"`; pass `"gitlab"` or `"azure"` to generate the
+equivalent for those providers — matching the cross-platform PR commenting
+above. Output shape per host:
+
+| `host` | Default path | What's generated |
+| --- | --- | --- |
+| `"github"` | `.github/workflows/ai-review.yml` | Full workflow — fork-gated, harden-runner + pinned checkout, base-branch fetch, `pull-requests: write` if any reviewer comments. |
+| `"gitlab"` | `.gitlab/ai-review.gitlab-ci.yml` | Merge-request-only job snippet on `denoland/deno:latest`. **Include from your `.gitlab-ci.yml`** (`include: { local: '.gitlab/ai-review.gitlab-ci.yml' }`). GitLab project-level CI variables flow into the job automatically — no `variables:` block emitted. |
+| `"azure"` | `pipelines/ai-review.azure-pipelines.yml` | PR-only job snippet. Each reviewer's secret is wired into the script step's `env:` block as `$(NAME)` (Azure doesn't expose pipeline secrets as env vars by default); `SYSTEM_ACCESSTOKEN` is added when any reviewer uses `.comment()`. **Use as a template** from your main pipeline. |
+
+```ts
+// Declare one per host you care about — they share the same reviewers.
+ghReview = aiReviewWorkflow({ reviewers: [this.security] });
+glReview = aiReviewWorkflow({ host: "gitlab", reviewers: [this.security] });
+azReview = aiReviewWorkflow({ host: "azure", reviewers: [this.security] });
+```
+
+Bitbucket Pipelines isn't generated yet (the core `CiProvider` model doesn't
+cover Bitbucket); for Bitbucket, write the workflow by hand and rely on
+`.comment()` for cross-platform commenting — which already supports it.
 
 ## Worked example: Zuke reviews itself
 

--- a/packages/ai/src/workflow.ts
+++ b/packages/ai/src/workflow.ts
@@ -4,11 +4,19 @@
  * (`discoverCiFiles`/`syncCiFiles`) keeps it on disk in sync with the build
  * definition, the same way every other generated workflow works.
  *
- * The workflow runs on every pull request, non-fork-only (the secrets must
- * never reach untrusted code), with a pinned harden-runner + checkout + a
- * `./zuke <target>` step that gets every reviewer's secret env var wired up.
- * If any reviewer has `.comment()` enabled, the workflow gains
- * `pull-requests: write` and passes `GITHUB_TOKEN`.
+ * The workflow targets one CI host at a time, mirroring the host the review
+ * comments are posted to:
+ *
+ *   - **GitHub Actions** — a fork-gated PR workflow with harden-runner, pinned
+ *     checkout, a base-branch fetch, and `pull-requests: write` when any
+ *     reviewer uses `.comment()`. Defaults: `.github/workflows/ai-review.yml`.
+ *   - **GitLab CI** — a small merge-request-only job snippet meant to be
+ *     `include:`-d from the project's `.gitlab-ci.yml`. Defaults:
+ *     `.gitlab/ai-review.gitlab-ci.yml`.
+ *   - **Azure Pipelines** — a PR-only job snippet meant to be used as a
+ *     template. Defaults: `pipelines/ai-review.azure-pipelines.yml`. Each
+ *     reviewer's secret is wired into the script step's `env:` block (Azure
+ *     does not expose pipeline secrets as env vars by default).
  *
  * @module
  */
@@ -16,7 +24,9 @@
 import {
   type AnyParameter,
   CiFile,
+  type CiJob,
   type CiPipeline,
+  type CiProvider,
   envVarName,
   generateCi,
 } from "@zuke/core";
@@ -29,10 +39,19 @@ const HARDEN_RUNNER =
 /** SHA-pinned `actions/checkout` (v6.0.3). */
 const CHECKOUT = "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10";
 
-/** The default output path on GitHub. */
-const DEFAULT_PATH = ".github/workflows/ai-review.yml";
+/** Default output paths per host — see {@link AiReviewWorkflowSpec}. */
+const DEFAULT_PATHS: Record<CiProvider, string> = {
+  github: ".github/workflows/ai-review.yml",
+  // GitLab/Azure root files are typically user-owned; emit a snippet the user
+  // includes/templates from their main pipeline so we never clobber it.
+  gitlab: ".gitlab/ai-review.gitlab-ci.yml",
+  azure: "pipelines/ai-review.azure-pipelines.yml",
+};
 
-/** The conventional name shown in the Actions UI. */
+/** The Docker image used for the GitLab job — the official Deno image. */
+const GITLAB_IMAGE = "denoland/deno:latest";
+
+/** The conventional workflow name shown in each host's UI. */
 const DEFAULT_NAME = "AI Review";
 
 /** The default base branch to diff against (FETCH_HEAD after the fetch step). */
@@ -41,7 +60,7 @@ const DEFAULT_BASE_BRANCH = "master";
 /** The default build target the workflow runs (`./zuke <target>`). */
 const DEFAULT_TARGET = "review";
 
-/** Per-job time cap (matches the original hand-written workflow). */
+/** Per-job time cap (matches the original hand-written GitHub workflow). */
 const DEFAULT_TIMEOUT_MINUTES = 15;
 
 /** What to generate — only `reviewers` is required. */
@@ -49,21 +68,26 @@ export interface AiReviewWorkflowSpec {
   /**
    * The reviewers whose key env vars and `.comment()` setting drive the
    * generated workflow. Each reviewer's `.apiKey(param)` parameter becomes an
-   * `env:` entry that maps the secret in; any reviewer with `.comment()`
-   * causes the workflow to grant `pull-requests: write` and pass
-   * `GITHUB_TOKEN`.
+   * `env:` entry (or its host equivalent) that maps the secret in; any
+   * reviewer with `.comment()` causes the workflow to grant the right
+   * commenting scope and pass the host's token env var.
    */
   reviewers: readonly Reviewer[];
+  /**
+   * The CI host the workflow targets. Defaults to `"github"`. Use `"gitlab"`
+   * or `"azure"` to generate the equivalent snippet for those hosts.
+   */
+  host?: CiProvider;
   /** The build target the workflow runs. Defaults to `"review"`. */
   target?: string;
   /**
-   * The base branch the diff is taken against, fetched into `FETCH_HEAD`.
-   * Defaults to `"master"`.
+   * The base branch the diff is taken against (used by the GitHub workflow's
+   * fetch step). Defaults to `"master"`.
    */
   baseBranch?: string;
-  /** Output path. Defaults to `.github/workflows/ai-review.yml`. */
+  /** Output path. Defaults to the host's conventional location. */
   path?: string;
-  /** Workflow name shown in the Actions UI. Defaults to `"AI Review"`. */
+  /** Workflow name shown in the host's UI. Defaults to `"AI Review"`. */
   name?: string;
   /** Per-job timeout in minutes. Defaults to 15. */
   timeoutMinutes?: number;
@@ -76,6 +100,43 @@ function envOf(param: AnyParameter): string | undefined {
   return envVarName(param.name_);
 }
 
+/** Each reviewer's effective key env var, plus whether any uses `.comment()`. */
+function reviewerEnv(
+  reviewers: readonly Reviewer[],
+): { keyEnvs: string[]; commentEnvs: string[]; commentEnabled: boolean } {
+  const keyEnvs: string[] = [];
+  const commentEnvs: string[] = [];
+  let commentEnabled = false;
+  for (const reviewer of reviewers) {
+    const key = reviewer.apiKey_;
+    if (typeof key === "object") {
+      const name = envOf(key);
+      if (name !== undefined && !keyEnvs.includes(name)) keyEnvs.push(name);
+    }
+    if (reviewer.commentEnabled_) {
+      commentEnabled = true;
+      const token = reviewer.commentToken_;
+      if (typeof token === "object") {
+        const name = envOf(token);
+        if (name !== undefined && !commentEnvs.includes(name)) {
+          commentEnvs.push(name);
+        }
+      }
+    }
+  }
+  return { keyEnvs, commentEnvs, commentEnabled };
+}
+
+/** GitHub-style secret reference, e.g. `${{ secrets.OPENAI_API_KEY }}`. */
+function githubRef(name: string): string {
+  return `\${{ secrets.${name} }}`;
+}
+
+/** Azure-style pipeline-variable reference, e.g. `$(OPENAI_API_KEY)`. */
+function azureRef(name: string): string {
+  return `$(${name})`;
+}
+
 /**
  * A {@link CiFile} subclass for the AI-review workflow. The pipeline is built
  * lazily on every `render()` so that reviewer fields whose parameters were
@@ -85,7 +146,8 @@ class AiReviewWorkflow extends CiFile {
   readonly #spec: AiReviewWorkflowSpec;
 
   constructor(spec: AiReviewWorkflowSpec) {
-    super({ provider: "github", path: spec.path ?? DEFAULT_PATH });
+    const host = spec.host ?? "github";
+    super({ provider: host, path: spec.path ?? DEFAULT_PATHS[host] });
     this.#spec = spec;
   }
 
@@ -93,66 +155,120 @@ class AiReviewWorkflow extends CiFile {
     return generateCi(this.#pipeline(), this.provider);
   }
 
-  /** Build the pipeline fresh — see the class JSDoc for the deferred-render rationale. */
+  /** Dispatch to the per-host pipeline builder. */
   #pipeline(): CiPipeline {
+    switch (this.provider) {
+      case "github":
+        return this.#github();
+      case "gitlab":
+        return this.#gitlab();
+      case "azure":
+        return this.#azure();
+    }
+  }
+
+  /** GitHub: a fork-gated PR workflow with harden-runner + pinned checkout. */
+  #github(): CiPipeline {
     const baseBranch = this.#spec.baseBranch ?? DEFAULT_BASE_BRANCH;
     const target = this.#spec.target ?? DEFAULT_TARGET;
+    const { keyEnvs, commentEnvs, commentEnabled } = reviewerEnv(
+      this.#spec.reviewers,
+    );
     const env: Record<string, string> = {};
-    let needsPrWrite = false;
-    for (const reviewer of this.#spec.reviewers) {
-      const key = reviewer.apiKey_;
-      if (typeof key === "object") {
-        const name = envOf(key);
-        if (name !== undefined) {
-          env[name] = `\${{ secrets.${name} }}`;
-        }
-      }
-      if (reviewer.commentEnabled_) {
-        needsPrWrite = true;
-        const token = reviewer.commentToken_;
-        if (token === undefined) {
-          env.GITHUB_TOKEN = "${{ secrets.GITHUB_TOKEN }}";
-        } else if (typeof token === "object") {
-          const name = envOf(token);
-          if (name !== undefined) {
-            env[name] = `\${{ secrets.${name} }}`;
-          }
-        }
-      }
+    for (const name of keyEnvs) env[name] = githubRef(name);
+    if (commentEnabled) {
+      // Default to GITHUB_TOKEN when no explicit comment token was set.
+      const tokens = commentEnvs.length > 0 ? commentEnvs : ["GITHUB_TOKEN"];
+      for (const name of tokens) env[name] = githubRef(name);
     }
     env.ZUKE_REVIEW_BASE = "FETCH_HEAD";
 
+    const job: CiJob = {
+      id: "review",
+      name: "AI review",
+      runsOn: "ubuntu-latest",
+      // Fork PRs must never see the secrets (pwn-request); they also receive
+      // no secrets, so the reviewers would skip there anyway.
+      if: "${{ github.event.pull_request.head.repo.fork == false }}",
+      timeoutMinutes: this.#spec.timeoutMinutes ?? DEFAULT_TIMEOUT_MINUTES,
+      steps: [
+        {
+          name: "Harden the runner",
+          uses: HARDEN_RUNNER,
+          with: { "egress-policy": "audit" },
+        },
+        { uses: CHECKOUT, with: { "persist-credentials": "false" } },
+        {
+          name: "Fetch the base branch",
+          run: `git fetch --no-tags --depth=1 origin ${baseBranch}`,
+        },
+        { name: "AI review with Zuke", run: `./zuke ${target}`, env },
+      ],
+    };
     return {
       name: this.#spec.name ?? DEFAULT_NAME,
       triggers: { pullRequest: [] }, // every branch
-      ...(needsPrWrite
+      ...(commentEnabled
         ? { permissions: { contents: "read", "pull-requests": "write" } }
         : { permissions: { contents: "read" } }),
       concurrency: {
         group: "ai-review-${{ github.workflow }}-${{ github.ref }}",
         cancelInProgress: true,
       },
+      jobs: [job],
+    };
+  }
+
+  /**
+   * GitLab: a merge-request-only job snippet. Variables defined in the
+   * project's CI settings flow into the job automatically — the YAML doesn't
+   * need an `env:` block. Include from `.gitlab-ci.yml` via
+   * `include: { local: '.gitlab/ai-review.gitlab-ci.yml' }`.
+   */
+  #gitlab(): CiPipeline {
+    const target = this.#spec.target ?? DEFAULT_TARGET;
+    return {
+      name: this.#spec.name ?? DEFAULT_NAME,
+      triggers: { pullRequest: [] }, // MR-only via workflow rules
+      jobs: [{
+        id: "review",
+        name: "AI review",
+        runsOn: GITLAB_IMAGE,
+        timeoutMinutes: this.#spec.timeoutMinutes ?? DEFAULT_TIMEOUT_MINUTES,
+        steps: [{ name: "AI review with Zuke", run: `./zuke ${target}` }],
+      }],
+    };
+  }
+
+  /**
+   * Azure Pipelines: a PR-only job snippet. Pipeline secrets are NOT exposed
+   * as env vars by default, so each reviewer's key env var is wired into the
+   * script step's `env:` block as `$(NAME)`. Use as a template from your main
+   * pipeline.
+   */
+  #azure(): CiPipeline {
+    const target = this.#spec.target ?? DEFAULT_TARGET;
+    const { keyEnvs, commentEnvs, commentEnabled } = reviewerEnv(
+      this.#spec.reviewers,
+    );
+    const env: Record<string, string> = {};
+    for (const name of keyEnvs) env[name] = azureRef(name);
+    if (commentEnabled) {
+      // Default to SYSTEM_ACCESSTOKEN when no explicit comment token was set.
+      const tokens = commentEnvs.length > 0
+        ? commentEnvs
+        : ["SYSTEM_ACCESSTOKEN"];
+      for (const name of tokens) env[name] = azureRef(name);
+    }
+    return {
+      name: this.#spec.name ?? DEFAULT_NAME,
+      triggers: { pullRequest: [] }, // every branch
       jobs: [{
         id: "review",
         name: "AI review",
         runsOn: "ubuntu-latest",
-        // Fork PRs must never see the secrets (pwn-request); they also receive
-        // no secrets, so the reviewers would skip there anyway.
-        if: "${{ github.event.pull_request.head.repo.fork == false }}",
         timeoutMinutes: this.#spec.timeoutMinutes ?? DEFAULT_TIMEOUT_MINUTES,
-        steps: [
-          {
-            name: "Harden the runner",
-            uses: HARDEN_RUNNER,
-            with: { "egress-policy": "audit" },
-          },
-          { uses: CHECKOUT, with: { "persist-credentials": "false" } },
-          {
-            name: "Fetch the base branch",
-            run: `git fetch --no-tags --depth=1 origin ${baseBranch}`,
-          },
-          { name: "AI review with Zuke", run: `./zuke ${target}`, env },
-        ],
+        steps: [{ name: "AI review with Zuke", run: `./zuke ${target}`, env }],
       }],
     };
   }
@@ -161,8 +277,8 @@ class AiReviewWorkflow extends CiFile {
 /**
  * Declare a generated AI-review workflow on the build. The returned
  * {@link CiFile} is automatically discovered by `discoverCiFiles` and kept on
- * disk by `syncCiFiles`, so the committed `.github/workflows/ai-review.yml` is
- * always in sync with the reviewers declared in the build.
+ * disk by `syncCiFiles`. Default `host: "github"`; pass `"gitlab"` or
+ * `"azure"` to target those hosts.
  *
  * ```ts
  * class Pipeline extends Build {
@@ -171,9 +287,8 @@ class AiReviewWorkflow extends CiFile {
  *     r.provider("openai").apiKey(this.openaiKey).comment()
  *   );
  *   reviewTarget = target().validateBefore(this.review).executes(() => {});
- *   aiReviewWorkflow = aiReviewWorkflow({
- *     reviewers: [this.review], target: "reviewTarget"
- *   });
+ *   ghWorkflow = aiReviewWorkflow({ reviewers: [this.review] });
+ *   glWorkflow = aiReviewWorkflow({ host: "gitlab", reviewers: [this.review] });
  * }
  * ```
  */

--- a/packages/ai/src/workflow.ts
+++ b/packages/ai/src/workflow.ts
@@ -17,6 +17,10 @@
  *     template. Defaults: `pipelines/ai-review.azure-pipelines.yml`. Each
  *     reviewer's secret is wired into the script step's `env:` block (Azure
  *     does not expose pipeline secrets as env vars by default).
+ *   - **Bitbucket Pipelines** — a `bitbucket-pipelines.yml` whose
+ *     `pull-requests` section runs the review. Repository/workspace variables
+ *     flow into the step automatically, so no env block is emitted. Bitbucket
+ *     has no `include`, so the file lives at the repo root.
  *
  * @module
  */
@@ -46,10 +50,12 @@ const DEFAULT_PATHS: Record<CiProvider, string> = {
   // includes/templates from their main pipeline so we never clobber it.
   gitlab: ".gitlab/ai-review.gitlab-ci.yml",
   azure: "pipelines/ai-review.azure-pipelines.yml",
+  // Bitbucket has no `include` mechanism — the file must be at the repo root.
+  bitbucket: "bitbucket-pipelines.yml",
 };
 
 /** The Docker image used for the GitLab job — the official Deno image. */
-const GITLAB_IMAGE = "denoland/deno:latest";
+const DENO_IMAGE = "denoland/deno:latest";
 
 /** The conventional workflow name shown in each host's UI. */
 const DEFAULT_NAME = "AI Review";
@@ -74,8 +80,8 @@ export interface AiReviewWorkflowSpec {
    */
   reviewers: readonly Reviewer[];
   /**
-   * The CI host the workflow targets. Defaults to `"github"`. Use `"gitlab"`
-   * or `"azure"` to generate the equivalent snippet for those hosts.
+   * The CI host the workflow targets. Defaults to `"github"`. Use `"gitlab"`,
+   * `"azure"`, or `"bitbucket"` to generate the equivalent for those hosts.
    */
   host?: CiProvider;
   /** The build target the workflow runs. Defaults to `"review"`. */
@@ -164,6 +170,8 @@ class AiReviewWorkflow extends CiFile {
         return this.#gitlab();
       case "azure":
         return this.#azure();
+      case "bitbucket":
+        return this.#bitbucket();
     }
   }
 
@@ -233,7 +241,29 @@ class AiReviewWorkflow extends CiFile {
       jobs: [{
         id: "review",
         name: "AI review",
-        runsOn: GITLAB_IMAGE,
+        runsOn: DENO_IMAGE,
+        timeoutMinutes: this.#spec.timeoutMinutes ?? DEFAULT_TIMEOUT_MINUTES,
+        steps: [{ name: "AI review with Zuke", run: `./zuke ${target}` }],
+      }],
+    };
+  }
+
+  /**
+   * Bitbucket Pipelines: a `bitbucket-pipelines.yml` whose `pull-requests`
+   * section runs the review on the Deno image. Like GitLab, repository and
+   * workspace variables flow into the step as env automatically, so no `env:`
+   * block is emitted — set the API keys and `BITBUCKET_TOKEN` in repository
+   * settings. Bitbucket has no `include`, so this must live at the repo root.
+   */
+  #bitbucket(): CiPipeline {
+    const target = this.#spec.target ?? DEFAULT_TARGET;
+    return {
+      name: this.#spec.name ?? DEFAULT_NAME,
+      triggers: { pullRequest: [] }, // every branch's PRs
+      jobs: [{
+        id: "review",
+        name: "AI review",
+        runsOn: DENO_IMAGE, // the official Deno image works on Bitbucket too
         timeoutMinutes: this.#spec.timeoutMinutes ?? DEFAULT_TIMEOUT_MINUTES,
         steps: [{ name: "AI review with Zuke", run: `./zuke ${target}` }],
       }],

--- a/packages/ai/tests/workflow_test.ts
+++ b/packages/ai/tests/workflow_test.ts
@@ -157,3 +157,115 @@ Deno.test("a literal-string apiKey is skipped from env (no parameter to map)", (
   assertEquals(yaml.includes("OPENAI_API_KEY"), false);
   assertStringIncludes(yaml, "ZUKE_REVIEW_BASE: FETCH_HEAD");
 });
+
+// ─── GitLab ─────────────────────────────────────────────────────────────────
+
+Deno.test("gitlab: defaults to the include-snippet path and an MR-only job", () => {
+  class B extends Build {
+    key = parameter("OpenAI key").secret().env("OPENAI_API_KEY");
+    rev = securityReviewer((r) =>
+      r.provider("openai").apiKey(this.key).comment()
+    );
+    wf = aiReviewWorkflow({ host: "gitlab", reviewers: [this.rev] });
+  }
+  const b = new B();
+  discoverParameters(b);
+  assertEquals(b.wf.path, ".gitlab/ai-review.gitlab-ci.yml");
+  assertEquals(b.wf.provider, "gitlab");
+
+  const yaml = b.wf.render();
+  // MR-only workflow rules.
+  assertStringIncludes(yaml, "merge_request_event");
+  // Single review job on the Deno image with our timeout.
+  assertStringIncludes(yaml, "review:\n  stage: build");
+  // The image string has a colon, so YAML emits it quoted.
+  assertStringIncludes(yaml, 'image: "denoland/deno:latest"');
+  assertStringIncludes(yaml, "timeout: 15 minutes");
+  assertStringIncludes(yaml, "script:\n    - ./zuke review");
+  // GitLab variables flow in from project settings — no env: block in YAML.
+  assertEquals(yaml.includes("OPENAI_API_KEY"), false);
+});
+
+Deno.test("gitlab: target and timeoutMinutes overrides apply", () => {
+  class B extends Build {
+    key = parameter("Key").secret().env("K");
+    rev = securityReviewer((r) => r.provider("openai").apiKey(this.key));
+    wf = aiReviewWorkflow({
+      host: "gitlab",
+      reviewers: [this.rev],
+      target: "audit",
+      timeoutMinutes: 30,
+    });
+  }
+  const b = new B();
+  discoverParameters(b);
+  const yaml = b.wf.render();
+  assertStringIncludes(yaml, "- ./zuke audit");
+  assertStringIncludes(yaml, "timeout: 30 minutes");
+});
+
+// ─── Azure Pipelines ────────────────────────────────────────────────────────
+
+Deno.test("azure: defaults, PR trigger, and each secret wired as $(NAME) env", () => {
+  class B extends Build {
+    openaiKey = parameter("OpenAI key").secret().env("OPENAI_API_KEY");
+    geminiKey = parameter("Gemini key").secret().env("GEMINI_API_KEY");
+    security = securityReviewer((r) =>
+      r.provider("openai").apiKey(this.openaiKey).comment()
+    );
+    general = genericReviewer((r) =>
+      r.provider("gemini").apiKey(this.geminiKey).comment()
+    );
+    wf = aiReviewWorkflow({
+      host: "azure",
+      reviewers: [this.security, this.general],
+    });
+  }
+  const b = new B();
+  discoverParameters(b);
+  assertEquals(b.wf.path, "pipelines/ai-review.azure-pipelines.yml");
+  assertEquals(b.wf.provider, "azure");
+
+  const yaml = b.wf.render();
+  // PR-only — every branch.
+  assertStringIncludes(yaml, 'pr:\n  branches:\n    include:\n      - "*"');
+  assertStringIncludes(yaml, "- job: review");
+  assertStringIncludes(yaml, "timeoutInMinutes: 15");
+  // Script step + env wiring with Azure-style $(NAME) references.
+  assertStringIncludes(yaml, "- script: ./zuke review");
+  assertStringIncludes(yaml, 'OPENAI_API_KEY: "$(OPENAI_API_KEY)"');
+  assertStringIncludes(yaml, 'GEMINI_API_KEY: "$(GEMINI_API_KEY)"');
+  // Comment is enabled → SYSTEM_ACCESSTOKEN must be mapped in too.
+  assertStringIncludes(yaml, 'SYSTEM_ACCESSTOKEN: "$(SYSTEM_ACCESSTOKEN)"');
+});
+
+Deno.test("azure: a custom .commentToken(param) replaces SYSTEM_ACCESSTOKEN", () => {
+  class B extends Build {
+    apiKey = parameter("Key").secret().env("OPENAI_API_KEY");
+    botToken = parameter("Bot token").secret().env("BOT_TOKEN");
+    rev = securityReviewer((r) =>
+      r.provider("openai").apiKey(this.apiKey).comment().commentToken(
+        this.botToken,
+      )
+    );
+    wf = aiReviewWorkflow({ host: "azure", reviewers: [this.rev] });
+  }
+  const b = new B();
+  discoverParameters(b);
+  const yaml = b.wf.render();
+  assertStringIncludes(yaml, 'BOT_TOKEN: "$(BOT_TOKEN)"');
+  assertEquals(yaml.includes("SYSTEM_ACCESSTOKEN"), false);
+});
+
+Deno.test("azure: no reviewer uses .comment() → no SYSTEM_ACCESSTOKEN mapping", () => {
+  class B extends Build {
+    key = parameter("Key").secret().env("ANTHROPIC_API_KEY");
+    rev = securityReviewer((r) => r.provider("claude").apiKey(this.key)); // no .comment()
+    wf = aiReviewWorkflow({ host: "azure", reviewers: [this.rev] });
+  }
+  const b = new B();
+  discoverParameters(b);
+  const yaml = b.wf.render();
+  assertStringIncludes(yaml, 'ANTHROPIC_API_KEY: "$(ANTHROPIC_API_KEY)"');
+  assertEquals(yaml.includes("SYSTEM_ACCESSTOKEN"), false);
+});

--- a/packages/ai/tests/workflow_test.ts
+++ b/packages/ai/tests/workflow_test.ts
@@ -269,3 +269,49 @@ Deno.test("azure: no reviewer uses .comment() → no SYSTEM_ACCESSTOKEN mapping"
   assertStringIncludes(yaml, 'ANTHROPIC_API_KEY: "$(ANTHROPIC_API_KEY)"');
   assertEquals(yaml.includes("SYSTEM_ACCESSTOKEN"), false);
 });
+
+// ─── Bitbucket Pipelines ─────────────────────────────────────────────────────
+
+Deno.test("bitbucket: defaults to bitbucket-pipelines.yml with a pull-requests step", () => {
+  class B extends Build {
+    key = parameter("OpenAI key").secret().env("OPENAI_API_KEY");
+    rev = securityReviewer((r) =>
+      r.provider("openai").apiKey(this.key).comment()
+    );
+    wf = aiReviewWorkflow({ host: "bitbucket", reviewers: [this.rev] });
+  }
+  const b = new B();
+  discoverParameters(b);
+  // Bitbucket has no include — the file must be at the repo root.
+  assertEquals(b.wf.path, "bitbucket-pipelines.yml");
+  assertEquals(b.wf.provider, "bitbucket");
+
+  const yaml = b.wf.render();
+  assertStringIncludes(yaml, "pipelines:\n  pull-requests:");
+  assertStringIncludes(yaml, '"**":'); // every branch's PRs
+  assertStringIncludes(yaml, "- step:");
+  assertStringIncludes(yaml, "name: AI review");
+  assertStringIncludes(yaml, 'image: "denoland/deno:latest"');
+  assertStringIncludes(yaml, "max-time: 15");
+  assertStringIncludes(yaml, "- ./zuke review");
+  // Like GitLab, repo variables flow in automatically — no env block.
+  assertEquals(yaml.includes("OPENAI_API_KEY"), false);
+});
+
+Deno.test("bitbucket: target and timeoutMinutes overrides apply", () => {
+  class B extends Build {
+    key = parameter("Key").secret().env("K");
+    rev = securityReviewer((r) => r.provider("openai").apiKey(this.key));
+    wf = aiReviewWorkflow({
+      host: "bitbucket",
+      reviewers: [this.rev],
+      target: "audit",
+      timeoutMinutes: 30,
+    });
+  }
+  const b = new B();
+  discoverParameters(b);
+  const yaml = b.wf.render();
+  assertStringIncludes(yaml, "- ./zuke audit");
+  assertStringIncludes(yaml, "max-time: 30");
+});

--- a/packages/core/src/ci.ts
+++ b/packages/core/src/ci.ts
@@ -50,7 +50,11 @@ export interface CiStep {
   uses?: string;
   /** Inputs for a {@link uses} Action (GitHub only). */
   with?: Record<string, string>;
-  /** Environment variables for this step (GitHub only). */
+  /**
+   * Environment variables for this step. Rendered as `env:` on GitHub Actions
+   * and on Azure Pipelines `script` steps; ignored on GitLab (which sources
+   * variables from project settings, not the job YAML).
+   */
   env?: Record<string, string>;
 }
 
@@ -289,7 +293,11 @@ function azure(pipeline: CiPipeline): YamlValue {
     const steps: YamlValue[] = [];
     for (const step of job.steps ?? DEFAULT_STEPS) {
       if (step.run !== undefined) {
-        steps.push({ script: step.run, displayName: step.name });
+        steps.push({
+          script: step.run,
+          displayName: step.name,
+          env: step.env,
+        });
       }
     }
     jobs.push({

--- a/packages/core/src/ci.ts
+++ b/packages/core/src/ci.ts
@@ -35,7 +35,7 @@ import { toYaml, type YamlValue } from "./yaml.ts";
 import { type Build, forEachField } from "./build.ts";
 
 /** The CI providers {@link generateCi} can target. */
-export type CiProvider = "github" | "gitlab" | "azure";
+export type CiProvider = "github" | "gitlab" | "azure" | "bitbucket";
 
 /** A single step in a job. */
 export interface CiStep {
@@ -157,6 +157,7 @@ const DEFAULT_PATHS: Record<CiProvider, string> = {
   github: ".github/workflows/ci.yml",
   gitlab: ".gitlab-ci.yml",
   azure: "azure-pipelines.yml",
+  bitbucket: "bitbucket-pipelines.yml",
 };
 
 /** Collect the shell commands of a job's `run` steps, in order. */
@@ -317,9 +318,55 @@ function azure(pipeline: CiPipeline): YamlValue {
 }
 
 /**
+ * Render a Bitbucket Pipelines object. Bitbucket's model is a set of trigger
+ * sections (`pull-requests`, `branches`, `default`, `custom`) each holding an
+ * ordered list of steps; there's no job DAG, no matrix, and no per-step env in
+ * the YAML (repository/workspace variables flow in as env automatically), so
+ * `needs`, `matrix`, `if`, and step `env` are ignored here.
+ */
+function bitbucket(pipeline: CiPipeline): YamlValue {
+  const triggers = pipeline.triggers ?? DEFAULT_TRIGGERS;
+  const steps: YamlValue[] = [];
+  for (const job of pipeline.jobs ?? DEFAULT_JOBS) {
+    steps.push({
+      step: {
+        name: job.name,
+        image: job.runsOn,
+        "max-time": job.timeoutMinutes,
+        script: runCommands(job.steps ?? DEFAULT_STEPS),
+      },
+    });
+  }
+  // An empty branch array means "every branch" — Bitbucket spells that `**`.
+  const patterns = (branches: string[]) =>
+    branches.length > 0 ? branches : ["**"];
+
+  const pipelines: Record<string, YamlValue> = {};
+  if (triggers.pullRequest) {
+    const prs: Record<string, YamlValue> = {};
+    for (const p of patterns(triggers.pullRequest)) prs[p] = steps;
+    pipelines["pull-requests"] = prs;
+  }
+  if (triggers.push) {
+    if (triggers.push.length > 0) {
+      const branches: Record<string, YamlValue> = {};
+      for (const b of triggers.push) branches[b] = steps;
+      pipelines.branches = branches;
+    } else {
+      pipelines.default = steps; // runs on every push
+    }
+  }
+  if (triggers.manual) pipelines.custom = { "ai-review": steps };
+  // Each step carries its own `image` (from `runsOn`); a step without one falls
+  // back to Bitbucket's default image.
+  return { pipelines };
+}
+
+/**
  * Render `pipeline` as the YAML configuration for `provider`:
- * `.github/workflows/*.yml`, `.gitlab-ci.yml`, or `azure-pipelines.yml`. The
- * pipeline may be empty (`{}`) to accept every default.
+ * `.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, or
+ * `bitbucket-pipelines.yml`. The pipeline may be empty (`{}`) to accept every
+ * default.
  */
 export function generateCi(
   pipeline: CiPipeline,
@@ -332,6 +379,8 @@ export function generateCi(
       return toYaml(gitlab(pipeline));
     case "azure":
       return toYaml(azure(pipeline));
+    case "bitbucket":
+      return toYaml(bitbucket(pipeline));
   }
 }
 

--- a/packages/core/tests/ci_test.ts
+++ b/packages/core/tests/ci_test.ts
@@ -131,6 +131,48 @@ Deno.test("azure: a step's env block renders alongside its script", () => {
   assertStringIncludes(yaml, "env:\n          KEY:");
 });
 
+Deno.test("bitbucket: a PR pipeline maps to pull-requests with a step list", () => {
+  const yaml = generateCi({
+    triggers: { pullRequest: [] }, // every branch → "**"
+    jobs: [{
+      id: "review",
+      name: "AI review",
+      runsOn: "denoland/deno:latest",
+      timeoutMinutes: 15,
+      steps: [{ run: "./zuke review" }],
+    }],
+  }, "bitbucket");
+  assertStringIncludes(yaml, "pipelines:\n  pull-requests:");
+  assertStringIncludes(yaml, '"**":'); // unfiltered branch pattern
+  assertStringIncludes(yaml, "- step:");
+  assertStringIncludes(yaml, "name: AI review");
+  assertStringIncludes(yaml, 'image: "denoland/deno:latest"');
+  assertStringIncludes(yaml, "max-time: 15");
+  assertStringIncludes(yaml, "script:\n            - ./zuke review");
+});
+
+Deno.test("bitbucket: push triggers map to branches, empty push to default", () => {
+  const named = generateCi({
+    triggers: { push: ["main"] },
+    jobs: [{ id: "a", steps: [{ run: "x" }] }],
+  }, "bitbucket");
+  assertStringIncludes(named, "branches:\n    main:");
+
+  const def = generateCi({
+    triggers: { push: [] }, // every branch → default section
+    jobs: [{ id: "a", steps: [{ run: "x" }] }],
+  }, "bitbucket");
+  assertStringIncludes(def, "pipelines:\n  default:");
+});
+
+Deno.test("bitbucket: a manual-only pipeline becomes a custom trigger", () => {
+  const yaml = generateCi({
+    triggers: { manual: true },
+    jobs: [{ id: "a", steps: [{ run: "x" }] }],
+  }, "bitbucket");
+  assertStringIncludes(yaml, "custom:\n    ai-review:");
+});
+
 Deno.test("gitlab: workflow rules, stages, image, parallel matrix, script", () => {
   const yaml = generateCi(pipeline, "gitlab");
   assertStringIncludes(yaml, "workflow:\n  rules:");
@@ -274,6 +316,10 @@ Deno.test("cicd: the path follows the provider unless overridden", () => {
   assertEquals(
     cicd({ provider: "azure", pipeline }).path,
     "azure-pipelines.yml",
+  );
+  assertEquals(
+    cicd({ provider: "bitbucket", pipeline }).path,
+    "bitbucket-pipelines.yml",
   );
   // An explicit path overrides the convention.
   assertEquals(

--- a/packages/core/tests/ci_test.ts
+++ b/packages/core/tests/ci_test.ts
@@ -119,6 +119,18 @@ Deno.test("azure: condition, timeout, and unfiltered pr branches render", () => 
   assertStringIncludes(yaml, "timeoutInMinutes: 15");
 });
 
+Deno.test("azure: a step's env block renders alongside its script", () => {
+  const yaml = generateCi({
+    jobs: [{
+      id: "review",
+      steps: [{ run: "./zuke review", env: { KEY: "$(KEY)" } }],
+    }],
+  }, "azure");
+  // Azure secrets aren't exposed by default — the env block is what wires them.
+  assertStringIncludes(yaml, "- script: ./zuke review");
+  assertStringIncludes(yaml, "env:\n          KEY:");
+});
+
 Deno.test("gitlab: workflow rules, stages, image, parallel matrix, script", () => {
   const yaml = generateCi(pipeline, "gitlab");
   assertStringIncludes(yaml, "workflow:\n  rules:");


### PR DESCRIPTION
## What

The follow-up to PR #110: extend `aiReviewWorkflow` so the same builder generates a snippet for **GitLab CI**, **Azure Pipelines**, or **Bitbucket Pipelines**, not just GitHub Actions. Workflow generation now matches the cross-platform commenting from #110.

```ts
// One per host you target — they share the same reviewers.
ghReview = aiReviewWorkflow({ reviewers: [this.security] });
glReview = aiReviewWorkflow({ host: "gitlab", reviewers: [this.security] });
azReview = aiReviewWorkflow({ host: "azure", reviewers: [this.security] });
bbReview = aiReviewWorkflow({ host: "bitbucket", reviewers: [this.security] });
```

## Output shape per host

| `host` | Default path | What's generated |
| --- | --- | --- |
| `"github"` (default) | `.github/workflows/ai-review.yml` | Full workflow — fork-gated, harden-runner + pinned checkout, base-branch fetch, `pull-requests: write` if any reviewer comments. **Unchanged from before.** |
| `"gitlab"` | `.gitlab/ai-review.gitlab-ci.yml` | Merge-request-only job snippet on `denoland/deno:latest`. **Include from your `.gitlab-ci.yml`** (`include: { local: '.gitlab/ai-review.gitlab-ci.yml' }`). GitLab project-level CI variables flow into the job automatically — no `variables:` block emitted. |
| `"azure"` | `pipelines/ai-review.azure-pipelines.yml` | PR-only job snippet. Each reviewer's secret is wired into the script step's `env:` block as `$(NAME)` (Azure doesn't expose pipeline secrets as env vars by default); `SYSTEM_ACCESSTOKEN` added when any reviewer uses `.comment()`. **Use as a template** from your main pipeline. |
| `"bitbucket"` | `bitbucket-pipelines.yml` | Pull-request-only step on `denoland/deno:latest`, written to the repo-root pipelines file Bitbucket expects (it has no `include` mechanism). Repository variables flow into the step automatically — no env block emitted; map your secrets as **secured** repository variables. |

Defaults for GitLab/Azure are sub-paths instead of the root `.gitlab-ci.yml` / `azure-pipelines.yml` on purpose — those are typically user-owned, and an AI-review snippet should be includable from whatever the user already has rather than clobbering it. Bitbucket is the exception: it has no `include` mechanism, so the generated step goes to the conventional repo-root `bitbucket-pipelines.yml`.

## Changes

- **`packages/ai/src/workflow.ts`** — accepts `host?: CiProvider`, dispatches to per-host pipeline builders (`#github` unchanged, new `#gitlab`, `#azure`, `#bitbucket`), defaults the output path per host via a `DEFAULT_PATHS` map. The shared Deno image constant is reused across GitLab and Bitbucket.
- **`packages/core/src/ci.ts`** — `CiProvider` gains `"bitbucket"` with a renderer that maps the job model onto Bitbucket's trigger-section/step-list structure (`pull-requests` / `branches` / `default` / `custom`), plus the existing Azure `env` pass-through fix.
- **`packages/ai/tests/workflow_test.ts`** / **`packages/core/tests/ci_test.ts`** — new tests covering the GitLab, Azure and Bitbucket output shapes and overrides.
- **`docs/ai-review.md`** — the "Multi-host" subsection now lists Bitbucket alongside the others.

## Notes

- `feat(ai)` title so release-please cuts a minor `@zuke/ai` bump; the PR also touches `packages/core/`.
- Fully backwards-compatible: existing `aiReviewWorkflow({ reviewers })` keeps the default `host: "github"`.
- Bitbucket has no DAG/matrix/`if`/per-step env support in its pipelines model, so those job features are ignored for that host (documented).

## Verification

`deno task ci` fully green — lint, fmt, spell, check, tests, coverage gate (98.9% lines / 96.8% branches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwBhMMWZBMBRXPe9pz2pp7

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwBhMMWZBMBRXPe9pz2pp7)_