### PR TITLE
feat(core): durable run records with a pluggable StateStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,8 +284,13 @@ Full documentation lives in [`docs/`](./docs/):
   vars (`parameter()`, `this.x.value`).
 - [Authoring API](./docs/authoring.md) — `target()`, `Build`, `run()`,
   code-first CI generation (`cicd()`), and gotchas.
+- [Run context & cancellation](./docs/run-context.md) — the `TargetContext` a
+  body receives (`runId`, `signal`, `state`) and cancelling a run.
 - [Caching](./docs/caching.md) — the incremental build cache
   (`.inputs()`/`.outputs()`) and the AI response cache (`aiCache`).
+- [Durable run state](./docs/state.md) — persist a run's status and per-target
+  metadata to a pluggable store (`StateStore`, `ctx.state`), with an
+  [HTTP API](./docs/state-api.md) for hosting a production backend.
 - [Shell wrapper (`$`)](./docs/shell.md) — ergonomic, injection-safe process
   execution.
 - [Paths (`absolutePath`)](./docs/paths.md) — the fluent path type.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,8 @@
 - [Core concepts](./concepts.md) — the build/target/graph model and execution
   semantics.
 - [Authoring API](./authoring.md) — `target()`, `Build`, `run()`, and gotchas.
+- [Run context & cancellation](./run-context.md) — the `TargetContext` a body
+  receives (`runId`, `signal`, `state`), and cancelling a run.
 - [Parameters](./parameters.md) — typed build inputs from flags, env, or
   defaults.
 - [Secrets](./secrets.md) — source secret values from a manager with
@@ -13,6 +15,10 @@
   server, a database) kept running while dependents execute, then torn down.
 - [Caching](./caching.md) — the incremental build cache, the remote
   (cross-machine) cache, and the AI response cache.
+- [Durable run state](./state.md) — persist a run's status and per-target
+  metadata to a pluggable store, and read it back after the process exits.
+- [State HTTP API](./state-api.md) — the REST contract for hosting a production
+  state backend.
 - [Shell wrapper (`$`)](./shell.md) — ergonomic, injection-safe process
   execution.
 - [Paths (`absolutePath`)](./paths.md) — the fluent path type.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -8,6 +8,8 @@
 | `zuke <target> --no-cache`          | Ignore the incremental cache; re-run every target.             |
 | `zuke <target> --affected[=<base>]` | Run only targets affected by files changed since a git base.   |
 | `zuke <target> --dry-run`           | Print the plan without executing any target body.              |
+| `zuke <target> --state`             | Persist [durable run state](./state.md) under `.zuke/runs`.    |
+| `zuke <target> --actor <name>`      | Attribute the run to `<name>` in its state record.            |
 | `zuke --list` / `-l`                | List all targets with descriptions and dependencies.           |
 | `zuke graph`                        | Print the dependency graph (`target → deps`).                  |
 | `zuke graph --output=html`          | Render an interactive HTML graph into `.zuke/` and open it.    |
@@ -223,3 +225,15 @@ honouring `--skip` and each target's `onlyWhen` condition — without executing
 any body or reading/writing the cache. Each planned target prints a
 `(dry run — not executed)` line, and the summary reflects what would have run.
 Programmatic callers pass `{ dryRun: true }` to `execute`.
+
+## Durable run state
+
+`--state` persists a versioned record of the run — its status, the graph it ran,
+resolved non-secret parameters, and per-target progress — under `.zuke/runs`, so
+it can be reconstructed after the process exits. `--actor <name>` labels who ran
+it (else `ZUKE_ACTOR`, the CI actor, or `"anonymous"`). Both are no-ops if a
+store is already configured via `ZUKE_STATE_URL` / `ZUKE_STATE_DIR` or the
+build's `stateStore()` override. A plain run with none of these writes nothing.
+See [Durable run state](./state.md) for the record shape, `ctx.state`, the
+pluggable backends, and the [HTTP API](./state-api.md) for hosting a production
+store.

--- a/docs/run-context.md
+++ b/docs/run-context.md
@@ -1,0 +1,81 @@
+# Run context & cancellation
+
+Every target body may receive a **`TargetContext`** — a small, typed handle to
+the run it is part of. It is entirely optional: an existing zero-argument body
+keeps working unchanged, because a `() => …` function is assignable to the
+one-parameter body type.
+
+```ts
+import { Build, target } from "jsr:@zuke/core";
+
+class Deploy extends Build {
+  ship = target().executes(async (ctx) => {
+    console.log(`run ${ctx.runId} · target ${ctx.target}`);
+    // ctx.signal, ctx.state, ctx.dryRun are here too — see below.
+  });
+}
+```
+
+## What's on the context
+
+| Field        | Type                | What it is                                                            |
+| ------------ | ------------------- | -------------------------------------------------------------------- |
+| `runId`      | `string`            | Unique id of this run, **stable for every target** in the run.       |
+| `target`     | `string`            | The executing target's dotted name.                                  |
+| `signal`     | `AbortSignal`       | Aborted when the run is cancelled (see below).                       |
+| `state`      | `TargetStateHandle` | Durable per-target metadata — see [Durable run state](./state.md).   |
+| `dryRun`     | `boolean`           | `true` when the run is a dry run (bodies don't execute in a dry run). |
+
+`runId` is minted once per run (`crypto.randomUUID()`), so it correlates every
+target, the run record ([Durable run state](./state.md)), and — in later
+milestones — spans and resumptions.
+
+## Cancellation
+
+A run can be cancelled by passing an `AbortSignal` to `execute`
+([programmatic API](./programmatic-api.md)):
+
+```ts
+import { execute } from "jsr:@zuke/core";
+
+const controller = new AbortController();
+const result = execute(build, build.deploy, { signal: controller.signal });
+// …later, from elsewhere:
+controller.abort();
+await result;
+```
+
+When the signal aborts:
+
+- **`ctx.signal` fires** for every in-flight target, so a body that watches it
+  can wind down cleanly.
+- **In-flight shell commands are terminated.** The run's signal is installed as
+  the shell's _ambient_ signal, so a plain `` $`…` `` in a target body is sent
+  `SIGTERM` on cancellation — no need to thread the signal through by hand:
+
+  ```ts
+  ship = target().executes(async () => {
+    await $`terraform apply`; // killed with SIGTERM if the run is cancelled
+  });
+  ```
+
+  To cancel a command explicitly (or to override the ambient signal), use
+  `.signal(...)`:
+
+  ```ts
+  await $`long-running`.signal(ctx.signal);
+  ```
+
+  `.signal()` composes with [`.killAfter()`](./shell.md): whichever fires first
+  — the timeout or the cancellation — terminates the process.
+
+A body that ignores its signal and never touches the shell still runs to
+completion; Zuke does not forcibly interrupt arbitrary JavaScript. Turning
+cancellation into a first-class graph operation — compensations that run in
+reverse order, `zuke cancel <run-id>`, `Ctrl-C` — is a later milestone.
+
+### Scope of the ambient signal
+
+The ambient signal is scoped to the run's async context (via
+`AsyncLocalStorage`), so concurrent in-process runs each see their own signal
+and none leaks past the run that set it.

