### PR TITLE
feat(core): suspendable targets with waitsFor and external signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ Full documentation lives in [`docs/`](./docs/):
   [HTTP API](./docs/state-api.md) for hosting a production backend.
 - [Cross-run locks](./docs/locks.md) — `.lock()` claims an exclusive resource
   across runs and machines, with a TTL backstop and typed `LockConflictError`s.
+- [Orchestration: waits](./docs/orchestration.md) — `.waitsFor()` suspends a run
+  until an external signal or predicate, saving its state to be resumed later.
 - [Shell wrapper (`$`)](./docs/shell.md) — ergonomic, injection-safe process
   execution.
 - [Paths (`absolutePath`)](./docs/paths.md) — the fluent path type.

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,8 @@
   metadata to a pluggable store, and read it back after the process exits.
 - [Cross-run locks](./locks.md) — `.lock()` claims an exclusive resource across
   runs and machines, with a TTL backstop and typed conflicts.
+- [Orchestration: waits & suspend/resume](./orchestration.md) — `.waitsFor()`
+  suspends a run until an external event, to be resumed later.
 - [State HTTP API](./state-api.md) — the REST contract for hosting a production
   state backend.
 - [Shell wrapper (`$`)](./shell.md) — ergonomic, injection-safe process

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -1,0 +1,89 @@
+# Orchestration: waits & suspend/resume
+
+A deployment pipeline often has to **pause for something outside the build** —
+manual QA sign-off, a soak period, another system's callback — and continue
+later, possibly days later and in a different process. Zuke models this as a
+**wait**: a target suspends the run until an external event occurs; the run's
+state is saved to the [state store](./state.md), and it is resumed when the
+event happens.
+
+> This page covers the **suspend** half — declaring a wait and what happens when
+> a run parks on it. Resuming a suspended run (`zuke resume`) lands in the next
+> release; the run's state is fully persisted in the meantime.
+
+## Declaring a wait — `.waitsFor()`
+
+`.waitsFor()` makes a target a **gate**: it has no body, and the run proceeds
+past it only once its trigger is satisfied.
+
+```ts
+import { Build, externalSignal, target } from "jsr:@zuke/core";
+
+class Deploy extends Build {
+  deployToSit = target().executes(async (ctx) => {
+    await applyToSit();
+    await ctx.state.set({ at: "sit-7" }); // survives the suspend (see below)
+  });
+
+  awaitTesting = target()
+    .dependsOn(this.deployToSit)
+    .waitsFor((s) =>
+      s.on(externalSignal("testing-approved"))
+        .timeout("72h")
+        .onTimeout(() => this.rollback));
+
+  promoteToProd = target()
+    .dependsOn(this.awaitTesting)
+    .executes((ctx) => {
+      const approval = ctx.signals.get("testing-approved"); // the signal payload
+      promote(approval?.data);
+    });
+
+  rollback = target().executes(() => rollBackSit());
+}
+```
+
+`.waitsFor((s) => …)` is a fluent settings lambda ([like the rest](./locks.md)):
+
+- **`s.on(trigger)`** — the event to wait for. Two triggers ship:
+  - **`externalSignal(name)`** — satisfied when a signal named `name` is
+    delivered to the run. Its JSON payload is exposed to later target bodies
+    through `ctx.signals`.
+  - **`resumeWhen(fn, { interval? })`** — satisfied when an async predicate
+    returns `true`. Zuke doesn't poll on its own; the predicate is re-checked on
+    each resume, so a cron or webhook drives it.
+- **`s.timeout("72h")`** — an optional deadline. Its purpose and enforcement
+  (running `onTimeout`) arrive with the resume half.
+- **`s.onTimeout(() => this.rollback)`** — what a timed-out wait does: a **thunk**
+  returning a sibling compensation target, or `"fail"` / `"cancel-run"`. A thunk
+  because the compensation is usually declared *below* the waiting target, and
+  fields initialise top-to-bottom.
+
+## What suspend does
+
+When the scheduler reaches a wait whose trigger is **not** satisfied:
+
+1. The target is recorded **`waiting`**, with its `waitingFor` (the trigger, the
+   deadline, and the timeout disposition).
+2. The run is recorded **`suspended`**.
+3. Targets **behind** the wait stay `pending` (a resume will run them);
+   **independent** branches run to completion.
+4. The process prints where the run was saved and **exits 0** — a suspended run
+   has not failed.
+
+A satisfied trigger, by contrast, passes straight through: the gate is
+`succeeded` and its dependents run in the same process.
+
+Because a wait must be resumable, **it requires a state store** — a build that
+uses `.waitsFor()` turns on the `.zuke/runs` filesystem store by default (like
+locks). Declaring a wait with state disabled fails with a friendly error.
+
+## State is the only thing that crosses the boundary
+
+A resume is a **fresh process**: the in-memory world of the suspending run is
+gone. Anything a later target needs must be in the durable record —
+`ctx.state` (per-target metadata) and `ctx.signals` (delivered payloads). This
+is the mental model to build around: persist what matters, read it back on the
+other side.
+
+See [Durable run state](./state.md) for the record shape and `ctx.state`.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -190,6 +190,11 @@ function executionSet(root: TargetBuilder): Set<TargetBuilder>
   Compute the execution set for a requested target: the target plus the
   transitive closure of its hard dependencies.
 
+function externalSignal(name: string): WaitTrigger
+  A trigger satisfied when a signal named `name` has been delivered to the run
+  (via `zuke resume <id> --signal <name>`). The signal's payload is exposed to
+  target bodies through {@link "./target.ts".TargetContext} `signals`.
+
 async function extractTarGzip(src: PathLike, destDir: PathLike): Promise<void>
   Read the `.tar.gz` at `src`, gunzip and unpack it, and write each entry under
   `destDir` (creating parent directories as needed).
@@ -383,6 +388,12 @@ async function restoreOutputs(artifact: Uint8Array, host: OutputHost): Promise<s
   validated first: an absolute path or one escaping the workspace (`..`) is
   rejected before anything is written, so a malicious archive can't plant files
   outside the current directory.
+
+function resumeWhen(check: () => boolean | Promise<boolean>, options: ResumeWhenOptions): WaitTrigger
+  A trigger satisfied when an async `check` predicate returns `true`. Zuke does
+  not poll on its own — the predicate is evaluated when the target is reached
+  and on each `zuke resume <id> --check`, so a cron or webhook nudging `--check`
+  drives it. Use it to wait on state Zuke can query (a row, a file, an API).
 
 async function run(BuildClass: new () => Build, options: RunOptions): Promise<void>
   Public entry point. Instantiate the build, parse arguments, run, and set the
@@ -1053,6 +1064,8 @@ class TargetBuilder
     Max fix-then-rerun cycles when the body fails (set by {@link recoverAttempts}).
   lock_?: Configure<LockSettings>
     Cross-run lock settings lambda, set by {@link lock} and run after params resolve.
+  waitsFor_?: Configure<WaitSettings>
+    External-event wait settings lambda, set by {@link waitsFor} and run when reached.
   description(text: string): this
     Set the human-readable description shown in `zuke --list`.
   dependsOn(...targets: Array<TargetBuilder | Group>): this
