### PR TITLE
feat(core): run() auto-detects entry point, removes need for import.meta.main

### DIFF
--- a/docs/ai-review.md
+++ b/docs/ai-review.md
@@ -32,7 +32,7 @@ class Pipeline extends Build {
     .executes(async () => {/* … */});
 }
 
-if (import.meta.main) await run(Pipeline);
+await run(Pipeline);
 ```
 
 ## The reviewers

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -24,7 +24,7 @@ const timing: Plugin = {
   onFinish: (result) => console.log(`done: ${result.ok ? "ok" : "failed"}`),
 };
 
-if (import.meta.main) await run(MyBuild, { plugins: [timing] });
+await run(MyBuild, { plugins: [timing] });
 ```
 
 | Hook                       | When it runs                                          |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -93,9 +93,7 @@ class MyBuild extends Build {
   default = target().dependsOn(this.test).executes(() => {});
 }
 
-if (import.meta.main) {
-  await run(MyBuild);
-}
+await run(MyBuild);
 ```
 
 ```sh

--- a/docs/node-projects.md
+++ b/docs/node-projects.md
@@ -59,9 +59,7 @@ class AppBuild extends Build {
     .executes(() => {});
 }
 
-if (import.meta.main) {
-  await run(AppBuild);
-}
+await run(AppBuild);
 ```
 
 4. Bridge it for npm-centric contributors — in `package.json`:

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -27,7 +27,7 @@ class Deploy extends Build {
   });
 }
 
-if (import.meta.main) await run(Deploy);
+await run(Deploy);
 ```
 
 ```sh

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -25,7 +25,7 @@ class Pipeline extends Build {
     .executes(async () => {/* … */});
 }
 
-if (import.meta.main) await run(Pipeline);
+await run(Pipeline);
 ```
 
 ## Reviewers

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -32,9 +32,7 @@ class ${name} extends Build {
     .executes(() => {});
 }
 
-if (import.meta.main) {
-  await run(${name});
-}
+await run(${name});
 `;
 }
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -13,7 +13,7 @@ class MyBuild extends Build {
     .executes(() => console.log("Hello from Zuke!"));
 }
 
-if (import.meta.main) await run(MyBuild);
+await run(MyBuild);
 ```
 
 Also exports `jsr:@zuke/core/shell` (the injection-safe `$` runner) and

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -15,7 +15,7 @@
  *     .executes(async () => { await $`deno test -A`; });
  * }
  *
- * if (import.meta.main) { await run(MyBuild); }
+ * await run(MyBuild);
  * ```
  *
  * The shell helper `$` lives in the `./shell` submodule

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -5,6 +5,7 @@
 
 import { type Build, discoverGroups, discoverTargets } from "./build.ts";
 import { discoverCiFiles, syncCiFiles } from "./ci.ts";
+import { isEntryModule } from "./entry.ts";
 import { isCI } from "./host.ts";
 import { GraphError, validateGraph } from "./graph.ts";
 import { execute } from "./executor.ts";
@@ -411,16 +412,23 @@ export interface RunOptions {
  * Public entry point. Instantiate the build, parse arguments, run, and set the
  * process exit code.
  *
+ * Call it at the bottom of your build file — no `import.meta.main` guard
+ * needed. `run` acts only when its module is the program's entry point; when
+ * the file is imported instead (for example under test) it does nothing.
+ *
  * ```ts
- * if (import.meta.main) await run(MyBuild);
+ * await run(MyBuild);
  * // …with plugins:
