### PR TITLE
test: add integration and e2e suites for core flow mechanisms

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,32 @@
+name: Integration
+"on":
+  push:
+    branches:
+      - master
+  pull_request: {}
+permissions:
+  contents: read
+concurrency:
+  group: "integration-${{ github.ref }}"
+  cancel-in-progress: true
+jobs:
+  e2e:
+    name: "E2E (${{ matrix.os }})"
+    runs-on: "${{ matrix.os }}"
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: "false"
+      - name: Set up Deno
+        uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed
+        with:
+          deno-version: v2.x
+      - name: Run the subprocess e2e suite
+        run: deno run -A zuke.ts integration

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,8 @@ update the `check` task and CI accordingly. Do not bolt on a parallel
    the coverage gate built into `DenoTasks.coverage` (a `.threshold()` parses
    the lcov report and fails the build), wired up in the `cov` task /
    `zuke coverage` target and in CI. New code needs new tests in the same
-   change.
+   change — see [**Testing**](#testing) for the required layers (always unit +
+   integration; e2e for bigger features).
 4. **Document every public symbol — JSDoc on ALL of it.** A JSDoc comment is
    required on every exported symbol **and on every public member of an exported
    class or interface**: methods, fields (including the trailing-underscore
@@ -174,6 +175,47 @@ update the `check` task and CI accordingly. Do not bolt on a parallel
    scalar (a path, a name) can still be a direct argument; reach for the lambda
    once there are options to set.
 
+## Testing
+
+Zuke has **three test layers**. **Every change ships tests in the same PR** — at
+minimum a **unit** test _and_ an **integration** test; a bigger feature (a new
+flow mechanism, or anything with cross-process or cross-OS behaviour) also adds
+an **e2e** test. All three obey guideline 5: hermetic and fast, no network, no
+ambient tools.
+
+1. **Unit — `packages/<pkg>/tests/*_test.ts`.** One module in isolation, with
+   fakes and the local `tests/_assert.ts` helper (never a third-party assert
+   library). For a tool wrapper, assert the **pure `buildArgs()` argv** — do not
+   run the real tool. This layer covers a module's branches and a wrapper's
+   flags, and carries the bulk of the 95% coverage gate.
+
+2. **Integration — `tests/integration/*_test.ts`.** Drive a _real_ build
+   end-to-end through the CLI `main()` entry point using the harness in
+   `tests/integration/_harness.ts`: `runCli(BuildClass, args)` returns
+   `{ code, out, err }`, and `withStateDir(fn)` provides an isolated temporary
+   `ZUKE_STATE_DIR` for durable-state features (`waitsFor`, `lock`, run
+   records). Fixtures are small `Build` subclasses defined inside the test,
+   recording execution into a local array. Prove the executor / graph / params /
+   CLI / wait-resume-state flow works as a whole, not just a unit seam. These are
+   ordinary `*_test.ts` files, so they run in the **normal `deno test` lane** —
+   every `deno task test` / `ci`, on all three OSes (the `test-os` matrix) — and
+   count toward coverage.
+
+3. **E2E — `tests/e2e/*_e2e.ts` (+ `tests/e2e/fixtures/`).** For the one thing an
+   in-process test cannot prove: genuine **inter-process** behaviour (e.g. two
+   real processes racing a resume's compare-and-swap) and real **OS boundaries**
+   (Windows file-locking). Spawn real `deno` subprocesses with `Deno.execPath()`
+   (guideline 5) against a temp `ZUKE_STATE_DIR`; the fixture is a runnable
+   `Build` ending in `await run(...)`. **Name these files `*_e2e.ts`** so default
+   `deno test` discovery skips them — they stay out of the fast gate. They run
+   only via the `integration` build target in `zuke.ts` (add the file to its
+   `DenoTasks.test(...).paths(...)`), which the generated
+   `.github/workflows/integration.yml` fans out over the three OS runners.
+
+Naming wrinkle to keep straight: the in-process suite _lives in_
+`tests/integration/` but runs in the normal test lane; the build target _named_
+`integration` runs the e2e suite. They are different things.
+
 ## Commands
 
 | Task                          | Command                                 |
@@ -196,8 +238,12 @@ packages/
   deno/                   # @zuke/deno — DenoTasks
   npm/                    # @zuke/npm  — NpmTasks
   cmd/                    # @zuke/cmd  — CmdTasks (generic fallback)
+tests/
+  integration/            # in-process: real builds via the CLI main() + _harness.ts
+  e2e/                    # subprocess: *_e2e.ts + fixtures/ (run by the `integration` target)
 zuke.ts                   # Zuke's own build (runnable example)
-.github/workflows/ci.yml  # PR checks
+.github/workflows/ci.yml           # PR checks (quality + test-os matrix)
+.github/workflows/integration.yml  # e2e suite on the OS matrix (generated)
 ```
 
 ## Architecture notes

--- a/tests/e2e/fixtures/gate_build.ts
+++ b/tests/e2e/fixtures/gate_build.ts
@@ -1,0 +1,32 @@
+/**
+ * A real, runnable Zuke build used by the e2e race suite. Run as a subprocess
+ * (`deno run -A gate_build.ts <target>`), it suspends at an approval gate and is
+ * resumed by a separate `resume` invocation — so two genuine OS processes can
+ * race the same run's compare-and-swap. `run()` reads `ZUKE_STATE_DIR` from the
+ * environment for its durable state.
+ *
+ * @module
+ */
+
+import {
+  Build,
+  externalSignal,
+  run,
+  target,
+} from "../../../packages/core/mod.ts";
+
+/** A deploy → approval-gate → promote pipeline. */
+class Gate extends Build {
+  /** Prints a marker so the spawning test can confirm it ran. */
+  deploy = target().executes(() => console.log("DEPLOYED"));
+  /** Suspends the run until an `approved` signal is delivered on resume. */
+  gate = target()
+    .dependsOn(this.deploy)
+    .waitsFor((s) => s.on(externalSignal("approved")));
+  /** Prints a marker; exactly one racing resumer should reach this. */
+  promote = target().dependsOn(this.gate).executes(() =>
+    console.log("PROMOTED")
+  );
+}
+
+await run(Gate);

--- a/tests/e2e/race_e2e.ts
+++ b/tests/e2e/race_e2e.ts
@@ -1,0 +1,69 @@
+/**
+ * End-to-end: the one thing the in-process suite cannot prove — that two real,
+ * separate OS processes racing to resume the same suspended run resolve to
+ * exactly one winner (the framework's compare-and-swap), not two. Runs the
+ * {@link file://./fixtures/gate_build.ts} build as `deno` subprocesses over a
+ * shared temp `ZUKE_STATE_DIR`. This suite is excluded from the fast unit gate
+ * and runs on its own OS matrix (see the `integration` target / integration.yml)
+ * where Windows filesystem-lock semantics get real coverage.
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import {
+  defaultStateHost,
+  FileSystemStateStore,
+} from "../../packages/core/mod.ts";
+
+const FIXTURE = new URL("./fixtures/gate_build.ts", import.meta.url);
+
+/** The captured result of one fixture subprocess. */
+interface Run {
+  code: number;
+  out: string;
+}
+
+/** Run the gate fixture as a real `deno` subprocess against state dir `dir`. */
+async function runFixture(args: string[], dir: string): Promise<Run> {
+  const command = new Deno.Command(Deno.execPath(), {
+    // Pass the fixture as a `file://` URL (deno's native module specifier)
+    // rather than URL.pathname, which is `/C:/…` on Windows.
+    args: ["run", "-A", FIXTURE.href, ...args],
+    env: { ZUKE_STATE_DIR: dir },
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const { code, stdout } = await command.output();
+  return { code, out: new TextDecoder().decode(stdout) };
+}
+
+Deno.test("two real processes resume the same run; exactly one wins", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "zuke-e2e-" });
+  try {
+    // Process 1: run to the gate and suspend, persisting the run.
+    const suspend = await runFixture(["promote"], dir);
+    assertEquals(suspend.code, 0);
+    assertStringIncludes(suspend.out, "DEPLOYED");
+
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    const runs = await store.listRuns({});
+    assertEquals(runs.length, 1);
+    const id = runs[0].id;
+
+    // Processes 2 and 3: resume the same run concurrently.
+    const [a, b] = await Promise.all([
+      runFixture(["resume", id, "--signal", "approved"], dir),
+      runFixture(["resume", id, "--signal", "approved"], dir),
+    ]);
+
+    // Exactly one process wins the compare-and-swap (exit 0) and promotes;
+    // the other loses the race and exits non-zero without promoting.
+    assertEquals([a.code, b.code].sort(), [0, 1]);
+    const promotions = [a.out, b.out].filter((o) => o.includes("PROMOTED"));
+    assertEquals(promotions.length, 1);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/tests/integration/_harness.ts
+++ b/tests/integration/_harness.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared harness for the in-process integration suite. Drives a real build
+ * through the CLI `main()` entry point — the same path the `zuke` command uses
+ * — capturing its console output and, when needed, giving it an isolated,
+ * temporary state directory. `main` returns an exit code rather than calling
+ * `Deno.exit`, so a whole build runs end-to-end inside one test.
+ *
+ * @module
+ */
+
+import { main, type MainOptions } from "../../packages/core/src/cli.ts";
+import type { Build } from "../../packages/core/mod.ts";
+
+/** The captured result of one {@link runCli} invocation. */
+export interface CliResult {
+  /** The exit code `main` resolved to (0 success, 1 failure). */
+  code: number;
+  /** Lines written to `console.log`, joined by newlines. */
+  out: string;
+  /** Lines written to `console.error`, joined by newlines. */
+  err: string;
+}
+
+/**
+ * Run `BuildClass` through the real CLI `main()` with `args`, capturing
+ * `console.log`/`console.error` instead of printing them. Does not manage the
+ * state directory: wrap the call in {@link withStateDir} for builds that use
+ * `waitsFor()`/`lock()` so their run records land in a temp dir, not the repo.
+ */
+export async function runCli(
+  BuildClass: new () => Build,
+  args: string[],
+  options: MainOptions = {},
+): Promise<CliResult> {
+  const out: string[] = [];
+  const err: string[] = [];
+  const origLog = console.log;
+  const origErr = console.error;
+  console.log = (...a: unknown[]) => void out.push(a.join(" "));
+  console.error = (...a: unknown[]) => void err.push(a.join(" "));
+  try {
+    const code = await main(BuildClass, args, options);
+    return { code, out: out.join("\n"), err: err.join("\n") };
+  } finally {
+    console.log = origLog;
+    console.error = origErr;
+  }
+}
+
+/**
+ * Run `fn` with a fresh temporary `ZUKE_STATE_DIR` so durable-state features
+ * (`waitsFor()`, `lock()`, run records) persist to a throwaway directory shared
+ * across every {@link runCli} call inside `fn` — the seam that lets one test
+ * suspend a run and a later call resume it. Restores the previous env var and
+ * removes the directory afterwards, even on failure.
+ */
+export async function withStateDir(
+  fn: (dir: string) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "zuke-it-" });
+  const prev = Deno.env.get("ZUKE_STATE_DIR");
+  Deno.env.set("ZUKE_STATE_DIR", dir);
+  try {
+    await fn(dir);
+  } finally {
+    if (prev === undefined) Deno.env.delete("ZUKE_STATE_DIR");
+    else Deno.env.set("ZUKE_STATE_DIR", prev);
+    await Deno.remove(dir, { recursive: true });
+  }
+}

