### PR TITLE
ci(ai): bump pinned actions/checkout to v7.0.0

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -18,7 +18,7 @@ jobs:
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411
         with:
           egress-policy: audit
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: "false"
       - name: Fetch the base branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -47,7 +47,7 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -61,7 +61,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Full history so gitleaks scans past commits, not just the tip.
           fetch-depth: 0

--- a/packages/ai/src/workflow.ts
+++ b/packages/ai/src/workflow.ts
@@ -40,8 +40,8 @@ import type { Reviewer } from "./reviewer.ts";
 const HARDEN_RUNNER =
   "step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411";
 
-/** SHA-pinned `actions/checkout` (v6.0.3). */
-const CHECKOUT = "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10";
+/** SHA-pinned `actions/checkout` (v7.0.0). */
+const CHECKOUT = "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0";
 
 /** Default output paths per host — see {@link AiReviewWorkflowSpec}. */
 const DEFAULT_PATHS: Record<CiProvider, string> = {

--- a/packages/ai/tests/workflow_test.ts
+++ b/packages/ai/tests/workflow_test.ts
@@ -69,7 +69,7 @@ Deno.test("the steps are: harden, checkout (no credentials), fetch base, run ./z
   assertStringIncludes(yaml, "egress-policy: audit");
   assertStringIncludes(
     yaml,
-    "uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10",
+    "uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
   );
   // `false` is a string here so YAML doesn't read it as a boolean.
   assertStringIncludes(yaml, 'persist-credentials: "false"');


### PR DESCRIPTION
## Why

Dependabot's #117 bumps `actions/checkout` 6.0.3 → 7.0.0, but it turned **every CI job red**. The failure isn't an incompatibility with checkout v7 — it's that Zuke generates its own workflow files from TypeScript source and verifies them on each run:

```
CI configuration is out of date: .github/workflows/ai-review.yml.
Run `zuke generate-ci` and commit the result.
##[error]Process completed with exit code 1.
```

Dependabot rewrote the committed YAML but had no way to know the checkout SHA is also hardcoded in the source that *generates* `ai-review.yml` (`packages/ai/src/workflow.ts`). The generator still emitted the v6.0.3 SHA, so the drift check failed — and since it's the first step in every workflow, all jobs failed.

## What this does

Updates the source of truth so generated output and committed YAML agree, completing the upgrade across the repo:

- bump the SHA-pinned `CHECKOUT` constant (and its JSDoc) in the AI workflow builder
- update the test that asserts the pinned SHA
- re-pin `actions/checkout` to `9c091bb…` (v7.0.0) in all five workflow files

This supersedes #117, which can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018Sqds8Ws4NVnoLrnUhYJWd)_