### PR TITLE
fix(ai): validate baseBranch and target for shell safety

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -117,6 +117,7 @@
     "matkoch",
     "Matthias",
     "Koch",
+    "metacharacter",
     "Mozilla"
   ],
   "ignorePaths": [

--- a/packages/ai/src/workflow.ts
+++ b/packages/ai/src/workflow.ts
@@ -99,6 +99,26 @@ export interface AiReviewWorkflowSpec {
   timeoutMinutes?: number;
 }
 
+/**
+ * A branch or target name safe to interpolate into a generated shell command:
+ * letters, digits, and `._/+-`. This forbids whitespace and every shell
+ * metacharacter, so a value baked into a `git fetch …` or `./zuke …` line can
+ * never broaden into a second command. Matches the characters git permits in a
+ * ref name.
+ */
+const SAFE_REF = /^[A-Za-z0-9][A-Za-z0-9._/+-]*$/;
+
+/** Reject a branch/target name that isn't shell-safe, with a friendly error. */
+function assertSafeRef(value: string, field: string): void {
+  if (!SAFE_REF.test(value)) {
+    throw new Error(
+      `aiReviewWorkflow: ${field} ${JSON.stringify(value)} is not a valid ` +
+        `branch/target name — use only letters, digits, and \`._/+-\` so it ` +
+        `is safe to interpolate into the generated command.`,
+    );
+  }
+}
+
 /** Resolve the env var name for a parameter — honours `.env(...)` overrides. */
 function envOf(param: AnyParameter): string | undefined {
   if (param.envName_ !== undefined) return param.envName_;
@@ -154,6 +174,12 @@ class AiReviewWorkflow extends CiFile {
   constructor(spec: AiReviewWorkflowSpec) {
     const host = spec.host ?? "github";
     super({ provider: host, path: spec.path ?? DEFAULT_PATHS[host] });
+    // Both are interpolated into shell commands in the generated YAML; reject
+    // anything that isn't a plain branch/target name up front.
+    if (spec.baseBranch !== undefined) {
+      assertSafeRef(spec.baseBranch, "baseBranch");
+    }
+    if (spec.target !== undefined) assertSafeRef(spec.target, "target");
     this.#spec = spec;
   }
 

--- a/packages/ai/tests/workflow_test.ts
+++ b/packages/ai/tests/workflow_test.ts
@@ -1,6 +1,7 @@
 import {
   assertEquals,
   assertStringIncludes,
+  assertThrows,
 } from "../../core/tests/_assert.ts";
 import { Build, discoverParameters, parameter, target } from "@zuke/core";
 import {
@@ -124,6 +125,47 @@ Deno.test("baseBranch, target, name, path, and timeoutMinutes override the defau
   assertStringIncludes(yaml, "run: ./zuke audit");
   assertStringIncludes(yaml, '"git fetch --no-tags --depth=1 origin main"');
   assertStringIncludes(yaml, "timeout-minutes: 30");
+});
+
+Deno.test("an unsafe baseBranch is rejected before it reaches the command", () => {
+  const rev = securityReviewer((r) => r.provider("openai").apiKey("k"));
+  assertThrows(
+    () => aiReviewWorkflow({ reviewers: [rev], baseBranch: "main; rm -rf /" }),
+    Error,
+    "baseBranch",
+  );
+  // Whitespace alone is enough to break the single-token git argument.
+  assertThrows(
+    () => aiReviewWorkflow({ reviewers: [rev], baseBranch: "a b" }),
+    Error,
+    "not a valid",
+  );
+});
+
+Deno.test("an unsafe target is rejected before it reaches the command", () => {
+  const rev = securityReviewer((r) => r.provider("openai").apiKey("k"));
+  assertThrows(
+    () => aiReviewWorkflow({ reviewers: [rev], target: "review && curl evil" }),
+    Error,
+    "target",
+  );
+});
+
+Deno.test("slashes and dots in a branch name are accepted", () => {
+  class B extends Build {
+    key = parameter("Key").secret().env("K");
+    rev = securityReviewer((r) => r.provider("openai").apiKey(this.key));
+    wf = aiReviewWorkflow({
+      reviewers: [this.rev],
+      baseBranch: "release/2.0.x",
+    });
+  }
+  const b = new B();
+  discoverParameters(b);
+  assertStringIncludes(
+    b.wf.render(),
+    "origin release/2.0.x",
+  );
 });
 
 Deno.test("a custom .githubToken(param) is wired by that parameter's env var", () => {


### PR DESCRIPTION
Prevent injection attacks by validating `baseBranch` and `target` parameters before they are interpolated into generated shell commands.

## Summary

The `aiReviewWorkflow` function now validates that `baseBranch` and `target` parameters contain only shell-safe characters (letters, digits, and `._/+-`) before accepting them. This prevents command injection vulnerabilities where unsafe input could break out of the intended git or zuke command.

## Changes

- Added `SAFE_REF` regex pattern that matches valid branch/target names safe for shell interpolation
- Added `assertSafeRef()` validation function that rejects unsafe values with a friendly error message
- Updated `AiReviewWorkflow` constructor to validate both `baseBranch` and `target` parameters upfront
- Added three new test cases:
  - Rejects `baseBranch` with shell metacharacters (e.g., `"main; rm -rf /"`)
  - Rejects `baseBranch` with whitespace (e.g., `"a b"`)
  - Rejects `target` with shell metacharacters (e.g., `"review && curl evil"`)
  - Accepts valid branch names with slashes and dots (e.g., `"release/2.0.x"`)
- Updated cspell dictionary to include "metacharacter"

## Implementation details

The validation regex `^[A-Za-z0-9][A-Za-z0-9._/+-]*$` ensures values start with an alphanumeric character and contain only safe characters, matching the set of characters git permits in ref names. This prevents any value from being interpolated into a git fetch or zuke command line in a way that could execute additional commands.

https://claude.ai/code/session_01DwBhMMWZBMBRXPe9pz2pp7