### PR TITLE
feat(core): cross-run TTL locks with typed conflict errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,20 @@ update the `check` task and CI accordingly. Do not bolt on a parallel
    not later. Prefer reusing core primitives (`FileTasks`,
    `glob`/`globToRegExp`, the `$`/`Command` shell, the HTTP helpers) over
    re-implementing them in a package.
+9. **Configuration is a fluent settings lambda, not an options object.** When an
+   API takes more than a trivial amount of configuration, expose it as a
+   chainable settings class configured through a lambda — the
+   `Configure<S> = (s: S) => S` shape the tool wrappers use — not a positional
+   options bag. Prefer
+   `.lock((s) => s.lockKey("deploy", repo).withTtl("4h").onConflict(...))` over
+   `.lock(key, { ttl, onConflict })`. Each setter returns `this`, the fields use
+   the trailing-underscore internal convention (and are still JSDoc'd), and the
+   lambda defers evaluation until call time — so a value derived from
+   `this.<param>.value` sees the resolved value. This keeps the whole authoring
+   surface consistent with `DenoTasks.test((s) => …)`, `service()`, and the CI
+   builder, and lets options grow without churning call sites. A single required
+   scalar (a path, a name) can still be a direct argument; reach for the lambda
+   once there are options to set.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ Full documentation lives in [`docs/`](./docs/):
 - [Durable run state](./docs/state.md) — persist a run's status and per-target
   metadata to a pluggable store (`StateStore`, `ctx.state`), with an
   [HTTP API](./docs/state-api.md) for hosting a production backend.
+- [Cross-run locks](./docs/locks.md) — `.lock()` claims an exclusive resource
+  across runs and machines, with a TTL backstop and typed `LockConflictError`s.
 - [Shell wrapper (`$`)](./docs/shell.md) — ergonomic, injection-safe process
   execution.
 - [Paths (`absolutePath`)](./docs/paths.md) — the fluent path type.

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,8 @@
   (cross-machine) cache, and the AI response cache.
 - [Durable run state](./state.md) — persist a run's status and per-target
   metadata to a pluggable store, and read it back after the process exits.
+- [Cross-run locks](./locks.md) — `.lock()` claims an exclusive resource across
+  runs and machines, with a TTL backstop and typed conflicts.
 - [State HTTP API](./state-api.md) — the REST contract for hosting a production
   state backend.
 - [Shell wrapper (`$`)](./shell.md) — ergonomic, injection-safe process

--- a/docs/locks.md
+++ b/docs/locks.md
@@ -1,0 +1,78 @@
+# Cross-run locks
+
+A **lock** lets a target claim an exclusive resource across runs and processes —
+"only one deploy of repo X at a time", "one migration at a time". It builds on
+[durable run state](./state.md): the lock lives in the same store, so it holds
+across separate `zuke` invocations, separate machines (with the HTTP backend),
+and process restarts.
+
+```ts
+import { Build, target } from "jsr:@zuke/core";
+
+class CD extends Build {
+  repo = parameter("service to deploy");
+
+  promote = target()
+    .lock((s) =>
+      s.lockKey("deploy", this.repo.value)
+        .withTtl("4h")
+        .onConflict((holder) =>
+          `${this.repo.value} is being deployed by ${holder.actor} ` +
+          `(run ${holder.runId}, since ${holder.since}). Wait, then retry.`))
+    .executes(async (ctx) => {/* … */});
+}
+```
+
+`.lock()` takes a **settings lambda** (the same style as the tool wrappers): `s`
+collects the key, TTL, and conflict message fluently. The lambda runs after
+parameters resolve, so the key can read `this.<param>.value`.
+
+## Semantics
+
+- **Exclusive.** While a run holds the lock for a `key`, any other run that
+  tries to acquire the same key **fails** with a `LockConflictError` — it does
+  not queue or block. The error's message is the rendered guidance and its
+  `holder` carries the structured identity (`actor`, `runId`, `since`,
+  `runUrl?`).
+- **The key** is set with `s.lockKey(...parts)` (sanitised and joined, safe as a
+  filename and URL segment) or `s.key(literal)`. Because the whole settings
+  lambda runs after parameters resolve, a key built from `this.repo.value` sees
+  the final value.
+- **TTL.** `s.withTtl(...)` (a duration like `"4h"`, `"30m"`, or milliseconds) bounds how
+  long the lock survives **if the holder disappears**. A live holder renews it
+  automatically at half the TTL while its body runs, so a long deploy under a
+  short TTL never loses its lock. If the holding process is `kill -9`'d, the
+  renewals stop and the lock becomes free once the TTL passes — no manual
+  cleanup, no wedged pipeline.
+- **Release.** The lock is released when the target settles — **success,
+  failure, or cancellation** — in a `finally`, so the common path never relies
+  on the TTL. The TTL is only the backstop for a killed process.
+
+## Conflicts
+
+The loser of a conflict gets actionable guidance, on every surface:
+
+- **CLI:** the run exits non-zero and the failure footer prints the guidance.
+- **Programmatic / MCP (later):** the thrown `LockConflictError` carries
+  `holder`, so a caller can relay who holds it and for how long.
+- **Run record:** the target is recorded `failed` with the guidance as its
+  error.
+
+Provide `s.onConflict(holder => …)` to phrase the guidance for your domain; omit
+it for a sensible default that names the holder and its run.
+
+## Requires a state store
+
+A lock needs somewhere durable to live, so a build that uses `.lock()` turns on
+the [filesystem state store](./state.md) (`.zuke/runs`) **by default** — no
+`--state` needed. Point it at the [HTTP backend](./state-api.md) (via
+`ZUKE_STATE_URL` or `stateStore()`) to share locks across machines; the server
+is authoritative for expiry, which side-steps client clock skew. A build that
+declares `.lock()` with state explicitly disabled fails with a friendly error.
+
+## Concurrency guarantee
+
+Acquisition is atomic. Two runs racing for the same free key → **exactly one**
+acquires; the other gets the conflict. An expired lock is taken over atomically.
+The filesystem backend is single-host (an `O_EXCL` marker serialises
+acquisition); the HTTP backend uses the same optimistic model across hosts.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -302,6 +302,11 @@ async function installRelease(options: InstallReleaseOptions): Promise<AbsoluteP
 function isCI(): boolean
   Whether the build appears to be running in a CI environment.
 
+function lockKey(...parts: Array<string | number>): string
+  Join parts into a lock key that is safe to use as a filename and URL segment.
+  Each part is sanitised (non-`[A-Za-z0-9._-]` runs become `_`) and empty parts
+  are dropped, so `lockKey("deploy", repo)` is stable and injection-free.
+
 function operatingSystem(os: typeof Deno.build.os): OperatingSystem
   The operating system as a Zuke {@link OperatingSystem}: `darwin` becomes
   `macos`, `windows` stays `windows`, and every other Unix (`linux`, the BSDs,
@@ -319,6 +324,11 @@ function parameter(description?: string): Parameter<string, string | undefined>
   `.number()`/`.boolean()` change the kind, `.options(...)` restricts a string,
   `.default(v)`/`.required()` set optionality, and `.env(name)` overrides the
   environment variable.
+
+function parseDuration(value: string | number): number
+  Parse a duration to milliseconds. Accepts a number (already milliseconds) or a
+  string of a non-negative amount and a unit — `ms`, `s`, `m`, `h`, or `d`
+  (e.g. `"90s"`, `"4h"`, `"1.5h"`). Throws a friendly error on anything else.
 
 function plan(root: TargetBuilder): TargetBuilder[]
   Topologically sort the execution set for `root`, honouring hard dependencies
@@ -714,6 +724,12 @@ class FileSystemStateStore implements StateStore
     Publish `record` under an exclusive lock, guarding the expected version.
   async listRuns(query: RunQuery): Promise<RunSummary[]>
     List runs matching `query`, newest first. Unreadable files are skipped.
+  async acquireLock(key: string, holder: LockHolder, ttlMs: number): Promise<LockResult>
+    Atomically acquire the lock `key` for `holder`, taking over if expired.
+  async renewLock(key: string, token: string, ttlMs: number): Promise<boolean>
+    Extend the lock `key` held under `token`; `false` if the token lost it.
+  async releaseLock(key: string, token: string): Promise<void>
+    Release the lock `key` if still held under `token`; a no-op otherwise.
 
 class GraphError extends Error
   Raised when the build graph is invalid (cycle or unknown dependency).
@@ -779,6 +795,51 @@ class HttpStateStore implements StateStore
     `PUT /runs/:id` guarded by `If-Match` / `If-None-Match`; `412` → conflict.
   async listRuns(query: RunQuery): Promise<RunSummary[]>
     `GET /runs?status=&target=&since=` → an array of {@link RunSummary}.
+  async acquireLock(key: string, holder: LockHolder, ttlMs: number): Promise<LockResult>
+    `POST /locks/:key` → `201 { token }`, or `409` with the current holder.
+  async renewLock(key: string, token: string, ttlMs: number): Promise<boolean>
+    `PUT /locks/:key` renews; a `409`/`404` means the token lost the lock.
+  async releaseLock(key: string, token: string): Promise<void>
+    `DELETE /locks/:key` releases; a missing lock (`404`) is not an error.
+
+class LockConflictError extends Error
+  Raised when a target's lock is already held by another run. Its `message` is
+  the rendered guidance (from the target's `onConflict`, else a default), so it
+  surfaces verbatim in the CLI failure footer and the run record; `holder`
+  carries the structured identity for programmatic surfaces (e.g. MCP).
+
+  constructor(readonly holder: LockHolder, guidance: string)
+    Build the error from the current holder and the rendered guidance.
+  override name: string
+    The error name.
+
+class LockSettings
+  Fluent configuration for {@link TargetBuilder.lock}, in the settings-lambda
+  style: `.lock((s) => s.lockKey("deploy", repo).withTtl("4h"))`. Set the key
+  (composed from sanitised parts with {@link LockSettings.lockKey}, or directly
+  with {@link LockSettings.key}), the {@link LockSettings.withTtl | TTL}, and an
+  optional {@link LockSettings.onConflict} message. The lambda runs after
+  parameters resolve, so the key may read `this.<param>.value`.
+
+  key_?: string
+    The resolved lock key; set by {@link key} or {@link lockKey}.
+  ttl_?: string | number
+    The TTL (a duration string or milliseconds); set by {@link withTtl}.
+  onConflict_?: (holder: LockHolder) => string
+    The conflict-guidance renderer; set by {@link onConflict}.
+  lockKey(...parts: Array<string | number>): this
+    Set the lock key from parts, sanitised and joined via
+    {@link "./state/lock.ts".lockKey} — e.g. `s.lockKey("deploy", repo)`.
+  key(key: string): this
+    Set the lock key directly (must be filename-safe; prefer {@link lockKey}).
+  withTtl(ttl: string | number): this
+    How long the lock survives a killed holder — a duration string like `"4h"`
+    / `"30m"` (see the duration parser) or raw milliseconds. A live holder
+    renews it while it runs, so it never expires under it.
+  onConflict(render: (holder: LockHolder) => string): this
+    Render the guidance shown to a run that loses the lock. Receives the
+    current {@link "./state/lock.ts".LockHolder}; the returned string becomes
+    the failure message. Defaults to a generic "held by … then retry" line.
 
 class Parameter<K extends ParamValue = ParamValue, T extends K | K[] | undefined = K | undefined> implements AnyParameter
   A typed build parameter. Declare one with {@link parameter} and configure it
@@ -990,6 +1051,8 @@ class TargetBuilder
     Remediations run after the body fails (set by {@link recoverWith}).
   recoverAttempts_: number
     Max fix-then-rerun cycles when the body fails (set by {@link recoverAttempts}).
+  lock_?: Configure<LockSettings>
+    Cross-run lock settings lambda, set by {@link lock} and run after params resolve.
   description(text: string): this
     Set the human-readable description shown in `zuke --list`.
   dependsOn(...targets: Array<TargetBuilder | Group>): this
@@ -1103,6 +1166,28 @@ class TargetBuilder
     and {@link recoverWith} remediations are configured (default 1). Each cycle
     runs every remediation, then re-runs the body once; the count bounds how
     many times that repeats before the failure is final. Clamped to at least 1.
+  lock(configure: Configure<LockSettings>): this
+    Hold a cross-run lock while this target runs: only one run may hold
+    `key` at a time, so a second run that tries to acquire it fails with a
+    {@link "./state/lock.ts".LockConflictError} naming the current holder. The
+    lock is released when the target settles — success, failure, or
+    cancellation — and expires after `options.ttl` as a backstop should the
+    holder be killed (a live holder renews it as it runs).
+
+    `key` may be a thunk, evaluated after parameters resolve, so it can depend
+    on `this.<param>.value`; compose composite keys with
+    {@link "./state/lock.ts".lockKey}. Requires a state store (a build that
+    uses `.lock()` gets a `.zuke/runs` filesystem store by default).
+
+    ```ts
+    promote = target()
+      .lock((s) =>
+        s.lockKey("deploy", this.repo.value)
+          .withTtl("4h")
+          .onConflict((h) =>
+            `${this.repo.value} is being deployed by ${h.actor} (run ${h.runId}).`))
+      .executes(...);
+    ```
 
 class TeamsAnnouncementSettings extends AnnouncementSettings
   Fluent settings for {@link AnnounceTasksApi.teams}. Bot mode
@@ -1691,6 +1776,18 @@ interface InstallReleaseOptions
     own hash — so pass a resolver `(platform) => string` (like `url`) to pin a
     checksum per platform, or a plain string when a single artifact is installed.
 
+interface LockHolder
+  Who holds a lock — surfaced to the loser of a conflict so it can act.
+
+  actor: string
+    The actor that acquired the lock.
+  runId: string
+    The run that holds it (`zuke cancel <runId>` releases it).
+  since: string
+    ISO-8601 timestamp when it was acquired.
+  runUrl?: string
+    A link to the holding run (e.g. its CI job), when known.
+
 interface OpenCacheOptions
   Optional extras for {@link openCache}: a remote store and a warning sink.
 
@@ -1954,6 +2051,8 @@ interface StateHost
     The entry names in a directory, or `[]` when the directory is absent.
   mkdirp(path: string): Promise<void>
     Create a directory and any missing parents.
+  now(): number
+    The current time in epoch milliseconds — the clock for lock expiry (injectable for tests).
 
 interface StateStore
   Pluggable persistence for run records. `version` is an opaque token (an ETag
@@ -1969,6 +2068,16 @@ interface StateStore
     the stored version has moved on — the caller re-reads and retries.
   listRuns(query: RunQuery): Promise<RunSummary[]>
     List runs matching `query`, newest first (by `createdAt`, then `id`).
+  acquireLock(key: string, holder: LockHolder, ttlMs: number): Promise<LockResult>
+    Atomically acquire the lock `key` for `holder`, expiring after `ttlMs`. An
+    expired lock is taken over. Returns a `token` on success, or the current
+    holder when the lock is live.
+  renewLock(key: string, token: string, ttlMs: number): Promise<boolean>
+    Extend the lock `key` held under `token` by another `ttlMs`. Returns `false`
+    if the token no longer owns it (expired and taken over), so a heartbeat can
+    detect a lost lock.
+  releaseLock(key: string, token: string): Promise<void>
+    Release the lock `key` if still held under `token`; a no-op otherwise.
 
 interface Style
   How a run renders its output.
@@ -2115,6 +2224,10 @@ type DownloadFn = (url: string, dest: PathLike) => Promise<void>
 type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue; }
   A JSON-serialisable value — the only thing that may be persisted in a
   target's {@link TargetStateHandle}, since run state is stored as JSON.
+
+type LockResult = { ok: true; token: string; } | { ok: false; holder: LockHolder; }
+  The result of {@link StateStore.acquireLock}: a `token` proving ownership, or
+  the current `holder` when the lock is already held.
 
 type OperatingSystem = "linux" | "macos" | "windows"
   The operating systems Zuke recognises — Deno's raw `Deno.build.os` values

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -356,6 +356,11 @@ async function installRelease(options: InstallReleaseOptions): Promise<AbsoluteP
 function isCI(): boolean
   Whether the build appears to be running in a CI environment.
 
+function lockKey(...parts: Array<string | number>): string
+  Join parts into a lock key that is safe to use as a filename and URL segment.
+  Each part is sanitised (non-`[A-Za-z0-9._-]` runs become `_`) and empty parts
+  are dropped, so `lockKey("deploy", repo)` is stable and injection-free.
+
 function operatingSystem(os: typeof Deno.build.os): OperatingSystem
   The operating system as a Zuke {@link OperatingSystem}: `darwin` becomes
   `macos`, `windows` stays `windows`, and every other Unix (`linux`, the BSDs,
@@ -373,6 +378,11 @@ function parameter(description?: string): Parameter<string, string | undefined>
   `.number()`/`.boolean()` change the kind, `.options(...)` restricts a string,
   `.default(v)`/`.required()` set optionality, and `.env(name)` overrides the
   environment variable.
+
+function parseDuration(value: string | number): number
+  Parse a duration to milliseconds. Accepts a number (already milliseconds) or a
+  string of a non-negative amount and a unit — `ms`, `s`, `m`, `h`, or `d`
+  (e.g. `"90s"`, `"4h"`, `"1.5h"`). Throws a friendly error on anything else.
 
 function plan(root: TargetBuilder): TargetBuilder[]
   Topologically sort the execution set for `root`, honouring hard dependencies
@@ -768,6 +778,12 @@ class FileSystemStateStore implements StateStore
     Publish `record` under an exclusive lock, guarding the expected version.
   async listRuns(query: RunQuery): Promise<RunSummary[]>
     List runs matching `query`, newest first. Unreadable files are skipped.
+  async acquireLock(key: string, holder: LockHolder, ttlMs: number): Promise<LockResult>
+    Atomically acquire the lock `key` for `holder`, taking over if expired.
+  async renewLock(key: string, token: string, ttlMs: number): Promise<boolean>
+    Extend the lock `key` held under `token`; `false` if the token lost it.
+  async releaseLock(key: string, token: string): Promise<void>
+    Release the lock `key` if still held under `token`; a no-op otherwise.
 
 class GraphError extends Error
   Raised when the build graph is invalid (cycle or unknown dependency).
@@ -833,6 +849,51 @@ class HttpStateStore implements StateStore
     `PUT /runs/:id` guarded by `If-Match` / `If-None-Match`; `412` → conflict.
   async listRuns(query: RunQuery): Promise<RunSummary[]>
     `GET /runs?status=&target=&since=` → an array of {@link RunSummary}.
+  async acquireLock(key: string, holder: LockHolder, ttlMs: number): Promise<LockResult>
+    `POST /locks/:key` → `201 { token }`, or `409` with the current holder.
+  async renewLock(key: string, token: string, ttlMs: number): Promise<boolean>
+    `PUT /locks/:key` renews; a `409`/`404` means the token lost the lock.
+  async releaseLock(key: string, token: string): Promise<void>
+    `DELETE /locks/:key` releases; a missing lock (`404`) is not an error.
+
+class LockConflictError extends Error
+  Raised when a target's lock is already held by another run. Its `message` is
+  the rendered guidance (from the target's `onConflict`, else a default), so it
+  surfaces verbatim in the CLI failure footer and the run record; `holder`
+  carries the structured identity for programmatic surfaces (e.g. MCP).
+
+  constructor(readonly holder: LockHolder, guidance: string)
+    Build the error from the current holder and the rendered guidance.
+  override name: string
+    The error name.
+
+class LockSettings
+  Fluent configuration for {@link TargetBuilder.lock}, in the settings-lambda
+  style: `.lock((s) => s.lockKey("deploy", repo).withTtl("4h"))`. Set the key
+  (composed from sanitised parts with {@link LockSettings.lockKey}, or directly
+  with {@link LockSettings.key}), the {@link LockSettings.withTtl | TTL}, and an
+  optional {@link LockSettings.onConflict} message. The lambda runs after
+  parameters resolve, so the key may read `this.<param>.value`.
+
+  key_?: string
+    The resolved lock key; set by {@link key} or {@link lockKey}.
+  ttl_?: string | number
+    The TTL (a duration string or milliseconds); set by {@link withTtl}.
+  onConflict_?: (holder: LockHolder) => string
+    The conflict-guidance renderer; set by {@link onConflict}.
+  lockKey(...parts: Array<string | number>): this
+    Set the lock key from parts, sanitised and joined via
+    {@link "./state/lock.ts".lockKey} — e.g. `s.lockKey("deploy", repo)`.
+  key(key: string): this
+    Set the lock key directly (must be filename-safe; prefer {@link lockKey}).
+  withTtl(ttl: string | number): this
+    How long the lock survives a killed holder — a duration string like `"4h"`
+    / `"30m"` (see the duration parser) or raw milliseconds. A live holder
+    renews it while it runs, so it never expires under it.
+  onConflict(render: (holder: LockHolder) => string): this
+    Render the guidance shown to a run that loses the lock. Receives the
+    current {@link "./state/lock.ts".LockHolder}; the returned string becomes
+    the failure message. Defaults to a generic "held by … then retry" line.
 
 class Parameter<K extends ParamValue = ParamValue, T extends K | K[] | undefined = K | undefined> implements AnyParameter
   A typed build parameter. Declare one with {@link parameter} and configure it
@@ -1044,6 +1105,8 @@ class TargetBuilder
     Remediations run after the body fails (set by {@link recoverWith}).
   recoverAttempts_: number
     Max fix-then-rerun cycles when the body fails (set by {@link recoverAttempts}).
+  lock_?: Configure<LockSettings>
+    Cross-run lock settings lambda, set by {@link lock} and run after params resolve.
   description(text: string): this
     Set the human-readable description shown in `zuke --list`.
   dependsOn(...targets: Array<TargetBuilder | Group>): this
@@ -1157,6 +1220,28 @@ class TargetBuilder
     and {@link recoverWith} remediations are configured (default 1). Each cycle
     runs every remediation, then re-runs the body once; the count bounds how
     many times that repeats before the failure is final. Clamped to at least 1.
+  lock(configure: Configure<LockSettings>): this
+    Hold a cross-run lock while this target runs: only one run may hold
+    `key` at a time, so a second run that tries to acquire it fails with a
+    {@link "./state/lock.ts".LockConflictError} naming the current holder. The
+    lock is released when the target settles — success, failure, or
+    cancellation — and expires after `options.ttl` as a backstop should the
+    holder be killed (a live holder renews it as it runs).
+
+    `key` may be a thunk, evaluated after parameters resolve, so it can depend
+    on `this.<param>.value`; compose composite keys with
+    {@link "./state/lock.ts".lockKey}. Requires a state store (a build that
+    uses `.lock()` gets a `.zuke/runs` filesystem store by default).
+
+    ```ts
+    promote = target()
+      .lock((s) =>
+        s.lockKey("deploy", this.repo.value)
+          .withTtl("4h")
+          .onConflict((h) =>
+            `${this.repo.value} is being deployed by ${h.actor} (run ${h.runId}).`))
+      .executes(...);
+    ```
 
 class TeamsAnnouncementSettings extends AnnouncementSettings
   Fluent settings for {@link AnnounceTasksApi.teams}. Bot mode
@@ -1745,6 +1830,18 @@ interface InstallReleaseOptions
     own hash — so pass a resolver `(platform) => string` (like `url`) to pin a
     checksum per platform, or a plain string when a single artifact is installed.
 
+interface LockHolder
+  Who holds a lock — surfaced to the loser of a conflict so it can act.
+
+  actor: string
+    The actor that acquired the lock.
+  runId: string
+    The run that holds it (`zuke cancel <runId>` releases it).
+  since: string
+    ISO-8601 timestamp when it was acquired.
+  runUrl?: string
+    A link to the holding run (e.g. its CI job), when known.
+
 interface OpenCacheOptions
   Optional extras for {@link openCache}: a remote store and a warning sink.
 
@@ -2008,6 +2105,8 @@ interface StateHost
     The entry names in a directory, or `[]` when the directory is absent.
   mkdirp(path: string): Promise<void>
     Create a directory and any missing parents.
+  now(): number
+    The current time in epoch milliseconds — the clock for lock expiry (injectable for tests).
 
 interface StateStore
   Pluggable persistence for run records. `version` is an opaque token (an ETag
@@ -2023,6 +2122,16 @@ interface StateStore
     the stored version has moved on — the caller re-reads and retries.
   listRuns(query: RunQuery): Promise<RunSummary[]>
     List runs matching `query`, newest first (by `createdAt`, then `id`).
+  acquireLock(key: string, holder: LockHolder, ttlMs: number): Promise<LockResult>
+    Atomically acquire the lock `key` for `holder`, expiring after `ttlMs`. An
+    expired lock is taken over. Returns a `token` on success, or the current
+    holder when the lock is live.
+  renewLock(key: string, token: string, ttlMs: number): Promise<boolean>
+    Extend the lock `key` held under `token` by another `ttlMs`. Returns `false`
+    if the token no longer owns it (expired and taken over), so a heartbeat can
+    detect a lost lock.
+  releaseLock(key: string, token: string): Promise<void>
+    Release the lock `key` if still held under `token`; a no-op otherwise.
 
 interface Style
   How a run renders its output.
@@ -2169,6 +2278,10 @@ type DownloadFn = (url: string, dest: PathLike) => Promise<void>
 type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue; }
   A JSON-serialisable value — the only thing that may be persisted in a
   target's {@link TargetStateHandle}, since run state is stored as JSON.
+
+type LockResult = { ok: true; token: string; } | { ok: false; holder: LockHolder; }
+  The result of {@link StateStore.acquireLock}: a `token` proving ownership, or
+  the current `holder` when the lock is already held.
 
 type OperatingSystem = "linux" | "macos" | "windows"
   The operating systems Zuke recognises — Deno's raw `Deno.build.os` values

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -45,6 +45,7 @@ export {
   Group,
   group,
   type JsonValue,
+  LockSettings,
   type Remediation,
   type RemediationContext,
   type RemediationResult,
@@ -95,10 +96,17 @@ export {
 } from "./src/remote_cache.ts";
 export {
   defaultStateHost,
+  type LockResult,
   type PutResult,
   type StateHost,
   type StateStore,
 } from "./src/state/store.ts";
+export {
+  LockConflictError,
+  type LockHolder,
+  lockKey,
+} from "./src/state/lock.ts";
+export { parseDuration } from "./src/duration.ts";
 export {
   type RunGraphNode,
   type RunQuery,

--- a/packages/core/src/duration.ts
+++ b/packages/core/src/duration.ts
@@ -1,0 +1,42 @@
+/**
+ * Parse a human duration string like `"4h"` or `"500ms"` into milliseconds.
+ *
+ * Used by lock TTLs (and, later, external-event wait timeouts) so a build author
+ * writes `ttl: "4h"` instead of `14_400_000`. A plain number is treated as
+ * milliseconds and returned unchanged.
+ *
+ * @module
+ */
+
+/** Milliseconds per supported unit. */
+const UNIT_MS: Record<string, number> = {
+  ms: 1,
+  s: 1000,
+  m: 60_000,
+  h: 3_600_000,
+  d: 86_400_000,
+};
+
+/**
+ * Parse a duration to milliseconds. Accepts a number (already milliseconds) or a
+ * string of a non-negative amount and a unit — `ms`, `s`, `m`, `h`, or `d`
+ * (e.g. `"90s"`, `"4h"`, `"1.5h"`). Throws a friendly error on anything else.
+ */
+export function parseDuration(value: string | number): number {
+  if (typeof value === "number") {
+    if (!Number.isFinite(value) || value < 0) {
+      throw new Error(
+        `invalid duration ${value} — expected a non-negative number of ms`,
+      );
+    }
+    return value;
+  }
+  const match = /^(\d+(?:\.\d+)?)\s*(ms|s|m|h|d)$/.exec(value.trim());
+  if (match === null) {
+    throw new Error(
+      `invalid duration "${value}" — use an amount and a unit, e.g. ` +
+        `"500ms", "90s", "30m", "4h", "1d".`,
+    );
+  }
+  return Number(match[1]) * UNIT_MS[match[2]];
+}

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -38,12 +38,19 @@ import { isCI } from "./host.ts";
 import { ServiceBuilder, ServiceRegistry } from "./service.ts";
 import { Redactor } from "./redact.ts";
 import { absolutePath } from "./path.ts";
-import type { Remediation, TargetBuilder, TargetContext } from "./target.ts";
+import {
+  LockSettings,
+  type Remediation,
+  type TargetBuilder,
+  type TargetContext,
+} from "./target.ts";
 import { withAmbientSignal } from "./ambient_signal.ts";
 import { defaultStateHost, type StateStore } from "./state/store.ts";
 import { resolveStateStore } from "./state/resolve.ts";
-import { buildRunRecord, resolveActor } from "./state/record.ts";
+import { buildRunRecord, ciRunUrl, resolveActor } from "./state/record.ts";
 import { inMemoryStateHandle, RunStateWriter } from "./state/writer.ts";
+import { LockConflictError, type LockHolder } from "./state/lock.ts";
+import { parseDuration } from "./duration.ts";
 import type { Plugin } from "./plugin.ts";
 import { detectWidth, type Style, type TargetReport } from "./report.ts";
 import { defaultRenderer, type Renderer } from "./renderer.ts";
@@ -381,12 +388,97 @@ interface RunEnv {
   runId: string;
   signal: AbortSignal;
   writer?: RunStateWriter;
+  /** The resolved state store, if any — needed to acquire cross-run locks. */
+  store?: StateStore;
+  /** The run's actor, stamped on a lock holder. */
+  actor: string;
+  /** A link to this run (CI job), stamped on a lock holder when known. */
+  runUrl?: string;
 }
 
 /** A failure's message, or `undefined` when there was none — for the state record. */
 function errorMessage(error: unknown): string | undefined {
   if (error === undefined) return undefined;
   return error instanceof Error ? error.message : String(error);
+}
+
+/** A held cross-run lock: `release` clears its heartbeat and frees it. */
+interface HeldLock {
+  release(): Promise<void>;
+}
+
+/** The default conflict guidance when a target declares no `onConflict`. */
+function defaultConflictGuidance(key: string, holder: LockHolder): string {
+  const url = holder.runUrl === undefined ? "" : ` — ${holder.runUrl}`;
+  return `Lock "${key}" is held by ${holder.actor} (run ${holder.runId}) ` +
+    `since ${holder.since}${url}. Wait for that run to finish, or stop it, ` +
+    `then retry.`;
+}
+
+/**
+ * Acquire a target's cross-run lock, if it declares one. Returns `null` when it
+ * declares no lock, or a {@link HeldLock} once acquired. Throws a
+ * {@link LockConflictError} when another run holds it, or a friendly error when
+ * a lock is declared but no store is configured.
+ */
+async function acquireTargetLock(
+  t: TargetBuilder,
+  env: RunEnv,
+): Promise<HeldLock | null> {
+  const configure = t.lock_;
+  if (configure === undefined) return null;
+  // Run the settings lambda now — after parameters have resolved — so a key
+  // built from `this.<param>.value` sees the final value.
+  const settings = configure(new LockSettings());
+  const name = t.name_ ?? "?";
+  const key = settings.key_;
+  if (key === undefined) {
+    throw new Error(
+      `Target "${name}" .lock(...) set no key — call s.lockKey(...) or s.key(...).`,
+    );
+  }
+  const store = env.store;
+  if (store === undefined) {
+    throw new Error(
+      `Target "${name}" declares .lock("${key}") but no state store is ` +
+        `configured — a lock needs one. Pass --state, set ZUKE_STATE_DIR / ` +
+        `ZUKE_STATE_URL, or override stateStore().`,
+    );
+  }
+  if (settings.ttl_ === undefined) {
+    throw new Error(
+      `Target "${name}" .lock("${key}") set no TTL — call s.withTtl(...).`,
+    );
+  }
+  const ttlMs = parseDuration(settings.ttl_);
+  const holder: LockHolder = {
+    actor: env.actor,
+    runId: env.runId,
+    since: new Date().toISOString(),
+  };
+  if (env.runUrl !== undefined) holder.runUrl = env.runUrl;
+
+  const result = await store.acquireLock(key, holder, ttlMs);
+  if (!result.ok) {
+    const guidance = settings.onConflict_
+      ? settings.onConflict_(result.holder)
+      : defaultConflictGuidance(key, result.holder);
+    throw new LockConflictError(result.holder, guidance);
+  }
+
+  const token = result.token;
+  // Renew at half the TTL so a long body keeps its short-TTL lock; cleared on
+  // release. The interval is unref'd so it never keeps the process alive.
+  const heartbeat = setInterval(() => {
+    void store.renewLock(key, token, ttlMs);
+  }, Math.max(1000, Math.floor(ttlMs / 2)));
+  Deno.unrefTimer(heartbeat);
+  return {
+    release: async () => {
+      clearInterval(heartbeat);
+      await store.releaseLock(key, token);
+    },
+  };
 }
 
 /**
@@ -616,6 +708,18 @@ async function runTarget(
     state: env.writer ? env.writer.stateHandle(name) : inMemoryStateHandle(),
     dryRun,
   };
+
+  // Acquire the target's cross-run lock (if any) before the body. A conflict —
+  // or a lock declared with no store — fails the target with the guidance.
+  let lock: HeldLock | null;
+  try {
+    lock = await acquireTargetLock(t, env);
+  } catch (error) {
+    const ms = performance.now() - start;
+    failTarget(reporter, renderer, style, name, ms, error);
+    return { status: "failed", ms, error };
+  }
+
   try {
     for (const v of t.validateBefore_) await v.validate({ target: name });
     await runBodyWithRecovery(t, name, globalRecovery, ctx);
@@ -628,6 +732,10 @@ async function runTarget(
     const ms = performance.now() - start;
     failTarget(reporter, renderer, style, name, ms, error);
     return { status: "failed", ms, error };
+  } finally {
+    // Release on every path — success, failure, cancellation. The TTL is only
+    // the backstop for a killed process.
+    if (lock !== null) await lock.release();
   }
 }
 
@@ -990,6 +1098,10 @@ export async function execute(
   // run and its per-target transitions. Never for a dry run — no body executes,
   // so there is no run to persist. State writes are best-effort: a store hiccup
   // is reported, never fatal (see RunStateWriter).
+  // A build that uses a durable feature (a cross-run lock; later, waits and
+  // compensations) turns the filesystem store on by default, so state "just
+  // works" without --state. Plain builds still opt in explicitly.
+  const usesDurableFeature = order.some((t) => t.lock_ !== undefined);
   const stateStore = dryRun ? undefined : resolveStateStore(
     options.stateStore,
     build.stateStore(),
@@ -999,9 +1111,11 @@ export async function execute(
       defaultDir: absolutePath(
         findConfigDir(Deno.cwd(), pathExists) ?? Deno.cwd(),
       )(ARTIFACT_DIR, "runs").path,
-      enableDefault: options.state ?? false,
+      enableDefault: (options.state ?? false) || usesDurableFeature,
     },
   );
+  const actor = resolveActor(options.actor, readEnv);
+  const runUrl = ciRunUrl(readEnv);
   const nowIso = () => new Date().toISOString();
   const writer = stateStore === undefined
     ? undefined
@@ -1011,7 +1125,7 @@ export async function execute(
         runId,
         build: build.constructor.name,
         rootTarget: root.name_ ?? "<unnamed>",
-        actor: resolveActor(options.actor, readEnv),
+        actor,
         now: nowIso(),
         order,
         params: params.values(),
@@ -1020,7 +1134,14 @@ export async function execute(
       redactor,
       (message) => reporter.info(message),
     );
-  const env: RunEnv = { runId, signal: runController.signal, writer };
+  const env: RunEnv = {
+    runId,
+    signal: runController.signal,
+    writer,
+    store: stateStore,
+    actor,
+    runUrl,
+  };
 
   // Services started during the run are held here and torn down in reverse
   // order once it finishes — in a `finally`, so a failure never leaks a process.

--- a/packages/core/src/state/fs_store.ts
+++ b/packages/core/src/state/fs_store.ts
@@ -14,6 +14,7 @@
 
 import {
   defaultStateHost,
+  type LockResult,
   type PutResult,
   type StateHost,
   type StateStore,
@@ -26,6 +27,12 @@ import {
   stringifyRunRecord,
   toSummary,
 } from "./types.ts";
+import {
+  type LockHolder,
+  type LockRecord,
+  parseLockRecord,
+  stringifyLockRecord,
+} from "./lock.ts";
 
 const encoder = new TextEncoder();
 
@@ -95,9 +102,23 @@ export class FileSystemStateStore implements StateStore {
     return `${this.#dir}/${id}.json.lock`;
   }
 
+  // Cross-run locks live in a `locks/` subdirectory: `<key>.json` is the lock
+  // record, `<key>.acq` the short-lived acquire mutex. The key is validated the
+  // same way a run id is, so it is safe as a filename.
+  #lockFile(key: string): string {
+    assertSafeId(key);
+    return `${this.#dir}/locks/${key}.json`;
+  }
+
+  #lockMarker(key: string): string {
+    assertSafeId(key);
+    return `${this.#dir}/locks/${key}.acq`;
+  }
+
   async #ensureDir(): Promise<void> {
     if (this.#ensured) return;
     await this.#host.mkdirp(this.#dir);
+    await this.#host.mkdirp(`${this.#dir}/locks`);
     this.#ensured = true;
   }
 
@@ -150,22 +171,100 @@ export class FileSystemStateStore implements StateStore {
     return sortNewestFirst(summaries);
   }
 
+  /** Atomically acquire the lock `key` for `holder`, taking over if expired. */
+  async acquireLock(
+    key: string,
+    holder: LockHolder,
+    ttlMs: number,
+  ): Promise<LockResult> {
+    await this.#ensureDir();
+    return await this.#withMutex(
+      this.#lockMarker(key),
+      `lock "${key}"`,
+      async () => {
+        const current = await this.#readLock(key);
+        const now = this.#host.now();
+        if (current !== null && current.expiresAt > now) {
+          return { ok: false, holder: current.holder };
+        }
+        const token = crypto.randomUUID();
+        await this.#writeLock(key, { holder, token, expiresAt: now + ttlMs });
+        return { ok: true, token };
+      },
+    );
+  }
+
+  /** Extend the lock `key` held under `token`; `false` if the token lost it. */
+  async renewLock(key: string, token: string, ttlMs: number): Promise<boolean> {
+    await this.#ensureDir();
+    return await this.#withMutex(
+      this.#lockMarker(key),
+      `lock "${key}"`,
+      async () => {
+        const current = await this.#readLock(key);
+        if (current === null || current.token !== token) return false;
+        await this.#writeLock(key, {
+          ...current,
+          expiresAt: this.#host.now() + ttlMs,
+        });
+        return true;
+      },
+    );
+  }
+
+  /** Release the lock `key` if still held under `token`; a no-op otherwise. */
+  async releaseLock(key: string, token: string): Promise<void> {
+    await this.#ensureDir();
+    await this.#withMutex(this.#lockMarker(key), `lock "${key}"`, async () => {
+      const current = await this.#readLock(key);
+      if (current !== null && current.token === token) {
+        await this.#host.remove(this.#lockFile(key));
+      }
+    });
+  }
+
+  /** Read a lock record, or `null` when the lock is free. */
+  async #readLock(key: string): Promise<LockRecord | null> {
+    const text = await this.#host.readText(this.#lockFile(key));
+    return text === null ? null : parseLockRecord(text);
+  }
+
+  /** Publish a lock record via an atomic temp-file rename. */
+  async #writeLock(key: string, record: LockRecord): Promise<void> {
+    const file = this.#lockFile(key);
+    const tmp = `${file}.tmp-${crypto.randomUUID()}`;
+    await this.#host.writeText(tmp, stringifyLockRecord(record));
+    await this.#host.rename(tmp, file);
+  }
+
   /** Take the run's lock (spinning briefly on contention), run `fn`, release. */
