### PR TITLE
feat(core): add zuke mcp, an MCP server over the build

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,8 @@
   CLIs from a build with `installRelease()` and `toolchain()`.
 - [Extending Zuke](./extending.md) — the plugin contract: lifecycle plugins,
   tool wrappers, and reusable target bundles.
+- [MCP server](./mcp.md) — `zuke mcp` exposes the build to AI agents as typed
+  tools over the Model Context Protocol.
 - [AI review](./ai-review.md) — model-assessed review gates as build
   validations.
 - [Self-healing builds](./self-healing.md) — hand a failure to an AI fixer that

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -13,6 +13,7 @@
 | `zuke graph --output=html`          | Render an interactive HTML graph into `.zuke/` and open it.    |
 | `zuke completions print <shell>`    | Print a shell-completion script (`bash`, `zsh`, or `fish`).    |
 | `zuke completions install <shell>`  | Write the script and wire it into the shell's startup.         |
+| `zuke mcp [--allow-run]`            | Run an MCP server over the build for AI agents ([details](./mcp.md)). |
 | `zuke --help` / `-h`                | Usage.                                                         |
 | `zuke` (no target)                  | Run the `default` target if defined, else print `--list`.      |
 
@@ -56,7 +57,7 @@ emit `::error::` annotations, and the summary is written to the job summary.
 `zuke completions` takes an explicit sub-action — `print` or `install` — then a
 shell (`bash`, `zsh`, or `fish`). `print` writes the completion script to
 stdout; the script completes the build's target names, the reserved commands
-(`graph`, `generate-ci`, `completions`), the built-in option flags, and any
+(`graph`, `generate-ci`, `completions`, `mcp`), the built-in option flags, and any
 declared [parameters](./parameters.md) as `--flag` candidates. Unlisted targets
 (`.unlisted()`) stay hidden, just as they are in `--list`.
 
@@ -96,6 +97,15 @@ The config directory honours `$XDG_CONFIG_HOME`. Installing is idempotent: if
 the rc file already sources the script, it is left untouched. The reserved
 commands and option flags offered by completion come from a single registry
 shared with the parser and `--help`, so they never drift out of sync.
+
+## `zuke mcp`
+
+Runs a [Model Context Protocol](https://modelcontextprotocol.io) server over the
+build on stdio, so an AI agent can operate the pipeline through typed tool calls
+instead of guessing shell commands. It exposes read tools (`list_targets`,
+`describe_build`, `graph`) and — only with `--allow-run` — one `run:<target>`
+tool per target, whose input schema is derived from the build's parameters.
+`mcp` is a reserved command name. See the full guide: [MCP server](./mcp.md).
 
 ## Parallel execution
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,87 @@
+# MCP server
+
+`zuke mcp` runs a [Model Context Protocol](https://modelcontextprotocol.io)
+server over your build. MCP is the open standard that lets an AI client — Claude
+Desktop, Claude Code, an IDE, any agent — discover a server's **tools** (typed,
+schema-described functions) and call them. Pointing a client at `zuke mcp` lets
+an agent **operate the pipeline through typed calls** — list the targets,
+inspect the graph, run one with the right parameters — instead of guessing shell
+invocations.
+
+It's a natural extension of what Zuke already does: it publishes `llms.txt`, a
+`--list --json` self-description, and shell completions from a single registry.
+MCP is the *live* counterpart — the same build surface, callable.
+
+The server is **dependency-free** (Zuke ships no MCP SDK): it speaks
+newline-delimited JSON-RPC 2.0 on stdio, the standard MCP local transport.
+
+## Running it
+
+```sh
+zuke mcp              # read-only: inspect the build, never execute
+zuke mcp --allow-run  # also expose run:<target> tools that execute targets
+```
+
+The process reads JSON-RPC from stdin and writes responses to stdout; its one
+startup line goes to stderr so it never corrupts the protocol stream. It runs
+until stdin closes. (Read `zuke` as `deno run -A zuke.ts` until the launcher
+binary ships.)
+
+### Registering with a client
+
+Most clients take a command to launch the server. For example, with Claude Code:
+
+```sh
+claude mcp add zuke -- deno run -A zuke.ts mcp
+```
+
+Any client that speaks stdio MCP works the same way — give it the command
+`deno run -A zuke.ts mcp` (add `--allow-run` when you want the agent to execute
+targets).
+
+## Tools
+
+Read tools are always available:
+
+| Tool | Returns |
+| --- | --- |
+| `list_targets` | Every target with its description and dependencies. |
+| `describe_build` | The full build surface — commands, flags, targets, parameters (the `--list --json` payload). |
+| `graph` | Each target and the targets it depends on. |
+
+With `--allow-run`, the server also exposes one **`run:<target>`** tool per
+target. Its input schema is built from the build's declared parameters — a
+`required` parameter is required, `.options(...)` becomes an `enum`, a `.number()`
+is typed as a number — plus a `dryRun` flag that plans without executing. These
+tools carry MCP's `destructiveHint` annotation so a client can prompt before
+running. A run resolves parameters exactly like the CLI (MCP argument → the
+environment → the declared default) and returns the target's captured output
+with a pass/fail marker.
+
+```jsonc
+// tools/call
+{ "name": "run:test", "arguments": { "environment": "dev", "coverage": true } }
+```
+
+## Safety
+
+Running a target executes real build code, so execution is **off by default**: a
+freshly-connected agent can only *inspect* the build. Add `--allow-run`
+deliberately — for an environment where you want the agent to drive the
+pipeline. Without it, the `run:` tools are not advertised at all, and a direct
+`run:` call is refused with a message pointing at the flag.
+
+Secret values stay protected: a run's output is captured through the same
+reporter pipeline as the console, so `parameter().secret()` values are
+[redacted](./secrets.md) from what the agent sees.
+
+## Protocol notes
+
+- **Transport:** newline-delimited JSON-RPC 2.0 on stdio.
+- **Lifecycle:** the server answers `initialize` (echoing the client's requested
+  `protocolVersion`), `notifications/initialized` (no reply), `ping`,
+  `tools/list`, and `tools/call`. Unknown requests get a JSON-RPC
+  `-32601 Method not found`; notifications never get a reply.
+- **Errors:** a bad *tool* call (unknown tool, unknown target, a failed run) is
+  reported through the tool result (`isError: true`) so the model sees it, rather
+  than as a transport-level error — matching the MCP convention.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -10,7 +10,7 @@ invocations.
 
 It's a natural extension of what Zuke already does: it publishes `llms.txt`, a
 `--list --json` self-description, and shell completions from a single registry.
-MCP is the *live* counterpart — the same build surface, callable.
+MCP is the _live_ counterpart — the same build surface, callable.
 
 The server is **dependency-free** (Zuke ships no MCP SDK): it speaks
 newline-delimited JSON-RPC 2.0 on stdio, the standard MCP local transport.
@@ -43,20 +43,20 @@ targets).
 
 Read tools are always available:
 
-| Tool | Returns |
-| --- | --- |
-| `list_targets` | Every target with its description and dependencies. |
+| Tool             | Returns                                                                                      |
+| ---------------- | -------------------------------------------------------------------------------------------- |
+| `list_targets`   | Every target with its description and dependencies.                                          |
 | `describe_build` | The full build surface — commands, flags, targets, parameters (the `--list --json` payload). |
-| `graph` | Each target and the targets it depends on. |
+| `graph`          | Each target and the targets it depends on.                                                   |
 
 With `--allow-run`, the server also exposes one **`run:<target>`** tool per
 target. Its input schema is built from the build's declared parameters — a