--- a/docs/state-api.md
+++ b/docs/state-api.md
@@ -1,0 +1,98 @@
+# State HTTP API
+
+This is the contract a service must implement to back
+[`HttpStateStore`](./state.md#httpstatestore--hosted-service-for-production) —
+the production store for [durable run state](./state.md). Zuke ships the client;
+you host the service (a thin layer over Postgres, a key-value store, a
+k8s-annotation store, an object store, …). It is deliberately small: three
+endpoints, bearer auth, and HTTP preconditions for compare-and-swap.
+
+The client is dependency-free and talks plain HTTP, so any stack can serve it.
+
+## Conventions
+
+- **Base URL.** Configured on the client; every path below is relative to it.
+- **Auth.** If a token is configured, every request carries
+  `Authorization: Bearer <token>`. The service should reject unauthenticated
+  requests with `401`.
+- **Body.** A run record is JSON, exactly the shape in
+  [Durable run state](./state.md#the-run-record). The service should store it
+  verbatim and return it verbatim.
+- **Version = `ETag`.** Every stored run has an opaque version. The service
+  returns it as an `ETag` response header and honours it in `If-Match` /
+  `If-None-Match` request headers. Any stable per-write token works (a row
+  version, a content hash, a monotonic counter).
+
+## Endpoints
+
+### `GET /runs/:id`
+
+Fetch one run.
+
+| Response | Meaning                                                         |
+| -------- | -------------------------------------------------------------- |
+| `200`    | Body is the run record; **`ETag` header is required**.         |
+| `404`    | No such run (the client treats this as "not found", not error). |
+| other    | The client raises an error.                                    |
+
+The client **requires** the `ETag` header on a `200`; omitting it is an error.
+
+### `PUT /runs/:id`
+
+Create or update a run, guarded by a precondition:
+
+- **Create** — the client sends `If-None-Match: *`. The service must store the
+  record only if no run with that id exists yet, else respond `412`.
+- **Update** — the client sends `If-Match: <etag>`. The service must store the
+  record only if the current version equals `<etag>`, else respond `412`.
+
+| Response      | Meaning                                                       |
+| ------------- | ------------------------------------------------------------- |
+| `200`/`201`   | Stored; **`ETag` header (the new version) is required**.      |
+| `412`         | Precondition failed → the client reports a compare-and-swap conflict and retries. |
+| other         | The client raises an error.                                   |
+
+The service is the authority for versioning, which side-steps client clock
+skew. Records are small (kilobytes); whole-document CAS is the intended model.
+
+### `GET /runs?status=&target=&since=`
+
+List runs as an array of **summaries** (a subset of the record):
+
+```jsonc
+[
+  {
+    "id": "3f2a…",
+    "build": "CD",
+    "rootTarget": "deploy",
+    "status": "succeeded",
+    "actor": "alice",
+    "createdAt": "2026-07-17T…Z",
+    "updatedAt": "2026-07-17T…Z"
+  }
+]
+```
+
+Query parameters (all optional, combined with AND):
+
+| Param    | Keeps runs where…                                        |
+| -------- | -------------------------------------------------------- |
+| `status` | the run status equals this value                         |
+| `target` | the run's graph contains a target with this dotted name  |
+| `since`  | `createdAt` is at or after this ISO-8601 timestamp       |
+
+The client validates every summary it receives (an untrusted service is checked,
+not trusted) and expects newest-first ordering is applied server-side where it
+matters; it does not re-sort the list.
+
+## Notes for implementers
+
+- **Never weaker than optimistic 409-retry.** The precondition model above is
+  the minimum; a store that already does optimistic concurrency (e.g. a
+  k8s-annotation store with resource versions) maps onto it directly.
+- **Secrets.** Records never contain secret parameters (Zuke excludes them
+  before sending), but treat the store as sensitive: it holds non-secret
+  parameters, target metadata, and actor identity.
+- **Transport security.** Terminate TLS and enforce authn/authz in front of the
+  service as you would any internal API; the client provides the bridge, not a
+  gateway.

--- a/docs/state.md
+++ b/docs/state.md
@@ -1,0 +1,174 @@
+# Durable run state
+
+By default a Zuke run is entirely in-memory: when the process exits, all that
+remains is the incremental [cache](./caching.md). **Durable run state** adds a
+persistent, versioned record of a run — its status, the graph it ran, its
+resolved (non-secret) parameters, and per-target progress — so that after the
+process is gone you can reconstruct exactly what happened, and a target can
+leave metadata behind for a later run to read.
+
+It is **opt-in and zero-overhead when unused**: a plain build with no state
+configuration writes nothing and pays nothing.
+
+## Turning it on
+
+A run gets a **state store** by the first of these that applies:
+
+| Precedence | Source                                             | Selects                                    |
+| ---------- | -------------------------------------------------- | ------------------------------------------ |
+| 1          | `execute(build, root, { stateStore })`             | that store (`false` disables state)        |
+| 2          | `Build.stateStore()` override                      | the returned store                         |
+| 3          | `ZUKE_STATE_URL` (+ optional `ZUKE_STATE_TOKEN`)   | an {@link HttpStateStore} (production)     |
+| 4          | `ZUKE_STATE_DIR`                                   | a `FileSystemStateStore` at that directory |
+| 5          | `--state` (CLI) with nothing above set             | a `FileSystemStateStore` at `.zuke/runs`   |
+
+If none apply, the run has no store and no record is written.
+
+```ts
+import { Build, HttpStateStore, parameter, target } from "jsr:@zuke/core";
+
+class CD extends Build {
+  stateUrl = parameter("state service URL");
+  stateToken = parameter("state service token").secret();
+
+  override stateStore() {
+    return new HttpStateStore({
+      url: this.stateUrl.value,
+      token: this.stateToken.value,
+    });
+  }
+
+  deploy = target().executes(async (ctx) => {
+    await ctx.state.set({ target: "sit-7" }); // persisted with the run
+  });
+}
+```
+
+## The run record
+
+Each run is stored as one JSON document:
+
+```jsonc
+{
+  "id": "3f2a…",                 // == ctx.runId
+  "build": "CD",                  // the Build class name
+  "rootTarget": "deploy",         // the requested target
+  "status": "succeeded",          // running | suspended | succeeded | failed | cancelled
+  "actor": "alice",               // who ran it (see below)
+  "createdAt": "2026-07-17T…Z",
+  "updatedAt": "2026-07-17T…Z",
+  "graph": [                      // the shape it planned, in declaration order
+    { "name": "build", "dependsOn": [] },
+    { "name": "deploy", "dependsOn": ["build"] }
+  ],
+  "params": { "env": "sit" },     // resolved, NON-secret parameters only
+  "targets": {
+    "build":  { "status": "succeeded", "meta": {}, "startedAt": "…", "endedAt": "…" },
+    "deploy": { "status": "succeeded", "meta": { "target": "sit-7" }, "startedAt": "…", "endedAt": "…" }
+  }
+}
+```
+
+A target's `status` is one of `pending`, `running`, `succeeded`, `failed`,
+`skipped` (and `waiting`, from a later milestone). This is a **separate
+vocabulary** from the console's `passed`/`cached`: both of those map to
+`succeeded` in the record.
+
+The executor writes the record when it is created, on each target's start and
+finish, and when the run ends. So if the process is killed mid-run, the record
+on disk shows the target that was executing as `running`, with its `startedAt`
+stamped.
+
+## Per-target state — `ctx.state`
+
+`ctx.state` ([run context](./run-context.md)) is a small durable key/value
+store scoped to the current target:
+
+```ts
+deploy = target().executes(async (ctx) => {
+  await ctx.state.set({ target: "sit-7", image: tag }); // merge a JSON patch
+  const meta = ctx.state.get(); // read it back (this run and later ones)
+});
+```
+
+`set` merges a JSON patch into the target's `meta` and awaits the write; `get`
+returns the current metadata. When no store is configured, the handle is an
+in-memory no-op — `set`/`get` are consistent within the run, but nothing is
+persisted. It is the carrier for anything that must survive across a
+suspend/resume boundary in later milestones.
+
+### Secrets never touch state
+
+State is persisted in plain JSON and read back by later runs and by anyone who
+can read the store, so it must never hold a secret:
+
+- **Parameters:** only non-secret parameters are copied into `params`. A
+  `.secret()` parameter is structurally excluded.
+- **`ctx.state`:** every value written is run through the run's redactor first,
+  so a secret value that slips into a patch is masked (`[redacted]`) before it
+  is stored — a belt to the braces of "don't put secrets here."
+
+See [Secrets](./secrets.md).
+
+## Backends
+
+Both backends are dependency-free and pluggable behind the `StateStore`
+interface.
+
+### `FileSystemStateStore` — single host, fine for dev
+
+One JSON file per run under a directory (`.zuke/runs/<id>.json` by default).
+Writes are atomic (write-temp-then-rename) and guarded by an `O_EXCL` lock file
+so two processes on the **same host** cannot corrupt a record. The version used
+for compare-and-swap is a content hash.
+
+```ts
+import { FileSystemStateStore } from "jsr:@zuke/core";
+const store = new FileSystemStateStore(".zuke/runs");
+```
+
+### `HttpStateStore` — hosted service, for production
+
+Talks to an HTTP service you host, using ETags for optimistic concurrency. This
+is the production path: point several machines (CI, developers) at one service
+and they share run state. The one-page contract is in
+[the state HTTP API](./state-api.md).
+
+```ts
+import { HttpStateStore } from "jsr:@zuke/core";
+const store = new HttpStateStore({ url: "https://zuke-state.internal", token });
+```
+
+> **Security.** A store's URL/token and directory are trusted configuration:
+> run records (with non-secret parameters and target metadata) are sent there.
+> Point it only at a store you control, and prefer a secret parameter or an
+> environment variable over a hard-coded value.
+
+## Concurrency & compare-and-swap
+
+Writes are **compare-and-swap**: each write carries the version the writer last
+read, and only lands if the stored version still matches. Two writers racing at
+the same version → exactly one wins; the loser gets a typed conflict and
+re-reads. Within a single process, Zuke serialises its own writes, so conflicts
+only arise across processes (which a later milestone — resuming a suspended run
+— relies on).
+
+State writes are **best-effort**: a store that is briefly unavailable is
+reported through the run's reporter but never crashes the build. The build's
+real work outweighs its bookkeeping.
+
+## Inspecting runs
+
+Programmatically, a store reconstructs runs from persistence alone:
+
+```ts
+const store = new FileSystemStateStore(".zuke/runs");
+for (const summary of await store.listRuns({ status: "failed" })) {
+  const { record } = (await store.getRun(summary.id))!;
+  console.log(record.id, record.rootTarget, record.status);
+}
+```
+
+`listRuns` filters by `status`, `target`, and `since`, newest first. Inspecting
+runs from the command line (`zuke runs list` / `zuke runs show <id>`) lands with
+the CLI surface for state — see the [CLI reference](./cli.md).

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -158,6 +158,12 @@ function envCacheStore(readEnv: (name: string) => string | undefined): RemoteCac
   `ZUKE_REMOTE_CACHE_TOKEN`) selects an {@link HttpCacheStore}; otherwise
   `ZUKE_REMOTE_CACHE_DIR` selects a {@link FileSystemCacheStore}.
 
+function envStateStore(readEnv: (name: string) => string | undefined, host: StateHost): StateStore | undefined
+  Resolve a {@link StateStore} from the environment, or `undefined` when none is
+  configured. `ZUKE_STATE_URL` (with an optional `ZUKE_STATE_TOKEN`) selects an
+  {@link HttpStateStore}; otherwise `ZUKE_STATE_DIR` selects a
+  {@link FileSystemStateStore}.
+
 function envVarName(name: string): string
   The environment variable for a parameter: its path in SCREAMING_SNAKE_CASE.
 
@@ -353,6 +359,14 @@ function resolveRemoteStore(option: RemoteCacheStore | false | undefined, declar
   build's `remoteCache()` override), then the {@link envCacheStore} environment
   fallback.
 
+function resolveStateStore(option: StateStore | false | undefined, declared: StateStore | undefined, options: ResolveStateOptions): StateStore | undefined
+  Pick the state store for a run by precedence: an explicit `option` wins
+  (`false` disables state entirely), then a `declared` store (a build's
+  `stateStore()` override), then the {@link envStateStore} environment
+  fallback, then — only when {@link ResolveStateOptions.enableDefault} — a
+  filesystem store under `<root>/.zuke/runs`. A plain build with no durable
+  feature and no configuration gets `undefined`, so it carries zero overhead.
+
 async function restoreOutputs(artifact: Uint8Array, host: OutputHost): Promise<string[]>
   Restore the files in `artifact` (a gzipped tar produced by
   {@link archiveOutputs}) to disk, returning the paths written. Entry names are
@@ -442,6 +456,9 @@ const ToolTasks: ToolTasksApi
 
 const defaultRenderer: Renderer
   The built-in renderer: Zuke's ruled headers and summary table.
+
+const defaultStateHost: StateHost
+  The real, `Deno`-backed {@link StateHost}.
 
 class AnnounceError extends Error
   Raised when an announcement is run before it is fully configured.
@@ -582,6 +599,21 @@ class Build
       build = target().inputs("src").outputs("dist").executes(...);
     }
     ```
+  stateStore(): StateStore | undefined
+    The {@link "./state/store.ts".StateStore} that persists this build's run
+    records. Override to declare one in code; the default is none, and — unless
+    overridden — the executor falls back to the `ZUKE_STATE_URL` /
+    `ZUKE_STATE_DIR` environment variables, then (only when the run opts into
+    durable state) a filesystem store under `<root>/.zuke/runs`.
+
+    ```ts
+    class CD extends Build {
+      override stateStore() {
+        return new HttpStateStore({ url: this.stateUrl.value, token: this.stateToken.value });
+      }
+      deploy = target().executes(async (ctx) => { await ctx.state.set({ at: "sit-7" }); });
+    }
+    ```
 
 class CiFile
   A declared CI file. Assign one (via {@link cicd}) to a build field and Zuke
@@ -662,6 +694,27 @@ class FileSystemCacheStore implements RemoteCacheStore
   async put(key: string, artifact: Uint8Array): Promise<void>
     Store `artifact` (a gzipped tar of a target's outputs) under `key`.
 
+class FileSystemStateStore implements StateStore
+  A {@link StateStore} that writes one `<id>.json` file per run under a
+  directory.
+
+  Security. `dir` is trusted configuration — the location you choose to
+  store run state (from `ZUKE_STATE_DIR`, `--state`, or an explicit store), the
+  same posture as {@link "../remote_cache.ts".FileSystemCacheStore}. The only
+  untrusted value that reaches a path is the run id, which is validated at
+  every point a path is built, so a traversal cannot be smuggled in through an
+  id.
+
+  constructor(dir: string, host: StateHost)
+    Build the store over `dir` (created on first write). Filesystem access goes
+    through `host`, which defaults to {@link defaultStateHost}.
+  async getRun(id: string): Promise<{ record: RunRecord; version: string; } | null>
+    Fetch a run and the content-hash version of its stored file.
+  async putRun(record: RunRecord, expectedVersion: string | null): Promise<PutResult>
+    Publish `record` under an exclusive lock, guarding the expected version.
+  async listRuns(query: RunQuery): Promise<RunSummary[]>
+    List runs matching `query`, newest first. Unreadable files are skipped.
+
 class GraphError extends Error
   Raised when the build graph is invalid (cycle or unknown dependency).
 
@@ -708,6 +761,24 @@ class HttpError extends Error
     Build the error from the failing response's status and URL.
   override name: string
     The error name.
+
+class HttpStateStore implements StateStore
+  A {@link StateStore} backed by HTTP.
+
+  Security. The `url` and `token` are trusted configuration — run
+  records (which include resolved non-secret parameters and target metadata)
+  are sent to that host, so point it only at a service you control and prefer a
+  {@link "../params.ts" | secret parameter} or environment variable over a
+  hard-coded value.
+
+  constructor(options: HttpStateStoreOptions)
+    Build the store from its URL, optional token, and `fetch` seam.
+  async getRun(id: string): Promise<{ record: RunRecord; version: string; } | null>
+    `GET /runs/:id` → record + `ETag`; a `404` is a miss.
+  async putRun(record: RunRecord, expectedVersion: string | null): Promise<PutResult>
+    `PUT /runs/:id` guarded by `If-Match` / `If-None-Match`; `412` → conflict.
+  async listRuns(query: RunQuery): Promise<RunSummary[]>
+    `GET /runs?status=&target=&since=` → an array of {@link RunSummary}.
 
 class Parameter<K extends ParamValue = ParamValue, T extends K | K[] | undefined = K | undefined> implements AnyParameter
   A typed build parameter. Declare one with {@link parameter} and configure it
@@ -1470,6 +1541,19 @@ interface ExecuteOptions
     as the shell's ambient default so an in-flight `$` command is terminated
     (SIGTERM) on cancellation. A body that ignores its signal still runs to completion —
     graph-level cancellation/compensation is a later milestone.
+  stateStore?: StateStore | false
+    Durable run state (see {@link "./state/store.ts".StateStore}). A supplied
+    store is used directly; `false` disables state entirely. When omitted, the
+    build's `stateStore()` override is used, falling back to `ZUKE_STATE_URL` /
+    `ZUKE_STATE_DIR`, and finally — only when {@link state} is set — a
+    filesystem store under `<root>/.zuke/runs`.
+  state?: boolean
+    Opt a plain build into durable state (CLI `--state`): fall back to a
+    `.zuke/runs` filesystem store when nothing else is configured. Ignored when
+    a store is resolved from {@link stateStore}, the build, or the environment.
+  actor?: string
+    Who to attribute the run to in its state record (CLI `--actor`). Falls back
+    to `ZUKE_ACTOR`, then the CI actor, then `"anonymous"`.
 
 interface FanOutOptions
   Options for {@link fanOutPipeline}: how a build's targets become parallel CI
@@ -1554,6 +1638,16 @@ interface HttpOptions
   fetch?: typeof fetch
     The `fetch` implementation to use. Defaults to the global `fetch`;
     override it to unit-test without network access.
+
+interface HttpStateStoreOptions
+  Configuration for an {@link HttpStateStore}.
+
+  url: string
+    The base URL run endpoints are built under (any trailing slash is ignored).
+  token?: string
+    A bearer token sent as `Authorization: Bearer <token>`, if set.
+  fetch?: typeof fetch
+    The `fetch` implementation; defaults to the global. Overridable for tests.
 
 interface InstallPlatform
   The host identity: a Zuke {@link OperatingSystem} and {@link Architecture}.
@@ -1727,6 +1821,28 @@ interface Reporter
   error(line: string): void
     Write an error line.
 
+interface ResolveStateOptions
+  Inputs {@link resolveStateStore} needs to build the default filesystem store.
+
+  readEnv: (name: string) => string | undefined
+    Reads an environment variable (injectable for tests).
+  host: StateHost
+    Filesystem effects for the default/env filesystem store.
+  defaultDir: string
+    Directory the default filesystem store writes to (`<root>/.zuke/runs`).
+  enableDefault: boolean
+    Fall back to the default filesystem store when nothing else is configured.
+    Set when the run opts into durable state (`--state`, or — from a later
+    milestone — a durable feature like a lock or a wait).
+
+interface RunGraphNode
+  One entry of a run's graph-shape snapshot.
+
+  name: string
+    The target's dotted name.
+  dependsOn: string[]
+    The dotted names of its direct dependencies.
+
 interface RunOptions
   Options for {@link run}.
 
@@ -1738,6 +1854,59 @@ interface RunOptions
     Renderer for the per-target banners and end-of-build summary. Defaults to
     Zuke's built-in look; inject `consoleRenderer` from `@zuke/console` (or a
     custom {@link Renderer}) to restyle a build's output.
+
+interface RunQuery
+  Filters for {@link "./store.ts".StateStore.listRuns}; all fields are optional.
+
+  status?: RunStatus
+    Keep only runs with this status.
+  target?: string
+    Keep only runs whose graph contains a target with this dotted name.
+  since?: string
+    Keep only runs created at or after this ISO-8601 timestamp.
+
+interface RunRecord
+  A versioned snapshot of one run. Persisted as JSON; a store's opaque
+  `version` (an ETag / content hash) drives compare-and-swap writes.
+
+  id: string
+    Unique run ID (matches {@link "../target.ts".TargetContext} `runId`).
+  build: string
+    The build class name.
+  rootTarget: string
+    The dotted name of the requested (root) target.
+  status: RunStatus
+    The run's lifecycle status.
+  actor: string
+    Who started the run (resolved from `--actor`, `ZUKE_ACTOR`, or CI env).
+  createdAt: string
+    ISO-8601 timestamp when the run was created.
+  updatedAt: string
+    ISO-8601 timestamp of the last write.
+  graph: RunGraphNode[]
+    The graph shape the run planned, in declaration order.
+  params: Record<string, string>
+    Resolved parameter values, keyed by name. Secrets are always omitted.
+  targets: Record<string, TargetRunState>
+    Per-target progress, keyed by dotted target name.
+
+interface RunSummary
+  A compact run listing row, returned by {@link "./store.ts".StateStore.listRuns}.
+
+  id: string
+    The run ID.
+  build: string
+    The build class name.
+  rootTarget: string
+    The dotted name of the requested (root) target.
+  status: RunStatus
+    The run's lifecycle status.
+  actor: string
+    Who started the run.
+  createdAt: string
+    ISO-8601 creation timestamp.
+  updatedAt: string
+    ISO-8601 timestamp of the last write.
 
 interface RunningService
   A started service the executor holds until it tears it down.
@@ -1765,6 +1934,42 @@ interface ServiceHandle
   stop(): void | Promise<void>
     Terminate the service. Called on teardown unless `.stop()` overrides it.
 
+interface StateHost
+  Injected filesystem effects for {@link "./fs_store.ts".FileSystemStateStore},
+  so it stays unit-testable. The default implementation is
+  {@link defaultStateHost}.
+
+  readText(path: string): Promise<string | null>
+    File contents, or `null` when the file does not exist.
+  writeText(path: string, content: string): Promise<void>
+    Write a file's contents, creating parent directories as needed.
+  rename(from: string, to: string): Promise<void>
+    Rename a file (used to publish a temp file atomically).
+  createExclusive(path: string): Promise<boolean>
+    Create `path` exclusively: resolve `true` if it was created, `false` if it
+    already existed. Used as an atomic lock marker.
+  remove(path: string): Promise<void>
+    Remove a file; a missing file is not an error.
+  listDir(path: string): Promise<string[]>
+    The entry names in a directory, or `[]` when the directory is absent.
+  mkdirp(path: string): Promise<void>
+    Create a directory and any missing parents.
+
+interface StateStore
+  Pluggable persistence for run records. `version` is an opaque token (an ETag
+  or content hash) used for optimistic concurrency: a write only lands if the
+  stored version still matches the one the writer last read, so two writers
+  racing at the same version cannot both win.
+
+  getRun(id: string): Promise<{ record: RunRecord; version: string; } | null>
+    Fetch a run and its current version, or `null` if it does not exist.
+  putRun(record: RunRecord, expectedVersion: string | null): Promise<PutResult>
+    Write `record` only if the stored version equals `expectedVersion` (`null`
+    meaning "must not exist yet"). Returns the new version, or a conflict when
+    the stored version has moved on — the caller re-reads and retries.
+  listRuns(query: RunQuery): Promise<RunSummary[]>
+    List runs matching `query`, newest first (by `createdAt`, then `id`).
+
 interface Style
   How a run renders its output.
 
@@ -1786,9 +1991,9 @@ interface TarEntry
 interface TargetContext
   The context passed to every target body. Optional to receive — an existing
   zero-argument `.executes(() => …)` stays valid, since a zero-argument
-  function is assignable to this one-parameter type — but a body that wants the run's
-  identity, a cancellation signal, or (in later milestones) durable state and
-  external-signal payloads reads them here.
+  function is assignable to this one-parameter type — but a body that wants the
+  run's identity, a cancellation signal, or durable per-target state reads them
+  here.
 
   readonly runId: string
     Unique ID of this run, stable for every target in the run.
@@ -1799,6 +2004,11 @@ interface TargetContext
     `signal`). Pass it to a shell command's `.signal()` to have that command
     terminated on cancellation; the executor also applies it as the shell's
     ambient default, so a plain `$` in the body is terminated too.
+  readonly state: TargetStateHandle
+    Durable per-target metadata. Persisted to the run's state store when one is
+    configured (see {@link "./state/store.ts".StateStore}), and an in-memory
+    no-op otherwise. The carrier for state that must survive across a
+    suspend/resume boundary — do not put secrets in it.
   readonly dryRun: boolean
     True when the run is a dry run (bodies do not execute under a dry run).
 
@@ -1811,6 +2021,35 @@ interface TargetReport
     The target's terminal status.
   ms: number
     The target's wall-clock duration in milliseconds.
+
+interface TargetRunState
+  The recorded progress of a single target.
+
+  status: TargetRunStatus
+    The target's current status within the run.
+  meta: Record<string, JsonValue>
+    Durable metadata written via {@link "../target.ts".TargetStateHandle}.
+  startedAt?: string
+    ISO-8601 timestamp when the body started, if it has.
+  endedAt?: string
+    ISO-8601 timestamp when the target settled, if it has.
+  error?: string
+    The failure message when `status` is `failed`.
+
+interface TargetStateHandle
+  A target's durable, per-target metadata, surfaced on {@link TargetContext} as
+  `state`. Writes are persisted to the run's state store (see
+  {@link "./state/store.ts".StateStore}) and are visible to later runs — e.g. a
+  resuming process reading what a suspended target recorded. When no store is
+  configured, the handle is an in-memory no-op scoped to the current run.
+
+  Never store a secret here — state is persisted in plain JSON and read
+  back by later runs and by `zuke runs show`.
+
+  set(patch: Record<string, JsonValue>): Promise<void>
+    Merge a JSON patch into this target's persisted metadata (awaits the write).
+  get(): Record<string, JsonValue>
+    Read this target's persisted metadata (from prior attempts/runs too).
 
 interface ToolTasksApi
   The task surface of {@link ToolTasks}.
@@ -1873,6 +2112,10 @@ type Condition = () => boolean | Promise<boolean>
 type DownloadFn = (url: string, dest: PathLike) => Promise<void>
   A download function: fetch `url` into the file at `dest`.
 
+type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue; }
+  A JSON-serialisable value — the only thing that may be persisted in a
+  target's {@link TargetStateHandle}, since run state is stored as JSON.
+
 type OperatingSystem = "linux" | "macos" | "windows"
   The operating systems Zuke recognises — Deno's raw `Deno.build.os` values
   normalised to a friendly set (notably `darwin` → `macos`). Used across the
@@ -1889,12 +2132,23 @@ type PathLike = string | AbsolutePath
   {@link AbsolutePath}. Anywhere a tool wrapper or build helper takes a path,
   it accepts a `PathLike` and coerces it to a string.
 
+type PutResult = { ok: true; version: string; } | { ok: false; conflict: true; }
+  The result of a {@link StateStore.putRun} compare-and-swap write.
+
+type RunStatus = "running" | "suspended" | "succeeded" | "failed" | "cancelled"
+  The lifecycle status of a whole run.
+
 type Target = TargetBuilder
   A configured target. Alias of {@link TargetBuilder} — the same object both
   builds and represents the target. Exposed as `Target` for use in signatures.
 
 type TargetFn = (ctx: TargetContext) => void | Promise<void>
   The executable body of a target. May be synchronous or asynchronous.
+
+type TargetRunStatus = "pending" | "running" | "waiting" | "succeeded" | "failed" | "skipped"
+  The status of one target within a run record. `waiting` (a suspended
+  external-event wait) is produced only from a later milestone; the executor
+  records the others.
 
 type TargetStatus = "passed" | "failed" | "skipped" | "cached"
   The outcome of a single target, reported in the summary and lifecycle hooks.

--- a/llms.txt
+++ b/llms.txt
@@ -56,6 +56,8 @@ Option flags:
 - `--no-remote-cache` — Use the local cache only; skip the remote cache store
 - `--affected` — Run only targets affected by changes since a git base
 - `--dry-run` — Print the plan without running targets
+- `--state` — Persist durable run state to .zuke/runs
+- `--actor` — Attribute the run to <name> in its state record
 - `--output` — Graph output format: text or html
 - `--no-open` — With --output=html, do not open a browser
 - `--check` — With generate-ci, verify files are current

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -212,6 +212,12 @@ function envCacheStore(readEnv: (name: string) => string | undefined): RemoteCac
   `ZUKE_REMOTE_CACHE_TOKEN`) selects an {@link HttpCacheStore}; otherwise
   `ZUKE_REMOTE_CACHE_DIR` selects a {@link FileSystemCacheStore}.
 
+function envStateStore(readEnv: (name: string) => string | undefined, host: StateHost): StateStore | undefined
+  Resolve a {@link StateStore} from the environment, or `undefined` when none is
+  configured. `ZUKE_STATE_URL` (with an optional `ZUKE_STATE_TOKEN`) selects an
+  {@link HttpStateStore}; otherwise `ZUKE_STATE_DIR` selects a
+  {@link FileSystemStateStore}.
+
 function envVarName(name: string): string
   The environment variable for a parameter: its path in SCREAMING_SNAKE_CASE.
 
@@ -407,6 +413,14 @@ function resolveRemoteStore(option: RemoteCacheStore | false | undefined, declar
   build's `remoteCache()` override), then the {@link envCacheStore} environment
   fallback.
 
+function resolveStateStore(option: StateStore | false | undefined, declared: StateStore | undefined, options: ResolveStateOptions): StateStore | undefined
+  Pick the state store for a run by precedence: an explicit `option` wins
+  (`false` disables state entirely), then a `declared` store (a build's
+  `stateStore()` override), then the {@link envStateStore} environment
+  fallback, then — only when {@link ResolveStateOptions.enableDefault} — a
+  filesystem store under `<root>/.zuke/runs`. A plain build with no durable
+  feature and no configuration gets `undefined`, so it carries zero overhead.
+
 async function restoreOutputs(artifact: Uint8Array, host: OutputHost): Promise<string[]>
   Restore the files in `artifact` (a gzipped tar produced by
   {@link archiveOutputs}) to disk, returning the paths written. Entry names are
@@ -496,6 +510,9 @@ const ToolTasks: ToolTasksApi
 
 const defaultRenderer: Renderer
   The built-in renderer: Zuke's ruled headers and summary table.
+
+const defaultStateHost: StateHost
+  The real, `Deno`-backed {@link StateHost}.
 
 class AnnounceError extends Error
   Raised when an announcement is run before it is fully configured.
@@ -636,6 +653,21 @@ class Build
       build = target().inputs("src").outputs("dist").executes(...);
     }
     ```
+  stateStore(): StateStore | undefined
+    The {@link "./state/store.ts".StateStore} that persists this build's run
+    records. Override to declare one in code; the default is none, and — unless
+    overridden — the executor falls back to the `ZUKE_STATE_URL` /
+    `ZUKE_STATE_DIR` environment variables, then (only when the run opts into
+    durable state) a filesystem store under `<root>/.zuke/runs`.
+
+    ```ts
+    class CD extends Build {
+      override stateStore() {
+        return new HttpStateStore({ url: this.stateUrl.value, token: this.stateToken.value });
+      }
+      deploy = target().executes(async (ctx) => { await ctx.state.set({ at: "sit-7" }); });
+    }
+    ```
 
 class CiFile
   A declared CI file. Assign one (via {@link cicd}) to a build field and Zuke
@@ -716,6 +748,27 @@ class FileSystemCacheStore implements RemoteCacheStore
   async put(key: string, artifact: Uint8Array): Promise<void>
     Store `artifact` (a gzipped tar of a target's outputs) under `key`.
 
+class FileSystemStateStore implements StateStore
+  A {@link StateStore} that writes one `<id>.json` file per run under a
+  directory.
+
+  Security. `dir` is trusted configuration — the location you choose to
+  store run state (from `ZUKE_STATE_DIR`, `--state`, or an explicit store), the
+  same posture as {@link "../remote_cache.ts".FileSystemCacheStore}. The only
+  untrusted value that reaches a path is the run id, which is validated at
+  every point a path is built, so a traversal cannot be smuggled in through an
+  id.
+
+  constructor(dir: string, host: StateHost)
+    Build the store over `dir` (created on first write). Filesystem access goes
+    through `host`, which defaults to {@link defaultStateHost}.
+  async getRun(id: string): Promise<{ record: RunRecord; version: string; } | null>
+    Fetch a run and the content-hash version of its stored file.
+  async putRun(record: RunRecord, expectedVersion: string | null): Promise<PutResult>
+    Publish `record` under an exclusive lock, guarding the expected version.
+  async listRuns(query: RunQuery): Promise<RunSummary[]>
+    List runs matching `query`, newest first. Unreadable files are skipped.
+
 class GraphError extends Error
   Raised when the build graph is invalid (cycle or unknown dependency).
 
@@ -762,6 +815,24 @@ class HttpError extends Error
     Build the error from the failing response's status and URL.
   override name: string
     The error name.
+
+class HttpStateStore implements StateStore
+  A {@link StateStore} backed by HTTP.
+
+  Security. The `url` and `token` are trusted configuration — run
+  records (which include resolved non-secret parameters and target metadata)
+  are sent to that host, so point it only at a service you control and prefer a
+  {@link "../params.ts" | secret parameter} or environment variable over a
+  hard-coded value.
+
+  constructor(options: HttpStateStoreOptions)
+    Build the store from its URL, optional token, and `fetch` seam.
+  async getRun(id: string): Promise<{ record: RunRecord; version: string; } | null>
+    `GET /runs/:id` → record + `ETag`; a `404` is a miss.
+  async putRun(record: RunRecord, expectedVersion: string | null): Promise<PutResult>
+    `PUT /runs/:id` guarded by `If-Match` / `If-None-Match`; `412` → conflict.
+  async listRuns(query: RunQuery): Promise<RunSummary[]>
+    `GET /runs?status=&target=&since=` → an array of {@link RunSummary}.
 
 class Parameter<K extends ParamValue = ParamValue, T extends K | K[] | undefined = K | undefined> implements AnyParameter
   A typed build parameter. Declare one with {@link parameter} and configure it
@@ -1524,6 +1595,19 @@ interface ExecuteOptions
     as the shell's ambient default so an in-flight `$` command is terminated
     (SIGTERM) on cancellation. A body that ignores its signal still runs to completion —
     graph-level cancellation/compensation is a later milestone.
+  stateStore?: StateStore | false
+    Durable run state (see {@link "./state/store.ts".StateStore}). A supplied
+    store is used directly; `false` disables state entirely. When omitted, the
+    build's `stateStore()` override is used, falling back to `ZUKE_STATE_URL` /
+    `ZUKE_STATE_DIR`, and finally — only when {@link state} is set — a
+    filesystem store under `<root>/.zuke/runs`.
+  state?: boolean
+    Opt a plain build into durable state (CLI `--state`): fall back to a
+    `.zuke/runs` filesystem store when nothing else is configured. Ignored when
+    a store is resolved from {@link stateStore}, the build, or the environment.
+  actor?: string
+    Who to attribute the run to in its state record (CLI `--actor`). Falls back
+    to `ZUKE_ACTOR`, then the CI actor, then `"anonymous"`.
 
 interface FanOutOptions
   Options for {@link fanOutPipeline}: how a build's targets become parallel CI
@@ -1608,6 +1692,16 @@ interface HttpOptions
   fetch?: typeof fetch
     The `fetch` implementation to use. Defaults to the global `fetch`;
     override it to unit-test without network access.
+
+interface HttpStateStoreOptions
+  Configuration for an {@link HttpStateStore}.
+
+  url: string
+    The base URL run endpoints are built under (any trailing slash is ignored).
+  token?: string
+    A bearer token sent as `Authorization: Bearer <token>`, if set.
+  fetch?: typeof fetch
+    The `fetch` implementation; defaults to the global. Overridable for tests.
 
 interface InstallPlatform
   The host identity: a Zuke {@link OperatingSystem} and {@link Architecture}.
@@ -1781,6 +1875,28 @@ interface Reporter
   error(line: string): void
     Write an error line.
 
+interface ResolveStateOptions
+  Inputs {@link resolveStateStore} needs to build the default filesystem store.
+
+  readEnv: (name: string) => string | undefined
+    Reads an environment variable (injectable for tests).
+  host: StateHost
+    Filesystem effects for the default/env filesystem store.
+  defaultDir: string
+    Directory the default filesystem store writes to (`<root>/.zuke/runs`).
+  enableDefault: boolean
+    Fall back to the default filesystem store when nothing else is configured.
+    Set when the run opts into durable state (`--state`, or — from a later
+    milestone — a durable feature like a lock or a wait).
+
+interface RunGraphNode
+  One entry of a run's graph-shape snapshot.
+
+  name: string
+    The target's dotted name.
+  dependsOn: string[]
+    The dotted names of its direct dependencies.
+
 interface RunOptions
   Options for {@link run}.
 
@@ -1792,6 +1908,59 @@ interface RunOptions
     Renderer for the per-target banners and end-of-build summary. Defaults to
     Zuke's built-in look; inject `consoleRenderer` from `@zuke/console` (or a
     custom {@link Renderer}) to restyle a build's output.
+
+interface RunQuery
+  Filters for {@link "./store.ts".StateStore.listRuns}; all fields are optional.
+
+  status?: RunStatus
+    Keep only runs with this status.
+  target?: string
+    Keep only runs whose graph contains a target with this dotted name.
+  since?: string
+    Keep only runs created at or after this ISO-8601 timestamp.
+
+interface RunRecord
+  A versioned snapshot of one run. Persisted as JSON; a store's opaque
+  `version` (an ETag / content hash) drives compare-and-swap writes.
+
+  id: string
+    Unique run ID (matches {@link "../target.ts".TargetContext} `runId`).
+  build: string
+    The build class name.
+  rootTarget: string
+    The dotted name of the requested (root) target.
+  status: RunStatus
+    The run's lifecycle status.
+  actor: string
+    Who started the run (resolved from `--actor`, `ZUKE_ACTOR`, or CI env).
+  createdAt: string
+    ISO-8601 timestamp when the run was created.
+  updatedAt: string
+    ISO-8601 timestamp of the last write.
+  graph: RunGraphNode[]
+    The graph shape the run planned, in declaration order.
+  params: Record<string, string>
+    Resolved parameter values, keyed by name. Secrets are always omitted.
+  targets: Record<string, TargetRunState>
+    Per-target progress, keyed by dotted target name.
+
+interface RunSummary
+  A compact run listing row, returned by {@link "./store.ts".StateStore.listRuns}.
+
+  id: string
+    The run ID.
+  build: string
+    The build class name.
+  rootTarget: string
+    The dotted name of the requested (root) target.
+  status: RunStatus
+    The run's lifecycle status.
+  actor: string
+    Who started the run.
+  createdAt: string
+    ISO-8601 creation timestamp.
+  updatedAt: string
+    ISO-8601 timestamp of the last write.
 
 interface RunningService
   A started service the executor holds until it tears it down.
@@ -1819,6 +1988,42 @@ interface ServiceHandle
   stop(): void | Promise<void>
     Terminate the service. Called on teardown unless `.stop()` overrides it.
 
+interface StateHost
+  Injected filesystem effects for {@link "./fs_store.ts".FileSystemStateStore},
+  so it stays unit-testable. The default implementation is
+  {@link defaultStateHost}.
+
+  readText(path: string): Promise<string | null>
+    File contents, or `null` when the file does not exist.
+  writeText(path: string, content: string): Promise<void>
+    Write a file's contents, creating parent directories as needed.
+  rename(from: string, to: string): Promise<void>
+    Rename a file (used to publish a temp file atomically).
+  createExclusive(path: string): Promise<boolean>
+    Create `path` exclusively: resolve `true` if it was created, `false` if it
+    already existed. Used as an atomic lock marker.
+  remove(path: string): Promise<void>
+    Remove a file; a missing file is not an error.
+  listDir(path: string): Promise<string[]>
+    The entry names in a directory, or `[]` when the directory is absent.
+  mkdirp(path: string): Promise<void>
+    Create a directory and any missing parents.
+
+interface StateStore
+  Pluggable persistence for run records. `version` is an opaque token (an ETag
+  or content hash) used for optimistic concurrency: a write only lands if the
+  stored version still matches the one the writer last read, so two writers
+  racing at the same version cannot both win.
+
+  getRun(id: string): Promise<{ record: RunRecord; version: string; } | null>
+    Fetch a run and its current version, or `null` if it does not exist.
+  putRun(record: RunRecord, expectedVersion: string | null): Promise<PutResult>
+    Write `record` only if the stored version equals `expectedVersion` (`null`
+    meaning "must not exist yet"). Returns the new version, or a conflict when
+    the stored version has moved on — the caller re-reads and retries.
+  listRuns(query: RunQuery): Promise<RunSummary[]>
+    List runs matching `query`, newest first (by `createdAt`, then `id`).
+
 interface Style
   How a run renders its output.
 
@@ -1840,9 +2045,9 @@ interface TarEntry
 interface TargetContext
   The context passed to every target body. Optional to receive — an existing
   zero-argument `.executes(() => …)` stays valid, since a zero-argument
-  function is assignable to this one-parameter type — but a body that wants the run's
-  identity, a cancellation signal, or (in later milestones) durable state and
-  external-signal payloads reads them here.
+  function is assignable to this one-parameter type — but a body that wants the
+  run's identity, a cancellation signal, or durable per-target state reads them
+  here.
 
   readonly runId: string
     Unique ID of this run, stable for every target in the run.
@@ -1853,6 +2058,11 @@ interface TargetContext
     `signal`). Pass it to a shell command's `.signal()` to have that command
     terminated on cancellation; the executor also applies it as the shell's
     ambient default, so a plain `$` in the body is terminated too.