-  async #withLock<T>(id: string, fn: () => Promise<T>): Promise<T> {
-    const lock = this.#lock(id);
+  #withLock<T>(id: string, fn: () => Promise<T>): Promise<T> {
+    return this.#withMutex(this.#lock(id), `run "${id}"`, fn);
+  }
+
+  /**
+   * Hold the exclusive `marker` file (spinning briefly on contention) for the
+   * duration of `fn`, then release it. `subject` names what is being guarded,
+   * for the error raised if the marker cannot be taken.
+   */
+  async #withMutex<T>(
+    marker: string,
+    subject: string,
+    fn: () => Promise<T>,
+  ): Promise<T> {
     for (let attempt = 0; attempt < LOCK_ATTEMPTS; attempt++) {
-      if (await this.#host.createExclusive(lock)) {
+      if (await this.#host.createExclusive(marker)) {
         try {
           return await fn();
         } finally {
-          await this.#host.remove(lock);
+          await this.#host.remove(marker);
         }
       }
       await delay(LOCK_DELAY_MS);
     }
     throw new Error(
-      `state: could not acquire the lock for run "${id}" — ` +
-        `a stale ${lock} may need removing.`,
+      `state: could not acquire the mutex for ${subject} — ` +
+        `a stale ${marker} may need removing.`,
     );
   }
 }