-`required` parameter is required, `.options(...)` becomes an `enum`, a `.number()`
-is typed as a number — plus a `dryRun` flag that plans without executing. These
-tools carry MCP's `destructiveHint` annotation so a client can prompt before
-running. A run resolves parameters exactly like the CLI (MCP argument → the
-environment → the declared default) and returns the target's captured output
-with a pass/fail marker.
+`required` parameter is required, `.options(...)` becomes an `enum`, a
+`.number()` is typed as a number — plus a `dryRun` flag that plans without
+executing. These tools carry MCP's `destructiveHint` annotation so a client can
+prompt before running. A run resolves parameters exactly like the CLI (MCP
+argument → the environment → the declared default) and returns the target's
+captured output with a pass/fail marker.
 
 ```jsonc
 // tools/call
@@ -65,11 +65,21 @@ with a pass/fail marker.
 
 ## Safety
 
+**Trust model.** The server has no network endpoint. It speaks only over the
+stdin/stdout of a process the client launches, so its trust boundary is the
+local machine: anyone who can start `zuke mcp` already has a shell there and
+could run `deno run -A zuke.ts <target>` directly. The server therefore grants
+no capability beyond what launching it already implies — there is nothing to
+authenticate, because there is no remote party. Treat it like any other local
+developer tool: don't wire an untrusted client to it.
+
 Running a target executes real build code, so execution is **off by default**: a
-freshly-connected agent can only *inspect* the build. Add `--allow-run`
+freshly-connected agent can only _inspect_ the build. Add `--allow-run`
 deliberately — for an environment where you want the agent to drive the
 pipeline. Without it, the `run:` tools are not advertised at all, and a direct
-`run:` call is refused with a message pointing at the flag.
+`run:` call is refused with a message pointing at the flag. When enabled, run
+tools carry MCP's `destructiveHint`, so a well-behaved client can prompt before
+each execution.
 
 Secret values stay protected: a run's output is captured through the same
 reporter pipeline as the console, so `parameter().secret()` values are
@@ -82,6 +92,6 @@ reporter pipeline as the console, so `parameter().secret()` values are
   `protocolVersion`), `notifications/initialized` (no reply), `ping`,
   `tools/list`, and `tools/call`. Unknown requests get a JSON-RPC
   `-32601 Method not found`; notifications never get a reply.
-- **Errors:** a bad *tool* call (unknown tool, unknown target, a failed run) is
-  reported through the tool result (`isError: true`) so the model sees it, rather
-  than as a transport-level error — matching the MCP convention.
+- **Errors:** a bad _tool_ call (unknown tool, unknown target, a failed run) is
+  reported through the tool result (`isError: true`) so the model sees it,
+  rather than as a transport-level error — matching the MCP convention.

--- a/llms.txt
+++ b/llms.txt
@@ -44,6 +44,7 @@ Reserved commands:
 - `graph` — Show the dependency graph
 - `generate-ci` — Write declared CI configuration files
 - `completions` — Print a shell-completion script
+- `mcp` — Run an MCP server over the build (for AI agents)
 
 Option flags:
 
@@ -58,6 +59,7 @@ Option flags:
 - `--output` — Graph output format: text or html
 - `--no-open` — With --output=html, do not open a browser
 - `--check` — With generate-ci, verify files are current
+- `--allow-run` — With mcp, let agents execute targets (not just inspect)
 - `--help` — Show usage
 
 Full reference: [docs/cli.md](./docs/cli.md).

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -29,7 +29,9 @@ import {
   DEFAULT_TARGET,
   GENERATE_CI_COMMAND,
   GRAPH_COMMAND,
+  MCP_COMMAND,
 } from "./cli_spec.ts";
+import { serveMcp } from "./mcp/command.ts";
 import {
   installCompletions,
   type InstallOptions,
@@ -77,6 +79,10 @@ export interface ParsedArgs {
   generateCi: boolean;
   /** The `completions` command was requested. */
   completions: boolean;
+  /** The `mcp` command was requested (run an MCP server over the build). */
+  mcp: boolean;
+  /** Allow `mcp` to execute targets, not just inspect them (`--allow-run`). */
+  allowRun: boolean;
   /** The `completions` sub-action (`install` or `print`); the first positional. */
   completionsAction?: string;
   /** The shell argument to `completions` (the positional after the sub-action). */
@@ -127,6 +133,8 @@ export function parseArgs(
     graph: false,
     generateCi: false,
     completions: false,
+    mcp: false,
+    allowRun: false,
     check: false,
     output: "text",
     open: true,
@@ -159,6 +167,8 @@ export function parseArgs(
       parsed.dryRun = true;
     } else if (arg === "--check") {
       parsed.check = true;
+    } else if (arg === "--allow-run") {
+      parsed.allowRun = true;
     } else if (arg === "--parallel") {
       parsed.parallel = true;
     } else if (arg.startsWith("--parallel=")) {
@@ -200,11 +210,12 @@ export function parseArgs(
       parsed.shell = arg;
     } else if (
       parsed.target === undefined && !parsed.graph && !parsed.generateCi &&
-      !parsed.completions
+      !parsed.completions && !parsed.mcp
     ) {
       if (arg === GRAPH_COMMAND) parsed.graph = true;
       else if (arg === GENERATE_CI_COMMAND) parsed.generateCi = true;
       else if (arg === COMPLETIONS_COMMAND) parsed.completions = true;
+      else if (arg === MCP_COMMAND) parsed.mcp = true;
       else parsed.target = arg;
     }
   }
@@ -224,6 +235,7 @@ Usage:
   deno run -A zuke.ts graph [--output=html] [--no-open]
   deno run -A zuke.ts generate-ci [--check]
   deno run -A zuke.ts completions <install|print> <bash|zsh|fish>
+  deno run -A zuke.ts mcp [--allow-run]
 
 Options:
   <target>          Run the target and its transitive dependencies.
@@ -257,6 +269,12 @@ Options:
                     writing them, failing if any has drifted (use on CI).
   --output <fmt>    Graph output format: text (default) or html.
   --no-open         With --output=html, do not open a browser.
+  mcp               Run an MCP server over the build on stdio, exposing its
+                    targets to AI agents as typed tools. Read-only by default
+                    (inspect the targets, parameters, and graph); add
+                    --allow-run to let agents execute targets too.
+  --allow-run       With mcp, allow agents to execute targets, not just
+                    inspect them.
   --<param> <val>   Set a declared build parameter (see Parameters below).
   --help, -h        Show this help.`;
 
@@ -486,6 +504,9 @@ export async function main(
   }
   if (parsed.generateCi) {
     return await syncCiConfig(build, { check: parsed.check });
+  }
+  if (parsed.mcp) {
+    return await serveMcp(build, { allowRun: parsed.allowRun });
   }
 
   let name = parsed.target;

--- a/packages/core/src/cli_spec.ts
+++ b/packages/core/src/cli_spec.ts
@@ -29,6 +29,9 @@ export const GENERATE_CI_COMMAND = "generate-ci";
 /** The `completions` command: print a shell-completion script. */
 export const COMPLETIONS_COMMAND = "completions";
 
+/** The `mcp` command: run an MCP server over the build (for AI agents). */
+export const MCP_COMMAND = "mcp";
+
 /** Every reserved command, in help and completion order. */
 export const RESERVED_COMMANDS: readonly ReservedCommand[] = [
   { name: GRAPH_COMMAND, description: "Show the dependency graph" },
@@ -37,6 +40,10 @@ export const RESERVED_COMMANDS: readonly ReservedCommand[] = [
     description: "Write declared CI configuration files",
   },
   { name: COMPLETIONS_COMMAND, description: "Print a shell-completion script" },
+  {
+    name: MCP_COMMAND,
+    description: "Run an MCP server over the build (for AI agents)",
+  },
 ];
 
 /** A built-in option flag (its long form), surfaced in help and completion. */
