### PR TITLE
feat(codecov): add handleNoReportsFound() upload flag

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4927,6 +4927,8 @@ class CodecovUploadSettings extends ToolSettings
     Report kind: `coverage` (default) or `test_results` (`--report-type`).
   disableSearch(): this
     Upload only the named files, skipping the auto-search (`--disable-search`).
+  handleNoReportsFound(): this
+    Succeed instead of erroring when no reports are found (`--handle-no-reports-found`).
   failOnError(): this
     Exit non-zero when the upload fails (`--fail-on-error`).
   dryRun(): this

--- a/packages/codecov/README.md
+++ b/packages/codecov/README.md
@@ -88,6 +88,8 @@ class CodecovUploadSettings extends ToolSettings
     Report kind: `coverage` (default) or `test_results` (`--report-type`).
   disableSearch(): this
     Upload only the named files, skipping the auto-search (`--disable-search`).
+  handleNoReportsFound(): this
+    Succeed instead of erroring when no reports are found (`--handle-no-reports-found`).
   failOnError(): this
     Exit non-zero when the upload fails (`--fail-on-error`).
   dryRun(): this

--- a/packages/codecov/src/codecov.ts
+++ b/packages/codecov/src/codecov.ts
@@ -37,6 +37,7 @@ export class CodecovUploadSettings extends ToolSettings {
   #networkRootFolder?: string;
   #reportType?: string;
   #disableSearch = false;
+  #handleNoReportsFound = false;
   #failOnError = false;
   #dryRun = false;
 
@@ -128,6 +129,12 @@ export class CodecovUploadSettings extends ToolSettings {
     return this;
   }
 
+  /** Succeed instead of erroring when no reports are found (`--handle-no-reports-found`). */
+  handleNoReportsFound(): this {
+    this.#handleNoReportsFound = true;
+    return this;
+  }
+
   /** Exit non-zero when the upload fails (`--fail-on-error`). */
   failOnError(): this {
     this.#failOnError = true;
@@ -162,6 +169,7 @@ export class CodecovUploadSettings extends ToolSettings {
     for (const flag of this.#flags) argv.push("--flag", flag);
     for (const plugin of this.#plugins) argv.push("--plugin", plugin);
     if (this.#disableSearch) argv.push("--disable-search");
+    if (this.#handleNoReportsFound) argv.push("--handle-no-reports-found");
     if (this.#failOnError) argv.push("--fail-on-error");
     if (this.#dryRun) argv.push("--dry-run");
     return argv;

--- a/packages/codecov/tests/codecov_test.ts
+++ b/packages/codecov/tests/codecov_test.ts
@@ -25,6 +25,7 @@ Deno.test("codecov: every setting renders in a deterministic order", () => {
     .flags("unit", "integration")
     .plugins("noop")
     .disableSearch()
+    .handleNoReportsFound()
     .failOnError()
     .dryRun()
     .argv();
@@ -62,6 +63,7 @@ Deno.test("codecov: every setting renders in a deterministic order", () => {
     "--plugin",
     "noop",
     "--disable-search",
+    "--handle-no-reports-found",
     "--fail-on-error",
     "--dry-run",
   ]);


### PR DESCRIPTION
## What & why

**The fix:** `@zuke/codecov` was never published to JSR after its creation in #130, and this PR cuts its first real release.

**Root cause.** PR #130 was titled `Add @zuke/codecov — typed Codecov CLI wrapper (#130)` — not a Conventional Commit. This repo squash-merges, and release-please parses only the squashed subject (the PR title). With no `type` prefix it found nothing releasable, so it never opened a release PR for the package. As a result `packages/codecov` stayed at `0.0.0` in `.release-please-manifest.json`, no `codecov-v*` tag was ever cut, and the `publishJsr` target (which skips any package still at `0.0.0` as "not released yet") silently passed it over. Everything else was wired correctly — workspace, release-please config/manifest, the `zuke.ts` PACKAGES list, and the release-config test all already include codecov — so the only thing missing was a conventional commit touching the package to make release-please bump it.

**The change.** This PR adds a genuine, conventional-commit feature under `packages/codecov/`, which gives release-please a `feat` to attribute to the package. It adds a `handleNoReportsFound()` setting to `CodecovUploadSettings` that emits codecovcli's `--handle-no-reports-found` flag, so an upload succeeds instead of erroring when no coverage report is found — a common situation in matrix CI jobs where not every job produces coverage. Once merged, release-please cuts `@zuke/codecov`'s first release and the publish job pushes it to JSR.

Included:
- New `handleNoReportsFound()` setter, backing field, and `buildArgs` emission (in deterministic order alongside the other boolean flags).
- Extended the deterministic-order test to cover the new flag.
- Regenerated the affected API docs (`llms-full.txt` and the package README `## API` block).

## Related issues

Follow-up to #130 (the codecov package was added there but never released/published).

## Checklist

- [x] The PR title is a [Conventional Commit](https://www.conventionalcommits.org/) (`type(scope): summary`).
- [ ] `deno task ci` passes locally — could not run in this environment: the egress policy blocks `deno.land`, so the `./zuke` launcher can't bootstrap Deno. Relying on CI to run the full gate.
- [x] Tests were added or updated; coverage stays at 95%+ (the new setter and its branch are exercised by the comprehensive settings test, and the default-false branch by the other tests).
- [x] Docs updated in the same PR.
- [x] Public API changes were regenerated — done by hand to match `deno doc`'s deterministic output (source-declaration order; verbatim single-line JSDoc), since `./zuke apiDocs` can't run without Deno here. `llms.txt` is unaffected (package summary unchanged).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/`.
- [ ] A new package was wired into all five places — N/A (codecov was already wired in #130; this only releases it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Da2u4oNJcqZLGJ2CyK9478)_