### PR TITLE
docs: refresh Zuke agent skills for newer features

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/skills/zuke-setup/SKILL.md
+++ b/skills/zuke-setup/SKILL.md
@@ -29,6 +29,26 @@ deno run -A jsr:@zuke/cli setup
 `setup` flags: `--dir <path>`, `--name <ClassName>`, `--force` (overwrite
 existing files), `--yes` (non-interactive).
 
+### Migrating an existing project: `zuke import`
+
+If the project already has `package.json` scripts or a `Makefile`, prefer
+`zuke import` over `setup` — it reads them and generates a `zuke.ts` with a
+target per task, a working starting point instead of a blank build:
+
+```sh
+zuke import                  # auto-detects package.json, then a Makefile
+zuke import --from makefile   # or pin the source (package.json | makefile)
+```
+
+Each script/target becomes a `target()`; a command maps to `CmdTasks.exec(...)`,
+an `&&` chain becomes sequential steps, a `run`/prerequisite delegation becomes
+`.dependsOn(...)`, and anything too shell-specific to translate (pipes,
+redirects, env assignments) is preserved behind a `// TODO` so the file still
+compiles. It scaffolds the launchers and `deno.json` exactly like `setup`, and
+takes the same `--dir`, `--name`, `--force`, `--yes` flags. Afterwards, use the
+**zuke-write-build** skill to replace the generated `CmdTasks.exec` calls with
+typed `*Tasks` wrappers.
+
 ### What `zuke setup` writes
 
 - **`zuke.ts`** — a starter build class with a sample target and a `default`.
@@ -46,8 +66,16 @@ existing files), `--yes` (non-interactive).
 ./zuke                 # run the default target  (Windows: .\zuke.ps1)
 ./zuke <target>        # run a specific target
 ./zuke --list          # list every target
+./zuke --list --json   # the whole build surface (commands, flags, targets) as JSON
 ./zuke <target> --dry-run   # print the plan without executing
 ```
+
+The CLI is self-describing: `./zuke --help` prints the usage grammar plus the
+build's live targets and parameters, so an agent discovers the real command
+surface instead of guessing. For an AI client to operate the build through typed
+calls, `zuke mcp` runs a Model Context Protocol server over it (register with
+`claude mcp add zuke -- deno run -A zuke.ts mcp`; add `--allow-run` to let the
+agent execute targets, not just inspect them).
 
 If Deno is already installed you can equivalently use
 `deno task zuke <target>` or `deno run -A zuke.ts <target>`. The `-A` flag

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -73,11 +73,27 @@ Before calling any task or settings method, confirm the real shape:
   concurrently; depend on the group to wait for all of them.
 - **Reusable bundles:** a *component* is a function returning related targets;
   assign it to a field and reference members as `this.release.publish`.
-- **Caching:** `.inputs(...)` / `.outputs(...)` make a target incremental.
+- **Long-lived processes:** `service()` models a process that must stay *running
+  while dependents execute* (dev server, database, mock API). Declared and
+  depended on like a target, but with a `.start(...)` / `.readyWhen(...)`
+  lifecycle instead of `.executes(...)`; the executor starts it, waits until
+  ready, then stops it in a `finally` so it never leaks. See the cheatsheet.
+- **Caching:** `.inputs(...)` / `.outputs(...)` make a target incremental. Add a
+  **remote store** to share results across machines (fresh CI, teammates);
+  `--affected` runs only targets changed since a git base; `--no-cache` /
+  `--no-remote-cache` bypass them.
 - **Typed inputs:** `parameter("...")` (with `.secret()` / `.required()`), read
   as `this.x.value`, gated with `.requires(this.x)`.
+- **Secrets from a manager:** `parameter(...).secret().from(source)` sources a
+  value at run time (e.g. `execSecret(...)` shelling out to a secret CLI) and
+  **redacts** it from all of Zuke's output. See the cheatsheet.
+- **Provisioning tools:** `ToolTasks.install((s) => …)` / `toolchain((t) => …)`
+  fetch pinned, checksum-verified tool binaries so a build is hermetic; hand the
+  returned path to a wrapper's `.toolPath(...)`.
 - **Code-first CI:** `cicd({ provider: "github" })` generates and verifies the
   workflow YAML from the build.
+- **Operate the build from an agent:** `zuke mcp` serves the build over MCP so an
+  AI client can list, inspect, and (with `--allow-run`) run targets.
 - **AI review & self-healing (`@zuke/ai`):** gate a target on a structured LLM
   review of the diff (`securityReviewer(...)` etc. via `.validateBefore`), or
   attach `aiFixer(...)` with `.recoverWith(...)` so a failing target is diagnosed

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -63,6 +63,43 @@ class MyBuild extends Build {
 }
 ```
 