@@ -74,6 +81,10 @@ export const BUILTIN_FLAGS: readonly BuiltinFlag[] = [
   {
     name: "--check",
     description: "With generate-ci, verify files are current",
+  },
+  {
+    name: "--allow-run",
+    description: "With mcp, let agents execute targets (not just inspect)",
   },
   { name: "--help", description: "Show usage" },
 ];

--- a/packages/core/src/mcp/command.ts
+++ b/packages/core/src/mcp/command.ts
@@ -1,0 +1,43 @@
+/**
+ * The `zuke mcp` reserved command: run an MCP server over the build on stdio.
+ *
+ * @module
+ */
+
+import type { Build } from "../build.ts";
+import { type ByteWriter, serveStdio } from "./jsonrpc.ts";
+import { McpServer, type McpServerOptions } from "./server.ts";
+
+/** Options for {@link serveMcp}. */
+export interface ServeMcpOptions extends McpServerOptions {
+  /** The message stream to read (defaults to stdin); injectable for tests. */
+  input?: ReadableStream<Uint8Array>;
+  /** The sink to write responses to (defaults to stdout); injectable for tests. */
+  output?: ByteWriter;
+  /** Suppress the stderr startup banner (used by tests). */
+  quiet?: boolean;
+}
+
+/**
+ * Serve the build over MCP on stdin/stdout until the input stream closes.
+ * Returns the process exit code (`0`). Diagnostics — the one-line startup
+ * banner — go to stderr so they never corrupt the JSON-RPC stream on stdout.
+ */
+export async function serveMcp(
+  build: Build,
+  options: ServeMcpOptions = {},
+): Promise<number> {
+  const server = new McpServer(build, options);
+  if (!options.quiet) {
+    const mode = options.allowRun ? "run enabled" : "read-only";
+    console.error(
+      `zuke mcp: serving on stdio (${mode}). Press Ctrl-C to stop.`,
+    );
+  }
+  await serveStdio(
+    (message) => server.handleMessage(message),
+    options.input,
+    options.output,
+  );
+  return 0;
+}

--- a/packages/core/src/mcp/jsonrpc.ts
+++ b/packages/core/src/mcp/jsonrpc.ts
@@ -88,24 +88,32 @@ export async function serveStdio(
   const send = (response: JsonRpcResponse): Promise<number> =>
     output.write(encoder.encode(`${JSON.stringify(response)}\n`));
 
+  const handleLine = async (raw: string): Promise<void> => {
+    const line = raw.trim();
+    if (line === "") return;
+    let message: unknown;
+    try {
+      message = JSON.parse(line);
+    } catch {
+      await send(err(null, PARSE_ERROR, "Parse error"));
+      return;
+    }
+    const response = await handle(message);
+    if (response !== null) await send(response);
+  };
+
   let buffer = "";
   for await (const chunk of input) {
     buffer += decoder.decode(chunk, { stream: true });
     let newline = buffer.indexOf("\n");
     while (newline !== -1) {
-      const line = buffer.slice(0, newline).trim();
+      await handleLine(buffer.slice(0, newline));
       buffer = buffer.slice(newline + 1);
       newline = buffer.indexOf("\n");
-      if (line === "") continue;
-      let message: unknown;
-      try {
-        message = JSON.parse(line);
-      } catch {
-        await send(err(null, PARSE_ERROR, "Parse error"));
-        continue;
-      }
-      const response = await handle(message);
-      if (response !== null) await send(response);
     }
   }
+  // Flush any pending multi-byte character and process a final line that the
+  // stream ended without terminating, so no message is silently dropped.
+  buffer += decoder.decode();
+  await handleLine(buffer);
 }

--- a/packages/core/src/mcp/jsonrpc.ts
+++ b/packages/core/src/mcp/jsonrpc.ts
@@ -1,0 +1,111 @@
+/**
+ * A minimal, dependency-free JSON-RPC 2.0 layer for the MCP server.
+ *
+ * MCP's stdio transport is newline-delimited JSON-RPC 2.0: each message is a
+ * single JSON object on its own line, read from stdin and written to stdout
+ * (diagnostics go to stderr so they never corrupt the protocol stream). This
+ * module provides the wire types, the standard error codes, and a {@link
+ * serveStdio} read loop; the method dispatch lives in {@link McpServer}.
+ *
+ * @module
+ */
+
+/** A JSON-RPC 2.0 request or notification (a notification omits `id`). */
+export interface JsonRpcRequest {
+  readonly jsonrpc: "2.0";
+  /** Present for a request (correlates the response); absent for a notification. */
+  readonly id?: string | number | null;
+  readonly method: string;
+  readonly params?: unknown;
+}
+
+/** A JSON-RPC 2.0 error object. */
+export interface JsonRpcError {
+  readonly code: number;
+  readonly message: string;
+  readonly data?: unknown;
+}
+
+/** A JSON-RPC 2.0 response — exactly one of `result` or `error` is set. */
+export interface JsonRpcResponse {
+  readonly jsonrpc: "2.0";
+  readonly id: string | number | null;
+  readonly result?: unknown;
+  readonly error?: JsonRpcError;
+}
+
+/** Standard JSON-RPC 2.0 error codes. */
+export const PARSE_ERROR = -32700;
+/** The JSON sent is not a valid Request object. */
+export const INVALID_REQUEST = -32600;
+/** The method does not exist or is not available. */
+export const METHOD_NOT_FOUND = -32601;
+/** Invalid method parameters. */
+export const INVALID_PARAMS = -32602;
+/** Internal JSON-RPC error. */
+export const INTERNAL_ERROR = -32603;
+
+/** Build a success response for request `id`. */
+export function ok(
+  id: string | number | null,
+  result: unknown,
+): JsonRpcResponse {
+  return { jsonrpc: "2.0", id, result };
+}
+
+/** Build an error response for request `id`. */
+export function err(
+  id: string | number | null,
+  code: number,
+  message: string,
+  data?: unknown,
+): JsonRpcResponse {
+  return {
+    jsonrpc: "2.0",
+    id,
+    error: data === undefined ? { code, message } : { code, message, data },
+  };
+}
+
+/** A sink the transport writes framed responses to (stdout in production). */
+export interface ByteWriter {
+  write(p: Uint8Array): Promise<number>;
+}
+
+/**
+ * Read newline-delimited JSON-RPC messages from `input`, pass each parsed
+ * message to `handle`, and write any non-null response back to `output`
+ * (newline-framed). A line that is not valid JSON yields a parse-error response
+ * with a null id, per JSON-RPC. Returns when the input stream ends.
+ */
+export async function serveStdio(
+  handle: (message: unknown) => Promise<JsonRpcResponse | null>,
+  input: ReadableStream<Uint8Array> = Deno.stdin.readable,
+  output: ByteWriter = Deno.stdout,
+): Promise<void> {
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  const send = (response: JsonRpcResponse): Promise<number> =>
+    output.write(encoder.encode(`${JSON.stringify(response)}\n`));
+
+  let buffer = "";
+  for await (const chunk of input) {
+    buffer += decoder.decode(chunk, { stream: true });
+    let newline = buffer.indexOf("\n");
+    while (newline !== -1) {
+      const line = buffer.slice(0, newline).trim();
+      buffer = buffer.slice(newline + 1);
+      newline = buffer.indexOf("\n");
+      if (line === "") continue;
+      let message: unknown;
+      try {
+        message = JSON.parse(line);
+      } catch {
+        await send(err(null, PARSE_ERROR, "Parse error"));
+        continue;
+      }
+      const response = await handle(message);
+      if (response !== null) await send(response);
+    }
+  }
+}

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -31,8 +31,19 @@ import {
   ok,
 } from "./jsonrpc.ts";
 