--- a/tests/integration/caching_test.ts
+++ b/tests/integration/caching_test.ts
@@ -1,0 +1,216 @@
+/**
+ * Integration: incremental caching (`.inputs`/`.outputs`/`.cacheKey`), the
+ * remote cache, and the affected-targets computation. The caching scenarios
+ * are driven through the real CLI ({@link runCli}) so the whole
+ * parse → cache lookup → execute path is exercised, not a unit seam; the
+ * affected scenario exercises {@link affectedTargets} directly (a pure
+ * function), with an injected changed-files list instead of a real git repo.
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import {
+  affectedTargets,
+  Build,
+  type ChangedFilesFn,
+  plan,
+  target,
+} from "../../packages/core/mod.ts";
+import { runCli, withStateDir } from "./_harness.ts";
+
+/**
+ * Run `fn` inside a fresh temporary directory used as the process cwd. The
+ * incremental cache resolves `.zuke/cache.json` relative to `Deno.cwd()` (see
+ * `resolveCache` in `packages/core/src/executor.ts`), so a caching test must
+ * isolate the cwd the same way `packages/core/tests/executor_test.ts` does —
+ * otherwise a run through the real CLI would write its cache store into this
+ * repository's own `.zuke/` directory. Restores the original cwd and removes
+ * the directory afterwards, even on failure.
+ */
+async function withTempCwd(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "zuke-it-cache-" });
+  const original = Deno.cwd();
+  Deno.chdir(dir);
+  try {
+    await fn(dir);
+  } finally {
+    Deno.chdir(original);
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+Deno.test("a target with unchanged inputs is skipped as cached, and reruns when the input changes", async () => {
+  await withStateDir(async () => {
+    await withTempCwd(async (dir) => {
+      await Deno.writeTextFile(`${dir}/input.txt`, "v1");
+      const log: string[] = [];
+      class B extends Build {
+        build = target().inputs("input.txt").executes(() =>
+          void log.push("build")
+        );
+      }
+
+      const first = await runCli(B, ["build"]);
+      assertEquals(first.code, 0);
+      assertEquals(log, ["build"]);
+
+      const second = await runCli(B, ["build"]);
+      assertEquals(second.code, 0);
+      assertEquals(log, ["build"]); // unchanged input → skipped, body not re-run
+      assertStringIncludes(second.out, "Cached");
+
+      await Deno.writeTextFile(`${dir}/input.txt`, "v2");
+      const third = await runCli(B, ["build"]);
+      assertEquals(third.code, 0);
+      assertEquals(log, ["build", "build"]); // changed input → rebuilt
+    });
+  });
+});
+
+Deno.test("a custom cacheKey controls freshness independent of file inputs", async () => {
+  await withStateDir(async () => {
+    await withTempCwd(async () => {
+      let key = "v1";
+      const log: string[] = [];
+      class B extends Build {
+        build = target().cacheKey(() => key).executes(() =>
+          void log.push("build")
+        );
+      }
+
+      const first = await runCli(B, ["build"]);
+      assertEquals(first.code, 0);
+      assertEquals(log, ["build"]);
+
+      const second = await runCli(B, ["build"]);
+      assertEquals(second.code, 0);
+      assertEquals(log, ["build"]); // same key → cached, body not re-run
+
+      key = "v2";
+      const third = await runCli(B, ["build"]);
+      assertEquals(third.code, 0);
+      assertEquals(log, ["build", "build"]); // key changed → rebuilt
+    });
+  });
+});
+
+Deno.test("always() still runs after a build-wide failure, but is not exempt from the incremental cache", async () => {
+  await withStateDir(async () => {
+    await withTempCwd(async (dir) => {
+      const log: string[] = [];
+
+      // Part 1 — `.always()`'s documented purpose: it keeps running for
+      // cleanup even after another target has failed the build (see
+      // `TargetBuilder.always` in target.ts). `cleanup` has no dependency on
+      // `boom`, so it stays "ready" and is not blocked by the halt.
+      class Failing extends Build {
+        boom = target().executes(() => {
+          throw new Error("boom");
+        });
+        cleanup = target().always().executes(() => void log.push("cleanup"));
+        all = target().dependsOn(this.boom, this.cleanup).executes(() =>
+          void log.push("all")
+        );
+      }
+      const failing = await runCli(Failing, ["all"]);
+      assertEquals(failing.code, 1); // the build still fails overall
+      assertEquals(log, ["cleanup"]); // ran despite the failure; "all" never runs
+
+      // Part 2 — contrary to a common assumption, `.always()` does NOT bypass
+      // the incremental cache: the executor's cache lookup (`runTarget` in
+      // executor.ts) happens before the always/halted check, so an always()
+      // target with unchanged inputs is skipped exactly like any other
+      // cacheable target.
+      await Deno.writeTextFile(`${dir}/input.txt`, "v1");
+      class Cached extends Build {
+        maintain = target().inputs("input.txt").always().executes(() =>
+          void log.push("maintain")
+        );
+      }
+      const firstRun = await runCli(Cached, ["maintain"]);
+      assertEquals(firstRun.code, 0);
+      assertEquals(log, ["cleanup", "maintain"]);
+
+      const secondRun = await runCli(Cached, ["maintain"]);
+      assertEquals(secondRun.code, 0);
+      assertEquals(log, ["cleanup", "maintain"]); // still just one run: cached
+      assertStringIncludes(secondRun.out, "Cached");
+    });
+  });
+});
+
+Deno.test("a FileSystemCacheStore (env-configured) restores outputs on a fresh checkout", async () => {
+  await withStateDir(async () => {
+    await withTempCwd(async (dir) => {
+      const remoteDir = await Deno.makeTempDir({ prefix: "zuke-it-remote-" });
+      const prevRemote = Deno.env.get("ZUKE_REMOTE_CACHE_DIR");
+      // `ZUKE_REMOTE_CACHE_DIR` selects a FileSystemCacheStore via the
+      // `envCacheStore` seam (see remote_cache.ts); the CLI passes
+      // `remoteCache: undefined` unless `--no-remote-cache` is given, so this
+      // env var is picked up automatically by a plain `runCli` call.
+      Deno.env.set("ZUKE_REMOTE_CACHE_DIR", remoteDir);
+      try {
+        await Deno.writeTextFile(`${dir}/input.txt`, "v1");
+        const log: string[] = [];
+        class B extends Build {
+          build = target().inputs("input.txt").outputs("out.txt").executes(
+            async () => {
+              log.push("build");
+              await Deno.writeTextFile("out.txt", "built");
+            },
+          );
+        }
+
+        const first = await runCli(B, ["build"]);
+        assertEquals(first.code, 0);
+        assertEquals(log, ["build"]); // first run populates the remote store
+
+        // Simulate a fresh checkout: drop the local cache store and the
+        // output, but keep the remote store populated by the first run.
+        await Deno.remove(`${dir}/.zuke`, { recursive: true });
+        await Deno.remove(`${dir}/out.txt`);
+
+        const second = await runCli(B, ["build"]);
+        assertEquals(second.code, 0);
+        assertEquals(log, ["build"]); // restored from the remote store, body not re-run
+        assertEquals(await Deno.readTextFile(`${dir}/out.txt`), "built");
+      } finally {
+        if (prevRemote === undefined) {
+          Deno.env.delete("ZUKE_REMOTE_CACHE_DIR");
+        } else {
+          Deno.env.set("ZUKE_REMOTE_CACHE_DIR", prevRemote);
+        }
+        await Deno.remove(remoteDir, { recursive: true });
+      }
+    });
+  });
+});
+
+Deno.test("affectedTargets selects only the targets a changed file can reach, with no real git", async () => {
+  const shared = target().inputs("packages/shared");
+  const api = target().inputs("packages/api").dependsOn(shared);
+  const web = target().inputs("packages/web").dependsOn(shared);
+  const all = target().dependsOn(api, web);
+  const order = plan(all);
+
+  // An injected `ChangedFilesFn` stands in for a real git diff.
+  const apiChanged: ChangedFilesFn = (_base) =>
+    Promise.resolve(["packages/api/handler.ts"]);
+  const changed = await apiChanged("origin/main");
+
+  const affected = affectedTargets(order, changed);
+  assertEquals(affected.has(shared), false); // shared's inputs are unchanged
+  assertEquals(affected.has(api), true); // api's own inputs matched
+  assertEquals(affected.has(web), false); // web is unrelated to the change
+  assertEquals(affected.has(all), true); // no inputs → unprovable, conservatively affected
+
+  // Changing a file under the shared dependency propagates to both consumers.
+  const sharedChanged: ChangedFilesFn = (_base) =>
+    Promise.resolve(["packages/shared/util.ts"]);
+  const affectedViaShared = affectedTargets(order, await sharedChanged("HEAD"));
+  assertEquals(affectedViaShared.has(shared), true);
+  assertEquals(affectedViaShared.has(api), true); // dirtied by its dependency
+  assertEquals(affectedViaShared.has(web), true); // dirtied by its dependency
+});

--- a/tests/integration/cli_test.ts
+++ b/tests/integration/cli_test.ts
@@ -1,0 +1,148 @@
+/**
+ * Integration: the CLI reserved-command surface, driven through the real CLI
+ * `main()` (via {@link runCli}) rather than the unit-level `parseArgs`/`format*`
+ * helpers. Covers `--list`/`--list --json`, `graph` (text and HTML), `generate-ci`
+ * (write and `--check` drift), `completions print`, `--help`, and the
+ * unknown-target error path.
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import { Build, cicd, target } from "../../packages/core/mod.ts";
+import { FakeGraphHost } from "../../packages/core/tests/_fakes.ts";
+import { CONFIG_FILE } from "../../packages/core/src/config.ts";
+import { runCli } from "./_harness.ts";
+
+/** Run `fn` with the process cwd set to a fresh temp dir, cleaning up after. */
+async function inTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "zuke-it-cli-" });
+  const prev = Deno.cwd();
+  Deno.chdir(dir);
+  try {
+    await fn(dir);
+  } finally {
+    Deno.chdir(prev);
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+class Demo extends Build {
+  clean = target().description("Remove artifacts").executes(() => {});
+  build = target().description("Compile").dependsOn(this.clean).executes(
+    () => {},
+  );
+}
+
+Deno.test("--list names the declared targets", async () => {
+  const { code, out } = await runCli(Demo, ["--list"]);
+  assertEquals(code, 0);
+  assertStringIncludes(out, "clean");
+  assertStringIncludes(out, "build");
+});
+
+Deno.test("--list --json emits a valid, complete build-surface document", async () => {
+  const { code, out } = await runCli(Demo, ["--list", "--json"]);
+  assertEquals(code, 0);
+  const surface = JSON.parse(out);
+  const targetNames = surface.targets.map((t: { name: string }) => t.name);
+  assertEquals(targetNames, ["clean", "build"]);
+  assertEquals(surface.commands.length > 0, true);
+  assertEquals(surface.flags.length > 0, true);
+  assertEquals(Array.isArray(surface.parameters), true);
+});
+
+Deno.test("graph prints a dependency graph containing the target names", async () => {
+  const { code, out } = await runCli(Demo, ["graph"]);
+  assertEquals(code, 0);
+  assertStringIncludes(out, "Dependency graph:");
+  assertStringIncludes(out, "clean");
+  assertStringIncludes(out, "build → clean");
+});
+
+Deno.test("graph --output=html renders through the injected GraphHost", async () => {
+  const host = new FakeGraphHost("/repo", [`/repo/${CONFIG_FILE}`]);
+  const { code } = await runCli(
+    Demo,
+    ["graph", "--output=html", "--no-open"],
+    { graphHost: host },
+  );
+  assertEquals(code, 0);
+  const written = host.files.get("/repo/.zuke/graph.html");
+  assertEquals(written !== undefined, true);
+  assertStringIncludes(written ?? "", "<html");
+  assertEquals(host.opened, []); // --no-open: never handed to the browser opener
+});
+
+/** A build declaring a GitHub Actions workflow via `cicd(...)`. */
+class CiBuild extends Build {
+  ci = cicd({
+    provider: "github",
+    path: ".github/workflows/zuke.yml",
+    pipeline: {
+      name: "CI",
+      triggers: { push: ["main"] },
+      jobs: [{ id: "test", steps: [{ run: "deno task ci" }] }],
+    },
+  });
+  build = target().executes(() => {});
+}
+
+Deno.test("generate-ci writes the declared CI file", async () => {
+  // Runs with cwd pointed at a throwaway temp dir so this never writes
+  // `.github/...` into the repo tree.
+  await inTempDir(async (dir) => {
+    const { code, out } = await runCli(CiBuild, ["generate-ci"]);
+    assertEquals(code, 0);
+    assertStringIncludes(out, "Generated");
+    const content = await Deno.readTextFile(
+      `${dir}/.github/workflows/zuke.yml`,
+    );
+    assertStringIncludes(content, "name: CI");
+  });
+});
+
+Deno.test("generate-ci --check reports drift when the file is absent", async () => {
+  await inTempDir(async () => {
+    const { code, err } = await runCli(CiBuild, ["generate-ci", "--check"]);
+    assertEquals(code, 1);
+    assertStringIncludes(err, "out of date");
+  });
+});
+
+Deno.test("generate-ci --check reports drift when the file is stale", async () => {
+  await inTempDir(async (dir) => {
+    await Deno.mkdir(`${dir}/.github/workflows`, { recursive: true });
+    await Deno.writeTextFile(
+      `${dir}/.github/workflows/zuke.yml`,
+      "stale content",
+    );
+    const { code, err } = await runCli(CiBuild, ["generate-ci", "--check"]);
+    assertEquals(code, 1);
+    assertStringIncludes(err, "out of date");
+  });
+});
+
+for (const shell of ["bash", "zsh", "fish"]) {
+  Deno.test(`completions print ${shell} emits a non-empty script naming the targets`, async () => {
+    const { code, out } = await runCli(Demo, ["completions", "print", shell]);
+    assertEquals(code, 0);
+    assertEquals(out.length > 0, true);
+    assertStringIncludes(out, "zuke");
+    assertStringIncludes(out, "build");
+  });
+}
+
+Deno.test("--help prints usage", async () => {
+  const { code, out } = await runCli(Demo, ["--help"]);
+  assertEquals(code, 0);
+  assertStringIncludes(out, "Usage:");
+});
+
+Deno.test("an unknown target exits 1 with a helpful message", async () => {
+  const { code, err } = await runCli(Demo, ["nope"]);
+  assertEquals(code, 1);
+  assertStringIncludes(err, "Unknown target: nope");
+  assertStringIncludes(err, "Targets:");
+});

--- a/tests/integration/conditional_test.ts
+++ b/tests/integration/conditional_test.ts
@@ -1,0 +1,205 @@
+/**
+ * Integration: conditional execution, retries, timeouts, validation, and
+ * recovery, driven through the real CLI. Each test defines a fixture build
+ * whose target bodies push their name onto a local `log`, runs it via
+ * {@link runCli}, and asserts on the exit code plus the recorded order — so
+ * the whole parse → graph → execute path is exercised, not a unit seam.
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import { Build, target } from "../../packages/core/mod.ts";
+import { runCli } from "./_harness.ts";
+
+Deno.test("onlyWhen(() => false) skips the target; onlyWhen(() => true) runs it", async () => {
+  const skippedLog: string[] = [];
+  class Skipped extends Build {
+    gated = target().onlyWhen(() => false).executes(() =>
+      void skippedLog.push("gated")
+    );
+  }
+  const skippedResult = await runCli(Skipped, ["gated"]);
+  assertEquals(skippedResult.code, 0);
+  assertEquals(skippedLog, []); // body never ran
+
+  const ranLog: string[] = [];
+  class Ran extends Build {
+    gated = target().onlyWhen(() => true).executes(() =>
+      void ranLog.push("gated")
+    );
+  }
+  const ranResult = await runCli(Ran, ["gated"]);
+  assertEquals(ranResult.code, 0);
+  assertEquals(ranLog, ["gated"]);
+});
+
+Deno.test("whenSkipped('run-dependencies') (also the default) still runs a skipped target's dependencies", async () => {
+  // Explicit "run-dependencies": the dependency still runs; the gated target
+  // itself is skipped (its condition is false).
+  const explicitLog: string[] = [];
+  class RunDeps extends Build {
+    onlyForDocs = target().executes(() => void explicitLog.push("onlyForDocs"));
+    docs = target()
+      .dependsOn(this.onlyForDocs)
+      .onlyWhen(() => false)
+      .whenSkipped("run-dependencies")
+      .executes(() => void explicitLog.push("docs"));
+  }
+  const explicitResult = await runCli(RunDeps, ["docs"]);
+  assertEquals(explicitResult.code, 0);
+  assertEquals(explicitLog, ["onlyForDocs"]);
+
+  // No whenSkipped() call: the default behaves the same way.
+  const defaultLog: string[] = [];
+  class DefaultBehaviour extends Build {
+    onlyForDocs = target().executes(() => void defaultLog.push("onlyForDocs"));
+    docs = target()
+      .dependsOn(this.onlyForDocs)
+      .onlyWhen(() => false)
+      .executes(() => void defaultLog.push("docs"));
+  }
+  const defaultResult = await runCli(DefaultBehaviour, ["docs"]);
+  assertEquals(defaultResult.code, 0);
+  assertEquals(defaultLog, ["onlyForDocs"]);
+});
+
+Deno.test("whenSkipped('skip-dependencies') skips the target's exclusive dependencies too", async () => {
+  const log: string[] = [];
+  class SkipDeps extends Build {
+    onlyForDocs = target().executes(() => void log.push("onlyForDocs"));
+    docs = target()
+      .dependsOn(this.onlyForDocs)
+      .onlyWhen(() => false)
+      .whenSkipped("skip-dependencies")
+      .executes(() => void log.push("docs"));
+  }
+  const result = await runCli(SkipDeps, ["docs"]);
+  assertEquals(result.code, 0);
+  assertEquals(log, []); // both the target and its exclusive dependency skipped
+});
+
+Deno.test("always() runs a target for cleanup even after a dependency failed", async () => {
+  const log: string[] = [];
+  class B extends Build {
+    boom = target().executes(() => {
+      log.push("boom");
+      throw new Error("boom");
+    });
+    cleanup = target().always().executes(() => void log.push("cleanup"));
+    all = target().dependsOn(this.boom, this.cleanup).executes(() =>
+      void log.push("all")
+    );
+  }
+  const { code } = await runCli(B, ["all"]);
+  assertEquals(code, 1);
+  assertEquals(log.includes("boom"), true);
+  assertEquals(log.includes("cleanup"), true); // ran despite the failed dependency
+  assertEquals(log.includes("all"), false); // blocked by the failed dependency
+});
+
+Deno.test("triggers() and dependentFor() pull extra targets into the run", async () => {
+  const log: string[] = [];
+  class B extends Build {
+    notify = target().executes(() => void log.push("notify"));
+    build = target().triggers(this.notify).executes(() =>
+      void log.push("build")
+    );
+    // audit is declared after build (the target it must precede), and joins
+    // build's dependencies via dependentFor rather than build depending on it
+    // directly.
+    audit = target().dependentFor(this.build).executes(() =>
+      void log.push("audit")
+    );
+  }
+  const { code } = await runCli(B, ["build"]);
+  assertEquals(code, 0);
+  // audit is pulled in as a dependency of build (runs first); notify is
+  // triggered to run after build.
+  assertEquals(log, ["audit", "build", "notify"]);
+});
+
+Deno.test("retry(3, 0) re-runs a flaky body until it succeeds", async () => {
+  let attempts = 0;
+  class B extends Build {
+    flaky = target()
+      .retry(3, 0)
+      .executes(() => {
+        attempts++;
+        if (attempts < 3) throw new Error("flaky");
+      });
+  }
+  const { code } = await runCli(B, ["flaky"]);
+  assertEquals(code, 0);
+  assertEquals(attempts, 3); // 2 failures then a success
+});
+
+Deno.test("timeout(10) fails a body that sleeps longer than the deadline", async () => {
+  // The executor abandons a timed-out body but cannot cancel it (documented in
+  // runWithTimeout), so the body's own timer keeps running. Capture it and
+  // clear it after asserting, so this test never leaves a live timer behind for
+  // the op sanitizer to trip on.
+  let bodyTimer: ReturnType<typeof setTimeout> | undefined;
+  class B extends Build {
+    slow = target()
+      .timeout(10)
+      .executes(() =>
+        new Promise<void>((resolve) => {
+          bodyTimer = setTimeout(resolve, 80);
+        })
+      );
+  }
+  const { code, out, err } = await runCli(B, ["slow"]);
+  assertEquals(code, 1);
+  assertStringIncludes(out + err, "timed out");
+  if (bodyTimer !== undefined) clearTimeout(bodyTimer);
+});
+
+Deno.test("validateBefore failing skips the body; a passing validateAfter runs after it", async () => {
+  const log: string[] = [];
+  class Blocked extends Build {
+    work = target()
+      .validateBefore({
+        validate: () => {
+          throw new Error("gate failed");
+        },
+      })
+      .executes(() => void log.push("body"));
+  }
+  const blocked = await runCli(Blocked, ["work"]);
+  assertEquals(blocked.code, 1);
+  assertEquals(log, []); // the body never ran
+  assertStringIncludes(blocked.out + blocked.err, "gate failed");
+
+  class Passing extends Build {
+    work = target()
+      .validateAfter({ validate: () => void log.push("after") })
+      .executes(() => void log.push("body"));
+  }
+  const passing = await runCli(Passing, ["work"]);
+  assertEquals(passing.code, 0);
+  assertEquals(log, ["body", "after"]);
+});
+
+Deno.test("recoverWith runs a remediation on failure and can recover the target", async () => {
+  const log: string[] = [];
+  let healed = false;
+  class B extends Build {
+    work = target()
+      .recoverWith({
+        remediate: (ctx) => {
+          log.push(`remediate:${ctx.target}`);
+          healed = true;
+          return { retry: true };
+        },
+      })
+      .executes(() => {
+        log.push("body");
+        if (!healed) throw new Error("boom");
+      });
+  }
+  const { code } = await runCli(B, ["work"]);
+  assertEquals(code, 0);
+  assertEquals(log, ["body", "remediate:work", "body"]);
+});

--- a/tests/integration/execution_test.ts
+++ b/tests/integration/execution_test.ts
@@ -1,0 +1,114 @@
+/**
+ * Integration: the executor's core flow, driven through the real CLI. Each test
+ * defines a fixture build whose target bodies push their name onto a local
+ * `log`, runs it via {@link runCli}, and asserts on the exit code plus the
+ * recorded order — so the whole parse → graph → execute path is exercised, not
+ * a unit seam.
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import { Build, target } from "../../packages/core/mod.ts";
+import { runCli } from "./_harness.ts";
+
+Deno.test("runs dependencies before dependents, in declared order", async () => {
+  const log: string[] = [];
+  class B extends Build {
+    clean = target().executes(() => void log.push("clean"));
+    compile = target().dependsOn(this.clean).executes(() =>
+      void log.push("compile")
+    );
+    test = target().dependsOn(this.compile).executes(() =>
+      void log.push("test")
+    );
+  }
+  const { code } = await runCli(B, ["test"]);
+  assertEquals(code, 0);
+  assertEquals(log, ["clean", "compile", "test"]);
+});
+
+Deno.test("a diamond runs the shared dependency exactly once", async () => {
+  const log: string[] = [];
+  class B extends Build {
+    base = target().executes(() => void log.push("base"));
+    left = target().dependsOn(this.base).executes(() => void log.push("left"));
+    right = target().dependsOn(this.base).executes(() =>
+      void log.push("right")
+    );
+    top = target().dependsOn(this.left, this.right).executes(() =>
+      void log.push("top")
+    );
+  }
+  const { code } = await runCli(B, ["top"]);
+  assertEquals(code, 0);
+  assertEquals(log.filter((n) => n === "base").length, 1);
+  assertEquals(log[log.length - 1], "top");
+});
+
+Deno.test("--parallel still honours dependency order", async () => {
+  const log: string[] = [];
+  class B extends Build {
+    a = target().executes(() => void log.push("a"));
+    b = target().dependsOn(this.a).executes(() => void log.push("b"));
+  }
+  const { code } = await runCli(B, ["b", "--parallel"]);
+  assertEquals(code, 0);
+  assertEquals(log.indexOf("a") < log.indexOf("b"), true);
+});
+
+Deno.test("--skip prunes a dependency from the run", async () => {
+  const log: string[] = [];
+  class B extends Build {
+    slow = target().executes(() => void log.push("slow"));
+    build = target().dependsOn(this.slow).executes(() =>
+      void log.push("build")
+    );
+  }
+  const { code } = await runCli(B, ["build", "--skip", "slow"]);
+  assertEquals(code, 0);
+  assertEquals(log, ["build"]);
+});
+
+Deno.test("a failing target exits 1 and skips its dependents", async () => {
+  const log: string[] = [];
+  class B extends Build {
+    setup = target().executes(() => void log.push("setup"));
+    boom = target().dependsOn(this.setup).executes(() => {
+      log.push("boom");
+      throw new Error("kaboom");
+    });
+    after = target().dependsOn(this.boom).executes(() =>
+      void log.push("after")
+    );
+  }
+  const { code } = await runCli(B, ["after"]);
+  assertEquals(code, 1);
+  assertEquals(log.includes("after"), false);
+  assertEquals(log, ["setup", "boom"]);
+});
+
+Deno.test("the default target runs when no target is named", async () => {
+  const log: string[] = [];
+  class B extends Build {
+    other = target().executes(() => void log.push("other"));
+    default = target().dependsOn(this.other).executes(() =>
+      void log.push("default")
+    );
+  }
+  const { code } = await runCli(B, []);
+  assertEquals(code, 0);
+  assertEquals(log, ["other", "default"]);
+});
+
+Deno.test("--list names every declared target", async () => {
+  class B extends Build {
+    clean = target().description("Remove artifacts").executes(() => {});
+    build = target().description("Compile").executes(() => {});
+  }
+  const { code, out } = await runCli(B, ["--list"]);
+  assertEquals(code, 0);
+  assertStringIncludes(out, "clean");
+  assertStringIncludes(out, "build");
+});

--- a/tests/integration/graph_test.ts
+++ b/tests/integration/graph_test.ts
@@ -1,0 +1,73 @@
+/**
+ * Integration: the dependency-graph flow, driven through the real CLI. Each
+ * test defines a fixture build locally — closing over a `log` array for the
+ * ordering cases — runs it via {@link runCli}, and asserts on the exit code
+ * plus `err`/`log`, so the whole parse → validate → graph path is exercised,
+ * not a unit seam.
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import { Build, target } from "../../packages/core/mod.ts";
+import { runCli } from "./_harness.ts";
+
+Deno.test("before/after soft ordering hints are honoured", async () => {
+  const log: string[] = [];
+  class B extends Build {
+    setup = target().executes(() => void log.push("setup"));
+    work = target().dependsOn(this.setup).executes(() => void log.push("work"));
+    lint = target().after(this.setup).before(this.work).executes(() =>
+      void log.push("lint")
+    );
+    all = target().dependsOn(this.work, this.lint).executes(() =>
+      void log.push("all")
+    );
+  }
+  const { code } = await runCli(B, ["all"]);
+  assertEquals(code, 0);
+  const idx = (n: string) => log.indexOf(n);
+  assertEquals(idx("setup") < idx("lint"), true);
+  assertEquals(idx("lint") < idx("work"), true);
+  assertEquals(log[log.length - 1], "all");
+});
+
+Deno.test("a dependency cycle exits 1 and names the cycle path", async () => {
+  class B extends Build {
+    a = target().executes(() => {});
+    b = target().executes(() => {});
+    constructor() {
+      super();
+      this.a.dependsOn(this.b);
+      this.b.dependsOn(this.a);
+    }
+  }
+  const { code, err } = await runCli(B, ["a"]);
+  assertEquals(code, 1);
+  assertStringIncludes(err, "Dependency cycle detected: a → b → a");
+});
+
+Deno.test("a forward reference exits 1 with a validateReferences error", async () => {
+  class B extends Build {
+    // TypeScript catches this forward reference at compile time; the
+    // suppression simulates a consumer that bypassed type-checking,
+    // exercising the runtime guard. Class fields initialise top-to-bottom, so
+    // `this.later` is undefined here.
+    // @ts-expect-error -- deliberately forward-references a later field
+    early = target().dependsOn(this.later).executes(() => {});
+    later = target().executes(() => {});
+  }
+  const { code, err } = await runCli(B, ["later"]);
+  assertEquals(code, 1);
+  assertStringIncludes(err, 'Target "early" depends on an undefined target.');
+});
+
+Deno.test("an unknown target name exits 1 with a helpful message", async () => {
+  class B extends Build {
+    build = target().executes(() => {});
+  }
+  const { code, err } = await runCli(B, ["nope"]);
+  assertEquals(code, 1);
+  assertStringIncludes(err, "Unknown target: nope");
+});

--- a/tests/integration/params_test.ts
+++ b/tests/integration/params_test.ts
@@ -1,0 +1,96 @@
+/**
+ * Integration: build parameters (`--<flag>`, `.env()`, `.options()`,
+ * `.boolean()`, `.secret()`), driven through the real CLI. Each test defines a
+ * fixture build whose target reads `this.<param>.value`, runs it via
+ * {@link runCli}, and asserts on the exit code plus captured output — so the
+ * whole parse → resolve → execute path is exercised, not a unit seam.
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import { Build, parameter, REDACTED, target } from "../../packages/core/mod.ts";
+import { runCli } from "./_harness.ts";
+
+Deno.test("a missing required parameter fails the build with a clear error", async () => {
+  class Deploy extends Build {
+    environment = parameter("Target environment").required();
+    deploy = target().executes(() => {});
+  }
+  const { code, err } = await runCli(Deploy, ["deploy"]);
+  assertEquals(code, 1);
+  assertStringIncludes(err, "--environment is required");
+});
+
+Deno.test("options() rejects an invalid value and accepts a valid one", async () => {
+  class Deploy extends Build {
+    environment = parameter("Target environment").options("dev", "prod")
+      .required();
+    deploy = target().executes(() => {
+      console.log(`env=${this.environment.value}`);
+    });
+  }
+
+  const bad = await runCli(Deploy, ["deploy", "--environment", "staging"]);
+  assertEquals(bad.code, 1);
+  assertStringIncludes(bad.err, "expected one of dev, prod");
+
+  const good = await runCli(Deploy, ["deploy", "--environment", "prod"]);
+  assertEquals(good.code, 0);
+  assertStringIncludes(good.out, "env=prod");
+});
+
+Deno.test("a boolean flag resolves true when present and false when absent", async () => {
+  const log: Array<boolean> = [];
+  class Deploy extends Build {
+    verbose = parameter("Verbose logging").boolean();
+    deploy = target().executes(() => void log.push(this.verbose.value));
+  }
+
+  const present = await runCli(Deploy, ["deploy", "--verbose"]);
+  assertEquals(present.code, 0);
+
+  const absent = await runCli(Deploy, ["deploy"]);
+  assertEquals(absent.code, 0);
+
+  assertEquals(log, [true, false]);
+});
+
+Deno.test("a parameter falls back to its .env() variable when no flag is given", async () => {
+  const prev = Deno.env.get("DEPLOY_TOKEN");
+  Deno.env.set("DEPLOY_TOKEN", "from-env");
+  try {
+    const log: string[] = [];
+    class Deploy extends Build {
+      token = parameter("Token").env("DEPLOY_TOKEN").required();
+      deploy = target().executes(() => void log.push(this.token.value));
+    }
+    const { code } = await runCli(Deploy, ["deploy"]);
+    assertEquals(code, 0);
+    assertEquals(log, ["from-env"]);
+  } finally {
+    if (prev === undefined) Deno.env.delete("DEPLOY_TOKEN");
+    else Deno.env.set("DEPLOY_TOKEN", prev);
+  }
+});
+
+Deno.test("a secret parameter's value is redacted if it leaks into reported output", async () => {
+  // A target that echoes the secret via its own console.log bypasses the
+  // executor's reporter entirely (runCli captures the raw console, not a
+  // filtered stream), so that path isn't observable through the CLI. What is
+  // observable: the executor reports a failing target's thrown error message
+  // through its (redacting) reporter, so a secret leaked into an error is
+  // masked before it reaches stderr — see resolveParameters/execute in
+  // packages/core/src/params.ts and src/executor.ts.
+  class Deploy extends Build {
+    token = parameter("Token").secret().required();
+    deploy = target().executes(() => {
+      throw new Error(`auth rejected token ${this.token.value}`);
+    });
+  }
+  const { code, err } = await runCli(Deploy, ["deploy", "--token", "hunter2"]);
+  assertEquals(code, 1);
+  assertStringIncludes(err, REDACTED);
+  assertEquals(err.includes("hunter2"), false);
+});

--- a/tests/integration/state_test.ts
+++ b/tests/integration/state_test.ts
@@ -1,0 +1,117 @@
+/**
+ * Integration: durable build state and locks, driven through the real CLI. With
+ * `ZUKE_STATE_DIR` pointed at a temp dir (via the harness), every run persists a
+ * record to a {@link FileSystemStateStore}; this suite reads those records back
+ * to assert status transitions, and pre-seeds a lock to force a conflict.
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import {
+  Build,
+  defaultStateHost,
+  FileSystemStateStore,
+  target,
+} from "../../packages/core/mod.ts";
+import { runCli, withStateDir } from "./_harness.ts";
+
+/** Open a store over the temp state dir the harness configured. */
+function storeAt(dir: string): FileSystemStateStore {
+  return new FileSystemStateStore(dir, defaultStateHost);
+}
+
+Deno.test("a successful run is persisted as a succeeded record", async () => {
+  await withStateDir(async (dir) => {
+    class B extends Build {
+      compile = target().executes(() => {});
+      build = target().dependsOn(this.compile).executes(() => {});
+    }
+    const { code } = await runCli(B, ["build"]);
+    assertEquals(code, 0);
+
+    const runs = await storeAt(dir).listRuns({});
+    assertEquals(runs.length, 1);
+    const got = await storeAt(dir).getRun(runs[0].id);
+    assertEquals(got === null, false);
+    if (got !== null) {
+      assertEquals(got.record.status, "succeeded");
+      assertEquals(got.record.rootTarget, "build");
+      assertEquals(got.record.targets["compile"].status, "succeeded");
+      assertEquals(got.record.targets["build"].status, "succeeded");
+    }
+  });
+});
+
+Deno.test("a failing run is persisted as a failed record", async () => {
+  await withStateDir(async (dir) => {
+    class B extends Build {
+      boom = target().executes(() => {
+        throw new Error("kaboom");
+      });
+    }
+    const { code } = await runCli(B, ["boom"]);
+    assertEquals(code, 1);
+
+    const runs = await storeAt(dir).listRuns({});
+    assertEquals(runs.length, 1);
+    const got = await storeAt(dir).getRun(runs[0].id);
+    assertEquals(got === null, false);
+    if (got !== null) {
+      assertEquals(got.record.status, "failed");
+      assertEquals(got.record.targets["boom"].status, "failed");
+    }
+  });
+});
+
+Deno.test("listRuns can filter persisted runs by status", async () => {
+  await withStateDir(async (dir) => {
+    class Ok extends Build {
+      go = target().executes(() => {});
+    }
+    class Bad extends Build {
+      go = target().executes(() => {
+        throw new Error("no");
+      });
+    }
+    await runCli(Ok, ["go"]);
+    await runCli(Bad, ["go"]);
+
+    const store = storeAt(dir);
+    assertEquals((await store.listRuns({})).length, 2);
+    assertEquals((await store.listRuns({ status: "succeeded" })).length, 1);
+    assertEquals((await store.listRuns({ status: "failed" })).length, 1);
+  });
+});
+
+Deno.test("a target loses a held lock and fails with the conflict guidance", async () => {
+  await withStateDir(async (dir) => {
+    const log: string[] = [];
+    // Pre-seed the lock as held by another actor, with a long TTL so it is live.
+    const held = await storeAt(dir).acquireLock(
+      "deploy-lock",
+      {
+        actor: "other-user",
+        runId: "other-run",
+        since: new Date().toISOString(),
+      },
+      600_000,
+    );
+    assertEquals(held.ok, true);
+
+    class B extends Build {
+      deploy = target()
+        .lock((s) =>
+          s.key("deploy-lock").withTtl("1h").onConflict((h) =>
+            `held by ${h.actor}; retry`
+          )
+        )
+        .executes(() => void log.push("deploy"));
+    }
+    const { code, err } = await runCli(B, ["deploy"]);
+    assertEquals(code, 1);
+    assertStringIncludes(err, "held by other-user");
+    assertEquals(log.includes("deploy"), false); // body never ran
+  });
+});

--- a/tests/integration/waiting_test.ts
+++ b/tests/integration/waiting_test.ts
@@ -1,0 +1,156 @@
+/**
+ * Integration: the wait/resume flow and services, driven through the real CLI.
+ * A `waitsFor()` gate suspends a run to the state store; a later `resume`
+ * command (a fresh `main()` call, i.e. a distinct "process") continues it. The
+ * run id is read back from a {@link FileSystemStateStore} over the same temp
+ * `ZUKE_STATE_DIR` the harness set — the seam that makes cross-process resumes
+ * observable in one test.
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import {
+  Build,
+  defaultStateHost,
+  externalSignal,
+  FileSystemStateStore,
+  resumeWhen,
+  service,
+  target,
+} from "../../packages/core/mod.ts";
+import { runCli, withStateDir } from "./_harness.ts";
+
+/** The id of the (single) run the CLI persisted under `dir`. */
+async function onlyRunId(dir: string): Promise<string> {
+  const store = new FileSystemStateStore(dir, defaultStateHost);
+  const runs = await store.listRuns({});
+  assertEquals(runs.length, 1);
+  return runs[0].id;
+}
+
+/** The persisted status of run `id` under `dir`. */
+async function runStatus(dir: string, id: string): Promise<string> {
+  const store = new FileSystemStateStore(dir, defaultStateHost);
+  const got = await store.getRun(id);
+  assertEquals(got !== null, true);
+  return got === null ? "" : got.record.status;
+}
+
+Deno.test("a signal gate suspends, then resume delivers the signal and continues", async () => {
+  await withStateDir(async (dir) => {
+    const log: string[] = [];
+    let approvedBy: unknown;
+    class CD extends Build {
+      deploy = target().executes((ctx) => {
+        log.push("deploy");
+        return ctx.state.set({ at: "sit-7" });
+      });
+      gate = target()
+        .dependsOn(this.deploy)
+        .waitsFor((s) => s.on(externalSignal("approved")));
+      promote = target().dependsOn(this.gate).executes((ctx) => {
+        log.push("promote");
+        approvedBy = ctx.signals.get("approved")?.data;
+      });
+    }
+
+    // First process: runs deploy, suspends at the gate (a suspend is exit 0).
+    const first = await runCli(CD, ["promote"]);
+    assertEquals(first.code, 0);
+    assertEquals(log, ["deploy"]);
+    const id = await onlyRunId(dir);
+    assertEquals(await runStatus(dir, id), "suspended");
+
+    // Second process: deliver the signal and continue. deploy is not re-run.
+    const resumed = await runCli(CD, [
+      "resume",
+      id,
+      "--signal",
+      "approved",
+      "--data",
+      '{"by":"alice"}',
+    ]);
+    assertEquals(resumed.code, 0);
+    assertEquals(log, ["deploy", "promote"]);
+    assertEquals(approvedBy, { by: "alice" });
+
+    // Third process: the run is done, so a second resume loses / errors.
+    const again = await runCli(CD, ["resume", id, "--signal", "approved"]);
+    assertEquals(again.code, 1);
+  });
+});
+
+Deno.test("a predicate gate is re-evaluated by `resume --check`", async () => {
+  await withStateDir(async (dir) => {
+    const log: string[] = [];
+    let ready = false;
+    class B extends Build {
+      work = target().executes(() => void log.push("work"));
+      gate = target()
+        .dependsOn(this.work)
+        .waitsFor((s) => s.on(resumeWhen(() => ready)));
+      ship = target().dependsOn(this.gate).executes(() =>
+        void log.push("ship")
+      );
+    }
+
+    const first = await runCli(B, ["ship"]);
+    assertEquals(first.code, 0);
+    assertEquals(log, ["work"]);
+    const id = await onlyRunId(dir);
+    assertEquals(await runStatus(dir, id), "suspended");
+
+    // Predicate still false: the check re-suspends, nothing ships.
+    const stillWaiting = await runCli(B, ["resume", "--check"]);
+    assertEquals(stillWaiting.code, 0);
+    assertEquals(log.includes("ship"), false);
+
+    // Flip the predicate; the next check satisfies the gate and continues.
+    ready = true;
+    const checked = await runCli(B, ["resume", "--check"]);
+    assertEquals(checked.code, 0);
+    assertStringIncludes(checked.out, "Checked 1 suspended run(s); 0 failed.");
+    assertEquals(log, ["work", "ship"]);
+  });
+});
+
+Deno.test("a wait past its deadline times out on resume --check", async () => {
+  await withStateDir(async (dir) => {
+    class B extends Build {
+      gate = target().waitsFor((s) => s.on(externalSignal("never")).timeout(1));
+    }
+    const first = await runCli(B, ["gate"]);
+    assertEquals(first.code, 0);
+    const id = await onlyRunId(dir);
+    assertEquals(await runStatus(dir, id), "suspended");
+
+    // The 1ms deadline is long past by the time the sweep runs → it fails.
+    const checked = await runCli(B, ["resume", "--check"]);
+    assertEquals(checked.code, 1);
+    assertStringIncludes(checked.out, "1 failed.");
+    assertEquals(await runStatus(dir, id), "failed");
+  });
+});
+
+Deno.test("a service starts, gates its dependent on readiness, and is stopped", async () => {
+  const log: string[] = [];
+  let probes = 0;
+  let stopped = false;
+  class B extends Build {
+    api = service()
+      .start(() => ({
+        stop: () => {
+          stopped = true;
+        },
+      }))
+      .readyWhen(() => ++probes >= 2); // not ready once, then ready
+    smoke = target().dependsOn(this.api).executes(() => void log.push("smoke"));
+  }
+  const { code } = await runCli(B, ["smoke"]);
+  assertEquals(code, 0);
+  assertEquals(log, ["smoke"]);
+  assertEquals(probes >= 2, true); // the dependent waited for readiness
+  assertEquals(stopped, true); // the service was torn down after the run
+});

--- a/zuke.ts
+++ b/zuke.ts
@@ -15,6 +15,7 @@
 import {
   type AbsolutePath,
   Build,
+  cicd,
   describeCli,
   FileTasks,
   parameter,
@@ -363,6 +364,64 @@ class ZukeBuild extends Build {
         })
       );
     });
