### PR TITLE
fix(ai): sync harden-runner pin with generated ai-review.yml

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920
         with:
           egress-policy: audit
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       # codecov API and the GCS bucket it streams cov.lcov to) for the
       # coverageUpload target. Add a host here if a run reports it blocked.
       - name: Harden the runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: block
           allowed-endpoints: >

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
@@ -57,7 +57,7 @@ jobs:
       id-token: write
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -19,7 +19,7 @@ jobs:
       id-token: write # publish results to the public Scorecard API
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
@@ -42,6 +42,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code scanning
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 

--- a/packages/ai/src/workflow.ts
+++ b/packages/ai/src/workflow.ts
@@ -36,9 +36,9 @@ import {
 } from "@zuke/core";
 import type { Reviewer } from "./reviewer.ts";
 
-/** SHA-pinned `step-security/harden-runner` (v2.19.4). */
+/** SHA-pinned `step-security/harden-runner` (v2.20.0). */
 const HARDEN_RUNNER =
-  "step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411";
+  "step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920";
 
 /** SHA-pinned `actions/checkout` (v7.0.0). */
 const CHECKOUT = "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0";

--- a/packages/ai/tests/workflow_test.ts
+++ b/packages/ai/tests/workflow_test.ts
@@ -64,7 +64,7 @@ Deno.test("the steps are: harden, checkout (no credentials), fetch base, run ./z
   const yaml = dualBuild().wf.render();
   assertStringIncludes(
     yaml,
-    "uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411",
+    "uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920",
   );
   assertStringIncludes(yaml, "egress-policy: audit");
   assertStringIncludes(


### PR DESCRIPTION
## What & why

Supersedes #143 (the Dependabot actions bump), which failed CI on every gate.

The failure was **not** the action versions — it was CI-config drift. `./zuke test` starts with a generation-integrity check that reported:

```
CI configuration is out of date: .github/workflows/ai-review.yml.
Run `zuke generate-ci` and commit the result.
```

`.github/workflows/ai-review.yml` is **generated** from `aiReviewWorkflow(...)`, backed by the `HARDEN_RUNNER` constant in `packages/ai/src/workflow.ts`. Dependabot updated the committed YAML to harden-runner v2.20.0 but couldn't update that source-of-truth constant, so `zuke generate-ci --check` saw the regenerated file diverge from the committed one and failed the build (cascading to every job that runs the build).

This branch is based on the Dependabot commit and adds the missing source fix, so the version bumps and the generation source agree:

- Update the `HARDEN_RUNNER` constant (and its JSDoc) to the v2.20.0 SHA so regeneration matches the committed `ai-review.yml`.
- Update the `packages/ai` workflow test assertion to the new pin.

The other four workflows Dependabot touched are hand-maintained (not generated), so they need no source change. `codeql-action`/`checkout` pins are unaffected, and the generated docs (`llms.txt`, `llms-full.txt`, READMEs) don't embed the SHA, so no `apiDocs` regeneration is needed.

## Related issues

Supersedes #143.

## Checklist

- [x] The PR title is a [Conventional Commit](https://www.conventionalcommits.org/) (`type(scope): summary`).
- [ ] `deno task ci` passes locally — could not run in this environment (egress policy blocks the Deno install); verification was by inspection and relies on CI here.
- [x] Tests were added or updated; the workflow test assertion tracks the new pin.
- [x] Docs updated where relevant (JSDoc on the pin constant).
- [x] Public API unchanged — no `apiDocs` regeneration needed.
- [x] No `any`, `as` casts, or `!` non-null assertions in `src/`.
- [x] No new package added.
- [x] The code is written using AI assisted coding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhhF5F2jGwVn8nvMsdiiq3

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhhF5F2jGwVn8nvMsdiiq3)_