### PR TITLE
feat(core): add zuke runs list/show

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,25 +1,27 @@
 # CLI reference
 
-| Command                             | Behaviour                                                      |
-| ----------------------------------- | -------------------------------------------------------------- |
-| `zuke <target>`                     | Run the target and all its transitive dependencies, in order.  |
-| `zuke <target> --skip <dep>`        | Run the target but skip the named dependency (repeatable).     |
-| `zuke <target> --parallel`          | Run independent targets concurrently (`--parallel=N` caps it). |
-| `zuke <target> --no-cache`          | Ignore the incremental cache; re-run every target.             |
-| `zuke <target> --affected[=<base>]` | Run only targets affected by files changed since a git base.   |
-| `zuke <target> --dry-run`           | Print the plan without executing any target body.              |
-| `zuke <target> --state`             | Persist [durable run state](./state.md) under `.zuke/runs`.    |
-| `zuke <target> --actor <name>`      | Attribute the run to `<name>` in its state record.            |
-| `zuke --list` / `-l`                | List all targets with descriptions and dependencies.           |
-| `zuke graph`                        | Print the dependency graph (`target → deps`).                  |
-| `zuke graph --output=html`          | Render an interactive HTML graph into `.zuke/` and open it.    |
-| `zuke completions print <shell>`    | Print a shell-completion script (`bash`, `zsh`, or `fish`).    |
-| `zuke completions install <shell>`  | Write the script and wire it into the shell's startup.         |
-| `zuke mcp [--allow-run]`            | Run an MCP server over the build for AI agents ([details](./mcp.md)). |
-| `zuke resume <id> [--signal <n>] [--data <json>]` | Resume a suspended run, optionally delivering a signal ([details](./orchestration.md)). |
-| `zuke resume --check [<id>]`        | Re-check suspended runs (predicate waits, timeouts).           |
-| `zuke --help` / `-h`                | Usage.                                                         |
-| `zuke` (no target)                  | Run the `default` target if defined, else print `--list`.      |
+| Command                                             | Behaviour                                                                               |
+| --------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `zuke <target>`                                     | Run the target and all its transitive dependencies, in order.                           |
+| `zuke <target> --skip <dep>`                        | Run the target but skip the named dependency (repeatable).                              |
+| `zuke <target> --parallel`                          | Run independent targets concurrently (`--parallel=N` caps it).                          |
+| `zuke <target> --no-cache`                          | Ignore the incremental cache; re-run every target.                                      |
+| `zuke <target> --affected[=<base>]`                 | Run only targets affected by files changed since a git base.                            |
+| `zuke <target> --dry-run`                           | Print the plan without executing any target body.                                       |
+| `zuke <target> --state`                             | Persist [durable run state](./state.md) under `.zuke/runs`.                             |
+| `zuke <target> --actor <name>`                      | Attribute the run to `<name>` in its state record.                                      |
+| `zuke --list` / `-l`                                | List all targets with descriptions and dependencies.                                    |
+| `zuke graph`                                        | Print the dependency graph (`target → deps`).                                           |
+| `zuke graph --output=html`                          | Render an interactive HTML graph into `.zuke/` and open it.                             |
+| `zuke completions print <shell>`                    | Print a shell-completion script (`bash`, `zsh`, or `fish`).                             |
+| `zuke completions install <shell>`                  | Write the script and wire it into the shell's startup.                                  |
+| `zuke mcp [--allow-run]`                            | Run an MCP server over the build for AI agents ([details](./mcp.md)).                   |
+| `zuke resume <id> [--signal <n>] [--data <json>]`   | Resume a suspended run, optionally delivering a signal ([details](./orchestration.md)). |
+| `zuke resume --check [<id>]`                        | Re-check suspended runs (predicate waits, timeouts).                                    |
+| `zuke runs list [--status/-target/-since] [--json]` | List persisted run records, newest first ([details](./state.md)).                       |
+| `zuke runs show <id> [--json]`                      | Show one run's full per-target status and metadata.                                     |
+| `zuke --help` / `-h`                                | Usage.                                                                                  |
+| `zuke` (no target)                                  | Run the `default` target if defined, else print `--list`.                               |
 
 (Read `zuke` as `deno run -A zuke.ts` until the launcher binary ships.)
 
@@ -61,9 +63,9 @@ emit `::error::` annotations, and the summary is written to the job summary.
 `zuke completions` takes an explicit sub-action — `print` or `install` — then a
 shell (`bash`, `zsh`, or `fish`). `print` writes the completion script to
 stdout; the script completes the build's target names, the reserved commands
-(`graph`, `generate-ci`, `completions`, `mcp`), the built-in option flags, and any
-declared [parameters](./parameters.md) as `--flag` candidates. Unlisted targets
-(`.unlisted()`) stay hidden, just as they are in `--list`.
+(`graph`, `generate-ci`, `completions`, `mcp`), the built-in option flags, and
+any declared [parameters](./parameters.md) as `--flag` candidates. Unlisted
+targets (`.unlisted()`) stay hidden, just as they are in `--list`.
 
 Source the printed script for the current shell:
 
@@ -244,9 +246,30 @@ store.
 
 A run parked at a [`.waitsFor()`](./orchestration.md) gate is continued with
 `zuke resume`. `--signal <name>` delivers a named external signal (with an
-optional `--data <json>` payload); `--check [<run-id>]` re-checks predicate waits
-and enforces timeouts across suspended runs (the cron/webhook entry point).
-Resumption is **exactly-once** — concurrent resumers race a compare-and-swap and
-all but one get `AlreadyResumedError` — and re-runs only the targets that hadn't
-yet succeeded. `--force-graph` continues even if the build graph changed since
-the run was suspended. See [Orchestration](./orchestration.md).
+optional `--data <json>` payload); `--check [<run-id>]` re-checks predicate
+waits and enforces timeouts across suspended runs (the cron/webhook entry
+point). Resumption is **exactly-once** — concurrent resumers race a
+compare-and-swap and all but one get `AlreadyResumedError` — and re-runs only
+the targets that hadn't yet succeeded. `--force-graph` continues even if the
+build graph changed since the run was suspended. See
+[Orchestration](./orchestration.md).
+
+## Inspecting runs
+
+`zuke runs` reads persisted [run records](./state.md) back from the store, so a
+run's full status survives the process that produced it.
+
+- `zuke runs list` prints one row per run — id, status, root target, actor, and
+  creation time — newest first. Narrow it with `--status <s>` (one of `running`,
+  `suspended`, `succeeded`, `failed`, `cancelled`), `--target <t>` (only runs
+  whose graph contains that target), and `--since <iso>` (only runs created at
+  or after an ISO-8601 timestamp). The filters compose.
+- `zuke runs show <run-id>` reconstructs one run in full: the header, resolved
+  (non-secret) parameters, each target's status with its duration, error, or
+  pending wait, and any external signals received.
+
+Both accept `--json` — `list` emits the summary array, `show` emits the whole
+record — for tools and agents. The store is resolved exactly as a run resolves
+it (`ZUKE_STATE_URL` / `ZUKE_STATE_DIR`, the build's `stateStore()` override, or
+the default `.zuke/runs`); with no store configured, both report a friendly
+error. (MCP `list_runs` / `show_run` tools arrive in a later milestone.)

--- a/docs/state.md
+++ b/docs/state.md
@@ -14,13 +14,13 @@ configuration writes nothing and pays nothing.
 
 A run gets a **state store** by the first of these that applies:
 
-| Precedence | Source                                             | Selects                                    |
-| ---------- | -------------------------------------------------- | ------------------------------------------ |
-| 1          | `execute(build, root, { stateStore })`             | that store (`false` disables state)        |
-| 2          | `Build.stateStore()` override                      | the returned store                         |
-| 3          | `ZUKE_STATE_URL` (+ optional `ZUKE_STATE_TOKEN`)   | an {@link HttpStateStore} (production)     |
-| 4          | `ZUKE_STATE_DIR`                                   | a `FileSystemStateStore` at that directory |
-| 5          | `--state` (CLI) with nothing above set             | a `FileSystemStateStore` at `.zuke/runs`   |
+| Precedence | Source                                           | Selects                                    |
+| ---------- | ------------------------------------------------ | ------------------------------------------ |
+| 1          | `execute(build, root, { stateStore })`           | that store (`false` disables state)        |
+| 2          | `Build.stateStore()` override                    | the returned store                         |
+| 3          | `ZUKE_STATE_URL` (+ optional `ZUKE_STATE_TOKEN`) | an {@link HttpStateStore} (production)     |
+| 4          | `ZUKE_STATE_DIR`                                 | a `FileSystemStateStore` at that directory |
+| 5          | `--state` (CLI) with nothing above set           | a `FileSystemStateStore` at `.zuke/runs`   |
 
 If none apply, the run has no store and no record is written.
 
