### PR TITLE
feat(cli): add zuke import to scaffold a build from package.json or a Makefile

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,6 +27,25 @@ zuke setup                                  # in your project
 Without installing, the same wizard runs via `deno run -A jsr:@zuke/cli setup`
 (flags: `--dir <path>`, `--name <Class>`, `--force`, `--yes`).
 
+## Migrate an existing project with `zuke import`
+
+Already have `package.json` scripts or a `Makefile`? `zuke import` reads them and
+generates a `zuke.ts` with a target per task — a working starting point you then
+refine into typed wrappers, instead of a blank page:
+
+```sh
+zuke import                 # auto-detects package.json, then a Makefile
+zuke import --from makefile  # or pin the source
+```
+
+Each script/target becomes a `target()`; a command maps to `CmdTasks.exec(...)`,
+an `&&` chain becomes sequential steps, a `package.json` `run` delegation (or a
+Makefile prerequisite) becomes `.dependsOn(...)`, and a command too shell-specific
+to translate (pipes, redirects, env assignments) is preserved behind a `// TODO`
+so the file still compiles and the tricky bits are flagged. It also scaffolds the
+launchers and `deno.json`, exactly like `zuke setup`. Flags: `--from
+<package.json|makefile>`, plus the same `--dir`, `--name`, `--force`, `--yes`.
+
 ## Run it yourself
 
 Or just create a `zuke.ts` in your project root and run it with Deno:

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2644,11 +2644,20 @@ async function main(args: string[], host: SetupHost, prompter: Prompter): Promis
   The CLI entry point. Returns a process exit code; `host`/`prompter` are
   injectable for testing.
 
+function parseImportFlags(args: string[]): ImportFlags
+  Parse the argument list following `zuke import`.
+
 function parseSetupFlags(args: string[]): SetupFlags
   Parse the argument list following `zuke setup`.
 
 const defaultPrompter: Prompter
   The real {@link Prompter}, backed by Deno's `prompt`/`confirm`.
+
+interface ImportFlags extends SetupFlags
+  Flags accepted by `zuke import` — the setup flags plus `--from`.
+
+  from?: ImportSource
+    Force a source (`package.json` or `makefile`); auto-detected when unset.
 
 interface Prompter
   The interactive surface, injectable so the wizard is testable without a TTY.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -29,11 +29,20 @@ async function main(args: string[], host: SetupHost, prompter: Prompter): Promis
   The CLI entry point. Returns a process exit code; `host`/`prompter` are
   injectable for testing.
 
+function parseImportFlags(args: string[]): ImportFlags
+  Parse the argument list following `zuke import`.
+
 function parseSetupFlags(args: string[]): SetupFlags
   Parse the argument list following `zuke setup`.
 
 const defaultPrompter: Prompter
   The real {@link Prompter}, backed by Deno's `prompt`/`confirm`.
+
+interface ImportFlags extends SetupFlags
+  Flags accepted by `zuke import` — the setup flags plus `--from`.
+
+  from?: ImportSource
+    Force a source (`package.json` or `makefile`); auto-detected when unset.
 
 interface Prompter
   The interactive surface, injectable so the wizard is testable without a TTY.

--- a/packages/cli/mod.ts
+++ b/packages/cli/mod.ts
@@ -11,6 +11,7 @@
  */
 
 import { defaultHost, runSetup, type SetupHost } from "./src/setup.ts";