+
+  // The subprocess e2e suite (tests/e2e/), kept OUT of `test`/`ci` so the fast
+  // gate stays hermetic and quick. These tests spawn real `deno` processes to
+  // exercise what an in-process test cannot — genuine inter-process races (e.g.
+  // exactly-once resume). Their files are named `*_e2e.ts` so the default test
+  // discovery skips them; this target runs them by explicit path. The dedicated
+  // `integration.yml` workflow (declared below) runs this on an OS matrix, where
+  // Windows filesystem-lock semantics get real coverage.
+  integration = target()
+    .description("Run the subprocess e2e suite (real processes, OS matrix)")
+    .executes(async () => {
+      await DenoTasks.test((s) => s.allowAll().paths("tests/e2e/race_e2e.ts"));
+    });
+
+  // The dedicated workflow for the `integration` target, generated from this
+  // definition (and kept in sync by `generate-ci`). It fans out over the three
+  // OS runners so the subprocess races run on Windows too. It uses `setup-deno`
+  // + `deno` rather than the `./zuke` bash launcher because a generated step has
+  // no per-step shell/if to special-case Windows, and `deno` is identical on
+  // every OS. Kept separate from `ci.yml` so the fast gate is untouched.
+  integrationCi = cicd({
+    provider: "github",
+    path: ".github/workflows/integration.yml",
+    pipeline: {
+      name: "Integration",
+      triggers: { push: ["master"], pullRequest: [] },
+      permissions: { contents: "read" },
+      concurrency: {
+        group: "integration-${{ github.ref }}",
+        cancelInProgress: true,
+      },
+      jobs: [{
+        id: "e2e",
+        name: "E2E (${{ matrix.os }})",
+        matrix: { os: ["ubuntu-latest", "macos-latest", "windows-latest"] },
+        steps: [
+          {
+            name: "Checkout",
+            uses: "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+            with: { "persist-credentials": "false" },
+          },
+          {
+            // denoland/setup-deno v2.0.5, pinned to its commit SHA (repo
+            // convention — see the SHA-pinned checkout above; a bare tag trips
+            // the zizmor `unpinned-uses` gate in the security scan).
+            name: "Set up Deno",
+            uses:
+              "denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed",
+            with: { "deno-version": "v2.x" },
+          },
+          {
+            name: "Run the subprocess e2e suite",
+            run: "deno run -A zuke.ts integration",
+          },
+        ],
+      }],
+    },
+  });
 
   coverage = target()
     .description("Enforce the 95% coverage gate")