+## Services — long-lived processes
+
+`service()` models a process that must stay **running while its dependents
+execute** (dev server, DB container, mock API). Declared and depended on like a
+target, but with a lifecycle instead of `.executes(...)`: the executor starts
+it, waits until ready, keeps it alive, then stops it in a `finally` (reverse
+order) so a failed test never leaks a process.
+
+```ts
+import { Build, run, service, target, tcpReachable } from "jsr:@zuke/core";
+import { $ } from "jsr:@zuke/core/shell";
+
+class E2E extends Build {
+  api = service()
+    .description("API under test")
+    .start(() => $`deno run -A server.ts`.spawn()) // spawn — don't await
+    .readyWhen(() => tcpReachable("localhost:8080")); // polled until ready
+
+  test = target()
+    .dependsOn(this.api) // started + ready before this runs
+    .executes(() => DenoTasks.test((s) => s.allowAll()));
+}
+```
+
+| Method | Purpose |
+| --- | --- |
+| `.start(() => handle)` | Start the process; return a handle with `.stop()`. **Required.** |
+| `.readyWhen(() => boolean)` | Readiness probe, polled (200ms) until `true`. |
+| `.readyTimeout(ms)` | Wait before failing readiness (default 30s). |
+| `.stop((handle) => …)` | Custom teardown; receives what `.start()` returned. |
+
+The shell's `Command` gains `.spawn()` (starts without awaiting, returns a
+`SpawnedProcess` whose `.stop()` sends `SIGTERM`) — a valid handle, so the
+common case needs no explicit `.stop()`. `tcpReachable("host:port")` is the
+built-in "is the port up yet?" probe. Shares `dependsOn`/`before`/`after`/
+`description` with `target()`.
+
 ## Parameters — typed build inputs
 
 ```ts
@@ -81,6 +118,41 @@ class MyBuild extends Build {
 
 Secrets are masked in CI output. Read a resolved value with `this.x.value`.
 
+### Secrets from a manager — `.from(source)`
+
+A `.secret()` parameter can be **sourced at run time** so the value never lands
+in a shell, `.env`, or CI YAML — and its resolved value is **redacted from all
+of Zuke's output**:
+
+```ts
+import { execSecret, parameter } from "jsr:@zuke/core";
+
+token = parameter("Deploy token")
+  .secret()
+  .from(execSecret((s) => s.command("op").arg("read", "op://vault/deploy/token")));
+```
+
+A sourced secret is still an ordinary parameter (flag, env var, `.required()`,
+`.number()`); `.from(...)` just adds the run-time provider.
+
+## Provisioning tools — hermetic builds
+
+Fetch pinned, checksum-verified tool binaries from the build itself instead of
+assuming they're installed. Both return the installed binary's `AbsolutePath`;
+hand it to a wrapper's `.toolPath(...)`, to `CmdTasks`, or to `defineTool`.
+
+```ts
+import { toolchain, ToolTasks } from "jsr:@zuke/core";
+
+// One tool:
+bin = target().executes(async () =>
+  await ToolTasks.install((s) => s.name("shellcheck").version("0.10.0"/* …checksum */))
+);
+
+// Many at once:
+tools = toolchain((t) => t.add(/* … */).add(/* … */));
+```
+
 ## Tool wrappers — the settings-lambda style
 
 Every external tool is a `*Tasks` object; each task takes `(s) => s.…` mirroring
@@ -89,17 +161,27 @@ the full task list and settings methods of each):
 
 | Package | Object | Typical tasks |
 | --- | --- | --- |
-| `@zuke/core` | `FileTasks`, `AnnounceTasks` | copy/move/remove files; Slack/Teams/Discord posts |
+| `@zuke/core` | `FileTasks`, `AnnounceTasks`, `ToolTasks` | copy/move/remove files; Slack/Teams/Discord posts; install tool binaries |
+| `@zuke/console` | `ConsoleTasks` | themed console output (headings, notices) so a build never hand-rolls `console.log` |
 | `@zuke/deno` | `DenoTasks` | `check`, `test`, `fmt`, `lint`, `cache`, `doc`, `run`, `publish` |
-| `@zuke/npm` | `NpmTasks` | `ci`, `install`, `run`, `exec`, `publish`, `version` |
+| `@zuke/docs` | `DocsTasks` | turn generated API docs into published output |
+| `@zuke/npm`, `@zuke/bun`, `@zuke/pnpm`, `@zuke/yarn`, `@zuke/node` | `NpmTasks`, `BunTasks`, ... | JS package managers + `node` |
 | `@zuke/cmd` | `CmdTasks` | `exec` — generic fallback for any CLI |
 | `@zuke/docker`, `@zuke/docker-compose` | `DockerTasks`, ... | build/run/compose |
 | `@zuke/git`, `@zuke/gh` | `GitTasks`, `GhTasks` | git and GitHub CLI |
-| `@zuke/cspell`, `@zuke/eslint`, `@zuke/oxlint`, `@zuke/biome`, `@zuke/dprint` | `*Tasks` | lint/format/spell |
+| `@zuke/cspell`, `@zuke/eslint`, `@zuke/oxlint`, `@zuke/biome`, `@zuke/dprint`, `@zuke/knip`, `@zuke/dpdm` | `*Tasks` | lint/format/spell/dead-code |
+| `@zuke/tsc`, `@zuke/tsgo`, `@zuke/tsx`, `@zuke/tsc-alias`, `@zuke/tsup`, `@zuke/tsdown`, `@zuke/vite`, `@zuke/turbo`, `@zuke/nx`, `@zuke/nest` | `*Tasks` | TS compile / bundle / monorepo / framework CLIs |
+| `@zuke/openapi-ts`, `@zuke/orval` | `*Tasks` | generate API clients from OpenAPI |
+| `@zuke/husky` | `HuskyTasks` | git hooks |
 | `@zuke/jest`, `@zuke/vitest`, `@zuke/playwright`, `@zuke/cypress` | `*Tasks` | test runners |
-| `@zuke/kubectl`, `@zuke/helm`, `@zuke/terraform`, `@zuke/tofu`, `@zuke/gcloud` | `*Tasks` | infra/deploy |
+| `@zuke/jsr`, `@zuke/codecov`, `@zuke/release-please` | `JsrTasks`, `CodecovTasks`, ... | publish / coverage upload / releases |
+| `@zuke/kubectl`, `@zuke/helm`, `@zuke/kustomize`, `@zuke/terraform`, `@zuke/tofu`, `@zuke/gcloud` | `*Tasks` | infra/deploy |
+| `@zuke/security` | `*Tasks` | security scanning |
 | `@zuke/claude`, `@zuke/codex`, `@zuke/gemini` | `ClaudeTasks`, ... | headless AI CLIs |
-| `@zuke/ai` | `securityReviewer`, ..., `aiFixer` | AI review gates + self-healing (see below) |
+| `@zuke/ai` | `securityReviewer`, ..., `aiFixer`, `agentFixer` | AI review gates + self-healing (see below) |
+
+The catalog keeps growing — `deno doc jsr:@zuke/<pkg>` (or the package list in
+`llms.txt`) is the source of truth for what exists.
 
 ```ts
 await DenoTasks.test((s) => s.allowAll().coverage("cov_profile"));