@@ -1188,6 +1201,22 @@ class TargetBuilder
             `${this.repo.value} is being deployed by ${h.actor} (run ${h.runId}).`))
       .executes(...);
     ```
+  waitsFor(configure: Configure<WaitSettings>): this
+    Suspend the run at this target until an external event occurs, then let the
+    run be resumed later (in a different process) — a settings lambda in the
+    same style as {@link lock}. The target is a gate (no body): when its
+    trigger is already satisfied it passes and dependents run; otherwise the
+    run's state is saved, the run is marked suspended, its independent branches
+    finish, and the process exits 0. Requires a state store.
+
+    ```ts
+    awaitApproval = target()
+      .dependsOn(this.deploy)
+      .waitsFor((s) =>
+        s.on(externalSignal("testing-approved"))
+          .timeout("72h")
+          .onTimeout(() => this.rollback));
+    ```
 
 class TeamsAnnouncementSettings extends AnnouncementSettings
   Fluent settings for {@link AnnounceTasksApi.teams}. Bot mode
@@ -1258,6 +1287,28 @@ class Toolchain
     Install every declared tool concurrently — reusing a cached copy where a
     pinned checksum matches — and return a map of tool name to installed
     {@link AbsolutePath}.
+
+class WaitSettings
+  Fluent configuration for {@link TargetBuilder.waitsFor}:
+  `.waitsFor((s) => s.on(externalSignal("approved")).timeout("72h"))`. Set the
+  {@link WaitSettings.on | trigger}, an optional {@link WaitSettings.timeout},
+  and an optional {@link WaitSettings.onTimeout} disposition. The lambda runs
+  when the target is reached, so the trigger may read `this.<param>.value`.
+
+  trigger_?: WaitTrigger
+    The trigger deciding when the wait is satisfied; set by {@link on}.
+  timeout_?: string | number
+    The deadline duration (string or ms); set by {@link timeout}.
+  onTimeout_?: OnTimeout
+    The timeout disposition thunk; set by {@link onTimeout}.
+  on(trigger: WaitTrigger): this
+    Set the {@link "./wait.ts".WaitTrigger} the wait is satisfied by.
+  timeout(duration: string | number): this
+    Give the wait a deadline (a duration like `"72h"` or milliseconds).
+  onTimeout(disposition: OnTimeout): this
+    What to do when the deadline passes: a thunk returning a sibling
+    compensation target (a thunk, so it can reference a target declared below
+    this one), or the string `"fail"` / `"cancel-run"`. Defaults to `"fail"`.
 
 interface AbsolutePath
   An immutable, absolute filesystem path with a fluent API.
@@ -1388,11 +1439,15 @@ interface BuildResult
   Result passed to the {@link Build.onFinish} lifecycle hook.
 
   ok: boolean
-    Whether every executed target succeeded.
+    Whether every executed target succeeded (also `true` for a suspended run).
   executed: string[]
     Names of the targets that ran, in execution order.
   error?: unknown
     The error that aborted the run, if any.
+  suspended?: boolean
+    True when the run suspended at a `.waitsFor(...)` gate rather than
+    finishing — its state is saved and it can be resumed later. The process
+    still exits 0.
 
 interface CiConcurrency
   A concurrency group: at most one run per group, optionally cancelling the prior one.
@@ -1932,6 +1987,12 @@ interface ResolveStateOptions
     Set when the run opts into durable state (`--state`, or — from a later
     milestone — a durable feature like a lock or a wait).
 
+interface ResumeWhenOptions
+  Options for {@link resumeWhen}.
+
+  interval?: string | number
+    How often `zuke resume --check` should re-evaluate the predicate.
+
 interface RunGraphNode
   One entry of a run's graph-shape snapshot.
 
@@ -1986,6 +2047,8 @@ interface RunRecord
     Resolved parameter values, keyed by name. Secrets are always omitted.
   targets: Record<string, TargetRunState>
     Per-target progress, keyed by dotted target name.
+  signals: Record<string, SignalRecord>
+    External signals received so far, keyed by name (see `.waitsFor(...)`).
 
 interface RunSummary
   A compact run listing row, returned by {@link "./store.ts".StateStore.listRuns}.
@@ -2030,6 +2093,14 @@ interface ServiceHandle
 
   stop(): void | Promise<void>
     Terminate the service. Called on teardown unless `.stop()` overrides it.
+
+interface SignalRecord
+  A payload received for an external signal (see {@link RunRecord.signals}).
+
+  data: JsonValue
+    The signal's JSON payload (`{}` when none was sent).
+  receivedAt: string
+    ISO-8601 timestamp when the signal was recorded.
 
 interface StateHost
   Injected filesystem effects for {@link "./fs_store.ts".FileSystemStateStore},
@@ -2118,6 +2189,10 @@ interface TargetContext
     configured (see {@link "./state/store.ts".StateStore}), and an in-memory
     no-op otherwise. The carrier for state that must survive across a
     suspend/resume boundary — do not put secrets in it.
+  readonly signals: ReadonlyMap<string, SignalRecord>
+    Payloads of the external signals received so far, keyed by name (see
+    `.waitsFor(...)` and {@link "./wait.ts".externalSignal}). Empty until a
+    signal is delivered by `zuke resume <id> --signal <name>`.
   readonly dryRun: boolean
     True when the run is a dry run (bodies do not execute under a dry run).
 
@@ -2144,6 +2219,8 @@ interface TargetRunState
     ISO-8601 timestamp when the target settled, if it has.
   error?: string
     The failure message when `status` is `failed`.
+  waitingFor?: WaitState
+    The pending wait when `status` is `waiting` (set by `.waitsFor(...)`).
 
 interface TargetStateHandle
   A target's durable, per-target metadata, surfaced on {@link TargetContext} as
@@ -2194,6 +2271,29 @@ interface ValidationContext
   target: string
     The name of the target the validation is attached to.
 
+interface WaitState
+  The pending wait recorded on a suspended target (see {@link TargetRunState.waitingFor}).
+
+  trigger: string
+    A human-readable descriptor of what is awaited (e.g. `signal:approved`).
+  deadline?: string
+    ISO-8601 deadline after which {@link onTimeout} applies, if a timeout was set.
+  onTimeout: WaitDisposition
+    What happens when the deadline passes.
+
+interface WaitTrigger
+  Decides whether the event a target waits for has occurred. `descriptor` is a
+  short, JSON-safe label recorded on the suspended target; `isSatisfied` is
+  evaluated against the run's received signals when the target is reached and
+  again on each resume attempt.
+
+  readonly descriptor: string
+    A short label recorded on the wait (e.g. `signal:approved`).
+  readonly pollIntervalMs?: number
+    Poll interval hint (ms) for predicate triggers driven by `zuke resume --check`.
+  isSatisfied(signals: ReadonlyMap<string, SignalRecord>): boolean | Promise<boolean>
+    Whether the awaited event has occurred, given the run's received signals.
+
 type AnnouncementLevel = "success" | "failure" | "warning" | "info"
   The outcome an announcement conveys. It drives the accent colour and the icon
   prepended to the message; defaults to `"info"`.
@@ -2229,6 +2329,9 @@ type LockResult = { ok: true; token: string; } | { ok: false; holder: LockHolder
   The result of {@link StateStore.acquireLock}: a `token` proving ownership, or
   the current `holder` when the lock is already held.
 
+type OnTimeout = () => TargetBuilder | "fail" | "cancel-run"
+  What a timed-out wait does — resolved from {@link WaitSettings.onTimeout}.
+
 type OperatingSystem = "linux" | "macos" | "windows"
   The operating systems Zuke recognises — Deno's raw `Deno.build.os` values
   normalised to a friendly set (notably `darwin` → `macos`). Used across the
@@ -2263,8 +2366,13 @@ type TargetRunStatus = "pending" | "running" | "waiting" | "succeeded" | "failed
   external-event wait) is produced only from a later milestone; the executor
   records the others.
 
-type TargetStatus = "passed" | "failed" | "skipped" | "cached"
+type TargetStatus = "passed" | "failed" | "skipped" | "cached" | "waiting"
   The outcome of a single target, reported in the summary and lifecycle hooks.
+  `waiting` marks a `.waitsFor(...)` gate whose event has not occurred — the run
+  suspends there.
+
+type WaitDisposition = "fail" | "cancel-run" | { target: string; }
+  What a timed-out wait does: fail, cancel the run, or run a compensation target.
 
 ========================================================================
 # @zuke/deno

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -244,6 +244,11 @@ function executionSet(root: TargetBuilder): Set<TargetBuilder>
   Compute the execution set for a requested target: the target plus the
   transitive closure of its hard dependencies.
 
+function externalSignal(name: string): WaitTrigger
+  A trigger satisfied when a signal named `name` has been delivered to the run
+  (via `zuke resume <id> --signal <name>`). The signal's payload is exposed to
+  target bodies through {@link "./target.ts".TargetContext} `signals`.
+
 async function extractTarGzip(src: PathLike, destDir: PathLike): Promise<void>
   Read the `.tar.gz` at `src`, gunzip and unpack it, and write each entry under
   `destDir` (creating parent directories as needed).
@@ -437,6 +442,12 @@ async function restoreOutputs(artifact: Uint8Array, host: OutputHost): Promise<s
   validated first: an absolute path or one escaping the workspace (`..`) is
   rejected before anything is written, so a malicious archive can't plant files
   outside the current directory.
+
+function resumeWhen(check: () => boolean | Promise<boolean>, options: ResumeWhenOptions): WaitTrigger
+  A trigger satisfied when an async `check` predicate returns `true`. Zuke does
+  not poll on its own — the predicate is evaluated when the target is reached
+  and on each `zuke resume <id> --check`, so a cron or webhook nudging `--check`
+  drives it. Use it to wait on state Zuke can query (a row, a file, an API).
 
 async function run(BuildClass: new () => Build, options: RunOptions): Promise<void>
   Public entry point. Instantiate the build, parse arguments, run, and set the
@@ -1107,6 +1118,8 @@ class TargetBuilder
     Max fix-then-rerun cycles when the body fails (set by {@link recoverAttempts}).
   lock_?: Configure<LockSettings>
     Cross-run lock settings lambda, set by {@link lock} and run after params resolve.
+  waitsFor_?: Configure<WaitSettings>
+    External-event wait settings lambda, set by {@link waitsFor} and run when reached.
   description(text: string): this
     Set the human-readable description shown in `zuke --list`.
   dependsOn(...targets: Array<TargetBuilder | Group>): this
@@ -1242,6 +1255,22 @@ class TargetBuilder
             `${this.repo.value} is being deployed by ${h.actor} (run ${h.runId}).`))
       .executes(...);
     ```
