### PR TITLE
feat(core): source secrets from a manager and redact them from output

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,8 @@
 - [Authoring API](./authoring.md) — `target()`, `Build`, `run()`, and gotchas.
 - [Parameters](./parameters.md) — typed build inputs from flags, env, or
   defaults.
+- [Secrets](./secrets.md) — source secret values from a manager with
+  `.from(...)`, and the guaranteed redaction of every secret from output.
 - [Caching](./caching.md) — the incremental build cache, the remote
   (cross-machine) cache, and the AI response cache.
 - [Shell wrapper (`$`)](./shell.md) — ergonomic, injection-safe process

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -331,8 +331,9 @@ url)` action. Each task POSTs the platform-native payload over
 non-2xx response.
 
 A webhook URL embeds the secret that authorises posting, so source it from a
-`parameter().secret()` build input rather than hard-coding it — Zuke masks the
-resolved value in CI output.
+`parameter().secret()` build input rather than hard-coding it — Zuke redacts the
+resolved value from all of its output, and can pull it from a secret manager
+with `.from(...)` (see [Secrets](./secrets.md)).
 
 ```ts
 import { AnnounceTasks, Build, parameter, target } from "jsr:@zuke/core";

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -7,7 +7,8 @@ precedence):
 
 1. a command-line flag — `--environment production` or `--environment=production`
 2. an environment variable — `ENVIRONMENT`
-3. the declared default
+3. a [secret source](./secrets.md) declared with `.from(...)`
+4. the declared default
 
 ```ts
 import { Build, parameter, run, target } from "jsr:@zuke/core";
@@ -50,7 +51,8 @@ declaration:
 | `.default(v)` | provide a default | non-optional (`T`) |
 | `.required()` | must be supplied | non-optional (`T`) |
 | `.env("NAME")` | override the env var name | unchanged |
-| `.secret()` | mark the value sensitive | unchanged |
+| `.secret()` | mark the value sensitive (masked everywhere) | unchanged |
+| `.from(source)` | resolve from a [secret manager](./secrets.md) | unchanged |
 | `.array()` | a comma-separated / repeatable list | `string[]` |
 
 `.number()` and `.boolean()` come first (they change the kind); `.options()`
@@ -77,12 +79,28 @@ TAGS=latest,canary ./zuke deploy        # from the environment
 
 ## Secrets
 
-`.secret()` marks a value sensitive. Under GitHub Actions, Zuke emits an
-`::add-mask::` for the resolved value so it is redacted from the logs.
+`.secret()` marks a value sensitive. Its resolved value is **redacted from all
+of Zuke's output** — every banner, target status, summary, and error message —
+and, under GitHub Actions, Zuke also emits an `::add-mask::` so the runner masks
+it in its own logs.
 
 ```ts
 token = parameter("Deploy token").secret().required();
 ```
+
+Pair `.secret()` with `.from(source)` to fetch the value from a secret manager
+(1Password, Vault, a mounted file, …) instead of the environment:
+
+```ts
+import { execSecret } from "jsr:@zuke/core";
+
+token = parameter("Deploy token")
+  .secret()
+  .from(execSecret((s) => s.command("op").arg("read", "op://vault/deploy/token")));
+```
+
+The [Secrets guide](./secrets.md) covers sources, resolution precedence, and the
+exact redaction guarantee (and its boundary) in full.
 
 ## Interactive input
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -14,7 +14,9 @@ import { Build, execSecret, parameter, run, target } from "jsr:@zuke/core";
 class Deploy extends Build {
   token = parameter("Deploy token")
     .secret()
-    .from(execSecret((s) => s.command("op").arg("read", "op://vault/deploy/token")));
+    .from(
+      execSecret((s) => s.command("op").arg("read", "op://vault/deploy/token")),
+    );
 
   deploy = target().executes(async () => {
     await fetch("https://api.example.com/deploy", {
@@ -27,8 +29,8 @@ await run(Deploy);
 ```
 
 A secret is still an ordinary [parameter](./parameters.md): it has a flag and an
-environment variable, it can be `.required()`, `.number()`, and so on. `.secret()`
-adds redaction; `.from(...)` adds a run-time provider.
+environment variable, it can be `.required()`, `.number()`, and so on.
+`.secret()` adds redaction; `.from(...)` adds a run-time provider.
 
 ## Marking a value secret
 
@@ -57,7 +59,7 @@ wrapping the executor's reporter, so it does not depend on running under a CI
 host that happens to mask logs.
 
 It does **not** reach inside a subprocess a target spawns: if a command a target
-runs echoes the secret to *its own* stdout/stderr, that output streams straight
+runs echoes the secret to _its own_ stdout/stderr, that output streams straight
 to the terminal without passing through Zuke's reporter. Two mitigations apply:
 
 - Under GitHub Actions, the `::add-mask::` directive Zuke emits makes the runner
@@ -67,9 +69,9 @@ to the terminal without passing through Zuke's reporter. Two mitigations apply:
 
 ## Secret sources
 
-A **source** resolves a secret's value on demand. Attach one with `.from(source)`.
-Zuke ships two dependency-free source builders; both shell out to a tool you
-already trust rather than bundling a provider SDK.
+A **source** resolves a secret's value on demand. Attach one with
+`.from(source)`. Zuke ships two dependency-free source builders; both shell out
+to a tool you already trust rather than bundling a provider SDK.
 
 ### `execSecret` — run a command, take its stdout
 
@@ -98,13 +100,13 @@ The command runs quietly (its output is captured, never streamed to the
 terminal), and its standard output becomes the value. A non-zero exit fails the
 build with a `SecretError` naming the command and its exit code.
 
-| `ExecSecretSettings` method | Effect |
-| --- | --- |
-| `.command(binary)` | the executable to run (**required**) |
-| `.arg(...values)` | append one or more arguments (repeatable) |
-| `.env(record)` | extra environment variables for the process |
-| `.cwd(path)` | working directory for the process |
-| `.trim(on = true)` | trim surrounding whitespace from stdout (default on) |
+| `ExecSecretSettings` method | Effect                                               |
+| --------------------------- | ---------------------------------------------------- |
+| `.command(binary)`          | the executable to run (**required**)                 |
+| `.arg(...values)`           | append one or more arguments (repeatable)            |
+| `.env(record)`              | extra environment variables for the process          |
+| `.cwd(path)`                | working directory for the process                    |
+| `.trim(on = true)`          | trim surrounding whitespace from stdout (default on) |
 
 Turn `.trim(false)` on for a whitespace-sensitive value (rare — most tokens are
 a single line and trimming the trailing newline is what you want).
@@ -120,10 +122,10 @@ import { fileSecret } from "jsr:@zuke/core";
 .from(fileSecret((s) => s.path("/run/secrets/registry_password")))
 ```
 
-| `FileSecretSettings` method | Effect |
-| --- | --- |
-| `.path(path)` | the file to read (**required**) |
-| `.trim(on = true)` | trim surrounding whitespace (default on) |
+| `FileSecretSettings` method | Effect                                   |
+| --------------------------- | ---------------------------------------- |
+| `.path(path)`               | the file to read (**required**)          |
+| `.trim(on = true)`          | trim surrounding whitespace (default on) |
 
 A missing or unreadable file fails the build with a `SecretError` naming the
 path.
@@ -159,9 +161,17 @@ Invalid or missing parameters:
 ```
 
 `SecretError` is exported for handling in programmatic use. The value returned
-by a source is registered for redaction **before** it is parsed, so even a
-parse error on a malformed secret (e.g. a `.secret().number()` whose source
-returns a non-number) is masked rather than echoed.
+by a source is registered for redaction **before** it is parsed, so even a parse
+error on a malformed secret (e.g. a `.secret().number()` whose source returns a
+non-number) is masked rather than echoed.
+
+The failure message deliberately includes the source's own output — a command's
+exit code and trimmed stderr, or the file-read error — so a misconfigured source
+is debuggable from the log. A source whose value never resolved has nothing
+registered for redaction, so **this one message is not masked**: choose a source
+command that reports failures on stderr without echoing the secret itself
+(secret managers such as `op`, `vault`, and `gcloud` do). This is the same
+boundary as any subprocess a target spawns.
 
 ## A complete example
 
