### PR TITLE
feat(core): MCP streamable-HTTP transport

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,7 +15,7 @@
 | `zuke graph --output=html`                          | Render an interactive HTML graph into `.zuke/` and open it.                             |
 | `zuke completions print <shell>`                    | Print a shell-completion script (`bash`, `zsh`, or `fish`).                             |
 | `zuke completions install <shell>`                  | Write the script and wire it into the shell's startup.                                  |
-| `zuke mcp [--allow-run]`                            | Run an MCP server over the build for AI agents ([details](./mcp.md)).                   |
+| `zuke mcp [--allow-run] [--http <host:port>]`       | Run an MCP server over the build for AI agents, on stdio or HTTP ([details](./mcp.md)). |
 | `zuke resume <id> [--signal <n>] [--data <json>]`   | Resume a suspended run, optionally delivering a signal ([details](./orchestration.md)). |
 | `zuke resume --check [<id>]`                        | Re-check suspended runs (predicate waits, timeouts).                                    |
 | `zuke runs list [--status/-target/-since] [--json]` | List persisted run records, newest first ([details](./state.md)).                       |
@@ -111,7 +111,10 @@ build on stdio, so an AI agent can operate the pipeline through typed tool calls
 instead of guessing shell commands. It exposes read tools (`list_targets`,
 `describe_build`, `graph`) and — only with `--allow-run` — one `run:<target>`
 tool per target, whose input schema is derived from the build's parameters.
-`mcp` is a reserved command name. See the full guide: [MCP server](./mcp.md).
+`--http <host:port>` serves the streamable-HTTP transport instead of stdio
+(loopback by default; a non-loopback bind requires a `ZUKE_MCP_TOKEN` bearer
+token). `mcp` is a reserved command name. See the full guide:
+[MCP server](./mcp.md).
 
 ## Parallel execution
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -39,6 +39,40 @@ Any client that speaks stdio MCP works the same way — give it the command
 `deno run -A zuke.ts mcp` (add `--allow-run` when you want the agent to execute
 targets).
 