@@ -50,21 +50,31 @@ Each run is stored as one JSON document:
 
 ```jsonc
 {
-  "id": "3f2a…",                 // == ctx.runId
-  "build": "CD",                  // the Build class name
-  "rootTarget": "deploy",         // the requested target
-  "status": "succeeded",          // running | suspended | succeeded | failed | cancelled
-  "actor": "alice",               // who ran it (see below)
+  "id": "3f2a…", // == ctx.runId
+  "build": "CD", // the Build class name
+  "rootTarget": "deploy", // the requested target
+  "status": "succeeded", // running | suspended | succeeded | failed | cancelled
+  "actor": "alice", // who ran it (see below)
   "createdAt": "2026-07-17T…Z",
   "updatedAt": "2026-07-17T…Z",
-  "graph": [                      // the shape it planned, in declaration order
+  "graph": [ // the shape it planned, in declaration order
     { "name": "build", "dependsOn": [] },
     { "name": "deploy", "dependsOn": ["build"] }
   ],
-  "params": { "env": "sit" },     // resolved, NON-secret parameters only
+  "params": { "env": "sit" }, // resolved, NON-secret parameters only
   "targets": {
-    "build":  { "status": "succeeded", "meta": {}, "startedAt": "…", "endedAt": "…" },
-    "deploy": { "status": "succeeded", "meta": { "target": "sit-7" }, "startedAt": "…", "endedAt": "…" }
+    "build": {
+      "status": "succeeded",
+      "meta": {},
+      "startedAt": "…",
+      "endedAt": "…"
+    },
+    "deploy": {
+      "status": "succeeded",
+      "meta": { "target": "sit-7" },
+      "startedAt": "…",
+      "endedAt": "…"
+    }
   }
 }
 ```
@@ -81,8 +91,8 @@ stamped.
 
 ## Per-target state — `ctx.state`
 
-`ctx.state` ([run context](./run-context.md)) is a small durable key/value
-store scoped to the current target:
+`ctx.state` ([run context](./run-context.md)) is a small durable key/value store
+scoped to the current target:
 
 ```ts
 deploy = target().executes(async (ctx) => {
@@ -139,9 +149,9 @@ import { HttpStateStore } from "jsr:@zuke/core";
 const store = new HttpStateStore({ url: "https://zuke-state.internal", token });
 ```
 
-> **Security.** A store's URL/token and directory are trusted configuration:
-> run records (with non-secret parameters and target metadata) are sent there.
-> Point it only at a store you control, and prefer a secret parameter or an
+> **Security.** A store's URL/token and directory are trusted configuration: run
+> records (with non-secret parameters and target metadata) are sent there. Point
+> it only at a store you control, and prefer a secret parameter or an
 > environment variable over a hard-coded value.
 
 ## Concurrency & compare-and-swap
@@ -159,16 +169,34 @@ real work outweighs its bookkeeping.
 
 ## Inspecting runs
 
