### PR TITLE
feat(ai): make suppressed findings auditable in the review report

### DIFF
--- a/docs/ai-review.md
+++ b/docs/ai-review.md
@@ -152,7 +152,9 @@ outage isn't a silent skip either.
   budget is spent, the review is skipped (not failed) with a note. See
   [Cost controls and learning](./self-healing.md#cost-controls-and-learning).
 - `.suppress(suppressions(...))` hides findings you've dismissed as false
-  positives, matched by the stable ID shown next to each finding in the report.
+  positives, matched by the stable ID shown next to each finding in the report. A
+  suppressed finding is still listed (under "Suppressed (not gating)") so the
+  dismissal is auditable — it mutes the gate, it never silently buries a finding.
 
 ## GitHub Actions summary
 

--- a/docs/self-healing.md
+++ b/docs/self-healing.md
@@ -243,6 +243,13 @@ the gate sees a clean assessment; a partial suppression lowers the overall
 severity to whatever remains. (Suppression is review-only — a fixer applies a
 whole fix, not individual findings.)
 
+**Suppression is auditable, not silent.** A suppressed finding still appears in
+the report and PR comment under a **Suppressed (not gating)** section — with its
+severity, location, and ID — it just no longer counts toward the gate. So
+suppression mutes the build break without burying the finding: a reviewer
+reading the PR can always see what was dismissed (and that nothing serious is
+being hidden behind the suppress list).
+
 ## Other knobs
 
 - `.model(...)`, `.effort(...)` — pick the model and thinking depth.

--- a/packages/ai/src/report.ts
+++ b/packages/ai/src/report.ts
@@ -5,7 +5,12 @@
  * @module
  */
 
-import type { Assessment, Provider, Usage } from "./types.ts";
+import type {
+  Assessment,
+  AssessmentFinding,
+  Provider,
+  Usage,
+} from "./types.ts";
 import type { RetryInfo } from "./retry.ts";
 
 /** The settings echoed when a review starts, so the run shows what it's doing. */
@@ -71,6 +76,11 @@ function cell(value: string): string {
 export interface ReportExtras {
   /** Number of findings hidden by the suppress list, when any. */
   suppressed?: number;
+  /**
+   * The findings the suppress list hid, listed in the report so suppression is
+   * auditable — it mutes the gate, it does not silently erase the record.
+   */
+  suppressedFindings?: AssessmentFinding[];
   /** Whether the response was served from the cache (no API call was made). */
   fromCache?: boolean;
   /** A one-line budget summary (see {@link "./budget.ts".Budget.describe_}). */
@@ -101,6 +111,15 @@ export function consoleLines(
   if (extras.suppressed) {
     lines.push(
       `  suppressed ${extras.suppressed} finding(s) via the suppress list`,
+    );
+  }
+  for (const f of extras.suppressedFindings ?? []) {
+    const where = location(f.file, f.line);
+    const id = f.id !== undefined ? ` · ${f.id}` : "";
+    lines.push(
+      `    suppressed: [${f.severity}] ${f.title}${
+        where === "" ? "" : ` (${where})`
+      }${id}`,
     );
   }
   if (extras.budget !== undefined) lines.push(`  budget: ${extras.budget}`);
@@ -144,10 +163,36 @@ export function toMarkdown(
     parts.push("");
     parts.push(...idHint(assessment.findings));
   }
+  parts.push(...suppressedSection(extras.suppressedFindings ?? []));
   if (assessment.summary !== "") {
     parts.push(`> ${cell(assessment.summary)}`, "");
   }
   return parts.join("\n");
+}
+
+/**
+ * A table of the findings the suppress list hid, so a reviewer can see exactly
+ * what was muted (and its ID) rather than a bare count — suppression must never
+ * silently bury a finding. Empty when nothing was suppressed.
+ */
+function suppressedSection(findings: AssessmentFinding[]): string[] {
+  if (findings.length === 0) return [];
+  const parts = [
+    "**Suppressed (not gating):**",
+    "",
+    "| Severity | Finding | Location | ID |",
+    "| --- | --- | --- | --- |",
+  ];
+  for (const f of findings) {
+    const where = location(f.file, f.line);
+    parts.push(
+      `| ${f.severity} | ${cell(f.title)} | ${where === "" ? "—" : where} | ${
+        f.id ?? "—"
+      } |`,
+    );
+  }
+  parts.push("");
+  return parts;
 }
 
 /**

--- a/packages/ai/src/reviewer.ts
+++ b/packages/ai/src/reviewer.ts
@@ -11,6 +11,7 @@ import type { Configure } from "@zuke/core/tooling";
 import { Command } from "@zuke/core/shell";
 import type {
   Assessment,
+  AssessmentFinding,
   AssessmentType,
   Effort,
   Provider,
@@ -311,23 +312,28 @@ export class Reviewer implements Validation {
 
   /**
    * Fingerprint every finding (so its ID shows in the report) and, when a
-   * suppress list is attached, drop the dismissed ones. Returns how many were
-   * suppressed. When suppression empties the findings, the score and severity
-   * are cleared so the gate sees a clean assessment.
+   * suppress list is attached, drop the dismissed ones. Returns the suppressed
+   * findings (so the report can list them — suppression mutes the gate, it does
+   * not erase the record). When suppression empties the findings, the score and
+   * severity are cleared so the gate sees a clean assessment.
    */
-  async #applySuppression(assessment: Assessment): Promise<number> {
+  async #applySuppression(
+    assessment: Assessment,
+  ): Promise<AssessmentFinding[]> {
     for (const finding of assessment.findings) {
       finding.id = findingFingerprint(this.#assessment, finding);
     }
-    if (this.#suppress === undefined) return 0;
+    if (this.#suppress === undefined) return [];
     const suppressed = await this.#suppress.load_();
-    if (suppressed.size === 0) return 0;
-    const kept = assessment.findings.filter((finding) => {
+    if (suppressed.size === 0) return [];
+    const kept: AssessmentFinding[] = [];
+    const dropped: AssessmentFinding[] = [];
+    for (const finding of assessment.findings) {
       const id = finding.id;
-      return id === undefined || !suppressed.has(id);
-    });
-    const count = assessment.findings.length - kept.length;
-    if (count === 0) return 0;
+      if (id !== undefined && suppressed.has(id)) dropped.push(finding);
+      else kept.push(finding);
+    }
+    if (dropped.length === 0) return [];
     assessment.findings = kept;
     if (kept.length === 0) {
       assessment.score = 0;
@@ -340,7 +346,7 @@ export class Reviewer implements Validation {
       }
       assessment.severity = highest;
     }
-    return count;
+    return dropped;
   }
 
   /**
@@ -488,7 +494,8 @@ export class Reviewer implements Validation {
 
     const suppressed = await this.#applySuppression(assessment);
     await this.#report(assessment, context.target, usage, {
-      suppressed,
+      suppressed: suppressed.length,
+      suppressedFindings: suppressed,
       fromCache,
       budget: this.#budget?.describe_(),
     });

--- a/packages/ai/tests/cost_controls_test.ts
+++ b/packages/ai/tests/cost_controls_test.ts
@@ -213,6 +213,11 @@ Deno.test("a finding whose id is suppressed is dropped from the review", async (
   );
   assertEquals(lines.some((l) => l.includes("suppressed 1 finding(s)")), true);
   assertEquals(lines.some((l) => l.includes("— 1 finding(s)")), true);
+  // The hidden finding is still listed (auditable), not silently erased.
+  assertEquals(
+    lines.some((l) => l.includes("suppressed: [low] weak hash")),
+    true,
+  );
 });
 
 Deno.test("suppressing every finding clears the score and passes the gate", async () => {
@@ -310,6 +315,57 @@ Deno.test("toMarkdown omits the dismiss hint when no finding has an id", () => {
     findings: [{ title: "x", severity: "low" }],
   });
   assertEquals(md.includes("Dismiss a false positive"), false);
+});
+
+Deno.test("toMarkdown lists suppressed findings in an auditable section", () => {
+  const md = toMarkdown(
+    "security review",
+    "t",
+    { score: 0, severity: "none", summary: "", findings: [] },
+    undefined,
+    {
+      suppressed: 1,
+      suppressedFindings: [
+        {
+          title: "sql | injection",
+          severity: "high",
+          file: "db.ts",
+          line: 9,
+          id: "abc1",
+        },
+      ],
+    },
+  );
+  assertEquals(md.includes("**Suppressed (not gating):**"), true);
+  // The hidden finding is shown with its ID and the pipe escaped in the cell.
+  assertEquals(
+    md.includes("| high | sql \\| injection | db.ts:9 | abc1 |"),
+    true,
+  );
+});
+
+Deno.test("consoleLines lists each suppressed finding under the count", () => {
+  const lines = consoleLines(
+    "r",
+    { score: 0, severity: "none", summary: "", findings: [] },
+    undefined,
+    {
+      suppressed: 1,
+      suppressedFindings: [
+        {
+          title: "weak hash",
+          severity: "high",
+          file: "db.ts",
+          line: 9,
+          id: "abc1",
+        },
+      ],
+    },
+  );
+  assertEquals(
+    lines.includes("    suppressed: [high] weak hash (db.ts:9) · abc1"),
+    true,
+  );
 });
 
 // ----- Fixer ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

Hardens the learned false-positive suppression from #126 in response to the AI security reviewer's note that a suppress file *"can hide security findings if modified by an attacker with repo write access."*

Previously suppression removed a dismissed finding entirely, so the report showed only a **count** — a finding (including a security one) could be dropped from the gate with nothing visible but a number. Now suppression **mutes the gate without burying the record**: a suppressed finding is still listed under a **Suppressed (not gating)** section, so a reviewer can always see exactly what was dismissed.

This keeps the feature's full value (you can still dismiss *any* false positive, including a high-severity one) while removing the "silent" part the reviewer was actually worried about. The stricter alternative — never letting suppression hide high/critical findings — was deliberately *not* taken, because it would trap you when the model genuinely over-rates a false positive.

## What changed

- **`Reviewer.#applySuppression`** now returns the dropped findings (not just a count) and threads them into the report via `ReportExtras.suppressedFindings`.
- **`report.ts`** renders them:
  - **Console:** each suppressed finding is listed under the count (`suppressed: [high] sql injection (db.ts:9) · abc1`).
  - **Job summary / PR comment:** a `**Suppressed (not gating):**` table with severity, finding, location, and ID.
- Suppression still mutes the gate as before (empty findings → score/severity cleared; partial → severity recomputed from what remains).

## Tests / gate

Extended the suppression integration test to assert the hidden finding is listed, plus new `toMarkdown`/`consoleLines` unit tests for the suppressed section. Backward compatible — all existing `@zuke/ai` tests pass unchanged. Full gate green: fmt, lint, spell, check, **apiDocsCheck**, coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ect9FtX22dHUxKjhy7dcoJ)_