### PR TITLE
docs: add GitHub issue forms for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,89 @@
+name: Bug report
+description: Report something in Zuke that isn't working as documented.
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug! A minimal reproduction is the
+        single most useful thing you can give us.
+
+        Before you start, please
+        [search existing issues](https://github.com/zuke-build/zuke/issues?q=is%3Aissue)
+        to avoid duplicates. **Do not report security vulnerabilities here** —
+        follow the private process in
+        [SECURITY.md](https://github.com/zuke-build/zuke/blob/master/SECURITY.md).
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight checklist
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: This is a bug, not a security vulnerability or a usage question.
+          required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear and concise description of the bug.
+      placeholder: Running `zuke test` fails to resolve a dependency that is declared above its dependent.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What did you expect to happen instead?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: >
+        The smallest build file and commands that reproduce the problem. Paste a
+        self-contained `zuke.ts` (or snippet) and the exact command you ran.
+        Code blocks here are automatically formatted, so no backticks are needed.
+      render: typescript
+    validations:
+      required: true
+  - type: input
+    id: package
+    attributes:
+      label: Affected package(s)
+      description: Which `@zuke/*` package(s) are involved, with versions if known.
+      placeholder: "@zuke/core 0.x, @zuke/deno 0.x"
+    validations:
+      required: true
+  - type: input
+    id: deno-version
+    attributes:
+      label: Deno version
+      description: Output of `deno --version`.
+      placeholder: "deno 2.x.x"
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "macOS 14, Ubuntu 24.04, Windows 11, …"
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or output
+      description: Any error output, stack traces, or `--list`/`graph` output. Automatically formatted as code.
+      render: shell
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else that helps us understand the problem.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/zuke-build/zuke/security/advisories/new
+    about: Do not file security issues publicly. Use private vulnerability reporting — see SECURITY.md.
+  - name: Documentation & API reference
+    url: https://github.com/zuke-build/zuke/blob/master/llms-full.txt
+    about: The full typed surface of every package, plus each package's README API section.
+  - name: Contributing guide
+    url: https://github.com/zuke-build/zuke/blob/master/CONTRIBUTING.md
+    about: How to set up, run the gate, and open a good pull request.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,55 @@
+name: Feature request
+description: Suggest a new capability, tool wrapper, or improvement.
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea! Zuke is pre-1.0 and evolving fast — if you are
+        planning a large change, opening this issue first lets us agree on the
+        direction before you invest the effort.
+
+        Please
+        [search existing issues](https://github.com/zuke-build/zuke/issues?q=is%3Aissue)
+        first to avoid duplicates.
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight checklist
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: What are you trying to do, and what makes it hard today? Focus on the "why".
+      placeholder: I want to wrap the `foo` CLI as a typed `FooTasks` object so my build doesn't fall back to raw shell.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: >
+        How would you like it to work? For a new tool wrapper, name the package
+        (`@zuke/<tool>`), the task methods, and the settings they mirror from the
+        real CLI. Sketches of the public surface are welcome.
+      render: typescript
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed, including the generic `@zuke/cmd` fallback or raw `@zuke/core/shell`.
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links to the tool's CLI docs, related issues, or anything else that helps.
+    validations:
+      required: false


### PR DESCRIPTION
Adds structured issue templates under .github/ISSUE_TEMPLATE/ so reports
arrive with the context maintainers need:

- bug_report.yml requires a minimal reproduction, affected @zuke/* package,
  Deno version, and OS, and reminds reporters to use private disclosure for
  security issues.
- feature_request.yml steers proposals toward the typed *Tasks wrapper shape
  and asks about the @zuke/cmd fallback as an alternative.
- config.yml disables blank issues and routes security reports to private
  advisories, plus links to the API reference and contributing guide.

Discussions are not enabled on the repo, so no discussions link is included.