+  readonly state: TargetStateHandle
+    Durable per-target metadata. Persisted to the run's state store when one is
+    configured (see {@link "./state/store.ts".StateStore}), and an in-memory
+    no-op otherwise. The carrier for state that must survive across a
+    suspend/resume boundary — do not put secrets in it.
   readonly dryRun: boolean
     True when the run is a dry run (bodies do not execute under a dry run).
 
@@ -1865,6 +2075,35 @@ interface TargetReport
     The target's terminal status.
   ms: number
     The target's wall-clock duration in milliseconds.
+
+interface TargetRunState
+  The recorded progress of a single target.
+
+  status: TargetRunStatus
+    The target's current status within the run.
+  meta: Record<string, JsonValue>
+    Durable metadata written via {@link "../target.ts".TargetStateHandle}.
+  startedAt?: string
+    ISO-8601 timestamp when the body started, if it has.
+  endedAt?: string
+    ISO-8601 timestamp when the target settled, if it has.
+  error?: string
+    The failure message when `status` is `failed`.
+
+interface TargetStateHandle
+  A target's durable, per-target metadata, surfaced on {@link TargetContext} as
+  `state`. Writes are persisted to the run's state store (see
+  {@link "./state/store.ts".StateStore}) and are visible to later runs — e.g. a
+  resuming process reading what a suspended target recorded. When no store is
+  configured, the handle is an in-memory no-op scoped to the current run.
+
+  Never store a secret here — state is persisted in plain JSON and read
+  back by later runs and by `zuke runs show`.
+
+  set(patch: Record<string, JsonValue>): Promise<void>
+    Merge a JSON patch into this target's persisted metadata (awaits the write).
+  get(): Record<string, JsonValue>
+    Read this target's persisted metadata (from prior attempts/runs too).
 
 interface ToolTasksApi
   The task surface of {@link ToolTasks}.
@@ -1927,6 +2166,10 @@ type Condition = () => boolean | Promise<boolean>
 type DownloadFn = (url: string, dest: PathLike) => Promise<void>
   A download function: fetch `url` into the file at `dest`.
 
+type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue; }
+  A JSON-serialisable value — the only thing that may be persisted in a
+  target's {@link TargetStateHandle}, since run state is stored as JSON.
+
 type OperatingSystem = "linux" | "macos" | "windows"
   The operating systems Zuke recognises — Deno's raw `Deno.build.os` values
   normalised to a friendly set (notably `darwin` → `macos`). Used across the
@@ -1943,12 +2186,23 @@ type PathLike = string | AbsolutePath
   {@link AbsolutePath}. Anywhere a tool wrapper or build helper takes a path,
   it accepts a `PathLike` and coerces it to a string.
 
+type PutResult = { ok: true; version: string; } | { ok: false; conflict: true; }
+  The result of a {@link StateStore.putRun} compare-and-swap write.
+
+type RunStatus = "running" | "suspended" | "succeeded" | "failed" | "cancelled"
+  The lifecycle status of a whole run.
+
 type Target = TargetBuilder
   A configured target. Alias of {@link TargetBuilder} — the same object both
   builds and represents the target. Exposed as `Target` for use in signatures.
 
 type TargetFn = (ctx: TargetContext) => void | Promise<void>
   The executable body of a target. May be synchronous or asynchronous.