+  waitsFor(configure: Configure<WaitSettings>): this
+    Suspend the run at this target until an external event occurs, then let the
+    run be resumed later (in a different process) — a settings lambda in the
+    same style as {@link lock}. The target is a gate (no body): when its
+    trigger is already satisfied it passes and dependents run; otherwise the
+    run's state is saved, the run is marked suspended, its independent branches
+    finish, and the process exits 0. Requires a state store.
+
+    ```ts
+    awaitApproval = target()
+      .dependsOn(this.deploy)
+      .waitsFor((s) =>
+        s.on(externalSignal("testing-approved"))
+          .timeout("72h")
+          .onTimeout(() => this.rollback));
+    ```
 
 class TeamsAnnouncementSettings extends AnnouncementSettings
   Fluent settings for {@link AnnounceTasksApi.teams}. Bot mode
@@ -1312,6 +1341,28 @@ class Toolchain
     Install every declared tool concurrently — reusing a cached copy where a
     pinned checksum matches — and return a map of tool name to installed
     {@link AbsolutePath}.
+
+class WaitSettings
+  Fluent configuration for {@link TargetBuilder.waitsFor}:
+  `.waitsFor((s) => s.on(externalSignal("approved")).timeout("72h"))`. Set the
+  {@link WaitSettings.on | trigger}, an optional {@link WaitSettings.timeout},
+  and an optional {@link WaitSettings.onTimeout} disposition. The lambda runs
+  when the target is reached, so the trigger may read `this.<param>.value`.
+
+  trigger_?: WaitTrigger
+    The trigger deciding when the wait is satisfied; set by {@link on}.
+  timeout_?: string | number
+    The deadline duration (string or ms); set by {@link timeout}.
+  onTimeout_?: OnTimeout
+    The timeout disposition thunk; set by {@link onTimeout}.
+  on(trigger: WaitTrigger): this
+    Set the {@link "./wait.ts".WaitTrigger} the wait is satisfied by.
+  timeout(duration: string | number): this
+    Give the wait a deadline (a duration like `"72h"` or milliseconds).
+  onTimeout(disposition: OnTimeout): this
+    What to do when the deadline passes: a thunk returning a sibling
+    compensation target (a thunk, so it can reference a target declared below
+    this one), or the string `"fail"` / `"cancel-run"`. Defaults to `"fail"`.
 
 interface AbsolutePath
   An immutable, absolute filesystem path with a fluent API.
@@ -1442,11 +1493,15 @@ interface BuildResult
   Result passed to the {@link Build.onFinish} lifecycle hook.
 
   ok: boolean
-    Whether every executed target succeeded.
+    Whether every executed target succeeded (also `true` for a suspended run).
   executed: string[]
     Names of the targets that ran, in execution order.
   error?: unknown
     The error that aborted the run, if any.
+  suspended?: boolean
+    True when the run suspended at a `.waitsFor(...)` gate rather than
+    finishing — its state is saved and it can be resumed later. The process
+    still exits 0.
 
 interface CiConcurrency
   A concurrency group: at most one run per group, optionally cancelling the prior one.
@@ -1986,6 +2041,12 @@ interface ResolveStateOptions
     Set when the run opts into durable state (`--state`, or — from a later
     milestone — a durable feature like a lock or a wait).
 
+interface ResumeWhenOptions
+  Options for {@link resumeWhen}.
+
+  interval?: string | number
+    How often `zuke resume --check` should re-evaluate the predicate.
+
 interface RunGraphNode
   One entry of a run's graph-shape snapshot.
 
@@ -2040,6 +2101,8 @@ interface RunRecord
     Resolved parameter values, keyed by name. Secrets are always omitted.
   targets: Record<string, TargetRunState>
     Per-target progress, keyed by dotted target name.
+  signals: Record<string, SignalRecord>
+    External signals received so far, keyed by name (see `.waitsFor(...)`).
 
 interface RunSummary
   A compact run listing row, returned by {@link "./store.ts".StateStore.listRuns}.
@@ -2084,6 +2147,14 @@ interface ServiceHandle
 
   stop(): void | Promise<void>
     Terminate the service. Called on teardown unless `.stop()` overrides it.
+
+interface SignalRecord
+  A payload received for an external signal (see {@link RunRecord.signals}).
+
+  data: JsonValue
+    The signal's JSON payload (`{}` when none was sent).
+  receivedAt: string
+    ISO-8601 timestamp when the signal was recorded.
 
 interface StateHost
   Injected filesystem effects for {@link "./fs_store.ts".FileSystemStateStore},
@@ -2172,6 +2243,10 @@ interface TargetContext
     configured (see {@link "./state/store.ts".StateStore}), and an in-memory
     no-op otherwise. The carrier for state that must survive across a
     suspend/resume boundary — do not put secrets in it.
+  readonly signals: ReadonlyMap<string, SignalRecord>
+    Payloads of the external signals received so far, keyed by name (see
+    `.waitsFor(...)` and {@link "./wait.ts".externalSignal}). Empty until a
+    signal is delivered by `zuke resume <id> --signal <name>`.
   readonly dryRun: boolean
     True when the run is a dry run (bodies do not execute under a dry run).
 
@@ -2198,6 +2273,8 @@ interface TargetRunState
     ISO-8601 timestamp when the target settled, if it has.
   error?: string
     The failure message when `status` is `failed`.
+  waitingFor?: WaitState
+    The pending wait when `status` is `waiting` (set by `.waitsFor(...)`).
 
 interface TargetStateHandle
   A target's durable, per-target metadata, surfaced on {@link TargetContext} as
@@ -2248,6 +2325,29 @@ interface ValidationContext
   target: string
     The name of the target the validation is attached to.
 
+interface WaitState
+  The pending wait recorded on a suspended target (see {@link TargetRunState.waitingFor}).
+
+  trigger: string
+    A human-readable descriptor of what is awaited (e.g. `signal:approved`).
+  deadline?: string
+    ISO-8601 deadline after which {@link onTimeout} applies, if a timeout was set.
+  onTimeout: WaitDisposition
+    What happens when the deadline passes.
+
+interface WaitTrigger
+  Decides whether the event a target waits for has occurred. `descriptor` is a
+  short, JSON-safe label recorded on the suspended target; `isSatisfied` is
+  evaluated against the run's received signals when the target is reached and
+  again on each resume attempt.
+
+  readonly descriptor: string
+    A short label recorded on the wait (e.g. `signal:approved`).
+  readonly pollIntervalMs?: number
+    Poll interval hint (ms) for predicate triggers driven by `zuke resume --check`.
+  isSatisfied(signals: ReadonlyMap<string, SignalRecord>): boolean | Promise<boolean>
+    Whether the awaited event has occurred, given the run's received signals.
+
 type AnnouncementLevel = "success" | "failure" | "warning" | "info"
   The outcome an announcement conveys. It drives the accent colour and the icon
   prepended to the message; defaults to `"info"`.
@@ -2283,6 +2383,9 @@ type LockResult = { ok: true; token: string; } | { ok: false; holder: LockHolder
   The result of {@link StateStore.acquireLock}: a `token` proving ownership, or
   the current `holder` when the lock is already held.
 
+type OnTimeout = () => TargetBuilder | "fail" | "cancel-run"
+  What a timed-out wait does — resolved from {@link WaitSettings.onTimeout}.
+
 type OperatingSystem = "linux" | "macos" | "windows"
   The operating systems Zuke recognises — Deno's raw `Deno.build.os` values
   normalised to a friendly set (notably `darwin` → `macos`). Used across the
@@ -2317,8 +2420,13 @@ type TargetRunStatus = "pending" | "running" | "waiting" | "succeeded" | "failed
   external-event wait) is produced only from a later milestone; the executor
   records the others.
 
-type TargetStatus = "passed" | "failed" | "skipped" | "cached"
+type TargetStatus = "passed" | "failed" | "skipped" | "cached" | "waiting"
   The outcome of a single target, reported in the summary and lifecycle hooks.
