### PR TITLE
chore: allow "Patrik Svensson" in the spell dictionary

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -151,6 +151,9 @@
     "matkoch",
     "Matthias",
     "Koch",
+    "patriksvensson",
+    "Patrik",
+    "Svensson",
     "metacharacter",
     "Mozilla"
   ],


### PR DESCRIPTION
## What & why

Master's CI gate is red on the `spell` step:

```
README.md:357:73 - Unknown word (Patrik)
✘ Build failed — 'spell' failed
```

Commit `db5e527` ("Enhance Spectre.Console description in README") expanded the acknowledgement to credit Spectre.Console's creator, **Patrik Svensson** (`github.com/patriksvensson`). cspell doesn't know that name, so `deno task spell` fails and takes the whole gate down. Everything else (`check`, `test`, `coverage`, `apiDocsCheck`) passes.

This adds `Patrik`, `Svensson`, and the `patriksvensson` handle to the cspell dictionary — mirroring how the NUKE author is already whitelisted (`Matthias`, `Koch`, `matkoch`). Verified locally: `cspell` reports 0 issues on `README.md`.

## Related issues

Fixes the failed CI run `28574410832` on master.

## Checklist

- [x] The PR title is a Conventional Commit (`type(scope): summary`).
- [x] `deno task ci` passes locally (spell now clean; no code touched).
- [ ] Tests were added or updated — N/A (dictionary/config only).
- [x] Docs updated in the same PR when behaviour changed — N/A (no behaviour change).
- [x] Public API changes were regenerated with `./zuke apiDocs` — N/A (no API change).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/`.
- [ ] A new package was wired into all five places — N/A.
- [x] The code is written using AI assisted coding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HEjD8DGN6kVR6Sy3gSfXfG)_