+
+type TargetRunStatus = "pending" | "running" | "waiting" | "succeeded" | "failed" | "skipped"
+  The status of one target within a run record. `waiting` (a suspended
+  external-event wait) is produced only from a later milestone; the executor
+  records the others.
 
 type TargetStatus = "passed" | "failed" | "skipped" | "cached"
   The outcome of a single target, reported in the summary and lifecycle hooks.

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -44,6 +44,7 @@ export {
   type Condition,
   Group,
   group,
+  type JsonValue,
   type Remediation,
   type RemediationContext,
   type RemediationResult,
@@ -52,6 +53,7 @@ export {
   TargetBuilder,
   type TargetContext,
   type TargetFn,
+  type TargetStateHandle,
   type Validation,
   type ValidationContext,
 } from "./src/target.ts";
@@ -91,6 +93,31 @@ export {
   resolveRemoteStore,
   restoreOutputs,
 } from "./src/remote_cache.ts";
+export {
+  defaultStateHost,
+  type PutResult,
+  type StateHost,
+  type StateStore,
+} from "./src/state/store.ts";
+export {
+  type RunGraphNode,
+  type RunQuery,
+  type RunRecord,
+  type RunStatus,
+  type RunSummary,
+  type TargetRunState,
+  type TargetRunStatus,
+} from "./src/state/types.ts";
+export { FileSystemStateStore } from "./src/state/fs_store.ts";
+export {
+  HttpStateStore,
+  type HttpStateStoreOptions,
+} from "./src/state/http_store.ts";
+export {
+  envStateStore,
+  type ResolveStateOptions,
+  resolveStateStore,
+} from "./src/state/resolve.ts";
 export { type AbsolutePath, absolutePath, type PathLike } from "./src/path.ts";
 export { CONFIG_FILE, repoRoot } from "./src/config.ts";
 export {

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -11,6 +11,7 @@
 
 import { Group, type Remediation, TargetBuilder } from "./target.ts";
 import type { RemoteCacheStore } from "./remote_cache.ts";
+import type { StateStore } from "./state/store.ts";
 
 /** Whether a value is a plain object (a component bundle), not a class instance. */
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -111,6 +112,26 @@ export class Build {
    * ```
    */
   remoteCache(): RemoteCacheStore | undefined {
+    return undefined;
+  }
+
+  /**
+   * The {@link "./state/store.ts".StateStore} that persists this build's run
+   * records. Override to declare one in code; the default is none, and — unless
+   * overridden — the executor falls back to the `ZUKE_STATE_URL` /
+   * `ZUKE_STATE_DIR` environment variables, then (only when the run opts into
+   * durable state) a filesystem store under `<root>/.zuke/runs`.
+   *
+   * ```ts
+   * class CD extends Build {
+   *   override stateStore() {
+   *     return new HttpStateStore({ url: this.stateUrl.value, token: this.stateToken.value });
+   *   }
+   *   deploy = target().executes(async (ctx) => { await ctx.state.set({ at: "sit-7" }); });
+   * }
+   * ```
+   */
+  stateStore(): StateStore | undefined {
     return undefined;
   }
 }

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -105,6 +105,10 @@ export interface ParsedArgs {
   affectedBase?: string;
   /** Print the plan without running any target bodies (`--dry-run`). */
   dryRun: boolean;
+  /** Persist durable run state to `.zuke/runs` when nothing else configures a store (`--state`). */
+  state: boolean;
+  /** Attribute the run to this actor in its state record (`--actor <name>`). */
+  actor?: string;
   /** Raw parameter values from declared flags, keyed by property name. */
   values: Record<string, string>;
   help: boolean;
@@ -141,6 +145,7 @@ export function parseArgs(
     values: {},
     affected: false,
     dryRun: false,
+    state: false,
     help: false,
   };
   const byFlag = new Map<string, ParamFlag>();
@@ -165,6 +170,13 @@ export function parseArgs(
       parsed.affectedBase = arg.slice("--affected=".length);
     } else if (arg === "--dry-run") {
       parsed.dryRun = true;
+    } else if (arg === "--state") {
+      parsed.state = true;
+    } else if (arg === "--actor") {
+      const who = args[++i];
+      if (who) parsed.actor = who;
+    } else if (arg.startsWith("--actor=")) {
+      parsed.actor = arg.slice("--actor=".length);
     } else if (arg === "--check") {
       parsed.check = true;
     } else if (arg === "--allow-run") {
@@ -251,6 +263,12 @@ Options:
                     changed file is under its declared inputs or a dependency is
                     affected; targets with no declared inputs always run.
   --dry-run         Print the execution plan without running target bodies.
+  --state           Persist durable run state under .zuke/runs (a run record
+                    with per-target status and metadata), unless a store is
+                    already configured via ZUKE_STATE_URL/ZUKE_STATE_DIR or the
+                    build's stateStore(). See docs/state.md.
+  --actor <name>    Attribute the run to <name> in its state record (else
+                    ZUKE_ACTOR, the CI actor, or "anonymous").
   --list, -l        List all targets with descriptions and dependencies.
   --json            With --list, print the build surface (commands, flags,
                     targets, parameters) as JSON for tools and agents.
@@ -545,6 +563,8 @@ export async function main(
     remoteCache: parsed.remoteCache === false ? false : undefined,
     affected: parsed.affected ? { base: parsed.affectedBase } : undefined,
     dryRun: parsed.dryRun,
+    state: parsed.state,
+    actor: parsed.actor,
     plugins: options.plugins,
     renderer: options.renderer,
   });

--- a/packages/core/src/cli_spec.ts
+++ b/packages/core/src/cli_spec.ts
@@ -73,6 +73,14 @@ export const BUILTIN_FLAGS: readonly BuiltinFlag[] = [
     description: "Run only targets affected by changes since a git base",
   },
   { name: "--dry-run", description: "Print the plan without running targets" },
+  {
+    name: "--state",
+    description: "Persist durable run state to .zuke/runs",
+  },
+  {
+    name: "--actor",
+    description: "Attribute the run to <name> in its state record",
+  },
   { name: "--output", description: "Graph output format: text or html" },
   {
     name: "--no-open",

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -40,6 +40,10 @@ import { Redactor } from "./redact.ts";
 import { absolutePath } from "./path.ts";
 import type { Remediation, TargetBuilder, TargetContext } from "./target.ts";
 import { withAmbientSignal } from "./ambient_signal.ts";
+import { defaultStateHost, type StateStore } from "./state/store.ts";
+import { resolveStateStore } from "./state/resolve.ts";
+import { buildRunRecord, resolveActor } from "./state/record.ts";
+import { inMemoryStateHandle, RunStateWriter } from "./state/writer.ts";
 import type { Plugin } from "./plugin.ts";
 import { detectWidth, type Style, type TargetReport } from "./report.ts";
 import { defaultRenderer, type Renderer } from "./renderer.ts";
@@ -165,6 +169,25 @@ export interface ExecuteOptions {
    * graph-level cancellation/compensation is a later milestone.
    */
   signal?: AbortSignal;
+  /**
+   * Durable run state (see {@link "./state/store.ts".StateStore}). A supplied
+   * store is used directly; `false` disables state entirely. When omitted, the
+   * build's `stateStore()` override is used, falling back to `ZUKE_STATE_URL` /
+   * `ZUKE_STATE_DIR`, and finally — only when {@link state} is set — a
+   * filesystem store under `<root>/.zuke/runs`.
+   */
+  stateStore?: StateStore | false;
+  /**
+   * Opt a plain build into durable state (CLI `--state`): fall back to a
+   * `.zuke/runs` filesystem store when nothing else is configured. Ignored when
+   * a store is resolved from {@link stateStore}, the build, or the environment.
+   */
+  state?: boolean;
+  /**
+   * Who to attribute the run to in its state record (CLI `--actor`). Falls back
+   * to `ZUKE_ACTOR`, then the CI actor, then `"anonymous"`.
+   */
+  actor?: string;
 }
 
 /** Whether the build is running inside a GitHub Actions runner. */
@@ -350,6 +373,23 @@ interface RunOutcome {
 }
 
 /**
+ * Per-run values threaded to the schedulers and each target: the run id, the
+ * cancellation signal handed to every {@link TargetContext}, and the optional
+ * durable-state writer that records transitions.
+ */
+interface RunEnv {
+  runId: string;
+  signal: AbortSignal;
+  writer?: RunStateWriter;
+}
+
+/** A failure's message, or `undefined` when there was none — for the state record. */
+function errorMessage(error: unknown): string | undefined {
+  if (error === undefined) return undefined;
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
  * The merged lifecycle: the build's own hooks plus any registered plugins,
  * invoked in order (build first, then each plugin). The run functions call
  * through this so they need not know about plugins.
@@ -505,8 +545,7 @@ async function runTarget(
   dryRun: boolean,
   globalRecovery: Remediation[],
   services: ServiceRegistry,
-  runId: string,
-  runSignal: AbortSignal,
+  env: RunEnv,
 ): Promise<TargetOutcome> {
   const name = t.name_ ?? "<unnamed>";
 
@@ -539,6 +578,7 @@ async function runTarget(
   if (t instanceof ServiceBuilder) {
     openTarget(reporter, renderer, style, name, opened);
     await life.targetStart(name);
+    void env.writer?.markTargetRunning(name);
     const start = performance.now();
     try {
       services.register(await t.launch_(name));
@@ -558,6 +598,7 @@ async function runTarget(
 
   openTarget(reporter, renderer, style, name, opened);
   await life.targetStart(name);
+  void env.writer?.markTargetRunning(name);
   const start = performance.now();
 
   if (!t.fn_) {
@@ -568,7 +609,13 @@ async function runTarget(
     return { status: "failed", ms: 0, error };
   }
 
-  const ctx: TargetContext = { runId, target: name, signal: runSignal, dryRun };
+  const ctx: TargetContext = {
+    runId: env.runId,
+    target: name,
+    signal: env.signal,
+    state: env.writer ? env.writer.stateHandle(name) : inMemoryStateHandle(),
+    dryRun,
+  };
   try {
     for (const v of t.validateBefore_) await v.validate({ target: name });
     await runBodyWithRecovery(t, name, globalRecovery, ctx);
@@ -629,8 +676,7 @@ async function runSequential(
   dryRun: boolean,
   globalRecovery: Remediation[],
   services: ServiceRegistry,
-  runId: string,
-  runSignal: AbortSignal,
+  env: RunEnv,
 ): Promise<RunOutcome> {
   const reports: TargetReport[] = [];
   const executed: string[] = [];
@@ -642,6 +688,7 @@ async function runSequential(
     const name = t.name_ ?? "<unnamed>";
     if (skip.has(name) || aborted) {
       reports.push({ name, status: "skipped", ms: 0 });
+      void env.writer?.markTargetSettled(name, "skipped");
       continue;
     }
     const outcome = await runTarget(
@@ -655,10 +702,14 @@ async function runSequential(
       dryRun,
       globalRecovery,
       services,
-      runId,
-      runSignal,
+      env,
     );
     await life.targetEnd(name, outcome.status);
+    void env.writer?.markTargetSettled(
+      name,
+      outcome.status,
+      errorMessage(outcome.error),
+    );
     if (outcome.status === "passed" || outcome.status === "failed") opened++;
     reports.push({ name, status: outcome.status, ms: outcome.ms });
     if (outcome.status === "passed") executed.push(name);
@@ -694,8 +745,7 @@ async function runScheduled(
   dryRun: boolean,
   globalRecovery: Remediation[],
   services: ServiceRegistry,
-  runId: string,
-  runSignal: AbortSignal,
+  env: RunEnv,
 ): Promise<RunOutcome> {
   const outcomes = new Map<TargetBuilder, TargetOutcome>();
   const done = new Set<TargetBuilder>(); // passed/cached/skipped → unblocks dependents
@@ -712,6 +762,7 @@ async function runScheduled(
       outcomes.set(t, { status: "skipped", ms: 0 });
       done.add(t);
       started.add(t);
+      void env.writer?.markTargetSettled(t.name_ ?? "<unnamed>", "skipped");
     }
   }
 
@@ -742,12 +793,16 @@ async function runScheduled(
           dryRun,
           globalRecovery,
           services,
-          runId,
-          runSignal,
+          env,
         )
           .then(
             async (outcome) => {
               await life.targetEnd(t.name_ ?? "<unnamed>", outcome.status);
+              void env.writer?.markTargetSettled(
+                t.name_ ?? "<unnamed>",
+                outcome.status,
+                errorMessage(outcome.error),
+              );
               // Only an executed target prints a block worth separating.
               const printed = outcome.status === "passed" ||
                 outcome.status === "failed";
@@ -776,6 +831,10 @@ async function runScheduled(
           if (!started.has(t)) {
             outcomes.set(t, { status: "skipped", ms: 0 });
             started.add(t);
+            void env.writer?.markTargetSettled(
+              t.name_ ?? "<unnamed>",
+              "skipped",
+            );
           }
         }
         resolve();
@@ -927,6 +986,42 @@ export async function execute(
     else options.signal.addEventListener("abort", onCancel, { once: true });
   }
 
+  // Resolve the durable state store (if any) and open a writer that records the
+  // run and its per-target transitions. Never for a dry run — no body executes,
+  // so there is no run to persist. State writes are best-effort: a store hiccup
+  // is reported, never fatal (see RunStateWriter).
+  const stateStore = dryRun ? undefined : resolveStateStore(
+    options.stateStore,
+    build.stateStore(),
+    {
+      readEnv,
+      host: defaultStateHost,
+      defaultDir: absolutePath(
+        findConfigDir(Deno.cwd(), pathExists) ?? Deno.cwd(),
+      )(ARTIFACT_DIR, "runs").path,
+      enableDefault: options.state ?? false,
+    },
+  );
+  const nowIso = () => new Date().toISOString();
+  const writer = stateStore === undefined
+    ? undefined
+    : await RunStateWriter.open(
+      stateStore,
+      buildRunRecord({
+        runId,
+        build: build.constructor.name,
+        rootTarget: root.name_ ?? "<unnamed>",
+        actor: resolveActor(options.actor, readEnv),
+        now: nowIso(),
+        order,
+        params: params.values(),
+      }),
+      nowIso,
+      redactor,
+      (message) => reporter.info(message),
+    );
+  const env: RunEnv = { runId, signal: runController.signal, writer };
+
   // Services started during the run are held here and torn down in reverse
   // order once it finishes — in a `finally`, so a failure never leaks a process.
   const services = new ServiceRegistry();
@@ -943,8 +1038,7 @@ export async function execute(
         dryRun,
         globalRecovery,
         services,
-        runId,
-        runController.signal,
+        env,
       );
     }
     // With `--parallel`, anything independent may overlap up to `limit`.
@@ -969,8 +1063,7 @@ export async function execute(
       dryRun,
       globalRecovery,
       services,
-      runId,
-      runController.signal,
+      env,
     );
   };
 
@@ -993,6 +1086,10 @@ export async function execute(
   const result: BuildResult = run.aborted
     ? { ok: false, executed: run.executed, error: run.failure }
     : { ok: true, executed: run.executed };
+
+  // Record the run's terminal status. Awaiting this drains the writer's queue,
+  // so every per-target transition has landed by the time the run returns.
+  await writer?.markRunFinished(result.ok);
 
   const totalMs = performance.now() - overallStart;
   for (

--- a/packages/core/src/state/fs_store.ts
+++ b/packages/core/src/state/fs_store.ts
@@ -1,0 +1,195 @@
+/**
+ * {@link FileSystemStateStore} — a {@link StateStore} backed by one JSON file
+ * per run under a directory (default `<repo root>/.zuke/runs`).
+ *
+ * It is single-host by design (fine for dev, per the requirement); production
+ * uses {@link "./http_store.ts".HttpStateStore}. Compare-and-swap is enforced
+ * with an `O_EXCL` lock marker plus an atomic temp-file rename: a writer takes
+ * the lock, re-reads the current version, and only publishes if it still
+ * matches — so two writers racing at the same version cannot both win. The
+ * version is a content hash, mirroring the ETag the HTTP backend uses.
+ *
+ * @module
+ */
+
+import {
+  defaultStateHost,
+  type PutResult,
+  type StateHost,
+  type StateStore,
+} from "./store.ts";
+import {
+  parseRunRecord,
+  type RunQuery,
+  type RunRecord,
+  type RunSummary,
+  stringifyRunRecord,
+  toSummary,
+} from "./types.ts";
+
+const encoder = new TextEncoder();
+
+/** Hex SHA-256 of a UTF-8 string — the opaque CAS version of a stored record. */
+async function hashText(text: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", encoder.encode(text));
+  return Array.from(
+    new Uint8Array(digest),
+    (b) => b.toString(16).padStart(2, "0"),
+  ).join("");
+}
+
+/**
+ * Reject a run id that could escape the runs directory. Ids are UUIDs in
+ * normal use; this guards the case where one arrives from the CLI or a query.
+ */
+function assertSafeId(id: string): void {
+  if (!/^[A-Za-z0-9._-]+$/.test(id)) {
+    throw new Error(`state: unsafe run id "${id}"`);
+  }
+}
+
+/** How long to wait for a contended lock before giving up. */
+const LOCK_ATTEMPTS = 100;
+const LOCK_DELAY_MS = 10;
+
+/** Resolve after `ms` milliseconds. */
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * A {@link StateStore} that writes one `<id>.json` file per run under a
+ * directory.
+ *
+ * **Security.** `dir` is *trusted configuration* — the location you choose to
+ * store run state (from `ZUKE_STATE_DIR`, `--state`, or an explicit store), the
+ * same posture as {@link "../remote_cache.ts".FileSystemCacheStore}. The only
+ * untrusted value that reaches a path is the run **id**, which is validated at
+ * every point a path is built, so a traversal cannot be smuggled in through an
+ * id.
+ */
+export class FileSystemStateStore implements StateStore {
+  readonly #dir: string;
+  readonly #host: StateHost;
+  #ensured = false;
+
+  /**
+   * Build the store over `dir` (created on first write). Filesystem access goes
+   * through `host`, which defaults to {@link defaultStateHost}.
+   */
+  constructor(dir: string, host: StateHost = defaultStateHost) {
+    this.#dir = dir.replace(/\/+$/, "");
+    this.#host = host;
+  }
+
+  // Every run-id-derived path is built through these two helpers, and both
+  // validate the id — so a traversal can't slip in via a caller that forgets to
+  // check (defence in depth, not a reliance on the boundary).
+  #file(id: string): string {
+    assertSafeId(id);
+    return `${this.#dir}/${id}.json`;
+  }
+
+  #lock(id: string): string {
+    assertSafeId(id);
+    return `${this.#dir}/${id}.json.lock`;
+  }
+
+  async #ensureDir(): Promise<void> {
+    if (this.#ensured) return;
+    await this.#host.mkdirp(this.#dir);
+    this.#ensured = true;
+  }
+
+  /** Fetch a run and the content-hash version of its stored file. */
+  async getRun(
+    id: string,
+  ): Promise<{ record: RunRecord; version: string } | null> {
+    const text = await this.#host.readText(this.#file(id));
+    if (text === null) return null;
+    return { record: parseRunRecord(text), version: await hashText(text) };
+  }
+
+  /** Publish `record` under an exclusive lock, guarding the expected version. */
+  async putRun(
+    record: RunRecord,
+    expectedVersion: string | null,
+  ): Promise<PutResult> {
+    // #lock/#file validate record.id before any path is used below.
+    await this.#ensureDir();
+    return await this.#withLock(record.id, async () => {
+      const current = await this.#host.readText(this.#file(record.id));
+      const currentVersion = current === null ? null : await hashText(current);
+      if (currentVersion !== expectedVersion) {
+        return { ok: false, conflict: true };
+      }
+      const content = stringifyRunRecord(record);
+      const tmp = `${this.#file(record.id)}.tmp-${crypto.randomUUID()}`;
+      await this.#host.writeText(tmp, content);
+      await this.#host.rename(tmp, this.#file(record.id));
+      return { ok: true, version: await hashText(content) };
+    });
+  }
+
+  /** List runs matching `query`, newest first. Unreadable files are skipped. */
+  async listRuns(query: RunQuery): Promise<RunSummary[]> {
+    const names = await this.#host.listDir(this.#dir);
+    const summaries: RunSummary[] = [];
+    for (const name of names) {
+      if (!name.endsWith(".json")) continue; // skip .lock / .tmp-* markers
+      const text = await this.#host.readText(`${this.#dir}/${name}`);
+      if (text === null) continue;
+      let record: RunRecord;
+      try {
+        record = parseRunRecord(text);
+      } catch {
+        continue; // a corrupt/partial file must not break listing the rest
+      }
+      if (matches(record, query)) summaries.push(toSummary(record));
+    }
+    return sortNewestFirst(summaries);
+  }
+
+  /** Take the run's lock (spinning briefly on contention), run `fn`, release. */
+  async #withLock<T>(id: string, fn: () => Promise<T>): Promise<T> {
+    const lock = this.#lock(id);
+    for (let attempt = 0; attempt < LOCK_ATTEMPTS; attempt++) {
+      if (await this.#host.createExclusive(lock)) {
+        try {
+          return await fn();
+        } finally {
+          await this.#host.remove(lock);
+        }
+      }
+      await delay(LOCK_DELAY_MS);
+    }
+    throw new Error(
+      `state: could not acquire the lock for run "${id}" — ` +
+        `a stale ${lock} may need removing.`,
+    );
+  }
+}
+
+/** Whether a record passes a {@link RunQuery}. */
+function matches(record: RunRecord, query: RunQuery): boolean {
+  if (query.status !== undefined && record.status !== query.status) {
+    return false;
+  }
+  if (
+    query.target !== undefined &&
+    !record.graph.some((node) => node.name === query.target)
+  ) {
+    return false;
+  }
+  if (query.since !== undefined && record.createdAt < query.since) return false;
+  return true;
+}
+
+/** Sort by `createdAt` descending, then `id` descending, for stable output. */
+function sortNewestFirst(summaries: RunSummary[]): RunSummary[] {
+  return summaries.sort((a, b) =>
+    a.createdAt !== b.createdAt
+      ? (a.createdAt < b.createdAt ? 1 : -1)
+      : (a.id < b.id ? 1 : a.id > b.id ? -1 : 0)
+  );
+}