+  `waiting` marks a `.waitsFor(...)` gate whose event has not occurred — the run
+  suspends there.
+
+type WaitDisposition = "fail" | "cancel-run" | { target: string; }
+  What a timed-out wait does: fail, cancel the run, or run a compensation target.
 ````
 
 </details>

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -46,6 +46,7 @@ export {
   group,
   type JsonValue,
   LockSettings,
+  type OnTimeout,
   type Remediation,
   type RemediationContext,
   type RemediationResult,
@@ -57,7 +58,14 @@ export {
   type TargetStateHandle,
   type Validation,
   type ValidationContext,
+  WaitSettings,
 } from "./src/target.ts";
+export {
+  externalSignal,
+  resumeWhen,
+  type ResumeWhenOptions,
+  type WaitTrigger,
+} from "./src/wait.ts";
 export { run, type RunOptions } from "./src/cli.ts";
 export {
   type CliCommandInfo,
@@ -113,8 +121,11 @@ export {
   type RunRecord,
   type RunStatus,
   type RunSummary,
+  type SignalRecord,
   type TargetRunState,
   type TargetRunStatus,
+  type WaitDisposition,
+  type WaitState,
 } from "./src/state/types.ts";
 export { FileSystemStateStore } from "./src/state/fs_store.ts";
 export {

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -43,17 +43,32 @@ export function forEachField(
   walk(root, "");
 }
 
-/** The outcome of a single target, reported in the summary and lifecycle hooks. */
-export type TargetStatus = "passed" | "failed" | "skipped" | "cached";
+/**
+ * The outcome of a single target, reported in the summary and lifecycle hooks.
+ * `waiting` marks a `.waitsFor(...)` gate whose event has not occurred — the run
+ * suspends there.
+ */
+export type TargetStatus =
+  | "passed"
+  | "failed"
+  | "skipped"
+  | "cached"
+  | "waiting";
 
 /** Result passed to the {@link Build.onFinish} lifecycle hook. */
 export interface BuildResult {
-  /** Whether every executed target succeeded. */
+  /** Whether every executed target succeeded (also `true` for a suspended run). */
   ok: boolean;
   /** Names of the targets that ran, in execution order. */
   executed: string[];
   /** The error that aborted the run, if any. */
   error?: unknown;
+  /**
+   * True when the run **suspended** at a `.waitsFor(...)` gate rather than
+   * finishing — its state is saved and it can be resumed later. The process
+   * still exits 0.
+   */
+  suspended?: boolean;
 }
 
 /**

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -40,10 +40,18 @@ import { Redactor } from "./redact.ts";
 import { absolutePath } from "./path.ts";
 import {
   LockSettings,
+  type OnTimeout,
   type Remediation,
   type TargetBuilder,
   type TargetContext,
+  WaitSettings,
 } from "./target.ts";
+import type { Configure } from "./tooling.ts";
+import type {
+  SignalRecord,
+  WaitDisposition,
+  WaitState,
+} from "./state/types.ts";
 import { withAmbientSignal } from "./ambient_signal.ts";
 import { defaultStateHost, type StateStore } from "./state/store.ts";
 import { resolveStateStore } from "./state/resolve.ts";
@@ -52,7 +60,12 @@ import { inMemoryStateHandle, RunStateWriter } from "./state/writer.ts";
 import { LockConflictError, type LockHolder } from "./state/lock.ts";
 import { parseDuration } from "./duration.ts";
 import type { Plugin } from "./plugin.ts";
-import { detectWidth, type Style, type TargetReport } from "./report.ts";
+import {
+  detectWidth,
+  type Style,
+  type TargetReport,
+  targetWaitFooter,
+} from "./report.ts";
 import { defaultRenderer, type Renderer } from "./renderer.ts";
 
 /** The artifact directory (under the repo root) for the cache store. */
@@ -377,6 +390,8 @@ interface RunOutcome {
   executed: string[];
   failure: unknown;
   aborted: boolean;
+  /** True when the run parked at a `.waitsFor(...)` gate rather than finishing. */
+  suspended: boolean;
 }
 
 /**
@@ -394,6 +409,8 @@ interface RunEnv {
   actor: string;
   /** A link to this run (CI job), stamped on a lock holder when known. */
   runUrl?: string;
+  /** External signals received so far, exposed to bodies via `ctx.signals`. */
+  signals: ReadonlyMap<string, SignalRecord>;
 }
 
 /** A failure's message, or `undefined` when there was none — for the state record. */
@@ -479,6 +496,51 @@ async function acquireTargetLock(
       await store.releaseLock(key, token);
     },
   };
+}
+
+/** Resolve a timeout thunk to a JSON-serialisable disposition (default `"fail"`). */
+function resolveDisposition(thunk: OnTimeout | undefined): WaitDisposition {
+  if (thunk === undefined) return "fail";
+  const disposition = thunk();
+  if (disposition === "fail" || disposition === "cancel-run") {
+    return disposition;
+  }
+  return { target: disposition.name_ ?? "?" };
+}
+
+/** The outcome of evaluating a target's `.waitsFor(...)` gate. */
+interface WaitResolution {
+  satisfied: boolean;
+  waitState: WaitState;
+  descriptor: string;
+}
+
+/**
+ * Run a target's wait settings lambda, evaluate its trigger against the run's
+ * signals, and build the {@link WaitState} to record if it must suspend.
+ */
+async function resolveWait(
+  configure: Configure<WaitSettings>,
+  env: RunEnv,
+  name: string,
+): Promise<WaitResolution> {
+  const settings = configure(new WaitSettings());
+  const trigger = settings.trigger_;
+  if (trigger === undefined) {
+    throw new Error(
+      `Target "${name}" .waitsFor(...) set no trigger — call s.on(...).`,
+    );
+  }
+  const satisfied = await trigger.isSatisfied(env.signals);
+  const waitState: WaitState = {
+    trigger: trigger.descriptor,
+    onTimeout: resolveDisposition(settings.onTimeout_),
+  };
+  if (settings.timeout_ !== undefined) {
+    waitState.deadline = new Date(Date.now() + parseDuration(settings.timeout_))
+      .toISOString();
+  }
+  return { satisfied, waitState, descriptor: trigger.descriptor };
 }
 
 /**
@@ -688,6 +750,28 @@ async function runTarget(
     return { status: "cached", ms: 0 };
   }
 
+  // A `.waitsFor(...)` target is a gate, not a body: if its trigger is already
+  // satisfied it passes (dependents run); otherwise the run suspends here.
+  if (t.waitsFor_ !== undefined) {
+    openTarget(reporter, renderer, style, name, opened);
+    let wait: WaitResolution;
+    try {
+      wait = await resolveWait(t.waitsFor_, env, name);
+    } catch (error) {
+      failTarget(reporter, renderer, style, name, 0, error);
+      return { status: "failed", ms: 0, error };
+    }
+    if (wait.satisfied) {
+      passTarget(reporter, renderer, style, name, 0);
+      return { status: "passed", ms: 0 };
+    }
+    void env.writer?.markTargetWaiting(name, wait.waitState);
+    for (const line of targetWaitFooter(style, name, wait.descriptor)) {
+      reporter.info(line);
+    }
+    return { status: "waiting", ms: 0 };
+  }
+
   openTarget(reporter, renderer, style, name, opened);
   await life.targetStart(name);
   void env.writer?.markTargetRunning(name);
@@ -706,6 +790,7 @@ async function runTarget(
     target: name,
     signal: env.signal,
     state: env.writer ? env.writer.stateHandle(name) : inMemoryStateHandle(),
+    signals: env.signals,
     dryRun,
   };
 
@@ -826,7 +911,7 @@ async function runSequential(
       aborted = true;
     }
   }
-  return { reports, executed, failure, aborted };
+  return { reports, executed, failure, aborted, suspended: false };
 }
 
 /**
@@ -861,6 +946,7 @@ async function runScheduled(
   const runningSet = new Set<TargetBuilder>();
   let failure: unknown;
   let anyFailed = false; // a failure occurred → the build fails
+  let anyWaiting = false; // a `.waitsFor(...)` gate parked → the run suspends
   let halted = false; // a non-lenient failure → stop launching new targets
   let flushed = 0;
 
@@ -906,14 +992,19 @@ async function runScheduled(
           .then(
             async (outcome) => {
               await life.targetEnd(t.name_ ?? "<unnamed>", outcome.status);
-              void env.writer?.markTargetSettled(
-                t.name_ ?? "<unnamed>",
-                outcome.status,
-                errorMessage(outcome.error),
-              );
-              // Only an executed target prints a block worth separating.
+              // A waiting gate already recorded its `waitingFor` via
+              // markTargetWaiting; settling it here would clobber that.
+              if (outcome.status !== "waiting") {
+                void env.writer?.markTargetSettled(
+                  t.name_ ?? "<unnamed>",
+                  outcome.status,
+                  errorMessage(outcome.error),
+                );
+              }
+              // An executed target (or a parked wait) prints a block worth
+              // separating.
               const printed = outcome.status === "passed" ||
-                outcome.status === "failed";
+                outcome.status === "failed" || outcome.status === "waiting";
               if (printed) {
                 if (!style.github && flushed > 0) reporter.info("");
                 buffer.flush(reporter);
@@ -927,6 +1018,10 @@ async function runScheduled(
                 // A lenient failure lets independent targets keep going; its
                 // own dependents stay blocked (never added to `done`).
                 if (!t.proceedAfterFailure_) halted = true;
+              } else if (outcome.status === "waiting") {
+                // The run suspends here: this target's dependents stay blocked
+                // (never `done`), but independent branches run to completion.
+                anyWaiting = true;
               } else {
                 done.add(t); // passed, cached, or condition-skipped
               }
@@ -939,10 +1034,14 @@ async function runScheduled(
           if (!started.has(t)) {
             outcomes.set(t, { status: "skipped", ms: 0 });
             started.add(t);
-            void env.writer?.markTargetSettled(
-              t.name_ ?? "<unnamed>",
-              "skipped",
-            );
+            // When the run suspends, targets blocked behind the wait are left
+            // `pending` in the record (a resume runs them) rather than skipped.
+            if (!anyWaiting) {
+              void env.writer?.markTargetSettled(
+                t.name_ ?? "<unnamed>",
+                "skipped",
+              );
+            }
           }
         }
         resolve();
@@ -959,7 +1058,13 @@ async function runScheduled(
     reports.push({ name, status: outcome.status, ms: outcome.ms });
     if (outcome.status === "passed") executed.push(name);
   }
-  return { reports, executed, failure, aborted: anyFailed };
+  return {
+    reports,
+    executed,
+    failure,
+    aborted: anyFailed,
+    suspended: anyWaiting && !anyFailed,
+  };
 }
 
 /**
@@ -1062,7 +1167,9 @@ export async function execute(
   const grouped = order.some((t) => t.group_ !== undefined);
   // `proceedAfterFailure` and `always` need the scheduler's per-target control,
   // so the simple sequential loop is only used when none of these apply.
-  const scheduled = order.some((t) => t.proceedAfterFailure_ || t.always_);
+  const scheduled = order.some((t) =>
+    t.proceedAfterFailure_ || t.always_ || t.waitsFor_ !== undefined
+  );
   const dryRun = options.dryRun ?? false;
   // A dry run never reads or writes the cache (no body runs to invalidate it).
   const cache = dryRun ? undefined : await resolveCache(
@@ -1101,7 +1208,9 @@ export async function execute(
   // A build that uses a durable feature (a cross-run lock; later, waits and
   // compensations) turns the filesystem store on by default, so state "just
   // works" without --state. Plain builds still opt in explicitly.
-  const usesDurableFeature = order.some((t) => t.lock_ !== undefined);
+  const usesDurableFeature = order.some((t) =>
+    t.lock_ !== undefined || t.waitsFor_ !== undefined
+  );
   const stateStore = dryRun ? undefined : resolveStateStore(
     options.stateStore,
     build.stateStore(),
@@ -1114,6 +1223,22 @@ export async function execute(
       enableDefault: (options.state ?? false) || usesDurableFeature,
     },
   );
+  // A wait needs somewhere to persist the suspension; without a store it could
+  // never be resumed. Fail fast with guidance instead of suspending into the
+  // void. (enableDefault turns the FS store on for waits, so this only triggers
+  // when state was explicitly disabled.)
+  if (
+    !dryRun && stateStore === undefined &&
+    order.some((t) => t.waitsFor_ !== undefined)
+  ) {
+    const error = new Error(
+      "A target uses .waitsFor(...), which needs a state store to persist the " +
+        "suspended run — but state is disabled. Enable it (drop stateStore: " +
+        "false, pass --state, or set ZUKE_STATE_DIR / ZUKE_STATE_URL).",
+    );
+    reporter.error(error.message);
+    return { ok: false, executed: [], error };
+  }
   const actor = resolveActor(options.actor, readEnv);
   const runUrl = ciRunUrl(readEnv);
   const nowIso = () => new Date().toISOString();
@@ -1141,6 +1266,7 @@ export async function execute(
     store: stateStore,
     actor,
     runUrl,
+    signals: writer ? writer.signals() : new Map<string, SignalRecord>(),
   };
 
   // Services started during the run are held here and torn down in reverse
@@ -1206,17 +1332,30 @@ export async function execute(
 
   const result: BuildResult = run.aborted
     ? { ok: false, executed: run.executed, error: run.failure }
+    : run.suspended
+    ? { ok: true, executed: run.executed, suspended: true }
     : { ok: true, executed: run.executed };
 
   // Record the run's terminal status. Awaiting this drains the writer's queue,
   // so every per-target transition has landed by the time the run returns.
-  await writer?.markRunFinished(result.ok);
+  if (run.suspended) await writer?.markRunSuspended();
+  else await writer?.markRunFinished(result.ok);
 
   const totalMs = performance.now() - overallStart;
   for (
     const line of renderer.summaryBlock(style, run.reports, totalMs, result.ok)
   ) {
     reporter.info(line);
+  }
+  // On suspension, point the operator at the saved run so it can be resumed.
+  if (run.suspended) {
+    const waiting = run.reports.filter((r) => r.status === "waiting")
+      .map((r) => r.name);
+    reporter.info(
+      `Run ${runId} suspended — state saved; waiting on: ${
+        waiting.join(", ")
+      }.`,
+    );
   }
   if (style.github && writesToConsole) {
     writeJobSummary(renderer, run.reports, totalMs, result.ok);

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -21,6 +21,7 @@ export const ICON: Record<TargetStatus, string> = {
   failed: "✘",
   skipped: "⊘",
   cached: "⊙",
+  waiting: "⏸",
 };
 
 /** Human label for a status — used in the summary table and PR comment. */