--- a/packages/core/src/state/http_store.ts
+++ b/packages/core/src/state/http_store.ts
@@ -14,7 +14,7 @@
  */
 
 import { HttpError } from "../http.ts";
-import type { PutResult, StateStore } from "./store.ts";
+import type { LockResult, PutResult, StateStore } from "./store.ts";
 import {
   parseRunRecord,
   parseRunSummary,
@@ -23,6 +23,7 @@ import {
   type RunSummary,
   stringifyRunRecord,
 } from "./types.ts";
+import { type LockHolder, parseLockHolder } from "./lock.ts";
 
 /** Configuration for an {@link HttpStateStore}. */
 export interface HttpStateStoreOptions {
@@ -138,4 +139,69 @@ export class HttpStateStore implements StateStore {
     }
     return parsed.map(parseRunSummary);
   }
+
+  #lockUrl(key: string): string {
+    return `${this.#base}/locks/${encodeURIComponent(key)}`;
+  }
+
+  /** `POST /locks/:key` → `201 { token }`, or `409` with the current holder. */
+  async acquireLock(
+    key: string,
+    holder: LockHolder,
+    ttlMs: number,
+  ): Promise<LockResult> {
+    const url = this.#lockUrl(key);
+    const response = await this.#fetch(url, {
+      method: "POST",
+      headers: this.#headers({ "content-type": "application/json" }),
+      body: JSON.stringify({ holder, ttlMs }),
+    });
+    if (response.status === 409) {
+      return { ok: false, holder: parseLockHolder(await response.json()) };
+    }
+    if (!response.ok) {
+      await response.body?.cancel();
+      throw new HttpError(response.status, url);
+    }
+    const token = tokenFrom(await response.json(), url);
+    return { ok: true, token };
+  }
+
+  /** `PUT /locks/:key` renews; a `409`/`404` means the token lost the lock. */
+  async renewLock(key: string, token: string, ttlMs: number): Promise<boolean> {
+    const url = this.#lockUrl(key);
+    const response = await this.#fetch(url, {
+      method: "PUT",
+      headers: this.#headers({ "content-type": "application/json" }),
+      body: JSON.stringify({ token, ttlMs }),
+    });
+    await response.body?.cancel();
+    if (response.status === 409 || response.status === 404) return false;
+    if (!response.ok) throw new HttpError(response.status, url);
+    return true;
+  }
+
+  /** `DELETE /locks/:key` releases; a missing lock (`404`) is not an error. */
+  async releaseLock(key: string, token: string): Promise<void> {
+    const url = this.#lockUrl(key);
+    const response = await this.#fetch(url, {
+      method: "DELETE",
+      headers: this.#headers({ "content-type": "application/json" }),
+      body: JSON.stringify({ token }),
+    });
+    await response.body?.cancel();
+    if (!response.ok && response.status !== 404) {
+      throw new HttpError(response.status, url);
+    }
+  }
+}
+
+/** Extract a string `token` from a lock-acquire response body. */
+function tokenFrom(body: unknown, url: string): string {
+  if (typeof body === "object" && body !== null && !Array.isArray(body)) {
+    for (const [key, value] of Object.entries(body)) {
+      if (key === "token" && typeof value === "string") return value;
+    }
+  }
+  throw new Error(`state: ${url} did not return a token`);
 }