+import { type ImportSource, runImport } from "./src/import.ts";
 import { VERSION } from "./src/version.ts";
 
 /**
@@ -82,13 +83,21 @@ export function parseSetupFlags(args: string[]): SetupFlags {
 const HELP = `zuke ${VERSION} — code-first build automation for Deno
 
 Usage:
-  zuke setup [options]   Scaffold Zuke into a directory
-  zuke --help            Show this help
-  zuke --version         Show the version
+  zuke setup [options]    Scaffold Zuke into a directory
+  zuke import [options]   Generate a build from package.json scripts or a Makefile
+  zuke --help             Show this help
+  zuke --version          Show the version
 
 Setup options:
   --dir <path>     Directory to scaffold into (default: .)
   --name <Class>   Build class name for zuke.ts (default: MyBuild)
+  --force, -f      Overwrite existing files
+  --yes, -y        Accept defaults without prompting
+
+Import options:
+  --dir <path>     Directory to read from and scaffold into (default: .)
+  --name <Class>   Build class name for zuke.ts (default: MyBuild)
+  --from <source>  Force a source: package.json or makefile (default: auto-detect)
   --force, -f      Overwrite existing files
   --yes, -y        Accept defaults without prompting
 
@@ -120,6 +129,68 @@ async function commandSetup(
   return 0;
 }
 
+/** Flags accepted by `zuke import` — the setup flags plus `--from`. */
+export interface ImportFlags extends SetupFlags {
+  /** Force a source (`package.json` or `makefile`); auto-detected when unset. */
+  from?: ImportSource;
+}
+
+/** Map a `--from` value to a source, or `undefined` when unrecognised. */
+function parseSource(value: string): ImportSource | undefined {
+  const lower = value.toLowerCase();
+  if (lower === "package.json" || lower === "package") return "package.json";
+  if (lower === "makefile") return "Makefile";
+  return undefined;
+}
+
+/** Parse the argument list following `zuke import`. */
+export function parseImportFlags(args: string[]): ImportFlags {
+  const flags: ImportFlags = parseSetupFlags(args);
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--from" && i + 1 < args.length) {
+      flags.from = parseSource(args[++i]);
+    } else if (arg.startsWith("--from=")) {
+      flags.from = parseSource(arg.slice("--from=".length));
+    }
+  }
+  return flags;
+}
+
+/** Run the `import` subcommand. */
+async function commandImport(
+  args: string[],
+  host: SetupHost,
+  prompter: Prompter,
+): Promise<number> {
+  const flags = parseImportFlags(args);
+  let name = flags.name ?? "MyBuild";
+  let force = flags.force;
+  const dir = flags.dir ?? ".";
+
+  if (!flags.yes && prompter.interactive()) {
+    name = prompter.ask("Build class name", name);
+    if (!force) {
+      force = prompter.confirm("Overwrite existing files if present?");
+    }
+  }
+
+  const result = await runImport({ dir, force, name, from: flags.from }, host);
+  if (result.source === null) {
+    host.log(
+      "Nothing to import: no package.json scripts or Makefile found" +
+        (flags.from ? ` for --from ${flags.from}` : "") + ".",
+    );
+    return 1;
+  }
+  const written = result.files.filter((f) => f.status !== "skipped").length;
+  host.log(
+    `Done — imported ${result.taskCount} task(s) from ${result.source}; ` +
+      `${written} file(s) written. Next: ./zuke`,
+  );
+  return 0;
+}
+
 /**
  * The CLI entry point. Returns a process exit code; `host`/`prompter` are
  * injectable for testing.
@@ -142,6 +213,9 @@ export async function main(
   }
   if (command === "setup") {
     return await commandSetup(rest, host, prompter);
+  }
+  if (command === "import") {
+    return await commandImport(rest, host, prompter);
   }
   host.log(`Unknown command: ${command}\n`);
   host.log(HELP);

--- a/packages/cli/src/import.ts
+++ b/packages/cli/src/import.ts
@@ -19,6 +19,7 @@
 
 import {
   isRecord,
+  joinPath,
   runSetup,
   type SetupHost,
   type SetupResult,
@@ -437,9 +438,7 @@ export async function runImport(
     : SOURCE_FILES.filter((c) => c.source === options.from);
 
   for (const candidate of candidates) {
-    const path = options.dir === "."
-      ? candidate.file
-      : `${options.dir}/${candidate.file}`;
+    const path = joinPath(options.dir, candidate.file);
     if (!(await host.exists(path))) continue;
     const tasks = candidate.parse(await host.readText(path));
     host.log(

--- a/packages/cli/src/import.ts
+++ b/packages/cli/src/import.ts
@@ -160,8 +160,11 @@ export function translateCommand(command: string): BodyItem[] {
     const segment = raw.trim();
     if (segment === "") continue;
     if (needsShell(segment)) {
+      // Collapse whitespace so an embedded newline cannot break the raw command
+      // out of its single-line `//` comment in the generated source.
+      const oneLine = segment.replace(/\s+/g, " ").trim();
       items.push({
-        code: `// TODO: translate this shell command: ${segment}`,
+        code: `// TODO: translate this shell command: ${oneLine}`,
         runnable: false,
       });
       continue;

--- a/packages/cli/src/import.ts
+++ b/packages/cli/src/import.ts
@@ -1,0 +1,460 @@
+/**
+ * The engine behind `zuke import`: read an existing project's task definitions —
+ * `package.json` scripts or a `Makefile` — and scaffold an equivalent typed
+ * `zuke.ts` build, so migrating to Zuke starts from a working translation
+ * instead of a blank page.
+ *
+ * Each discovered task becomes a `target()`. A command maps to
+ * {@link https://jsr.io/@zuke/cmd CmdTasks.exec} (typed, injection-safe); an
+ * `&&` chain becomes sequential steps; a reference to another task becomes a
+ * `dependsOn`; and a command too shell-specific to translate faithfully (pipes,
+ * redirects, substitutions, env assignments) is preserved verbatim behind a
+ * `// TODO` so the file still compiles and the few tricky scripts are flagged.
+ *
+ * The parsing and generation are pure functions; {@link runImport} adds the
+ * file I/O (reusing `zuke setup`'s scaffolder via its `buildContent` hook).
+ *
+ * @module
+ */
+
+import {
+  isRecord,
+  runSetup,
+  type SetupHost,
+  type SetupResult,
+} from "./setup.ts";
+
+/** A task discovered in an existing project, before identifier normalisation. */
+export interface RawTask {
+  /** The task's original name (a `package.json` script key, a Makefile target). */
+  readonly name: string;
+  /** The shell command to run (may be empty for an aggregate/phony target). */
+  readonly command: string;
+  /** Names of other tasks this one depends on / delegates to. */
+  readonly deps: readonly string[];
+}
+
+// --- package.json ---------------------------------------------------------
+
+/** The package managers whose `run` delegations become dependencies. */
+const RUNNERS = ["npm", "pnpm", "yarn", "bun", "deno"];
+
+/**
+ * Parse the `scripts` block of a `package.json` document into tasks, in
+ * declaration order. A script segment that merely delegates to another script
+ * (`npm run lint`, `pnpm test`, …) is recorded as a dependency rather than an
+ * inlined command.
+ */
+export function parsePackageJson(text: string): RawTask[] {
+  const parsed: unknown = JSON.parse(text);
+  if (!isRecord(parsed) || !isRecord(parsed.scripts)) return [];
+  const names = new Set(Object.keys(parsed.scripts));
+  const tasks: RawTask[] = [];
+  for (const [name, value] of Object.entries(parsed.scripts)) {
+    if (typeof value !== "string") continue;
+    const deps: string[] = [];
+    const kept: string[] = [];
+    for (const segment of splitChain(value)) {
+      const target = delegatedScript(segment, names);
+      if (target !== undefined && target !== name) deps.push(target);
+      else kept.push(segment.trim());
+    }
+    tasks.push({ name, command: kept.join(" && "), deps });
+  }
+  return tasks;
+}
+
+/** If `segment` is a `<runner> [run] <script>` delegation, the script name. */
+function delegatedScript(
+  segment: string,
+  scripts: Set<string>,
+): string | undefined {
+  const tokens = tokenize(segment.trim());
+  if (tokens.length === 0 || !RUNNERS.includes(tokens[0])) return undefined;
+  const rest = tokens[1] === "run" ? tokens.slice(2) : tokens.slice(1);
+  // A pure delegation is exactly the runner and one known script name.
+  if (rest.length === 1 && scripts.has(rest[0])) return rest[0];
+  return undefined;
+}
+
+// --- Makefile -------------------------------------------------------------
+
+/**
+ * Parse a `Makefile` into tasks: each rule (`target: prerequisites`) becomes a
+ * task whose recipe lines are its command and whose prerequisites become
+ * dependencies. Pattern rules, variable assignments, and directives are
+ * skipped.
+ */
+export function parseMakefile(text: string): RawTask[] {
+  const lines = text.split(/\r?\n/);
+  const tasks: RawTask[] = [];
+  let current: { name: string; deps: string[]; recipe: string[] } | undefined;
+  const flush = () => {
+    if (current !== undefined) {
+      tasks.push({
+        name: current.name,
+        command: current.recipe.join(" && "),
+        deps: current.deps,
+      });
+    }
+    current = undefined;
+  };
+  for (const line of lines) {
+    // Recipe lines are tab-indented and belong to the open rule.
+    if (current !== undefined && line.startsWith("\t")) {
+      const recipe = stripRecipePrefix(line.slice(1).trim());
+      if (recipe !== "") current.recipe.push(recipe);
+      continue;
+    }
+    const rule = line.match(/^([A-Za-z0-9_.-]+)\s*:(?!=)\s*(.*)$/);
+    // Skip non-rules and special targets (`.PHONY`, `.DEFAULT`, …).
+    if (rule === null || rule[1].startsWith(".")) {
+      flush();
+      continue;
+    }
+    flush();
+    const deps = rule[2].trim().split(/\s+/).filter((d) => d !== "");
+    current = { name: rule[1], deps, recipe: [] };
+  }
+  flush();
+  // Prerequisites that are not themselves targets (files) are not dependencies.
+  const targetNames = new Set(tasks.map((t) => t.name));
+  return tasks.map((t) => ({
+    ...t,
+    deps: t.deps.filter((d) => targetNames.has(d)),
+  }));
+}
+
+/** Drop a leading recipe modifier (`@` silent, `-` ignore-errors) from a line. */
+function stripRecipePrefix(recipe: string): string {
+  return recipe.replace(/^[@-]+/, "");
+}
+
+// --- command translation --------------------------------------------------
+
+/** One statement in a generated target body. */
+interface BodyItem {
+  /** The code — a `CmdTasks.exec(...)` call or a `// TODO` comment. */
+  readonly code: string;
+  /** Whether this is a runnable command (vs. a comment placeholder). */
+  readonly runnable: boolean;
+}
+
+/** Shell features a single `CmdTasks.exec` argv cannot faithfully express. */
+function needsShell(segment: string): boolean {
+  if (/[|<>;`$]/.test(segment)) return true; // pipe, redirect, subst, env expand
+  if (/(^|\s)&(\s|$)/.test(segment)) return true; // background job
+  const first = segment.trim().split(/\s+/)[0] ?? "";
+  return /^[A-Za-z_][A-Za-z0-9_]*=/.test(first); // leading VAR=value assignment
+}
+
+/**
+ * Translate a shell command into target-body statements: each `&&`-separated
+ * segment becomes a `CmdTasks.exec(...)` call, or a `// TODO` comment
+ * preserving the raw text when it is too shell-specific to translate.
+ */
+export function translateCommand(command: string): BodyItem[] {
+  const items: BodyItem[] = [];
+  for (const raw of splitChain(command)) {
+    const segment = raw.trim();
+    if (segment === "") continue;
+    if (needsShell(segment)) {
+      items.push({
+        code: `// TODO: translate this shell command: ${segment}`,
+        runnable: false,
+      });
+      continue;
+    }
+    const tokens = tokenize(segment);
+    const bin = tokens[0];
+    if (bin === undefined) continue;
+    const args = tokens.slice(1);
+    const call = args.length === 0
+      ? `CmdTasks.exec(${str(bin)})`
+      : `CmdTasks.exec(${str(bin)}, (s) => s.args(${
+        args.map(str).join(", ")
+      }))`;
+    items.push({ code: call, runnable: true });
+  }
+  return items;
+}
+
+/** Split a command on top-level `&&`, ignoring `&&` inside quotes. */
+function splitChain(command: string): string[] {
+  const parts: string[] = [];
+  let current = "";
+  let quote: string | undefined;
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i];
+    if (quote !== undefined) {
+      current += ch;
+      if (ch === quote) quote = undefined;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      current += ch;
+      continue;
+    }
+    if (ch === "&" && command[i + 1] === "&") {
+      parts.push(current);
+      current = "";
+      i++;
+      continue;
+    }
+    current += ch;
+  }
+  parts.push(current);
+  return parts;
+}
+
+/** Split a command segment into argv, honouring single/double quotes. */
+function tokenize(segment: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: string | undefined;
+  let has = false;
+  for (const ch of segment) {
+    if (quote !== undefined) {
+      if (ch === quote) quote = undefined;
+      else {
+        current += ch;
+        has = true;
+      }
+    } else if (ch === '"' || ch === "'") {
+      quote = ch;
+      has = true;
+    } else if (ch === " " || ch === "\t") {
+      if (has) {
+        tokens.push(current);
+        current = "";
+        has = false;
+      }
+    } else {
+      current += ch;
+      has = true;
+    }
+  }
+  if (has) tokens.push(current);
+  return tokens;
+}
+
+/** A double-quoted TypeScript string literal for `value`. */
+function str(value: string): string {
+  return JSON.stringify(value);
+}
+
+// --- identifiers ----------------------------------------------------------
+
+/**
+ * Turn a task name into a valid, camelCase JavaScript identifier for a target
+ * field — `build:prod` → `buildProd`, `test-watch` → `testWatch`. Falls back to
+ * `task` for an empty result and prefixes a leading digit.
+ */
+export function toIdentifier(name: string): string {
+  const parts = name.split(/[^A-Za-z0-9]+/).filter((p) => p !== "");
+  if (parts.length === 0) return "task";
+  const head = parts[0];
+  const camel = head.charAt(0).toLowerCase() + head.slice(1) +
+    parts.slice(1)
+      .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
+      .join("");
+  return /^[0-9]/.test(camel) ? `task_${camel}` : camel;
+}
+
+/** A task with a unique identifier and dependencies remapped to identifiers. */
+interface NamedTask {
+  readonly id: string;
+  readonly label: string;
+  readonly command: string;
+  readonly deps: readonly string[];
+}
+
+/** Assign each raw task a unique identifier and remap its deps to identifiers. */
+function normalize(tasks: readonly RawTask[]): NamedTask[] {
+  const idByName = new Map<string, string>();
+  const used = new Set<string>();
+  for (const task of tasks) {
+    let id = toIdentifier(task.name);
+    while (used.has(id)) id = `${id}_`;
+    used.add(id);
+    idByName.set(task.name, id);
+  }
+  return tasks.map((task) => ({
+    id: idByName.get(task.name) ?? toIdentifier(task.name),
+    label: task.name,
+    command: task.command,
+    deps: task.deps
+      .map((d) => idByName.get(d))
+      .filter((d): d is string => d !== undefined),
+  }));
+}
+
+/**
+ * Order tasks so every dependency is declared before its dependents (Zuke
+ * forbids forward references), dropping the edges that would close a cycle.
+ * Returns the order plus, per task id, any dependency ids that were dropped.
+ */
+function order(
+  tasks: readonly NamedTask[],
+): { ordered: NamedTask[]; dropped: Map<string, string[]> } {
+  const byId = new Map(tasks.map((t) => [t.id, t]));
+  const state = new Map<string, "open" | "done">();
+  const ordered: NamedTask[] = [];
+  const dropped = new Map<string, string[]>();
+  const visit = (task: NamedTask) => {
+    state.set(task.id, "open");
+    for (const dep of task.deps) {
+      const target = byId.get(dep);
+      if (target === undefined) continue;
+      const st = state.get(dep);
+      if (st === "open") {
+        dropped.set(task.id, [...(dropped.get(task.id) ?? []), dep]);
+      } else if (st === undefined) {
+        visit(target);
+      }
+    }
+    state.set(task.id, "done");
+    ordered.push(task);
+  };
+  for (const task of tasks) {
+    if (state.get(task.id) === undefined) visit(task);
+  }
+  return { ordered, dropped };
+}
+
+// --- generation -----------------------------------------------------------
+
+/** Render a target body from its statements (single-expression when it can). */
+function renderBody(items: readonly BodyItem[]): string {
+  if (items.length === 0) return "() => {}";
+  if (items.length === 1 && items[0].runnable) return `() => ${items[0].code}`;
+  const runnable = items.some((i) => i.runnable);
+  const lines = items
+    .map((i) => `      ${i.runnable ? `await ${i.code};` : i.code}`)
+    .join("\n");
+  return `${runnable ? "async " : ""}() => {\n${lines}\n    }`;
+}
+
+/**
+ * Generate a `zuke.ts` build class named `className` from imported tasks.
+ * Exposed for tools and tests; {@link runImport} writes the result to disk.
+ */
+export function generateBuild(
+  className: string,
+  raw: readonly RawTask[],
+): string {
+  const { ordered, dropped } = order(normalize(raw));
+  const bodies = new Map(
+    ordered.map((t) => [t.id, translateCommand(t.command)]),
+  );
+  const usesCmd = [...bodies.values()].some((b) => b.some((i) => i.runnable));
+
+  const fields = ordered.map((task) => {
+    const body = bodies.get(task.id) ?? [];
+    const chain = [`  ${task.id} = target()`];
+    chain.push(`    .description(${str(`imported: ${task.label}`)})`);
+    if (task.deps.length > 0) {
+      const refs = task.deps.map((d) => `this.${d}`).join(", ");
+      chain.push(`    .dependsOn(${refs})`);
+    }
+    const skipped = dropped.get(task.id);
+    if (skipped !== undefined && skipped.length > 0) {
+      chain.push(
+        `    // TODO: dependency cycle — dropped .dependsOn(${
+          skipped.map((d) => `this.${d}`).join(", ")
+        })`,
+      );
+    }
+    chain.push(`    .executes(${renderBody(body)});`);
+    return chain.join("\n");
+  });
+
+  const imports = [`import { Build, run, target } from "jsr:@zuke/core";`];
+  if (usesCmd) imports.push(`import { CmdTasks } from "jsr:@zuke/cmd";`);
+
+  const body = fields.length > 0
+    ? fields.join("\n\n")
+    : "  // No tasks were found to import — add targets here.";
+
+  return `${imports.join("\n")}
+
+/** Imported build — refine these targets into typed Zuke tasks. */
+class ${className} extends Build {
+${body}
+}
+
+await run(${className});
+`;
+}
+
+// --- orchestration --------------------------------------------------------
+
+/** The kinds of project `zuke import` can read. */
+export type ImportSource = "package.json" | "Makefile";
+
+/** Options controlling {@link runImport}. */
+export interface ImportOptions {
+  /** Directory to import from and scaffold into. */
+  dir: string;
+  /** Overwrite existing scaffolded files instead of skipping them. */
+  force: boolean;
+  /** Build class name for the generated `zuke.ts`. */
+  name: string;
+  /** Force a specific source; auto-detected (package.json, then Makefile) when unset. */
+  from?: ImportSource;
+}
+
+/** The outcome of {@link runImport}. */
+export interface ImportResult extends SetupResult {
+  /** The source that was imported, or `null` when none was found. */
+  source: ImportSource | null;
+  /** The number of tasks discovered. */
+  taskCount: number;
+}
+
+/** The source files probed during auto-detection, in priority order. */
+const SOURCE_FILES: ReadonlyArray<
+  { source: ImportSource; file: string; parse: (text: string) => RawTask[] }
+> = [
+  { source: "package.json", file: "package.json", parse: parsePackageJson },
+  { source: "Makefile", file: "Makefile", parse: parseMakefile },
+];
+
+/**
+ * Import an existing project's tasks into a generated `zuke.ts`, then scaffold
+ * the launchers and `deno.json` around it (via `zuke setup`). Detects the
+ * source automatically — `package.json` scripts, then a `Makefile` — unless
+ * {@link ImportOptions.from} pins one. Returns `source: null` when nothing was
+ * found (and writes nothing).
+ */
+export async function runImport(
+  options: ImportOptions,
+  host: SetupHost,
+): Promise<ImportResult> {
+  const candidates = options.from === undefined
+    ? SOURCE_FILES
+    : SOURCE_FILES.filter((c) => c.source === options.from);
+
+  for (const candidate of candidates) {
+    const path = options.dir === "."
+      ? candidate.file
+      : `${options.dir}/${candidate.file}`;
+    if (!(await host.exists(path))) continue;
+    const tasks = candidate.parse(await host.readText(path));
+    host.log(
+      `Importing ${tasks.length} task(s) from ${candidate.file} into ${
+        options.dir === "." ? "the current directory" : options.dir
+      }:`,
+    );
+    const setup = await runSetup({
+      dir: options.dir,
+      force: options.force,
+      name: options.name,
+      buildContent: generateBuild(options.name, tasks),
+    }, host);
+    return { ...setup, source: candidate.source, taskCount: tasks.length };
+  }
+
+  return { files: [], source: null, taskCount: 0 };
+}

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -178,6 +178,11 @@ export interface SetupOptions {
   force: boolean;
   /** Build class name for the starter `zuke.ts`. */
   name: string;
+  /**
+   * The `zuke.ts` contents to write. Defaults to {@link starterBuild}; `zuke
+   * import` passes a build generated from an existing project's tasks instead.
+   */
+  buildContent?: string;
 }
 
 /** What happened to one scaffolded file. */
@@ -222,7 +227,10 @@ export async function runSetup(
   const files: FileResult[] = [];
 
   const scaffold: readonly ScaffoldFile[] = [
-    { name: "zuke.ts", content: starterBuild(options.name) },
+    {
+      name: "zuke.ts",
+      content: options.buildContent ?? starterBuild(options.name),
+    },
     { name: "zuke", content: launcherBash(), mode: 0o755 },
     { name: "zuke.ps1", content: launcherPwsh() },
     { name: "zuke.json", content: starterConfig(options.name) },

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -203,7 +203,7 @@ export interface SetupResult {
 }
 
 /** Join a directory and file name without pulling in path utilities. */
-function joinPath(dir: string, name: string): string {
+export function joinPath(dir: string, name: string): string {
   return dir === "." ? name : `${dir}/${name}`;
 }
 

--- a/packages/cli/tests/import_test.ts
+++ b/packages/cli/tests/import_test.ts
@@ -1,0 +1,303 @@
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../core/tests/_assert.ts";
+import { FakeHost, FakePrompter } from "./_fakes.ts";
+import { main, parseImportFlags } from "../mod.ts";
+import {
+  generateBuild,
+  parseMakefile,
+  parsePackageJson,
+  runImport,
+  toIdentifier,
+  translateCommand,
+} from "../src/import.ts";
+
+// --- parsePackageJson ---
+
+Deno.test("parsePackageJson reads scripts in order and detects delegations", () => {
+  const pkg = JSON.stringify({
+    scripts: {
+      build: "tsc -p .",
+      test: "jest",
+      ci: "npm run build && pnpm test",
+      bad: 42, // non-string is skipped
+    },
+  });
+  const tasks = parsePackageJson(pkg);
+  assertEquals(tasks.map((t) => t.name), ["build", "test", "ci"]);
+  const ci = tasks.find((t) => t.name === "ci");
+  assertEquals(ci?.deps, ["build", "test"]); // both runners → dependencies
+  assertEquals(ci?.command, ""); // pure delegation leaves no inline command
+});
+
+Deno.test("parsePackageJson returns nothing without a scripts object", () => {
+  assertEquals(parsePackageJson("{}"), []);
+  assertEquals(parsePackageJson(JSON.stringify({ scripts: "nope" })), []);
+});
+
+Deno.test("parsePackageJson keeps a runner command that is not a script delegation", () => {
+  const pkg = JSON.stringify({
+    scripts: {
+      // `npm ci` (no such script) and `npm run test extra` are real commands,
+      // not delegations, so they stay inline rather than becoming a dependency.
+      setup: "npm ci",
+      run2: "npm run test extra",
+    },
+  });
+  const tasks = parsePackageJson(pkg);
+  assertEquals(tasks.find((t) => t.name === "setup")?.deps, []);
+  assertEquals(tasks.find((t) => t.name === "setup")?.command, "npm ci");
+  assertEquals(tasks.find((t) => t.name === "run2")?.deps, []);
+});
+
+// --- parseMakefile ---
+
+Deno.test("parseMakefile reads rules, prerequisites, and recipes", () => {
+  const mk = [
+    "CC = gcc", // variable assignment, skipped
+    "all: build test",
+    "\t@echo done", // '@' prefix stripped
+    "build:",
+    "\t-go build ./...", // '-' prefix stripped",
+    "test: build out.o", // out.o is a file, not a target → dropped",
+    "\tgo test ./...",
+    ".PHONY: all", // special target, skipped
+  ].join("\n");
+  const tasks = parseMakefile(mk);
+  assertEquals(tasks.map((t) => t.name), ["all", "build", "test"]);
+  assertEquals(tasks.find((t) => t.name === "all")?.deps, ["build", "test"]);
+  assertEquals(tasks.find((t) => t.name === "all")?.command, "echo done");
+  assertEquals(
+    tasks.find((t) => t.name === "build")?.command,
+    "go build ./...",
+  );
+  // A prerequisite that is not itself a target (a file) is not a dependency.
+  assertEquals(tasks.find((t) => t.name === "test")?.deps, ["build"]);
+});
+
+// --- translateCommand ---
+
+Deno.test("translateCommand maps clean commands and chains", () => {
+  assertEquals(translateCommand("tsc -p ."), [
+    { code: `CmdTasks.exec("tsc", (s) => s.args("-p", "."))`, runnable: true },
+  ]);
+  assertEquals(translateCommand("jest").length, 1);
+  const chain = translateCommand("eslint . && prettier -w .");
+  assertEquals(chain.length, 2);
+  assertEquals(chain.every((i) => i.runnable), true);
+});
+
+Deno.test("translateCommand flags shell-specific commands as TODO", () => {
+  for (
+    const shellCmd of [
+      "cat x | grep y", // pipe
+      "esbuild in > out.js", // redirect
+      "echo `date`", // backtick substitution
+      "run $HOME/x", // env expansion
+      "NODE_ENV=prod webpack", // env assignment
+      "server &", // background
+    ]
+  ) {
+    const items = translateCommand(shellCmd);
+    assertEquals(items.length, 1);
+    assertEquals(items[0].runnable, false);
+    assertStringIncludes(items[0].code, "// TODO");
+  }
+});
+
+Deno.test("translateCommand keeps quoted arguments together", () => {
+  const items = translateCommand(`prettier --write "src/**/*.ts"`);
+  assertEquals(
+    items[0].code,
+    `CmdTasks.exec("prettier", (s) => s.args("--write", "src/**/*.ts"))`,
+  );
+});
+
+// --- toIdentifier ---
+
+Deno.test("toIdentifier produces valid camelCase field names", () => {
+  assertEquals(toIdentifier("build"), "build");
+  assertEquals(toIdentifier("build:prod"), "buildProd");
+  assertEquals(toIdentifier("test-watch"), "testWatch");
+  assertEquals(toIdentifier("lint.fix"), "lintFix");
+  assertEquals(toIdentifier("2fast"), "task_2fast");
+  assertEquals(toIdentifier("---"), "task");
+});
+
+// --- generateBuild ---
+
+Deno.test("generateBuild emits a runnable class with ordered deps", () => {
+  const out = generateBuild("MyBuild", [
+    { name: "test", command: "jest", deps: ["build"] },
+    { name: "build", command: "tsc", deps: [] },
+  ]);
+  assertStringIncludes(out, `import { CmdTasks } from "jsr:@zuke/cmd";`);
+  assertStringIncludes(out, "class MyBuild extends Build");
+  assertStringIncludes(out, "await run(MyBuild);");
+  // A dependency must be declared before its dependent (topological order).
+  assertEquals(
+    out.indexOf("build = target()") < out.indexOf("test = target()"),
+    true,
+  );
+  assertStringIncludes(out, ".dependsOn(this.build)");
+});
+
+Deno.test("generateBuild omits the cmd import when nothing runs", () => {
+  const out = generateBuild("B", [{
+    name: "aggregate",
+    command: "",
+    deps: [],
+  }]);
+  assertEquals(out.includes("@zuke/cmd"), false);
+  assertStringIncludes(out, ".executes(() => {})");
+});
+
+Deno.test("generateBuild breaks a dependency cycle with a note", () => {
+  const out = generateBuild("B", [
+    { name: "a", command: "", deps: ["b"] },
+    { name: "b", command: "", deps: ["a"] },
+  ]);
+  assertStringIncludes(out, "dependency cycle");
+});
+
+Deno.test("generateBuild de-duplicates colliding identifiers", () => {
+  const out = generateBuild("B", [
+    { name: "build:prod", command: "a", deps: [] },
+    { name: "build-prod", command: "b", deps: [] },
+  ]);
+  assertStringIncludes(out, "buildProd = target()");
+  assertStringIncludes(out, "buildProd_ = target()");
+});
+
+Deno.test("generateBuild renders a shell-only task as a TODO body without async", () => {
+  const out = generateBuild("B", [
+    { name: "bundle", command: "esbuild in > out.js", deps: [] },
+  ]);
+  assertEquals(out.includes("@zuke/cmd"), false); // nothing runnable
+  assertStringIncludes(out, ".executes(() => {");
+  assertStringIncludes(
+    out,
+    "// TODO: translate this shell command: esbuild in > out.js",
+  );
+  assertEquals(out.includes("async"), false);
+});
+
+Deno.test("generateBuild handles an empty task list", () => {
+  const out = generateBuild("Empty", []);
+  assertStringIncludes(out, "No tasks were found to import");
+});
+
+// --- runImport (orchestration) ---
+
+Deno.test("runImport auto-detects package.json and scaffolds", async () => {
+  const host = new FakeHost({
+    "package.json": JSON.stringify({ scripts: { build: "tsc" } }),
+  });
+  const result = await runImport(
+    { dir: ".", force: true, name: "MyBuild" },
+    host,
+  );
+  assertEquals(result.source, "package.json");
+  assertEquals(result.taskCount, 1);
+  assertStringIncludes(host.files.get("zuke.ts") ?? "", "build = target()");
+  assertEquals(host.files.has("zuke"), true); // launcher scaffolded too
+});
+
+Deno.test("runImport falls back to a Makefile", async () => {
+  const host = new FakeHost({ "Makefile": "build:\n\tgo build\n" });
+  const result = await runImport({ dir: ".", force: true, name: "B" }, host);
+  assertEquals(result.source, "Makefile");
+  assertEquals(result.taskCount, 1);
+});
+
+Deno.test("runImport honours an explicit --from source", async () => {
+  const host = new FakeHost({
+    "package.json": JSON.stringify({ scripts: { a: "x" } }),
+    "Makefile": "b:\n\ty\n",
+  });
+  const result = await runImport(
+    { dir: ".", force: true, name: "B", from: "Makefile" },
+    host,
+  );
+  assertEquals(result.source, "Makefile");
+  assertStringIncludes(host.files.get("zuke.ts") ?? "", "b = target()");
+});
+
+Deno.test("runImport reports when there is nothing to import", async () => {
+  const host = new FakeHost({});
+  const result = await runImport({ dir: ".", force: true, name: "B" }, host);
+  assertEquals(result.source, null);
+  assertEquals(result.taskCount, 0);
+  assertEquals(host.files.has("zuke.ts"), false); // wrote nothing
+});
+
+// --- CLI wiring ---
+
+Deno.test("parseImportFlags reads --from, --dir, --name, --force", () => {
+  const flags = parseImportFlags([
+    "--from",
+    "makefile",
+    "--dir=app",
+    "--name",
+    "CI",
+    "-f",
+  ]);
+  assertEquals(flags.from, "Makefile");
+  assertEquals(flags.dir, "app");
+  assertEquals(flags.name, "CI");
+  assertEquals(flags.force, true);
+  // An unrecognised source is ignored (auto-detect).
+  assertEquals(parseImportFlags(["--from=nonsense"]).from, undefined);
+});
+
+Deno.test("main dispatches the import command", async () => {
+  const host = new FakeHost({
+    "package.json": JSON.stringify({ scripts: { lint: "eslint ." } }),
+  });
+  const code = await main(
+    ["import", "--yes", "--force"],
+    host,
+    new FakePrompter(false),
+  );
+  assertEquals(code, 0);
+  assertStringIncludes(host.files.get("zuke.ts") ?? "", "lint = target()");
+  assertStringIncludes(
+    host.logs.join("\n"),
+    "imported 1 task(s) from package.json",
+  );
+});
+
+Deno.test("main import prompts for the name at an interactive terminal", async () => {
+  const host = new FakeHost({
+    "package.json": JSON.stringify({ scripts: { build: "tsc" } }),
+  });
+  // Interactive: the prompter supplies the class name and confirms overwrite.
+  const code = await main(
+    ["import"],
+    host,
+    new FakePrompter(true, "Pipeline", true),
+  );
+  assertEquals(code, 0);
+  assertStringIncludes(
+    host.files.get("zuke.ts") ?? "",
+    "class Pipeline extends Build",
+  );
+});
+
+Deno.test("main import returns 1 when nothing is found (with --from)", async () => {
+  const host = new FakeHost({});
+  const code = await main(
+    ["import", "--yes", "--from", "makefile"],
+    host,
+    new FakePrompter(false),
+  );
+  assertEquals(code, 1);
+  assertStringIncludes(host.logs.join("\n"), "for --from Makefile");
+});
+
+Deno.test("help lists the import command", async () => {
+  const host = new FakeHost({});
+  await main(["--help"], host, new FakePrompter(false));
+  assertStringIncludes(host.logs.join("\n"), "zuke import");
+});

--- a/packages/cli/tests/import_test.ts
+++ b/packages/cli/tests/import_test.ts
@@ -106,6 +106,24 @@ Deno.test("translateCommand flags shell-specific commands as TODO", () => {
   }
 });
 
+Deno.test("translateCommand keeps a newline from breaking out of the TODO comment", () => {
+  // A command whose text spans lines must stay on one `//` comment line.
+  const items = translateCommand("cat x | grep y\nmalicious()");
+  assertEquals(items.length, 1);
+  assertEquals(items[0].runnable, false);
+  assertEquals(items[0].code.includes("\n"), false);
+  assertStringIncludes(items[0].code, "cat x | grep y malicious()");
+});
+
+Deno.test("generateBuild escapes an unusual task name in the description", () => {
+  // A name with a quote/newline is emitted through a string literal, so it
+  // cannot break out of the generated source.
+  const out = generateBuild("B", [
+    { name: 'weird"\nname', command: "echo hi", deps: [] },
+  ]);
+  assertStringIncludes(out, String.raw`imported: weird\"\nname`);
+});
+
 Deno.test("translateCommand keeps quoted arguments together", () => {
   const items = translateCommand(`prettier --write "src/**/*.ts"`);
   assertEquals(


### PR DESCRIPTION
## What & why

Adds a **`zuke import`** subcommand that reads an existing project's task definitions and generates an equivalent typed `zuke.ts`, so migrating to Zuke starts from a working translation rather than a blank page. This is the "lower the switching cost" item from the brainstorm — a 60-second on-ramp for projects that already have `package.json` scripts or a `Makefile`.

```sh
zuke import                  # auto-detects package.json, then a Makefile
zuke import --from makefile  # or pin the source
```

It scaffolds the launchers and `deno.json` around the generated build too, exactly like `zuke setup` (reusing that engine via a new `buildContent` hook on `SetupOptions`).

## Sources

- **`package.json` scripts** — each script becomes a target; a `run` delegation (`npm run lint`, `pnpm test`, …) becomes a `.dependsOn(...)`.
- **`Makefile`** — each rule becomes a target; prerequisites become `.dependsOn(...)`. The parser strips recipe `@`/`-` prefixes and skips variable assignments, special targets (`.PHONY`, …), and file-only prerequisites.

## Command translation

- A command maps to **`CmdTasks.exec("bin", (s) => s.args(...))`** — typed and injection-safe (the generic `@zuke/cmd` wrapper).
- An **`&&` chain** becomes sequential `await` steps.
- A command too shell-specific to translate faithfully (pipes, redirects, `$(…)`/`` `…` `` substitutions, env-var expansion, `VAR=…` assignments, background `&`) is **preserved verbatim behind a `// TODO`**, so the file still compiles and the few tricky scripts are clearly flagged.
- Task names are normalised to valid camelCase identifiers (`build:prod` → `buildProd`), de-duplicated on collision, and targets are emitted in **topological order** — with cycle edges dropped and noted — because a Zuke target may only depend on siblings declared above it.

### Example

`{"scripts": {"build": "tsc -p .", "lint": "eslint . && prettier -w .", "ci": "npm run build && npm run lint"}}` →

```ts
build = target().description("imported: build")
  .executes(() => CmdTasks.exec("tsc", (s) => s.args("-p", ".")));

lint = target().description("imported: lint").executes(async () => {
  await CmdTasks.exec("eslint", (s) => s.args("."));
  await CmdTasks.exec("prettier", (s) => s.args("-w", "."));
});

ci = target().description("imported: ci").dependsOn(this.build, this.lint)
  .executes(() => {});
```

## Testing & docs

- The parser and generator are pure, unit-tested functions. New `import_test.ts` (25 cases): both parsers (delegations, prerequisites, recipe prefixes, special/file targets, non-string scripts), the command translator (clean commands, `&&` chains, quoted args, every shell-metacharacter → `// TODO`), identifier normalisation, topological ordering + cycle-breaking, generator structure, orchestration with a fake host, and CLI dispatch/flags/help. All pass.
- Full `deno task ci` green — `import.ts` is 100% line coverage; aggregate above the 95% gate; `apiDocsCheck` in sync (regenerated `llms-full.txt`, `packages/cli/README.md`).
- New "Migrate an existing project with `zuke import`" section in `docs/getting-started.md`.

## Related issues

Part of the "lower the switching cost" brainstorm section.

## Checklist

- [x] The PR title is a [Conventional Commit](https://www.conventionalcommits.org/) (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`).
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`, `llms-full.txt`, package README `## API`).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with type guards instead).
- [ ] A new package was wired into all five places — n/a (no new package; all changes are within `@zuke/cli`).
- [x] The code is written using AI assisted coding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFVtbsGNx9piPuknJXqgrH

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFVtbsGNx9piPuknJXqgrH)_