+## HTTP transport
+
+For a client that connects over the network rather than launching the process,
+`--http` serves MCP's **streamable-HTTP** transport instead of stdio:
+
+```sh
+zuke mcp --http 7777                 # bind 127.0.0.1:7777 (local only)
+zuke mcp --http 0.0.0.0:7777         # bind all interfaces — needs a token
+```
+
+Each request is a `POST` whose body is one JSON-RPC message; the response is
+that message's JSON-RPC reply. A notification (no `id`) is answered
+`202 Accepted` with no body. Zuke never initiates server→client messages, so the
+optional server-sent-events stream is not implemented — a `GET` is answered
+`405`, and clients fall back to POST-only (which is spec-compliant). Messages
+are processed **one at a time**, mirroring stdio, so two concurrent runs of the
+one build can't race.
+
+**Security defaults — a bridge, not an internet gateway:**
+
+- `--http <port>` binds **loopback** (`127.0.0.1`), reachable only from the same
+  host.
+- Binding a **non-loopback** address requires a bearer token: set
+  `ZUKE_MCP_TOKEN`, and every request must send `Authorization: Bearer <token>`
+  (a missing or wrong token gets `401`). Without a token, Zuke **refuses to
+  bind** a non-loopback address rather than exposing an unauthenticated
+  endpoint.
+- A token is also enforced on a loopback bind when `ZUKE_MCP_TOKEN` is set.
+- This is a bridge for a trusted network segment: **put real TLS and
+  authentication in front of it** (a reverse proxy, a service mesh) for anything
+  production-facing. Zuke provides the transport, not an internet gateway.
+
+`--allow-run` and the [safety](#safety) model below apply identically over HTTP.
+
 ## Tools
 
 Read tools are always available:
@@ -65,13 +99,14 @@ captured output with a pass/fail marker.
 
 ## Safety
 
-**Trust model.** The server has no network endpoint. It speaks only over the
-stdin/stdout of a process the client launches, so its trust boundary is the
-local machine: anyone who can start `zuke mcp` already has a shell there and
-could run `deno run -A zuke.ts <target>` directly. The server therefore grants
-no capability beyond what launching it already implies — there is nothing to
-authenticate, because there is no remote party. Treat it like any other local
-developer tool: don't wire an untrusted client to it.
+**Trust model.** On the default stdio transport the server has no network
+endpoint: it speaks only over the stdin/stdout of a process the client launches,
+so its trust boundary is the local machine — anyone who can start `zuke mcp`
+already has a shell there and could run `deno run -A zuke.ts <target>` directly.
+The [HTTP transport](#http-transport) adds a network endpoint, so it moves that
+boundary: it binds loopback by default, requires a bearer token off loopback,
+and is meant to sit behind real TLS/authentication. Either way, treat the server
+like any other local developer tool and don't wire an untrusted client to it.
 
 Running a target executes real build code, so execution is **off by default**: a
 freshly-connected agent can only _inspect_ the build. Add `--allow-run`
@@ -87,7 +122,8 @@ reporter pipeline as the console, so `parameter().secret()` values are
 
 ## Protocol notes
 
-- **Transport:** newline-delimited JSON-RPC 2.0 on stdio.
+- **Transport:** newline-delimited JSON-RPC 2.0 on stdio, or one JSON-RPC
+  message per `POST` over the [HTTP transport](#http-transport) (`--http`).
 - **Lifecycle:** the server answers `initialize` (echoing the client's requested
   `protocolVersion`), `notifications/initialized` (no reply), `ping`,
   `tools/list`, and `tools/call`. Unknown requests get a JSON-RPC

--- a/llms.txt
+++ b/llms.txt
@@ -70,6 +70,7 @@ Option flags:
 - `--target` — With runs list, keep only runs whose graph has this target
 - `--since` — With runs list, keep only runs created at/after this time
 - `--allow-run` — With mcp, let agents execute targets (not just inspect)
+- `--http` — With mcp, serve over HTTP on <host:port> instead of stdio
 - `--help` — Show usage
 
 Full reference: [docs/cli.md](./docs/cli.md).

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -33,7 +33,7 @@ import {
   RESUME_COMMAND,
   RUNS_COMMAND,
 } from "./cli_spec.ts";
-import { serveMcp } from "./mcp/command.ts";
+import { type HttpAddress, serveMcp } from "./mcp/command.ts";
 import { resumeCheck, resumeRun } from "./resume.ts";
 import { runsCommand } from "./runs.ts";
 import { isRunStatus, RUN_STATUS_NAMES, type RunQuery } from "./state/types.ts";
@@ -88,6 +88,8 @@ export interface ParsedArgs {
   mcp: boolean;
   /** Allow `mcp` to execute targets, not just inspect them (`--allow-run`). */
   allowRun: boolean;
+  /** Serve `mcp` over HTTP on this `<host:port>` instead of stdio (`--http`). */
+  httpAddr?: string;
   /** The `completions` sub-action (`install` or `print`); the first positional. */
   completionsAction?: string;
   /** The shell argument to `completions` (the positional after the sub-action). */
@@ -238,6 +240,11 @@ export function parseArgs(
       parsed.check = true;
     } else if (arg === "--allow-run") {
       parsed.allowRun = true;
+    } else if (arg === "--http") {
+      const value = args[++i];
+      if (value) parsed.httpAddr = value;
+    } else if (arg.startsWith("--http=")) {
+      parsed.httpAddr = arg.slice("--http=".length);
     } else if (arg === "--parallel") {
       parsed.parallel = true;
     } else if (arg.startsWith("--parallel=")) {
@@ -315,7 +322,7 @@ Usage:
   deno run -A zuke.ts graph [--output=html] [--no-open]
   deno run -A zuke.ts generate-ci [--check]
   deno run -A zuke.ts completions <install|print> <bash|zsh|fish>
-  deno run -A zuke.ts mcp [--allow-run]
+  deno run -A zuke.ts mcp [--allow-run] [--http <host:port>]
   deno run -A zuke.ts resume <run-id> [--signal <name>] [--data <json>]
   deno run -A zuke.ts resume --check [<run-id>]
   deno run -A zuke.ts runs list [--status <s>] [--target <t>] [--since <iso>] [--json]
@@ -365,6 +372,11 @@ Options:
                     --allow-run to let agents execute targets too.
   --allow-run       With mcp, allow agents to execute targets, not just
                     inspect them.
+  --http <host:port>
+                    With mcp, serve the streamable-HTTP transport on the given
+                    address instead of stdio. Just <port> binds 127.0.0.1. A
+                    non-loopback host requires a bearer token (ZUKE_MCP_TOKEN);
+                    put real TLS/authn in front for production. See docs/mcp.md.
   resume            Continue a suspended run (a .waitsFor() gate). Exactly one
                     resumer wins; the rest report "already resumed". With
                     --check [<run-id>] it re-checks suspended runs (predicate
@@ -608,6 +620,33 @@ async function runResume(build: Build, parsed: ParsedArgs): Promise<number> {
   }
 }
 
+/** Parse a `--http` value: `<port>` (binds 127.0.0.1) or `<host:port>`. */
+function parseHttpAddress(raw: string): HttpAddress {
+  const colon = raw.lastIndexOf(":");
+  const host = colon === -1 ? "127.0.0.1" : raw.slice(0, colon) || "127.0.0.1";
+  const port = Number(colon === -1 ? raw : raw.slice(colon + 1));
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(
+      `mcp: invalid --http address "${raw}" — expected <port> or <host:port>.`,
+    );
+  }
+  return { host, port };
+}
+
+/** Run the `mcp` command over stdio, or over HTTP when `--http` is given. */
+async function runMcp(build: Build, parsed: ParsedArgs): Promise<number> {
+  let http: HttpAddress | undefined;
+  if (parsed.httpAddr !== undefined) {
+    try {
+      http = parseHttpAddress(parsed.httpAddr);
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : String(error));
+      return 1;
+    }
+  }
+  return await serveMcp(build, { allowRun: parsed.allowRun, http });
+}
+
 /** Run the `runs` command: build the query (validating `--status`) and dispatch. */
 async function runRuns(build: Build, parsed: ParsedArgs): Promise<number> {
   const query: RunQuery = {};
@@ -702,7 +741,7 @@ export async function main(
     return await syncCiConfig(build, { check: parsed.check });
   }
   if (parsed.mcp) {
-    return await serveMcp(build, { allowRun: parsed.allowRun });
+    return await runMcp(build, parsed);
   }
   if (parsed.resume) {
     return await runResume(build, parsed);

--- a/packages/core/src/cli_spec.ts
+++ b/packages/core/src/cli_spec.ts
@@ -133,5 +133,9 @@ export const BUILTIN_FLAGS: readonly BuiltinFlag[] = [
     name: "--allow-run",
     description: "With mcp, let agents execute targets (not just inspect)",
   },
+  {
+    name: "--http",
+    description: "With mcp, serve over HTTP on <host:port> instead of stdio",
+  },
   { name: "--help", description: "Show usage" },
 ];

--- a/packages/core/src/mcp/command.ts
+++ b/packages/core/src/mcp/command.ts
@@ -1,12 +1,22 @@
 /**
- * The `zuke mcp` reserved command: run an MCP server over the build on stdio.
+ * The `zuke mcp` reserved command: run an MCP server over the build, on stdio
+ * (the default) or over HTTP (`--http <host:port>`).
  *
  * @module
  */
 
 import type { Build } from "../build.ts";
 import { type ByteWriter, serveStdio } from "./jsonrpc.ts";
+import { serveHttp } from "./http.ts";
 import { McpServer, type McpServerOptions } from "./server.ts";
+
+/** A parsed `--http` bind address. */
+export interface HttpAddress {
+  /** The hostname/address to bind. */
+  host: string;
+  /** The TCP port to bind. */
+  port: number;
+}
 
 /** Options for {@link serveMcp}. */
 export interface ServeMcpOptions extends McpServerOptions {
@@ -16,18 +26,46 @@ export interface ServeMcpOptions extends McpServerOptions {
   output?: ByteWriter;
   /** Suppress the stderr startup banner (used by tests). */
   quiet?: boolean;
+  /** Serve over HTTP on this address instead of stdio. */
+  http?: HttpAddress;
+  /** Bearer token for the HTTP transport (defaults to `ZUKE_MCP_TOKEN`). */
+  token?: string;
+  /** Reads an environment variable (injectable for tests). */
+  readEnv?: (name: string) => string | undefined;
+  /** Abort to stop the HTTP server (test hook; the CLI runs until killed). */
+  signal?: AbortSignal;
+  /** Called once the HTTP listener is bound, with its address (test hook). */
+  onListen?: (address: { hostname: string; port: number }) => void;
+}
+
+/** Read an environment variable, treating missing env access as unset. */
+function defaultReadEnv(name: string): string | undefined {
+  try {
+    return Deno.env.get(name);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Whether `host` is a loopback address (no bearer token required to bind it). */
+function isLoopback(host: string): boolean {
+  return host === "127.0.0.1" || host === "::1" || host === "localhost";
 }
 
 /**
- * Serve the build over MCP on stdin/stdout until the input stream closes.
- * Returns the process exit code (`0`). Diagnostics — the one-line startup
- * banner — go to stderr so they never corrupt the JSON-RPC stream on stdout.
+ * Serve the build over MCP. Without {@link ServeMcpOptions.http} it runs on
+ * stdin/stdout until the input stream closes; with it, over HTTP until the
+ * server is stopped. Returns the process exit code. Diagnostics go to stderr so
+ * they never corrupt a JSON-RPC stream.
  */
 export async function serveMcp(
   build: Build,
   options: ServeMcpOptions = {},
 ): Promise<number> {
   const server = new McpServer(build, options);
+  if (options.http !== undefined) {
+    return await serveMcpHttp(server, options.http, options);
+  }
   if (!options.quiet) {
     const mode = options.allowRun ? "run enabled" : "read-only";
     console.error(
@@ -39,5 +77,45 @@ export async function serveMcp(
     options.input,
     options.output,
   );
+  return 0;
+}
+
+/**
+ * Serve over the HTTP transport. Enforces the security default: a non-loopback
+ * bind **must** have a bearer token (from {@link ServeMcpOptions.token} or
+ * `ZUKE_MCP_TOKEN`), else the server refuses to start rather than exposing an
+ * unauthenticated endpoint. A loopback bind may run without one.
+ */
+async function serveMcpHttp(
+  server: McpServer,
+  address: HttpAddress,
+  options: ServeMcpOptions,
+): Promise<number> {
+  const readEnv = options.readEnv ?? defaultReadEnv;
+  const token = options.token ?? readEnv("ZUKE_MCP_TOKEN");
+  const hasToken = token !== undefined && token !== "";
+  if (!isLoopback(address.host) && !hasToken) {
+    console.error(
+      `zuke mcp: refusing to bind ${address.host}:${address.port} without a ` +
+        `bearer token. A non-loopback MCP endpoint must be authenticated — set ` +
+        `ZUKE_MCP_TOKEN, or bind 127.0.0.1 for local-only access.`,
+    );
+    return 1;
+  }
+  if (!options.quiet) {
+    const mode = options.allowRun ? "run enabled" : "read-only";
+    const auth = hasToken ? "bearer token required" : "no auth (loopback only)";
+    console.error(
+      `zuke mcp: serving on http://${address.host}:${address.port} ` +
+        `(${mode}, ${auth}). Press Ctrl-C to stop.`,
+    );
+  }
+  await serveHttp((message) => server.handleMessage(message), {
+    host: address.host,
+    port: address.port,
+    token: hasToken ? token : undefined,
+    signal: options.signal,
+    onListen: options.onListen,
+  });
   return 0;
 }

--- a/packages/core/src/mcp/http.ts
+++ b/packages/core/src/mcp/http.ts
@@ -1,0 +1,137 @@
+/**
+ * A dependency-free HTTP transport for the MCP server, implementing the
+ * client→server half of MCP's streamable-HTTP transport: a JSON-RPC message is
+ * POSTed as a JSON body and its response returned as the JSON body of the reply.
+ * Zuke never initiates server→client messages, so the optional SSE stream (a GET
+ * that stays open) is not implemented — a GET is answered `405`, and clients
+ * fall back to POST-only, which is spec-compliant.
+ *
+ * It feeds the same {@link "./server.ts".McpServer.handleMessage} the stdio
+ * transport does. Messages are processed **one at a time** (see the serialising
+ * chain below), because the server and {@link "../executor.ts".execute} assume
+ * serial handling — a build's parameters resolve into shared state per run, so
+ * two concurrent runs of one build instance would race.
+ *
+ * This is a **bridge, not an internet gateway**: it binds loopback by default,
+ * a non-loopback bind requires a bearer token, and production deployments should
+ * put real TLS/authentication in front of it.
+ *
+ * @module
+ */
+
+import {
+  err,
+  INVALID_REQUEST,
+  type JsonRpcResponse,
+  PARSE_ERROR,
+} from "./jsonrpc.ts";
+
+/** Options for {@link serveHttp}. */
+export interface HttpTransportOptions {
+  /** The hostname/address to bind (e.g. `127.0.0.1`). */
+  host: string;
+  /** The TCP port to bind (`0` picks a free port — used in tests). */
+  port: number;
+  /**
+   * Bearer token required on every request (`Authorization: Bearer <token>`).
+   * When set, a missing or wrong token gets `401`; when unset, requests are
+   * unauthenticated (only safe on loopback — the caller enforces that).
+   */
+  token?: string;
+  /** Abort to stop the server (its {@link serveHttp} promise then resolves). */
+  signal?: AbortSignal;
+  /** Called once the listener is bound, with the actual address (test hook). */
+  onListen?: (address: { hostname: string; port: number }) => void;
+}
+
+/** A JSON `Response` with the given status and `application/json` content type. */
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/**
+ * Constant-time string comparison, so token validation does not leak the token
+ * through response timing. The length is compared first (a length difference is
+ * not itself sensitive), then every character regardless of early mismatches.
+ */
+function safeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+/**
+ * Serve JSON-RPC over HTTP: each `POST` carries one JSON-RPC message as its
+ * body, `handle` produces the response, and it is returned as JSON. A
+ * notification (`handle` returns `null`) is answered `202 Accepted` with no
+ * body. Unparseable JSON gets a `400` JSON-RPC parse error; a non-`POST` gets
+ * `405`; a bad/absent bearer token (when one is configured) gets `401`.
+ *
+ * Resolves when the server closes (abort {@link HttpTransportOptions.signal}).
+ */
+export async function serveHttp(
+  handle: (message: unknown) => Promise<JsonRpcResponse | null>,
+  options: HttpTransportOptions,
+): Promise<void> {
+  const { host, port, token, signal, onListen } = options;
+  const authExpected = token !== undefined && token !== ""
+    ? `Bearer ${token}`
+    : undefined;
+
+  // Process messages one at a time: the server/execute path mutates per-run
+  // parameter state, so concurrent handling of two POSTs would race. Requests
+  // still arrive concurrently; this chain resolves them in arrival order.
+  let queue: Promise<unknown> = Promise.resolve();
+  const serial = (message: unknown): Promise<JsonRpcResponse | null> => {
+    const result = queue.then(() => handle(message));
+    queue = result.then(() => {}, () => {});
+    return result;
+  };
+
+  const onRequest = async (request: Request): Promise<Response> => {
+    if (request.method !== "POST") {
+      return jsonResponse(
+        err(null, INVALID_REQUEST, "This MCP endpoint accepts POST only."),
+        405,
+      );
+    }
+    if (authExpected !== undefined) {
+      const provided = request.headers.get("authorization") ?? "";
+      if (!safeEqual(provided, authExpected)) {
+        return new Response(
+          JSON.stringify(err(null, INVALID_REQUEST, "Unauthorized")),
+          {
+            status: 401,
+            headers: {
+              "content-type": "application/json",
+              "www-authenticate": "Bearer",
+            },
+          },
+        );
+      }
+    }
+    let message: unknown;
+    try {
+      message = JSON.parse(await request.text());
+    } catch {
+      return jsonResponse(err(null, PARSE_ERROR, "Parse error"), 400);
+    }
+    const response = await serial(message);
+    if (response === null) return new Response(null, { status: 202 });
+    return jsonResponse(response, 200);
+  };
+
+  const server = Deno.serve({
+    hostname: host,
+    port,
+    signal,
+    // Suppress Deno's default "Listening on …" line; the command prints its own
+    // banner. Tests use this to learn the port bound for `port: 0`.
+    onListen: onListen ?? (() => {}),
+  }, onRequest);
+  await server.finished;
+}

--- a/packages/core/src/mcp/http.ts
+++ b/packages/core/src/mcp/http.ts
@@ -66,19 +66,21 @@ function safeEqual(a: string, b: string): boolean {
 
 /**
  * Extract the credential from an `Authorization: Bearer <token>` header, or
- * `undefined` when it is absent or not the Bearer scheme. The scheme name is
- * matched case-insensitively (per RFC 7235) and surrounding whitespace is
- * tolerated, so trivial client formatting differences don't spuriously fail
- * auth — the token itself is still compared exactly. Parsed by hand (no regex)
- * to keep it linear on adversarial input.
+ * `undefined` when it is absent, not the Bearer scheme, or not exactly one
+ * token. The scheme is matched case-insensitively (per RFC 7235) and extra
+ * surrounding/inner whitespace is tolerated, so trivial client formatting
+ * differences don't spuriously fail auth — but a credential is required to be a
+ * single `token68` (RFC 6750), so `Bearer <token> <anything-else>` is rejected
+ * rather than treated as the token. `split` on whitespace is a linear scan (no
+ * backtracking), so this stays safe on adversarial input.
  */
 function bearerToken(header: string | null): string | undefined {
   if (header === null) return undefined;
-  const trimmed = header.trim();
-  const space = trimmed.indexOf(" ");
-  if (space === -1) return undefined;
-  if (trimmed.slice(0, space).toLowerCase() !== "bearer") return undefined;
-  return trimmed.slice(space + 1).trimStart();
+  const parts = header.trim().split(/\s+/);
+  if (parts.length !== 2 || parts[0].toLowerCase() !== "bearer") {
+    return undefined;
+  }
+  return parts[1];
 }
 
 /**

--- a/packages/core/src/mcp/http.ts
+++ b/packages/core/src/mcp/http.ts
@@ -65,6 +65,23 @@ function safeEqual(a: string, b: string): boolean {
 }
 
 /**
+ * Extract the credential from an `Authorization: Bearer <token>` header, or
+ * `undefined` when it is absent or not the Bearer scheme. The scheme name is
+ * matched case-insensitively (per RFC 7235) and surrounding whitespace is
+ * tolerated, so trivial client formatting differences don't spuriously fail
+ * auth — the token itself is still compared exactly. Parsed by hand (no regex)
+ * to keep it linear on adversarial input.
+ */
+function bearerToken(header: string | null): string | undefined {
+  if (header === null) return undefined;
+  const trimmed = header.trim();
+  const space = trimmed.indexOf(" ");
+  if (space === -1) return undefined;
+  if (trimmed.slice(0, space).toLowerCase() !== "bearer") return undefined;
+  return trimmed.slice(space + 1).trimStart();
+}
+
+/**
  * Serve JSON-RPC over HTTP: each `POST` carries one JSON-RPC message as its
  * body, `handle` produces the response, and it is returned as JSON. A
  * notification (`handle` returns `null`) is answered `202 Accepted` with no
@@ -78,9 +95,6 @@ export async function serveHttp(
   options: HttpTransportOptions,
 ): Promise<void> {
   const { host, port, token, signal, onListen } = options;
-  const authExpected = token !== undefined && token !== ""
-    ? `Bearer ${token}`
-    : undefined;
 
   // Process messages one at a time: the server/execute path mutates per-run
   // parameter state, so concurrent handling of two POSTs would race. Requests
@@ -99,9 +113,9 @@ export async function serveHttp(
         405,
       );
     }
-    if (authExpected !== undefined) {
-      const provided = request.headers.get("authorization") ?? "";
-      if (!safeEqual(provided, authExpected)) {
+    if (token !== undefined && token !== "") {
+      const provided = bearerToken(request.headers.get("authorization"));
+      if (provided === undefined || !safeEqual(provided, token)) {
         return new Response(
           JSON.stringify(err(null, INVALID_REQUEST, "Unauthorized")),
           {

--- a/packages/core/tests/cli_test.ts
+++ b/packages/core/tests/cli_test.ts
@@ -300,6 +300,23 @@ Deno.test("main: runs list rejects an unknown --status", async () => {
   assertStringIncludes(err.join("\n"), 'unknown --status "bogus"');
 });
 
+Deno.test("parseArgs reads the mcp --http address", () => {
+  assertEquals(parseArgs(["mcp", "--http", "7777"]).httpAddr, "7777");
+  assertEquals(
+    parseArgs(["mcp", "--http=127.0.0.1:8080"]).httpAddr,
+    "127.0.0.1:8080",
+  );
+  assertEquals(parseArgs(["mcp"]).httpAddr, undefined);
+});
+
+Deno.test("main: mcp --http rejects an invalid address", async () => {
+  const { code, err } = await capture(() =>
+    main(Demo, ["mcp", "--http", "nope"])
+  );
+  assertEquals(code, 1);
+  assertStringIncludes(err.join("\n"), "invalid --http");
+});
+
 Deno.test("parseArgs reads --affected with an optional base", () => {
   assertEquals(parseArgs(["build"]).affected, false);
   assertEquals(parseArgs(["build", "--affected"]).affected, true);

--- a/packages/core/tests/mcp_http_test.ts
+++ b/packages/core/tests/mcp_http_test.ts
@@ -1,0 +1,184 @@
+import { assertEquals, assertStringIncludes } from "./_assert.ts";
+import { Build, target } from "../mod.ts";
+import type { JsonRpcResponse } from "../src/mcp/jsonrpc.ts";
+import { McpServer } from "../src/mcp/server.ts";
+import { serveHttp } from "../src/mcp/http.ts";
+import { serveMcp } from "../src/mcp/command.ts";
+
+/** A minimal build for the transport tests. */
+class Demo extends Build {
+  lint = target().description("Lint").executes(() => {});
+}
+
+/** A JSON-RPC request/notification object. */
+function rpc(method: string, id?: number, params?: unknown): string {
+  return JSON.stringify({
+    jsonrpc: "2.0",
+    ...(id === undefined ? {} : { id }),
+    method,
+    ...(params ? { params } : {}),
+  });
+}
+
+/** Start `serveHttp` on an ephemeral loopback port; returns the port and a stop. */
+async function startHttp(
+  handle: (m: unknown) => Promise<JsonRpcResponse | null>,
+  opts: { token?: string } = {},
+): Promise<{ port: number; stop: () => Promise<void> }> {
+  const ac = new AbortController();
+  let setPort = (_: number) => {};
+  const portReady = new Promise<number>((r) => (setPort = r));
+  const finished = serveHttp(handle, {
+    host: "127.0.0.1",
+    port: 0,
+    token: opts.token,
+    signal: ac.signal,
+    onListen: (a) => setPort(a.port),
+  });
+  const port = await portReady;
+  return {
+    port,
+    stop: async () => {
+      ac.abort();
+      await finished;
+    },
+  };
+}
+
+Deno.test("http transport answers a POST JSON-RPC request", async () => {
+  const server = new McpServer(new Demo());
+  const s = await startHttp((m) => server.handleMessage(m));
+  try {
+    const res = await fetch(`http://127.0.0.1:${s.port}/`, {
+      method: "POST",
+      body: rpc("initialize", 1, {}),
+    });
+    assertEquals(res.status, 200);
+    assertEquals(res.headers.get("content-type"), "application/json");
+    const body = await res.json();
+    assertEquals(body.id, 1);
+    assertStringIncludes(JSON.stringify(body.result), "protocolVersion");
+  } finally {
+    await s.stop();
+  }
+});
+
+Deno.test("http transport rejects a non-POST with 405", async () => {
+  const server = new McpServer(new Demo());
+  const s = await startHttp((m) => server.handleMessage(m));
+  try {
+    const res = await fetch(`http://127.0.0.1:${s.port}/`);
+    assertEquals(res.status, 405);
+    await res.json();
+  } finally {
+    await s.stop();
+  }
+});
+
+Deno.test("http transport answers unparseable JSON with a 400 parse error", async () => {
+  const server = new McpServer(new Demo());
+  const s = await startHttp((m) => server.handleMessage(m));
+  try {
+    const res = await fetch(`http://127.0.0.1:${s.port}/`, {
+      method: "POST",
+      body: "{ not json",
+    });
+    assertEquals(res.status, 400);
+    const body = await res.json();
+    assertEquals(body.error.code, -32700);
+  } finally {
+    await s.stop();
+  }
+});
+
+Deno.test("http transport answers a notification with 202 and no body", async () => {
+  const server = new McpServer(new Demo());
+  const s = await startHttp((m) => server.handleMessage(m));
+  try {
+    const res = await fetch(`http://127.0.0.1:${s.port}/`, {
+      method: "POST",
+      body: rpc("notifications/initialized"), // no id → notification
+    });
+    assertEquals(res.status, 202);
+    assertEquals(await res.text(), "");
+  } finally {
+    await s.stop();
+  }
+});
+
+Deno.test("http transport enforces a configured bearer token", async () => {
+  const server = new McpServer(new Demo());
+  const s = await startHttp((m) => server.handleMessage(m), {
+    token: "swordfish",
+  });
+  const url = `http://127.0.0.1:${s.port}/`;
+  try {
+    // Missing token → 401.
+    const missing = await fetch(url, { method: "POST", body: rpc("ping", 1) });
+    assertEquals(missing.status, 401);
+    assertEquals(missing.headers.get("www-authenticate"), "Bearer");
+    await missing.json();
+
+    // Wrong token → 401.
+    const wrong = await fetch(url, {
+      method: "POST",
+      headers: { authorization: "Bearer nope" },
+      body: rpc("ping", 1),
+    });
+    assertEquals(wrong.status, 401);
+    await wrong.json();
+
+    // Correct token → 200.
+    const good = await fetch(url, {
+      method: "POST",
+      headers: { authorization: "Bearer swordfish" },
+      body: rpc("ping", 1),
+    });
+    assertEquals(good.status, 200);
+    await good.json();
+  } finally {
+    await s.stop();
+  }
+});
+
+Deno.test("serveMcp serves over HTTP on loopback", async () => {
+  const ac = new AbortController();
+  let setPort = (_: number) => {};
+  const portReady = new Promise<number>((r) => (setPort = r));
+  const finished = serveMcp(new Demo(), {
+    http: { host: "127.0.0.1", port: 0 },
+    quiet: true,
+    signal: ac.signal,
+    onListen: (a) => setPort(a.port),
+  });
+  const port = await portReady;
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/`, {
+      method: "POST",
+      body: rpc("ping", 1),
+    });
+    assertEquals(res.status, 200);
+    const body = await res.json();
+    assertEquals(body.result, {});
+  } finally {
+    ac.abort();
+    assertEquals(await finished, 0);
+  }
+});
+
+Deno.test("serveMcp refuses a non-loopback HTTP bind without a token", async () => {
+  const origErr = console.error;
+  const errs: string[] = [];
+  console.error = (...a: unknown[]) => void errs.push(a.join(" "));
+  try {
+    const code = await serveMcp(new Demo(), {
+      http: { host: "0.0.0.0", port: 0 },
+      quiet: true,
+      readEnv: () => undefined, // no ZUKE_MCP_TOKEN
+    });
+    assertEquals(code, 1);
+    assertStringIncludes(errs.join("\n"), "must be authenticated");
+  } finally {
+    console.error = origErr;
+  }
+});

--- a/packages/core/tests/mcp_http_test.ts
+++ b/packages/core/tests/mcp_http_test.ts
@@ -136,6 +136,16 @@ Deno.test("http transport enforces a configured bearer token", async () => {
     });
     assertEquals(good.status, 200);
     await good.json();
+
+    // The scheme is case-insensitive and surrounding whitespace is tolerated,
+    // but the token itself must still match exactly.
+    const lenient = await fetch(url, {
+      method: "POST",
+      headers: { authorization: "bearer   swordfish" },
+      body: rpc("ping", 1),
+    });
+    assertEquals(lenient.status, 200);
+    await lenient.json();
   } finally {
     await s.stop();
   }

--- a/packages/core/tests/mcp_http_test.ts
+++ b/packages/core/tests/mcp_http_test.ts
@@ -146,6 +146,15 @@ Deno.test("http transport enforces a configured bearer token", async () => {
     });
     assertEquals(lenient.status, 200);
     await lenient.json();
+
+    // Trailing content after the token is rejected (not treated as the token).
+    const trailing = await fetch(url, {
+      method: "POST",
+      headers: { authorization: "Bearer swordfish extra" },
+      body: rpc("ping", 1),
+    });
+    assertEquals(trailing.status, 401);
+    await trailing.json();
   } finally {
     await s.stop();
   }

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -135,7 +135,9 @@ Before calling any task or settings method, confirm the real shape:
 - **Code-first CI:** `cicd({ provider: "github" })` generates and verifies the
   workflow YAML from the build.
 - **Operate the build from an agent:** `zuke mcp` serves the build over MCP so
-  an AI client can list, inspect, and (with `--allow-run`) run targets.
+  an AI client can list, inspect, and (with `--allow-run`) run targets — on
+  stdio, or over HTTP with `--http <host:port>` (loopback by default; a
+  non-loopback bind needs a `ZUKE_MCP_TOKEN` bearer token).
 - **AI review & self-healing (`@zuke/ai`):** gate a target on a structured LLM
   review of the diff (`securityReviewer(...)` etc. via `.validateBefore`), or
   attach `aiFixer(...)` with `.recoverWith(...)` so a failing target is

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -465,7 +465,8 @@ is current (`zuke generate-ci --check` is a dedicated gate).
 ./zuke <target> --actor <who> # attribute the run in its state record
 ./zuke runs list [--status s] # list persisted runs (also --target, --since, --json)
 ./zuke runs show <id>         # one run's full per-target status (+ --json)
-./zuke mcp [--allow-run]      # serve the build over MCP for an AI client
+./zuke mcp [--allow-run]      # serve the build over MCP for an AI client (stdio)
+./zuke mcp --http 7777        # ...or over HTTP (loopback; token off-loopback)
 ```
 
 **Caching:** a target with `.inputs(...)`/`.outputs(...)` is incremental


### PR DESCRIPTION
## What

First half of **M5** — a non-stdio transport for `zuke mcp`. Adds
`zuke mcp --http <host:port>`, so a client can reach the MCP server over the
network rather than launching the process. (Authz tiers, the audit log, and the
store-backed run tools — `list_runs`/`signal_run` — are the second M5 PR.)

```sh
zuke mcp --http 7777              # bind 127.0.0.1:7777 (local only)
zuke mcp --http 0.0.0.0:7777      # all interfaces — requires ZUKE_MCP_TOKEN
```

## How

- **New `mcp/http.ts`** — MCP streamable-HTTP over `Deno.serve`, dependency-free,
  feeding the same `McpServer.handleMessage` as stdio. A `POST` body is one
  JSON-RPC message; the reply is its JSON-RPC response. Notification → `202`;
  bad JSON → `400` parse error; non-`POST` → `405` (Zuke never initiates
  server→client messages, so the optional SSE stream is omitted — clients fall
  back to POST-only, which is spec-compliant).
- **Serial handling** — messages are processed one at a time via a promise
  chain, because `execute` resolves parameters into shared per-run state, so
  concurrent handling of two POSTs would race. Mirrors the stdio invariant.
- **Security defaults (bridge, not gateway)** — loopback bind by default; a
  non-loopback bind *requires* a bearer token (`ZUKE_MCP_TOKEN`) or the server
  refuses to start; a configured token is checked on every request with a
  constant-time compare (`401` on missing/wrong, `WWW-Authenticate: Bearer`).
- **Wiring** — `serveMcp` gains an HTTP mode (`command.ts`); the CLI adds
  `--http` with address parsing (`<port>` or `<host:port>`), surfaced in
  `--help`/completions via `cli_spec.ts`.

## Verification

`deno task ci` green — coverage 98.4% lines / 95.5% branches. `apiDocsCheck` and
`deno doc --lint` clean. New `mcp_http_test.ts` (7 cases: POST round-trip, 405,
400, 202, the token matrix, `serveMcp` HTTP, and the non-loopback refusal) plus
CLI parser/dispatch tests. Smoke-tested live: `ping` over HTTP returns
`result: {}`, `GET` → `405`. Docs (`mcp.md` HTTP + trust-model, `cli.md`), skill,
and cheatsheet updated.