@@ -179,7 +189,9 @@ class Release extends Build {
   // From 1Password locally; from the REGISTRY_TOKEN env var in CI.
   registryToken = parameter("Container registry token")
     .secret()
-    .from(execSecret((s) => s.command("op").arg("read", "op://ci/registry/token")));
+    .from(
+      execSecret((s) => s.command("op").arg("read", "op://ci/registry/token")),
+    );
 
   // A cluster token mounted into the deploy job as a file.
   clusterToken = parameter("Cluster token")
@@ -207,4 +219,5 @@ await run(Release);
   [`packages/core/README.md`](../packages/core/README.md) and
   [`llms-full.txt`](../llms-full.txt).
 - Parameters in general: [Parameters](./parameters.md).
-- Installing the CLIs a source shells out to: [Installing tools](./installing-tools.md).
+- Installing the CLIs a source shells out to:
+  [Installing tools](./installing-tools.md).

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,0 +1,210 @@
+# Secrets
+
+Builds need secrets — a deploy token, a registry password, an API key. Zuke
+treats a secret as a **parameter with two extra guarantees**:
+
+1. **It can be sourced from a secret manager** at run time with `.from(source)`,
+   so the value never has to be pasted into a shell, a `.env` file, or CI YAML.
+2. **Its resolved value is redacted from all of Zuke's output** — so a secret
+   cannot leak into a log, a summary, or an error message, on any platform.
+
+```ts
+import { Build, execSecret, parameter, run, target } from "jsr:@zuke/core";
+
+class Deploy extends Build {
+  token = parameter("Deploy token")
+    .secret()
+    .from(execSecret((s) => s.command("op").arg("read", "op://vault/deploy/token")));
+
+  deploy = target().executes(async () => {
+    await fetch("https://api.example.com/deploy", {
+      headers: { authorization: `Bearer ${this.token.value}` },
+    });
+  });
+}
+
+await run(Deploy);
+```
+
+A secret is still an ordinary [parameter](./parameters.md): it has a flag and an
+environment variable, it can be `.required()`, `.number()`, and so on. `.secret()`
+adds redaction; `.from(...)` adds a run-time provider.
+
+## Marking a value secret
+
+`.secret()` marks a parameter sensitive. From then on Zuke masks its resolved
+value wherever it prints:
+
+- Every line the executor writes through its reporter — banners, per-target
+  status, the build summary, and **error messages** (including a target that
+  throws with the secret in its message, or a parse error on a malformed value).
+- Under GitHub Actions, Zuke additionally emits `::add-mask::<value>` so the
+  runner masks the value in its own log stream.
+
+The mask is the literal text `[redacted]`. Matching is a plain substring
+replace, never a regular expression, so a secret containing regex-significant
+characters is masked literally and there is no injection surface.
+
+```ts
+token = parameter("Deploy token").secret().required();
+// --token …, or the TOKEN env var; redacted everywhere Zuke prints it.
+```
+
+### What redaction does — and does not — cover
+
+Redaction is **guaranteed for everything Zuke itself prints**. It is applied by
+wrapping the executor's reporter, so it does not depend on running under a CI
+host that happens to mask logs.
+
+It does **not** reach inside a subprocess a target spawns: if a command a target
+runs echoes the secret to *its own* stdout/stderr, that output streams straight
+to the terminal without passing through Zuke's reporter. Two mitigations apply:
+
+- Under GitHub Actions, the `::add-mask::` directive Zuke emits makes the runner
+  mask the value in subprocess output too.
+- As a rule, don't pass secrets as command-line arguments (they show up in
+  process listings) or echo them; pass them through the environment or stdin.
+
+## Secret sources
+
+A **source** resolves a secret's value on demand. Attach one with `.from(source)`.
+Zuke ships two dependency-free source builders; both shell out to a tool you
+already trust rather than bundling a provider SDK.
+
+### `execSecret` — run a command, take its stdout
+
+For any secret manager with a CLI: 1Password (`op`), HashiCorp Vault (`vault`),
+Google Secret Manager (`gcloud`), Doppler, AWS (`aws`), and so on.
+
+```ts
+import { execSecret } from "jsr:@zuke/core";
+
+// 1Password
+.from(execSecret((s) => s.command("op").arg("read", "op://vault/deploy/token")))
+
+// HashiCorp Vault
+.from(execSecret((s) =>
+  s.command("vault").arg("kv", "get", "-field=token", "secret/ci/deploy")
+))
+
+// Google Secret Manager
+.from(execSecret((s) =>
+  s.command("gcloud")
+    .arg("secrets", "versions", "access", "latest", "--secret=deploy-token")
+))
+```
+
+The command runs quietly (its output is captured, never streamed to the
+terminal), and its standard output becomes the value. A non-zero exit fails the
+build with a `SecretError` naming the command and its exit code.
+
+| `ExecSecretSettings` method | Effect |
+| --- | --- |
+| `.command(binary)` | the executable to run (**required**) |
+| `.arg(...values)` | append one or more arguments (repeatable) |
+| `.env(record)` | extra environment variables for the process |
+| `.cwd(path)` | working directory for the process |
+| `.trim(on = true)` | trim surrounding whitespace from stdout (default on) |
+
+Turn `.trim(false)` on for a whitespace-sensitive value (rare — most tokens are
+a single line and trimming the trailing newline is what you want).
+
+### `fileSecret` — read a file
+
+For a secret mounted into the environment as a file — a Kubernetes/Docker
+secret, or a CI-provided credential file.
+
+```ts
+import { fileSecret } from "jsr:@zuke/core";
+
+.from(fileSecret((s) => s.path("/run/secrets/registry_password")))
+```
+
+| `FileSecretSettings` method | Effect |
+| --- | --- |
+| `.path(path)` | the file to read (**required**) |
+| `.trim(on = true)` | trim surrounding whitespace (default on) |
+
+A missing or unreadable file fails the build with a `SecretError` naming the
+path.
+
+## Resolution precedence
+
+A source is a **fallback provider, not an override**. Zuke resolves a parameter
+from, in order:
+
+1. a command-line flag (`--token …`)
+2. the environment variable (`TOKEN`)
+3. the `.from(...)` source
+4. the declared default
+
+So the source is consulted only when neither a flag nor an environment variable
+supplied a value. This is what makes the same build portable: in CI, a token is
+usually injected as an environment variable (and the source is never invoked);
+on a developer's machine, the source pulls it from their secret manager. Neither
+path requires a code change.
+
+Because a source runs a subprocess or reads a file, parameter resolution is
+asynchronous — but this is entirely internal; a build declares parameters
+exactly as before.
+
+## Errors
+
+A source that fails is reported as a parameter error, before any target runs —
+the same as a missing required value:
+
+```
+Invalid or missing parameters:
+  --token: execSecret command "op" exited with code 1: [ERROR] not signed in
+```
+
+`SecretError` is exported for handling in programmatic use. The value returned
+by a source is registered for redaction **before** it is parsed, so even a
+parse error on a malformed secret (e.g. a `.secret().number()` whose source
+returns a non-number) is masked rather than echoed.
+
+## A complete example
+
+```ts
+import {
+  Build,
+  execSecret,
+  fileSecret,
+  parameter,
+  run,
+  target,
+} from "jsr:@zuke/core";
+
+class Release extends Build {
+  // From 1Password locally; from the REGISTRY_TOKEN env var in CI.
+  registryToken = parameter("Container registry token")
+    .secret()
+    .from(execSecret((s) => s.command("op").arg("read", "op://ci/registry/token")));
+
+  // A cluster token mounted into the deploy job as a file.
+  clusterToken = parameter("Cluster token")
+    .secret()
+    .from(fileSecret((s) => s.path("/run/secrets/cluster_token")));
+
+  publish = target().executes(async () => {
+    // Prefer the environment/headers over argv, so the secret never appears in
+    // a process list. Anything printed here that contains the value is masked.
+    await fetch("https://registry.example.com/publish", {
+      method: "POST",
+      headers: { authorization: `Bearer ${this.registryToken.value}` },
+    });
+  });
+}
+
+await run(Release);
+```
+
+## Reference
+
+- `execSecret`, `fileSecret`, `ExecSecretSettings`, `FileSecretSettings`,
+  `SecretSource`, and `SecretError` are exported from `@zuke/core`; see the
+  generated API blocks in
+  [`packages/core/README.md`](../packages/core/README.md) and
+  [`llms-full.txt`](../llms-full.txt).
+- Parameters in general: [Parameters](./parameters.md).
+- Installing the CLIs a source shells out to: [Installing tools](./installing-tools.md).

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -161,6 +161,16 @@ function envCacheStore(readEnv: (name: string) => string | undefined): RemoteCac
 function envVarName(name: string): string
   The environment variable for a parameter: its path in SCREAMING_SNAKE_CASE.
 
+function execSecret(configure: Configure<ExecSecretSettings>): SecretSource
+  A {@link SecretSource} that runs a command and takes its standard output as
+  the secret value. Configure it through an {@link ExecSecretSettings} lambda.
+
+  ```ts
+  parameter("Vault token").secret().from(
+    execSecret((s) => s.command("vault").arg("kv", "get", "-field=token", "secret/ci")),
+  );
+  ```
+
 async function execute(build: Build, root: TargetBuilder, options: ExecuteOptions): Promise<BuildResult>
   Execute the requested target and its transitive dependencies.
 
@@ -194,6 +204,17 @@ function fanOutPipeline(targets: Map<string, TargetBuilder>, base: CiPipeline, o
   concurrency); its `jobs` are ignored in favour of the generated ones. Targets
   with no body, and (unless {@link FanOutOptions.includeUnlisted}) `unlisted`
   targets, are omitted, and `needs` edges to omitted targets are dropped.
+
+function fileSecret(configure: Configure<FileSecretSettings>): SecretSource
+  A {@link SecretSource} that reads a file and takes its content as the secret
+  value — for a mounted Kubernetes/Docker secret or a CI-provided file.
+  Configure it through a {@link FileSecretSettings} lambda.
+
+  ```ts
+  parameter("Registry password").secret().from(
+    fileSecret((s) => s.path("/run/secrets/registry_password")),
+  );
+  ```
 
 function findCycle(targets: Map<string, TargetBuilder>): string[] | null
   Detect a cycle in the hard-dependency (`dependsOn`) graph across all targets.