- * if (import.meta.main) await run(MyBuild, { plugins: [timing] });
+ * await run(MyBuild, { plugins: [timing] });
  * ```
  */
 export async function run(
   BuildClass: new () => Build,
   options: RunOptions = {},
 ): Promise<void> {
+  // Run only when this build's module is the one Deno was started with, so the
+  // caller needn't write `if (import.meta.main)`. Imported elsewhere, no-op.
+  if (!isEntryModule(new Error().stack ?? "", import.meta.url)) return;
   const code = await main(BuildClass, options.args ?? Deno.args, {
     plugins: options.plugins,
   });

--- a/packages/core/src/entry.ts
+++ b/packages/core/src/entry.ts
@@ -1,0 +1,48 @@
+/**
+ * Detecting the program's entry point.
+ *
+ * {@link run} uses this so a build file can call `run(MyBuild)` at the top
+ * level without an `if (import.meta.main)` guard: when the module is the one
+ * Deno was started with it runs; when it is merely imported (for example under
+ * test) `run` returns without doing anything.
+ *
+ * The decision recovers the module that called `run` from a stack trace and
+ * compares it against {@link Deno.mainModule}. Both are passed in as arguments
+ * so the logic stays pure and unit-testable.
+ *
+ * @module
+ */
+
+/** The `file://` module URL within a single V8 stack frame, sans `:line:col`. */
+const FRAME = /(file:\/\/.+?):\d+:\d+/;
+
+/**
+ * The URL of the first stack frame whose module differs from `selfUrl` — the
+ * caller of the code that captured `stack`. Frames from `selfUrl` itself (where
+ * the stack was taken) are skipped. Returns `undefined` when no other module
+ * frame is present.
+ */
+export function callerModule(
+  stack: string,
+  selfUrl: string,
+): string | undefined {
+  for (const line of stack.split("\n")) {
+    const match = FRAME.exec(line);
+    if (match !== null && match[1] !== selfUrl) return match[1];
+  }
+  return undefined;
+}
+
+/**
+ * Whether the module that invoked `run` is the program's entry point. When the
+ * caller can't be identified, defaults to `true` so `run` keeps its
+ * always-execute behaviour rather than silently skipping.
+ */
+export function isEntryModule(
+  stack: string,
+  selfUrl: string,
+  mainModule: string = Deno.mainModule,
+): boolean {
+  const caller = callerModule(stack, selfUrl);
+  return caller === undefined || caller === mainModule;
+}

--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -16,7 +16,7 @@
  *   onTargetEnd: (target, status) => console.log(`${target}: ${status}`),
  * };
  *
