### PR TITLE
docs: add dedicated caching page and fill documentation gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,8 @@ Full documentation lives in [`docs/`](./docs/):
   vars (`parameter()`, `this.x.value`).
 - [Authoring API](./docs/authoring.md) — `target()`, `Build`, `run()`,
   code-first CI generation (`cicd()`), and gotchas.
+- [Caching](./docs/caching.md) — the incremental build cache
+  (`.inputs()`/`.outputs()`) and the AI response cache (`aiCache`).
 - [Shell wrapper (`$`)](./docs/shell.md) — ergonomic, injection-safe process
   execution.
 - [Paths (`absolutePath`)](./docs/paths.md) — the fluent path type.

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,10 +3,14 @@
 - [Getting started](./getting-started.md) — install, scaffold, the launcher, and a first build.
 - [Core concepts](./concepts.md) — the build/target/graph model and execution semantics.
 - [Authoring API](./authoring.md) — `target()`, `Build`, `run()`, and gotchas.
+- [Parameters](./parameters.md) — typed build inputs from flags, env, or defaults.
+- [Caching](./caching.md) — the incremental build cache and the AI response cache.
 - [Shell wrapper (`$`)](./shell.md) — ergonomic, injection-safe process execution.
 - [Paths (`absolutePath`)](./paths.md) — the fluent path type.
 - [Tools](./tools.md) — the typed tool-wrapper packages and their tasks.
 - [Extending Zuke](./extending.md) — the plugin contract: lifecycle plugins, tool wrappers, and reusable target bundles.
+- [AI review](./ai-review.md) — model-assessed review gates as build validations.
+- [Self-healing builds](./self-healing.md) — hand a failure to an AI fixer that re-runs the command to verify.
 - [Using Zuke in a Node/npm project](./node-projects.md) — drive a Node build with Deno.
 - [CLI reference](./cli.md) — commands and flags.
 - [Programmatic API](./programmatic-api.md) — drive Zuke from your own code.

--- a/docs/ai-review.md
+++ b/docs/ai-review.md
@@ -148,8 +148,10 @@ outage isn't a silent skip either.
   — or re-pay — when the diff is unchanged.
 - `.budget(budget(...))` caps spend by an exact token count across all reviewers
   and fixers sharing it (a USD cap is opt-in, from prices you supply);