--- a/packages/core/src/state/lock.ts
+++ b/packages/core/src/state/lock.ts
@@ -1,0 +1,128 @@
+/**
+ * Cross-run locks: the {@link LockHolder} identity, the typed
+ * {@link LockConflictError}, the {@link lockKey} joiner, and the stored lock
+ * record with its parser.
+ *
+ * A lock lets a target claim an exclusive resource across runs and processes —
+ * "only one deploy of repo X at a time". The {@link "./store.ts".StateStore}
+ * owns acquisition (atomic, with a TTL so a crashed holder cannot wedge it
+ * forever); this module holds the value types they exchange.
+ *
+ * @module
+ */
+
+/** Who holds a lock — surfaced to the loser of a conflict so it can act. */
+export interface LockHolder {
+  /** The actor that acquired the lock. */
+  actor: string;
+  /** The run that holds it (`zuke cancel <runId>` releases it). */
+  runId: string;
+  /** ISO-8601 timestamp when it was acquired. */
+  since: string;
+  /** A link to the holding run (e.g. its CI job), when known. */
+  runUrl?: string;
+}
+
+/**
+ * Raised when a target's lock is already held by another run. Its `message` is
+ * the rendered guidance (from the target's `onConflict`, else a default), so it
+ * surfaces verbatim in the CLI failure footer and the run record; `holder`
+ * carries the structured identity for programmatic surfaces (e.g. MCP).
+ */
+export class LockConflictError extends Error {
+  /** The error name. */
+  override name = "LockConflictError";
+  /** Build the error from the current holder and the rendered guidance. */
+  constructor(
+    /** Who currently holds the contended lock. */
+    readonly holder: LockHolder,
+    /** The human-facing guidance shown to the loser. */
+    guidance: string,
+  ) {
+    super(guidance);
+  }
+}
+
+/**
+ * Join parts into a lock key that is safe to use as a filename and URL segment.
+ * Each part is sanitised (non-`[A-Za-z0-9._-]` runs become `_`) and empty parts
+ * are dropped, so `lockKey("deploy", repo)` is stable and injection-free.
+ */
+export function lockKey(...parts: Array<string | number>): string {
+  return parts
+    .map((part) => String(part).replace(/[^A-Za-z0-9._-]+/g, "_"))
+    .filter((part) => part.length > 0)
+    .join("-");
+}
+
+/** A stored lock: its holder, the acquisition token, and its expiry. */
+export interface LockRecord {
+  /** The current holder's identity. */
+  holder: LockHolder;
+  /** The opaque token the holder proves ownership with (renew/release). */
+  token: string;
+  /** Epoch-millisecond expiry; a lock at or past this is free to take over. */
+  expiresAt: number;
+}
+
+/** Narrow an unknown value to a plain object without casting, else `null`. */
+function asObject(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  const out: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value)) out[key] = val;
+  return out;
+}
+
+/** Read a required string field, throwing a descriptive error otherwise. */
+function str(object: Record<string, unknown>, field: string): string {
+  const value = object[field];
+  if (typeof value !== "string") {
+    throw new Error(`state: lock field "${field}" is not a string`);
+  }
+  return value;
+}
+
+/** Parse and validate a {@link LockHolder} from an untrusted value. */
+export function parseLockHolder(value: unknown): LockHolder {
+  const object = asObject(value);
+  if (object === null) throw new Error("state: lock holder is not an object");
+  const runUrl = object.runUrl;
+  if (runUrl !== undefined && typeof runUrl !== "string") {
+    throw new Error(`state: lock field "runUrl" is not a string`);
+  }
+  const holder: LockHolder = {
+    actor: str(object, "actor"),
+    runId: str(object, "runId"),
+    since: str(object, "since"),
+  };
+  if (runUrl !== undefined) holder.runUrl = runUrl;
+  return holder;
+}
+
+/** Parse and validate a stored {@link LockRecord}. */
+export function parseLockRecord(text: string): LockRecord {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error("state: lock record is not valid JSON");
+  }
+  const object = asObject(parsed);
+  if (object === null) throw new Error("state: lock record is not an object");
+  const expiresAt = object.expiresAt;
+  if (typeof expiresAt !== "number") {
+    throw new Error(`state: lock field "expiresAt" is not a number`);
+  }
+  return {
+    holder: parseLockHolder(object.holder),
+    token: str(object, "token"),
+    expiresAt,
+  };
+}
+
+/** Serialise a lock record to its stored form (pretty JSON + newline). */
+export function stringifyLockRecord(record: LockRecord): string {
+  return `${JSON.stringify(record, null, 2)}\n`;
+}