@@ -196,6 +278,18 @@ is current (`zuke generate-ci --check` is a dedicated gate).
 
 ```sh
 ./zuke --list                 # all targets
+./zuke --list --json          # whole surface (commands, flags, targets) as JSON
 ./zuke <target> --dry-run     # preview the plan, run nothing
 ./zuke <target>               # run it
+./zuke <target> --parallel    # run independent targets concurrently
+./zuke <target> --affected    # run only targets changed since a git base
+./zuke <target> --no-cache    # ignore the incremental cache
+./zuke mcp [--allow-run]      # serve the build over MCP for an AI client
 ```
+
+**Caching:** a target with `.inputs(...)`/`.outputs(...)` is incremental
+(skipped and reported `cached` when inputs are unchanged and outputs exist). Add
+a **remote store** to share results across machines — a fresh CI checkout or a
+teammate's clone restores outputs instead of rebuilding; `--no-remote-cache`
+uses the local cache only. `--affected` limits a run to targets touched since a
+git base (great for CI job fan-out).


### PR DESCRIPTION
## What & why

The `zuke-setup` and `zuke-write-build` agent skills (and the shared cheatsheet) had drifted behind the feature work that has landed since they were written. An agent following them would miss whole capabilities and fall back to guessing or shelling out — exactly what the skills exist to prevent. This brings them current.