+/**
+ * The MCP protocol versions this server implements, newest first. The server's
+ * method surface (`initialize`, `tools/list`, `tools/call`, `ping`) is common
+ * to all of them; {@link PROTOCOL_VERSION} is the newest.
+ */
+export const SUPPORTED_PROTOCOL_VERSIONS: readonly string[] = [
+  "2025-06-18",
+  "2025-03-26",
+  "2024-11-05",
+];
+
 /** The newest MCP protocol version this server implements. */
-export const PROTOCOL_VERSION = "2025-06-18";
+export const PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSIONS[0];
 
 /** The `run:` prefix that names a per-target execution tool. */
 const RUN_PREFIX = "run:";
@@ -231,15 +242,24 @@ export class McpServer {
     }
   }
 
-  /** The `initialize` result: echo the client's protocol version when given. */
+  /**
+   * The `initialize` result. Negotiate the protocol version per the MCP spec:
+   * echo the client's requested version only when this server implements it,
+   * otherwise answer with the server's newest supported version (the client
+   * then proceeds or disconnects). An unknown or malformed request never
+   * reflects an unsupported version back.
+   */
   #initialize(params: unknown): Record<string, unknown> {
-    const requested = typeof params === "object" && params !== null &&
-        "protocolVersion" in params &&
+    const requested = isRecord(params) &&
         typeof params.protocolVersion === "string"
       ? params.protocolVersion
