### PR TITLE
feat(ai): agent-delegation fixer (agentFixer) and propose-vs-apply reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,28 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      # Audit (and optionally block) outbound network from the runner, so a
-      # compromised dependency can't exfiltrate or reach an unexpected host.
+      # This job carries live secrets (OPENAI_API_KEY) and a write-scoped token
+      # while it executes build code, so block egress to everything except the
+      # hosts the build legitimately needs. Even if untrusted code in `./zuke ci`
+      # reads a token from the environment, it cannot POST it to an attacker host
+      # — the connection is dropped. The allowlist is derived from the source:
+      # Deno bootstrap (deno.land + the release CDN), JSR resolution (jsr.io),
+      # the OpenAI API (provider.ts), and the GitHub API / git push for the
+      # fixer's comment and commit. Add a host here if a run reports it blocked.
       - name: Harden the runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            deno.land:443
+            dl.deno.land:443
+            jsr.io:443
+            api.openai.com:443
+            api.github.com:443
+            github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
 
       # persist-credentials keeps the token in git config so the lint fixer can
       # push its commit. For a same-repo PR, check out the head branch (not the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,9 @@ jobs:
       # hosts the build legitimately needs. Even if untrusted code in `./zuke ci`
       # reads a token from the environment, it cannot POST it to an attacker host
       # — the connection is dropped. The allowlist is derived from the source:
-      # Deno bootstrap (deno.land + the release CDN), JSR resolution (jsr.io),
-      # the OpenAI API (provider.ts), and the GitHub API / git push for the
+      # Deno bootstrap (deno.land + the release CDN), module resolution (jsr.io
+      # and registry.npmjs.org for the npm: cspell tooling), the OpenAI API
+      # (provider.ts), and the GitHub API / git push for the
       # fixer's comment and commit. Add a host here if a run reports it blocked.
       - name: Harden the runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -47,6 +48,7 @@ jobs:
             deno.land:443
             dl.deno.land:443
             jsr.io:443
+            registry.npmjs.org:443
             api.openai.com:443
             api.github.com:443
             github.com:443

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,13 @@ jobs:
   quality:
     name: Build & verify with Zuke
     runs-on: ubuntu-latest
-    # Read the repo, and comment on the PR for the lint self-healing fixer. The
-    # OpenAI key is a same-repo secret, so on fork PRs it is absent and the fixer
-    # simply skips — CI still runs read-only.
+    # The lint self-healing fixer auto-applies the fix and pushes it to the PR
+    # branch, so this job needs `contents: write` (the push) and
+    # `pull-requests: write` (the comment). The OpenAI key is a same-repo secret,
+    # so on fork PRs it is absent and the token is read-only — the fixer skips
+    # and CI runs without writing anything.
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     steps:
       # Audit (and optionally block) outbound network from the runner, so a
@@ -36,18 +38,24 @@ jobs:
         with:
           egress-policy: audit
 
+      # persist-credentials keeps the token in git config so the lint fixer can
+      # push its commit. For a same-repo PR, check out the head branch (not the
+      # detached merge ref) so the push targets it; for a fork PR (or a push),
+      # fall back to the default checkout — the fixer can't and won't push there.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          persist-credentials: false
+          persist-credentials: true
+          ref: ${{ (github.event.pull_request.head.repo.full_name == github.repository) && github.head_ref || '' }}
 
       # No "set up Deno" step: the ./zuke launcher bootstraps Deno, pinned to a
       # known version by default (override with DENO_VERSION). Running through
       # the launcher keeps CI exercising the same entry point everyone else uses.
       #
       # OPENAI_API_KEY powers the lint target's self-healing fixer: on a lint
-      # failure it posts the diagnosis (and an inline suggestion) to the PR. The
-      # key is optional — without it the fixer skips and lint just fails. The
-      # fixer fetches the PR base branch itself for diff context (no manual step).
+      # failure it fixes the file, commits and pushes to the PR branch, and posts
+      # an overview comment of what it changed. The key is optional — without it
+      # the fixer skips and lint just fails. The fixer fetches the PR base branch
+      # itself for diff context (no manual step).
       - name: Run the full gate with Zuke
         run: ./zuke ci
         env:

--- a/README.md
+++ b/README.md
@@ -201,12 +201,16 @@ model a first-class citizen of the build graph, two ways:
   assessment (score, severity, findings), writes it to the job summary and the
   pull request, and **breaks the build** when the risk crosses a threshold you
   choose. The output is a typed verdict, not a blob of prose.
-- **Self-healing builds** — attach `aiFixer` to any target with
-  `.recoverWith(...)`. When the target fails, the fixer diagnoses the failure
-  from the error output and the diff and posts a **committable, Copilot-style
-  inline suggestion** to the PR. Opt into `.autoApply()` / `.commitFixes()` and
-  it fixes the working tree, commits, and **re-runs the real command to
-  verify** — a fix only counts when the build actually goes green.
+- **Self-healing builds** — attach a fixer to any target with
+  `.recoverWith(...)`. When the target fails, `aiFixer` diagnoses it from the
+  error output and the diff and (diagnose-only default) posts a **committable,
+  Copilot-style inline suggestion** to the PR. Opt into `.autoApply()` /
+  `.commitFixes()` and it fixes the working tree, commits, and **re-runs the
+  real command to verify** — a fix only counts when the build actually goes
+  green — posting an overview of what it changed instead of a suggestion.
+- **Agent delegation** — for open-ended fixes, `agentFixer` hands the failure to
+  a coding agent you inject (Claude Code, Codex, Gemini CLI) which edits files
+  itself; one generic fixer, agent chosen at the call site.
 
 ```ts
 test = target()
@@ -215,6 +219,7 @@ test = target()
   .recoverWith(aiFixer((f) => f.provider("openai").apiKey(this.key)));
 ```
 
+Apply a fixer to **every** target by overriding `recoverWith()` on the build.
 Safe by default (provider + key only): the fixer writes no files and just
 diagnoses. Edits are gated behind a path allowlist, a file cap, and local-only
 defaults, and nothing is committed unless you ask. See
