### PR TITLE
feat(core): make the CLI surface discoverable to tools and agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,16 @@ exact signatures are published — read them:
 - **A single wrapper on the command line:** `deno doc jsr:@zuke/<package>`
   (e.g. `deno doc jsr:@zuke/deno`).
 - **On each package's JSR page / README:** a generated `## API` section.
+- **The CLI surface — commands, flags, and a build's actual targets:** run
+  `zuke --help` (or `deno run -A zuke.ts --help`). It prints the usage grammar,
+  every reserved command (`graph`, `generate-ci`,
+  `completions <print|install> <shell>`) and flag, **plus the current build's
+  targets — with descriptions and dependencies — and its parameters.** So an
+  agent asked to set up or run a build discovers the real command surface live
+  instead of guessing; `zuke --list` is the targets-only view. The written
+  reference is [`docs/cli.md`](./docs/cli.md). (These CLI commands are not in
+  `llms-full.txt`, which documents the importable `*Tasks` API, not the `zuke`
+  command.)
 
 The mental model:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,10 +26,12 @@ exact signatures are published — read them:
   `completions <print|install> <shell>`) and flag, **plus the current build's
   targets — with descriptions and dependencies — and its parameters.** So an
   agent asked to set up or run a build discovers the real command surface live
-  instead of guessing; `zuke --list` is the targets-only view. The written
-  reference is [`docs/cli.md`](./docs/cli.md). (These CLI commands are not in
-  `llms-full.txt`, which documents the importable `*Tasks` API, not the `zuke`
-  command.)
+  instead of guessing; `zuke --list` is the targets-only view and
+  `zuke --list --json` emits the whole surface (commands, flags, targets,
+  parameters) as JSON for tools. The written reference is
+  [`docs/cli.md`](./docs/cli.md), and [`llms.txt`](./llms.txt) carries a
+  generated `## CLI` section; the same data is available in code via the
+  exported `describeCli(build)`.
 
 The mental model:
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -99,6 +99,18 @@ async function createTarGzip(files: PathLike[], dest: PathLike, options: { cwd?:
   Read `files` (relative to `cwd`), pack them into a tar archive named by their
   path relative to `cwd`, gzip it, and write the result to `dest`.
 
+function describeCli(build: Build): CliDescription
+  Describe a build's full CLI surface — reserved commands, option flags, targets
+  (with descriptions and dependencies), and declared parameters — as a plain
+  object ready for JSON. This is the same data `zuke --list --json` prints, made
+  available to tooling and agents that introspect a build in code.
+
+  ```ts
+  import { describeCli } from "jsr:@zuke/core";
+  const surface = describeCli(new MyBuild());
+  console.log(surface.targets.map((t) => t.name));
+  ```
+
 function detectCiHost(env: (name: string) => string | undefined): CiHost
   Detect the CI host from the environment. Recognises GitHub Actions
   (`GITHUB_ACTIONS`), GitLab CI (`GITLAB_CI`), Azure Pipelines (`TF_BUILD`), and
@@ -865,6 +877,64 @@ interface CiTriggers
   manual?: boolean
     Allow manual runs (workflow dispatch / web).
 
+interface CliCommandInfo
+  A reserved command (`graph`, `generate-ci`, `completions`).
+
+  readonly name: string
+    The command word.
+  readonly description: string
+    One-line summary.
+
+interface CliDescription
+  A build's full CLI surface, suitable for JSON serialization.
+
+  readonly commands: CliCommandInfo[]
+    The reserved positional commands.
+  readonly flags: CliFlagInfo[]
+    The built-in option flags.
+  readonly targets: CliTargetInfo[]
+    The build's targets, in declaration order.
+  readonly parameters: CliParameterInfo[]
+    The build's declared parameters, in declaration order.
+
+interface CliFlagInfo
+  A built-in option flag.
+
+  readonly name: string
+    The flag, with leading dashes.
+  readonly description: string
+    One-line summary.
+
+interface CliParameterInfo
+  A parameter declared on the build.
+
+  readonly flag: string
+    The CLI flag (without leading dashes), e.g. `environment`.
+  readonly description: string
+    The parameter's description, or `""` when none was set.
+  readonly required: boolean
+    Whether a value is required.
+  readonly boolean: boolean
+    Whether the flag is a value-less boolean.
+  readonly array: boolean
+    Whether repeated flags accumulate into a list.
+  readonly options: string[]
+    The allowed values, when the parameter is constrained to a set.
+
+interface CliTargetInfo
+  A target declared on the build.
+
+  readonly name: string
+    The target's name (its field name on the build).
+  readonly description: string
+    The target's description, or `""` when none was set.
+  readonly dependsOn: string[]
+    The names of its direct dependencies, in declaration order.
+  readonly default: boolean
+    Whether this is the conventional `default` target.
+  readonly unlisted: boolean
+    Whether the target is hidden from `--list` (still runnable by name).
+
 interface CopyOptions
   Options for {@link FileTasksApi.copy}.
 
@@ -1415,6 +1485,11 @@ interface ProjectInfo
     An optional install/scaffold command, shown in the "do not guess" list.
   guidance?: string[]
     Extra bullet lines appended to the "do not guess" list.
+  cli?: string
+    An optional pre-rendered markdown block describing the `zuke` command
+    surface, rendered under a `## CLI` heading in the index. The caller builds
+    it (e.g. from the build's command/flag registry) so this package stays
+    agnostic about CLI specifics.
 
 ========================================================================
 # @zuke/npm

--- a/llms.txt
+++ b/llms.txt
@@ -23,6 +23,43 @@ class CI extends Build {
 await run(CI);
 ```
 
+## CLI
+
+Run a build with the `zuke` command — `deno run -A zuke.ts <target>` (or
+the `./zuke` launcher). The CLI is self-describing:
+
+```sh
+zuke <target> [--skip <dep>] [--parallel[=N]]    # run a target and its deps
+zuke --list [--json]                             # list targets (JSON: full surface)
+zuke graph [--output=html]                       # dependency graph
+zuke generate-ci [--check]                       # write declared CI files
+zuke completions <print|install> <bash|zsh|fish> # shell completion
+```
+
+`zuke --help` prints the usage grammar plus the build's live targets and
+parameters; `zuke --list --json` emits the whole surface for tools.
+
+Reserved commands:
+
+- `graph` — Show the dependency graph
+- `generate-ci` — Write declared CI configuration files
+- `completions` — Print a shell-completion script
+
+Option flags:
+
+- `--list` — List all targets with descriptions
+- `--json` — Print the build surface (commands, flags, targets) as JSON
+- `--skip` — Skip the named dependency
+- `--parallel` — Run independent targets concurrently
+- `--no-cache` — Ignore the incremental cache
+- `--dry-run` — Print the plan without running targets
+- `--output` — Graph output format: text or html
+- `--no-open` — With --output=html, do not open a browser
+- `--check` — With generate-ci, verify files are current
+- `--help` — Show usage
+
+Full reference: [docs/cli.md](./docs/cli.md).
+
 ## Packages
 
 - [@zuke/core](https://jsr.io/@zuke/core) — a code-first, strongly-typed build automation system for Deno

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -153,6 +153,18 @@ async function createTarGzip(files: PathLike[], dest: PathLike, options: { cwd?:
   Read `files` (relative to `cwd`), pack them into a tar archive named by their
   path relative to `cwd`, gzip it, and write the result to `dest`.
 
+function describeCli(build: Build): CliDescription
+  Describe a build's full CLI surface — reserved commands, option flags, targets
+  (with descriptions and dependencies), and declared parameters — as a plain
+  object ready for JSON. This is the same data `zuke --list --json` prints, made
+  available to tooling and agents that introspect a build in code.
+
+  ```ts
+  import { describeCli } from "jsr:@zuke/core";
+  const surface = describeCli(new MyBuild());
+  console.log(surface.targets.map((t) => t.name));
+  ```
+
 function detectCiHost(env: (name: string) => string | undefined): CiHost
   Detect the CI host from the environment. Recognises GitHub Actions
   (`GITHUB_ACTIONS`), GitLab CI (`GITLAB_CI`), Azure Pipelines (`TF_BUILD`), and
@@ -918,6 +930,64 @@ interface CiTriggers
     means every branch (no filter); omit the field to disable the trigger.
   manual?: boolean
     Allow manual runs (workflow dispatch / web).
+
+interface CliCommandInfo
+  A reserved command (`graph`, `generate-ci`, `completions`).
+
+  readonly name: string
+    The command word.
+  readonly description: string
+    One-line summary.
+
+interface CliDescription
+  A build's full CLI surface, suitable for JSON serialization.
+
+  readonly commands: CliCommandInfo[]
+    The reserved positional commands.
+  readonly flags: CliFlagInfo[]
+    The built-in option flags.
+  readonly targets: CliTargetInfo[]
+    The build's targets, in declaration order.
+  readonly parameters: CliParameterInfo[]
+    The build's declared parameters, in declaration order.
+
+interface CliFlagInfo
+  A built-in option flag.
+
+  readonly name: string
+    The flag, with leading dashes.
+  readonly description: string
+    One-line summary.
+
+interface CliParameterInfo
+  A parameter declared on the build.
+
+  readonly flag: string
+    The CLI flag (without leading dashes), e.g. `environment`.
+  readonly description: string
+    The parameter's description, or `""` when none was set.
+  readonly required: boolean
+    Whether a value is required.
+  readonly boolean: boolean
+    Whether the flag is a value-less boolean.
+  readonly array: boolean
+    Whether repeated flags accumulate into a list.
+  readonly options: string[]
+    The allowed values, when the parameter is constrained to a set.
+
+interface CliTargetInfo
+  A target declared on the build.
+
+  readonly name: string
+    The target's name (its field name on the build).
+  readonly description: string
+    The target's description, or `""` when none was set.
+  readonly dependsOn: string[]
+    The names of its direct dependencies, in declaration order.
+  readonly default: boolean
+    Whether this is the conventional `default` target.
+  readonly unlisted: boolean
+    Whether the target is hidden from `--list` (still runnable by name).
 
 interface CopyOptions
   Options for {@link FileTasksApi.copy}.

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -47,6 +47,14 @@ export {
   type ValidationContext,
 } from "./src/target.ts";
 export { run, type RunOptions } from "./src/cli.ts";
+export {
+  type CliCommandInfo,
+  type CliDescription,
+  type CliFlagInfo,
+  type CliParameterInfo,
+  type CliTargetInfo,
+  describeCli,
+} from "./src/describe.ts";
 export type { Plugin } from "./src/plugin.ts";
 export { execute, type ExecuteOptions, type Reporter } from "./src/executor.ts";
 export type { BuildCache } from "./src/cache.ts";

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -25,6 +25,7 @@ import {
 } from "./completions.ts";
 import {
   COMPLETIONS_COMMAND,
+  DEFAULT_TARGET,
   GENERATE_CI_COMMAND,
   GRAPH_COMMAND,
 } from "./cli_spec.ts";
@@ -32,9 +33,7 @@ import {
   installCompletions,
   type InstallOptions,
 } from "./completions_install.ts";
-
-/** Convention: a target literally named `default` runs when none is requested. */
-const DEFAULT_TARGET = "default";
+import { describeBuildSurface } from "./describe.ts";
 
 /** `completions` sub-action: print the script to stdout. */
 const PRINT_SUBCOMMAND = "print";
@@ -69,6 +68,8 @@ export interface ParsedArgs {
   /** Dependencies to skip (`--skip <dep>`, repeatable). */
   skip: string[];
   list: boolean;
+  /** Emit the build surface as JSON (`--json`) instead of human text. */
+  json: boolean;
   /** The `graph` command was requested. */
   graph: boolean;
   /** The `generate-ci` command was requested. */
@@ -115,6 +116,7 @@ export function parseArgs(
   const parsed: ParsedArgs = {
     skip: [],
     list: false,
+    json: false,
     graph: false,
     generateCi: false,
     completions: false,
@@ -132,6 +134,8 @@ export function parseArgs(
     const arg = args[i];
     if (arg === "--list" || arg === "-l") {
       parsed.list = true;
+    } else if (arg === "--json") {
+      parsed.json = true;
     } else if (arg === "--no-open") {
       parsed.open = false;
     } else if (arg === "--no-cache") {
@@ -201,7 +205,7 @@ const USAGE = `zuke — code-first build automation
 
 Usage:
   deno run -A zuke.ts <target> [--skip <dep>] [--parallel[=N]]
-  deno run -A zuke.ts --list
+  deno run -A zuke.ts --list [--json]
   deno run -A zuke.ts graph [--output=html] [--no-open]
   deno run -A zuke.ts generate-ci [--check]
   deno run -A zuke.ts completions <install|print> <bash|zsh|fish>
@@ -214,6 +218,8 @@ Options:
   --no-cache        Ignore the incremental cache; re-run every target.
   --dry-run         Print the execution plan without running target bodies.
   --list, -l        List all targets with descriptions and dependencies.
+  --json            With --list, print the build surface (commands, flags,
+                    targets, parameters) as JSON for tools and agents.
   graph             Show the dependency graph. Default output is the terminal
                     adjacency listing; --output=html writes an interactive
                     page to .zuke/ and opens it in a browser.
@@ -422,6 +428,11 @@ export async function main(
     throw error;
   }
 
+  if (parsed.json) {
+    const surface = describeBuildSurface(targets, params);
+    console.log(JSON.stringify(surface, null, 2));
+    return 0;
+  }
   if (parsed.list) {
     console.log(formatList(targets, params));
     return 0;

--- a/packages/core/src/cli_spec.ts
+++ b/packages/core/src/cli_spec.ts
@@ -9,6 +9,9 @@
  * @module
  */
 
+/** Convention: a target literally named `default` runs when none is requested. */
+export const DEFAULT_TARGET = "default";
+
 /** A reserved positional command: a CLI word that is not a target name. */
 export interface ReservedCommand {
   /** The literal command word typed on the command line. */
@@ -47,6 +50,10 @@ export interface BuiltinFlag {
 /** Every built-in option flag, in completion order. */
 export const BUILTIN_FLAGS: readonly BuiltinFlag[] = [
   { name: "--list", description: "List all targets with descriptions" },
+  {
+    name: "--json",
+    description: "Print the build surface (commands, flags, targets) as JSON",
+  },
   { name: "--skip", description: "Skip the named dependency" },
   { name: "--parallel", description: "Run independent targets concurrently" },
   { name: "--no-cache", description: "Ignore the incremental cache" },

--- a/packages/core/src/describe.ts
+++ b/packages/core/src/describe.ts
@@ -1,0 +1,139 @@
+/**
+ * A machine-readable description of a build's CLI surface — its reserved
+ * commands, option flags, targets, and parameters — for tooling and agents.
+ * This backs `zuke --list --json`, and {@link describeCli} is exported so a
+ * caller can introspect a build programmatically without parsing help text.
+ *
+ * @module
+ */
+
+import { type Build, discoverTargets } from "./build.ts";
+import { type AnyParameter, discoverParameters, flagName } from "./params.ts";
+import type { TargetBuilder } from "./target.ts";
+import {
+  BUILTIN_FLAGS,
+  DEFAULT_TARGET,
+  RESERVED_COMMANDS,
+} from "./cli_spec.ts";
+
+/** A reserved command (`graph`, `generate-ci`, `completions`). */
+export interface CliCommandInfo {
+  /** The command word. */
+  readonly name: string;
+  /** One-line summary. */
+  readonly description: string;
+}
+
+/** A built-in option flag. */
+export interface CliFlagInfo {
+  /** The flag, with leading dashes. */
+  readonly name: string;
+  /** One-line summary. */
+  readonly description: string;
+}
+
+/** A target declared on the build. */
+export interface CliTargetInfo {
+  /** The target's name (its field name on the build). */
+  readonly name: string;
+  /** The target's description, or `""` when none was set. */
+  readonly description: string;
+  /** The names of its direct dependencies, in declaration order. */
+  readonly dependsOn: string[];
+  /** Whether this is the conventional `default` target. */
+  readonly default: boolean;
+  /** Whether the target is hidden from `--list` (still runnable by name). */
+  readonly unlisted: boolean;
+}
+
+/** A parameter declared on the build. */
+export interface CliParameterInfo {
+  /** The CLI flag (without leading dashes), e.g. `environment`. */
+  readonly flag: string;
+  /** The parameter's description, or `""` when none was set. */
+  readonly description: string;
+  /** Whether a value is required. */
+  readonly required: boolean;
+  /** Whether the flag is a value-less boolean. */
+  readonly boolean: boolean;
+  /** Whether repeated flags accumulate into a list. */
+  readonly array: boolean;
+  /** The allowed values, when the parameter is constrained to a set. */
+  readonly options: string[];
+}
+
+/** A build's full CLI surface, suitable for JSON serialization. */
+export interface CliDescription {
+  /** The reserved positional commands. */
+  readonly commands: CliCommandInfo[];
+  /** The built-in option flags. */
+  readonly flags: CliFlagInfo[];
+  /** The build's targets, in declaration order. */
+  readonly targets: CliTargetInfo[];
+  /** The build's declared parameters, in declaration order. */
+  readonly parameters: CliParameterInfo[];
+}
+
+/** Describe one target. */
+function targetInfo(name: string, t: TargetBuilder): CliTargetInfo {
+  return {
+    name,
+    description: t.description_ ?? "",
+    dependsOn: t.dependsOn_.map((d) => d.name_ ?? "?"),
+    default: name === DEFAULT_TARGET,
+    unlisted: t.unlisted_,
+  };
+}
+
+/** Describe one parameter. */
+function parameterInfo(name: string, p: AnyParameter): CliParameterInfo {
+  return {
+    flag: flagName(name),
+    description: p.description_ ?? "",
+    required: p.required_,
+    boolean: p.kind_ === "boolean",
+    array: p.array_,
+    options: [...(p.options_ ?? [])],
+  };
+}
+
+/**
+ * Build a {@link CliDescription} from already-discovered targets and parameters.
+ * Used by the CLI's `--json` output, which has the maps in hand.
+ */
+export function describeBuildSurface(
+  targets: Map<string, TargetBuilder>,
+  params: Map<string, AnyParameter>,
+): CliDescription {
+  return {
+    commands: RESERVED_COMMANDS.map((c) => ({
+      name: c.name,
+      description: c.description,
+    })),
+    flags: BUILTIN_FLAGS.map((f) => ({
+      name: f.name,
+      description: f.description,
+    })),
+    targets: [...targets].map(([name, t]) => targetInfo(name, t)),
+    parameters: [...params].map(([name, p]) => parameterInfo(name, p)),
+  };
+}
+
+/**
+ * Describe a build's full CLI surface — reserved commands, option flags, targets
+ * (with descriptions and dependencies), and declared parameters — as a plain
+ * object ready for JSON. This is the same data `zuke --list --json` prints, made
+ * available to tooling and agents that introspect a build in code.
+ *
+ * ```ts
+ * import { describeCli } from "jsr:@zuke/core";
+ * const surface = describeCli(new MyBuild());
+ * console.log(surface.targets.map((t) => t.name));
+ * ```
+ */
+export function describeCli(build: Build): CliDescription {
+  return describeBuildSurface(
+    discoverTargets(build),
+    discoverParameters(build),
+  );
+}

--- a/packages/core/tests/cli_test.ts
+++ b/packages/core/tests/cli_test.ts
@@ -93,6 +93,24 @@ Deno.test("parseArgs defaults graph to false, output to text, open to true", () 
   ]);
 });
 
+Deno.test("parseArgs reads the --json flag, defaulting to false", () => {
+  assertEquals(parseArgs(["build"]).json, false);
+  assertEquals(parseArgs(["--list", "--json"]).json, true);
+  assertEquals(parseArgs(["--json"]).json, true);
+});
+
+Deno.test("main --json prints the build surface as JSON", async () => {
+  const { code, out } = await capture(() => main(Demo, ["--list", "--json"]));
+  assertEquals(code, 0);
+  const surface = JSON.parse(out.join("\n"));
+  assertEquals(surface.targets.map((t: { name: string }) => t.name), [
+    "clean",
+    "build",
+  ]);
+  assertEquals(surface.commands.length > 0, true);
+  assertEquals(surface.flags.length > 0, true);
+});
+
 Deno.test("parseArgs reads the completions sub-action and shell", () => {
   const print = parseArgs(["completions", "print", "zsh"]);
   assertEquals(

--- a/packages/core/tests/describe_test.ts
+++ b/packages/core/tests/describe_test.ts
@@ -1,0 +1,56 @@
+import { assertEquals } from "./_assert.ts";
+import { Build, describeCli, parameter, target } from "../mod.ts";
+import { BUILTIN_FLAGS, RESERVED_COMMANDS } from "../src/cli_spec.ts";
+
+class Sample extends Build {
+  clean = target().description("Clean").executes(() => {});
+  build = target().description("Build it").dependsOn(this.clean).executes(
+    () => {},
+  );
+  hidden = target().unlisted().executes(() => {});
+  default = target().dependsOn(this.build).executes(() => {});
+  environment = parameter("Target environment").options("dev", "prod")
+    .required();
+  tags = parameter("Tags").array();
+  verbose = parameter("Verbose").boolean();
+}
+
+Deno.test("describeCli mirrors the shared command and flag registry", () => {
+  const d = describeCli(new Sample());
+  assertEquals(
+    d.commands.map((c) => c.name),
+    RESERVED_COMMANDS.map((c) => c.name),
+  );
+  assertEquals(d.flags.map((f) => f.name), BUILTIN_FLAGS.map((f) => f.name));
+});
+
+Deno.test("describeCli reports targets with deps, default, and unlisted", () => {
+  const targets = describeCli(new Sample()).targets;
+
+  const build = targets.find((t) => t.name === "build");
+  assertEquals(build?.description, "Build it");
+  assertEquals(build?.dependsOn, ["clean"]);
+  assertEquals(build?.default, false);
+  assertEquals(build?.unlisted, false);
+
+  const def = targets.find((t) => t.name === "default");
+  assertEquals(def?.default, true);
+  assertEquals(def?.dependsOn, ["build"]);
+
+  // Unlisted targets are still reported (with the flag set), unlike `--list`.
+  const hidden = targets.find((t) => t.name === "hidden");
+  assertEquals(hidden?.unlisted, true);
+  assertEquals(hidden?.description, "");
+});
+
+Deno.test("describeCli reports parameter flags, kinds, and options", () => {
+  const params = describeCli(new Sample()).parameters;
+
+  const env = params.find((p) => p.flag === "environment");
+  assertEquals(env?.required, true);
+  assertEquals(env?.options, ["dev", "prod"]);
+  assertEquals(env?.boolean, false);
+
+  assertEquals(params.find((p) => p.flag === "tags")?.array, true);
+  assertEquals(params.find((p) => p.flag === "verbose")?.boolean, true);
+});

--- a/packages/docs/README.md
+++ b/packages/docs/README.md
@@ -127,6 +127,11 @@ interface ProjectInfo
     An optional install/scaffold command, shown in the "do not guess" list.
   guidance?: string[]
     Extra bullet lines appended to the "do not guess" list.
+  cli?: string
+    An optional pre-rendered markdown block describing the `zuke` command
+    surface, rendered under a `## CLI` heading in the index. The caller builds
+    it (e.g. from the build's command/flag registry) so this package stays
+    agnostic about CLI specifics.
 ````
 
 </details>

--- a/packages/docs/src/render.ts
+++ b/packages/docs/src/render.ts
@@ -111,6 +111,9 @@ export function buildIndex(
   if (project.example !== undefined) {
     lines.push("", "## Example", "", "```ts", project.example, "```");
   }
+  if (project.cli !== undefined) {
+    lines.push("", "## CLI", "", project.cli);
+  }
   lines.push("", "## Packages", "");
   for (const e of entries) {
     lines.push(`- [${e.name}](${options.jsrBaseUrl}/${e.name}) — ${e.summary}`);

--- a/packages/docs/src/types.ts
+++ b/packages/docs/src/types.ts
@@ -31,6 +31,13 @@ export interface ProjectInfo {
   install?: string;
   /** Extra bullet lines appended to the "do not guess" list. */
   guidance?: string[];
+  /**
+   * An optional pre-rendered markdown block describing the `zuke` command
+   * surface, rendered under a `## CLI` heading in the index. The caller builds
+   * it (e.g. from the build's command/flag registry) so this package stays
+   * agnostic about CLI specifics.
+   */
+  cli?: string;
 }
 
 /** Options accepted by {@link DocsTasks.apiDocs} and {@link DocsTasks.checkApiDocs}. */

--- a/packages/docs/tests/render_test.ts
+++ b/packages/docs/tests/render_test.ts
@@ -90,6 +90,7 @@ Deno.test("buildIndex renders title, blockquote, example, install, guidance, lin
       example: "const x = 1;",
       install: "deno add jsr:@acme/cli",
       guidance: ["A single package: `deno doc jsr:@acme/<package>`"],
+      cli: "Run `acme <target>`.",
     },
   });
   const index = buildIndex([FOO], opts);
@@ -98,6 +99,8 @@ Deno.test("buildIndex renders title, blockquote, example, install, guidance, lin
   assertStringIncludes(index, "> Line two.");
   assertStringIncludes(index, "## Example");
   assertStringIncludes(index, "const x = 1;");
+  assertStringIncludes(index, "## CLI");
+  assertStringIncludes(index, "Run `acme <target>`.");
   assertStringIncludes(index, "Scaffold/install: `deno add jsr:@acme/cli`");
   assertStringIncludes(
     index,
@@ -118,6 +121,7 @@ Deno.test("buildIndex omits the optional example, install, and guidance", () => 
   const index = buildIndex([FOO], opts);
   assertEquals(/## Example/.test(index), false);
   assertEquals(/Scaffold\/install/.test(index), false);
+  assertEquals(/## CLI/.test(index), false);
 });
 
 Deno.test("buildReference renders the header and one section per package", () => {

--- a/zuke.ts
+++ b/zuke.ts
@@ -15,6 +15,7 @@
 import {
   type AbsolutePath,
   Build,
+  describeCli,
   FileTasks,
   installRelease,
   parameter,
@@ -39,7 +40,12 @@ import {
   ReleasePleaseTasks,
 } from "@zuke/release-please";
 import { SecurityTasks } from "@zuke/security";
-import { type ApiDocsOptions, DocsTasks, type PackageDoc } from "@zuke/docs";
+import {
+  type ApiDocsOptions,
+  DocsTasks,
+  type PackageDoc,
+  type ProjectInfo,
+} from "@zuke/docs";
 
 /** Workspace packages, in dependency order: core must publish before the rest. */
 const PACKAGES = [
@@ -98,35 +104,79 @@ const PACKAGES = [
 ];
 
 /** Project framing for the generated API docs (`@zuke/docs`). */
+const DOCS_PROJECT: ProjectInfo = {
+  title: "Zuke",
+  summary:
+    "Code-first, strongly-typed build automation for Deno/TypeScript. Define " +
+    "a build by extending `Build`; declare targets with the `target()` fluent " +
+    "builder, wiring dependencies as `this.<field>` references (not strings) " +
+    "for compile-time safety. Every external tool has a typed `*Tasks` wrapper " +
+    "in a settings-lambda style — never shell out by hand.",
+  install: "deno run -A jsr:@zuke/cli setup",
+  example: [
+    'import { Build, run, target } from "jsr:@zuke/core";',
+    'import { DenoTasks } from "jsr:@zuke/deno";',
+    "",
+    "class CI extends Build {",
+    "  lint = target().executes(() => DenoTasks.lint());",
+    "  test = target().dependsOn(this.lint)",
+    "    .executes(() => DenoTasks.test((s) => s.allowAll()));",
+    "}",
+    "",
+    "await run(CI);",
+  ].join("\n"),
+  guidance: [
+    "A single package's API on the command line: " +
+    "`deno doc jsr:@zuke/<package>`",
+  ],
+};
+
 const DOCS_OPTIONS: ApiDocsOptions = {
   regenerateCommand: "./zuke apiDocs",
-  project: {
-    title: "Zuke",
-    summary:
-      "Code-first, strongly-typed build automation for Deno/TypeScript. Define " +
-      "a build by extending `Build`; declare targets with the `target()` fluent " +
-      "builder, wiring dependencies as `this.<field>` references (not strings) " +
-      "for compile-time safety. Every external tool has a typed `*Tasks` wrapper " +
-      "in a settings-lambda style — never shell out by hand.",
-    install: "deno run -A jsr:@zuke/cli setup",
-    example: [
-      'import { Build, run, target } from "jsr:@zuke/core";',
-      'import { DenoTasks } from "jsr:@zuke/deno";',
-      "",
-      "class CI extends Build {",
-      "  lint = target().executes(() => DenoTasks.lint());",
-      "  test = target().dependsOn(this.lint)",
-      "    .executes(() => DenoTasks.test((s) => s.allowAll()));",
-      "}",
-      "",
-      "await run(CI);",
-    ].join("\n"),
-    guidance: [
-      "A single package's API on the command line: " +
-      "`deno doc jsr:@zuke/<package>`",
-    ],
-  },
+  project: DOCS_PROJECT,
 };
+
+/**
+ * Render the `## CLI` block for the generated index from the build's own
+ * command/flag registry (via `describeCli`), so the agent docs describe the
+ * `zuke` command — not just the importable API — and never drift from the CLI.
+ */
+function cliReference(): string {
+  const { commands, flags } = describeCli(new ZukeBuild());
+  const bullets = (
+    items: ReadonlyArray<{ name: string; description: string }>,
+  ) => items.map((i) => `- \`${i.name}\` — ${i.description}`);
+  return [
+    "Run a build with the `zuke` command — `deno run -A zuke.ts <target>` (or",
+    "the `./zuke` launcher). The CLI is self-describing:",
+    "",
+    "```sh",
+    "zuke <target> [--skip <dep>] [--parallel[=N]]    # run a target and its deps",
+    "zuke --list [--json]                             # list targets (JSON: full surface)",
+    "zuke graph [--output=html]                       # dependency graph",
+    "zuke generate-ci [--check]                       # write declared CI files",
+    "zuke completions <print|install> <bash|zsh|fish> # shell completion",
+    "```",
+    "",
+    "`zuke --help` prints the usage grammar plus the build's live targets and",
+    "parameters; `zuke --list --json` emits the whole surface for tools.",
+    "",
+    "Reserved commands:",
+    "",
+    ...bullets(commands),
+    "",
+    "Option flags:",
+    "",
+    ...bullets(flags),
+    "",
+    "Full reference: [docs/cli.md](./docs/cli.md).",
+  ].join("\n");
+}
+
+/** {@link DOCS_OPTIONS} with the freshly rendered CLI block injected. */
+function docsOptions(): ApiDocsOptions {
+  return { ...DOCS_OPTIONS, project: { ...DOCS_PROJECT, cli: cliReference() } };
+}
 
 /**
  * Produce each package's API documentation text with `deno doc` (from
@@ -374,7 +424,7 @@ class ZukeBuild extends Build {
     .executes(async () => {
       const written = await DocsTasks.apiDocs(
         await collectPackageDocs(),
-        DOCS_OPTIONS,
+        docsOptions(),
       );
       console.log(
         written.length === 0
@@ -388,7 +438,7 @@ class ZukeBuild extends Build {
     .executes(async () => {
       const stale = await DocsTasks.checkApiDocs(
         await collectPackageDocs(),
-        DOCS_OPTIONS,
+        docsOptions(),
       );
       if (stale.length > 0) {
         throw new Error(


### PR DESCRIPTION
## What & why

When you ask an AI agent to "set up my zuke build," it reads the agent docs — which describe the importable `*Tasks` **API** but said nothing about the `zuke` **command**. So an agent had no authoritative pointer to the CLI it needs to run and verify a build. This makes the CLI surface discoverable three ways, from one source of truth.

1. **Docs pointer** — `CLAUDE.md`/`AGENTS.md` now explain that `zuke --help` prints the usage grammar, the reserved commands and flags, and the build's live targets and parameters, with `docs/cli.md` as the written reference.

2. **A generated `## CLI` section in `llms.txt`** — `@zuke/docs` gains an optional pre-rendered CLI block on the project info; `zuke.ts` renders one from `describeCli`, so the agent index now carries the command/flag vocabulary and `apiDocsCheck` keeps it from drifting.

3. **Machine-readable output** — `zuke --list --json` prints the build's full surface (commands, flags, targets with descriptions/dependencies, parameters with kinds/options) as JSON. The same data is exported as `describeCli(build)` for programmatic use by tooling and agents.

All command/flag data comes from the shared `cli_spec` registry added earlier, so the parser, `--help`, completion, `--json`, and the generated docs can't disagree. The `default`-target constant moved into that registry too.

## Related issues

Follow-up to the shell-completion work in #135; no tracked issue.

## Checklist

- [x] The PR title is a [Conventional Commit](https://www.conventionalcommits.org/) (`feat(core):` — minor bump).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell) — also re-run with `XDG_CONFIG_HOME` set.
- [x] Tests were added or updated; coverage stays at 95%+ (98.9% lines / 96.7% branches). New `describe_test.ts`, `--json` cases in `cli_test.ts`, and a `## CLI` render test.
- [x] Docs updated in the same PR (`CLAUDE.md`/`AGENTS.md`, `docs/cli.md` already covers the CLI).
- [x] Public API changes were regenerated with `./zuke apiDocs` (`describeCli` + types now in `llms.txt`, `llms-full.txt`, and `packages/core` / `packages/docs` READMEs).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrowed with control flow).
- [x] A new package was wired into all five places — N/A, no new package.
- [x] The code is written using AI assisted coding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqvMBA7vgqwHWbNcAabsH5)_