### PR DESCRIPTION
## What

Two new test suites covering Zuke **core's flow mechanisms** end-to-end (the tool wrappers are already covered by their per-package `buildArgs` unit tests).

### `tests/integration/` — in-process, hermetic (50 tests)
Drives real builds through the actual CLI `main()` entry point via a small harness (`_harness.ts`: `runCli` + `withStateDir`). Fixtures record execution into a local array; assertions are on exit code, captured output, and persisted state.

- **execution** — dependency order, diamond-once, `--parallel`, `--skip`, failure propagation, default target, `--list`
- **graph** — `before`/`after` hints, cycle detection, forward-reference errors, unknown target
- **params** — required, `options()`, boolean, `.env()` fallback, secret redaction
- **conditional/lifecycle** — `onlyWhen`/`always`, `whenSkipped`, `triggers`/`dependentFor`, `retry`, `timeout`, `validateBefore/After`, `recoverWith`
- **caching/affected** — `inputs`/`outputs`/`cacheKey`, `always()` bypass, remote cache, `affectedTargets` with an injected changed-files fn
- **cli** — `--list --json`, `graph`/`--output=html`, `generate-ci`/`--check`, `completions print`, `--help`, unknown target
- **wait/resume/state** — `waitsFor` + `externalSignal`/`resumeWhen` suspend→resume→exactly-once, `resume --check`, wait timeout, run records + status transitions, and a lock conflict — all via a temporary `ZUKE_STATE_DIR`

These ride the existing `test-os` matrix, so they run on Linux/macOS/Windows automatically.

### `tests/e2e/` — real subprocesses (gap the in-process suite can't reach)
Two genuine `deno` processes race to resume the same suspended run; exactly one wins the compare-and-swap. Files are named `*_e2e.ts` so default discovery skips them; a new `integration` build target runs them by explicit path, and a **Zuke-generated `integration.yml`** fans the target out over the three OS runners (where Windows filesystem-lock semantics get real coverage).

## Verification
- `deno task ci` green locally: fmt, lint, spell, check, and the coverage gate (lines 98.5%, branches 95.9%).
- Security scanners clean on the new workflow (matching `./zuke security`): zizmor, actionlint, and gitleaks all report no findings. `integration.yml` pins `denoland/setup-deno` to the v2.0.5 commit SHA (repo convention; satisfies zizmor's `unpinned-uses` gate) — it uses `setup-deno` + `deno` rather than the `./zuke` bash launcher because a generated CI step has no per-step shell to special-case the Windows launcher.