-  `.cache(aiCache(...))` reuses a prior verdict for an identical review. Once the
-  budget is spent, the review is skipped (not failed) with a note. See
+  `.cache(aiCache(...))` reuses a prior verdict for an identical review (same
+  provider, model, and diff), with a 7-day default TTL — see
+  [Caching → AI response cache](./caching.md#ai-response-cache). Once the budget
+  is spent, the review is skipped (not failed) with a note. See
   [Cost controls and learning](./self-healing.md#cost-controls-and-learning).
 - `.suppress(suppressions(...))` hides findings you've dismissed as false
   positives, matched by the stable ID shown next to each finding in the report. A

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -29,6 +29,8 @@ body, which is required before the target can run.
 | `.retry(times, delayMs?)`   | `(times: number, delayMs?: number) => this`           | Retry the body on failure, optionally pausing between.   |
 | `.validateBefore(...v)`     | `(...v: Validation[]) => this`                        | Run checks before the body; a throw skips it and fails.  |
 | `.validateAfter(...v)`      | `(...v: Validation[]) => this`                        | Run checks after a successful body; a throw fails it.    |
+| `.recoverWith(...r)`        | `(...r: Remediation[]) => this`                       | On failure, hand it to a remediation that can re-run the body ([self-healing](./self-healing.md)). |
+| `.recoverAttempts(n)`       | `(n: number) => this`                                 | Bound how many fix-then-rerun cycles are tried (default 1). |
 
 `dependsOn` pulls targets into the plan; `before`/`after` only reorder targets
 that are _already_ in the plan — they never pull new targets in.
@@ -145,9 +147,14 @@ compile = target()
 ```
 
 Fingerprints live in `<repo root>/.zuke/cache.json` (git-ignored). A target with
-no inputs always runs. Pass `--no-cache` (or `execute(..., { cache: false })`)
-to ignore the cache and rebuild everything. A skipped/cached target counts as
-satisfied, so its dependents still run.
+no inputs (and no cache keys) always runs. Pass `--no-cache` (or
+`execute(..., { cache: false })`) to ignore the cache and rebuild everything. A
+skipped/cached target counts as satisfied, so its dependents still run.
+
+See the dedicated **[Caching](./caching.md)** page for the full picture — the
+fingerprint algorithm, how adding or removing a file invalidates a target, the
+`.cacheKey()` non-file input, the store's corrupt-file tolerance, and the
+separate AI response cache.
 
 ### Conditional execution — `.onlyWhen()`
 
@@ -222,6 +229,10 @@ format = target().executes(async () => {
 });
 ```
 
+To match a pattern without touching the filesystem, `globToRegExp(pattern)`
+compiles the same syntax to a `RegExp` — handy for filtering an in-memory list
+of paths.
+
 ### Dry runs — `--dry-run`
 
 `zuke <target> --dry-run` resolves and prints every target that **would** run —
@@ -244,6 +255,48 @@ import { assert, assertExists, assertFileExists } from "jsr:@zuke/core";
 const token = assertExists(Deno.env.get("TOKEN"), "TOKEN is required");
 assert(this.environment.value !== "", "environment must be set");
 await assertFileExists("dist/app.js");
+```
+
+### Filesystem — `FileTasks`
+
+`FileTasks` groups the filesystem operations a `clean`/`package` target reaches
+for — create, clean, remove, copy, move a path, and read/write its contents — as
+a namespaced task object in the same shape as the [tool wrappers](./tools.md).
+Unlike the CLI wrappers it runs no subprocess, so each method takes direct
+arguments rather than a settings-lambda. Paths are [`PathLike`](./paths.md), so an
+`absolutePath(...)` or a plain string both work.
+
+```ts
+import { FileTasks } from "jsr:@zuke/core";
+
+await FileTasks.cleanDirectory("dist"); // empty it if it exists
+await FileTasks.createDirectory("dist/assets"); // mkdir -p
+await FileTasks.copy("static", "dist/static"); // recursive
+```
+
+| Method | Purpose |
+| --- | --- |
+| `exists(path)` | Whether `path` exists. |
+| `createDirectory(path, { recursive? })` | Create a directory; parents by default (`recursive: true`). A recursive create over an existing directory is a no-op. |
+| `cleanDirectory(path)` | Empty a directory, leaving it in place. A no-op if `path` is missing (it is _not_ created). |
+| `remove(path, { recursive? })` | Delete `path`, tolerating a missing target like `rm -f`. Returns `true` if something was removed, `false` if it was already absent. Pass `recursive: true` to remove a non-empty directory. |
+| `copy(source, dest, { overwrite? })` | Copy a file or directory tree (recursive). `overwrite` defaults to `true`. |
+| `move(source, dest)` | Move (rename) a path. |
+| `readText(path)` | Read a file's UTF-8 content. |
+| `writeText(path, content)` | Write a file, creating or truncating it. |
+| `readJson<T>(path)` | Read and `JSON.parse` a file, typed as `T`. |
+| `homeDirectory()` | The current user's home directory (`$HOME`, or `$USERPROFILE` on Windows); throws a clear error if neither is set. |
+
+The mutating operations are deliberately **missing-target-tolerant**, so the
+common `clean`/`package` sequence stays idempotent: `cleanDirectory` and
+`remove` no-op on an absent path instead of throwing, and a recursive
+`createDirectory` is safe to call repeatedly.
+
+```ts
+clean = target().executes(async () => {
+  await FileTasks.remove("dist", { recursive: true }); // gone or already gone
+  await FileTasks.createDirectory("dist");
+});
 ```
 
 ### HTTP — `httpDownload()` / `httpText()` / `httpJson()`

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -1,0 +1,182 @@
+# Caching
+
+Zuke has **two independent caches**, and they solve different problems. Reach for
+whichever matches what you're trying to avoid re-doing:
+
+| Cache | What it skips | Where it lives | Opt in with |
+| --- | --- | --- | --- |
+| **Incremental build cache** | Re-running a target whose inputs are unchanged | `<repo root>/.zuke/cache.json` | `.inputs()` (and/or `.cacheKey()`) on a target |
+| **AI response cache** | Re-paying a model for an identical review/fix call | `<repo root>/.zuke/ai-cache/` | `.cache(aiCache(...))` on a reviewer or fixer |
+
+Both are file-backed, git-ignored, dependency-free, and **best-effort**: a
+missing or corrupt store is treated as empty (everything just rebuilds), so a
+broken cache never breaks a build.
+
+## Incremental build cache
+
+A target that declares **inputs** becomes _incremental_. Before running it, Zuke
+fingerprints the declared inputs; if the fingerprint matches the last successful
+run **and** every declared output still exists, the target is **skipped** and
+reported `cached`. Otherwise it runs and its fingerprint is refreshed.
+
+```ts
+compile = target()
+  .inputs("src", "deno.json") // re-run only when these change…
+  .outputs("dist") // …or when dist is missing
+  .executes(async () => {
+    await DenoTasks.run((s) => s.script("build.ts"));
+  });
+```
+
+### What "unchanged" means
+
+The fingerprint is a **SHA-256** computed with the built-in Web Crypto API — no
+dependency:
+
+- A **file** hashes to the SHA-256 of its contents.
+- A **directory** hashes to the SHA-256 of its sorted `name:hash` entries,
+  **recursively** — so a change anywhere in the tree changes the result, but
+  reordering the filesystem does not (entries are sorted first).
+- A **missing** path hashes to a sentinel, so a file's **appearance or removal**
+  invalidates the cache just as an edit does. Renaming, adding, or deleting an
+  input file all force a rebuild.
+
+Inputs are combined in **declaration order**, so the same files always produce
+the same fingerprint (deterministic across machines and runs).
+
+### Outputs guard the cache
+
+`.outputs(...)` lists the files or directories the target produces. A cache hit
+**also** requires every declared output to still exist — so deleting `dist/`
+(or any declared output) forces a rebuild even when the inputs are untouched.
+Outputs are optional; a target with inputs but no outputs is cached purely on
+its input fingerprint.
+
+### Non-file inputs — `.cacheKey()`
+
+Not every input is a file. `.cacheKey(fn)` folds an extra value — a parameter, a
+tool version, a git commit — into the fingerprint, so the target also rebuilds
+when that value changes. The function may be async and is repeatable.
+
+```ts
+compile = target()
+  .inputs("src")
+  .cacheKey(() => this.configuration.value) // rebuild when the config flips
+  .cacheKey(() => Deno.version.deno) // …or the toolchain moves
+  .executes(/* … */);
+```
+
+A `.cacheKey()` **on its own makes a target cacheable** — you don't need
+`.inputs()` for it to take effect. A target that declares neither inputs nor
+cache keys is never cached and always runs.
+
+### The store
+
+Fingerprints persist in `<repo root>/.zuke/cache.json` (git-ignored). A few
+details worth knowing:
+
+- The file is created **only when the build has at least one cacheable target**.
+  A build with no `.inputs()`/`.cacheKey()` anywhere never opens or writes it.
+- A **corrupt or hand-edited** `cache.json` is tolerated: if it can't be parsed,
+  Zuke treats it as empty and everything rebuilds — it never errors on a bad
+  store.
+- The store is only rewritten when a fingerprint actually changed, so an
+  all-cached run touches no files.
+
+### Interaction with the rest of the build
+
+- A **cached (or condition-skipped) target counts as satisfied**, so its
+  dependents still run. Caching a target doesn't strand what depends on it.
+- The fingerprint is recorded **only after a successful run** — a failed target
+  is never marked up-to-date.
+- **`--no-cache`** (or `execute(..., { cache: false })`) ignores the cache
+  entirely and re-runs every target.
+- **`--dry-run`** never reads or writes the cache: it prints the plan without
+  running any body, so it can't invalidate or refresh a fingerprint.
+
+See the CLI's [Incremental builds](./cli.md#incremental-builds) section and the
+[`.inputs()`/`.outputs()`](./authoring.md#incremental-caching-inputs--outputs)
+authoring reference for the same feature from those angles.
+
+## AI response cache
+
+An [AI review](./ai-review.md) or [fix](./self-healing.md) call is expensive: it
+spends tokens and round-trips to a provider. Yet the **same** call often runs
+again and again — a flaky CI retry, a re-pushed branch, a local loop over an
+unchanged diff. `aiCache(...)` persists each provider response so an **identical**
+call reuses the stored answer instead of paying for the model again.
+
+```ts
+import { aiCache, securityReviewer } from "jsr:@zuke/ai";
+
+review = target()
+  .validateBefore(
+    securityReviewer((r) =>
+      r.provider("openai").apiKey(this.key)
+        .cache(aiCache((c) => c.dir(".zuke/ai-cache").ttl(86_400)))
+    ),
+  )
+  .executes(/* … */);
+```
+
+The same cache attaches to a [fixer](./self-healing.md) with `.cache(...)`:
+
+```ts
+test = target()
+  .executes(() => DenoTasks.test((s) => s.allowAll()))
+  .recoverWith(
+    aiFixer((f) =>
+      f.provider("openai").apiKey(this.key)
+        .cache(aiCache((c) => c.ttl(3_600)))
+    ),
+  );
+```
+
+### How a call is keyed
+
+An entry is keyed by a **stable hash of the call's salient parts** — the
+provider, the model, and the exact prompt (which, for a review, incorporates the
+diff). Change any of them and it's a different key, so a new diff or a swapped
+model is a natural miss. A cache **hit costs nothing** and does **not** draw down
+a [budget](./ai-review.md#scoping-the-diff-and-cost).
+
+### Configuring `aiCache`
+
+`aiCache((c) => …)` builds the cache inline. Every knob is optional:
+
+| Method | Effect |
+| --- | --- |
+| `.dir(path)` | Directory for the default file store (default `.zuke/ai-cache`). |
+| `.ttl(seconds)` | Entries older than this are ignored. **Default `604800` (7 days)**; `0` means never expire. |
+| `.disable()` | Turn the cache off programmatically — every read misses, every write is a no-op. |
+| `.store(custom)` | Inject a custom [`CacheStore`](#custom-stores) instead of the file store. |
+
+The cache is **opt-in per reviewer/fixer** — it does nothing until you attach it
+with `.cache(...)`. It is deliberately **best-effort**: a missing file, a corrupt
+or truncated entry, or a failed write is swallowed and treated as a miss, so a
+broken cache never breaks the build it caches for.
+
+### Custom stores
+
+The default backing store writes one JSON file per key under `.dir()`. Any object
+implementing `CacheStore` — `get(key)` / `set(key, entry)` — can replace it via
+`.store(...)`, which is how tests inject an in-memory store for a single run:
+
+```ts
+import { type CacheEntry, type CacheStore } from "jsr:@zuke/ai";
+
+const memory = new Map<string, CacheEntry>();
+const inMemory: CacheStore = {
+  get: (k) => Promise.resolve(memory.get(k)),
+  set: (k, e) => {
+    memory.set(k, e);
+    return Promise.resolve();
+  },
+};
+
+securityReviewer((r) => r.provider("openai").cache(aiCache((c) => c.store(inMemory))));
+```
+
+Caching pairs naturally with the other [cost controls](./ai-review.md#scoping-the-diff-and-cost)
+(`budget`, `maxDiffTokens`, a cheaper `model`) — see the AI review docs for the
+full picture.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -6,18 +6,26 @@
 | **Target**           | A named unit of work: a description, dependencies, and a body.        |
 | **Dependency graph** | A DAG derived from `.dependsOn(...)`. Cycles are an error.            |
 | **Plan**             | The requested target's transitive dependencies, topologically sorted. |
-| **Executor**         | Runs the plan sequentially, with timing and pass/fail reporting.      |
+| **Executor**         | Runs the plan (serially or in parallel), with timing and pass/fail reporting. |
 
 ## Execution semantics
 
 1. Instantiate the build class.
 2. Discover targets by property introspection.
-3. Build the dependency graph from `.dependsOn(...)`.
-4. **Validate:** an undefined/unknown dependency or a cycle fails fast (with the
+3. Resolve [parameters](./parameters.md) (flags → env → defaults) before any
+   target runs.
+4. Build the dependency graph from `.dependsOn(...)`.
+5. **Validate:** an undefined/unknown dependency or a cycle fails fast (with the
    offending path) and exits `1`.
-5. Compute the requested target's transitive closure.
-6. **Topologically sort** (honouring `before`/`after`); v0 runs
-   **sequentially**.
-7. Run each body. On throw, stop and report.
-8. Each target runs **at most once** per invocation — diamond dependencies
-   dedupe.
+6. Compute the requested target's transitive closure.
+7. **Topologically sort** (honouring `before`/`after`). Targets run one at a time
+   in deterministic order by default; [`--parallel`](./cli.md#parallel-execution)
+   (or a [`group()`](./authoring.md#group-and-partof)) runs independent targets
+   concurrently while still completing every dependency before its dependents.
+8. For each target, honour its `onlyWhen` conditions and the incremental
+   [cache](./caching.md): a target whose inputs are unchanged is skipped and
+   reported `cached`, without running its body.
+9. Run each body. On throw, stop and report (unless the target opted into
+   `.proceedAfterFailure()`).
+10. Each target runs **at most once** per invocation — diamond dependencies
+    dedupe.

--- a/docs/programmatic-api.md
+++ b/docs/programmatic-api.md
@@ -15,5 +15,75 @@ import {
 } from "jsr:@zuke/core";
 ```
 
-`execute` accepts `{ silent?, reporter?, skip? }`. Provide a custom `reporter`
-(`{ info(line), error(line) }`) to capture or redirect output.
+## `execute` options
+
+`execute(build, rootTarget, options?)` resolves parameters and runs the plan. The
+options object mirrors the CLI flags:
+
+| Option | Type | Effect |
+| --- | --- | --- |
+| `silent` | `boolean` | Suppress all banner/summary output. |
+| `reporter` | `{ info(line), error(line) }` | Custom output sink; overrides `silent`. |
+| `renderer` | `Renderer` | Restyle the per-target banners and summary (see below). |
+| `plugins` | `Plugin[]` | [Lifecycle observers](./extending.md) invoked alongside the build's hooks. |
+| `skip` | `string[]` | Target names to skip even if planned (`--skip`). |
+| `parallel` | `boolean \| number` | Run independent targets concurrently (`--parallel`). |
+| `cache` | `boolean \| BuildCache` | Incremental [caching](./caching.md); `false` disables it (`--no-cache`). |
+| `dryRun` | `boolean` | Print the plan without running any body (`--dry-run`). |
+| `params` | `Record<string, string>` | Raw [parameter](./parameters.md) values, keyed by property name. |
+
+`readEnv`, `prompt`, `github`, and `color` are additional test/CI seams — see the
+`ExecuteOptions` JSDoc for the full list.
+
+```ts
+import { discoverTargets, execute } from "jsr:@zuke/core";
+
+const build = new MyBuild();
+const target = discoverTargets(build).get("test");
+if (target) {
+  const result = await execute(build, target, { parallel: true, cache: false });
+  console.log(result.ok ? "green" : "red");
+}
+```
+
+`BuildResult` is `{ ok: boolean; executed: string[]; error?: unknown }`.
+
+## Inspecting the CLI shape — `describeCli`
+
+`describeCli(build)` returns a structured `CliDescription` of a build's whole
+command surface — its reserved commands, option flags, targets (with
+descriptions and dependencies), and [parameters](./parameters.md) — the same data
+that backs `zuke --help`, `zuke --list`, and `zuke --list --json`. Use it to
+build tooling around a build without shelling out or parsing `--help` text.
+
+```ts
+import { describeCli } from "jsr:@zuke/core";
+
+const cli = describeCli(new MyBuild());
+for (const t of cli.targets) console.log(t.name, "→", t.dependsOn.join(", "));
+```
+
+## Custom output — `Renderer`
+
+The per-target banners and the end-of-build summary are produced by a
+`Renderer`. Zuke ships `defaultRenderer`; pass your own (or
+[`@zuke/console`](./tools.md)'s alternative) via `execute(..., { renderer })` to
+restyle the output. A renderer receives each `TargetReport` and the `Style`
+palette, so custom rendering doesn't have to reimplement colour handling.
+
+```ts
+import { defaultRenderer, execute, type Renderer } from "jsr:@zuke/core";
+
+const quiet: Renderer = {
+  ...defaultRenderer,
+  // override only the hooks you want to change…
+};
+await execute(build, target, { renderer: quiet });
+```
+
+## Injecting a cache — `BuildCache`
+
+The `cache` option normally takes a boolean, but it also accepts a `BuildCache`
+instance directly. This is mainly a test seam: supply an in-memory or
+pre-seeded [cache](./caching.md) so a run's cache behaviour is deterministic
+without touching `.zuke/cache.json`.

--- a/docs/self-healing.md
+++ b/docs/self-healing.md
@@ -222,6 +222,10 @@ const cache = aiCache((c) => c.dir(".zuke/ai-cache").ttl(86_400)); // 1-day TTL
 aiFixer((f) => f.provider("openai").apiKey(this.key).cache(cache));
 ```
 
+The TTL defaults to 7 days (`0` never expires) and the store is best-effort — see
+[Caching → AI response cache](./caching.md#ai-response-cache) for the full
+behaviour, the `.disable()`/`.store()` knobs, and custom stores.
+
 ### Learned false-positive suppression (review)
 
 `suppressions(...)` hides reviewer findings whose **stable ID** you've dismissed.


### PR DESCRIPTION
Add docs/caching.md covering both caching systems as first-class topics:
the incremental build cache (fingerprint algorithm, add/remove
invalidation, cacheKey non-file inputs, outputs guard, store location and
corrupt-store tolerance, --no-cache/--dry-run) and the AI response cache
(keying, TTL default and semantics, best-effort behaviour, configurators,
custom stores).

Also close the surrounding gaps surfaced while auditing coverage:

- Link caching, parameters, self-healing, and ai-review from the docs
  index and the root README (previously unlinked or missing).
- Document FileTasks (the filesystem task object) in the authoring guide.
- Rewrite the programmatic API page: correct the stale execute options
  table and add describeCli, custom renderers, and BuildCache injection.
- Note globToRegExp alongside glob, and add recoverWith/recoverAttempts
  to the target method table.
- Refresh concepts execution semantics (parameters, parallel, caching)
  which still described the sequential-only v0 model.
- Cross-link the AI response cache from ai-review and self-healing.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01V2AAHqhumt9Bgp9oMPPJPx