--- a/packages/core/src/state/http_store.ts
+++ b/packages/core/src/state/http_store.ts
@@ -1,0 +1,141 @@
+/**
+ * {@link HttpStateStore} — a {@link StateStore} backed by a hosted HTTP service,
+ * the production path for durable run state. See `docs/state-api.md` for the
+ * one-page REST contract a consumer implements.
+ *
+ * Compare-and-swap rides on HTTP preconditions: `GET /runs/:id` returns the
+ * record and an `ETag`; `PUT /runs/:id` sends `If-Match: <etag>` (or
+ * `If-None-Match: *` to create), and the server answers `412 Precondition
+ * Failed` when the version has moved on. The option shape mirrors
+ * {@link "../remote_cache.ts".HttpCacheStore} — `{ url, token?, fetch? }`, the
+ * `fetch` seam keeping tests hermetic.
+ *
+ * @module
+ */
+
+import { HttpError } from "../http.ts";
+import type { PutResult, StateStore } from "./store.ts";
+import {
+  parseRunRecord,
+  parseRunSummary,
+  type RunQuery,
+  type RunRecord,
+  type RunSummary,
+  stringifyRunRecord,
+} from "./types.ts";
+
+/** Configuration for an {@link HttpStateStore}. */
+export interface HttpStateStoreOptions {
+  /** The base URL run endpoints are built under (any trailing slash is ignored). */
+  url: string;
+  /** A bearer token sent as `Authorization: Bearer <token>`, if set. */
+  token?: string;
+  /** The `fetch` implementation; defaults to the global. Overridable for tests. */
+  fetch?: typeof fetch;
+}
+
+/**
+ * A {@link StateStore} backed by HTTP.
+ *
+ * **Security.** The `url` and `token` are *trusted configuration* — run
+ * records (which include resolved non-secret parameters and target metadata)
+ * are sent to that host, so point it only at a service you control and prefer a
+ * {@link "../params.ts" | secret parameter} or environment variable over a
+ * hard-coded value.
+ */
+export class HttpStateStore implements StateStore {
+  readonly #base: string;
+  readonly #token?: string;
+  readonly #fetch: typeof fetch;
+
+  /** Build the store from its URL, optional token, and `fetch` seam. */
+  constructor(options: HttpStateStoreOptions) {
+    this.#base = options.url.replace(/\/+$/, "");
+    this.#token = options.token;
+    this.#fetch = options.fetch ?? fetch;
+  }
+
+  #runUrl(id: string): string {
+    return `${this.#base}/runs/${encodeURIComponent(id)}`;
+  }
+
+  #headers(extra?: Record<string, string>): Record<string, string> {
+    const headers: Record<string, string> = { ...extra };
+    if (this.#token !== undefined && this.#token !== "") {
+      headers.Authorization = `Bearer ${this.#token}`;
+    }
+    return headers;
+  }
+
+  /** `GET /runs/:id` → record + `ETag`; a `404` is a miss. */
+  async getRun(
+    id: string,
+  ): Promise<{ record: RunRecord; version: string } | null> {
+    const url = this.#runUrl(id);
+    const response = await this.#fetch(url, { headers: this.#headers() });
+    if (response.status === 404) {
+      await response.body?.cancel();
+      return null;
+    }
+    if (!response.ok) {
+      await response.body?.cancel();
+      throw new HttpError(response.status, url);
+    }
+    const version = response.headers.get("etag");
+    const text = await response.text();
+    if (version === null) {
+      throw new Error(`state: ${url} did not return an ETag`);
+    }
+    return { record: parseRunRecord(text), version };
+  }
+
+  /** `PUT /runs/:id` guarded by `If-Match` / `If-None-Match`; `412` → conflict. */
+  async putRun(
+    record: RunRecord,
+    expectedVersion: string | null,
+  ): Promise<PutResult> {
+    const url = this.#runUrl(record.id);
+    const precondition: Record<string, string> = expectedVersion === null
+      ? { "If-None-Match": "*" }
+      : { "If-Match": expectedVersion };
+    const response = await this.#fetch(url, {
+      method: "PUT",
+      headers: this.#headers({
+        "content-type": "application/json",
+        ...precondition,
+      }),
+      body: stringifyRunRecord(record),
+    });
+    if (response.status === 412) {
+      await response.body?.cancel();
+      return { ok: false, conflict: true };
+    }
+    await response.body?.cancel();
+    if (!response.ok) throw new HttpError(response.status, url);
+    const version = response.headers.get("etag");
+    if (version === null) {
+      throw new Error(`state: ${url} did not return an ETag on write`);
+    }
+    return { ok: true, version };
+  }
+
+  /** `GET /runs?status=&target=&since=` → an array of {@link RunSummary}. */
+  async listRuns(query: RunQuery): Promise<RunSummary[]> {
+    const params = new URLSearchParams();
+    if (query.status !== undefined) params.set("status", query.status);
+    if (query.target !== undefined) params.set("target", query.target);
+    if (query.since !== undefined) params.set("since", query.since);
+    const qs = params.toString();
+    const url = `${this.#base}/runs${qs === "" ? "" : `?${qs}`}`;
+    const response = await this.#fetch(url, { headers: this.#headers() });
+    if (!response.ok) {
+      await response.body?.cancel();
+      throw new HttpError(response.status, url);
+    }
+    const parsed: unknown = JSON.parse(await response.text());
+    if (!Array.isArray(parsed)) {
+      throw new Error(`state: ${url} did not return a JSON array`);
+    }
+    return parsed.map(parseRunSummary);
+  }
+}

--- a/packages/core/src/state/record.ts
+++ b/packages/core/src/state/record.ts
@@ -1,0 +1,111 @@
+/**
+ * Building a {@link RunRecord} from a planned build, and the small mappings the
+ * executor needs to keep the record current.
+ *
+ * Secrets are excluded structurally: only non-secret parameter values are
+ * copied into {@link RunRecord.params}. The record's per-target status is a
+ * different vocabulary from the executor's {@link TargetStatus} — see
+ * {@link recordStatusOf}.
+ *
+ * @module
+ */
+
+import type { TargetStatus } from "../build.ts";
+import type { AnyParameter } from "../params.ts";
+import type { TargetBuilder } from "../target.ts";
+import type { RunRecord, TargetRunState, TargetRunStatus } from "./types.ts";
+
+/** Map an executor {@link TargetStatus} onto a {@link TargetRunStatus}. */
+export function recordStatusOf(status: TargetStatus): TargetRunStatus {
+  switch (status) {
+    case "passed":
+    case "cached":
+      return "succeeded";
+    case "failed":
+      return "failed";
+    case "skipped":
+      return "skipped";
+  }
+}
+
+/**
+ * Resolve who a run is attributed to: the explicit `--actor`, then
+ * `ZUKE_ACTOR`, then the CI actor (`GITHUB_ACTOR`), else `"anonymous"`. A later
+ * milestone widens this to bearer-token and MCP-client identities.
+ */
+export function resolveActor(
+  explicit: string | undefined,
+  readEnv: (name: string) => string | undefined,
+): string {
+  const candidates = [explicit, readEnv("ZUKE_ACTOR"), readEnv("GITHUB_ACTOR")];
+  for (const candidate of candidates) {
+    if (candidate !== undefined && candidate !== "") return candidate;
+  }
+  return "anonymous";
+}
+
+/** The inputs needed to build a run's initial {@link RunRecord}. */
+export interface RunRecordInput {
+  /** The run's unique id. */
+  runId: string;
+  /** The build class name. */
+  build: string;
+  /** The dotted name of the requested (root) target. */
+  rootTarget: string;
+  /** The resolved run actor. */
+  actor: string;
+  /** ISO-8601 timestamp used for `createdAt` and the initial `updatedAt`. */
+  now: string;
+  /** The planned targets, in execution/declaration order. */
+  order: TargetBuilder[];
+  /** All discovered parameters (secrets are skipped when copying values). */
+  params: Iterable<AnyParameter>;
+}
+
+/**
+ * Build the initial {@link RunRecord} for a run: status `running`, a graph-shape
+ * snapshot in declaration order, resolved non-secret parameters, and every
+ * planned target seeded `pending`.
+ */
+export function buildRunRecord(input: RunRecordInput): RunRecord {
+  const graph = input.order.map((t) => ({
+    name: t.name_ ?? "",
+    dependsOn: dependencyNames(t),
+  }));
+
+  const params: Record<string, string> = {};
+  for (const parameter of input.params) {
+    if (parameter.secret_ || !parameter.isSet_()) continue;
+    const value = parameter.stringValue_();
+    if (parameter.name_ !== undefined && value !== undefined) {
+      params[parameter.name_] = value;
+    }
+  }
+
+  const targets: Record<string, TargetRunState> = {};
+  for (const t of input.order) {
+    targets[t.name_ ?? ""] = { status: "pending", meta: {} };
+  }
+
+  return {
+    id: input.runId,
+    build: input.build,
+    rootTarget: input.rootTarget,
+    status: "running",
+    actor: input.actor,
+    createdAt: input.now,
+    updatedAt: input.now,
+    graph,
+    params,
+    targets,
+  };
+}
+
+/** The dotted names of a target's direct dependencies (undefined names dropped). */
+function dependencyNames(target: TargetBuilder): string[] {
+  const names: string[] = [];
+  for (const dependency of target.dependsOn_) {
+    if (dependency.name_ !== undefined) names.push(dependency.name_);
+  }
+  return names;
+}

--- a/packages/core/src/state/resolve.ts
+++ b/packages/core/src/state/resolve.ts
@@ -1,0 +1,71 @@
+/**
+ * Selection of the {@link StateStore} for a run, by precedence — the state
+ * analogue of {@link "../remote_cache.ts".resolveRemoteStore}.
+ *
+ * @module
+ */
+
+import type { StateHost, StateStore } from "./store.ts";
+import { FileSystemStateStore } from "./fs_store.ts";
+import { HttpStateStore } from "./http_store.ts";
+
+/**
+ * Resolve a {@link StateStore} from the environment, or `undefined` when none is
+ * configured. `ZUKE_STATE_URL` (with an optional `ZUKE_STATE_TOKEN`) selects an
+ * {@link HttpStateStore}; otherwise `ZUKE_STATE_DIR` selects a
+ * {@link FileSystemStateStore}.
+ */
+export function envStateStore(
+  readEnv: (name: string) => string | undefined,
+  host: StateHost,
+): StateStore | undefined {
+  const url = readEnv("ZUKE_STATE_URL");
+  if (url !== undefined && url !== "") {
+    return new HttpStateStore({ url, token: readEnv("ZUKE_STATE_TOKEN") });
+  }
+  const dir = readEnv("ZUKE_STATE_DIR");
+  if (dir !== undefined && dir !== "") {
+    return new FileSystemStateStore(dir, host);
+  }
+  return undefined;
+}
+
+/** Inputs {@link resolveStateStore} needs to build the default filesystem store. */
+export interface ResolveStateOptions {
+  /** Reads an environment variable (injectable for tests). */
+  readEnv: (name: string) => string | undefined;
+  /** Filesystem effects for the default/env filesystem store. */
+  host: StateHost;
+  /** Directory the default filesystem store writes to (`<root>/.zuke/runs`). */
+  defaultDir: string;
+  /**
+   * Fall back to the default filesystem store when nothing else is configured.
+   * Set when the run opts into durable state (`--state`, or — from a later
+   * milestone — a durable feature like a lock or a wait).
+   */
+  enableDefault: boolean;
+}
+
+/**
+ * Pick the state store for a run by precedence: an explicit `option` wins
+ * (`false` disables state entirely), then a `declared` store (a build's
+ * `stateStore()` override), then the {@link envStateStore} environment
+ * fallback, then — only when {@link ResolveStateOptions.enableDefault} — a
+ * filesystem store under `<root>/.zuke/runs`. A plain build with no durable
+ * feature and no configuration gets `undefined`, so it carries zero overhead.
+ */
+export function resolveStateStore(
+  option: StateStore | false | undefined,
+  declared: StateStore | undefined,
+  options: ResolveStateOptions,
+): StateStore | undefined {
+  if (option === false) return undefined;
+  if (option !== undefined) return option;
+  if (declared !== undefined) return declared;
+  const fromEnv = envStateStore(options.readEnv, options.host);
+  if (fromEnv !== undefined) return fromEnv;
+  if (options.enableDefault) {
+    return new FileSystemStateStore(options.defaultDir, options.host);
+  }
+  return undefined;
+}

--- a/packages/core/src/state/store.ts
+++ b/packages/core/src/state/store.ts
@@ -1,0 +1,118 @@
+/**
+ * The pluggable {@link StateStore} — persistence for {@link RunRecord}s — and
+ * its injected filesystem host.
+ *
+ * The shape mirrors the remote-cache layer: a small interface plus an injected
+ * host of filesystem effects, so the default backend stays unit-testable. Two
+ * backends ship (both dependency-free): {@link "./fs_store.ts".FileSystemStateStore}
+ * for a single host (fine for dev) and {@link "./http_store.ts".HttpStateStore}
+ * for a hosted service (the production path — see `docs/state-api.md`).
+ * Selection lives in {@link "./resolve.ts".resolveStateStore}. A later
+ * milestone adds lock methods to this same interface.
+ *
+ * @module
+ */
+
+import type { RunQuery, RunRecord, RunSummary } from "./types.ts";
+
+/** The result of a {@link StateStore.putRun} compare-and-swap write. */
+export type PutResult =
+  | { ok: true; version: string }
+  | { ok: false; conflict: true };
+
+/**
+ * Pluggable persistence for run records. `version` is an opaque token (an ETag
+ * or content hash) used for optimistic concurrency: a write only lands if the
+ * stored version still matches the one the writer last read, so two writers
+ * racing at the same version cannot both win.
+ */
+export interface StateStore {
+  /** Fetch a run and its current version, or `null` if it does not exist. */
+  getRun(id: string): Promise<{ record: RunRecord; version: string } | null>;
+  /**
+   * Write `record` only if the stored version equals `expectedVersion` (`null`
+   * meaning "must not exist yet"). Returns the new version, or a conflict when
+   * the stored version has moved on — the caller re-reads and retries.
+   */
+  putRun(
+    record: RunRecord,
+    expectedVersion: string | null,
+  ): Promise<PutResult>;
+  /** List runs matching `query`, newest first (by `createdAt`, then `id`). */
+  listRuns(query: RunQuery): Promise<RunSummary[]>;
+}
+
+/**
+ * Injected filesystem effects for {@link "./fs_store.ts".FileSystemStateStore},
+ * so it stays unit-testable. The default implementation is
+ * {@link defaultStateHost}.
+ */
+export interface StateHost {
+  /** File contents, or `null` when the file does not exist. */
+  readText(path: string): Promise<string | null>;
+  /** Write a file's contents, creating parent directories as needed. */
+  writeText(path: string, content: string): Promise<void>;
+  /** Rename a file (used to publish a temp file atomically). */
+  rename(from: string, to: string): Promise<void>;
+  /**
+   * Create `path` exclusively: resolve `true` if it was created, `false` if it
+   * already existed. Used as an atomic lock marker.
+   */
+  createExclusive(path: string): Promise<boolean>;
+  /** Remove a file; a missing file is not an error. */
+  remove(path: string): Promise<void>;
+  /** The entry names in a directory, or `[]` when the directory is absent. */
+  listDir(path: string): Promise<string[]>;
+  /** Create a directory and any missing parents. */
+  mkdirp(path: string): Promise<void>;
+}
+
+/** The real, `Deno`-backed {@link StateHost}. */
+export const defaultStateHost: StateHost = {
+  async readText(path: string): Promise<string | null> {
+    try {
+      return await Deno.readTextFile(path);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) return null;
+      throw error;
+    }
+  },
+  async writeText(path: string, content: string): Promise<void> {
+    const slash = path.replace(/\\/g, "/").lastIndexOf("/");
+    if (slash > 0) await Deno.mkdir(path.slice(0, slash), { recursive: true });
+    await Deno.writeTextFile(path, content);
+  },
+  rename(from: string, to: string): Promise<void> {
+    return Deno.rename(from, to);
+  },
+  async createExclusive(path: string): Promise<boolean> {
+    try {
+      const file = await Deno.open(path, { createNew: true, write: true });
+      file.close();
+      return true;
+    } catch (error) {
+      if (error instanceof Deno.errors.AlreadyExists) return false;
+      throw error;
+    }
+  },
+  async remove(path: string): Promise<void> {
+    try {
+      await Deno.remove(path);
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) throw error;
+    }
+  },
+  async listDir(path: string): Promise<string[]> {
+    const names: string[] = [];
+    try {
+      for await (const entry of Deno.readDir(path)) names.push(entry.name);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) return [];
+      throw error;
+    }
+    return names;
+  },
+  async mkdirp(path: string): Promise<void> {
+    await Deno.mkdir(path, { recursive: true });
+  },
+};

