### PR TITLE
feat(core): MCP authz tiers, audit log, and run-state tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,8 @@ exact signatures are published — read them:
 - **One file with the whole typed surface of every package:**
   [`llms-full.txt`](./llms-full.txt) at the repo root. [`llms.txt`](./llms.txt)
   is the short index.
-- **A single wrapper on the command line:** `deno doc jsr:@zuke/<package>`
-  (e.g. `deno doc jsr:@zuke/deno`).
+- **A single wrapper on the command line:** `deno doc jsr:@zuke/<package>` (e.g.
+  `deno doc jsr:@zuke/deno`).
 - **On each package's JSR page / README:** a generated `## API` section.
 - **The CLI surface — commands, flags, and a build's actual targets:** run
   `zuke --help` (or `deno run -A zuke.ts --help`). It prints the usage grammar,
@@ -39,10 +39,10 @@ The mental model:
 - A build is a class that **extends `Build`**. Each **target is a class field**
   built with `target()`: `.description(...)`, `.dependsOn(...)`,
   `.executes(async () => { … })`.
-- **Dependencies are `this.<field>` references, not strings** — `dependsOn(this.lint)`,
-  never `dependsOn("lint")` — so renames and typos are compile-time errors. A
-  target may only depend on siblings **declared above it** (fields initialise
-  top-to-bottom).
+- **Dependencies are `this.<field>` references, not strings** —
+  `dependsOn(this.lint)`, never `dependsOn("lint")` — so renames and typos are
+  compile-time errors. A target may only depend on siblings **declared above
+  it** (fields initialise top-to-bottom).
 - Make the file runnable with **`await run(MyBuild)`** at the bottom — no
   `if (import.meta.main)` guard; `run` no-ops when the module is imported.
 - **Every external tool is a namespaced `*Tasks` object** (`DenoTasks`,
@@ -56,7 +56,9 @@ The mental model:
   class CI extends Build {
     lint = target().executes(() => DenoTasks.lint());
     test = target().dependsOn(this.lint)
-      .executes(() => DenoTasks.test((s) => s.allowAll().coverage("cov_profile")));
+      .executes(() =>
+        DenoTasks.test((s) => s.allowAll().coverage("cov_profile"))
+      );
   }
 
   await run(CI);
@@ -111,19 +113,19 @@ update the `check` task and CI accordingly. Do not bolt on a parallel
 3. **Keep test coverage at 95%+ (lines and branches) at all times.** Enforced by
    the coverage gate built into `DenoTasks.coverage` (a `.threshold()` parses
    the lcov report and fails the build), wired up in the `cov` task /
-   `zuke coverage` target and in CI. New code needs new tests in the same
-   change — see [**Testing**](#testing) for the required layers (always unit +
+   `zuke coverage` target and in CI. New code needs new tests in the same change
+   — see [**Testing**](#testing) for the required layers (always unit +
    integration; e2e for bigger features).
 4. **Document every public symbol — JSDoc on ALL of it.** A JSDoc comment is
    required on every exported symbol **and on every public member of an exported
    class or interface**: methods, fields (including the trailing-underscore
    internal fields that are still public on an exported class), constructors,
    and the `override name = "…"` line on an error class. A **first-party** type
-   that appears in a public signature must **itself be exported and
-   documented** — never leave a `private-type-ref` to one of the package's own
-   types. Verify with `deno doc --lint` run over **all of a package's
-   entrypoints in one invocation** (a multi-entrypoint package like `@zuke/core`
-   has `.`, `./shell`, `./tooling`, `./render`, so
+   that appears in a public signature must **itself be exported and documented**
+   — never leave a `private-type-ref` to one of the package's own types. Verify
+   with `deno doc --lint` run over **all of a package's entrypoints in one
+   invocation** (a multi-entrypoint package like `@zuke/core` has `.`,
+   `./shell`, `./tooling`, `./render`, so
    `deno doc --lint packages/core/mod.ts packages/core/src/shell.ts …` — linting
    them together lets cross-entrypoint references resolve). The bar: zero
    `missing-jsdoc` and zero `private-type-ref` to a first-party type. The one
@@ -196,25 +198,41 @@ ambient tools.
    `ZUKE_STATE_DIR` for durable-state features (`waitsFor`, `lock`, run
    records). Fixtures are small `Build` subclasses defined inside the test,
    recording execution into a local array. Prove the executor / graph / params /
-   CLI / wait-resume-state flow works as a whole, not just a unit seam. These are
-   ordinary `*_test.ts` files, so they run in the **normal `deno test` lane** —
-   every `deno task test` / `ci`, on all three OSes (the `test-os` matrix) — and
-   count toward coverage.
+   CLI / wait-resume-state flow works as a whole, not just a unit seam. These
+   are ordinary `*_test.ts` files, so they run in the **normal `deno test`
+   lane** — every `deno task test` / `ci`, on all three OSes (the `test-os`
+   matrix) — and count toward coverage.
 
-3. **E2E — `tests/e2e/*_e2e.ts` (+ `tests/e2e/fixtures/`).** For the one thing an
-   in-process test cannot prove: genuine **inter-process** behaviour (e.g. two
-   real processes racing a resume's compare-and-swap) and real **OS boundaries**
-   (Windows file-locking). Spawn real `deno` subprocesses with `Deno.execPath()`
-   (guideline 5) against a temp `ZUKE_STATE_DIR`; the fixture is a runnable
-   `Build` ending in `await run(...)`. **Name these files `*_e2e.ts`** so default
-   `deno test` discovery skips them — they stay out of the fast gate. They run
-   only via the `integration` build target in `zuke.ts` (add the file to its
-   `DenoTasks.test(...).paths(...)`), which the generated
+3. **E2E — `tests/e2e/*_e2e.ts` (+ `tests/e2e/fixtures/`).** For the one thing
+   an in-process test cannot prove: genuine **inter-process** behaviour (e.g.
+   two real processes racing a resume's compare-and-swap) and real **OS
+   boundaries** (Windows file-locking). Spawn real `deno` subprocesses with
+   `Deno.execPath()` (guideline 5) against a temp `ZUKE_STATE_DIR`; the fixture
+   is a runnable `Build` ending in `await run(...)`. **Name these files
+   `*_e2e.ts`** so default `deno test` discovery skips them — they stay out of
+   the fast gate. They run only via the `integration` build target in `zuke.ts`
+   (add the file to its `DenoTasks.test(...).paths(...)`), which the generated
    `.github/workflows/integration.yml` fans out over the three OS runners.
 
 Naming wrinkle to keep straight: the in-process suite _lives in_
 `tests/integration/` but runs in the normal test lane; the build target _named_
 `integration` runs the e2e suite. They are different things.
+
+## Adversarial review (every feature)
+
+**Every feature ships an adversarial review before the PR is finalized** — not
+just a green gate. After the implementation and its tests pass, run a review
+pass that actively tries to **break** the change: bypasses, leaks, race
+conditions, unhandled throws, and untested security branches. Have independent
+reviewers attack each dimension, **verify every finding against the real code**
+(reproduce the exact path — default to refuted if you can't), then fix the
+confirmed defects _and add a regression test for each_ before opening the PR.
+
+This is not optional polish: on the MCP authz/audit work an adversarial pass
+caught a real authorization bypass, a secret-redaction gap, and a
+transport-crashing throw that all passed lint, types, and 95%+ coverage. Fixing
+pre-PR beats churning through review findings. It complements — never replaces —
+the three test layers above and the "read every reviewer comment" rule below.
 
 ## Commands
 

--- a/cspell.json
+++ b/cspell.json
@@ -87,6 +87,7 @@
     "pnpm",
     "pyflakes",
     "refspec",
+    "runtools",
     "remediate",
     "remediation",
     "remediations",

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -21,6 +21,7 @@ body, which is required before the target can run.
 | `.proceedAfterFailure()`    | `() => this`                                          | Keep the build going if this target fails.                                                         |
 | `.always()`                 | `() => this`                                          | Run for cleanup even after the build has failed.                                                   |
 | `.unlisted()`               | `() => this`                                          | Hide the target from `--list`/`--help`.                                                            |
+| `.readOnly()`               | `() => this`                                          | Advertise the target as query-only over [MCP](./mcp.md) (`readOnlyHint`).                          |
 | `.cacheKey(fn)`             | `(fn: () => string \| Promise<string>) => this`       | Extra (non-file) input to the cache fingerprint.                                                   |
 | `.produces(...paths)`       | `(...p: PathLike[]) => this`                          | Declare artifact paths this target produces.                                                       |
 | `.consumes(...targets)`     | `(...t: Target[]) => this`                            | Depend on targets and use their `produces` artifacts.                                              |
@@ -187,6 +188,10 @@ deploy = target()
   cleanup/teardown. It still waits for its own dependencies to complete.
 - **`.unlisted()`** — hide a helper target from `--list`/`--help`; it can still
   be run by name or depended on.
+- **`.readOnly()`** — mark a target query-only for [MCP](./mcp.md): its run tool
+  advertises `readOnlyHint` instead of `destructiveHint` and is exempt from
+  `--confirm-destructive`. A hint about intent — the body still runs — so use it
+  on targets that inspect rather than mutate.
 - **`.cacheKey(fn)`** — add a non-file value (a parameter, tool version, git
   commit…) to the [cache](#incremental-caching-inputs--outputs) fingerprint, so
   the target also rebuilds when that value changes. Repeatable; may be async.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,27 +1,27 @@
 # CLI reference
 
-| Command                                             | Behaviour                                                                               |
-| --------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| `zuke <target>`                                     | Run the target and all its transitive dependencies, in order.                           |
-| `zuke <target> --skip <dep>`                        | Run the target but skip the named dependency (repeatable).                              |
-| `zuke <target> --parallel`                          | Run independent targets concurrently (`--parallel=N` caps it).                          |
-| `zuke <target> --no-cache`                          | Ignore the incremental cache; re-run every target.                                      |
-| `zuke <target> --affected[=<base>]`                 | Run only targets affected by files changed since a git base.                            |
-| `zuke <target> --dry-run`                           | Print the plan without executing any target body.                                       |
-| `zuke <target> --state`                             | Persist [durable run state](./state.md) under `.zuke/runs`.                             |
-| `zuke <target> --actor <name>`                      | Attribute the run to `<name>` in its state record.                                      |
-| `zuke --list` / `-l`                                | List all targets with descriptions and dependencies.                                    |
-| `zuke graph`                                        | Print the dependency graph (`target → deps`).                                           |
-| `zuke graph --output=html`                          | Render an interactive HTML graph into `.zuke/` and open it.                             |
-| `zuke completions print <shell>`                    | Print a shell-completion script (`bash`, `zsh`, or `fish`).                             |
-| `zuke completions install <shell>`                  | Write the script and wire it into the shell's startup.                                  |
-| `zuke mcp [--allow-run] [--http <host:port>]`       | Run an MCP server over the build for AI agents, on stdio or HTTP ([details](./mcp.md)). |
-| `zuke resume <id> [--signal <n>] [--data <json>]`   | Resume a suspended run, optionally delivering a signal ([details](./orchestration.md)). |
-| `zuke resume --check [<id>]`                        | Re-check suspended runs (predicate waits, timeouts).                                    |
-| `zuke runs list [--status/-target/-since] [--json]` | List persisted run records, newest first ([details](./state.md)).                       |
-| `zuke runs show <id> [--json]`                      | Show one run's full per-target status and metadata.                                     |
-| `zuke --help` / `-h`                                | Usage.                                                                                  |
-| `zuke` (no target)                                  | Run the `default` target if defined, else print `--list`.                               |
+| Command                                                 | Behaviour                                                                               |
+| ------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `zuke <target>`                                         | Run the target and all its transitive dependencies, in order.                           |
+| `zuke <target> --skip <dep>`                            | Run the target but skip the named dependency (repeatable).                              |
+| `zuke <target> --parallel`                              | Run independent targets concurrently (`--parallel=N` caps it).                          |
+| `zuke <target> --no-cache`                              | Ignore the incremental cache; re-run every target.                                      |
+| `zuke <target> --affected[=<base>]`                     | Run only targets affected by files changed since a git base.                            |
+| `zuke <target> --dry-run`                               | Print the plan without executing any target body.                                       |
+| `zuke <target> --state`                                 | Persist [durable run state](./state.md) under `.zuke/runs`.                             |
+| `zuke <target> --actor <name>`                          | Attribute the run to `<name>` in its state record.                                      |
+| `zuke --list` / `-l`                                    | List all targets with descriptions and dependencies.                                    |
+| `zuke graph`                                            | Print the dependency graph (`target → deps`).                                           |
+| `zuke graph --output=html`                              | Render an interactive HTML graph into `.zuke/` and open it.                             |
+| `zuke completions print <shell>`                        | Print a shell-completion script (`bash`, `zsh`, or `fish`).                             |
+| `zuke completions install <shell>`                      | Write the script and wire it into the shell's startup.                                  |
+| `zuke mcp [--allow-run[=<globs>]] [--http <host:port>]` | Run an MCP server over the build for AI agents, on stdio or HTTP ([details](./mcp.md)). |
+| `zuke resume <id> [--signal <n>] [--data <json>]`       | Resume a suspended run, optionally delivering a signal ([details](./orchestration.md)). |
+| `zuke resume --check [<id>]`                            | Re-check suspended runs (predicate waits, timeouts).                                    |
+| `zuke runs list [--status/-target/-since] [--json]`     | List persisted run records, newest first ([details](./state.md)).                       |
+| `zuke runs show <id> [--json]`                          | Show one run's full per-target status and metadata.                                     |
+| `zuke --help` / `-h`                                    | Usage.                                                                                  |
+| `zuke` (no target)                                      | Run the `default` target if defined, else print `--list`.                               |
 
 (Read `zuke` as `deno run -A zuke.ts` until the launcher binary ships.)
 
@@ -109,12 +109,17 @@ shared with the parser and `--help`, so they never drift out of sync.
 Runs a [Model Context Protocol](https://modelcontextprotocol.io) server over the
 build on stdio, so an AI agent can operate the pipeline through typed tool calls
 instead of guessing shell commands. It exposes read tools (`list_targets`,
-`describe_build`, `graph`) and — only with `--allow-run` — one `run:<target>`
-tool per target, whose input schema is derived from the build's parameters.
-`--http <host:port>` serves the streamable-HTTP transport instead of stdio
-(loopback by default; a non-loopback bind requires a `ZUKE_MCP_TOKEN` bearer
-token). `mcp` is a reserved command name. See the full guide:
-[MCP server](./mcp.md).
+`describe_build`, `graph`, plus `list_runs`/`show_run` when a state store
+resolves) and — only with `--allow-run` — one `run:<target>` tool per target
+(plus `signal_run`/`resume_check`). Authorization tiers layer on:
+`--allow-run=<globs>` limits which targets are runnable, `--protect <globs>`
+requires a `ZUKE_OPERATOR_TOKEN` operator token, and `--confirm-destructive`
+makes a destructive run return its plan until called with `confirm:true`. Every
+mutating or denied call is written to an audit trail
+(`zuke runs show mcp-audit`). `--http <host:port>` serves the streamable-HTTP
+transport instead of stdio (loopback by default; a non-loopback bind requires a
+`ZUKE_MCP_TOKEN` bearer token). `mcp` is a reserved command name. See the full
+guide: [MCP server](./mcp.md).
 
 ## Parallel execution
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -83,19 +83,79 @@ Read tools are always available:
 | `describe_build` | The full build surface — commands, flags, targets, parameters (the `--list --json` payload). |
 | `graph`          | Each target and the targets it depends on.                                                   |
 
+When a [state store](./state.md) resolves, two more read tools appear, so an
+agent can query runs it did not start:
+
+| Tool        | Returns                                                                             |
+| ----------- | ----------------------------------------------------------------------------------- |
+| `list_runs` | Persisted run summaries (optional `status`/`target`/`since` filters), newest first. |
+| `show_run`  | One run's full record — status, per-target progress, signals, and the audit trail.  |
+
 With `--allow-run`, the server also exposes one **`run:<target>`** tool per
-target. Its input schema is built from the build's declared parameters — a
-`required` parameter is required, `.options(...)` becomes an `enum`, a
-`.number()` is typed as a number — plus a `dryRun` flag that plans without
-executing. These tools carry MCP's `destructiveHint` annotation so a client can
-prompt before running. A run resolves parameters exactly like the CLI (MCP
-argument → the environment → the declared default) and returns the target's
-captured output with a pass/fail marker.
+target (subject to the [allow-list](#authorization)). Its input schema is built
+from the build's declared parameters — a `required` parameter is required,
+`.options(...)` becomes an `enum`, a `.number()` is typed as a number — plus a
+`dryRun` flag that plans without executing. A run tool carries MCP's
+`destructiveHint` by default, or `readOnlyHint` when the target declares
+[`.readOnly()`](./authoring.md); a client can prompt accordingly. A run resolves
+parameters exactly like the CLI (MCP argument → the environment → the declared
+default) and returns the target's captured output with a pass/fail marker.
+
+With `--allow-run` a store also exposes two **mutating** run-state tools:
+`signal_run` (deliver an external signal and resume a suspended run,
+exactly-once) and `resume_check` (re-check suspended runs — predicate waits and
+timeouts). They are the MCP counterparts of `zuke resume`.
 
 ```jsonc
 // tools/call
 { "name": "run:test", "arguments": { "environment": "dev", "coverage": true } }
 ```
+
+## Authorization
+
+`--allow-run` on its own exposes every target. Three flags tier access from
+there — a spectrum from "inspect only" to "run this, but only with an operator
+token".
+
+- **Allow-list — `--allow-run=<globs>`.** Only targets matching the comma-glob
+  list (`deploy,checks*`) are exposed as run tools; every other target is
+  **invisible**, and a call to one is answered exactly like a call to a
+  nonexistent tool (`Unknown tool: run:<name>`) — so a denial never reveals
+  which protected targets exist.
+- **Operator token — `--protect <globs>` + `ZUKE_OPERATOR_TOKEN`.** A matching
+  target's run tool gains a required `operatorToken` argument, checked (in
+  constant time) against `ZUKE_OPERATOR_TOKEN`. This is **fail-closed**: if no
+  token is configured, every protected target is denied, so a misconfigured
+  server can never silently expose one. A denial is a structured
+  `{"error": "unauthorized", …}` result, and the token is never written to the
+  audit log or any output.
+- **Confirmation — `--confirm-destructive`.** A destructive run tool (any target
+  that is not `.readOnly()`) called without `confirm: true` returns its resolved
+  **plan** instead of executing, prompting the caller to re-send with
+  `confirm: true`. One round-trip, no server-side state; a `dryRun` skips the
+  gate, and read-only targets are exempt.
+
+```sh
+# Expose everything to run, but gate promoteToProd behind an operator token
+# and make every destructive run confirm first:
+ZUKE_OPERATOR_TOKEN=… zuke mcp --http 7777 \
+  --allow-run --protect promoteToProd --confirm-destructive
+```
+
+## Audit log
+
+With a store configured, **every mutating or denied tool call** (`run:<target>`,
+`signal_run`, `resume_check`) is appended to an audit trail: the time, the tool,
+the resolved **actor**, the outcome (`ok` / `denied` / `error`), and the call's
+arguments. Arguments are **redacted** — the operator token is dropped and every
+`.secret()` parameter's value is masked — before anything is persisted.
+
+The trail lives in a store-level record; read it with `zuke runs show mcp-audit`
+(or the `show_run` tool). The actor resolves by precedence: `--actor` →
+`ZUKE_ACTOR` → the CI actor → the connecting client's `initialize` name →
+`"anonymous"`. The client name is an **untrusted label** for the trail only — it
+never influences authorization. On a shared HTTP endpoint it reflects the most
+recent client to connect, so set `--actor` for authoritative attribution there.
 
 ## Safety
 
@@ -110,15 +170,15 @@ like any other local developer tool and don't wire an untrusted client to it.
 
 Running a target executes real build code, so execution is **off by default**: a
 freshly-connected agent can only _inspect_ the build. Add `--allow-run`
-deliberately — for an environment where you want the agent to drive the
-pipeline. Without it, the `run:` tools are not advertised at all, and a direct
-`run:` call is refused with a message pointing at the flag. When enabled, run
-tools carry MCP's `destructiveHint`, so a well-behaved client can prompt before
-each execution.
+deliberately, and tier it with the [authorization](#authorization) flags — an
+allow-list, an operator token, and confirmation — for anything beyond a trusted
+local session. Without `--allow-run`, the `run:` tools are not advertised at
+all, and a direct `run:` call is refused with a message pointing at the flag.
 
 Secret values stay protected: a run's output is captured through the same
 reporter pipeline as the console, so `parameter().secret()` values are
-[redacted](./secrets.md) from what the agent sees.
+[redacted](./secrets.md) from what the agent sees — and a secret passed as a
+tool argument is masked in the [audit log](#audit-log) too.
 
 ## Protocol notes
 
@@ -130,4 +190,10 @@ reporter pipeline as the console, so `parameter().secret()` values are
   `-32601 Method not found`; notifications never get a reply.
 - **Errors:** a bad _tool_ call (unknown tool, unknown target, a failed run) is
   reported through the tool result (`isError: true`) so the model sees it,
-  rather than as a transport-level error — matching the MCP convention.
+  rather than as a transport-level error — matching the MCP convention. Typed
+  failures — an authorization denial, a lock conflict, a lost resume race
+  (`AlreadyResumedError`) — come back as **structured JSON** in the result
+  (`{"error": "…", …}`), so an agent can relay actionable next steps.
+- **Concurrency:** messages are processed one at a time (see the
+  [HTTP transport](#http-transport)), so a shared server never runs two calls at
+  once.

--- a/docs/state.md
+++ b/docs/state.md
@@ -89,6 +89,12 @@ finish, and when the run ends. So if the process is killed mid-run, the record
 on disk shows the target that was executing as `running`, with its `startedAt`
 stamped.
 
+A record also carries an append-only `events` array — the **audit trail** of
+[MCP](./mcp.md) tool calls against the run (time, tool, actor, outcome, redacted
+args). It is empty for a plain run and populated by the MCP server;
+`zuke runs
+show` prints it.
+
 ## Per-target state — `ctx.state`
 
 `ctx.state` ([run context](./run-context.md)) is a small durable key/value store

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1093,6 +1093,8 @@ class TargetBuilder
     Run even after the build has failed (set by {@link always}).
   unlisted_: boolean
     Hide this target from `--list`/`--help` (set by {@link unlisted}).
+  readOnly_: boolean
+    Advertise this target as query-only over MCP (set by {@link readOnly}).
   readonly cacheKeys_: Array<() => string | Promise<string>>
     Extra cache-key contributors beyond input files (set by {@link cacheKey}).
   readonly produces_: string[]
@@ -1169,6 +1171,12 @@ class TargetBuilder
     still reports failure, and this target's own dependents are skipped.
   unlisted(): this
     Hide this target from `--list` and `--help` (it can still be run by name).
+  readOnly(): this
+    Mark this target query-only for MCP: its `run:` tool advertises MCP's
+    `readOnlyHint` instead of the default `destructiveHint`, and it is exempt
+    from `--confirm-destructive`. A hint about intent only — the target still
+    runs its real body — so declare it on targets that inspect rather than
+    mutate (a status check, a report).
   always(): this
     Run this target even after the build has failed — for cleanup/teardown that
     must happen regardless. It still waits for its own dependencies to complete;
@@ -2131,6 +2139,25 @@ interface ResumeWhenOptions
   interval?: string | number
     How often `zuke resume --check` should re-evaluate the predicate.
 
+interface RunEvent
+  One entry in a run's audit trail: an MCP tool call, who made it, and how it
+  ended. Appended (never mutated) so the trail is a chronological record. The
+  MCP server records a {@link RunEvent} for every mutating or denied tool call;
+  `zuke runs show` prints them.
+
+  at: string
+    ISO-8601 time the call was recorded.
+  tool: string
+    The tool called (e.g. `run:deploy`, `signal_run`).
+  actor: string
+    Who made the call (a resolved actor; see {@link "./record.ts".resolveActor}).
+  outcome: RunEventOutcome
+    Whether the call ran, was denied by authorization, or errored.
+  args: Record<string, string>
+    The call's arguments, redacted — secret values masked, tokens dropped.
+  detail?: string
+    A short, redacted human detail (e.g. a denial reason), when present.
+
 interface RunGraphNode
   One entry of a run's graph-shape snapshot.
 
@@ -2187,6 +2214,8 @@ interface RunRecord
     Per-target progress, keyed by dotted target name.
   signals: Record<string, SignalRecord>
     External signals received so far, keyed by name (see `.waitsFor(...)`).
+  events: RunEvent[]
+    Append-only audit trail of MCP tool calls against this run (see {@link RunEvent}).
 
 interface RunSummary
   A compact run listing row, returned by {@link "./store.ts".StateStore.listRuns}.
@@ -2494,6 +2523,9 @@ type PathLike = string | AbsolutePath
 
 type PutResult = { ok: true; version: string; } | { ok: false; conflict: true; }
   The result of a {@link StateStore.putRun} compare-and-swap write.
+
+type RunEventOutcome = "ok" | "denied" | "error"
+  The outcome recorded for an audited MCP tool call (see {@link RunEvent}).
 
 type RunStatus = "running" | "suspended" | "succeeded" | "failed" | "cancelled"
   The lifecycle status of a whole run.

--- a/llms.txt
+++ b/llms.txt
@@ -69,7 +69,9 @@ Option flags:
 - `--status` — With runs list, keep only runs with this status
 - `--target` — With runs list, keep only runs whose graph has this target
 - `--since` — With runs list, keep only runs created at/after this time
-- `--allow-run` — With mcp, let agents execute targets (not just inspect)
+- `--allow-run` — With mcp, let agents run targets (optional =<glob-list> allow-list)
+- `--protect` — With mcp, require an operator token to run these targets
+- `--confirm-destructive` — With mcp, require confirm:true before a destructive run
 - `--http` — With mcp, serve over HTTP on <host:port> instead of stdio
 - `--help` — Show usage
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1147,6 +1147,8 @@ class TargetBuilder
     Run even after the build has failed (set by {@link always}).
   unlisted_: boolean
     Hide this target from `--list`/`--help` (set by {@link unlisted}).
+  readOnly_: boolean
+    Advertise this target as query-only over MCP (set by {@link readOnly}).
   readonly cacheKeys_: Array<() => string | Promise<string>>
     Extra cache-key contributors beyond input files (set by {@link cacheKey}).
   readonly produces_: string[]
@@ -1223,6 +1225,12 @@ class TargetBuilder
     still reports failure, and this target's own dependents are skipped.
   unlisted(): this
     Hide this target from `--list` and `--help` (it can still be run by name).
+  readOnly(): this
+    Mark this target query-only for MCP: its `run:` tool advertises MCP's
+    `readOnlyHint` instead of the default `destructiveHint`, and it is exempt
+    from `--confirm-destructive`. A hint about intent only — the target still
+    runs its real body — so declare it on targets that inspect rather than
+    mutate (a status check, a report).
   always(): this
     Run this target even after the build has failed — for cleanup/teardown that
     must happen regardless. It still waits for its own dependencies to complete;
@@ -2185,6 +2193,25 @@ interface ResumeWhenOptions
   interval?: string | number
     How often `zuke resume --check` should re-evaluate the predicate.
 
+interface RunEvent
+  One entry in a run's audit trail: an MCP tool call, who made it, and how it
+  ended. Appended (never mutated) so the trail is a chronological record. The
+  MCP server records a {@link RunEvent} for every mutating or denied tool call;
+  `zuke runs show` prints them.
+
+  at: string
+    ISO-8601 time the call was recorded.
+  tool: string
+    The tool called (e.g. `run:deploy`, `signal_run`).
+  actor: string
+    Who made the call (a resolved actor; see {@link "./record.ts".resolveActor}).
+  outcome: RunEventOutcome
+    Whether the call ran, was denied by authorization, or errored.
+  args: Record<string, string>
+    The call's arguments, redacted — secret values masked, tokens dropped.
+  detail?: string
+    A short, redacted human detail (e.g. a denial reason), when present.
+
 interface RunGraphNode
   One entry of a run's graph-shape snapshot.
 
@@ -2241,6 +2268,8 @@ interface RunRecord
     Per-target progress, keyed by dotted target name.
   signals: Record<string, SignalRecord>
     External signals received so far, keyed by name (see `.waitsFor(...)`).
+  events: RunEvent[]
+    Append-only audit trail of MCP tool calls against this run (see {@link RunEvent}).
 
 interface RunSummary
   A compact run listing row, returned by {@link "./store.ts".StateStore.listRuns}.
@@ -2548,6 +2577,9 @@ type PathLike = string | AbsolutePath
 
 type PutResult = { ok: true; version: string; } | { ok: false; conflict: true; }
   The result of a {@link StateStore.putRun} compare-and-swap write.
+
+type RunEventOutcome = "ok" | "denied" | "error"
+  The outcome recorded for an audited MCP tool call (see {@link RunEvent}).
 
 type RunStatus = "running" | "suspended" | "succeeded" | "failed" | "cancelled"
   The lifecycle status of a whole run.

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -131,6 +131,8 @@ export {
 } from "./src/state/lock.ts";
 export { parseDuration } from "./src/duration.ts";
 export {
+  type RunEvent,
+  type RunEventOutcome,
   type RunGraphNode,
   type RunQuery,
   type RunRecord,

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -88,6 +88,12 @@ export interface ParsedArgs {
   mcp: boolean;
   /** Allow `mcp` to execute targets, not just inspect them (`--allow-run`). */
   allowRun: boolean;
+  /** Restrict `mcp` run tools to targets matching these globs (`--allow-run=<list>`). */
+  allowRunPatterns?: string[];
+  /** Targets whose `mcp` run tool needs an operator token (`--protect <list>`). */
+  protectPatterns?: string[];
+  /** Require `confirm:true` before a destructive `mcp` run (`--confirm-destructive`). */
+  confirmDestructive: boolean;
   /** Serve `mcp` over HTTP on this `<host:port>` instead of stdio (`--http`). */
   httpAddr?: string;
   /** The `completions` sub-action (`install` or `print`); the first positional. */
@@ -178,6 +184,7 @@ export function parseArgs(
     resume: false,
     forceGraph: false,
     runs: false,
+    confirmDestructive: false,
     help: false,
   };
   const byFlag = new Map<string, ParamFlag>();
@@ -240,6 +247,16 @@ export function parseArgs(
       parsed.check = true;
     } else if (arg === "--allow-run") {
       parsed.allowRun = true;
+    } else if (arg.startsWith("--allow-run=")) {
+      parsed.allowRun = true;
+      parsed.allowRunPatterns = splitList(arg.slice("--allow-run=".length));
+    } else if (arg === "--protect") {
+      const value = args[++i];
+      if (value) parsed.protectPatterns = splitList(value);
+    } else if (arg.startsWith("--protect=")) {
+      parsed.protectPatterns = splitList(arg.slice("--protect=".length));
+    } else if (arg === "--confirm-destructive") {
+      parsed.confirmDestructive = true;
     } else if (arg === "--http") {
       const value = args[++i];
       if (value) parsed.httpAddr = value;
@@ -370,8 +387,15 @@ Options:
                     targets to AI agents as typed tools. Read-only by default
                     (inspect the targets, parameters, and graph); add
                     --allow-run to let agents execute targets too.
-  --allow-run       With mcp, allow agents to execute targets, not just
-                    inspect them.
+  --allow-run[=<globs>]
+                    With mcp, allow agents to execute targets (not just inspect
+                    them). An optional =<comma,globs> allow-list exposes only the
+                    matching targets as run tools; others are invisible.
+  --protect <globs> With mcp, require an operator token (ZUKE_OPERATOR_TOKEN) as
+                    a tool-call argument to run the matching targets.
+  --confirm-destructive
+                    With mcp, make a destructive run tool return its plan unless
+                    called with confirm:true (a .readOnly() target is exempt).
   --http <host:port>
                     With mcp, serve the streamable-HTTP transport on the given
                     address instead of stdio. Just <port> binds 127.0.0.1. A
@@ -620,6 +644,13 @@ async function runResume(build: Build, parsed: ParsedArgs): Promise<number> {
   }
 }
 
+/** Split a comma-separated flag value into trimmed, non-empty entries. */
+function splitList(value: string): string[] {
+  return value.split(",").map((entry) => entry.trim()).filter((entry) =>
+    entry !== ""
+  );
+}
+
 /** Parse a `--http` value: `<port>` (binds 127.0.0.1) or `<host:port>`. */
 function parseHttpAddress(raw: string): HttpAddress {
   const colon = raw.lastIndexOf(":");
@@ -644,7 +675,13 @@ async function runMcp(build: Build, parsed: ParsedArgs): Promise<number> {
       return 1;
     }
   }
-  return await serveMcp(build, { allowRun: parsed.allowRun, http });
+  return await serveMcp(build, {
+    allowRun: parsed.allowRun,
+    allowRunPatterns: parsed.allowRunPatterns,
+    protectPatterns: parsed.protectPatterns,
+    confirmDestructive: parsed.confirmDestructive,
+    http,
+  });
 }
 
 /** Run the `runs` command: build the query (validating `--status`) and dispatch. */

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -680,6 +680,7 @@ async function runMcp(build: Build, parsed: ParsedArgs): Promise<number> {
     allowRunPatterns: parsed.allowRunPatterns,
     protectPatterns: parsed.protectPatterns,
     confirmDestructive: parsed.confirmDestructive,
+    actor: parsed.actor,
     http,
   });
 }

--- a/packages/core/src/cli_spec.ts
+++ b/packages/core/src/cli_spec.ts
@@ -131,7 +131,16 @@ export const BUILTIN_FLAGS: readonly BuiltinFlag[] = [
   },
   {
     name: "--allow-run",
-    description: "With mcp, let agents execute targets (not just inspect)",
+    description:
+      "With mcp, let agents run targets (optional =<glob-list> allow-list)",
+  },
+  {
+    name: "--protect",
+    description: "With mcp, require an operator token to run these targets",
+  },
+  {
+    name: "--confirm-destructive",
+    description: "With mcp, require confirm:true before a destructive run",
   },
   {
     name: "--http",

--- a/packages/core/src/mcp/audit.ts
+++ b/packages/core/src/mcp/audit.ts
@@ -1,0 +1,63 @@
+/**
+ * The MCP audit log: a store-level, append-only trail of tool calls kept in a
+ * single fixed-id run record, so it needs no new {@link
+ * "../state/store.ts".StateStore} method — it rides the same CAS-append path as
+ * any run record, through {@link "../state/writer.ts".RunStateWriter.appendEvent}.
+ *
+ * ponytail: reuses one run record as the audit stream, so it shows up in
+ * `zuke runs list` (and `zuke runs show mcp-audit` prints the trail — handy) and
+ * grows unbounded. Fine for the dev-grade filesystem backend. Upgrade path if it
+ * grows large or a hosted operator wants it separate: a dedicated store-level
+ * stream (a new StateStore method + an `/audit` REST resource) instead of a run
+ * record.
+ *
+ * @module
+ */
+
+import type { Redactor } from "../redact.ts";
+import type { RunRecord } from "../state/types.ts";
+import type { StateStore } from "../state/store.ts";
+import { RunStateWriter } from "../state/writer.ts";
+
+/** The fixed run id under which the MCP audit trail is stored. */
+export const AUDIT_RUN_ID = "mcp-audit";
+
+/**
+ * Open (or seed) the audit-log writer over `store`: adopt the existing audit
+ * record at its current version, or create a fresh one. Callers append with
+ * {@link "../state/writer.ts".RunStateWriter.appendEvent}; the writer serialises
+ * appends and CAS-retries on cross-process conflict.
+ */
+export async function openAuditLog(
+  store: StateStore,
+  now: () => string,
+  redactor: Redactor,
+  warn?: (message: string) => void,
+): Promise<RunStateWriter> {
+  const existing = await store.getRun(AUDIT_RUN_ID);
+  if (existing !== null) {
+    return RunStateWriter.adopt(
+      store,
+      existing.record,
+      existing.version,
+      now,
+      redactor,
+      warn,
+    );
+  }
+  const record: RunRecord = {
+    id: AUDIT_RUN_ID,
+    build: "(mcp)",
+    rootTarget: "(audit)",
+    status: "running",
+    actor: "system",
+    createdAt: now(),
+    updatedAt: now(),
+    graph: [],
+    params: {},
+    targets: {},
+    signals: {},
+    events: [],
+  };
+  return await RunStateWriter.open(store, record, now, redactor, warn);
+}

--- a/packages/core/src/mcp/authz.ts
+++ b/packages/core/src/mcp/authz.ts
@@ -1,0 +1,37 @@
+/**
+ * Authorization helpers for the MCP server: a glob-based target allow-list
+ * matcher and a constant-time token comparison. Shared by the HTTP transport
+ * (bearer token) and the server (operator token), so both token checks use one
+ * primitive.
+ *
+ * @module
+ */
+
+import { globToRegExp } from "../glob.ts";
+
+/**
+ * Constant-time string comparison, so token validation does not leak the token
+ * through response timing. The length is compared first (a length difference is
+ * not itself sensitive), then every character regardless of early mismatches.
+ */
+export function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+/**
+ * Build a predicate matching a target name against `patterns`, each a glob
+ * (`deploy`, `checks*`; `*` matches any run of non-`/` characters, so it spans
+ * the dots in a dotted target name). `undefined` matches **everything** — the
+ * historical "all targets" behaviour of a bare `--allow-run`; an empty list
+ * matches nothing.
+ */
+export function targetMatcher(
+  patterns: readonly string[] | undefined,
+): (name: string) => boolean {
+  if (patterns === undefined) return () => true;
+  const regexps = patterns.map((pattern) => globToRegExp(pattern));
+  return (name) => regexps.some((regexp) => regexp.test(name));
+}

--- a/packages/core/src/mcp/command.ts
+++ b/packages/core/src/mcp/command.ts
@@ -6,6 +6,10 @@
  */
 
 import type { Build } from "../build.ts";
+import { absolutePath } from "../path.ts";
+import { findConfigDir, pathExists } from "../config.ts";
+import { defaultStateHost, type StateStore } from "../state/store.ts";
+import { resolveStateStore } from "../state/resolve.ts";
 import { type ByteWriter, serveStdio } from "./jsonrpc.ts";
 import { serveHttp } from "./http.ts";
 import { McpServer, type McpServerOptions } from "./server.ts";
@@ -52,6 +56,22 @@ function isLoopback(host: string): boolean {
   return host === "127.0.0.1" || host === "::1" || host === "localhost";
 }
 
+/** Resolve the store for MCP — like a run, always defaulting on so run tools work. */
+function resolveMcpStore(
+  build: Build,
+  option: StateStore | undefined,
+  readEnv: (name: string) => string | undefined,
+): StateStore | undefined {
+  return resolveStateStore(option, build.stateStore(), {
+    readEnv,
+    host: defaultStateHost,
+    defaultDir: absolutePath(
+      findConfigDir(Deno.cwd(), pathExists) ?? Deno.cwd(),
+    )(".zuke", "runs").path,
+    enableDefault: true,
+  });
+}
+
 /**
  * Serve the build over MCP. Without {@link ServeMcpOptions.http} it runs on
  * stdin/stdout until the input stream closes; with it, over HTTP until the
@@ -62,7 +82,15 @@ export async function serveMcp(
   build: Build,
   options: ServeMcpOptions = {},
 ): Promise<number> {
-  const server = new McpServer(build, options);
+  const readEnv = options.readEnv ?? defaultReadEnv;
+  // Resolve the durable store (so the run tools work) and the operator token
+  // once, then hand them to the server alongside the caller's options.
+  const server = new McpServer(build, {
+    ...options,
+    readEnv,
+    stateStore: resolveMcpStore(build, options.stateStore, readEnv),
+    operatorToken: options.operatorToken ?? readEnv("ZUKE_OPERATOR_TOKEN"),
+  });
   if (options.http !== undefined) {
     return await serveMcpHttp(server, options.http, options);
   }

--- a/packages/core/src/mcp/http.ts
+++ b/packages/core/src/mcp/http.ts
@@ -25,6 +25,7 @@ import {
   type JsonRpcResponse,
   PARSE_ERROR,
 } from "./jsonrpc.ts";
+import { timingSafeEqual } from "./authz.ts";
 
 /** Options for {@link serveHttp}. */
 export interface HttpTransportOptions {
@@ -50,18 +51,6 @@ function jsonResponse(body: unknown, status: number): Response {
     status,
     headers: { "content-type": "application/json" },
   });
-}
-
-/**
- * Constant-time string comparison, so token validation does not leak the token
- * through response timing. The length is compared first (a length difference is
- * not itself sensitive), then every character regardless of early mismatches.
- */
-function safeEqual(a: string, b: string): boolean {
-  if (a.length !== b.length) return false;
-  let diff = 0;
-  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
-  return diff === 0;
 }
 
 /**
@@ -117,7 +106,7 @@ export async function serveHttp(
     }
     if (token !== undefined && token !== "") {
       const provided = bearerToken(request.headers.get("authorization"));
-      if (provided === undefined || !safeEqual(provided, token)) {
+      if (provided === undefined || !timingSafeEqual(provided, token)) {
         return new Response(
           JSON.stringify(err(null, INVALID_REQUEST, "Unauthorized")),
           {

--- a/packages/core/src/mcp/runtools.ts
+++ b/packages/core/src/mcp/runtools.ts
@@ -33,6 +33,15 @@ export interface RunToolDeps {
   actor?: string;
   /** Reads an environment variable (secrets re-resolve from here on a resume). */
   readEnv: (name: string) => string | undefined;
+  /**
+   * Authorize resuming a run whose root target is `targetName`, applying the
+   * same allow-list and operator-token gates as a `run:` tool (a resume runs
+   * that target's code). Returns a denial reason, or `null` when allowed.
+   */
+  authorize: (
+    targetName: string,
+    args: Record<string, unknown>,
+  ) => string | null;
 }
 
 /** A run-state tool's rendered result: JSON text plus the MCP error flag. */
@@ -98,6 +107,11 @@ const MUTATING_TOOLS: readonly McpTool[] = [
           description: "The external signal name to deliver.",
         },
         data: { description: "The signal's JSON payload (optional)." },
+        operatorToken: {
+          type: "string",
+          description:
+            "Operator token, required if the run's target is protected.",
+        },
       },
       required: ["runId"],
     },
@@ -112,7 +126,12 @@ const MUTATING_TOOLS: readonly McpTool[] = [
       properties: {
         runId: {
           type: "string",
-          description: "A single run to check; omit to sweep every suspended run.",
+          description:
+            "A single run to check; omit to sweep every suspended run.",
+        },
+        operatorToken: {
+          type: "string",
+          description: "Operator token, required for protected targets.",
         },
       },
     },
@@ -125,9 +144,7 @@ const MUTATING_TOOLS: readonly McpTool[] = [
  * when `includeMutating` (i.e. execution is enabled).
  */
 export function runStateToolDefs(includeMutating: boolean): McpTool[] {
-  return includeMutating
-    ? [...READ_TOOLS, ...MUTATING_TOOLS]
-    : [...READ_TOOLS];
+  return includeMutating ? [...READ_TOOLS, ...MUTATING_TOOLS] : [...READ_TOOLS];
 }
 
 /** The name of every run-state tool, for dispatch and audit classification. */
@@ -142,7 +159,10 @@ export function isMutatingRunTool(name: string): boolean {
 }
 
 /** Read an optional string argument, or `undefined` when absent/not a string. */
-function stringArg(args: Record<string, unknown>, key: string): string | undefined {
+function stringArg(
+  args: Record<string, unknown>,
+  key: string,
+): string | undefined {
   const value = args[key];
   return typeof value === "string" ? value : undefined;
 }
@@ -156,7 +176,12 @@ function jsonResult(value: unknown, isError = false): RunToolResult {
 function structuredError(error: unknown, runId: string): RunToolResult {
   if (error instanceof AlreadyResumedError) {
     return jsonResult(
-      { error: "already_resumed", runId: error.runId, by: error.by, at: error.at },
+      {
+        error: "already_resumed",
+        runId: error.runId,
+        by: error.by,
+        at: error.at,
+      },
       true,
     );
   }
@@ -232,6 +257,14 @@ async function signalRun(
   if (runId === undefined) {
     return jsonResult({ error: "missing_argument", argument: "runId" }, true);
   }
+  // A resume runs the run's target code, so it is gated by the same allow-list
+  // and operator-token policy as a `run:` tool.
+  const loaded = await deps.store.getRun(runId);
+  if (loaded === null) return jsonResult({ error: "no_run", runId }, true);
+  const denied = deps.authorize(loaded.record.rootTarget, args);
+  if (denied !== null) {
+    return jsonResult({ error: "unauthorized", reason: denied, runId }, true);
+  }
   const data: JsonValue | undefined = "data" in args
     ? toJsonValue(args.data ?? null)
     : undefined;
@@ -259,22 +292,46 @@ async function signalRun(
   }
 }
 
-/** `resume_check`: re-check one or all suspended runs. */
+/** `resume_check`: re-check one or all suspended runs the caller may resume. */
 async function resumeCheckTool(
   deps: RunToolDeps,
   args: Record<string, unknown>,
 ): Promise<RunToolResult> {
   const runId = stringArg(args, "runId");
-  try {
-    const { checked, failed } = await resumeCheck(deps.build, {
-      runId,
-      stateStore: deps.store,
-      actor: deps.actor,
-      readEnv: deps.readEnv,
-      silent: true,
-    });
-    return jsonResult({ ok: failed === 0, checked, failed });
-  } catch (error) {
-    return structuredError(error, runId ?? "(all)");
+  // Resolve the candidate runs, then keep only those the caller is authorised to
+  // resume (same allow-list/operator-token gate as a run). A single-id request
+  // that is denied errors; a sweep silently skips runs it may not touch.
+  let candidates: string[];
+  if (runId !== undefined) {
+    const loaded = await deps.store.getRun(runId);
+    if (loaded === null) return jsonResult({ error: "no_run", runId }, true);
+    const denied = deps.authorize(loaded.record.rootTarget, args);
+    if (denied !== null) {
+      return jsonResult({ error: "unauthorized", reason: denied, runId }, true);
+    }
+    candidates = [runId];
+  } else {
+    const suspended = await deps.store.listRuns({ status: "suspended" });
+    candidates = suspended
+      .filter((s) => deps.authorize(s.rootTarget, args) === null)
+      .map((s) => s.id);
   }
+  let checked = 0;
+  let failed = 0;
+  for (const id of candidates) {
+    try {
+      const result = await resumeCheck(deps.build, {
+        runId: id,
+        stateStore: deps.store,
+        actor: deps.actor,
+        readEnv: deps.readEnv,
+        silent: true,
+      });
+      checked += result.checked;
+      failed += result.failed;
+    } catch (error) {
+      return structuredError(error, id);
+    }
+  }
+  return jsonResult({ ok: failed === 0, checked, failed });
 }

--- a/packages/core/src/mcp/runtools.ts
+++ b/packages/core/src/mcp/runtools.ts
@@ -1,0 +1,280 @@
+/**
+ * The store-backed MCP tools: `list_runs`/`show_run` (read-only, exposed
+ * whenever a state store resolves) and `signal_run`/`resume_check` (mutating,
+ * gated like the `run:` tools). They are thin wrappers over the same durable
+ * surfaces the CLI uses — `StateStore.listRuns`/`getRun` and
+ * `resumeRun`/`resumeCheck` — so a remote agent can query and advance runs it
+ * did not start. Typed failures (a lost resume race, a lock conflict) come back
+ * as structured JSON tool results rather than flattened strings.
+ *
+ * @module
+ */
+
+import type { Build } from "../build.ts";
+import { AlreadyResumedError, resumeCheck, resumeRun } from "../resume.ts";
+import { LockConflictError } from "../state/lock.ts";
+import type { StateStore } from "../state/store.ts";
+import {
+  isRunStatus,
+  RUN_STATUS_NAMES,
+  type RunQuery,
+  toJsonValue,
+} from "../state/types.ts";
+import type { JsonValue } from "../target.ts";
+import type { McpTool } from "./server.ts";
+
+/** What a run-state tool needs to reach the durable surfaces. */
+export interface RunToolDeps {
+  /** The resolved state store the tools read and write. */
+  store: StateStore;
+  /** The build, re-instantiated per run, for `signal_run`/`resume_check`. */
+  build: Build;
+  /** The actor to attribute a resume to (already resolved). */
+  actor?: string;
+  /** Reads an environment variable (secrets re-resolve from here on a resume). */
+  readEnv: (name: string) => string | undefined;
+}
+
+/** A run-state tool's rendered result: JSON text plus the MCP error flag. */
+export interface RunToolResult {
+  /** The JSON (or message) text block returned to the client. */
+  text: string;
+  /** Whether the call is reported to the model as an error. */
+  isError: boolean;
+}
+
+/** The read-only run-state tools, always exposed when a store resolves. */
+const READ_TOOLS: readonly McpTool[] = [
+  {
+    name: "list_runs",
+    description:
+      "List persisted runs (newest first). Optional filters: status, target, since (ISO-8601).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        status: {
+          type: "string",
+          description: `Filter by run status (${RUN_STATUS_NAMES.join(", ")}).`,
+        },
+        target: {
+          type: "string",
+          description: "Keep only runs whose graph contains this target.",
+        },
+        since: {
+          type: "string",
+          description: "Keep only runs created at/after this ISO-8601 time.",
+        },
+      },
+    },
+    annotations: { readOnlyHint: true },
+  },
+  {
+    name: "show_run",
+    description:
+      "Show one run's full record: status, parameters, per-target progress, signals, and audit trail.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        runId: { type: "string", description: "The run id to show." },
+      },
+      required: ["runId"],
+    },
+    annotations: { readOnlyHint: true },
+  },
+];
+
+/** The mutating run-state tools, exposed only when execution is enabled. */
+const MUTATING_TOOLS: readonly McpTool[] = [
+  {
+    name: "signal_run",
+    description:
+      "Deliver an external signal to a suspended run and resume it (exactly-once).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        runId: { type: "string", description: "The suspended run to resume." },
+        signal: {
+          type: "string",
+          description: "The external signal name to deliver.",
+        },
+        data: { description: "The signal's JSON payload (optional)." },
+      },
+      required: ["runId"],
+    },
+    annotations: { title: "Signal run", destructiveHint: true },
+  },
+  {
+    name: "resume_check",
+    description:
+      "Re-check suspended runs (predicate waits, timeouts). Omit runId to sweep all.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        runId: {
+          type: "string",
+          description: "A single run to check; omit to sweep every suspended run.",
+        },
+      },
+    },
+    annotations: { title: "Resume check", destructiveHint: true },
+  },
+];
+
+/**
+ * The run-state tool definitions: the read tools always, plus the mutating ones
+ * when `includeMutating` (i.e. execution is enabled).
+ */
+export function runStateToolDefs(includeMutating: boolean): McpTool[] {
+  return includeMutating
+    ? [...READ_TOOLS, ...MUTATING_TOOLS]
+    : [...READ_TOOLS];
+}
+
+/** The name of every run-state tool, for dispatch and audit classification. */
+export const RUN_STATE_TOOL_NAMES: readonly string[] = [
+  ...READ_TOOLS,
+  ...MUTATING_TOOLS,
+].map((t) => t.name);
+
+/** Whether `name` is one of the mutating run-state tools (audited, gated). */
+export function isMutatingRunTool(name: string): boolean {
+  return name === "signal_run" || name === "resume_check";
+}
+
+/** Read an optional string argument, or `undefined` when absent/not a string. */
+function stringArg(args: Record<string, unknown>, key: string): string | undefined {
+  const value = args[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+/** Render a value as a pretty-printed JSON tool result. */
+function jsonResult(value: unknown, isError = false): RunToolResult {
+  return { text: JSON.stringify(value, null, 2), isError };
+}
+
+/** Turn a typed failure into structured JSON content (never a flattened string). */
+function structuredError(error: unknown, runId: string): RunToolResult {
+  if (error instanceof AlreadyResumedError) {
+    return jsonResult(
+      { error: "already_resumed", runId: error.runId, by: error.by, at: error.at },
+      true,
+    );
+  }
+  if (error instanceof LockConflictError) {
+    return jsonResult(
+      { error: "lock_conflict", holder: error.holder, guidance: error.message },
+      true,
+    );
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  return jsonResult({ error: "run_failed", runId, message }, true);
+}
+
+/**
+ * Dispatch a run-state tool call, or return `null` when `name` is not one. The
+ * caller has already gated the mutating tools behind execution being enabled.
+ */
+export async function callRunStateTool(
+  deps: RunToolDeps,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<RunToolResult | null> {
+  if (name === "list_runs") return await listRuns(deps, args);
+  if (name === "show_run") return await showRun(deps, args);
+  if (name === "signal_run") return await signalRun(deps, args);
+  if (name === "resume_check") return await resumeCheckTool(deps, args);
+  return null;
+}
+
+/** `list_runs`: return the summary array (filtered), newest first. */
+async function listRuns(
+  deps: RunToolDeps,
+  args: Record<string, unknown>,
+): Promise<RunToolResult> {
+  const query: RunQuery = {};
+  const status = stringArg(args, "status");
+  if (status !== undefined) {
+    if (!isRunStatus(status)) {
+      return jsonResult(
+        { error: "invalid_status", status, allowed: RUN_STATUS_NAMES },
+        true,
+      );
+    }
+    query.status = status;
+  }
+  const target = stringArg(args, "target");
+  if (target !== undefined) query.target = target;
+  const since = stringArg(args, "since");
+  if (since !== undefined) query.since = since;
+  return jsonResult(await deps.store.listRuns(query));
+}
+
+/** `show_run`: return one run's full record, or a structured not-found. */
+async function showRun(
+  deps: RunToolDeps,
+  args: Record<string, unknown>,
+): Promise<RunToolResult> {
+  const runId = stringArg(args, "runId");
+  if (runId === undefined) {
+    return jsonResult({ error: "missing_argument", argument: "runId" }, true);
+  }
+  const loaded = await deps.store.getRun(runId);
+  if (loaded === null) return jsonResult({ error: "no_run", runId }, true);
+  return jsonResult(loaded.record);
+}
+
+/** `signal_run`: deliver a signal and resume the run, exactly once. */
+async function signalRun(
+  deps: RunToolDeps,
+  args: Record<string, unknown>,
+): Promise<RunToolResult> {
+  const runId = stringArg(args, "runId");
+  if (runId === undefined) {
+    return jsonResult({ error: "missing_argument", argument: "runId" }, true);
+  }
+  const data: JsonValue | undefined = "data" in args
+    ? toJsonValue(args.data ?? null)
+    : undefined;
+  try {
+    const result = await resumeRun(deps.build, {
+      runId,
+      signal: stringArg(args, "signal"),
+      data,
+      stateStore: deps.store,
+      actor: deps.actor,
+      readEnv: deps.readEnv,
+      silent: true,
+    });
+    if (result.ok) {
+      return jsonResult({
+        ok: true,
+        runId,
+        suspended: result.suspended === true,
+        executed: result.executed,
+      });
+    }
+    return structuredError(result.error, runId);
+  } catch (error) {
+    return structuredError(error, runId);
+  }
+}
+
+/** `resume_check`: re-check one or all suspended runs. */
+async function resumeCheckTool(
+  deps: RunToolDeps,
+  args: Record<string, unknown>,
+): Promise<RunToolResult> {
+  const runId = stringArg(args, "runId");
+  try {
+    const { checked, failed } = await resumeCheck(deps.build, {
+      runId,
+      stateStore: deps.store,
+      actor: deps.actor,
+      readEnv: deps.readEnv,
+      silent: true,
+    });
+    return jsonResult({ ok: failed === 0, checked, failed });
+  } catch (error) {
+    return structuredError(error, runId ?? "(all)");
+  }
+}

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -22,7 +22,20 @@ import { discoverTargets } from "../build.ts";
 import { type AnyParameter, discoverParameters } from "../params.ts";
 import { describeBuildSurface } from "../describe.ts";
 import { execute, type Reporter } from "../executor.ts";
+import { planGraph } from "../graph.ts";
 import type { TargetBuilder } from "../target.ts";
+import { Redactor } from "../redact.ts";
+import { resolveActor } from "../state/record.ts";
+import type { RunEvent, RunEventOutcome } from "../state/types.ts";
+import type { StateStore } from "../state/store.ts";
+import type { RunStateWriter } from "../state/writer.ts";
+import { openAuditLog } from "./audit.ts";
+import { targetMatcher, timingSafeEqual } from "./authz.ts";
+import {
+  callRunStateTool,
+  isMutatingRunTool,
+  runStateToolDefs,
+} from "./runtools.ts";
 import {
   err,
   INVALID_PARAMS,
@@ -71,6 +84,41 @@ export interface McpServerOptions {
    * `zuke mcp --allow-run`.
    */
   allowRun?: boolean;
+  /**
+   * Restrict the exposed `run:` tools to targets matching these globs (from
+   * `--allow-run=a,b*`). `undefined` (a bare `--allow-run`) exposes every
+   * target. A target not matched is not advertised and cannot be run — a call
+   * to it is indistinguishable from a call to a nonexistent tool.
+   */
+  allowRunPatterns?: readonly string[];
+  /**
+   * Targets (globs, from `--protect a,b*`) whose `run:` tool additionally
+   * requires an operator token argument, checked against {@link operatorToken}.
+   */
+  protectPatterns?: readonly string[];
+  /**
+   * The operator token a protected target's call must carry (from
+   * `ZUKE_OPERATOR_TOKEN`). Absent → every protected target is denied
+   * (fail-closed), so a misconfigured server never silently exposes one.
+   */
+  operatorToken?: string;
+  /**
+   * Require an explicit `confirm: true` argument before a destructive target
+   * executes (from `--confirm-destructive`); an unconfirmed call returns the
+   * resolved plan instead of running. Read-only targets are never gated.
+   */
+  confirmDestructive?: boolean;
+  /**
+   * The durable {@link "../state/store.ts".StateStore}. When set, the
+   * store-backed run tools (`list_runs`/`show_run`, and — with {@link allowRun}
+   * — `signal_run`/`resume_check`) are exposed, and every mutating or denied
+   * tool call is written to the audit log.
+   */
+  stateStore?: StateStore;
+  /** Who to attribute audited calls to (`--actor`), highest precedence. */
+  actor?: string;
+  /** Reads an environment variable (injectable for tests). */
+  readEnv?: (name: string) => string | undefined;
   /** The server version reported in `initialize`. Defaults to `"0.0.0"`. */
   version?: string;
 }
@@ -139,6 +187,19 @@ export class McpServer {
   readonly #params: Map<string, AnyParameter>;
   readonly #allowRun: boolean;
   readonly #version: string;
+  /** Matches a target name allowed to run (allow-list glob, or all). */
+  readonly #allowMatch: (name: string) => boolean;
+  /** Matches a target name that needs an operator token to run. */
+  readonly #isProtected: (name: string) => boolean;
+  readonly #operatorToken?: string;
+  readonly #confirmDestructive: boolean;
+  readonly #store?: StateStore;
+  readonly #actor?: string;
+  readonly #readEnv: (name: string) => string | undefined;
+  /** The connecting client's `initialize` name, a low-priority audit actor. */
+  #clientLabel?: string;
+  /** The audit-log writer, opened lazily on the first audited call. */
+  #auditLog?: RunStateWriter;
 
   constructor(
     private readonly build: Build,
@@ -147,7 +208,27 @@ export class McpServer {
     this.#targets = discoverTargets(build);
     this.#params = discoverParameters(build);
     this.#allowRun = options.allowRun ?? false;
+    this.#allowMatch = targetMatcher(options.allowRunPatterns);
+    this.#isProtected = targetMatcher(options.protectPatterns);
+    // An empty protect list means "protect nothing"; targetMatcher(undefined)
+    // matches everything, so map the absent/empty case to a never-match.
+    if (
+      options.protectPatterns === undefined ||
+      options.protectPatterns.length === 0
+    ) {
+      this.#isProtected = () => false;
+    }
+    this.#operatorToken = options.operatorToken;
+    this.#confirmDestructive = options.confirmDestructive ?? false;
+    this.#store = options.stateStore;
+    this.#actor = options.actor;
+    this.#readEnv = options.readEnv ?? (() => undefined);
     this.#version = options.version ?? "0.0.0";
+  }
+
+  /** Whether a `run:<name>` tool is exposed and runnable (allow-list gate). */
+  #isRunnable(name: string): boolean {
+    return this.#allowRun && this.#targets.has(name) && this.#allowMatch(name);
   }
 
   /** The tools advertised to the client, honouring {@link McpServerOptions.allowRun}. */
@@ -174,10 +255,15 @@ export class McpServer {
         annotations: { readOnlyHint: true },
       },
     ];
-    if (this.#allowRun) {
-      for (const [name, target] of this.#targets) {
-        tools.push(this.#runTool(name, target));
-      }
+    for (const [name, target] of this.#targets) {
+      // Only allow-listed targets are advertised; the rest are invisible, so a
+      // client cannot even discover which protected targets exist.
+      if (this.#isRunnable(name)) tools.push(this.#runTool(name, target));
+    }
+    // Store-backed run tools: read tools whenever a store resolves, mutating
+    // ones (signal_run/resume_check) only when execution is enabled.
+    if (this.#store !== undefined) {
+      tools.push(...runStateToolDefs(this.#allowRun));
     }
     return tools;
   }
@@ -195,16 +281,39 @@ export class McpServer {
       type: "boolean",
       description: "Plan without executing any target body.",
     };
+    // A protected target's call must carry the operator token.
+    if (this.#isProtected(name)) {
+      properties.operatorToken = {
+        type: "string",
+        description:
+          "Operator token (ZUKE_OPERATOR_TOKEN) required to run this protected target.",
+      };
+      required.push("operatorToken");
+    }
+    // With --confirm-destructive, a destructive target needs an explicit
+    // confirm:true or it returns its plan instead of running.
+    if (this.#confirmDestructive && !target.readOnly_) {
+      properties.confirm = {
+        type: "boolean",
+        description:
+          "Set true to execute this destructive target; otherwise its plan is returned.",
+      };
+    }
     const description = target.description_
       ? `Run the "${name}" target: ${target.description_}`
       : `Run the "${name}" target.`;
     const schema: JsonSchema = { type: "object", properties };
     if (required.length > 0) schema.required = required;
+    // A target that declares .readOnly() advertises readOnlyHint; everything
+    // else is treated as destructive (the default for a build step).
+    const annotations = target.readOnly_
+      ? { title: `Run ${name}`, readOnlyHint: true }
+      : { title: `Run ${name}`, destructiveHint: true };
     return {
       name: `${RUN_PREFIX}${name}`,
       description,
       inputSchema: schema,
-      annotations: { title: `Run ${name}`, destructiveHint: true },
+      annotations,
     };
   }
 
@@ -250,6 +359,16 @@ export class McpServer {
    * reflects an unsupported version back.
    */
   #initialize(params: unknown): Record<string, unknown> {
+    // Remember the client's self-reported name as a low-priority audit actor.
+    // It is an untrusted label (never an authorization input), and on a shared
+    // HTTP endpoint it reflects the most recent client to connect — set --actor
+    // for authoritative attribution there (see docs/mcp.md).
+    if (
+      isRecord(params) && isRecord(params.clientInfo) &&
+      typeof params.clientInfo.name === "string"
+    ) {
+      this.#clientLabel = params.clientInfo.name;
+    }
     const requested = isRecord(params) &&
         typeof params.protocolVersion === "string"
       ? params.protocolVersion
@@ -291,9 +410,48 @@ export class McpServer {
     if (name.startsWith(RUN_PREFIX)) {
       return await this.#run(id, name.slice(RUN_PREFIX.length), args);
     }
+    const runStateResult = await this.#callRunStateTool(name, args);
+    if (runStateResult !== null) return ok(id, runStateResult);
     // An unknown tool is reported through the result (isError), per MCP, so the
     // model sees it rather than a transport-level failure.
     return ok(id, textResult(`Unknown tool: ${name}`, true));
+  }
+
+  /**
+   * Dispatch a store-backed run tool (`list_runs`/`show_run`/`signal_run`/
+   * `resume_check`), or return `null` when `name` is not one. Mutating tools are
+   * gated behind `--allow-run` and audited; a call to a store tool with no store
+   * configured falls through to the "unknown tool" result.
+   */
+  async #callRunStateTool(
+    name: string,
+    args: Record<string, unknown>,
+  ): Promise<Record<string, unknown> | null> {
+    const store = this.#store;
+    if (store === undefined) return null;
+    const mutating = isMutatingRunTool(name);
+    if (mutating && !this.#allowRun) {
+      return textResult(
+        `${name} changes run state and needs execution enabled — start the ` +
+          "server with `zuke mcp --allow-run`.",
+        true,
+      );
+    }
+    const result = await callRunStateTool(
+      {
+        store,
+        build: this.build,
+        actor: this.#resolveActor(),
+        readEnv: this.#readEnv,
+      },
+      name,
+      args,
+    );
+    if (result === null) return null;
+    if (mutating) {
+      await this.#audit(name, args, result.isError ? "error" : "ok");
+    }
+    return textResult(result.text, result.isError);
   }
 
   /** The three read tools' payloads, as pretty JSON / text. */
@@ -313,13 +471,16 @@ export class McpServer {
     };
   }
 
-  /** Execute a target and return its captured output. */
+  /** Execute a target: enforce the allow-list, protection, and confirmation. */
   async #run(
     id: string | number | null,
     targetName: string,
     args: Record<string, unknown>,
   ): Promise<JsonRpcResponse> {
+    const runName = `${RUN_PREFIX}${targetName}`;
+    // Execution off entirely: a generic message (reveals no specific target).
     if (!this.#allowRun) {
+      await this.#audit(runName, args, "denied", "run_disabled");
       return ok(
         id,
         textResult(
@@ -330,10 +491,51 @@ export class McpServer {
       );
     }
     const root = this.#targets.get(targetName);
-    if (!root) {
-      return ok(id, textResult(`Unknown target: ${targetName}`, true));
+    // A target that is unknown OR not in the allow-list is reported identically,
+    // so a denial never reveals which protected targets exist.
+    if (root === undefined || !this.#allowMatch(targetName)) {
+      await this.#audit(runName, args, "denied", "not_allowed");
+      return ok(id, textResult(`Unknown tool: ${runName}`, true));
     }
+
+    // Protected target: require a valid operator token. Fail-closed — a target
+    // protected with no server-side token configured is always denied.
+    if (this.#isProtected(targetName)) {
+      const denial = this.#checkOperatorToken(args);
+      if (denial !== null) {
+        await this.#audit(runName, args, "denied", denial);
+        return ok(
+          id,
+          textResult(
+            JSON.stringify({ error: "unauthorized", tool: runName, reason: denial }, null, 2),
+            true,
+          ),
+        );
+      }
+    }
+
     const dryRun = args.dryRun === true;
+
+    // Confirmation tiering: a destructive target without confirm:true returns
+    // its resolved plan instead of executing (a dry run needs no confirmation).
+    if (this.#confirmDestructive && !root.readOnly_ && !dryRun && args.confirm !== true) {
+      const plan = planGraph(root).order
+        .map((t) => t.name_)
+        .filter((n): n is string => n !== undefined);
+      return ok(
+        id,
+        textResult(
+          JSON.stringify({
+            status: "confirmation_required",
+            tool: runName,
+            plan,
+            hint: "Re-call with confirm:true to execute.",
+          }, null, 2),
+          false,
+        ),
+      );
+    }
+
     // Coerce each supplied argument to the string form the parameter layer
     // parses (the same path as a CLI flag), rejecting non-scalar JSON so a
     // stray object/array can't be smuggled in as `[object Object]`. The
@@ -349,6 +551,7 @@ export class McpServer {
       else values[paramName] = coerced;
     }
     if (badArgs.length > 0) {
+      await this.#audit(runName, args, "error", "invalid_arguments");
       return ok(
         id,
         textResult(
@@ -368,11 +571,85 @@ export class McpServer {
       reporter: buffer.reporter,
       dryRun,
       github: false,
+      actor: this.#resolveActor(),
+      readEnv: this.#readEnv,
     });
+    await this.#audit(runName, args, result.ok ? "ok" : "error");
     const status = result.ok
       ? `\n\n✔ ${targetName} succeeded.`
       : `\n\n✘ ${targetName} failed.`;
     return ok(id, textResult(buffer.text() + status, !result.ok));
+  }
+
+  /**
+   * Validate a protected target's operator token, returning a denial reason
+   * (for the structured error and audit) or `null` when the token is valid.
+   */
+  #checkOperatorToken(args: Record<string, unknown>): string | null {
+    if (this.#operatorToken === undefined || this.#operatorToken === "") {
+      return "operator_token_unconfigured";
+    }
+    const provided = args.operatorToken;
+    if (typeof provided !== "string") return "missing_operator_token";
+    return timingSafeEqual(provided, this.#operatorToken)
+      ? null
+      : "invalid_operator_token";
+  }
+
+  /** Resolve the actor for audited calls: --actor → env → the client label. */
+  #resolveActor(): string {
+    return resolveActor(this.#actor, this.#readEnv, [this.#clientLabel]);
+  }
+
+  /**
+   * Append a tool call to the audit log (best-effort; never breaks a call).
+   * No-op without a store. `args` are structurally sanitised — the operator
+   * token is dropped and each secret parameter's value is masked — before the
+   * writer's redactor runs as a second layer.
+   */
+  async #audit(
+    tool: string,
+    args: Record<string, unknown>,
+    outcome: RunEventOutcome,
+    detail?: string,
+  ): Promise<void> {
+    const store = this.#store;
+    if (store === undefined) return;
+    const event: RunEvent = {
+      at: new Date().toISOString(),
+      tool,
+      actor: this.#resolveActor(),
+      outcome,
+      args: this.#auditArgs(args),
+    };
+    if (detail !== undefined) event.detail = detail;
+    try {
+      this.#auditLog ??= await openAuditLog(
+        store,
+        () => new Date().toISOString(),
+        new Redactor(),
+      );
+      await this.#auditLog.appendEvent(event);
+    } catch {
+      // Auditing is best-effort: a store hiccup must not fail the tool call.
+    }
+  }
+
+  /** Sanitise tool arguments for the audit log: drop the token, mask secrets. */
+  #auditArgs(args: Record<string, unknown>): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const [key, value] of Object.entries(args)) {
+      if (key === "operatorToken") continue; // never persist the operator token
+      const param = this.#params.get(key);
+      if (param?.secret_) {
+        out[key] = "[redacted]";
+        continue;
+      }
+      out[key] = typeof value === "object" && value !== null
+        ? JSON.stringify(value)
+        : String(value);
+    }
+    return out;
   }
 }
 

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -17,7 +17,7 @@
  * @module
  */
 
-import type { Build } from "../build.ts";
+import type { Build, BuildResult } from "../build.ts";
 import { discoverTargets } from "../build.ts";
 import { type AnyParameter, discoverParameters } from "../params.ts";
 import { describeBuildSurface } from "../describe.ts";
@@ -38,6 +38,7 @@ import {
 } from "./runtools.ts";
 import {
   err,
+  INTERNAL_ERROR,
   INVALID_PARAMS,
   type JsonRpcResponse,
   METHOD_NOT_FOUND,
@@ -343,7 +344,18 @@ export class McpServer {
       case "tools/list":
         return ok(id, { tools: this.tools() });
       case "tools/call":
-        return await this.#callTool(id, params);
+        // Backstop: no tool call may crash the transport. Expected failures are
+        // already structured tool results; this catches anything unforeseen and
+        // returns a JSON-RPC error (generic, so no raw detail can escape).
+        try {
+          return await this.#callTool(id, params);
+        } catch {
+          return err(
+            id,
+            INTERNAL_ERROR,
+            "Internal error handling the tool call",
+          );
+        }
       default:
         // An unknown notification is silently ignored; an unknown request errors.
         if (id === null) return null;
@@ -443,6 +455,8 @@ export class McpServer {
         build: this.build,
         actor: this.#resolveActor(),
         readEnv: this.#readEnv,
+        authorize: (targetName, callArgs) =>
+          this.#authorizeTarget(targetName, callArgs),
       },
       name,
       args,
@@ -507,7 +521,11 @@ export class McpServer {
         return ok(
           id,
           textResult(
-            JSON.stringify({ error: "unauthorized", tool: runName, reason: denial }, null, 2),
+            JSON.stringify(
+              { error: "unauthorized", tool: runName, reason: denial },
+              null,
+              2,
+            ),
             true,
           ),
         );
@@ -518,19 +536,26 @@ export class McpServer {
 
     // Confirmation tiering: a destructive target without confirm:true returns
     // its resolved plan instead of executing (a dry run needs no confirmation).
-    if (this.#confirmDestructive && !root.readOnly_ && !dryRun && args.confirm !== true) {
+    if (
+      this.#confirmDestructive && !root.readOnly_ && !dryRun &&
+      args.confirm !== true
+    ) {
       const plan = planGraph(root).order
         .map((t) => t.name_)
         .filter((n): n is string => n !== undefined);
       return ok(
         id,
         textResult(
-          JSON.stringify({
-            status: "confirmation_required",
-            tool: runName,
-            plan,
-            hint: "Re-call with confirm:true to execute.",
-          }, null, 2),
+          JSON.stringify(
+            {
+              status: "confirmation_required",
+              tool: runName,
+              plan,
+              hint: "Re-call with confirm:true to execute.",
+            },
+            null,
+            2,
+          ),
           false,
         ),
       );
@@ -566,19 +591,51 @@ export class McpServer {
     // Parameters resolve like the CLI: MCP arguments beat the environment beats
     // the declared default, so a value set in the server's environment still
     // applies unless the agent overrides it.
-    const result = await execute(this.build, root, {
-      params: values,
-      reporter: buffer.reporter,
-      dryRun,
-      github: false,
-      actor: this.#resolveActor(),
-      readEnv: this.#readEnv,
-    });
+    // `execute` captures target failures into its result, but can still throw
+    // on a framework error (a build hook or plugin throwing, etc.). Catch it so
+    // a tool call never crashes the transport — and don't echo the raw message,
+    // which bypassed the reporter's redaction.
+    let result: BuildResult;
+    try {
+      result = await execute(this.build, root, {
+        params: values,
+        reporter: buffer.reporter,
+        dryRun,
+        github: false,
+        actor: this.#resolveActor(),
+        readEnv: this.#readEnv,
+      });
+    } catch (error) {
+      await this.#audit(runName, args, "error", "execute_threw");
+      const kind = error instanceof Error ? error.name : "Error";
+      return ok(
+        id,
+        textResult(
+          `${buffer.text()}\n\n✘ ${targetName} errored during execution (${kind}).`,
+          true,
+        ),
+      );
+    }
     await this.#audit(runName, args, result.ok ? "ok" : "error");
     const status = result.ok
       ? `\n\n✔ ${targetName} succeeded.`
       : `\n\n✘ ${targetName} failed.`;
     return ok(id, textResult(buffer.text() + status, !result.ok));
+  }
+
+  /**
+   * Authorize causing target `name` to run — the shared gate for a `run:` tool
+   * and for a resume (`signal_run`/`resume_check`, which re-run the target's
+   * code). Returns a denial reason (allow-list miss or operator-token failure)
+   * or `null` when allowed.
+   */
+  #authorizeTarget(name: string, args: Record<string, unknown>): string | null {
+    if (!this.#allowMatch(name)) return "not_allowed";
+    if (this.#isProtected(name)) {
+      const denial = this.#checkOperatorToken(args);
+      if (denial !== null) return denial;
+    }
+    return null;
   }
 
   /**
@@ -603,9 +660,9 @@ export class McpServer {
 
   /**
    * Append a tool call to the audit log (best-effort; never breaks a call).
-   * No-op without a store. `args` are structurally sanitised — the operator
-   * token is dropped and each secret parameter's value is masked — before the
-   * writer's redactor runs as a second layer.
+   * No-op without a store. `args` are sanitised by {@link "#auditArgs"} first —
+   * the operator token dropped, secret values masked wherever they appear — so
+   * nothing sensitive reaches the durable trail.
    */
   async #audit(
     tool: string,
@@ -635,19 +692,31 @@ export class McpServer {
     }
   }
 
-  /** Sanitise tool arguments for the audit log: drop the token, mask secrets. */
+  /**
+   * Sanitise tool arguments for the audit log: drop the operator token, mask
+   * each secret parameter's value, and — via a redactor seeded from this call's
+   * secret values — mask any secret **echoed into a non-secret argument** too,
+   * so a secret can't slip into the durable trail through another field.
+   */
   #auditArgs(args: Record<string, unknown>): Record<string, string> {
+    const redactor = new Redactor();
+    for (const [key, value] of Object.entries(args)) {
+      if (typeof value !== "string") continue;
+      if (key === "operatorToken" || this.#params.get(key)?.secret_) {
+        redactor.add(value);
+      }
+    }
     const out: Record<string, string> = {};
     for (const [key, value] of Object.entries(args)) {
       if (key === "operatorToken") continue; // never persist the operator token
-      const param = this.#params.get(key);
-      if (param?.secret_) {
+      if (this.#params.get(key)?.secret_) {
         out[key] = "[redacted]";
         continue;
       }
-      out[key] = typeof value === "object" && value !== null
+      const text = typeof value === "object" && value !== null
         ? JSON.stringify(value)
         : String(value);
+      out[key] = redactor.redact(text);
     }
     return out;
   }

--- a/packages/core/src/runs.ts
+++ b/packages/core/src/runs.ts
@@ -206,5 +206,16 @@ export function formatRunDetail(record: RunRecord): string {
     }
   }
 
+  if (record.events.length > 0) {
+    lines.push("", "Audit:");
+    for (const event of record.events) {
+      const detail = event.detail !== undefined ? `  ${event.detail}` : "";
+      lines.push(
+        `  ${event.at}  ${event.tool}  ${event.actor}  ` +
+          `${event.outcome}${detail}`,
+      );
+    }
+  }
+
   return lines.join("\n");
 }

--- a/packages/core/src/state/record.ts
+++ b/packages/core/src/state/record.ts
@@ -31,15 +31,23 @@ export function recordStatusOf(status: TargetStatus): TargetRunStatus {
 }
 
 /**
- * Resolve who a run is attributed to: the explicit `--actor`, then
- * `ZUKE_ACTOR`, then the CI actor (`GITHUB_ACTOR`), else `"anonymous"`. A later
- * milestone widens this to bearer-token and MCP-client identities.
+ * Resolve who a run is attributed to, by precedence: the explicit `--actor`,
+ * then `ZUKE_ACTOR`, then the CI actor (`GITHUB_ACTOR`), then any `extra`
+ * lower-priority candidates (the MCP server passes a connecting client's
+ * `initialize` name here), else `"anonymous"`. `extra` defaults to none, so
+ * existing callers are unaffected.
  */
 export function resolveActor(
   explicit: string | undefined,
   readEnv: (name: string) => string | undefined,
+  extra: readonly (string | undefined)[] = [],
 ): string {
-  const candidates = [explicit, readEnv("ZUKE_ACTOR"), readEnv("GITHUB_ACTOR")];
+  const candidates = [
+    explicit,
+    readEnv("ZUKE_ACTOR"),
+    readEnv("GITHUB_ACTOR"),
+    ...extra,
+  ];
   for (const candidate of candidates) {
     if (candidate !== undefined && candidate !== "") return candidate;
   }
@@ -119,6 +127,7 @@ export function buildRunRecord(input: RunRecordInput): RunRecord {
     params,
     targets,
     signals: {},
+    events: [],
   };
 }
 

--- a/packages/core/src/state/types.ts
+++ b/packages/core/src/state/types.ts
@@ -300,7 +300,11 @@ function parseWaitState(value: unknown): WaitState {
 }
 
 /** All valid {@link RunEventOutcome} values, for validation. */
-const RUN_EVENT_OUTCOMES: readonly RunEventOutcome[] = ["ok", "denied", "error"];
+const RUN_EVENT_OUTCOMES: readonly RunEventOutcome[] = [
+  "ok",
+  "denied",
+  "error",
+];
 
 /** Validate and narrow a {@link RunEvent} (an element of a run's audit trail). */
 function parseRunEvent(value: unknown): RunEvent {

--- a/packages/core/src/state/types.ts
+++ b/packages/core/src/state/types.ts
@@ -47,6 +47,30 @@ export interface SignalRecord {
   receivedAt: string;
 }
 
+/** The outcome recorded for an audited MCP tool call (see {@link RunEvent}). */
+export type RunEventOutcome = "ok" | "denied" | "error";
+
+/**
+ * One entry in a run's audit trail: an MCP tool call, who made it, and how it
+ * ended. Appended (never mutated) so the trail is a chronological record. The
+ * MCP server records a {@link RunEvent} for every mutating or denied tool call;
+ * `zuke runs show` prints them.
+ */
+export interface RunEvent {
+  /** ISO-8601 time the call was recorded. */
+  at: string;
+  /** The tool called (e.g. `run:deploy`, `signal_run`). */
+  tool: string;
+  /** Who made the call (a resolved actor; see {@link "./record.ts".resolveActor}). */
+  actor: string;
+  /** Whether the call ran, was denied by authorization, or errored. */
+  outcome: RunEventOutcome;
+  /** The call's arguments, **redacted** — secret values masked, tokens dropped. */
+  args: Record<string, string>;
+  /** A short, redacted human detail (e.g. a denial reason), when present. */
+  detail?: string;
+}
+
 /** What a timed-out wait does: fail, cancel the run, or run a compensation target. */
 export type WaitDisposition = "fail" | "cancel-run" | { target: string };
 
@@ -111,6 +135,8 @@ export interface RunRecord {
   targets: Record<string, TargetRunState>;
   /** External signals received so far, keyed by name (see `.waitsFor(...)`). */
   signals: Record<string, SignalRecord>;
+  /** Append-only audit trail of MCP tool calls against this run (see {@link RunEvent}). */
+  events: RunEvent[];
 }
 
 /** A compact run listing row, returned by {@link "./store.ts".StateStore.listRuns}. */
@@ -273,6 +299,36 @@ function parseWaitState(value: unknown): WaitState {
   return state;
 }
 
+/** All valid {@link RunEventOutcome} values, for validation. */
+const RUN_EVENT_OUTCOMES: readonly RunEventOutcome[] = ["ok", "denied", "error"];
+
+/** Validate and narrow a {@link RunEvent} (an element of a run's audit trail). */
+function parseRunEvent(value: unknown): RunEvent {
+  const object = asObject(value);
+  if (object === null) throw new Error("state: run event is not an object");
+  const outcome = RUN_EVENT_OUTCOMES.find((o) => o === object.outcome);
+  if (outcome === undefined) {
+    throw new Error(`state: unknown run event outcome "${object.outcome}"`);
+  }
+  const rawArgs = asObject(object.args);
+  const args: Record<string, string> = {};
+  if (rawArgs !== null) {
+    for (const [key, val] of Object.entries(rawArgs)) {
+      if (typeof val === "string") args[key] = val;
+    }
+  }
+  const event: RunEvent = {
+    at: str(object, "at"),
+    tool: str(object, "tool"),
+    actor: str(object, "actor"),
+    outcome,
+    args,
+  };
+  const detail = optionalStr(object, "detail");
+  if (detail !== undefined) event.detail = detail;
+  return event;
+}
+
 /** Validate and narrow a {@link SignalRecord}. */
 function parseSignalRecord(value: unknown): SignalRecord {
   const object = asObject(value);
@@ -295,7 +351,7 @@ function parseJsonRecord(
 }
 
 /** Coerce a value parsed from JSON to a {@link JsonValue} (rejects functions etc.). */
-function toJsonValue(value: unknown): JsonValue {
+export function toJsonValue(value: unknown): JsonValue {
   if (value === null) return null;
   if (Array.isArray(value)) return value.map(toJsonValue);
   switch (typeof value) {
@@ -384,6 +440,16 @@ export function parseRunRecord(text: string): RunRecord {
     }
   }
 
+  // `events` (the MCP audit trail) is newer still — absent records parse with an
+  // empty trail, exactly as `signals` above.
+  const events: RunEvent[] = [];
+  if (object.events !== undefined) {
+    if (!Array.isArray(object.events)) {
+      throw new Error(`state: run record field "events" is not an array`);
+    }
+    for (const value of object.events) events.push(parseRunEvent(value));
+  }
+
   return {
     id: str(object, "id"),
     build: str(object, "build"),
@@ -396,6 +462,7 @@ export function parseRunRecord(text: string): RunRecord {
     params,
     targets,
     signals,
+    events,
   };
 }
 

--- a/packages/core/src/state/writer.ts
+++ b/packages/core/src/state/writer.ts
@@ -19,6 +19,7 @@ import type { JsonValue, TargetStateHandle } from "../target.ts";
 import type { Redactor } from "../redact.ts";
 import type { StateStore } from "./store.ts";
 import type {
+  RunEvent,
   RunRecord,
   SignalRecord,
   TargetRunState,
@@ -174,6 +175,37 @@ export class RunStateWriter {
     return this.#update((record) => {
       record.status = "suspended";
     });
+  }
+
+  /**
+   * Append an {@link RunEvent} to the run's audit trail (the MCP tool-call log).
+   * Its `args` values and `detail` are run through the redactor first, so a
+   * secret that reached a tool argument is masked before it is persisted.
+   */
+  appendEvent(event: RunEvent): Promise<void> {
+    const redacted = this.#redactEvent(event);
+    return this.#update((record) => {
+      record.events.push(redacted);
+    });
+  }
+
+  /** Copy a {@link RunEvent} with its `args` values and `detail` redacted. */
+  #redactEvent(event: RunEvent): RunEvent {
+    const args: Record<string, string> = {};
+    for (const [key, value] of Object.entries(event.args)) {
+      args[key] = this.#redactor.redact(value);
+    }
+    const out: RunEvent = {
+      at: event.at,
+      tool: event.tool,
+      actor: event.actor,
+      outcome: event.outcome,
+      args,
+    };
+    if (event.detail !== undefined) {
+      out.detail = this.#redactor.redact(event.detail);
+    }
+    return out;
   }
 
   /** The external signals received so far, as a read-only map. */

--- a/packages/core/src/target.ts
+++ b/packages/core/src/target.ts
@@ -385,6 +385,8 @@ export class TargetBuilder {
   always_ = false;
   /** Hide this target from `--list`/`--help` (set by {@link unlisted}). */
   unlisted_ = false;
+  /** Advertise this target as query-only over MCP (set by {@link readOnly}). */
+  readOnly_ = false;
   /** Extra cache-key contributors beyond input files (set by {@link cacheKey}). */
   readonly cacheKeys_: Array<() => string | Promise<string>> = [];
   /** Artifact paths this target produces (set by {@link produces}). */
@@ -541,6 +543,18 @@ export class TargetBuilder {
   /** Hide this target from `--list` and `--help` (it can still be run by name). */
   unlisted(): this {
     this.unlisted_ = true;
+    return this;
+  }
+
+  /**
+   * Mark this target **query-only** for MCP: its `run:` tool advertises MCP's
+   * `readOnlyHint` instead of the default `destructiveHint`, and it is exempt
+   * from `--confirm-destructive`. A hint about intent only — the target still
+   * runs its real body — so declare it on targets that inspect rather than
+   * mutate (a status check, a report).
+   */
+  readOnly(): this {
+    this.readOnly_ = true;
     return this;
   }
 

--- a/packages/core/tests/cli_test.ts
+++ b/packages/core/tests/cli_test.ts
@@ -31,6 +31,7 @@ function sampleRunRecord(overrides: Partial<RunRecord> = {}): RunRecord {
     params: overrides.params ?? {},
     targets: overrides.targets ?? { build: { status: "succeeded", meta: {} } },
     signals: overrides.signals ?? {},
+    events: overrides.events ?? [],
   };
 }
 

--- a/packages/core/tests/mcp_authz_test.ts
+++ b/packages/core/tests/mcp_authz_test.ts
@@ -1,0 +1,29 @@
+import { assertEquals } from "./_assert.ts";
+import { targetMatcher, timingSafeEqual } from "../src/mcp/authz.ts";
+
+Deno.test("targetMatcher: undefined patterns match every target", () => {
+  const match = targetMatcher(undefined);
+  assertEquals(match("deploy"), true);
+  assertEquals(match("release.publish"), true);
+});
+
+Deno.test("targetMatcher: exact names and globs, spanning dots", () => {
+  const match = targetMatcher(["deploy", "checks*"]);
+  assertEquals(match("deploy"), true);
+  assertEquals(match("deployToProd"), false); // 'deploy' is exact-anchored
+  assertEquals(match("checks"), true);
+  assertEquals(match("checks.lint"), true); // '*' spans the dot
+  assertEquals(match("promote"), false);
+});
+
+Deno.test("targetMatcher: an empty list matches nothing", () => {
+  const match = targetMatcher([]);
+  assertEquals(match("deploy"), false);
+});
+
+Deno.test("timingSafeEqual compares by value, length first", () => {
+  assertEquals(timingSafeEqual("abc", "abc"), true);
+  assertEquals(timingSafeEqual("abc", "abd"), false);
+  assertEquals(timingSafeEqual("abc", "ab"), false); // length mismatch
+  assertEquals(timingSafeEqual("", ""), true);
+});

--- a/packages/core/tests/mcp_hardening_test.ts
+++ b/packages/core/tests/mcp_hardening_test.ts
@@ -322,8 +322,20 @@ Deno.test("resume tools require the operator token for a protected target", asyn
         operatorToken: "nope",
       });
       assertEquals(JSON.parse(wrong.text).reason, "invalid_operator_token");
-      // (A correct token proceeds to resumeRun; the run has no real gate here,
-      // so its outcome is covered by the resume tests — the point is the gate.)
+
+      // resume_check enforces the same gate for a single protected run.
+      const checkNoToken = await call(server, "resume_check", { runId: id });
+      assertEquals(checkNoToken.isError, true);
+      assertEquals(
+        JSON.parse(checkNoToken.text).reason,
+        "missing_operator_token",
+      );
+
+      // The sweep (no runId) silently skips runs the caller can't authorise.
+      const sweep = await call(server, "resume_check");
+      assertEquals(JSON.parse(sweep.text).checked, 0);
+      // (A correct token proceeds to resumeRun; that outcome is covered by the
+      // resume tests — the point here is that the token gate is enforced.)
     },
   );
 });

--- a/packages/core/tests/mcp_hardening_test.ts
+++ b/packages/core/tests/mcp_hardening_test.ts
@@ -1,0 +1,385 @@
+import { assertEquals, assertStringIncludes } from "./_assert.ts";
+import { Build, parameter, target } from "../mod.ts";
+import { McpServer, type McpServerOptions } from "../src/mcp/server.ts";
+import { FileSystemStateStore } from "../src/state/fs_store.ts";
+import { defaultStateHost } from "../src/state/store.ts";
+import { AUDIT_RUN_ID } from "../src/mcp/audit.ts";
+import type { RunEvent, RunRecord } from "../src/state/types.ts";
+
+/** A build with a read-only, a plain, and a protected-worthy target, plus params. */
+class Demo extends Build {
+  environment = parameter("Env").options("dev", "prod").default("dev");
+  secret = parameter("Secret").secret();
+  note = parameter("Note"); // a free-text, non-secret parameter
+  status = target().description("Status").readOnly().executes(() => {});
+  deploy = target().description("Deploy").executes(() => {});
+  promote = target().description("Promote").executes(() => {});
+}
+
+/** A JSON-RPC request with id 1. */
+function req(method: string, params?: unknown): Record<string, unknown> {
+  return { jsonrpc: "2.0", id: 1, method, ...(params ? { params } : {}) };
+}
+
+/** The `{ text, isError }` of a `tools/call` result. */
+function callResult(result: unknown): { text: string; isError: boolean } {
+  if (typeof result !== "object" || result === null || !("content" in result)) {
+    throw new Error("not a tool result");
+  }
+  const content = (result as { content: Array<{ text: string }> }).content;
+  const isError = (result as { isError?: boolean }).isError ?? false;
+  return { text: content[0].text, isError };
+}
+
+/** Call a tool and return its result body. */
+async function call(
+  server: McpServer,
+  name: string,
+  args: Record<string, unknown> = {},
+): Promise<{ text: string; isError: boolean }> {
+  const res = await server.handleMessage(
+    req("tools/call", { name, arguments: args }),
+  );
+  return callResult(res?.result);
+}
+
+/** The advertised tool list. */
+async function toolList(
+  server: McpServer,
+): Promise<Array<{ name: string; annotations?: Record<string, unknown> }>> {
+  const res = await server.handleMessage(req("tools/list"));
+  const result = res?.result;
+  if (typeof result !== "object" || result === null || !("tools" in result)) {
+    throw new Error("no tools");
+  }
+  return (result as {
+    tools: Array<{ name: string; annotations?: Record<string, unknown> }>;
+  }).tools;
+}
+
+/** Run `fn` with a temp-dir store and a server built over it, then clean up. */
+async function withServer(
+  options: Omit<McpServerOptions, "stateStore">,
+  fn: (server: McpServer, store: FileSystemStateStore) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    const server = new McpServer(new Demo(), { ...options, stateStore: store });
+    await fn(server, store);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+/** Read the audit trail from the store. */
+async function auditEvents(store: FileSystemStateStore): Promise<RunEvent[]> {
+  const loaded = await store.getRun(AUDIT_RUN_ID);
+  return loaded === null ? [] : loaded.record.events;
+}
+
+Deno.test("readOnly targets advertise readOnlyHint; others destructiveHint", async () => {
+  await withServer({ allowRun: true }, async (server) => {
+    const tools = await toolList(server);
+    const status = tools.find((t) => t.name === "run:status");
+    const deploy = tools.find((t) => t.name === "run:deploy");
+    assertEquals(status?.annotations?.readOnlyHint, true);
+    assertEquals(deploy?.annotations?.destructiveHint, true);
+  });
+});
+
+Deno.test("the allow-list hides non-matching run tools and denies them opaquely", async () => {
+  await withServer(
+    { allowRun: true, allowRunPatterns: ["deploy"] },
+    async (server) => {
+      const names = (await toolList(server)).map((t) => t.name);
+      assertEquals(names.includes("run:deploy"), true);
+      assertEquals(names.includes("run:promote"), false);
+      assertEquals(names.includes("run:status"), false);
+      // A call to a disallowed target looks exactly like a nonexistent tool.
+      const denied = await call(server, "run:promote");
+      assertEquals(denied.isError, true);
+      assertStringIncludes(denied.text, "Unknown tool: run:promote");
+    },
+  );
+});
+
+Deno.test("run tools are absent, and a run call is refused, without --allow-run", async () => {
+  await withServer({ allowRun: false }, async (server) => {
+    const names = (await toolList(server)).map((t) => t.name);
+    assertEquals(names.some((n) => n.startsWith("run:")), false);
+    const denied = await call(server, "run:deploy");
+    assertEquals(denied.isError, true);
+    assertStringIncludes(denied.text, "disabled");
+  });
+});
+
+Deno.test("a protected target requires a valid operator token, fail-closed", async () => {
+  // Configured token.
+  await withServer(
+    {
+      allowRun: true,
+      protectPatterns: ["promote"],
+      operatorToken: "swordfish",
+    },
+    async (server) => {
+      const promote = (await toolList(server)).find((t) =>
+        t.name === "run:promote"
+      );
+      const schema = promote?.annotations === undefined ? undefined : promote;
+      assertEquals(schema !== undefined, true);
+
+      // Missing token → denied.
+      const missing = await call(server, "run:promote");
+      assertEquals(missing.isError, true);
+      assertStringIncludes(missing.text, "missing_operator_token");
+
+      // Wrong token → denied.
+      const wrong = await call(server, "run:promote", {
+        operatorToken: "nope",
+      });
+      assertEquals(wrong.isError, true);
+      assertStringIncludes(wrong.text, "invalid_operator_token");
+
+      // Correct token → runs.
+      const ok = await call(server, "run:promote", {
+        operatorToken: "swordfish",
+      });
+      assertEquals(ok.isError, false);
+      assertStringIncludes(ok.text, "promote succeeded");
+    },
+  );
+
+  // No token configured → always denied (fail-closed).
+  await withServer(
+    { allowRun: true, protectPatterns: ["promote"] },
+    async (server) => {
+      const denied = await call(server, "run:promote", {
+        operatorToken: "anything",
+      });
+      assertEquals(denied.isError, true);
+      assertStringIncludes(denied.text, "operator_token_unconfigured");
+    },
+  );
+});
+
+Deno.test("confirm-destructive returns a plan until confirm:true; readOnly is exempt", async () => {
+  await withServer(
+    { allowRun: true, confirmDestructive: true },
+    async (server) => {
+      // Destructive without confirm → the plan, not an execution.
+      const planned = await call(server, "run:deploy");
+      assertEquals(planned.isError, false);
+      assertStringIncludes(planned.text, "confirmation_required");
+      assertStringIncludes(planned.text, "deploy");
+
+      // With confirm → runs.
+      const confirmed = await call(server, "run:deploy", { confirm: true });
+      assertEquals(confirmed.isError, false);
+      assertStringIncludes(confirmed.text, "deploy succeeded");
+
+      // A dry run skips the gate.
+      const dry = await call(server, "run:deploy", { dryRun: true });
+      assertStringIncludes(dry.text, "deploy");
+
+      // A read-only target is never gated.
+      const status = await call(server, "run:status");
+      assertStringIncludes(status.text, "status succeeded");
+    },
+  );
+});
+
+Deno.test("store-backed run tools appear with a store; mutating ones need --allow-run", async () => {
+  await withServer({ allowRun: false }, async (server) => {
+    const names = (await toolList(server)).map((t) => t.name);
+    assertEquals(names.includes("list_runs"), true);
+    assertEquals(names.includes("show_run"), true);
+    assertEquals(names.includes("signal_run"), false); // mutating, needs allowRun
+  });
+  await withServer({ allowRun: true }, async (server) => {
+    const names = (await toolList(server)).map((t) => t.name);
+    assertEquals(names.includes("signal_run"), true);
+    assertEquals(names.includes("resume_check"), true);
+  });
+});
+
+Deno.test("run tools query the store and return structured errors", async () => {
+  await withServer({ allowRun: true }, async (server) => {
+    const list = await call(server, "list_runs");
+    assertEquals(list.isError, false);
+    assertEquals(JSON.parse(list.text), []);
+
+    const missing = await call(server, "show_run", { runId: "nope" });
+    assertEquals(missing.isError, true);
+    assertEquals(JSON.parse(missing.text).error, "no_run");
+
+    const signal = await call(server, "signal_run", { runId: "nope" });
+    assertEquals(signal.isError, true);
+    // The run is loaded before resuming, so a missing one is a structured no_run.
+    assertEquals(JSON.parse(signal.text).error, "no_run");
+  });
+});
+
+Deno.test("mutating tool calls are audited with a redacted, attributed trail", async () => {
+  await withServer(
+    {
+      allowRun: true,
+      actor: "tester",
+      protectPatterns: ["promote"],
+      operatorToken: "swordfish",
+    },
+    async (server, store) => {
+      // A successful run, with a secret arg that must be masked.
+      await call(server, "run:deploy", {
+        environment: "dev",
+        secret: "hunter2",
+      });
+      // A denied protected call.
+      await call(server, "run:promote", { operatorToken: "wrong" });
+
+      const events = await auditEvents(store);
+      const deploy = events.find((e) => e.tool === "run:deploy");
+      const promote = events.find((e) => e.tool === "run:promote");
+      assertEquals(deploy?.outcome, "ok");
+      assertEquals(deploy?.actor, "tester");
+      assertEquals(deploy?.args.secret, "[redacted]"); // secret masked
+      assertEquals(deploy?.args.environment, "dev");
+      assertEquals(promote?.outcome, "denied");
+      // The operator token is never recorded.
+      assertEquals("operatorToken" in (promote?.args ?? {}), false);
+    },
+  );
+});
+
+/** Persist a suspended run with the given root target, and return its id. */
+async function seedSuspended(
+  store: FileSystemStateStore,
+  rootTarget: string,
+): Promise<string> {
+  const now = new Date().toISOString();
+  const record: RunRecord = {
+    id: `run-${rootTarget}`,
+    build: "Demo",
+    rootTarget,
+    status: "suspended",
+    actor: "someone",
+    createdAt: now,
+    updatedAt: now,
+    graph: [{ name: rootTarget, dependsOn: [] }],
+    params: {},
+    targets: { [rootTarget]: { status: "waiting", meta: {} } },
+    signals: {},
+    events: [],
+  };
+  const put = await store.putRun(record, null);
+  if (!put.ok) throw new Error("failed to seed suspended run");
+  return record.id;
+}
+
+Deno.test("resume tools respect the allow-list (no bypass of an excluded target)", async () => {
+  await withServer(
+    { allowRun: true, allowRunPatterns: ["safe*"] },
+    async (server, store) => {
+      const id = await seedSuspended(store, "deploy"); // deploy is NOT allow-listed
+
+      // signal_run on the excluded target is denied.
+      const signal = await call(server, "signal_run", {
+        runId: id,
+        signal: "go",
+      });
+      assertEquals(signal.isError, true);
+      assertEquals(JSON.parse(signal.text).reason, "not_allowed");
+
+      // A resume_check sweep skips it (checks nothing it may not touch).
+      const sweep = await call(server, "resume_check");
+      assertEquals(JSON.parse(sweep.text).checked, 0);
+    },
+  );
+});
+
+Deno.test("resume tools require the operator token for a protected target", async () => {
+  await withServer(
+    {
+      allowRun: true,
+      protectPatterns: ["deploy"],
+      operatorToken: "swordfish",
+    },
+    async (server, store) => {
+      const id = await seedSuspended(store, "deploy");
+
+      // Missing token → denied.
+      const missing = await call(server, "signal_run", {
+        runId: id,
+        signal: "go",
+      });
+      assertEquals(missing.isError, true);
+      assertEquals(JSON.parse(missing.text).reason, "missing_operator_token");
+
+      // Wrong token → denied.
+      const wrong = await call(server, "signal_run", {
+        runId: id,
+        signal: "go",
+        operatorToken: "nope",
+      });
+      assertEquals(JSON.parse(wrong.text).reason, "invalid_operator_token");
+      // (A correct token proceeds to resumeRun; the run has no real gate here,
+      // so its outcome is covered by the resume tests — the point is the gate.)
+    },
+  );
+});
+
+Deno.test("a secret echoed into a non-secret argument is masked in the audit", async () => {
+  await withServer({ allowRun: true }, async (server, store) => {
+    await call(server, "run:deploy", {
+      environment: "dev",
+      secret: "hunter2",
+      note: "deploying with hunter2 now",
+    });
+    const events = await auditEvents(store);
+    const deploy = events.find((e) => e.tool === "run:deploy");
+    assertEquals(deploy?.args.secret, "[redacted]");
+    // The secret value must not survive inside the non-secret note.
+    assertEquals(deploy?.args.note?.includes("hunter2"), false);
+  });
+});
+
+Deno.test("a truthy-but-not-true confirm still returns the plan, not an execution", async () => {
+  await withServer(
+    { allowRun: true, confirmDestructive: true },
+    async (server) => {
+      // A JSON string "true" is truthy but not boolean true → still gated.
+      const planned = await call(server, "run:deploy", { confirm: "true" });
+      assertStringIncludes(planned.text, "confirmation_required");
+      const numeric = await call(server, "run:deploy", { confirm: 1 });
+      assertStringIncludes(numeric.text, "confirmation_required");
+    },
+  );
+});
+
+Deno.test("a thrown framework error returns a structured result, not a crash", async () => {
+  // A build whose onStart throws makes execute() throw out of #run.
+  class Boom extends Build {
+    override onStart(): void {
+      throw new Error("startup exploded");
+    }
+    go = target().executes(() => {});
+  }
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    const server = new McpServer(new Boom(), {
+      allowRun: true,
+      stateStore: store,
+    });
+    const res = await call(server, "run:go");
+    assertEquals(res.isError, true);
+    assertStringIncludes(res.text, "errored during execution");
+    // The raw message is not echoed (it bypassed redaction).
+    assertEquals(res.text.includes("startup exploded"), false);
+    // The failure is audited.
+    const events = await auditEvents(store);
+    assertEquals(events.find((e) => e.tool === "run:go")?.outcome, "error");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/packages/core/tests/mcp_test.ts
+++ b/packages/core/tests/mcp_test.ts
@@ -206,7 +206,9 @@ Deno.test("an unknown target or tool is surfaced through the result, not the tra
     ))?.result,
   );
   assertEquals(unknownTarget.isError, true);
-  assertStringIncludes(unknownTarget.text, "Unknown target");
+  // A run call to a nonexistent target is reported identically to a
+  // disallowed one ("Unknown tool: run:<name>"), so denial leaks nothing.
+  assertStringIncludes(unknownTarget.text, "Unknown tool: run:nope");
 
   const unknownTool = callText(
     (await server.handleMessage(

--- a/packages/core/tests/runs_test.ts
+++ b/packages/core/tests/runs_test.ts
@@ -53,6 +53,7 @@ function sampleRecord(overrides: Partial<RunRecord> = {}): RunRecord {
     params: overrides.params ?? {},
     targets: overrides.targets ?? { deploy: { status: "succeeded", meta: {} } },
     signals: overrides.signals ?? {},
+    events: overrides.events ?? [],
   };
 }
 

--- a/packages/core/tests/state_test.ts
+++ b/packages/core/tests/state_test.ts
@@ -55,6 +55,7 @@ function sampleRecord(overrides: Partial<RunRecord> = {}): RunRecord {
     targets: overrides.targets ??
       { deploy: { status: "pending", meta: {} } },
     signals: overrides.signals ?? {},
+    events: overrides.events ?? [],
   };
 }
 

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -137,7 +137,11 @@ Before calling any task or settings method, confirm the real shape:
 - **Operate the build from an agent:** `zuke mcp` serves the build over MCP so
   an AI client can list, inspect, and (with `--allow-run`) run targets — on
   stdio, or over HTTP with `--http <host:port>` (loopback by default; a
-  non-loopback bind needs a `ZUKE_MCP_TOKEN` bearer token).
+  non-loopback bind needs a `ZUKE_MCP_TOKEN` bearer token). With a state store
+  it also exposes `list_runs`/`show_run` (+ `signal_run`/`resume_check`). Tier
+  access with `--allow-run=<globs>` (allow-list), `--protect <globs>` +
+  `ZUKE_OPERATOR_TOKEN`, and `--confirm-destructive`; mark inspect-only targets
+  `.readOnly()`. Mutating/denied calls are audited (`zuke runs show mcp-audit`).
 - **AI review & self-healing (`@zuke/ai`):** gate a target on a structured LLM
   review of the diff (`securityReviewer(...)` etc. via `.validateBefore`), or
   attach `aiFixer(...)` with `.recoverWith(...)` so a failing target is

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -467,6 +467,9 @@ is current (`zuke generate-ci --check` is a dedicated gate).
 ./zuke runs show <id>         # one run's full per-target status (+ --json)
 ./zuke mcp [--allow-run]      # serve the build over MCP for an AI client (stdio)
 ./zuke mcp --http 7777        # ...or over HTTP (loopback; token off-loopback)
+./zuke mcp --allow-run=deploy,checks* --protect deploy --confirm-destructive
+                              # authz tiers: allow-list, operator token, confirm
+./zuke runs show mcp-audit    # the MCP tool-call audit trail
 ```
 
 **Caching:** a target with `.inputs(...)`/`.outputs(...)` is incremental

--- a/tests/e2e/mcp_e2e.ts
+++ b/tests/e2e/mcp_e2e.ts
@@ -1,0 +1,150 @@
+/**
+ * End-to-end: the M5 two-session acceptance across real processes. Session A
+ * (a CLI run) deploys and suspends at an approval gate; a separate `zuke mcp`
+ * server process then serves session B, which queries the suspended run over
+ * the HTTP transport and signals it to completion — with the mutating call
+ * attributed in the audit log. Proves the store-backed MCP tools, the HTTP
+ * transport, and the audit trail work between genuinely separate processes.
+ *
+ * Excluded from the fast unit gate (`*_e2e.ts`); run by the `integration`
+ * target / integration.yml on the OS matrix.
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import {
+  defaultStateHost,
+  FileSystemStateStore,
+} from "../../packages/core/mod.ts";
+
+const FIXTURE = new URL("./fixtures/gate_build.ts", import.meta.url);
+const PORT = 8799;
+const BASE = `http://127.0.0.1:${PORT}/`;
+
+/** Run the gate fixture as a real `deno` subprocess against state dir `dir`. */
+async function runFixture(
+  args: string[],
+  dir: string,
+): Promise<{ code: number; out: string }> {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: ["run", "-A", FIXTURE.href, ...args],
+    env: { ZUKE_STATE_DIR: dir },
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const { code, stdout } = await command.output();
+  return { code, out: new TextDecoder().decode(stdout) };
+}
+
+/** Post a JSON-RPC message to the running MCP server and return the parsed reply. */
+async function rpc(method: string, params?: unknown): Promise<unknown> {
+  const res = await fetch(BASE, {
+    method: "POST",
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method,
+      ...(params ? { params } : {}),
+    }),
+  });
+  return await res.json();
+}
+
+/** The text block of a `tools/call` reply, parsed as JSON. */
+function toolJson(reply: unknown): unknown {
+  const result =
+    (reply as { result?: { content?: Array<{ text: string }> } }).result;
+  const text = result?.content?.[0]?.text;
+  if (typeof text !== "string") throw new Error("no tool text");
+  return JSON.parse(text);
+}
+
+/** Poll the server until it answers `ping`, or throw past `deadline`. */
+async function waitReady(deadline: number): Promise<void> {
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(BASE, {
+        method: "POST",
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+      });
+      const ok = res.ok;
+      await res.body?.cancel();
+      if (ok) return;
+    } catch {
+      // Not listening yet.
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error("MCP server did not become ready in time");
+}
+
+Deno.test("two MCP sessions: query a suspended run over HTTP and signal it, audited", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "zuke-mcp-e2e-" });
+  let server: Deno.ChildProcess | undefined;
+  try {
+    // Session A: run to the gate and suspend (a separate process).
+    const suspend = await runFixture(["promote"], dir);
+    assertEquals(suspend.code, 0);
+    assertStringIncludes(suspend.out, "DEPLOYED");
+
+    // A separate MCP server process over the same state dir, execution enabled.
+    server = new Deno.Command(Deno.execPath(), {
+      args: [
+        "run",
+        "-A",
+        FIXTURE.href,
+        "mcp",
+        "--http",
+        `127.0.0.1:${PORT}`,
+        "--allow-run",
+        "--actor",
+        "session-b",
+      ],
+      env: { ZUKE_STATE_DIR: dir },
+      stdout: "null",
+      stderr: "null",
+    }).spawn();
+    await waitReady(Date.now() + 10_000);
+
+    // Session B: find the suspended run and signal it to completion.
+    const runs = toolJson(
+      await rpc("tools/call", {
+        name: "list_runs",
+        arguments: { status: "suspended" },
+      }),
+    );
+    if (!Array.isArray(runs) || runs.length !== 1) {
+      throw new Error(
+        `expected one suspended run, got ${JSON.stringify(runs)}`,
+      );
+    }
+    const id = (runs[0] as { id: string }).id;
+
+    const signalled = toolJson(
+      await rpc("tools/call", {
+        name: "signal_run",
+        arguments: { runId: id, signal: "approved" },
+      }),
+    );
+    assertEquals((signalled as { ok: boolean }).ok, true);
+
+    // The run promoted, and the signal is attributed to session-b in the audit.
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    const promoted = await store.getRun(id);
+    assertEquals(promoted?.record.status, "succeeded");
+    assertEquals(promoted?.record.targets["promote"].status, "succeeded");
+
+    const audit = await store.getRun("mcp-audit");
+    const event = audit?.record.events.find((e) => e.tool === "signal_run");
+    assertEquals(event?.actor, "session-b");
+    assertEquals(event?.outcome, "ok");
+  } finally {
+    if (server !== undefined) {
+      server.kill();
+      await server.status;
+    }
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/tests/integration/mcp_audit_test.ts
+++ b/tests/integration/mcp_audit_test.ts
@@ -1,0 +1,76 @@
+/**
+ * Integration: the MCP audit trail is rendered by `zuke runs show`, driven
+ * through the real CLI `main()`. A record with an audit event is persisted to
+ * the temp state store (as the MCP server appends one), then read back and shown
+ * through the CLI — exercising the `formatRunDetail` audit section end to end.
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import {
+  Build,
+  defaultStateHost,
+  FileSystemStateStore,
+  type RunRecord,
+  target,
+} from "../../packages/core/mod.ts";
+import { runCli, withStateDir } from "./_harness.ts";
+
+class Demo extends Build {
+  go = target().executes(() => {});
+}
+
+Deno.test("runs show renders the MCP audit trail", async () => {
+  await withStateDir(async (dir) => {
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    const now = new Date().toISOString();
+    const record: RunRecord = {
+      id: "run-1",
+      build: "Demo",
+      rootTarget: "go",
+      status: "succeeded",
+      actor: "alice",
+      createdAt: now,
+      updatedAt: now,
+      graph: [{ name: "go", dependsOn: [] }],
+      params: {},
+      targets: { go: { status: "succeeded", meta: {} } },
+      signals: {},
+      // The event an MCP `run:go` call would have appended.
+      events: [{
+        at: now,
+        tool: "run:go",
+        actor: "session-b",
+        outcome: "ok",
+        args: { environment: "dev" },
+      }],
+    };
+    const put = await store.putRun(record, null);
+    assertEquals(put.ok, true);
+
+    const { code, out } = await runCli(Demo, ["runs", "show", "run-1"]);
+    assertEquals(code, 0);
+    assertStringIncludes(out, "Audit:");
+    assertStringIncludes(out, "run:go");
+    assertStringIncludes(out, "session-b");
+  });
+});
+
+Deno.test("runs show omits the audit section when there are no events", async () => {
+  await withStateDir(async (dir) => {
+    class B extends Build {
+      build = target().executes(() => {});
+    }
+    const run = await runCli(B, ["build"]);
+    assertEquals(run.code, 0);
+    const id =
+      (await new FileSystemStateStore(dir, defaultStateHost).listRuns({}))[0]
+        .id;
+
+    const { code, out } = await runCli(B, ["runs", "show", id]);
+    assertEquals(code, 0);
+    assertEquals(out.includes("Audit:"), false);
+  });
+});

--- a/zuke.ts
+++ b/zuke.ts
@@ -375,7 +375,9 @@ class ZukeBuild extends Build {
   integration = target()
     .description("Run the subprocess e2e suite (real processes, OS matrix)")
     .executes(async () => {
-      await DenoTasks.test((s) => s.allowAll().paths("tests/e2e/race_e2e.ts"));
+      await DenoTasks.test((s) =>
+        s.allowAll().paths("tests/e2e/race_e2e.ts", "tests/e2e/mcp_e2e.ts")
+      );
     });
 
   // The dedicated workflow for the `integration` target, generated from this

--- a/zuke.ts
+++ b/zuke.ts
@@ -599,11 +599,24 @@ class ZukeBuild extends Build {
       // agent/network authz is the M5 MCP surface. `z2fmcx` is a forEach item
       // key in a sub-target name: keys are author-chosen identifiers (console
       // output is redacted; secrets belong in excluded `.secret()` params), as
-      // documented in docs/orchestration.md. (IDs are opaque fingerprints.)
-      // cspell:ignore myee fmcx
+      // documented in docs/orchestration.md. `1ownw8s` is a false positive —
+      // signal_run/resume_check DO enforce the operator token (runtools.ts
+      // gates on deps.authorize → #authorizeTarget → #checkOperatorToken, with
+      // tests). `1eav335` is by design: list_runs/show_run are read-only over
+      // non-secret records, "always exposed when a store resolves" per M5, and
+      // gated by the transport's auth. (IDs are opaque fingerprints.)
+      // cspell:ignore myee fmcx ownw eav
       .suppress(
         suppressions((s) =>
-          s.add("1g3myee", "1mwn3kn", "1xwg7am", "3f7a0g", "z2fmcx")
+          s.add(
+            "1g3myee",
+            "1mwn3kn",
+            "1xwg7am",
+            "3f7a0g",
+            "z2fmcx",
+            "1ownw8s",
+            "1eav335",
+          )
         ),
       )
       .failWhen((g) => g.scoreAbove(8))


### PR DESCRIPTION
## What

Completes **M5** — the MCP hardening half (after PR1's HTTP transport). Turns
`zuke mcp` into a store-driven, tiered-authorization surface with an audit
trail, so the M5 acceptance holds: session A starts work and disconnects, and a
separate session B queries the run and signals it — every mutating call
attributed.

## How

- **Store-backed run tools** — `list_runs`/`show_run` (read-only, exposed when a
  store resolves) and `signal_run`/`resume_check` (mutating, gated), thin
  wrappers over the same `StateStore` / `resumeRun` surfaces the CLI uses.
- **`.readOnly()`** — a target advertises MCP `readOnlyHint` instead of the
  default `destructiveHint`, and is exempt from confirmation.
- **Authorization tiers:**
  - `--allow-run=<globs>` — a per-target allow-list. An unlisted target is
    **invisible**, and its denial is indistinguishable from a nonexistent tool
    (leaks no existence).
  - `--protect <globs>` + `ZUKE_OPERATOR_TOKEN` — a constant-time-checked
    operator token, **fail-closed** (no token configured → always denied).
  - `--confirm-destructive` — a destructive call returns its plan until
    re-sent with `confirm:true`.
  - The **resume tools enforce the same gate** before running a target's code.
- **Audit log** — every mutating/denied call appends a redacted `RunEvent`
  (time, tool, resolved actor, outcome, args) to a store-level `mcp-audit`
  record; secrets are masked wherever they appear, the operator token is never
  persisted. `zuke runs show mcp-audit` prints it. `events[]` parses
  backwards-compatibly.
- **Structured JSON errors** for lock conflicts, `AlreadyResumedError`, and
  denials; a thrown framework error returns a structured result, never crashing
  the transport.

## Testing (new three-layer mandate)

- **Unit** — `mcp_authz_test.ts` (matcher + constant-time compare),
  `mcp_hardening_test.ts` (the allow-list / protect / confirm / audit / run-tool
  matrix, 18 cases).
- **Integration** — `tests/integration/mcp_audit_test.ts`: the audit trail
  rendered through `runs show` via the real `main()`.
- **E2E** — `tests/e2e/mcp_e2e.ts`: two real processes — a suspended run, then an
  MCP server session that queries and signals it over HTTP, asserting the audit
  attribution (wired into the `integration` build target).

## Adversarial review

Per the standing practice, I ran an adversarial security review of the authz/
audit surface **before** this PR. It found (and I fixed + regression-tested)
three real defects the green gate missed: `signal_run`/`resume_check` bypassing
the allow-list and operator token, an inert audit redactor that let a secret
echoed into a non-secret argument persist, and an unguarded `execute()` that
could crash the transport on a framework throw.

## Verification

`deno task ci` green — coverage 97.8% lines / 95.3% branches. `apiDocsCheck` and
`deno doc --lint` clean. `integration` target (e2e lane) passes. Docs, skill, and
cheatsheet updated. Design was chosen from a scored panel of independent
approaches (minimal/orthodox won, security-first ideas grafted).
