### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,37 @@
+<!--
+Thanks for contributing to Zuke! A few things that make review fast:
+
+The PR title IS the release trigger. This repo squash-merges, and
+release-please parses only the squashed subject (your PR title). Title this PR
+as a Conventional Commit so the right version is cut:
+
+  feat(deno): add coverage threshold flag     -> minor bump
+  fix(core): resolve forward-reference order   -> patch bump
+  docs|chore|refactor|test(...): ...           -> no release
+
+The scope is cosmetic; the bump is attributed to whichever package's files
+under packages/<name>/ this PR changes.
+-->
+
+## What & why
+
+<!-- What does this change do, and what problem does it solve? Explain the
+motivation, not just the mechanics. -->
+
+## Related issues
+
+<!-- e.g. "Closes #123". Link any issue this addresses. -->
+
+## Checklist
+
+- [ ] The PR title is a [Conventional Commit](https://www.conventionalcommits.org/) (`type(scope): summary`).
+- [ ] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
+- [ ] Tests were added or updated; coverage stays at 95%+ (lines and branches).
+- [ ] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour changed.
+- [ ] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`, `llms-full.txt`, package README `## API`).
+- [ ] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with type guards instead).
+- [ ] A new package was wired into all five places (see [CONTRIBUTING](../blob/master/CONTRIBUTING.md)), if applicable.
+
+<!-- Keep illustrative code in this description, not in commit message bodies:
+release-please's strict parser can drop a commit whose body contains code with
+parentheses, silently skipping it from the release. -->


### PR DESCRIPTION
## What & why

Adds `.github/pull_request_template.md`, the companion to the issue forms added in #131. The template pre-fills new PRs with the context this repo's release flow depends on:

- Foregrounds the **Conventional-Commit title** in a top comment — since the repo squash-merges and release-please parses only the squashed subject (the PR title), with examples of what bumps minor / patch / nothing.
- A **checklist** drawn from `CLAUDE.md` and `CONTRIBUTING.md`: the `deno task ci` gate, 95% coverage, regenerated API docs (`./zuke apiDocs`), the no-`any`/no-`as`/no-`!` rule, and the five-place wiring for a new package.
- A closing comment warning against **code snippets in commit bodies**, which can break release-please's strict parser.

The body you're reading also doubles as a worked example of the template.

## Related issues

None — follow-up to the issue templates in #131.

## Checklist

- [x] The PR title is a [Conventional Commit](https://www.conventionalcommits.org/) (`docs:` — release-neutral).
- [x] `deno task ci` passes locally — N/A, docs-only change (no code touched).
- [x] Tests were added or updated; coverage stays at 95%+ — N/A, no code change.
- [x] Docs updated in the same PR — this change is the doc.
- [x] Public API changes were regenerated with `./zuke apiDocs` — N/A, no API change.
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` — N/A, no `src/` change.
- [x] A new package was wired into all five places — N/A, no new package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqvMBA7vgqwHWbNcAabsH5)_