--- a/packages/core/src/state/types.ts
+++ b/packages/core/src/state/types.ts
@@ -1,0 +1,345 @@
+/**
+ * The durable run-state vocabulary: {@link RunRecord} and its parts.
+ *
+ * A run record is a versioned JSON snapshot of one build run — its status, the
+ * graph shape it ran, resolved (non-secret) parameters, and per-target
+ * progress. It is written to a {@link "./store.ts".StateStore} at each state
+ * transition so a run's full status can be reconstructed after the process
+ * exits, and (from later milestones) so a suspended run can be resumed by a
+ * different process.
+ *
+ * The record's target statuses are a **different vocabulary** from the
+ * executor's in-memory {@link "../build.ts".TargetStatus} (`passed`/`cached`
+ * both map to `succeeded`; `waiting` exists only here) — the two are kept
+ * separate on purpose.
+ *
+ * @module
+ */
+
+import type { JsonValue } from "../target.ts";
+
+/** The lifecycle status of a whole run. */
+export type RunStatus =
+  | "running"
+  | "suspended"
+  | "succeeded"
+  | "failed"
+  | "cancelled";
+
+/**
+ * The status of one target within a run record. `waiting` (a suspended
+ * external-event wait) is produced only from a later milestone; the executor
+ * records the others.
+ */
+export type TargetRunStatus =
+  | "pending"
+  | "running"
+  | "waiting"
+  | "succeeded"
+  | "failed"
+  | "skipped";
+
+/** The recorded progress of a single target. */
+export interface TargetRunState {
+  /** The target's current status within the run. */
+  status: TargetRunStatus;
+  /** Durable metadata written via {@link "../target.ts".TargetStateHandle}. */
+  meta: Record<string, JsonValue>;
+  /** ISO-8601 timestamp when the body started, if it has. */
+  startedAt?: string;
+  /** ISO-8601 timestamp when the target settled, if it has. */
+  endedAt?: string;
+  /** The failure message when `status` is `failed`. */
+  error?: string;
+}
+
+/** One entry of a run's graph-shape snapshot. */
+export interface RunGraphNode {
+  /** The target's dotted name. */
+  name: string;
+  /** The dotted names of its direct dependencies. */
+  dependsOn: string[];
+}
+
+/**
+ * A versioned snapshot of one run. Persisted as JSON; a store's opaque
+ * `version` (an ETag / content hash) drives compare-and-swap writes.
+ */
+export interface RunRecord {
+  /** Unique run ID (matches {@link "../target.ts".TargetContext} `runId`). */
+  id: string;
+  /** The build class name. */
+  build: string;
+  /** The dotted name of the requested (root) target. */
+  rootTarget: string;
+  /** The run's lifecycle status. */
+  status: RunStatus;
+  /** Who started the run (resolved from `--actor`, `ZUKE_ACTOR`, or CI env). */
+  actor: string;
+  /** ISO-8601 timestamp when the run was created. */
+  createdAt: string;
+  /** ISO-8601 timestamp of the last write. */
+  updatedAt: string;
+  /** The graph shape the run planned, in declaration order. */
+  graph: RunGraphNode[];
+  /** Resolved parameter values, keyed by name. Secrets are always omitted. */
+  params: Record<string, string>;
+  /** Per-target progress, keyed by dotted target name. */
+  targets: Record<string, TargetRunState>;
+}
+
+/** A compact run listing row, returned by {@link "./store.ts".StateStore.listRuns}. */
+export interface RunSummary {
+  /** The run ID. */
+  id: string;
+  /** The build class name. */
+  build: string;
+  /** The dotted name of the requested (root) target. */
+  rootTarget: string;
+  /** The run's lifecycle status. */
+  status: RunStatus;
+  /** Who started the run. */
+  actor: string;
+  /** ISO-8601 creation timestamp. */
+  createdAt: string;
+  /** ISO-8601 timestamp of the last write. */
+  updatedAt: string;
+}
+
+/** Filters for {@link "./store.ts".StateStore.listRuns}; all fields are optional. */
+export interface RunQuery {
+  /** Keep only runs with this status. */
+  status?: RunStatus;
+  /** Keep only runs whose graph contains a target with this dotted name. */
+  target?: string;
+  /** Keep only runs created at or after this ISO-8601 timestamp. */
+  since?: string;
+}
+
+/** The projection of a {@link RunRecord} down to its {@link RunSummary}. */
+export function toSummary(record: RunRecord): RunSummary {
+  return {
+    id: record.id,
+    build: record.build,
+    rootTarget: record.rootTarget,
+    status: record.status,
+    actor: record.actor,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+  };
+}
+
+/** All valid {@link RunStatus} values, for validation. */
+const RUN_STATUSES: readonly RunStatus[] = [
+  "running",
+  "suspended",
+  "succeeded",
+  "failed",
+  "cancelled",
+];
+
+/** All valid {@link TargetRunStatus} values, for validation. */
+const TARGET_STATUSES: readonly TargetRunStatus[] = [
+  "pending",
+  "running",
+  "waiting",
+  "succeeded",
+  "failed",
+  "skipped",
+];
+
+/** Serialise a run record to the canonical stored form (pretty JSON + newline). */
+export function stringifyRunRecord(record: RunRecord): string {
+  return `${JSON.stringify(record, null, 2)}\n`;
+}
+
+/** Narrow an unknown value to a plain object without casting, else `null`. */
+function asObject(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  const out: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value)) out[key] = val;
+  return out;
+}
+
+/** Read a required string field, throwing a descriptive error if it is not one. */
+function str(object: Record<string, unknown>, field: string): string {
+  const value = object[field];
+  if (typeof value !== "string") {
+    throw new Error(`state: run record field "${field}" is not a string`);
+  }
+  return value;
+}
+
+/** Read an optional string field, throwing if present but not a string. */
+function optionalStr(
+  object: Record<string, unknown>,
+  field: string,
+): string | undefined {
+  const value = object[field];
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") {
+    throw new Error(`state: run record field "${field}" is not a string`);
+  }
+  return value;
+}
+
+/** Validate a target status string, narrowing it to {@link TargetRunStatus}. */
+function targetStatus(value: string): TargetRunStatus {
+  const match = TARGET_STATUSES.find((s) => s === value);
+  if (match === undefined) {
+    throw new Error(`state: unknown target status "${value}"`);
+  }
+  return match;
+}
+
+/** Validate and narrow one target's recorded state. */
+function parseTargetState(value: unknown): TargetRunState {
+  const object = asObject(value);
+  if (object === null) throw new Error("state: target state is not an object");
+  const meta = asObject(object.meta);
+  const state: TargetRunState = {
+    status: targetStatus(str(object, "status")),
+    meta: meta === null ? {} : parseJsonRecord(meta),
+  };
+  // Only set optional fields that are present, so a round-trip preserves the
+  // exact key set (JSON drops undefined, so re-parsing must not re-add them).
+  const startedAt = optionalStr(object, "startedAt");
+  if (startedAt !== undefined) state.startedAt = startedAt;
+  const endedAt = optionalStr(object, "endedAt");
+  if (endedAt !== undefined) state.endedAt = endedAt;
+  const error = optionalStr(object, "error");
+  if (error !== undefined) state.error = error;
+  return state;
+}
+
+/** Coerce an object's values to {@link JsonValue}s (they came from JSON already). */
+function parseJsonRecord(
+  object: Record<string, unknown>,
+): Record<string, JsonValue> {
+  const out: Record<string, JsonValue> = {};
+  for (const [key, value] of Object.entries(object)) {
+    out[key] = toJsonValue(value);
+  }
+  return out;
+}
+
+/** Coerce a value parsed from JSON to a {@link JsonValue} (rejects functions etc.). */
+function toJsonValue(value: unknown): JsonValue {
+  if (value === null) return null;
+  if (Array.isArray(value)) return value.map(toJsonValue);
+  switch (typeof value) {
+    case "string":
+    case "number":
+    case "boolean":
+      return value;
+    case "object": {
+      const object = asObject(value);
+      return object === null ? null : parseJsonRecord(object);
+    }
+    default:
+      throw new Error(`state: value of type "${typeof value}" is not JSON`);
+  }
+}
+
+/**
+ * Parse and validate a stored run record. Throws a descriptive error when the
+ * text is not JSON or does not match the {@link RunRecord} shape — the HTTP
+ * backend reads records from a service Zuke does not control, so the shape is
+ * checked rather than trusted.
+ */
+export function parseRunRecord(text: string): RunRecord {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error("state: run record is not valid JSON");
+  }
+  const object = asObject(parsed);
+  if (object === null) throw new Error("state: run record is not an object");
+
+  const status = str(object, "status");
+  const runStatus = RUN_STATUSES.find((s) => s === status);
+  if (runStatus === undefined) {
+    throw new Error(`state: unknown run status "${status}"`);
+  }
+
+  const rawGraph = object.graph;
+  if (!Array.isArray(rawGraph)) {
+    throw new Error(`state: run record field "graph" is not an array`);
+  }
+  const graph: RunGraphNode[] = rawGraph.map((node) => {
+    const n = asObject(node);
+    if (n === null) throw new Error("state: graph node is not an object");
+    const dependsOn = n.dependsOn;
+    if (
+      !Array.isArray(dependsOn) || dependsOn.some((d) => typeof d !== "string")
+    ) {
+      throw new Error(`state: graph node "dependsOn" is not a string array`);
+    }
+    return { name: str(n, "name"), dependsOn: dependsOn.filter(isString) };
+  });
+
+  const rawParams = asObject(object.params);
+  if (rawParams === null) {
+    throw new Error(`state: run record field "params" is not an object`);
+  }
+  const params: Record<string, string> = {};
+  for (const [key, value] of Object.entries(rawParams)) {
+    if (typeof value !== "string") {
+      throw new Error(`state: param "${key}" is not a string`);
+    }
+    params[key] = value;
+  }
+
+  const rawTargets = asObject(object.targets);
+  if (rawTargets === null) {
+    throw new Error(`state: run record field "targets" is not an object`);
+  }
+  const targets: Record<string, TargetRunState> = {};
+  for (const [name, value] of Object.entries(rawTargets)) {
+    targets[name] = parseTargetState(value);
+  }
+
+  return {
+    id: str(object, "id"),
+    build: str(object, "build"),
+    rootTarget: str(object, "rootTarget"),
+    status: runStatus,
+    actor: str(object, "actor"),
+    createdAt: str(object, "createdAt"),
+    updatedAt: str(object, "updatedAt"),
+    graph,
+    params,
+    targets,
+  };
+}
+
+/** A `filter` type guard that narrows to `string`. */
+function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+/**
+ * Parse and validate a {@link RunSummary} from an untrusted value (an element
+ * of the HTTP list response). Throws when a field is missing or the wrong type.
+ */
+export function parseRunSummary(value: unknown): RunSummary {
+  const object = asObject(value);
+  if (object === null) throw new Error("state: run summary is not an object");
+  const status = str(object, "status");
+  const runStatus = RUN_STATUSES.find((s) => s === status);
+  if (runStatus === undefined) {
+    throw new Error(`state: unknown run status "${status}"`);
+  }
+  return {
+    id: str(object, "id"),
+    build: str(object, "build"),
+    rootTarget: str(object, "rootTarget"),
+    status: runStatus,
+    actor: str(object, "actor"),
+    createdAt: str(object, "createdAt"),
+    updatedAt: str(object, "updatedAt"),
+  };
+}

--- a/packages/core/src/state/writer.ts
+++ b/packages/core/src/state/writer.ts
@@ -1,0 +1,205 @@
+/**
+ * {@link RunStateWriter} — the executor's live view of a run's {@link RunRecord},
+ * persisting each transition to a {@link StateStore}.
+ *
+ * Writes are serialised through an internal promise chain, so concurrent
+ * targets never race each other's compare-and-swap; a conflict from *another*
+ * process is handled by re-reading and re-applying. Every write is best-effort:
+ * a store hiccup is reported through `warn` but never crashes the build — the
+ * build's real work outweighs its bookkeeping. Every value written through
+ * {@link "../target.ts".TargetStateHandle} is passed through the run's
+ * {@link Redactor} first, so a secret that slips into `ctx.state` is masked
+ * before it is persisted.
+ *
+ * @module
+ */
+
+import type { TargetStatus } from "../build.ts";
+import type { JsonValue, TargetStateHandle } from "../target.ts";
+import type { Redactor } from "../redact.ts";
+import type { StateStore } from "./store.ts";
+import type { RunRecord, TargetRunState } from "./types.ts";
+import { recordStatusOf } from "./record.ts";
+
+/** Extract a message from an unknown thrown value without casting. */
+function messageOf(value: unknown): string {
+  return value instanceof Error ? value.message : String(value);
+}
+
+/** How many times a conflicting write is re-read and retried before giving up. */
+const MAX_RETRIES = 5;
+
+/** Ensure a target's entry exists in the record, seeding it `pending`. */
+function ensureTarget(record: RunRecord, name: string): TargetRunState {
+  const existing = record.targets[name];
+  if (existing !== undefined) return existing;
+  const seeded: TargetRunState = { status: "pending", meta: {} };
+  record.targets[name] = seeded;
+  return seeded;
+}
+
+/** Recursively mask any secret string within a JSON value. */
+function redactJson(value: JsonValue, redactor: Redactor): JsonValue {
+  if (typeof value === "string") return redactor.redact(value);
+  if (Array.isArray(value)) return value.map((v) => redactJson(v, redactor));
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, JsonValue> = {};
+    for (const [key, v] of Object.entries(value)) {
+      out[key] = redactJson(v, redactor);
+    }
+    return out;
+  }
+  return value;
+}
+
+/** Keeps a run's {@link RunRecord} in sync with a {@link StateStore}. */
+export class RunStateWriter {
+  readonly #store: StateStore;
+  readonly #now: () => string;
+  readonly #redactor: Redactor;
+  readonly #warn?: (message: string) => void;
+  #record: RunRecord;
+  #version: string | null;
+  #chain: Promise<void> = Promise.resolve();
+
+  private constructor(
+    store: StateStore,
+    record: RunRecord,
+    now: () => string,
+    redactor: Redactor,
+    warn?: (message: string) => void,
+  ) {
+    this.#store = store;
+    this.#record = record;
+    this.#now = now;
+    this.#redactor = redactor;
+    this.#warn = warn;
+    this.#version = null; // no stored version yet; the first write creates it
+  }
+
+  /**
+   * Create a writer and persist the initial record (status `running`, targets
+   * `pending`). The create rides the same best-effort path as every other
+   * write, so a store that is briefly unavailable is reported, not fatal.
+   */
+  static async open(
+    store: StateStore,
+    record: RunRecord,
+    now: () => string,
+    redactor: Redactor,
+    warn?: (message: string) => void,
+  ): Promise<RunStateWriter> {
+    const writer = new RunStateWriter(store, record, now, redactor, warn);
+    await writer.#update(() => {});
+    return writer;
+  }
+
+  /** The current run id. */
+  get runId(): string {
+    return this.#record.id;
+  }
+
+  /** Mark a target `running` and stamp its start time. */
+  markTargetRunning(name: string): Promise<void> {
+    const at = this.#now();
+    return this.#update((record) => {
+      const target = ensureTarget(record, name);
+      target.status = "running";
+      target.startedAt = at;
+    });
+  }
+
+  /** Record a target's terminal status (mapped from the executor's vocabulary). */
+  markTargetSettled(
+    name: string,
+    status: TargetStatus,
+    error?: string,
+  ): Promise<void> {
+    const at = this.#now();
+    const recorded = recordStatusOf(status);
+    const message = error === undefined
+      ? undefined
+      : this.#redactor.redact(error);
+    return this.#update((record) => {
+      const target = ensureTarget(record, name);
+      target.status = recorded;
+      target.endedAt = at;
+      if (message !== undefined) target.error = message;
+    });
+  }
+
+  /** Record the run's terminal status. */
+  markRunFinished(ok: boolean): Promise<void> {
+    return this.#update((record) => {
+      record.status = ok ? "succeeded" : "failed";
+    });
+  }
+
+  /** A {@link TargetStateHandle} bound to `name`, persisting through this writer. */
+  stateHandle(name: string): TargetStateHandle {
+    return {
+      get: () => ({ ...(this.#record.targets[name]?.meta ?? {}) }),
+      set: (patch) => {
+        const redacted: Record<string, JsonValue> = {};
+        for (const [key, value] of Object.entries(patch)) {
+          redacted[key] = redactJson(value, this.#redactor);
+        }
+        return this.#update((record) => {
+          const target = ensureTarget(record, name);
+          target.meta = { ...target.meta, ...redacted };
+        });
+      },
+    };
+  }
+
+  /** Serialise `mutator` after all pending writes, then persist (best-effort). */
+  #update(mutator: (record: RunRecord) => void): Promise<void> {
+    this.#chain = this.#chain.then(() => this.#applyAndPersist(mutator));
+    return this.#chain;
+  }
+
+  /** Apply `mutator` and CAS-write, re-reading and retrying on conflict. */
+  async #applyAndPersist(mutator: (record: RunRecord) => void): Promise<void> {
+    try {
+      for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+        mutator(this.#record);
+        this.#record.updatedAt = this.#now();
+        const result = await this.#store.putRun(this.#record, this.#version);
+        if (result.ok) {
+          this.#version = result.version;
+          return;
+        }
+        // Another writer moved the record on: re-read and re-apply the mutator.
+        const fresh = await this.#store.getRun(this.#record.id);
+        this.#record = fresh?.record ?? this.#record;
+        this.#version = fresh?.version ?? null;
+      }
+      this.#warn?.(
+        `state: gave up persisting run "${this.#record.id}" after ` +
+          `${MAX_RETRIES} conflicting writes`,
+      );
+    } catch (error) {
+      this.#warn?.(
+        `state: failed to persist run "${this.#record.id}": ${
+          messageOf(error)
+        }`,
+      );
+    }
+  }
+}
+
+/**
+ * A no-op {@link TargetStateHandle} for runs with no store: `set` retains the
+ * patch in memory for the current process so `get` is consistent within the
+ * run, but nothing is persisted.
+ */
+export function inMemoryStateHandle(): TargetStateHandle {
+  const meta: Record<string, JsonValue> = {};
+  return {
+    get: () => ({ ...meta }),
+    set: (patch) => {
+      Object.assign(meta, patch);
+      return Promise.resolve();
+    },
+  };
+}

