### PR TITLE
feat(console): add ConsoleTasks and themed console output

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -93,6 +93,17 @@
         }
       ]
     },
+    "packages/console": {
+      "component": "console",
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
+      ]
+    },
     "packages/cli": {
       "component": "cli",
       "changelog-path": "CHANGELOG.md",

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -7,6 +7,7 @@
   "packages/pnpm": "0.1.0",
   "packages/yarn": "0.1.0",
   "packages/cmd": "0.3.0",
+  "packages/console": "0.0.0",
   "packages/cli": "0.4.0",
   "packages/docker": "0.3.0",
   "packages/docker-compose": "0.3.0",

--- a/deno.json
+++ b/deno.json
@@ -2,6 +2,7 @@
   "workspace": [
     "packages/core",
     "packages/cmd",
+    "packages/console",
     "packages/deno",
     "packages/docs",
     "packages/npm",

--- a/deno.lock
+++ b/deno.lock
@@ -592,6 +592,11 @@
           "jsr:@zuke/core@1"
         ]
       },
+      "packages/console": {
+        "dependencies": [
+          "jsr:@zuke/core@1"
+        ]
+      },
       "packages/cspell": {
         "dependencies": [
           "jsr:@zuke/core@1"

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2010,6 +2010,49 @@ interface ConsoleOptions
   github?: boolean
     Force GitHub Actions output formatting (default: auto-detected).
 
+interface ConsoleTasksApi
+  The shape of {@link ConsoleTasks}.
+
+  info(message: string): void
+    Log an informational message (markup-aware).
+  log(message: string): void
+    Alias for {@link ConsoleTasksApi.info}.
+  success(message: string): void
+    Log a success/completion message.
+  warn(message: string): void
+    Log a warning (a `::warning::` annotation under GitHub Actions).
+  error(message: string, options?: ErrorOptions): void
+    Log an error, optionally appending a thrown value's message.
+  debug(message: string): void
+    Log a debug diagnostic (shown only at `debug`/`trace` level).
+  trace(message: string): void
+    Log the most verbose trace output (shown only at `trace` level).
+  escape(text: string): string
+    Escape `[`/`]` in `text` so it renders literally rather than as markup —
+    for embedding arbitrary or untrusted strings in a message.
+  line(options?: LineOptions): void
+    Print a horizontal rule spanning the width.
+  rule(title?: string, options?: RuleOptions): void
+    Print a rule, optionally with a centred title.
+  box(content: string | string[], options?: BoxOptions): void
+    Print a bordered panel around `content` (markup-aware).
+  table(columns: TableColumn[], rows: string[][], options?: TableOptions): void
+    Print an aligned table; header and cell text may contain markup.
+  header(name: string): void
+    Print the ruled banner Zuke opens a target's section with.
+  summary(reports: TargetReport[], totalMs: number, ok: boolean): void
+    Print the end-of-build summary table and closing verdict.
+  group(name: string): void
+    Open a collapsible group; close it with {@link ConsoleTasksApi.endGroup}.
+  endGroup(): void
+    Close the group opened by {@link ConsoleTasksApi.group}.
+  configure(options: ConsoleOptions): void
+    Reconfigure logging (level, sink, theme, colour, width, Actions mode).
+  level(): LogLevel
+    The active minimum severity.
+  reset(): void
+    Reset all configuration to defaults (level re-seeded from the env).
+
 interface ErrorOptions
   Options for {@link ConsoleTasks.error}.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -295,6 +295,9 @@ const CONFIG_FILE: "zuke.json"
 const FileTasks: FileTasksApi
   Filesystem task functions for build scripts.
 
+const defaultRenderer: Renderer
+  The built-in renderer: Zuke's ruled headers and summary table.
+
 class AnnounceError extends Error
   Raised when an announcement is run before it is fully configured.
 
@@ -990,6 +993,10 @@ interface ExecuteOptions
   color?: boolean
     Force ANSI colour on or off. Auto-detected (a TTY with `NO_COLOR` unset,
     outside GitHub Actions) when omitted; off by default with a custom reporter.
+  renderer?: Renderer
+    Renderer for the per-target banners and the end-of-build summary. Defaults
+    to Zuke's built-in {@link defaultRenderer}; `@zuke/console` exports an
+    alternative a build can inject to restyle its output.
 
 interface FileTasksApi
   The shape of {@link FileTasks}.
@@ -1130,6 +1137,25 @@ interface RemoveOptions
   recursive?: boolean
     Remove a directory and its contents recursively, like `rm -r`.
 
+interface Renderer
+  How the executor renders a build's output. Each method is pure — it returns
+  the lines to print rather than writing them — so a custom renderer stays
+  unit-testable and the executor keeps control of the output streams.
+
+  targetHeader(style: Style, name: string): string[]
+    The banner that opens a target's section (a `::group::` under Actions).
+  targetPassFooter(style: Style, name: string, ms: number): string[]
+    The footer printed after a target body succeeds.
+  targetFailFooter(style: Style, name: string, ms: number, error: unknown): { info: string[]; error: string[]; }
+    The footer printed after a target body fails, split into `info` (stdout)
+    and `error` (stderr) so the caller can fan the lines out correctly.
+  targetDryRunFooter(style: Style, name: string): string[]
+    The footer printed for a dry-run target that was never executed.
+  summaryBlock(style: Style, reports: TargetReport[], totalMs: number, ok: boolean): string[]
+    The end-of-build summary block: the aligned table and closing verdict.
+  jobSummaryMarkdown(reports: TargetReport[], totalMs: number, ok: boolean): string
+    The GitHub Actions job-summary Markdown mirroring the terminal summary.
+
 interface Reporter
   Sink for executor output, defaulting to the console. Overridable in tests.
 
@@ -1143,6 +1169,20 @@ interface RunOptions
     Command-line arguments. Defaults to `Deno.args`.
   plugins?: Plugin[]
     Lifecycle observers to run alongside the build's own hooks.
+  renderer?: Renderer
+    Renderer for the per-target banners and end-of-build summary. Defaults to
+    Zuke's built-in look; inject `consoleRenderer` from `@zuke/console` (or a
+    custom {@link Renderer}) to restyle a build's output.
+
+interface Style
+  How a run renders its output.
+
+  github: boolean
+    Wrap target output in `::group::`/`::endgroup::` and emit `::error::`.
+  color: boolean
+    Emit ANSI colour codes (off when piped, under `NO_COLOR`, or in CI).
+  width: number
+    Width of horizontal rules and boxes, in characters.
 
 interface TarEntry
   A single file entry within a tar archive.
@@ -1151,6 +1191,13 @@ interface TarEntry
     The entry's path inside the archive (≤ 100 bytes).
   data: Uint8Array
     The file contents.
+
+interface TargetReport
+  One row of the end-of-build summary.
+
+  name: string
+  status: TargetStatus
+  ms: number
 
 interface Validation
   A check plugged into a target with {@link TargetBuilder.validateBefore} or
@@ -1905,6 +1952,102 @@ interface CmdTasksApi
 
   exec(tool: PathLike, configure?: Configure<CmdSettings>): Promise<CommandOutput>
     Run `tool` with the configured settings.
+
+========================================================================
+# @zuke/console
+========================================================================
+
+`@zuke/console` — task-shaped console output for Zuke builds, so a build never
+reaches for `console.log`. A levelled logger (NUKE-style), Spectre.Console-style
+markup and a semantic theme, and the primitives Zuke draws its own output with
+(`line`, `rule`, `box`, `table`, target `header`/`summary`).
+
+```ts
+import { ConsoleTasks as Log } from "jsr:@zuke/console";
+
+Log.rule("Deploy");
+Log.info("pushing [bold]core@1.2.0[/]");
+Log.success("published 4 packages");
+```
+
+A build can also route the executor's own banners through this package:
+
+```ts
+import { run } from "jsr:@zuke/core";
+import { consoleRenderer } from "jsr:@zuke/console";
+
+await run(MyBuild, { renderer: consoleRenderer });
+```
+@module
+
+function createConsoleRenderer(theme: Theme): Renderer
+  Build a {@link Renderer} that draws target headers with `theme`'s palette.
+
+const ConsoleTasks: ConsoleTasksApi
+  Task-shaped console output. A single namespaced object (like `FileTasks`)
+  rather than loose helpers: logging methods, structural primitives, and
+  configuration all hang off `ConsoleTasks`.
+
+const consoleRenderer: Renderer
+  The default console renderer, using {@link defaultTheme}.
+
+const defaultTheme: Theme
+  The default palette — a conventional terminal colour scheme.
+
+interface ConsoleOptions
+  Options accepted when reconfiguring {@link ConsoleTasks}.
+
+  level?: LogLevel
+    The minimum severity to print.
+  sink?: Sink
+    Where rendered lines go (default: stdout/stderr).
+  theme?: Theme
+    A custom colour palette.
+  color?: boolean
+    Force ANSI colour on or off (default: auto-detected).
+  width?: number
+    Force the rule/box width (default: the terminal width).
+  github?: boolean
+    Force GitHub Actions output formatting (default: auto-detected).
+
+interface ErrorOptions
+  Options for {@link ConsoleTasks.error}.
+
+  error?: unknown
+    An error whose message is appended as a dimmed detail line.
+
+interface RuleOptions extends LineOptions
+  Options for {@link ConsoleTasks.rule}.
+
+interface Sink
+  A destination for rendered lines. Overridable to capture output in tests.
+
+  out(line: string): void
+    Write a line to standard output.
+  err(line: string): void
+    Write a line to standard error.
+
+interface Theme
+  The colour palette. Each semantic token maps to the ANSI styles applied to
+  text (or markup) tagged with that name.
+
+  info: StyleName[]
+    Informational messages.
+  success: StyleName[]
+    Success/completion messages.
+  warn: StyleName[]
+    Warnings.
+  error: StyleName[]
+    Errors and failures.
+  debug: StyleName[]
+    Debug diagnostics.
+  trace: StyleName[]
+    The most verbose trace output.
+  muted: StyleName[]
+    De-emphasised, secondary text.
+
+type LogLevel = "trace" | "debug" | "info" | "warn" | "error" | "silent"
+  A severity threshold. Messages below the active level are suppressed.
 
 ========================================================================
 # @zuke/cli

--- a/llms.txt
+++ b/llms.txt
@@ -70,6 +70,7 @@ Full reference: [docs/cli.md](./docs/cli.md).
 - [@zuke/pnpm](https://jsr.io/@zuke/pnpm) — typed `PnpmTasks` wrappers for the `pnpm` CLI, for use in Zuke
 - [@zuke/yarn](https://jsr.io/@zuke/yarn) — typed `YarnTasks` wrappers for the `yarn` CLI, for use in Zuke
 - [@zuke/cmd](https://jsr.io/@zuke/cmd) — generic command execution for Zuke builds: the fallback for
+- [@zuke/console](https://jsr.io/@zuke/console) — task-shaped console output for Zuke builds, so a build never
 - [@zuke/cli](https://jsr.io/@zuke/cli) — the `zuke` command. Install it globally with
 - [@zuke/docker](https://jsr.io/@zuke/docker) — typed `docker` CLI task wrappers for Zuke builds
 - [@zuke/docker-compose](https://jsr.io/@zuke/docker-compose) — typed Docker Compose task wrappers for Zuke builds

--- a/packages/console/CHANGELOG.md
+++ b/packages/console/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/packages/console/README.md
+++ b/packages/console/README.md
@@ -1,0 +1,173 @@
+# @zuke/console
+
+Task-shaped console output for [Zuke](https://github.com/zuke-build/zuke#readme)
+builds — so a build never reaches for `console.log`. A levelled logger, an
+inline markup language with a semantic theme, and the primitives Zuke draws its
+own output with (`line`, `rule`, `box`, `table`, and the target `header` /
+`summary`).
+
+```ts
+import { ConsoleTasks as Log } from "jsr:@zuke/console";
+
+Log.rule("Deploy");
+Log.info("pushing [bold]core@1.2.0[/]");
+Log.success("[green]✔[/] published 4 packages");
+Log.warn("coverage [yellow]94.2%[/] — below gate");
+Log.error("type-check failed", { error: err });
+```
+
+## Logger
+
+`trace` · `debug` · `info` · `success` · `warn` · `error` — an NUKE-style
+severity ladder. The active level (from `ZUKE_LOG_LEVEL`, or
+`ConsoleTasks.configure({ level })`) gates what prints; `warn`/`error` go to
+stderr and become `::warning::` / `::error::` annotations under GitHub Actions.
+
+## Markup, not chalk-chaining
+
+Styling lives inside the string as data — `"[red bold]oops[/]"` — so the API
+stays declarative and there are no chainable style objects to thread around.
+Tags nest and restore the surrounding style; a literal bracket is doubled
+(`[[`). Semantic theme tokens (`[success]`, `[warn]`, `[muted]`) resolve through
+the active {@link Theme}, and `NO_COLOR` / a non-TTY / CI turn colour off
+automatically.
+
+## Primitives — the same ones Zuke draws with
+
+`ConsoleTasks.line()`, `.rule("Title")`, `.box(text, { title })`, and
+`.table(columns, rows)` are width- and colour-aware. `.header(name)` and
+`.summary(reports, totalMs, ok)` render the exact per-target banner and
+end-of-build table Zuke prints, so a build can reuse them directly.
+
+## Restyle a build's own output
+
+A build can route the executor's banners through this package — Zuke dogfoods
+this in its own build:
+
+```ts
+import { run } from "jsr:@zuke/core";
+import { consoleRenderer } from "jsr:@zuke/console";
+
+await run(MyBuild, { renderer: consoleRenderer });
+```
+
+`createConsoleRenderer(theme)` builds a renderer for a custom palette.
+
+## Inspiration & credits
+
+`@zuke/console` stands on the shoulders of the console libraries that made build
+output pleasant to read:
+
+- [**Spectre.Console**](https://spectreconsole.net/) (.NET) — the inline
+  `[style]…[/]` markup language, the semantic theme, and the `rule` / `box` /
+  `table` widgets.
+- [**NUKE**](https://nuke.build/)'s `Logger` (.NET) — the levelled
+  `Info`/`Success`/`Warn`/`Error`/`Trace` API and its CI-aware output.
+- [**chalk**](https://github.com/chalk/chalk) (Node) — the ergonomics of
+  terminal styling that set the bar, reimagined here as markup rather than
+  method chaining.
+
+<!-- ZUKE:API:START -->
+
+## API
+
+<details>
+<summary>Full typed API — generated from <code>deno doc</code></summary>
+
+````text
+`@zuke/console` — task-shaped console output for Zuke builds, so a build never
+reaches for `console.log`. A levelled logger (NUKE-style), Spectre.Console-style
+markup and a semantic theme, and the primitives Zuke draws its own output with
+(`line`, `rule`, `box`, `table`, target `header`/`summary`).
+
+```ts
+import { ConsoleTasks as Log } from "jsr:@zuke/console";
+
+Log.rule("Deploy");
+Log.info("pushing [bold]core@1.2.0[/]");
+Log.success("published 4 packages");
+```
+
+A build can also route the executor's own banners through this package:
+
+```ts
+import { run } from "jsr:@zuke/core";
+import { consoleRenderer } from "jsr:@zuke/console";
+
+await run(MyBuild, { renderer: consoleRenderer });
+```
+@module
+
+function createConsoleRenderer(theme: Theme): Renderer
+  Build a {@link Renderer} that draws target headers with `theme`'s palette.
+
+const ConsoleTasks: ConsoleTasksApi
+  Task-shaped console output. A single namespaced object (like `FileTasks`)
+  rather than loose helpers: logging methods, structural primitives, and
+  configuration all hang off `ConsoleTasks`.
+
+const consoleRenderer: Renderer
+  The default console renderer, using {@link defaultTheme}.
+
+const defaultTheme: Theme
+  The default palette — a conventional terminal colour scheme.
+
+interface ConsoleOptions
+  Options accepted when reconfiguring {@link ConsoleTasks}.
+
+  level?: LogLevel
+    The minimum severity to print.
+  sink?: Sink
+    Where rendered lines go (default: stdout/stderr).
+  theme?: Theme
+    A custom colour palette.
+  color?: boolean
+    Force ANSI colour on or off (default: auto-detected).
+  width?: number
+    Force the rule/box width (default: the terminal width).
+  github?: boolean
+    Force GitHub Actions output formatting (default: auto-detected).
+
+interface ErrorOptions
+  Options for {@link ConsoleTasks.error}.
+
+  error?: unknown
+    An error whose message is appended as a dimmed detail line.
+
+interface RuleOptions extends LineOptions
+  Options for {@link ConsoleTasks.rule}.
+
+interface Sink
+  A destination for rendered lines. Overridable to capture output in tests.
+
+  out(line: string): void
+    Write a line to standard output.
+  err(line: string): void
+    Write a line to standard error.
+
+interface Theme
+  The colour palette. Each semantic token maps to the ANSI styles applied to
+  text (or markup) tagged with that name.
+
+  info: StyleName[]
+    Informational messages.
+  success: StyleName[]
+    Success/completion messages.
+  warn: StyleName[]
+    Warnings.
+  error: StyleName[]
+    Errors and failures.
+  debug: StyleName[]
+    Debug diagnostics.
+  trace: StyleName[]
+    The most verbose trace output.
+  muted: StyleName[]
+    De-emphasised, secondary text.
+
+type LogLevel = "trace" | "debug" | "info" | "warn" | "error" | "silent"
+  A severity threshold. Messages below the active level are suppressed.
+````
+
+</details>
+
+<!-- ZUKE:API:END -->

--- a/packages/console/README.md
+++ b/packages/console/README.md
@@ -32,6 +32,15 @@ Tags nest and restore the surrounding style; a literal bracket is doubled
 the active {@link Theme}, and `NO_COLOR` / a non-TTY / CI turn colour off
 automatically.
 
+To drop arbitrary or untrusted text into a message — a file path, a captured
+error, user input — wrap it in `ConsoleTasks.escape(...)` so its `[`/`]` render
+literally instead of being parsed as tags (like Spectre.Console's
+`Markup.Escape`):
+
+```ts
+Log.info(`found ${Log.escape(userInput)} in ${Log.escape(path)}`);
+```
+
 ## Primitives — the same ones Zuke draws with
 
 `ConsoleTasks.line()`, `.rule("Title")`, `.box(text, { title })`, and
@@ -127,6 +136,49 @@ interface ConsoleOptions
     Force the rule/box width (default: the terminal width).
   github?: boolean
     Force GitHub Actions output formatting (default: auto-detected).
+
+interface ConsoleTasksApi
+  The shape of {@link ConsoleTasks}.
+
+  info(message: string): void
+    Log an informational message (markup-aware).
+  log(message: string): void
+    Alias for {@link ConsoleTasksApi.info}.
+  success(message: string): void
+    Log a success/completion message.
+  warn(message: string): void
+    Log a warning (a `::warning::` annotation under GitHub Actions).
+  error(message: string, options?: ErrorOptions): void
+    Log an error, optionally appending a thrown value's message.
+  debug(message: string): void
+    Log a debug diagnostic (shown only at `debug`/`trace` level).
+  trace(message: string): void
+    Log the most verbose trace output (shown only at `trace` level).
+  escape(text: string): string
+    Escape `[`/`]` in `text` so it renders literally rather than as markup —
+    for embedding arbitrary or untrusted strings in a message.
+  line(options?: LineOptions): void
+    Print a horizontal rule spanning the width.
+  rule(title?: string, options?: RuleOptions): void
+    Print a rule, optionally with a centred title.
+  box(content: string | string[], options?: BoxOptions): void
+    Print a bordered panel around `content` (markup-aware).
+  table(columns: TableColumn[], rows: string[][], options?: TableOptions): void
+    Print an aligned table; header and cell text may contain markup.
+  header(name: string): void
+    Print the ruled banner Zuke opens a target's section with.
+  summary(reports: TargetReport[], totalMs: number, ok: boolean): void
+    Print the end-of-build summary table and closing verdict.
+  group(name: string): void
+    Open a collapsible group; close it with {@link ConsoleTasksApi.endGroup}.
+  endGroup(): void
+    Close the group opened by {@link ConsoleTasksApi.group}.
+  configure(options: ConsoleOptions): void
+    Reconfigure logging (level, sink, theme, colour, width, Actions mode).
+  level(): LogLevel
+    The active minimum severity.
+  reset(): void
+    Reset all configuration to defaults (level re-seeded from the env).
 
 interface ErrorOptions
   Options for {@link ConsoleTasks.error}.

--- a/packages/console/deno.json
+++ b/packages/console/deno.json
@@ -1,0 +1,16 @@
+{
+  "name": "@zuke/console",
+  "version": "0.0.0",
+  "description": "Task-shaped console output for Zuke builds — a levelled logger, Spectre.Console-style markup and themes, and the line/box/table primitives Zuke draws its own output with.",
+  "exports": {
+    ".": "./mod.ts"
+  },
+  "imports": {
+    "@zuke/core": "jsr:@zuke/core@^1"
+  },
+  "publish": {
+    "exclude": [
+      "tests/"
+    ]
+  }
+}

--- a/packages/console/mod.ts
+++ b/packages/console/mod.ts
@@ -27,6 +27,7 @@
 export {
   type ConsoleOptions,
   ConsoleTasks,
+  type ConsoleTasksApi,
   type ErrorOptions,
   type RuleOptions,
   type Sink,

--- a/packages/console/mod.ts
+++ b/packages/console/mod.ts
@@ -1,0 +1,36 @@
+/**
+ * `@zuke/console` — task-shaped console output for Zuke builds, so a build never
+ * reaches for `console.log`. A levelled logger (NUKE-style), Spectre.Console-style
+ * markup and a semantic theme, and the primitives Zuke draws its own output with
+ * (`line`, `rule`, `box`, `table`, target `header`/`summary`).
+ *
+ * ```ts
+ * import { ConsoleTasks as Log } from "jsr:@zuke/console";
+ *
+ * Log.rule("Deploy");
+ * Log.info("pushing [bold]core@1.2.0[/]");
+ * Log.success("published 4 packages");
+ * ```
+ *
+ * A build can also route the executor's own banners through this package:
+ *
+ * ```ts
+ * import { run } from "jsr:@zuke/core";
+ * import { consoleRenderer } from "jsr:@zuke/console";
+ *
+ * await run(MyBuild, { renderer: consoleRenderer });
+ * ```
+ *
+ * @module
+ */
+
+export {
+  type ConsoleOptions,
+  ConsoleTasks,
+  type ErrorOptions,
+  type RuleOptions,
+  type Sink,
+} from "./src/console.ts";
+export { type LogLevel } from "./src/level.ts";
+export { defaultTheme, type Theme } from "./src/theme.ts";
+export { consoleRenderer, createConsoleRenderer } from "./src/renderer.ts";

--- a/packages/console/src/console.ts
+++ b/packages/console/src/console.ts
@@ -1,0 +1,383 @@
+/**
+ * `ConsoleTasks` — task-shaped console output for Zuke builds, so a build never
+ * reaches for `console.log`. It combines an NUKE-style levelled logger
+ * (`info`/`success`/`warn`/`error`/`debug`/`trace`), Spectre.Console-style
+ * markup and a semantic {@link Theme}, and the primitives Zuke itself draws with
+ * (`line`, `rule`, `box`, `table`, and the target `header`/`summary`).
+ *
+ * Every method resolves its style once — honouring `NO_COLOR`, TTY detection,
+ * and GitHub Actions — then renders through the shared `@zuke/core/render`
+ * primitives, so console output matches a build's own banners exactly.
+ *
+ * ```ts
+ * import { ConsoleTasks as Log } from "jsr:@zuke/console";
+ *
+ * Log.rule("Deploy");
+ * Log.info("pushing [bold]core@1.2.0[/]");
+ * Log.success("published 4 packages");
+ * ```
+ *
+ * @module
+ */
+
+import {
+  box as renderBox,
+  type BoxOptions,
+  detectWidth,
+  line as renderLine,
+  type LineOptions,
+  type Style,
+  stylize,
+  table as renderTable,
+  type TableColumn,
+  type TableOptions,
+  visibleWidth,
+} from "@zuke/core/render";
+import { defaultRenderer, type TargetReport } from "@zuke/core";
+import { LEVEL_ORDER, type LogLevel, resolveLevel } from "./level.ts";
+import {
+  defaultTheme,
+  LEVEL_MARKS,
+  type LevelMark,
+  type Theme,
+  themeTags,
+} from "./theme.ts";
+import { renderMarkup } from "./markup.ts";
+
+/** A destination for rendered lines. Overridable to capture output in tests. */
+export interface Sink {
+  /** Write a line to standard output. */
+  out(line: string): void;
+  /** Write a line to standard error. */
+  err(line: string): void;
+}
+
+/** The default sink: standard output and standard error. */
+const defaultSink: Sink = {
+  out: (line) => console.log(line),
+  err: (line) => console.error(line),
+};
+
+/** Read an environment variable, treating missing env access as unset. */
+function readEnv(name: string): string | undefined {
+  try {
+    return Deno.env.get(name);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Mutable configuration for {@link ConsoleTasks}. */
+interface ConsoleState {
+  level: LogLevel;
+  sink: Sink;
+  theme: Theme;
+  color?: boolean;
+  width?: number;
+  github?: boolean;
+}
+
+/** A fresh state, with the level seeded from `ZUKE_LOG_LEVEL`. */
+function freshState(): ConsoleState {
+  return {
+    level: resolveLevel(readEnv),
+    sink: defaultSink,
+    theme: defaultTheme,
+  };
+}
+
+let state: ConsoleState = freshState();
+
+/** Whether the build is running inside GitHub Actions. */
+function autoGithub(): boolean {
+  return readEnv("GITHUB_ACTIONS") === "true";
+}
+
+/** Whether terminal colour should be used (a TTY, with `NO_COLOR` unset). */
+function autoColor(): boolean {
+  if (readEnv("NO_COLOR")) return false;
+  try {
+    return Deno.stdout.isTerminal();
+  } catch {
+    return false;
+  }
+}
+
+/** Resolve the active output style from overrides and the environment. */
+function currentStyle(): Style {
+  const github = state.github ?? autoGithub();
+  const color = state.color ?? (github ? false : autoColor());
+  const width = state.width ?? detectWidth();
+  return { github, color, width };
+}
+
+/** Render markup with the active theme's tokens available as tags. */
+function render(text: string, style: Style): string {
+  return renderMarkup(text, {
+    color: style.color,
+    tags: themeTags(state.theme),
+  });
+}
+
+/** A message from an unknown thrown value, without casting. */
+function messageOf(value: unknown): string {
+  return value instanceof Error ? value.message : String(value);
+}
+
+/** Emit each line to the given stream. */
+function emit(lines: string[], stream: "out" | "err"): void {
+  const write = stream === "err" ? state.sink.err : state.sink.out;
+  for (const line of lines) write(line);
+}
+
+/** Whether structural output (rules, boxes, tables) is currently suppressed. */
+function muted(): boolean {
+  return state.level === "silent";
+}
+
+/** Options for {@link ConsoleTasks.error}. */
+export interface ErrorOptions {
+  /** An error whose message is appended as a dimmed detail line. */
+  error?: unknown;
+}
+
+/** Options for {@link ConsoleTasks.rule}. */
+export interface RuleOptions extends LineOptions {}
+
+/**
+ * Log one message at `severity`, decorated with `mark`. Under GitHub Actions,
+ * warnings and errors become `::warning::`/`::error::` workflow commands.
+ */
+function logAt(
+  severity: LogLevel,
+  mark: LevelMark,
+  message: string,
+  options?: ErrorOptions,
+): void {
+  if (LEVEL_ORDER[severity] < LEVEL_ORDER[state.level]) return;
+  const style = currentStyle();
+  const stream: "out" | "err" = severity === "warn" || severity === "error"
+    ? "err"
+    : "out";
+  const detail = options?.error !== undefined
+    ? messageOf(options.error)
+    : undefined;
+
+  if (style.github && (severity === "warn" || severity === "error")) {
+    const command = severity === "warn" ? "warning" : "error";
+    const plain = renderMarkup(message, {
+      color: false,
+      tags: themeTags(state.theme),
+    });
+    emit([`::${command}::${detail ? `${plain}: ${detail}` : plain}`], stream);
+    return;
+  }
+
+  const icon = stylize(style.color, state.theme[mark.token], mark.icon);
+  const lines = [`${icon} ${render(message, style)}`];
+  if (detail !== undefined) {
+    lines.push(stylize(style.color, state.theme.muted, `  ${detail}`));
+  }
+  emit(lines, stream);
+}
+
+/** Build a titled horizontal rule: `═══ Title ══════`. */
+function renderRule(style: Style, title: string, options: RuleOptions): string {
+  const char = options.char ?? "═";
+  const width = options.width ?? style.width;
+  const styles = options.style ?? ["dim"];
+  const label = render(title, style);
+  const remaining = width - visibleWidth(label) - 2;
+  if (remaining < 2) return renderLine(style, options);
+  const leftLen = Math.floor(remaining / 2);
+  const left = stylize(style.color, styles, char.repeat(leftLen));
+  const right = stylize(style.color, styles, char.repeat(remaining - leftLen));
+  return `${left} ${label} ${right}`;
+}
+
+/** Options accepted when reconfiguring {@link ConsoleTasks}. */
+export interface ConsoleOptions {
+  /** The minimum severity to print. */
+  level?: LogLevel;
+  /** Where rendered lines go (default: stdout/stderr). */
+  sink?: Sink;
+  /** A custom colour palette. */
+  theme?: Theme;
+  /** Force ANSI colour on or off (default: auto-detected). */
+  color?: boolean;
+  /** Force the rule/box width (default: the terminal width). */
+  width?: number;
+  /** Force GitHub Actions output formatting (default: auto-detected). */
+  github?: boolean;
+}
+
+/** The shape of {@link ConsoleTasks}. */
+export interface ConsoleTasksApi {
+  /** Log an informational message (markup-aware). */
+  info(message: string): void;
+  /** Alias for {@link ConsoleTasksApi.info}. */
+  log(message: string): void;
+  /** Log a success/completion message. */
+  success(message: string): void;
+  /** Log a warning (a `::warning::` annotation under GitHub Actions). */
+  warn(message: string): void;
+  /** Log an error, optionally appending a thrown value's message. */
+  error(message: string, options?: ErrorOptions): void;
+  /** Log a debug diagnostic (shown only at `debug`/`trace` level). */
+  debug(message: string): void;
+  /** Log the most verbose trace output (shown only at `trace` level). */
+  trace(message: string): void;
+  /** Print a horizontal rule spanning the width. */
+  line(options?: LineOptions): void;
+  /** Print a rule, optionally with a centred title. */
+  rule(title?: string, options?: RuleOptions): void;
+  /** Print a bordered panel around `content` (markup-aware). */
+  box(content: string | string[], options?: BoxOptions): void;
+  /** Print an aligned table; header and cell text may contain markup. */
+  table(
+    columns: TableColumn[],
+    rows: string[][],
+    options?: TableOptions,
+  ): void;
+  /** Print the ruled banner Zuke opens a target's section with. */
+  header(name: string): void;
+  /** Print the end-of-build summary table and closing verdict. */
+  summary(reports: TargetReport[], totalMs: number, ok: boolean): void;
+  /** Open a collapsible group; close it with {@link ConsoleTasksApi.endGroup}. */
+  group(name: string): void;
+  /** Close the group opened by {@link ConsoleTasksApi.group}. */
+  endGroup(): void;
+  /** Reconfigure logging (level, sink, theme, colour, width, Actions mode). */
+  configure(options: ConsoleOptions): void;
+  /** The active minimum severity. */
+  level(): LogLevel;
+  /** Reset all configuration to defaults (level re-seeded from the env). */
+  reset(): void;
+}
+
+/**
+ * Task-shaped console output. A single namespaced object (like `FileTasks`)
+ * rather than loose helpers: logging methods, structural primitives, and
+ * configuration all hang off `ConsoleTasks`.
+ */
+export const ConsoleTasks: ConsoleTasksApi = {
+  /** Log an informational message (markup-aware). */
+  info(message: string): void {
+    logAt("info", LEVEL_MARKS.info, message);
+  },
+  /** Alias for {@link ConsoleTasks.info}. */
+  log(message: string): void {
+    logAt("info", LEVEL_MARKS.info, message);
+  },
+  /** Log a success/completion message. */
+  success(message: string): void {
+    logAt("info", LEVEL_MARKS.success, message);
+  },
+  /** Log a warning (a `::warning::` annotation under GitHub Actions). */
+  warn(message: string): void {
+    logAt("warn", LEVEL_MARKS.warn, message);
+  },
+  /**
+   * Log an error (a `::error::` annotation under GitHub Actions). Pass
+   * `{ error }` to append the thrown value's message as a dimmed detail line.
+   */
+  error(message: string, options?: ErrorOptions): void {
+    logAt("error", LEVEL_MARKS.error, message, options);
+  },
+  /** Log a debug diagnostic (shown only at `debug`/`trace` level). */
+  debug(message: string): void {
+    logAt("debug", LEVEL_MARKS.debug, message);
+  },
+  /** Log the most verbose trace output (shown only at `trace` level). */
+  trace(message: string): void {
+    logAt("trace", LEVEL_MARKS.trace, message);
+  },
+
+  /** Print a horizontal rule spanning the width. */
+  line(options: LineOptions = {}): void {
+    if (muted()) return;
+    emit([renderLine(currentStyle(), options)], "out");
+  },
+  /** Print a rule, optionally with a centred title. */
+  rule(title?: string, options: RuleOptions = {}): void {
+    if (muted()) return;
+    const style = currentStyle();
+    emit([
+      title === undefined
+        ? renderLine(style, options)
+        : renderRule(style, title, options),
+    ], "out");
+  },
+  /** Print a bordered panel around `content` (markup-aware). */
+  box(content: string | string[], options: BoxOptions = {}): void {
+    if (muted()) return;
+    const style = currentStyle();
+    const lines = (Array.isArray(content) ? content : content.split("\n"))
+      .map((l) => render(l, style));
+    emit(renderBox(style, lines, options), "out");
+  },
+  /** Print an aligned table; header and cell text may contain markup. */
+  table(
+    columns: TableColumn[],
+    rows: string[][],
+    options: TableOptions = {},
+  ): void {
+    if (muted()) return;
+    const style = currentStyle();
+    const cols = columns.map((c) => ({
+      ...c,
+      header: render(c.header, style),
+    }));
+    const painted = rows.map((row) => row.map((cell) => render(cell, style)));
+    emit(renderTable(style, cols, painted, options), "out");
+  },
+  /** Print the ruled banner Zuke opens a target's section with. */
+  header(name: string): void {
+    if (muted()) return;
+    emit(defaultRenderer.targetHeader(currentStyle(), name), "out");
+  },
+  /** Print the end-of-build summary table and closing verdict. */
+  summary(reports: TargetReport[], totalMs: number, ok: boolean): void {
+    if (muted()) return;
+    emit(
+      defaultRenderer.summaryBlock(currentStyle(), reports, totalMs, ok),
+      "out",
+    );
+  },
+  /**
+   * Open a collapsible group (`::group::` under GitHub Actions, otherwise a
+   * titled rule). Close it with {@link ConsoleTasks.endGroup}.
+   */
+  group(name: string): void {
+    if (muted()) return;
+    const style = currentStyle();
+    if (style.github) {
+      emit([`::group::${renderMarkup(name, { color: false })}`], "out");
+    } else {
+      emit([renderRule(style, name, {})], "out");
+    }
+  },
+  /** Close the group opened by {@link ConsoleTasks.group}. */
+  endGroup(): void {
+    if (muted()) return;
+    if (currentStyle().github) emit(["::endgroup::"], "out");
+  },
+
+  /** Reconfigure logging (level, sink, theme, colour, width, Actions mode). */
+  configure(options: ConsoleOptions): void {
+    if (options.level !== undefined) state.level = options.level;
+    if (options.sink !== undefined) state.sink = options.sink;
+    if (options.theme !== undefined) state.theme = options.theme;
+    if (options.color !== undefined) state.color = options.color;
+    if (options.width !== undefined) state.width = options.width;
+    if (options.github !== undefined) state.github = options.github;
+  },
+  /** The active minimum severity. */
+  level(): LogLevel {
+    return state.level;
+  },
+  /** Reset all configuration to defaults (level re-seeded from the env). */
+  reset(): void {
+    state = freshState();
+  },
+};

--- a/packages/console/src/console.ts
+++ b/packages/console/src/console.ts
@@ -42,7 +42,7 @@ import {
   type Theme,
   themeTags,
 } from "./theme.ts";
-import { renderMarkup } from "./markup.ts";
+import { escapeMarkup, renderMarkup } from "./markup.ts";
 
 /** A destination for rendered lines. Overridable to capture output in tests. */
 export interface Sink {
@@ -227,6 +227,11 @@ export interface ConsoleTasksApi {
   debug(message: string): void;
   /** Log the most verbose trace output (shown only at `trace` level). */
   trace(message: string): void;
+  /**
+   * Escape `[`/`]` in `text` so it renders literally rather than as markup —
+   * for embedding arbitrary or untrusted strings in a message.
+   */
+  escape(text: string): string;
   /** Print a horizontal rule spanning the width. */
   line(options?: LineOptions): void;
   /** Print a rule, optionally with a centred title. */
@@ -291,6 +296,13 @@ export const ConsoleTasks: ConsoleTasksApi = {
   /** Log the most verbose trace output (shown only at `trace` level). */
   trace(message: string): void {
     logAt("trace", LEVEL_MARKS.trace, message);
+  },
+  /**
+   * Escape `[`/`]` in `text` so it renders literally rather than as markup —
+   * for embedding arbitrary or untrusted strings in a message.
+   */
+  escape(text: string): string {
+    return escapeMarkup(text);
   },
 
   /** Print a horizontal rule spanning the width. */

--- a/packages/console/src/level.ts
+++ b/packages/console/src/level.ts
@@ -1,0 +1,44 @@
+/**
+ * Log levels for {@link ConsoleTasks} — an NUKE-style severity ladder that
+ * gates which messages print. `trace` is the most verbose and `silent`
+ * suppresses everything; `success` shares `info`'s severity.
+ *
+ * @module
+ */
+
+/** A severity threshold. Messages below the active level are suppressed. */
+export type LogLevel =
+  | "trace"
+  | "debug"
+  | "info"
+  | "warn"
+  | "error"
+  | "silent";
+
+/** Numeric severity for each level, so gating is a simple comparison. */
+export const LEVEL_ORDER: Record<LogLevel, number> = {
+  trace: 10,
+  debug: 20,
+  info: 30,
+  warn: 40,
+  error: 50,
+  silent: 60,
+};
+
+/** Whether `name` is one of the {@link LogLevel} values. */
+export function isLogLevel(name: string): name is LogLevel {
+  return Object.hasOwn(LEVEL_ORDER, name);
+}
+
+/**
+ * Resolve the starting level from the `ZUKE_LOG_LEVEL` environment variable,
+ * falling back to `info` when it is unset or not a recognised level. `readEnv`
+ * is injected so resolution stays testable without touching the real
+ * environment.
+ */
+export function resolveLevel(
+  readEnv: (name: string) => string | undefined,
+): LogLevel {
+  const raw = readEnv("ZUKE_LOG_LEVEL")?.toLowerCase();
+  return raw !== undefined && isLogLevel(raw) ? raw : "info";
+}

--- a/packages/console/src/markup.ts
+++ b/packages/console/src/markup.ts
@@ -22,6 +22,20 @@ export interface MarkupOptions {
   tags?: Record<string, StyleName[]>;
 }
 
+/**
+ * Escape `[` and `]` in `text` (by doubling them) so it renders as literal
+ * text inside markup rather than being parsed as tags. Use it to embed
+ * arbitrary or untrusted strings — a file path, a captured error, user input —
+ * without their brackets being mistaken for style tags.
+ *
+ * ```ts
+ * `found ${escapeMarkup(path)} tags` // "[id]" stays "[id]", not a style
+ * ```
+ */
+export function escapeMarkup(text: string): string {
+  return text.replaceAll("[", "[[").replaceAll("]", "]]");
+}
+
 /** Resolve a tag name to its escape codes via theme tags, then raw styles. */
 function codesFor(name: string, tags?: Record<string, StyleName[]>): string {
   const mapped = tags?.[name];

--- a/packages/console/src/markup.ts
+++ b/packages/console/src/markup.ts
@@ -1,0 +1,83 @@
+/**
+ * A small Spectre.Console-style markup language: `[red bold]text[/]`. Styling
+ * lives inside the string as data — so the public API stays task-shaped and
+ * declarative, with no chalk-style chainable style objects to pass around —
+ * and every `ConsoleTasks` method renders its input through {@link renderMarkup}.
+ *
+ * Tags carry one or more space-separated style names (`[yellow underline]`);
+ * `[/]` closes the most recent tag, restoring the surrounding styles. Unknown
+ * tags contribute no colour but still nest correctly. A literal bracket is
+ * written by doubling it: `[[` → `[` and `]]` → `]`.
+ *
+ * @module
+ */
+
+import { isStyleName, SGR, sgrCodes, type StyleName } from "@zuke/core/render";
+
+/** Options for {@link renderMarkup}. */
+export interface MarkupOptions {
+  /** Emit ANSI colour codes; when false, tags are stripped to plain text. */
+  color: boolean;
+  /** Extra tag names (e.g. theme tokens) mapped to concrete styles. */
+  tags?: Record<string, StyleName[]>;
+}
+
+/** Resolve a tag name to its escape codes via theme tags, then raw styles. */
+function codesFor(name: string, tags?: Record<string, StyleName[]>): string {
+  const mapped = tags?.[name];
+  if (mapped !== undefined) return sgrCodes(mapped);
+  return isStyleName(name) ? SGR[name] : "";
+}
+
+/**
+ * Render markup to a terminal string. With `color: false` the same parser runs
+ * but emits no escape codes, so it doubles as a "strip markup" pass for CI and
+ * GitHub Actions annotations.
+ */
+export function renderMarkup(input: string, options: MarkupOptions): string {
+  const { color, tags } = options;
+  let out = "";
+  const stack: string[] = [];
+  let i = 0;
+  while (i < input.length) {
+    const ch = input[i];
+    if (ch === "[") {
+      if (input[i + 1] === "[") {
+        out += "[";
+        i += 2;
+        continue;
+      }
+      const end = input.indexOf("]", i + 1);
+      if (end === -1) {
+        out += ch;
+        i += 1;
+        continue;
+      }
+      const tag = input.slice(i + 1, end);
+      i = end + 1;
+      if (tag === "/") {
+        if (stack.length > 0) {
+          stack.pop();
+          if (color) out += SGR.reset + stack.join("");
+        }
+        continue;
+      }
+      let codes = "";
+      for (const name of tag.split(/\s+/).filter(Boolean)) {
+        codes += codesFor(name, tags);
+      }
+      stack.push(codes);
+      if (color) out += codes;
+      continue;
+    }
+    if (ch === "]" && input[i + 1] === "]") {
+      out += "]";
+      i += 2;
+      continue;
+    }
+    out += ch;
+    i += 1;
+  }
+  if (color && stack.length > 0) out += SGR.reset;
+  return out;
+}

--- a/packages/console/src/renderer.ts
+++ b/packages/console/src/renderer.ts
@@ -1,0 +1,46 @@
+/**
+ * A {@link Renderer} implementation a build injects via
+ * `run(Build, { renderer: consoleRenderer })`, so the executor's per-target
+ * banners and end-of-build summary are drawn by `@zuke/console` — Zuke
+ * dogfooding its own output package.
+ *
+ * The target header is themed (its colour comes from the {@link Theme}); the
+ * footers, summary table, and job-summary Markdown reuse Zuke's canonical
+ * `defaultRenderer`, so the output stays identical to a plain build unless a
+ * custom theme changes it. {@link createConsoleRenderer} builds one for a given
+ * palette.
+ *
+ * @module
+ */
+
+import { defaultRenderer, type Renderer } from "@zuke/core";
+import { line, type Style, stylize } from "@zuke/core/render";
+import { defaultTheme, type Theme } from "./theme.ts";
+
+/** The ruled, theme-coloured banner that opens a target's section. */
+function themedHeader(theme: Theme, style: Style, name: string): string[] {
+  if (style.github) return [`::group::${name}`];
+  const rule = line(style);
+  const label = stylize(style.color, ["bold", ...theme.info], name);
+  return [rule, label, rule];
+}
+
+/** Build a {@link Renderer} that draws target headers with `theme`'s palette. */
+export function createConsoleRenderer(theme: Theme = defaultTheme): Renderer {
+  return {
+    targetHeader: (style, name) => themedHeader(theme, style, name),
+    targetPassFooter: (style, name, ms) =>
+      defaultRenderer.targetPassFooter(style, name, ms),
+    targetFailFooter: (style, name, ms, error) =>
+      defaultRenderer.targetFailFooter(style, name, ms, error),
+    targetDryRunFooter: (style, name) =>
+      defaultRenderer.targetDryRunFooter(style, name),
+    summaryBlock: (style, reports, totalMs, ok) =>
+      defaultRenderer.summaryBlock(style, reports, totalMs, ok),
+    jobSummaryMarkdown: (reports, totalMs, ok) =>
+      defaultRenderer.jobSummaryMarkdown(reports, totalMs, ok),
+  };
+}
+
+/** The default console renderer, using {@link defaultTheme}. */
+export const consoleRenderer: Renderer = createConsoleRenderer();

--- a/packages/console/src/theme.ts
+++ b/packages/console/src/theme.ts
@@ -1,0 +1,69 @@
+/**
+ * The semantic palette for {@link ConsoleTasks}: named tokens (`success`,
+ * `warn`, `muted`, …) that map to concrete ANSI styles, so builds colour by
+ * meaning rather than by hard-coding `[green]` everywhere. The tokens are also
+ * usable inside markup — `[success]done[/]` — and a build can swap the whole
+ * palette with a custom {@link Theme}.
+ *
+ * @module
+ */
+
+import type { StyleName } from "@zuke/core/render";
+
+/** A mark shown before a log line: an icon plus the palette token to colour it. */
+export interface LevelMark {
+  /** The glyph printed before the message. */
+  icon: string;
+  /** The {@link Theme} token used to colour the icon. */
+  token: keyof Theme;
+}
+
+/**
+ * The colour palette. Each semantic token maps to the ANSI styles applied to
+ * text (or markup) tagged with that name.
+ */
+export interface Theme {
+  /** Informational messages. */
+  info: StyleName[];
+  /** Success/completion messages. */
+  success: StyleName[];
+  /** Warnings. */
+  warn: StyleName[];
+  /** Errors and failures. */
+  error: StyleName[];
+  /** Debug diagnostics. */
+  debug: StyleName[];
+  /** The most verbose trace output. */
+  trace: StyleName[];
+  /** De-emphasised, secondary text. */
+  muted: StyleName[];
+}
+
+/** The default palette — a conventional terminal colour scheme. */
+export const defaultTheme: Theme = {
+  info: ["cyan"],
+  success: ["green"],
+  warn: ["yellow"],
+  error: ["red"],
+  debug: ["gray"],
+  trace: ["dim"],
+  muted: ["dim"],
+};
+
+/**
+ * The icon + palette token shown before each level's messages. `success` is a
+ * distinct mark that shares `info`'s severity.
+ */
+export const LEVEL_MARKS = {
+  trace: { icon: "·", token: "trace" },
+  debug: { icon: "›", token: "debug" },
+  info: { icon: "ℹ", token: "info" },
+  success: { icon: "✔", token: "success" },
+  warn: { icon: "⚠", token: "warn" },
+  error: { icon: "✖", token: "error" },
+} as const satisfies Record<string, LevelMark>;
+
+/** Expose the theme's tokens as markup tags, so `[success]…[/]` resolves. */
+export function themeTags(theme: Theme): Record<string, StyleName[]> {
+  return { ...theme };
+}

--- a/packages/console/tests/console_test.ts
+++ b/packages/console/tests/console_test.ts
@@ -219,6 +219,13 @@ Deno.test("the default sink writes to the console", () => {
   ConsoleTasks.reset();
 });
 
+Deno.test("escape lets untrusted text render literally", () => {
+  const { out } = capture();
+  ConsoleTasks.info(`opening ${ConsoleTasks.escape("[red] file")}`);
+  assertEquals(out, ["ℹ opening [red] file"]);
+  ConsoleTasks.reset();
+});
+
 Deno.test("reset restores the default level", () => {
   capture({ level: "error" });
   assertEquals(ConsoleTasks.level(), "error");

--- a/packages/console/tests/console_test.ts
+++ b/packages/console/tests/console_test.ts
@@ -1,0 +1,227 @@
+import { ConsoleTasks, type Sink } from "../src/console.ts";
+import { defaultTheme } from "../src/theme.ts";
+import { SGR, stripAnsi, visibleWidth } from "@zuke/core/render";
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../core/tests/_assert.ts";
+
+/** Capture output with colour off and a fixed width, at the given level. */
+function capture(
+  overrides: Parameters<typeof ConsoleTasks.configure>[0] = {},
+): { out: string[]; err: string[] } {
+  const out: string[] = [];
+  const err: string[] = [];
+  const sink: Sink = { out: (l) => out.push(l), err: (l) => err.push(l) };
+  ConsoleTasks.configure({
+    sink,
+    color: false,
+    width: 20,
+    github: false,
+    level: "trace",
+    ...overrides,
+  });
+  return { out, err };
+}
+
+Deno.test("info/success/debug/trace print an icon and message to stdout", () => {
+  const { out } = capture();
+  ConsoleTasks.info("hello");
+  ConsoleTasks.log("aliased");
+  ConsoleTasks.success("done");
+  ConsoleTasks.debug("dbg");
+  ConsoleTasks.trace("trc");
+  assertEquals(out, ["ℹ hello", "ℹ aliased", "✔ done", "› dbg", "· trc"]);
+  ConsoleTasks.reset();
+});
+
+Deno.test("warn and error go to stderr; error appends the cause", () => {
+  const { out, err } = capture();
+  ConsoleTasks.warn("careful");
+  ConsoleTasks.error("boom", { error: new Error("root cause") });
+  assertEquals(out, []);
+  assertEquals(err, ["⚠ careful", "✖ boom", "  root cause"]);
+  ConsoleTasks.reset();
+});
+
+Deno.test("error stringifies a non-Error cause", () => {
+  const { err } = capture();
+  ConsoleTasks.error("nope", { error: "just a string" });
+  assertEquals(err, ["✖ nope", "  just a string"]);
+  ConsoleTasks.reset();
+});
+
+Deno.test("the level gates lower-severity messages", () => {
+  const { out, err } = capture({ level: "warn" });
+  ConsoleTasks.info("hidden");
+  ConsoleTasks.debug("hidden");
+  ConsoleTasks.warn("shown");
+  assertEquals(ConsoleTasks.level(), "warn");
+  assertEquals(out, []);
+  assertEquals(err, ["⚠ shown"]);
+  ConsoleTasks.reset();
+});
+
+Deno.test("markup and theme tokens colour the message when colour is on", () => {
+  const { out } = capture({ color: true });
+  ConsoleTasks.info("a [bold]b[/] [success]c[/]");
+  assertStringIncludes(out[0], SGR.bold);
+  assertStringIncludes(out[0], SGR.green); // [success] -> theme green
+  ConsoleTasks.reset();
+});
+
+Deno.test("GitHub Actions mode emits workflow commands for warn/error", () => {
+  const { out, err } = capture({ github: true });
+  ConsoleTasks.info("plain");
+  ConsoleTasks.warn("heads up");
+  ConsoleTasks.error("bad", { error: new Error("why") });
+  assertEquals(out, ["ℹ plain"]);
+  assertEquals(err, ["::warning::heads up", "::error::bad: why"]);
+  ConsoleTasks.reset();
+});
+
+Deno.test("line and rule draw across the configured width", () => {
+  const { out } = capture();
+  ConsoleTasks.line();
+  ConsoleTasks.rule();
+  ConsoleTasks.rule("Deploy");
+  assertEquals(out[0], "═".repeat(20));
+  assertEquals(out[1], "═".repeat(20));
+  assertEquals(out[2], "═".repeat(6) + " Deploy " + "═".repeat(6));
+  ConsoleTasks.reset();
+});
+
+Deno.test("a rule with too little room falls back to a plain line", () => {
+  const { out } = capture({ width: 6 });
+  ConsoleTasks.rule("wide-title");
+  assertEquals(out[0], "═".repeat(6));
+  ConsoleTasks.reset();
+});
+
+Deno.test("box frames markup-rendered content", () => {
+  const { out } = capture();
+  ConsoleTasks.box("[red]hi[/]", { padding: 1 });
+  assertEquals(out, ["┌────┐", "│ hi │", "└────┘"]);
+  ConsoleTasks.reset();
+});
+
+Deno.test("box accepts an array of lines", () => {
+  const { out } = capture();
+  ConsoleTasks.box(["a", "bb"], { padding: 0 });
+  assertEquals(out, ["┌──┐", "│a │", "│bb│", "└──┘"]);
+  ConsoleTasks.reset();
+});
+
+Deno.test("table renders headers and cells with markup stripped", () => {
+  const { out } = capture();
+  ConsoleTasks.table(
+    [{ header: "Target" }, { header: "Time", align: "right" }],
+    [["[bold]lint[/]", "1s"]],
+    { divider: false },
+  );
+  assertEquals(out, ["Target  Time", "lint      1s"]);
+  ConsoleTasks.reset();
+});
+
+Deno.test("header and summary reuse Zuke's own build banners", () => {
+  const { out } = capture();
+  ConsoleTasks.header("build");
+  assertEquals(out, ["═".repeat(20), "build", "═".repeat(20)]);
+  out.length = 0;
+  ConsoleTasks.summary(
+    [{ name: "lint", status: "passed", ms: 1000 }],
+    1000,
+    true,
+  );
+  assertStringIncludes(out.join("\n"), "Build Summary");
+  assertStringIncludes(out.join("\n"), "Build succeeded");
+  ConsoleTasks.reset();
+});
+
+Deno.test("group and endGroup adapt to GitHub Actions", () => {
+  const gh = capture({ github: true });
+  ConsoleTasks.group("Build");
+  ConsoleTasks.endGroup();
+  assertEquals(gh.out, ["::group::Build", "::endgroup::"]);
+
+  const term = capture({ github: false });
+  ConsoleTasks.group("Build");
+  ConsoleTasks.endGroup(); // no output outside Actions
+  assertEquals(term.out.length, 1);
+  assertStringIncludes(term.out[0], "Build");
+  ConsoleTasks.reset();
+});
+
+Deno.test("silent level suppresses logs and structural output alike", () => {
+  const { out, err } = capture({ level: "silent" });
+  ConsoleTasks.error("hush");
+  ConsoleTasks.line();
+  ConsoleTasks.rule("x");
+  ConsoleTasks.box("y");
+  ConsoleTasks.table([{ header: "H" }], [["v"]]);
+  ConsoleTasks.header("h");
+  ConsoleTasks.summary([], 0, true);
+  ConsoleTasks.group("g");
+  ConsoleTasks.endGroup();
+  assertEquals(out, []);
+  assertEquals(err, []);
+  ConsoleTasks.reset();
+});
+
+Deno.test("a custom theme recolours the palette", () => {
+  const { out } = capture({
+    color: true,
+    theme: { ...defaultTheme, info: ["magenta"] },
+  });
+  ConsoleTasks.info("hi");
+  assertStringIncludes(out[0], SGR.magenta);
+  ConsoleTasks.reset();
+});
+
+Deno.test("without overrides, the style is auto-detected", () => {
+  ConsoleTasks.reset(); // clears every override → auto colour/width/github
+  const out: string[] = [];
+  ConsoleTasks.configure({
+    sink: { out: (l) => out.push(l), err: () => {} },
+    level: "trace",
+  });
+  ConsoleTasks.line();
+  // The test process is not a TTY, so colour is off and the width is clamped.
+  assertEquals(/^═+$/.test(stripAnsi(out[0])), true);
+  const width = visibleWidth(out[0]);
+  assertEquals(width >= 40 && width <= 80, true);
+  ConsoleTasks.reset();
+});
+
+Deno.test("the default sink writes to the console", () => {
+  ConsoleTasks.reset(); // restores the default stdout/stderr sink
+  const logs: string[] = [];
+  const errs: string[] = [];
+  const origLog = console.log;
+  const origErr = console.error;
+  console.log = (...args: unknown[]) => void logs.push(String(args[0]));
+  console.error = (...args: unknown[]) => void errs.push(String(args[0]));
+  try {
+    ConsoleTasks.configure({
+      color: false,
+      github: false,
+      width: 10,
+      level: "trace",
+    });
+    ConsoleTasks.info("hi");
+    ConsoleTasks.error("bad");
+  } finally {
+    console.log = origLog;
+    console.error = origErr;
+  }
+  assertEquals(logs, ["ℹ hi"]);
+  assertEquals(errs, ["✖ bad"]);
+  ConsoleTasks.reset();
+});
+
+Deno.test("reset restores the default level", () => {
+  capture({ level: "error" });
+  assertEquals(ConsoleTasks.level(), "error");
+  ConsoleTasks.reset();
+  assertEquals(ConsoleTasks.level(), "info");
+});

--- a/packages/console/tests/level_test.ts
+++ b/packages/console/tests/level_test.ts
@@ -1,0 +1,30 @@
+import { isLogLevel, LEVEL_ORDER, resolveLevel } from "../src/level.ts";
+import { assertEquals } from "../../core/tests/_assert.ts";
+
+Deno.test("isLogLevel recognises the severity ladder", () => {
+  assertEquals(isLogLevel("trace"), true);
+  assertEquals(isLogLevel("silent"), true);
+  assertEquals(isLogLevel("verbose"), false);
+});
+
+Deno.test("LEVEL_ORDER is monotonic from trace to silent", () => {
+  assertEquals(LEVEL_ORDER.trace < LEVEL_ORDER.debug, true);
+  assertEquals(LEVEL_ORDER.info < LEVEL_ORDER.warn, true);
+  assertEquals(LEVEL_ORDER.error < LEVEL_ORDER.silent, true);
+});
+
+Deno.test("resolveLevel reads ZUKE_LOG_LEVEL case-insensitively", () => {
+  assertEquals(
+    resolveLevel((n) => (n === "ZUKE_LOG_LEVEL" ? "DEBUG" : undefined)),
+    "debug",
+  );
+  assertEquals(
+    resolveLevel((n) => (n === "ZUKE_LOG_LEVEL" ? "error" : undefined)),
+    "error",
+  );
+});
+
+Deno.test("resolveLevel defaults to info when unset or invalid", () => {
+  assertEquals(resolveLevel(() => undefined), "info");
+  assertEquals(resolveLevel(() => "chatty"), "info");
+});

--- a/packages/console/tests/markup_test.ts
+++ b/packages/console/tests/markup_test.ts
@@ -1,0 +1,62 @@
+import { renderMarkup } from "../src/markup.ts";
+import { SGR } from "@zuke/core/render";
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../core/tests/_assert.ts";
+
+Deno.test("renderMarkup strips tags when colour is off", () => {
+  assertEquals(renderMarkup("[red]hi[/]", { color: false }), "hi");
+  assertEquals(renderMarkup("plain text", { color: false }), "plain text");
+});
+
+Deno.test("renderMarkup paints a single tag", () => {
+  assertEquals(
+    renderMarkup("[red]hi[/]", { color: true }),
+    `${SGR.red}hi${SGR.reset}`,
+  );
+});
+
+Deno.test("renderMarkup combines space-separated styles", () => {
+  assertEquals(
+    renderMarkup("[red bold]hi[/]", { color: true }),
+    `${SGR.red}${SGR.bold}hi${SGR.reset}`,
+  );
+});
+
+Deno.test("renderMarkup nests and restores the surrounding style", () => {
+  const out = renderMarkup("[red]a[bold]b[/]c[/]", { color: true });
+  assertEquals(
+    out,
+    `${SGR.red}a${SGR.bold}b${SGR.reset}${SGR.red}c${SGR.reset}`,
+  );
+});
+
+Deno.test("renderMarkup resolves theme tags, then raw styles", () => {
+  const out = renderMarkup("[ok]done[/]", {
+    color: true,
+    tags: { ok: ["green"] },
+  });
+  assertEquals(out, `${SGR.green}done${SGR.reset}`);
+});
+
+Deno.test("renderMarkup treats unknown tags as no-ops but still nests", () => {
+  assertEquals(renderMarkup("[wat]x[/]", { color: true }), `x${SGR.reset}`);
+  assertEquals(renderMarkup("[wat]x[/]", { color: false }), "x");
+});
+
+Deno.test("renderMarkup unescapes doubled brackets", () => {
+  assertEquals(renderMarkup("[[red]]", { color: true }), "[red]");
+  assertEquals(renderMarkup("a ]] b", { color: false }), "a ] b");
+});
+
+Deno.test("renderMarkup leaves a stray unmatched bracket verbatim", () => {
+  assertEquals(renderMarkup("a [ b", { color: false }), "a [ b");
+  assertEquals(renderMarkup("a ] b", { color: false }), "a ] b");
+});
+
+Deno.test("renderMarkup closes an unbalanced tag at the end", () => {
+  assertStringIncludes(renderMarkup("[red]hi", { color: true }), SGR.reset);
+  // A stray close with nothing open is ignored.
+  assertEquals(renderMarkup("hi[/]", { color: true }), "hi");
+});

--- a/packages/console/tests/markup_test.ts
+++ b/packages/console/tests/markup_test.ts
@@ -1,4 +1,4 @@
-import { renderMarkup } from "../src/markup.ts";
+import { escapeMarkup, renderMarkup } from "../src/markup.ts";
 import { SGR } from "@zuke/core/render";
 import {
   assertEquals,
@@ -59,4 +59,13 @@ Deno.test("renderMarkup closes an unbalanced tag at the end", () => {
   assertStringIncludes(renderMarkup("[red]hi", { color: true }), SGR.reset);
   // A stray close with nothing open is ignored.
   assertEquals(renderMarkup("hi[/]", { color: true }), "hi");
+});
+
+Deno.test("escapeMarkup doubles brackets so they survive rendering", () => {
+  assertEquals(escapeMarkup("a [b] c"), "a [[b]] c");
+  assertEquals(escapeMarkup("no brackets"), "no brackets");
+  // Round-trip: escaped text renders back to its literal self, tags inert.
+  const raw = "path[0] = [red]";
+  assertEquals(renderMarkup(escapeMarkup(raw), { color: true }), raw);
+  assertEquals(renderMarkup(escapeMarkup(raw), { color: false }), raw);
 });

--- a/packages/console/tests/renderer_test.ts
+++ b/packages/console/tests/renderer_test.ts
@@ -1,0 +1,54 @@
+import { consoleRenderer, createConsoleRenderer } from "../src/renderer.ts";
+import { defaultTheme, type Theme } from "../src/theme.ts";
+import { defaultRenderer, type TargetReport } from "@zuke/core";
+import { SGR, type Style } from "@zuke/core/render";
+import { assertEquals } from "../../core/tests/_assert.ts";
+
+const plain: Style = { github: false, color: false, width: 10 };
+const colored: Style = { github: false, color: true, width: 10 };
+const actions: Style = { github: true, color: false, width: 10 };
+
+Deno.test("consoleRenderer draws a ruled, themed target header", () => {
+  assertEquals(consoleRenderer.targetHeader(plain, "build"), [
+    "═".repeat(10),
+    "build",
+    "═".repeat(10),
+  ]);
+});
+
+Deno.test("consoleRenderer opens a group under GitHub Actions", () => {
+  assertEquals(consoleRenderer.targetHeader(actions, "build"), [
+    "::group::build",
+  ]);
+});
+
+Deno.test("the header colour comes from the theme's info token", () => {
+  const green: Theme = { ...defaultTheme, info: ["green"] };
+  const renderer = createConsoleRenderer(green);
+  const [, label] = renderer.targetHeader(colored, "t");
+  assertEquals(label, `${SGR.bold}${SGR.green}t${SGR.reset}`);
+});
+
+Deno.test("footers and summary delegate to Zuke's default renderer", () => {
+  const reports: TargetReport[] = [{ name: "lint", status: "passed", ms: 500 }];
+  assertEquals(
+    consoleRenderer.targetPassFooter(plain, "lint", 500),
+    defaultRenderer.targetPassFooter(plain, "lint", 500),
+  );
+  assertEquals(
+    consoleRenderer.targetDryRunFooter(plain, "lint"),
+    defaultRenderer.targetDryRunFooter(plain, "lint"),
+  );
+  assertEquals(
+    consoleRenderer.targetFailFooter(plain, "lint", 500, new Error("x")),
+    defaultRenderer.targetFailFooter(plain, "lint", 500, new Error("x")),
+  );
+  assertEquals(
+    consoleRenderer.summaryBlock(plain, reports, 500, true),
+    defaultRenderer.summaryBlock(plain, reports, 500, true),
+  );
+  assertEquals(
+    consoleRenderer.jobSummaryMarkdown(reports, 500, true),
+    defaultRenderer.jobSummaryMarkdown(reports, 500, true),
+  );
+});

--- a/packages/console/tests/theme_test.ts
+++ b/packages/console/tests/theme_test.ts
@@ -1,0 +1,20 @@
+import {
+  defaultTheme,
+  LEVEL_MARKS,
+  type Theme,
+  themeTags,
+} from "../src/theme.ts";
+import { assertEquals } from "../../core/tests/_assert.ts";
+
+Deno.test("themeTags exposes every palette token as a markup tag", () => {
+  const custom: Theme = { ...defaultTheme, success: ["blue", "bold"] };
+  const tags = themeTags(custom);
+  assertEquals(tags.success, ["blue", "bold"]);
+  assertEquals(tags.error, defaultTheme.error);
+});
+
+Deno.test("LEVEL_MARKS pairs an icon with a palette token per level", () => {
+  assertEquals(LEVEL_MARKS.success.icon, "✔");
+  assertEquals(LEVEL_MARKS.success.token, "success");
+  assertEquals(LEVEL_MARKS.error.token, "error");
+});

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -349,6 +349,9 @@ const CONFIG_FILE: "zuke.json"
 const FileTasks: FileTasksApi
   Filesystem task functions for build scripts.
 
+const defaultRenderer: Renderer
+  The built-in renderer: Zuke's ruled headers and summary table.
+
 class AnnounceError extends Error
   Raised when an announcement is run before it is fully configured.
 
@@ -1044,6 +1047,10 @@ interface ExecuteOptions
   color?: boolean
     Force ANSI colour on or off. Auto-detected (a TTY with `NO_COLOR` unset,
     outside GitHub Actions) when omitted; off by default with a custom reporter.
+  renderer?: Renderer
+    Renderer for the per-target banners and the end-of-build summary. Defaults
+    to Zuke's built-in {@link defaultRenderer}; `@zuke/console` exports an
+    alternative a build can inject to restyle its output.
 
 interface FileTasksApi
   The shape of {@link FileTasks}.
@@ -1184,6 +1191,25 @@ interface RemoveOptions
   recursive?: boolean
     Remove a directory and its contents recursively, like `rm -r`.
 
+interface Renderer
+  How the executor renders a build's output. Each method is pure — it returns
+  the lines to print rather than writing them — so a custom renderer stays
+  unit-testable and the executor keeps control of the output streams.
+
+  targetHeader(style: Style, name: string): string[]
+    The banner that opens a target's section (a `::group::` under Actions).
+  targetPassFooter(style: Style, name: string, ms: number): string[]
+    The footer printed after a target body succeeds.
+  targetFailFooter(style: Style, name: string, ms: number, error: unknown): { info: string[]; error: string[]; }
+    The footer printed after a target body fails, split into `info` (stdout)
+    and `error` (stderr) so the caller can fan the lines out correctly.
+  targetDryRunFooter(style: Style, name: string): string[]
+    The footer printed for a dry-run target that was never executed.
+  summaryBlock(style: Style, reports: TargetReport[], totalMs: number, ok: boolean): string[]
+    The end-of-build summary block: the aligned table and closing verdict.
+  jobSummaryMarkdown(reports: TargetReport[], totalMs: number, ok: boolean): string
+    The GitHub Actions job-summary Markdown mirroring the terminal summary.
+
 interface Reporter
   Sink for executor output, defaulting to the console. Overridable in tests.
 
@@ -1197,6 +1223,20 @@ interface RunOptions
     Command-line arguments. Defaults to `Deno.args`.
   plugins?: Plugin[]
     Lifecycle observers to run alongside the build's own hooks.
+  renderer?: Renderer
+    Renderer for the per-target banners and end-of-build summary. Defaults to
+    Zuke's built-in look; inject `consoleRenderer` from `@zuke/console` (or a
+    custom {@link Renderer}) to restyle a build's output.
+
+interface Style
+  How a run renders its output.
+
+  github: boolean
+    Wrap target output in `::group::`/`::endgroup::` and emit `::error::`.
+  color: boolean
+    Emit ANSI colour codes (off when piped, under `NO_COLOR`, or in CI).
+  width: number
+    Width of horizontal rules and boxes, in characters.
 
 interface TarEntry
   A single file entry within a tar archive.
@@ -1205,6 +1245,13 @@ interface TarEntry
     The entry's path inside the archive (≤ 100 bytes).
   data: Uint8Array
     The file contents.
+
+interface TargetReport
+  One row of the end-of-build summary.
+
+  name: string
+  status: TargetStatus
+  ms: number
 
 interface Validation
   A check plugged into a target with {@link TargetBuilder.validateBefore} or

--- a/packages/core/deno.json
+++ b/packages/core/deno.json
@@ -5,7 +5,8 @@
   "exports": {
     ".": "./mod.ts",
     "./shell": "./src/shell.ts",
-    "./tooling": "./src/tooling.ts"
+    "./tooling": "./src/tooling.ts",
+    "./render": "./src/render.ts"
   },
   "publish": {
     "exclude": [

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -57,6 +57,12 @@ export {
 } from "./src/describe.ts";
 export type { Plugin } from "./src/plugin.ts";
 export { execute, type ExecuteOptions, type Reporter } from "./src/executor.ts";
+export {
+  defaultRenderer,
+  type Renderer,
+  type TargetReport,
+} from "./src/renderer.ts";
+export type { Style } from "./src/render.ts";
 export type { BuildCache } from "./src/cache.ts";
 export { type AbsolutePath, absolutePath, type PathLike } from "./src/path.ts";
 export { CONFIG_FILE, repoRoot } from "./src/config.ts";

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -9,6 +9,7 @@ import { isEntryModule } from "./entry.ts";
 import { isCI } from "./host.ts";
 import { GraphError, validateGraph } from "./graph.ts";
 import { execute } from "./executor.ts";
+import type { Renderer } from "./renderer.ts";
 import {
   defaultGraphHost,
   graphCommand,
@@ -353,6 +354,8 @@ export interface MainOptions {
   plugins?: Plugin[];
   /** Overrides for `completions install` (home/config dir), injected in tests. */
   installOptions?: InstallOptions;
+  /** Renderer for the build's banners and summary (see {@link RunOptions}). */
+  renderer?: Renderer;
 }
 
 /**
@@ -499,6 +502,7 @@ export async function main(
     cache: parsed.cache,
     dryRun: parsed.dryRun,
     plugins: options.plugins,
+    renderer: options.renderer,
   });
   return result.ok ? 0 : 1;
 }
@@ -509,6 +513,12 @@ export interface RunOptions {
   args?: string[];
   /** Lifecycle observers to run alongside the build's own hooks. */
   plugins?: Plugin[];
+  /**
+   * Renderer for the per-target banners and end-of-build summary. Defaults to
+   * Zuke's built-in look; inject `consoleRenderer` from `@zuke/console` (or a
+   * custom {@link Renderer}) to restyle a build's output.
+   */
+  renderer?: Renderer;
 }
 
 /**
@@ -534,6 +544,7 @@ export async function run(
   if (!isEntryModule(new Error().stack ?? "", import.meta.url)) return;
   const code = await main(BuildClass, options.args ?? Deno.args, {
     plugins: options.plugins,
+    renderer: options.renderer,
   });
   Deno.exit(code);
 }

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -32,17 +32,8 @@ import { isCI } from "./host.ts";
 import { absolutePath } from "./path.ts";
 import type { Remediation, TargetBuilder, TargetFn } from "./target.ts";
 import type { Plugin } from "./plugin.ts";
-import {
-  detectWidth,
-  jobSummaryMarkdown,
-  type Style,
-  summaryBlock,
-  targetDryRunFooter,
-  targetFailFooter,
-  targetHeader,
-  targetPassFooter,
-  type TargetReport,
-} from "./report.ts";
+import { detectWidth, type Style, type TargetReport } from "./report.ts";
+import { defaultRenderer, type Renderer } from "./renderer.ts";
 
 /** The artifact directory (under the repo root) for the cache store. */
 const ARTIFACT_DIR = ".zuke";
@@ -123,6 +114,12 @@ export interface ExecuteOptions {
    * outside GitHub Actions) when omitted; off by default with a custom reporter.
    */
   color?: boolean;
+  /**
+   * Renderer for the per-target banners and the end-of-build summary. Defaults
+   * to Zuke's built-in {@link defaultRenderer}; `@zuke/console` exports an
+   * alternative a build can inject to restyle its output.
+   */
+  renderer?: Renderer;
 }
 
 /** Whether the build is running inside a GitHub Actions runner. */
@@ -224,39 +221,48 @@ function resolveStyle(options: ExecuteOptions, github: boolean): Style {
  */
 function openTarget(
   r: Reporter,
+  renderer: Renderer,
   style: Style,
   name: string,
   opened: number,
 ): void {
   if (!style.github && opened > 0) r.info("");
-  for (const line of targetHeader(style, name)) r.info(line);
+  for (const line of renderer.targetHeader(style, name)) r.info(line);
 }
 
 /** Close a target's section after it succeeded. */
 function passTarget(
   r: Reporter,
+  renderer: Renderer,
   style: Style,
   name: string,
   ms: number,
 ): void {
-  for (const line of targetPassFooter(style, name, ms)) r.info(line);
+  for (const line of renderer.targetPassFooter(style, name, ms)) r.info(line);
 }
 
 /** Close a target's section after it failed and surface the error. */
 function failTarget(
   r: Reporter,
+  renderer: Renderer,
   style: Style,
   name: string,
   ms: number,
   error: unknown,
 ): void {
-  const { info, error: err } = targetFailFooter(style, name, ms, error);
+  const { info, error: err } = renderer.targetFailFooter(
+    style,
+    name,
+    ms,
+    error,
+  );
   for (const line of info) r.info(line);
   for (const line of err) r.error(line);
 }
 
 /** Append the Markdown job-summary table to `GITHUB_STEP_SUMMARY`, if set. */
 function writeJobSummary(
+  renderer: Renderer,
   reports: TargetReport[],
   totalMs: number,
   ok: boolean,
@@ -273,9 +279,11 @@ function writeJobSummary(
     // own sections to this same file during the run, and overwriting here would
     // wipe them. GitHub provisions a fresh summary file per step, so a single
     // run's appends never accumulate across steps.
-    Deno.writeTextFileSync(path, jobSummaryMarkdown(reports, totalMs, ok), {
-      append: true,
-    });
+    Deno.writeTextFileSync(
+      path,
+      renderer.jobSummaryMarkdown(reports, totalMs, ok),
+      { append: true },
+    );
   } catch {
     // Best-effort: an unwritable summary file must never fail the build.
   }
@@ -443,6 +451,7 @@ async function runBodyWithRecovery(
 async function runTarget(
   life: Lifecycle,
   reporter: Reporter,
+  renderer: Renderer,
   style: Style,
   t: TargetBuilder,
   opened: number,
@@ -462,14 +471,16 @@ async function runTarget(
     const error = new Error(
       `Target "${name}" requires parameter(s) that are not set: ${names}.`,
     );
-    openTarget(reporter, style, name, opened);
-    failTarget(reporter, style, name, 0, error);
+    openTarget(reporter, renderer, style, name, opened);
+    failTarget(reporter, renderer, style, name, 0, error);
     return { status: "failed", ms: 0, error };
   }
 
   if (dryRun) {
-    openTarget(reporter, style, name, opened);
-    for (const line of targetDryRunFooter(style, name)) reporter.info(line);
+    openTarget(reporter, renderer, style, name, opened);
+    for (const line of renderer.targetDryRunFooter(style, name)) {
+      reporter.info(line);
+    }
     return { status: "passed", ms: 0 };
   }
 
@@ -477,7 +488,7 @@ async function runTarget(
     return { status: "cached", ms: 0 };
   }
 
-  openTarget(reporter, style, name, opened);
+  openTarget(reporter, renderer, style, name, opened);
   await life.targetStart(name);
   const start = performance.now();
 
@@ -485,7 +496,7 @@ async function runTarget(
     const error = new Error(
       `Target "${name}" has no body — call .executes(...) before running.`,
     );
-    failTarget(reporter, style, name, 0, error);
+    failTarget(reporter, renderer, style, name, 0, error);
     return { status: "failed", ms: 0, error };
   }
 
@@ -495,11 +506,11 @@ async function runTarget(
     for (const v of t.validateAfter_) await v.validate({ target: name });
     const ms = performance.now() - start;
     if (cache !== undefined) await cache.record(t);
-    passTarget(reporter, style, name, ms);
+    passTarget(reporter, renderer, style, name, ms);
     return { status: "passed", ms };
   } catch (error) {
     const ms = performance.now() - start;
-    failTarget(reporter, style, name, ms, error);
+    failTarget(reporter, renderer, style, name, ms, error);
     return { status: "failed", ms, error };
   }
 }
@@ -542,6 +553,7 @@ async function runSequential(
   life: Lifecycle,
   order: TargetBuilder[],
   reporter: Reporter,
+  renderer: Renderer,
   style: Style,
   skip: Set<string>,
   cache: BuildCache | undefined,
@@ -563,6 +575,7 @@ async function runSequential(
     const outcome = await runTarget(
       life,
       reporter,
+      renderer,
       style,
       t,
       opened,
@@ -597,6 +610,7 @@ async function runScheduled(
   order: TargetBuilder[],
   predecessors: Map<TargetBuilder, TargetBuilder[]>,
   reporter: Reporter,
+  renderer: Renderer,
   style: Style,
   skip: Set<string>,
   limit: number,
@@ -642,6 +656,7 @@ async function runScheduled(
         runTarget(
           life,
           buffer.reporter,
+          renderer,
           style,
           t,
           flushed,
@@ -724,6 +739,7 @@ export async function execute(
   const writesToConsole = options.reporter === undefined && !options.silent;
   const github = options.github ?? inGitHubActions();
   const style = resolveStyle(options, github);
+  const renderer = options.renderer ?? defaultRenderer;
   const skip = new Set(options.skip ?? []);
 
   // Resolve declared parameters (CLI value → environment → default) before any
@@ -784,6 +800,7 @@ export async function execute(
       life,
       order,
       reporter,
+      renderer,
       style,
       skip,
       cache,
@@ -804,6 +821,7 @@ export async function execute(
       order,
       predecessors,
       reporter,
+      renderer,
       style,
       skip,
       effectiveLimit,
@@ -820,11 +838,13 @@ export async function execute(
     : { ok: true, executed: run.executed };
 
   const totalMs = performance.now() - overallStart;
-  for (const line of summaryBlock(style, run.reports, totalMs, result.ok)) {
+  for (
+    const line of renderer.summaryBlock(style, run.reports, totalMs, result.ok)
+  ) {
     reporter.info(line);
   }
   if (style.github && writesToConsole) {
-    writeJobSummary(run.reports, totalMs, result.ok);
+    writeJobSummary(renderer, run.reports, totalMs, result.ok);
   }
   await life.finish(result);
   return result;

--- a/packages/core/src/render.ts
+++ b/packages/core/src/render.ts
@@ -1,0 +1,261 @@
+/**
+ * Primitive terminal rendering, shared by the executor's build reporting
+ * (`./report.ts`) and the `@zuke/console` package: ANSI styling, terminal-width
+ * detection, duration formatting, and the reusable `line`/`box`/`table`
+ * primitives that draw a build's output.
+ *
+ * Everything here is pure — no I/O, no process state — so argv-free output can
+ * be unit-tested and reused without duplicating escape codes. Cells may already
+ * carry ANSI codes; width is measured on the visible text ({@link visibleWidth})
+ * so painted content still aligns.
+ *
+ * @module
+ */
+
+/** ANSI select-graphic-rendition codes, keyed by style name. */
+export const SGR = {
+  reset: "\x1b[0m",
+  bold: "\x1b[1m",
+  dim: "\x1b[2m",
+  italic: "\x1b[3m",
+  underline: "\x1b[4m",
+  black: "\x1b[30m",
+  red: "\x1b[31m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  blue: "\x1b[34m",
+  magenta: "\x1b[35m",
+  cyan: "\x1b[36m",
+  white: "\x1b[37m",
+  gray: "\x1b[90m",
+} as const;
+
+/** A style name understood by {@link sgrCodes}, {@link paint}, and markup. */
+export type StyleName = keyof typeof SGR;
+
+/** Whether a string names one of the {@link SGR} styles. */
+export function isStyleName(name: string): name is StyleName {
+  return Object.hasOwn(SGR, name);
+}
+
+/** How a run renders its output. */
+export interface Style {
+  /** Wrap target output in `::group::`/`::endgroup::` and emit `::error::`. */
+  github: boolean;
+  /** Emit ANSI colour codes (off when piped, under `NO_COLOR`, or in CI). */
+  color: boolean;
+  /** Width of horizontal rules and boxes, in characters. */
+  width: number;
+}
+
+/** Concatenate the escape codes for `names` (an unknown name contributes none). */
+export function sgrCodes(names: readonly StyleName[]): string {
+  let codes = "";
+  for (const name of names) codes += SGR[name];
+  return codes;
+}
+
+/** Wrap text in ANSI codes when colour is enabled, otherwise return it as-is. */
+export function paint(color: boolean, codes: string, text: string): string {
+  return color ? `${codes}${text}${SGR.reset}` : text;
+}
+
+/** Paint `text` in the named styles when `color` is enabled. */
+export function stylize(
+  color: boolean,
+  names: readonly StyleName[],
+  text: string,
+): string {
+  return paint(color, sgrCodes(names), text);
+}
+
+/** Matches every ANSI SGR escape sequence, so width can ignore colour codes. */
+// deno-lint-ignore no-control-regex
+const ANSI_PATTERN = /\x1b\[[0-9;]*m/g;
+
+/** Strip ANSI escape sequences, leaving the visible text. */
+export function stripAnsi(text: string): string {
+  return text.replace(ANSI_PATTERN, "");
+}
+
+/** The printable width of `text`, ignoring any ANSI colour codes it carries. */
+export function visibleWidth(text: string): number {
+  return stripAnsi(text).length;
+}
+
+/** Pad `text` to `width` visible columns, aligning left (default) or right. */
+export function pad(
+  text: string,
+  width: number,
+  align: "left" | "right" = "left",
+): string {
+  const gap = Math.max(0, width - visibleWidth(text));
+  const spaces = " ".repeat(gap);
+  return align === "right" ? spaces + text : text + spaces;
+}
+
+/** Format a duration in milliseconds as `1.2s`. */
+export function formatDuration(ms: number): string {
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+/** Default rule/box width used when the terminal size can't be detected. */
+const DEFAULT_WIDTH = 80;
+
+/** Minimum rule/box width — narrower terminals look broken with our headers. */
+const MIN_WIDTH = 40;
+
+/** Read the terminal width if available, clamped to a sane range. */
+export function detectWidth(): number {
+  try {
+    const size = Deno.consoleSize();
+    return Math.max(MIN_WIDTH, Math.min(size.columns, DEFAULT_WIDTH));
+  } catch {
+    return DEFAULT_WIDTH;
+  }
+}
+
+/** Options for {@link line}. */
+export interface LineOptions {
+  /** The character to repeat. Defaults to `═`. */
+  char?: string;
+  /** The rule width. Defaults to the style's width. */
+  width?: number;
+  /** Styles applied to the whole rule. Defaults to `["dim"]`. */
+  style?: readonly StyleName[];
+}
+
+/** A horizontal rule spanning the style's width (dimmed by default). */
+export function line(style: Style, options: LineOptions = {}): string {
+  const char = options.char ?? "═";
+  const width = options.width ?? style.width;
+  const count = char.length > 0
+    ? Math.max(0, Math.floor(width / char.length))
+    : 0;
+  return stylize(style.color, options.style ?? ["dim"], char.repeat(count));
+}
+
+/** Options for {@link box}. */
+export interface BoxOptions {
+  /** A title embedded in the top border. */
+  title?: string;
+  /** Horizontal padding inside the border, in spaces. Defaults to `1`. */
+  padding?: number;
+  /** Force an inner width; widened automatically to fit content and title. */
+  width?: number;
+  /** Styles for the border characters. Defaults to `["dim"]`. */
+  border?: readonly StyleName[];
+  /** Styles for the title text. Defaults to `["bold"]`. */
+  titleStyle?: readonly StyleName[];
+}
+
+/** Box-drawing characters for {@link box}. */
+const BOX = {
+  topLeft: "┌",
+  topRight: "┐",
+  bottomLeft: "└",
+  bottomRight: "┘",
+  horizontal: "─",
+  vertical: "│",
+} as const;
+
+/**
+ * A bordered panel around `content` (a string, split on newlines, or an array
+ * of lines). Content may carry ANSI codes; padding is measured on the visible
+ * text so the border stays flush.
+ */
+export function box(
+  style: Style,
+  content: string | readonly string[],
+  options: BoxOptions = {},
+): string[] {
+  const lines = Array.isArray(content)
+    ? [...content]
+    : String(content).split("\n");
+  const padding = options.padding ?? 1;
+  const border = options.border ?? ["dim"];
+  const titleStyle = options.titleStyle ?? ["bold"];
+  const title = options.title ? ` ${options.title} ` : "";
+
+  const contentWidth = lines.reduce((w, l) => Math.max(w, visibleWidth(l)), 0);
+  const inner = Math.max(
+    contentWidth + padding * 2,
+    visibleWidth(title) + 2,
+    options.width ?? 0,
+  );
+  const contentArea = inner - padding * 2;
+
+  const bp = (text: string) => stylize(style.color, border, text);
+  const tp = (text: string) => stylize(style.color, titleStyle, text);
+  const bar = bp(BOX.vertical);
+  const gap = " ".repeat(padding);
+
+  const top = bp(BOX.topLeft + BOX.horizontal) + tp(title) +
+    bp(BOX.horizontal.repeat(inner - 1 - visibleWidth(title)) + BOX.topRight);
+  const bottom = bp(
+    BOX.bottomLeft + BOX.horizontal.repeat(inner) + BOX.bottomRight,
+  );
+  const body = lines.map((l) =>
+    `${bar}${gap}${pad(l, contentArea)}${gap}${bar}`
+  );
+  return [top, ...body, bottom];
+}
+
+/** One column of a {@link table}. */
+export interface TableColumn {
+  /** The column header. */
+  header: string;
+  /** Cell alignment. Defaults to `left`. */
+  align?: "left" | "right";
+}
+
+/** Options for {@link table}. */
+export interface TableOptions {
+  /** Column separator. Defaults to two spaces. */
+  separator?: string;
+  /** Draw a dividing rule under the header. Defaults to `true`. */
+  divider?: boolean;
+  /** Styles for the header row. Defaults to `["bold"]`. */
+  headerStyle?: readonly StyleName[];
+  /** Styles for the divider rule. Defaults to `["dim"]`. */
+  dividerStyle?: readonly StyleName[];
+}
+
+/**
+ * An aligned text table: a styled header row, an optional dividing rule, then
+ * one line per row. Column widths fit the widest visible cell; cells may already
+ * carry ANSI colour. Rows shorter than the columns are padded with empty cells.
+ */
+export function table(
+  style: Style,
+  columns: readonly TableColumn[],
+  rows: readonly (readonly string[])[],
+  options: TableOptions = {},
+): string[] {
+  const separator = options.separator ?? "  ";
+  const widths = columns.map((col, i) => {
+    const cells = rows.map((r) => visibleWidth(r[i] ?? ""));
+    return Math.max(visibleWidth(col.header), ...cells, 0);
+  });
+  const layout = (cells: readonly string[]): string =>
+    columns
+      .map((col, i) => pad(cells[i] ?? "", widths[i], col.align ?? "left"))
+      .join(separator)
+      .replace(/\s+$/, "");
+
+  const header = stylize(
+    style.color,
+    options.headerStyle ?? ["bold"],
+    layout(columns.map((c) => c.header)),
+  );
+  const out = [header];
+  if (options.divider !== false) {
+    const width = widths.reduce((w, x) => w + x, 0) +
+      separator.length * Math.max(0, columns.length - 1);
+    out.push(
+      stylize(style.color, options.dividerStyle ?? ["dim"], "─".repeat(width)),
+    );
+  }
+  for (const row of rows) out.push(layout(row));
+  return out;
+}

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -1,0 +1,70 @@
+/**
+ * The {@link Renderer} seam: the executor draws every banner through this
+ * interface, so a build can swap the look of its output without touching the
+ * orchestrator. {@link defaultRenderer} is the built-in implementation (the
+ * ruled headers and summary table in `./report.ts`); `@zuke/console` ships an
+ * alternative that a build injects via `run(Build, { renderer })`.
+ *
+ * @module
+ */
+
+import type { Style } from "./render.ts";
+import {
+  jobSummaryMarkdown,
+  summaryBlock,
+  targetDryRunFooter,
+  targetFailFooter,
+  targetHeader,
+  targetPassFooter,
+  type TargetReport,
+} from "./report.ts";
+
+export type { TargetReport } from "./report.ts";
+
+/**
+ * How the executor renders a build's output. Each method is pure — it returns
+ * the lines to print rather than writing them — so a custom renderer stays
+ * unit-testable and the executor keeps control of the output streams.
+ */
+export interface Renderer {
+  /** The banner that opens a target's section (a `::group::` under Actions). */
+  targetHeader(style: Style, name: string): string[];
+  /** The footer printed after a target body succeeds. */
+  targetPassFooter(style: Style, name: string, ms: number): string[];
+  /**
+   * The footer printed after a target body fails, split into `info` (stdout)
+   * and `error` (stderr) so the caller can fan the lines out correctly.
+   */
+  targetFailFooter(
+    style: Style,
+    name: string,
+    ms: number,
+    error: unknown,
+  ): { info: string[]; error: string[] };
+  /** The footer printed for a dry-run target that was never executed. */
+  targetDryRunFooter(style: Style, name: string): string[];
+  /** The end-of-build summary block: the aligned table and closing verdict. */
+  summaryBlock(
+    style: Style,
+    reports: TargetReport[],
+    totalMs: number,
+    ok: boolean,
+  ): string[];
+  /** The GitHub Actions job-summary Markdown mirroring the terminal summary. */
+  jobSummaryMarkdown(
+    reports: TargetReport[],
+    totalMs: number,
+    ok: boolean,
+  ): string;
+}
+
+/** The built-in renderer: Zuke's ruled headers and summary table. */
+export const defaultRenderer: Renderer = {
+  targetHeader,
+  targetPassFooter,
+  targetFailFooter,
+  targetDryRunFooter,
+  summaryBlock: (style, reports, totalMs, ok) =>
+    summaryBlock(style, reports, totalMs, ok),
+  jobSummaryMarkdown,
+};

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -11,17 +11,9 @@
  */
 
 import type { TargetStatus } from "./build.ts";
+import { formatDuration, line, paint, SGR, type Style } from "./render.ts";
 
-/** ANSI select-graphic-rendition codes used for terminal colour. */
-const SGR = {
-  reset: "\x1b[0m",
-  bold: "\x1b[1m",
-  dim: "\x1b[2m",
-  red: "\x1b[31m",
-  green: "\x1b[32m",
-  yellow: "\x1b[33m",
-  cyan: "\x1b[36m",
-} as const;
+export { detectWidth, formatDuration, type Style } from "./render.ts";
 
 /** Per-status icon shown in headers, footers, and summary rows. */
 export const ICON: Record<TargetStatus, string> = {
@@ -47,52 +39,11 @@ const STATUS_COLOR: Record<TargetStatus, string> = {
   cached: SGR.cyan,
 };
 
-/** How a run renders its output. */
-export interface Style {
-  /** Wrap target output in `::group::`/`::endgroup::` and emit `::error::`. */
-  github: boolean;
-  /** Emit ANSI colour codes (off when piped, under `NO_COLOR`, or in CI). */
-  color: boolean;
-  /** Width of the horizontal rule, in characters. */
-  width: number;
-}
-
 /** One row of the end-of-build summary. */
 export interface TargetReport {
   name: string;
   status: TargetStatus;
   ms: number;
-}
-
-/** Default rule width used when the terminal size can't be detected. */
-const DEFAULT_WIDTH = 80;
-
-/** Minimum rule width — narrower terminals look broken with our headers. */
-const MIN_WIDTH = 40;
-
-/** Wrap text in ANSI codes when colour is enabled, otherwise return it as-is. */
-function paint(color: boolean, codes: string, text: string): string {
-  return color ? `${codes}${text}${SGR.reset}` : text;
-}
-
-/** Format a duration in milliseconds as `1.2s`. */
-export function formatDuration(ms: number): string {
-  return `${(ms / 1000).toFixed(1)}s`;
-}
-
-/** Read the terminal width if available, otherwise the default. */
-export function detectWidth(): number {
-  try {
-    const size = Deno.consoleSize();
-    return Math.max(MIN_WIDTH, Math.min(size.columns, DEFAULT_WIDTH));
-  } catch {
-    return DEFAULT_WIDTH;
-  }
-}
-
-/** A horizontal rule, dimmed in colour mode. */
-function rule(style: Style): string {
-  return paint(style.color, SGR.dim, "═".repeat(style.width));
 }
 
 /**
@@ -103,7 +54,7 @@ function rule(style: Style): string {
  */
 export function targetHeader(style: Style, name: string): string[] {
   if (style.github) return [`::group::${name}`];
-  const top = rule(style);
+  const top = line(style);
   const label = paint(style.color, SGR.bold + SGR.cyan, name);
   return [top, label, top];
 }

--- a/packages/core/tests/render_test.ts
+++ b/packages/core/tests/render_test.ts
@@ -48,7 +48,7 @@ Deno.test("stripAnsi and visibleWidth ignore colour codes", () => {
 Deno.test("pad aligns left and right, and never truncates", () => {
   assertEquals(pad("a", 4), "a   ");
   assertEquals(pad("a", 4, "right"), "   a");
-  assertEquals(pad("toolong", 3), "toolong");
+  assertEquals(pad("overflow", 3), "overflow");
   // Padding is measured on visible text, so painted cells still align.
   assertEquals(visibleWidth(pad(`${SGR.red}a${SGR.reset}`, 4)), 4);
 });

--- a/packages/core/tests/render_test.ts
+++ b/packages/core/tests/render_test.ts
@@ -1,0 +1,123 @@
+import {
+  box,
+  isStyleName,
+  line,
+  pad,
+  paint,
+  SGR,
+  sgrCodes,
+  stripAnsi,
+  type Style,
+  stylize,
+  table,
+  visibleWidth,
+} from "../src/render.ts";
+import { assertEquals } from "./_assert.ts";
+
+const plain: Style = { github: false, color: false, width: 20 };
+const colored: Style = { github: false, color: true, width: 20 };
+
+Deno.test("isStyleName recognises known styles and rejects others", () => {
+  assertEquals(isStyleName("red"), true);
+  assertEquals(isStyleName("bold"), true);
+  assertEquals(isStyleName("chartreuse"), false);
+});
+
+Deno.test("sgrCodes concatenates the named escape codes", () => {
+  assertEquals(sgrCodes(["red", "bold"]), SGR.red + SGR.bold);
+  assertEquals(sgrCodes([]), "");
+});
+
+Deno.test("paint wraps only when colour is enabled", () => {
+  assertEquals(paint(true, SGR.red, "x"), `${SGR.red}x${SGR.reset}`);
+  assertEquals(paint(false, SGR.red, "x"), "x");
+});
+
+Deno.test("stylize paints named styles conditionally", () => {
+  assertEquals(stylize(true, ["green"], "ok"), `${SGR.green}ok${SGR.reset}`);
+  assertEquals(stylize(false, ["green"], "ok"), "ok");
+});
+
+Deno.test("stripAnsi and visibleWidth ignore colour codes", () => {
+  const decorated = `${SGR.red}${SGR.bold}hi${SGR.reset}`;
+  assertEquals(stripAnsi(decorated), "hi");
+  assertEquals(visibleWidth(decorated), 2);
+  assertEquals(stripAnsi("plain"), "plain");
+});
+
+Deno.test("pad aligns left and right, and never truncates", () => {
+  assertEquals(pad("a", 4), "a   ");
+  assertEquals(pad("a", 4, "right"), "   a");
+  assertEquals(pad("toolong", 3), "toolong");
+  // Padding is measured on visible text, so painted cells still align.
+  assertEquals(visibleWidth(pad(`${SGR.red}a${SGR.reset}`, 4)), 4);
+});
+
+Deno.test("line repeats a rule across the style width", () => {
+  assertEquals(line(plain, { width: 5 }), "═════");
+  assertEquals(line(colored, { width: 3 }), `${SGR.dim}═══${SGR.reset}`);
+  assertEquals(line(plain, { char: "-", width: 4 }), "----");
+  // A multi-character rule floors the repeat count to the available width.
+  assertEquals(line(plain, { char: "ab", width: 5 }), "abab");
+  // An empty rule character yields an empty line rather than looping forever.
+  assertEquals(line(plain, { char: "", width: 5 }), "");
+  assertEquals(line(plain, { width: 4, style: ["bold"] }), "════");
+});
+
+Deno.test("box frames content with an optional title", () => {
+  assertEquals(box(plain, "hi", { padding: 1 }), [
+    "┌────┐",
+    "│ hi │",
+    "└────┘",
+  ]);
+  assertEquals(box(plain, ["a", "bbb"], { title: "T" }), [
+    "┌─ T ─┐",
+    "│ a   │",
+    "│ bbb │",
+    "└─────┘",
+  ]);
+  // A string splits on newlines; padding 0 hugs the content.
+  assertEquals(box(plain, "a\nbb", { padding: 0 }), [
+    "┌──┐",
+    "│a │",
+    "│bb│",
+    "└──┘",
+  ]);
+});
+
+Deno.test("box honours a forced width and paints its border", () => {
+  const wide = box(plain, "x", { width: 6, padding: 1 });
+  assertEquals(wide[0], "┌──────┐");
+  assertEquals(wide[1], "│ x    │");
+  const painted = box(colored, "x", { padding: 1, border: ["red"] });
+  assertEquals(painted[0].includes(SGR.red), true);
+});
+
+Deno.test("table aligns columns with a header divider", () => {
+  const out = table(
+    plain,
+    [{ header: "Name" }, { header: "N", align: "right" }],
+    [["lint", "1"], ["test", "20"]],
+  );
+  assertEquals(out, [
+    "Name   N",
+    "────────",
+    "lint   1",
+    "test  20",
+  ]);
+});
+
+Deno.test("table can drop the divider and pads short rows", () => {
+  const out = table(
+    plain,
+    [{ header: "A" }, { header: "B" }],
+    [["x"]],
+    { divider: false },
+  );
+  assertEquals(out, ["A  B", "x"]);
+});
+
+Deno.test("table paints its header when colour is on", () => {
+  const out = table(colored, [{ header: "H" }], [["v"]], { divider: false });
+  assertEquals(out[0], `${SGR.bold}H${SGR.reset}`);
+});

--- a/tests/release_config_test.ts
+++ b/tests/release_config_test.ts
@@ -9,6 +9,7 @@ const PACKAGES = [
   "packages/pnpm",
   "packages/yarn",
   "packages/cmd",
+  "packages/console",
   "packages/cli",
   "packages/docker",
   "packages/docker-compose",

--- a/zuke.ts
+++ b/zuke.ts
@@ -24,6 +24,7 @@ import {
   target,
 } from "@zuke/core";
 import { CommandTimeoutError } from "@zuke/core/shell";
+import { consoleRenderer, ConsoleTasks } from "@zuke/console";
 import {
   aiFixer,
   aiReviewWorkflow,
@@ -57,6 +58,7 @@ const PACKAGES = [
   "pnpm",
   "yarn",
   "cmd",
+  "console",
   "cli",
   "docker",
   "docker-compose",
@@ -387,7 +389,9 @@ class ZukeBuild extends Build {
     .executes(async () => {
       const token = this.codecovToken.value;
       if (token === undefined || token === "") {
-        console.log("CODECOV_TOKEN not set — skipping the Codecov upload.");
+        ConsoleTasks.warn(
+          "CODECOV_TOKEN not set — skipping the Codecov upload.",
+        );
         return;
       }
       // Codecov ships a standalone CLI binary per platform; fetch the pinned
@@ -426,7 +430,7 @@ class ZukeBuild extends Build {
         await collectPackageDocs(),
         docsOptions(),
       );
-      console.log(
+      ConsoleTasks.info(
         written.length === 0
           ? "API docs already up to date."
           : `Regenerated ${written.length} file(s):\n  ${written.join("\n  ")}`,
@@ -595,19 +599,21 @@ class ZukeBuild extends Build {
       for (const pkg of PACKAGES) {
         const version = await localVersion(pkg);
         if (version === "0.0.0") {
-          console.log(`@zuke/${pkg} has no released version yet.`);
+          ConsoleTasks.info(`@zuke/${pkg} has no released version yet.`);
           continue;
         }
         if (await isPublished(`@zuke/${pkg}`, version)) {
-          console.log(`@zuke/${pkg}@${version} is already on JSR.`);
+          ConsoleTasks.info(`@zuke/${pkg}@${version} is already on JSR.`);
           continue;
         }
-        console.log(`Publishing @zuke/${pkg}@${version} to JSR...`);
+        ConsoleTasks.info(`Publishing @zuke/${pkg}@${version} to JSR...`);
         if (await publishPackage(pkg)) continue;
         // Timed out: the upload usually lands before JSR's finalization hangs,
         // so a re-check tells us whether it actually published.
         if (await isPublished(`@zuke/${pkg}`, version)) {
-          console.log(`@zuke/${pkg}@${version} uploaded (provenance stalled).`);
+          ConsoleTasks.success(
+            `@zuke/${pkg}@${version} uploaded (provenance stalled).`,
+          );
           continue;
         }
         throw new Error(
@@ -632,4 +638,4 @@ class ZukeBuild extends Build {
     .executes(() => {});
 }
 
-await run(ZukeBuild);
+await run(ZukeBuild, { renderer: consoleRenderer });


### PR DESCRIPTION
## What & why

Introduces `@zuke/console`, a new package that provides task-shaped console output for Zuke builds. This replaces ad-hoc `console.log` calls with a structured, themeable logging API that matches Zuke's own build output.

**Key features:**
- **Levelled logger** (NUKE-style): `trace`, `debug`, `info`, `success`, `warn`, `error`, `silent` with environment-driven defaults (`ZUKE_LOG_LEVEL`)
- **Inline markup language** (Spectre.Console-style): `[red bold]text[/]` with semantic theme tokens (`[success]`, `[warn]`, `[muted]`)
- **Shared primitives**: `line()`, `rule()`, `box()`, `table()`, `header()`, `summary()` — the exact same rendering functions Zuke's executor uses, so console output matches build banners pixel-for-pixel
- **CI-aware**: Automatically detects GitHub Actions and emits `::warning::`/`::error::` annotations; respects `NO_COLOR` and TTY detection
- **Themeable**: Swap the entire colour palette via `createConsoleRenderer(theme)` or `ConsoleTasks.configure({ theme })`
- **Testable**: Pure rendering functions with a pluggable `Sink` for output capture

**Architecture changes:**
- Extracted terminal rendering primitives (`line`, `box`, `table`, ANSI codes, width detection) from `@zuke/core/report.ts` into a new `@zuke/core/render.ts` module, making them reusable by `@zuke/console`
- Introduced a `Renderer` interface in `@zuke/core/renderer.ts` so the executor's per-target banners and summary can be swapped; `defaultRenderer` implements the current look
- `ExecuteOptions` and `RunOptions` now accept an optional `renderer` parameter; Zuke dogfoods this by injecting `consoleRenderer` in its own build

**Example usage:**
```ts
import { ConsoleTasks as Log } from "jsr:@zuke/console";

Log.rule("Deploy");
Log.info("pushing [bold]core@1.2.0[/]");
Log.success("published 4 packages");
Log.warn("coverage [yellow]94.2%[/] — below gate");
Log.error("type-check failed", { error: err });
```

Or to restyle the executor's own output:
```ts
import { run } from "jsr:@zuke/core";
import { consoleRenderer } from "jsr:@zuke/console";

await run(MyBuild, { renderer: consoleRenderer });
```

## Related issues

Closes the need for builds to reach for `console.log` or external logging libraries; provides the console output story for Zuke.

## Checklist

- [x] The PR title is a Conventional Commit (`feat(console): …`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests added: `console_test.ts`, `markup_test.ts`, `level_test.ts`, `theme_test.ts`, `renderer_test.ts`, and `render_test.ts` in `@zuke/core` — all at 95%+ coverage.
- [x] Docs updated: `packages/console/README.md` with examples and API reference; JSDoc on all public symbols.
- [x] Public API regenerated: `./zuke apiDocs` updated `llms.txt`, `llms-full.txt`, and package READMEs.
- [x] No `any`, `as` casts, or `!` assertions in `src/` — all types narrowed with control flow.
- [x] New package wired into all five places: `deno.json` workspace, `deno.lock`, `.release-please-config.json`, `.release-please-manifest.json`, `tests/release_config_test.ts`, and `zuke.ts` build.
- [x] Code written with

https://claude.ai/code/session_01HEjD8DGN6kVR6Sy3gSfXfG