- * if (import.meta.main) await run(MyBuild, { plugins: [timing] });
+ * await run(MyBuild, { plugins: [timing] });
  * ```
  *
  * @module

--- a/packages/core/tests/cli_test.ts
+++ b/packages/core/tests/cli_test.ts
@@ -338,6 +338,36 @@ Deno.test("run() drives main and sets the process exit code", async () => {
   assertEquals(captured, 0);
 });
 
+Deno.test("run() is a no-op when its module isn't the program entry", async () => {
+  // Simulate the build file being imported (e.g. under test) rather than run
+  // directly: point Deno.mainModule at a different module than this caller.
+  const origExit = Deno.exit;
+  const mainDesc = Object.getOwnPropertyDescriptor(Deno, "mainModule");
+  let exited = false;
+  let ran = false;
+  Deno.exit = (_code?: number): never => {
+    exited = true;
+    throw new ExitSignal();
+  };
+  Object.defineProperty(Deno, "mainModule", {
+    value: "file:///somewhere/else.ts",
+    configurable: true,
+  });
+  class Demo2 extends Build {
+    go = target().executes(() => void (ran = true));
+  }
+  try {
+    await run(Demo2, { args: ["go"] });
+  } finally {
+    Deno.exit = origExit;
+    if (mainDesc !== undefined) {
+      Object.defineProperty(Deno, "mainModule", mainDesc);
+    }
+  }
+  assertEquals(exited, false);
+  assertEquals(ran, false);
+});
+
 Deno.test("main honours --skip", async () => {
   const log: string[] = [];
   class Tracked extends Build {

--- a/packages/core/tests/entry_test.ts
+++ b/packages/core/tests/entry_test.ts
@@ -1,0 +1,67 @@
+import { assertEquals } from "./_assert.ts";
+import { callerModule, isEntryModule } from "../src/entry.ts";
+
+const SELF = "file:///repo/packages/core/src/cli.ts";
+
+/** A V8-style stack with the given frames after the `Error` header line. */
+function stack(...frames: string[]): string {
+  return ["Error", ...frames.map((f) => `    ${f}`)].join("\n");
+}
+
+Deno.test("callerModule returns the first frame outside selfUrl", () => {
+  const s = stack(
+    `at run (${SELF}:425:13)`,
+    "at file:///repo/zuke.ts:396:7",
+  );
+  assertEquals(callerModule(s, SELF), "file:///repo/zuke.ts");
+});
+
+Deno.test("callerModule reads both parenthesised and bare frame forms", () => {
+  // bare `at <url>` (top-level await frames have no function name)
+  assertEquals(
+    callerModule(stack(`at ${SELF}:1:1`, "at file:///repo/build.ts:9:5"), SELF),
+    "file:///repo/build.ts",
+  );
+  // parenthesised `at name (<url>)`
+  assertEquals(
+    callerModule(
+      stack(`at run (${SELF}:1:1)`, "at x (file:///repo/build.ts:9:5)"),
+      SELF,
+    ),
+    "file:///repo/build.ts",
+  );
+});
+
+Deno.test("callerModule skips every selfUrl frame", () => {
+  const s = stack(
+    `at run (${SELF}:425:13)`,
+    `at inner (${SELF}:200:3)`,
+    "at file:///repo/zuke.ts:1:1",
+  );
+  assertEquals(callerModule(s, SELF), "file:///repo/zuke.ts");
+});
+
+Deno.test("callerModule handles Windows file URLs with a drive colon", () => {
+  const s = stack(`at run (${SELF}:1:1)`, "at file:///C:/proj/zuke.ts:3:9");
+  assertEquals(callerModule(s, SELF), "file:///C:/proj/zuke.ts");
+});
+
+Deno.test("callerModule returns undefined when no other module is present", () => {
+  assertEquals(callerModule(stack(`at run (${SELF}:1:1)`), SELF), undefined);
+  assertEquals(callerModule("Error", SELF), undefined);
+});
+
+Deno.test("isEntryModule is true when the caller is the main module", () => {
+  const s = stack(`at run (${SELF}:1:1)`, "at file:///repo/zuke.ts:5:1");
+  assertEquals(isEntryModule(s, SELF, "file:///repo/zuke.ts"), true);
+});
+
+Deno.test("isEntryModule is false when the caller is some other module", () => {
+  const s = stack(`at run (${SELF}:1:1)`, "at file:///repo/zuke.ts:5:1");
+  assertEquals(isEntryModule(s, SELF, "file:///repo/test_main.ts"), false);
+});
+
+Deno.test("isEntryModule defaults to true when the caller is unknown", () => {
+  // No identifiable caller frame — keep run()'s always-execute behaviour.
+  assertEquals(isEntryModule("Error", SELF, "file:///repo/anything.ts"), true);
+});

--- a/zuke.ts
+++ b/zuke.ts
@@ -393,6 +393,4 @@ class ZukeBuild extends Build {
     .executes(() => {});
 }
 
-if (import.meta.main) {
-  await run(ZukeBuild);
-}
+await run(ZukeBuild);


### PR DESCRIPTION
## Summary

Eliminates the need for `if (import.meta.main)` guards in build files by making `run()` automatically detect whether its module is the program's entry point. When called from an imported module (e.g., under test), `run()` now silently returns; when called from the main module, it executes as before.

## Changes

- **New module `packages/core/src/entry.ts`**: Implements entry point detection logic
  - `callerModule(stack, selfUrl)`: Extracts the first caller module from a V8 stack trace, skipping frames from `selfUrl` itself
  - `isEntryModule(stack, selfUrl, mainModule)`: Determines if the caller is the program's entry point by comparing against `Deno.mainModule`
  - Handles both parenthesized (`at name (url)`) and bare (`at url`) V8 stack frame formats
  - Supports Windows file URLs with drive colons

- **Updated `packages/core/src/cli.ts`**: Modified `run()` to check entry point before executing
  - Captures stack trace and calls `isEntryModule()` to gate execution
  - Returns early (no-op) when module is not the entry point
  - Updated JSDoc to reflect new behavior and simplified usage pattern

- **New test suite `packages/core/tests/entry_test.ts`**: Comprehensive coverage of entry point detection
  - Tests stack frame parsing (both formats, Windows paths)
  - Tests filtering of self-module frames
  - Tests edge cases (no caller, empty stack)
  - Tests `isEntryModule` logic with various scenarios

- **Updated `packages/core/tests/cli_test.ts`**: Added integration test verifying `run()` is a no-op when not the entry point

- **Documentation updates**: Simplified all examples across docs and READMEs to remove `if (import.meta.main)` guards
  - `docs/getting-started.md`, `docs/node-projects.md`, `docs/extending.md`, `docs/parameters.md`, `docs/ai-review.md`
  - `packages/core/README.md`, `packages/core/mod.ts`, `packages/core/src/plugin.ts`, `packages/ai/README.md`
  - `packages/cli/src/setup.ts` (generated template)
  - `zuke.ts` (project's own build file)

## Implementation Details

- Stack trace inspection is pure and unit-testable; `Deno.mainModule` is passed as an argument to `isEntryModule()` for testability
- Defaults to `true` when caller cannot be identified, preserving `run()`'s always-execute behavior for edge cases
- Uses regex to extract file URLs from V8 stack frames, handling both standard and Windows paths
- No runtime dependencies added; uses only Deno built-ins

https://claude.ai/code/session_01DwBhMMWZBMBRXPe9pz2pp7