@@ -391,6 +412,9 @@ const DEFAULT_TOOLS_DIR: ".zuke/tools"
 const FileTasks: FileTasksApi
   Filesystem task functions for build scripts.
 
+const REDACTED: "[redacted]"
+  The placeholder a {@link Redactor} substitutes for each secret value.
+
 const ToolTasks: ToolTasksApi
   Provision external CLIs from a build. `ToolTasks.install((s) => …)` fetches a
   single tool; group several with {@link toolchain}.
@@ -551,6 +575,42 @@ class DiscordAnnouncementSettings extends AnnouncementSettings
   override protected payload(): Record<string, unknown>
   override protected sendBot(): Promise<void>
 
+class ExecSecretSettings
+  Fluent settings for {@link execSecret}: a command whose standard output is
+  the secret. Configure the binary with {@link ExecSecretSettings.command},
+  arguments with {@link ExecSecretSettings.arg}, and optionally the environment
+  and working directory. Output is trimmed of surrounding whitespace unless
+  {@link ExecSecretSettings.trim} is turned off (some values are
+  whitespace-sensitive).
+
+  command(binary: PathLike): this
+    The binary to run (e.g. `op`, `vault`, `gcloud`). Required.
+  arg(...values: Array<string | number | AbsolutePath>): this
+    Append one or more arguments to the command.
+  env(record: Record<string, string>): this
+    Merge additional environment variables for the process.
+  cwd(path: PathLike): this
+    Set the working directory for the process.
+  trim(on: boolean): this
+    Whether to trim surrounding whitespace from stdout (default `true`).
+  async resolve_(): Promise<string>
+    Run the command and return its captured stdout as the secret. Streaming is
+    suppressed (`quiet`) so the value is never echoed to the terminal, and a
+    non-zero exit throws a {@link SecretError} naming the command.
+
+class FileSecretSettings
+  Fluent settings for {@link fileSecret}: read a secret from a file. Set the
+  path with {@link FileSecretSettings.path}; the content is trimmed of
+  surrounding whitespace unless {@link FileSecretSettings.trim} is turned off.
+
+  path(path: PathLike): this
+    The file to read the secret from. Required.
+  trim(on: boolean): this
+    Whether to trim surrounding whitespace from the content (default `true`).
+  async resolve_(): Promise<string>
+    Read the file and return its content as the secret. A missing or
+    unreadable file throws a {@link SecretError} naming the path.
+
 class FileSystemCacheStore implements RemoteCacheStore
   A {@link RemoteCacheStore} backed by a shared or mounted directory.
 
@@ -622,12 +682,21 @@ class Parameter<K extends ParamValue = ParamValue, T extends K | K[] | undefined
   readonly hasFallback_: boolean
   readonly secret_: boolean
   readonly array_: boolean
+  readonly source_?: SecretSource
   get value(): T
     The resolved value. Throws if read before the build resolves parameters.
   isSet_(): boolean
   stringValue_(): string | undefined
   secret(): Parameter<K, T>
-    Mark the value as sensitive, so it is masked in CI output (`::add-mask::`).
+    Mark the value as sensitive: it is masked in CI output (`::add-mask::`) and
+    redacted from all of Zuke's reporter output. Pair with {@link Parameter.from}
+    to resolve the value from a secret manager rather than the environment.
+  from(source: SecretSource): Parameter<K, T>
+    Resolve the value from a {@link SecretSource} (see {@link execSecret} /
+    {@link fileSecret}) when neither a `--flag` nor an environment variable
+    supplied one — the source is a fallback provider, consulted before the
+    declared default. Typically paired with {@link Parameter.secret} so the
+    resolved value is redacted.
   number(this: Parameter<string, string | undefined>): Parameter<number, number | undefined>
     Parse the value as a number (e.g. `--workers 4`).
   boolean(this: Parameter<string, string | undefined>): Parameter<boolean, boolean>
@@ -648,6 +717,25 @@ class Parameter<K extends ParamValue = ParamValue, T extends K | K[] | undefined
 
 class ParameterError extends Error
   Raised when a parameter value is invalid or read before resolution.
+
+  override name: string
+
+class Redactor
+  Collects secret values and masks them in text. Register a value with
+  {@link Redactor.add} and rewrite a line with {@link Redactor.redact}; empty
+  strings are ignored (they would match everywhere) and duplicates are recorded
+  once. Longer secrets are applied first so a secret that contains another is
+  masked whole rather than partially.
+
+  add(value: string): void
+    Register a secret value to mask. Ignores empty strings and duplicates.
+  redact(line: string): string
+    Replace every registered secret in `line` with {@link REDACTED}.
+  get size(): number
+    The number of distinct secret values registered.
+
+class SecretError extends Error
+  Raised when a {@link SecretSource} cannot produce a value.
 
   override name: string
 
@@ -978,6 +1066,8 @@ interface AnyParameter
     Whether the value is sensitive and should be masked in CI output.
   readonly array_: boolean
     Whether the value is a comma-separated / repeatable list (`.array()`).
+  readonly source_?: SecretSource
+    A provider that resolves the value when no flag/env supplied one.
   resolve_(raw: string | undefined): void
     Resolve from a raw input (or `undefined` when none was supplied).
   isSet_(): boolean
@@ -1498,6 +1588,15 @@ interface RunOptions
     Renderer for the per-target banners and end-of-build summary. Defaults to
     Zuke's built-in look; inject `consoleRenderer` from `@zuke/console` (or a
     custom {@link Renderer}) to restyle a build's output.
+
+interface SecretSource
+  A provider that resolves a secret's value on demand. Built by
+  {@link execSecret} or {@link fileSecret} and attached to a parameter with
+  `.from(source)`; the framework calls {@link SecretSource.resolve} during
+  parameter resolution.
+
+  resolve(): Promise<string>
+    Produce the secret value, or throw {@link SecretError} on failure.
 
 interface Style
   How a run renders its output.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -215,6 +215,16 @@ function envCacheStore(readEnv: (name: string) => string | undefined): RemoteCac
 function envVarName(name: string): string
   The environment variable for a parameter: its path in SCREAMING_SNAKE_CASE.
 
+function execSecret(configure: Configure<ExecSecretSettings>): SecretSource
+  A {@link SecretSource} that runs a command and takes its standard output as
+  the secret value. Configure it through an {@link ExecSecretSettings} lambda.
+
+  ```ts
+  parameter("Vault token").secret().from(
+    execSecret((s) => s.command("vault").arg("kv", "get", "-field=token", "secret/ci")),
+  );
+  ```
+
 async function execute(build: Build, root: TargetBuilder, options: ExecuteOptions): Promise<BuildResult>
   Execute the requested target and its transitive dependencies.
 
@@ -248,6 +258,17 @@ function fanOutPipeline(targets: Map<string, TargetBuilder>, base: CiPipeline, o
   concurrency); its `jobs` are ignored in favour of the generated ones. Targets
   with no body, and (unless {@link FanOutOptions.includeUnlisted}) `unlisted`
   targets, are omitted, and `needs` edges to omitted targets are dropped.
+
+function fileSecret(configure: Configure<FileSecretSettings>): SecretSource
+  A {@link SecretSource} that reads a file and takes its content as the secret
+  value — for a mounted Kubernetes/Docker secret or a CI-provided file.
+  Configure it through a {@link FileSecretSettings} lambda.
+
+  ```ts
+  parameter("Registry password").secret().from(
+    fileSecret((s) => s.path("/run/secrets/registry_password")),
+  );
+  ```
 
 function findCycle(targets: Map<string, TargetBuilder>): string[] | null
   Detect a cycle in the hard-dependency (`dependsOn`) graph across all targets.
@@ -445,6 +466,9 @@ const DEFAULT_TOOLS_DIR: ".zuke/tools"
 const FileTasks: FileTasksApi
   Filesystem task functions for build scripts.
 
+const REDACTED: "[redacted]"
+  The placeholder a {@link Redactor} substitutes for each secret value.
+
 const ToolTasks: ToolTasksApi
   Provision external CLIs from a build. `ToolTasks.install((s) => …)` fetches a
   single tool; group several with {@link toolchain}.
@@ -605,6 +629,42 @@ class DiscordAnnouncementSettings extends AnnouncementSettings
   override protected payload(): Record<string, unknown>
   override protected sendBot(): Promise<void>
 
