### PR TITLE
feat: release @zuke/docs and the @zuke/deno doc wrapper

### DIFF
--- a/packages/deno/deno.json
+++ b/packages/deno/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@zuke/deno",
   "version": "0.4.0",
-  "description": "Typed deno CLI task wrappers for Zuke builds — run, test, check, fmt, lint, cache, coverage, and task via an injection-free settings-lambda API.",
+  "description": "Typed deno CLI task wrappers for Zuke builds — run, test, check, fmt, lint, doc, cache, coverage, and task via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"
   },

--- a/packages/docs/deno.json
+++ b/packages/docs/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@zuke/docs",
   "version": "0.1.0",
-  "description": "Typed Zuke tasks that generate and verify API documentation — turn `deno doc` into an llms.txt index, a full reference, and per-package README API blocks, with a check task to gate them in CI.",
+  "description": "Typed Zuke tasks that render already-generated API docs (e.g. `deno doc` output) into an llms.txt index, an llms-full.txt reference, and per-package README API blocks — plus a check task to gate them in CI. Pure: runs no subprocess and depends only on @zuke/core.",
   "exports": {
     ".": "./mod.ts"
   },


### PR DESCRIPTION
## Why

`@zuke/docs` (new package) and `DenoTasks.doc` (a `deno doc` wrapper in `@zuke/deno`) both landed in **#118** — but that PR squash-merged under a **`docs:`** title, which release-please treats as a no-bump type. So neither was released: `@zuke/docs` isn't on JSR, and `@zuke/deno` wasn't bumped for the new `doc` task.

This PR carries the matching description fixes and, crucially, uses a **`feat`** title touching files under **both** `packages/docs/` and `packages/deno/`, so release-please cuts releases for both:

- **`@zuke/docs`** → first release (publishes to JSR)
- **`@zuke/deno`** → minor bump including `DenoTasks.doc`

## What changed

- `packages/docs/deno.json` — corrected the description: the package **consumes** already-generated doc text (e.g. `deno doc` output) rather than running `deno doc` itself, and depends only on `@zuke/core`. (The previous wording implied it ran `deno doc`.)
- `packages/deno/deno.json` — added `doc` to the listed subcommands.

No code or generated-doc changes: `deno doc` reads each `mod.ts`, not `deno.json`, so `llms.txt`/`llms-full.txt`/READMEs are unaffected and `apiDocsCheck` stays green. Full `./zuke ci` passes (9/9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwBhMMWZBMBRXPe9pz2pp7

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwBhMMWZBMBRXPe9pz2pp7)_