--- a/packages/core/src/state/record.ts
+++ b/packages/core/src/state/record.ts
@@ -44,6 +44,24 @@ export function resolveActor(
   return "anonymous";
 }
 
+/**
+ * A URL for the current CI run, when derivable — used as a lock holder's
+ * `runUrl` so a conflict can link to who holds it. GitHub Actions only for now
+ * (`GITHUB_SERVER_URL`/`GITHUB_REPOSITORY`/`GITHUB_RUN_ID`); `undefined`
+ * elsewhere.
+ */
+export function ciRunUrl(
+  readEnv: (name: string) => string | undefined,
+): string | undefined {
+  const server = readEnv("GITHUB_SERVER_URL");
+  const repo = readEnv("GITHUB_REPOSITORY");
+  const runId = readEnv("GITHUB_RUN_ID");
+  if (server && repo && runId) {
+    return `${server}/${repo}/actions/runs/${runId}`;
+  }
+  return undefined;
+}
+
 /** The inputs needed to build a run's initial {@link RunRecord}. */
 export interface RunRecordInput {
   /** The run's unique id. */

--- a/packages/core/src/state/store.ts
+++ b/packages/core/src/state/store.ts
@@ -14,11 +14,20 @@
  */
 
 import type { RunQuery, RunRecord, RunSummary } from "./types.ts";
+import type { LockHolder } from "./lock.ts";
 
 /** The result of a {@link StateStore.putRun} compare-and-swap write. */
 export type PutResult =
   | { ok: true; version: string }
   | { ok: false; conflict: true };
+
+/**
+ * The result of {@link StateStore.acquireLock}: a `token` proving ownership, or
+ * the current `holder` when the lock is already held.
+ */
+export type LockResult =
+  | { ok: true; token: string }
+  | { ok: false; holder: LockHolder };
 
 /**
  * Pluggable persistence for run records. `version` is an opaque token (an ETag
@@ -40,6 +49,24 @@ export interface StateStore {
   ): Promise<PutResult>;
   /** List runs matching `query`, newest first (by `createdAt`, then `id`). */
   listRuns(query: RunQuery): Promise<RunSummary[]>;
+  /**
+   * Atomically acquire the lock `key` for `holder`, expiring after `ttlMs`. An
+   * expired lock is taken over. Returns a `token` on success, or the current
+   * holder when the lock is live.
+   */
+  acquireLock(
+    key: string,
+    holder: LockHolder,
+    ttlMs: number,
+  ): Promise<LockResult>;
+  /**
+   * Extend the lock `key` held under `token` by another `ttlMs`. Returns `false`
+   * if the token no longer owns it (expired and taken over), so a heartbeat can
+   * detect a lost lock.
+   */
+  renewLock(key: string, token: string, ttlMs: number): Promise<boolean>;
+  /** Release the lock `key` if still held under `token`; a no-op otherwise. */
+  releaseLock(key: string, token: string): Promise<void>;
 }
 
 /**
@@ -65,6 +92,8 @@ export interface StateHost {
   listDir(path: string): Promise<string[]>;
   /** Create a directory and any missing parents. */
   mkdirp(path: string): Promise<void>;