@@ -29,6 +30,7 @@ const STATUS_LABEL: Record<TargetStatus, string> = {
   failed: "Failed",
   skipped: "Skipped",
   cached: "Cached",
+  waiting: "Waiting",
 };
 
 /** Per-status ANSI colour for the icon/label. */
@@ -37,6 +39,7 @@ const STATUS_COLOR: Record<TargetStatus, string> = {
   failed: SGR.red,
   skipped: SGR.yellow,
   cached: SGR.cyan,
+  waiting: SGR.magenta,
 };
 
 /** One row of the end-of-build summary. */
@@ -101,6 +104,18 @@ export function targetFailFooter(
     info: ["::endgroup::"],
     error: [line, detail, `::error title=${name}::${name} failed: ${message}`],
   };
+}
+
+/** The footer printed for a target that suspended the run at a `.waitsFor(...)` gate. */
+export function targetWaitFooter(
+  style: Style,
+  name: string,
+  trigger: string,
+): string[] {
+  const icon = paint(style.color, SGR.magenta, ICON.waiting);
+  const note = paint(style.color, SGR.dim, `waiting for ${trigger}`);
+  const line = `${icon} ${name} ${note}`;
+  return style.github ? [line, "::endgroup::"] : [line];
 }
 
 /** The footer printed for a dry-run target — never actually executed. */