+class ExecSecretSettings
+  Fluent settings for {@link execSecret}: a command whose standard output is
+  the secret. Configure the binary with {@link ExecSecretSettings.command},
+  arguments with {@link ExecSecretSettings.arg}, and optionally the environment
+  and working directory. Output is trimmed of surrounding whitespace unless
+  {@link ExecSecretSettings.trim} is turned off (some values are
+  whitespace-sensitive).
+
+  command(binary: PathLike): this
+    The binary to run (e.g. `op`, `vault`, `gcloud`). Required.
+  arg(...values: Array<string | number | AbsolutePath>): this
+    Append one or more arguments to the command.
+  env(record: Record<string, string>): this
+    Merge additional environment variables for the process.
+  cwd(path: PathLike): this
+    Set the working directory for the process.
+  trim(on: boolean): this
+    Whether to trim surrounding whitespace from stdout (default `true`).
+  async resolve_(): Promise<string>
+    Run the command and return its captured stdout as the secret. Streaming is
+    suppressed (`quiet`) so the value is never echoed to the terminal, and a
+    non-zero exit throws a {@link SecretError} naming the command.
+
+class FileSecretSettings
+  Fluent settings for {@link fileSecret}: read a secret from a file. Set the
+  path with {@link FileSecretSettings.path}; the content is trimmed of
+  surrounding whitespace unless {@link FileSecretSettings.trim} is turned off.
+
+  path(path: PathLike): this
+    The file to read the secret from. Required.
+  trim(on: boolean): this
+    Whether to trim surrounding whitespace from the content (default `true`).
+  async resolve_(): Promise<string>
+    Read the file and return its content as the secret. A missing or
+    unreadable file throws a {@link SecretError} naming the path.
+
 class FileSystemCacheStore implements RemoteCacheStore
   A {@link RemoteCacheStore} backed by a shared or mounted directory.
 
@@ -676,12 +736,21 @@ class Parameter<K extends ParamValue = ParamValue, T extends K | K[] | undefined
   readonly hasFallback_: boolean
   readonly secret_: boolean
   readonly array_: boolean
+  readonly source_?: SecretSource
   get value(): T
     The resolved value. Throws if read before the build resolves parameters.
   isSet_(): boolean
   stringValue_(): string | undefined
   secret(): Parameter<K, T>
-    Mark the value as sensitive, so it is masked in CI output (`::add-mask::`).
+    Mark the value as sensitive: it is masked in CI output (`::add-mask::`) and
+    redacted from all of Zuke's reporter output. Pair with {@link Parameter.from}
+    to resolve the value from a secret manager rather than the environment.
+  from(source: SecretSource): Parameter<K, T>
+    Resolve the value from a {@link SecretSource} (see {@link execSecret} /
+    {@link fileSecret}) when neither a `--flag` nor an environment variable
+    supplied one — the source is a fallback provider, consulted before the
+    declared default. Typically paired with {@link Parameter.secret} so the
+    resolved value is redacted.
   number(this: Parameter<string, string | undefined>): Parameter<number, number | undefined>
     Parse the value as a number (e.g. `--workers 4`).
   boolean(this: Parameter<string, string | undefined>): Parameter<boolean, boolean>
@@ -702,6 +771,25 @@ class Parameter<K extends ParamValue = ParamValue, T extends K | K[] | undefined
 
 class ParameterError extends Error
   Raised when a parameter value is invalid or read before resolution.
+
+  override name: string
+
+class Redactor
+  Collects secret values and masks them in text. Register a value with
+  {@link Redactor.add} and rewrite a line with {@link Redactor.redact}; empty
+  strings are ignored (they would match everywhere) and duplicates are recorded
+  once. Longer secrets are applied first so a secret that contains another is
+  masked whole rather than partially.
+
+  add(value: string): void
+    Register a secret value to mask. Ignores empty strings and duplicates.
+  redact(line: string): string
+    Replace every registered secret in `line` with {@link REDACTED}.
+  get size(): number
+    The number of distinct secret values registered.
+
+class SecretError extends Error
+  Raised when a {@link SecretSource} cannot produce a value.
 
   override name: string
 
@@ -1032,6 +1120,8 @@ interface AnyParameter
     Whether the value is sensitive and should be masked in CI output.
   readonly array_: boolean
     Whether the value is a comma-separated / repeatable list (`.array()`).
+  readonly source_?: SecretSource
+    A provider that resolves the value when no flag/env supplied one.
   resolve_(raw: string | undefined): void
     Resolve from a raw input (or `undefined` when none was supplied).
   isSet_(): boolean
@@ -1552,6 +1642,15 @@ interface RunOptions
     Renderer for the per-target banners and end-of-build summary. Defaults to
     Zuke's built-in look; inject `consoleRenderer` from `@zuke/console` (or a
     custom {@link Renderer}) to restyle a build's output.
+
+interface SecretSource
+  A provider that resolves a secret's value on demand. Built by
+  {@link execSecret} or {@link fileSecret} and attached to a parameter with
+  `.from(source)`; the framework calls {@link SecretSource.resolve} during
+  parameter resolution.
+
+  resolve(): Promise<string>
+    Produce the secret value, or throw {@link SecretError} on failure.
 
 interface Style
   How a run renders its output.

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -102,6 +102,15 @@ export {
   type ParamValue,
 } from "./src/params.ts";
 export {
+  execSecret,
+  ExecSecretSettings,
+  fileSecret,
+  FileSecretSettings,
+  SecretError,
+  type SecretSource,
+} from "./src/secret.ts";
+export { REDACTED, Redactor } from "./src/redact.ts";
+export {
   executionSet,
   findCycle,
   GraphError,

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -35,6 +35,7 @@ import {
 } from "./affected.ts";
 import { type RemoteCacheStore, resolveRemoteStore } from "./remote_cache.ts";
 import { isCI } from "./host.ts";
+import { Redactor } from "./redact.ts";
 import { absolutePath } from "./path.ts";
 import type { Remediation, TargetBuilder, TargetFn } from "./target.ts";
 import type { Plugin } from "./plugin.ts";
@@ -56,6 +57,14 @@ const consoleReporter: Reporter = {
 };
 
 const silentReporter: Reporter = { info: () => {}, error: () => {} };
+
+/** Wrap a reporter so every line is passed through the {@link Redactor} first. */
+function redactingReporter(inner: Reporter, redactor: Redactor): Reporter {
+  return {
+    info: (line) => inner.info(redactor.redact(line)),
+    error: (line) => inner.error(redactor.redact(line)),
+  };
+}
 
 /** Options for {@link execute}. */
 export interface ExecuteOptions {
@@ -752,8 +761,14 @@ export async function execute(
   root: TargetBuilder,
   options: ExecuteOptions = {},
 ): Promise<BuildResult> {
-  const reporter = options.reporter ??
+  const baseReporter = options.reporter ??
     (options.silent ? silentReporter : consoleReporter);
+  // Every line Zuke prints passes through the redactor, which masks the
+  // resolved value of each `secret` parameter. The redactor is populated during
+  // parameter resolution below; since nothing meaningful is reported before
+  // then, wrapping the reporter up-front is safe.
+  const redactor = new Redactor();
+  const reporter = redactingReporter(baseReporter, redactor);
   // The GitHub job summary is a real-world output side effect (it appends to a
   // shared file named by GITHUB_STEP_SUMMARY). Only write it when output goes to
   // the default console — i.e. neither silenced nor redirected to a custom
@@ -771,12 +786,32 @@ export async function execute(
   // required parameter or an invalid value fails the build before it starts.
   const params = discoverParameters(build);
   const readEnv = options.readEnv ?? defaultReadEnv;
-  const paramErrors = resolveParameters(
+  const paramErrors = await resolveParameters(
     params,
     options.params ?? {},
     readEnv,
     options.prompt ?? defaultPrompt,
+    redactor,
   );
+  // Register each secret's final parsed value too — its raw form was already
+  // added during resolution, but a source that trims or a parser that
+  // normalises could yield a slightly different printed string.
+  for (const p of params.values()) {
+    if (!p.secret_) continue;
+    const value = p.stringValue_();
+    if (value !== undefined && value !== "") redactor.add(value);
+  }
+  // Under GitHub Actions, also emit `::add-mask::` with the real value so the
+  // runner masks it in its own logs. This goes through the base reporter, which
+  // is not wrapped in the redactor — a masked directive would hide nothing.
+  if (style.github) {
+    for (const p of params.values()) {
+      const value = p.secret_ ? p.stringValue_() : undefined;
+      if (value !== undefined && value !== "") {
+        baseReporter.info(`::add-mask::${value}`);
+      }
+    }
+  }
   if (paramErrors.length > 0) {
     reporter.error("Invalid or missing parameters:");
     for (const message of paramErrors) reporter.error(`  ${message}`);
@@ -785,15 +820,6 @@ export async function execute(
       executed: [],
       error: new ParameterError(paramErrors.join("; ")),
     };
-  }
-  // Under GitHub Actions, mask resolved secret values so they don't leak.
-  if (style.github) {
-    for (const p of params.values()) {
-      const value = p.secret_ ? p.stringValue_() : undefined;
-      if (value !== undefined && value !== "") {
-        reporter.info(`::add-mask::${value}`);
-      }
-    }
   }
 
   const { order, predecessors } = planGraph(root);

--- a/packages/core/src/params.ts
+++ b/packages/core/src/params.ts
@@ -30,6 +30,8 @@
  */
 
 import { forEachField } from "./build.ts";
+import type { Redactor } from "./redact.ts";
+import type { SecretSource } from "./secret.ts";
 
 /** The value kinds a parameter can hold. */
 export type ParamValue = string | number | boolean;
@@ -103,6 +105,8 @@ export interface AnyParameter {
   readonly secret_: boolean;
   /** Whether the value is a comma-separated / repeatable list (`.array()`). */
   readonly array_: boolean;
+  /** A provider that resolves the value when no flag/env supplied one. */
+  readonly source_?: SecretSource;
   /** Resolve from a raw input (or `undefined` when none was supplied). */
   resolve_(raw: string | undefined): void;
   /** Whether the parameter resolved to a defined value (used by `.requires()`). */
@@ -122,6 +126,7 @@ interface ParamSpec<K extends ParamValue, T extends K | K[] | undefined> {
   fallback: Fallback<T>;
   secret?: boolean;
   array?: boolean;
+  source?: SecretSource;
 }
 
 /**
@@ -146,6 +151,7 @@ export class Parameter<
   readonly hasFallback_: boolean;
   readonly secret_: boolean;
   readonly array_: boolean;
+  readonly source_?: SecretSource;
   readonly #parse: (raw: string) => T;
   readonly #fallback: Fallback<T>;
   #state: Resolved<T> = { ok: false };
@@ -178,6 +184,7 @@ export class Parameter<
     this.hasFallback_ = spec.fallback.has;
     this.secret_ = spec.secret ?? false;
     this.array_ = spec.array ?? false;
+    this.source_ = spec.source;
   }
 
   /** The resolved value. Throws if read before the build resolves parameters. */
@@ -201,7 +208,11 @@ export class Parameter<
       : undefined;
   }
 
-  /** Mark the value as sensitive, so it is masked in CI output (`::add-mask::`). */
+  /**
+   * Mark the value as sensitive: it is masked in CI output (`::add-mask::`) and
+   * redacted from all of Zuke's reporter output. Pair with {@link Parameter.from}
+   * to resolve the value from a secret manager rather than the environment.
+   */
   secret(): Parameter<K, T> {
     return new Parameter<K, T>({
       description: this.description_,
@@ -213,6 +224,29 @@ export class Parameter<
       fallback: this.#fallback,
       secret: true,
       array: this.array_,
+      source: this.source_,
+    });
+  }
+
+  /**
+   * Resolve the value from a {@link SecretSource} (see {@link execSecret} /
+   * {@link fileSecret}) when neither a `--flag` nor an environment variable
+   * supplied one — the source is a fallback provider, consulted before the
+   * declared default. Typically paired with {@link Parameter.secret} so the
+   * resolved value is redacted.
+   */
+  from(source: SecretSource): Parameter<K, T> {
+    return new Parameter<K, T>({
+      description: this.description_,
+      kind: this.kind_,
+      required: this.required_,
+      options: this.options_,
+      envName: this.envName_,
+      parse: this.#parse,
+      fallback: this.#fallback,
+      secret: this.secret_,
+      array: this.array_,
+      source,
     });
   }
 
@@ -228,6 +262,7 @@ export class Parameter<
       parse: parseNumber,
       fallback: { has: true, value: undefined },
       secret: this.secret_,
+      source: this.source_,
     });
   }
 
@@ -243,6 +278,7 @@ export class Parameter<
       parse: parseBoolean,
       fallback: { has: true, value: false },
       secret: this.secret_,
+      source: this.source_,
     });
   }
 