-Programmatically, a store reconstructs runs from persistence alone:
+From the command line, `zuke runs` reads records back from the store — a run's
+status survives the process that produced it:
+
+```sh
+# All runs, newest first (id, status, target, actor, created).
+zuke runs list
+
+# Just the failed ones touching a given target, since a cutoff.
+zuke runs list --status failed --target deploy --since 2026-07-01
+
+# One run in full: header, parameters, per-target status, and signals.
+zuke runs show 6f1c…             # add --json to emit the raw record
+```
+
+The store resolves the same way a run resolves it (`ZUKE_STATE_URL` /
+`ZUKE_STATE_DIR`, a build's `stateStore()` override, or the default
+`.zuke/runs`); with none configured, `runs` reports a friendly error. See the
+[CLI reference](./cli.md#inspecting-runs) for every flag.
+
+Programmatically, the same data is a `listRuns` / `getRun` away:
 
 ```ts
 const store = new FileSystemStateStore(".zuke/runs");
 for (const summary of await store.listRuns({ status: "failed" })) {
-  const { record } = (await store.getRun(summary.id))!;
-  console.log(record.id, record.rootTarget, record.status);
+  const loaded = await store.getRun(summary.id);
+  if (loaded === null) continue;
+  console.log(loaded.record.id, loaded.record.rootTarget, loaded.record.status);
 }
 ```
 
-`listRuns` filters by `status`, `target`, and `since`, newest first. Inspecting
-runs from the command line (`zuke runs list` / `zuke runs show <id>`) lands with
-the CLI surface for state — see the [CLI reference](./cli.md).
+`listRuns` filters by `status`, `target`, and `since`, newest first.

--- a/llms.txt
+++ b/llms.txt
@@ -46,6 +46,7 @@ Reserved commands:
 - `completions` — Print a shell-completion script
 - `mcp` — Run an MCP server over the build (for AI agents)
 - `resume` — Resume a suspended run (or --check all suspended runs)
+- `runs` — List or show persisted run records
 
 Option flags:
 
@@ -65,6 +66,9 @@ Option flags:
 - `--signal` — With resume, deliver a named external signal
 - `--data` — With resume --signal, the signal's JSON payload
 - `--force-graph` — With resume, continue even if the build graph changed
+- `--status` — With runs list, keep only runs with this status
+- `--target` — With runs list, keep only runs whose graph has this target
+- `--since` — With runs list, keep only runs created at/after this time
 - `--allow-run` — With mcp, let agents execute targets (not just inspect)
 - `--help` — Show usage
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -31,9 +31,12 @@ import {
   GRAPH_COMMAND,
   MCP_COMMAND,
   RESUME_COMMAND,
+  RUNS_COMMAND,
 } from "./cli_spec.ts";
 import { serveMcp } from "./mcp/command.ts";
 import { resumeCheck, resumeRun } from "./resume.ts";
+import { runsCommand } from "./runs.ts";
+import { isRunStatus, RUN_STATUS_NAMES, type RunQuery } from "./state/types.ts";
 import {
   installCompletions,
   type InstallOptions,
@@ -121,6 +124,18 @@ export interface ParsedArgs {
   data?: string;
   /** Continue a resume even if the build graph changed (`--force-graph`). */
   forceGraph: boolean;
+  /** The `runs` command was requested (list/show persisted runs). */
+  runs: boolean;
+  /** The `runs` sub-action (`list` or `show`); the first positional after `runs`. */
+  runsAction?: string;
+  /** The run id to show (`runs show <id>`); the positional after the sub-action. */
+  runsRunId?: string;
+  /** With `runs list`, keep only runs with this status (`--status`). */
+  runStatus?: string;
+  /** With `runs list`, keep only runs whose graph has this target (`--target`). */
+  runTarget?: string;
+  /** With `runs list`, keep only runs created at/after this ISO-8601 time (`--since`). */
+  since?: string;
   /** Raw parameter values from declared flags, keyed by property name. */
   values: Record<string, string>;
   help: boolean;
@@ -160,6 +175,7 @@ export function parseArgs(
     state: false,
     resume: false,
     forceGraph: false,
+    runs: false,
     help: false,
   };
   const byFlag = new Map<string, ParamFlag>();
@@ -203,6 +219,21 @@ export function parseArgs(
       parsed.data = arg.slice("--data=".length);
     } else if (arg === "--force-graph") {
       parsed.forceGraph = true;
+    } else if (arg === "--status") {
+      const value = args[++i];
+      if (value) parsed.runStatus = value;
+    } else if (arg.startsWith("--status=")) {
+      parsed.runStatus = arg.slice("--status=".length);
+    } else if (arg === "--target") {
+      const value = args[++i];
+      if (value) parsed.runTarget = value;
+    } else if (arg.startsWith("--target=")) {
+      parsed.runTarget = arg.slice("--target=".length);
+    } else if (arg === "--since") {
+      const value = args[++i];
+      if (value) parsed.since = value;
+    } else if (arg.startsWith("--since=")) {
+      parsed.since = arg.slice("--since=".length);
     } else if (arg === "--check") {
       parsed.check = true;
     } else if (arg === "--allow-run") {
@@ -249,15 +280,22 @@ export function parseArgs(
     } else if (parsed.resume && parsed.resumeRunId === undefined) {
       // `resume` takes the run id as its positional.
       parsed.resumeRunId = arg;
+    } else if (parsed.runs && parsed.runsAction === undefined) {
+      // `runs` takes a sub-action first (list or show)...
+      parsed.runsAction = arg;
+    } else if (parsed.runs && parsed.runsRunId === undefined) {
+      // ...then, for `show`, the run id.
+      parsed.runsRunId = arg;
     } else if (
       parsed.target === undefined && !parsed.graph && !parsed.generateCi &&
-      !parsed.completions && !parsed.mcp && !parsed.resume
+      !parsed.completions && !parsed.mcp && !parsed.resume && !parsed.runs
     ) {
       if (arg === GRAPH_COMMAND) parsed.graph = true;
       else if (arg === GENERATE_CI_COMMAND) parsed.generateCi = true;
       else if (arg === COMPLETIONS_COMMAND) parsed.completions = true;
       else if (arg === MCP_COMMAND) parsed.mcp = true;
       else if (arg === RESUME_COMMAND) parsed.resume = true;
+      else if (arg === RUNS_COMMAND) parsed.runs = true;
       else parsed.target = arg;
     }
   }
@@ -280,6 +318,8 @@ Usage:
   deno run -A zuke.ts mcp [--allow-run]
   deno run -A zuke.ts resume <run-id> [--signal <name>] [--data <json>]
   deno run -A zuke.ts resume --check [<run-id>]
+  deno run -A zuke.ts runs list [--status <s>] [--target <t>] [--since <iso>] [--json]
+  deno run -A zuke.ts runs show <run-id> [--json]
 
 Options:
   <target>          Run the target and its transitive dependencies.
@@ -333,6 +373,16 @@ Options:
   --data <json>     With resume --signal, the signal's JSON payload (default {}).
   --force-graph     With resume, continue even if the build graph changed since
                     the run was suspended.
+  runs              Inspect persisted run records from the state store. 'list'
+                    prints one row per run (newest first); 'show <run-id>'
+                    reconstructs a run's full per-target status and metadata.
+                    Both accept --json for tools. See docs/state.md.
+  --status <s>      With runs list, keep only runs with this status (running,
+                    suspended, succeeded, failed, cancelled).
+  --target <t>      With runs list, keep only runs whose graph contains this
+                    target.
+  --since <iso>     With runs list, keep only runs created at or after this
+                    ISO-8601 timestamp.
   --<param> <val>   Set a declared build parameter (see Parameters below).
   --help, -h        Show this help.`;
 
@@ -556,6 +606,29 @@ async function runResume(build: Build, parsed: ParsedArgs): Promise<number> {
   }
 }
 
+/** Run the `runs` command: build the query (validating `--status`) and dispatch. */
+async function runRuns(build: Build, parsed: ParsedArgs): Promise<number> {
+  const query: RunQuery = {};
+  if (parsed.runStatus !== undefined) {
+    if (!isRunStatus(parsed.runStatus)) {
+      console.error(
+        `runs: unknown --status "${parsed.runStatus}" ` +
+          `(one of: ${RUN_STATUS_NAMES.join(", ")}).`,
+      );
+      return 1;
+    }
+    query.status = parsed.runStatus;
+  }
+  if (parsed.runTarget !== undefined) query.target = parsed.runTarget;
+  if (parsed.since !== undefined) query.since = parsed.since;
+  return await runsCommand(build, {
+    action: parsed.runsAction,
+    runId: parsed.runsRunId,
+    json: parsed.json,
+    query,
+  });
+}
+
 export async function main(
   BuildClass: new () => Build,
   args: string[],
@@ -589,7 +662,9 @@ export async function main(
     throw error;
   }
 
-  if (parsed.json) {
+  // `--json` prints the build surface, except when a command consumes it
+  // itself (`runs list/show --json` emits run data, not the build surface).
+  if (parsed.json && !parsed.runs) {
     const surface = describeBuildSurface(targets, params);
     console.log(JSON.stringify(surface, null, 2));
     return 0;
@@ -629,6 +704,9 @@ export async function main(
   }
   if (parsed.resume) {
     return await runResume(build, parsed);
+  }
+  if (parsed.runs) {
+    return await runRuns(build, parsed);
   }
 
   let name = parsed.target;

--- a/packages/core/src/cli_spec.ts
+++ b/packages/core/src/cli_spec.ts
@@ -35,6 +35,9 @@ export const MCP_COMMAND = "mcp";
 /** The `resume` command: continue a suspended run (external-event waits). */
 export const RESUME_COMMAND = "resume";
 
+/** The `runs` command: list and show persisted run records. */
+export const RUNS_COMMAND = "runs";
+
 /** Every reserved command, in help and completion order. */
 export const RESERVED_COMMANDS: readonly ReservedCommand[] = [
   { name: GRAPH_COMMAND, description: "Show the dependency graph" },
@@ -50,6 +53,10 @@ export const RESERVED_COMMANDS: readonly ReservedCommand[] = [
   {
     name: RESUME_COMMAND,
     description: "Resume a suspended run (or --check all suspended runs)",
+  },
+  {
+    name: RUNS_COMMAND,
+    description: "List or show persisted run records",
   },
 ];
 
@@ -109,6 +116,18 @@ export const BUILTIN_FLAGS: readonly BuiltinFlag[] = [
   {
     name: "--force-graph",
     description: "With resume, continue even if the build graph changed",
+  },
+  {
+    name: "--status",
+    description: "With runs list, keep only runs with this status",
+  },
+  {
+    name: "--target",
+    description: "With runs list, keep only runs whose graph has this target",
+  },
+  {
+    name: "--since",
+    description: "With runs list, keep only runs created at/after this time",
   },
   {
     name: "--allow-run",

--- a/packages/core/src/runs.ts
+++ b/packages/core/src/runs.ts
@@ -1,0 +1,210 @@
+/**
+ * The `zuke runs` command: list persisted run records and show one run's full
+ * detail from a {@link "./state/store.ts".StateStore}, reconstructing a run's
+ * status after its process has exited. This is the read side of durable run
+ * state (the write side lives in the executor and `zuke resume`).
+ *
+ * @module
+ */
+
+import type { Build } from "./build.ts";
+import { absolutePath } from "./path.ts";
+import { findConfigDir, pathExists } from "./config.ts";
+import { defaultStateHost, type StateStore } from "./state/store.ts";
+import { resolveStateStore } from "./state/resolve.ts";
+import type {
+  RunQuery,
+  RunRecord,
+  RunSummary,
+  TargetRunState,
+  TargetRunStatus,
+} from "./state/types.ts";
+import { formatDuration } from "./render.ts";
+
+/** Inputs for {@link runsCommand}. */
+export interface RunsOptions {
+  /** The sub-action: `list` (the default) or `show`. */
+  action?: string;
+  /** The run id to show; required by the `show` sub-action. */
+  runId?: string;
+  /** Emit JSON (a summary array, or the whole record) instead of a human view. */
+  json?: boolean;
+  /** Filters for `list` — status, a target in the run, a creation time. */
+  query?: RunQuery;
+  /**
+   * Store override, resolved like a run (explicit → `stateStore()` → env →
+   * `.zuke/runs`); `false` disables state. Tests inject a store here.
+   */
+  stateStore?: StateStore | false;
+  /** Reads an environment variable (injectable for tests). */
+  readEnv?: (name: string) => string | undefined;
+}
+
+/** Read an environment variable, treating missing env access as unset. */
+function defaultReadEnv(name: string): string | undefined {
+  try {
+    return Deno.env.get(name);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Resolve the store for a `runs` query — like a run, but always defaulting on. */
+function resolveRunsStore(
+  option: StateStore | false | undefined,
+  build: Build,
+  readEnv: (name: string) => string | undefined,
+): StateStore | undefined {
+  return resolveStateStore(option, build.stateStore(), {
+    readEnv,
+    host: defaultStateHost,
+    defaultDir: absolutePath(
+      findConfigDir(Deno.cwd(), pathExists) ?? Deno.cwd(),
+    )(".zuke", "runs").path,
+    enableDefault: true,
+  });
+}
+
+/**
+ * Run `zuke runs list`/`show`, printing to the console and resolving to a
+ * process exit code (0 success, 1 on a misuse or missing run/store).
+ */
+export async function runsCommand(
+  build: Build,
+  options: RunsOptions,
+): Promise<number> {
+  const readEnv = options.readEnv ?? defaultReadEnv;
+  const store = resolveRunsStore(options.stateStore, build, readEnv);
+  if (store === undefined) {
+    console.error(
+      "runs: no state store is configured. Set ZUKE_STATE_DIR / " +
+        "ZUKE_STATE_URL, override stateStore(), or run a build with --state first.",
+    );
+    return 1;
+  }
+
+  const action = options.action ?? "list";
+  if (action === "list") {
+    const summaries = await store.listRuns(options.query ?? {});
+    console.log(
+      options.json
+        ? JSON.stringify(summaries, null, 2)
+        : formatRunList(summaries),
+    );
+    return 0;
+  }
+  if (action === "show") {
+    if (options.runId === undefined) {
+      console.error("Usage: zuke runs show <run-id>");
+      return 1;
+    }
+    const loaded = await store.getRun(options.runId);
+    if (loaded === null) {
+      console.error(`runs: no run "${options.runId}" found in the store.`);
+      return 1;
+    }
+    console.log(
+      options.json
+        ? JSON.stringify(loaded.record, null, 2)
+        : formatRunDetail(loaded.record),
+    );
+    return 0;
+  }
+  console.error("Usage: zuke runs <list|show> [<run-id>]");
+  return 1;
+}
+
+/** A single-glyph status marker, kept ASCII so it renders in any terminal/log. */
+const STATUS_MARK: Record<TargetRunStatus, string> = {
+  pending: "·",
+  running: "»",
+  waiting: "~",
+  succeeded: "+",
+  failed: "x",
+  skipped: "-",
+};
+
+/** Render `runs list`: one row per run, newest first (as the store returns them). */
+export function formatRunList(summaries: readonly RunSummary[]): string {
+  if (summaries.length === 0) return "No runs found.";
+  const rows = summaries.map((s) => [
+    s.id,
+    s.status,
+    s.rootTarget,
+    s.actor,
+    s.createdAt,
+  ]);
+  const headers = ["ID", "STATUS", "TARGET", "ACTOR", "CREATED"];
+  const widths = headers.map((h, col) =>
+    Math.max(h.length, ...rows.map((r) => r[col].length))
+  );
+  const line = (cells: string[]) =>
+    cells.map((c, col) => c.padEnd(widths[col])).join("  ").trimEnd();
+  return [line(headers), ...rows.map(line)].join("\n");
+}
+
+/** The elapsed time of a target, when both timestamps are present and parse. */
+function targetDuration(state: TargetRunState): string | undefined {
+  if (state.startedAt === undefined || state.endedAt === undefined) {
+    return undefined;
+  }
+  const ms = Date.parse(state.endedAt) - Date.parse(state.startedAt);
+  return Number.isFinite(ms) && ms >= 0 ? formatDuration(ms) : undefined;
+}
+
+/** The trailing note for one target line: a duration, error, or wait descriptor. */
+function targetNote(state: TargetRunState): string {
+  if (state.status === "failed" && state.error !== undefined) {
+    return `  ${state.error}`;
+  }
+  if (state.status === "waiting" && state.waitingFor !== undefined) {
+    const { trigger, deadline } = state.waitingFor;
+    const until = deadline !== undefined ? ` (deadline ${deadline})` : "";
+    return `  waiting for ${trigger}${until}`;
+  }
+  const duration = targetDuration(state);
+  return duration !== undefined ? `  ${duration}` : "";
+}
+
+/** Render `runs show <id>`: the run header, parameters, targets, and signals. */
+export function formatRunDetail(record: RunRecord): string {
+  const lines = [
+    `Run ${record.id}`,
+    `  build:    ${record.build}`,
+    `  target:   ${record.rootTarget}`,
+    `  status:   ${record.status}`,
+    `  actor:    ${record.actor}`,
+    `  created:  ${record.createdAt}`,
+    `  updated:  ${record.updatedAt}`,
+  ];
+
+  const params = Object.entries(record.params);
+  if (params.length > 0) {
+    lines.push("", "Parameters:");
+    for (const [name, value] of params) lines.push(`  ${name} = ${value}`);
+  }
+
+  lines.push("", "Targets:");
+  const entries = Object.entries(record.targets);
+  if (entries.length === 0) {
+    lines.push("  (none recorded)");
+  } else {
+    const width = Math.max(...entries.map(([name]) => name.length));
+    for (const [name, state] of entries) {
+      lines.push(
+        `  ${STATUS_MARK[state.status]} ${name.padEnd(width)}  ` +
+          `${state.status}${targetNote(state)}`,
+      );
+    }
+  }
+
+  const signals = Object.entries(record.signals);
+  if (signals.length > 0) {
+    lines.push("", "Signals:");
+    for (const [name, sig] of signals) {
+      lines.push(`  ${name}  (received ${sig.receivedAt})`);
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/packages/core/src/state/types.ts
+++ b/packages/core/src/state/types.ts
@@ -163,6 +163,14 @@ const RUN_STATUSES: readonly RunStatus[] = [
   "cancelled",
 ];
 
+/** The {@link RunStatus} values as a list, for CLI help and error messages. */
+export const RUN_STATUS_NAMES: readonly string[] = RUN_STATUSES;
+
+/** True when `value` is a valid {@link RunStatus} (used to validate CLI filters). */
+export function isRunStatus(value: string): value is RunStatus {
+  return RUN_STATUSES.some((s) => s === value);
+}
+
 /** All valid {@link TargetRunStatus} values, for validation. */
 const TARGET_STATUSES: readonly TargetRunStatus[] = [
   "pending",

--- a/packages/core/tests/cli_test.ts
+++ b/packages/core/tests/cli_test.ts
@@ -13,6 +13,26 @@ import { FakeGraphHost } from "./_fakes.ts";
 import { CONFIG_FILE } from "../src/config.ts";
 import { parameter } from "../src/params.ts";
 import { BUILTIN_FLAGS, RESERVED_COMMANDS } from "../src/cli_spec.ts";
+import { FileSystemStateStore } from "../src/state/fs_store.ts";
+import { defaultStateHost } from "../src/state/store.ts";
+import type { RunRecord } from "../src/state/types.ts";
+
+/** A minimal valid run record for the `runs` command tests. */
+function sampleRunRecord(overrides: Partial<RunRecord> = {}): RunRecord {
+  return {
+    id: overrides.id ?? "run-z",
+    build: overrides.build ?? "Demo",
+    rootTarget: overrides.rootTarget ?? "build",
+    status: overrides.status ?? "succeeded",
+    actor: overrides.actor ?? "alice",
+    createdAt: overrides.createdAt ?? "2026-07-17T10:00:00.000Z",
+    updatedAt: overrides.updatedAt ?? "2026-07-17T10:00:00.000Z",
+    graph: overrides.graph ?? [{ name: "build", dependsOn: [] }],
+    params: overrides.params ?? {},
+    targets: overrides.targets ?? { build: { status: "succeeded", meta: {} } },
+    signals: overrides.signals ?? {},
+  };
+}
 
 /** A build with declared parameters, for the parameter-aware CLI tests. */
 class Parameterised extends Build {
@@ -204,6 +224,80 @@ Deno.test("parseArgs reads resume with its run id, signal, data, and flags", () 
   assertEquals(check.resume, true);
   assertEquals(check.check, true);
   assertEquals(check.resumeRunId, undefined);
+});
+
+Deno.test("parseArgs reads the runs command, sub-action, id, and filters", () => {
+  assertEquals(parseArgs(["runs"]).runs, true);
+  assertEquals(parseArgs(["build"]).runs, false);
+
+  const list = parseArgs([
+    "runs",
+    "list",
+    "--status",
+    "failed",
+    "--target",
+    "deploy",
+    "--since",
+    "2026-01-01",
+  ]);
+  assertEquals(
+    [list.runs, list.runsAction, list.runStatus, list.runTarget, list.since],
+    [true, "list", "failed", "deploy", "2026-01-01"],
+  );
+
+  const show = parseArgs(["runs", "show", "run-9"]);
+  assertEquals([show.runsAction, show.runsRunId], ["show", "run-9"]);
+
+  // Inline `=` forms of the filters.
+  const eq = parseArgs([
+    "runs",
+    "list",
+    "--status=succeeded",
+    "--target=t",
+    "--since=x",
+  ]);
+  assertEquals([eq.runStatus, eq.runTarget, eq.since], ["succeeded", "t", "x"]);
+});
+
+Deno.test("main: runs list reads persisted runs; --json emits run data", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    await store.putRun(sampleRunRecord({ id: "run-z" }), null);
+    class Stateful extends Build {
+      override stateStore() {
+        return store;
+      }
+      build = target().executes(() => {});
+    }
+
+    const list = await capture(() => main(Stateful, ["runs", "list"]));
+    assertEquals(list.code, 0);
+    assertStringIncludes(list.out.join("\n"), "run-z");
+
+    // --json must emit the run summaries, not the build surface.
+    const json = await capture(() =>
+      main(Stateful, ["runs", "list", "--json"])
+    );
+    assertEquals(json.code, 0);
+    const summaries = JSON.parse(json.out.join("\n"));
+    assertEquals(Array.isArray(summaries), true);
+    assertEquals(summaries[0].id, "run-z");
+
+    const show = await capture(() => main(Stateful, ["runs", "show", "run-z"]));
+    assertEquals(show.code, 0);
+    assertStringIncludes(show.out.join("\n"), "Run run-z");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("main: runs list rejects an unknown --status", async () => {
+  const { code, err } = await capture(() =>
+    main(Demo, ["runs", "list", "--status", "bogus"])
+  );
+  assertEquals(code, 1);
+  assertStringIncludes(err.join("\n"), 'unknown --status "bogus"');
 });
 
 Deno.test("parseArgs reads --affected with an optional base", () => {

--- a/packages/core/tests/runs_test.ts
+++ b/packages/core/tests/runs_test.ts
@@ -1,0 +1,286 @@
+import { assertEquals, assertStringIncludes } from "./_assert.ts";
+import { Build } from "../src/build.ts";
+import { formatRunDetail, formatRunList, runsCommand } from "../src/runs.ts";
+import { FileSystemStateStore } from "../src/state/fs_store.ts";
+import { defaultStateHost } from "../src/state/store.ts";
+import type { RunRecord } from "../src/state/types.ts";
+
+/** A trivial build; `runsCommand` only reads `build.stateStore()` from it. */
+class B extends Build {}
+
+/** Run `fn` with `console.log`/`console.error` captured instead of printed. */
+async function capture(
+  fn: () => Promise<number> | number,
+): Promise<{ code: number; out: string; err: string }> {
+  const out: string[] = [];
+  const err: string[] = [];
+  const origLog = console.log;
+  const origErr = console.error;
+  console.log = (...args: unknown[]) => void out.push(args.join(" "));
+  console.error = (...args: unknown[]) => void err.push(args.join(" "));
+  try {
+    const code = await fn();
+    return { code, out: out.join("\n"), err: err.join("\n") };
+  } finally {
+    console.log = origLog;
+    console.error = origErr;
+  }
+}
+
+/** Run `fn` with a temp-dir-backed store, cleaned up afterwards. */
+async function withStore(
+  fn: (store: FileSystemStateStore) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir();
+  try {
+    await fn(new FileSystemStateStore(`${dir}/runs`, defaultStateHost));
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+/** A minimal valid run record. */
+function sampleRecord(overrides: Partial<RunRecord> = {}): RunRecord {
+  return {
+    id: overrides.id ?? "run-1",
+    build: overrides.build ?? "CI",
+    rootTarget: overrides.rootTarget ?? "deploy",
+    status: overrides.status ?? "succeeded",
+    actor: overrides.actor ?? "alice",
+    createdAt: overrides.createdAt ?? "2026-07-17T10:00:00.000Z",
+    updatedAt: overrides.updatedAt ?? "2026-07-17T10:05:00.000Z",
+    graph: overrides.graph ?? [{ name: "deploy", dependsOn: [] }],
+    params: overrides.params ?? {},
+    targets: overrides.targets ?? { deploy: { status: "succeeded", meta: {} } },
+    signals: overrides.signals ?? {},
+  };
+}
+
+Deno.test("formatRunList renders headers and one row per run", () => {
+  const text = formatRunList([
+    {
+      id: "run-9",
+      build: "CI",
+      rootTarget: "promote",
+      status: "failed",
+      actor: "bob",
+      createdAt: "2026-07-17T12:00:00.000Z",
+      updatedAt: "2026-07-17T12:01:00.000Z",
+    },
+  ]);
+  assertStringIncludes(text, "ID");
+  assertStringIncludes(text, "STATUS");
+  assertStringIncludes(text, "run-9");
+  assertStringIncludes(text, "failed");
+  assertStringIncludes(text, "promote");
+});
+
+Deno.test("formatRunList reports an empty listing", () => {
+  assertEquals(formatRunList([]), "No runs found.");
+});
+
+Deno.test("formatRunDetail shows header, params, targets, and signals", () => {
+  const record = sampleRecord({
+    status: "failed",
+    params: { env: "sit", repo: "expense-service" },
+    targets: {
+      deploy: {
+        status: "succeeded",
+        meta: {},
+        startedAt: "2026-07-17T10:00:00.000Z",
+        endedAt: "2026-07-17T10:00:02.000Z",
+      },
+      gate: {
+        status: "waiting",
+        meta: {},
+        waitingFor: {
+          trigger: "signal:approved",
+          deadline: "2026-07-19T10:00:00.000Z",
+          onTimeout: "fail",
+        },
+      },
+      promote: {
+        status: "failed",
+        meta: {},
+        error: "Error: boom",
+      },
+      cleanup: { status: "pending", meta: {} },
+      // Reversed timestamps: the duration is dropped rather than shown negative.
+      weird: {
+        status: "succeeded",
+        meta: {},
+        startedAt: "2026-07-17T10:00:05.000Z",
+        endedAt: "2026-07-17T10:00:00.000Z",
+      },
+    },
+    signals: {
+      approved: { data: { by: "qa" }, receivedAt: "2026-07-18T09:00:00.000Z" },
+    },
+  });
+  const text = formatRunDetail(record);
+  assertStringIncludes(text, "Run run-1");
+  assertStringIncludes(text, "status:   failed");
+  assertStringIncludes(text, "Parameters:");
+  assertStringIncludes(text, "env = sit");
+  assertStringIncludes(text, "Targets:");
+  assertStringIncludes(text, "deploy");
+  assertStringIncludes(text, "waiting for signal:approved");
+  assertStringIncludes(text, "deadline 2026-07-19T10:00:00.000Z");
+  assertStringIncludes(text, "Error: boom");
+  assertStringIncludes(text, "Signals:");
+  assertStringIncludes(text, "approved");
+});
+
+Deno.test("formatRunDetail handles no params, no signals, no targets", () => {
+  const text = formatRunDetail(sampleRecord({ targets: {} }));
+  assertEquals(text.includes("Parameters:"), false);
+  assertEquals(text.includes("Signals:"), false);
+  assertStringIncludes(text, "(none recorded)");
+});
+
+Deno.test("formatRunDetail renders a waiting target without a deadline", () => {
+  const text = formatRunDetail(sampleRecord({
+    status: "suspended",
+    targets: {
+      gate: {
+        status: "waiting",
+        meta: {},
+        waitingFor: { trigger: "predicate", onTimeout: "fail" },
+      },
+    },
+  }));
+  assertStringIncludes(text, "waiting for predicate");
+  assertEquals(text.includes("deadline"), false);
+});
+
+Deno.test("runsCommand list prints seeded runs and defaults to list", async () => {
+  await withStore(async (store) => {
+    await store.putRun(sampleRecord({ id: "run-a" }), null);
+    await store.putRun(sampleRecord({ id: "run-b", actor: "bob" }), null);
+    // No action given → defaults to `list`.
+    const { code, out } = await capture(() =>
+      runsCommand(new B(), { stateStore: store })
+    );
+    assertEquals(code, 0);
+    assertStringIncludes(out, "run-a");
+    assertStringIncludes(out, "run-b");
+  });
+});
+
+Deno.test("runsCommand list --json emits a summary array", async () => {
+  await withStore(async (store) => {
+    await store.putRun(sampleRecord({ id: "run-a" }), null);
+    const { code, out } = await capture(() =>
+      runsCommand(new B(), { action: "list", json: true, stateStore: store })
+    );
+    assertEquals(code, 0);
+    const summaries = JSON.parse(out);
+    assertEquals(Array.isArray(summaries), true);
+    assertEquals(summaries[0].id, "run-a");
+  });
+});
+
+Deno.test("runsCommand list applies a status filter", async () => {
+  await withStore(async (store) => {
+    await store.putRun(sampleRecord({ id: "ok", status: "succeeded" }), null);
+    await store.putRun(sampleRecord({ id: "bad", status: "failed" }), null);
+    const { code, out } = await capture(() =>
+      runsCommand(new B(), {
+        action: "list",
+        query: { status: "failed" },
+        stateStore: store,
+      })
+    );
+    assertEquals(code, 0);
+    assertStringIncludes(out, "bad");
+    assertEquals(out.includes("ok "), false);
+  });
+});
+
+Deno.test("runsCommand show prints one run's detail, and --json its record", async () => {
+  await withStore(async (store) => {
+    await store.putRun(sampleRecord({ id: "run-x" }), null);
+
+    const human = await capture(() =>
+      runsCommand(new B(), {
+        action: "show",
+        runId: "run-x",
+        stateStore: store,
+      })
+    );
+    assertEquals(human.code, 0);
+    assertStringIncludes(human.out, "Run run-x");
+    assertStringIncludes(human.out, "Targets:");
+
+    const json = await capture(() =>
+      runsCommand(new B(), {
+        action: "show",
+        runId: "run-x",
+        json: true,
+        stateStore: store,
+      })
+    );
+    assertEquals(json.code, 0);
+    const record = JSON.parse(json.out);
+    assertEquals(record.id, "run-x");
+    assertEquals(record.targets.deploy.status, "succeeded");
+  });
+});
+
+Deno.test("runsCommand show without an id is a usage error", async () => {
+  await withStore(async (store) => {
+    const { code, err } = await capture(() =>
+      runsCommand(new B(), { action: "show", stateStore: store })
+    );
+    assertEquals(code, 1);
+    assertStringIncludes(err, "Usage: zuke runs show");
+  });
+});
+
+Deno.test("runsCommand show reports an unknown run id", async () => {
+  await withStore(async (store) => {
+    const { code, err } = await capture(() =>
+      runsCommand(new B(), { action: "show", runId: "nope", stateStore: store })
+    );
+    assertEquals(code, 1);
+    assertStringIncludes(err, 'no run "nope"');
+  });
+});
+
+Deno.test("runsCommand resolves the store from ZUKE_STATE_DIR", async () => {
+  const dir = await Deno.makeTempDir();
+  const prev = Deno.env.get("ZUKE_STATE_DIR");
+  Deno.env.set("ZUKE_STATE_DIR", `${dir}/runs`);
+  try {
+    const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    await store.putRun(sampleRecord({ id: "env-run" }), null);
+    // No explicit store or readEnv → resolves from the environment.
+    const { code, out } = await capture(() =>
+      runsCommand(new B(), { action: "list" })
+    );
+    assertEquals(code, 0);
+    assertStringIncludes(out, "env-run");
+  } finally {
+    if (prev === undefined) Deno.env.delete("ZUKE_STATE_DIR");
+    else Deno.env.set("ZUKE_STATE_DIR", prev);
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("runsCommand errors with no store configured", async () => {
+  const { code, err } = await capture(() =>
+    runsCommand(new B(), { action: "list", stateStore: false })
+  );
+  assertEquals(code, 1);
+  assertStringIncludes(err, "no state store is configured");
+});
+
+Deno.test("runsCommand rejects an unknown sub-action", async () => {
+  await withStore(async (store) => {
+    const { code, err } = await capture(() =>
+      runsCommand(new B(), { action: "delete", stateStore: store })
+    );
+    assertEquals(code, 1);
+    assertStringIncludes(err, "Usage: zuke runs <list|show>");
+  });
+});

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -21,7 +21,9 @@ class CI extends Build {
   test = target()
     .description("Type-check and test")
     .dependsOn(this.lint)
-    .executes(() => DenoTasks.test((s) => s.allowAll().coverage("cov_profile")));
+    .executes(() =>
+      DenoTasks.test((s) => s.allowAll().coverage("cov_profile"))
+    );
 
   // A field named `default` runs when no target is named on the CLI.
   default = target().dependsOn(this.test).executes(() => {});
@@ -41,9 +43,9 @@ await run(CI);
    dependencies come first.
 3. **Never guess the API and never shell out by hand.** Every external tool is a
    namespaced `*Tasks` object configured with a **settings lambda** that mirrors
-   the real CLI's flags — `DenoTasks`, `NpmTasks`, `DockerTasks`, `GitTasks`, and
-   30+ more. Reach for `jsr:@zuke/cmd` (`CmdTasks.exec`) or the `$` shell from
-   `jsr:@zuke/core/shell` only when no typed wrapper exists.
+   the real CLI's flags — `DenoTasks`, `NpmTasks`, `DockerTasks`, `GitTasks`,
+   and 30+ more. Reach for `jsr:@zuke/cmd` (`CmdTasks.exec`) or the `$` shell
+   from `jsr:@zuke/core/shell` only when no typed wrapper exists.
 4. **A body is required.** Set `.executes(...)`; it may be sync or async.
 
 ## Find the exact signature first
@@ -51,10 +53,11 @@ await run(CI);
 Before calling any task or settings method, confirm the real shape:
 
 - **Whole surface:** read `llms-full.txt` at the repo root (index: `llms.txt`).
-- **One package:** `deno doc jsr:@zuke/<package>` (e.g. `deno doc jsr:@zuke/deno`).
+- **One package:** `deno doc jsr:@zuke/<package>` (e.g.
+  `deno doc jsr:@zuke/deno`).
 - A quick map of the most common methods and task objects is in
-  [`references/cheatsheet.md`](references/cheatsheet.md) next to this file — read
-  it when wiring targets, then verify specifics against the sources above.
+  [`references/cheatsheet.md`](references/cheatsheet.md) next to this file —
+  read it when wiring targets, then verify specifics against the sources above.
 
 ## Workflow for a change
 
@@ -71,10 +74,10 @@ Before calling any task or settings method, confirm the real shape:
 
 - **Parallel batches:** `group()` + `.partOf(this.group)` run members
   concurrently; depend on the group to wait for all of them.
-- **Reusable bundles:** a *component* is a function returning related targets;
+- **Reusable bundles:** a _component_ is a function returning related targets;
   assign it to a field and reference members as `this.release.publish`.
-- **Long-lived processes:** `service()` models a process that must stay *running
-  while dependents execute* (dev server, database, mock API). Declared and
+- **Long-lived processes:** `service()` models a process that must stay _running
+  while dependents execute_ (dev server, database, mock API). Declared and
   depended on like a target, but with a `.start(...)` / `.readyWhen(...)`
   lifecycle instead of `.executes(...)`; the executor starts it, waits until
   ready, then stops it in a `finally` so it never leaks. See the cheatsheet.
@@ -92,8 +95,10 @@ Before calling any task or settings method, confirm the real shape:
   pluggable `StateStore` so it survives the process — turn it on with `--state`,
   `ZUKE_STATE_DIR` / `ZUKE_STATE_URL`, or `override stateStore()`. In a body,
   `ctx.state.set({ … })` / `ctx.state.get()` records per-target metadata (JSON,
-  **never secrets** — secret parameters and redacted values are excluded). See
-  the cheatsheet.
+  **never secrets** — secret parameters and redacted values are excluded).
+  Inspect persisted runs afterwards with `zuke runs list` (filter by
+  `--status`/`--target`/`--since`) and `zuke runs show <id>` (`--json` on both).
+  See the cheatsheet.
 - **Cross-run locks:** `.lock((s) => s.lockKey(...).withTtl("4h"))` — a settings
   lambda — gives a target an exclusive claim across runs/machines; a second run
   wanting the same key fails with a `LockConflictError` naming the holder. The
@@ -101,11 +106,12 @@ Before calling any task or settings method, confirm the real shape:
   The lock releases when the target settles and expires after the TTL if the
   holder is killed. Needs a state store (a build with `.lock()` enables the
   filesystem store by default). See the cheatsheet.
-- **External-event waits:** `.waitsFor((s) => s.on(externalSignal("approved")).timeout("72h"))`
-  makes a target a **gate** with no body: the run proceeds past it only when the
-  trigger is satisfied, otherwise it **suspends** (state saved, exits 0) to be
-  resumed later in a fresh process. Triggers: `externalSignal(name)` (payload
-  read via `ctx.signals`) and `resumeWhen(predicate)`. Continue it with
+- **External-event waits:**
+  `.waitsFor((s) => s.on(externalSignal("approved")).timeout("72h"))` makes a
+  target a **gate** with no body: the run proceeds past it only when the trigger
+  is satisfied, otherwise it **suspends** (state saved, exits 0) to be resumed
+  later in a fresh process. Triggers: `externalSignal(name)` (payload read via
+  `ctx.signals`) and `resumeWhen(predicate)`. Continue it with
   `zuke resume <id> --signal <name> [--data <json>]` (or `--check` for predicate
   waits/timeouts) — exactly-once, re-running only the not-yet-succeeded targets.
   Needs a state store. See the cheatsheet / `docs/orchestration.md`.
@@ -119,11 +125,11 @@ Before calling any task or settings method, confirm the real shape:
   returned path to a wrapper's `.toolPath(...)`.
 - **Code-first CI:** `cicd({ provider: "github" })` generates and verifies the
   workflow YAML from the build.
-- **Operate the build from an agent:** `zuke mcp` serves the build over MCP so an
-  AI client can list, inspect, and (with `--allow-run`) run targets.
+- **Operate the build from an agent:** `zuke mcp` serves the build over MCP so
+  an AI client can list, inspect, and (with `--allow-run`) run targets.
 - **AI review & self-healing (`@zuke/ai`):** gate a target on a structured LLM
   review of the diff (`securityReviewer(...)` etc. via `.validateBefore`), or
-  attach `aiFixer(...)` with `.recoverWith(...)` so a failing target is diagnosed
-  and (opt-in) auto-fixed, with a committable PR suggestion. Override
+  attach `aiFixer(...)` with `.recoverWith(...)` so a failing target is
+  diagnosed and (opt-in) auto-fixed, with a committable PR suggestion. Override
   `recoverWith()` on the build to apply one fixer to every target. See the
   cheatsheet's AI section.

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -8,29 +8,29 @@ summary, not the source of truth.
 
 Everything is optional except a body (`.executes`).
 
-| Method | Purpose |
-| --- | --- |
-| `.description(text)` | Summary shown in `--list`. |
-| `.dependsOn(...t)` | Hard prerequisites; run first, transitively. Pass `this.<field>`. |
-| `.executes(fn)` | The body. Sync or async. **Required.** `fn` may take a `TargetContext` (`(ctx) => …`); see below. |
-| `.before(...t)` / `.after(...t)` | Soft ordering — only reorders targets already in the plan; never pulls new ones in. |
-| `.triggers(...t)` | Pull targets into the plan and run them *after* this one. |
-| `.dependentFor(...t)` | Reverse of `dependsOn`: make this a prerequisite of others. |
-| `.inputs(...p)` / `.outputs(...p)` | Incremental cache: skip when inputs unchanged and outputs exist. |
-| `.cacheKey(fn)` | Add a non-file value (version, git sha, param) to the cache fingerprint. |
-| `.onlyWhen(cond)` | Run only when the (possibly async) predicate holds, else skip. |
-| `.requires(...params)` | Fail unless the listed parameters resolved to a value. |
-| `.retry(times, delayMs?)` | Retry the body on failure. |
-| `.timeout(ms)` | Fail the body if it runs longer than `ms` (per attempt). |
-| `.lock((s) => s.lockKey(...).withTtl(...))` | Hold a cross-run lock while running; a second run wanting the key fails. See below. |
-| `.waitsFor((s) => s.on(externalSignal(...)))` | Gate (no body): suspend the run until an external event; resume later. See below. |
-| `.proceedAfterFailure()` | Keep the build going if this target fails. |
-| `.always()` | Run even after the build failed (cleanup/teardown). |
-| `.unlisted()` | Hide from `--list`/`--help`; still runnable by name. |
-| `.validateBefore(...v)` / `.validateAfter(...v)` | Run `Validation` checks around the body; a throw fails the target. |
-| `.recoverWith(...r)` / `.recoverAttempts(n)` | Run `Remediation`s if the body fails (self-healing); re-run when one asks to. See AI section. |
-| `.partOf(group)` | Join a parallel batch (see `group()`). |
-| `.produces(...p)` / `.consumes(...t)` | Declare and consume artifact paths. |
+| Method                                           | Purpose                                                                                           |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| `.description(text)`                             | Summary shown in `--list`.                                                                        |
+| `.dependsOn(...t)`                               | Hard prerequisites; run first, transitively. Pass `this.<field>`.                                 |
+| `.executes(fn)`                                  | The body. Sync or async. **Required.** `fn` may take a `TargetContext` (`(ctx) => …`); see below. |
+| `.before(...t)` / `.after(...t)`                 | Soft ordering — only reorders targets already in the plan; never pulls new ones in.               |
+| `.triggers(...t)`                                | Pull targets into the plan and run them _after_ this one.                                         |
+| `.dependentFor(...t)`                            | Reverse of `dependsOn`: make this a prerequisite of others.                                       |
+| `.inputs(...p)` / `.outputs(...p)`               | Incremental cache: skip when inputs unchanged and outputs exist.                                  |
+| `.cacheKey(fn)`                                  | Add a non-file value (version, git sha, param) to the cache fingerprint.                          |
+| `.onlyWhen(cond)`                                | Run only when the (possibly async) predicate holds, else skip.                                    |
+| `.requires(...params)`                           | Fail unless the listed parameters resolved to a value.                                            |
+| `.retry(times, delayMs?)`                        | Retry the body on failure.                                                                        |
+| `.timeout(ms)`                                   | Fail the body if it runs longer than `ms` (per attempt).                                          |
+| `.lock((s) => s.lockKey(...).withTtl(...))`      | Hold a cross-run lock while running; a second run wanting the key fails. See below.               |
+| `.waitsFor((s) => s.on(externalSignal(...)))`    | Gate (no body): suspend the run until an external event; resume later. See below.                 |
+| `.proceedAfterFailure()`                         | Keep the build going if this target fails.                                                        |
+| `.always()`                                      | Run even after the build failed (cleanup/teardown).                                               |
+| `.unlisted()`                                    | Hide from `--list`/`--help`; still runnable by name.                                              |
+| `.validateBefore(...v)` / `.validateAfter(...v)` | Run `Validation` checks around the body; a throw fails the target.                                |
+| `.recoverWith(...r)` / `.recoverAttempts(n)`     | Run `Remediation`s if the body fails (self-healing); re-run when one asks to. See AI section.     |
+| `.partOf(group)`                                 | Join a parallel batch (see `group()`).                                                            |
+| `.produces(...p)` / `.consumes(...t)`            | Declare and consume artifact paths.                                                               |
 
 ## `group()` — parallel batches
 
@@ -89,12 +89,12 @@ class E2E extends Build {
 }
 ```
 
-| Method | Purpose |
-| --- | --- |
-| `.start(() => handle)` | Start the process; return a handle with `.stop()`. **Required.** |
-| `.readyWhen(() => boolean)` | Readiness probe, polled (200ms) until `true`. |
-| `.readyTimeout(ms)` | Wait before failing readiness (default 30s). |
-| `.stop((handle) => …)` | Custom teardown; receives what `.start()` returned. |
+| Method                      | Purpose                                                          |
+| --------------------------- | ---------------------------------------------------------------- |
+| `.start(() => handle)`      | Start the process; return a handle with `.stop()`. **Required.** |
+| `.readyWhen(() => boolean)` | Readiness probe, polled (200ms) until `true`.                    |
+| `.readyTimeout(ms)`         | Wait before failing readiness (default 30s).                     |
+| `.stop((handle) => …)`      | Custom teardown; receives what `.start()` returned.              |
 
 The shell's `Command` gains `.spawn()` (starts without awaiting, returns a
 `SpawnedProcess` whose `.stop()` sends `SIGTERM`) — a valid handle, so the
@@ -150,8 +150,10 @@ class CD extends Build {
   `HttpStateStore({ url, token? })` (hosted, production — see
   `docs/state-api.md`). Both dependency-free and pluggable behind `StateStore`.
 - The run record holds status, the graph shape, resolved **non-secret**
-  parameters, and per-target status/timing/metadata. Inspect programmatically
-  with `store.listRuns({ status?, target?, since? })` and `store.getRun(id)`.
+  parameters, and per-target status/timing/metadata. Inspect it from the CLI
+  with `zuke runs list [--status <s>] [--target <t>] [--since <iso>]` (newest
+  first) and `zuke runs show <id>` (`--json` on both), or programmatically with
+  `store.listRuns({ status?, target?, since? })` and `store.getRun(id)`.
 - **Never put secrets in `ctx.state`** — it is stored as plain JSON. Secret
   parameters are excluded from the record and state values are run through the
   redactor, but treat state as a non-secret channel. See `docs/state.md`.
@@ -172,7 +174,10 @@ class CD extends Build {
     .lock((s) =>
       s.lockKey("deploy", this.repo.value) // sanitised composite key
         .withTtl("4h") // renewed while running; expires this long after a kill -9
-        .onConflict((h) => `${this.repo.value} held by ${h.actor} (run ${h.runId}).`))
+        .onConflict((h) =>
+          `${this.repo.value} held by ${h.actor} (run ${h.runId}).`
+        )
+    )
     .executes(async (ctx) => {/* … */});
 }
 ```
@@ -206,7 +211,8 @@ class Deploy extends Build {
     .waitsFor((s) =>
       s.on(externalSignal("qa-approved")) // or resumeWhen(async () => …)
         .timeout("72h")
-        .onTimeout(() => this.rollback)); // thunk: sibling compensation target
+        .onTimeout(() => this.rollback)
+    ); // thunk: sibling compensation target
   promote = target().dependsOn(this.awaitQa).executes((ctx) => {
     const approval = ctx.signals.get("qa-approved"); // the signal's JSON payload
   });
@@ -219,8 +225,9 @@ class Deploy extends Build {
 - Needs a state store (a build with `.waitsFor()` enables `.zuke/runs` by
   default). A resume is a fresh process, so **only `ctx.state`/`ctx.signals`
   cross the boundary**. See `docs/orchestration.md`.
-- Continue a suspended run with `zuke resume <id> --signal <name> [--data <json>]`
-  (or `zuke resume --check [<id>]` for predicate waits/timeouts). Resumption is
+- Continue a suspended run with
+  `zuke resume <id> --signal <name> [--data <json>]` (or
+  `zuke resume --check [<id>]` for predicate waits/timeouts). Resumption is
   **exactly-once** (concurrent resumers get `AlreadyResumedError`) and re-runs
   only the not-yet-succeeded targets; `--force-graph` overrides a changed graph.
 
@@ -253,7 +260,9 @@ import { execSecret, parameter } from "jsr:@zuke/core";
 
 token = parameter("Deploy token")
   .secret()
-  .from(execSecret((s) => s.command("op").arg("read", "op://vault/deploy/token")));
+  .from(
+    execSecret((s) => s.command("op").arg("read", "op://vault/deploy/token")),
+  );
 ```
 
 A sourced secret is still an ordinary parameter (flag, env var, `.required()`,
@@ -270,7 +279,9 @@ import { toolchain, ToolTasks } from "jsr:@zuke/core";
 
 // One tool:
 bin = target().executes(async () =>
-  await ToolTasks.install((s) => s.name("shellcheck").version("0.10.0"/* …checksum */))
+  await ToolTasks.install((s) =>
+    s.name("shellcheck").version("0.10.0" /* …checksum */)
+  )
 );
 
 // Many at once:
@@ -283,26 +294,26 @@ Every external tool is a `*Tasks` object; each task takes `(s) => s.…` mirrori
 the real CLI's flags. A non-exhaustive map (run `deno doc jsr:@zuke/<pkg>` for
 the full task list and settings methods of each):
 
-| Package | Object | Typical tasks |
-| --- | --- | --- |
-| `@zuke/core` | `FileTasks`, `AnnounceTasks`, `ToolTasks` | copy/move/remove files; Slack/Teams/Discord posts; install tool binaries |
-| `@zuke/console` | `ConsoleTasks` | themed console output (headings, notices) so a build never hand-rolls `console.log` |
-| `@zuke/deno` | `DenoTasks` | `check`, `test`, `fmt`, `lint`, `cache`, `doc`, `run`, `publish` |
-| `@zuke/docs` | `DocsTasks` | turn generated API docs into published output |
-| `@zuke/npm`, `@zuke/npx`, `@zuke/bun`, `@zuke/pnpm`, `@zuke/yarn`, `@zuke/node` | `NpmTasks`, `NpxTasks`, `BunTasks`, ... | JS package managers + `npx` runner + `node` |
-| `@zuke/cmd` | `CmdTasks` | `exec` — generic fallback for any CLI |
-| `@zuke/docker`, `@zuke/docker-compose` | `DockerTasks`, ... | build/run/compose |
-| `@zuke/git`, `@zuke/gh` | `GitTasks`, `GhTasks` | git and GitHub CLI |
-| `@zuke/cspell`, `@zuke/eslint`, `@zuke/oxlint`, `@zuke/biome`, `@zuke/dprint`, `@zuke/knip`, `@zuke/dpdm` | `*Tasks` | lint/format/spell/dead-code |
-| `@zuke/tsc`, `@zuke/tsgo`, `@zuke/tsx`, `@zuke/tsc-alias`, `@zuke/tsup`, `@zuke/tsdown`, `@zuke/vite`, `@zuke/turbo`, `@zuke/nx`, `@zuke/nest` | `*Tasks` | TS compile / bundle / monorepo / framework CLIs |
-| `@zuke/openapi-ts`, `@zuke/orval` | `*Tasks` | generate API clients from OpenAPI |
-| `@zuke/husky` | `HuskyTasks` | git hooks |
-| `@zuke/jest`, `@zuke/vitest`, `@zuke/playwright`, `@zuke/cypress` | `*Tasks` | test runners |
-| `@zuke/jsr`, `@zuke/codecov`, `@zuke/release-please` | `JsrTasks`, `CodecovTasks`, ... | publish / coverage upload / releases |
-| `@zuke/kubectl`, `@zuke/helm`, `@zuke/kustomize`, `@zuke/terraform`, `@zuke/tofu`, `@zuke/gcloud` | `*Tasks` | infra/deploy |
-| `@zuke/security` | `*Tasks` | security scanning |
-| `@zuke/claude`, `@zuke/codex`, `@zuke/gemini` | `ClaudeTasks`, ... | headless AI CLIs |
-| `@zuke/ai` | `securityReviewer`, ..., `aiFixer`, `agentFixer` | AI review gates + self-healing (see below) |
+| Package                                                                                                                                        | Object                                           | Typical tasks                                                                       |
+| ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| `@zuke/core`                                                                                                                                   | `FileTasks`, `AnnounceTasks`, `ToolTasks`        | copy/move/remove files; Slack/Teams/Discord posts; install tool binaries            |
+| `@zuke/console`                                                                                                                                | `ConsoleTasks`                                   | themed console output (headings, notices) so a build never hand-rolls `console.log` |
+| `@zuke/deno`                                                                                                                                   | `DenoTasks`                                      | `check`, `test`, `fmt`, `lint`, `cache`, `doc`, `run`, `publish`                    |
+| `@zuke/docs`                                                                                                                                   | `DocsTasks`                                      | turn generated API docs into published output                                       |
+| `@zuke/npm`, `@zuke/npx`, `@zuke/bun`, `@zuke/pnpm`, `@zuke/yarn`, `@zuke/node`                                                                | `NpmTasks`, `NpxTasks`, `BunTasks`, ...          | JS package managers + `npx` runner + `node`                                         |
+| `@zuke/cmd`                                                                                                                                    | `CmdTasks`                                       | `exec` — generic fallback for any CLI                                               |
+| `@zuke/docker`, `@zuke/docker-compose`                                                                                                         | `DockerTasks`, ...                               | build/run/compose                                                                   |
+| `@zuke/git`, `@zuke/gh`                                                                                                                        | `GitTasks`, `GhTasks`                            | git and GitHub CLI                                                                  |
+| `@zuke/cspell`, `@zuke/eslint`, `@zuke/oxlint`, `@zuke/biome`, `@zuke/dprint`, `@zuke/knip`, `@zuke/dpdm`                                      | `*Tasks`                                         | lint/format/spell/dead-code                                                         |
+| `@zuke/tsc`, `@zuke/tsgo`, `@zuke/tsx`, `@zuke/tsc-alias`, `@zuke/tsup`, `@zuke/tsdown`, `@zuke/vite`, `@zuke/turbo`, `@zuke/nx`, `@zuke/nest` | `*Tasks`                                         | TS compile / bundle / monorepo / framework CLIs                                     |
+| `@zuke/openapi-ts`, `@zuke/orval`                                                                                                              | `*Tasks`                                         | generate API clients from OpenAPI                                                   |
+| `@zuke/husky`                                                                                                                                  | `HuskyTasks`                                     | git hooks                                                                           |
+| `@zuke/jest`, `@zuke/vitest`, `@zuke/playwright`, `@zuke/cypress`                                                                              | `*Tasks`                                         | test runners                                                                        |
+| `@zuke/jsr`, `@zuke/codecov`, `@zuke/release-please`                                                                                           | `JsrTasks`, `CodecovTasks`, ...                  | publish / coverage upload / releases                                                |
+| `@zuke/kubectl`, `@zuke/helm`, `@zuke/kustomize`, `@zuke/terraform`, `@zuke/tofu`, `@zuke/gcloud`                                              | `*Tasks`                                         | infra/deploy                                                                        |
+| `@zuke/security`                                                                                                                               | `*Tasks`                                         | security scanning                                                                   |
+| `@zuke/claude`, `@zuke/codex`, `@zuke/gemini`                                                                                                  | `ClaudeTasks`, ...                               | headless AI CLIs                                                                    |
+| `@zuke/ai`                                                                                                                                     | `securityReviewer`, ..., `aiFixer`, `agentFixer` | AI review gates + self-healing (see below)                                          |
 
 The catalog keeps growing — `deno doc jsr:@zuke/<pkg>` (or the package list in
 `llms.txt`) is the source of truth for what exists.
@@ -315,9 +326,9 @@ await CmdTasks.exec("my-tool", (s) => s.args("--flag", "value")); // no wrapper?
 
 ## AI review & self-healing — `@zuke/ai`
 
-A model becomes part of the build graph two ways. Only the provider
-(`"claude"` | `"openai"` | `"gemini"`) and an API key (pass a `parameter().secret()`)
-are required; everything else is defaulted.
+A model becomes part of the build graph two ways. Only the provider (`"claude"`
+| `"openai"` | `"gemini"`) and an API key (pass a `parameter().secret()`) are
+required; everything else is defaulted.
 
 **Review gate** — a reviewer is a `Validation`; attach with `.validateBefore` /
 `.validateAfter`. It scores the diff and breaks the build past a threshold.
@@ -335,10 +346,11 @@ deploy = target().validateBefore(this.review).executes(() => {/* ... */});
 Factories: `securityReviewer`, `secretsReviewer`, `correctnessReviewer`,
 `licenseReviewer`, `genericReviewer`.
 
-**Self-healing** — `aiFixer` is a `Remediation`; attach with `.recoverWith(...)`.
-On a failing body it diagnoses the failure and (safe default) posts the
-diagnosis + a committable, Copilot-style inline suggestion to the PR — writing
-no files. The build re-runs the real command to verify any applied fix.
+**Self-healing** — `aiFixer` is a `Remediation`; attach with
+`.recoverWith(...)`. On a failing body it diagnoses the failure and (safe
+default) posts the diagnosis + a committable, Copilot-style inline suggestion to
+the PR — writing no files. The build re-runs the real command to verify any
+applied fix.
 
 ```ts
 import { aiFixer } from "jsr:@zuke/ai";
@@ -354,11 +366,12 @@ override recoverWith() {
 }
 ```
 
-Both compose: a target's own `.recoverWith(...)` runs first, then the build-level
-`recoverWith()`. Opt into changes with `.autoApply()` (path allowlist, file cap,
-local-only unless `.allowCI()`) and `.commitFixes()`; `.diff((d) => d.fetchBase())`
-fetches the PR base branch for context so CI needs no manual `git fetch`. Keys
-ride through `parameter().secret()`, which Zuke masks in CI output.
+Both compose: a target's own `.recoverWith(...)` runs first, then the
+build-level `recoverWith()`. Opt into changes with `.autoApply()` (path
+allowlist, file cap, local-only unless `.allowCI()`) and `.commitFixes()`;
+`.diff((d) => d.fetchBase())` fetches the PR base branch for context so CI needs
+no manual `git fetch`. Keys ride through `parameter().secret()`, which Zuke
+masks in CI output.
 
 **Delegate to a coding agent** — `agentFixer(runner)` is a `Remediation` that
 hands the failure to a coding agent you inject (`@zuke/claude`, `@zuke/codex`,
@@ -395,7 +408,7 @@ ci = cicd({ provider: "github" }); // .github/workflows/ci.yml, push/PR to main
 ```
 
 `provider` is the only required field (`"github"` / `"gitlab"` / `"azure"`).
-Running any target regenerates the YAML; on CI it *verifies* the committed file
+Running any target regenerates the YAML; on CI it _verifies_ the committed file
 is current (`zuke generate-ci --check` is a dedicated gate).
 
 ## Run & inspect
@@ -410,6 +423,8 @@ is current (`zuke generate-ci --check` is a dedicated gate).
 ./zuke <target> --no-cache    # ignore the incremental cache
 ./zuke <target> --state       # persist run state to .zuke/runs (durable state)
 ./zuke <target> --actor <who> # attribute the run in its state record
+./zuke runs list [--status s] # list persisted runs (also --target, --since, --json)
+./zuke runs show <id>         # one run's full per-target status (+ --json)
 ./zuke mcp [--allow-run]      # serve the build over MCP for an AI client
 ```
 

--- a/zuke.ts
+++ b/zuke.ts
@@ -533,9 +533,13 @@ class ZukeBuild extends Build {
       // in the build file, and no untrusted input. `1xwg7am` is AlreadyResumedError
       // naming the `--actor` that won a resume race — operator attribution by
       // design (like LockConflictError naming the holder), not a secret leak.
-      // (IDs are opaque fingerprints.)
+      // `3f7a0g` is `zuke runs`, a local read-only inspect of an operator-owned
+      // store of non-secret records — the FS/HTTP layer already owns access;
+      // agent/network authz is the M5 MCP surface. (IDs are opaque fingerprints.)
       // cspell:ignore myee
-      .suppress(suppressions((s) => s.add("1g3myee", "1mwn3kn", "1xwg7am")))
+      .suppress(
+        suppressions((s) => s.add("1g3myee", "1mwn3kn", "1xwg7am", "3f7a0g")),
+      )
       .failWhen((g) => g.scoreAbove(8))
       .onError("warn")
   );


### PR DESCRIPTION
## What

Closes **M1 PR2** — the read side of durable run state. Runs already
persisted to the `StateStore`, but nothing surfaced them from the CLI, so
M1's acceptance ("kill the process, then reconstruct full per-target status
from disk alone") wasn't actually reachable. This adds the `runs` command.

- `zuke runs list` — one row per run (id, status, target, actor, created),
  newest first. Filters: `--status`, `--target`, `--since` (compose). `--json`
  emits the summary array.
- `zuke runs show <id>` — one run in full: header, non-secret parameters,
  per-target status with duration / error / pending-wait, and any signals.
  `--json` emits the whole record.

## How

- New `packages/core/src/runs.ts`: store resolution (same precedence as a run —
  `ZUKE_STATE_URL`/`ZUKE_STATE_DIR` → `stateStore()` → default `.zuke/runs`) plus
  pure `formatRunList` / `formatRunDetail`.
- `cli_spec.ts` gains the `runs` command and the `--status`/`--target`/`--since`
  flags, so `--help`, completions, and `describeCli` stay in step (guarded by
  `cli_test.ts`). `--json` now defers to a command that consumes it, so
  `runs … --json` emits run data rather than the build surface. An invalid
  `--status` fails with the valid set listed.
- Docs: `docs/cli.md` (command table + "Inspecting runs"), `docs/state.md`
  (leads with `zuke runs`). Agent skill + cheatsheet updated. `llms.txt`
  regenerated.

## Verification

`deno task ci` green — coverage 98.4% lines / 95.7% branches. `apiDocsCheck`
clean, `deno doc --lint` clean over the four core entrypoints. New
`runs_test.ts` (13 cases) plus parser + `main()` dispatch tests in `cli_test.ts`.