@@ -214,6 +229,15 @@ export function closingLine(
     reports.filter((r) => r.status === "passed" || r.status === "cached")
       .length;
   const stamp = timestamp(now);
+  const waiting = reports.filter((r) => r.status === "waiting");
+  if (waiting.length > 0) {
+    return paint(
+      style.color,
+      SGR.bold + SGR.magenta,
+      `${ICON.waiting} Build suspended — ${waiting.length} target(s) waiting ` +
+        `after ${formatDuration(totalMs)} · ${stamp}`,
+    );
+  }
   if (ok) {
     return paint(
       style.color,

--- a/packages/core/src/state/record.ts
+++ b/packages/core/src/state/record.ts
@@ -25,6 +25,8 @@ export function recordStatusOf(status: TargetStatus): TargetRunStatus {
       return "failed";
     case "skipped":
       return "skipped";
+    case "waiting":
+      return "waiting";
   }
 }
 
@@ -116,6 +118,7 @@ export function buildRunRecord(input: RunRecordInput): RunRecord {
     graph,
     params,
     targets,
+    signals: {},
   };
 }
 

--- a/packages/core/src/state/types.ts
+++ b/packages/core/src/state/types.ts
@@ -39,6 +39,27 @@ export type TargetRunStatus =
   | "failed"
   | "skipped";
 
+/** A payload received for an external signal (see {@link RunRecord.signals}). */
+export interface SignalRecord {
+  /** The signal's JSON payload (`{}` when none was sent). */
+  data: JsonValue;
+  /** ISO-8601 timestamp when the signal was recorded. */
+  receivedAt: string;
+}
+
+/** What a timed-out wait does: fail, cancel the run, or run a compensation target. */
+export type WaitDisposition = "fail" | "cancel-run" | { target: string };
+
+/** The pending wait recorded on a suspended target (see {@link TargetRunState.waitingFor}). */
+export interface WaitState {
+  /** A human-readable descriptor of what is awaited (e.g. `signal:approved`). */
+  trigger: string;
+  /** ISO-8601 deadline after which {@link onTimeout} applies, if a timeout was set. */
+  deadline?: string;
+  /** What happens when the deadline passes. */
+  onTimeout: WaitDisposition;
+}
+
 /** The recorded progress of a single target. */
 export interface TargetRunState {
   /** The target's current status within the run. */
@@ -51,6 +72,8 @@ export interface TargetRunState {
   endedAt?: string;
   /** The failure message when `status` is `failed`. */
   error?: string;
+  /** The pending wait when `status` is `waiting` (set by `.waitsFor(...)`). */
+  waitingFor?: WaitState;
 }
 
 /** One entry of a run's graph-shape snapshot. */
@@ -86,6 +109,8 @@ export interface RunRecord {
   params: Record<string, string>;
   /** Per-target progress, keyed by dotted target name. */
   targets: Record<string, TargetRunState>;
+  /** External signals received so far, keyed by name (see `.waitsFor(...)`). */
+  signals: Record<string, SignalRecord>;
 }
 
 /** A compact run listing row, returned by {@link "./store.ts".StateStore.listRuns}. */
@@ -211,7 +236,43 @@ function parseTargetState(value: unknown): TargetRunState {
   if (endedAt !== undefined) state.endedAt = endedAt;
   const error = optionalStr(object, "error");
   if (error !== undefined) state.error = error;
+  if (object.waitingFor !== undefined) {
+    state.waitingFor = parseWaitState(object.waitingFor);
+  }
   return state;
+}
+
+/** Validate a timed-out-wait disposition. */
+function parseWaitDisposition(value: unknown): WaitDisposition {
+  if (value === "fail" || value === "cancel-run") return value;
+  const object = asObject(value);
+  if (object !== null && typeof object.target === "string") {
+    return { target: object.target };
+  }
+  throw new Error("state: invalid wait onTimeout disposition");
+}
+
+/** Validate and narrow a {@link WaitState}. */
+function parseWaitState(value: unknown): WaitState {
+  const object = asObject(value);
+  if (object === null) throw new Error("state: waitingFor is not an object");
+  const state: WaitState = {
+    trigger: str(object, "trigger"),
+    onTimeout: parseWaitDisposition(object.onTimeout),
+  };
+  const deadline = optionalStr(object, "deadline");
+  if (deadline !== undefined) state.deadline = deadline;
+  return state;
+}
+
+/** Validate and narrow a {@link SignalRecord}. */
+function parseSignalRecord(value: unknown): SignalRecord {
+  const object = asObject(value);
+  if (object === null) throw new Error("state: signal record is not an object");
+  return {
+    data: toJsonValue(object.data ?? null),
+    receivedAt: str(object, "receivedAt"),
+  };
 }
 
 /** Coerce an object's values to {@link JsonValue}s (they came from JSON already). */
@@ -302,6 +363,19 @@ export function parseRunRecord(text: string): RunRecord {
     targets[name] = parseTargetState(value);
   }
 
+  // `signals` is newer than the first records — treat its absence as empty so
+  // records written before external-event waits existed still parse.
+  const signals: Record<string, SignalRecord> = {};
+  if (object.signals !== undefined) {
+    const rawSignals = asObject(object.signals);
+    if (rawSignals === null) {
+      throw new Error(`state: run record field "signals" is not an object`);
+    }
+    for (const [name, value] of Object.entries(rawSignals)) {
+      signals[name] = parseSignalRecord(value);
+    }
+  }
+
   return {
     id: str(object, "id"),
     build: str(object, "build"),
@@ -313,6 +387,7 @@ export function parseRunRecord(text: string): RunRecord {
     graph,
     params,
     targets,
+    signals,
   };
 }
 

--- a/packages/core/src/state/writer.ts
+++ b/packages/core/src/state/writer.ts
@@ -18,7 +18,12 @@ import type { TargetStatus } from "../build.ts";
 import type { JsonValue, TargetStateHandle } from "../target.ts";
 import type { Redactor } from "../redact.ts";
 import type { StateStore } from "./store.ts";
-import type { RunRecord, TargetRunState } from "./types.ts";
+import type {
+  RunRecord,
+  SignalRecord,
+  TargetRunState,
+  WaitState,
+} from "./types.ts";
 import { recordStatusOf } from "./record.ts";
 
 /** Extract a message from an unknown thrown value without casting. */
@@ -133,6 +138,27 @@ export class RunStateWriter {
     return this.#update((record) => {
       record.status = ok ? "succeeded" : "failed";
     });
+  }
+
+  /** Record a target as waiting on an external event, with its pending wait. */
+  markTargetWaiting(name: string, wait: WaitState): Promise<void> {
+    return this.#update((record) => {
+      const target = ensureTarget(record, name);
+      target.status = "waiting";
+      target.waitingFor = wait;
+    });
+  }
+
+  /** Record the run as suspended (parked at a `.waitsFor(...)` gate). */
+  markRunSuspended(): Promise<void> {
+    return this.#update((record) => {
+      record.status = "suspended";
+    });
+  }
+
+  /** The external signals received so far, as a read-only map. */
+  signals(): ReadonlyMap<string, SignalRecord> {
+    return new Map(Object.entries(this.#record.signals));
   }
 
   /** A {@link TargetStateHandle} bound to `name`, persisting through this writer. */

--- a/packages/core/src/target.ts
+++ b/packages/core/src/target.ts
@@ -31,6 +31,8 @@ import type { PathLike } from "./path.ts";
 import type { AnyParameter } from "./params.ts";
 import type { Configure } from "./tooling.ts";
 import { type LockHolder, lockKey } from "./state/lock.ts";
+import type { WaitTrigger } from "./wait.ts";
+import type { SignalRecord } from "./state/types.ts";
 
 /**
  * Fluent configuration for {@link TargetBuilder.lock}, in the settings-lambda
@@ -80,6 +82,47 @@ export class LockSettings {
    */
   onConflict(render: (holder: LockHolder) => string): this {
     this.onConflict_ = render;
+    return this;
+  }
+}
+
+/** What a timed-out wait does — resolved from {@link WaitSettings.onTimeout}. */
+export type OnTimeout = () => TargetBuilder | "fail" | "cancel-run";
+
+/**
+ * Fluent configuration for {@link TargetBuilder.waitsFor}:
+ * `.waitsFor((s) => s.on(externalSignal("approved")).timeout("72h"))`. Set the
+ * {@link WaitSettings.on | trigger}, an optional {@link WaitSettings.timeout},
+ * and an optional {@link WaitSettings.onTimeout} disposition. The lambda runs
+ * when the target is reached, so the trigger may read `this.<param>.value`.
+ */
+export class WaitSettings {
+  /** The trigger deciding when the wait is satisfied; set by {@link on}. */
+  trigger_?: WaitTrigger;
+  /** The deadline duration (string or ms); set by {@link timeout}. */
+  timeout_?: string | number;
+  /** The timeout disposition thunk; set by {@link onTimeout}. */
+  onTimeout_?: OnTimeout;
+
+  /** Set the {@link "./wait.ts".WaitTrigger} the wait is satisfied by. */
+  on(trigger: WaitTrigger): this {
+    this.trigger_ = trigger;
+    return this;
+  }
+
+  /** Give the wait a deadline (a duration like `"72h"` or milliseconds). */
+  timeout(duration: string | number): this {
+    this.timeout_ = duration;
+    return this;
+  }
+
+  /**
+   * What to do when the deadline passes: a thunk returning a sibling
+   * compensation target (a thunk, so it can reference a target declared *below*
+   * this one), or the string `"fail"` / `"cancel-run"`. Defaults to `"fail"`.
+   */
+  onTimeout(disposition: OnTimeout): this {
+    this.onTimeout_ = disposition;
     return this;
   }
 }
@@ -139,6 +182,12 @@ export interface TargetContext {
    * suspend/resume boundary — do not put secrets in it.
    */
   readonly state: TargetStateHandle;
+  /**
+   * Payloads of the external signals received so far, keyed by name (see
+   * `.waitsFor(...)` and {@link "./wait.ts".externalSignal}). Empty until a
+   * signal is delivered by `zuke resume <id> --signal <name>`.
+   */
+  readonly signals: ReadonlyMap<string, SignalRecord>;
   /** True when the run is a dry run (bodies do not execute under a dry run). */
   readonly dryRun: boolean;
 }
@@ -284,6 +333,8 @@ export class TargetBuilder {
   recoverAttempts_ = 1;
   /** Cross-run lock settings lambda, set by {@link lock} and run after params resolve. */
   lock_?: Configure<LockSettings>;
+  /** External-event wait settings lambda, set by {@link waitsFor} and run when reached. */
+  waitsFor_?: Configure<WaitSettings>;
 
   /** Set the human-readable description shown in `zuke --list`. */
   description(text: string): this {
@@ -567,6 +618,28 @@ export class TargetBuilder {
    */
   lock(configure: Configure<LockSettings>): this {
     this.lock_ = configure;
+    return this;
+  }
+
+  /**
+   * Suspend the run at this target until an external event occurs, then let the
+   * run be resumed later (in a different process) — a settings lambda in the
+   * same style as {@link lock}. The target is a **gate** (no body): when its
+   * trigger is already satisfied it passes and dependents run; otherwise the
+   * run's state is saved, the run is marked suspended, its independent branches
+   * finish, and the process exits 0. Requires a state store.
+   *
+   * ```ts
+   * awaitApproval = target()
+   *   .dependsOn(this.deploy)
+   *   .waitsFor((s) =>
+   *     s.on(externalSignal("testing-approved"))
+   *       .timeout("72h")
+   *       .onTimeout(() => this.rollback));
+   * ```
+   */
+  waitsFor(configure: Configure<WaitSettings>): this {
+    this.waitsFor_ = configure;
     return this;
   }
 }

--- a/packages/core/src/wait.ts
+++ b/packages/core/src/wait.ts
@@ -1,0 +1,70 @@
+/**
+ * External-event wait triggers for {@link "./target.ts".TargetBuilder.waitsFor}.
+ *
+ * A target can **suspend** a run until an external event occurs — an approval,
+ * another system's callback — and be resumed later, in a different process. A
+ * {@link WaitTrigger} decides whether that event has happened; two ship:
+ * {@link externalSignal} (a named signal delivered to the run) and
+ * {@link resumeWhen} (an async predicate polled on resume). The interface is
+ * exported so wrapper packages can add their own triggers (e.g. "wait for a
+ * GitHub workflow").
+ *
+ * @module
+ */
+
+import type { SignalRecord } from "./state/types.ts";
+import { parseDuration } from "./duration.ts";
+
+/**
+ * Decides whether the event a target waits for has occurred. `descriptor` is a
+ * short, JSON-safe label recorded on the suspended target; `isSatisfied` is
+ * evaluated against the run's received signals when the target is reached and
+ * again on each resume attempt.
+ */
+export interface WaitTrigger {
+  /** A short label recorded on the wait (e.g. `signal:approved`). */
+  readonly descriptor: string;
+  /** Poll interval hint (ms) for predicate triggers driven by `zuke resume --check`. */
+  readonly pollIntervalMs?: number;
+  /** Whether the awaited event has occurred, given the run's received signals. */
+  isSatisfied(
+    signals: ReadonlyMap<string, SignalRecord>,
+  ): boolean | Promise<boolean>;
+}
+
+/**
+ * A trigger satisfied when a signal named `name` has been delivered to the run
+ * (via `zuke resume <id> --signal <name>`). The signal's payload is exposed to
+ * target bodies through {@link "./target.ts".TargetContext} `signals`.
+ */
+export function externalSignal(name: string): WaitTrigger {
+  return {
+    descriptor: `signal:${name}`,
+    isSatisfied: (signals) => signals.has(name),
+  };
+}
+
+/** Options for {@link resumeWhen}. */
+export interface ResumeWhenOptions {
+  /** How often `zuke resume --check` should re-evaluate the predicate. */
+  interval?: string | number;
+}
+
+/**
+ * A trigger satisfied when an async `check` predicate returns `true`. Zuke does
+ * not poll on its own — the predicate is evaluated when the target is reached
+ * and on each `zuke resume <id> --check`, so a cron or webhook nudging `--check`
+ * drives it. Use it to wait on state Zuke can query (a row, a file, an API).
+ */
+export function resumeWhen(
+  check: () => boolean | Promise<boolean>,
+  options: ResumeWhenOptions = {},
+): WaitTrigger {
+  return {
+    descriptor: "predicate",
+    pollIntervalMs: options.interval === undefined
+      ? undefined
+      : parseDuration(options.interval),
+    isSatisfied: () => check(),
+  };
+}

--- a/packages/core/tests/executor_test.ts
+++ b/packages/core/tests/executor_test.ts
@@ -37,6 +37,7 @@ import { $ } from "../src/shell.ts";
 import { FileSystemStateStore } from "../src/state/fs_store.ts";
 import { defaultStateHost } from "../src/state/store.ts";
 import { LockConflictError } from "../src/state/lock.ts";
+import { externalSignal, resumeWhen } from "../src/wait.ts";
 
 const silent: ExecuteOptions = { silent: true };
 
@@ -1961,6 +1962,127 @@ Deno.test("cancelling a locked run releases the lock", async () => {
       since: "t",
     }, 1000);
     assertEquals(acq.ok, true); // lock was freed on cancellation
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("an unsatisfied waitsFor suspends the run and records it", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    const log: string[] = [];
+    class B extends Build {
+      deploy = target().executes(() => void log.push("deploy"));
+      independent = target().executes(() => void log.push("independent"));
+      rollback = target().executes(() => void log.push("rollback"));
+      gate = target()
+        .dependsOn(this.deploy)
+        .waitsFor((s) =>
+          s.on(externalSignal("approved")).timeout("72h").onTimeout(() =>
+            this.rollback
+          )
+        );
+      promote = target().dependsOn(this.gate).executes(() =>
+        void log.push("promote")
+      );
+      all = target().dependsOn(this.promote, this.independent).executes(
+        () => {},
+      );
+    }
+    const b = new B();
+    discoverTargets(b);
+
+    const result = await execute(b, b.all, {
+      silent: true,
+      stateStore: store,
+      parallel: true,
+      actor: "alice",
+    });
+    assertEquals(result.ok, true); // suspended, not failed
+    assertEquals(result.suspended, true);
+    assertEquals(log.includes("deploy"), true);
+    assertEquals(log.includes("independent"), true); // independent branch finished
+    assertEquals(log.includes("promote"), false); // blocked behind the gate
+
+    const summaries = await store.listRuns({});
+    const loaded = await store.getRun(summaries[0].id);
+    assertEquals(loaded?.record.status, "suspended");
+    assertEquals(loaded?.record.targets.deploy.status, "succeeded");
+    assertEquals(loaded?.record.targets.gate.status, "waiting");
+    assertEquals(
+      loaded?.record.targets.gate.waitingFor?.trigger,
+      "signal:approved",
+    );
+    assertEquals(
+      typeof loaded?.record.targets.gate.waitingFor?.deadline,
+      "string",
+    );
+    assertEquals(loaded?.record.targets.gate.waitingFor?.onTimeout, {
+      target: "rollback",
+    });
+    // promote is left pending (a resume runs it), not skipped.
+    assertEquals(loaded?.record.targets.promote.status, "pending");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("a satisfied waitsFor passes through and dependents run", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    const log: string[] = [];
+    class B extends Build {
+      gate = target().waitsFor((s) => s.on(resumeWhen(() => true)));
+      promote = target().dependsOn(this.gate).executes(() =>
+        void log.push("promote")
+      );
+    }
+    const b = new B();
+    discoverTargets(b);
+
+    const result = await execute(b, b.promote, {
+      silent: true,
+      stateStore: store,
+    });
+    assertEquals(result.ok, true);
+    assertEquals(result.suspended, undefined);
+    assertEquals(log, ["promote"]);
+    const loaded = await store.getRun((await store.listRuns({}))[0].id);
+    assertEquals(loaded?.record.status, "succeeded");
+    assertEquals(loaded?.record.targets.gate.status, "succeeded");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("waitsFor with no store fails with a friendly error", async () => {
+  class B extends Build {
+    gate = target().waitsFor((s) => s.on(externalSignal("x")));
+  }
+  const b = new B();
+  discoverTargets(b);
+  const result = await execute(b, b.gate, { silent: true, stateStore: false });
+  assertEquals(result.ok, false);
+  assertStringIncludes(messageOf(result.error), "needs a state store");
+});
+
+Deno.test("waitsFor with no trigger fails with a friendly error", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    class B extends Build {
+      gate = target().waitsFor((s) => s); // never called .on(...)
+    }
+    const b = new B();
+    discoverTargets(b);
+    const result = await execute(b, b.gate, {
+      silent: true,
+      stateStore: store,
+    });
+    assertEquals(result.ok, false);
+    assertStringIncludes(messageOf(result.error), "set no trigger");
   } finally {
     await Deno.remove(dir, { recursive: true });
   }

--- a/packages/core/tests/state_test.ts
+++ b/packages/core/tests/state_test.ts
@@ -28,6 +28,7 @@ import {
 import { inMemoryStateHandle, RunStateWriter } from "../src/state/writer.ts";
 import { Redactor } from "../src/redact.ts";
 import { LockSettings, target } from "../src/target.ts";
+import { externalSignal, resumeWhen } from "../src/wait.ts";
 import { Build, discoverTargets } from "../src/build.ts";
 import { discoverParameters, parameter } from "../src/params.ts";
 import { parseDuration } from "../src/duration.ts";
@@ -53,6 +54,7 @@ function sampleRecord(overrides: Partial<RunRecord> = {}): RunRecord {
     params: overrides.params ?? { env: "sit" },
     targets: overrides.targets ??
       { deploy: { status: "pending", meta: {} } },
+    signals: overrides.signals ?? {},
   };
 }
 
@@ -170,10 +172,75 @@ Deno.test("parseRunRecord rejects malformed records", () => {
       JSON.stringify({ ...sampleRecord(), targets: { a: 5 } }),
       "target state is not an object",
     ],
+    [
+      JSON.stringify({ ...sampleRecord(), signals: "x" }),
+      '"signals" is not an object',
+    ],
+    [
+      JSON.stringify({
+        ...sampleRecord(),
+        targets: {
+          a: {
+            status: "waiting",
+            meta: {},
+            waitingFor: { trigger: "signal:x", onTimeout: "bogus" },
+          },
+        },
+      }),
+      "invalid wait onTimeout disposition",
+    ],
   ];
   for (const [text, needle] of cases) {
     assertThrows(() => parseRunRecord(text), Error, needle);
   }
+});
+
+Deno.test("parseRunRecord round-trips signals and a waiting target", () => {
+  const record = sampleRecord({
+    status: "suspended",
+    signals: {
+      approved: { data: { by: "qa" }, receivedAt: "2026-07-17T10:00:00.000Z" },
+    },
+    targets: {
+      gate: {
+        status: "waiting",
+        meta: {},
+        waitingFor: {
+          trigger: "signal:approved",
+          deadline: "2026-07-20T10:00:00.000Z",
+          onTimeout: { target: "rollback" },
+        },
+      },
+    },
+  });
+  assertEquals(parseRunRecord(stringifyRunRecord(record)), record);
+});
+
+Deno.test("parseRunRecord defaults missing signals to empty (backwards compat)", () => {
+  const { signals: _signals, ...withoutSignals } = sampleRecord();
+  assertEquals(parseRunRecord(JSON.stringify(withoutSignals)).signals, {});
+});
+
+Deno.test("externalSignal is satisfied only when the named signal is present", async () => {
+  const trigger = externalSignal("approved");
+  assertEquals(trigger.descriptor, "signal:approved");
+  assertEquals(await trigger.isSatisfied(new Map()), false);
+  assertEquals(
+    await trigger.isSatisfied(
+      new Map([["approved", { data: {}, receivedAt: "t" }]]),
+    ),
+    true,
+  );
+});
+
+Deno.test("resumeWhen evaluates the predicate and carries a poll interval", async () => {
+  assertEquals(await resumeWhen(() => true).isSatisfied(new Map()), true);
+  assertEquals(await resumeWhen(() => false).isSatisfied(new Map()), false);
+  assertEquals(
+    resumeWhen(() => true, { interval: "30s" }).pollIntervalMs,
+    30_000,
+  );
+  assertEquals(resumeWhen(() => true).pollIntervalMs, undefined);
 });
 
 Deno.test("parseRunRecord preserves nested target meta as JSON", () => {

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -101,6 +101,12 @@ Before calling any task or settings method, confirm the real shape:
   The lock releases when the target settles and expires after the TTL if the
   holder is killed. Needs a state store (a build with `.lock()` enables the
   filesystem store by default). See the cheatsheet.
+- **External-event waits:** `.waitsFor((s) => s.on(externalSignal("approved")).timeout("72h"))`
+  makes a target a **gate** with no body: the run proceeds past it only when the
+  trigger is satisfied, otherwise it **suspends** (state saved, exits 0) to be
+  resumed later in a fresh process. Triggers: `externalSignal(name)` (payload
+  read via `ctx.signals`) and `resumeWhen(predicate)`. Needs a state store. See
+  the cheatsheet / `docs/orchestration.md`.
 - **Typed inputs:** `parameter("...")` (with `.secret()` / `.required()`), read
   as `this.x.value`, gated with `.requires(this.x)`.
 - **Secrets from a manager:** `parameter(...).secret().from(source)` sources a

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -23,6 +23,7 @@ Everything is optional except a body (`.executes`).
 | `.retry(times, delayMs?)` | Retry the body on failure. |
 | `.timeout(ms)` | Fail the body if it runs longer than `ms` (per attempt). |
 | `.lock((s) => s.lockKey(...).withTtl(...))` | Hold a cross-run lock while running; a second run wanting the key fails. See below. |
+| `.waitsFor((s) => s.on(externalSignal(...)))` | Gate (no body): suspend the run until an external event; resume later. See below. |
 | `.proceedAfterFailure()` | Keep the build going if this target fails. |
 | `.always()` | Run even after the build failed (cleanup/teardown). |
 | `.unlisted()` | Hide from `--list`/`--help`; still runnable by name. |
@@ -184,6 +185,40 @@ class CD extends Build {
 - Needs a state store — a build using `.lock()` enables the `.zuke/runs`
   filesystem store by default; use the HTTP backend to share locks across
   machines. See `docs/locks.md`.
+
+## External-event waits
+
+`.waitsFor((s) => …)` makes a target a **gate** (no body): the run proceeds past
+it only when the trigger is satisfied; otherwise it **suspends** — the run's
+state is saved, independent branches finish, and the process exits 0 — to be
+resumed later in a fresh process.
+
+```ts
+import { Build, externalSignal, target } from "jsr:@zuke/core";
+
+class Deploy extends Build {
+  deploy = target().executes(async (ctx) => {
+    await applyToSit();
+    await ctx.state.set({ at: "sit-7" }); // only durable state crosses the resume
+  });
+  awaitQa = target()
+    .dependsOn(this.deploy)
+    .waitsFor((s) =>
+      s.on(externalSignal("qa-approved")) // or resumeWhen(async () => …)
+        .timeout("72h")
+        .onTimeout(() => this.rollback)); // thunk: sibling compensation target
+  promote = target().dependsOn(this.awaitQa).executes((ctx) => {
+    const approval = ctx.signals.get("qa-approved"); // the signal's JSON payload
+  });
+  rollback = target().executes(() => rollBack());
+}
+```
+
+- Triggers: `externalSignal(name)` (payload read via `ctx.signals`) and
+  `resumeWhen(fn, { interval? })` (async predicate, re-checked on resume).
+- Needs a state store (a build with `.waitsFor()` enables `.zuke/runs` by
+  default). A resume is a fresh process, so **only `ctx.state`/`ctx.signals`
+  cross the boundary**. See `docs/orchestration.md`.
 
 ## Parameters — typed build inputs
 


### PR DESCRIPTION
## What

**M3, PR 1 of 2** of the orchestration plan — the **suspend half** of suspend/resume. A target can pause a run until an external event occurs; the run's state is saved so it can be resumed later, in a different process.

```ts
awaitTesting = target()
  .dependsOn(this.deploy)
  .waitsFor((s) =>
    s.on(externalSignal("testing-approved"))
      .timeout("72h")
      .onTimeout(() => this.rollback));
```

### Authoring
- `.waitsFor((s) => …)` — a fluent settings lambda (per the new AGENTS.md guideline 9) — makes a target a **gate** with no body. Triggers: **`externalSignal(name)`** (satisfied when a named signal is delivered; payload exposed via `ctx.signals`) and **`resumeWhen(predicate)`** (async predicate, re-checked on resume). `WaitTrigger` is exported so wrappers can add their own (e.g. M9's "wait for a GitHub workflow").

### Semantics
- **Unsatisfied → suspend:** the target is recorded `waiting` (with its trigger, deadline, and `onTimeout` disposition), the run is recorded `suspended`, targets behind the gate stay `pending`, **independent branches finish**, and the process **exits 0**.
- **Satisfied → pass through:** the gate is `succeeded` and dependents run in the same process.
- A wait **requires a state store** (a build with `.waitsFor()` enables the `.zuke/runs` store by default); declaring one with state disabled fails with a friendly error.

### Record & surfaces
- `RunRecord` gains a `signals` map and a per-target `waitingFor`; parsing defaults missing `signals` to `{}` (backwards compatible with M1/M2 records). `ctx.signals` exposes received payloads to bodies.
- `TargetStatus` and the summary gain a `waiting` state; `BuildResult` gains `suspended` (a suspended run is `ok: true`, exits 0).

### Docs & skills
- New `docs/orchestration.md`; `zuke-write-build` SKILL + cheatsheet updated.

## Acceptance (this PR's subset)
- Unsatisfied wait suspends: reconstructed from disk the run is `suspended`, the gate `waiting` with its `waitingFor` (trigger + deadline + `{target: "rollback"}`), the prior target `succeeded`, the blocked dependent left `pending`, and an independent branch ran — integration test.
- Satisfied wait passes through; no-store and no-trigger both fail with friendly errors.

## Verification
`deno task ci` green — fmt, lint, spell, `deno check`, coverage (lines **98.7%**, branches **96.0%**). `deno doc --lint` clean; `apiDocsCheck` no drift.

## Not in this PR
**PR 2** — `zuke resume <id> --signal … --data …` with exactly-once CAS, run continuation (re-instantiate the build, seed `done` from the record, graph-drift check), `AlreadyResumedError`, and lazy timeout enforcement. The full three-process acceptance scenario lands there. (Also still pending from earlier: **M1 PR2** `zuke runs list/show`.)