+  /** The current time in epoch milliseconds — the clock for lock expiry (injectable for tests). */
+  now(): number;
 }
 
 /** The real, `Deno`-backed {@link StateHost}. */
@@ -114,5 +143,8 @@ export const defaultStateHost: StateHost = {
   },
   async mkdirp(path: string): Promise<void> {
     await Deno.mkdir(path, { recursive: true });
+  },
+  now(): number {
+    return Date.now();
   },
 };

--- a/packages/core/src/target.ts
+++ b/packages/core/src/target.ts
@@ -29,6 +29,60 @@
 
 import type { PathLike } from "./path.ts";
 import type { AnyParameter } from "./params.ts";
+import type { Configure } from "./tooling.ts";
+import { type LockHolder, lockKey } from "./state/lock.ts";
+
+/**
+ * Fluent configuration for {@link TargetBuilder.lock}, in the settings-lambda
+ * style: `.lock((s) => s.lockKey("deploy", repo).withTtl("4h"))`. Set the key
+ * (composed from sanitised parts with {@link LockSettings.lockKey}, or directly
+ * with {@link LockSettings.key}), the {@link LockSettings.withTtl | TTL}, and an
+ * optional {@link LockSettings.onConflict} message. The lambda runs after
+ * parameters resolve, so the key may read `this.<param>.value`.
+ */
+export class LockSettings {
+  /** The resolved lock key; set by {@link key} or {@link lockKey}. */
+  key_?: string;
+  /** The TTL (a duration string or milliseconds); set by {@link withTtl}. */
+  ttl_?: string | number;
+  /** The conflict-guidance renderer; set by {@link onConflict}. */
+  onConflict_?: (holder: LockHolder) => string;
+
+  /**
+   * Set the lock key from parts, sanitised and joined via
+   * {@link "./state/lock.ts".lockKey} — e.g. `s.lockKey("deploy", repo)`.
+   */
+  lockKey(...parts: Array<string | number>): this {
+    this.key_ = lockKey(...parts);
+    return this;
+  }
+
+  /** Set the lock key directly (must be filename-safe; prefer {@link lockKey}). */
+  key(key: string): this {
+    this.key_ = key;
+    return this;
+  }
+
+  /**
+   * How long the lock survives a killed holder — a duration string like `"4h"`
+   * / `"30m"` (see the duration parser) or raw milliseconds. A live holder
+   * renews it while it runs, so it never expires under it.
+   */
+  withTtl(ttl: string | number): this {
+    this.ttl_ = ttl;
+    return this;
+  }
+
+  /**
+   * Render the guidance shown to a run that loses the lock. Receives the
+   * current {@link "./state/lock.ts".LockHolder}; the returned string becomes
+   * the failure message. Defaults to a generic "held by … then retry" line.
+   */
+  onConflict(render: (holder: LockHolder) => string): this {
+    this.onConflict_ = render;
+    return this;
+  }
+}
 
 /**
  * A JSON-serialisable value — the only thing that may be persisted in a
@@ -228,6 +282,8 @@ export class TargetBuilder {
   readonly recoverWith_: Remediation[] = [];
   /** Max fix-then-rerun cycles when the body fails (set by {@link recoverAttempts}). */
   recoverAttempts_ = 1;