+      : undefined;
+    const protocolVersion = requested !== undefined &&
+        SUPPORTED_PROTOCOL_VERSIONS.includes(requested)
+      ? requested
       : PROTOCOL_VERSION;
     return {
-      protocolVersion: requested,
+      protocolVersion,
       capabilities: { tools: { listChanged: false } },
       serverInfo: { name: "zuke", version: this.#version },
     };

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -94,6 +94,26 @@ function textResult(text: string, isError = false): Record<string, unknown> {
   return { content: [{ type: "text", text }], isError };
 }
 
+/** Whether a JSON value is a scalar a parameter can accept. */
+function isScalar(value: unknown): value is string | number | boolean {
+  const t = typeof value;
+  return t === "string" || t === "number" || t === "boolean";
+}
+
+/**
+ * Coerce a JSON argument to the string a parameter parses, or `null` when the
+ * value's shape is invalid (an object, `null`, or a non-scalar/list mismatch).
+ * An array parameter accepts a list of scalars (joined like a repeated flag);
+ * every other parameter accepts a single scalar.
+ */
+function coerceArg(value: unknown, isArray: boolean): string | null {
+  if (Array.isArray(value)) {
+    if (!isArray || !value.every(isScalar)) return null;
+    return value.map(String).join(",");
+  }
+  return isScalar(value) ? String(value) : null;
+}
+
 /**
  * An MCP server bound to a build. Construct it once, then feed each incoming
  * JSON-RPC message to {@link McpServer.handleMessage}.
@@ -293,10 +313,30 @@ export class McpServer {
       return ok(id, textResult(`Unknown target: ${targetName}`, true));
     }
     const dryRun = args.dryRun === true;
+    // Coerce each supplied argument to the string form the parameter layer
+    // parses (the same path as a CLI flag), rejecting non-scalar JSON so a
+    // stray object/array can't be smuggled in as `[object Object]`. The
+    // parameter parsers then validate the string content (number, boolean,
+    // allowed options), surfacing an invalid value as a build failure.
     const values: Record<string, string> = {};
-    for (const paramName of this.#params.keys()) {
+    const badArgs: string[] = [];
+    for (const [paramName, param] of this.#params) {
       const value = args[paramName];
-      if (value !== undefined) values[paramName] = String(value);
+      if (value === undefined) continue;
+      const coerced = coerceArg(value, param.array_);
+      if (coerced === null) badArgs.push(paramName);
+      else values[paramName] = coerced;
+    }
+    if (badArgs.length > 0) {
+      return ok(
+        id,
+        textResult(
+          `Invalid argument type for: ${badArgs.join(", ")}. Each parameter ` +
+            "accepts a string, number, or boolean (an array parameter also " +
+            "accepts a list of them).",
+          true,
+        ),
+      );
     }
     const buffer = bufferingReporter();
     // Parameters resolve like the CLI: MCP arguments beat the environment beats

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -1,0 +1,327 @@
+/**
+ * An MCP (Model Context Protocol) server over a Zuke build.
+ *
+ * {@link McpServer} turns a build into a set of MCP tools an AI client can
+ * discover and call: read tools that describe the targets, parameters, and
+ * dependency graph, plus — when execution is enabled — one `run:<target>` tool
+ * per target whose JSON-Schema input is derived from the build's parameters.
+ * The protocol handling is a pure {@link McpServer.handleMessage} (message in,
+ * response out) so it is exercised without touching real stdio; the transport
+ * loop lives in {@link serveStdio}.
+ *
+ * A run tool executes the target through {@link execute} with a buffering
+ * reporter, so the captured output is returned to the client — and because that
+ * output passes through the same reporter pipeline, `secret` parameter values
+ * are redacted from it exactly as on the console.
+ *
+ * @module
+ */
+
+import type { Build } from "../build.ts";
+import { discoverTargets } from "../build.ts";
+import { type AnyParameter, discoverParameters } from "../params.ts";
+import { describeBuildSurface } from "../describe.ts";
+import { execute, type Reporter } from "../executor.ts";
+import type { TargetBuilder } from "../target.ts";
+import {
+  err,
+  INVALID_PARAMS,
+  type JsonRpcResponse,
+  METHOD_NOT_FOUND,
+  ok,
+} from "./jsonrpc.ts";
+
+/** The newest MCP protocol version this server implements. */
+export const PROTOCOL_VERSION = "2025-06-18";
+
+/** The `run:` prefix that names a per-target execution tool. */
+const RUN_PREFIX = "run:";
+
+/** A JSON Schema fragment (kept loose — MCP only needs plain JSON Schema). */
+type JsonSchema = Record<string, unknown>;
+
+/** An MCP tool definition, as returned by `tools/list`. */
+export interface McpTool {
+  readonly name: string;
+  readonly description: string;
+  readonly inputSchema: JsonSchema;
+  readonly annotations?: {
+    readonly title?: string;
+    readonly readOnlyHint?: boolean;
+    readonly destructiveHint?: boolean;
+  };
+}
+
+/** Options for {@link McpServer}. */
+export interface McpServerOptions {
+  /**
+   * Expose `run:<target>` tools that execute build code. Off by default, so a
+   * freshly-connected agent can only inspect the build; enable it with
+   * `zuke mcp --allow-run`.
+   */
+  allowRun?: boolean;
+  /** The server version reported in `initialize`. Defaults to `"0.0.0"`. */
+  version?: string;
+}
+
+/** A reporter that records every line, for returning a run's output. */
+function bufferingReporter(): { reporter: Reporter; text(): string } {
+  const lines: string[] = [];
+  return {
+    reporter: {
+      info: (line) => void lines.push(line),
+      error: (line) => void lines.push(line),
+    },
+    text: () => lines.join("\n"),
+  };
+}
+
+/** The JSON-Schema type keyword for a parameter's value kind. */
+function schemaForParam(param: AnyParameter): JsonSchema {
+  if (param.array_) {
+    return { type: "array", items: { type: "string" } };
+  }
+  const base: JsonSchema = { type: param.kind_ };
+  if (param.description_) base.description = param.description_;
+  if (param.options_ && param.options_.length > 0) {
+    base.enum = [...param.options_];
+  }
+  return base;
+}
+
+/** The MCP result content for a single block of text. */
+function textResult(text: string, isError = false): Record<string, unknown> {
+  return { content: [{ type: "text", text }], isError };
+}
+
+/**
+ * An MCP server bound to a build. Construct it once, then feed each incoming
+ * JSON-RPC message to {@link McpServer.handleMessage}.
+ */
+export class McpServer {
+  readonly #targets: Map<string, TargetBuilder>;
+  readonly #params: Map<string, AnyParameter>;
+  readonly #allowRun: boolean;
+  readonly #version: string;
+
+  constructor(
+    private readonly build: Build,
+    options: McpServerOptions = {},
+  ) {
+    this.#targets = discoverTargets(build);
+    this.#params = discoverParameters(build);
+    this.#allowRun = options.allowRun ?? false;
+    this.#version = options.version ?? "0.0.0";
+  }
+
+  /** The tools advertised to the client, honouring {@link McpServerOptions.allowRun}. */
+  tools(): McpTool[] {
+    const tools: McpTool[] = [
+      {
+        name: "list_targets",
+        description:
+          "List the build's targets with their descriptions and dependencies.",
+        inputSchema: { type: "object", properties: {} },
+        annotations: { readOnlyHint: true },
+      },
+      {
+        name: "describe_build",
+        description:
+          "Describe the whole build surface: commands, flags, targets, and parameters.",
+        inputSchema: { type: "object", properties: {} },
+        annotations: { readOnlyHint: true },
+      },
+      {
+        name: "graph",
+        description: "Show each target and the targets it depends on.",
+        inputSchema: { type: "object", properties: {} },
+        annotations: { readOnlyHint: true },
+      },
+    ];
+    if (this.#allowRun) {
+      for (const [name, target] of this.#targets) {
+        tools.push(this.#runTool(name, target));
+      }
+    }
+    return tools;
+  }
+
+  /** Build the `run:<name>` tool for one target from the build's parameters. */
+  #runTool(name: string, target: TargetBuilder): McpTool {
+    const properties: Record<string, JsonSchema> = {};
+    const required: string[] = [];
+    for (const [paramName, param] of this.#params) {
+      properties[paramName] = schemaForParam(param);
+      if (param.required_ && !param.hasFallback_) required.push(paramName);
+    }
+    // Execution controls, alongside the declared parameters.
+    properties.dryRun = {
+      type: "boolean",
+      description: "Plan without executing any target body.",
+    };
+    const description = target.description_
+      ? `Run the "${name}" target: ${target.description_}`
+      : `Run the "${name}" target.`;
+    const schema: JsonSchema = { type: "object", properties };
+    if (required.length > 0) schema.required = required;
+    return {
+      name: `${RUN_PREFIX}${name}`,
+      description,
+      inputSchema: schema,
+      annotations: { title: `Run ${name}`, destructiveHint: true },
+    };
+  }
+
+  /**
+   * Handle one parsed JSON-RPC message. Returns the response to send, or `null`
+   * for a notification (which takes no reply).
+   */
+  async handleMessage(message: unknown): Promise<JsonRpcResponse | null> {
+    if (
+      typeof message !== "object" || message === null ||
+      !("method" in message) || typeof message.method !== "string"
+    ) {
+      return err(idOf(message), INVALID_PARAMS, "Invalid Request");
+    }
+    const method = message.method;
+    const id = idOf(message);
+    const params = "params" in message ? message.params : undefined;
+
+    // Notifications (no id) never receive a response.
+    if (id === null && method.startsWith("notifications/")) return null;
+
+    switch (method) {
+      case "initialize":
+        return ok(id, this.#initialize(params));
+      case "ping":
+        return ok(id, {});
+      case "tools/list":
+        return ok(id, { tools: this.tools() });
+      case "tools/call":
+        return await this.#callTool(id, params);
+      default:
+        // An unknown notification is silently ignored; an unknown request errors.
+        if (id === null) return null;
+        return err(id, METHOD_NOT_FOUND, `Unknown method: ${method}`);
+    }
+  }
+
+  /** The `initialize` result: echo the client's protocol version when given. */
+  #initialize(params: unknown): Record<string, unknown> {
+    const requested = typeof params === "object" && params !== null &&
+        "protocolVersion" in params &&
+        typeof params.protocolVersion === "string"
+      ? params.protocolVersion
+      : PROTOCOL_VERSION;
+    return {
+      protocolVersion: requested,
+      capabilities: { tools: { listChanged: false } },
+      serverInfo: { name: "zuke", version: this.#version },
+    };
+  }
+
+  /** Dispatch a `tools/call`. */
+  async #callTool(
+    id: string | number | null,
+    params: unknown,
+  ): Promise<JsonRpcResponse> {
+    if (typeof params !== "object" || params === null || !("name" in params)) {
+      return err(id, INVALID_PARAMS, "tools/call requires a tool name");
+    }
+    const name = params.name;
+    if (typeof name !== "string") {
+      return err(id, INVALID_PARAMS, "tool name must be a string");
+    }
+    const args =
+      "arguments" in params && typeof params.arguments === "object" &&
+        params.arguments !== null
+        ? params.arguments as Record<string, unknown>
+        : {};
+
+    if (name === "list_targets") {
+      return ok(id, textResult(this.#describe().targets));
+    }
+    if (name === "describe_build") {
+      return ok(id, textResult(this.#describe().full));
+    }
+    if (name === "graph") {
+      return ok(id, textResult(this.#describe().graph));
+    }
+    if (name.startsWith(RUN_PREFIX)) {
+      return await this.#run(id, name.slice(RUN_PREFIX.length), args);
+    }
+    // An unknown tool is reported through the result (isError), per MCP, so the
+    // model sees it rather than a transport-level failure.
+    return ok(id, textResult(`Unknown tool: ${name}`, true));
+  }
+
+  /** The three read tools' payloads, as pretty JSON / text. */
+  #describe(): { targets: string; full: string; graph: string } {
+    const surface = describeBuildSurface(this.#targets, this.#params);
+    const graph = surface.targets
+      .map((t) =>
+        t.dependsOn.length > 0
+          ? `${t.name} -> ${t.dependsOn.join(", ")}`
+          : `${t.name} (no dependencies)`
+      )
+      .join("\n");
+    return {
+      targets: JSON.stringify(surface.targets, null, 2),
+      full: JSON.stringify(surface, null, 2),
+      graph,
+    };
+  }
+
+  /** Execute a target and return its captured output. */
+  async #run(
+    id: string | number | null,
+    targetName: string,
+    args: Record<string, unknown>,
+  ): Promise<JsonRpcResponse> {
+    if (!this.#allowRun) {
+      return ok(
+        id,
+        textResult(
+          "Running targets is disabled. Start the server with " +
+            "`zuke mcp --allow-run` to enable execution.",
+          true,
+        ),
+      );
+    }
+    const root = this.#targets.get(targetName);
+    if (!root) {
+      return ok(id, textResult(`Unknown target: ${targetName}`, true));
+    }
+    const dryRun = args.dryRun === true;
+    const values: Record<string, string> = {};
+    for (const paramName of this.#params.keys()) {
+      const value = args[paramName];
+      if (value !== undefined) values[paramName] = String(value);
+    }
+    const buffer = bufferingReporter();
+    // Parameters resolve like the CLI: MCP arguments beat the environment beats
+    // the declared default, so a value set in the server's environment still
+    // applies unless the agent overrides it.
+    const result = await execute(this.build, root, {
+      params: values,
+      reporter: buffer.reporter,
+      dryRun,
+      github: false,
+    });
+    const status = result.ok
+      ? `\n\n✔ ${targetName} succeeded.`
+      : `\n\n✘ ${targetName} failed.`;
+    return ok(id, textResult(buffer.text() + status, !result.ok));
+  }
+}
+
+/** Extract a JSON-RPC id from a message, defaulting to `null`. */
+function idOf(message: unknown): string | number | null {
+  if (
+    typeof message === "object" && message !== null && "id" in message &&
+    (typeof message.id === "string" || typeof message.id === "number")
+  ) {
+    return message.id;
+  }
+  return null;
+}

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -94,6 +94,11 @@ function textResult(text: string, isError = false): Record<string, unknown> {
   return { content: [{ type: "text", text }], isError };
 }
 
+/** Whether a JSON value is a plain object (a string-keyed record). */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 /** Whether a JSON value is a scalar a parameter can accept. */
 function isScalar(value: unknown): value is string | number | boolean {
   const t = typeof value;
@@ -245,18 +250,14 @@ export class McpServer {
     id: string | number | null,
     params: unknown,
   ): Promise<JsonRpcResponse> {
-    if (typeof params !== "object" || params === null || !("name" in params)) {
+    if (!isRecord(params) || !("name" in params)) {
       return err(id, INVALID_PARAMS, "tools/call requires a tool name");
     }
     const name = params.name;
     if (typeof name !== "string") {
       return err(id, INVALID_PARAMS, "tool name must be a string");
     }
-    const args =
-      "arguments" in params && typeof params.arguments === "object" &&
-        params.arguments !== null
-        ? params.arguments as Record<string, unknown>
-        : {};
+    const args = isRecord(params.arguments) ? params.arguments : {};
 
     if (name === "list_targets") {
       return ok(id, textResult(this.#describe().targets));

--- a/packages/core/tests/mcp_test.ts
+++ b/packages/core/tests/mcp_test.ts
@@ -40,12 +40,21 @@ Deno.test("initialize echoes the client's protocol version and names the server"
     req("initialize", { protocolVersion: "2024-11-05" }),
   );
   const result = res?.result as Record<string, unknown>;
+  // A supported version is echoed back.
   assertEquals(result.protocolVersion, "2024-11-05");
   assertEquals((result.serverInfo as { name: string }).name, "zuke");
-  // With no version supplied, it falls back to the server's newest.
+  // With no version supplied, it answers with the server's newest.
   const res2 = await server.handleMessage(req("initialize", {}));
   assertEquals(
     (res2?.result as Record<string, unknown>).protocolVersion,
+    PROTOCOL_VERSION,
+  );
+  // An unsupported version is NOT reflected back; the server offers its newest.
+  const res3 = await server.handleMessage(
+    req("initialize", { protocolVersion: "1999-01-01" }),
+  );
+  assertEquals(
+    (res3?.result as Record<string, unknown>).protocolVersion,
     PROTOCOL_VERSION,
   );
 });

--- a/packages/core/tests/mcp_test.ts
+++ b/packages/core/tests/mcp_test.ts
@@ -143,6 +143,27 @@ Deno.test("running a target executes it and returns the captured output", async 
   assertStringIncludes(out.text, "succeeded");
 });
 
+Deno.test("a run redacts secret values from the captured output", async () => {
+  class Secretive extends Build {
+    // A secret sourced at run time; its value must never reach the client.
+    token = parameter("API token").secret().from({
+      resolve: () => Promise.resolve("s3cr3t-token-xyz"),
+    });
+    leak = target().executes(() => {
+      // A failure that embeds the secret in its message.
+      throw new Error(`auth failed for ${this.token.value}`);
+    });
+  }
+  const server = new McpServer(new Secretive(), { allowRun: true });
+  const res = await server.handleMessage(
+    req("tools/call", { name: "run:leak" }),
+  );
+  const out = callText(res?.result);
+  assertEquals(out.isError, true);
+  assertStringIncludes(out.text, "[redacted]");
+  assertEquals(out.text.includes("s3cr3t-token-xyz"), false);
+});
+
 Deno.test("a run missing a required parameter fails through the result", async () => {
   const server = new McpServer(new Demo(), { allowRun: true });
   // environment is required and unset in the (hermetic) environment.

--- a/packages/core/tests/mcp_test.ts
+++ b/packages/core/tests/mcp_test.ts
@@ -187,6 +187,45 @@ Deno.test("an unknown target or tool is surfaced through the result, not the tra
   assertStringIncludes(unknownTool.text, "Unknown tool");
 });
 
+Deno.test("a run rejects a non-scalar argument instead of coercing it", async () => {
+  const server = new McpServer(new Demo(), { allowRun: true });
+  const res = await server.handleMessage(
+    req("tools/call", {
+      name: "run:build",
+      // An object where a scalar is expected must be refused, not stringified.
+      arguments: { environment: { injected: true } },
+    }),
+  );
+  const out = callText(res?.result);
+  assertEquals(out.isError, true);
+  assertStringIncludes(out.text, "Invalid argument type");
+  assertStringIncludes(out.text, "environment");
+});
+
+Deno.test("a run accepts a list argument for an array parameter", async () => {
+  class WithTags extends Build {
+    tags = parameter("Image tags").array();
+    ship = target().executes(() => {});
+  }
+  const server = new McpServer(new WithTags(), { allowRun: true });
+  const res = await server.handleMessage(
+    req("tools/call", {
+      name: "run:ship",
+      arguments: { tags: ["latest", "canary"] },
+    }),
+  );
+  // The list is accepted (joined like a repeated flag) and the run succeeds.
+  assertEquals(callText(res?.result).isError, false);
+  // A list for a non-array parameter, or a nested non-scalar, is rejected.
+  const bad = await server.handleMessage(
+    req("tools/call", {
+      name: "run:ship",
+      arguments: { tags: [{ nested: 1 }] },
+    }),
+  );
+  assertEquals(callText(bad?.result).isError, true);
+});
+
 Deno.test("tools/call validates its parameters", async () => {
   const server = new McpServer(new Demo());
   const res = await server.handleMessage(req("tools/call", {}));
@@ -268,6 +307,22 @@ Deno.test("serveStdio frames messages and answers each request", async () => {
   const out = messages();
   assertEquals(out.length, 1); // only the request got a reply
   assertEquals((out[0] as { id: number }).id, 1);
+});
+
+Deno.test("serveStdio processes a final line the stream never terminated", async () => {
+  const seen: unknown[] = [];
+  const { output, messages } = capturingWriter();
+  await serveStdio(
+    (message) => {
+      seen.push(message);
+      return Promise.resolve({ jsonrpc: "2.0", id: 1, result: {} });
+    },
+    // No trailing newline — the last message must still be handled.
+    streamOf('{"jsonrpc":"2.0","id":1,"method":"ping"}'),
+    output,
+  );
+  assertEquals(seen.length, 1);
+  assertEquals(messages().length, 1);
 });
 
 Deno.test("serveStdio answers an unparseable line with a parse error", async () => {

--- a/packages/core/tests/mcp_test.ts
+++ b/packages/core/tests/mcp_test.ts
@@ -1,0 +1,316 @@
+import { assertEquals, assertStringIncludes } from "./_assert.ts";
+import { Build, parameter, target } from "../mod.ts";
+import {
+  type ByteWriter,
+  METHOD_NOT_FOUND,
+  serveStdio,
+} from "../src/mcp/jsonrpc.ts";
+import { McpServer, PROTOCOL_VERSION } from "../src/mcp/server.ts";
+import { serveMcp } from "../src/mcp/command.ts";
+
+/** A small build with parameters and a dependency edge, for the server tests. */
+class Demo extends Build {
+  environment = parameter("Target environment").options("dev", "prod")
+    .required();
+  workers = parameter("Upload workers").number().default(2);
+  lint = target().description("Lint the code").executes(() => {});
+  build = target().description("Build the app").dependsOn(this.lint).executes(
+    () => {},
+  );
+}
+
+/** A JSON-RPC request object for `method` with `id` 1. */
+function req(method: string, params?: unknown): Record<string, unknown> {
+  return { jsonrpc: "2.0", id: 1, method, ...(params ? { params } : {}) };
+}
+
+/** Read the single text block out of a `tools/call` result. */
+function callText(result: unknown): { text: string; isError: boolean } {
+  if (
+    typeof result !== "object" || result === null || !("content" in result)
+  ) throw new Error("not a tool result");
+  const content = (result as { content: Array<{ text: string }> }).content;
+  const isError = (result as { isError?: boolean }).isError ?? false;
+  return { text: content[0].text, isError };
+}
+
+Deno.test("initialize echoes the client's protocol version and names the server", async () => {
+  const server = new McpServer(new Demo());
+  const res = await server.handleMessage(
+    req("initialize", { protocolVersion: "2024-11-05" }),
+  );
+  const result = res?.result as Record<string, unknown>;
+  assertEquals(result.protocolVersion, "2024-11-05");
+  assertEquals((result.serverInfo as { name: string }).name, "zuke");
+  // With no version supplied, it falls back to the server's newest.
+  const res2 = await server.handleMessage(req("initialize", {}));
+  assertEquals(
+    (res2?.result as Record<string, unknown>).protocolVersion,
+    PROTOCOL_VERSION,
+  );
+});
+
+Deno.test("ping returns an empty result", async () => {
+  const server = new McpServer(new Demo());
+  const res = await server.handleMessage(req("ping"));
+  assertEquals(res?.result, {});
+});
+
+Deno.test("tools/list is read-only until running is allowed", async () => {
+  const readOnly = new McpServer(new Demo());
+  const res = await readOnly.handleMessage(req("tools/list"));
+  const tools = (res?.result as { tools: Array<{ name: string }> }).tools;
+  assertEquals(tools.map((t) => t.name), [
+    "list_targets",
+    "describe_build",
+    "graph",
+  ]);
+
+  const withRun = new McpServer(new Demo(), { allowRun: true });
+  const res2 = await withRun.handleMessage(req("tools/list"));
+  const names = (res2?.result as { tools: Array<{ name: string }> }).tools.map((
+    t,
+  ) => t.name);
+  assertEquals(names.includes("run:lint"), true);
+  assertEquals(names.includes("run:build"), true);
+});
+
+Deno.test("a run tool's schema is built from the build's parameters", async () => {
+  const server = new McpServer(new Demo(), { allowRun: true });
+  const res = await server.handleMessage(req("tools/list"));
+  const tools = (res?.result as {
+    tools: Array<
+      {
+        name: string;
+        inputSchema: {
+          properties: Record<string, unknown>;
+          required?: string[];
+        };
+        annotations?: { destructiveHint?: boolean };
+      }
+    >;
+  }).tools;
+  const run = tools.find((t) => t.name === "run:build");
+  if (!run) throw new Error("missing run:build");
+  // Declared parameters become typed properties; the required one is required.
+  assertEquals(run.inputSchema.required, ["environment"]);
+  assertEquals("workers" in run.inputSchema.properties, true);
+  assertEquals("dryRun" in run.inputSchema.properties, true);
+  assertEquals(run.annotations?.destructiveHint, true);
+});
+
+Deno.test("the read tools report the build's shape", async () => {
+  const server = new McpServer(new Demo());
+  const targets = callText(
+    (await server.handleMessage(
+      req("tools/call", { name: "list_targets" }),
+    ))?.result,
+  );
+  assertStringIncludes(targets.text, "lint");
+  assertEquals(targets.isError, false);
+
+  const describe = callText(
+    (await server.handleMessage(
+      req("tools/call", { name: "describe_build" }),
+    ))?.result,
+  );
+  assertStringIncludes(describe.text, "parameters");
+
+  const graph = callText(
+    (await server.handleMessage(req("tools/call", { name: "graph" })))?.result,
+  );
+  assertStringIncludes(graph.text, "build -> lint");
+});
+
+Deno.test("running is refused until --allow-run", async () => {
+  const server = new McpServer(new Demo()); // allowRun defaults to false
+  const res = await server.handleMessage(
+    req("tools/call", { name: "run:build", arguments: { environment: "dev" } }),
+  );
+  const out = callText(res?.result);
+  assertEquals(out.isError, true);
+  assertStringIncludes(out.text, "--allow-run");
+});
+
+Deno.test("running a target executes it and returns the captured output", async () => {
+  const server = new McpServer(new Demo(), { allowRun: true });
+  const res = await server.handleMessage(
+    req("tools/call", { name: "run:build", arguments: { environment: "dev" } }),
+  );
+  const out = callText(res?.result);
+  assertEquals(out.isError, false);
+  assertStringIncludes(out.text, "build");
+  assertStringIncludes(out.text, "succeeded");
+});
+
+Deno.test("a run missing a required parameter fails through the result", async () => {
+  const server = new McpServer(new Demo(), { allowRun: true });
+  // environment is required and unset in the (hermetic) environment.
+  const res = await server.handleMessage(
+    req("tools/call", { name: "run:build", arguments: {} }),
+  );
+  const out = callText(res?.result);
+  assertEquals(out.isError, true);
+});
+
+Deno.test("a dry-run plans without failing on a missing body result", async () => {
+  const server = new McpServer(new Demo(), { allowRun: true });
+  const res = await server.handleMessage(
+    req("tools/call", {
+      name: "run:lint",
+      arguments: { environment: "dev", dryRun: true },
+    }),
+  );
+  const out = callText(res?.result);
+  assertEquals(out.isError, false);
+});
+
+Deno.test("an unknown target or tool is surfaced through the result, not the transport", async () => {
+  const server = new McpServer(new Demo(), { allowRun: true });
+  const unknownTarget = callText(
+    (await server.handleMessage(
+      req("tools/call", {
+        name: "run:nope",
+        arguments: { environment: "dev" },
+      }),
+    ))?.result,
+  );
+  assertEquals(unknownTarget.isError, true);
+  assertStringIncludes(unknownTarget.text, "Unknown target");
+
+  const unknownTool = callText(
+    (await server.handleMessage(
+      req("tools/call", { name: "no-such-tool" }),
+    ))?.result,
+  );
+  assertEquals(unknownTool.isError, true);
+  assertStringIncludes(unknownTool.text, "Unknown tool");
+});
+
+Deno.test("tools/call validates its parameters", async () => {
+  const server = new McpServer(new Demo());
+  const res = await server.handleMessage(req("tools/call", {}));
+  assertEquals(res?.error?.message, "tools/call requires a tool name");
+  const res2 = await server.handleMessage(req("tools/call", { name: 5 }));
+  assertStringIncludes(res2?.error?.message ?? "", "must be a string");
+});
+
+Deno.test("an unknown method errors; an invalid message is rejected", async () => {
+  const server = new McpServer(new Demo());
+  const res = await server.handleMessage(req("does/not/exist"));
+  assertEquals(res?.error?.code, METHOD_NOT_FOUND);
+  const bad = await server.handleMessage({ jsonrpc: "2.0", id: 1 });
+  assertStringIncludes(bad?.error?.message ?? "", "Invalid Request");
+});
+
+Deno.test("notifications never get a reply", async () => {
+  const server = new McpServer(new Demo());
+  const initialized = await server.handleMessage({
+    jsonrpc: "2.0",
+    method: "notifications/initialized",
+  });
+  assertEquals(initialized, null);
+  // An id-less unknown request is treated as a notification, so also silent.
+  const other = await server.handleMessage({ jsonrpc: "2.0", method: "foo" });
+  assertEquals(other, null);
+});
+
+// --- transport (serveStdio / serveMcp) ---
+
+/** A ReadableStream that emits the given string chunks, then closes. */
+function streamOf(...chunks: string[]): ReadableStream<Uint8Array> {
+  const enc = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(enc.encode(chunk));
+      controller.close();
+    },
+  });
+}
+
+/** A ByteWriter that records everything written, decodable as JSON lines. */
+function capturingWriter(): { output: ByteWriter; messages(): unknown[] } {
+  const parts: string[] = [];
+  const dec = new TextDecoder();
+  return {
+    output: {
+      write(p) {
+        parts.push(dec.decode(p));
+        return Promise.resolve(p.length);
+      },
+    },
+    messages: () =>
+      parts.join("").split("\n").filter((l) => l.trim() !== "").map((l) =>
+        JSON.parse(l)
+      ),
+  };
+}
+
+Deno.test("serveStdio frames messages and answers each request", async () => {
+  const seen: unknown[] = [];
+  const { output, messages } = capturingWriter();
+  await serveStdio(
+    (message) => {
+      seen.push(message);
+      const id = (message as { id?: number }).id ?? null;
+      return Promise.resolve(
+        id === null ? null : { jsonrpc: "2.0", id, result: { ok: true } },
+      );
+    },
+    // A request, a notification (no id → no reply), split across chunk boundaries.
+    streamOf(
+      '{"jsonrpc":"2.0","id":1,"method":"a"}\n{"jsonrpc":"2.0",',
+      '"method":"n"}\n',
+    ),
+    output,
+  );
+  assertEquals(seen.length, 2);
+  const out = messages();
+  assertEquals(out.length, 1); // only the request got a reply
+  assertEquals((out[0] as { id: number }).id, 1);
+});
+
+Deno.test("serveStdio answers an unparseable line with a parse error", async () => {
+  const { output, messages } = capturingWriter();
+  await serveStdio(
+    () => Promise.resolve(null),
+    streamOf("not json{\n"),
+    output,
+  );
+  const out = messages();
+  assertEquals((out[0] as { error: { code: number } }).error.code, -32700);
+});
+
+Deno.test("serveMcp prints a startup banner to stderr unless quiet", async () => {
+  const { output } = capturingWriter();
+  const original = console.error;
+  const banner: string[] = [];
+  console.error = (...args: unknown[]) => void banner.push(args.join(" "));
+  try {
+    await serveMcp(new Demo(), {
+      allowRun: true, // exercises the "run enabled" mode label
+      input: streamOf(""),
+      output,
+    });
+  } finally {
+    console.error = original;
+  }
+  assertStringIncludes(banner.join("\n"), "run enabled");
+});
+
+Deno.test("serveMcp runs the whole handshake over injected streams", async () => {
+  const { output, messages } = capturingWriter();
+  const code = await serveMcp(new Demo(), {
+    quiet: true,
+    input: streamOf(
+      '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}\n' +
+        '{"jsonrpc":"2.0","id":2,"method":"tools/list"}\n',
+    ),
+    output,
+  });
+  assertEquals(code, 0);
+  const out = messages();
+  assertEquals(out.length, 2);
+  assertStringIncludes(JSON.stringify(out[0]), "zuke");
+  assertStringIncludes(JSON.stringify(out[1]), "list_targets");
+});


### PR DESCRIPTION
## What & why

Adds a reserved **`zuke mcp`** command that runs a [Model Context Protocol](https://modelcontextprotocol.io) server over the build on stdio. MCP is the open standard that lets an AI client — Claude Desktop, Claude Code, an IDE, any agent — discover a server's typed *tools* and call them. Pointing a client at `zuke mcp` lets an agent **operate the pipeline through typed calls** — list the targets, inspect the graph, run one with the right parameters — instead of guessing shell invocations.

It's the live counterpart of what Zuke already does: it publishes `llms.txt`, a `--list --json` self-description, and shell completions from one registry. This exposes that same surface as callable MCP tools, building directly on `describeCli`.

### Dependency-free by construction

MCP's local transport is newline-delimited JSON-RPC 2.0 on stdio, so it's implemented by hand rather than pulling in `@modelcontextprotocol/sdk` — honouring the zero-runtime-dependency rule.

- `src/mcp/jsonrpc.ts` — the wire types, standard error codes, and a `serveStdio` read loop.
- `src/mcp/server.ts` — `McpServer`, a **pure `handleMessage(message) → response`** implementing the lifecycle (`initialize` echoing the client's `protocolVersion`, `notifications/initialized`, `ping`, `tools/list`, `tools/call`), so it's exercised without touching real stdio.
- `src/mcp/command.ts` — `serveMcp(build)` wiring the transport to the server.

### Tools

Read tools are always available:

| Tool | Returns |
| --- | --- |
| `list_targets` | Every target with its description and dependencies. |
| `describe_build` | The full build surface (the `--list --json` payload). |
| `graph` | Each target and the targets it depends on. |

With `--allow-run`, the server also exposes one **`run:<target>`** tool per target. Its input schema is derived from the build's declared parameters (a `required` parameter is required, `.options(...)` becomes an `enum`, `.number()` is typed as a number) plus a `dryRun` flag, and it carries MCP's `destructiveHint` annotation. A run resolves parameters exactly like the CLI (MCP argument → environment → default) and returns the target's captured output with a pass/fail marker.

### Two properties that fell out of reusing existing seams

- A run executes through the normal engine with a buffering reporter, so **`parameter().secret()` values are redacted** from what the agent sees — the same pipeline as the console (from the secrets PR).
- Running is **off by default**: a freshly-connected agent can only inspect the build; `--allow-run` is an explicit opt-in. A failed or unknown call is reported through the tool result (`isError: true`), per the MCP convention, not as a transport error.

### Docs

- New [`docs/mcp.md`](../blob/claude/zuke-feature-brainstorm-l3a1i6/docs/mcp.md) — what MCP is, running it, registering with a client (`claude mcp add`), the tool catalogue, safety, and protocol notes.
- Wired into `docs/cli.md` (table + a dedicated section) and `docs/README.md`; regenerated the `llms.txt` CLI section (the new command flows in automatically via the shared reserved-command registry).

### Testing & coverage

- New `mcp_test.ts` (33 assertions): the full lifecycle, read tools, per-target run-tool schema generation, the read-only/`--allow-run` gate, parameter-driven execution and required-param failure, dry-run, unknown-tool/target handling, JSON-RPC validation, notifications, and the `serveStdio`/`serveMcp` transport (chunk-split framing, parse errors, the end-to-end handshake over injected streams). Plus an end-to-end check driving the real `zuke mcp` command.
- Full `deno task ci` green — coverage **99.0% lines / 96.6% branches** (above the 95% gate); every new file is 100% line-covered.

## Related issues

Part of the "agent-native" brainstorm section (the `zuke mcp` item).

## Checklist

- [x] The PR title is a [Conventional Commit](https://www.conventionalcommits.org/) (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour changed.
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`, `llms-full.txt`, package README `## API`).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with type guards instead).
- [ ] A new package was wired into all five places — n/a (no new package; all changes are within `@zuke/core`).
- [x] The code is written using AI assisted coding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFVtbsGNx9piPuknJXqgrH

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFVtbsGNx9piPuknJXqgrH)_