### PR TITLE
feat(core): pass a typed TargetContext to target bodies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 
 # Specs
 docs/superpowers/
+plans/
 
 # OMC session state
 .omc/

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1464,6 +1464,12 @@ interface ExecuteOptions
     Renderer for the per-target banners and the end-of-build summary. Defaults
     to Zuke's built-in {@link defaultRenderer}; `@zuke/console` exports an
     alternative a build can inject to restyle its output.
+  signal?: AbortSignal
+    Cancel the run when this signal aborts. Every target body's
+    {@link "./target.ts".TargetContext} `signal` mirrors it, and it is applied
+    as the shell's ambient default so an in-flight `$` command is terminated
+    (SIGTERM) on cancellation. A body that ignores its signal still runs to completion —
+    graph-level cancellation/compensation is a later milestone.
 
 interface FanOutOptions
   Options for {@link fanOutPipeline}: how a build's targets become parallel CI
@@ -1777,6 +1783,25 @@ interface TarEntry
   data: Uint8Array
     The file contents.
 
+interface TargetContext
+  The context passed to every target body. Optional to receive — an existing
+  zero-argument `.executes(() => …)` stays valid, since a zero-argument
+  function is assignable to this one-parameter type — but a body that wants the run's
+  identity, a cancellation signal, or (in later milestones) durable state and
+  external-signal payloads reads them here.
+
+  readonly runId: string
+    Unique ID of this run, stable for every target in the run.
+  readonly target: string
+    Dotted name of the executing target.
+  readonly signal: AbortSignal
+    Aborted when the run is cancelled (see {@link "./executor.ts".ExecuteOptions}
+    `signal`). Pass it to a shell command's `.signal()` to have that command
+    terminated on cancellation; the executor also applies it as the shell's
+    ambient default, so a plain `$` in the body is terminated too.
+  readonly dryRun: boolean
+    True when the run is a dry run (bodies do not execute under a dry run).
+
 interface TargetReport
   One row of the end-of-build summary.
 
@@ -1868,7 +1893,7 @@ type Target = TargetBuilder
   A configured target. Alias of {@link TargetBuilder} — the same object both
   builds and represents the target. Exposed as `Target` for use in signatures.
 
-type TargetFn = () => void | Promise<void>
+type TargetFn = (ctx: TargetContext) => void | Promise<void>
   The executable body of a target. May be synchronous or asynchronous.
 
 type TargetStatus = "passed" | "failed" | "skipped" | "cached"

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1518,6 +1518,12 @@ interface ExecuteOptions
     Renderer for the per-target banners and the end-of-build summary. Defaults
     to Zuke's built-in {@link defaultRenderer}; `@zuke/console` exports an
     alternative a build can inject to restyle its output.
+  signal?: AbortSignal
+    Cancel the run when this signal aborts. Every target body's
+    {@link "./target.ts".TargetContext} `signal` mirrors it, and it is applied
+    as the shell's ambient default so an in-flight `$` command is terminated
+    (SIGTERM) on cancellation. A body that ignores its signal still runs to completion —
+    graph-level cancellation/compensation is a later milestone.
 
 interface FanOutOptions
   Options for {@link fanOutPipeline}: how a build's targets become parallel CI
@@ -1831,6 +1837,25 @@ interface TarEntry
   data: Uint8Array
     The file contents.
 
+interface TargetContext
+  The context passed to every target body. Optional to receive — an existing
+  zero-argument `.executes(() => …)` stays valid, since a zero-argument
+  function is assignable to this one-parameter type — but a body that wants the run's
+  identity, a cancellation signal, or (in later milestones) durable state and
+  external-signal payloads reads them here.
+
+  readonly runId: string
+    Unique ID of this run, stable for every target in the run.
+  readonly target: string
+    Dotted name of the executing target.
+  readonly signal: AbortSignal
+    Aborted when the run is cancelled (see {@link "./executor.ts".ExecuteOptions}
+    `signal`). Pass it to a shell command's `.signal()` to have that command
+    terminated on cancellation; the executor also applies it as the shell's
+    ambient default, so a plain `$` in the body is terminated too.
+  readonly dryRun: boolean
+    True when the run is a dry run (bodies do not execute under a dry run).
+
 interface TargetReport
   One row of the end-of-build summary.
 