- **`zuke-setup`** — documents `zuke import` (scaffold a build from existing `package.json` scripts or a `Makefile`) as the preferred migration path, and points at the self-describing CLI (`--list --json`, `--help`) plus `zuke mcp` for agents operating the build.
- **`zuke-write-build`** — adds the newer authoring primitives to the "common building blocks" list: `service()` targets for long-lived processes, secret sourcing with `.from(...)` + output redaction, hermetic tool provisioning (`ToolTasks.install` / `toolchain`), remote cache + `--affected` runs, and serving the build over MCP.
- **`cheatsheet.md`** — new Services, secret-sourcing, and tool-provisioning sections; remote-cache/affected notes in Run & inspect; and a substantially expanded wrapper catalog (bun/pnpm/yarn/node, tsc/tsgo/tsx/vite/turbo/nx/nest, openapi-ts/orval, husky, console, docs, codecov, security, knip/dpdm, …).
- **Plugin version** bumped `0.1.0 → 0.2.0` in both `plugins/zuke/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` so installed Claude Code clients are offered the update (`/plugin marketplace update zuke` then `/plugin update zuke@zuke`).

No `packages/` files change, so this is a `docs:`-titled, no-release PR.

## Related issues

_None._

## Checklist

- [x] The PR title is a [Conventional Commit](https://www.conventionalcommits.org/) (`type(scope): summary`).
- [ ] `deno task ci` passes locally — Deno is not installed in this environment; changes are Markdown/JSON only and outside the `deno fmt` scope. Spell terms were verified against `cspell.json` and existing docs, and both JSON manifests were parse-checked.
- [x] Tests were added or updated; coverage stays at 95%+ — n/a, docs/skills only.
- [x] Docs updated in the same PR when behaviour changed — this PR *is* the docs update.
- [x] Public API changes were regenerated — n/a, no public API change.
- [x] No `any`/`as`/`!` in `src/` — n/a.
- [x] A new package was wired into all five places, if applicable — n/a, no new package.
- [x] The code is written using AI assisted coding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H44BGkq9Q7gooQdt1MTZCx

---
_Generated by [Claude Code](https://claude.ai/code/session_01H44BGkq9Q7gooQdt1MTZCx)_