@@ -228,9 +233,9 @@ right way — using the typed `*Tasks` wrappers instead of guessing the API or
 shelling out. Two skills, authored once as portable
 [`SKILL.md`](https://agentskills.io) folders under [`skills/`](./skills):
 
-| Skill | Use it to |
-| ----------------- | ----------------------------------------------------------- |
-| `zuke-setup` | Scaffold Zuke into a project (`zuke setup`, the `./zuke` launcher, a first build). |
+| Skill              | Use it to                                                                                    |
+| ------------------ | -------------------------------------------------------------------------------------------- |
+| `zuke-setup`       | Scaffold Zuke into a project (`zuke setup`, the `./zuke` launcher, a first build).           |
 | `zuke-write-build` | Write or edit a `zuke.ts` — add targets, wire dependencies, call tool wrappers, generate CI. |
 
 ### Claude Code

--- a/docs/self-healing.md
+++ b/docs/self-healing.md
@@ -116,6 +116,37 @@ aiFixer((f) =>
 A fix is **never auto-committed** unless you opt in, and the post-apply re-run
 is always the gate: a bad edit fails the build instead of landing silently.
 
+## Delegating to a coding agent — `agentFixer`
+
+`aiFixer` makes one structured API call and applies the edits itself. For
+open-ended failures, `agentFixer` instead hands the failure to a **coding agent**
+you inject — Claude Code, Codex, or the Gemini CLI — which reads and edits files
+autonomously; the executor then re-runs the target to verify. There's one
+generic fixer, not one per agent: you pick the agent at the call site.
+
+```ts
+import { agentFixer } from "jsr:@zuke/ai";
+import { ClaudeTasks } from "jsr:@zuke/claude";
+
+test = target()
+  .executes(() => DenoTasks.test((s) => s.allowAll()))
+  .recoverWith(
+    agentFixer((ctx) =>
+      // ctx.prompt is assembled from the failure; ctx also has the raw
+      // target/command/output if you'd rather build your own.
+      ClaudeTasks.run((s) => s.prompt(ctx.prompt).permissionMode("acceptEdits"))
+    ),
+  );
+```
+
+Any runner that takes the context and returns works — `CodexTasks.exec`,
+`GeminiTasks.run`, or a custom function. Because the agent edits files directly,
+`agentFixer` is **gated to local runs by default** (`.allowCI()` to opt in), and
+`.commitFixes()` stages *all* of the agent's changes, commits, and pushes (it
+makes no commit if the agent changed nothing). It reuses the same `.comment()` /
+`.commentToken()` / `.criteria()` / `.conventions()` / `.noPush()` knobs as
+`aiFixer`; the agent's output becomes the PR comment and job-summary note.
+
 ## Diff context without a CI step
 
 For good diagnoses the fixer wants the PR diff. `.diff((d) => d.fetchBase())`

--- a/docs/self-healing.md
+++ b/docs/self-healing.md
@@ -80,14 +80,19 @@ test = target()
 
 ### Copilot-style inline suggestions
 
-On GitHub, the fixer posts each problem as an **inline review comment with a
-committable `suggestion` block** — anchored to the exact `file:line` in the
-diff, deduplicated across re-runs, and skipped gracefully if a line isn't in the
-diff. Off GitHub (or when the model reports no specific locations) it falls back
-to a single overview comment. The structured fix carries per-problem locations
-(file, line, the verbatim offending code, and the replacement), so the comment
-shows real code, not prose. Use `.noSuggest()` to force the overview comment
-instead.
+When the fix is **only proposed** (diagnose-only — the default), the fixer posts
+each problem on GitHub as an **inline review comment with a committable
+`suggestion` block**, anchored to the exact `file:line`, deduplicated across
+re-runs, and skipped gracefully if a line isn't in the diff. The structured fix
+carries per-problem locations (file, line, the verbatim offending code, and the
+replacement), so the comment shows real code, not prose.
+
+When the fix is **applied** (`.autoApply()`), a committable suggestion would be
+contradictory — the change is already made — so the fixer posts a **single
+overview comment showing what it fixed (with the code diff)** instead. Off
+GitHub, or when the model reports no specific locations, it also falls back to
+the overview comment. Use `.noSuggest()` to force the overview comment even in
+diagnose mode.
 
 ### Applying and committing fixes
 
@@ -141,11 +146,16 @@ test = target()
 
 Any runner that takes the context and returns works — `CodexTasks.exec`,
 `GeminiTasks.run`, or a custom function. Because the agent edits files directly,
-`agentFixer` is **gated to local runs by default** (`.allowCI()` to opt in), and
-`.commitFixes()` stages *all* of the agent's changes, commits, and pushes (it
-makes no commit if the agent changed nothing). It reuses the same `.comment()` /
-`.commentToken()` / `.criteria()` / `.conventions()` / `.noPush()` knobs as
-`aiFixer`; the agent's output becomes the PR comment and job-summary note.
+`agentFixer` is **gated to local runs by default** (`.allowCI()` to opt in). It
+reuses the same `.comment()` / `.commentToken()` / `.criteria()` /
+`.conventions()` knobs as `aiFixer`, and mirrors the same propose-vs-apply rule:
+
+- **`.suggest()` (propose)** — render the agent's `git diff` as **committable
+  inline suggestions** on the PR and leave the build failed for the human to
+  apply. Suggestions only ever appear in this not-auto-fixing mode.
+- **`.commitFixes()` (apply)** — stage *all* of the agent's changes, commit, and
+  push (no commit if it changed nothing), then re-run the target to verify, and
+  post an **overview comment** of what it did. Takes precedence over `.suggest()`.
 
 ## Diff context without a CI step
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5025,6 +5025,10 @@ class Pipeline extends Build {
 ```
 @module
 
+function agentFixer(run: AgentRunner, configure?: Configure<AgentFixer>): AgentFixer
+  Construct an {@link AgentFixer} from an {@link AgentRunner} and apply the
+  configuration lambda. Plug the result into a target with `.recoverWith(...)`.
+
 function aiFixer(configure?: Configure<AiFixer>): AiFixer
   Construct an {@link AiFixer} and apply the configuration lambda. Plug the
   result into a target with `.recoverWith(...)`:
@@ -5069,6 +5073,51 @@ function secretsReviewer(configure?: Configure<Reviewer>): Reviewer
 
 function securityReviewer(configure?: Configure<Reviewer>): Reviewer
   A reviewer that scores the diff for security vulnerabilities.
+
+class AgentFixer implements Remediation
+  A fluent agent fixer. Construct one via {@link agentFixer} with a runner, and
+  attach it to a target with `.recoverWith(...)`. Diagnose/report defaults are
+  on; file changes happen through the agent, gated to local runs unless
+  `.allowCI()`.
+
+  constructor(run: AgentRunner)
+  name: string
+    A name for diagnostics — `"agent fix"`.
+  allowCI(): this
+    Permit the agent to run (and edit files) on CI; off by default.
+  commitFixes(): this
+    After the agent runs, stage all its changes, commit, and push to the current
+    branch so a healed PR carries the fix. Requires a checkout that can push; a
+    failed push is reported, not fatal.
+  commitMessage(message: string): this
+    Override the commit subject used by {@link commitFixes}.
+  noPush(): this
+    Commit the fix but do not push it.
+  comment(): this
+    Also post what the agent did as a PR comment (on by default).
+  noComment(): this
+    Do not post a PR comment (the job summary is still written).
+  commentToken(token: AnyParameter | string): this
+    The token used to post the PR comment (defaults to the host's env var).
+  criteria(criteria: string): this
+    Project-specific notes appended to the agent's prompt.
+  conventions(text: string): this
+    Supply the project conventions text directly instead of reading
+    `CLAUDE.md`/`AGENTS.md`. Pass an empty string to send none.
+  quiet(): this
+    Suppress the console printout (the summary/comment are still written).
+  env(reader: EnvReader): this
+    The environment reader used to detect CI and the comment host (test seam).
+  exec(run: (argv: string[]) => Promise<string>): this
+    The `git` runner used for committing (test seam).
+  readFile(impl: (path: string) => Promise<string | undefined>): this
+    The convention-file reader (test seam).
+  fetch(impl: typeof fetch): this
+    The `fetch` implementation used to post the PR comment (test seam).
+  async remediate(context: RemediationContext): Promise<RemediationResult>
+    Run the agent against the failure, optionally commit its changes, and ask
+    the executor to re-run the target as the verifier. Skips (no retry) on CI
+    unless {@link allowCI} is set, or if the agent run itself fails.
 
 class AiFixer implements Remediation
   A fluent AI fixer. Construct one via {@link aiFixer}, configure it, and attach
@@ -5267,6 +5316,22 @@ class Reviewer implements Validation
     Run the review and gate the build. Throws an {@link AiReviewError} when the
     gate trips (or on a configuration/API error with `onError: "fail"`).
 
+interface AgentContext
+  The failure context handed to an {@link AgentRunner}, plus a ready prompt.
+
+  target: string
+    The name of the failed target.
+  attempt: number
+    The 1-based recovery attempt.
+  command?: string
+    The command line that failed, if known.
+  output: string
+    The captured error output (stderr, or the error message).
+  conventions?: string
+    Project conventions (CLAUDE.md / AGENTS.md), if found.
+  prompt: string
+    A ready-to-use prompt assembled from the fields above.
+
 interface AiReviewWorkflowSpec
   What to generate — only `reviewers` is required.
 
@@ -5391,6 +5456,15 @@ interface Usage
     Tokens in the model's output / completion.
   totalTokens?: number
     Total tokens, reported by the provider or derived from input + output.
+
+type AgentResult = CommandOutput | string | void
+  What an {@link AgentRunner} may resolve to: a {@link CommandOutput} (its
+  stdout is captured for the report), a string, or nothing.
+
+type AgentRunner = (context: AgentContext) => Promise<AgentResult> | AgentResult
+  Runs the coding agent against the assembled {@link AgentContext}. The agent is
+  expected to edit files in place; the executor then re-runs the target. Throw
+  (or let the underlying command throw) to signal the agent could not run.
 
 type AssessmentType = "generic" | "security" | "secrets" | "correctness" | "license"
   The kind of review an assessment performs.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5085,6 +5085,12 @@ class AgentFixer implements Remediation
     A name for diagnostics — `"agent fix"`.
   allowCI(): this
     Permit the agent to run (and edit files) on CI; off by default.
+  suggest(): this
+    Propose the agent's changes as committable inline `suggestion`s on the
+    pull request (from its `git diff`) instead of committing them. The build
+    stays failed — the human applies the suggestions to fix it. Mutually
+    exclusive with {@link commitFixes} (suggest takes precedence). GitHub only;
+    elsewhere it falls back to the overview comment.
   commitFixes(): this
     After the agent runs, stage all its changes, commit, and push to the current
     branch so a healed PR carries the fix. Requires a checkout that can push; a

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -141,6 +141,10 @@ class Pipeline extends Build {
 ```
 @module
 
+function agentFixer(run: AgentRunner, configure?: Configure<AgentFixer>): AgentFixer
+  Construct an {@link AgentFixer} from an {@link AgentRunner} and apply the
+  configuration lambda. Plug the result into a target with `.recoverWith(...)`.
+
 function aiFixer(configure?: Configure<AiFixer>): AiFixer
   Construct an {@link AiFixer} and apply the configuration lambda. Plug the
   result into a target with `.recoverWith(...)`:
@@ -185,6 +189,51 @@ function secretsReviewer(configure?: Configure<Reviewer>): Reviewer
 
 function securityReviewer(configure?: Configure<Reviewer>): Reviewer
   A reviewer that scores the diff for security vulnerabilities.
+
+class AgentFixer implements Remediation
+  A fluent agent fixer. Construct one via {@link agentFixer} with a runner, and
+  attach it to a target with `.recoverWith(...)`. Diagnose/report defaults are
+  on; file changes happen through the agent, gated to local runs unless
+  `.allowCI()`.
+
+  constructor(run: AgentRunner)
+  name: string
+    A name for diagnostics — `"agent fix"`.
+  allowCI(): this
+    Permit the agent to run (and edit files) on CI; off by default.
+  commitFixes(): this
+    After the agent runs, stage all its changes, commit, and push to the current
+    branch so a healed PR carries the fix. Requires a checkout that can push; a
+    failed push is reported, not fatal.
+  commitMessage(message: string): this
+    Override the commit subject used by {@link commitFixes}.
+  noPush(): this
+    Commit the fix but do not push it.
+  comment(): this
+    Also post what the agent did as a PR comment (on by default).
+  noComment(): this
+    Do not post a PR comment (the job summary is still written).
+  commentToken(token: AnyParameter | string): this
+    The token used to post the PR comment (defaults to the host's env var).
+  criteria(criteria: string): this
+    Project-specific notes appended to the agent's prompt.
+  conventions(text: string): this
+    Supply the project conventions text directly instead of reading
+    `CLAUDE.md`/`AGENTS.md`. Pass an empty string to send none.
+  quiet(): this
+    Suppress the console printout (the summary/comment are still written).
+  env(reader: EnvReader): this
+    The environment reader used to detect CI and the comment host (test seam).
+  exec(run: (argv: string[]) => Promise<string>): this
+    The `git` runner used for committing (test seam).
+  readFile(impl: (path: string) => Promise<string | undefined>): this
+    The convention-file reader (test seam).
+  fetch(impl: typeof fetch): this
+    The `fetch` implementation used to post the PR comment (test seam).
+  async remediate(context: RemediationContext): Promise<RemediationResult>
+    Run the agent against the failure, optionally commit its changes, and ask
+    the executor to re-run the target as the verifier. Skips (no retry) on CI
+    unless {@link allowCI} is set, or if the agent run itself fails.
 
 class AiFixer implements Remediation
   A fluent AI fixer. Construct one via {@link aiFixer}, configure it, and attach
@@ -383,6 +432,22 @@ class Reviewer implements Validation
     Run the review and gate the build. Throws an {@link AiReviewError} when the
     gate trips (or on a configuration/API error with `onError: "fail"`).
 
+interface AgentContext
+  The failure context handed to an {@link AgentRunner}, plus a ready prompt.
+
+  target: string
+    The name of the failed target.
+  attempt: number
+    The 1-based recovery attempt.
+  command?: string
+    The command line that failed, if known.
+  output: string
+    The captured error output (stderr, or the error message).
+  conventions?: string
+    Project conventions (CLAUDE.md / AGENTS.md), if found.
+  prompt: string
+    A ready-to-use prompt assembled from the fields above.
+
 interface AiReviewWorkflowSpec
   What to generate — only `reviewers` is required.
 
@@ -507,6 +572,15 @@ interface Usage
     Tokens in the model's output / completion.
   totalTokens?: number
     Total tokens, reported by the provider or derived from input + output.
+
+type AgentResult = CommandOutput | string | void
+  What an {@link AgentRunner} may resolve to: a {@link CommandOutput} (its
+  stdout is captured for the report), a string, or nothing.
+
+type AgentRunner = (context: AgentContext) => Promise<AgentResult> | AgentResult
+  Runs the coding agent against the assembled {@link AgentContext}. The agent is
+  expected to edit files in place; the executor then re-runs the target. Throw
+  (or let the underlying command throw) to signal the agent could not run.
 
 type AssessmentType = "generic" | "security" | "secrets" | "correctness" | "license"
   The kind of review an assessment performs.

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -201,6 +201,12 @@ class AgentFixer implements Remediation
     A name for diagnostics — `"agent fix"`.
   allowCI(): this
     Permit the agent to run (and edit files) on CI; off by default.
+  suggest(): this
+    Propose the agent's changes as committable inline `suggestion`s on the
+    pull request (from its `git diff`) instead of committing them. The build
+    stays failed — the human applies the suggestions to fix it. Mutually
+    exclusive with {@link commitFixes} (suggest takes precedence). GitHub only;
+    elsewhere it falls back to the overview comment.
   commitFixes(): this
     After the agent runs, stage all its changes, commit, and push to the current
     branch so a healed PR carries the fix. Requires a checkout that can push; a

--- a/packages/ai/mod.ts
+++ b/packages/ai/mod.ts
@@ -31,6 +31,12 @@ export type {
 } from "./src/types.ts";
 export { AiFixer, aiFixer } from "./src/fixer.ts";
 export type { Confidence, FileEdit, Fix, FixLocation } from "./src/fix.ts";
+export { AgentFixer, agentFixer } from "./src/agent_fixer.ts";
+export type {
+  AgentContext,
+  AgentResult,
+  AgentRunner,
+} from "./src/agent_fixer.ts";
 export { DiffSettings } from "./src/diff.ts";
 export { GateSettings } from "./src/gate.ts";
 export type { RetryInfo, RetryOptions } from "./src/retry.ts";

--- a/packages/ai/src/agent_fixer.ts
+++ b/packages/ai/src/agent_fixer.ts
@@ -1,0 +1,334 @@
+/**
+ * The fluent {@link AgentFixer} and the {@link agentFixer} factory — a
+ * {@link "jsr:@zuke/core".Remediation} that delegates the actual fixing to a
+ * coding agent (Claude Code, Codex, Gemini CLI, …) you inject, then asks the
+ * executor to re-run the target so the real command verifies the fix.
+ *
+ * Unlike {@link "./fixer.ts".AiFixer} (one structured API call, edits applied by
+ * Zuke), the agent reads and edits files autonomously. It is therefore gated to
+ * local runs by default — opt into CI with `.allowCI()`. Bring your own runner:
+ *
+ * ```ts
+ * import { agentFixer } from "jsr:@zuke/ai";
+ * import { ClaudeTasks } from "jsr:@zuke/claude";
+ *
+ * test = target()
+ *   .executes(() => DenoTasks.test((s) => s.allowAll()))
+ *   .recoverWith(
+ *     agentFixer((ctx) =>
+ *       ClaudeTasks.run((s) => s.prompt(ctx.prompt).permissionMode("acceptEdits"))
+ *     ),
+ *   );
+ * ```
+ *
+ * @module
+ */
+
+import {
+  type AnyParameter,
+  detectCiHost,
+  type Remediation,
+  type RemediationContext,
+  type RemediationResult,
+} from "@zuke/core";
+import type { Configure } from "@zuke/core/tooling";
+import { Command, CommandOutput } from "@zuke/core/shell";
+import {
+  describeError,
+  readTextOrUndefined,
+  resolveConventions,
+} from "./context.ts";
+import { agentPrompt } from "./prompts/agent.ts";
+import { commitAll, type GitRunner } from "./commit.ts";
+import { writeStepSummary } from "./report.ts";
+import { postComment } from "./comment.ts";
+import { type EnvReader, readEnv } from "./hosts.ts";
+
+/** The failure context handed to an {@link AgentRunner}, plus a ready prompt. */
+export interface AgentContext {
+  /** The name of the failed target. */
+  target: string;
+  /** The 1-based recovery attempt. */
+  attempt: number;
+  /** The command line that failed, if known. */
+  command?: string;
+  /** The captured error output (stderr, or the error message). */
+  output: string;
+  /** Project conventions (CLAUDE.md / AGENTS.md), if found. */
+  conventions?: string;
+  /** A ready-to-use prompt assembled from the fields above. */
+  prompt: string;
+}
+
+/**
+ * What an {@link AgentRunner} may resolve to: a {@link CommandOutput} (its
+ * stdout is captured for the report), a string, or nothing.
+ */
+export type AgentResult = CommandOutput | string | void;
+
+/**
+ * Runs the coding agent against the assembled {@link AgentContext}. The agent is
+ * expected to edit files in place; the executor then re-runs the target. Throw
+ * (or let the underlying command throw) to signal the agent could not run.
+ */
+export type AgentRunner = (
+  context: AgentContext,
+) => Promise<AgentResult> | AgentResult;
+
+/** The agent's captured text output, for the report. */
+function textOf(result: AgentResult): string {
+  if (typeof result === "string") return result.trim();
+  if (result instanceof CommandOutput) return result.text();
+  return "";
+}
+
+/** A Markdown section reporting what the agent did, for the summary/PR comment. */
+function agentMarkdown(
+  name: string,
+  target: string,
+  action: string,
+  output: string,
+): string {
+  const parts = [
+    `## 🤖 ${name} — \`${target}\``,
+    "",
+    `**Action:** ${action.replaceAll("|", "\\|")}`,
+    "",
+  ];
+  const trimmed = output.trim();
+  if (trimmed !== "") {
+    const capped = trimmed.length > 4000
+      ? `${trimmed.slice(0, 4000)}\n… (truncated) …`
+      : trimmed;
+    parts.push(
+      "<details><summary>Agent output</summary>",
+      "",
+      "```",
+      capped,
+      "```",
+      "</details>",
+      "",
+    );
+  }
+  return parts.join("\n");
+}
+
+/**
+ * A fluent agent fixer. Construct one via {@link agentFixer} with a runner, and
+ * attach it to a target with `.recoverWith(...)`. Diagnose/report defaults are
+ * on; file changes happen through the agent, gated to local runs unless
+ * `.allowCI()`.
+ */
+export class AgentFixer implements Remediation {
+  readonly #run: AgentRunner;
+  #onlyLocal = true;
+  #commitFixes = false;
+  #commitMessage?: string;
+  #push = true;
+  #comment = true;
+  #commentToken?: AnyParameter | string;
+  #criteria = "";
+  #conventions?: string;
+  #quiet = false;
+  #env: EnvReader = readEnv;
+  #exec?: (argv: string[]) => Promise<string>;
+  #readFile?: (path: string) => Promise<string | undefined>;
+  #fetch?: typeof fetch;
+
+  /** A name for diagnostics — `"agent fix"`. */
+  name = "agent fix";
+
+  constructor(run: AgentRunner) {
+    this.#run = run;
+  }
+
+  /** Permit the agent to run (and edit files) on CI; off by default. */
+  allowCI(): this {
+    this.#onlyLocal = false;
+    return this;
+  }
+
+  /**
+   * After the agent runs, stage all its changes, commit, and push to the current
+   * branch so a healed PR carries the fix. Requires a checkout that can push; a
+   * failed push is reported, not fatal.
+   */
+  commitFixes(): this {
+    this.#commitFixes = true;
+    return this;
+  }
+
+  /** Override the commit subject used by {@link commitFixes}. */
+  commitMessage(message: string): this {
+    this.#commitMessage = message;
+    return this;
+  }
+
+  /** Commit the fix but do not push it. */
+  noPush(): this {
+    this.#push = false;
+    return this;
+  }
+
+  /** Also post what the agent did as a PR comment (on by default). */
+  comment(): this {
+    this.#comment = true;
+    return this;
+  }
+
+  /** Do not post a PR comment (the job summary is still written). */
+  noComment(): this {
+    this.#comment = false;
+    return this;
+  }
+
+  /** The token used to post the PR comment (defaults to the host's env var). */
+  commentToken(token: AnyParameter | string): this {
+    this.#commentToken = token;
+    return this;
+  }
+
+  /** Project-specific notes appended to the agent's prompt. */
+  criteria(criteria: string): this {
+    this.#criteria = criteria;
+    return this;
+  }
+
+  /**
+   * Supply the project conventions text directly instead of reading
+   * `CLAUDE.md`/`AGENTS.md`. Pass an empty string to send none.
+   */
+  conventions(text: string): this {
+    this.#conventions = text;
+    return this;
+  }
+
+  /** Suppress the console printout (the summary/comment are still written). */
+  quiet(): this {
+    this.#quiet = true;
+    return this;
+  }
+
+  /** The environment reader used to detect CI and the comment host (test seam). */
+  env(reader: EnvReader): this {
+    this.#env = reader;
+    return this;
+  }
+
+  /** The `git` runner used for committing (test seam). */
+  exec(run: (argv: string[]) => Promise<string>): this {
+    this.#exec = run;
+    return this;
+  }
+
+  /** The convention-file reader (test seam). */
+  readFile(impl: (path: string) => Promise<string | undefined>): this {
+    this.#readFile = impl;
+    return this;
+  }
+
+  /** The `fetch` implementation used to post the PR comment (test seam). */
+  fetch(impl: typeof fetch): this {
+    this.#fetch = impl;
+    return this;
+  }
+
+  /** The git runner: the configured seam, or the real shell `Command`. */
+  #git(): GitRunner {
+    return this.#exec ?? ((argv) => new Command(argv).text());
+  }
+
+  /** Report what the agent did to the console, the job summary, and the PR. */
+  async #report(target: string, action: string, output: string): Promise<void> {
+    if (!this.#quiet) console.log(`[${this.name}] "${target}" — ${action}`);
+    const markdown = agentMarkdown(this.name, target, action, output);
+    writeStepSummary(markdown);
+    if (this.#comment) {
+      await postComment(this.name, markdown, {
+        commentToken: this.#commentToken,
+        env: this.#env,
+        fetch: this.#fetch,
+      });
+    }
+  }
+
+  /**
+   * Run the agent against the failure, optionally commit its changes, and ask
+   * the executor to re-run the target as the verifier. Skips (no retry) on CI
+   * unless {@link allowCI} is set, or if the agent run itself fails.
+   */
+  async remediate(context: RemediationContext): Promise<RemediationResult> {
+    if (this.#onlyLocal && detectCiHost(this.#env) !== "local") {
+      await this.#report(
+        context.target,
+        "skipped — agent fixer is disabled on CI (.allowCI() to enable)",
+        "",
+      );
+      return { retry: false };
+    }
+
+    const { command, output } = describeError(context.error);
+    const conventions = await resolveConventions(
+      this.#conventions,
+      this.#readFile ?? readTextOrUndefined,
+    );
+    const prompt = agentPrompt({
+      target: context.target,
+      command,
+      output,
+      conventions,
+      criteria: this.#criteria === "" ? undefined : this.#criteria,
+    });
+
+    let agentOutput: string;
+    try {
+      agentOutput = textOf(
+        await this.#run({
+          target: context.target,
+          attempt: context.attempt,
+          command,
+          output,
+          conventions,
+          prompt,
+        }),
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[${this.name}] agent run failed: ${message}`);
+      return { retry: false };
+    }
+
+    let action = "ran the agent; re-running the target to verify";
+    if (this.#commitFixes) {
+      try {
+        await commitAll({
+          message: this.#commitMessage ??
+            `Apply Zuke agent fix for "${context.target}"`,
+          push: this.#push,
+          run: this.#git(),
+        });
+        action = this.#push
+          ? "ran the agent, committed, and pushed; re-running to verify"
+          : "ran the agent and committed; re-running to verify";
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        action =
+          `ran the agent (commit failed: ${message}); re-running to verify`;
+      }
+    }
+    await this.#report(context.target, action, agentOutput);
+    return { retry: true };
+  }
+}
+
+/**
+ * Construct an {@link AgentFixer} from an {@link AgentRunner} and apply the
+ * configuration lambda. Plug the result into a target with `.recoverWith(...)`.
+ */
+export function agentFixer(
+  run: AgentRunner,
+  configure?: Configure<AgentFixer>,
+): AgentFixer {
+  const fixer = new AgentFixer(run);
+  return configure ? configure(fixer) : fixer;
+}

--- a/packages/ai/src/agent_fixer.ts
+++ b/packages/ai/src/agent_fixer.ts
@@ -43,6 +43,10 @@ import { commitAll, type GitRunner } from "./commit.ts";
 import { writeStepSummary } from "./report.ts";
 import { postComment } from "./comment.ts";
 import { type EnvReader, readEnv } from "./hosts.ts";
+import { resolveKey } from "./provider.ts";
+import { resolveGithubContext } from "./hosts/github.ts";
+import { postSuggestions } from "./hosts/github_review.ts";
+import { diffToSuggestions } from "./diff_suggest.ts";
 
 /** The failure context handed to an {@link AgentRunner}, plus a ready prompt. */
 export interface AgentContext {
@@ -122,6 +126,7 @@ function agentMarkdown(
 export class AgentFixer implements Remediation {
   readonly #run: AgentRunner;
   #onlyLocal = true;
+  #suggest = false;
   #commitFixes = false;
   #commitMessage?: string;
   #push = true;
@@ -145,6 +150,18 @@ export class AgentFixer implements Remediation {
   /** Permit the agent to run (and edit files) on CI; off by default. */
   allowCI(): this {
     this.#onlyLocal = false;
+    return this;
+  }
+
+  /**
+   * Propose the agent's changes as **committable inline `suggestion`s** on the
+   * pull request (from its `git diff`) instead of committing them. The build
+   * stays failed — the human applies the suggestions to fix it. Mutually
+   * exclusive with {@link commitFixes} (suggest takes precedence). GitHub only;
+   * elsewhere it falls back to the overview comment.
+   */
+  suggest(): this {
+    this.#suggest = true;
     return this;
   }
 
@@ -238,6 +255,38 @@ export class AgentFixer implements Remediation {
     return this.#exec ?? ((argv) => new Command(argv).text());
   }
 
+  /**
+   * Post the agent's working-tree changes (`git diff HEAD`) as committable
+   * inline suggestions on the PR. Returns the number posted; a no-op off GitHub,
+   * without a PR context, or when the agent produced no committable hunks.
+   */
+  async #postSuggestions(target: string): Promise<number> {
+    if (detectCiHost(this.#env) !== "github") return 0;
+    let diff: string;
+    try {
+      diff = await this.#git()(["git", "diff", "HEAD"]);
+    } catch {
+      return 0;
+    }
+    const suggestions = diffToSuggestions(
+      diff,
+      `Proposed by the agent fix for \`${target}\`.`,
+    );
+    if (suggestions.length === 0) return 0;
+    const token = this.#commentToken !== undefined
+      ? resolveKey(this.#commentToken)
+      : this.#env("GITHUB_TOKEN") ?? "";
+    const context = resolveGithubContext(token, this.#env);
+    if (context === undefined) return 0;
+    try {
+      return await postSuggestions(context, suggestions, this.#fetch ?? fetch);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[${this.name}] could not post suggestions: ${message}`);
+      return 0;
+    }
+  }
+
   /** Report what the agent did to the console, the job summary, and the PR. */
   async #report(target: string, action: string, output: string): Promise<void> {
     if (!this.#quiet) console.log(`[${this.name}] "${target}" — ${action}`);
@@ -295,6 +344,19 @@ export class AgentFixer implements Remediation {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       console.warn(`[${this.name}] agent run failed: ${message}`);
+      return { retry: false };
+    }
+
+    // Suggest mode: render the agent's changes as committable inline
+    // suggestions and leave the build failed — the human applies them. Only
+    // when not auto-fixing; `.commitFixes()` (auto-fix) takes precedence and
+    // reports an overview of what it committed instead.
+    if (this.#suggest && !this.#commitFixes) {
+      const posted = await this.#postSuggestions(context.target);
+      const action = posted > 0
+        ? `ran the agent and proposed ${posted} inline suggestion(s) — apply them to fix`
+        : "ran the agent (no committable suggestions produced)";
+      await this.#report(context.target, action, agentOutput);
       return { retry: false };
     }
 

--- a/packages/ai/src/comment.ts
+++ b/packages/ai/src/comment.ts
@@ -1,0 +1,46 @@
+/**
+ * Posting a single overview comment to the pull/merge request via the active CI
+ * host — shared by the AI fixer and the agent fixer. Keyed by the fixer's name
+ * so re-runs update one comment in place; best-effort, so a failure to post
+ * never breaks the build.
+ *
+ * @module
+ */
+
+import type { AnyParameter } from "@zuke/core";
+import { detectReviewHost, type EnvReader } from "./hosts.ts";
+import { resolveKey } from "./provider.ts";
+
+/** How to post a comment: the token source, the env reader, and a `fetch` seam. */
+export interface CommentOptions {
+  /** The token to post with; defaults to the host's conventional env var. */
+  commentToken?: AnyParameter | string;
+  /** The environment reader used to detect the host and read the token. */
+  env: EnvReader;
+  /** The `fetch` implementation (test seam). */
+  fetch?: typeof fetch;
+}
+
+/**
+ * Upsert a single comment, identified by `name`, on the current PR/MR. A no-op
+ * when no CI host or PR context is detected (e.g. local runs).
+ */
+export async function postComment(
+  name: string,
+  markdown: string,
+  options: CommentOptions,
+): Promise<void> {
+  const host = detectReviewHost(options.env);
+  if (host === undefined) return;
+  const token = options.commentToken !== undefined
+    ? resolveKey(options.commentToken)
+    : options.env(host.defaultTokenEnv) ?? "";
+  const upsert = host.prepare(token, options.env);
+  if (upsert === undefined) return;
+  try {
+    await upsert(name, markdown, options.fetch ?? fetch);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`[${name}] could not post PR comment: ${message}`);
+  }
+}

--- a/packages/ai/src/commit.ts
+++ b/packages/ai/src/commit.ts
@@ -35,3 +35,29 @@ export async function commitAndPush(options: CommitOptions): Promise<void> {
     await options.run(["git", "push"]);
   }
 }
+
+/** How to commit (and optionally push) every change in the working tree. */
+export interface CommitAllOptions {
+  /** The commit message subject. */
+  message: string;
+  /** Push to the current branch after committing (default true). */
+  push?: boolean;
+  /** The git runner. */
+  run: GitRunner;
+}
+
+/**
+ * Stage **all** working-tree changes, commit them, and (unless `push` is false)
+ * push. Used by the agent fixer, which lets the agent edit arbitrary files, so
+ * the changed set isn't known ahead of time. A no-op when the working tree is
+ * clean (the agent made no change), so it never creates an empty commit.
+ */
+export async function commitAll(options: CommitAllOptions): Promise<void> {
+  await options.run(["git", "add", "-A"]);
+  const status = await options.run(["git", "status", "--porcelain"]);
+  if (status.trim() === "") return; // the agent changed nothing
+  await options.run(["git", "commit", "-m", options.message]);
+  if (options.push !== false) {
+    await options.run(["git", "push"]);
+  }
+}

--- a/packages/ai/src/context.ts
+++ b/packages/ai/src/context.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared failure-context helpers used by both the structured {@link
+ * "./fixer.ts".AiFixer} and the delegating {@link "./agent_fixer.ts".AgentFixer}:
+ * extracting the failed command and output from an error, and resolving the
+ * project conventions to feed the model.
+ *
+ * @module
+ */
+
+import { CommandError } from "@zuke/core/shell";
+
+/** The files a fixer reads, in order, for project conventions. */
+const CONVENTION_FILES = ["CLAUDE.md", "AGENTS.md"];
+
+/** Read a text file, returning `undefined` when it cannot be read. */
+export async function readTextOrUndefined(
+  path: string,
+): Promise<string | undefined> {
+  try {
+    return await Deno.readTextFile(path);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Extract the failed command and its output from a target's error. A shell
+ * {@link CommandError} carries the command line and captured `stderr`; anything
+ * else falls back to the error message.
+ */
+export function describeError(
+  error: unknown,
+): { command?: string; output: string } {
+  if (error instanceof CommandError) {
+    const output = error.stderr.trim();
+    return {
+      command: error.command,
+      output: output === "" ? error.message : output,
+    };
+  }
+  if (error instanceof Error) return { output: error.message };
+  return { output: String(error) };
+}
+
+/**
+ * Resolve the project conventions sent to the model: the explicitly-supplied
+ * text (an empty string means "send none"), or the first of `CLAUDE.md` /
+ * `AGENTS.md` that can be read. The `read` seam is overridable for tests.
+ */
+export async function resolveConventions(
+  explicit: string | undefined,
+  read: (path: string) => Promise<string | undefined> = readTextOrUndefined,
+): Promise<string | undefined> {
+  if (explicit !== undefined) return explicit === "" ? undefined : explicit;
+  for (const file of CONVENTION_FILES) {
+    const text = await read(file);
+    if (text !== undefined && text !== "") return text;
+  }
+  return undefined;
+}

--- a/packages/ai/src/diff_suggest.ts
+++ b/packages/ai/src/diff_suggest.ts
@@ -1,0 +1,97 @@
+/**
+ * Turn a unified `git diff` into GitHub inline {@link Suggestion}s — used by the
+ * {@link "./agent_fixer.ts".AgentFixer} to render the changes an agent made as
+ * committable suggestions, instead of (or before) committing them.
+ *
+ * Each contiguous block of removed lines (with the additions that follow it) in
+ * a hunk becomes one suggestion anchored to those line numbers on the new file
+ * (the PR head). Pure insertions are skipped — GitHub suggestions replace
+ * existing lines, so there is nothing to anchor an insertion to.
+ *
+ * @module
+ */
+
+import type { Suggestion } from "./hosts/github_review.ts";
+
+/** The hunk header `@@ -oldStart,oldCount +newStart,newCount @@`. */
+const HUNK = /^@@ -(\d+)(?:,(\d+))? \+\d+(?:,\d+)? @@/;
+
+/** The `suggestion` comment body: a prelude plus a committable block. */
+function suggestionBody(prelude: string, additions: string[]): string {
+  const block = additions.length === 0
+    ? ["```suggestion", "```"]
+    : ["```suggestion", ...additions, "```"];
+  return [prelude, "", ...block].join("\n");
+}
+
+/**
+ * Parse a unified diff into inline replacement suggestions. `prelude` is the
+ * note shown above each suggestion block.
+ */
+export function diffToSuggestions(
+  diff: string,
+  prelude: string,
+): Suggestion[] {
+  const suggestions: Suggestion[] = [];
+  let path: string | undefined;
+  let oldLine = 0;
+  let inHunk = false;
+
+  // The current contiguous change block within a hunk.
+  let blockStart = -1;
+  let blockEnd = -1;
+  let hasRemoval = false;
+  let additions: string[] = [];
+
+  const flush = () => {
+    if (path !== undefined && hasRemoval) {
+      suggestions.push({
+        path,
+        startLine: blockStart,
+        line: blockEnd,
+        body: suggestionBody(prelude, additions),
+        key: `${path}:${blockStart}`,
+      });
+    }
+    blockStart = -1;
+    blockEnd = -1;
+    hasRemoval = false;
+    additions = [];
+  };
+
+  for (const line of diff.split("\n")) {
+    if (line.startsWith("diff --git ")) {
+      flush();
+      inHunk = false;
+      path = undefined;
+      continue;
+    }
+    if (line.startsWith("+++ b/")) {
+      path = line.slice("+++ b/".length).trim();
+      continue;
+    }
+    const hunk = line.match(HUNK);
+    if (hunk) {
+      flush();
+      oldLine = Number(hunk[1]);
+      inHunk = true;
+      continue;
+    }
+    if (!inHunk || path === undefined) continue;
+    if (line.startsWith("---") || line.startsWith("\\")) continue;
+    if (line.startsWith("-")) {
+      if (blockStart === -1) blockStart = oldLine;
+      blockEnd = oldLine;
+      hasRemoval = true;
+      oldLine++;
+    } else if (line.startsWith("+")) {
+      additions.push(line.slice(1));
+    } else {
+      // A context line ends the current change block.
+      flush();
+      oldLine++;
+    }
+  }
+  flush();
+  return suggestions;
+}

--- a/packages/ai/src/fixer.ts
+++ b/packages/ai/src/fixer.ts
@@ -352,9 +352,11 @@ export class AiFixer implements Remediation {
   }
 
   /**
-   * Report the fix to the console and the job summary, then post to the PR: as
-   * Copilot-style committable inline suggestions on GitHub when there are code
-   * locations, otherwise as a single overview comment.
+   * Report the fix to the console and the job summary, then post to the PR.
+   * When the fix is only *proposed* (diagnose-only), post Copilot-style
+   * committable inline suggestions so the human can apply them. When it was
+   * *applied* (`autoApply`), suggesting the same change is contradictory — post
+   * a single overview comment showing what was fixed (with the code) instead.
    */
   async #report(target: string, report: FixReport): Promise<void> {
     if (!this.#quiet) {
@@ -365,7 +367,11 @@ export class AiFixer implements Remediation {
     const markdown = fixMarkdown(this.name, target, report);
     writeStepSummary(markdown);
     if (!this.#comment) return;
-    if (this.#suggest && await this.#postSuggestions(report)) return;
+    if (
+      this.#suggest && !this.#autoApply && await this.#postSuggestions(report)
+    ) {
+      return;
+    }
     await this.#postIssueComment(markdown);
   }
 

--- a/packages/ai/src/fixer.ts
+++ b/packages/ai/src/fixer.ts
@@ -20,7 +20,7 @@ import {
   type RemediationResult,
 } from "@zuke/core";
 import type { Configure } from "@zuke/core/tooling";
-import { Command, CommandError } from "@zuke/core/shell";
+import { Command } from "@zuke/core/shell";
 import type { Effort, Provider, Usage } from "./types.ts";
 import { type Fix, type FixLocation, parseFix } from "./fix.ts";
 import { FIX_GEMINI_SCHEMA, FIX_JSON_SCHEMA } from "./fix_schema.ts";
@@ -44,22 +44,14 @@ import {
   fixSkipMarkdown,
 } from "./fix_report.ts";
 import { retryLine, writeStepSummary } from "./report.ts";
-import { detectReviewHost, type EnvReader, readEnv } from "./hosts.ts";
+import { type EnvReader, readEnv } from "./hosts.ts";
+import {
+  describeError,
+  readTextOrUndefined,
+  resolveConventions,
+} from "./context.ts";
+import { postComment } from "./comment.ts";
 import type { RetryInfo, RetryOptions } from "./retry.ts";
-
-/** The files a fixer reads, in order, for project conventions. */
-const CONVENTION_FILES = ["CLAUDE.md", "AGENTS.md"];
-
-/** Read a text file, returning `undefined` when it cannot be read. */
-export async function readTextOrUndefined(
-  path: string,
-): Promise<string | undefined> {
-  try {
-    return await Deno.readTextFile(path);
-  } catch {
-    return undefined;
-  }
-}
 
 /**
  * The body of an inline review comment for one location: the diagnosis plus a
@@ -81,19 +73,6 @@ function suggestionBody(diagnosis: string, loc: FixLocation): string {
  */
 function safeGitArg(value: string): boolean {
   return value !== "" && !value.startsWith("-");
-}
-
-/** Extract the failed command and its output from a target's error. */
-function describeError(error: unknown): { command?: string; output: string } {
-  if (error instanceof CommandError) {
-    const output = error.stderr.trim();
-    return {
-      command: error.command,
-      output: output === "" ? error.message : output,
-    };
-  }
-  if (error instanceof Error) return { output: error.message };
-  return { output: String(error) };
 }
 
 /**
@@ -365,16 +344,11 @@ export class AiFixer implements Remediation {
   }
 
   /** Read project conventions: the explicit text, or the first file found. */
-  async #resolveConventions(): Promise<string | undefined> {
-    if (this.#conventions !== undefined) {
-      return this.#conventions === "" ? undefined : this.#conventions;
-    }
-    const read = this.#readFile ?? readTextOrUndefined;
-    for (const file of CONVENTION_FILES) {
-      const text = await read(file);
-      if (text !== undefined && text !== "") return text;
-    }
-    return undefined;
+  #resolveConventions(): Promise<string | undefined> {
+    return resolveConventions(
+      this.#conventions,
+      this.#readFile ?? readTextOrUndefined,
+    );
   }
 
   /**
@@ -437,20 +411,12 @@ export class AiFixer implements Remediation {
   }
 
   /** Upsert the single overview comment via the active CI host. */
-  async #postIssueComment(markdown: string): Promise<void> {
-    const host = detectReviewHost(this.#env);
-    if (host === undefined) return;
-    const token = this.#commentToken !== undefined
-      ? resolveKey(this.#commentToken)
-      : this.#env(host.defaultTokenEnv) ?? "";
-    const upsert = host.prepare(token, this.#env);
-    if (upsert === undefined) return;
-    try {
-      await upsert(this.name, markdown, this.#fetch ?? fetch);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.warn(`[${this.name}] could not post PR comment: ${message}`);
-    }
+  #postIssueComment(markdown: string): Promise<void> {
+    return postComment(this.name, markdown, {
+      commentToken: this.#commentToken,
+      env: this.#env,
+      fetch: this.#fetch,
+    });
   }
 
   /** The commit subject for an applied fix. */

--- a/packages/ai/src/prompts/agent.ts
+++ b/packages/ai/src/prompts/agent.ts
@@ -1,0 +1,46 @@
+/**
+ * The prompt handed to a coding agent (Claude/Codex/Gemini) by the {@link
+ * "../agent_fixer.ts".AgentFixer}. The agent reads files and edits them itself,
+ * so the prompt frames the failure and the task rather than asking for
+ * structured output.
+ *
+ * @module
+ */
+
+/** The failure context a fix prompt is built from. */
+export interface AgentPromptContext {
+  /** The name of the failed target. */
+  target: string;
+  /** The command line that failed, if known. */
+  command?: string;
+  /** The captured error output. */
+  output: string;
+  /** Project conventions (e.g. the contents of CLAUDE.md / AGENTS.md). */
+  conventions?: string;
+  /** Optional project-specific notes appended by the caller. */
+  criteria?: string;
+}
+
+/** Assemble the instruction handed to the coding agent. */
+export function agentPrompt(context: AgentPromptContext): string {
+  const parts = [
+    `A build target failed and you are fixing it. Investigate the relevant ` +
+    `files, make the smallest correct change so the command passes, and stop. ` +
+    `Respect the project's existing conventions and types; do not introduce ` +
+    `new dependencies, reformat unrelated code, or weaken or delete tests to ` +
+    `force a pass — fix the underlying cause.`,
+    ``,
+    `Failed target: ${context.target}`,
+  ];
+  if (context.command !== undefined && context.command !== "") {
+    parts.push(`\nFailed command:\n${context.command}`);
+  }
+  parts.push(`\nError output:\n${context.output}`);
+  if (context.conventions !== undefined && context.conventions !== "") {
+    parts.push(`\nProject conventions:\n${context.conventions}`);
+  }
+  if (context.criteria !== undefined && context.criteria !== "") {
+    parts.push(`\nAdditional notes:\n${context.criteria}`);
+  }
+  return parts.join("\n");
+}

--- a/packages/ai/tests/agent_fixer_test.ts
+++ b/packages/ai/tests/agent_fixer_test.ts
@@ -1,0 +1,240 @@
+import { assertEquals } from "../../core/tests/_assert.ts";
+import { CommandError, CommandOutput } from "@zuke/core/shell";
+import { type AgentContext, type AgentFixer, agentFixer } from "../mod.ts";
+import { commitAll } from "../src/commit.ts";
+import type { RemediationContext } from "@zuke/core";
+
+const CTX: RemediationContext = {
+  target: "test",
+  attempt: 1,
+  error: new Error("boom: a test failed"),
+};
+
+/** A runner that records each AgentContext it receives. */
+function recorder() {
+  const calls: AgentContext[] = [];
+  const run = (ctx: AgentContext): Promise<void> => {
+    calls.push(ctx);
+    return Promise.resolve();
+  };
+  return { calls, run };
+}
+
+/** Apply the hermetic seams (no disk, no real git, local env, no comment). */
+function hermetic(f: AgentFixer, git?: string[][]): AgentFixer {
+  return f
+    .conventions("")
+    .env(() => undefined)
+    .readFile(() => Promise.resolve(undefined))
+    .exec((argv) => {
+      git?.push(argv);
+      return Promise.resolve(argv[1] === "status" ? " M src/app.ts" : "");
+    })
+    .quiet();
+}
+
+Deno.test("runs the agent and asks the executor to retry", async () => {
+  const r = recorder();
+  const fixer = hermetic(agentFixer(r.run));
+  const result = await fixer.remediate(CTX);
+  assertEquals(result.retry, true);
+  assertEquals(r.calls.length, 1);
+  assertEquals(r.calls[0].target, "test");
+  assertEquals(r.calls[0].prompt.includes("boom: a test failed"), true);
+});
+
+Deno.test("the failed command and stderr feed the prompt", async () => {
+  const r = recorder();
+  const fixer = hermetic(agentFixer(r.run));
+  await fixer.remediate({
+    target: "lint",
+    attempt: 1,
+    error: new CommandError("deno lint", 1, "error: unused variable x"),
+  });
+  assertEquals(r.calls[0].command, "deno lint");
+  assertEquals(r.calls[0].prompt.includes("deno lint"), true);
+  assertEquals(r.calls[0].prompt.includes("unused variable x"), true);
+});
+
+Deno.test("the agent is gated off CI unless allowCI is set", async () => {
+  const r = recorder();
+  const ciEnv = (n: string) => n === "GITHUB_ACTIONS" ? "true" : undefined;
+  const fixer = agentFixer(r.run).conventions("").readFile(() =>
+    Promise.resolve(undefined)
+  ).env(ciEnv).quiet();
+  const blocked = await fixer.remediate(CTX);
+  assertEquals(blocked.retry, false);
+  assertEquals(r.calls.length, 0); // never ran the agent on CI
+
+  const allowed = await fixer.allowCI().remediate(CTX);
+  assertEquals(allowed.retry, true);
+  assertEquals(r.calls.length, 1);
+});
+
+Deno.test("commitFixes stages all changes, commits, and pushes", async () => {
+  const git: string[][] = [];
+  const r = recorder();
+  const fixer = hermetic(agentFixer(r.run, (f) => f.commitFixes()), git);
+  const result = await fixer.remediate(CTX);
+  assertEquals(result.retry, true);
+  assertEquals(git, [
+    ["git", "add", "-A"],
+    ["git", "status", "--porcelain"],
+    ["git", "commit", "-m", 'Apply Zuke agent fix for "test"'],
+    ["git", "push"],
+  ]);
+});
+
+Deno.test("commitFixes makes no commit when the agent changed nothing", async () => {
+  const git: string[][] = [];
+  const r = recorder();
+  const fixer = agentFixer(r.run, (f) => f.commitFixes())
+    .conventions("").env(() => undefined).readFile(() =>
+      Promise.resolve(undefined)
+    )
+    .exec((argv) => {
+      git.push(argv);
+      return Promise.resolve(""); // clean working tree
+    })
+    .quiet();
+  await fixer.remediate(CTX);
+  assertEquals(git, [
+    ["git", "add", "-A"],
+    ["git", "status", "--porcelain"],
+  ]); // no commit, no push
+});
+
+Deno.test("a failed push is reported but the fix still retries", async () => {
+  const r = recorder();
+  const fixer = agentFixer(r.run, (f) => f.commitFixes())
+    .conventions("").env(() => undefined).readFile(() =>
+      Promise.resolve(undefined)
+    )
+    .exec((argv) => {
+      if (argv[1] === "push") return Promise.reject(new Error("no upstream"));
+      return Promise.resolve(argv[1] === "status" ? " M x" : "");
+    })
+    .quiet();
+  const result = await fixer.remediate(CTX);
+  assertEquals(result.retry, true);
+});
+
+Deno.test("a failing agent run is swallowed (no retry, build failure intact)", async () => {
+  const fixer = hermetic(
+    agentFixer(() => Promise.reject(new Error("agent crashed"))),
+  );
+  const result = await fixer.remediate(CTX);
+  assertEquals(result.retry, false);
+});
+
+Deno.test("noPush commits without pushing, with a custom message", async () => {
+  const git: string[][] = [];
+  const r = recorder();
+  const fixer = hermetic(
+    agentFixer(
+      r.run,
+      (f) => f.commitFixes().noPush().commitMessage("fix: heal"),
+    ),
+    git,
+  );
+  await fixer.remediate(CTX);
+  assertEquals(git, [
+    ["git", "add", "-A"],
+    ["git", "status", "--porcelain"],
+    ["git", "commit", "-m", "fix: heal"],
+  ]);
+});
+
+Deno.test("conventions and criteria reach the prompt", async () => {
+  const r = recorder();
+  const fixer = agentFixer(r.run, (f) => f.criteria("NO ANY"))
+    .conventions("Never use any.").env(() => undefined).quiet();
+  await fixer.remediate(CTX);
+  assertEquals(r.calls[0].prompt.includes("Never use any."), true);
+  assertEquals(r.calls[0].prompt.includes("NO ANY"), true);
+});
+
+Deno.test("the agent's stdout is captured and posted as a PR comment", async () => {
+  const prEnv: Record<string, string> = {
+    GITHUB_ACTIONS: "true",
+    GITHUB_REPOSITORY: "o/r",
+    GITHUB_REF: "refs/pull/7/merge",
+    GITHUB_TOKEN: "tok",
+  };
+  const calls: { url: string; body: string }[] = [];
+  const impl = ((input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method ?? "GET";
+    calls.push({ url, body: typeof init?.body === "string" ? init.body : "" });
+    const payload = method === "GET" ? "[]" : "{}";
+    return Promise.resolve(new Response(payload, { status: 200 }));
+  }) as typeof fetch;
+  const fixer = agentFixer(() =>
+    Promise.resolve(new CommandOutput(0, "Fixed the unused variable.", ""))
+  )
+    .allowCI().conventions("").readFile(() => Promise.resolve(undefined))
+    .env((n) => prEnv[n]).fetch(impl).quiet();
+  const result = await fixer.remediate(CTX);
+  assertEquals(result.retry, true);
+  // The POST carries the agent's stdout in the comment body.
+  const posted = calls.some((c) =>
+    c.url.includes("/comments") && c.body.includes("Fixed the unused variable.")
+  );
+  assertEquals(posted, true);
+});
+
+Deno.test("noComment writes no PR comment", async () => {
+  const prEnv: Record<string, string> = {
+    GITHUB_ACTIONS: "true",
+    GITHUB_REPOSITORY: "o/r",
+    GITHUB_REF: "refs/pull/7/merge",
+    GITHUB_TOKEN: "tok",
+  };
+  const calls: string[] = [];
+  const impl = ((input: string | URL | Request) => {
+    calls.push(String(input));
+    return Promise.resolve(new Response("[]", { status: 200 }));
+  }) as typeof fetch;
+  const fixer = agentFixer(() => Promise.resolve("done"))
+    .allowCI().noComment().conventions("").readFile(() =>
+      Promise.resolve(undefined)
+    )
+    .env((n) => prEnv[n]).fetch(impl).quiet();
+  await fixer.remediate(CTX);
+  assertEquals(calls.some((u) => u.includes("api.github.com")), false);
+});
+
+Deno.test("a non-quiet run prints what the agent did", async () => {
+  const r = recorder();
+  const fixer = agentFixer(r.run).conventions("").env(() => undefined)
+    .readFile(() => Promise.resolve(undefined));
+  const result = await fixer.remediate(CTX);
+  assertEquals(result.retry, true);
+});
+
+Deno.test("commitAll is a no-op on a clean tree and commits on a dirty one", async () => {
+  const clean: string[][] = [];
+  await commitAll({
+    message: "m",
+    run: (argv) => {
+      clean.push(argv);
+      return Promise.resolve(""); // porcelain empty
+    },
+  });
+  assertEquals(clean, [["git", "add", "-A"], ["git", "status", "--porcelain"]]);
+
+  const dirty: string[][] = [];
+  await commitAll({
+    message: "m",
+    push: false,
+    run: (argv) => {
+      dirty.push(argv);
+      return Promise.resolve(argv[1] === "status" ? " M f" : "");
+    },
+  });
+  assertEquals(dirty, [
+    ["git", "add", "-A"],
+    ["git", "status", "--porcelain"],
+    ["git", "commit", "-m", "m"],
+  ]);
+});

--- a/packages/ai/tests/agent_fixer_test.ts
+++ b/packages/ai/tests/agent_fixer_test.ts
@@ -183,6 +183,94 @@ Deno.test("the agent's stdout is captured and posted as a PR comment", async () 
   assertEquals(posted, true);
 });
 
+Deno.test("suggest mode posts the agent's diff as inline suggestions, no commit, no retry", async () => {
+  const prEnv: Record<string, string> = {
+    GITHUB_ACTIONS: "true",
+    GITHUB_REPOSITORY: "o/r",
+    GITHUB_REF: "refs/pull/7/merge",
+    GITHUB_TOKEN: "tok",
+  };
+  const diff = [
+    "diff --git a/zuke.ts b/zuke.ts",
+    "--- a/zuke.ts",
+    "+++ b/zuke.ts",
+    "@@ -45,1 +45,1 @@",
+    '-const X = "remove me";',
+    '+const _X = "remove me";',
+  ].join("\n");
+  const git: string[][] = [];
+  const calls: { url: string; body: string }[] = [];
+  const impl = ((input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method ?? "GET";
+    calls.push({ url, body: typeof init?.body === "string" ? init.body : "" });
+    if (url.includes("/comments")) {
+      return Promise.resolve(
+        new Response(method === "GET" ? "[]" : "{}", { status: 200 }),
+      );
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify({ head: { sha: "abc123" } }), {
+        status: 200,
+      }),
+    );
+  }) as typeof fetch;
+  const fixer = agentFixer(() => Promise.resolve())
+    .allowCI().suggest().conventions("").readFile(() =>
+      Promise.resolve(undefined)
+    )
+    .env((n) => prEnv[n])
+    .exec((argv) => {
+      git.push(argv);
+      return Promise.resolve(argv[1] === "diff" ? diff : "");
+    })
+    .fetch(impl).quiet();
+  const result = await fixer.remediate(CTX);
+  assertEquals(result.retry, false); // proposal mode — build stays failed
+  // It read the agent's diff and never committed.
+  assertEquals(git.some((a) => a[1] === "diff"), true);
+  assertEquals(git.some((a) => a[1] === "commit"), false);
+  // A review comment with a suggestion block was posted.
+  const posted = calls.some((c) =>
+    c.url.endsWith("/pulls/7/comments") && c.body.includes("```suggestion")
+  );
+  assertEquals(posted, true);
+});
+
+Deno.test("suggest mode off GitHub reports no committable suggestions", async () => {
+  const r = recorder();
+  const fixer = agentFixer(r.run, (f) => f.suggest())
+    .conventions("").env(() => undefined).readFile(() =>
+      Promise.resolve(undefined)
+    )
+    .exec(() => Promise.resolve("")).quiet();
+  const result = await fixer.remediate(CTX);
+  assertEquals(result.retry, false);
+  assertEquals(r.calls.length, 1); // the agent still ran
+});
+
+Deno.test("suggest mode tolerates a git diff failure", async () => {
+  const prEnv: Record<string, string> = {
+    GITHUB_ACTIONS: "true",
+    GITHUB_REPOSITORY: "o/r",
+    GITHUB_REF: "refs/pull/7/merge",
+    GITHUB_TOKEN: "tok",
+  };
+  const fixer = agentFixer(() => Promise.resolve())
+    .allowCI().suggest().conventions("").readFile(() =>
+      Promise.resolve(undefined)
+    )
+    .env((n) => prEnv[n])
+    .exec((argv) =>
+      argv[1] === "diff"
+        ? Promise.reject(new Error("no HEAD"))
+        : Promise.resolve("")
+    )
+    .noComment().quiet();
+  const result = await fixer.remediate(CTX);
+  assertEquals(result.retry, false);
+});
+
 Deno.test("noComment writes no PR comment", async () => {
   const prEnv: Record<string, string> = {
     GITHUB_ACTIONS: "true",

--- a/packages/ai/tests/diff_suggest_test.ts
+++ b/packages/ai/tests/diff_suggest_test.ts
@@ -1,0 +1,78 @@
+import { assertEquals } from "../../core/tests/_assert.ts";
+import { diffToSuggestions } from "../src/diff_suggest.ts";
+
+const PRELUDE = "note";
+
+Deno.test("a modification hunk becomes a replacement suggestion", () => {
+  const diff = [
+    "diff --git a/zuke.ts b/zuke.ts",
+    "--- a/zuke.ts",
+    "+++ b/zuke.ts",
+    "@@ -45,3 +45,3 @@",
+    " context",
+    '-const X = "remove me";',
+    '+const _X = "remove me";',
+    " more",
+  ].join("\n");
+  const s = diffToSuggestions(diff, PRELUDE);
+  assertEquals(s.length, 1);
+  assertEquals(s[0].path, "zuke.ts");
+  assertEquals(s[0].startLine, 46); // line after the leading context
+  assertEquals(s[0].line, 46);
+  assertEquals(s[0].body.includes("```suggestion"), true);
+  assertEquals(s[0].body.includes('const _X = "remove me";'), true);
+  assertEquals(s[0].key, "zuke.ts:46");
+});
+
+Deno.test("a deletion hunk suggests an empty (delete) block", () => {
+  const diff = [
+    "diff --git a/a.ts b/a.ts",
+    "--- a/a.ts",
+    "+++ b/a.ts",
+    "@@ -10,1 +9,0 @@",
+    "-const REMOVE = 1;",
+  ].join("\n");
+  const s = diffToSuggestions(diff, PRELUDE);
+  assertEquals(s.length, 1);
+  assertEquals(s[0].startLine, 10);
+  assertEquals(s[0].line, 10);
+  // An empty suggestion block deletes the targeted line on GitHub.
+  assertEquals(s[0].body.includes("```suggestion\n```"), true);
+});
+
+Deno.test("a pure insertion is skipped (nothing to anchor)", () => {
+  const diff = [
+    "diff --git a/a.ts b/a.ts",
+    "--- a/a.ts",
+    "+++ b/a.ts",
+    "@@ -5,0 +6,1 @@",
+    "+const ADDED = 1;",
+  ].join("\n");
+  assertEquals(diffToSuggestions(diff, PRELUDE), []);
+});
+
+Deno.test("multiple files and hunks each produce a suggestion", () => {
+  const diff = [
+    "diff --git a/one.ts b/one.ts",
+    "--- a/one.ts",
+    "+++ b/one.ts",
+    "@@ -1,1 +1,1 @@",
+    "-let a = 1;",
+    "+const a = 1;",
+    "diff --git a/two.ts b/two.ts",
+    "--- a/two.ts",
+    "+++ b/two.ts",
+    "@@ -8,1 +8,1 @@",
+    "-let b = 2;",
+    "+const b = 2;",
+  ].join("\n");
+  const s = diffToSuggestions(diff, PRELUDE);
+  assertEquals(s.map((x) => `${x.path}:${x.startLine}`), [
+    "one.ts:1",
+    "two.ts:8",
+  ]);
+});
+
+Deno.test("an empty diff yields no suggestions", () => {
+  assertEquals(diffToSuggestions("", PRELUDE), []);
+});

--- a/packages/ai/tests/fixer_test.ts
+++ b/packages/ai/tests/fixer_test.ts
@@ -718,6 +718,27 @@ Deno.test("on GitHub with locations, posts inline suggestions, not an overview c
   assertEquals(calls.some((c) => c.url.includes("/issues/")), false);
 });
 
+Deno.test("autoApply posts an overview comment with the code, not inline suggestions", async () => {
+  const { fetch, calls } = suggestFetch(claudeFix(FIX_WITH_LOC));
+  const prEnv: Record<string, string> = {
+    GITHUB_ACTIONS: "true",
+    GITHUB_REPOSITORY: "o/r",
+    GITHUB_REF: "refs/pull/7/merge",
+    GITHUB_TOKEN: "tok",
+  };
+  const fixer = aiFixer((f) =>
+    f.provider("claude").apiKey("k").autoApply().allowCI()
+  )
+    .conventions("").diff((d) => d.text("")).env((n) => prEnv[n])
+    .write(() => Promise.resolve()) // apply the fix
+    .fetch(fetch).quiet();
+  await fixer.remediate(CTX);
+  // Applied → overview issue comment (with the file:line code diff), never
+  // inline review-comment suggestions.
+  assertEquals(calls.some((c) => c.url.includes("/issues/")), true);
+  assertEquals(calls.some((c) => c.url.endsWith("/pulls/7/comments")), false);
+});
+
 Deno.test("noSuggest falls back to the overview comment on GitHub", async () => {
   const { fetch, calls } = suggestFetch(claudeFix(FIX_WITH_LOC));
   const prEnv: Record<string, string> = {

--- a/packages/ai/tests/fixer_test.ts
+++ b/packages/ai/tests/fixer_test.ts
@@ -3,7 +3,7 @@ import { CommandError } from "@zuke/core/shell";
 import { AiFixer, aiFixer, type Fix } from "../mod.ts";
 import { checkEdits, DEFAULT_FIX_EXCLUDES } from "../src/apply.ts";
 import { parseFix } from "../src/fix.ts";
-import { readTextOrUndefined } from "../src/fixer.ts";
+import { readTextOrUndefined } from "../src/context.ts";
 import { commitAndPush } from "../src/commit.ts";
 import { fixMarkdown } from "../src/fix_report.ts";
 import type { RemediationContext } from "@zuke/core";

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -154,6 +154,24 @@ local-only unless `.allowCI()`) and `.commitFixes()`; `.diff((d) => d.fetchBase(
 fetches the PR base branch for context so CI needs no manual `git fetch`. Keys
 ride through `parameter().secret()`, which Zuke masks in CI output.
 
+**Delegate to a coding agent** — `agentFixer(runner)` is a `Remediation` that
+hands the failure to a coding agent you inject (`@zuke/claude`, `@zuke/codex`,
+`@zuke/gemini`) which edits files itself, then re-runs the target to verify. One
+generic fixer, agent chosen at the call site; local-only unless `.allowCI()`.
+
+```ts
+import { agentFixer } from "jsr:@zuke/ai";
+import { ClaudeTasks } from "jsr:@zuke/claude";
+
+test = target()
+  .executes(() => DenoTasks.test((s) => s.allowAll()))
+  .recoverWith(
+    agentFixer((ctx) =>
+      ClaudeTasks.run((s) => s.prompt(ctx.prompt).permissionMode("acceptEdits"))
+    ),
+  );
+```
+
 ## Helpers from `@zuke/core`
 
 - `glob(pattern, { cwd? })` — expand a glob to sorted paths.

--- a/zuke.ts
+++ b/zuke.ts
@@ -231,16 +231,22 @@ class ZukeBuild extends Build {
 
   lint = target()
     .description("Lint the workspace (deno lint)")
-    // Self-heal lint failures with @zuke/ai. On a failing `deno lint`, the fixer
-    // sends the error output and the PR diff to OpenAI and posts a diagnosis
-    // plus a proposed patch as a PR comment and job summary — its safe default,
-    // which writes no files. A missing key (e.g. local runs) is skipped cleanly,
-    // and the lint failure still stands.
+    // Self-heal lint failures with @zuke/ai, dogfooding the full loop: on a
+    // failing `deno lint` the fixer applies the fix, commits and pushes it to
+    // the PR branch, re-runs lint to verify, and — because it auto-fixed —
+    // posts an overview comment of what it changed (with the code) plus the job
+    // summary. A missing key (e.g. local runs, or fork PRs where the secret is
+    // withheld) is skipped cleanly and the lint failure still stands. The CI
+    // workflow grants this job `contents: write` so the push can land.
     .recoverWith(
       aiFixer((f) =>
         f
           .provider("openai")
           .apiKey(this.openaiKey)
+          .autoApply()
+          .allowCI()
+          .commitFixes()
+          .allowPaths("packages/**", "tests/**", "zuke.ts")
           // Fetch the PR base branch itself (auto-detected from the CI env) for
           // diff context — no manual `git fetch` step in the workflow.
           .diff((d) => d.fetchBase())


### PR DESCRIPTION
## Summary

Phase 3 of self-healing: a generic **`agentFixer`** that delegates a failed target to a coding agent, plus a clear **propose-vs-apply** reporting rule for both fixers, and dogfooding the auto-fix loop into zuke's own CI.

### `agentFixer` — one generic agent-delegation fixer
- A single `Remediation` you give an agent runner to (`ClaudeTasks.run`, `CodexTasks.exec`, `GeminiTasks.run`, or a custom function). The agent reads/edits files autonomously; the executor re-runs the target to verify. **No per-package duplication** — the agent is chosen at the call site, so `@zuke/claude`/`codex`/`gemini` stay core-only.
- Local-only by default (`.allowCI()` to opt in, since the agent edits files). The `AgentContext` exposes `target`/`command`/`output`/`conventions` and a ready-made `prompt`; `.criteria()` adds instructions.
- Shared helpers (`describeError`, `resolveConventions`, PR-comment posting) were **extracted** so `aiFixer` and `agentFixer` reuse them rather than copying — `aiFixer` got smaller.

### Propose-vs-apply reporting
A committable inline suggestion is a *proposal*, so it only makes sense when **not** auto-fixing:
- **`aiFixer`**: inline suggestions only in diagnose-only mode; with `.autoApply()` it posts a **single overview comment showing what it fixed (with the code diff)**.
- **`agentFixer`**: `.suggest()` renders the agent's `git diff` as committable inline suggestions (build stays failed for the human to apply), via a new diff→suggestions parser; `.commitFixes()` applies + reports an overview and takes precedence.

### Dogfood
zuke's own `lint` fixer now `autoApply().allowCI().commitFixes()` — on a CI lint failure it fixes the file, pushes to the PR branch, re-runs lint to verify, and posts the overview comment.

> ⚠️ **CI security change to review.** The `quality` job gains `contents: write` + `persist-credentials: true` and checks out the PR head branch (same-repo PRs only; fork PRs fall back and the fixer skips, since the secret is withheld and the token is read-only). This is the auto-push-from-CI pattern your zizmor/scorecard scans flag, and it reverses `persist-credentials: false` on that job. It's isolated in the last commit (`ci: dogfood…`) and reverts cleanly if you'd prefer diagnose-only.

## Tests / gate
New hermetic tests for `agentFixer`, the diff→suggestions parser, the suggest mode, and the auto-apply overview rule; existing `@zuke/ai` tests still pass after the refactor. Full gate green: fmt, lint, spell, check, **apiDocsCheck**, coverage **98.8% lines / 96.5% branches**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ect9FtX22dHUxKjhy7dcoJ)_