--- a/packages/core/src/target.ts
+++ b/packages/core/src/target.ts
@@ -31,11 +31,40 @@ import type { PathLike } from "./path.ts";
 import type { AnyParameter } from "./params.ts";
 
 /**
+ * A JSON-serialisable value — the only thing that may be persisted in a
+ * target's {@link TargetStateHandle}, since run state is stored as JSON.
+ */
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+/**
+ * A target's durable, per-target metadata, surfaced on {@link TargetContext} as
+ * `state`. Writes are persisted to the run's state store (see
+ * {@link "./state/store.ts".StateStore}) and are visible to later runs — e.g. a
+ * resuming process reading what a suspended target recorded. When no store is
+ * configured, the handle is an in-memory no-op scoped to the current run.
+ *
+ * **Never store a secret here** — state is persisted in plain JSON and read
+ * back by later runs and by `zuke runs show`.
+ */
+export interface TargetStateHandle {
+  /** Merge a JSON patch into this target's persisted metadata (awaits the write). */
+  set(patch: Record<string, JsonValue>): Promise<void>;
+  /** Read this target's persisted metadata (from prior attempts/runs too). */
+  get(): Record<string, JsonValue>;
+}
+
+/**
  * The context passed to every target body. Optional to receive — an existing
  * zero-argument `.executes(() => …)` stays valid, since a zero-argument
- * function is assignable to this one-parameter type — but a body that wants the run's
- * identity, a cancellation signal, or (in later milestones) durable state and
- * external-signal payloads reads them here.
+ * function is assignable to this one-parameter type — but a body that wants the
+ * run's identity, a cancellation signal, or durable per-target state reads them
+ * here.
  */
 export interface TargetContext {
   /** Unique ID of this run, stable for every target in the run. */
@@ -49,6 +78,13 @@ export interface TargetContext {
    * ambient default, so a plain `$` in the body is terminated too.
    */
   readonly signal: AbortSignal;
+  /**
+   * Durable per-target metadata. Persisted to the run's state store when one is
+   * configured (see {@link "./state/store.ts".StateStore}), and an in-memory
+   * no-op otherwise. The carrier for state that must survive across a
+   * suspend/resume boundary — do not put secrets in it.
+   */
+  readonly state: TargetStateHandle;
   /** True when the run is a dry run (bodies do not execute under a dry run). */
   readonly dryRun: boolean;
 }

--- a/packages/core/tests/cli_test.ts
+++ b/packages/core/tests/cli_test.ts
@@ -176,6 +176,14 @@ Deno.test("parseArgs reads --dry-run, defaulting to false", () => {
   assertEquals(parseArgs(["build", "--dry-run"]).dryRun, true);
 });
 
+Deno.test("parseArgs reads --state and --actor", () => {
+  assertEquals(parseArgs(["build"]).state, false);
+  assertEquals(parseArgs(["build"]).actor, undefined);
+  assertEquals(parseArgs(["build", "--state"]).state, true);
+  assertEquals(parseArgs(["build", "--actor", "alice"]).actor, "alice");
+  assertEquals(parseArgs(["build", "--actor=bob"]).actor, "bob");
+});
+
 Deno.test("parseArgs reads --affected with an optional base", () => {
   assertEquals(parseArgs(["build"]).affected, false);
   assertEquals(parseArgs(["build", "--affected"]).affected, true);

--- a/packages/core/tests/executor_test.ts
+++ b/packages/core/tests/executor_test.ts
@@ -34,6 +34,8 @@ import {
 } from "../src/executor.ts";
 import type { Plugin } from "../src/plugin.ts";
 import { $ } from "../src/shell.ts";
+import { FileSystemStateStore } from "../src/state/fs_store.ts";
+import { defaultStateHost } from "../src/state/store.ts";
 
 const silent: ExecuteOptions = { silent: true };
 
@@ -1756,4 +1758,63 @@ Deno.test("a pre-aborted options.signal aborts the context signal", async () => 
   });
   assertEquals(sawAborted, true);
   assertEquals(result.ok, true); // no shell command to kill, so the body succeeds
+});
+
+Deno.test("a run with a state store reconstructs full status from disk", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    const log: string[] = [];
+    class B extends Build {
+      token = parameter("api token").secret();
+      env = parameter("environment");
+      prep = target().executes(() => void log.push("prep"));
+      deploy = target().dependsOn(this.prep).executes(async (ctx) => {
+        await ctx.state.set({ where: "sit-7" });
+      });
+    }
+    const b = new B();
+    discoverTargets(b);
+
+    const result = await execute(b, b.deploy, {
+      silent: true,
+      stateStore: store,
+      params: { token: "swordfish", env: "sit" },
+    });
+    assertEquals(result.ok, true);
+
+    // A fresh store over the same directory reconstructs the run from disk alone.
+    const fresh = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    const summaries = await fresh.listRuns({});
+    assertEquals(summaries.length, 1);
+    const loaded = await fresh.getRun(summaries[0].id);
+    assertEquals(loaded?.record.status, "succeeded");
+    assertEquals(loaded?.record.build, "B");
+    assertEquals(loaded?.record.rootTarget, "deploy");
+    assertEquals(loaded?.record.targets.prep.status, "succeeded");
+    assertEquals(loaded?.record.targets.deploy.status, "succeeded");
+    // The running transition landed (startedAt stamped) ...
+    assertEquals(typeof loaded?.record.targets.deploy.startedAt, "string");
+    // ... ctx.state was persisted ...
+    assertEquals(loaded?.record.targets.deploy.meta.where, "sit-7");
+    // ... and the secret parameter was excluded from the record.
+    assertEquals(loaded?.record.params, { env: "sit" });
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("with no state store, ctx.state is an in-memory no-op", async () => {
+  let readBack: unknown;
+  class B extends Build {
+    a = target().executes(async (ctx) => {
+      await ctx.state.set({ k: "v" });
+      readBack = ctx.state.get().k;
+    });
+  }
+  const b = new B();
+  discoverTargets(b);
+  const result = await execute(b, b.a, silent); // no stateStore
+  assertEquals(result.ok, true);
+  assertEquals(readBack, "v"); // visible within the run, persisted nowhere
 });

--- a/packages/core/tests/state_test.ts
+++ b/packages/core/tests/state_test.ts
@@ -1,0 +1,722 @@
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+  assertThrows,
+} from "./_assert.ts";
+import {
+  parseRunRecord,
+  parseRunSummary,
+  type RunRecord,
+  stringifyRunRecord,
+  toSummary,
+} from "../src/state/types.ts";
+import {
+  defaultStateHost,
+  type StateHost,
+  type StateStore,
+} from "../src/state/store.ts";
+import { FileSystemStateStore } from "../src/state/fs_store.ts";
+import { HttpStateStore } from "../src/state/http_store.ts";
+import { envStateStore, resolveStateStore } from "../src/state/resolve.ts";
+import { HttpError } from "../src/http.ts";
+import {
+  buildRunRecord,
+  recordStatusOf,
+  resolveActor,
+} from "../src/state/record.ts";
+import { inMemoryStateHandle, RunStateWriter } from "../src/state/writer.ts";
+import { Redactor } from "../src/redact.ts";
+import { target } from "../src/target.ts";
+import { Build, discoverTargets } from "../src/build.ts";
+import { discoverParameters, parameter } from "../src/params.ts";
+
+/** A minimal, valid run record for tests. */
+function sampleRecord(overrides: Partial<RunRecord> = {}): RunRecord {
+  return {
+    id: overrides.id ?? "run-1",
+    build: overrides.build ?? "CI",
+    rootTarget: overrides.rootTarget ?? "deploy",
+    status: overrides.status ?? "running",
+    actor: overrides.actor ?? "alice",
+    createdAt: overrides.createdAt ?? "2026-07-17T10:00:00.000Z",
+    updatedAt: overrides.updatedAt ?? "2026-07-17T10:00:00.000Z",
+    graph: overrides.graph ?? [{ name: "deploy", dependsOn: [] }],
+    params: overrides.params ?? { env: "sit" },
+    targets: overrides.targets ??
+      { deploy: { status: "pending", meta: {} } },
+  };
+}
+
+/** An in-memory {@link StateHost}: a flat file map plus a lock set. */
+class FakeStateHost implements StateHost {
+  readonly files = new Map<string, string>();
+  readonly locks = new Set<string>();
+
+  readText(path: string): Promise<string | null> {
+    return Promise.resolve(this.files.get(path) ?? null);
+  }
+  writeText(path: string, content: string): Promise<void> {
+    this.files.set(path, content);
+    return Promise.resolve();
+  }
+  rename(from: string, to: string): Promise<void> {
+    const content = this.files.get(from);
+    if (content !== undefined) {
+      this.files.set(to, content);
+      this.files.delete(from);
+    }
+    return Promise.resolve();
+  }
+  createExclusive(path: string): Promise<boolean> {
+    if (this.locks.has(path)) return Promise.resolve(false);
+    this.locks.add(path);
+    return Promise.resolve(true);
+  }
+  remove(path: string): Promise<void> {
+    this.files.delete(path);
+    this.locks.delete(path);
+    return Promise.resolve();
+  }
+  listDir(path: string): Promise<string[]> {
+    const prefix = `${path}/`;
+    const names: string[] = [];
+    for (const key of this.files.keys()) {
+      if (key.startsWith(prefix)) names.push(key.slice(prefix.length));
+    }
+    return Promise.resolve(names);
+  }
+  mkdirp(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+// ---------------------------------------------------------------- types
+
+Deno.test("stringify then parse round-trips a run record", () => {
+  const record = sampleRecord();
+  assertEquals(parseRunRecord(stringifyRunRecord(record)), record);
+});
+
+Deno.test("toSummary projects a record's summary fields", () => {
+  assertEquals(toSummary(sampleRecord({ id: "r9" })), {
+    id: "r9",
+    build: "CI",
+    rootTarget: "deploy",
+    status: "running",
+    actor: "alice",
+    createdAt: "2026-07-17T10:00:00.000Z",
+    updatedAt: "2026-07-17T10:00:00.000Z",
+  });
+});
+
+Deno.test("parseRunRecord rejects malformed records", () => {
+  const cases: Array<[string, string]> = [
+    ["not json", "not valid JSON"],
+    ["42", "not an object"],
+    [JSON.stringify({ ...sampleRecord(), id: 1 }), 'field "id"'],
+    [
+      JSON.stringify({ ...sampleRecord(), status: "weird" }),
+      "unknown run status",
+    ],
+    [
+      JSON.stringify({ ...sampleRecord(), graph: "x" }),
+      '"graph" is not an array',
+    ],
+    [
+      JSON.stringify({ ...sampleRecord(), graph: [1] }),
+      "graph node is not an object",
+    ],
+    [
+      JSON.stringify({
+        ...sampleRecord(),
+        graph: [{ name: "a", dependsOn: [1] }],
+      }),
+      "not a string array",
+    ],
+    [
+      JSON.stringify({ ...sampleRecord(), params: "x" }),
+      '"params" is not an object',
+    ],
+    [
+      JSON.stringify({ ...sampleRecord(), params: { a: 1 } }),
+      'param "a" is not a string',
+    ],
+    [
+      JSON.stringify({ ...sampleRecord(), targets: "x" }),
+      '"targets" is not an object',
+    ],
+    [
+      JSON.stringify({
+        ...sampleRecord(),
+        targets: { a: { status: "bogus", meta: {} } },
+      }),
+      "unknown target status",
+    ],
+    [
+      JSON.stringify({ ...sampleRecord(), targets: { a: 5 } }),
+      "target state is not an object",
+    ],
+  ];
+  for (const [text, needle] of cases) {
+    assertThrows(() => parseRunRecord(text), Error, needle);
+  }
+});
+
+Deno.test("parseRunRecord preserves nested target meta as JSON", () => {
+  const record = sampleRecord({
+    targets: {
+      deploy: {
+        status: "succeeded",
+        meta: {
+          at: "sit-7",
+          tries: 2,
+          ok: true,
+          tags: ["a"],
+          extra: { n: null },
+        },
+        startedAt: "2026-07-17T10:00:01.000Z",
+        endedAt: "2026-07-17T10:00:02.000Z",
+      },
+    },
+  });
+  assertEquals(parseRunRecord(stringifyRunRecord(record)), record);
+});
+
+Deno.test("parseRunSummary validates untrusted summaries", () => {
+  const good = toSummary(sampleRecord());
+  assertEquals(parseRunSummary(good), good);
+  assertThrows(() => parseRunSummary(5), Error, "not an object");
+  assertThrows(
+    () => parseRunSummary({ ...good, status: "nope" }),
+    Error,
+    "unknown run status",
+  );
+});
+
+// ---------------------------------------------------------------- fs store
+
+Deno.test("FileSystemStateStore persists and reconstructs a record", async () => {
+  const host = new FakeStateHost();
+  const store = new FileSystemStateStore("/runs", host);
+  assertEquals(await store.getRun("run-1"), null);
+
+  const created = await store.putRun(sampleRecord(), null);
+  assertEquals(created.ok, true);
+
+  const loaded = await store.getRun("run-1");
+  assertEquals(loaded?.record, sampleRecord());
+  assertEquals(typeof loaded?.version, "string");
+});
+
+Deno.test("FileSystemStateStore CAS rejects a stale write", async () => {
+  const host = new FakeStateHost();
+  const store = new FileSystemStateStore("/runs", host);
+  const created = await store.putRun(sampleRecord(), null);
+  if (!created.ok) throw new Error("expected create to succeed");
+
+  // A second create at the same (null) expectation loses: the record exists.
+  const stale = await store.putRun(sampleRecord({ actor: "bob" }), null);
+  assertEquals(stale, { ok: false, conflict: true });
+
+  // Writing at the current version succeeds and moves the version on.
+  const updated = await store.putRun(
+    sampleRecord({ status: "succeeded" }),
+    created.version,
+  );
+  assertEquals(updated.ok, true);
+  // The old version no longer matches.
+  const conflict = await store.putRun(sampleRecord(), created.version);
+  assertEquals(conflict, { ok: false, conflict: true });
+});
+
+Deno.test("FileSystemStateStore: concurrent writers — exactly one wins", async () => {
+  const host = new FakeStateHost();
+  const store = new FileSystemStateStore("/runs", host);
+  const created = await store.putRun(sampleRecord(), null);
+  if (!created.ok) throw new Error("expected create to succeed");
+
+  const results = await Promise.all([
+    store.putRun(sampleRecord({ actor: "b" }), created.version),
+    store.putRun(sampleRecord({ actor: "c" }), created.version),
+  ]);
+  const wins = results.filter((r) => r.ok).length;
+  const conflicts = results.filter((r) => !r.ok).length;
+  assertEquals(wins, 1);
+  assertEquals(conflicts, 1);
+});
+
+Deno.test("FileSystemStateStore listRuns filters, sorts, and skips junk", async () => {
+  const host = new FakeStateHost();
+  const store = new FileSystemStateStore("/runs", host);
+  await store.putRun(
+    sampleRecord({ id: "r1", createdAt: "2026-01-01T00:00:00.000Z" }),
+    null,
+  );
+  await store.putRun(
+    sampleRecord({
+      id: "r2",
+      createdAt: "2026-02-01T00:00:00.000Z",
+      status: "failed",
+    }),
+    null,
+  );
+  await store.putRun(
+    sampleRecord({
+      id: "r3",
+      createdAt: "2026-03-01T00:00:00.000Z",
+      graph: [{ name: "other", dependsOn: [] }],
+    }),
+    null,
+  );
+  // Junk files that must be ignored.
+  host.files.set("/runs/broken.json", "not json");
+  host.files.set("/runs/note.txt", "ignored");
+
+  const all = await store.listRuns({});
+  assertEquals(all.map((s) => s.id), ["r3", "r2", "r1"]); // newest first
+
+  assertEquals((await store.listRuns({ status: "failed" })).map((s) => s.id), [
+    "r2",
+  ]);
+  assertEquals((await store.listRuns({ target: "other" })).map((s) => s.id), [
+    "r3",
+  ]);
+  assertEquals(
+    (await store.listRuns({ since: "2026-02-15T00:00:00.000Z" })).map((s) =>
+      s.id
+    ),
+    ["r3"],
+  );
+});
+
+Deno.test("FileSystemStateStore rejects an unsafe run id on read and write", async () => {
+  const store = new FileSystemStateStore("/runs", new FakeStateHost());
+  await assertRejects(() => store.getRun("../escape"), Error, "unsafe run id");
+  await assertRejects(
+    () => store.putRun(sampleRecord({ id: "../escape" }), null),
+    Error,
+    "unsafe run id",
+  );
+});
+
+Deno.test("FileSystemStateStore round-trips through the real filesystem", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    const created = await store.putRun(sampleRecord(), null);
+    if (!created.ok) throw new Error("expected create to succeed");
+    const loaded = await store.getRun("run-1");
+    assertEquals(loaded?.record.actor, "alice");
+    assertEquals((await store.listRuns({})).length, 1);
+    // Concurrent writers against the real O_EXCL lock: exactly one wins.
+    const results = await Promise.all([
+      store.putRun(sampleRecord({ actor: "b" }), created.version),
+      store.putRun(sampleRecord({ actor: "c" }), created.version),
+    ]);
+    assertEquals(results.filter((r) => r.ok).length, 1);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+// ---------------------------------------------------------------- http store
+
+/** A fetch double answering from a handler. */
+function fakeFetch(
+  handler: (url: string, init: RequestInit | undefined) => Response,
+): typeof fetch {
+  return (input: string | URL | Request, init?: RequestInit) =>
+    Promise.resolve(handler(String(input), init));
+}
+
+Deno.test("HttpStateStore.getRun returns record + ETag, or null on 404", async () => {
+  const store = new HttpStateStore({
+    url: "https://s.example/",
+    token: "t",
+    fetch: fakeFetch((url, init) => {
+      assertEquals(init?.headers, { Authorization: "Bearer t" });
+      if (url.endsWith("/runs/missing")) {
+        return new Response(null, { status: 404 });
+      }
+      return new Response(stringifyRunRecord(sampleRecord()), {
+        status: 200,
+        headers: { etag: "v1" },
+      });
+    }),
+  });
+  const loaded = await store.getRun("run-1");
+  assertEquals(loaded?.version, "v1");
+  assertEquals(loaded?.record.id, "run-1");
+  assertEquals(await store.getRun("missing"), null);
+});
+
+Deno.test("HttpStateStore.getRun errors without an ETag or on failure", async () => {
+  const noEtag = new HttpStateStore({
+    url: "https://s.example",
+    fetch: fakeFetch(() =>
+      new Response(stringifyRunRecord(sampleRecord()), { status: 200 })
+    ),
+  });
+  await assertRejects(
+    () => noEtag.getRun("run-1"),
+    Error,
+    "did not return an ETag",
+  );
+
+  const boom = new HttpStateStore({
+    url: "https://s.example",
+    fetch: fakeFetch(() => new Response(null, { status: 500 })),
+  });
+  await assertRejects(() => boom.getRun("run-1"), HttpError);
+});
+
+Deno.test("HttpStateStore.putRun sends preconditions and maps 412 to a conflict", async () => {
+  const seen: Array<Record<string, string>> = [];
+  const store = new HttpStateStore({
+    url: "https://s.example",
+    fetch: fakeFetch((_url, init) => {
+      const headers = new Headers(init?.headers);
+      seen.push({
+        ifMatch: headers.get("if-match") ?? "",
+        ifNoneMatch: headers.get("if-none-match") ?? "",
+      });
+      if (headers.get("if-match") === "stale") {
+        return new Response(null, { status: 412 });
+      }
+      return new Response(null, { status: 200, headers: { etag: "v2" } });
+    }),
+  });
+  const created = await store.putRun(sampleRecord(), null);
+  assertEquals(created, { ok: true, version: "v2" });
+  assertEquals(seen[0].ifNoneMatch, "*");
+
+  const updated = await store.putRun(sampleRecord(), "v1");
+  assertEquals(updated, { ok: true, version: "v2" });
+  assertEquals(seen[1].ifMatch, "v1");
+
+  const conflict = await store.putRun(sampleRecord(), "stale");
+  assertEquals(conflict, { ok: false, conflict: true });
+});
+
+Deno.test("HttpStateStore.putRun errors without an ETag or on failure", async () => {
+  const noEtag = new HttpStateStore({
+    url: "https://s.example",
+    fetch: fakeFetch(() => new Response(null, { status: 200 })),
+  });
+  await assertRejects(
+    () => noEtag.putRun(sampleRecord(), null),
+    Error,
+    "did not return an ETag on write",
+  );
+  const boom = new HttpStateStore({
+    url: "https://s.example",
+    fetch: fakeFetch(() => new Response(null, { status: 500 })),
+  });
+  await assertRejects(() => boom.putRun(sampleRecord(), null), HttpError);
+});
+
+Deno.test("HttpStateStore.listRuns builds a query and validates the array", async () => {
+  let lastUrl = "";
+  const store = new HttpStateStore({
+    url: "https://s.example",
+    fetch: fakeFetch((url) => {
+      lastUrl = url;
+      return new Response(JSON.stringify([toSummary(sampleRecord())]), {
+        status: 200,
+      });
+    }),
+  });
+  const list = await store.listRuns({
+    status: "running",
+    target: "deploy",
+    since: "x",
+  });
+  assertEquals(list.length, 1);
+  assertStringIncludes(lastUrl, "status=running");
+  assertStringIncludes(lastUrl, "target=deploy");
+
+  const emptyQuery = new HttpStateStore({
+    url: "https://s.example",
+    fetch: fakeFetch((url) => {
+      assertEquals(url, "https://s.example/runs");
+      return new Response("{}", { status: 200 });
+    }),
+  });
+  await assertRejects(
+    () => emptyQuery.listRuns({}),
+    Error,
+    "did not return a JSON array",
+  );
+
+  const boom = new HttpStateStore({
+    url: "https://s.example",
+    fetch: fakeFetch(() => new Response(null, { status: 503 })),
+  });
+  await assertRejects(() => boom.listRuns({}), HttpError);
+});
+
+// ---------------------------------------------------------------- resolve
+
+Deno.test("resolveStateStore honours precedence", () => {
+  const host = new FakeStateHost();
+  const explicit = new FileSystemStateStore("/explicit", host);
+  const declared = new FileSystemStateStore("/declared", host);
+  const base = {
+    host,
+    defaultDir: "/root/.zuke/runs",
+    enableDefault: false,
+    readEnv: () => undefined,
+  };
+
+  assertEquals(resolveStateStore(false, declared, base), undefined);
+  assertEquals(resolveStateStore(explicit, declared, base), explicit);
+  assertEquals(resolveStateStore(undefined, declared, base), declared);
+  assertEquals(resolveStateStore(undefined, undefined, base), undefined);
+  // With no explicit/declared/env store, the default kicks in only when enabled.
+  const def = resolveStateStore(undefined, undefined, {
+    ...base,
+    enableDefault: true,
+  });
+  assertEquals(def instanceof FileSystemStateStore, true);
+});
+
+Deno.test("envStateStore selects HTTP by URL then filesystem by DIR", () => {
+  const host = new FakeStateHost();
+  const url = envStateStore(
+    (n) => (n === "ZUKE_STATE_URL" ? "https://s" : undefined),
+    host,
+  );
+  assertEquals(url instanceof HttpStateStore, true);
+  const dir = envStateStore(
+    (n) => (n === "ZUKE_STATE_DIR" ? "/d" : undefined),
+    host,
+  );
+  assertEquals(dir instanceof FileSystemStateStore, true);
+  assertEquals(envStateStore(() => undefined, host), undefined);
+});
+
+// ---------------------------------------------------------------- record
+
+Deno.test("recordStatusOf maps executor statuses onto record statuses", () => {
+  assertEquals(recordStatusOf("passed"), "succeeded");
+  assertEquals(recordStatusOf("cached"), "succeeded");
+  assertEquals(recordStatusOf("failed"), "failed");
+  assertEquals(recordStatusOf("skipped"), "skipped");
+});
+
+Deno.test("resolveActor prefers explicit, then env, then anonymous", () => {
+  assertEquals(resolveActor("me", () => "env"), "me");
+  assertEquals(
+    resolveActor(undefined, (n) => (n === "ZUKE_ACTOR" ? "z" : undefined)),
+    "z",
+  );
+  assertEquals(
+    resolveActor(undefined, (n) => (n === "GITHUB_ACTOR" ? "gh" : undefined)),
+    "gh",
+  );
+  assertEquals(resolveActor(undefined, () => undefined), "anonymous");
+});
+
+Deno.test("buildRunRecord snapshots the graph, seeds targets, excludes secrets", () => {
+  class B extends Build {
+    token = parameter("api token").secret();
+    env = parameter("environment");
+    optional = parameter("optional flag");
+    clean = target().executes(() => {});
+    deploy = target().dependsOn(this.clean).executes(() => {});
+  }
+  const build = new B();
+  discoverTargets(build);
+  const params = discoverParameters(build);
+  build.token.resolve_("shh"); // secret → excluded
+  build.env.resolve_("sit"); // non-secret, set → included
+  // `optional` left unresolved → excluded (not set).
+
+  const record = buildRunRecord({
+    runId: "run-x",
+    build: "B",
+    rootTarget: "deploy",
+    actor: "alice",
+    now: "2026-07-17T10:00:00.000Z",
+    order: [build.clean, build.deploy],
+    params: params.values(),
+  });
+  assertEquals(record.graph, [
+    { name: "clean", dependsOn: [] },
+    { name: "deploy", dependsOn: ["clean"] },
+  ]);
+  assertEquals(record.targets, {
+    clean: { status: "pending", meta: {} },
+    deploy: { status: "pending", meta: {} },
+  });
+  assertEquals(record.status, "running");
+  assertEquals(record.params, { env: "sit" }); // secret + unset excluded
+});
+
+// ---------------------------------------------------------------- writer
+
+/** An in-memory {@link StateStore} with a bump counter version. */
+class MemStore implements StateStore {
+  record: RunRecord | null = null;
+  version = 0;
+  failNextPut = false;
+  forceConflicts = 0;
+  listRuns(): Promise<never[]> {
+    return Promise.resolve([]);
+  }
+  getRun(): Promise<{ record: RunRecord; version: string } | null> {
+    return Promise.resolve(
+      this.record === null ? null : {
+        record: structuredClone(this.record),
+        version: String(this.version),
+      },
+    );
+  }
+  putRun(record: RunRecord, expected: string | null): Promise<
+    { ok: true; version: string } | { ok: false; conflict: true }
+  > {
+    if (this.failNextPut) {
+      this.failNextPut = false;
+      return Promise.reject(new Error("store down"));
+    }
+    if (this.forceConflicts > 0) {
+      this.forceConflicts -= 1;
+      return Promise.resolve({ ok: false, conflict: true });
+    }
+    const current = this.record === null ? null : String(this.version);
+    if (current !== expected) {
+      return Promise.resolve({ ok: false, conflict: true });
+    }
+    this.record = structuredClone(record);
+    this.version += 1;
+    return Promise.resolve({ ok: true, version: String(this.version) });
+  }
+}
+
+Deno.test("RunStateWriter records transitions and redacted state", async () => {
+  const store = new MemStore();
+  const redactor = new Redactor();
+  redactor.add("swordfish");
+  const writer = await RunStateWriter.open(
+    store,
+    sampleRecord({ targets: { deploy: { status: "pending", meta: {} } } }),
+    () => "2026-07-17T10:00:05.000Z",
+    redactor,
+  );
+  await writer.markTargetRunning("deploy");
+  await writer.stateHandle("deploy").set({
+    where: "sit-7",
+    token: "swordfish",
+  });
+  await writer.markTargetSettled("deploy", "passed");
+  await writer.markRunFinished(true);
+
+  const persisted = store.record;
+  assertEquals(persisted?.status, "succeeded");
+  assertEquals(persisted?.targets.deploy.status, "succeeded");
+  assertEquals(persisted?.targets.deploy.startedAt, "2026-07-17T10:00:05.000Z");
+  assertEquals(persisted?.targets.deploy.meta.where, "sit-7");
+  assertEquals(persisted?.targets.deploy.meta.token, "[redacted]"); // secret masked
+  assertEquals(writer.stateHandle("deploy").get().where, "sit-7");
+});
+
+Deno.test("RunStateWriter records a failure message, redacted", async () => {
+  const store = new MemStore();
+  const redactor = new Redactor();
+  redactor.add("hunter2");
+  const writer = await RunStateWriter.open(
+    store,
+    sampleRecord(),
+    () => "t",
+    redactor,
+  );
+  await writer.markTargetSettled("deploy", "failed", "bad password hunter2");
+  assertEquals(store.record?.targets.deploy.status, "failed");
+  assertEquals(store.record?.targets.deploy.error, "bad password [redacted]");
+});
+
+Deno.test("RunStateWriter survives a store error without throwing", async () => {
+  const store = new MemStore();
+  const warnings: string[] = [];
+  const writer = await RunStateWriter.open(
+    store,
+    sampleRecord(),
+    () => "t",
+    new Redactor(),
+    (m) => warnings.push(m),
+  );
+  store.failNextPut = true;
+  await writer.markRunFinished(true); // best-effort: must not throw
+  assertEquals(warnings.some((w) => w.includes("failed to persist")), true);
+});
+
+Deno.test("RunStateWriter re-reads and retries on a conflict", async () => {
+  const store = new MemStore();
+  const writer = await RunStateWriter.open(
+    store,
+    sampleRecord(),
+    () => "t",
+    new Redactor(),
+  );
+  store.forceConflicts = 1; // first write conflicts, then the retry succeeds
+  await writer.markRunFinished(true);
+  assertEquals(store.record?.status, "succeeded");
+});
+
+Deno.test("RunStateWriter warns and gives up after repeated conflicts", async () => {
+  const store = new MemStore();
+  const warnings: string[] = [];
+  const writer = await RunStateWriter.open(
+    store,
+    sampleRecord(),
+    () => "t",
+    new Redactor(),
+    (m) => warnings.push(m),
+  );
+  store.forceConflicts = 99; // exceeds the retry budget
+  await writer.markRunFinished(true);
+  assertEquals(warnings.some((w) => w.includes("gave up")), true);
+});
+
+Deno.test("inMemoryStateHandle stores within the run but persists nothing", async () => {
+  const handle = inMemoryStateHandle();
+  assertEquals(handle.get(), {});
+  await handle.set({ a: 1 });
+  await handle.set({ b: "x" });
+  assertEquals(handle.get(), { a: 1, b: "x" });
+});
+
+// ---------------------------------------------------------------- host
+
+Deno.test("defaultStateHost performs real filesystem effects", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const host = defaultStateHost;
+    assertEquals(await host.readText(`${dir}/none`), null); // missing → null
+    await host.mkdirp(`${dir}/sub`);
+    await host.writeText(`${dir}/sub/a.txt`, "hi"); // creates parent
+    assertEquals(await host.readText(`${dir}/sub/a.txt`), "hi");
+    assertEquals(await host.createExclusive(`${dir}/lock`), true);
+    assertEquals(await host.createExclusive(`${dir}/lock`), false); // exists
+    await host.remove(`${dir}/lock`);
+    await host.remove(`${dir}/lock`); // missing → no throw
+    await host.rename(`${dir}/sub/a.txt`, `${dir}/sub/b.txt`);
+    assertEquals(await host.readText(`${dir}/sub/b.txt`), "hi");
+    assertEquals((await host.listDir(`${dir}/sub`)).includes("b.txt"), true);
+    assertEquals(await host.listDir(`${dir}/missing`), []); // absent → []
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("FileSystemStateStore errors when a lock is permanently held", async () => {
+  const host = new FakeStateHost();
+  host.locks.add("/runs/run-1.json.lock"); // never released
+  const store = new FileSystemStateStore("/runs", host);
+  await assertRejects(
+    () => store.putRun(sampleRecord(), null),
+    Error,
+    "could not acquire",
+  );
+});

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -78,10 +78,22 @@ Before calling any task or settings method, confirm the real shape:
   depended on like a target, but with a `.start(...)` / `.readyWhen(...)`
   lifecycle instead of `.executes(...)`; the executor starts it, waits until
   ready, then stops it in a `finally` so it never leaks. See the cheatsheet.
+- **Target context & cancellation:** a body may take a context —
+  `.executes((ctx) => …)` — with `ctx.runId`, `ctx.target`, `ctx.signal` (an
+  `AbortSignal` fired when the run is cancelled; a plain `` $`…` `` in the body
+  is `SIGTERM`'d automatically), `ctx.state`, and `ctx.dryRun`. Zero-argument
+  bodies keep working unchanged. Cancel a run programmatically by passing
+  `{ signal }` to `execute`. See the cheatsheet.
 - **Caching:** `.inputs(...)` / `.outputs(...)` make a target incremental. Add a
   **remote store** to share results across machines (fresh CI, teammates);
   `--affected` runs only targets changed since a git base; `--no-cache` /
   `--no-remote-cache` bypass them.
+- **Durable run state:** persist a run's status and per-target metadata to a
+  pluggable `StateStore` so it survives the process — turn it on with `--state`,
+  `ZUKE_STATE_DIR` / `ZUKE_STATE_URL`, or `override stateStore()`. In a body,
+  `ctx.state.set({ … })` / `ctx.state.get()` records per-target metadata (JSON,
+  **never secrets** — secret parameters and redacted values are excluded). See
+  the cheatsheet.
 - **Typed inputs:** `parameter("...")` (with `.secret()` / `.required()`), read
   as `this.x.value`, gated with `.requires(this.x)`.
 - **Secrets from a manager:** `parameter(...).secret().from(source)` sources a

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -12,7 +12,7 @@ Everything is optional except a body (`.executes`).
 | --- | --- |
 | `.description(text)` | Summary shown in `--list`. |
 | `.dependsOn(...t)` | Hard prerequisites; run first, transitively. Pass `this.<field>`. |
-| `.executes(fn)` | The body. Sync or async. **Required.** |
+| `.executes(fn)` | The body. Sync or async. **Required.** `fn` may take a `TargetContext` (`(ctx) => …`); see below. |
 | `.before(...t)` / `.after(...t)` | Soft ordering — only reorders targets already in the plan; never pulls new ones in. |
 | `.triggers(...t)` | Pull targets into the plan and run them *after* this one. |
 | `.dependentFor(...t)` | Reverse of `dependsOn`: make this a prerequisite of others. |
@@ -99,6 +99,60 @@ The shell's `Command` gains `.spawn()` (starts without awaiting, returns a
 common case needs no explicit `.stop()`. `tcpReachable("host:port")` is the
 built-in "is the port up yet?" probe. Shares `dependsOn`/`before`/`after`/
 `description` with `target()`.
+
+## Target context — `ctx`
+
+A body may accept a `TargetContext`. Zero-argument bodies keep working — the
+parameter is optional.
+
+```ts
+deploy = target().executes(async (ctx) => {
+  ctx.runId; // stable id for the whole run
+  ctx.target; // "deploy"
+  ctx.signal; // AbortSignal, fired when the run is cancelled
+  ctx.dryRun; // true under a dry run
+  await ctx.state.set({ where: "sit-7" }); // durable metadata — see below
+});
+```
+
+**Cancellation.** When the run is cancelled, `ctx.signal` fires and any plain
+`` $`…` `` in the body is terminated with `SIGTERM` automatically (the run's
+signal is the shell's ambient signal). Pass `ctx.signal` to `.signal(...)` to
+cancel a command explicitly; it composes with `.killAfter(ms)`. Cancel a run
+programmatically with `execute(build, root, { signal })`. A body that ignores
+its signal and never shells out runs to completion.
+
+## Durable run state
+
+Persist a run's status and per-target metadata so it survives the process
+exiting. **Opt-in** — a plain build writes nothing. Enable a store by (first
+wins): `execute(..., { stateStore })` → `override stateStore()` →
+`ZUKE_STATE_URL` (+ `ZUKE_STATE_TOKEN`) → `ZUKE_STATE_DIR` → `--state` (defaults
+to `.zuke/runs`).
+
+```ts
+import { Build, HttpStateStore, target } from "jsr:@zuke/core";
+
+class CD extends Build {
+  override stateStore() {
+    return new HttpStateStore({ url: this.url.value, token: this.token.value });
+  }
+  deploy = target().executes(async (ctx) => {
+    await ctx.state.set({ image: tag }); // JSON patch, merged and persisted
+    const meta = ctx.state.get(); // read back (this run and later ones)
+  });
+}
+```
+
+- Backends: `FileSystemStateStore(dir)` (single host, dev) and
+  `HttpStateStore({ url, token? })` (hosted, production — see
+  `docs/state-api.md`). Both dependency-free and pluggable behind `StateStore`.
+- The run record holds status, the graph shape, resolved **non-secret**
+  parameters, and per-target status/timing/metadata. Inspect programmatically
+  with `store.listRuns({ status?, target?, since? })` and `store.getRun(id)`.
+- **Never put secrets in `ctx.state`** — it is stored as plain JSON. Secret
+  parameters are excluded from the record and state values are run through the
+  redactor, but treat state as a non-secret channel. See `docs/state.md`.
 
 ## Parameters — typed build inputs
 
@@ -284,6 +338,8 @@ is current (`zuke generate-ci --check` is a dedicated gate).
 ./zuke <target> --parallel    # run independent targets concurrently
 ./zuke <target> --affected    # run only targets changed since a git base
 ./zuke <target> --no-cache    # ignore the incremental cache
+./zuke <target> --state       # persist run state to .zuke/runs (durable state)
+./zuke <target> --actor <who> # attribute the run in its state record
 ./zuke mcp [--allow-run]      # serve the build over MCP for an AI client
 ```
 


### PR DESCRIPTION
## What

**M1, PR 1 of 2** of the orchestration plan (`plans/orchestrationplan.md`): a **pluggable `StateStore`** that persists a run's status, graph shape, resolved non-secret parameters, and per-target progress — so a run can be reconstructed after the process exits, and a target can leave metadata for a later run to read. **Opt-in and zero-overhead when unused.**

### Store
- `StateStore` interface with whole-record **compare-and-swap** (`putRun(record, expectedVersion)`), `getRun`, and `listRuns({ status?, target?, since? })`.
- **`FileSystemStateStore`** — one `.zuke/runs/<id>.json` per run; atomic write-temp-then-rename under an `O_EXCL` lock; content-hash version. Single host (fine for dev).
- **`HttpStateStore`** — a hosted service using `ETag` / `If-Match` for optimistic concurrency (the production path). Same `{ url, token?, fetch? }` shape as `HttpCacheStore`.
- Selection by precedence: explicit option → `Build.stateStore()` override → `ZUKE_STATE_URL`/`ZUKE_STATE_DIR` → a `.zuke/runs` default **only when the run opts in** (`--state`).

### `ctx.state` (fills in the M0 seam)
- `ctx.state.set(patch)` merges a JSON patch, persisted through a serialized best-effort writer; `ctx.state.get()` reads it back. In-memory no-op when no store is configured.
- **Secrets stay out of state:** secret parameters are excluded from the record, and every `ctx.state` value is run through the run's redactor before persisting.

### Executor + CLI
- The executor records each target's start/finish and the run's terminal status, and drains the writer before returning. State writes are **best-effort** — a store hiccup is reported, never fatal.
- `--state` opts a plain run into the filesystem store; `--actor <name>` attributes it.

### Docs & skills
- New `docs/state.md`, `docs/state-api.md` (the REST contract for hosting a backend), and `docs/run-context.md` (the M0 context + cancellation, whose docs were deferred). `zuke-write-build` skill + cheatsheet updated for both M0 and M1.

## Acceptance (met)
- A build run with the FS store is reconstructed from disk alone by a fresh store (status, per-target status/`startedAt`, `ctx.state` metadata, secret excluded from `params`) — integration test.
- Two concurrent `putRun` writers at the same version → exactly one wins, the loser gets a typed conflict — tested against both the fake host and the real `O_EXCL` lock.

## Verification
`deno task ci` green — fmt, lint, spell, `deno check`, coverage (lines **98.8%**, branches **96.1%**, above the 95% gate). `deno doc --lint` clean over all core entrypoints; `apiDocsCheck` shows no drift.

## Not in this PR
`zuke runs list/show` (reading state from the command line) is **PR 2**.