+  /** Cross-run lock settings lambda, set by {@link lock} and run after params resolve. */
+  lock_?: Configure<LockSettings>;
 
   /** Set the human-readable description shown in `zuke --list`. */
   description(text: string): this {
@@ -483,6 +539,34 @@ export class TargetBuilder {
    */
   recoverAttempts(times: number): this {
     this.recoverAttempts_ = Math.max(1, Math.floor(times));
+    return this;
+  }
+
+  /**
+   * Hold a **cross-run lock** while this target runs: only one run may hold
+   * `key` at a time, so a second run that tries to acquire it fails with a
+   * {@link "./state/lock.ts".LockConflictError} naming the current holder. The
+   * lock is released when the target settles — success, failure, or
+   * cancellation — and expires after `options.ttl` as a backstop should the
+   * holder be killed (a live holder renews it as it runs).
+   *
+   * `key` may be a thunk, evaluated after parameters resolve, so it can depend
+   * on `this.<param>.value`; compose composite keys with
+   * {@link "./state/lock.ts".lockKey}. Requires a state store (a build that
+   * uses `.lock()` gets a `.zuke/runs` filesystem store by default).
+   *
+   * ```ts
+   * promote = target()
+   *   .lock((s) =>
+   *     s.lockKey("deploy", this.repo.value)
+   *       .withTtl("4h")
+   *       .onConflict((h) =>
+   *         `${this.repo.value} is being deployed by ${h.actor} (run ${h.runId}).`))
+   *   .executes(...);
+   * ```
+   */
+  lock(configure: Configure<LockSettings>): this {
+    this.lock_ = configure;
     return this;
   }
 }

--- a/packages/core/tests/executor_test.ts
+++ b/packages/core/tests/executor_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, messageOf } from "./_assert.ts";
+import { assertEquals, assertStringIncludes, messageOf } from "./_assert.ts";
 import {
   Build,
   type BuildResult,
@@ -36,6 +36,7 @@ import type { Plugin } from "../src/plugin.ts";
 import { $ } from "../src/shell.ts";
 import { FileSystemStateStore } from "../src/state/fs_store.ts";
 import { defaultStateHost } from "../src/state/store.ts";
+import { LockConflictError } from "../src/state/lock.ts";
 
 const silent: ExecuteOptions = { silent: true };
 
@@ -1817,4 +1818,150 @@ Deno.test("with no state store, ctx.state is an in-memory no-op", async () => {
   const result = await execute(b, b.a, silent); // no stateStore
   assertEquals(result.ok, true);
   assertEquals(readBack, "v"); // visible within the run, persisted nowhere
+});
+
+Deno.test("a second run of a locked target fails with a typed conflict", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    let acquired: () => void = () => {};
+    const ready = new Promise<void>((resolve) => (acquired = resolve));
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => (release = resolve));
+    const conflict = (h: { actor: string; runId: string }) =>
+      `busy: held by ${h.actor} run ${h.runId}`;
+    class Holder extends Build {
+      promote = target()
+        .lock((s) => s.key("deploy-x").withTtl("1h").onConflict(conflict))
+        .executes(async () => {
+          acquired();
+          await gate;
+        });
+    }
+    class Contender extends Build {
+      promote = target()
+        .lock((s) => s.key("deploy-x").withTtl("1h").onConflict(conflict))
+        .executes(() => {});
+    }
+    const h = new Holder();
+    discoverTargets(h);
+    const c = new Contender();
+    discoverTargets(c);
+
+    const run1 = execute(h, h.promote, {
+      silent: true,
+      stateStore: store,
+      actor: "alice",
+    });
+    await ready; // run1 holds the lock
+
+    const result2 = await execute(c, c.promote, {
+      silent: true,
+      stateStore: store,
+      actor: "bob",
+    });
+    assertEquals(result2.ok, false);
+    assertEquals(result2.error instanceof LockConflictError, true);
+    assertStringIncludes(messageOf(result2.error), "busy: held by alice");
+
+    release();
+    assertEquals((await run1).ok, true); // releases the lock
+
+    // Free again — a later run acquires cleanly.
+    const result3 = await execute(c, c.promote, {
+      silent: true,
+      stateStore: store,
+      actor: "carol",
+    });
+    assertEquals(result3.ok, true);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("a locked target with no store fails with a friendly error", async () => {
+  class B extends Build {
+    promote = target().lock((s) => s.key("k").withTtl("1h")).executes(() => {});
+  }
+  const b = new B();
+  discoverTargets(b);
+  const result = await execute(b, b.promote, {
+    silent: true,
+    stateStore: false,
+  });
+  assertEquals(result.ok, false);
+  assertStringIncludes(messageOf(result.error), "no state store");
+});
+
+Deno.test("a lock with no key or no TTL fails with a friendly error", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    class NoKey extends Build {
+      go = target().lock((s) => s.withTtl("1h")).executes(() => {});
+    }
+    class NoTtl extends Build {
+      go = target().lock((s) => s.lockKey("deploy")).executes(() => {});
+    }
+    const noKey = new NoKey();
+    discoverTargets(noKey);
+    const r1 = await execute(noKey, noKey.go, {
+      silent: true,
+      stateStore: store,
+    });
+    assertEquals(r1.ok, false);
+    assertStringIncludes(messageOf(r1.error), "set no key");
+
+    const noTtl = new NoTtl();
+    discoverTargets(noTtl);
+    const r2 = await execute(noTtl, noTtl.go, {
+      silent: true,
+      stateStore: store,
+    });
+    assertEquals(r2.ok, false);
+    assertStringIncludes(messageOf(r2.error), "set no TTL");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("cancelling a locked run releases the lock", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    const controller = new AbortController();
+    let started: () => void = () => {};
+    const ready = new Promise<void>((resolve) => (started = resolve));
+    class B extends Build {
+      hold = target().lock((s) => s.key("k").withTtl("1h")).executes((ctx) =>
+        new Promise<void>((_, reject) => {
+          started();
+          ctx.signal.addEventListener(
+            "abort",
+            () => reject(new Error("cancelled")),
+            { once: true },
+          );
+        })
+      );
+    }
+    const b = new B();
+    discoverTargets(b);
+    const run = execute(b, b.hold, {
+      silent: true,
+      stateStore: store,
+      signal: controller.signal,
+    });
+    await ready;
+    controller.abort();
+    await run; // body rejects on abort → target fails → finally releases the lock
+
+    const acq = await store.acquireLock("k", {
+      actor: "x",
+      runId: "r",
+      since: "t",
+    }, 1000);
+    assertEquals(acq.ok, true); // lock was freed on cancellation
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
 });

--- a/packages/core/tests/state_test.ts
+++ b/packages/core/tests/state_test.ts
@@ -27,9 +27,17 @@ import {
 } from "../src/state/record.ts";
 import { inMemoryStateHandle, RunStateWriter } from "../src/state/writer.ts";
 import { Redactor } from "../src/redact.ts";
-import { target } from "../src/target.ts";
+import { LockSettings, target } from "../src/target.ts";
 import { Build, discoverTargets } from "../src/build.ts";
 import { discoverParameters, parameter } from "../src/params.ts";
+import { parseDuration } from "../src/duration.ts";
+import {
+  LockConflictError,
+  lockKey,
+  parseLockHolder,
+  parseLockRecord,
+  stringifyLockRecord,
+} from "../src/state/lock.ts";
 
 /** A minimal, valid run record for tests. */
 function sampleRecord(overrides: Partial<RunRecord> = {}): RunRecord {
@@ -88,6 +96,11 @@ class FakeStateHost implements StateHost {
   }
   mkdirp(): Promise<void> {
     return Promise.resolve();
+  }
+  /** A controllable clock for lock-TTL tests; advance it with `time`. */
+  time = 1_000_000;
+  now(): number {
+    return this.time;
   }
 }
 
@@ -592,6 +605,16 @@ class MemStore implements StateStore {
     this.version += 1;
     return Promise.resolve({ ok: true, version: String(this.version) });
   }
+  // Locks are exercised against the real backends, not this run-only fake.
+  acquireLock(): Promise<never> {
+    throw new Error("MemStore: acquireLock is unused in these tests");
+  }
+  renewLock(): Promise<never> {
+    throw new Error("MemStore: renewLock is unused in these tests");
+  }
+  releaseLock(): Promise<never> {
+    throw new Error("MemStore: releaseLock is unused in these tests");
+  }
 }
 
 Deno.test("RunStateWriter records transitions and redacted state", async () => {
@@ -718,5 +741,223 @@ Deno.test("FileSystemStateStore errors when a lock is permanently held", async (
     () => store.putRun(sampleRecord(), null),
     Error,
     "could not acquire",
+  );
+});
+
+// ---------------------------------------------------------------- duration
+
+Deno.test("parseDuration parses units and passes numbers through", () => {
+  assertEquals(parseDuration("500ms"), 500);
+  assertEquals(parseDuration("90s"), 90_000);
+  assertEquals(parseDuration("30m"), 1_800_000);
+  assertEquals(parseDuration("4h"), 14_400_000);
+  assertEquals(parseDuration("1.5h"), 5_400_000);
+  assertEquals(parseDuration("1d"), 86_400_000);
+  assertEquals(parseDuration(1234), 1234);
+});
+
+Deno.test("parseDuration rejects nonsense", () => {
+  assertThrows(() => parseDuration("soon"), Error, "invalid duration");
+  assertThrows(() => parseDuration("10x"), Error, "invalid duration");
+  assertThrows(() => parseDuration(-5), Error, "non-negative");
+});
+
+// ---------------------------------------------------------------- lock types
+
+Deno.test("LockSettings collects key, ttl, and onConflict fluently", () => {
+  const render = (h: { actor: string }) => `held by ${h.actor}`;
+  const composed = new LockSettings().lockKey("deploy", "x").withTtl("4h")
+    .onConflict(render);
+  assertEquals(composed.key_, "deploy-x");
+  assertEquals(composed.ttl_, "4h");
+  assertEquals(composed.onConflict_, render);
+  // .key() sets a literal key.
+  assertEquals(new LockSettings().key("raw").key_, "raw");
+});
+
+Deno.test("lockKey sanitises and joins parts", () => {
+  assertEquals(lockKey("deploy", "expense-service"), "deploy-expense-service");
+  assertEquals(lockKey("deploy", "a/b:c"), "deploy-a_b_c");
+  assertEquals(lockKey("", "x"), "x"); // empty parts dropped
+});
+
+Deno.test("LockConflictError carries the holder and guidance", () => {
+  const holder = { actor: "bob", runId: "r7", since: "t" };
+  const err = new LockConflictError(holder, "held by bob");
+  assertEquals(err.message, "held by bob");
+  assertEquals(err.holder.actor, "bob");
+  assertEquals(err.name, "LockConflictError");
+});
+
+Deno.test("parseLockHolder validates untrusted holders", () => {
+  const holder = { actor: "a", runId: "r", since: "t", runUrl: "https://x" };
+  assertEquals(parseLockHolder(holder), holder);
+  assertEquals(parseLockHolder({ actor: "a", runId: "r", since: "t" }), {
+    actor: "a",
+    runId: "r",
+    since: "t",
+  });
+  assertThrows(() => parseLockHolder(5), Error, "not an object");
+  assertThrows(() => parseLockHolder({ actor: "a" }), Error, "runId");
+  assertThrows(
+    () => parseLockHolder({ actor: "a", runId: "r", since: "t", runUrl: 5 }),
+    Error,
+    "runUrl",
+  );
+});
+
+Deno.test("parseLockRecord round-trips and rejects malformed", () => {
+  const record = {
+    holder: { actor: "a", runId: "r", since: "t" },
+    token: "tok",
+    expiresAt: 123,
+  };
+  assertEquals(parseLockRecord(stringifyLockRecord(record)), record);
+  assertThrows(() => parseLockRecord("nope"), Error, "not valid JSON");
+  assertThrows(() => parseLockRecord("[]"), Error, "not an object");
+  assertThrows(
+    () => parseLockRecord(JSON.stringify({ ...record, expiresAt: "soon" })),
+    Error,
+    "expiresAt",
+  );
+});
+
+// ---------------------------------------------------------------- fs locks
+
+Deno.test("FileSystemStateStore locks: acquire, conflict, renew, release", async () => {
+  const host = new FakeStateHost();
+  const store = new FileSystemStateStore("/s", host);
+  const holderA = { actor: "a", runId: "r1", since: "t1" };
+  const holderB = { actor: "b", runId: "r2", since: "t2" };
+
+  const first = await store.acquireLock("deploy", holderA, 60_000);
+  if (!first.ok) throw new Error("expected first acquire to win");
+
+  // A second acquire while live loses, and learns the holder.
+  const second = await store.acquireLock("deploy", holderB, 60_000);
+  assertEquals(second.ok, false);
+  assertEquals(second.ok === false && second.holder.runId, "r1");
+
+  // Renew with the right token succeeds; a wrong token does not.
+  assertEquals(await store.renewLock("deploy", first.token, 60_000), true);
+  assertEquals(await store.renewLock("deploy", "wrong", 60_000), false);
+
+  // Release frees it; a fresh acquire then wins.
+  await store.releaseLock("deploy", first.token);
+  const third = await store.acquireLock("deploy", holderB, 60_000);
+  assertEquals(third.ok, true);
+});
+
+Deno.test("FileSystemStateStore locks: an expired lock is taken over (fake clock)", async () => {
+  const host = new FakeStateHost();
+  const store = new FileSystemStateStore("/s", host);
+  const won = await store.acquireLock("k", {
+    actor: "a",
+    runId: "r1",
+    since: "t",
+  }, 1000);
+  if (!won.ok) throw new Error("expected acquire to win");
+
+  // Still live: a second acquirer loses.
+  const blocked = await store.acquireLock("k", {
+    actor: "b",
+    runId: "r2",
+    since: "t",
+  }, 1000);
+  assertEquals(blocked.ok, false);
+
+  // Advance past the TTL (simulating the holder being kill -9'd): take over.
+  host.time += 2000;
+  const took = await store.acquireLock("k", {
+    actor: "b",
+    runId: "r2",
+    since: "t",
+  }, 1000);
+  assertEquals(took.ok, true);
+  // The stale holder's renew now fails — it lost the lock.
+  assertEquals(await store.renewLock("k", won.token, 1000), false);
+});
+
+Deno.test("FileSystemStateStore locks: concurrent acquire — exactly one wins", async () => {
+  const host = new FakeStateHost();
+  const store = new FileSystemStateStore("/s", host);
+  const results = await Promise.all([
+    store.acquireLock("k", { actor: "a", runId: "r1", since: "t" }, 60_000),
+    store.acquireLock("k", { actor: "b", runId: "r2", since: "t" }, 60_000),
+  ]);
+  assertEquals(results.filter((r) => r.ok).length, 1);
+  assertEquals(results.filter((r) => !r.ok).length, 1);
+});
+
+Deno.test("FileSystemStateStore locks: release/renew with no lock is safe", async () => {
+  const store = new FileSystemStateStore("/s", new FakeStateHost());
+  await store.releaseLock("absent", "tok"); // no throw
+  assertEquals(await store.renewLock("absent", "tok", 1000), false);
+});
+
+// ---------------------------------------------------------------- http locks
+
+Deno.test("HttpStateStore locks: acquire 201/409, renew, release", async () => {
+  const holder = { actor: "a", runId: "r1", since: "t" };
+  const store = new HttpStateStore({
+    url: "https://s",
+    fetch: fakeFetch((url, init) => {
+      const method = init?.method;
+      if (url.endsWith("/locks/held") && method === "POST") {
+        return new Response(JSON.stringify(holder), { status: 409 });
+      }
+      if (method === "POST") {
+        return new Response(JSON.stringify({ token: "tok-9" }), {
+          status: 201,
+        });
+      }
+      if (method === "PUT") return new Response(null, { status: 200 });
+      if (method === "DELETE") return new Response(null, { status: 200 });
+      return new Response(null, { status: 500 });
+    }),
+  });
+  const ok = await store.acquireLock("free", holder, 1000);
+  assertEquals(ok, { ok: true, token: "tok-9" });
+  const conflict = await store.acquireLock("held", holder, 1000);
+  assertEquals(conflict.ok === false && conflict.holder.runId, "r1");
+  assertEquals(await store.renewLock("free", "tok-9", 1000), true);
+  await store.releaseLock("free", "tok-9"); // no throw
+});
+
+Deno.test("HttpStateStore locks: renew 409/404 → lost; errors throw", async () => {
+  const lost = new HttpStateStore({
+    url: "https://s",
+    fetch: fakeFetch(() => new Response(null, { status: 409 })),
+  });
+  assertEquals(await lost.renewLock("k", "t", 1000), false);
+
+  const missing = new HttpStateStore({
+    url: "https://s",
+    fetch: fakeFetch(() => new Response(null, { status: 404 })),
+  });
+  assertEquals(await missing.renewLock("k", "t", 1000), false);
+  await missing.releaseLock("k", "t"); // 404 on release is not an error
+
+  const boom = new HttpStateStore({
+    url: "https://s",
+    fetch: fakeFetch(() => new Response(null, { status: 500 })),
+  });
+  await assertRejects(
+    () => boom.acquireLock("k", { actor: "a", runId: "r", since: "t" }, 1000),
+    HttpError,
+  );
+  await assertRejects(() => boom.renewLock("k", "t", 1000), HttpError);
+  await assertRejects(() => boom.releaseLock("k", "t"), HttpError);
+});
+
+Deno.test("HttpStateStore locks: a 201 without a token is an error", async () => {
+  const store = new HttpStateStore({
+    url: "https://s",
+    fetch: fakeFetch(() => new Response("{}", { status: 201 })),
+  });
+  await assertRejects(
+    () => store.acquireLock("k", { actor: "a", runId: "r", since: "t" }, 1000),
+    Error,
+    "did not return a token",
   );
 });

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -94,6 +94,13 @@ Before calling any task or settings method, confirm the real shape:
   `ctx.state.set({ … })` / `ctx.state.get()` records per-target metadata (JSON,
   **never secrets** — secret parameters and redacted values are excluded). See
   the cheatsheet.
+- **Cross-run locks:** `.lock((s) => s.lockKey(...).withTtl("4h"))` — a settings
+  lambda — gives a target an exclusive claim across runs/machines; a second run
+  wanting the same key fails with a `LockConflictError` naming the holder. The
+  lambda runs after params resolve, so the key can read `this.<param>.value`.
+  The lock releases when the target settles and expires after the TTL if the
+  holder is killed. Needs a state store (a build with `.lock()` enables the
+  filesystem store by default). See the cheatsheet.
 - **Typed inputs:** `parameter("...")` (with `.secret()` / `.required()`), read
   as `this.x.value`, gated with `.requires(this.x)`.
 - **Secrets from a manager:** `parameter(...).secret().from(source)` sources a

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -22,6 +22,7 @@ Everything is optional except a body (`.executes`).
 | `.requires(...params)` | Fail unless the listed parameters resolved to a value. |
 | `.retry(times, delayMs?)` | Retry the body on failure. |
 | `.timeout(ms)` | Fail the body if it runs longer than `ms` (per attempt). |
+| `.lock((s) => s.lockKey(...).withTtl(...))` | Hold a cross-run lock while running; a second run wanting the key fails. See below. |
 | `.proceedAfterFailure()` | Keep the build going if this target fails. |
 | `.always()` | Run even after the build failed (cleanup/teardown). |
 | `.unlisted()` | Hide from `--list`/`--help`; still runnable by name. |
@@ -153,6 +154,36 @@ class CD extends Build {
 - **Never put secrets in `ctx.state`** — it is stored as plain JSON. Secret
   parameters are excluded from the record and state values are run through the
   redactor, but treat state as a non-secret channel. See `docs/state.md`.
+
+## Cross-run locks
+
+`.lock((s) => …)` takes a **settings lambda** (like the tool wrappers) and
+claims an exclusive resource across runs and machines. A second run that wants
+the same key **fails** with a `LockConflictError` (naming the holder) — it does
+not queue.
+
+```ts
+import { Build, target } from "jsr:@zuke/core";
+
+class CD extends Build {
+  repo = parameter("service");
+  promote = target()
+    .lock((s) =>
+      s.lockKey("deploy", this.repo.value) // sanitised composite key
+        .withTtl("4h") // renewed while running; expires this long after a kill -9
+        .onConflict((h) => `${this.repo.value} held by ${h.actor} (run ${h.runId}).`))
+    .executes(async (ctx) => {/* … */});
+}
+```
+
+- `s.lockKey(...parts)` sanitises and joins a composite key; `s.key(literal)`
+  sets one directly. The lambda runs after params resolve, so the key can read
+  `this.<param>.value`.
+- Released when the target settles (success, failure, cancellation); `ttl` is
+  only the backstop for a killed holder.
+- Needs a state store — a build using `.lock()` enables the `.zuke/runs`
+  filesystem store by default; use the HTTP backend to share locks across
+  machines. See `docs/locks.md`.
 
 ## Parameters — typed build inputs
 


### PR DESCRIPTION
## What

**M2** of the orchestration plan: a target can hold a **cross-run lock** — an exclusive claim on a resource across runs, processes, and machines ("only one deploy of repo X at a time").

```ts
promote = target()
  .lock(() => lockKey("deploy", this.repo.value), {
    ttl: "4h",
    onConflict: (h) => `${this.repo.value} held by ${h.actor} (run ${h.runId}).`,
  })
  .executes(async (ctx) => { /* … */ });
```

### Authoring
- `.lock(key, { ttl, onConflict? })` on `TargetBuilder`; `key` is a string or thunk (evaluated after params resolve). `lockKey(...parts)` sanitises + joins a composite key. A second run wanting a held key **fails** with a typed `LockConflictError` (carrying `holder`), not a queue.

### Store
- `StateStore` gains `acquireLock` / `renewLock` / `releaseLock`. **Filesystem** backend: an `O_EXCL` acquire mutex + a lock record with `expiresAt`. **HTTP** backend: `POST`/`PUT`/`DELETE /locks/:key`, server authoritative for expiry. Acquisition is atomic (two runs racing a free key → exactly one wins); an expired lock is taken over.
- New `StateHost.now()` clock (injectable → deterministic TTL tests) and a shared `parseDuration` (`"4h"`, `"30m"`, ms), which M3 reuses.

### Lifecycle
- Released when the target settles — success, failure, **or cancellation** — in a `finally`. A live holder renews at ½ TTL, so a long body under a short TTL keeps its lock; TTL is only the backstop for a `kill -9`'d holder. A build using `.lock()` enables the `.zuke/runs` filesystem store **by default**; declaring a lock with state disabled fails with a friendly error.

### Docs & skills
- New `docs/locks.md`; `zuke-write-build` SKILL + cheatsheet updated.

## Acceptance (met)
- **Concurrent acquire → exactly one winner + typed loser** — tested at the store (fake host + real `O_EXCL`) and end-to-end through `execute` (`LockConflictError` with guidance).
- **TTL expiry after a simulated `kill -9`** — advance an injected clock past the TTL, a new holder takes over, the stale holder's renew returns `false`.
- **A cancelled run releases immediately** — cancel a locked run; a subsequent acquire succeeds.

## Verification
`deno task ci` green — fmt, lint, spell, `deno check`, coverage (lines **98.7%**, branches **96.0%**). `deno doc --lint` clean; `apiDocsCheck` no drift.

## Notes / not in this PR
- Default conflict guidance says "wait for that run to finish, or stop it" — it does **not** yet reference `zuke cancel`, which arrives in **M6**. Structured conflict on MCP is **M5**.
- **M1 PR2** (`zuke runs list/show` — reading state from the CLI) was skipped to proceed to M2; durable state is written but not yet CLI-viewable.