@@ -1922,7 +1947,7 @@ type Target = TargetBuilder
   A configured target. Alias of {@link TargetBuilder} — the same object both
   builds and represents the target. Exposed as `Target` for use in signatures.
 
-type TargetFn = () => void | Promise<void>
+type TargetFn = (ctx: TargetContext) => void | Promise<void>
   The executable body of a target. May be synchronous or asynchronous.
 
 type TargetStatus = "passed" | "failed" | "skipped" | "cached"

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -50,6 +50,7 @@ export {
   type Target,
   target,
   TargetBuilder,
+  type TargetContext,
   type TargetFn,
   type Validation,
   type ValidationContext,

--- a/packages/core/src/ambient_signal.ts
+++ b/packages/core/src/ambient_signal.ts
@@ -1,0 +1,38 @@
+/**
+ * The ambient {@link AbortSignal} for `$` commands.
+ *
+ * The executor runs each build's plan inside {@link withAmbientSignal} (see
+ * `./executor.ts`); every `$`/{@link "./shell.ts".Command} started without an
+ * explicit `.signal()` picks the run's signal up at spawn time, so a target
+ * body's shell commands are terminated when the run is cancelled without the
+ * body having to thread the signal through by hand.
+ *
+ * The signal lives in an `AsyncLocalStorage`, so it is scoped to the run's
+ * async context rather than a process global: concurrent in-process runs each
+ * see their own signal, and nothing is left behind when a run ends — even if it
+ * throws. This is internal (not part of any published entrypoint).
+ *
+ * @module
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/** Per-async-context store holding the current run's cancellation signal. */
+const storage = new AsyncLocalStorage<AbortSignal>();
+
+/** The ambient signal in effect, read by {@link "./shell.ts".Command} at spawn time. */
+export function ambientSignal(): AbortSignal | undefined {
+  return storage.getStore();
+}
+
+/**
+ * Run `fn` with `signal` installed as the ambient signal for its entire async
+ * subtree, returning `fn`'s result. The binding is confined to this call — it
+ * is not visible to concurrent runs and needs no manual teardown.
+ */
+export function withAmbientSignal<T>(
+  signal: AbortSignal,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return storage.run(signal, fn);
+}

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -38,7 +38,8 @@ import { isCI } from "./host.ts";
 import { ServiceBuilder, ServiceRegistry } from "./service.ts";
 import { Redactor } from "./redact.ts";
 import { absolutePath } from "./path.ts";
-import type { Remediation, TargetBuilder, TargetFn } from "./target.ts";
+import type { Remediation, TargetBuilder, TargetContext } from "./target.ts";
+import { withAmbientSignal } from "./ambient_signal.ts";
 import type { Plugin } from "./plugin.ts";
 import { detectWidth, type Style, type TargetReport } from "./report.ts";
 import { defaultRenderer, type Renderer } from "./renderer.ts";
@@ -156,6 +157,14 @@ export interface ExecuteOptions {
    * alternative a build can inject to restyle its output.
    */
   renderer?: Renderer;
+  /**
+   * Cancel the run when this signal aborts. Every target body's
+   * {@link "./target.ts".TargetContext} `signal` mirrors it, and it is applied
+   * as the shell's ambient default so an in-flight `$` command is terminated
+   * (SIGTERM) on cancellation. A body that ignores its signal still runs to completion —
+   * graph-level cancellation/compensation is a later milestone.
+   */
+  signal?: AbortSignal;
 }
 
 /** Whether the build is running inside a GitHub Actions runner. */
@@ -385,7 +394,7 @@ function delay(ms: number): Promise<void> {
  * primitive), so it keeps running in the background — but its result is ignored.
  */
 function runWithTimeout(
-  fn: TargetFn,
+  fn: () => void | Promise<void>,
   timeoutMs: number | undefined,
 ): Promise<void> {
   const result = Promise.resolve().then(fn);
@@ -414,13 +423,13 @@ function runWithTimeout(
  * and a failure is retried (after an optional delay) up to the retry count
  * before the last error propagates.
  */
-async function runBody(t: TargetBuilder): Promise<void> {
+async function runBody(t: TargetBuilder, ctx: TargetContext): Promise<void> {
   const fn = t.fn_;
   if (fn === undefined) return; // guarded by the caller
   const attempts = t.retries_ + 1;
   for (let attempt = 1;; attempt++) {
     try {
-      await runWithTimeout(fn, t.timeout_);
+      await runWithTimeout(() => fn(ctx), t.timeout_);
       return;
     } catch (error) {
       if (attempt >= attempts) throw error;
@@ -441,9 +450,10 @@ async function runBodyWithRecovery(
   t: TargetBuilder,
   name: string,
   globalRecovery: Remediation[],
+  ctx: TargetContext,
 ): Promise<void> {
   try {
-    await runBody(t);
+    await runBody(t, ctx);
     return;
   } catch (error) {
     // A target's own remediations run first, then any build-level ones.
@@ -467,7 +477,7 @@ async function runBodyWithRecovery(
       }
       if (!willRetry) break;
       try {
-        await runBody(t);
+        await runBody(t, ctx);
         return;
       } catch (retryError) {
         lastError = retryError;
@@ -495,6 +505,8 @@ async function runTarget(
   dryRun: boolean,
   globalRecovery: Remediation[],
   services: ServiceRegistry,
+  runId: string,
+  runSignal: AbortSignal,
 ): Promise<TargetOutcome> {
   const name = t.name_ ?? "<unnamed>";
 
@@ -556,9 +568,10 @@ async function runTarget(
     return { status: "failed", ms: 0, error };
   }
 
+  const ctx: TargetContext = { runId, target: name, signal: runSignal, dryRun };
   try {
     for (const v of t.validateBefore_) await v.validate({ target: name });
-    await runBodyWithRecovery(t, name, globalRecovery);
+    await runBodyWithRecovery(t, name, globalRecovery, ctx);
     for (const v of t.validateAfter_) await v.validate({ target: name });
     const ms = performance.now() - start;
     if (cache !== undefined) await cache.record(t);
@@ -616,6 +629,8 @@ async function runSequential(
   dryRun: boolean,
   globalRecovery: Remediation[],
   services: ServiceRegistry,
+  runId: string,
+  runSignal: AbortSignal,
 ): Promise<RunOutcome> {
   const reports: TargetReport[] = [];
   const executed: string[] = [];
@@ -640,6 +655,8 @@ async function runSequential(
       dryRun,
       globalRecovery,
       services,
+      runId,
+      runSignal,
     );
     await life.targetEnd(name, outcome.status);
     if (outcome.status === "passed" || outcome.status === "failed") opened++;
@@ -677,6 +694,8 @@ async function runScheduled(
   dryRun: boolean,
   globalRecovery: Remediation[],
   services: ServiceRegistry,
+  runId: string,
+  runSignal: AbortSignal,
 ): Promise<RunOutcome> {
   const outcomes = new Map<TargetBuilder, TargetOutcome>();
   const done = new Set<TargetBuilder>(); // passed/cached/skipped → unblocks dependents
@@ -723,6 +742,8 @@ async function runScheduled(
           dryRun,
           globalRecovery,
           services,
+          runId,
+          runSignal,
         )
           .then(
             async (outcome) => {
@@ -894,6 +915,18 @@ export async function execute(
   // resolved once before the run.
   const globalRecovery = dryRun ? [] : build.recoverWith();
 
+  // One run identity and one cancellation controller per run. The controller
+  // aborts when the caller's `options.signal` does; its signal is handed to
+  // every target's context and installed as the shell's ambient signal, so a
+  // cancelled run terminates in-flight `$` child processes.
+  const runId = crypto.randomUUID();
+  const runController = new AbortController();
+  const onCancel = () => runController.abort();
+  if (options.signal !== undefined) {
+    if (options.signal.aborted) runController.abort();
+    else options.signal.addEventListener("abort", onCancel, { once: true });
+  }
+
   // Services started during the run are held here and torn down in reverse
   // order once it finishes — in a `finally`, so a failure never leaks a process.
   const services = new ServiceRegistry();
@@ -910,6 +943,8 @@ export async function execute(
         dryRun,
         globalRecovery,
         services,
+        runId,
+        runController.signal,
       );
     }
     // With `--parallel`, anything independent may overlap up to `limit`.
@@ -934,13 +969,21 @@ export async function execute(
       dryRun,
       globalRecovery,
       services,
+      runId,
+      runController.signal,
     );
   };
 
   let run: RunOutcome;
   try {
-    run = await runPlan();
+    // Run the plan inside the ambient-signal scope so a plain `$` in a target
+    // body is cancelled with the run; the binding unwinds on its own, even if
+    // the plan throws — nothing to restore.
+    run = await withAmbientSignal(runController.signal, runPlan);
   } finally {
+    if (options.signal !== undefined) {
+      options.signal.removeEventListener("abort", onCancel);
+    }
     if (services.size > 0) {
       await services.stopAll((line) => reporter.info(line));
     }

--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -17,6 +17,16 @@
  */
 
 import type { AbsolutePath, PathLike } from "./path.ts";
+import { ambientSignal } from "./ambient_signal.ts";
+
+/** Combine an optional timeout signal and an optional cancellation signal. */
+function combineSignals(
+  a: AbortSignal | undefined,
+  b: AbortSignal | undefined,
+): AbortSignal | undefined {
+  if (a !== undefined && b !== undefined) return AbortSignal.any([a, b]);
+  return a ?? b;
+}
 
 /** A value that may be interpolated into a `$` template. */
 export type Interpolatable =
@@ -195,6 +205,7 @@ export class Command implements PromiseLike<CommandOutput> {
   #quiet = false;
   #capturing = false;
   #timeoutMs?: number;
+  #signal?: AbortSignal;
   #result?: Promise<RunResult>;
 
   /** Build a command from a discrete argv array (binary first). */
@@ -235,6 +246,17 @@ export class Command implements PromiseLike<CommandOutput> {
     return this;
   }
 
+  /**
+   * Terminate the process (via `SIGTERM`) when `signal` aborts — for example
+   * when the enclosing run is cancelled. Overrides the executor's ambient
+   * run signal for this command. Composes with {@link killAfter}: either the
+   * timeout or the abort kills the process, whichever fires first.
+   */
+  signal(signal: AbortSignal): this {
+    this.#signal = signal;
+    return this;
+  }
+
   /** The command line, for diagnostics. */
   get commandLine(): string {
     return this.#argv.join(" ");
@@ -259,6 +281,14 @@ export class Command implements PromiseLike<CommandOutput> {
       controller?.abort();
     }, ms);
 
+    // The timeout's own signal is folded together with the cancellation signal
+    // (an explicit `.signal()`, else the executor's ambient run signal), so an
+    // aborted run terminates the child even when a timeout is also armed.
+    const signal = combineSignals(
+      controller?.signal,
+      this.#signal ?? ambientSignal(),
+    );
+
     try {
       const child = new Deno.Command(cmd, {
         args,
@@ -266,7 +296,7 @@ export class Command implements PromiseLike<CommandOutput> {
         env: this.#env,
         stdout: "piped",
         stderr: "piped",
-        signal: controller?.signal,
+        signal,
       }).spawn();
 
       // When capturing programmatically, don't echo stdout to the terminal.
@@ -347,6 +377,7 @@ export class Command implements PromiseLike<CommandOutput> {
       env: this.#env,
       stdout: "inherit",
       stderr: "inherit",
+      signal: this.#signal ?? ambientSignal(),
     }).spawn();
     return new SpawnedProcess(child, this.commandLine);
   }

--- a/packages/core/src/target.ts
+++ b/packages/core/src/target.ts
@@ -30,8 +30,31 @@
 import type { PathLike } from "./path.ts";
 import type { AnyParameter } from "./params.ts";
 
+/**
+ * The context passed to every target body. Optional to receive — an existing
+ * zero-argument `.executes(() => …)` stays valid, since a zero-argument
+ * function is assignable to this one-parameter type — but a body that wants the run's
+ * identity, a cancellation signal, or (in later milestones) durable state and
+ * external-signal payloads reads them here.
+ */
+export interface TargetContext {
+  /** Unique ID of this run, stable for every target in the run. */
+  readonly runId: string;
+  /** Dotted name of the executing target. */
+  readonly target: string;
+  /**
+   * Aborted when the run is cancelled (see {@link "./executor.ts".ExecuteOptions}
+   * `signal`). Pass it to a shell command's `.signal()` to have that command
+   * terminated on cancellation; the executor also applies it as the shell's
+   * ambient default, so a plain `$` in the body is terminated too.
+   */
+  readonly signal: AbortSignal;
+  /** True when the run is a dry run (bodies do not execute under a dry run). */
+  readonly dryRun: boolean;
+}
+
 /** The executable body of a target. May be synchronous or asynchronous. */
-export type TargetFn = () => void | Promise<void>;
+export type TargetFn = (ctx: TargetContext) => void | Promise<void>;
 
 /** A predicate gating whether a target runs; may be synchronous or async. */
 export type Condition = () => boolean | Promise<boolean>;

--- a/packages/core/tests/executor_test.ts
+++ b/packages/core/tests/executor_test.ts
@@ -33,8 +33,12 @@ import {
   type Reporter,
 } from "../src/executor.ts";
 import type { Plugin } from "../src/plugin.ts";
+import { $ } from "../src/shell.ts";
 
 const silent: ExecuteOptions = { silent: true };
+
+/** `deno` — always present under the test runner, shell-free, cross-platform. */
+const DENO = Deno.execPath();
 
 /** A reporter that records every line, for asserting output. */
 function recorder(): { lines: string[]; reporter: Reporter } {
@@ -1606,4 +1610,150 @@ Deno.test("execute uploads to and restores from a remote cache store", async () 
     Deno.chdir(original);
     await Deno.remove(dir, { recursive: true });
   }
+});
+
+Deno.test("target body receives a context with a stable runId and its name", async () => {
+  const runIds: string[] = [];
+  const names: string[] = [];
+  let signalPresent = false;
+  let dryRunSeen = true;
+  class B extends Build {
+    a = target().executes((ctx) => {
+      runIds.push(ctx.runId);
+      names.push(ctx.target);
+    });
+    b = target().dependsOn(this.a).executes((ctx) => {
+      runIds.push(ctx.runId);
+      names.push(ctx.target);
+      signalPresent = ctx.signal instanceof AbortSignal && !ctx.signal.aborted;
+      dryRunSeen = ctx.dryRun;
+    });
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  const result = await execute(b, b.b, silent);
+  assertEquals(result.ok, true);
+  assertEquals(names, ["a", "b"]);
+  assertEquals(runIds.length, 2);
+  assertEquals(runIds[0], runIds[1]); // one identity for the whole run
+  assertEquals(runIds[0].length > 0, true);
+  assertEquals(signalPresent, true); // live, un-aborted signal
+  assertEquals(dryRunSeen, false);
+});
+
+Deno.test("options.signal aborts the context signal of an in-flight target", async () => {
+  // Deterministic: no subprocess, no timing — proves the run's cancellation
+  // reaches a running body through ctx.signal.
+  let started: () => void = () => {};
+  const ready = new Promise<void>((resolve) => (started = resolve));
+  const controller = new AbortController();
+  let observedAbort = false;
+  class B extends Build {
+    waits = target().executes((ctx) =>
+      new Promise<void>((resolve) => {
+        ctx.signal.addEventListener("abort", () => {
+          observedAbort = true;
+          resolve();
+        }, { once: true });
+        started();
+      })
+    );
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  const runPromise = execute(b, b.waits, {
+    silent: true,
+    signal: controller.signal,
+  });
+  await ready;
+  controller.abort();
+  const result = await runPromise;
+  assertEquals(observedAbort, true);
+  assertEquals(result.ok, true); // body resolved cleanly once its signal fired
+});
+
+Deno.test("cancelling a run terminates an in-flight shell command", async () => {
+  let started: () => void = () => {};
+  const ready = new Promise<void>((resolve) => (started = resolve));
+  const controller = new AbortController();
+  class B extends Build {
+    slow = target().executes(async () => {
+      started();
+      // A plain `$` — no explicit .signal() — is terminated via the executor's
+      // ambient run signal when the run is cancelled.
+      await $`${DENO} eval ${"await new Promise((r) => setTimeout(r, 30000))"}`
+        .quiet();
+    });
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  const runPromise = execute(b, b.slow, {
+    silent: true,
+    signal: controller.signal,
+  });
+  await ready;
+  // Let the child fully spawn before cancelling (Deno wires its abort→SIGTERM
+  // listener a tick after spawn); the same 30s sleep proves it was killed, not
+  // waited out.
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  controller.abort();
+  const result = await runPromise;
+  assertEquals(result.ok, false); // the killed command failed the target
+});
+
+Deno.test("cancelling a parallel run terminates in-flight commands in every branch", async () => {
+  // Proves the ambient signal propagates through the scheduled (parallel)
+  // runner's callback-based pump, not just the sequential path.
+  let up = 0;
+  let ready: () => void = () => {};
+  const bothUp = new Promise<void>((resolve) => (ready = resolve));
+  const controller = new AbortController();
+  const sleep = "await new Promise((r) => setTimeout(r, 30000))";
+  class B extends Build {
+    a = target().executes(async () => {
+      if (++up === 2) ready();
+      await $`${DENO} eval ${sleep}`.quiet();
+    });
+    b = target().executes(async () => {
+      if (++up === 2) ready();
+      await $`${DENO} eval ${sleep}`.quiet();
+    });
+    all = target().dependsOn(this.a, this.b).executes(() => {});
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  const runPromise = execute(b, b.all, {
+    silent: true,
+    signal: controller.signal,
+    parallel: true,
+  });
+  await bothUp;
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  controller.abort();
+  const result = await runPromise;
+  assertEquals(result.ok, false); // both branches' commands were killed
+});
+
+Deno.test("a pre-aborted options.signal aborts the context signal", async () => {
+  const controller = new AbortController();
+  controller.abort();
+  let sawAborted = false;
+  class B extends Build {
+    a = target().executes((ctx) => {
+      sawAborted = ctx.signal.aborted;
+    });
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  const result = await execute(b, b.a, {
+    silent: true,
+    signal: controller.signal,
+  });
+  assertEquals(sawAborted, true);
+  assertEquals(result.ok, true); // no shell command to kill, so the body succeeds
 });

--- a/packages/core/tests/shell_test.ts
+++ b/packages/core/tests/shell_test.ts
@@ -5,6 +5,10 @@ import {
   CommandTimeoutError,
   tokenize,
 } from "../src/shell.ts";
+import { withAmbientSignal } from "../src/ambient_signal.ts";
+
+/** A command that sleeps far longer than any test would wait. */
+const SLEEP = "await new Promise((r) => setTimeout(r, 30000))";
 
 // `deno` is guaranteed present (we are running under it) and shell-free, so it
 // makes a reliable, cross-platform subject for these tests.
@@ -151,4 +155,58 @@ Deno.test("$ .killAfter() fires even under .noThrow()", async () => {
         .then(),
     CommandTimeoutError,
   );
+});
+
+Deno.test("$ .signal() terminates a running command when it aborts", async () => {
+  const controller = new AbortController();
+  const running = $`${DENO} eval ${SLEEP}`
+    .quiet()
+    .noThrow()
+    .signal(controller.signal)
+    .then();
+  setTimeout(() => controller.abort(), 50);
+  const result = await running;
+  // The child was killed rather than sleeping 30s — a non-zero termination code.
+  assertEquals(result.code !== 0, true);
+});
+
+Deno.test("$ picks up the ambient signal and is terminated on abort", async () => {
+  const controller = new AbortController();
+  await withAmbientSignal(controller.signal, async () => {
+    const running = $`${DENO} eval ${SLEEP}`.quiet().noThrow().then();
+    setTimeout(() => controller.abort(), 50);
+    const result = await running;
+    assertEquals(result.code !== 0, true);
+  });
+});
+
+Deno.test("$ .signal() overrides the ambient signal", async () => {
+  // Ambient stays un-aborted; the explicit per-command signal does the killing.
+  const ambient = new AbortController();
+  await withAmbientSignal(ambient.signal, async () => {
+    const explicit = new AbortController();
+    const running = $`${DENO} eval ${SLEEP}`
+      .quiet()
+      .noThrow()
+      .signal(explicit.signal)
+      .then();
+    setTimeout(() => explicit.abort(), 50);
+    const result = await running;
+    assertEquals(result.code !== 0, true);
+    assertEquals(ambient.signal.aborted, false);
+  });
+});
+
+Deno.test("$ .killAfter() and .signal() combine — either can end it", async () => {
+  // A generous timeout is armed, but the abort signal fires first and kills it.
+  const controller = new AbortController();
+  const running = $`${DENO} eval ${SLEEP}`
+    .quiet()
+    .noThrow()
+    .killAfter(30000)
+    .signal(controller.signal)
+    .then();
+  setTimeout(() => controller.abort(), 50);
+  const result = await running;
+  assertEquals(result.code !== 0, true);
 });


### PR DESCRIPTION
## What

M0 of the orchestration plan (`plans/orchestrationplan.md`): the **execution-context seam** every cross-run feature (durable state, waits, locks, cancellation, fan-out) will build on.

- `TargetFn` now receives a `TargetContext` — the run id, the target name, a cancellation `AbortSignal`, and the dry-run flag. **Backwards compatible:** an existing zero-argument `executes` body still type-checks and runs unchanged (a zero-arg function is assignable to the one-parameter type).
- The executor mints one run id and one `AbortController` per run. A new `ExecuteOptions.signal` cancels the run; the run signal is mirrored on every target's context and installed as the shell's ambient default, so an in-flight `$` command is terminated (SIGTERM) on cancellation.
- `Command` gains a `.signal()` method plus an internal ambient-signal seam (`src/ambient_signal.ts`, not a published entrypoint) so a plain `$` in a body is cancelled without threading the signal by hand.

## Deferred (by design, to their milestones)

- Durable `state` and external-signal `signals` on the context → M1 / M3 (their backing types don't exist yet).
- OS `SIGINT`/`SIGTERM` wiring and per-target-timeout child abort → M6 (owns cancellation UX; avoids global signal-handler side effects and a retry-vs-signal race here).
- Printing the run id in the run header / job summary → M1 (would change the `Renderer` interface `@zuke/console` implements, and shifts ~20 output-pinned test assertions).

## Acceptance (met)

- Existing suite passes untouched.
- A body observes a `ctx` with a stable `runId` across targets, its own name, a live signal, and `dryRun=false`.
- Cancelling a run terminates its in-flight child process (the kill test settles in ~54ms against a 30s sleep).

## Verification

`deno task ci` green — fmt, lint, spell, `deno check`, and coverage (lines 98.9%, branches 96.5%, both above the 95% gate). `deno doc --lint` clean over all core entrypoints; `apiDocsCheck` shows no drift (`llms-full.txt` + core `README.md` regenerated).