@@ -260,6 +296,7 @@ export class Parameter<
       parse: makeStringParser(values),
       fallback: this.#fallback,
       secret: this.secret_,
+      source: this.source_,
     });
   }
 
@@ -274,6 +311,7 @@ export class Parameter<
       parse: this.#definiteParse(),
       fallback: { has: true, value },
       secret: this.secret_,
+      source: this.source_,
     });
   }
 
@@ -288,6 +326,7 @@ export class Parameter<
       parse: this.#definiteParse(),
       fallback: { has: false },
       secret: this.secret_,
+      source: this.source_,
     });
   }
 
@@ -303,6 +342,7 @@ export class Parameter<
       fallback: this.#fallback,
       secret: this.secret_,
       array: this.array_,
+      source: this.source_,
     });
   }
 
@@ -325,6 +365,7 @@ export class Parameter<
       fallback: { has: true, value: [] },
       secret: this.secret_,
       array: true,
+      source: this.source_,
     });
   }
 
@@ -392,12 +433,19 @@ export function envVarName(name: string): string {
  * environment, applying defaults. Returns a list of human-readable errors for
  * missing-required or invalid values; empty means success.
  *
+ * Resolution precedence is CLI value, then environment variable, then a
+ * declared {@link Parameter.from} secret source, then the declared default. A
+ * secret parameter's raw value is registered with the optional {@link Redactor}
+ * as soon as it is obtained — before parsing — so even a parse error cannot
+ * echo it.
+ *
  * @param params Discovered parameters.
  * @param cliValues Raw values parsed from the command line, keyed by name.
  * @param readEnv Reads an environment variable by name.
  * @param prompt Optional: ask for a missing required value (interactive input).
+ * @param redactor Optional: collects secret raw values for output masking.
  */
-export function resolveParameters(
+export async function resolveParameters(
   params: Map<string, AnyParameter>,
   cliValues: Record<string, string>,
   readEnv: (name: string) => string | undefined,
@@ -405,7 +453,8 @@ export function resolveParameters(
     flag: string,
     description: string | undefined,
   ) => string | undefined,
-): string[] {
+  redactor?: Redactor,
+): Promise<string[]> {
   const errors: string[] = [];
   for (const [name, param] of params) {
     const envName = param.envName_ ?? envVarName(name);
@@ -414,6 +463,21 @@ export function resolveParameters(
     if (raw === undefined && param.required_ && !param.hasFallback_ && prompt) {
       const answer = prompt(flagName(name), param.description_);
       if (answer !== undefined && answer !== "") raw = answer;
+    }
+    // Fall back to a secret source when nothing else supplied a value.
+    if (raw === undefined && param.source_ !== undefined) {
+      try {
+        raw = await param.source_.resolve();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        errors.push(`--${flagName(name)}: ${message}`);
+        continue;
+      }
+    }
+    // Register a secret's raw value for redaction before it is parsed, so a
+    // parse error below is masked too.
+    if (redactor && param.secret_ && raw !== undefined && raw !== "") {
+      redactor.add(raw);
     }
     try {
       param.resolve_(raw);

--- a/packages/core/src/redact.ts
+++ b/packages/core/src/redact.ts
@@ -1,0 +1,54 @@
+/**
+ * Secret redaction for reporter output.
+ *
+ * A {@link Redactor} collects the resolved values of `secret` parameters and
+ * rewrites any line that contains one, replacing every occurrence with
+ * {@link REDACTED}. The executor wraps its {@link Reporter} in a redactor so a
+ * secret can never surface in Zuke's own output — a banner, a target status, a
+ * summary, or an error message — on any platform, not just under a CI host that
+ * happens to mask logs.
+ *
+ * Matching is a plain substring replace (never a regex), so a secret with
+ * regex-significant characters is redacted literally and there is no injection
+ * surface. The guarantee covers everything Zuke prints through the reporter; a
+ * subprocess a target spawns writes to its own stdout/stderr directly, so a
+ * command that deliberately echoes a secret is outside this boundary (GitHub
+ * Actions still masks it via `::add-mask::`, which the executor also emits).
+ *
+ * @module
+ */
+
+/** The placeholder a {@link Redactor} substitutes for each secret value. */
+export const REDACTED = "[redacted]";
+
+/**
+ * Collects secret values and masks them in text. Register a value with
+ * {@link Redactor.add} and rewrite a line with {@link Redactor.redact}; empty
+ * strings are ignored (they would match everywhere) and duplicates are recorded
+ * once. Longer secrets are applied first so a secret that contains another is
+ * masked whole rather than partially.
+ */
+export class Redactor {
+  readonly #secrets: string[] = [];
+
+  /** Register a secret value to mask. Ignores empty strings and duplicates. */
+  add(value: string): void {
+    if (value.length === 0 || this.#secrets.includes(value)) return;
+    this.#secrets.push(value);
+    // Keep the list longest-first so a secret that is a substring of another
+    // never masks only the inner part, leaving the rest exposed.
+    this.#secrets.sort((a, b) => b.length - a.length);
+  }
+
+  /** Replace every registered secret in `line` with {@link REDACTED}. */
+  redact(line: string): string {
+    let out = line;
+    for (const secret of this.#secrets) out = out.split(secret).join(REDACTED);
+    return out;
+  }
+
+  /** The number of distinct secret values registered. */
+  get size(): number {
+    return this.#secrets.length;
+  }
+}

--- a/packages/core/src/secret.ts
+++ b/packages/core/src/secret.ts
@@ -1,0 +1,214 @@
+/**
+ * Secret sources: resolve a `secret` parameter's value at run time from an
+ * external provider instead of requiring it pre-set in the environment.
+ *
+ * A build declares where a secret comes from with
+ * `parameter(...).secret().from(source)`, where `source` is built by
+ * {@link execSecret} (run a command, take its stdout) or {@link fileSecret}
+ * (read a file). Both are dependency-free — they shell out to a tool you
+ * already trust (`op`, `vault`, `gcloud`, …) or read a mounted secret file —
+ * so Zuke ships no provider SDKs and no registry to maintain.
+ *
+ * ```ts
+ * import { execSecret, fileSecret, parameter } from "jsr:@zuke/core";
+ *
+ * // 1Password CLI:
+ * const dbPassword = parameter("Database password")
+ *   .secret()
+ *   .from(execSecret((s) => s.command("op").arg("read", "op://vault/db/password")));
+ *
+ * // A Kubernetes secret mounted into the pod:
+ * const apiToken = parameter("API token")
+ *   .secret()
+ *   .from(fileSecret((s) => s.path("/run/secrets/api_token")));
+ * ```
+ *
+ * A source is only consulted when no `--flag` and no environment variable
+ * supplied the value, so a source is a fallback provider, not an override.
+ * Because the parameter is `secret()`, its resolved value is redacted from all
+ * of Zuke's reporter output (see {@link Redactor}).
+ *
+ * @module
+ */
+
+import { Command } from "./shell.ts";
+import { FileTasks } from "./file.ts";
+import type { AbsolutePath, PathLike } from "./path.ts";
+import type { Configure } from "./tooling.ts";
+
+/** Raised when a {@link SecretSource} cannot produce a value. */
+export class SecretError extends Error {
+  override name = "SecretError";
+}
+
+/**
+ * A provider that resolves a secret's value on demand. Built by
+ * {@link execSecret} or {@link fileSecret} and attached to a parameter with
+ * `.from(source)`; the framework calls {@link SecretSource.resolve} during
+ * parameter resolution.
+ */
+export interface SecretSource {
+  /** Produce the secret value, or throw {@link SecretError} on failure. */
+  resolve(): Promise<string>;
+}
+
+/**
+ * Fluent settings for {@link execSecret}: a command whose standard output is
+ * the secret. Configure the binary with {@link ExecSecretSettings.command},
+ * arguments with {@link ExecSecretSettings.arg}, and optionally the environment
+ * and working directory. Output is trimmed of surrounding whitespace unless
+ * {@link ExecSecretSettings.trim} is turned off (some values are
+ * whitespace-sensitive).
+ */
+export class ExecSecretSettings {
+  #command?: string;
+  #args: string[] = [];
+  #env: Record<string, string> = {};
+  #cwd?: string;
+  #trim = true;
+
+  /** The binary to run (e.g. `op`, `vault`, `gcloud`). Required. */
+  command(binary: PathLike): this {
+    this.#command = String(binary);
+    return this;
+  }
+
+  /** Append one or more arguments to the command. */
+  arg(...values: Array<string | number | AbsolutePath>): this {
+    this.#args.push(...values.map(String));
+    return this;
+  }
+
+  /** Merge additional environment variables for the process. */
+  env(record: Record<string, string>): this {
+    this.#env = { ...this.#env, ...record };
+    return this;
+  }
+
+  /** Set the working directory for the process. */
+  cwd(path: PathLike): this {
+    this.#cwd = String(path);
+    return this;
+  }
+
+  /** Whether to trim surrounding whitespace from stdout (default `true`). */
+  trim(on = true): this {
+    this.#trim = on;
+    return this;
+  }
+
+  /**
+   * Run the command and return its captured stdout as the secret. Streaming is
+   * suppressed (`quiet`) so the value is never echoed to the terminal, and a
+   * non-zero exit throws a {@link SecretError} naming the command.
+   */
+  async resolve_(): Promise<string> {
+    if (this.#command === undefined) {
+      throw new SecretError(
+        "execSecret requires a command; call .command(...) in the settings.",
+      );
+    }
+    const command = new Command([this.#command, ...this.#args])
+      .env(this.#env)
+      .quiet()
+      .noThrow();
+    if (this.#cwd !== undefined) command.cwd(this.#cwd);
+    let output;
+    try {
+      output = await command;
+    } catch (error) {
+      // A missing binary (or other spawn failure) surfaces as a clean
+      // SecretError rather than a raw Deno error.
+      const message = error instanceof Error ? error.message : String(error);
+      throw new SecretError(
+        `execSecret command "${this.#command}" failed: ${message}`,
+      );
+    }
+    if (output.code !== 0) {
+      throw new SecretError(
+        `execSecret command "${this.#command}" exited with code ` +
+          `${output.code}${output.stderr ? `: ${output.stderr.trim()}` : ""}`,
+      );
+    }
+    return this.#trim ? output.stdout.trim() : output.stdout;
+  }
+}
+
+/**
+ * Fluent settings for {@link fileSecret}: read a secret from a file. Set the
+ * path with {@link FileSecretSettings.path}; the content is trimmed of
+ * surrounding whitespace unless {@link FileSecretSettings.trim} is turned off.
+ */
+export class FileSecretSettings {
+  #path?: string;
+  #trim = true;
+
+  /** The file to read the secret from. Required. */
+  path(path: PathLike): this {
+    this.#path = String(path);
+    return this;
+  }
+
+  /** Whether to trim surrounding whitespace from the content (default `true`). */
+  trim(on = true): this {
+    this.#trim = on;
+    return this;
+  }
+
+  /**
+   * Read the file and return its content as the secret. A missing or
+   * unreadable file throws a {@link SecretError} naming the path.
+   */
+  async resolve_(): Promise<string> {
+    if (this.#path === undefined) {
+      throw new SecretError(
+        "fileSecret requires a path; call .path(...) in the settings.",
+      );
+    }
+    let text: string;
+    try {
+      text = await FileTasks.readText(this.#path);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new SecretError(
+        `fileSecret could not read "${this.#path}": ${message}`,
+      );
+    }
+    return this.#trim ? text.trim() : text;
+  }
+}
+
+/**
+ * A {@link SecretSource} that runs a command and takes its standard output as
+ * the secret value. Configure it through an {@link ExecSecretSettings} lambda.
+ *
+ * ```ts
+ * parameter("Vault token").secret().from(
+ *   execSecret((s) => s.command("vault").arg("kv", "get", "-field=token", "secret/ci")),
+ * );
+ * ```
+ */
+export function execSecret(
+  configure: Configure<ExecSecretSettings>,
+): SecretSource {
+  const settings = configure(new ExecSecretSettings());
+  return { resolve: () => settings.resolve_() };
+}
+
+/**
+ * A {@link SecretSource} that reads a file and takes its content as the secret
+ * value — for a mounted Kubernetes/Docker secret or a CI-provided file.
+ * Configure it through a {@link FileSecretSettings} lambda.
+ *
+ * ```ts
+ * parameter("Registry password").secret().from(
+ *   fileSecret((s) => s.path("/run/secrets/registry_password")),
+ * );
+ * ```
+ */
+export function fileSecret(
+  configure: Configure<FileSecretSettings>,
+): SecretSource {
+  const settings = configure(new FileSecretSettings());
+  return { resolve: () => settings.resolve_() };
+}

--- a/packages/core/tests/params_test.ts
+++ b/packages/core/tests/params_test.ts
@@ -385,8 +385,12 @@ Deno.test("execute redacts a secret leaked in a target's failure message", async
   const build = new Deploy();
   const root = discoverTargets(build).get("deploy");
   if (!root) throw new Error("no deploy target");
+  // github:false isolates this from the ambient CI env — the point is the
+  // platform-independent reporter redaction, not the GitHub `::add-mask::`
+  // directive (which intentionally carries the real value; covered separately).
   const result = await execute(build, root, {
     reporter,
+    github: false,
     readEnv: () => undefined,
   });
   assertEquals(result.ok, false);
@@ -409,6 +413,7 @@ Deno.test("execute redacts a secret's invalid value from the parameter error", a
   if (!root) throw new Error("no deploy target");
   const result = await execute(build, root, {
     reporter,
+    github: false,
     readEnv: () => undefined,
   });
   assertEquals(result.ok, false);

--- a/packages/core/tests/params_test.ts
+++ b/packages/core/tests/params_test.ts
@@ -1,7 +1,7 @@
-import { assertEquals, assertThrows } from "./_assert.ts";
+import { assertEquals, assertStringIncludes, assertThrows } from "./_assert.ts";
 import { Build, target } from "../mod.ts";
 import { discoverTargets } from "../src/build.ts";
-import { execute } from "../src/executor.ts";
+import { execute, type Reporter } from "../src/executor.ts";
 import {
   type AnyParameter,
   discoverParameters,
@@ -12,6 +12,30 @@ import {
   ParameterError,
   resolveParameters,
 } from "../src/params.ts";
+import { REDACTED, Redactor } from "../src/redact.ts";
+import type { SecretSource } from "../src/secret.ts";
+
+/** A canned secret source that yields a fixed value, for hermetic tests. */
+function fixedSource(value: string): SecretSource {
+  return { resolve: () => Promise.resolve(value) };
+}
+
+/** A secret source that always fails, for the error path. */
+function failingSource(message: string): SecretSource {
+  return { resolve: () => Promise.reject(new Error(message)) };
+}
+
+/** A reporter that records every line it is given. */
+function recordingReporter(): { reporter: Reporter; lines: string[] } {
+  const lines: string[] = [];
+  return {
+    lines,
+    reporter: {
+      info: (line) => void lines.push(line),
+      error: (line) => void lines.push(line),
+    },
+  };
+}
 
 Deno.test("a fresh parameter is an optional string", () => {
   const p = parameter("desc");
@@ -117,24 +141,28 @@ Deno.test("array preserves env override and secret flags", () => {
   assertEquals([p.array_, p.envName_, p.secret_], [true, "TAGS", true]);
 });
 
-Deno.test("array parameters resolve through the CLI map (repeated flag joined)", () => {
+Deno.test("array parameters resolve through the CLI map (repeated flag joined)", async () => {
   class B extends Build {
     tags = parameter("Tags").array();
   }
   const params = discoverParameters(new B());
   // The CLI joins repeated flags with commas before resolution.
-  const errors = resolveParameters(params, { tags: "x,y" }, () => undefined);
+  const errors = await resolveParameters(
+    params,
+    { tags: "x,y" },
+    () => undefined,
+  );
   assertEquals(errors, []);
   const p = params.get("tags");
   if (p instanceof Parameter) assertEquals(p.value, ["x", "y"]);
 });
 
-Deno.test("resolveParameters prompts for a missing required value", () => {
+Deno.test("resolveParameters prompts for a missing required value", async () => {
   class B extends Build {
     token = parameter("API token").required();
   }
   const params = discoverParameters(new B());
-  const errors = resolveParameters(
+  const errors = await resolveParameters(
     params,
     {},
     () => undefined,
@@ -181,10 +209,10 @@ Deno.test("discoverParameters names and collects parameters", () => {
   assertEquals(params.get("environment")?.name_, "environment");
 });
 
-Deno.test("resolveParameters: CLI beats env beats default", () => {
+Deno.test("resolveParameters: CLI beats env beats default", async () => {
   const params = discoverParameters(new Demo());
   const env = (name: string) => (name === "WORKERS" ? "8" : undefined);
-  const errors = resolveParameters(params, { environment: "prod" }, env);
+  const errors = await resolveParameters(params, { environment: "prod" }, env);
   assertEquals(errors, []);
   const get = (n: string): AnyParameter => {
     const p = params.get(n);
@@ -200,9 +228,9 @@ Deno.test("resolveParameters: CLI beats env beats default", () => {
   if (verbose instanceof Parameter) assertEquals(verbose.value, false); // default
 });
 
-Deno.test("resolveParameters reports missing required and invalid values", () => {
+Deno.test("resolveParameters reports missing required and invalid values", async () => {
   const params = discoverParameters(new Demo());
-  const errors = resolveParameters(
+  const errors = await resolveParameters(
     params,
     { workers: "lots" },
     () => undefined,
@@ -269,4 +297,144 @@ Deno.test("execute fails before running when a required parameter is missing", a
   assertEquals(result.ok, false);
   assertEquals(ran, false);
   assertEquals(result.error instanceof ParameterError, true);
+});
+
+Deno.test("a secret source resolves the value when no flag/env supplied one", async () => {
+  class B extends Build {
+    token = parameter("Token").secret().from(fixedSource("from-source"));
+  }
+  const params = discoverParameters(new B());
+  const errors = await resolveParameters(params, {}, () => undefined);
+  assertEquals(errors, []);
+  const p = params.get("token");
+  if (p instanceof Parameter) assertEquals(p.value, "from-source");
+});
+
+Deno.test("a flag and env both beat a secret source", async () => {
+  class B extends Build {
+    token = parameter("Token").secret().from(fixedSource("from-source"));
+  }
+  // CLI wins.
+  const viaCli = discoverParameters(new B());
+  await resolveParameters(viaCli, { token: "from-cli" }, () => undefined);
+  const cli = viaCli.get("token");
+  if (cli instanceof Parameter) assertEquals(cli.value, "from-cli");
+  // Env wins over the source too.
+  const viaEnv = discoverParameters(new B());
+  await resolveParameters(
+    viaEnv,
+    {},
+    (name) => (name === "TOKEN" ? "from-env" : undefined),
+  );
+  const env = viaEnv.get("token");
+  if (env instanceof Parameter) assertEquals(env.value, "from-env");
+});
+
+Deno.test("a failing secret source is reported as a parameter error", async () => {
+  class B extends Build {
+    token = parameter("Token").secret().from(failingSource("vault is sealed"));
+  }
+  const params = discoverParameters(new B());
+  const errors = await resolveParameters(params, {}, () => undefined);
+  assertEquals(errors.length, 1);
+  assertStringIncludes(errors[0], "--token: vault is sealed");
+});
+
+Deno.test("from() preserves the source across further configuration", async () => {
+  // Order-independent: whether .secret() or .from() comes first, and after a
+  // kind change, the source survives.
+  class B extends Build {
+    a = parameter("A").from(fixedSource("11")).secret().number();
+    b = parameter("B").secret().from(fixedSource("later"));
+  }
+  const params = discoverParameters(new B());
+  await resolveParameters(params, {}, () => undefined);
+  const a = params.get("a");
+  if (a instanceof Parameter) assertEquals(a.value, 11);
+  const b = params.get("b");
+  if (b instanceof Parameter) assertEquals(b.value, "later");
+});
+
+Deno.test("resolveParameters registers a secret's raw value with the redactor", async () => {
+  class B extends Build {
+    token = parameter("Token").secret().from(fixedSource("top-secret"));
+    plain = parameter("Plain").default("visible");
+  }
+  const params = discoverParameters(new B());
+  const redactor = new Redactor();
+  await resolveParameters(params, {}, () => undefined, undefined, redactor);
+  assertEquals(redactor.size, 1); // only the secret was registered
+  assertEquals(
+    redactor.redact("using top-secret and visible"),
+    `using ${REDACTED} and visible`,
+  );
+});
+
+Deno.test("execute redacts a secret leaked in a target's failure message", async () => {
+  const { reporter, lines } = recordingReporter();
+  class Deploy extends Build {
+    token = parameter("Token").secret().from(fixedSource("hunter2xyz"));
+    deploy = target()
+      .description("deploy")
+      .executes(() => {
+        // A failure that echoes the secret in its message must be masked when
+        // the executor reports the failure through its reporter.
+        throw new Error(`auth rejected token ${this.token.value}`);
+      });
+  }
+  const build = new Deploy();
+  const root = discoverTargets(build).get("deploy");
+  if (!root) throw new Error("no deploy target");
+  const result = await execute(build, root, {
+    reporter,
+    readEnv: () => undefined,
+  });
+  assertEquals(result.ok, false);
+  const joined = lines.join("\n");
+  assertStringIncludes(joined, REDACTED);
+  assertEquals(joined.includes("hunter2xyz"), false);
+});
+
+Deno.test("execute redacts a secret's invalid value from the parameter error", async () => {
+  const { reporter, lines } = recordingReporter();
+  class Deploy extends Build {
+    // A source that yields a non-numeric value fails to parse; the error must
+    // not echo the raw secret.
+    port = parameter("Port").secret().from(fixedSource("s3cr3t-not-a-number"))
+      .number();
+    deploy = target().executes(() => {});
+  }
+  const build = new Deploy();
+  const root = discoverTargets(build).get("deploy");
+  if (!root) throw new Error("no deploy target");
+  const result = await execute(build, root, {
+    reporter,
+    readEnv: () => undefined,
+  });
+  assertEquals(result.ok, false);
+  const joined = lines.join("\n");
+  assertEquals(joined.includes("s3cr3t-not-a-number"), false);
+  assertStringIncludes(joined, REDACTED);
+});
+
+Deno.test("execute emits ::add-mask:: with the real value under GitHub", async () => {
+  const { reporter, lines } = recordingReporter();
+  class Deploy extends Build {
+    token = parameter("Token").secret().from(fixedSource("real-value-123"));
+    deploy = target().executes(() => {});
+  }
+  const build = new Deploy();
+  const root = discoverTargets(build).get("deploy");
+  if (!root) throw new Error("no deploy target");
+  await execute(build, root, {
+    reporter,
+    github: true,
+    readEnv: () => undefined,
+  });
+  // The add-mask directive carries the true value so the runner can mask it;
+  // redacting it would defeat the purpose.
+  assertEquals(
+    lines.some((l) => l === "::add-mask::real-value-123"),
+    true,
+  );
 });

--- a/packages/core/tests/redact_test.ts
+++ b/packages/core/tests/redact_test.ts
@@ -1,0 +1,45 @@
+import { assertEquals } from "./_assert.ts";
+import { REDACTED, Redactor } from "../src/redact.ts";
+
+Deno.test("Redactor masks a registered secret anywhere in a line", () => {
+  const r = new Redactor();
+  r.add("s3cr3t");
+  assertEquals(
+    r.redact("token=s3cr3t sent to s3cr3t-host"),
+    `token=${REDACTED} sent to ${REDACTED}-host`,
+  );
+});
+
+Deno.test("Redactor ignores empty strings and de-duplicates", () => {
+  const r = new Redactor();
+  r.add("");
+  r.add("abc");
+  r.add("abc");
+  assertEquals(r.size, 1);
+  // An empty secret must not turn every position into the placeholder.
+  assertEquals(r.redact("nothing here"), "nothing here");
+});
+
+Deno.test("Redactor leaves lines without a secret untouched", () => {
+  const r = new Redactor();
+  r.add("hunter2");
+  assertEquals(r.redact("plain output"), "plain output");
+});
+
+Deno.test("Redactor masks the longest overlapping secret whole", () => {
+  const r = new Redactor();
+  // Registered short-first, but a value containing another must still be
+  // masked as one unit, not leave the outer part exposed.
+  r.add("abc");
+  r.add("abcdef");
+  assertEquals(r.redact("value abcdef here"), `value ${REDACTED} here`);
+});
+
+Deno.test("Redactor treats regex-significant secrets literally", () => {
+  const r = new Redactor();
+  r.add("a.c*");
+  assertEquals(r.redact("literal a.c* only"), `literal ${REDACTED} only`);
+  // A line that would match the pattern as a regex, but does not contain it
+  // literally, is left untouched.
+  assertEquals(r.redact("nothing to mask"), "nothing to mask");
+});

--- a/packages/core/tests/secret_test.ts
+++ b/packages/core/tests/secret_test.ts
@@ -1,0 +1,131 @@
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "./_assert.ts";
+import {
+  execSecret,
+  ExecSecretSettings,
+  fileSecret,
+  FileSecretSettings,
+  SecretError,
+} from "../src/secret.ts";
+
+/** The running `deno`, used as a hermetic, always-present subprocess. */
+const deno = Deno.execPath();
+
+Deno.test("execSecret runs a command and returns its trimmed stdout", async () => {
+  const source = execSecret((s) =>
+    s.command(deno).arg("eval", "console.log('  s3cr3t-value  ')")
+  );
+  assertEquals(await source.resolve(), "s3cr3t-value");
+});
+
+Deno.test("execSecret with trim(false) keeps surrounding whitespace", async () => {
+  const source = execSecret((s) =>
+    s.command(deno).arg(
+      "eval",
+      "Deno.stdout.write(new TextEncoder().encode('tok\\n'))",
+    )
+      .trim(false)
+  );
+  assertEquals(await source.resolve(), "tok\n");
+});
+
+Deno.test("execSecret passes environment variables to the command", async () => {
+  const source = execSecret((s) =>
+    s.command(deno)
+      .arg("eval", "console.log(Deno.env.get('ZUKE_TEST_SECRET'))")
+      .env({ ZUKE_TEST_SECRET: "from-env" })
+  );
+  assertEquals(await source.resolve(), "from-env");
+});
+
+Deno.test("execSecret honours the working directory", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    await Deno.writeTextFile(`${dir}/token.txt`, "in-cwd");
+    const source = execSecret((s) =>
+      s.command(deno)
+        .arg("eval", "console.log(Deno.readTextFileSync('token.txt'))")
+        .cwd(dir)
+    );
+    assertEquals(await source.resolve(), "in-cwd");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("execSecret without a command throws SecretError", async () => {
+  const source = execSecret((s) => s.trim());
+  await assertRejects(
+    () => source.resolve(),
+    SecretError,
+    "requires a command",
+  );
+});
+
+Deno.test("execSecret surfaces a non-zero exit as SecretError", async () => {
+  const source = execSecret((s) =>
+    s.command(deno).arg("eval", "console.error('nope'); Deno.exit(3)")
+  );
+  const error = await assertRejects(() => source.resolve(), SecretError);
+  assertStringIncludes(error.message, "exited with code 3");
+  assertStringIncludes(error.message, "nope");
+});
+
+Deno.test("execSecret reports a non-zero exit with no stderr", async () => {
+  const source = execSecret((s) => s.command(deno).arg("eval", "Deno.exit(4)"));
+  const error = await assertRejects(() => source.resolve(), SecretError);
+  assertStringIncludes(error.message, "exited with code 4");
+});
+
+Deno.test("execSecret wraps a missing binary as SecretError", async () => {
+  const source = execSecret((s) => s.command("zuke-no-such-binary-xyz"));
+  await assertRejects(() => source.resolve(), SecretError, "failed");
+});
+
+Deno.test("fileSecret reads a file and trims by default", async () => {
+  const file = await Deno.makeTempFile();
+  try {
+    await Deno.writeTextFile(file, "  file-secret\n");
+    const source = fileSecret((s) => s.path(file));
+    assertEquals(await source.resolve(), "file-secret");
+  } finally {
+    await Deno.remove(file);
+  }
+});
+
+Deno.test("fileSecret with trim(false) preserves the raw content", async () => {
+  const file = await Deno.makeTempFile();
+  try {
+    await Deno.writeTextFile(file, "raw\n");
+    const source = fileSecret((s) => s.path(file).trim(false));
+    assertEquals(await source.resolve(), "raw\n");
+  } finally {
+    await Deno.remove(file);
+  }
+});
+
+Deno.test("fileSecret without a path throws SecretError", async () => {
+  const source = fileSecret((s) => s.trim());
+  await assertRejects(() => source.resolve(), SecretError, "requires a path");
+});
+
+Deno.test("fileSecret surfaces a missing file as SecretError", async () => {
+  const source = fileSecret((s) => s.path("/no/such/zuke/secret/file"));
+  await assertRejects(
+    () => source.resolve(),
+    SecretError,
+    "could not read",
+  );
+});
+
+Deno.test("the settings classes are exported for direct configuration", () => {
+  // The fluent classes are part of the public surface (parity with the tool
+  // settings), so a build can construct and inspect one directly.
+  const exec = new ExecSecretSettings().command("op").arg("read", "op://v/i/f");
+  const file = new FileSecretSettings().path("/run/secrets/x");
+  assertEquals(exec instanceof ExecSecretSettings, true);
+  assertEquals(file instanceof FileSecretSettings, true);
+});


### PR DESCRIPTION
## What & why

Second of two PRs for **hermeticity** (the first, #151, added verified, cached toolchain provisioning). Today a `secret` parameter can only be pre-set in the environment, and its value is masked only under GitHub Actions via `::add-mask::` — off GitHub, or in Zuke's own error/summary output, it can still leak. This PR gives a `secret` parameter two guarantees: it can be **sourced from a secret manager** at run time, and its resolved value is **redacted from all of Zuke's output on every platform**.

### 1. Secret sources — `parameter().secret().from(source)`

A **source** resolves a secret's value on demand. Two dependency-free, fluent source builders shell out to a tool you already trust rather than bundling a provider SDK:

- **`execSecret`** runs a command and takes its stdout — 1Password (`op`), HashiCorp Vault, Google Secret Manager (`gcloud`), Doppler, AWS, … Configurable `command` / `arg` / `env` / `cwd` / `trim`. It runs quietly (output captured, never streamed), and a non-zero exit fails the build with a `SecretError` naming the command and code.
- **`fileSecret`** reads a file — a mounted Kubernetes/Docker secret or a CI-provided credential file.

Resolution precedence is **flag → env → `.from(...)` source → default**, so a source is a *fallback provider*, consulted only when neither a flag nor an environment variable supplied a value. The same build is therefore portable: env-injected in CI (the source never runs), manager-sourced on a developer machine — with no code change.

Because a source runs a subprocess or reads a file, parameter resolution is now asynchronous. This is entirely internal; parameters are declared exactly as before.

### 2. Guaranteed redaction

The executor now wraps its reporter in a `Redactor` that masks every `secret` parameter's resolved value across **all** of Zuke's output — banners, per-target status, the build summary, and error messages (including a target that throws with the secret in its message). This is applied at the reporter, so it does not depend on running under a CI host that happens to mask logs. A secret's raw value is registered **before** it is parsed, so even a parse error on a malformed value is masked rather than echoed. The GitHub `::add-mask::` directive is still emitted with the real value so the runner masks subprocess output too.

Matching is a plain substring replace (never a regex), so a secret with regex-significant characters is masked literally and there is no injection surface. The one boundary — documented in the new guide — is that a subprocess a target spawns writes to its own stdout/stderr, outside Zuke's reporter (GitHub's `::add-mask::` still covers that case).

### New public API

- `Parameter.from(source)` and the `secret()` flag now imply redaction everywhere.
- `execSecret`, `fileSecret`, `ExecSecretSettings`, `FileSecretSettings`, `SecretSource`, `SecretError`, `Redactor`, `REDACTED` — all from `@zuke/core`.

### Docs

- New **[`docs/secrets.md`](../blob/claude/zuke-feature-brainstorm-l3a1i6/docs/secrets.md)** — an exhaustive guide: marking secrets, the two sources with per-manager examples, resolution precedence, the redaction guarantee and its boundary, errors, and a complete example.
- Updated `docs/parameters.md` (precedence, table, expanded Secrets section), `docs/authoring.md`, and `docs/README.md`.
- Regenerated `llms-full.txt` and `packages/core/README.md` with `./zuke apiDocs`.

### Testing & coverage

- New `secret_test.ts` (both sources: stdout capture, trim on/off, env/cwd, missing command/path, non-zero exit with and without stderr, missing binary/file) and `redact_test.ts` (masking, dedupe, empty-string safety, longest-first overlap, regex-literal). Extended `params_test.ts` (source precedence, source failure → error, `.from()` threading through further configuration, redactor registration, and two end-to-end executor tests: a secret leaked in a failure message and in a parse error are both masked; `::add-mask::` carries the real value under GitHub). All seams are hermetic — `execSecret` tests drive the running `deno` as the subprocess.
- Full `deno task ci` green — coverage **99.1% lines / 96.6% branches** (above the 95% gate).

## Related issues

Part of the "hermeticity" brainstorm section; the follow-up to #151.

## Checklist

- [x] The PR title is a [Conventional Commit](https://www.conventionalcommits.org/) (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour changed.
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`, `llms-full.txt`, package README `## API`).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with type guards instead).
- [ ] A new package was wired into all five places — n/a (no new package; all changes are within `@zuke/core`).
- [x] The code is written using AI assisted coding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFVtbsGNx9piPuknJXqgrH

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFVtbsGNx9piPuknJXqgrH)_