### PR TITLE
feat(core): distributed caching, affected-target execution, and CI job fan-out

### DIFF
--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -442,6 +442,41 @@ ci = cicd({
   and fails if they have drifted (use `zuke generate-ci --check` for a dedicated
   gate). `--dry-run` skips regeneration.
 
+#### Fanned-out jobs — one CI job per target
+
+Instead of one job that runs the whole build, `fanOut` turns **each target into
+its own CI job**, wired together with `needs:` edges that mirror the targets'
+`dependsOn`. Independent targets then run in parallel on the CI provider, and
+the build's own dependency graph shapes the workflow — something a hand-written
+YAML can't stay in sync with.
+
+```ts
+class CI extends Build {
+  lint = target().inputs("src").outputs("dist/lint").executes(/* … */);
+  test = target().dependsOn(this.lint).inputs("src").executes(/* … */);
+  build = target().dependsOn(this.lint).inputs("src").outputs("dist").executes(
+    /* … */
+  );
+
+  ci = cicd({
+    provider: "github",
+    fanOut: { env: { ZUKE_REMOTE_CACHE_DIR: "/mnt/zuke-cache" } },
+  });
+}
+```
+
+This emits a `lint` job and `test`/`build` jobs that each declare
+`needs: [lint]`, so they wait for `lint` and then run concurrently. Each job
+runs only its own target (`./zuke <target>`); its dependencies run in their own
+jobs, so pair fan-out with the [remote cache](./cli.md#remote-cache) (configured
+here via `env`) to restore their outputs instead of rebuilding them. Pass
+`fanOut: true` for the defaults, or `FanOutOptions` to set the per-job
+`command`, `setupSteps` (default: a checkout), `runsOn`, `env`, or
+`includeUnlisted`. The `pipeline` field still supplies the workflow-level
+`name`, `triggers`, `permissions`, and `concurrency`. Targets with no body, and
+`unlisted` ones, are omitted. `fanOutPipeline(targets, base, options)` exposes
+the same expansion directly.
+
 The model is a portable subset: a `run` step (a shell command) maps to every
 provider; a `uses` step (a GitHub Action) renders only for GitHub and is skipped
 elsewhere, since GitLab and Azure check out the repo automatically. `runsOn` is

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,19 +1,20 @@
 # CLI reference
 
-| Command                      | Behaviour                                                     |
-| ---------------------------- | ------------------------------------------------------------- |
-| `zuke <target>`              | Run the target and all its transitive dependencies, in order. |
-| `zuke <target> --skip <dep>` | Run the target but skip the named dependency (repeatable).    |
-| `zuke <target> --parallel`   | Run independent targets concurrently (`--parallel=N` caps it). |
-| `zuke <target> --no-cache`   | Ignore the incremental cache; re-run every target.            |
-| `zuke <target> --dry-run`    | Print the plan without executing any target body.             |
-| `zuke --list` / `-l`         | List all targets with descriptions and dependencies.          |
-| `zuke graph`                 | Print the dependency graph (`target → deps`).                 |
-| `zuke graph --output=html`   | Render an interactive HTML graph into `.zuke/` and open it.   |
-| `zuke completions print <shell>` | Print a shell-completion script (`bash`, `zsh`, or `fish`). |
-| `zuke completions install <shell>` | Write the script and wire it into the shell's startup. |
-| `zuke --help` / `-h`         | Usage.                                                        |
-| `zuke` (no target)           | Run the `default` target if defined, else print `--list`.     |
+| Command                             | Behaviour                                                      |
+| ----------------------------------- | -------------------------------------------------------------- |
+| `zuke <target>`                     | Run the target and all its transitive dependencies, in order.  |
+| `zuke <target> --skip <dep>`        | Run the target but skip the named dependency (repeatable).     |
+| `zuke <target> --parallel`          | Run independent targets concurrently (`--parallel=N` caps it). |
+| `zuke <target> --no-cache`          | Ignore the incremental cache; re-run every target.             |
+| `zuke <target> --affected[=<base>]` | Run only targets affected by files changed since a git base.   |
+| `zuke <target> --dry-run`           | Print the plan without executing any target body.              |
+| `zuke --list` / `-l`                | List all targets with descriptions and dependencies.           |
+| `zuke graph`                        | Print the dependency graph (`target → deps`).                  |
+| `zuke graph --output=html`          | Render an interactive HTML graph into `.zuke/` and open it.    |
+| `zuke completions print <shell>`    | Print a shell-completion script (`bash`, `zsh`, or `fish`).    |
+| `zuke completions install <shell>`  | Write the script and wire it into the shell's startup.         |
+| `zuke --help` / `-h`                | Usage.                                                         |
+| `zuke` (no target)                  | Run the `default` target if defined, else print `--list`.      |
 
 (Read `zuke` as `deno run -A zuke.ts` until the launcher binary ships.)
 
@@ -36,10 +37,10 @@ Targets in a [`group()`](./authoring.md#group-and-partof) are drawn inside a
 labelled box (a Cytoscape compound node); the text listing tags them
 `[group: name]`.
 
-| Option          | Behaviour                                                   |
-| --------------- | ----------------------------------------------------------- |
-| `--output=html` | Render the interactive HTML page instead of terminal text.  |
-| `--no-open`     | With `--output=html`, write the file without opening it.    |
+| Option          | Behaviour                                                  |
+| --------------- | ---------------------------------------------------------- |
+| `--output=html` | Render the interactive HTML page instead of terminal text. |
+| `--no-open`     | With `--output=html`, write the file without opening it.   |
 
 `graph` is a reserved command name: a target called `graph` can't be run by
 name.
@@ -84,43 +85,68 @@ called `completions` can't be run by name.
 to a file under your config directory and makes the shell load it on the next
 start — no manual `source` step.
 
-- **bash** → writes `~/.config/zuke/completions/zuke.bash` and appends a `source`
-  line to `~/.bashrc`.
+- **bash** → writes `~/.config/zuke/completions/zuke.bash` and appends a
+  `source` line to `~/.bashrc`.
 - **zsh** → writes `~/.config/zuke/completions/zuke.zsh` and appends a `source`
   line to `~/.zshrc`.
 - **fish** → writes `~/.config/fish/completions/zuke.fish`, which fish loads
   automatically (no rc edit).
 
-The config directory honours `$XDG_CONFIG_HOME`. Installing is idempotent: if the
-rc file already sources the script, it is left untouched. The reserved commands
-and option flags offered by completion come from a single registry shared with
-the parser and `--help`, so they never drift out of sync.
+The config directory honours `$XDG_CONFIG_HOME`. Installing is idempotent: if
+the rc file already sources the script, it is left untouched. The reserved
+commands and option flags offered by completion come from a single registry
+shared with the parser and `--help`, so they never drift out of sync.
 
 ## Parallel execution
 
-By default targets run one at a time in a deterministic order. `--parallel`
-runs independent targets concurrently while still completing every dependency
-before its dependents; `--parallel=N` caps the number in flight (the default is
-the host's CPU count). Each target's banner block is buffered and flushed as a
-unit, so concurrent runs don't interleave their headers (a target's own
-subprocess output may still interleave, as with `make -j`). The first failure
-stops new launches; targets already running finish, and the rest are reported
-as skipped. The build summary stays in declaration order regardless.
+By default targets run one at a time in a deterministic order. `--parallel` runs
+independent targets concurrently while still completing every dependency before
+its dependents; `--parallel=N` caps the number in flight (the default is the
+host's CPU count). Each target's banner block is buffered and flushed as a unit,
+so concurrent runs don't interleave their headers (a target's own subprocess
+output may still interleave, as with `make -j`). The first failure stops new
+launches; targets already running finish, and the rest are reported as skipped.
+The build summary stays in declaration order regardless.
 
-Programmatic callers get the same behaviour via `execute(build, target, { parallel: true })`
-(or a number) — see the [programmatic API](./programmatic-api.md).
+Programmatic callers get the same behaviour via
+`execute(build, target, { parallel: true })` (or a number) — see the
+[programmatic API](./programmatic-api.md).
 
-For parallelism scoped to specific targets rather than the whole build, put
-them in a [`group()`](./authoring.md#group-and-partof) with `.partOf(...)` — the
+For parallelism scoped to specific targets rather than the whole build, put them
+in a [`group()`](./authoring.md#group-and-partof) with `.partOf(...)` — the
 group's members run concurrently even without `--parallel`.
 
 ## Incremental builds
 
-Targets that declare [`.inputs()`](./authoring.md#incremental-caching-inputs--outputs)
-are cached: Zuke skips one (showing it `cached` in the summary) when its inputs
-are unchanged since the last successful run and its outputs still exist.
+Targets that declare
+[`.inputs()`](./authoring.md#incremental-caching-inputs--outputs) are cached:
+Zuke skips one (showing it `cached` in the summary) when its inputs are
+unchanged since the last successful run and its outputs still exist.
 Fingerprints live in `.zuke/cache.json`. `--no-cache` ignores the cache and
 re-runs everything.
+
+## Affected targets
+
+`--affected` restricts a run to the targets that a set of file changes can reach
+— the monorepo-scale complement to the incremental cache. Zuke asks git for the
+files changed since a base revision and keeps only the **affected** targets; the
+rest are skipped (their prior outputs are assumed current, so a skipped
+dependency still unblocks its dependents).
+
+```sh
+zuke ci --affected                 # vs HEAD (uncommitted changes)
+zuke ci --affected=origin/main     # vs a base branch — the usual CI form
+```
+
+A target is affected when a changed file falls inside one of its declared
+[`.inputs()`](./authoring.md#incremental-caching-inputs--outputs), **or** when
+any of its dependencies is affected (affectedness flows downstream along
+`dependsOn` and `triggers`). A target that declares **no** inputs can't be
+proven unaffected, so it is always run — declare `inputs` on the targets you
+want `--affected` to be able to skip. The base defaults to `HEAD`; pass
+`--affected=<ref>` for any git revision (e.g. `origin/main`, a tag, or `main...`
+for a merge-base comparison). Programmatic callers pass `{ affected: { base } }`
+to `execute`, optionally with a `changedFiles` seam in place of git.
 
 ## Dry runs
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -175,6 +175,14 @@ both.
 > **Note:** archive entry names use the POSIX `ustar` format (a 100-byte path
 > limit), so extremely deep output paths are rejected with a clear error.
 
+**Security.** The store URL and token are trusted configuration — outputs are
+uploaded there and archives are extracted from it — so point them only at a
+cache you control (a secret parameter or env var, not a hard-coded value), and
+on CI restrict egress to the cache host so an overridden URL can't exfiltrate
+artifacts. Restore is hardened against a poisoned store: an archive entry with
+an absolute path or one containing `..` is rejected before any file is written,
+so nothing lands outside the workspace.
+
 ## Affected targets
 
 `--affected` restricts a run to the targets that a set of file changes can reach

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -125,6 +125,56 @@ unchanged since the last successful run and its outputs still exist.
 Fingerprints live in `.zuke/cache.json`. `--no-cache` ignores the cache and
 re-runs everything.
 
+## Remote cache
+
+The incremental cache is local. A **remote cache** shares a target's built
+[`.outputs()`](./authoring.md#incremental-caching-inputs--outputs) across
+machines: on a local miss, Zuke **restores** the outputs from the store instead
+of rebuilding them; after a successful run it **uploads** them for the next
+machine. It applies to targets that declare both `inputs` and `outputs`, and is
+keyed by the same input fingerprint the local cache uses. A store outage is
+never fatal — Zuke logs a warning and falls back to a local rebuild.
+
+Two dependency-free backends ship, behind one `RemoteCacheStore` interface:
+
+- **`FileSystemCacheStore`** — a shared or mounted directory (an NFS mount, a CI
+  volume). Archives are `<dir>/<key>.tar.gz`.
+- **`HttpCacheStore`** — `GET`/`PUT <url>/<key>` with an optional bearer token.
+  Works with any object store or cache server behind a URL (an S3/GCS/R2 bucket,
+  or a self-hosted endpoint).
+
+Declare one in code with a typed `remoteCache()` override:
+
+```ts
+import { Build, HttpCacheStore, parameter, target } from "jsr:@zuke/core";
+
+class CI extends Build {
+  cacheToken = parameter("Cache auth token").secret().env("CACHE_TOKEN");
+  override remoteCache() {
+    return new HttpCacheStore({
+      url: "https://cache.example.com",
+      token: this.cacheToken.value,
+    });
+  }
+  build = target().inputs("src").outputs("dist").executes(/* … */);
+}
+```
+
+Or configure it from the environment (no build-file change) — handy for CI:
+
+```sh
+ZUKE_REMOTE_CACHE_URL=https://cache.example.com ZUKE_REMOTE_CACHE_TOKEN=… ./zuke ci
+ZUKE_REMOTE_CACHE_DIR=/mnt/zuke-cache ./zuke ci     # filesystem backend
+```
+
+Precedence is: an explicit `execute({ remoteCache })` option, then the build's
+`remoteCache()` override, then the `ZUKE_REMOTE_CACHE_*` environment variables.
+`--no-remote-cache` uses the local cache only for a run; `--no-cache` disables
+both.
+
+> **Note:** archive entry names use the POSIX `ustar` format (a 100-byte path
+> limit), so extremely deep output paths are rejected with a clear error.
+
 ## Affected targets
 
 `--affected` restricts a run to the targets that a set of file changes can reach

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -181,6 +181,20 @@ async function extractTarGzip(src: PathLike, destDir: PathLike): Promise<void>
 function fail(message: string): never
   Throw an {@link AssertionError} with `message`. Never returns.
 
+function fanOutPipeline(targets: Map<string, TargetBuilder>, base: CiPipeline, options: FanOutOptions): CiPipeline
+  Expand a build's target graph into a fanned-out pipeline: one CI job per
+  runnable target, wired together with `needs:` edges that mirror the targets'
+  `dependsOn` dependencies — so independent targets run in parallel and a
+  target's job waits for its prerequisites. Each job runs just its own target;
+  upstream outputs are shared through the {@link "./remote_cache.ts" | remote
+  cache}, so configure one (e.g. `ZUKE_REMOTE_CACHE_*` on the jobs) to avoid
+  rebuilding dependencies in every job.
+
+  `base` contributes the pipeline-level fields (name, triggers, permissions,
+  concurrency); its `jobs` are ignored in favour of the generated ones. Targets
+  with no body, and (unless {@link FanOutOptions.includeUnlisted}) `unlisted`
+  targets, are omitted, and `needs` edges to omitted targets are dropped.
+
 function findCycle(targets: Map<string, TargetBuilder>): string[] | null
   Detect a cycle in the hard-dependency (`dependsOn`) graph across all targets.
 
@@ -474,9 +488,14 @@ class CiFile
   readonly path: string
     The output path.
   readonly pipeline: CiPipeline
-    The pipeline this file renders.
+    The base pipeline (pipeline-level fields, and the jobs unless fanning out).
+  readonly fanOut?: FanOutOptions
+    Fan-out options, when this file expands the build's targets into jobs.
+  pipelineFor(targets: Map<string, TargetBuilder>): CiPipeline
+    The pipeline this file renders. With fan-out, the build's `targets` are
+    expanded into one job per target; otherwise the declared {@link pipeline}.
   render(): string
-    Render the file's YAML content.
+    Render the file's YAML content (the base pipeline; fan-out is resolved at discovery).
 
 class DiscordAnnouncementSettings extends AnnouncementSettings
   Fluent settings for {@link AnnounceTasksApi.discord}. Bot mode
@@ -893,6 +912,11 @@ interface CiFileSpec
     `.gitlab-ci.yml`, or `azure-pipelines.yml`).
   pipeline?: CiPipeline
     The pipeline to render. Defaults to a single `build` job that runs the build.
+  fanOut?: boolean | FanOutOptions
+    Fan the build's targets out into one CI job per target, wired by their
+    dependencies (see {@link fanOutPipeline}). `true` uses the defaults; pass
+    {@link FanOutOptions} to customise. When set, {@link pipeline} supplies the
+    pipeline-level fields (name, triggers, …) and its `jobs` are ignored.
 
 interface CiJob
   A job: a named unit of work with steps, optionally fanned out by a matrix.
@@ -1095,6 +1119,27 @@ interface ExecuteOptions
     Renderer for the per-target banners and the end-of-build summary. Defaults
     to Zuke's built-in {@link defaultRenderer}; `@zuke/console` exports an
     alternative a build can inject to restyle its output.
+
+interface FanOutOptions
+  Options for {@link fanOutPipeline}: how a build's targets become parallel CI
+  jobs.
+
+  command?: (target: string) => string
+    The command a job runs for its target, given the target name. Defaults to
+    the `./zuke <target>` launcher (which bootstraps Deno). Each job runs only
+    its own target; its dependencies run in their own jobs and are shared via
+    the {@link "./remote_cache.ts" | remote cache}, so pair fan-out with one.
+  setupSteps?: CiStep[]
+    Steps prepended to every job — checkout, tool setup, cache restore. Defaults
+    to a single `actions/checkout` (rendered on GitHub; GitLab and Azure check
+    out automatically). Provide `env` for `ZUKE_REMOTE_CACHE_*` here or via
+    {@link env}.
+  runsOn?: string
+    The runner for every job (see {@link CiJob.runsOn}).
+  includeUnlisted?: boolean
+    Include targets hidden from `--list` via `.unlisted()`. Defaults to false.
+  env?: Record<string, string>
+    Environment variables set on every job (e.g. the remote-cache config).
 
 interface FileTasksApi
   The shape of {@link FileTasks}.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -62,6 +62,9 @@ function affectedTargets(order: readonly TargetBuilder[], changed: readonly stri
   affected), when a dependency is affected, or when an affected target triggers
   it.
 
+async function archiveOutputs(outputs: readonly string[], host: OutputHost): Promise<Uint8Array>
+  Archive a target's `outputs` into a gzipped tar of their current contents.
+
 function assert(condition: unknown, message: string): asserts condition
   Assert that `condition` is truthy, narrowing it for the rest of the scope.
   Throws an {@link AssertionError} with `message` otherwise.
@@ -148,6 +151,12 @@ function discoverTargets(build: Build): Map<string, TargetBuilder>
   @throws
       if two properties reference the same builder instance under different
       names (a programming error that would corrupt naming).
+
+function envCacheStore(readEnv: (name: string) => string | undefined): RemoteCacheStore | undefined
+  Resolve a {@link RemoteCacheStore} from the environment, or `undefined` when
+  none is configured. `ZUKE_REMOTE_CACHE_URL` (with an optional
+  `ZUKE_REMOTE_CACHE_TOKEN`) selects an {@link HttpCacheStore}; otherwise
+  `ZUKE_REMOTE_CACHE_DIR` selects a {@link FileSystemCacheStore}.
 
 function envVarName(name: string): string
   The environment variable for a parameter: its path in SCREAMING_SNAKE_CASE.
@@ -256,6 +265,10 @@ function plan(root: TargetBuilder): TargetBuilder[]
       if the planned graph contains a cycle (which can happen
       via soft edges even when the hard graph is acyclic).
 
+function remoteCacheKey(name: string, fingerprint: string): string
+  The store key for a target's outputs: its name and input `fingerprint`. The
+  name is sanitised so the key is safe as a filename and a URL path segment.
+
 function repoRoot(...segments: string[]): AbsolutePath
   The absolute path of the repository root — the directory containing
   {@link CONFIG_FILE} — with any `segments` appended. The returned value is an
@@ -272,6 +285,16 @@ function repoRoot(...segments: string[]): AbsolutePath
 
   @throws
       if no {@link CONFIG_FILE} is found in the cwd or any ancestor.
+
+function resolveRemoteStore(option: RemoteCacheStore | false | undefined, declared: RemoteCacheStore | undefined, readEnv: (name: string) => string | undefined): RemoteCacheStore | undefined
+  Pick the remote store for a run by precedence: an explicit `option` wins
+  (`false` disables the remote cache entirely), then a `declared` store (a
+  build's `remoteCache()` override), then the {@link envCacheStore} environment
+  fallback.
+
+async function restoreOutputs(artifact: Uint8Array, host: OutputHost): Promise<string[]>
+  Restore the files in `artifact` (a gzipped tar produced by
+  {@link archiveOutputs}) to disk, returning the paths written.
 
 async function run(BuildClass: new () => Build, options: RunOptions): Promise<void>
   Public entry point. Instantiate the build, parse arguments, run, and set the
@@ -424,6 +447,22 @@ class Build
       lint = target().executes(() => DenoTasks.lint()); // healed globally
     }
     ```
+  remoteCache(): RemoteCacheStore | undefined
+    The {@link "./remote_cache.ts".RemoteCacheStore} that shares target
+    {@link "./target.ts".TargetBuilder.outputs} across machines. Override to
+    declare one in code; the default is none, and — unless overridden — the
+    executor falls back to {@link "./remote_cache.ts".envCacheStore} (the
+    `ZUKE_REMOTE_CACHE_*` environment variables). Applies to targets that
+    declare both `inputs` and `outputs`.
+
+    ```ts
+    class CI extends Build {
+      override remoteCache() {
+        return new HttpCacheStore({ url: this.cacheUrl.value, token: this.cacheToken.value });
+      }
+      build = target().inputs("src").outputs("dist").executes(...);
+    }
+    ```
 
 class CiFile
   A declared CI file. Assign one (via {@link cicd}) to a build field and Zuke
@@ -446,6 +485,17 @@ class DiscordAnnouncementSettings extends AnnouncementSettings
   override protected payload(): Record<string, unknown>
   override protected sendBot(): Promise<void>
 
+class FileSystemCacheStore implements RemoteCacheStore
+  A {@link RemoteCacheStore} backed by a shared or mounted directory.
+
+  constructor(dir: string)
+
+    @param dir
+        The directory archives are read from and written to.
+
+  get(key: string): Promise<Uint8Array | null>
+  async put(key: string, artifact: Uint8Array): Promise<void>
+
 class GraphError extends Error
   Raised when the build graph is invalid (cycle or unknown dependency).
 
@@ -462,6 +512,16 @@ class Group
     Members that declared themselves part of this group, in declaration order.
   name_?: string
     Property name, assigned during discovery. Undefined until then.
+
+class HttpCacheStore implements RemoteCacheStore
+  A {@link RemoteCacheStore} backed by HTTP: `GET <url>/<key>` fetches an
+  artifact (a `404` means a miss) and `PUT <url>/<key>` stores one. Works with
+  any object store or cache server that speaks plain HTTP GET/PUT — an S3, GCS,
+  or R2 bucket behind a URL, or a self-hosted cache endpoint.
+
+  constructor(options: HttpCacheStoreOptions)
+  async get(key: string): Promise<Uint8Array | null>
+  async put(key: string, artifact: Uint8Array): Promise<void>
 
 class HttpError extends Error
   Raised when an HTTP request returns a non-2xx status.
@@ -995,6 +1055,13 @@ interface ExecuteOptions
     are unchanged since the last successful run (and whose outputs still exist).
     Defaults to on; pass `false` to disable (CLI `--no-cache`). A {@link
     BuildCache} may be supplied directly (used in tests).
+  remoteCache?: RemoteCacheStore | false
+    A {@link RemoteCacheStore} that shares target {@link TargetBuilder.outputs}
+    across machines: a local cache miss restores outputs from it, and a
+    successful run uploads them. `false` disables it (CLI `--no-remote-cache`).
+    When omitted, the build's `remoteCache()` override is used, falling back to
+    the `ZUKE_REMOTE_CACHE_*` environment variables. Ignored when `cache` is a
+    supplied {@link BuildCache} or is `false`.
   params?: Record<string, string>
     Raw parameter values from the command line, keyed by parameter (property)
     name. Each declared {@link Parameter} is resolved from this map, then the
@@ -1073,6 +1140,16 @@ interface GlobOptions
   cwd?: string
     Directory to resolve the pattern against (default: `Deno.cwd()`).
 
+interface HttpCacheStoreOptions
+  Configuration for an {@link HttpCacheStore}.
+
+  url: string
+    The base URL keys are appended to (any trailing slash is ignored).
+  token?: string
+    A bearer token sent as `Authorization: Bearer <token>`, if set.
+  fetch?: typeof fetch
+    The `fetch` implementation; defaults to the global. Overridable for tests.
+
 interface HttpOptions
   Options shared by the HTTP helpers.
 
@@ -1111,6 +1188,28 @@ interface InstallReleaseOptions
   download?: DownloadFn
     The download implementation. Defaults to {@link httpDownload}; override it
     to unit-test without network access.
+
+interface OpenCacheOptions
+  Optional extras for {@link openCache}: a remote store and a warning sink.
+
+  remote?: RemoteCacheStore
+    A {@link RemoteCacheStore} to restore outputs from (on a local miss) and
+    upload them to (after a successful run). Applies only to targets that
+    declare {@link TargetBuilder.outputs}.
+  warn?: (message: string) => void
+    Report a non-fatal remote-cache error (a get/put failure never fails the build).
+
+interface OutputHost
+  Filesystem effects used to archive and restore a target's outputs.
+
+  readFile(path: string): Promise<Uint8Array | null>
+    File contents, or `null` if the path does not exist.
+  stat(path: string): Promise<{ isDirectory: boolean; } | null>
+    Whether a path exists and is a directory, or `null` if it is missing.
+  readDir(path: string): Promise<string[]>
+    The entry names within a directory.
+  writeFile(path: string, bytes: Uint8Array): Promise<void>
+    Write a file, creating parent directories as needed.
 
 interface Plugin
   A lifecycle observer. Every hook is optional; implement only the ones you
@@ -1161,6 +1260,17 @@ interface RemediationResult
     explained the failure).
   summary?: string
     A one-line description of what was diagnosed or done, for diagnostics.
+
+interface RemoteCacheStore
+  A content-addressed store for archived target outputs, keyed by
+  {@link remoteCacheKey}. Both operations are best-effort from the build's
+  point of view: the executor never fails a build because the store is
+  unreachable — it just rebuilds and, where it can, re-uploads.
+
+  get(key: string): Promise<Uint8Array | null>
+    Fetch the archived outputs stored under `key`, or `null` if there are none.
+  put(key: string, artifact: Uint8Array): Promise<void>
+    Store `artifact` (a gzipped tar of a target's outputs) under `key`.
 
 interface RemoveOptions
   Options for {@link FileTasksApi.remove}.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -308,7 +308,10 @@ function resolveRemoteStore(option: RemoteCacheStore | false | undefined, declar
 
 async function restoreOutputs(artifact: Uint8Array, host: OutputHost): Promise<string[]>
   Restore the files in `artifact` (a gzipped tar produced by
-  {@link archiveOutputs}) to disk, returning the paths written.
+  {@link archiveOutputs}) to disk, returning the paths written. Entry names are
+  validated first: an absolute path or one escaping the workspace (`..`) is
+  rejected before anything is written, so a malicious archive can't plant files
+  outside the current directory.
 
 async function run(BuildClass: new () => Build, options: RunOptions): Promise<void>
   Public entry point. Instantiate the build, parse arguments, run, and set the
@@ -537,6 +540,14 @@ class HttpCacheStore implements RemoteCacheStore
   artifact (a `404` means a miss) and `PUT <url>/<key>` stores one. Works with
   any object store or cache server that speaks plain HTTP GET/PUT — an S3, GCS,
   or R2 bucket behind a URL, or a self-hosted cache endpoint.
+
+  Security. The `url` (and `token`) are trusted configuration: outputs are
+  uploaded to that host and archives are extracted from it, so point it only at
+  a cache you control, and prefer a {@link "./params.ts" | secret parameter} or
+  an environment variable over a hard-coded value. On CI, restrict egress to
+  the cache host so a misconfigured or overridden URL can't exfiltrate
+  artifacts. Restored archives are always confined to the workspace (see
+  {@link restoreOutputs}), so a poisoned store cannot write outside it.
 
   constructor(options: HttpCacheStoreOptions)
   async get(key: string): Promise<Uint8Array | null>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -52,6 +52,16 @@ function absolutePath(first: string, ...rest: string[]): AbsolutePath
   @param rest
       Additional segments to append.
 
+function affectedTargets(order: readonly TargetBuilder[], changed: readonly string[]): Set<TargetBuilder>
+  Compute the set of targets in `order` affected by the given `changed` files.
+
+  `order` must be a valid execution order (dependencies before dependents, as
+  produced by {@link plan}/{@link planGraph}) so each target's dependencies are
+  already decided when it is visited. A target is affected when its own inputs
+  cover a changed file, when it declares no inputs (unprovable — treated as
+  affected), when a dependency is affected, or when an affected target triggers
+  it.
+
 function assert(condition: unknown, message: string): asserts condition
   Assert that `condition` is truthy, narrowing it for the rest of the scope.
   Throws an {@link AssertionError} with `message` otherwise.
@@ -173,6 +183,12 @@ function generateCi(pipeline: CiPipeline, provider: CiProvider): string
   `.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, or
   `bitbucket-pipelines.yml`. The pipeline may be empty (`{}`) to accept every
   default.
+
+async function gitChangedFiles(base: string, run: (args: string[]) => Promise<string>): Promise<string[]>
+  List the files changed since `base` (default `HEAD`) via git: tracked changes
+  versus `base` plus untracked files not covered by `.gitignore`. `run` invokes
+  git and returns stdout (defaults to a real `git` subprocess); override it to
+  test without a repository.
 
 async function glob(pattern: string, options: GlobOptions): Promise<string[]>
   Expand a glob pattern to the matching paths, relative to `cwd`, sorted for
@@ -725,6 +741,14 @@ interface AbsolutePath
   toString(): string
     The normalised path string.
 
+interface AffectedOptions
+  Configure {@link ExecuteOptions.affected}: the base revision and diff seam.
+
+  base?: string
+    The git revision to diff against. Defaults to `HEAD` (uncommitted changes).
+  changedFiles?: ChangedFilesFn
+    How to list changed files. Defaults to {@link gitChangedFiles}.
+
 interface AnnounceTasksApi
   The shape of {@link AnnounceTasks}.
 
@@ -987,6 +1011,13 @@ interface ExecuteOptions
     Plan only: resolve and print every target that would run (honouring
     `--skip` and `onlyWhen` conditions) without executing any body or touching
     the cache (CLI `--dry-run`).
+  affected?: AffectedOptions
+    Restrict the run to the targets affected by files changed since a base git
+    revision (CLI `--affected[=<base>]`). A target is affected when a changed
+    file falls inside its declared {@link TargetBuilder.inputs} or a dependency
+    is affected; a target that declares no inputs is always considered affected.
+    Unaffected targets are skipped. The base revision defaults to `HEAD`; supply
+    `changedFiles` to inject the diff (used in tests).
   github?: boolean
     Force GitHub Actions output formatting on or off. Auto-detected from the
     `GITHUB_ACTIONS` environment variable when omitted.
@@ -1220,6 +1251,12 @@ interface ValidationContext
 type AnnouncementLevel = "success" | "failure" | "warning" | "info"
   The outcome an announcement conveys. It drives the accent colour and the icon
   prepended to the message; defaults to `"info"`.
+
+type ChangedFilesFn = (base: string) => Promise<string[]>
+  Lists the files changed since `base` (a git revision), each path relative to
+  the repository root. The seam behind {@link ExecuteOptions.affected}; defaults
+  to {@link gitChangedFiles} and is overridable so the affected plan can be
+  tested without a real git repository.
 
 type CiHost = "github" | "gitlab" | "azure" | "bitbucket" | "local"
   The CI host a build is running on, or `"local"` when not on CI. The names

--- a/llms.txt
+++ b/llms.txt
@@ -52,6 +52,7 @@ Option flags:
 - `--skip` — Skip the named dependency
 - `--parallel` — Run independent targets concurrently
 - `--no-cache` — Ignore the incremental cache
+- `--affected` — Run only targets affected by changes since a git base
 - `--dry-run` — Print the plan without running targets
 - `--output` — Graph output format: text or html
 - `--no-open` — With --output=html, do not open a browser

--- a/llms.txt
+++ b/llms.txt
@@ -52,6 +52,7 @@ Option flags:
 - `--skip` — Skip the named dependency
 - `--parallel` — Run independent targets concurrently
 - `--no-cache` — Ignore the incremental cache
+- `--no-remote-cache` — Use the local cache only; skip the remote cache store
 - `--affected` — Run only targets affected by changes since a git base
 - `--dry-run` — Print the plan without running targets
 - `--output` — Graph output format: text or html

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -235,6 +235,20 @@ async function extractTarGzip(src: PathLike, destDir: PathLike): Promise<void>
 function fail(message: string): never
   Throw an {@link AssertionError} with `message`. Never returns.
 
+function fanOutPipeline(targets: Map<string, TargetBuilder>, base: CiPipeline, options: FanOutOptions): CiPipeline
+  Expand a build's target graph into a fanned-out pipeline: one CI job per
+  runnable target, wired together with `needs:` edges that mirror the targets'
+  `dependsOn` dependencies — so independent targets run in parallel and a
+  target's job waits for its prerequisites. Each job runs just its own target;
+  upstream outputs are shared through the {@link "./remote_cache.ts" | remote
+  cache}, so configure one (e.g. `ZUKE_REMOTE_CACHE_*` on the jobs) to avoid
+  rebuilding dependencies in every job.
+
+  `base` contributes the pipeline-level fields (name, triggers, permissions,
+  concurrency); its `jobs` are ignored in favour of the generated ones. Targets
+  with no body, and (unless {@link FanOutOptions.includeUnlisted}) `unlisted`
+  targets, are omitted, and `needs` edges to omitted targets are dropped.
+
 function findCycle(targets: Map<string, TargetBuilder>): string[] | null
   Detect a cycle in the hard-dependency (`dependsOn`) graph across all targets.
 
@@ -528,9 +542,14 @@ class CiFile
   readonly path: string
     The output path.
   readonly pipeline: CiPipeline
-    The pipeline this file renders.
+    The base pipeline (pipeline-level fields, and the jobs unless fanning out).
+  readonly fanOut?: FanOutOptions
+    Fan-out options, when this file expands the build's targets into jobs.
+  pipelineFor(targets: Map<string, TargetBuilder>): CiPipeline
+    The pipeline this file renders. With fan-out, the build's `targets` are
+    expanded into one job per target; otherwise the declared {@link pipeline}.
   render(): string
-    Render the file's YAML content.
+    Render the file's YAML content (the base pipeline; fan-out is resolved at discovery).
 
 class DiscordAnnouncementSettings extends AnnouncementSettings
   Fluent settings for {@link AnnounceTasksApi.discord}. Bot mode
@@ -947,6 +966,11 @@ interface CiFileSpec
     `.gitlab-ci.yml`, or `azure-pipelines.yml`).
   pipeline?: CiPipeline
     The pipeline to render. Defaults to a single `build` job that runs the build.
+  fanOut?: boolean | FanOutOptions
+    Fan the build's targets out into one CI job per target, wired by their
+    dependencies (see {@link fanOutPipeline}). `true` uses the defaults; pass
+    {@link FanOutOptions} to customise. When set, {@link pipeline} supplies the
+    pipeline-level fields (name, triggers, …) and its `jobs` are ignored.
 
 interface CiJob
   A job: a named unit of work with steps, optionally fanned out by a matrix.
@@ -1149,6 +1173,27 @@ interface ExecuteOptions
     Renderer for the per-target banners and the end-of-build summary. Defaults
     to Zuke's built-in {@link defaultRenderer}; `@zuke/console` exports an
     alternative a build can inject to restyle its output.
+
+interface FanOutOptions
+  Options for {@link fanOutPipeline}: how a build's targets become parallel CI
+  jobs.
+
+  command?: (target: string) => string
+    The command a job runs for its target, given the target name. Defaults to
+    the `./zuke <target>` launcher (which bootstraps Deno). Each job runs only
+    its own target; its dependencies run in their own jobs and are shared via
+    the {@link "./remote_cache.ts" | remote cache}, so pair fan-out with one.
+  setupSteps?: CiStep[]
+    Steps prepended to every job — checkout, tool setup, cache restore. Defaults
+    to a single `actions/checkout` (rendered on GitHub; GitLab and Azure check
+    out automatically). Provide `env` for `ZUKE_REMOTE_CACHE_*` here or via
+    {@link env}.
+  runsOn?: string
+    The runner for every job (see {@link CiJob.runsOn}).
+  includeUnlisted?: boolean
+    Include targets hidden from `--list` via `.unlisted()`. Defaults to false.
+  env?: Record<string, string>
+    Environment variables set on every job (e.g. the remote-cache config).
 
 interface FileTasksApi
   The shape of {@link FileTasks}.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -362,7 +362,10 @@ function resolveRemoteStore(option: RemoteCacheStore | false | undefined, declar
 
 async function restoreOutputs(artifact: Uint8Array, host: OutputHost): Promise<string[]>
   Restore the files in `artifact` (a gzipped tar produced by
-  {@link archiveOutputs}) to disk, returning the paths written.
+  {@link archiveOutputs}) to disk, returning the paths written. Entry names are
+  validated first: an absolute path or one escaping the workspace (`..`) is
+  rejected before anything is written, so a malicious archive can't plant files
+  outside the current directory.
 
 async function run(BuildClass: new () => Build, options: RunOptions): Promise<void>
   Public entry point. Instantiate the build, parse arguments, run, and set the
@@ -591,6 +594,14 @@ class HttpCacheStore implements RemoteCacheStore
   artifact (a `404` means a miss) and `PUT <url>/<key>` stores one. Works with
   any object store or cache server that speaks plain HTTP GET/PUT — an S3, GCS,
   or R2 bucket behind a URL, or a self-hosted cache endpoint.
+
+  Security. The `url` (and `token`) are trusted configuration: outputs are
+  uploaded to that host and archives are extracted from it, so point it only at
+  a cache you control, and prefer a {@link "./params.ts" | secret parameter} or
+  an environment variable over a hard-coded value. On CI, restrict egress to
+  the cache host so a misconfigured or overridden URL can't exfiltrate
+  artifacts. Restored archives are always confined to the workspace (see
+  {@link restoreOutputs}), so a poisoned store cannot write outside it.
 
   constructor(options: HttpCacheStoreOptions)
   async get(key: string): Promise<Uint8Array | null>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -116,6 +116,9 @@ function affectedTargets(order: readonly TargetBuilder[], changed: readonly stri
   affected), when a dependency is affected, or when an affected target triggers
   it.
 
+async function archiveOutputs(outputs: readonly string[], host: OutputHost): Promise<Uint8Array>
+  Archive a target's `outputs` into a gzipped tar of their current contents.
+
 function assert(condition: unknown, message: string): asserts condition
   Assert that `condition` is truthy, narrowing it for the rest of the scope.
   Throws an {@link AssertionError} with `message` otherwise.
@@ -202,6 +205,12 @@ function discoverTargets(build: Build): Map<string, TargetBuilder>
   @throws
       if two properties reference the same builder instance under different
       names (a programming error that would corrupt naming).
+
+function envCacheStore(readEnv: (name: string) => string | undefined): RemoteCacheStore | undefined
+  Resolve a {@link RemoteCacheStore} from the environment, or `undefined` when
+  none is configured. `ZUKE_REMOTE_CACHE_URL` (with an optional
+  `ZUKE_REMOTE_CACHE_TOKEN`) selects an {@link HttpCacheStore}; otherwise
+  `ZUKE_REMOTE_CACHE_DIR` selects a {@link FileSystemCacheStore}.
 
 function envVarName(name: string): string
   The environment variable for a parameter: its path in SCREAMING_SNAKE_CASE.
@@ -310,6 +319,10 @@ function plan(root: TargetBuilder): TargetBuilder[]
       if the planned graph contains a cycle (which can happen
       via soft edges even when the hard graph is acyclic).
 
+function remoteCacheKey(name: string, fingerprint: string): string
+  The store key for a target's outputs: its name and input `fingerprint`. The
+  name is sanitised so the key is safe as a filename and a URL path segment.
+
 function repoRoot(...segments: string[]): AbsolutePath
   The absolute path of the repository root — the directory containing
   {@link CONFIG_FILE} — with any `segments` appended. The returned value is an
@@ -326,6 +339,16 @@ function repoRoot(...segments: string[]): AbsolutePath
 
   @throws
       if no {@link CONFIG_FILE} is found in the cwd or any ancestor.
+
+function resolveRemoteStore(option: RemoteCacheStore | false | undefined, declared: RemoteCacheStore | undefined, readEnv: (name: string) => string | undefined): RemoteCacheStore | undefined
+  Pick the remote store for a run by precedence: an explicit `option` wins
+  (`false` disables the remote cache entirely), then a `declared` store (a
+  build's `remoteCache()` override), then the {@link envCacheStore} environment
+  fallback.
+
+async function restoreOutputs(artifact: Uint8Array, host: OutputHost): Promise<string[]>
+  Restore the files in `artifact` (a gzipped tar produced by
+  {@link archiveOutputs}) to disk, returning the paths written.
 
 async function run(BuildClass: new () => Build, options: RunOptions): Promise<void>
   Public entry point. Instantiate the build, parse arguments, run, and set the
@@ -478,6 +501,22 @@ class Build
       lint = target().executes(() => DenoTasks.lint()); // healed globally
     }
     ```
+  remoteCache(): RemoteCacheStore | undefined
+    The {@link "./remote_cache.ts".RemoteCacheStore} that shares target
+    {@link "./target.ts".TargetBuilder.outputs} across machines. Override to
+    declare one in code; the default is none, and — unless overridden — the
+    executor falls back to {@link "./remote_cache.ts".envCacheStore} (the
+    `ZUKE_REMOTE_CACHE_*` environment variables). Applies to targets that
+    declare both `inputs` and `outputs`.
+
+    ```ts
+    class CI extends Build {
+      override remoteCache() {
+        return new HttpCacheStore({ url: this.cacheUrl.value, token: this.cacheToken.value });
+      }
+      build = target().inputs("src").outputs("dist").executes(...);
+    }
+    ```
 
 class CiFile
   A declared CI file. Assign one (via {@link cicd}) to a build field and Zuke
@@ -500,6 +539,17 @@ class DiscordAnnouncementSettings extends AnnouncementSettings
   override protected payload(): Record<string, unknown>
   override protected sendBot(): Promise<void>
 
+class FileSystemCacheStore implements RemoteCacheStore
+  A {@link RemoteCacheStore} backed by a shared or mounted directory.
+
+  constructor(dir: string)
+
+    @param dir
+        The directory archives are read from and written to.
+
+  get(key: string): Promise<Uint8Array | null>
+  async put(key: string, artifact: Uint8Array): Promise<void>
+
 class GraphError extends Error
   Raised when the build graph is invalid (cycle or unknown dependency).
 
@@ -516,6 +566,16 @@ class Group
     Members that declared themselves part of this group, in declaration order.
   name_?: string
     Property name, assigned during discovery. Undefined until then.
+
+class HttpCacheStore implements RemoteCacheStore
+  A {@link RemoteCacheStore} backed by HTTP: `GET <url>/<key>` fetches an
+  artifact (a `404` means a miss) and `PUT <url>/<key>` stores one. Works with
+  any object store or cache server that speaks plain HTTP GET/PUT — an S3, GCS,
+  or R2 bucket behind a URL, or a self-hosted cache endpoint.
+
+  constructor(options: HttpCacheStoreOptions)
+  async get(key: string): Promise<Uint8Array | null>
+  async put(key: string, artifact: Uint8Array): Promise<void>
 
 class HttpError extends Error
   Raised when an HTTP request returns a non-2xx status.
@@ -1049,6 +1109,13 @@ interface ExecuteOptions
     are unchanged since the last successful run (and whose outputs still exist).
     Defaults to on; pass `false` to disable (CLI `--no-cache`). A {@link
     BuildCache} may be supplied directly (used in tests).
+  remoteCache?: RemoteCacheStore | false
+    A {@link RemoteCacheStore} that shares target {@link TargetBuilder.outputs}
+    across machines: a local cache miss restores outputs from it, and a
+    successful run uploads them. `false` disables it (CLI `--no-remote-cache`).
+    When omitted, the build's `remoteCache()` override is used, falling back to
+    the `ZUKE_REMOTE_CACHE_*` environment variables. Ignored when `cache` is a
+    supplied {@link BuildCache} or is `false`.
   params?: Record<string, string>
     Raw parameter values from the command line, keyed by parameter (property)
     name. Each declared {@link Parameter} is resolved from this map, then the
@@ -1127,6 +1194,16 @@ interface GlobOptions
   cwd?: string
     Directory to resolve the pattern against (default: `Deno.cwd()`).
 
+interface HttpCacheStoreOptions
+  Configuration for an {@link HttpCacheStore}.
+
+  url: string
+    The base URL keys are appended to (any trailing slash is ignored).
+  token?: string
+    A bearer token sent as `Authorization: Bearer <token>`, if set.
+  fetch?: typeof fetch
+    The `fetch` implementation; defaults to the global. Overridable for tests.
+
 interface HttpOptions
   Options shared by the HTTP helpers.
 
@@ -1165,6 +1242,28 @@ interface InstallReleaseOptions
   download?: DownloadFn
     The download implementation. Defaults to {@link httpDownload}; override it
     to unit-test without network access.
+
+interface OpenCacheOptions
+  Optional extras for {@link openCache}: a remote store and a warning sink.
+
+  remote?: RemoteCacheStore
+    A {@link RemoteCacheStore} to restore outputs from (on a local miss) and
+    upload them to (after a successful run). Applies only to targets that
+    declare {@link TargetBuilder.outputs}.
+  warn?: (message: string) => void
+    Report a non-fatal remote-cache error (a get/put failure never fails the build).
+
+interface OutputHost
+  Filesystem effects used to archive and restore a target's outputs.
+
+  readFile(path: string): Promise<Uint8Array | null>
+    File contents, or `null` if the path does not exist.
+  stat(path: string): Promise<{ isDirectory: boolean; } | null>
+    Whether a path exists and is a directory, or `null` if it is missing.
+  readDir(path: string): Promise<string[]>
+    The entry names within a directory.
+  writeFile(path: string, bytes: Uint8Array): Promise<void>
+    Write a file, creating parent directories as needed.
 
 interface Plugin
   A lifecycle observer. Every hook is optional; implement only the ones you
@@ -1215,6 +1314,17 @@ interface RemediationResult
     explained the failure).
   summary?: string
     A one-line description of what was diagnosed or done, for diagnostics.
+
+interface RemoteCacheStore
+  A content-addressed store for archived target outputs, keyed by
+  {@link remoteCacheKey}. Both operations are best-effort from the build's
+  point of view: the executor never fails a build because the store is
+  unreachable — it just rebuilds and, where it can, re-uploads.
+
+  get(key: string): Promise<Uint8Array | null>
+    Fetch the archived outputs stored under `key`, or `null` if there are none.
+  put(key: string, artifact: Uint8Array): Promise<void>
+    Store `artifact` (a gzipped tar of a target's outputs) under `key`.
 
 interface RemoveOptions
   Options for {@link FileTasksApi.remove}.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -106,6 +106,16 @@ function absolutePath(first: string, ...rest: string[]): AbsolutePath
   @param rest
       Additional segments to append.
 
+function affectedTargets(order: readonly TargetBuilder[], changed: readonly string[]): Set<TargetBuilder>
+  Compute the set of targets in `order` affected by the given `changed` files.
+
+  `order` must be a valid execution order (dependencies before dependents, as
+  produced by {@link plan}/{@link planGraph}) so each target's dependencies are
+  already decided when it is visited. A target is affected when its own inputs
+  cover a changed file, when it declares no inputs (unprovable — treated as
+  affected), when a dependency is affected, or when an affected target triggers
+  it.
+
 function assert(condition: unknown, message: string): asserts condition
   Assert that `condition` is truthy, narrowing it for the rest of the scope.
   Throws an {@link AssertionError} with `message` otherwise.
@@ -227,6 +237,12 @@ function generateCi(pipeline: CiPipeline, provider: CiProvider): string
   `.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, or
   `bitbucket-pipelines.yml`. The pipeline may be empty (`{}`) to accept every
   default.
+
+async function gitChangedFiles(base: string, run: (args: string[]) => Promise<string>): Promise<string[]>
+  List the files changed since `base` (default `HEAD`) via git: tracked changes
+  versus `base` plus untracked files not covered by `.gitignore`. `run` invokes
+  git and returns stdout (defaults to a real `git` subprocess); override it to
+  test without a repository.
 
 async function glob(pattern: string, options: GlobOptions): Promise<string[]>
   Expand a glob pattern to the matching paths, relative to `cwd`, sorted for
@@ -779,6 +795,14 @@ interface AbsolutePath
   toString(): string
     The normalised path string.
 
+interface AffectedOptions
+  Configure {@link ExecuteOptions.affected}: the base revision and diff seam.
+
+  base?: string
+    The git revision to diff against. Defaults to `HEAD` (uncommitted changes).
+  changedFiles?: ChangedFilesFn
+    How to list changed files. Defaults to {@link gitChangedFiles}.
+
 interface AnnounceTasksApi
   The shape of {@link AnnounceTasks}.
 
@@ -1041,6 +1065,13 @@ interface ExecuteOptions
     Plan only: resolve and print every target that would run (honouring
     `--skip` and `onlyWhen` conditions) without executing any body or touching
     the cache (CLI `--dry-run`).
+  affected?: AffectedOptions
+    Restrict the run to the targets affected by files changed since a base git
+    revision (CLI `--affected[=<base>]`). A target is affected when a changed
+    file falls inside its declared {@link TargetBuilder.inputs} or a dependency
+    is affected; a target that declares no inputs is always considered affected.
+    Unaffected targets are skipped. The base revision defaults to `HEAD`; supply
+    `changedFiles` to inject the diff (used in tests).
   github?: boolean
     Force GitHub Actions output formatting on or off. Auto-detected from the
     `GITHUB_ACTIONS` environment variable when omitted.
@@ -1274,6 +1305,12 @@ interface ValidationContext
 type AnnouncementLevel = "success" | "failure" | "warning" | "info"
   The outcome an announcement conveys. It drives the accent colour and the icon
   prepended to the message; defaults to `"info"`.
+
+type ChangedFilesFn = (base: string) => Promise<string[]>
+  Lists the files changed since `base` (a git revision), each path relative to
+  the repository root. The seam behind {@link ExecuteOptions.affected}; defaults
+  to {@link gitChangedFiles} and is overridable so the affected plan can be
+  tested without a real git repository.
 
 type CiHost = "github" | "gitlab" | "azure" | "bitbucket" | "local"
   The CI host a build is running on, or `"local"` when not on CI. The names

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -56,6 +56,12 @@ export {
   describeCli,
 } from "./src/describe.ts";
 export type { Plugin } from "./src/plugin.ts";
+export {
+  type AffectedOptions,
+  affectedTargets,
+  type ChangedFilesFn,
+  gitChangedFiles,
+} from "./src/affected.ts";
 export { execute, type ExecuteOptions, type Reporter } from "./src/executor.ts";
 export {
   defaultRenderer,

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -69,7 +69,19 @@ export {
   type TargetReport,
 } from "./src/renderer.ts";
 export type { Style } from "./src/render.ts";
-export type { BuildCache } from "./src/cache.ts";
+export type { BuildCache, OpenCacheOptions } from "./src/cache.ts";
+export {
+  archiveOutputs,
+  envCacheStore,
+  FileSystemCacheStore,
+  HttpCacheStore,
+  type HttpCacheStoreOptions,
+  type OutputHost,
+  remoteCacheKey,
+  type RemoteCacheStore,
+  resolveRemoteStore,
+  restoreOutputs,
+} from "./src/remote_cache.ts";
 export { type AbsolutePath, absolutePath, type PathLike } from "./src/path.ts";
 export { CONFIG_FILE, repoRoot } from "./src/config.ts";
 export {

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -160,5 +160,7 @@ export {
   type CiProvider,
   type CiStep,
   type CiTriggers,
+  type FanOutOptions,
+  fanOutPipeline,
   generateCi,
 } from "./src/ci.ts";

--- a/packages/core/src/affected.ts
+++ b/packages/core/src/affected.ts
@@ -1,0 +1,143 @@
+/**
+ * Git-aware execution: restrict a run to the targets *affected* by the files
+ * that changed since a base git revision. Pairs with the incremental
+ * {@link "./cache.ts" | cache} — `--affected` prunes the plan to the targets a
+ * change can reach, and the cache skips unchanged work within what remains.
+ *
+ * A target is **affected** when a changed file falls inside one of its declared
+ * {@link TargetBuilder.inputs}, or when any of its dependencies is affected.
+ * Affectedness propagates forward along `dependsOn` (a dependency's change
+ * dirties its dependents) and `triggers` (a triggering target pulls its
+ * triggered ones along). A target that declares **no** inputs cannot be proven
+ * unaffected, so it is conservatively treated as always affected — declare
+ * `inputs` on the targets you want `--affected` to be able to skip.
+ *
+ * The set of changed files comes from git through an injectable seam
+ * ({@link ChangedFilesFn}), so the affected computation itself stays a pure,
+ * unit-testable function ({@link affectedTargets}).
+ *
+ * @module
+ */
+
+import type { TargetBuilder } from "./target.ts";
+
+/**
+ * Lists the files changed since `base` (a git revision), each path relative to
+ * the repository root. The seam behind {@link ExecuteOptions.affected}; defaults
+ * to {@link gitChangedFiles} and is overridable so the affected plan can be
+ * tested without a real git repository.
+ */
+export type ChangedFilesFn = (base: string) => Promise<string[]>;
+
+/** Configure {@link ExecuteOptions.affected}: the base revision and diff seam. */
+export interface AffectedOptions {
+  /** The git revision to diff against. Defaults to `HEAD` (uncommitted changes). */
+  base?: string;
+  /** How to list changed files. Defaults to {@link gitChangedFiles}. */
+  changedFiles?: ChangedFilesFn;
+}
+
+/** Normalise a path for comparison: `\`→`/`, drop a leading `./` and any trailing `/`. */
+function normalize(path: string): string {
+  let p = path.replace(/\\/g, "/");
+  while (p.startsWith("./")) p = p.slice(2);
+  while (p.length > 1 && p.endsWith("/")) p = p.slice(0, -1);
+  return p;
+}
+
+/**
+ * Whether `changed` (a normalised repo-relative path) falls inside the declared
+ * input `input`: an exact match, a file under an input directory, or any path
+ * when the input is the repository root (`.`).
+ */
+function inputCovers(input: string, changed: string): boolean {
+  const base = normalize(input);
+  if (base === "" || base === ".") return true;
+  return changed === base || changed.startsWith(`${base}/`);
+}
+
+/** Whether any changed file falls inside one of the target's declared inputs. */
+function inputsChanged(t: TargetBuilder, changed: readonly string[]): boolean {
+  return t.inputs_.some((input) => changed.some((c) => inputCovers(input, c)));
+}
+
+/**
+ * Compute the set of targets in `order` affected by the given `changed` files.
+ *
+ * `order` must be a valid execution order (dependencies before dependents, as
+ * produced by {@link plan}/{@link planGraph}) so each target's dependencies are
+ * already decided when it is visited. A target is affected when its own inputs
+ * cover a changed file, when it declares no inputs (unprovable — treated as
+ * affected), when a dependency is affected, or when an affected target triggers
+ * it.
+ */
+export function affectedTargets(
+  order: readonly TargetBuilder[],
+  changed: readonly string[],
+): Set<TargetBuilder> {
+  const normalized = changed.map(normalize).filter((c) => c !== "");
+  const affected = new Set<TargetBuilder>();
+  const triggered = new Set<TargetBuilder>();
+  for (const t of order) {
+    const self = t.inputs_.length === 0 || inputsChanged(t, normalized);
+    const viaDep = t.dependsOn_.some((d) => affected.has(d));
+    if (self || viaDep || triggered.has(t)) {
+      affected.add(t);
+      for (const tr of t.triggers_) triggered.add(tr);
+    }
+  }
+  return affected;
+}
+
+/** Split command output into non-empty, trimmed lines. */
+function lines(text: string): string[] {
+  return text.split("\n").map((l) => l.trim()).filter((l) => l !== "");
+}
+
+/**
+ * Run `bin` (default `git`) with `args`, returning its stdout. Throws a friendly
+ * error if the binary cannot be spawned or exits non-zero. Kept generic (the
+ * binary is a parameter) so the subprocess path is testable with a stand-in
+ * executable.
+ */
+export async function runGitProcess(
+  args: string[],
+  bin = "git",
+): Promise<string> {
+  let output: Deno.CommandOutput;
+  try {
+    output = await new Deno.Command(bin, {
+      args,
+      stdout: "piped",
+      stderr: "piped",
+    }).output();
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `could not run \`${bin}\`: ${detail}. Is git installed and on your PATH?`,
+    );
+  }
+  if (!output.success) {
+    const stderr = new TextDecoder().decode(output.stderr).trim();
+    throw new Error(
+      `\`${bin} ${args.join(" ")}\` failed${stderr ? `: ${stderr}` : ""}. ` +
+        `Is this a git repository, and does the base revision exist?`,
+    );
+  }
+  return new TextDecoder().decode(output.stdout);
+}
+
+/**
+ * List the files changed since `base` (default `HEAD`) via git: tracked changes
+ * versus `base` plus untracked files not covered by `.gitignore`. `run` invokes
+ * git and returns stdout (defaults to a real `git` subprocess); override it to
+ * test without a repository.
+ */
+export async function gitChangedFiles(
+  base = "HEAD",
+  run: (args: string[]) => Promise<string> = runGitProcess,
+): Promise<string[]> {
+  const diff = await run(["diff", "--name-only", base, "--"]);
+  const untracked = await run(["ls-files", "--others", "--exclude-standard"]);
+  return [...new Set([...lines(diff), ...lines(untracked)])];
+}

--- a/packages/core/src/affected.ts
+++ b/packages/core/src/affected.ts
@@ -137,6 +137,16 @@ export async function gitChangedFiles(
   base = "HEAD",
   run: (args: string[]) => Promise<string> = runGitProcess,
 ): Promise<string[]> {
+  // The base is passed to git as an argument, not through a shell, so there is
+  // no shell-injection surface — but a value beginning with "-" would be read
+  // as a git *option* (e.g. `--output=…` writes the diff to a file). A real
+  // revision never starts with "-", so reject one that does.
+  if (base.startsWith("-")) {
+    throw new Error(
+      `invalid git base revision "${base}": a revision must not start with "-" ` +
+        `(git would read it as an option, not a commit).`,
+    );
+  }
   const diff = await run(["diff", "--name-only", base, "--"]);
   const untracked = await run(["ls-files", "--others", "--exclude-standard"]);
   return [...new Set([...lines(diff), ...lines(untracked)])];

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -10,6 +10,7 @@
  */
 
 import { Group, type Remediation, TargetBuilder } from "./target.ts";
+import type { RemoteCacheStore } from "./remote_cache.ts";
 
 /** Whether a value is a plain object (a component bundle), not a class instance. */
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -90,6 +91,27 @@ export class Build {
    */
   recoverWith(): Remediation[] {
     return [];
+  }
+
+  /**
+   * The {@link "./remote_cache.ts".RemoteCacheStore} that shares target
+   * {@link "./target.ts".TargetBuilder.outputs} across machines. Override to
+   * declare one in code; the default is none, and — unless overridden — the
+   * executor falls back to {@link "./remote_cache.ts".envCacheStore} (the
+   * `ZUKE_REMOTE_CACHE_*` environment variables). Applies to targets that
+   * declare both `inputs` and `outputs`.
+   *
+   * ```ts
+   * class CI extends Build {
+   *   override remoteCache() {
+   *     return new HttpCacheStore({ url: this.cacheUrl.value, token: this.cacheToken.value });
+   *   }
+   *   build = target().inputs("src").outputs("dist").executes(...);
+   * }
+   * ```
+   */
+  remoteCache(): RemoteCacheStore | undefined {
+    return undefined;
   }
 }
 

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -14,18 +14,23 @@
  */
 
 import type { TargetBuilder } from "./target.ts";
+import {
+  archiveOutputs,
+  type OutputHost,
+  remoteCacheKey,
+  type RemoteCacheStore,
+  restoreOutputs,
+} from "./remote_cache.ts";
 
 /** The cache store file name within the `.zuke/` artifact directory. */
 export const CACHE_FILE = "cache.json";
 
-/** Injected filesystem effects, so {@link openCache} is unit-testable. */
-export interface CacheHost {
-  /** File contents, or `null` if the path does not exist. */
-  readFile(path: string): Promise<Uint8Array | null>;
-  /** Whether a path exists and is a directory, or `null` if it is missing. */
-  stat(path: string): Promise<{ isDirectory: boolean } | null>;
-  /** The entry names within a directory. */
-  readDir(path: string): Promise<string[]>;
+/**
+ * Injected filesystem effects, so {@link openCache} is unit-testable. Extends
+ * {@link OutputHost} (read/write files for remote output archiving) with the
+ * cache-store read/write used by the local fingerprint store.
+ */
+export interface CacheHost extends OutputHost {
   /** The cache store text, or `null` if it does not exist yet. */
   readStore(path: string): Promise<string | null>;
   /** Write the cache store text, creating parent directories. */
@@ -55,6 +60,11 @@ export const defaultCacheHost: CacheHost = {
     const names: string[] = [];
     for await (const entry of Deno.readDir(path)) names.push(entry.name);
     return names;
+  },
+  async writeFile(path: string, bytes: Uint8Array): Promise<void> {
+    const slash = path.replace(/\\/g, "/").lastIndexOf("/");
+    if (slash > 0) await Deno.mkdir(path.slice(0, slash), { recursive: true });
+    await Deno.writeFile(path, bytes);
   },
   async readStore(path: string): Promise<string | null> {
     try {
@@ -158,33 +168,86 @@ function parseStore(text: string | null): Record<string, string> {
   }
 }
 
-/** Filesystem-backed {@link BuildCache}. */
+/** Extract a message from an unknown thrown value without casting. */
+function messageOf(value: unknown): string {
+  return value instanceof Error ? value.message : String(value);
+}
+
+/** Optional extras for {@link openCache}: a remote store and a warning sink. */
+export interface OpenCacheOptions {
+  /**
+   * A {@link RemoteCacheStore} to restore outputs from (on a local miss) and
+   * upload them to (after a successful run). Applies only to targets that
+   * declare {@link TargetBuilder.outputs}.
+   */
+  remote?: RemoteCacheStore;
+  /** Report a non-fatal remote-cache error (a get/put failure never fails the build). */
+  warn?: (message: string) => void;
+}
+
+/** Filesystem-backed {@link BuildCache}, optionally backed by a remote store. */
 class FsCache implements BuildCache {
   readonly #host: CacheHost;
   readonly #storePath: string;
   readonly #store: Record<string, string>;
   readonly #computed = new Map<TargetBuilder, string>();
+  readonly #restored = new Set<TargetBuilder>();
+  readonly #remote?: RemoteCacheStore;
+  readonly #warn?: (message: string) => void;
   #dirty = false;
 
   constructor(
     host: CacheHost,
     storePath: string,
     store: Record<string, string>,
+    options: OpenCacheOptions = {},
   ) {
     this.#host = host;
     this.#storePath = storePath;
     this.#store = store;
+    this.#remote = options.remote;
+    this.#warn = options.warn;
   }
 
-  async upToDate(target: TargetBuilder): Promise<boolean> {
-    if (!isCacheable(target)) return false;
-    const fp = await fingerprint(target, this.#host);
-    this.#computed.set(target, fp);
-    if (this.#store[target.name_ ?? ""] !== fp) return false;
+  /** Whether every declared output of `target` still exists on disk. */
+  async #outputsExist(target: TargetBuilder): Promise<boolean> {
     for (const output of target.outputs_) {
       if (await this.#host.stat(output) === null) return false;
     }
     return true;
+  }
+
+  async upToDate(target: TargetBuilder): Promise<boolean> {
+    if (!isCacheable(target)) return false;
+    const name = target.name_ ?? "";
+    const fp = await fingerprint(target, this.#host);
+    this.#computed.set(target, fp);
+    if (this.#store[name] === fp && await this.#outputsExist(target)) {
+      return true;
+    }
+
+    // A local miss on a target that produces outputs: try to restore them from
+    // the remote store. A store error is non-fatal — fall through to a rebuild.
+    if (this.#remote !== undefined && target.outputs_.length > 0) {
+      const key = remoteCacheKey(name, fp);
+      let artifact: Uint8Array | null = null;
+      try {
+        artifact = await this.#remote.get(key);
+      } catch (error) {
+        this.#warn?.(
+          `remote cache lookup for "${name}" failed: ${messageOf(error)}`,
+        );
+        return false;
+      }
+      if (artifact !== null) {
+        await restoreOutputs(artifact, this.#host);
+        this.#store[name] = fp;
+        this.#dirty = true;
+        this.#restored.add(target);
+        return true;
+      }
+    }
+    return false;
   }
 
   async record(target: TargetBuilder): Promise<void> {
@@ -195,6 +258,21 @@ class FsCache implements BuildCache {
     if (this.#store[name] !== fp) {
       this.#store[name] = fp;
       this.#dirty = true;
+    }
+    // Upload the freshly built outputs — unless we just restored them from the
+    // store, in which case they are already there. Upload errors are non-fatal.
+    if (
+      this.#remote !== undefined && target.outputs_.length > 0 &&
+      !this.#restored.has(target)
+    ) {
+      try {
+        const artifact = await archiveOutputs(target.outputs_, this.#host);
+        await this.#remote.put(remoteCacheKey(name, fp), artifact);
+      } catch (error) {
+        this.#warn?.(
+          `remote cache upload for "${name}" failed: ${messageOf(error)}`,
+        );
+      }
     }
   }
 
@@ -209,12 +287,15 @@ class FsCache implements BuildCache {
 
 /**
  * Open the incremental cache stored at `storePath`, loading any existing
- * fingerprints. Filesystem access goes through `host`.
+ * fingerprints. Filesystem access goes through `host`; pass a
+ * {@link OpenCacheOptions.remote} store to also restore and upload target
+ * outputs across machines.
  */
 export async function openCache(
   storePath: string,
   host: CacheHost = defaultCacheHost,
+  options: OpenCacheOptions = {},
 ): Promise<BuildCache> {
   const store = parseStore(await host.readStore(storePath));
-  return new FsCache(host, storePath, store);
+  return new FsCache(host, storePath, store, options);
 }

--- a/packages/core/src/ci.ts
+++ b/packages/core/src/ci.ts
@@ -32,7 +32,8 @@
  */
 
 import { toYaml, type YamlValue } from "./yaml.ts";
-import { type Build, forEachField } from "./build.ts";
+import { type Build, discoverTargets, forEachField } from "./build.ts";
+import type { TargetBuilder } from "./target.ts";
 
 /** The CI providers {@link generateCi} can target. */
 export type CiProvider = "github" | "gitlab" | "azure" | "bitbucket";
@@ -384,6 +385,94 @@ export function generateCi(
   }
 }
 
+/**
+ * Options for {@link fanOutPipeline}: how a build's targets become parallel CI
+ * jobs.
+ */
+export interface FanOutOptions {
+  /**
+   * The command a job runs for its target, given the target name. Defaults to
+   * the `./zuke <target>` launcher (which bootstraps Deno). Each job runs only
+   * its own target; its dependencies run in their own jobs and are shared via
+   * the {@link "./remote_cache.ts" | remote cache}, so pair fan-out with one.
+   */
+  command?: (target: string) => string;
+  /**
+   * Steps prepended to every job — checkout, tool setup, cache restore. Defaults
+   * to a single `actions/checkout` (rendered on GitHub; GitLab and Azure check
+   * out automatically). Provide `env` for `ZUKE_REMOTE_CACHE_*` here or via
+   * {@link env}.
+   */
+  setupSteps?: CiStep[];
+  /** The runner for every job (see {@link CiJob.runsOn}). */
+  runsOn?: string;
+  /** Include targets hidden from `--list` via `.unlisted()`. Defaults to false. */
+  includeUnlisted?: boolean;
+  /** Environment variables set on every job (e.g. the remote-cache config). */
+  env?: Record<string, string>;
+}
+
+/** The default per-job setup: check out the repo (GitHub only; others auto-checkout). */
+const DEFAULT_SETUP_STEPS: CiStep[] = [{ uses: "actions/checkout@v4" }];
+
+/** A CI-safe job id derived from a (possibly dotted) target name. */
+function jobId(name: string): string {
+  return name.replace(/[^A-Za-z0-9_-]/g, "-");
+}
+
+/**
+ * Expand a build's target graph into a **fanned-out** pipeline: one CI job per
+ * runnable target, wired together with `needs:` edges that mirror the targets'
+ * `dependsOn` dependencies — so independent targets run in parallel and a
+ * target's job waits for its prerequisites. Each job runs just its own target;
+ * upstream outputs are shared through the {@link "./remote_cache.ts" | remote
+ * cache}, so configure one (e.g. `ZUKE_REMOTE_CACHE_*` on the jobs) to avoid
+ * rebuilding dependencies in every job.
+ *
+ * `base` contributes the pipeline-level fields (name, triggers, permissions,
+ * concurrency); its `jobs` are ignored in favour of the generated ones. Targets
+ * with no body, and (unless {@link FanOutOptions.includeUnlisted}) `unlisted`
+ * targets, are omitted, and `needs` edges to omitted targets are dropped.
+ */
+export function fanOutPipeline(
+  targets: Map<string, TargetBuilder>,
+  base: CiPipeline = {},
+  options: FanOutOptions = {},
+): CiPipeline {
+  const command = options.command ?? ((target) => `./zuke ${target}`);
+  const setup = options.setupSteps ?? DEFAULT_SETUP_STEPS;
+  const included = new Map<string, TargetBuilder>();
+  for (const [name, t] of targets) {
+    if (t.fn_ === undefined) continue; // nothing to run
+    if (t.unlisted_ && !options.includeUnlisted) continue;
+    included.set(name, t);
+  }
+
+  const jobs: CiJob[] = [];
+  for (const [name, t] of included) {
+    const needs = t.dependsOn_
+      .map((d) => d.name_)
+      .filter((n): n is string => n !== undefined && included.has(n))
+      .map(jobId);
+    jobs.push({
+      id: jobId(name),
+      name: t.description_ ?? name,
+      runsOn: options.runsOn,
+      needs: needs.length > 0 ? needs : undefined,
+      env: options.env,
+      steps: [...setup, { name: `Run ${name}`, run: command(name) }],
+    });
+  }
+
+  return {
+    name: base.name,
+    triggers: base.triggers,
+    permissions: base.permissions,
+    concurrency: base.concurrency,
+    jobs,
+  };
+}
+
 /** A CI configuration file declared on a build: a pipeline bound to a path. */
 export interface CiFileSpec {
   /** The provider to render for — the one field you must choose. */
@@ -396,6 +485,13 @@ export interface CiFileSpec {
   path?: string;
   /** The pipeline to render. Defaults to a single `build` job that runs the build. */
   pipeline?: CiPipeline;
+  /**
+   * Fan the build's targets out into one CI job per target, wired by their
+   * dependencies (see {@link fanOutPipeline}). `true` uses the defaults; pass
+   * {@link FanOutOptions} to customise. When set, {@link pipeline} supplies the
+   * pipeline-level fields (name, triggers, …) and its `jobs` are ignored.
+   */
+  fanOut?: boolean | FanOutOptions;
 }
 
 /**
@@ -407,16 +503,30 @@ export class CiFile {
   readonly provider: CiProvider;
   /** The output path. */
   readonly path: string;
-  /** The pipeline this file renders. */
+  /** The base pipeline (pipeline-level fields, and the jobs unless fanning out). */
   readonly pipeline: CiPipeline;
+  /** Fan-out options, when this file expands the build's targets into jobs. */
+  readonly fanOut?: FanOutOptions;
 
   constructor(spec: CiFileSpec) {
     this.provider = spec.provider;
     this.path = spec.path ?? DEFAULT_PATHS[this.provider];
     this.pipeline = spec.pipeline ?? {};
+    if (spec.fanOut === true) this.fanOut = {};
+    else if (spec.fanOut) this.fanOut = spec.fanOut;
   }
 
-  /** Render the file's YAML content. */
+  /**
+   * The pipeline this file renders. With fan-out, the build's `targets` are
+   * expanded into one job per target; otherwise the declared {@link pipeline}.
+   */
+  pipelineFor(targets: Map<string, TargetBuilder>): CiPipeline {
+    return this.fanOut === undefined
+      ? this.pipeline
+      : fanOutPipeline(targets, this.pipeline, this.fanOut);
+  }
+
+  /** Render the file's YAML content (the base pipeline; fan-out is resolved at discovery). */
   render(): string {
     return generateCi(this.pipeline, this.provider);
   }
@@ -443,13 +553,25 @@ export function cicd(spec: CiFileSpec): CiFile {
   return new CiFile(spec);
 }
 
-/** Find every {@link CiFile} declared on a build instance. */
+/**
+ * Find every {@link CiFile} declared on a build instance. A fan-out file is
+ * resolved here — its jobs are expanded from the build's targets — so the
+ * returned files render the same whether they fan out or not.
+ */
 export function discoverCiFiles(build: Build): CiFile[] {
-  const files: CiFile[] = [];
+  const found: CiFile[] = [];
   forEachField(build, (_path, value) => {
-    if (value instanceof CiFile) files.push(value);
+    if (value instanceof CiFile) found.push(value);
   });
-  return files;
+  if (!found.some((f) => f.fanOut !== undefined)) return found;
+  const targets = discoverTargets(build);
+  return found.map((f) =>
+    f.fanOut === undefined ? f : new CiFile({
+      provider: f.provider,
+      path: f.path,
+      pipeline: f.pipelineFor(targets),
+    })
+  );
 }
 
 /** What {@link syncCiFiles} did to a file. */

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -91,6 +91,8 @@ export interface ParsedArgs {
   parallel?: boolean | number;
   /** Disable the incremental cache (`--no-cache`); undefined leaves it on. */
   cache?: boolean;
+  /** Disable only the remote cache store (`--no-remote-cache`); undefined leaves it on. */
+  remoteCache?: boolean;
   /** Restrict the run to targets affected since a git base (`--affected[=<base>]`). */
   affected: boolean;
   /** The git base revision for `--affected` (the `=<base>` value); undefined uses the default. */
@@ -146,6 +148,8 @@ export function parseArgs(
       parsed.open = false;
     } else if (arg === "--no-cache") {
       parsed.cache = false;
+    } else if (arg === "--no-remote-cache") {
+      parsed.remoteCache = false;
     } else if (arg === "--affected") {
       parsed.affected = true;
     } else if (arg.startsWith("--affected=")) {
@@ -227,6 +231,8 @@ Options:
   --parallel[=N]    Run independent targets concurrently (N = max in flight,
                     default = CPU count).
   --no-cache        Ignore the incremental cache; re-run every target.
+  --no-remote-cache Use the local cache only; do not restore from or upload to
+                    the configured remote cache store.
   --affected[=<base>]
                     Run only targets affected by files changed since <base>
                     (a git revision; default HEAD). A target is affected when a
@@ -515,6 +521,7 @@ export async function main(
     params: parsed.values,
     parallel: parsed.parallel,
     cache: parsed.cache,
+    remoteCache: parsed.remoteCache === false ? false : undefined,
     affected: parsed.affected ? { base: parsed.affectedBase } : undefined,
     dryRun: parsed.dryRun,
     plugins: options.plugins,

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -91,6 +91,10 @@ export interface ParsedArgs {
   parallel?: boolean | number;
   /** Disable the incremental cache (`--no-cache`); undefined leaves it on. */
   cache?: boolean;
+  /** Restrict the run to targets affected since a git base (`--affected[=<base>]`). */
+  affected: boolean;
+  /** The git base revision for `--affected` (the `=<base>` value); undefined uses the default. */
+  affectedBase?: string;
   /** Print the plan without running any target bodies (`--dry-run`). */
   dryRun: boolean;
   /** Raw parameter values from declared flags, keyed by property name. */
@@ -125,6 +129,7 @@ export function parseArgs(
     output: "text",
     open: true,
     values: {},
+    affected: false,
     dryRun: false,
     help: false,
   };
@@ -141,6 +146,11 @@ export function parseArgs(
       parsed.open = false;
     } else if (arg === "--no-cache") {
       parsed.cache = false;
+    } else if (arg === "--affected") {
+      parsed.affected = true;
+    } else if (arg.startsWith("--affected=")) {
+      parsed.affected = true;
+      parsed.affectedBase = arg.slice("--affected=".length);
     } else if (arg === "--dry-run") {
       parsed.dryRun = true;
     } else if (arg === "--check") {
@@ -205,7 +215,7 @@ function depNames(t: TargetBuilder): string[] {
 const USAGE = `zuke — code-first build automation
 
 Usage:
-  deno run -A zuke.ts <target> [--skip <dep>] [--parallel[=N]]
+  deno run -A zuke.ts <target> [--skip <dep>] [--parallel[=N]] [--affected[=<base>]]
   deno run -A zuke.ts --list [--json]
   deno run -A zuke.ts graph [--output=html] [--no-open]
   deno run -A zuke.ts generate-ci [--check]
@@ -217,6 +227,11 @@ Options:
   --parallel[=N]    Run independent targets concurrently (N = max in flight,
                     default = CPU count).
   --no-cache        Ignore the incremental cache; re-run every target.
+  --affected[=<base>]
+                    Run only targets affected by files changed since <base>
+                    (a git revision; default HEAD). A target is affected when a
+                    changed file is under its declared inputs or a dependency is
+                    affected; targets with no declared inputs always run.
   --dry-run         Print the execution plan without running target bodies.
   --list, -l        List all targets with descriptions and dependencies.
   --json            With --list, print the build surface (commands, flags,
@@ -500,6 +515,7 @@ export async function main(
     params: parsed.values,
     parallel: parsed.parallel,
     cache: parsed.cache,
+    affected: parsed.affected ? { base: parsed.affectedBase } : undefined,
     dryRun: parsed.dryRun,
     plugins: options.plugins,
     renderer: options.renderer,

--- a/packages/core/src/cli_spec.ts
+++ b/packages/core/src/cli_spec.ts
@@ -57,6 +57,10 @@ export const BUILTIN_FLAGS: readonly BuiltinFlag[] = [
   { name: "--skip", description: "Skip the named dependency" },
   { name: "--parallel", description: "Run independent targets concurrently" },
   { name: "--no-cache", description: "Ignore the incremental cache" },
+  {
+    name: "--affected",
+    description: "Run only targets affected by changes since a git base",
+  },
   { name: "--dry-run", description: "Print the plan without running targets" },
   { name: "--output", description: "Graph output format: text or html" },
   {

--- a/packages/core/src/cli_spec.ts
+++ b/packages/core/src/cli_spec.ts
@@ -58,6 +58,10 @@ export const BUILTIN_FLAGS: readonly BuiltinFlag[] = [
   { name: "--parallel", description: "Run independent targets concurrently" },
   { name: "--no-cache", description: "Ignore the incremental cache" },
   {
+    name: "--no-remote-cache",
+    description: "Use the local cache only; skip the remote cache store",
+  },
+  {
     name: "--affected",
     description: "Run only targets affected by changes since a git base",
   },

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -28,6 +28,11 @@ import {
   openCache,
 } from "./cache.ts";
 import { findConfigDir, pathExists } from "./config.ts";
+import {
+  type AffectedOptions,
+  affectedTargets,
+  gitChangedFiles,
+} from "./affected.ts";
 import { isCI } from "./host.ts";
 import { absolutePath } from "./path.ts";
 import type { Remediation, TargetBuilder, TargetFn } from "./target.ts";
@@ -104,6 +109,15 @@ export interface ExecuteOptions {
    * the cache (CLI `--dry-run`).
    */
   dryRun?: boolean;
+  /**
+   * Restrict the run to the targets affected by files changed since a base git
+   * revision (CLI `--affected[=<base>]`). A target is affected when a changed
+   * file falls inside its declared {@link TargetBuilder.inputs} or a dependency
+   * is affected; a target that declares no inputs is always considered affected.
+   * Unaffected targets are skipped. The base revision defaults to `HEAD`; supply
+   * `changedFiles` to inject the diff (used in tests).
+   */
+  affected?: AffectedOptions;
   /**
    * Force GitHub Actions output formatting on or off. Auto-detected from the
    * `GITHUB_ACTIONS` environment variable when omitted.
@@ -775,6 +789,25 @@ export async function execute(
   // Evaluate up-front conditions for `whenSkipped("skip-dependencies")` targets
   // and skip them plus any dependencies that nothing else needs.
   for (const name of await conditionSkips(root, order)) skip.add(name);
+
+  // With `--affected`, skip every planned target a change cannot reach. Skipped
+  // targets still unblock their dependents (their prior outputs are assumed
+  // current), so an affected target downstream of an unaffected one still runs.
+  if (options.affected !== undefined) {
+    const changedFiles = options.affected.changedFiles ?? gitChangedFiles;
+    const changed = await changedFiles(options.affected.base ?? "HEAD");
+    const affected = affectedTargets(order, changed);
+    for (const t of order) {
+      if (!affected.has(t)) skip.add(t.name_ ?? "<unnamed>");
+    }
+    if (affected.size === 0) {
+      reporter.info(
+        `No targets affected by changes since ${
+          options.affected.base ?? "HEAD"
+        }.`,
+      );
+    }
+  }
 
   const limit = resolveConcurrency(options.parallel);
   const globalParallel = limit > 1;

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -33,6 +33,7 @@ import {
   affectedTargets,
   gitChangedFiles,
 } from "./affected.ts";
+import { type RemoteCacheStore, resolveRemoteStore } from "./remote_cache.ts";
 import { isCI } from "./host.ts";
 import { absolutePath } from "./path.ts";
 import type { Remediation, TargetBuilder, TargetFn } from "./target.ts";
@@ -82,6 +83,15 @@ export interface ExecuteOptions {
    * BuildCache} may be supplied directly (used in tests).
    */
   cache?: boolean | BuildCache;
+  /**
+   * A {@link RemoteCacheStore} that shares target {@link TargetBuilder.outputs}
+   * across machines: a local cache miss restores outputs from it, and a
+   * successful run uploads them. `false` disables it (CLI `--no-remote-cache`).
+   * When omitted, the build's `remoteCache()` override is used, falling back to
+   * the `ZUKE_REMOTE_CACHE_*` environment variables. Ignored when `cache` is a
+   * supplied {@link BuildCache} or is `false`.
+   */
+  remoteCache?: RemoteCacheStore | false;
   /**
    * Raw parameter values from the command line, keyed by parameter (property)
    * name. Each declared {@link Parameter} is resolved from this map, then the
@@ -760,10 +770,11 @@ export async function execute(
   // target runs, so a target body can read `this.param.value`. A missing
   // required parameter or an invalid value fails the build before it starts.
   const params = discoverParameters(build);
+  const readEnv = options.readEnv ?? defaultReadEnv;
   const paramErrors = resolveParameters(
     params,
     options.params ?? {},
-    options.readEnv ?? defaultReadEnv,
+    readEnv,
     options.prompt ?? defaultPrompt,
   );
   if (paramErrors.length > 0) {
@@ -794,18 +805,14 @@ export async function execute(
   // targets still unblock their dependents (their prior outputs are assumed
   // current), so an affected target downstream of an unaffected one still runs.
   if (options.affected !== undefined) {
+    const base = options.affected.base ?? "HEAD";
     const changedFiles = options.affected.changedFiles ?? gitChangedFiles;
-    const changed = await changedFiles(options.affected.base ?? "HEAD");
-    const affected = affectedTargets(order, changed);
+    const affected = affectedTargets(order, await changedFiles(base));
     for (const t of order) {
       if (!affected.has(t)) skip.add(t.name_ ?? "<unnamed>");
     }
     if (affected.size === 0) {
-      reporter.info(
-        `No targets affected by changes since ${
-          options.affected.base ?? "HEAD"
-        }.`,
-      );
+      reporter.info(`No targets affected by changes since ${base}.`);
     }
   }
 
@@ -817,7 +824,14 @@ export async function execute(
   const scheduled = order.some((t) => t.proceedAfterFailure_ || t.always_);
   const dryRun = options.dryRun ?? false;
   // A dry run never reads or writes the cache (no body runs to invalidate it).
-  const cache = dryRun ? undefined : await resolveCache(options.cache, order);
+  const cache = dryRun ? undefined : await resolveCache(
+    options.cache,
+    order,
+    build,
+    options.remoteCache,
+    readEnv,
+    reporter,
+  );
   const overallStart = performance.now();
 
   const life = makeLifecycle(build, options.plugins ?? []);
@@ -886,16 +900,26 @@ export async function execute(
 /**
  * Resolve the incremental cache for a run: `false` disables it, a supplied
  * {@link BuildCache} is used directly, and otherwise a `.zuke/cache.json`-backed
- * cache is opened — but only when at least one target declares inputs.
+ * cache is opened — but only when at least one target declares inputs. A remote
+ * output store is wired in when one is configured (see
+ * {@link resolveRemoteStore}).
  */
 async function resolveCache(
   option: boolean | BuildCache | undefined,
   order: TargetBuilder[],
+  build: Build,
+  remoteOption: RemoteCacheStore | false | undefined,
+  readEnv: (name: string) => string | undefined,
+  reporter: Reporter,
 ): Promise<BuildCache | undefined> {
   if (option === false) return undefined;
   if (typeof option === "object") return option;
   if (!order.some(isCacheable)) return undefined;
   const root = findConfigDir(Deno.cwd(), pathExists) ?? Deno.cwd();
   const storePath = absolutePath(root)(ARTIFACT_DIR, CACHE_FILE).path;
-  return await openCache(storePath, defaultCacheHost);
+  const remote = resolveRemoteStore(remoteOption, build.remoteCache(), readEnv);
+  return await openCache(storePath, defaultCacheHost, {
+    remote,
+    warn: (message) => reporter.info(message),
+  });
 }

--- a/packages/core/src/remote_cache.ts
+++ b/packages/core/src/remote_cache.ts
@@ -88,15 +88,42 @@ export async function archiveOutputs(
 }
 
 /**
+ * Reject an archive entry whose name would escape the workspace — an absolute
+ * path or one containing a `..` segment. A remote store is only as trustworthy
+ * as whoever can write to it, so a poisoned or malicious archive must never be
+ * able to place files outside the current directory (a "zip slip").
+ */
+function assertSafeEntryName(name: string): void {
+  const normalized = name.replace(/\\/g, "/");
+  if (normalized.startsWith("/") || /^[A-Za-z]:/.test(normalized)) {
+    throw new Error(
+      `remote cache: refusing to restore an absolute path from an archive: "${name}".`,
+    );
+  }
+  if (normalized.split("/").some((segment) => segment === "..")) {
+    throw new Error(
+      `remote cache: refusing to restore a path that escapes the workspace: "${name}".`,
+    );
+  }
+}
+
+/**
  * Restore the files in `artifact` (a gzipped tar produced by
- * {@link archiveOutputs}) to disk, returning the paths written.
+ * {@link archiveOutputs}) to disk, returning the paths written. Entry names are
+ * validated first: an absolute path or one escaping the workspace (`..`) is
+ * rejected before anything is written, so a malicious archive can't plant files
+ * outside the current directory.
  */
 export async function restoreOutputs(
   artifact: Uint8Array,
   host: OutputHost,
 ): Promise<string[]> {
+  const entries = untar(await gunzip(artifact));
+  // Validate every entry up front so a bad name aborts the whole restore
+  // instead of leaving a half-written, partially-trusted output tree.
+  for (const entry of entries) assertSafeEntryName(entry.name);
   const written: string[] = [];
-  for (const entry of untar(await gunzip(artifact))) {
+  for (const entry of entries) {
     await host.writeFile(entry.name, entry.data);
     written.push(entry.name);
   }
@@ -160,6 +187,14 @@ export interface HttpCacheStoreOptions {
  * artifact (a `404` means a miss) and `PUT <url>/<key>` stores one. Works with
  * any object store or cache server that speaks plain HTTP GET/PUT — an S3, GCS,
  * or R2 bucket behind a URL, or a self-hosted cache endpoint.
+ *
+ * **Security.** The `url` (and `token`) are *trusted configuration*: outputs are
+ * uploaded to that host and archives are extracted from it, so point it only at
+ * a cache you control, and prefer a {@link "./params.ts" | secret parameter} or
+ * an environment variable over a hard-coded value. On CI, restrict egress to
+ * the cache host so a misconfigured or overridden URL can't exfiltrate
+ * artifacts. Restored archives are always confined to the workspace (see
+ * {@link restoreOutputs}), so a poisoned store cannot write outside it.
  */
 export class HttpCacheStore implements RemoteCacheStore {
   readonly #base: string;

--- a/packages/core/src/remote_cache.ts
+++ b/packages/core/src/remote_cache.ts
@@ -1,0 +1,250 @@
+/**
+ * Remote build cache: share a target's built {@link TargetBuilder.outputs}
+ * across machines. The incremental {@link "./cache.ts" | cache} skips a target
+ * whose inputs are unchanged *locally*; a {@link RemoteCacheStore} extends that
+ * across a team and CI — a fresh checkout **restores** a target's outputs from
+ * the store instead of rebuilding them, and a successful build **uploads** them
+ * for the next run.
+ *
+ * A store is content-addressed: the key is derived from the target and its
+ * input fingerprint ({@link remoteCacheKey}), and the value is a gzipped tar of
+ * the target's outputs (built with the dependency-free {@link "./compression.ts"
+ * | tar/gzip} helpers). Two backends ship, both dependency-free:
+ * {@link FileSystemCacheStore} (a shared/mounted directory) and
+ * {@link HttpCacheStore} (any object store or cache server behind a URL). A
+ * build selects one with a typed `remoteCache()` override, or one is picked up
+ * from the environment by {@link envCacheStore}.
+ *
+ * @module
+ */
+
+import { gunzip, gzip, tar, type TarEntry, untar } from "./compression.ts";
+import { HttpError } from "./http.ts";
+
+/**
+ * A content-addressed store for archived target outputs, keyed by
+ * {@link remoteCacheKey}. Both operations are best-effort from the build's
+ * point of view: the executor never fails a build because the store is
+ * unreachable — it just rebuilds and, where it can, re-uploads.
+ */
+export interface RemoteCacheStore {
+  /** Fetch the archived outputs stored under `key`, or `null` if there are none. */
+  get(key: string): Promise<Uint8Array | null>;
+  /** Store `artifact` (a gzipped tar of a target's outputs) under `key`. */
+  put(key: string, artifact: Uint8Array): Promise<void>;
+}
+
+/** Filesystem effects used to archive and restore a target's outputs. */
+export interface OutputHost {
+  /** File contents, or `null` if the path does not exist. */
+  readFile(path: string): Promise<Uint8Array | null>;
+  /** Whether a path exists and is a directory, or `null` if it is missing. */
+  stat(path: string): Promise<{ isDirectory: boolean } | null>;
+  /** The entry names within a directory. */
+  readDir(path: string): Promise<string[]>;
+  /** Write a file, creating parent directories as needed. */
+  writeFile(path: string, bytes: Uint8Array): Promise<void>;
+}
+
+/** Normalise a path for archive entry names: `\`→`/`, drop a leading `./`. */
+function normalize(path: string): string {
+  let p = path.replace(/\\/g, "/");
+  while (p.startsWith("./")) p = p.slice(2);
+  return p;
+}
+
+/**
+ * Collect every file under `outputs` (directories walked recursively) as tar
+ * entries named by their normalised path, sorted so the archive is reproducible.
+ */
+async function collectEntries(
+  outputs: readonly string[],
+  host: OutputHost,
+): Promise<TarEntry[]> {
+  const entries: TarEntry[] = [];
+  const walk = async (path: string): Promise<void> => {
+    const info = await host.stat(path);
+    if (info === null) return; // a declared output that isn't there — skip it
+    if (!info.isDirectory) {
+      const data = await host.readFile(path);
+      if (data !== null) entries.push({ name: normalize(path), data });
+      return;
+    }
+    for (const name of (await host.readDir(path)).slice().sort()) {
+      await walk(`${path}/${name}`);
+    }
+  };
+  for (const output of outputs) await walk(normalize(output));
+  entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  return entries;
+}
+
+/** Archive a target's `outputs` into a gzipped tar of their current contents. */
+export async function archiveOutputs(
+  outputs: readonly string[],
+  host: OutputHost,
+): Promise<Uint8Array> {
+  return await gzip(tar(await collectEntries(outputs, host)));
+}
+
+/**
+ * Restore the files in `artifact` (a gzipped tar produced by
+ * {@link archiveOutputs}) to disk, returning the paths written.
+ */
+export async function restoreOutputs(
+  artifact: Uint8Array,
+  host: OutputHost,
+): Promise<string[]> {
+  const written: string[] = [];
+  for (const entry of untar(await gunzip(artifact))) {
+    await host.writeFile(entry.name, entry.data);
+    written.push(entry.name);
+  }
+  return written;
+}
+
+/**
+ * The store key for a target's outputs: its name and input `fingerprint`. The
+ * name is sanitised so the key is safe as a filename and a URL path segment.
+ */
+export function remoteCacheKey(name: string, fingerprint: string): string {
+  const safe = name.replace(/[^A-Za-z0-9._-]/g, "_");
+  return `${safe}-${fingerprint}`;
+}
+
+/** A {@link RemoteCacheStore} backed by a shared or mounted directory. */
+export class FileSystemCacheStore implements RemoteCacheStore {
+  readonly #dir: string;
+
+  /** @param dir The directory archives are read from and written to. */
+  constructor(dir: string) {
+    this.#dir = dir;
+  }
+
+  #path(key: string): string {
+    return `${this.#dir}/${key}.tar.gz`;
+  }
+
+  get(key: string): Promise<Uint8Array | null> {
+    return readFileOrNull(this.#path(key));
+  }
+
+  async put(key: string, artifact: Uint8Array): Promise<void> {
+    await Deno.mkdir(this.#dir, { recursive: true });
+    await Deno.writeFile(this.#path(key), artifact);
+  }
+}
+
+/** Read a file's bytes, or `null` when it does not exist. */
+async function readFileOrNull(path: string): Promise<Uint8Array | null> {
+  try {
+    return await Deno.readFile(path);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return null;
+    throw error;
+  }
+}
+
+/** Configuration for an {@link HttpCacheStore}. */
+export interface HttpCacheStoreOptions {
+  /** The base URL keys are appended to (any trailing slash is ignored). */
+  url: string;
+  /** A bearer token sent as `Authorization: Bearer <token>`, if set. */
+  token?: string;
+  /** The `fetch` implementation; defaults to the global. Overridable for tests. */
+  fetch?: typeof fetch;
+}
+
+/**
+ * A {@link RemoteCacheStore} backed by HTTP: `GET <url>/<key>` fetches an
+ * artifact (a `404` means a miss) and `PUT <url>/<key>` stores one. Works with
+ * any object store or cache server that speaks plain HTTP GET/PUT — an S3, GCS,
+ * or R2 bucket behind a URL, or a self-hosted cache endpoint.
+ */
+export class HttpCacheStore implements RemoteCacheStore {
+  readonly #base: string;
+  readonly #token?: string;
+  readonly #fetch: typeof fetch;
+
+  constructor(options: HttpCacheStoreOptions) {
+    this.#base = options.url.replace(/\/+$/, "");
+    this.#token = options.token;
+    this.#fetch = options.fetch ?? fetch;
+  }
+
+  #url(key: string): string {
+    return `${this.#base}/${encodeURIComponent(key)}`;
+  }
+
+  #headers(extra?: Record<string, string>): Record<string, string> {
+    const headers: Record<string, string> = { ...extra };
+    if (this.#token !== undefined && this.#token !== "") {
+      headers.Authorization = `Bearer ${this.#token}`;
+    }
+    return headers;
+  }
+
+  async get(key: string): Promise<Uint8Array | null> {
+    const url = this.#url(key);
+    const response = await this.#fetch(url, { headers: this.#headers() });
+    if (response.status === 404) {
+      await response.body?.cancel();
+      return null;
+    }
+    if (!response.ok) {
+      await response.body?.cancel();
+      throw new HttpError(response.status, url);
+    }
+    return new Uint8Array(await response.arrayBuffer());
+  }
+
+  async put(key: string, artifact: Uint8Array): Promise<void> {
+    const url = this.#url(key);
+    const response = await this.#fetch(url, {
+      method: "PUT",
+      headers: this.#headers({ "content-type": "application/octet-stream" }),
+      // Copy into a fresh ArrayBuffer-backed Blob so the body type is unambiguous
+      // regardless of the source buffer (e.g. a SharedArrayBuffer).
+      body: new Blob([new Uint8Array(artifact)]),
+    });
+    await response.body?.cancel();
+    if (!response.ok) throw new HttpError(response.status, url);
+  }
+}
+
+/**
+ * Resolve a {@link RemoteCacheStore} from the environment, or `undefined` when
+ * none is configured. `ZUKE_REMOTE_CACHE_URL` (with an optional
+ * `ZUKE_REMOTE_CACHE_TOKEN`) selects an {@link HttpCacheStore}; otherwise
+ * `ZUKE_REMOTE_CACHE_DIR` selects a {@link FileSystemCacheStore}.
+ */
+export function envCacheStore(
+  readEnv: (name: string) => string | undefined,
+): RemoteCacheStore | undefined {
+  const url = readEnv("ZUKE_REMOTE_CACHE_URL");
+  if (url !== undefined && url !== "") {
+    return new HttpCacheStore({
+      url,
+      token: readEnv("ZUKE_REMOTE_CACHE_TOKEN"),
+    });
+  }
+  const dir = readEnv("ZUKE_REMOTE_CACHE_DIR");
+  if (dir !== undefined && dir !== "") return new FileSystemCacheStore(dir);
+  return undefined;
+}
+
+/**
+ * Pick the remote store for a run by precedence: an explicit `option` wins
+ * (`false` disables the remote cache entirely), then a `declared` store (a
+ * build's `remoteCache()` override), then the {@link envCacheStore} environment
+ * fallback.
+ */
+export function resolveRemoteStore(
+  option: RemoteCacheStore | false | undefined,
+  declared: RemoteCacheStore | undefined,
+  readEnv: (name: string) => string | undefined,
+): RemoteCacheStore | undefined {
+  if (option === false) return undefined;
+  if (option !== undefined) return option;
+  return declared ?? envCacheStore(readEnv);
+}

--- a/packages/core/tests/affected_test.ts
+++ b/packages/core/tests/affected_test.ts
@@ -110,6 +110,19 @@ Deno.test("gitChangedFiles defaults the base to HEAD", async () => {
   assertEquals(calls[0][2], "HEAD");
 });
 
+Deno.test("gitChangedFiles rejects a base that git would read as an option", async () => {
+  let ran = false;
+  const run = (): Promise<string> => {
+    ran = true;
+    return Promise.resolve("");
+  };
+  const err = await assertRejects(() =>
+    gitChangedFiles("--output=/tmp/pwn", run)
+  );
+  assertStringIncludes(err.message, "must not start with");
+  assertEquals(ran, false); // rejected before git ran
+});
+
 Deno.test("runGitProcess returns stdout of a successful process", async () => {
   // Stand in the running `deno` for `git` (always present, shell-free).
   const out = await runGitProcess(

--- a/packages/core/tests/affected_test.ts
+++ b/packages/core/tests/affected_test.ts
@@ -1,0 +1,198 @@
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "./_assert.ts";
+import { target } from "../src/target.ts";
+import { plan } from "../src/graph.ts";
+import {
+  affectedTargets,
+  gitChangedFiles,
+  runGitProcess,
+} from "../src/affected.ts";
+import { Build, discoverTargets } from "../src/build.ts";
+import { execute, type Reporter } from "../src/executor.ts";
+
+/** Whether the affected set (by identity) contains `t`. */
+const has = (set: Set<unknown>, t: unknown) => set.has(t);
+
+Deno.test("affectedTargets: a target's own inputs gate it", () => {
+  const a = target().inputs("packages/a");
+  const b = target().inputs("packages/b").dependsOn(a);
+  const order = plan(b); // [a, b]
+
+  const forB = affectedTargets(order, ["packages/b/y.ts"]);
+  assertEquals(has(forB, a), false); // a's inputs unchanged
+  assertEquals(has(forB, b), true); // b's own inputs changed
+
+  const none = affectedTargets(order, ["unrelated/z.ts"]);
+  assertEquals(none.size, 0);
+});
+
+Deno.test("affectedTargets: affectedness propagates along dependencies", () => {
+  const a = target().inputs("packages/a");
+  const b = target().inputs("packages/b").dependsOn(a);
+  const order = plan(b);
+
+  const set = affectedTargets(order, ["packages/a/x.ts"]);
+  assertEquals(has(set, a), true); // changed directly
+  assertEquals(has(set, b), true); // dirtied by its dependency
+});
+
+Deno.test("affectedTargets: a target with no inputs is always affected", () => {
+  const c = target();
+  const set = affectedTargets(plan(c), []);
+  assertEquals(has(set, c), true);
+});
+
+Deno.test("affectedTargets: an affected target pulls its triggers along", () => {
+  const t2 = target().inputs("y");
+  const t1 = target().inputs("x").triggers(t2);
+  const order = plan(t1); // t1 before its trigger t2
+
+  const viaTrigger = affectedTargets(order, ["x/f.ts"]);
+  assertEquals(has(viaTrigger, t1), true); // own inputs changed
+  assertEquals(has(viaTrigger, t2), true); // pulled in by the trigger, though y is unchanged
+
+  const neither = affectedTargets(order, ["z/f.ts"]);
+  assertEquals(neither.size, 0);
+});
+
+Deno.test("affectedTargets: input matching covers files, directories, and the repo root", () => {
+  const dir = target().inputs("src");
+  assertEquals(has(affectedTargets([dir], ["src/a.ts"]), dir), true);
+  assertEquals(has(affectedTargets([dir], ["./src/a.ts"]), dir), true); // leading ./
+  assertEquals(has(affectedTargets([dir], ["src\\a.ts"]), dir), true); // backslashes
+  assertEquals(has(affectedTargets([dir], ["src-lib/a.ts"]), dir), false); // prefix isn't a path segment
+
+  const file = target().inputs("config.json");
+  assertEquals(has(affectedTargets([file], ["config.json"]), file), true);
+  assertEquals(has(affectedTargets([file], ["config.json.map"]), file), false);
+
+  const wholeRepo = target().inputs(".");
+  assertEquals(
+    has(affectedTargets([wholeRepo], ["anywhere/x"]), wholeRepo),
+    true,
+  );
+
+  const trailingSlash = target().inputs("src/");
+  assertEquals(
+    has(affectedTargets([trailingSlash], ["src/a.ts"]), trailingSlash),
+    true,
+  );
+
+  // Empty changed entries are ignored rather than matching everything.
+  const empty = target().inputs("src");
+  assertEquals(has(affectedTargets([empty], [""]), empty), false);
+});
+
+Deno.test("gitChangedFiles queries git and merges tracked + untracked, deduped", async () => {
+  const calls: string[][] = [];
+  const run = (args: string[]): Promise<string> => {
+    calls.push(args);
+    return Promise.resolve(
+      args[0] === "diff" ? "a.ts\n b.ts \n\n" : "a.ts\nc.ts\n",
+    );
+  };
+  const files = await gitChangedFiles("main", run);
+  assertEquals(files, ["a.ts", "b.ts", "c.ts"]); // trimmed, blank dropped, a.ts deduped
+  assertEquals(calls[0], ["diff", "--name-only", "main", "--"]);
+  assertEquals(calls[1], ["ls-files", "--others", "--exclude-standard"]);
+});
+
+Deno.test("gitChangedFiles defaults the base to HEAD", async () => {
+  const calls: string[][] = [];
+  const run = (args: string[]): Promise<string> => {
+    calls.push(args);
+    return Promise.resolve("");
+  };
+  await gitChangedFiles(undefined, run);
+  assertEquals(calls[0][2], "HEAD");
+});
+
+Deno.test("runGitProcess returns stdout of a successful process", async () => {
+  // Stand in the running `deno` for `git` (always present, shell-free).
+  const out = await runGitProcess(
+    ["eval", "console.log('src/a.ts'); console.log('src/b.ts')"],
+    Deno.execPath(),
+  );
+  assertEquals(out.trim().split("\n"), ["src/a.ts", "src/b.ts"]);
+});
+
+Deno.test("runGitProcess throws with stderr detail on a non-zero exit", async () => {
+  const err = await assertRejects(() =>
+    runGitProcess(
+      ["eval", "console.error('bad revision'); Deno.exit(1)"],
+      Deno.execPath(),
+    )
+  );
+  assertStringIncludes(err.message, "failed");
+  assertStringIncludes(err.message, "bad revision");
+});
+
+Deno.test("runGitProcess throws without detail when a failure prints nothing", async () => {
+  const err = await assertRejects(() =>
+    runGitProcess(["eval", "Deno.exit(2)"], Deno.execPath())
+  );
+  assertStringIncludes(err.message, "Is this a git repository");
+});
+
+Deno.test("runGitProcess reports a friendly error when git cannot be spawned", async () => {
+  const err = await assertRejects(() =>
+    runGitProcess(["diff"], "zuke-no-such-binary-xyz")
+  );
+  assertStringIncludes(err.message, "could not run");
+});
+
+/** A reporter that records every emitted line. */
+function recorder(): { lines: string[]; reporter: Reporter } {
+  const lines: string[] = [];
+  return {
+    lines,
+    reporter: {
+      info: (line) => void lines.push(line),
+      error: (line) => void lines.push(line),
+    },
+  };
+}
+
+Deno.test("execute --affected skips targets a change cannot reach", async () => {
+  class B extends Build {
+    a = target().inputs("packages/a").executes(() => {});
+    b = target().inputs("packages/b").dependsOn(this.a).executes(() => {});
+  }
+  const b = new B();
+  discoverTargets(b);
+  const result = await execute(b, b.b, {
+    silent: true,
+    cache: false,
+    affected: {
+      base: "origin/main",
+      changedFiles: () => Promise.resolve(["packages/b/f.ts"]),
+    },
+  });
+  assertEquals(result.executed, ["b"]); // a is unaffected and skipped; b still runs
+});
+
+Deno.test("execute --affected reports when nothing is affected", async () => {
+  class B extends Build {
+    a = target().inputs("packages/a").executes(() => {});
+    b = target().inputs("packages/b").dependsOn(this.a).executes(() => {});
+  }
+  const b = new B();
+  discoverTargets(b);
+  const { lines, reporter } = recorder();
+  const result = await execute(b, b.b, {
+    reporter,
+    cache: false,
+    affected: {
+      base: "x",
+      changedFiles: () => Promise.resolve(["unrelated/z"]),
+    },
+  });
+  assertEquals(result.executed, []);
+  assertStringIncludes(
+    lines.join("\n"),
+    "No targets affected by changes since x.",
+  );
+});

--- a/packages/core/tests/affected_test.ts
+++ b/packages/core/tests/affected_test.ts
@@ -185,14 +185,12 @@ Deno.test("execute --affected reports when nothing is affected", async () => {
   const result = await execute(b, b.b, {
     reporter,
     cache: false,
-    affected: {
-      base: "x",
-      changedFiles: () => Promise.resolve(["unrelated/z"]),
-    },
+    // No base → defaults to HEAD; changedFiles injected so no git is needed.
+    affected: { changedFiles: () => Promise.resolve(["unrelated/z"]) },
   });
   assertEquals(result.executed, []);
   assertStringIncludes(
     lines.join("\n"),
-    "No targets affected by changes since x.",
+    "No targets affected by changes since HEAD.",
   );
 });

--- a/packages/core/tests/cache_test.ts
+++ b/packages/core/tests/cache_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "./_assert.ts";
+import { assertEquals, assertStringIncludes } from "./_assert.ts";
 import { target } from "../src/target.ts";
 import {
   type CacheHost,
@@ -6,8 +6,14 @@ import {
   fingerprint,
   openCache,
 } from "../src/cache.ts";
+import {
+  archiveOutputs,
+  remoteCacheKey,
+  type RemoteCacheStore,
+} from "../src/remote_cache.ts";
 
 const enc = (text: string) => new TextEncoder().encode(text);
+const dec = (bytes: Uint8Array) => new TextDecoder().decode(bytes);
 
 /** An in-memory {@link CacheHost} for hermetic cache tests. */
 class MemHost implements CacheHost {
@@ -25,6 +31,10 @@ class MemHost implements CacheHost {
   }
   readDir(path: string): Promise<string[]> {
     return Promise.resolve(this.dirs.get(path) ?? []);
+  }
+  writeFile(path: string, bytes: Uint8Array): Promise<void> {
+    this.files.set(path, bytes);
+    return Promise.resolve();
   }
   readStore(path: string): Promise<string | null> {
     return Promise.resolve(this.stores.get(path) ?? null);
@@ -156,4 +166,141 @@ Deno.test("a corrupt or non-object store is treated as empty", async () => {
   host.stores.set(STORE, '{"build": 42}');
   const mixed = await openCache(STORE, host);
   assertEquals(await mixed.upToDate(t), false);
+});
+
+/** A recording in-memory {@link RemoteCacheStore}. */
+class MemStore implements RemoteCacheStore {
+  readonly map = new Map<string, Uint8Array>();
+  readonly gets: string[] = [];
+  readonly puts: string[] = [];
+  failGet = false;
+  failPut = false;
+  get(key: string): Promise<Uint8Array | null> {
+    this.gets.push(key);
+    if (this.failGet) return Promise.reject(new Error("network down"));
+    return Promise.resolve(this.map.get(key) ?? null);
+  }
+  put(key: string, artifact: Uint8Array): Promise<void> {
+    this.puts.push(key);
+    if (this.failPut) return Promise.reject(new Error("network down"));
+    this.map.set(key, artifact);
+    return Promise.resolve();
+  }
+}
+
+/** A cacheable target with one input and one output directory, named `build`. */
+function buildTarget(): ReturnType<typeof target> {
+  const t = target().inputs("in.txt").outputs("dist");
+  t.name_ = "build";
+  return t;
+}
+
+Deno.test("the remote store restores outputs on a local miss", async () => {
+  const host = new MemHost();
+  host.files.set("in.txt", enc("v1"));
+  host.dirs.set("dist", ["app.js"]);
+  host.files.set("dist/app.js", enc("built"));
+  const t = buildTarget();
+
+  // Pre-seed the store with an archive keyed by the current fingerprint, then
+  // simulate a fresh checkout by dropping the local output.
+  const fp = await fingerprint(t, host);
+  const store = new MemStore();
+  store.map.set(
+    remoteCacheKey("build", fp),
+    await archiveOutputs(["dist"], host),
+  );
+  host.dirs.delete("dist");
+  host.files.delete("dist/app.js");
+
+  const cache = await openCache(STORE, host, { remote: store });
+  assertEquals(await cache.upToDate(t), true); // restored, counts as a hit
+  assertEquals(store.gets, [remoteCacheKey("build", fp)]);
+  assertEquals(dec(host.files.get("dist/app.js") ?? enc("")), "built"); // written back
+});
+
+Deno.test("a successful run uploads outputs to the remote store", async () => {
+  const host = new MemHost();
+  host.files.set("in.txt", enc("v1"));
+  host.dirs.set("dist", ["app.js"]);
+  host.files.set("dist/app.js", enc("built"));
+  const t = buildTarget();
+  const store = new MemStore();
+
+  const cache = await openCache(STORE, host, { remote: store });
+  await cache.record(t);
+  const fp = await fingerprint(t, host);
+  assertEquals(store.puts, [remoteCacheKey("build", fp)]);
+  assertEquals(store.map.has(remoteCacheKey("build", fp)), true);
+});
+
+Deno.test("outputs just restored are not re-uploaded", async () => {
+  const host = new MemHost();
+  host.files.set("in.txt", enc("v1"));
+  host.dirs.set("dist", ["app.js"]);
+  host.files.set("dist/app.js", enc("built"));
+  const t = buildTarget();
+  const fp = await fingerprint(t, host);
+  const store = new MemStore();
+  store.map.set(
+    remoteCacheKey("build", fp),
+    await archiveOutputs(["dist"], host),
+  );
+  host.dirs.delete("dist");
+  host.files.delete("dist/app.js");
+
+  const cache = await openCache(STORE, host, { remote: store });
+  await cache.upToDate(t); // restores
+  await cache.record(t); // should not upload again
+  assertEquals(store.puts, []);
+});
+
+Deno.test("a remote lookup failure warns and falls back to a rebuild", async () => {
+  const host = new MemHost();
+  host.files.set("in.txt", enc("v1"));
+  host.dirs.set("dist", ["app.js"]);
+  host.files.set("dist/app.js", enc("built"));
+  const t = buildTarget();
+  const store = new MemStore();
+  store.failGet = true;
+  const warnings: string[] = [];
+
+  const cache = await openCache(STORE, host, {
+    remote: store,
+    warn: (m) => warnings.push(m),
+  });
+  assertEquals(await cache.upToDate(t), false); // rebuild rather than fail
+  assertStringIncludes(warnings.join("\n"), "lookup");
+});
+
+Deno.test("a remote upload failure warns but never fails the build", async () => {
+  const host = new MemHost();
+  host.files.set("in.txt", enc("v1"));
+  host.dirs.set("dist", ["app.js"]);
+  host.files.set("dist/app.js", enc("built"));
+  const t = buildTarget();
+  const store = new MemStore();
+  store.failPut = true;
+  const warnings: string[] = [];
+
+  const cache = await openCache(STORE, host, {
+    remote: store,
+    warn: (m) => warnings.push(m),
+  });
+  await cache.record(t); // resolves despite the upload error
+  assertStringIncludes(warnings.join("\n"), "upload");
+});
+
+Deno.test("targets without outputs never touch the remote store", async () => {
+  const host = new MemHost();
+  host.files.set("in.txt", enc("v1"));
+  const t = target().inputs("in.txt"); // no outputs
+  t.name_ = "lint";
+  const store = new MemStore();
+
+  const cache = await openCache(STORE, host, { remote: store });
+  assertEquals(await cache.upToDate(t), false);
+  await cache.record(t);
+  assertEquals(store.gets, []);
+  assertEquals(store.puts, []);
 });

--- a/packages/core/tests/ci_test.ts
+++ b/packages/core/tests/ci_test.ts
@@ -1,12 +1,14 @@
 import { assertEquals, assertStringIncludes } from "./_assert.ts";
 import {
   cicd,
+  CiFile,
   type CiPipeline,
   discoverCiFiles,
+  fanOutPipeline,
   generateCi,
   syncCiFiles,
 } from "../src/ci.ts";
-import { Build } from "../src/build.ts";
+import { Build, discoverTargets } from "../src/build.ts";
 import { target } from "../src/target.ts";
 
 /** A small pipeline exercised across providers. */
@@ -453,4 +455,134 @@ Deno.test("syncCiFiles uses the real filesystem by default", async () => {
   } finally {
     await Deno.remove(dir, { recursive: true });
   }
+});
+
+/** A small build whose targets exercise the fan-out. */
+class FanBuild extends Build {
+  lint = target().description("Lint").executes(() => {});
+  test = target().dependsOn(this.lint).executes(() => {});
+  build = target().dependsOn(this.lint).executes(() => {});
+  hidden = target().unlisted().executes(() => {});
+  empty = target().description("no body"); // not runnable
+}
+
+Deno.test("fanOutPipeline makes one job per runnable target, wired by dependencies", () => {
+  const targets = discoverTargets(new FanBuild());
+  const pipeline = fanOutPipeline(targets);
+  const jobs = pipeline.jobs ?? [];
+  const ids = jobs.map((j) => j.id);
+  // lint/test/build only: `hidden` is unlisted and `empty` has no body.
+  assertEquals(ids, ["lint", "test", "build"]);
+
+  const test = jobs.find((j) => j.id === "test");
+  assertEquals(test?.needs, ["lint"]); // mirrors dependsOn
+  assertEquals(test?.steps?.at(-1)?.run, "./zuke test"); // default launcher command
+  assertEquals(test?.steps?.[0]?.uses, "actions/checkout@v4"); // default setup
+
+  const lint = jobs.find((j) => j.id === "lint");
+  assertEquals(lint?.needs, undefined); // no dependencies → no needs
+  assertEquals(lint?.name, "Lint"); // description becomes the job name
+});
+
+Deno.test("fanOutPipeline honours includeUnlisted and drops needs to omitted jobs", () => {
+  const targets = discoverTargets(new FanBuild());
+  const pipeline = fanOutPipeline(targets, {}, { includeUnlisted: true });
+  const ids = (pipeline.jobs ?? []).map((j) => j.id);
+  assertEquals(ids.includes("hidden"), true);
+});
+
+Deno.test("fanOutPipeline drops needs edges to excluded targets", () => {
+  class B extends Build {
+    hiddenDep = target().unlisted().executes(() => {});
+    app = target().dependsOn(this.hiddenDep).executes(() => {});
+  }
+  const pipeline = fanOutPipeline(discoverTargets(new B()));
+  const app = (pipeline.jobs ?? []).find((j) => j.id === "app");
+  assertEquals(app?.needs, undefined); // the only dep was excluded
+});
+
+Deno.test("fanOutPipeline applies command, runsOn, env, and setup overrides", () => {
+  const targets = discoverTargets(new FanBuild());
+  const pipeline = fanOutPipeline(targets, {}, {
+    command: (t) => `make ${t}`,
+    runsOn: "self-hosted",
+    env: { KEY: "v" },
+    setupSteps: [{ name: "Prep", run: "echo prep" }],
+  });
+  const lint = (pipeline.jobs ?? []).find((j) => j.id === "lint");
+  assertEquals(lint?.runsOn, "self-hosted");
+  assertEquals(lint?.env, { KEY: "v" });
+  assertEquals(lint?.steps?.[0]?.run, "echo prep");
+  assertEquals(lint?.steps?.at(-1)?.run, "make lint");
+});
+
+Deno.test("fanOutPipeline carries base pipeline fields and ignores base jobs", () => {
+  const targets = discoverTargets(new FanBuild());
+  const pipeline = fanOutPipeline(targets, {
+    name: "My CI",
+    triggers: { push: ["release"] },
+    permissions: { contents: "read" },
+    concurrency: { group: "g", cancelInProgress: true },
+    jobs: [{ id: "ignored", steps: [{ run: "nope" }] }],
+  });
+  assertEquals(pipeline.name, "My CI");
+  assertEquals(pipeline.triggers?.push, ["release"]);
+  assertEquals(pipeline.permissions, { contents: "read" });
+  assertEquals(pipeline.concurrency?.group, "g");
+  assertEquals((pipeline.jobs ?? []).some((j) => j.id === "ignored"), false);
+});
+
+Deno.test("fanOutPipeline sanitises dotted component target names into job ids", () => {
+  const release = { publish: target().dependsOn().executes(() => {}) };
+  class B extends Build {
+    release = release;
+    deploy = target().dependsOn(release.publish).executes(() => {});
+  }
+  const pipeline = fanOutPipeline(discoverTargets(new B()));
+  const ids = (pipeline.jobs ?? []).map((j) => j.id);
+  assertEquals(ids.includes("release-publish"), true); // dot → dash
+  const deploy = (pipeline.jobs ?? []).find((j) => j.id === "deploy");
+  assertEquals(deploy?.needs, ["release-publish"]);
+});
+
+Deno.test("cicd fanOut expands into a per-target workflow via discoverCiFiles", () => {
+  class WithFanOut extends Build {
+    lint = target().executes(() => {});
+    test = target().dependsOn(this.lint).executes(() => {});
+    ci = cicd({
+      provider: "github",
+      fanOut: true,
+      pipeline: { name: "Fanned" },
+    });
+  }
+  const files = discoverCiFiles(new WithFanOut());
+  assertEquals(files.length, 1);
+  const yaml = files[0].render();
+  assertStringIncludes(yaml, "name: Fanned");
+  assertStringIncludes(yaml, "run: ./zuke lint");
+  assertStringIncludes(yaml, "run: ./zuke test");
+  assertStringIncludes(yaml, "needs:");
+});
+
+Deno.test("a non-fan-out cicd file is unaffected by discovery resolution", () => {
+  class Plain extends Build {
+    build = target().executes(() => {});
+    ci = cicd({ provider: "github", pipeline: { name: "Plain" } });
+  }
+  const yaml = discoverCiFiles(new Plain())[0].render();
+  assertStringIncludes(yaml, "name: Plain");
+});
+
+Deno.test("CiFile.pipelineFor returns the base pipeline when not fanning out", () => {
+  const file = new CiFile({ provider: "github", pipeline: { name: "Base" } });
+  assertEquals(file.pipelineFor(new Map()).name, "Base");
+});
+
+Deno.test("cicd accepts fan-out options directly", () => {
+  class B extends Build {
+    lint = target().executes(() => {});
+    ci = cicd({ provider: "github", fanOut: { runsOn: "self-hosted" } });
+  }
+  const yaml = discoverCiFiles(new B())[0].render();
+  assertStringIncludes(yaml, "runs-on: self-hosted");
 });

--- a/packages/core/tests/cli_test.ts
+++ b/packages/core/tests/cli_test.ts
@@ -176,6 +176,20 @@ Deno.test("parseArgs reads --dry-run, defaulting to false", () => {
   assertEquals(parseArgs(["build", "--dry-run"]).dryRun, true);
 });
 
+Deno.test("parseArgs reads --affected with an optional base", () => {
+  assertEquals(parseArgs(["build"]).affected, false);
+  assertEquals(parseArgs(["build", "--affected"]).affected, true);
+  assertEquals(parseArgs(["build", "--affected"]).affectedBase, undefined);
+  const based = parseArgs(["build", "--affected=origin/main"]);
+  assertEquals(based.affected, true);
+  assertEquals(based.affectedBase, "origin/main");
+});
+
+Deno.test("parseArgs reads --no-remote-cache, defaulting to undefined", () => {
+  assertEquals(parseArgs(["build"]).remoteCache, undefined);
+  assertEquals(parseArgs(["build", "--no-remote-cache"]).remoteCache, false);
+});
+
 Deno.test("parseArgs accumulates repeated list flags comma-joined", () => {
   const flags = [
     { name: "tags", flag: "tags", boolean: false, array: true },

--- a/packages/core/tests/executor_test.ts
+++ b/packages/core/tests/executor_test.ts
@@ -7,6 +7,7 @@ import {
 } from "../src/build.ts";
 import { group, target } from "../src/target.ts";
 import type { BuildCache } from "../src/cache.ts";
+import type { RemoteCacheStore } from "../src/remote_cache.ts";
 import { parameter } from "../src/params.ts";
 
 /** An in-memory {@link BuildCache} for executor caching tests. */
@@ -1548,4 +1549,61 @@ Deno.test("recoverWith only runs after a body failure, not on success", async ()
   const result = await execute(b, b.work, silent);
   assertEquals(result.ok, true);
   assertEquals(fixed, false);
+});
+
+/** A recording in-memory {@link RemoteCacheStore} for executor tests. */
+class MemStore implements RemoteCacheStore {
+  readonly map = new Map<string, Uint8Array>();
+  readonly puts: string[] = [];
+  get(key: string): Promise<Uint8Array | null> {
+    return Promise.resolve(this.map.get(key) ?? null);
+  }
+  put(key: string, artifact: Uint8Array): Promise<void> {
+    this.puts.push(key);
+    this.map.set(key, artifact);
+    return Promise.resolve();
+  }
+}
+
+Deno.test("execute uploads to and restores from a remote cache store", async () => {
+  const dir = await Deno.makeTempDir();
+  const original = Deno.cwd();
+  try {
+    await Deno.writeTextFile(`${dir}/zuke.json`, "{}\n");
+    await Deno.writeTextFile(`${dir}/input.txt`, "v1");
+    await Deno.mkdir(`${dir}/out`);
+    await Deno.writeTextFile(`${dir}/out/app.js`, "built");
+    Deno.chdir(dir);
+    const store = new MemStore();
+
+    class B extends Build {
+      build = target().inputs("input.txt").outputs("out").executes(() => {});
+    }
+    const first = new B();
+    discoverTargets(first);
+    await execute(first, first.build, { silent: true, remoteCache: store });
+    assertEquals(store.puts.length, 1); // outputs uploaded after the run
+
+    // Simulate a fresh checkout: drop the local cache and outputs, keep the store.
+    await Deno.remove(`${dir}/.zuke`, { recursive: true });
+    await Deno.remove(`${dir}/out`, { recursive: true });
+    let ran = false;
+    class B2 extends Build {
+      build = target().inputs("input.txt").outputs("out").executes(() => {
+        ran = true;
+      });
+    }
+    const second = new B2();
+    discoverTargets(second);
+    const result = await execute(second, second.build, {
+      silent: true,
+      remoteCache: store,
+    });
+    assertEquals(ran, false); // restored from the store, body skipped
+    assertEquals(await Deno.readTextFile(`${dir}/out/app.js`), "built");
+    assertEquals(result.ok, true);
+  } finally {
+    Deno.chdir(original);
+    await Deno.remove(dir, { recursive: true });
+  }
 });

--- a/packages/core/tests/remote_cache_test.ts
+++ b/packages/core/tests/remote_cache_test.ts
@@ -1,4 +1,8 @@
-import { assertEquals, assertRejects } from "./_assert.ts";
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "./_assert.ts";
 import {
   archiveOutputs,
   envCacheStore,
@@ -11,6 +15,7 @@ import {
   restoreOutputs,
 } from "../src/remote_cache.ts";
 import { HttpError } from "../src/http.ts";
+import { gzip, tar } from "../src/compression.ts";
 
 const enc = (text: string) => new TextEncoder().encode(text);
 const dec = (bytes: Uint8Array) => new TextDecoder().decode(bytes);
@@ -54,6 +59,22 @@ Deno.test("archiveOutputs/restoreOutputs round-trip files and directories", asyn
   assertEquals(dec(out.files.get("dist/app.js") ?? enc("")), "built");
   assertEquals(dec(out.files.get("dist/assets/logo.svg") ?? enc("")), "<svg/>");
   assertEquals(dec(out.files.get("README.md") ?? enc("")), "readme");
+});
+
+Deno.test("restoreOutputs refuses archive entries that escape the workspace", async () => {
+  const out = new MemFs();
+  // A ".." entry would land outside the current directory.
+  const escaping = await gzip(tar([{ name: "../evil.sh", data: enc("x") }]));
+  const escapeErr = await assertRejects(() => restoreOutputs(escaping, out));
+  assertStringIncludes(escapeErr.message, "escapes the workspace");
+
+  // An absolute path would ignore the workspace entirely.
+  const absolute = await gzip(tar([{ name: "/etc/evil", data: enc("x") }]));
+  const absErr = await assertRejects(() => restoreOutputs(absolute, out));
+  assertStringIncludes(absErr.message, "absolute path");
+
+  // Nothing was written for either malicious archive.
+  assertEquals(out.files.size, 0);
 });
 
 Deno.test("archiveOutputs skips a declared output that is missing", async () => {

--- a/packages/core/tests/remote_cache_test.ts
+++ b/packages/core/tests/remote_cache_test.ts
@@ -1,0 +1,241 @@
+import { assertEquals, assertRejects } from "./_assert.ts";
+import {
+  archiveOutputs,
+  envCacheStore,
+  FileSystemCacheStore,
+  HttpCacheStore,
+  type OutputHost,
+  remoteCacheKey,
+  type RemoteCacheStore,
+  resolveRemoteStore,
+  restoreOutputs,
+} from "../src/remote_cache.ts";
+import { HttpError } from "../src/http.ts";
+
+const enc = (text: string) => new TextEncoder().encode(text);
+const dec = (bytes: Uint8Array) => new TextDecoder().decode(bytes);
+
+/** An in-memory {@link OutputHost} for archive/restore tests. */
+class MemFs implements OutputHost {
+  readonly files = new Map<string, Uint8Array>();
+  readonly dirs = new Map<string, string[]>();
+
+  readFile(path: string): Promise<Uint8Array | null> {
+    return Promise.resolve(this.files.get(path) ?? null);
+  }
+  stat(path: string): Promise<{ isDirectory: boolean } | null> {
+    if (this.dirs.has(path)) return Promise.resolve({ isDirectory: true });
+    if (this.files.has(path)) return Promise.resolve({ isDirectory: false });
+    return Promise.resolve(null);
+  }
+  readDir(path: string): Promise<string[]> {
+    return Promise.resolve(this.dirs.get(path) ?? []);
+  }
+  writeFile(path: string, bytes: Uint8Array): Promise<void> {
+    this.files.set(path, bytes);
+    return Promise.resolve();
+  }
+}
+
+Deno.test("archiveOutputs/restoreOutputs round-trip files and directories", async () => {
+  const src = new MemFs();
+  src.files.set("dist/app.js", enc("built"));
+  src.dirs.set("dist", ["app.js", "assets"]);
+  src.dirs.set("dist/assets", ["logo.svg"]);
+  src.files.set("dist/assets/logo.svg", enc("<svg/>"));
+  src.files.set("README.md", enc("readme"));
+
+  const artifact = await archiveOutputs(["dist", "README.md"], src);
+
+  const out = new MemFs();
+  const written = await restoreOutputs(artifact, out);
+  // Entries are sorted for a reproducible archive.
+  assertEquals(written, ["README.md", "dist/app.js", "dist/assets/logo.svg"]);
+  assertEquals(dec(out.files.get("dist/app.js") ?? enc("")), "built");
+  assertEquals(dec(out.files.get("dist/assets/logo.svg") ?? enc("")), "<svg/>");
+  assertEquals(dec(out.files.get("README.md") ?? enc("")), "readme");
+});
+
+Deno.test("archiveOutputs skips a declared output that is missing", async () => {
+  const src = new MemFs();
+  src.files.set("dist/app.js", enc("built"));
+  src.dirs.set("dist", ["app.js"]);
+  const artifact = await archiveOutputs(["dist", "gone"], src);
+  const out = new MemFs();
+  const written = await restoreOutputs(artifact, out);
+  assertEquals(written, ["dist/app.js"]);
+});
+
+Deno.test("remoteCacheKey sanitises the name and carries the fingerprint", () => {
+  assertEquals(
+    remoteCacheKey("release.publish", "abc123"),
+    "release.publish-abc123",
+  );
+  assertEquals(remoteCacheKey("weird name/slash", "ff"), "weird_name_slash-ff");
+});
+
+Deno.test("FileSystemCacheStore stores and retrieves artifacts", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemCacheStore(`${dir}/cache`);
+    assertEquals(await store.get("missing"), null);
+    await store.put("k1", enc("payload"));
+    const got = await store.get("k1");
+    assertEquals(got === null ? "" : dec(got), "payload");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+/** Build a `typeof fetch` stand-in from a synchronous handler, recording calls. */
+function fakeFetch(
+  handler: (url: string, init?: RequestInit) => Response,
+): { fetch: typeof fetch; calls: Array<{ url: string; init?: RequestInit }> } {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fetchFn: typeof fetch = (input, init) => {
+    const url = input instanceof Request ? input.url : String(input);
+    calls.push({ url, init });
+    return Promise.resolve(handler(url, init));
+  };
+  return { fetch: fetchFn, calls };
+}
+
+Deno.test("HttpCacheStore GET returns bytes, and null on 404", async () => {
+  const hit = fakeFetch(() =>
+    new Response(new Uint8Array([1, 2, 3]), { status: 200 })
+  );
+  const store = new HttpCacheStore({
+    url: "https://cache.test/",
+    token: "tok",
+    fetch: hit.fetch,
+  });
+  const got = await store.get("build-abc");
+  assertEquals(got === null ? [] : Array.from(got), [1, 2, 3]);
+  assertEquals(hit.calls[0].url, "https://cache.test/build-abc"); // trailing slash trimmed
+  assertEquals(
+    new Headers(hit.calls[0].init?.headers).get("Authorization"),
+    "Bearer tok",
+  );
+
+  const miss = fakeFetch(() => new Response(null, { status: 404 }));
+  const missStore = new HttpCacheStore({
+    url: "https://cache.test",
+    fetch: miss.fetch,
+  });
+  assertEquals(await missStore.get("nope"), null);
+});
+
+Deno.test("HttpCacheStore GET throws on a non-404 error status", async () => {
+  const { fetch } = fakeFetch(() => new Response("boom", { status: 500 }));
+  const store = new HttpCacheStore({ url: "https://cache.test", fetch });
+  const err = await assertRejects(() => store.get("k"));
+  assertEquals(err instanceof HttpError, true);
+});
+
+Deno.test("HttpCacheStore PUT sends the artifact and throws on failure", async () => {
+  const ok = fakeFetch(() => new Response(null, { status: 201 }));
+  const store = new HttpCacheStore({
+    url: "https://cache.test",
+    token: "t",
+    fetch: ok.fetch,
+  });
+  await store.put("k1", enc("data"));
+  assertEquals(ok.calls[0].init?.method, "PUT");
+  assertEquals(ok.calls[0].url, "https://cache.test/k1");
+
+  const bad = fakeFetch(() => new Response(null, { status: 403 }));
+  const badStore = new HttpCacheStore({
+    url: "https://cache.test",
+    fetch: bad.fetch,
+  });
+  const err = await assertRejects(() => badStore.put("k", enc("x")));
+  assertEquals(err instanceof HttpError, true);
+});
+
+Deno.test("envCacheStore selects HTTP, then filesystem, then nothing", () => {
+  const env =
+    (vars: Record<string, string>) => (name: string): string | undefined =>
+      Object.prototype.hasOwnProperty.call(vars, name) ? vars[name] : undefined;
+
+  assertEquals(
+    envCacheStore(
+      env({
+        ZUKE_REMOTE_CACHE_URL: "https://c.test",
+        ZUKE_REMOTE_CACHE_TOKEN: "t",
+      }),
+    ) instanceof
+      HttpCacheStore,
+    true,
+  );
+  // A URL wins even when a directory is also set.
+  assertEquals(
+    envCacheStore(
+      env({
+        ZUKE_REMOTE_CACHE_URL: "https://c.test",
+        ZUKE_REMOTE_CACHE_DIR: "/tmp/x",
+      }),
+    ) instanceof
+      HttpCacheStore,
+    true,
+  );
+  assertEquals(
+    envCacheStore(env({ ZUKE_REMOTE_CACHE_DIR: "/tmp/cache" })) instanceof
+      FileSystemCacheStore,
+    true,
+  );
+  assertEquals(envCacheStore(() => undefined), undefined);
+  // An empty value is treated as unset.
+  assertEquals(envCacheStore(env({ ZUKE_REMOTE_CACHE_URL: "" })), undefined);
+});
+
+Deno.test("archiveOutputs ignores an entry whose file reads back as null", async () => {
+  // A host that claims a file exists (stat) but yields no bytes (readFile null).
+  const host: OutputHost = {
+    stat: () => Promise.resolve({ isDirectory: false }),
+    readFile: () => Promise.resolve(null),
+    readDir: () => Promise.resolve([]),
+    writeFile: () => Promise.resolve(),
+  };
+  const artifact = await archiveOutputs(["ghost"], host);
+  const out = new MemFs();
+  assertEquals(await restoreOutputs(artifact, out), []); // nothing archived
+});
+
+Deno.test("FileSystemCacheStore.get propagates a non-NotFound read error", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemCacheStore(dir);
+    // Make the artifact path a directory so reading it fails (not NotFound).
+    await Deno.mkdir(`${dir}/busy.tar.gz`);
+    const err = await assertRejects(() => store.get("busy"));
+    assertEquals(err instanceof Error, true); // a non-NotFound error propagates
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("resolveRemoteStore honours option, then declared, then env", () => {
+  const explicit: RemoteCacheStore = {
+    get: () => Promise.resolve(null),
+    put: () => Promise.resolve(),
+  };
+  const declared: RemoteCacheStore = {
+    get: () => Promise.resolve(null),
+    put: () => Promise.resolve(),
+  };
+  const env = (name: string): string | undefined =>
+    name === "ZUKE_REMOTE_CACHE_DIR" ? "/tmp/c" : undefined;
+
+  assertEquals(resolveRemoteStore(false, declared, env), undefined); // disabled wins
+  assertEquals(resolveRemoteStore(explicit, declared, env), explicit); // explicit option
+  assertEquals(resolveRemoteStore(undefined, declared, env), declared); // build override
+  assertEquals(
+    resolveRemoteStore(undefined, undefined, env) instanceof
+      FileSystemCacheStore,
+    true, // environment fallback
+  );
+  assertEquals(
+    resolveRemoteStore(undefined, undefined, () => undefined),
+    undefined,
+  );
+});


### PR DESCRIPTION
## What & why

This PR adds three composable, CI-focused capabilities to **`@zuke/core`**, aimed at the single biggest reason teams adopt (or abandon) a build tool: **how fast, and how little, it re-runs.** Each is independently useful; together they let a monorepo run only what a change touched, restore the rest from a shared cache, and fan the whole thing out across parallel CI jobs.

All three build on machinery Zuke already had — the input-fingerprint cache, the declared target graph, and the provider-agnostic CI model — so they gap-fill rather than duplicate. No new runtime dependencies; both cache backends and the archiver use the platform (`fetch`, `CompressionStream`, Web Crypto) and the existing dependency-free `tar`/`gzip` helpers.

> Bundled as one PR at the author's request. It's three clean commits (one per feature) if you'd prefer to review or land them separately.

---

### 1. `--affected` — git-aware execution

**Problem.** In a monorepo, `zuke ci` runs every target even when a change touched one package. The incremental cache skips *unchanged* work, but you still pay to discover that nothing changed across the whole graph.

**What it adds.** `--affected` asks git for the files changed since a base revision and runs **only the targets a change can reach** — the monorepo-scale complement to the per-target cache. Unaffected targets are skipped (their prior outputs are assumed current, so a skipped dependency still unblocks its dependents).

A target is **affected** when a changed file falls inside one of its declared `.inputs()`, **or** when any of its dependencies is affected (affectedness propagates downstream along `dependsOn` and `triggers`). A target that declares **no** inputs can't be proven unaffected, so it always runs — declare `inputs` on the targets you want `--affected` to be able to skip.

```sh
zuke ci --affected                 # vs HEAD (uncommitted changes)
zuke ci --affected=origin/main     # vs a base branch — the usual CI form
```

- New module `src/affected.ts`: a **pure** `affectedTargets(order, changed)` (fully unit-tested, no git needed) plus an **injectable** git-diff seam (`gitChangedFiles`, `runGitProcess`) so the affected plan is hermetic to test.
- New `execute({ affected: { base?, changedFiles? } })` option and a `--affected[=<base>]` CLI flag (base defaults to `HEAD`).
- The git diff combines tracked changes vs the base with untracked files; a repo/revision error surfaces a friendly message.

### 2. Remote cache with output restore

**Problem.** The incremental cache is **local-only** and only *skips* — it never *restores*. A fresh CI checkout or a teammate's machine rebuilds everything from scratch.

**What it adds.** A `RemoteCacheStore` that shares a target's built `.outputs()` across machines: on a local miss, Zuke **restores** the outputs from the store instead of rebuilding; after a successful run it **uploads** them for the next machine. It applies to targets that declare both `inputs` and `outputs`, keyed by the same input fingerprint the local cache already computes. **A store outage is never fatal** — Zuke logs a warning and falls back to a local rebuild.

Two dependency-free backends ship behind one interface:

| Backend | Use case | Storage |
| --- | --- | --- |
| `FileSystemCacheStore` | Self-hosted runners, NFS/CI volumes | `<dir>/<key>.tar.gz` |
| `HttpCacheStore` | Any S3/GCS/R2 bucket or cache server behind a URL | `GET`/`PUT <url>/<key>`, optional bearer token |

Configured by precedence: an explicit `execute({ remoteCache })` option → a typed `remoteCache()` build override → the `ZUKE_REMOTE_CACHE_*` environment variables.

```ts
class CI extends Build {
  cacheToken = parameter("Cache token").secret().env("CACHE_TOKEN");
  override remoteCache() {
    return new HttpCacheStore({ url: "https://cache.example.com", token: this.cacheToken.value });
  }
  build = target().inputs("src").outputs("dist").executes(/* … */);
}
```

```sh
ZUKE_REMOTE_CACHE_URL=https://cache.example.com ZUKE_REMOTE_CACHE_TOKEN=… ./zuke ci
ZUKE_REMOTE_CACHE_DIR=/mnt/zuke-cache ./zuke ci      # filesystem backend
```

- New module `src/remote_cache.ts`: the interface, both stores, the env resolver, output archiving/restore (`archiveOutputs`/`restoreOutputs` over an injectable `OutputHost`), the store-key derivation, and the precedence resolver.
- `src/cache.ts` grows a remote-aware `FsCache`: local miss → remote restore → counts as a hit; successful run → upload (skipped if it was just restored). Adds `writeFile` to `CacheHost` and an `OpenCacheOptions` (`remote`, `warn`).
- New `--no-remote-cache` flag uses the **local** cache only for a run (`--no-cache` still disables both).

### 3. CI job fan-out in `generate-ci`

**Problem.** `cicd()` emitted a single job that runs the whole build. A hand-written multi-job YAML with `needs:` edges can't stay in sync with the build's real dependency graph.

**What it adds.** A **fan-out** mode that turns **each target into its own CI job**, wired together with `needs:` edges that mirror the targets' `dependsOn` — so independent targets run in parallel on the provider and the build graph *is* the workflow shape. Each job runs only its own target (`./zuke <target>`); dependencies run in their own jobs and share outputs through the remote cache (#2), so fan-out pairs naturally with a configured store.

```ts
ci = cicd({
  provider: "github",
  fanOut: { env: { ZUKE_REMOTE_CACHE_DIR: "/mnt/zuke-cache" } },
});
```

This emits a `lint` job plus `test`/`build` jobs that each declare `needs: [lint]`. `fanOut: true` uses the defaults; `FanOutOptions` sets the per-job `command`, `setupSteps` (default: an `actions/checkout`, rendered on GitHub, auto on GitLab/Azure), `runsOn`, `env`, and `includeUnlisted`. The `pipeline` field still supplies the workflow-level `name`/`triggers`/`permissions`/`concurrency`. Targets with no body, and `unlisted` ones, are omitted, and `needs` edges to omitted targets are dropped. `discoverCiFiles` resolves fan-out against the build's targets; `fanOutPipeline(targets, base, options)` exposes the expansion directly.

---

### New public API surface

<details><summary>Exports added to <code>@zuke/core</code> (click to expand)</summary>

- **Affected** — `affectedTargets`, `gitChangedFiles`, `type ChangedFilesFn`, `type AffectedOptions`
- **Remote cache** — `RemoteCacheStore`, `FileSystemCacheStore`, `HttpCacheStore`, `type HttpCacheStoreOptions`, `type OutputHost`, `archiveOutputs`, `restoreOutputs`, `remoteCacheKey`, `resolveRemoteStore`, `envCacheStore`, `type OpenCacheOptions`
- **CI fan-out** — `fanOutPipeline`, `type FanOutOptions`, `CiFileSpec.fanOut`, `CiFile.pipelineFor(...)`
- **Build** — new `Build.remoteCache()` override
- **`ExecuteOptions`** — new `affected` and `remoteCache` fields

</details>

**CLI / env additions:** `--affected[=<base>]`, `--no-remote-cache`; env `ZUKE_REMOTE_CACHE_URL`, `ZUKE_REMOTE_CACHE_TOKEN`, `ZUKE_REMOTE_CACHE_DIR`. New flags are registered in the single `cli_spec.ts` registry, so they appear in `--help`, completions, and the `--json` surface automatically.

### How they compose

`--affected` prunes the plan to changed targets → the local cache skips unchanged work within what remains → the remote cache restores anything not built on this machine → fan-out spreads it all across parallel CI jobs that share those artifacts. Each is opt-in and useful alone.

### Files changed

20 files, +2086 / −75. New source `src/affected.ts`, `src/remote_cache.ts`; edits to `src/cache.ts`, `src/ci.ts`, `src/cli.ts`, `src/cli_spec.ts`, `src/executor.ts`, `src/build.ts`, `mod.ts`. New tests `affected_test.ts`, `remote_cache_test.ts`; extended `cache_test.ts`, `ci_test.ts`, `cli_test.ts`, `executor_test.ts`. Docs + regenerated `llms.txt`/`llms-full.txt`/`packages/core/README.md`.

### Testing & coverage

- Hermetic throughout: git and network are behind injectable seams (the subprocess path is exercised with the running `deno` as a stand-in, per the repo convention); HTTP uses a `fetch` seam; filesystem tests use temp dirs.
- Full `deno task ci` is green locally — fmt, lint, spell, type-check, and the coverage gate. **1142 tests pass**, aggregate coverage **99.1% lines / 96.6% branches** (above the 95% gate).

### Docs

- `docs/cli.md` — new **Remote cache** and **Affected targets** sections, the command table, and `--help` text.
- `docs/authoring.md` — new **Fanned-out jobs** section under CI config generation.
- Regenerated with `./zuke apiDocs`: `llms.txt`, `llms-full.txt`, and `packages/core/README.md` `## API`.

### Design notes

- Both cache backends are dependency-free; cloud SDKs are intentionally avoided (an S3/GCS/R2 bucket is reached through `HttpCacheStore`'s URL).
- Archives use the existing POSIX `ustar` writer (100-byte entry-name limit), so extremely deep output paths are rejected with a clear error rather than silently truncated.
- `--affected`'s no-inputs-means-always-run rule is the safe default (correctness over aggressiveness); it's documented so authors know to declare `inputs` to unlock skipping.

## Related issues

None — these come from a feature brainstorm on making Zuke's caching and CI story more attractive for real pipelines. Happy to open tracking issues if useful.

## Checklist

- [x] The PR title is a [Conventional Commit](https://www.conventionalcommits.org/) (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour changed.
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`, `llms-full.txt`, package README `## API`).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrowed with type guards instead).
- [ ] A new package was wired into all five places — n/a (no new package; all changes are within `@zuke/core`).
- [x] The code is written using AI assisted coding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFVtbsGNx9piPuknJXqgrH