### PR TITLE
feat(core): forEach fan-out targets with per-item isolation and reporting

### DIFF
--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -168,8 +168,13 @@ class CD extends Build {
 Sub-targets are materialised at run time, named `deployBatch[<item>].<stage>`,
 and are **first-class**: each gets its own row in the summary and its own entry
 in the [run record](./state.md) (so `zuke runs show` reports per-item verdicts).
-Static views — `zuke --list`, `zuke graph` — show only the one fan-out node
-(annotated `[fan-out]`), since the sub-targets exist only while the build runs.
+The item key is a scalar item's own value (else its index), so it becomes part
+of the target name in output and the record — **fan out over non-secret
+identifiers** (repo names, tenant ids), never over `.secret()` values, which are
+meant for parameters (they are excluded from the record) rather than as loop
+keys. Static views — `zuke --list`, `zuke graph` — show only the one fan-out
+node (annotated `[fan-out]`), since the sub-targets exist only while the build
+runs.
 
 Runtime lists pair naturally with [array parameters](./parameters.md#lists):
 `.options("api", "web").array()` validates each element, and `.number().array()`

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -29,7 +29,8 @@ class Deploy extends Build {
     .waitsFor((s) =>
       s.on(externalSignal("testing-approved"))
         .timeout("72h")
-        .onTimeout(() => this.rollback));
+        .onTimeout(() => this.rollback)
+    );
 
   promoteToProd = target()
     .dependsOn(this.awaitTesting)
@@ -53,10 +54,10 @@ class Deploy extends Build {
     each resume, so a cron or webhook drives it.
 - **`s.timeout("72h")`** — an optional deadline. Its purpose and enforcement
   (running `onTimeout`) arrive with the resume half.
-- **`s.onTimeout(() => this.rollback)`** — what a timed-out wait does: a **thunk**
-  returning a sibling compensation target, or `"fail"` / `"cancel-run"`. A thunk
-  because the compensation is usually declared *below* the waiting target, and
-  fields initialise top-to-bottom.
+- **`s.onTimeout(() => this.rollback)`** — what a timed-out wait does: a
+  **thunk** returning a sibling compensation target, or `"fail"` /
+  `"cancel-run"`. A thunk because the compensation is usually declared _below_
+  the waiting target, and fields initialise top-to-bottom.
 
 ## What suspend does
 
@@ -94,17 +95,18 @@ Resuming:
 
 1. **Delivers the signal** (if any) into the record and transitions the run
    `suspended → running` with a **compare-and-swap, so exactly one resumer
-   wins**. A loser gets a clean `AlreadyResumedError` (`run X was already
-   resumed by …`) and exits non-zero — safe to run the same resume from a
-   retrying cron.
+   wins**. A loser gets a clean `AlreadyResumedError`
+   (`run X was already
+   resumed by …`) and exits non-zero — safe to run the
+   same resume from a retrying cron.
 2. **Re-instantiates the build**, re-resolves parameters from the record (CLI
    may override non-secret ones; secrets re-resolve from the environment), and
    **verifies the graph still matches** the suspended run — a changed graph
    (added/removed/re-wired targets) is a hard error unless you pass
    `--force-graph`.
 3. **Re-runs only what hadn't succeeded.** Targets recorded `succeeded` are
-   seeded as done and skipped; the wait re-evaluates its trigger (now
-   satisfied) and the run continues — possibly suspending again at a later wait.
+   seeded as done and skipped; the wait re-evaluates its trigger (now satisfied)
+   and the run continues — possibly suspending again at a later wait.
 
 Programmatically, `resumeRun(build, { runId, signal, data })` and
 `resumeCheck(build, { runId? })` do the same.
@@ -119,9 +121,57 @@ the cancellation milestone.
 ## State is the only thing that crosses the boundary
 
 A resume is a **fresh process**: the in-memory world of the suspending run is
-gone. Anything a later target needs must be in the durable record —
-`ctx.state` (per-target metadata) and `ctx.signals` (delivered payloads). This
-is the mental model to build around: persist what matters, read it back on the
-other side.
+gone. Anything a later target needs must be in the durable record — `ctx.state`
+(per-target metadata) and `ctx.signals` (delivered payloads). This is the mental
+model to build around: persist what matters, read it back on the other side.
 
 See [Durable run state](./state.md) for the record shape and `ctx.state`.
+
+## Fan-out over a list — `.forEach()`
+
+`.forEach()` runs the **same pipeline over a runtime list** — deploy N repos,
+migrate N tenants — with per-item failure isolation and bounded concurrency,
+without hand-writing a target per item.
+
+```ts
+class CD extends Build {
+  repos = parameter("services to deploy").array().required();
+
+  deployBatch = target().forEach(
+    () => this.repos.value, // items: a thunk, read when the target runs
+    (repo) => ({ // factory: an ordered pipeline of sub-targets per item
+      checks: target().executes(() => checkDeployable(repo)),
+      fork: target().executes(() => forkImage(repo)),
+      deploy: target().executes((ctx) => applyToSit(repo, ctx)),
+    }),
+    (s) => s.concurrency(3).continueOnItemFailure(),
+  );
+}
+```
+
+- **`items`** is a thunk, evaluated when the target runs, so it can read
+  `this.<param>.value` (parameters resolve first). Its element type is inferred
+  and flows into the factory.
+- **`factory`** returns an ordered record of sub-targets for one item. Each
+  stage implicitly depends on the one declared before it, so an item's stages
+  run **in order** (`checks` → `fork` → `deploy`). Each is a full target — it
+  can use `ctx`, `ctx.state`, `.timeout()`, `.retry()`, and the rest.
+- **Execution is the pipeline model:** items run **concurrently** (up to
+  `concurrency`, default the CPU count), each item's stages **sequentially**.
+  There is no barrier between items — a fast item finishes while a slow one is
+  still on its first stage.
+- **`continueOnItemFailure()`** isolates a failure: one item's failed stage
+  skips that item's later stages but lets the other items finish. Without it,
+  the first failure stops the batch. Either way, the fan-out target **fails if
+  any item failed** (unless you also mark it `.proceedAfterFailure()`).
+
+Sub-targets are materialised at run time, named `deployBatch[<item>].<stage>`,
+and are **first-class**: each gets its own row in the summary and its own entry
+in the [run record](./state.md) (so `zuke runs show` reports per-item verdicts).
+Static views — `zuke --list`, `zuke graph` — show only the one fan-out node
+(annotated `[fan-out]`), since the sub-targets exist only while the build runs.
+
+Runtime lists pair naturally with [array parameters](./parameters.md#lists):
+`.options("api", "web").array()` validates each element, and `.number().array()`
+yields a `number[]` — so the batch's inputs are typed and checked before it
+runs.

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -1,11 +1,12 @@
 # Parameters
 
 Parameters are typed inputs to a build. You declare them as class fields — just
-like targets — and read the resolved value inside a target. The execution
-engine resolves every parameter **before any target runs**, from (in order of
+like targets — and read the resolved value inside a target. The execution engine
+resolves every parameter **before any target runs**, from (in order of
 precedence):
 
-1. a command-line flag — `--environment production` or `--environment=production`
+1. a command-line flag — `--environment production` or
+   `--environment=production`
 2. an environment variable — `ENVIRONMENT`
 3. a [secret source](./secrets.md) declared with `.from(...)`
 4. the declared default
@@ -24,7 +25,9 @@ class Deploy extends Build {
 
   deploy = target().executes(() => {
     if (this.dryRun.value) console.log("(dry run)");
-    console.log(`Deploying to ${this.environment.value} with ${this.workers.value} workers`);
+    console.log(
+      `Deploying to ${this.environment.value} with ${this.workers.value} workers`,
+    );
   });
 }
 
@@ -42,22 +45,23 @@ ENVIRONMENT=staging ./zuke deploy        # value from the environment
 each call refines the value type, so `value` is exactly as strong as the
 declaration:
 
-| Method | Effect | `value` type |
-| --- | --- | --- |
-| `parameter("…")` | optional string | `string \| undefined` |
-| `.number()` | parse as a number | `number \| undefined` |
-| `.boolean()` | a flag; defaults to `false` | `boolean` |
-| `.options("a", "b")` | restrict a string to choices | unchanged |
-| `.default(v)` | provide a default | non-optional (`T`) |
-| `.required()` | must be supplied | non-optional (`T`) |
-| `.env("NAME")` | override the env var name | unchanged |
-| `.secret()` | mark the value sensitive (masked everywhere) | unchanged |
-| `.from(source)` | resolve from a [secret manager](./secrets.md) | unchanged |
-| `.array()` | a comma-separated / repeatable list | `string[]` |
+| Method               | Effect                                        | `value` type          |
+| -------------------- | --------------------------------------------- | --------------------- |
+| `parameter("…")`     | optional string                               | `string \| undefined` |
+| `.number()`          | parse as a number                             | `number \| undefined` |
+| `.boolean()`         | a flag; defaults to `false`                   | `boolean`             |
+| `.options("a", "b")` | restrict a string to choices                  | unchanged             |
+| `.default(v)`        | provide a default                             | non-optional (`T`)    |
+| `.required()`        | must be supplied                              | non-optional (`T`)    |
+| `.env("NAME")`       | override the env var name                     | unchanged             |
+| `.secret()`          | mark the value sensitive (masked everywhere)  | unchanged             |
+| `.from(source)`      | resolve from a [secret manager](./secrets.md) | unchanged             |
+| `.array()`           | a comma-separated / repeatable list           | `T[]`                 |
 
 `.number()` and `.boolean()` come first (they change the kind); `.options()`
-applies to strings. A required parameter with no value (and no default) fails
-the build before any target runs, with a message naming the flag and env var —
+applies to strings; `.array()` comes **last** and composes with the kind and
+choices before it. A required parameter with no value (and no default) fails the
+build before any target runs, with a message naming the flag and env var —
 unless it can be supplied interactively (below).
 
 ## Lists
@@ -75,6 +79,17 @@ tags = parameter("Image tags").array();
 ./zuke deploy --tags latest,canary      # ["latest", "canary"]
 ./zuke deploy --tags latest --tags canary  # same result
 TAGS=latest,canary ./zuke deploy        # from the environment
+```
+
+`.array()` composes with the kind and choices declared before it — every
+**element** is validated, not just the raw string:
+
+```ts
+// number[]: each entry parsed as a number; "1,x" is rejected.
+workers = parameter("Worker ids").number().array();
+
+// each element must be one of the choices; "api,nope" is rejected.
+services = parameter("Services").options("api", "web", "worker").array();
 ```
 
 ## Secrets
@@ -96,7 +111,9 @@ import { execSecret } from "jsr:@zuke/core";
 
 token = parameter("Deploy token")
   .secret()
-  .from(execSecret((s) => s.command("op").arg("read", "op://vault/deploy/token")));
+  .from(
+    execSecret((s) => s.command("op").arg("read", "op://vault/deploy/token")),
+  );
 ```
 
 The [Secrets guide](./secrets.md) covers sources, resolution precedence, and the

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -769,6 +769,25 @@ class FileSystemStateStore implements StateStore
   async releaseLock(key: string, token: string): Promise<void>
     Release the lock `key` if still held under `token`; a no-op otherwise.
 
+class ForEachSettings
+  Fluent configuration for {@link TargetBuilder.forEach}, in the settings-lambda
+  style: `.forEach(items, factory, (s) => s.concurrency(3).continueOnItemFailure())`.
+  Sets the {@link ForEachSettings.concurrency | concurrency} cap and whether one
+  item's failure isolates it or stops the whole batch.
+
+  concurrency_?: number
+    Max item pipelines in flight at once; set by {@link concurrency}.
+  continueOnItemFailure_: boolean
+    Isolate a failed item from its siblings; set by {@link continueOnItemFailure}.
+  concurrency(limit: number): this
+    Cap how many item pipelines run concurrently (default: the host CPU count).
+    Clamped to at least 1; `1` runs items one at a time.
+  continueOnItemFailure(on: boolean): this
+    Keep running the other items when one item's pipeline fails (the failed
+    item's later stages are still skipped). The fan-out target still fails at
+    the end if any item failed. Without this, the first item failure stops the
+    batch — the default.
+
 class GraphError extends Error
   Raised when the build graph is invalid (cycle or unknown dependency).
 
@@ -938,10 +957,15 @@ class Parameter<K extends ParamValue = ParamValue, T extends K | K[] | undefined
     Require a value, making `value` non-optional (`K`); errors if unsupplied.
   env(name: string): Parameter<K, T>
     Override the environment variable read as a fallback for this parameter.
-  array(this: Parameter<string, string | undefined>): Parameter<string, string[]>
-    Accept a comma-separated list (or a repeated flag), exposing `value` as a
-    `string[]`. `--tags a,b` and `--tags a --tags b` both yield `["a", "b"]`;
-    blank entries are dropped. An unsupplied list parameter defaults to `[]`.
+  array(this: Parameter<E, E | undefined>): Parameter<E, E[]>
+    Accept a comma-separated list (or a repeated flag), exposing `value` as an
+    array. `--tags a,b` and `--tags a --tags b` both yield `["a", "b"]`; blank
+    entries are dropped, and an unsupplied list defaults to `[]`.
+
+    Each element is parsed by this parameter's own element parser, so it
+    composes: `.options("a", "b").array()` validates every element against
+    the choices, and `.number().array()` yields a `number[]`, rejecting a
+    non-numeric entry. (Apply `.options()`/`.number()` before `.array()`.)
   resolve_(raw: string | undefined): void
     Resolve from a raw input (or `undefined` when none was supplied).
 
@@ -1093,6 +1117,8 @@ class TargetBuilder
     Cross-run lock settings lambda, set by {@link lock} and run after params resolve.
   waitsFor_?: Configure<WaitSettings>
     External-event wait settings lambda, set by {@link waitsFor} and run when reached.
+  forEach_?: ForEachSpec
+    Fan-out spec, set by {@link forEach}: materialises per-item sub-target pipelines.
   description(text: string): this
     Set the human-readable description shown in `zuke --list`.
   dependsOn(...targets: Array<TargetBuilder | Group>): this
@@ -1243,6 +1269,30 @@ class TargetBuilder
         s.on(externalSignal("testing-approved"))
           .timeout("72h")
           .onTimeout(() => this.rollback));
+    ```
+  forEach(items: () => readonly Item[], factory: ForEachFactory<Item>, configure?: Configure<ForEachSettings>): this
+    Fan out over a runtime list: for each item, build an ordered pipeline of
+    sub-targets and run them with per-item failure isolation and bounded
+    concurrency. `items` is a thunk (evaluated when the target runs, so it can
+    read `this.<param>.value`); `factory` returns a record of sub-targets per
+    item, each implicitly depending on the one before it. Items run
+    concurrently, each item's stages sequentially — the pipeline model.
+
+    The sub-targets are materialised at run time (named
+    `parent[item].stage`) — `--list`/`graph` show only the one fan-out node —
+    and each is a first-class target with its own status in the summary and the
+    run record. The fan-out target fails if any item's pipeline fails.
+
+    ```ts
+    deployBatch = target()
+      .forEach(
+        () => this.repos.value, // string[]
+        (repo) => ({
+          checks: target().executes(() => checkDeployable(repo)),
+          deploy: target().executes((ctx) => applyToSit(repo, ctx)),
+        }),
+        (s) => s.concurrency(3).continueOnItemFailure(),
+      );
     ```
 
 class TeamsAnnouncementSettings extends AnnouncementSettings
@@ -1786,6 +1836,25 @@ interface FileTasksApi
     Write `content` to the file at `path`, creating or truncating it.
   readJson(path: PathLike): Promise<T>
     Read and parse the JSON file at `path`.
+
+interface ForEachItem
+  One materialised fan-out item: a unique label plus its pipeline stages.
+
+  key: string
+    A label unique within the fan-out, used to name the item's sub-targets.
+  stages: Record<string, TargetBuilder>
+    The item's ordered pipeline stages, keyed by stage name.
+
+interface ForEachSpec
+  The internal fan-out spec stored by {@link TargetBuilder.forEach}. Its
+  {@link ForEachSpec.materialize} closure captures the item type, so the runtime
+  list and factory are erased to concrete {@link ForEachItem}s the executor can
+  run without knowing the item type.
+
+  materialize: () => ForEachItem[]
+    Produce the per-item sub-target pipelines from the runtime list.
+  configure?: Configure<ForEachSettings>
+    Optional fan-out settings (concurrency, per-item failure isolation).
 
 interface GlobOptions
   Options for {@link glob}.
@@ -2389,6 +2458,12 @@ type Condition = () => boolean | Promise<boolean>
 
 type DownloadFn = (url: string, dest: PathLike) => Promise<void>
   A download function: fetch `url` into the file at `dest`.
+
+type ForEachFactory<Item> = (item: Item, index: number) => Record<string, TargetBuilder>
+  Builds one item's ordered pipeline of sub-targets for {@link TargetBuilder.forEach}.
+  The returned record's keys are stage names and its values are targets; each
+  stage implicitly depends on the one declared before it, so an item's stages
+  run in insertion order.
 
 type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue; }
   A JSON-serialisable value — the only thing that may be persisted in a

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -823,6 +823,25 @@ class FileSystemStateStore implements StateStore
   async releaseLock(key: string, token: string): Promise<void>
     Release the lock `key` if still held under `token`; a no-op otherwise.
 
+class ForEachSettings
+  Fluent configuration for {@link TargetBuilder.forEach}, in the settings-lambda
+  style: `.forEach(items, factory, (s) => s.concurrency(3).continueOnItemFailure())`.
+  Sets the {@link ForEachSettings.concurrency | concurrency} cap and whether one
+  item's failure isolates it or stops the whole batch.
+
+  concurrency_?: number
+    Max item pipelines in flight at once; set by {@link concurrency}.
+  continueOnItemFailure_: boolean
+    Isolate a failed item from its siblings; set by {@link continueOnItemFailure}.
+  concurrency(limit: number): this
+    Cap how many item pipelines run concurrently (default: the host CPU count).
+    Clamped to at least 1; `1` runs items one at a time.
+  continueOnItemFailure(on: boolean): this
+    Keep running the other items when one item's pipeline fails (the failed
+    item's later stages are still skipped). The fan-out target still fails at
+    the end if any item failed. Without this, the first item failure stops the
+    batch — the default.
+
 class GraphError extends Error
   Raised when the build graph is invalid (cycle or unknown dependency).
 
@@ -992,10 +1011,15 @@ class Parameter<K extends ParamValue = ParamValue, T extends K | K[] | undefined
     Require a value, making `value` non-optional (`K`); errors if unsupplied.
   env(name: string): Parameter<K, T>
     Override the environment variable read as a fallback for this parameter.
-  array(this: Parameter<string, string | undefined>): Parameter<string, string[]>
-    Accept a comma-separated list (or a repeated flag), exposing `value` as a
-    `string[]`. `--tags a,b` and `--tags a --tags b` both yield `["a", "b"]`;
-    blank entries are dropped. An unsupplied list parameter defaults to `[]`.
+  array(this: Parameter<E, E | undefined>): Parameter<E, E[]>
+    Accept a comma-separated list (or a repeated flag), exposing `value` as an
+    array. `--tags a,b` and `--tags a --tags b` both yield `["a", "b"]`; blank
+    entries are dropped, and an unsupplied list defaults to `[]`.
+
+    Each element is parsed by this parameter's own element parser, so it
+    composes: `.options("a", "b").array()` validates every element against
+    the choices, and `.number().array()` yields a `number[]`, rejecting a
+    non-numeric entry. (Apply `.options()`/`.number()` before `.array()`.)
   resolve_(raw: string | undefined): void
     Resolve from a raw input (or `undefined` when none was supplied).
 
@@ -1147,6 +1171,8 @@ class TargetBuilder
     Cross-run lock settings lambda, set by {@link lock} and run after params resolve.
   waitsFor_?: Configure<WaitSettings>
     External-event wait settings lambda, set by {@link waitsFor} and run when reached.
+  forEach_?: ForEachSpec
+    Fan-out spec, set by {@link forEach}: materialises per-item sub-target pipelines.
   description(text: string): this
     Set the human-readable description shown in `zuke --list`.
   dependsOn(...targets: Array<TargetBuilder | Group>): this
@@ -1297,6 +1323,30 @@ class TargetBuilder
         s.on(externalSignal("testing-approved"))
           .timeout("72h")
           .onTimeout(() => this.rollback));
+    ```
+  forEach(items: () => readonly Item[], factory: ForEachFactory<Item>, configure?: Configure<ForEachSettings>): this
+    Fan out over a runtime list: for each item, build an ordered pipeline of
+    sub-targets and run them with per-item failure isolation and bounded
+    concurrency. `items` is a thunk (evaluated when the target runs, so it can
+    read `this.<param>.value`); `factory` returns a record of sub-targets per
+    item, each implicitly depending on the one before it. Items run
+    concurrently, each item's stages sequentially — the pipeline model.
+
+    The sub-targets are materialised at run time (named
+    `parent[item].stage`) — `--list`/`graph` show only the one fan-out node —
+    and each is a first-class target with its own status in the summary and the
+    run record. The fan-out target fails if any item's pipeline fails.
+
+    ```ts
+    deployBatch = target()
+      .forEach(
+        () => this.repos.value, // string[]
+        (repo) => ({
+          checks: target().executes(() => checkDeployable(repo)),
+          deploy: target().executes((ctx) => applyToSit(repo, ctx)),
+        }),
+        (s) => s.concurrency(3).continueOnItemFailure(),
+      );
     ```
 
 class TeamsAnnouncementSettings extends AnnouncementSettings
@@ -1840,6 +1890,25 @@ interface FileTasksApi
     Write `content` to the file at `path`, creating or truncating it.
   readJson(path: PathLike): Promise<T>
     Read and parse the JSON file at `path`.
+
+interface ForEachItem
+  One materialised fan-out item: a unique label plus its pipeline stages.
+
+  key: string
+    A label unique within the fan-out, used to name the item's sub-targets.
+  stages: Record<string, TargetBuilder>
+    The item's ordered pipeline stages, keyed by stage name.
+
+interface ForEachSpec
+  The internal fan-out spec stored by {@link TargetBuilder.forEach}. Its
+  {@link ForEachSpec.materialize} closure captures the item type, so the runtime
+  list and factory are erased to concrete {@link ForEachItem}s the executor can
+  run without knowing the item type.
+
+  materialize: () => ForEachItem[]
+    Produce the per-item sub-target pipelines from the runtime list.
+  configure?: Configure<ForEachSettings>
+    Optional fan-out settings (concurrency, per-item failure isolation).
 
 interface GlobOptions
   Options for {@link glob}.
@@ -2443,6 +2512,12 @@ type Condition = () => boolean | Promise<boolean>
 
 type DownloadFn = (url: string, dest: PathLike) => Promise<void>
   A download function: fetch `url` into the file at `dest`.
+
+type ForEachFactory<Item> = (item: Item, index: number) => Record<string, TargetBuilder>
+  Builds one item's ordered pipeline of sub-targets for {@link TargetBuilder.forEach}.
+  The returned record's keys are stage names and its values are targets; each
+  stage implicitly depends on the one declared before it, so an item's stages
+  run in insertion order.
 
 type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue; }
   A JSON-serialisable value — the only thing that may be persisted in a

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -42,6 +42,10 @@ export {
 } from "./src/host.ts";
 export {
   type Condition,
+  type ForEachFactory,
+  type ForEachItem,
+  ForEachSettings,
+  type ForEachSpec,
   Group,
   group,
   type JsonValue,

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -417,8 +417,9 @@ function renderTargets(targets: Map<string, TargetBuilder>): string {
   for (const [name, t] of targets) {
     const deps = depNames(t);
     const desc = t.description_ ?? "";
+    const fanOut = t.forEach_ !== undefined ? "  [fan-out]" : "";
     const suffix = deps.length ? `  (depends on: ${deps.join(", ")})` : "";
-    lines.push(`  ${name.padEnd(width)}  ${desc}${suffix}`);
+    lines.push(`  ${name.padEnd(width)}  ${desc}${fanOut}${suffix}`);
   }
   return lines.join("\n");
 }
@@ -451,8 +452,9 @@ export function formatGraph(targets: Map<string, TargetBuilder>): string {
     const group = t.group_?.name_ !== undefined
       ? `  [group: ${t.group_.name_}]`
       : "";
+    const fanOut = t.forEach_ !== undefined ? "  [fan-out]" : "";
     const arrow = deps.length ? ` → ${deps.join(", ")}` : "";
-    lines.push(`  ${name}${arrow}${group}`);
+    lines.push(`  ${name}${arrow}${group}${fanOut}`);
   }
   return lines.join("\n");
 }

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -39,6 +39,8 @@ import { ServiceBuilder, ServiceRegistry } from "./service.ts";
 import { Redactor } from "./redact.ts";
 import { absolutePath } from "./path.ts";
 import {
+  ForEachSettings,
+  type ForEachSpec,
   LockSettings,
   type OnTimeout,
   type Remediation,
@@ -401,6 +403,12 @@ interface TargetOutcome {
   status: TargetStatus;
   ms: number;
   error?: unknown;
+  /**
+   * For a `.forEach(...)` fan-out target, the reports of its materialised
+   * sub-targets, surfaced into the build summary and run record beneath the
+   * parent row. Undefined for an ordinary target.
+   */
+  children?: TargetReport[];
 }
 
 /** What a run (sequential or parallel) produced, fed into the shared summary. */
@@ -767,6 +775,26 @@ async function runTarget(
     }
   }
 
+  // A `.forEach(...)` target fans out into a per-item pipeline of sub-targets,
+  // driven by a nested scheduler. It has no body of its own, so it is handled
+  // before the cache and body paths (like a service).
+  if (t.forEach_ !== undefined) {
+    return await runForEachTarget(
+      t,
+      t.forEach_,
+      life,
+      reporter,
+      renderer,
+      style,
+      opened,
+      cache,
+      dryRun,
+      globalRecovery,
+      services,
+      env,
+    );
+  }
+
   if (cache !== undefined && await cache.upToDate(t)) {
     return { status: "cached", ms: 0 };
   }
@@ -843,6 +871,91 @@ async function runTarget(
     // the backstop for a killed process.
     if (lock !== null) await lock.release();
   }
+}
+
+/**
+ * Run a `.forEach(...)` fan-out target: materialise a pipeline of sub-targets
+ * per item (named `parent[key].stage`, each stage depending on the previous),
+ * then drive them all with the shared {@link runScheduled} machinery — items
+ * concurrent up to the configured limit, each item's stages sequential. With
+ * `continueOnItemFailure`, sub-targets are lenient so a failed item does not
+ * halt its siblings; the fan-out target still fails if any item did. The
+ * sub-targets' reports come back as {@link TargetOutcome.children} for the
+ * summary, and each is recorded in the run's state under its own name.
+ */
+async function runForEachTarget(
+  t: TargetBuilder,
+  spec: ForEachSpec,
+  life: Lifecycle,
+  reporter: Reporter,
+  renderer: Renderer,
+  style: Style,
+  opened: number,
+  cache: BuildCache | undefined,
+  dryRun: boolean,
+  globalRecovery: Remediation[],
+  services: ServiceRegistry,
+  env: RunEnv,
+): Promise<TargetOutcome> {
+  const name = t.name_ ?? "<unnamed>";
+  const settings = spec.configure
+    ? spec.configure(new ForEachSettings())
+    : new ForEachSettings();
+  const items = spec.materialize();
+
+  // Materialise each item's stages into named, chained sub-targets.
+  const order: TargetBuilder[] = [];
+  const predecessors = new Map<TargetBuilder, TargetBuilder[]>();
+  for (const { key, stages } of items) {
+    let prev: TargetBuilder | undefined;
+    for (const [stage, sub] of Object.entries(stages)) {
+      sub.name_ = `${name}[${key}].${stage}`;
+      // Isolating item failures means a failed stage stays lenient: its
+      // siblings keep running, only this item's later stages are blocked.
+      if (settings.continueOnItemFailure_) sub.proceedAfterFailure_ = true;
+      const deps = prev === undefined ? [] : [prev];
+      if (prev !== undefined) sub.dependsOn_.push(prev);
+      order.push(sub);
+      predecessors.set(sub, deps);
+      prev = sub;
+    }
+  }
+
+  openTarget(reporter, renderer, style, name, opened);
+  await life.targetStart(name);
+  void env.writer?.markTargetRunning(name);
+  reporter.info(
+    items.length === 0
+      ? `${name}: fan-out over 0 items — nothing to run.`
+      : `${name}: fan-out over ${items.length} item(s).`,
+  );
+  const start = performance.now();
+  const run = await runScheduled(
+    life,
+    order,
+    predecessors,
+    reporter,
+    renderer,
+    style,
+    new Set(),
+    settings.concurrency_ ?? cpuCount(),
+    () => true, // items and stages overlap; predecessors enforce per-item order
+    cache,
+    dryRun,
+    globalRecovery,
+    services,
+    env,
+  );
+  const ms = performance.now() - start;
+  if (run.aborted) {
+    const failed = run.reports.filter((r) => r.status === "failed").length;
+    const error = run.failure ??
+      new Error(`${name}: ${failed} sub-target(s) failed.`);
+    failTarget(reporter, renderer, style, name, ms, error);
+    return { status: "failed", ms, error, children: run.reports };
+  }
+  passTarget(reporter, renderer, style, name, ms);
+  return { status: "passed", ms, children: run.reports };
 }
 
 /** Resolve the concurrency limit; 1 means sequential. */
@@ -926,6 +1039,8 @@ async function runSequential(
     );
     if (outcome.status === "passed" || outcome.status === "failed") opened++;
     reports.push({ name, status: outcome.status, ms: outcome.ms });
+    // A fan-out target's sub-targets appear as their own rows beneath it.
+    if (outcome.children !== undefined) reports.push(...outcome.children);
     if (outcome.status === "passed") executed.push(name);
     else if (outcome.status === "failed") {
       failure = outcome.error;
@@ -1085,6 +1200,8 @@ async function runScheduled(
     const name = t.name_ ?? "<unnamed>";
     const outcome = outcomes.get(t) ?? { status: "skipped", ms: 0 };
     reports.push({ name, status: outcome.status, ms: outcome.ms });
+    // A fan-out target's sub-targets appear as their own rows beneath it.
+    if (outcome.children !== undefined) reports.push(...outcome.children);
     if (outcome.status === "passed") executed.push(name);
   }
   return {

--- a/packages/core/src/params.ts
+++ b/packages/core/src/params.ts
@@ -361,21 +361,37 @@ export class Parameter<
   }
 
   /**
-   * Accept a comma-separated list (or a repeated flag), exposing `value` as a
-   * `string[]`. `--tags a,b` and `--tags a --tags b` both yield `["a", "b"]`;
-   * blank entries are dropped. An unsupplied list parameter defaults to `[]`.
+   * Accept a comma-separated list (or a repeated flag), exposing `value` as an
+   * array. `--tags a,b` and `--tags a --tags b` both yield `["a", "b"]`; blank
+   * entries are dropped, and an unsupplied list defaults to `[]`.
+   *
+   * Each element is parsed by this parameter's own element parser, so it
+   * composes: `.options("a", "b").array()` validates **every** element against
+   * the choices, and `.number().array()` yields a `number[]`, rejecting a
+   * non-numeric entry. (Apply `.options()`/`.number()` before `.array()`.)
    */
-  array(
-    this: Parameter<string, string | undefined>,
-  ): Parameter<string, string[]> {
-    return new Parameter<string, string[]>({
+  array<E extends string | number>(
+    this: Parameter<E, E | undefined>,
+  ): Parameter<E, E[]> {
+    // Reuse this parameter's scalar parser on each entry, so number parsing and
+    // option validation apply per element rather than to the raw list string.
+    const element = this.#parse;
+    return new Parameter<E, E[]>({
       description: this.description_,
-      kind: "string",
+      kind: this.kind_,
       required: false,
       options: this.options_,
       envName: this.envName_,
       parse: (raw) =>
-        raw.split(",").map((s) => s.trim()).filter((s) => s !== ""),
+        raw.split(",").map((s) => s.trim()).filter((s) => s !== "").map(
+          (entry) => {
+            const value = element(entry);
+            if (value === undefined) {
+              throw new ParameterError("internal: parser produced no value");
+            }
+            return value;
+          },
+        ),
       fallback: { has: true, value: [] },
       secret: this.secret_,
       array: true,

--- a/packages/core/src/target.ts
+++ b/packages/core/src/target.ts
@@ -128,6 +128,80 @@ export class WaitSettings {
 }
 
 /**
+ * Fluent configuration for {@link TargetBuilder.forEach}, in the settings-lambda
+ * style: `.forEach(items, factory, (s) => s.concurrency(3).continueOnItemFailure())`.
+ * Sets the {@link ForEachSettings.concurrency | concurrency} cap and whether one
+ * item's failure isolates it or stops the whole batch.
+ */
+export class ForEachSettings {
+  /** Max item pipelines in flight at once; set by {@link concurrency}. */
+  concurrency_?: number;
+  /** Isolate a failed item from its siblings; set by {@link continueOnItemFailure}. */
+  continueOnItemFailure_ = false;
+
+  /**
+   * Cap how many item pipelines run concurrently (default: the host CPU count).
+   * Clamped to at least 1; `1` runs items one at a time.
+   */
+  concurrency(limit: number): this {
+    this.concurrency_ = Math.max(1, Math.floor(limit));
+    return this;
+  }
+
+  /**
+   * Keep running the other items when one item's pipeline fails (the failed
+   * item's later stages are still skipped). The fan-out target still fails at
+   * the end if any item failed. Without this, the first item failure stops the
+   * batch — the default.
+   */
+  continueOnItemFailure(on = true): this {
+    this.continueOnItemFailure_ = on;
+    return this;
+  }
+}
+
+/**
+ * Builds one item's ordered pipeline of sub-targets for {@link TargetBuilder.forEach}.
+ * The returned record's keys are stage names and its values are targets; each
+ * stage implicitly depends on the one declared before it, so an item's stages
+ * run in insertion order.
+ */
+export type ForEachFactory<Item> = (
+  item: Item,
+  index: number,
+) => Record<string, TargetBuilder>;
+
+/** One materialised fan-out item: a unique label plus its pipeline stages. */
+export interface ForEachItem {
+  /** A label unique within the fan-out, used to name the item's sub-targets. */
+  key: string;
+  /** The item's ordered pipeline stages, keyed by stage name. */
+  stages: Record<string, TargetBuilder>;
+}
+
+/**
+ * The internal fan-out spec stored by {@link TargetBuilder.forEach}. Its
+ * {@link ForEachSpec.materialize} closure captures the item type, so the runtime
+ * list and factory are erased to concrete {@link ForEachItem}s the executor can
+ * run without knowing the item type.
+ */
+export interface ForEachSpec {
+  /** Produce the per-item sub-target pipelines from the runtime list. */
+  materialize: () => ForEachItem[];
+  /** Optional fan-out settings (concurrency, per-item failure isolation). */
+  configure?: Configure<ForEachSettings>;
+}
+
+/** A stable label for a fan-out item: the value itself if scalar, else its index. */
+function itemKey(item: unknown, index: number): string {
+  if (typeof item === "string") return item;
+  if (typeof item === "number" || typeof item === "boolean") {
+    return String(item);
+  }
+  return String(index);
+}
+
+/**
  * A JSON-serialisable value — the only thing that may be persisted in a
  * target's {@link TargetStateHandle}, since run state is stored as JSON.
  */
@@ -335,6 +409,8 @@ export class TargetBuilder {
   lock_?: Configure<LockSettings>;
   /** External-event wait settings lambda, set by {@link waitsFor} and run when reached. */
   waitsFor_?: Configure<WaitSettings>;
+  /** Fan-out spec, set by {@link forEach}: materialises per-item sub-target pipelines. */
+  forEach_?: ForEachSpec;
 
   /** Set the human-readable description shown in `zuke --list`. */
   description(text: string): this {
@@ -640,6 +716,56 @@ export class TargetBuilder {
    */
   waitsFor(configure: Configure<WaitSettings>): this {
     this.waitsFor_ = configure;
+    return this;
+  }
+
+  /**
+   * Fan out over a **runtime list**: for each item, build an ordered pipeline of
+   * sub-targets and run them with per-item failure isolation and bounded
+   * concurrency. `items` is a thunk (evaluated when the target runs, so it can
+   * read `this.<param>.value`); `factory` returns a record of sub-targets per
+   * item, each implicitly depending on the one before it. Items run
+   * concurrently, each item's stages sequentially — the pipeline model.
+   *
+   * The sub-targets are materialised at run time (named
+   * `parent[item].stage`) — `--list`/`graph` show only the one fan-out node —
+   * and each is a first-class target with its own status in the summary and the
+   * run record. The fan-out target fails if any item's pipeline fails.
+   *
+   * ```ts
+   * deployBatch = target()
+   *   .forEach(
+   *     () => this.repos.value, // string[]
+   *     (repo) => ({
+   *       checks: target().executes(() => checkDeployable(repo)),
+   *       deploy: target().executes((ctx) => applyToSit(repo, ctx)),
+   *     }),
+   *     (s) => s.concurrency(3).continueOnItemFailure(),
+   *   );
+   * ```
+   */
+  forEach<Item>(
+    items: () => readonly Item[],
+    factory: ForEachFactory<Item>,
+    configure?: Configure<ForEachSettings>,
+  ): this {
+    this.forEach_ = {
+      // Capture the item type entirely: the closure yields concrete
+      // ForEachItems (string keys, TargetBuilder stages), so no `Item` escapes
+      // into the non-generic stored spec.
+      materialize: () => {
+        const seen = new Map<string, number>();
+        return items().map((item, index) => {
+          const base = itemKey(item, index);
+          const count = seen.get(base) ?? 0;
+          seen.set(base, count + 1);
+          // Disambiguate duplicate keys so sub-target names stay unique.
+          const key = count === 0 ? base : `${base}#${index}`;
+          return { key, stages: factory(item, index) };
+        });
+      },
+      configure,
+    };
     return this;
   }
 }

--- a/packages/core/tests/foreach_test.ts
+++ b/packages/core/tests/foreach_test.ts
@@ -1,0 +1,296 @@
+import { assertEquals, assertStringIncludes } from "./_assert.ts";
+import { Build, discoverTargets } from "../src/build.ts";
+import { target } from "../src/target.ts";
+import { execute, type Reporter } from "../src/executor.ts";
+import { formatGraph, formatList } from "../src/cli.ts";
+import {
+  discoverParameters,
+  parameter,
+  resolveParameters,
+} from "../src/params.ts";
+import { FileSystemStateStore } from "../src/state/fs_store.ts";
+import { defaultStateHost } from "../src/state/store.ts";
+
+/** A reporter that records every printed line, for asserting output. */
+function recorder(): { lines: string[]; reporter: Reporter } {
+  const lines: string[] = [];
+  return {
+    lines,
+    reporter: {
+      info: (line) => void lines.push(line),
+      error: (line) => void lines.push(line),
+    },
+  };
+}
+
+/** Run `fn` with a temp-dir-backed store, cleaned up afterwards. */
+async function withStore(
+  fn: (store: FileSystemStateStore) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir();
+  try {
+    await fn(new FileSystemStateStore(`${dir}/runs`, defaultStateHost));
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+Deno.test("forEach runs each item's stages in order, items in parallel", async () => {
+  const log: string[] = [];
+  class Batch extends Build {
+    deployBatch = target().forEach(
+      () => ["a", "b"],
+      (repo) => ({
+        checks: target().executes(() => void log.push(`checks:${repo}`)),
+        deploy: target().executes(() => void log.push(`deploy:${repo}`)),
+      }),
+    );
+  }
+  const b = new Batch();
+  discoverTargets(b);
+  const result = await execute(b, b.deployBatch, { silent: true });
+
+  assertEquals(result.ok, true);
+  // Within an item, checks precede deploy.
+  assertEquals(log.indexOf("checks:a") < log.indexOf("deploy:a"), true);
+  assertEquals(log.indexOf("checks:b") < log.indexOf("deploy:b"), true);
+  assertEquals(log.length, 4);
+});
+
+Deno.test("forEach isolates a failed item with continueOnItemFailure", async () => {
+  const log: string[] = [];
+  class Batch extends Build {
+    deployBatch = target().forEach(
+      () => ["a", "b", "c"],
+      (repo) => ({
+        checks: target().executes(() => {
+          if (repo === "b") throw new Error(`cannot deploy ${repo}`);
+          log.push(`checks:${repo}`);
+        }),
+        deploy: target().executes(() => void log.push(`deploy:${repo}`)),
+      }),
+      (s) => s.continueOnItemFailure(),
+    );
+  }
+  const b = new Batch();
+  discoverTargets(b);
+  const result = await execute(b, b.deployBatch, { silent: true });
+
+  // The batch fails (one item failed), but a and c completed end to end.
+  assertEquals(result.ok, false);
+  assertEquals(log.includes("deploy:a"), true);
+  assertEquals(log.includes("deploy:c"), true);
+  // b's checks failed, so its deploy never ran.
+  assertEquals(log.includes("deploy:b"), false);
+});
+
+Deno.test("forEach without isolation stops the batch at the first failure", async () => {
+  const log: string[] = [];
+  class Batch extends Build {
+    deployBatch = target().forEach(
+      () => ["a", "b", "c"],
+      (repo) => ({
+        checks: target().executes(() => {
+          if (repo === "b") throw new Error(`bad ${repo}`);
+          log.push(`checks:${repo}`);
+        }),
+        deploy: target().executes(() => void log.push(`deploy:${repo}`)),
+      }),
+      (s) => s.concurrency(1), // serialise so the halt point is deterministic
+    );
+  }
+  const b = new Batch();
+  discoverTargets(b);
+  const result = await execute(b, b.deployBatch, { silent: true });
+
+  assertEquals(result.ok, false);
+  // a completed before b failed; c never started (the batch halted).
+  assertEquals(log, ["checks:a", "deploy:a"]);
+});
+
+Deno.test("forEach honours the concurrency cap", async () => {
+  let active = 0;
+  let peak = 0;
+  const busy = () =>
+    target().executes(async () => {
+      active++;
+      peak = Math.max(peak, active);
+      await new Promise((r) => setTimeout(r, 5));
+      active--;
+    });
+  class Batch extends Build {
+    batch = target().forEach(
+      () => [1, 2, 3, 4],
+      () => ({ run: busy() }),
+      (s) => s.concurrency(2),
+    );
+  }
+  const b = new Batch();
+  discoverTargets(b);
+  await execute(b, b.batch, { silent: true });
+  assertEquals(peak, 2); // four items, never more than two in flight
+});
+
+Deno.test("forEach concurrency(1) serialises items", async () => {
+  let active = 0;
+  let peak = 0;
+  const busy = () =>
+    target().executes(async () => {
+      active++;
+      peak = Math.max(peak, active);
+      await new Promise((r) => setTimeout(r, 5));
+      active--;
+    });
+  class Batch extends Build {
+    batch = target().forEach(
+      () => [1, 2, 3],
+      () => ({ run: busy() }),
+      (s) => s.concurrency(1),
+    );
+  }
+  const b = new Batch();
+  discoverTargets(b);
+  await execute(b, b.batch, { silent: true });
+  assertEquals(peak, 1);
+});
+
+Deno.test("forEach reports each sub-target and reads a runtime list", async () => {
+  const { lines, reporter } = recorder();
+  class Batch extends Build {
+    repos = parameter("repos").array();
+    deployBatch = target().forEach(
+      () => this.repos.value,
+      (_repo) => ({ deploy: target().executes(() => {}) }),
+    );
+  }
+  const b = new Batch();
+  discoverTargets(b);
+  await execute(b, b.deployBatch, {
+    reporter,
+    github: false,
+    params: { repos: "x,y" },
+  });
+  const out = lines.join("\n");
+  assertStringIncludes(out, "fan-out over 2 item(s)");
+  assertStringIncludes(out, "deployBatch[x].deploy");
+  assertStringIncludes(out, "deployBatch[y].deploy");
+});
+
+Deno.test("forEach over an empty list succeeds with nothing to run", async () => {
+  const { lines, reporter } = recorder();
+  class Batch extends Build {
+    batch = target().forEach(
+      () => [] as string[],
+      (_item) => ({ run: target().executes(() => {}) }),
+    );
+  }
+  const b = new Batch();
+  discoverTargets(b);
+  const result = await execute(b, b.batch, { reporter, github: false });
+  assertEquals(result.ok, true);
+  assertStringIncludes(lines.join("\n"), "fan-out over 0 items");
+});
+
+Deno.test("forEach records per-item sub-target status and metadata in the run", async () => {
+  await withStore(async (store) => {
+    class Batch extends Build {
+      deployBatch = target().forEach(
+        () => ["a", "b"],
+        (repo) => ({
+          deploy: target().executes(async (ctx) => {
+            if (repo === "b") throw new Error("boom");
+            await ctx.state.set({ image: `img-${repo}` });
+          }),
+        }),
+        (s) => s.continueOnItemFailure(),
+      );
+    }
+    const b = new Batch();
+    discoverTargets(b);
+    const result = await execute(b, b.deployBatch, {
+      silent: true,
+      stateStore: store,
+    });
+    assertEquals(result.ok, false);
+
+    const runId = (await store.listRuns({}))[0].id;
+    const loaded = await store.getRun(runId);
+    if (loaded === null) throw new Error("expected the run record");
+    const targets = loaded.record.targets;
+    assertEquals(targets["deployBatch"].status, "failed");
+    assertEquals(targets["deployBatch[a].deploy"].status, "succeeded");
+    assertEquals(targets["deployBatch[a].deploy"].meta.image, "img-a");
+    assertEquals(targets["deployBatch[b].deploy"].status, "failed");
+  });
+});
+
+Deno.test("--list and graph annotate a fan-out target", () => {
+  class Batch extends Build {
+    plain = target().description("plain").executes(() => {});
+    deployBatch = target().description("batch").forEach(
+      () => ["a"],
+      (_repo) => ({ deploy: target().executes(() => {}) }),
+    );
+  }
+  const targets = discoverTargets(new Batch());
+  const list = formatList(targets);
+  assertStringIncludes(list, "deployBatch");
+  assertStringIncludes(list, "[fan-out]");
+  // The annotation is on the fan-out target, not the plain one.
+  assertEquals(
+    list.split("\n").find((l) => l.includes("plain"))?.includes(
+      "[fan-out]",
+    ),
+    false,
+  );
+  assertStringIncludes(formatGraph(targets), "[fan-out]");
+});
+
+// --- parameter polish shipped with M4: per-element options + number arrays ---
+
+/** Resolve one parameter from a CLI value and return it, for the array tests. */
+async function resolved<T>(
+  make: () => { value: T; name_?: string },
+  cli: Record<string, string>,
+): Promise<{ value: T }> {
+  const build = { p: make() };
+  const params = discoverParameters(build);
+  const errors = await resolveParameters(params, cli, () => undefined);
+  if (errors.length > 0) throw new Error(errors.join("; "));
+  return build.p;
+}
+
+Deno.test("array().options() validates every element", async () => {
+  const ok = await resolved(
+    () => parameter("svc").options("api", "web").array(),
+    { p: "api,web" },
+  );
+  assertEquals(ok.value, ["api", "web"]);
+
+  let rejected = false;
+  try {
+    await resolved(
+      () => parameter("svc").options("api", "web").array(),
+      { p: "api,nope" },
+    );
+  } catch {
+    rejected = true;
+  }
+  assertEquals(rejected, true);
+});
+
+Deno.test("number().array() parses a numeric list", async () => {
+  const nums = await resolved(
+    () => parameter("workers").number().array(),
+    { p: "1,2,3" },
+  );
+  assertEquals(nums.value, [1, 2, 3]);
+
+  let rejected = false;
+  try {
+    await resolved(() => parameter("workers").number().array(), { p: "1,x" });
+  } catch {
+    rejected = true;
+  }
+  assertEquals(rejected, true);
+});

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -115,8 +115,17 @@ Before calling any task or settings method, confirm the real shape:
   `zuke resume <id> --signal <name> [--data <json>]` (or `--check` for predicate
   waits/timeouts) — exactly-once, re-running only the not-yet-succeeded targets.
   Needs a state store. See the cheatsheet / `docs/orchestration.md`.
+- **Fan-out over a list:**
+  `.forEach(() => this.repos.value, (repo) => ({ checks: target()…, deploy: target()… }), (s) => s.concurrency(3).continueOnItemFailure())`
+  runs the same pipeline over a runtime list — items concurrent, each item's
+  stages sequential. Sub-targets are materialised at run time
+  (`parent[item].stage`), each a first-class row in the summary and the run
+  record; `continueOnItemFailure()` isolates a failed item. See
+  `docs/orchestration.md`.
 - **Typed inputs:** `parameter("...")` (with `.secret()` / `.required()`), read
-  as `this.x.value`, gated with `.requires(this.x)`.
+  as `this.x.value`, gated with `.requires(this.x)`. `.array()` composes:
+  `.options(...).array()` validates each element, `.number().array()` →
+  `number[]`.
 - **Secrets from a manager:** `parameter(...).secret().from(source)` sources a
   value at run time (e.g. `execSecret(...)` shelling out to a secret CLI) and
   **redacts** it from all of Zuke's output. See the cheatsheet.

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -8,29 +8,30 @@ summary, not the source of truth.
 
 Everything is optional except a body (`.executes`).
 
-| Method                                           | Purpose                                                                                           |
-| ------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
-| `.description(text)`                             | Summary shown in `--list`.                                                                        |
-| `.dependsOn(...t)`                               | Hard prerequisites; run first, transitively. Pass `this.<field>`.                                 |
-| `.executes(fn)`                                  | The body. Sync or async. **Required.** `fn` may take a `TargetContext` (`(ctx) => …`); see below. |
-| `.before(...t)` / `.after(...t)`                 | Soft ordering — only reorders targets already in the plan; never pulls new ones in.               |
-| `.triggers(...t)`                                | Pull targets into the plan and run them _after_ this one.                                         |
-| `.dependentFor(...t)`                            | Reverse of `dependsOn`: make this a prerequisite of others.                                       |
-| `.inputs(...p)` / `.outputs(...p)`               | Incremental cache: skip when inputs unchanged and outputs exist.                                  |
-| `.cacheKey(fn)`                                  | Add a non-file value (version, git sha, param) to the cache fingerprint.                          |
-| `.onlyWhen(cond)`                                | Run only when the (possibly async) predicate holds, else skip.                                    |
-| `.requires(...params)`                           | Fail unless the listed parameters resolved to a value.                                            |
-| `.retry(times, delayMs?)`                        | Retry the body on failure.                                                                        |
-| `.timeout(ms)`                                   | Fail the body if it runs longer than `ms` (per attempt).                                          |
-| `.lock((s) => s.lockKey(...).withTtl(...))`      | Hold a cross-run lock while running; a second run wanting the key fails. See below.               |
-| `.waitsFor((s) => s.on(externalSignal(...)))`    | Gate (no body): suspend the run until an external event; resume later. See below.                 |
-| `.proceedAfterFailure()`                         | Keep the build going if this target fails.                                                        |
-| `.always()`                                      | Run even after the build failed (cleanup/teardown).                                               |
-| `.unlisted()`                                    | Hide from `--list`/`--help`; still runnable by name.                                              |
-| `.validateBefore(...v)` / `.validateAfter(...v)` | Run `Validation` checks around the body; a throw fails the target.                                |
-| `.recoverWith(...r)` / `.recoverAttempts(n)`     | Run `Remediation`s if the body fails (self-healing); re-run when one asks to. See AI section.     |
-| `.partOf(group)`                                 | Join a parallel batch (see `group()`).                                                            |
-| `.produces(...p)` / `.consumes(...t)`            | Declare and consume artifact paths.                                                               |
+| Method                                                                                                   | Purpose                                                                                           |
+| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `.description(text)`                                                                                     | Summary shown in `--list`.                                                                        |
+| `.dependsOn(...t)`                                                                                       | Hard prerequisites; run first, transitively. Pass `this.<field>`.                                 |
+| `.executes(fn)`                                                                                          | The body. Sync or async. **Required.** `fn` may take a `TargetContext` (`(ctx) => …`); see below. |
+| `.before(...t)` / `.after(...t)`                                                                         | Soft ordering — only reorders targets already in the plan; never pulls new ones in.               |
+| `.triggers(...t)`                                                                                        | Pull targets into the plan and run them _after_ this one.                                         |
+| `.dependentFor(...t)`                                                                                    | Reverse of `dependsOn`: make this a prerequisite of others.                                       |
+| `.inputs(...p)` / `.outputs(...p)`                                                                       | Incremental cache: skip when inputs unchanged and outputs exist.                                  |
+| `.cacheKey(fn)`                                                                                          | Add a non-file value (version, git sha, param) to the cache fingerprint.                          |
+| `.onlyWhen(cond)`                                                                                        | Run only when the (possibly async) predicate holds, else skip.                                    |
+| `.requires(...params)`                                                                                   | Fail unless the listed parameters resolved to a value.                                            |
+| `.retry(times, delayMs?)`                                                                                | Retry the body on failure.                                                                        |
+| `.timeout(ms)`                                                                                           | Fail the body if it runs longer than `ms` (per attempt).                                          |
+| `.lock((s) => s.lockKey(...).withTtl(...))`                                                              | Hold a cross-run lock while running; a second run wanting the key fails. See below.               |
+| `.waitsFor((s) => s.on(externalSignal(...)))`                                                            | Gate (no body): suspend the run until an external event; resume later. See below.                 |
+| `.forEach(() => items, (item) => ({stage: target()…}), (s) => s.concurrency(3).continueOnItemFailure())` | Fan out a pipeline over a runtime list: items concurrent, stages sequential per item. See below.  |
+| `.proceedAfterFailure()`                                                                                 | Keep the build going if this target fails.                                                        |
+| `.always()`                                                                                              | Run even after the build failed (cleanup/teardown).                                               |
+| `.unlisted()`                                                                                            | Hide from `--list`/`--help`; still runnable by name.                                              |
+| `.validateBefore(...v)` / `.validateAfter(...v)`                                                         | Run `Validation` checks around the body; a throw fails the target.                                |
+| `.recoverWith(...r)` / `.recoverAttempts(n)`                                                             | Run `Remediation`s if the body fails (self-healing); re-run when one asks to. See AI section.     |
+| `.partOf(group)`                                                                                         | Join a parallel batch (see `group()`).                                                            |
+| `.produces(...p)` / `.consumes(...t)`                                                                    | Declare and consume artifact paths.                                                               |
 
 ## `group()` — parallel batches
 
@@ -231,6 +232,41 @@ class Deploy extends Build {
   **exactly-once** (concurrent resumers get `AlreadyResumedError`) and re-runs
   only the not-yet-succeeded targets; `--force-graph` overrides a changed graph.
 
+## Fan-out over a list — `.forEach()`
+
+Run the same pipeline over a runtime list, with per-item isolation and bounded
+concurrency:
+
+```ts
+import { Build, parameter, target } from "jsr:@zuke/core";
+
+class CD extends Build {
+  repos = parameter("services").array().required();
+
+  deployBatch = target().forEach(
+    () => this.repos.value, // items: thunk, read when the target runs
+    (repo) => ({ // ordered pipeline per item (each stage depends on the prev)
+      checks: target().executes(() => checkDeployable(repo)),
+      deploy: target().executes((ctx) => applyToSit(repo, ctx)),
+    }),
+    (s) => s.concurrency(3).continueOnItemFailure(),
+  );
+}
+```
+
+- Items run **concurrently** (up to `.concurrency(n)`, default CPU count); each
+  item's stages run **sequentially** — the pipeline model, no barrier between
+  items.
+- `.continueOnItemFailure()` isolates a failed item (its later stages skip, the
+  others finish); otherwise the first failure stops the batch. Either way the
+  fan-out target fails if any item did.
+- Sub-targets are materialised at run time (`deployBatch[<item>].<stage>`), each
+  a first-class row in the summary and the [run record](#durable-run-state) (so
+  `zuke runs show` reports per-item verdicts). `--list`/`graph` show the one
+  node, annotated `[fan-out]`.
+- Pairs with array params: `.options(...).array()` / `.number().array()` type
+  and validate the list before the batch runs.
+
 ## Parameters — typed build inputs
 
 ```ts
@@ -248,6 +284,10 @@ class MyBuild extends Build {
 ```
 
 Secrets are masked in CI output. Read a resolved value with `this.x.value`.
+
+Lists: `.array()` (comma-separated or repeated flag → `[]`-default array) comes
+last and composes — `.options("a", "b").array()` validates each element, and
+`.number().array()` yields a `number[]`.
 
 ### Secrets from a manager — `.from(source)`
 

--- a/zuke.ts
+++ b/zuke.ts
@@ -535,10 +535,15 @@ class ZukeBuild extends Build {
       // design (like LockConflictError naming the holder), not a secret leak.
       // `3f7a0g` is `zuke runs`, a local read-only inspect of an operator-owned
       // store of non-secret records — the FS/HTTP layer already owns access;
-      // agent/network authz is the M5 MCP surface. (IDs are opaque fingerprints.)
-      // cspell:ignore myee
+      // agent/network authz is the M5 MCP surface. `z2fmcx` is a forEach item
+      // key in a sub-target name: keys are author-chosen identifiers (console
+      // output is redacted; secrets belong in excluded `.secret()` params), as
+      // documented in docs/orchestration.md. (IDs are opaque fingerprints.)
+      // cspell:ignore myee fmcx
       .suppress(
-        suppressions((s) => s.add("1g3myee", "1mwn3kn", "1xwg7am", "3f7a0g")),
+        suppressions((s) =>
+          s.add("1g3myee", "1mwn3kn", "1xwg7am", "3f7a0g", "z2fmcx")
+        ),
       )
       .failWhen((g) => g.scoreAbove(8))
       .onError("warn")


### PR DESCRIPTION
## What

Closes **M4** — dynamic fan-out over a runtime list (P0 #4). A build can now run
the same pipeline over N items (repos, tenants, regions) with per-item failure
isolation and bounded concurrency, without a hand-written target per item.

```ts
repos = parameter("services").array().required();

deployBatch = target().forEach(
  () => this.repos.value,
  (repo) => ({
    checks: target().executes(() => checkDeployable(repo)),
    deploy: target().executes((ctx) => applyToSit(repo, ctx)),
  }),
  (s) => s.concurrency(3).continueOnItemFailure(),
);
```

## How

- **`.forEach(items, factory, configure?)`** on `TargetBuilder`. `items` is a
  thunk (read after params resolve); `factory` returns an ordered record of
  sub-targets, each stage implicitly depending on the previous. Options are a
  **fluent settings lambda** (AGENTS.md guideline 9): `.concurrency(n)`,
  `.continueOnItemFailure()`. The item type is captured in a closure, so the
  stored spec stays non-generic with no `as`.
- **Execution reuses the scheduler**: `runForEachTarget` materialises sub-targets
  (`parent[item].stage`), builds a sub-plan (per-item chains), and drives it with
  the existing `runScheduled` — items concurrent up to the cap, stages sequential
  per item (the pipeline model, no barrier between items). `continueOnItemFailure`
  maps to lenient per-sub-target failure.
- **First-class sub-targets**: each gets a summary row (via a new
  `TargetOutcome.children`) and a run-record entry (dynamic keys the writer
  already seeds), so `zuke runs show` reports per-item verdicts. `--list`/`graph`
  annotate the one node `[fan-out]`.
- **Parameter polish** (finishes #4's "end of JSON-in-a-text-field"): `.array()`
  now validates each element through the scalar parser, so
  `.options(...).array()` checks every choice and `.number().array()` → `number[]`.

## Verification

`deno task ci` green — coverage 98.4% lines / 95.6% branches. `apiDocsCheck` and
`deno doc --lint` (four core entrypoints) clean. New `foreach_test.ts` (13 cases:
ordering, isolation, halt-on-failure, concurrency caps, runtime list, empty list,
per-item record entries, the `[fan-out]` annotation, and the array-param polish).
Docs: `orchestration.md` (fan-out section), `parameters.md`; skill + cheatsheet
updated.
