### PR TITLE
feat(core): compensation targets and zuke cancel

### DIFF
--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -186,6 +186,12 @@ deploy = target()
   target's own dependents are skipped.
 - **`.always()`** — run even after the build has already failed, for
   cleanup/teardown. It still waits for its own dependencies to complete.
+- **`.onCancel(target | () => target)`** — register a **compensation** that
+  undoes this target when the run is [cancelled](./orchestration.md#cancellation--compensation-oncancel).
+  It runs only if this target **succeeded**; on cancel, compensations run in
+  reverse order. The compensation body's `ctx.state` exposes _this_ target's
+  persisted metadata (so a rollback reads what the deploy recorded). Use the
+  thunk form to reference a compensation declared below. Needs a state store.
 - **`.unlisted()`** — hide a helper target from `--list`/`--help`; it can still
   be run by name or depended on.
 - **`.readOnly()`** — mark a target query-only for [MCP](./mcp.md): its run tool

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -20,6 +20,7 @@
 | `zuke resume --check [<id>]`                            | Re-check suspended runs (predicate waits, timeouts).                                    |
 | `zuke runs list [--status/-target/-since] [--json]`     | List persisted run records, newest first ([details](./state.md)).                       |
 | `zuke runs show <id> [--json]`                          | Show one run's full per-target status and metadata.                                     |
+| `zuke cancel <id> [--actor <name>]`                     | Cancel a run and run its compensations ([details](./orchestration.md#cancellation--compensation-oncancel)). |
 | `zuke --help` / `-h`                                    | Usage.                                                                                  |
 | `zuke` (no target)                                      | Run the `default` target if defined, else print `--list`.                               |
 
@@ -262,6 +263,17 @@ the targets that hadn't yet succeeded. `--force-graph` continues even if the
 build graph changed since the run was suspended. See
 [Orchestration](./orchestration.md).
 
+## Cancelling runs
+
+`zuke cancel <run-id>` cancels a run and runs its
+[compensations](./orchestration.md#cancellation--compensation-oncancel): every
+target that had **succeeded** and declared `.onCancel(...)` is unwound in reverse
+order, then the record settles `cancelled`. `--actor <name>` attributes the
+cancellation in the audit trail. Cancelling a run another process is executing
+stops it (a live run aborts on its next state write); cancelling an
+already-finished run is a friendly no-op. `Ctrl-C` (or `SIGTERM`) cancels the run
+in the current process the same way — a second `Ctrl-C` forces an immediate exit.
+
 ## Inspecting runs
 
 `zuke runs` reads persisted [run records](./state.md) back from the store, so a
@@ -269,7 +281,7 @@ run's full status survives the process that produced it.
 
 - `zuke runs list` prints one row per run — id, status, root target, actor, and
   creation time — newest first. Narrow it with `--status <s>` (one of `running`,
-  `suspended`, `succeeded`, `failed`, `cancelled`), `--target <t>` (only runs
+  `suspended`, `cancelling`, `succeeded`, `failed`, `cancelled`), `--target <t>` (only runs
   whose graph contains that target), and `--since <iso>` (only runs created at
   or after an ISO-8601 timestamp). The filters compose.
 - `zuke runs show <run-id>` reconstructs one run in full: the header, resolved

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -101,10 +101,15 @@ from the build's declared parameters — a `required` parameter is required,
 parameters exactly like the CLI (MCP argument → the environment → the declared
 default) and returns the target's captured output with a pass/fail marker.
 
-With `--allow-run` a store also exposes two **mutating** run-state tools:
+With `--allow-run` a store also exposes three **mutating** run-state tools:
 `signal_run` (deliver an external signal and resume a suspended run,
-exactly-once) and `resume_check` (re-check suspended runs — predicate waits and
-timeouts). They are the MCP counterparts of `zuke resume`.
+exactly-once), `resume_check` (re-check suspended runs — predicate waits and
+timeouts), and `cancel_run` (cancel a run and run its
+[compensations](./orchestration.md#cancellation--compensation-oncancel)). They
+are the MCP counterparts of `zuke resume` and `zuke cancel`. Each runs the
+target's code (a resume continues it; a cancel runs its compensations), so it is
+gated by the same [allow-list and operator-token](#authorization) policy as a
+`run:` tool and appended to the [audit log](#audit-log).
 
 ```jsonc
 // tools/call
@@ -145,7 +150,7 @@ ZUKE_OPERATOR_TOKEN=… zuke mcp --http 7777 \
 ## Audit log
 
 With a store configured, **every mutating or denied tool call** (`run:<target>`,
-`signal_run`, `resume_check`) is appended to an audit trail: the time, the tool,
+`signal_run`, `resume_check`, `cancel_run`) is appended to an audit trail: the time, the tool,
 the resolved **actor**, the outcome (`ok` / `denied` / `error`), and the call's
 arguments. Arguments are **redacted** — the operator token is dropped and every
 `.secret()` parameter's value is masked — before anything is persisted.

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -113,10 +113,20 @@ Programmatically, `resumeRun(build, { runId, signal, data })` and
 
 ### Timeouts
 
-A wait past its `timeout` deadline **times out** instead of resuming: the target
-is failed and the run fails, its recorded `onTimeout` disposition preserved.
-Running a compensation target on timeout (rather than just failing) arrives with
-the cancellation milestone.
+A wait past its `timeout` deadline **times out** instead of resuming, honouring
+its recorded `onTimeout` disposition:
+
+- **`"fail"`** (the default) — the waiting target is failed and the run fails.
+- **`"cancel-run"`** — the run is **cancelled**: every succeeded target's
+  compensation runs (see [Cancellation](#cancellation--compensation-oncancel))
+  and the record settles `cancelled`. This is what unwinds a stuck deploy → wait
+  and releases its locks, rather than leaving them held until their TTL.
+- **a sibling target** (`.onTimeout(() => this.rollback)`) — that specific
+  target runs as a compensation, then the run is cancelled (running the rest of
+  the compensations too).
+
+Timeouts are enforced lazily on any `zuke resume`/`resume --check`, so a single
+cron that sweeps suspended runs also enforces every deadline.
 
 ## State is the only thing that crosses the boundary
 
@@ -126,6 +136,70 @@ gone. Anything a later target needs must be in the durable record — `ctx.state
 model to build around: persist what matters, read it back on the other side.
 
 See [Durable run state](./state.md) for the record shape and `ctx.state`.
+
+## Cancellation & compensation — `.onCancel()`
+
+Cancelling a run should be **safe and complete**: work that already happened is
+undone, locks are released, and the record ends `cancelled`. Zuke does this with
+**compensation targets** — the inverse of a target, declared with `.onCancel()`.
+
+```ts
+class CD extends Build {
+  deploy = target()
+    .executes((ctx) => ctx.state.set({ slot: "sit-7" })) // record what it did
+    .onCancel(() => this.rollback); // …and how to undo it
+  rollback = target().executes((ctx) => tearDown(ctx.state.get().slot));
+
+  gate = target().dependsOn(this.deploy)
+    .waitsFor((s) => s.on(externalSignal("approved")));
+  promote = target().dependsOn(this.gate).executes(() => {});
+}
+```
+
+Cancel it three ways — all run the same walk:
+
+```bash
+zuke cancel <run-id>     # cancel a persisted run (any process)
+# Ctrl-C / SIGTERM       # cancel the run in this process
+# MCP cancel_run tool    # cancel over MCP (gated like a run tool)
+```
+
+What a cancellation does:
+
+- **A compensation runs iff its target succeeded.** A target that never ran, was
+  skipped, or failed has nothing to undo. Compensations run in **reverse order**
+  of the targets that succeeded, so later work is unwound before the work it was
+  built on.
+- **Each compensation reads its target's persisted state.** The compensation
+  body gets a normal `ctx` whose `ctx.state` exposes **the original target's**
+  metadata — the `deploy` above rolls back from exactly the `slot` it recorded.
+  So persist what a rollback needs in `ctx.state` at the time you do the work.
+- **A live run stops.** Cancelling a run another process is executing flips it
+  to `cancelling`; the owner observes that on its next state write and aborts —
+  its in-flight `$` commands get SIGTERM through the ambient signal, releasing
+  the locks they held. (A body that ignores its `ctx.signal` runs to completion,
+  so pass `ctx.signal` to long shell commands.)
+- **Cleanup is maximal.** A compensation that throws is recorded but does
+  **not** stop the walk — every other compensation still runs. The failures are
+  reported and land in the run's audit trail.
+- **It is idempotent.** Cancelling an already-finished (or already-cancelled)
+  run is a friendly no-op — safe to run from a retrying operator or a double
+  Ctrl-C.
+
+The compensation is a **thunk** (`() => this.rollback`) so it can reference a
+target declared _below_ the one it cleans up (class fields initialise
+top-to-bottom, exactly like `waitsFor`'s `onTimeout`). The whole cancellation is
+recorded as a `cancel` event in the run's [audit trail](./state.md), attributed
+to whoever cancelled it, so `zuke runs show <id>` shows what was unwound.
+
+Cancellation needs a state store, so a build that uses `.onCancel()` turns on
+the `.zuke/runs` filesystem store by default (like `.lock()` and `.waitsFor()`).
+
+> **Limitation:** the cancel walk considers only the static plan, so an
+> `.onCancel()` on a [`.forEach()`](#fan-out-over-a-list--foreach)
+> **sub-target** is not run (sub-targets are materialised at run time and don't
+> exist at cancel time). Put a compensation on an ordinary target, or on the
+> parent fan-out target itself.
 
 ## Fan-out over a list — `.forEach()`
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -53,7 +53,7 @@ Each run is stored as one JSON document:
   "id": "3f2a…", // == ctx.runId
   "build": "CD", // the Build class name
   "rootTarget": "deploy", // the requested target
-  "status": "succeeded", // running | suspended | succeeded | failed | cancelled
+  "status": "succeeded", // running | suspended | cancelling | succeeded | failed | cancelled
   "actor": "alice", // who ran it (see below)
   "createdAt": "2026-07-17T…Z",
   "updatedAt": "2026-07-17T…Z",

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -83,6 +83,16 @@ function assertExists<T>(value: T, message: string): NonNullable<T>
 async function assertFileExists(path: PathLike): Promise<void>
   Assert that `path` exists and is a file. Async (stats the filesystem).
 
+async function cancelRun(build: Build, options: CancelOptions): Promise<CancelResult>
+  Cancel the run `options.runId` for `build`: transition it to `cancelling`
+  (exactly one canceller drives the walk; a live owning process observes the
+  change and aborts), run the compensations of every succeeded target in reverse
+  order, and settle the record as `cancelled`. Idempotent — cancelling an
+  already-terminal run is a friendly no-op.
+
+  @throws
+      if no state store is configured, or the run does not exist.
+
 function ciHost(): string
   A short identifier for the detected CI host, or `"local"` when not on CI.
   Recognises GitHub Actions, GitLab CI, Azure Pipelines, Bitbucket Pipelines,
@@ -1121,6 +1131,8 @@ class TargetBuilder
     External-event wait settings lambda, set by {@link waitsFor} and run when reached.
   forEach_?: ForEachSpec
     Fan-out spec, set by {@link forEach}: materialises per-item sub-target pipelines.
+  onCancel_?: () => TargetBuilder
+    Compensation thunk, set by {@link onCancel}: runs on cancel iff this target succeeded.
   description(text: string): this
     Set the human-readable description shown in `zuke --list`.
   dependsOn(...targets: Array<TargetBuilder | Group>): this
@@ -1277,6 +1289,29 @@ class TargetBuilder
         s.on(externalSignal("testing-approved"))
           .timeout("72h")
           .onTimeout(() => this.rollback));
+    ```
+  onCancel(compensation: OnCancel): this
+    Register a compensation target that undoes this target's effect when the
+    run is later cancelled (via `zuke cancel <run-id>`, an MCP `cancel_run`, or a
+    timed-out wait). The compensation runs iff this target succeeded — a
+    target that never ran, was skipped, or failed has nothing to undo. On
+    cancellation, compensations run in reverse order of the targets that
+    succeeded, so later work is unwound before the work it built on.
+
+    `compensation` is a sibling target, or a thunk returning one (use the thunk
+    form to reference a target declared below this one — class fields
+    initialise top-to-bottom). The compensation body receives a normal
+    {@link TargetContext} whose `state` exposes this target's persisted
+    metadata, so a deploy that recorded `{ slot: "sit-7" }` in `ctx.state` can be
+    rolled back from exactly that slot. Compensation failures are recorded but do
+    not stop the walk (cleanup is maximal). Requires a state store.
+
+    ```ts
+    deploy = target()
+      .executes((ctx) => ctx.state.set({ slot: "sit-7" }))
+      .onCancel(() => this.rollback);
+    rollback = target()
+      .executes((ctx) => tearDown(ctx.state.get().slot)); // reads deploy's meta
     ```
   forEach(items: () => readonly Item[], factory: ForEachFactory<Item>, configure?: Configure<ForEachSettings>): this
     Fan out over a runtime list: for each item, build an ordered pipeline of
@@ -1533,6 +1568,49 @@ interface BuildResult
     True when the run suspended at a `.waitsFor(...)` gate rather than
     finishing — its state is saved and it can be resumed later. The process
     still exits 0.
+  cancelled?: boolean
+    True when the run was cancelled (via `options.signal` / Ctrl-C, or by
+    another process running `zuke cancel`) rather than failing on its own.
+    Its compensations have run and the record is `cancelled`. `ok` is `false`.
+  runId?: string
+    The run's id, when a run identity was established (always, in practice —
+    every {@link "./executor.ts".execute} generates one). Lets the caller point
+    a follow-up (`zuke runs show`, `zuke cancel`) at this run.
+
+interface CancelOptions
+  Options for {@link cancelRun}.
+
+  runId: string
+    The id of the run to cancel.
+  stateStore?: StateStore | false
+    Durable store the run lives in. Defaults to the same resolution as a normal
+    run (explicit → `stateStore()` override → env → `.zuke/runs`); cancel always
+    needs one.
+  actor?: string
+    Who to attribute the cancellation to in the audit trail.
+  readEnv?: (name: string) => string | undefined
+    Reads an environment variable (secrets re-resolve from here for compensations).
+  silent?: boolean
+    Suppress progress output.
+  reporter?: Reporter
+    Custom reporter; overrides `silent`.
+  also?: string[]
+    Extra compensation target names to run first (a timed-out wait whose
+    `onTimeout` names a specific compensation target routes through here).
+
+interface CancelResult
+  The outcome of {@link cancelRun}.
+
+  runId: string
+    The run that was cancelled.
+  status: RunStatus
+    The run's status after cancelling (`cancelled`, or the terminal status on a no-op).
+  noop: boolean
+    True when the run was already terminal and nothing was done.
+  compensated: string[]
+    Names of compensation targets whose bodies ran.
+  failures: CompensationFailure[]
+    Compensations that threw (recorded, non-fatal).
 
 interface CiConcurrency
   A concurrency group: at most one run per group, optionally cancelling the prior one.
@@ -1687,6 +1765,16 @@ interface CliTargetInfo
   readonly unlisted: boolean
     Whether the target is hidden from `--list` (still runnable by name).
 
+interface CompensationFailure
+  A compensation that threw during the cancel walk (recorded, non-fatal).
+
+  target: string
+    The compensation target that failed.
+  forTarget: string
+    The original target whose compensation this was.
+  error: string
+    The failure message.
+
 interface CopyOptions
   Options for {@link FileTasksApi.copy}.
 
@@ -1761,11 +1849,16 @@ interface ExecuteOptions
     to Zuke's built-in {@link defaultRenderer}; `@zuke/console` exports an
     alternative a build can inject to restyle its output.
   signal?: AbortSignal
-    Cancel the run when this signal aborts. Every target body's
+    Cancel the run when this signal aborts (wired to Ctrl-C/SIGTERM by the CLI,
+    or fired by another process running `zuke cancel`). Every target body's
     {@link "./target.ts".TargetContext} `signal` mirrors it, and it is applied
     as the shell's ambient default so an in-flight `$` command is terminated
-    (SIGTERM) on cancellation. A body that ignores its signal still runs to completion —
-    graph-level cancellation/compensation is a later milestone.
+    (SIGTERM) on cancellation. When the run is cancelled, the compensations of
+    every target that had succeeded run in reverse order (see
+    {@link "./target.ts".TargetBuilder.onCancel}) and the result is a non-ok
+    `cancelled` outcome. A body that ignores its signal still runs to
+    completion, so promptly-cancellable work should pass `ctx.signal` to its
+    shell commands.
   stateStore?: StateStore | false
     Durable run state (see {@link "./state/store.ts".StateStore}). A supplied
     store is used directly; `false` disables state entirely. When omitted, the
@@ -2502,6 +2595,12 @@ type LockResult = { ok: true; token: string; } | { ok: false; holder: LockHolder
   The result of {@link StateStore.acquireLock}: a `token` proving ownership, or
   the current `holder` when the lock is already held.
 
+type OnCancel = TargetBuilder | (() => TargetBuilder)
+  A compensation registered with {@link TargetBuilder.onCancel}: either a
+  sibling target directly, or a thunk returning one. The thunk form defers
+  evaluation so a compensation declared below the target it cleans up (class
+  fields initialise top-to-bottom) can still be referenced.
+
 type OnTimeout = () => TargetBuilder | "fail" | "cancel-run"
   What a timed-out wait does — resolved from {@link WaitSettings.onTimeout}.
 
@@ -2527,8 +2626,10 @@ type PutResult = { ok: true; version: string; } | { ok: false; conflict: true; }
 type RunEventOutcome = "ok" | "denied" | "error"
   The outcome recorded for an audited MCP tool call (see {@link RunEvent}).
 
-type RunStatus = "running" | "suspended" | "succeeded" | "failed" | "cancelled"
-  The lifecycle status of a whole run.
+type RunStatus = "running" | "suspended" | "cancelling" | "succeeded" | "failed" | "cancelled"
+  The lifecycle status of a whole run. `cancelling` is the transient state a
+  cancellation moves through — the run has been asked to stop and its
+  compensations are running — before it settles as `cancelled`.
 
 type Target = TargetBuilder
   A configured target. Alias of {@link TargetBuilder} — the same object both

--- a/llms.txt
+++ b/llms.txt
@@ -47,6 +47,7 @@ Reserved commands:
 - `mcp` — Run an MCP server over the build (for AI agents)
 - `resume` — Resume a suspended run (or --check all suspended runs)
 - `runs` — List or show persisted run records
+- `cancel` — Cancel a run and run its compensations
 
 Option flags:
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -137,6 +137,16 @@ function assertExists<T>(value: T, message: string): NonNullable<T>
 async function assertFileExists(path: PathLike): Promise<void>
   Assert that `path` exists and is a file. Async (stats the filesystem).
 
+async function cancelRun(build: Build, options: CancelOptions): Promise<CancelResult>
+  Cancel the run `options.runId` for `build`: transition it to `cancelling`
+  (exactly one canceller drives the walk; a live owning process observes the
+  change and aborts), run the compensations of every succeeded target in reverse
+  order, and settle the record as `cancelled`. Idempotent — cancelling an
+  already-terminal run is a friendly no-op.
+
+  @throws
+      if no state store is configured, or the run does not exist.
+
 function ciHost(): string
   A short identifier for the detected CI host, or `"local"` when not on CI.
   Recognises GitHub Actions, GitLab CI, Azure Pipelines, Bitbucket Pipelines,
@@ -1175,6 +1185,8 @@ class TargetBuilder
     External-event wait settings lambda, set by {@link waitsFor} and run when reached.
   forEach_?: ForEachSpec
     Fan-out spec, set by {@link forEach}: materialises per-item sub-target pipelines.
+  onCancel_?: () => TargetBuilder
+    Compensation thunk, set by {@link onCancel}: runs on cancel iff this target succeeded.
   description(text: string): this
     Set the human-readable description shown in `zuke --list`.
   dependsOn(...targets: Array<TargetBuilder | Group>): this
@@ -1331,6 +1343,29 @@ class TargetBuilder
         s.on(externalSignal("testing-approved"))
           .timeout("72h")
           .onTimeout(() => this.rollback));
+    ```
+  onCancel(compensation: OnCancel): this
+    Register a compensation target that undoes this target's effect when the
+    run is later cancelled (via `zuke cancel <run-id>`, an MCP `cancel_run`, or a
+    timed-out wait). The compensation runs iff this target succeeded — a
+    target that never ran, was skipped, or failed has nothing to undo. On
+    cancellation, compensations run in reverse order of the targets that
+    succeeded, so later work is unwound before the work it built on.
+
+    `compensation` is a sibling target, or a thunk returning one (use the thunk
+    form to reference a target declared below this one — class fields
+    initialise top-to-bottom). The compensation body receives a normal
+    {@link TargetContext} whose `state` exposes this target's persisted
+    metadata, so a deploy that recorded `{ slot: "sit-7" }` in `ctx.state` can be
+    rolled back from exactly that slot. Compensation failures are recorded but do
+    not stop the walk (cleanup is maximal). Requires a state store.
+
+    ```ts
+    deploy = target()
+      .executes((ctx) => ctx.state.set({ slot: "sit-7" }))
+      .onCancel(() => this.rollback);
+    rollback = target()
+      .executes((ctx) => tearDown(ctx.state.get().slot)); // reads deploy's meta
     ```
   forEach(items: () => readonly Item[], factory: ForEachFactory<Item>, configure?: Configure<ForEachSettings>): this
     Fan out over a runtime list: for each item, build an ordered pipeline of
@@ -1587,6 +1622,49 @@ interface BuildResult
     True when the run suspended at a `.waitsFor(...)` gate rather than
     finishing — its state is saved and it can be resumed later. The process
     still exits 0.
+  cancelled?: boolean
+    True when the run was cancelled (via `options.signal` / Ctrl-C, or by
+    another process running `zuke cancel`) rather than failing on its own.
+    Its compensations have run and the record is `cancelled`. `ok` is `false`.
+  runId?: string
+    The run's id, when a run identity was established (always, in practice —
+    every {@link "./executor.ts".execute} generates one). Lets the caller point
+    a follow-up (`zuke runs show`, `zuke cancel`) at this run.
+
+interface CancelOptions
+  Options for {@link cancelRun}.
+
+  runId: string
+    The id of the run to cancel.
+  stateStore?: StateStore | false
+    Durable store the run lives in. Defaults to the same resolution as a normal
+    run (explicit → `stateStore()` override → env → `.zuke/runs`); cancel always
+    needs one.
+  actor?: string
+    Who to attribute the cancellation to in the audit trail.
+  readEnv?: (name: string) => string | undefined
+    Reads an environment variable (secrets re-resolve from here for compensations).
+  silent?: boolean
+    Suppress progress output.
+  reporter?: Reporter
+    Custom reporter; overrides `silent`.
+  also?: string[]
+    Extra compensation target names to run first (a timed-out wait whose
+    `onTimeout` names a specific compensation target routes through here).
+
+interface CancelResult
+  The outcome of {@link cancelRun}.
+
+  runId: string
+    The run that was cancelled.
+  status: RunStatus
+    The run's status after cancelling (`cancelled`, or the terminal status on a no-op).
+  noop: boolean
+    True when the run was already terminal and nothing was done.
+  compensated: string[]
+    Names of compensation targets whose bodies ran.
+  failures: CompensationFailure[]
+    Compensations that threw (recorded, non-fatal).
 
 interface CiConcurrency
   A concurrency group: at most one run per group, optionally cancelling the prior one.
@@ -1741,6 +1819,16 @@ interface CliTargetInfo
   readonly unlisted: boolean
     Whether the target is hidden from `--list` (still runnable by name).
 
+interface CompensationFailure
+  A compensation that threw during the cancel walk (recorded, non-fatal).
+
+  target: string
+    The compensation target that failed.
+  forTarget: string
+    The original target whose compensation this was.
+  error: string
+    The failure message.
+
 interface CopyOptions
   Options for {@link FileTasksApi.copy}.
 
@@ -1815,11 +1903,16 @@ interface ExecuteOptions
     to Zuke's built-in {@link defaultRenderer}; `@zuke/console` exports an
     alternative a build can inject to restyle its output.
   signal?: AbortSignal
-    Cancel the run when this signal aborts. Every target body's
+    Cancel the run when this signal aborts (wired to Ctrl-C/SIGTERM by the CLI,
+    or fired by another process running `zuke cancel`). Every target body's
     {@link "./target.ts".TargetContext} `signal` mirrors it, and it is applied
     as the shell's ambient default so an in-flight `$` command is terminated
-    (SIGTERM) on cancellation. A body that ignores its signal still runs to completion —
-    graph-level cancellation/compensation is a later milestone.
+    (SIGTERM) on cancellation. When the run is cancelled, the compensations of
+    every target that had succeeded run in reverse order (see
+    {@link "./target.ts".TargetBuilder.onCancel}) and the result is a non-ok
+    `cancelled` outcome. A body that ignores its signal still runs to
+    completion, so promptly-cancellable work should pass `ctx.signal` to its
+    shell commands.
   stateStore?: StateStore | false
     Durable run state (see {@link "./state/store.ts".StateStore}). A supplied
     store is used directly; `false` disables state entirely. When omitted, the
@@ -2556,6 +2649,12 @@ type LockResult = { ok: true; token: string; } | { ok: false; holder: LockHolder
   The result of {@link StateStore.acquireLock}: a `token` proving ownership, or
   the current `holder` when the lock is already held.
 
+type OnCancel = TargetBuilder | (() => TargetBuilder)
+  A compensation registered with {@link TargetBuilder.onCancel}: either a
+  sibling target directly, or a thunk returning one. The thunk form defers
+  evaluation so a compensation declared below the target it cleans up (class
+  fields initialise top-to-bottom) can still be referenced.
+
 type OnTimeout = () => TargetBuilder | "fail" | "cancel-run"
   What a timed-out wait does — resolved from {@link WaitSettings.onTimeout}.
 
@@ -2581,8 +2680,10 @@ type PutResult = { ok: true; version: string; } | { ok: false; conflict: true; }
 type RunEventOutcome = "ok" | "denied" | "error"
   The outcome recorded for an audited MCP tool call (see {@link RunEvent}).
 
-type RunStatus = "running" | "suspended" | "succeeded" | "failed" | "cancelled"
-  The lifecycle status of a whole run.
+type RunStatus = "running" | "suspended" | "cancelling" | "succeeded" | "failed" | "cancelled"
+  The lifecycle status of a whole run. `cancelling` is the transient state a
+  cancellation moves through — the run has been asked to stop and its
+  compensations are running — before it settles as `cancelled`.
 
 type Target = TargetBuilder
   A configured target. Alias of {@link TargetBuilder} — the same object both

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -50,6 +50,7 @@ export {
   group,
   type JsonValue,
   LockSettings,
+  type OnCancel,
   type OnTimeout,
   type Remediation,
   type RemediationContext,
@@ -98,6 +99,12 @@ export {
   type ResumeOptions,
   resumeRun,
 } from "./src/resume.ts";
+export {
+  type CancelOptions,
+  type CancelResult,
+  cancelRun,
+  type CompensationFailure,
+} from "./src/cancel.ts";
 export {
   defaultRenderer,
   type Renderer,

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -69,6 +69,18 @@ export interface BuildResult {
    * still exits 0.
    */
   suspended?: boolean;
+  /**
+   * True when the run was **cancelled** (via `options.signal` / Ctrl-C, or by
+   * another process running `zuke cancel`) rather than failing on its own.
+   * Its compensations have run and the record is `cancelled`. `ok` is `false`.
+   */
+  cancelled?: boolean;
+  /**
+   * The run's id, when a run identity was established (always, in practice —
+   * every {@link "./executor.ts".execute} generates one). Lets the caller point
+   * a follow-up (`zuke runs show`, `zuke cancel`) at this run.
+   */
+  runId?: string;
 }
 
 /**

--- a/packages/core/src/cancel.ts
+++ b/packages/core/src/cancel.ts
@@ -1,0 +1,559 @@
+/**
+ * Cancel a run and run its compensations — the cancellation half of the
+ * durable-run lifecycle (see `./resume.ts` for the resume half, and
+ * `./target.ts` `.onCancel(...)` for the authoring surface).
+ *
+ * {@link cancelRun} takes a build and a run id, transitions the run
+ * `running`/`suspended → cancelling` (a compare-and-swap so a live owning
+ * process observes the change and stops — see
+ * {@link "./state/writer.ts".RunStateWriter}), runs the **compensations** of the
+ * targets that had already succeeded — in reverse topological order, so later
+ * work is unwound before the work it built on — releases the run's grip on any
+ * locks (the owning process frees them as it aborts; the TTL is the backstop),
+ * and settles the record as `cancelled`. A second cancel of an
+ * already-terminal run is a friendly no-op.
+ *
+ * A compensation body gets a normal {@link TargetContext} whose `state` exposes
+ * **the original target's** persisted metadata — a deploy that recorded
+ * `{ slot: "sit-7" }` can be rolled back from exactly that slot. Compensation
+ * failures are recorded but never stop the walk (cleanup is maximal).
+ *
+ * The same {@link runCompensations} walk is reused by the executor for an
+ * in-process cancellation (Ctrl-C / an aborted `options.signal`).
+ *
+ * @module
+ */
+
+import { type Build, discoverTargets } from "./build.ts";
+import type { Reporter } from "./executor.ts";
+import { planGraph } from "./graph.ts";
+import { discoverParameters, resolveParameters } from "./params.ts";
+import { Redactor } from "./redact.ts";
+import type {
+  JsonValue,
+  TargetBuilder,
+  TargetContext,
+  TargetStateHandle,
+} from "./target.ts";
+import { absolutePath } from "./path.ts";
+import { findConfigDir, pathExists } from "./config.ts";
+import { defaultStateHost, type StateStore } from "./state/store.ts";
+import { resolveStateStore } from "./state/resolve.ts";
+import { resolveActor } from "./state/record.ts";
+import type {
+  RunEvent,
+  RunRecord,
+  RunStatus,
+  SignalRecord,
+} from "./state/types.ts";
+
+/** How many times a conflicting cancel CAS is re-read and retried. */
+const MAX_RETRIES = 10;
+
+/**
+ * A never-aborted signal handed to compensation bodies: the run is already being
+ * cancelled, but the cleanup itself must run to completion.
+ */
+const NEVER_ABORTED: AbortSignal = new AbortController().signal;
+
+/** Read an environment variable, treating missing env access as unset. */
+function defaultReadEnv(name: string): string | undefined {
+  try {
+    return Deno.env.get(name);
+  } catch {
+    return undefined;
+  }
+}
+
+/** A message from an unknown thrown value, without casting. */
+function messageOf(value: unknown): string {
+  return value instanceof Error ? value.message : String(value);
+}
+
+/**
+ * Run `fn`, rejecting if it runs longer than `timeoutMs` (undefined → no bound).
+ * A timed-out compensation keeps running in the background but its result is
+ * ignored — the same limitation as a target body's `.timeout()`.
+ */
+function withTimeout(
+  fn: () => void | Promise<void>,
+  timeoutMs: number | undefined,
+): Promise<void> {
+  const result = Promise.resolve().then(fn);
+  if (timeoutMs === undefined) return result;
+  return new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`timed out after ${timeoutMs}ms`)),
+      timeoutMs,
+    );
+    result.then(
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+/** The console reporter cancel prints through when none is supplied. */
+const consoleReporter: Reporter = {
+  info: (line) => console.log(line),
+  error: (line) => console.error(line),
+};
+
+/** A reporter that discards output (for `silent`). */
+const silentReporter: Reporter = { info: () => {}, error: () => {} };
+
+/** A run status past which nothing more happens. */
+function isTerminal(status: RunStatus): boolean {
+  return status === "succeeded" || status === "failed" ||
+    status === "cancelled";
+}
+
+/** An empty compensation outcome (nothing ran, nothing failed). */
+const EMPTY_OUTCOME: CompensationOutcome = { compensated: [], failures: [] };
+
+/** One compensation to run: the target undoing an original, plus that original's meta. */
+interface CompensationStep {
+  /** The compensation target (its `.executes(...)` body is run). */
+  compensation: TargetBuilder;
+  /** The name of the succeeded target this compensation undoes. */
+  forTarget: string;
+  /** The original target's persisted metadata, exposed to the body via `ctx.state`. */
+  meta: Record<string, JsonValue>;
+}
+
+/** A compensation that threw during the cancel walk (recorded, non-fatal). */
+export interface CompensationFailure {
+  /** The compensation target that failed. */
+  target: string;
+  /** The original target whose compensation this was. */
+  forTarget: string;
+  /** The failure message. */
+  error: string;
+}
+
+/** What a compensation walk did: which cleanups ran, and which threw. */
+export interface CompensationOutcome {
+  /** Names of compensation targets whose bodies completed. */
+  compensated: string[];
+  /** Compensations that threw (the walk continued past each). */
+  failures: CompensationFailure[];
+}
+
+/** Dependencies for {@link runCompensations}. */
+export interface CompensationDeps {
+  /** The run id, stamped on every compensation's {@link TargetContext}. */
+  runId: string;
+  /** The run's received signals, exposed to compensation bodies via `ctx.signals`. */
+  signals: ReadonlyMap<string, SignalRecord>;
+  /** Where the walk narrates its progress. */
+  reporter: Reporter;
+  /**
+   * Masks secrets in a compensation's failure message before it is recorded,
+   * returned, or printed — a failed shell command's error can carry a secret in
+   * its argv. When absent, messages are used verbatim (no secrets are known).
+   */
+  redactor?: Redactor;
+  /**
+   * Extra compensation steps run **before** the reverse-topological walk — used
+   * by a timed-out wait whose `onTimeout` names a specific compensation target.
+   */
+  extra?: CompensationStep[];
+}
+
+/** An in-memory {@link TargetStateHandle} seeded with a target's persisted meta. */
+function seededStateHandle(seed: Record<string, JsonValue>): TargetStateHandle {
+  // A compensation reads the original target's recorded meta; writes stay
+  // in-memory (the run is ending, so persisting cleanup state adds no value).
+  const meta: Record<string, JsonValue> = { ...seed };
+  return {
+    get: () => ({ ...meta }),
+    set: (patch) => {
+      Object.assign(meta, patch);
+      return Promise.resolve();
+    },
+  };
+}
+
+/**
+ * Run the compensations for a cancelled run: every succeeded target that
+ * declared `.onCancel(...)`, in reverse topological order (later successes
+ * unwound first). Each compensation body gets a normal {@link TargetContext}
+ * whose `state` exposes the original target's persisted metadata. A compensation
+ * that throws is recorded and the walk continues. Shared by {@link cancelRun}
+ * and the executor's in-process cancellation.
+ */
+export async function runCompensations(
+  order: TargetBuilder[],
+  record: RunRecord,
+  deps: CompensationDeps,
+): Promise<CompensationOutcome> {
+  const redact = (message: string): string =>
+    deps.redactor ? deps.redactor.redact(message) : message;
+  const compensated: string[] = [];
+  const failures: CompensationFailure[] = [];
+  const steps: CompensationStep[] = [...(deps.extra ?? [])];
+  // Reverse topological order: undo the work that ran last before the work it
+  // was built on.
+  // ponytail: walks the static plan `order` only, so a `.forEach(...)` fan-out
+  // sub-target's `.onCancel(...)` is not run (sub-targets are materialised at
+  // run time and aren't in `order`). Put compensations on ordinary targets or
+  // the parent fan-out target; re-materialising the fan-out here would need the
+  // runtime item list, which cancel doesn't have. Documented in docs/orchestration.md.
+  for (const t of [...order].reverse()) {
+    const name = t.name_ ?? "";
+    if (record.targets[name]?.status !== "succeeded") continue;
+    if (t.onCancel_ === undefined) continue;
+    // The thunk is user code: a throw here must be recorded, not allowed to
+    // escape and wedge the run mid-cancel (cleanup stays maximal).
+    let compensation: TargetBuilder | undefined;
+    try {
+      compensation = t.onCancel_();
+    } catch (error) {
+      const message = redact(messageOf(error));
+      failures.push({
+        target: `${name}.onCancel`,
+        forTarget: name,
+        error: message,
+      });
+      deps.reporter.error(
+        `✘ .onCancel() thunk for "${name}" threw: ${message}`,
+      );
+      continue;
+    }
+    if (compensation === undefined) {
+      deps.reporter.error(
+        `cancel: target "${name}" .onCancel() resolved to undefined — ` +
+          `skipping. Declare the compensation above "${name}", or pass a thunk.`,
+      );
+      continue;
+    }
+    steps.push({
+      compensation,
+      forTarget: name,
+      meta: record.targets[name]?.meta ?? {},
+    });
+  }
+
+  for (const step of steps) {
+    const compName = step.compensation.name_ ??
+      `${step.forTarget}.onCancel`;
+    const body = step.compensation.fn_;
+    if (body === undefined) {
+      deps.reporter.info(
+        `cancel: compensation "${compName}" for "${step.forTarget}" has no ` +
+          `body — skipping.`,
+      );
+      continue;
+    }
+    const ctx: TargetContext = {
+      runId: deps.runId,
+      target: compName,
+      signal: NEVER_ABORTED,
+      state: seededStateHandle(step.meta),
+      signals: deps.signals,
+      dryRun: false,
+    };
+    try {
+      deps.reporter.info(`↩ compensating ${step.forTarget} → ${compName}`);
+      // Honour the compensation's own `.timeout()` so a hung cleanup can't wedge
+      // the walk (and leave the record non-terminal); no default, like a body.
+      await withTimeout(() => body(ctx), step.compensation.timeout_);
+      compensated.push(compName);
+    } catch (error) {
+      const message = redact(messageOf(error));
+      failures.push({
+        target: compName,
+        forTarget: step.forTarget,
+        error: message,
+      });
+      deps.reporter.error(`✘ compensation ${compName} failed: ${message}`);
+    }
+  }
+  return { compensated, failures };
+}
+
+/** Options for {@link cancelRun}. */
+export interface CancelOptions {
+  /** The id of the run to cancel. */
+  runId: string;
+  /**
+   * Durable store the run lives in. Defaults to the same resolution as a normal
+   * run (explicit → `stateStore()` override → env → `.zuke/runs`); cancel always
+   * needs one.
+   */
+  stateStore?: StateStore | false;
+  /** Who to attribute the cancellation to in the audit trail. */
+  actor?: string;
+  /** Reads an environment variable (secrets re-resolve from here for compensations). */
+  readEnv?: (name: string) => string | undefined;
+  /** Suppress progress output. */
+  silent?: boolean;
+  /** Custom reporter; overrides `silent`. */
+  reporter?: Reporter;
+  /**
+   * Extra compensation target names to run first (a timed-out wait whose
+   * `onTimeout` names a specific compensation target routes through here).
+   */
+  also?: string[];
+}
+
+/** The outcome of {@link cancelRun}. */
+export interface CancelResult {
+  /** The run that was cancelled. */
+  runId: string;
+  /** The run's status after cancelling (`cancelled`, or the terminal status on a no-op). */
+  status: RunStatus;
+  /** True when the run was already terminal and nothing was done. */
+  noop: boolean;
+  /** Names of compensation targets whose bodies ran. */
+  compensated: string[];
+  /** Compensations that threw (recorded, non-fatal). */
+  failures: CompensationFailure[];
+}
+
+/**
+ * Cancel the run `options.runId` for `build`: transition it to `cancelling`
+ * (exactly one canceller drives the walk; a live owning process observes the
+ * change and aborts), run the compensations of every succeeded target in reverse
+ * order, and settle the record as `cancelled`. Idempotent — cancelling an
+ * already-terminal run is a friendly no-op.
+ *
+ * @throws if no state store is configured, or the run does not exist.
+ */
+export async function cancelRun(
+  build: Build,
+  options: CancelOptions,
+): Promise<CancelResult> {
+  const readEnv = options.readEnv ?? defaultReadEnv;
+  const store = resolveCancelStore(options, build, readEnv);
+  if (store === undefined) {
+    throw new Error(
+      "cancel: no state store is configured. Set ZUKE_STATE_DIR / " +
+        "ZUKE_STATE_URL, override stateStore(), or pass one.",
+    );
+  }
+  const runId = options.runId;
+  const actor = resolveActor(options.actor, readEnv);
+  const reporter = options.reporter ??
+    (options.silent ? silentReporter : consoleReporter);
+  const now = () => new Date().toISOString();
+
+  const initial = await store.getRun(runId);
+  if (initial === null) {
+    throw new Error(`cancel: no run "${runId}" found in the store.`);
+  }
+  if (isTerminal(initial.record.status)) {
+    reporter.info(
+      `Run ${runId} is already ${initial.record.status}; nothing to cancel.`,
+    );
+    return {
+      runId,
+      status: initial.record.status,
+      noop: true,
+      compensated: [],
+      failures: [],
+    };
+  }
+
+  // Transition running/suspended → cancelling.
+  const transitioned = await transitionToCancelling(store, runId, initial, now);
+  if (transitioned === "noop") {
+    const fresh = await store.getRun(runId);
+    const status = fresh?.record.status ?? "cancelled";
+    reporter.info(`Run ${runId} is already ${status}; nothing to cancel.`);
+    return { runId, status, noop: true, compensated: [], failures: [] };
+  }
+  if (transitioned === "recover") {
+    // The run was left `cancelling` by an interrupted cancellation (a crashed
+    // canceller, or a store hiccup mid-finalize). Settle it to `cancelled`
+    // without re-running compensations — they may not be idempotent, so a second
+    // pass is more dangerous than the small chance an interrupted first pass
+    // left some cleanup undone. `zuke cancel` becomes retryable, not a dead end.
+    reporter.info(`Run ${runId} was mid-cancellation; finalizing it.`);
+    await finalizeCancelled(store, runId, actor, EMPTY_OUTCOME, now);
+    return {
+      runId,
+      status: "cancelled",
+      noop: false,
+      compensated: [],
+      failures: [],
+    };
+  }
+  const record = transitioned.record;
+
+  // Resolve compensation targets by reference, and make `this.<param>.value`
+  // available to their bodies (from the record's non-secret params; secrets
+  // re-resolve from the environment, exactly as a resume does). Retain the
+  // seeded redactor so a compensation's failure message can't leak a secret.
+  const targets = discoverTargets(build);
+  const params = discoverParameters(build);
+  const redactor = new Redactor();
+  await resolveParameters(
+    params,
+    record.params,
+    readEnv,
+    () => undefined,
+    redactor,
+  );
+  for (const p of params.values()) {
+    if (!p.secret_) continue;
+    const value = p.stringValue_();
+    if (value !== undefined && value !== "") redactor.add(value);
+  }
+
+  let outcome: CompensationOutcome = EMPTY_OUTCOME;
+  const root = targets.get(record.rootTarget);
+  if (root === undefined) {
+    reporter.info(
+      `cancel: build "${build.constructor.name}" has no target ` +
+        `"${record.rootTarget}" — cancelling without compensations.`,
+    );
+  } else {
+    const order = planGraph(root).order;
+    outcome = await runCompensations(order, record, {
+      runId,
+      signals: new Map(Object.entries(record.signals)),
+      reporter,
+      redactor,
+      extra: resolveExtra(options.also, targets, record),
+    });
+  }
+
+  await finalizeCancelled(store, runId, actor, outcome, now);
+  reporter.info(
+    `Run ${runId} cancelled — ${outcome.compensated.length} compensation(s) ` +
+      `ran${
+        outcome.failures.length > 0 ? `, ${outcome.failures.length} failed` : ""
+      }.`,
+  );
+  return {
+    runId,
+    status: "cancelled",
+    noop: false,
+    compensated: outcome.compensated,
+    failures: outcome.failures,
+  };
+}
+
+/** Resolve the store for a cancel — like a run, but always defaulting on. */
+function resolveCancelStore(
+  options: CancelOptions,
+  build: Build,
+  readEnv: (name: string) => string | undefined,
+): StateStore | undefined {
+  return resolveStateStore(options.stateStore, build.stateStore(), {
+    readEnv,
+    host: defaultStateHost,
+    defaultDir: absolutePath(
+      findConfigDir(Deno.cwd(), pathExists) ?? Deno.cwd(),
+    )(".zuke", "runs").path,
+    enableDefault: true,
+  });
+}
+
+/** Resolve `also` target names to compensation steps (timeout `{target}` disposition). */
+function resolveExtra(
+  also: string[] | undefined,
+  targets: Map<string, TargetBuilder>,
+  record: RunRecord,
+): CompensationStep[] {
+  const steps: CompensationStep[] = [];
+  for (const name of also ?? []) {
+    const target = targets.get(name);
+    if (target === undefined) continue;
+    steps.push({
+      compensation: target,
+      forTarget: name,
+      meta: record.targets[name]?.meta ?? {},
+    });
+  }
+  return steps;
+}
+
+/**
+ * Compare-and-swap the run from `running`/`suspended` to `cancelling`. Returns
+ * `"noop"` when the run has become terminal, or `"recover"` when it is already
+ * `cancelling` — an interrupted cancellation the caller should finalize rather
+ * than re-walk.
+ */
+async function transitionToCancelling(
+  store: StateStore,
+  id: string,
+  initial: { record: RunRecord; version: string },
+  now: () => string,
+): Promise<{ record: RunRecord; version: string } | "noop" | "recover"> {
+  let record = initial.record;
+  let version = initial.version;
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    if (isTerminal(record.status)) return "noop";
+    if (record.status === "cancelling") return "recover";
+    const next = structuredClone(record);
+    next.status = "cancelling";
+    next.updatedAt = now();
+    const result = await store.putRun(next, version);
+    if (result.ok) return { record: next, version: result.version };
+    const fresh = await store.getRun(id);
+    if (fresh === null) return "noop"; // vanished mid-cancel
+    record = fresh.record;
+    version = fresh.version;
+  }
+  throw new Error(
+    `cancel: gave up cancelling ${id} after repeated conflicts.`,
+  );
+}
+
+/**
+ * CAS the run to `cancelled` and append the cancellation audit event. Throws if
+ * it cannot land the write after {@link MAX_RETRIES} conflicts — surfacing a
+ * store outage rather than silently leaving the run stuck `cancelling` (a
+ * re-`cancel` then recovers it).
+ */
+async function finalizeCancelled(
+  store: StateStore,
+  id: string,
+  actor: string,
+  outcome: CompensationOutcome,
+  now: () => string,
+): Promise<void> {
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    const loaded = await store.getRun(id);
+    if (loaded === null || loaded.record.status === "cancelled") return;
+    const next = structuredClone(loaded.record);
+    next.status = "cancelled";
+    next.updatedAt = now();
+    next.events.push(cancelEvent(actor, outcome, now()));
+    const result = await store.putRun(next, loaded.version);
+    if (result.ok) return;
+  }
+  throw new Error(
+    `cancel: gave up finalizing ${id} to cancelled after repeated conflicts.`,
+  );
+}
+
+/** Build the audit event summarising a cancellation. Shared with the executor. */
+export function cancelEvent(
+  actor: string,
+  outcome: CompensationOutcome,
+  at: string,
+): RunEvent {
+  const ran = outcome.compensated.length;
+  const failed = outcome.failures.length;
+  const detail = ran === 0 && failed === 0
+    ? "no compensations"
+    : `ran ${ran} compensation(s)` +
+      (failed > 0 ? `, ${failed} failed` : "");
+  return {
+    at,
+    tool: "cancel",
+    actor,
+    outcome: failed > 0 ? "error" : "ok",
+    args: {},
+    detail,
+  };
+}

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -559,11 +559,20 @@ export interface MainOptions {
   /** Renderer for the build's banners and summary (see {@link RunOptions}). */
   renderer?: Renderer;
   /**
-   * Cancel the running build when this signal aborts (wired to SIGINT/SIGTERM by
-   * {@link run}). The run stops, its succeeded targets' compensations run, and
-   * the record is marked cancelled.
+   * Cancel a running **build** when this signal aborts (its compensations run and
+   * the record is marked cancelled). Applies only to a target run; other
+   * commands ignore it. Tests inject one directly; {@link run} does not use it —
+   * see {@link watchSignals}.
    */
   signal?: AbortSignal;
+  /**
+   * Install OS SIGINT/SIGTERM handlers that gracefully cancel a **build run**
+   * (running its compensations; a second signal force-exits). Set by
+   * {@link run}. Scoped to the target-run path on purpose, so a signal keeps its
+   * default terminate behaviour for a long-lived `mcp` server and every other
+   * command.
+   */
+  watchSignals?: boolean;
 }
 
 /**
@@ -862,21 +871,70 @@ export async function main(
     if (ciCode !== 0) return ciCode;
   }
 
-  const result = await execute(build, root, {
-    skip: parsed.skip,
-    params: parsed.values,
-    parallel: parsed.parallel,
-    cache: parsed.cache,
-    remoteCache: parsed.remoteCache === false ? false : undefined,
-    affected: parsed.affected ? { base: parsed.affectedBase } : undefined,
-    dryRun: parsed.dryRun,
-    state: parsed.state,
-    actor: parsed.actor,
-    plugins: options.plugins,
-    renderer: options.renderer,
-    signal: options.signal,
-  });
-  return result.ok ? 0 : 1;
+  // A running build cancels gracefully on Ctrl-C/SIGTERM — running its
+  // compensations — when `run` asks for it (`watchSignals`); a second signal
+  // force-exits. Handlers are installed only here, around the build, so a signal
+  // keeps its default terminate behaviour for `mcp` and every other command.
+  // A test can inject `options.signal` directly instead.
+  const controller = new AbortController();
+  const cleanupSignals = options.watchSignals
+    ? installCancelSignals(controller)
+    : undefined;
+  try {
+    const result = await execute(build, root, {
+      skip: parsed.skip,
+      params: parsed.values,
+      parallel: parsed.parallel,
+      cache: parsed.cache,
+      remoteCache: parsed.remoteCache === false ? false : undefined,
+      affected: parsed.affected ? { base: parsed.affectedBase } : undefined,
+      dryRun: parsed.dryRun,
+      state: parsed.state,
+      actor: parsed.actor,
+      plugins: options.plugins,
+      renderer: options.renderer,
+      signal: cleanupSignals ? controller.signal : options.signal,
+    });
+    return result.ok ? 0 : 1;
+  } finally {
+    cleanupSignals?.();
+  }
+}
+
+/**
+ * Install SIGINT/SIGTERM handlers that abort `controller` on the first signal
+ * (graceful cancel) and force-exit on a second, so a stuck build never traps the
+ * operator. Returns a cleanup function that removes them. SIGTERM is skipped on
+ * Windows (unsupported there).
+ */
+function installCancelSignals(controller: AbortController): () => void {
+  let cancelling = false;
+  const onSignal = () => {
+    if (cancelling) Deno.exit(130);
+    cancelling = true;
+    controller.abort();
+  };
+  const wanted: Deno.Signal[] = Deno.build.os === "windows"
+    ? ["SIGINT"]
+    : ["SIGINT", "SIGTERM"];
+  const installed: Deno.Signal[] = [];
+  for (const sig of wanted) {
+    try {
+      Deno.addSignalListener(sig, onSignal);
+      installed.push(sig);
+    } catch {
+      // A platform that doesn't support this signal — skip it.
+    }
+  }
+  return () => {
+    for (const sig of installed) {
+      try {
+        Deno.removeSignalListener(sig, onSignal);
+      } catch {
+        // Best-effort teardown.
+      }
+    }
+  };
 }
 
 /** Options for {@link run}. */
@@ -914,43 +972,12 @@ export async function run(
   // Run only when this build's module is the one Deno was started with, so the
   // caller needn't write `if (import.meta.main)`. Imported elsewhere, no-op.
   if (!isEntryModule(new Error().stack ?? "", import.meta.url)) return;
-
-  // Wire Ctrl-C (and SIGTERM, where supported) to graceful cancellation: the
-  // first signal aborts the run so its compensations run; a second forces an
-  // immediate exit, so a stuck build can never trap the operator.
-  const controller = new AbortController();
-  let cancelling = false;
-  const onSignal = () => {
-    if (cancelling) Deno.exit(130);
-    cancelling = true;
-    controller.abort();
-  };
-  const signals: Deno.Signal[] = Deno.build.os === "windows"
-    ? ["SIGINT"]
-    : ["SIGINT", "SIGTERM"];
-  for (const sig of signals) {
-    try {
-      Deno.addSignalListener(sig, onSignal);
-    } catch {
-      // A platform that doesn't support this signal — skip it.
-    }
-  }
-
-  let code: number;
-  try {
-    code = await main(BuildClass, options.args ?? Deno.args, {
-      plugins: options.plugins,
-      renderer: options.renderer,
-      signal: controller.signal,
-    });
-  } finally {
-    for (const sig of signals) {
-      try {
-        Deno.removeSignalListener(sig, onSignal);
-      } catch {
-        // Best-effort teardown; ignore an unsupported signal.
-      }
-    }
-  }
+  // `watchSignals` lets `main` wire Ctrl-C/SIGTERM to graceful cancellation, but
+  // only around a build run — every other command keeps default signal handling.
+  const code = await main(BuildClass, options.args ?? Deno.args, {
+    plugins: options.plugins,
+    renderer: options.renderer,
+    watchSignals: true,
+  });
   Deno.exit(code);
 }

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -25,6 +25,7 @@ import {
   isCompletionShell,
 } from "./completions.ts";
 import {
+  CANCEL_COMMAND,
   COMPLETIONS_COMMAND,
   DEFAULT_TARGET,
   GENERATE_CI_COMMAND,
@@ -34,6 +35,7 @@ import {
   RUNS_COMMAND,
 } from "./cli_spec.ts";
 import { type HttpAddress, serveMcp } from "./mcp/command.ts";
+import { cancelRun } from "./cancel.ts";
 import { resumeCheck, resumeRun } from "./resume.ts";
 import { runsCommand } from "./runs.ts";
 import { isRunStatus, RUN_STATUS_NAMES, type RunQuery } from "./state/types.ts";
@@ -144,6 +146,10 @@ export interface ParsedArgs {
   runTarget?: string;
   /** With `runs list`, keep only runs created at/after this ISO-8601 time (`--since`). */
   since?: string;
+  /** The `cancel` command was requested (cancel a run and run its compensations). */
+  cancel: boolean;
+  /** The run id to cancel (the positional after `cancel`). */
+  cancelRunId?: string;
   /** Raw parameter values from declared flags, keyed by property name. */
   values: Record<string, string>;
   help: boolean;
@@ -184,6 +190,7 @@ export function parseArgs(
     resume: false,
     forceGraph: false,
     runs: false,
+    cancel: false,
     confirmDestructive: false,
     help: false,
   };
@@ -310,9 +317,13 @@ export function parseArgs(
     } else if (parsed.runs && parsed.runsRunId === undefined) {
       // ...then, for `show`, the run id.
       parsed.runsRunId = arg;
+    } else if (parsed.cancel && parsed.cancelRunId === undefined) {
+      // `cancel` takes the run id as its positional.
+      parsed.cancelRunId = arg;
     } else if (
       parsed.target === undefined && !parsed.graph && !parsed.generateCi &&
-      !parsed.completions && !parsed.mcp && !parsed.resume && !parsed.runs
+      !parsed.completions && !parsed.mcp && !parsed.resume && !parsed.runs &&
+      !parsed.cancel
     ) {
       if (arg === GRAPH_COMMAND) parsed.graph = true;
       else if (arg === GENERATE_CI_COMMAND) parsed.generateCi = true;
@@ -320,6 +331,7 @@ export function parseArgs(
       else if (arg === MCP_COMMAND) parsed.mcp = true;
       else if (arg === RESUME_COMMAND) parsed.resume = true;
       else if (arg === RUNS_COMMAND) parsed.runs = true;
+      else if (arg === CANCEL_COMMAND) parsed.cancel = true;
       else parsed.target = arg;
     }
   }
@@ -344,6 +356,7 @@ Usage:
   deno run -A zuke.ts resume --check [<run-id>]
   deno run -A zuke.ts runs list [--status <s>] [--target <t>] [--since <iso>] [--json]
   deno run -A zuke.ts runs show <run-id> [--json]
+  deno run -A zuke.ts cancel <run-id> [--actor <name>]
 
 Options:
   <target>          Run the target and its transitive dependencies.
@@ -413,6 +426,10 @@ Options:
                     prints one row per run (newest first); 'show <run-id>'
                     reconstructs a run's full per-target status and metadata.
                     Both accept --json for tools. See docs/state.md.
+  cancel            Cancel a run <run-id>: stop it (a live run aborts), run the
+                    compensations of every target that had succeeded — in
+                    reverse order — and mark the record cancelled. Idempotent:
+                    cancelling a finished run is a no-op. See docs/orchestration.md.
   --status <s>      With runs list, keep only runs with this status (running,
                     suspended, succeeded, failed, cancelled).
   --target <t>      With runs list, keep only runs whose graph contains this
@@ -541,6 +558,12 @@ export interface MainOptions {
   installOptions?: InstallOptions;
   /** Renderer for the build's banners and summary (see {@link RunOptions}). */
   renderer?: Renderer;
+  /**
+   * Cancel the running build when this signal aborts (wired to SIGINT/SIGTERM by
+   * {@link run}). The run stops, its succeeded targets' compensations run, and
+   * the record is marked cancelled.
+   */
+  signal?: AbortSignal;
 }
 
 /**
@@ -685,6 +708,26 @@ async function runMcp(build: Build, parsed: ParsedArgs): Promise<number> {
   });
 }
 
+/** Run the `cancel` command: cancel a run and run its compensations. */
+async function runCancel(build: Build, parsed: ParsedArgs): Promise<number> {
+  if (parsed.cancelRunId === undefined) {
+    console.error("Usage: zuke cancel <run-id> [--actor <name>]");
+    return 1;
+  }
+  try {
+    const result = await cancelRun(build, {
+      runId: parsed.cancelRunId,
+      actor: parsed.actor,
+    });
+    // A no-op (already-terminal run) and a completed cancellation both succeed;
+    // a compensation that threw surfaces non-zero so the operator notices.
+    return result.failures.length > 0 ? 1 : 0;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}
+
 /** Run the `runs` command: build the query (validating `--status`) and dispatch. */
 async function runRuns(build: Build, parsed: ParsedArgs): Promise<number> {
   const query: RunQuery = {};
@@ -787,6 +830,9 @@ export async function main(
   if (parsed.runs) {
     return await runRuns(build, parsed);
   }
+  if (parsed.cancel) {
+    return await runCancel(build, parsed);
+  }
 
   let name = parsed.target;
   if (name === undefined) {
@@ -828,6 +874,7 @@ export async function main(
     actor: parsed.actor,
     plugins: options.plugins,
     renderer: options.renderer,
+    signal: options.signal,
   });
   return result.ok ? 0 : 1;
 }
@@ -867,9 +914,43 @@ export async function run(
   // Run only when this build's module is the one Deno was started with, so the
   // caller needn't write `if (import.meta.main)`. Imported elsewhere, no-op.
   if (!isEntryModule(new Error().stack ?? "", import.meta.url)) return;
-  const code = await main(BuildClass, options.args ?? Deno.args, {
-    plugins: options.plugins,
-    renderer: options.renderer,
-  });
+
+  // Wire Ctrl-C (and SIGTERM, where supported) to graceful cancellation: the
+  // first signal aborts the run so its compensations run; a second forces an
+  // immediate exit, so a stuck build can never trap the operator.
+  const controller = new AbortController();
+  let cancelling = false;
+  const onSignal = () => {
+    if (cancelling) Deno.exit(130);
+    cancelling = true;
+    controller.abort();
+  };
+  const signals: Deno.Signal[] = Deno.build.os === "windows"
+    ? ["SIGINT"]
+    : ["SIGINT", "SIGTERM"];
+  for (const sig of signals) {
+    try {
+      Deno.addSignalListener(sig, onSignal);
+    } catch {
+      // A platform that doesn't support this signal — skip it.
+    }
+  }
+
+  let code: number;
+  try {
+    code = await main(BuildClass, options.args ?? Deno.args, {
+      plugins: options.plugins,
+      renderer: options.renderer,
+      signal: controller.signal,
+    });
+  } finally {
+    for (const sig of signals) {
+      try {
+        Deno.removeSignalListener(sig, onSignal);
+      } catch {
+        // Best-effort teardown; ignore an unsupported signal.
+      }
+    }
+  }
   Deno.exit(code);
 }

--- a/packages/core/src/cli_spec.ts
+++ b/packages/core/src/cli_spec.ts
@@ -38,6 +38,9 @@ export const RESUME_COMMAND = "resume";
 /** The `runs` command: list and show persisted run records. */
 export const RUNS_COMMAND = "runs";
 
+/** The `cancel` command: cancel a run and run its compensations. */
+export const CANCEL_COMMAND = "cancel";
+
 /** Every reserved command, in help and completion order. */
 export const RESERVED_COMMANDS: readonly ReservedCommand[] = [
   { name: GRAPH_COMMAND, description: "Show the dependency graph" },
@@ -57,6 +60,10 @@ export const RESERVED_COMMANDS: readonly ReservedCommand[] = [
   {
     name: RUNS_COMMAND,
     description: "List or show persisted run records",
+  },
+  {
+    name: CANCEL_COMMAND,
+    description: "Cancel a run and run its compensations",
   },
 ];
 

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -60,6 +60,7 @@ import { defaultStateHost, type StateStore } from "./state/store.ts";
 import { resolveStateStore } from "./state/resolve.ts";
 import { buildRunRecord, ciRunUrl, resolveActor } from "./state/record.ts";
 import { inMemoryStateHandle, RunStateWriter } from "./state/writer.ts";
+import { cancelEvent, runCompensations } from "./cancel.ts";
 import { LockConflictError, type LockHolder } from "./state/lock.ts";
 import { parseDuration } from "./duration.ts";
 import type { Plugin } from "./plugin.ts";
@@ -185,11 +186,16 @@ export interface ExecuteOptions {
    */
   renderer?: Renderer;
   /**
-   * Cancel the run when this signal aborts. Every target body's
+   * Cancel the run when this signal aborts (wired to Ctrl-C/SIGTERM by the CLI,
+   * or fired by another process running `zuke cancel`). Every target body's
    * {@link "./target.ts".TargetContext} `signal` mirrors it, and it is applied
    * as the shell's ambient default so an in-flight `$` command is terminated
-   * (SIGTERM) on cancellation. A body that ignores its signal still runs to completion —
-   * graph-level cancellation/compensation is a later milestone.
+   * (SIGTERM) on cancellation. When the run is cancelled, the compensations of
+   * every target that had **succeeded** run in reverse order (see
+   * {@link "./target.ts".TargetBuilder.onCancel}) and the result is a non-ok
+   * `cancelled` outcome. A body that ignores its signal still runs to
+   * completion, so promptly-cancellable work should pass `ctx.signal` to its
+   * shell commands.
    */
   signal?: AbortSignal;
   /**
@@ -1347,6 +1353,14 @@ export async function execute(
     if (options.signal.aborted) runController.abort();
     else options.signal.addEventListener("abort", onCancel, { once: true });
   }
+  // Set when a state write discovers another process moved this run to
+  // `cancelling`/`cancelled` (a `zuke cancel` elsewhere). We then abort and let
+  // that canceller own the compensation walk — we do not run it ourselves.
+  let externallyCancelled = false;
+  const onExternalCancel = () => {
+    externallyCancelled = true;
+    runController.abort();
+  };
 
   // Resolve the durable state store (if any) and open a writer that records the
   // run and its per-target transitions. Never for a dry run — no body executes,
@@ -1356,7 +1370,8 @@ export async function execute(
   // compensations) turns the filesystem store on by default, so state "just
   // works" without --state. Plain builds still opt in explicitly.
   const usesDurableFeature = order.some((t) =>
-    t.lock_ !== undefined || t.waitsFor_ !== undefined
+    t.lock_ !== undefined || t.waitsFor_ !== undefined ||
+    t.onCancel_ !== undefined
   );
   const stateStore = dryRun ? undefined : resolveStateStore(
     options.stateStore,
@@ -1401,6 +1416,7 @@ export async function execute(
       nowIso,
       redactor,
       warn,
+      onExternalCancel,
     )
     : await RunStateWriter.open(
       stateStore,
@@ -1416,6 +1432,7 @@ export async function execute(
       nowIso,
       redactor,
       warn,
+      onExternalCancel,
     );
   const env: RunEnv = {
     runId,
@@ -1489,16 +1506,69 @@ export async function execute(
   }
   if (cache !== undefined) await cache.save();
 
-  const result: BuildResult = run.aborted
-    ? { ok: false, executed: run.executed, error: run.failure }
-    : run.suspended
-    ? { ok: true, executed: run.executed, suspended: true }
-    : { ok: true, executed: run.executed };
-
-  // Record the run's terminal status. Awaiting this drains the writer's queue,
-  // so every per-target transition has landed by the time the run returns.
-  if (run.suspended) await writer?.markRunSuspended();
-  else await writer?.markRunFinished(result.ok);
+  // A cancellation (Ctrl-C / an aborted `options.signal`, or another process
+  // running `zuke cancel`) takes precedence over an ordinary failure: the
+  // aborted target failing is a symptom, not the outcome.
+  const cancelled = runController.signal.aborted;
+  let result: BuildResult;
+  if (cancelled) {
+    result = {
+      ok: false,
+      executed: run.executed,
+      cancelled: true,
+      runId,
+    };
+    if (externallyCancelled) {
+      // Another process owns the cancellation: it runs the compensations and
+      // settles the record. We stop and leave the run `cancelling`, draining any
+      // pending per-target writes so none races the process exit.
+      await writer?.drain();
+      reporter.info(
+        `Run ${runId} cancelled by another process — stopping.`,
+      );
+    } else if (writer !== undefined) {
+      // We initiated it (Ctrl-C / options.signal): mark cancelling (which also
+      // drains every pending per-target write, so the snapshot is current).
+      await writer.markRunCancelling();
+      // markRunCancelling drains the write chain, so if another process's
+      // `zuke cancel` won the race in the meantime, the conflict has already
+      // fired onExternalCancel. Re-check before walking, so we never run the
+      // compensations twice (that canceller owns them now).
+      if (externallyCancelled) {
+        await writer.drain();
+        reporter.info(
+          `Run ${runId} cancelled by another process — stopping.`,
+        );
+      } else {
+        // Run the succeeded targets' compensations in reverse order, record the
+        // cancellation in the audit trail (as `zuke cancel` does), then settle.
+        const comp = await runCompensations(order, writer.snapshot(), {
+          runId,
+          signals: env.signals,
+          reporter,
+          redactor,
+        });
+        await writer.appendEvent(cancelEvent(actor, comp, nowIso()));
+        await writer.markRunCancelled();
+        reporter.info(
+          `Run ${runId} cancelled — ${comp.compensated.length} ` +
+            `compensation(s) ran${
+              comp.failures.length > 0 ? `, ${comp.failures.length} failed` : ""
+            }.`,
+        );
+      }
+    }
+  } else {
+    result = run.aborted
+      ? { ok: false, executed: run.executed, error: run.failure, runId }
+      : run.suspended
+      ? { ok: true, executed: run.executed, suspended: true, runId }
+      : { ok: true, executed: run.executed, runId };
+    // Record the run's terminal status. Awaiting this drains the writer's queue,
+    // so every per-target transition has landed by the time the run returns.
+    if (run.suspended) await writer?.markRunSuspended();
+    else await writer?.markRunFinished(result.ok);
+  }
 
   const totalMs = performance.now() - overallStart;
   for (
@@ -1507,7 +1577,8 @@ export async function execute(
     reporter.info(line);
   }
   // On suspension, point the operator at the saved run so it can be resumed.
-  if (run.suspended) {
+  // A cancelled run never resumes, so it skips this even if it parked a wait.
+  if (run.suspended && !cancelled) {
     const waiting = run.reports.filter((r) => r.status === "waiting")
       .map((r) => r.name);
     reporter.info(

--- a/packages/core/src/mcp/runtools.ts
+++ b/packages/core/src/mcp/runtools.ts
@@ -11,6 +11,7 @@
  */
 
 import type { Build } from "../build.ts";
+import { cancelRun } from "../cancel.ts";
 import { AlreadyResumedError, resumeCheck, resumeRun } from "../resume.ts";
 import { LockConflictError } from "../state/lock.ts";
 import type { StateStore } from "../state/store.ts";
@@ -137,6 +138,24 @@ const MUTATING_TOOLS: readonly McpTool[] = [
     },
     annotations: { title: "Resume check", destructiveHint: true },
   },
+  {
+    name: "cancel_run",
+    description:
+      "Cancel a run and run its compensations (reverse order). Idempotent — a finished run is a no-op.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        runId: { type: "string", description: "The run to cancel." },
+        operatorToken: {
+          type: "string",
+          description:
+            "Operator token, required if the run's target is protected.",
+        },
+      },
+      required: ["runId"],
+    },
+    annotations: { title: "Cancel run", destructiveHint: true },
+  },
 ];
 
 /**
@@ -155,7 +174,8 @@ export const RUN_STATE_TOOL_NAMES: readonly string[] = [
 
 /** Whether `name` is one of the mutating run-state tools (audited, gated). */
 export function isMutatingRunTool(name: string): boolean {
-  return name === "signal_run" || name === "resume_check";
+  return name === "signal_run" || name === "resume_check" ||
+    name === "cancel_run";
 }
 
 /** Read an optional string argument, or `undefined` when absent/not a string. */
@@ -208,6 +228,7 @@ export async function callRunStateTool(
   if (name === "show_run") return await showRun(deps, args);
   if (name === "signal_run") return await signalRun(deps, args);
   if (name === "resume_check") return await resumeCheckTool(deps, args);
+  if (name === "cancel_run") return await cancelRunTool(deps, args);
   return null;
 }
 
@@ -334,4 +355,42 @@ async function resumeCheckTool(
     }
   }
   return jsonResult({ ok: failed === 0, checked, failed });
+}
+
+/** `cancel_run`: cancel a run and run its compensations, exactly like `zuke cancel`. */
+async function cancelRunTool(
+  deps: RunToolDeps,
+  args: Record<string, unknown>,
+): Promise<RunToolResult> {
+  const runId = stringArg(args, "runId");
+  if (runId === undefined) {
+    return jsonResult({ error: "missing_argument", argument: "runId" }, true);
+  }
+  // Cancelling runs the run's compensation code, so it is gated by the same
+  // allow-list and operator-token policy as a `run:` tool.
+  const loaded = await deps.store.getRun(runId);
+  if (loaded === null) return jsonResult({ error: "no_run", runId }, true);
+  const denied = deps.authorize(loaded.record.rootTarget, args);
+  if (denied !== null) {
+    return jsonResult({ error: "unauthorized", reason: denied, runId }, true);
+  }
+  try {
+    const result = await cancelRun(deps.build, {
+      runId,
+      stateStore: deps.store,
+      actor: deps.actor,
+      readEnv: deps.readEnv,
+      silent: true,
+    });
+    return jsonResult({
+      ok: result.failures.length === 0,
+      runId,
+      status: result.status,
+      noop: result.noop,
+      compensated: result.compensated,
+      failures: result.failures,
+    });
+  } catch (error) {
+    return structuredError(error, runId);
+  }
 }

--- a/packages/core/src/resume.ts
+++ b/packages/core/src/resume.ts
@@ -17,6 +17,7 @@
  */
 
 import { type Build, type BuildResult, discoverTargets } from "./build.ts";
+import { cancelRun } from "./cancel.ts";
 import { execute, type Reporter } from "./executor.ts";
 import { planGraph } from "./graph.ts";
 import type { JsonValue, TargetBuilder } from "./target.ts";
@@ -25,7 +26,12 @@ import { findConfigDir, pathExists } from "./config.ts";
 import { defaultStateHost, type StateStore } from "./state/store.ts";
 import { resolveStateStore } from "./state/resolve.ts";
 import { resolveActor } from "./state/record.ts";
-import type { RunGraphNode, RunRecord, WaitState } from "./state/types.ts";
+import type {
+  RunGraphNode,
+  RunRecord,
+  WaitDisposition,
+  WaitState,
+} from "./state/types.ts";
 
 /** Raised when a run has already been resumed by another process. */
 export class AlreadyResumedError extends Error {
@@ -115,12 +121,24 @@ export async function resumeRun(
   const resumerActor = resolveActor(options.actor, readEnv);
   const now = () => new Date().toISOString();
 
-  // A wait past its deadline times out instead of resuming. Its recorded
-  // onTimeout disposition is honoured as "fail" for now; running a compensation
-  // target is a later milestone (cancellation), so the disposition is preserved.
+  // A wait past its deadline times out instead of resuming, honouring its
+  // recorded onTimeout disposition: "fail" fails the run; "cancel-run" and a
+  // named compensation target both cancel the run (running its compensations).
   const expired = expiredWait(initial.record, Date.now());
   if (initial.record.status === "suspended" && expired !== null) {
-    return await failTimedOut(store, initial, expired, now);
+    const disposition = expired.waitingFor.onTimeout;
+    if (disposition === "fail") {
+      return await failTimedOut(store, initial, expired, now);
+    }
+    return await cancelTimedOut(
+      build,
+      store,
+      options,
+      expired,
+      disposition,
+      resumerActor,
+      readEnv,
+    );
   }
   // Validate the root and graph shape *before* transitioning, so a mismatch
   // leaves the run suspended (retryable with --force-graph) rather than stuck.
@@ -333,6 +351,47 @@ async function failTimedOut(
 }
 
 /**
+ * Handle a timed-out wait whose disposition **cancels** the run: `"cancel-run"`
+ * cancels it (running the compensations of every succeeded target), and a named
+ * target additionally runs that specific compensation first. Delegates to
+ * {@link "./cancel.ts".cancelRun}, so a stuck deploy → wait → (timeout) is
+ * unwound and its locks released — the failure mode a bare timeout can't fix.
+ */
+async function cancelTimedOut(
+  build: Build,
+  store: StateStore,
+  options: ResumeOptions,
+  expired: { name: string; waitingFor: WaitState },
+  disposition: WaitDisposition,
+  actor: string,
+  readEnv: (name: string) => string | undefined,
+): Promise<BuildResult> {
+  const also = typeof disposition === "object"
+    ? [disposition.target]
+    : undefined;
+  const result = await cancelRun(build, {
+    runId: options.runId,
+    stateStore: store,
+    actor,
+    readEnv,
+    silent: options.silent,
+    reporter: options.reporter,
+    also,
+  });
+  return {
+    ok: false,
+    executed: [],
+    cancelled: true,
+    runId: options.runId,
+    error: new Error(
+      `resume: run ${options.runId}: wait "${expired.name}" timed out ` +
+        `(deadline ${expired.waitingFor.deadline}) — run cancelled ` +
+        `(${result.compensated.length} compensation(s) ran).`,
+    ),
+  };
+}
+
+/**
  * Re-attempt every suspended run in the store (or just `runId`): predicate-based
  * waits are re-evaluated and expired waits time out. Signal-based waits with no
  * new signal simply re-suspend. Returns the number of runs that ended in
@@ -359,7 +418,14 @@ export async function resumeCheck(
       if (!result.ok) failed += 1;
     } catch (error) {
       if (error instanceof AlreadyResumedError) continue; // another process has it
-      throw error;
+      // Isolate a per-run failure: one run erroring (a bad graph, a throwing
+      // compensation) must not abort the sweep and strand every run behind it.
+      failed += 1;
+      options.reporter?.error(
+        `resume --check: run ${id} errored: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
     }
   }
   return { checked: ids.length, failed };

--- a/packages/core/src/state/types.ts
+++ b/packages/core/src/state/types.ts
@@ -18,10 +18,15 @@
 
 import type { JsonValue } from "../target.ts";
 
-/** The lifecycle status of a whole run. */
+/**
+ * The lifecycle status of a whole run. `cancelling` is the transient state a
+ * cancellation moves through — the run has been asked to stop and its
+ * compensations are running — before it settles as `cancelled`.
+ */
 export type RunStatus =
   | "running"
   | "suspended"
+  | "cancelling"
   | "succeeded"
   | "failed"
   | "cancelled";
@@ -184,6 +189,7 @@ export function toSummary(record: RunRecord): RunSummary {
 const RUN_STATUSES: readonly RunStatus[] = [
   "running",
   "suspended",
+  "cancelling",
   "succeeded",
   "failed",
   "cancelled",

--- a/packages/core/src/state/writer.ts
+++ b/packages/core/src/state/writer.ts
@@ -64,6 +64,8 @@ export class RunStateWriter {
   readonly #now: () => string;
   readonly #redactor: Redactor;
   readonly #warn?: (message: string) => void;
+  /** Fired when a CAS re-read finds the run cancelling/cancelled by another process. */
+  readonly #onExternalCancel?: () => void;
   #record: RunRecord;
   #version: string | null;
   #chain: Promise<void> = Promise.resolve();
@@ -75,12 +77,14 @@ export class RunStateWriter {
     now: () => string,
     redactor: Redactor,
     warn?: (message: string) => void,
+    onExternalCancel?: () => void,
   ) {
     this.#store = store;
     this.#record = record;
     this.#now = now;
     this.#redactor = redactor;
     this.#warn = warn;
+    this.#onExternalCancel = onExternalCancel;
     this.#version = version;
   }
 
@@ -88,6 +92,8 @@ export class RunStateWriter {
    * Create a writer and persist the initial record (status `running`, targets
    * `pending`). The create rides the same best-effort path as every other
    * write, so a store that is briefly unavailable is reported, not fatal.
+   * `onExternalCancel` is invoked if a later write discovers the run has been
+   * moved to `cancelling`/`cancelled` by another process (see {@link "#applyAndPersist"}).
    */
   static async open(
     store: StateStore,
@@ -95,9 +101,18 @@ export class RunStateWriter {
     now: () => string,
     redactor: Redactor,
     warn?: (message: string) => void,
+    onExternalCancel?: () => void,
   ): Promise<RunStateWriter> {
     // version null → the first write is a create.
-    const writer = new RunStateWriter(store, record, null, now, redactor, warn);
+    const writer = new RunStateWriter(
+      store,
+      record,
+      null,
+      now,
+      redactor,
+      warn,
+      onExternalCancel,
+    );
     await writer.#update(() => {});
     return writer;
   }
@@ -114,13 +129,32 @@ export class RunStateWriter {
     now: () => string,
     redactor: Redactor,
     warn?: (message: string) => void,
+    onExternalCancel?: () => void,
   ): RunStateWriter {
-    return new RunStateWriter(store, record, version, now, redactor, warn);
+    return new RunStateWriter(
+      store,
+      record,
+      version,
+      now,
+      redactor,
+      warn,
+      onExternalCancel,
+    );
   }
 
   /** The current run id. */
   get runId(): string {
     return this.#record.id;
+  }
+
+  /** The live in-memory record — its per-target `meta` drives an in-process cancel walk. */
+  snapshot(): RunRecord {
+    return this.#record;
+  }
+
+  /** Await every write queued so far, so nothing is still persisting on return. */
+  drain(): Promise<void> {
+    return this.#chain;
   }
 
   /** Mark a target `running` and stamp its start time. */
@@ -174,6 +208,20 @@ export class RunStateWriter {
   markRunSuspended(): Promise<void> {
     return this.#update((record) => {
       record.status = "suspended";
+    });
+  }
+
+  /** Record the run as `cancelling` — asked to stop; compensations are running. */
+  markRunCancelling(): Promise<void> {
+    return this.#update((record) => {
+      record.status = "cancelling";
+    });
+  }
+
+  /** Record the run as `cancelled` — the terminal state after compensations. */
+  markRunCancelled(): Promise<void> {
+    return this.#update((record) => {
+      record.status = "cancelled";
     });
   }
 
@@ -251,6 +299,30 @@ export class RunStateWriter {
         const fresh = await this.#store.getRun(this.#record.id);
         this.#record = fresh?.record ?? this.#record;
         this.#version = fresh?.version ?? null;
+        // The other writer may be a `zuke cancel` in another process. If it has
+        // moved the run to cancelling/cancelled, re-apply our (target-level)
+        // change onto its record — so a just-settled `succeeded` target isn't
+        // lost to the canceller's compensation walk — but never revert the run's
+        // cancel status. Then signal the run to abort: its compensations are the
+        // canceller's responsibility now. Best-effort (a conflict here is
+        // harmless; the canceller owns finalisation).
+        if (
+          fresh !== null &&
+          (fresh.record.status === "cancelling" ||
+            fresh.record.status === "cancelled")
+        ) {
+          const cancelStatus = fresh.record.status;
+          mutator(this.#record);
+          this.#record.status = cancelStatus;
+          this.#record.updatedAt = this.#now();
+          const reapply = await this.#store.putRun(
+            this.#record,
+            this.#version,
+          );
+          if (reapply.ok) this.#version = reapply.version;
+          this.#onExternalCancel?.();
+          return;
+        }
       }
       this.#warn?.(
         `state: gave up persisting run "${this.#record.id}" after ` +

--- a/packages/core/src/target.ts
+++ b/packages/core/src/target.ts
@@ -90,6 +90,14 @@ export class LockSettings {
 export type OnTimeout = () => TargetBuilder | "fail" | "cancel-run";
 
 /**
+ * A compensation registered with {@link TargetBuilder.onCancel}: either a
+ * sibling target directly, or a thunk returning one. The thunk form defers
+ * evaluation so a compensation declared *below* the target it cleans up (class
+ * fields initialise top-to-bottom) can still be referenced.
+ */
+export type OnCancel = TargetBuilder | (() => TargetBuilder);
+
+/**
  * Fluent configuration for {@link TargetBuilder.waitsFor}:
  * `.waitsFor((s) => s.on(externalSignal("approved")).timeout("72h"))`. Set the
  * {@link WaitSettings.on | trigger}, an optional {@link WaitSettings.timeout},
@@ -413,6 +421,8 @@ export class TargetBuilder {
   waitsFor_?: Configure<WaitSettings>;
   /** Fan-out spec, set by {@link forEach}: materialises per-item sub-target pipelines. */
   forEach_?: ForEachSpec;
+  /** Compensation thunk, set by {@link onCancel}: runs on cancel iff this target succeeded. */
+  onCancel_?: () => TargetBuilder;
 
   /** Set the human-readable description shown in `zuke --list`. */
   description(text: string): this {
@@ -730,6 +740,37 @@ export class TargetBuilder {
    */
   waitsFor(configure: Configure<WaitSettings>): this {
     this.waitsFor_ = configure;
+    return this;
+  }
+
+  /**
+   * Register a **compensation** target that undoes this target's effect when the
+   * run is later cancelled (via `zuke cancel <run-id>`, an MCP `cancel_run`, or a
+   * timed-out wait). The compensation runs **iff this target succeeded** — a
+   * target that never ran, was skipped, or failed has nothing to undo. On
+   * cancellation, compensations run in **reverse order** of the targets that
+   * succeeded, so later work is unwound before the work it built on.
+   *
+   * `compensation` is a sibling target, or a thunk returning one (use the thunk
+   * form to reference a target declared *below* this one — class fields
+   * initialise top-to-bottom). The compensation body receives a normal
+   * {@link TargetContext} whose `state` exposes **this target's** persisted
+   * metadata, so a deploy that recorded `{ slot: "sit-7" }` in `ctx.state` can be
+   * rolled back from exactly that slot. Compensation failures are recorded but do
+   * not stop the walk (cleanup is maximal). Requires a state store.
+   *
+   * ```ts
+   * deploy = target()
+   *   .executes((ctx) => ctx.state.set({ slot: "sit-7" }))
+   *   .onCancel(() => this.rollback);
+   * rollback = target()
+   *   .executes((ctx) => tearDown(ctx.state.get().slot)); // reads deploy's meta
+   * ```
+   */
+  onCancel(compensation: OnCancel): this {
+    this.onCancel_ = typeof compensation === "function"
+      ? compensation
+      : () => compensation;
     return this;
   }
 

--- a/packages/core/tests/cancel_test.ts
+++ b/packages/core/tests/cancel_test.ts
@@ -1,0 +1,641 @@
+import { assertEquals, assertRejects } from "./_assert.ts";
+import { Build, discoverTargets } from "../src/build.ts";
+import { parameter } from "../src/params.ts";
+import { target } from "../src/target.ts";
+import { execute } from "../src/executor.ts";
+import { cancelRun } from "../src/cancel.ts";
+import { resumeRun } from "../src/resume.ts";
+import { FileSystemStateStore } from "../src/state/fs_store.ts";
+import { defaultStateHost, type StateStore } from "../src/state/store.ts";
+import { externalSignal } from "../src/wait.ts";
+
+/** Run `fn` with a temp filesystem store, cleaned up afterwards. */
+async function withTempStore(
+  fn: (store: FileSystemStateStore) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir();
+  try {
+    await fn(new FileSystemStateStore(`${dir}/runs`, defaultStateHost));
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+Deno.test("cancelRun runs a suspended run's compensations in reverse order", async () => {
+  await withTempStore(async (store) => {
+    const undone: string[] = [];
+    let rolledBackSlot: unknown;
+    const makeBuild = () => {
+      class CD extends Build {
+        deploy = target()
+          .executes((ctx) => ctx.state.set({ slot: "sit-7" }))
+          .onCancel(() => this.rollbackDeploy);
+        rollbackDeploy = target().executes((ctx) => {
+          undone.push("deploy");
+          rolledBackSlot = ctx.state.get().slot;
+        });
+        migrate = target()
+          .dependsOn(this.deploy)
+          .executes(() => {})
+          .onCancel(() => this.rollbackMigrate);
+        rollbackMigrate = target().executes(() => void undone.push("migrate"));
+        gate = target()
+          .dependsOn(this.migrate)
+          .waitsFor((s) => s.on(externalSignal("approved")));
+        promote = target().dependsOn(this.gate).executes(() => {});
+      }
+      const build = new CD();
+      discoverTargets(build);
+      return build;
+    };
+
+    // Process A: deploy + migrate succeed, then the run suspends at the gate.
+    const a = makeBuild();
+    const resA = await execute(a, a.promote, {
+      silent: true,
+      stateStore: store,
+    });
+    assertEquals(resA.suspended, true);
+    const runId = (await store.listRuns({}))[0].id;
+
+    // A fresh process cancels it.
+    const result = await cancelRun(makeBuild(), {
+      runId,
+      stateStore: store,
+      silent: true,
+      actor: "ops",
+    });
+    assertEquals(result.noop, false);
+    assertEquals(result.status, "cancelled");
+    // Reverse topological: migrate is unwound before deploy.
+    assertEquals(undone, ["migrate", "deploy"]);
+    // The compensation read the original target's persisted metadata.
+    assertEquals(rolledBackSlot, "sit-7");
+
+    const loaded = await store.getRun(runId);
+    assertEquals(loaded?.record.status, "cancelled");
+    // The cancellation is recorded in the audit trail, attributed to the canceller.
+    const event = loaded?.record.events.find((e) => e.tool === "cancel");
+    assertEquals(event?.actor, "ops");
+    assertEquals(event?.outcome, "ok");
+  });
+});
+
+Deno.test("cancelRun is a friendly no-op on an already-finished run", async () => {
+  await withTempStore(async (store) => {
+    const makeBuild = () => {
+      class B extends Build {
+        go = target().executes(() => {});
+      }
+      const build = new B();
+      discoverTargets(build);
+      return build;
+    };
+    await execute(makeBuild(), makeBuild().go, {
+      silent: true,
+      stateStore: store,
+    });
+    // The above ran a throwaway build; run a real one to get a persisted record.
+    const b = makeBuild();
+    await execute(b, b.go, { silent: true, stateStore: store });
+    const runId = (await store.listRuns({}))[0].id;
+
+    const result = await cancelRun(makeBuild(), {
+      runId,
+      stateStore: store,
+      silent: true,
+    });
+    assertEquals(result.noop, true);
+    assertEquals(result.status, "succeeded");
+    const loaded = await store.getRun(runId);
+    assertEquals(loaded?.record.status, "succeeded"); // untouched
+  });
+});
+
+Deno.test("cancelRun throws on a missing run", async () => {
+  await withTempStore(async (store) => {
+    class B extends Build {
+      go = target().executes(() => {});
+    }
+    const b = new B();
+    discoverTargets(b);
+    await assertRejects(
+      () => cancelRun(b, { runId: "nope", stateStore: store, silent: true }),
+      Error,
+      "no run",
+    );
+  });
+});
+
+Deno.test("a failing compensation is recorded but the walk continues", async () => {
+  await withTempStore(async (store) => {
+    const undone: string[] = [];
+    const makeBuild = () => {
+      class B extends Build {
+        a = target().executes(() => {}).onCancel(() => this.rollbackA);
+        rollbackA = target().executes(() => {
+          throw new Error("boom");
+        });
+        b = target()
+          .dependsOn(this.a)
+          .executes(() => {})
+          .onCancel(() => this.rollbackB);
+        rollbackB = target().executes(() => void undone.push("b"));
+        gate = target()
+          .dependsOn(this.b)
+          .waitsFor((s) => s.on(externalSignal("x")));
+      }
+      const build = new B();
+      discoverTargets(build);
+      return build;
+    };
+    const a = makeBuild();
+    await execute(a, a.gate, { silent: true, stateStore: store });
+    const runId = (await store.listRuns({}))[0].id;
+
+    const result = await cancelRun(makeBuild(), {
+      runId,
+      stateStore: store,
+      silent: true,
+    });
+    assertEquals(result.status, "cancelled");
+    assertEquals(result.failures.length, 1);
+    assertEquals(result.failures[0].forTarget, "a");
+    // rollbackB ran despite rollbackA throwing (reverse order: b before a).
+    assertEquals(undone, ["b"]);
+    const loaded = await store.getRun(runId);
+    assertEquals(loaded?.record.status, "cancelled");
+    const event = loaded?.record.events.find((e) => e.tool === "cancel");
+    assertEquals(event?.outcome, "error");
+  });
+});
+
+Deno.test("an in-process cancellation (options.signal) runs compensations", async () => {
+  await withTempStore(async (store) => {
+    const undone: string[] = [];
+    let started: () => void = () => {};
+    const ready = new Promise<void>((resolve) => (started = resolve));
+    const controller = new AbortController();
+    class B extends Build {
+      deploy = target()
+        .executes((ctx) => ctx.state.set({ slot: "sit-1" }))
+        .onCancel(() => this.rollback);
+      rollback = target().executes((ctx) =>
+        void undone.push(`rollback:${ctx.state.get().slot}`)
+      );
+      hang = target()
+        .dependsOn(this.deploy)
+        .executes((ctx) =>
+          new Promise<void>((resolve) => {
+            ctx.signal.addEventListener("abort", () => resolve(), {
+              once: true,
+            });
+            started();
+          })
+        );
+    }
+    const b = new B();
+    discoverTargets(b);
+
+    const runPromise = execute(b, b.hang, {
+      silent: true,
+      stateStore: store,
+      signal: controller.signal,
+    });
+    await ready;
+    controller.abort();
+    const result = await runPromise;
+
+    assertEquals(result.ok, false);
+    assertEquals(result.cancelled, true);
+    // deploy succeeded → its compensation ran, reading its persisted slot.
+    assertEquals(undone, ["rollback:sit-1"]);
+    const loaded = result.runId ? await store.getRun(result.runId) : null;
+    assertEquals(loaded?.record.status, "cancelled");
+  });
+});
+
+Deno.test("a live run observes an external cancel on its next write and stops", async () => {
+  await withTempStore(async (store) => {
+    const undone: string[] = [];
+    let started: () => void = () => {};
+    const ready = new Promise<void>((resolve) => (started = resolve));
+    let release: () => void = () => {};
+    const released = new Promise<void>((resolve) => (release = resolve));
+    let abortedInside = false;
+    class B extends Build {
+      deploy = target()
+        .executes((ctx) => ctx.state.set({ slot: "sit-9" }))
+        .onCancel(() => this.rollback);
+      rollback = target().executes(() => void undone.push("deploy"));
+      work = target().dependsOn(this.deploy).executes(async (ctx) => {
+        started();
+        await released; // pause until the external cancel has landed
+        // This write finds the record moved to `cancelling` → observe → abort.
+        await ctx.state.set({ step: 1 });
+        abortedInside = ctx.signal.aborted;
+      });
+    }
+    const b = new B();
+    discoverTargets(b);
+
+    const runPromise = execute(b, b.work, { silent: true, stateStore: store });
+    await ready;
+    const runId = (await store.listRuns({}))[0].id;
+
+    // Another process cancels: move the record to `cancelling`. Retry until it
+    // lands (the owning writer may still be flushing `work`'s markTargetRunning).
+    await forceCancelling(store, runId);
+    release();
+    const result = await runPromise;
+
+    assertEquals(result.cancelled, true);
+    assertEquals(abortedInside, true); // the running body saw its signal abort
+    // The owning process did NOT run compensations (the canceller owns them)…
+    assertEquals(undone, []);
+    // …and left the record `cancelling` for the canceller to settle.
+    const after = await store.getRun(runId);
+    assertEquals(after?.record.status, "cancelling");
+    // The conflicting write was re-applied onto the cancelling record (not
+    // dropped), so a target update racing the cancel isn't lost to the canceller.
+    assertEquals(after?.record.targets.work?.meta.step, 1);
+  });
+});
+
+Deno.test("cancelRun throws when state is disabled", async () => {
+  class B extends Build {
+    go = target().executes(() => {});
+  }
+  const b = new B();
+  discoverTargets(b);
+  await assertRejects(
+    () => cancelRun(b, { runId: "x", stateStore: false, silent: true }),
+    Error,
+    "no state store",
+  );
+});
+
+Deno.test("cancelRun recovers a run stranded mid-cancellation, without re-compensating", async () => {
+  await withTempStore(async (store) => {
+    const undone: string[] = [];
+    const makeBuild = () => {
+      class B extends Build {
+        deploy = target().executes(() => {}).onCancel(() => this.rollback);
+        rollback = target().executes(() => void undone.push("deploy"));
+        gate = target()
+          .dependsOn(this.deploy)
+          .waitsFor((s) => s.on(externalSignal("x")));
+      }
+      const build = new B();
+      discoverTargets(build);
+      return build;
+    };
+    const a = makeBuild();
+    await execute(a, a.gate, { silent: true, stateStore: store });
+    const id = (await store.listRuns({}))[0].id;
+    // A crashed canceller left it `cancelling`. A re-cancel must not strand it —
+    // it finalizes to cancelled without re-running compensations.
+    const loaded = await store.getRun(id);
+    if (loaded === null) throw new Error("run vanished");
+    await store.putRun(
+      { ...loaded.record, status: "cancelling" },
+      loaded.version,
+    );
+
+    const result = await cancelRun(makeBuild(), {
+      runId: id,
+      stateStore: store,
+      silent: true,
+    });
+    assertEquals(result.noop, false);
+    assertEquals(result.status, "cancelled");
+    assertEquals(undone, []); // compensations are NOT re-run on recovery
+    assertEquals((await store.getRun(id))?.record.status, "cancelled");
+  });
+});
+
+Deno.test("cancelRun cancels a run whose root target no longer exists", async () => {
+  await withTempStore(async (store) => {
+    class Old extends Build {
+      gate = target().waitsFor((s) => s.on(externalSignal("x")));
+      deploy = target().dependsOn(this.gate).executes(() => {});
+    }
+    const a = new Old();
+    discoverTargets(a);
+    await execute(a, a.deploy, { silent: true, stateStore: store });
+    const id = (await store.listRuns({}))[0].id;
+
+    // A build that no longer declares the recorded root target.
+    class New extends Build {
+      other = target().executes(() => {});
+    }
+    const b = new New();
+    discoverTargets(b);
+    const result = await cancelRun(b, {
+      runId: id,
+      stateStore: store,
+      silent: true,
+    });
+    assertEquals(result.status, "cancelled");
+    assertEquals(result.compensated, []); // no graph → no compensations
+  });
+});
+
+Deno.test("a compensation resolving to undefined or lacking a body is skipped", async () => {
+  await withTempStore(async (store) => {
+    const makeBuild = () => {
+      class B extends Build {
+        // @ts-expect-error deliberately return undefined to exercise the runtime skip
+        a = target().executes(() => {}).onCancel(() => undefined);
+        // A compensation target with no .executes() body.
+        noBody = target();
+        b = target()
+          .dependsOn(this.a)
+          .executes(() => {})
+          .onCancel(() => this.noBody);
+        gate = target()
+          .dependsOn(this.b)
+          .waitsFor((s) => s.on(externalSignal("x")));
+      }
+      const build = new B();
+      discoverTargets(build);
+      return build;
+    };
+    const a = makeBuild();
+    await execute(a, a.gate, { silent: true, stateStore: store });
+    const id = (await store.listRuns({}))[0].id;
+    const result = await cancelRun(makeBuild(), {
+      runId: id,
+      stateStore: store,
+      silent: true,
+    });
+    assertEquals(result.status, "cancelled");
+    assertEquals(result.compensated, []); // undefined + body-less → both skipped
+    assertEquals(result.failures, []);
+  });
+});
+
+Deno.test("a compensation can write to its in-memory state handle", async () => {
+  await withTempStore(async (store) => {
+    let observed: unknown;
+    const makeBuild = () => {
+      class B extends Build {
+        deploy = target()
+          .executes((ctx) => ctx.state.set({ slot: "s1" }))
+          .onCancel(() => this.rollback);
+        rollback = target().executes(async (ctx) => {
+          await ctx.state.set({ note: "cleaned" }); // exercises the in-memory set
+          observed = ctx.state.get().note;
+        });
+        gate = target()
+          .dependsOn(this.deploy)
+          .waitsFor((s) => s.on(externalSignal("x")));
+      }
+      const build = new B();
+      discoverTargets(build);
+      return build;
+    };
+    const a = makeBuild();
+    await execute(a, a.gate, { silent: true, stateStore: store });
+    const id = (await store.listRuns({}))[0].id;
+    await cancelRun(makeBuild(), {
+      runId: id,
+      stateStore: store,
+      silent: true,
+    });
+    assertEquals(observed, "cleaned");
+  });
+});
+
+Deno.test("a timed-out wait with onTimeout cancel-run cancels the run", async () => {
+  await withTempStore(async (store) => {
+    const undone: string[] = [];
+    const makeBuild = () => {
+      class B extends Build {
+        deploy = target().executes(() => {}).onCancel(() => this.rollback);
+        rollback = target().executes(() => void undone.push("deploy"));
+        gate = target()
+          .dependsOn(this.deploy)
+          .waitsFor((s) =>
+            s.on(externalSignal("never")).timeout(0).onTimeout(() =>
+              "cancel-run"
+            )
+          );
+        done = target().dependsOn(this.gate).executes(() => {});
+      }
+      const build = new B();
+      discoverTargets(build);
+      return build;
+    };
+    const a = makeBuild();
+    await execute(a, a.done, { silent: true, stateStore: store });
+    const id = (await store.listRuns({}))[0].id;
+
+    // Resuming past the deadline routes the timeout through cancellation.
+    const result = await resumeRun(makeBuild(), {
+      runId: id,
+      stateStore: store,
+      silent: true,
+    });
+    assertEquals(result.ok, false);
+    assertEquals(result.cancelled, true);
+    assertEquals(undone, ["deploy"]); // deploy's compensation ran
+    assertEquals((await store.getRun(id))?.record.status, "cancelled");
+  });
+});
+
+Deno.test("a timed-out wait with a named onTimeout target runs it as a compensation", async () => {
+  await withTempStore(async (store) => {
+    const ran: string[] = [];
+    const makeBuild = () => {
+      class B extends Build {
+        deploy = target().executes(() => {});
+        gate = target()
+          .dependsOn(this.deploy)
+          .waitsFor((s) =>
+            s.on(externalSignal("never")).timeout(0).onTimeout(() =>
+              this.cleanup
+            )
+          );
+        cleanup = target().executes(() => void ran.push("cleanup"));
+        done = target().dependsOn(this.gate).executes(() => {});
+      }
+      const build = new B();
+      discoverTargets(build);
+      return build;
+    };
+    const a = makeBuild();
+    await execute(a, a.done, { silent: true, stateStore: store });
+    const id = (await store.listRuns({}))[0].id;
+
+    const result = await resumeRun(makeBuild(), {
+      runId: id,
+      stateStore: store,
+      silent: true,
+    });
+    assertEquals(result.ok, false);
+    assertEquals(ran, ["cleanup"]); // the named onTimeout target ran (resolveExtra)
+    assertEquals((await store.getRun(id))?.record.status, "cancelled");
+  });
+});
+
+Deno.test("a throwing .onCancel() thunk is recorded, not fatal", async () => {
+  await withTempStore(async (store) => {
+    const undone: string[] = [];
+    const makeBuild = () => {
+      class B extends Build {
+        // A thunk that always throws (return type `never`, so still assignable).
+        a = target().executes(() => {}).onCancel(() => {
+          throw new Error("thunk boom");
+        });
+        b = target()
+          .dependsOn(this.a)
+          .executes(() => {})
+          .onCancel(() => this.rollbackB);
+        rollbackB = target().executes(() => void undone.push("b"));
+        gate = target()
+          .dependsOn(this.b)
+          .waitsFor((s) => s.on(externalSignal("x")));
+      }
+      const build = new B();
+      discoverTargets(build);
+      return build;
+    };
+    const a = makeBuild();
+    await execute(a, a.gate, { silent: true, stateStore: store });
+    const id = (await store.listRuns({}))[0].id;
+    const result = await cancelRun(makeBuild(), {
+      runId: id,
+      stateStore: store,
+      silent: true,
+    });
+    // The throwing thunk is recorded as a failure; the walk continues (rollbackB
+    // ran) and the run still settles cancelled — never wedged.
+    assertEquals(result.status, "cancelled");
+    assertEquals(result.failures.some((f) => f.forTarget === "a"), true);
+    assertEquals(undone, ["b"]);
+    assertEquals((await store.getRun(id))?.record.status, "cancelled");
+  });
+});
+
+Deno.test("a secret in a compensation failure message is redacted", async () => {
+  await withTempStore(async (store) => {
+    const makeBuild = () => {
+      class B extends Build {
+        token = parameter("api token").secret();
+        deploy = target().executes(() => {}).onCancel(() => this.rollback);
+        rollback = target().executes(() => {
+          throw new Error(`cleanup failed using ${this.token.value}`);
+        });
+        gate = target()
+          .dependsOn(this.deploy)
+          .waitsFor((s) => s.on(externalSignal("x")));
+      }
+      const build = new B();
+      discoverTargets(build);
+      return build;
+    };
+    const readEnv = (name: string) =>
+      name === "TOKEN" ? "s3cr3t-value" : undefined;
+    const a = makeBuild();
+    await execute(a, a.gate, { silent: true, stateStore: store, readEnv });
+    const id = (await store.listRuns({}))[0].id;
+
+    const result = await cancelRun(makeBuild(), {
+      runId: id,
+      stateStore: store,
+      silent: true,
+      readEnv,
+    });
+    const messages = result.failures.map((f) => f.error).join("\n");
+    assertEquals(messages.includes("s3cr3t-value"), false); // masked
+    assertEquals(result.failures.length, 1);
+  });
+});
+
+Deno.test("an in-process cancellation records a cancel audit event", async () => {
+  await withTempStore(async (store) => {
+    let started: () => void = () => {};
+    const ready = new Promise<void>((resolve) => (started = resolve));
+    const controller = new AbortController();
+    class B extends Build {
+      deploy = target().executes(() => {}).onCancel(() => this.rollback);
+      rollback = target().executes(() => {});
+      hang = target()
+        .dependsOn(this.deploy)
+        .executes((ctx) =>
+          new Promise<void>((resolve) => {
+            ctx.signal.addEventListener("abort", () => resolve(), {
+              once: true,
+            });
+            started();
+          })
+        );
+    }
+    const b = new B();
+    discoverTargets(b);
+    const runPromise = execute(b, b.hang, {
+      silent: true,
+      stateStore: store,
+      actor: "operator",
+      signal: controller.signal,
+    });
+    await ready;
+    controller.abort();
+    const result = await runPromise;
+    assertEquals(result.cancelled, true);
+    const loaded = result.runId ? await store.getRun(result.runId) : null;
+    // Ctrl-C records the cancellation in the audit trail, like `zuke cancel`.
+    const event = loaded?.record.events.find((e) => e.tool === "cancel");
+    assertEquals(event?.actor, "operator");
+  });
+});
+
+Deno.test("a hung compensation is bounded by its .timeout()", async () => {
+  await withTempStore(async (store) => {
+    const makeBuild = () => {
+      class B extends Build {
+        deploy = target().executes(() => {}).onCancel(() => this.rollback);
+        rollback = target()
+          .timeout(20)
+          .executes(() => new Promise<void>(() => {})); // never resolves
+        gate = target()
+          .dependsOn(this.deploy)
+          .waitsFor((s) => s.on(externalSignal("x")));
+      }
+      const build = new B();
+      discoverTargets(build);
+      return build;
+    };
+    const a = makeBuild();
+    await execute(a, a.gate, { silent: true, stateStore: store });
+    const id = (await store.listRuns({}))[0].id;
+    // The walk does not hang; the timed-out compensation is a recorded failure
+    // and the run still settles cancelled.
+    const result = await cancelRun(makeBuild(), {
+      runId: id,
+      stateStore: store,
+      silent: true,
+    });
+    assertEquals(result.status, "cancelled");
+    assertEquals(result.failures.length, 1);
+    assertEquals(result.failures[0].error.includes("timed out"), true);
+  });
+});
+
+/** Force a run to `cancelling`, retrying the CAS until it lands. */
+async function forceCancelling(
+  store: StateStore,
+  runId: string,
+): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    const loaded = await store.getRun(runId);
+    if (loaded === null) throw new Error(`run ${runId} vanished`);
+    const put = await store.putRun(
+      { ...loaded.record, status: "cancelling" },
+      loaded.version,
+    );
+    if (put.ok) return;
+  }
+  throw new Error(`could not move run ${runId} to cancelling`);
+}

--- a/packages/core/tests/executor_test.ts
+++ b/packages/core/tests/executor_test.ts
@@ -1675,7 +1675,10 @@ Deno.test("options.signal aborts the context signal of an in-flight target", asy
   controller.abort();
   const result = await runPromise;
   assertEquals(observedAbort, true);
-  assertEquals(result.ok, true); // body resolved cleanly once its signal fired
+  // Cancelling the run is now a first-class outcome (M6): even though the body
+  // resolved cleanly once its signal fired, the run is reported cancelled.
+  assertEquals(result.ok, false);
+  assertEquals(result.cancelled, true);
 });
 
 Deno.test("cancelling a run terminates an in-flight shell command", async () => {
@@ -1759,7 +1762,10 @@ Deno.test("a pre-aborted options.signal aborts the context signal", async () => 
     signal: controller.signal,
   });
   assertEquals(sawAborted, true);
-  assertEquals(result.ok, true); // no shell command to kill, so the body succeeds
+  // A pre-aborted signal cancels the run: no body ran to completion, and the
+  // result is a non-ok cancellation (M6).
+  assertEquals(result.ok, false);
+  assertEquals(result.cancelled, true);
 });
 
 Deno.test("a run with a state store reconstructs full status from disk", async () => {

--- a/packages/core/tests/mcp_hardening_test.ts
+++ b/packages/core/tests/mcp_hardening_test.ts
@@ -200,6 +200,36 @@ Deno.test("store-backed run tools appear with a store; mutating ones need --allo
     const names = (await toolList(server)).map((t) => t.name);
     assertEquals(names.includes("signal_run"), true);
     assertEquals(names.includes("resume_check"), true);
+    assertEquals(names.includes("cancel_run"), true);
+  });
+});
+
+Deno.test("cancel_run cancels a suspended run, gated by the allow-list and audited", async () => {
+  await withServer(
+    { allowRun: true, allowRunPatterns: ["safe*"], actor: "ops" },
+    async (server, store) => {
+      const excluded = await seedSuspended(store, "deploy"); // not allow-listed
+      const denied = await call(server, "cancel_run", { runId: excluded });
+      assertEquals(denied.isError, true);
+      assertEquals(JSON.parse(denied.text).reason, "not_allowed");
+    },
+  );
+  await withServer({ allowRun: true, actor: "ops" }, async (server, store) => {
+    // A missing run is a structured no_run.
+    const missing = await call(server, "cancel_run", { runId: "nope" });
+    assertEquals(missing.isError, true);
+    assertEquals(JSON.parse(missing.text).error, "no_run");
+
+    // A real suspended run cancels; the call is audited under the actor.
+    const id = await seedSuspended(store, "deploy");
+    const ok = await call(server, "cancel_run", { runId: id });
+    assertEquals(ok.isError, false);
+    const body = JSON.parse(ok.text);
+    assertEquals(body.status, "cancelled");
+    const loaded = await store.getRun(id);
+    assertEquals(loaded?.record.status, "cancelled");
+    const audit = await auditEvents(store);
+    assertEquals(audit.some((e) => e.tool === "cancel_run"), true);
   });
 });
 

--- a/packages/core/tests/resume_test.ts
+++ b/packages/core/tests/resume_test.ts
@@ -231,6 +231,53 @@ Deno.test("resuming a run already running gives AlreadyResumedError", async () =
   });
 });
 
+Deno.test("resumeCheck isolates a per-run error and keeps sweeping", async () => {
+  await withTempStore(async (store) => {
+    let ready = false;
+    let ran = false;
+    const makeBuild = () => {
+      class B extends Build {
+        gate = target().waitsFor((s) => s.on(resumeWhen(() => ready)));
+        work = target().dependsOn(this.gate).executes(() => void (ran = true));
+      }
+      const build = new B();
+      discoverTargets(build);
+      return build;
+    };
+    // A normal run that suspends now (predicate false) and resumes in the sweep.
+    const a = makeBuild();
+    await execute(a, a.work, { silent: true, stateStore: store });
+
+    // A broken suspended run whose root target the build lacks → resumeRun throws.
+    // It is newer, so the sweep hits it first; the old behaviour would re-throw
+    // and strand the good run behind it.
+    const now = new Date().toISOString();
+    await store.putRun({
+      id: "broken",
+      build: "B",
+      rootTarget: "ghost",
+      status: "suspended" as const,
+      actor: "x",
+      createdAt: now,
+      updatedAt: now,
+      graph: [{ name: "ghost", dependsOn: [] }],
+      params: {},
+      targets: { ghost: { status: "waiting", meta: {} } },
+      signals: {},
+      events: [],
+    }, null);
+
+    ready = true; // the good run's predicate is now satisfied
+    const result = await resumeCheck(makeBuild(), {
+      stateStore: store,
+      silent: true,
+    });
+    assertEquals(result.checked, 2); // both were checked
+    assertEquals(result.failed >= 1, true); // the broken one counted as failed
+    assertEquals(ran, true); // the good run still ran despite the broken one
+  });
+});
+
 Deno.test("resumeCheck sweeps suspended runs and advances satisfied predicates", async () => {
   await withTempStore(async (store) => {
     let ready = false;

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -115,6 +115,14 @@ Before calling any task or settings method, confirm the real shape:
   `zuke resume <id> --signal <name> [--data <json>]` (or `--check` for predicate
   waits/timeouts) — exactly-once, re-running only the not-yet-succeeded targets.
   Needs a state store. See the cheatsheet / `docs/orchestration.md`.
+- **Cancellation & compensation:** `.onCancel(() => this.rollback)` registers a
+  compensation that runs **iff this target succeeded** when the run is later
+  cancelled — compensations run in reverse order, and the compensation body's
+  `ctx.state` exposes the original target's persisted metadata (so a rollback
+  reads what the deploy recorded). Cancel with `zuke cancel <id>` (or Ctrl-C, or
+  the MCP `cancel_run` tool). Idempotent; a timed-out wait can route its
+  `onTimeout` here (`"cancel-run"` or a named target). Needs a state store. See
+  `docs/orchestration.md`.
 - **Fan-out over a list:**
   `.forEach(() => this.repos.value, (repo) => ({ checks: target()…, deploy: target()… }), (s) => s.concurrency(3).continueOnItemFailure())`
   runs the same pipeline over a runtime list — items concurrent, each item's

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -24,6 +24,7 @@ Everything is optional except a body (`.executes`).
 | `.timeout(ms)`                                                                                           | Fail the body if it runs longer than `ms` (per attempt).                                          |
 | `.lock((s) => s.lockKey(...).withTtl(...))`                                                              | Hold a cross-run lock while running; a second run wanting the key fails. See below.               |
 | `.waitsFor((s) => s.on(externalSignal(...)))`                                                            | Gate (no body): suspend the run until an external event; resume later. See below.                 |
+| `.onCancel(() => this.rollback)`                                                                         | Compensation run (reverse order) iff this target succeeded when the run is cancelled. See below.   |
 | `.forEach(() => items, (item) => ({stage: target()…}), (s) => s.concurrency(3).continueOnItemFailure())` | Fan out a pipeline over a runtime list: items concurrent, stages sequential per item. See below.  |
 | `.proceedAfterFailure()`                                                                                 | Keep the build going if this target fails.                                                        |
 | `.always()`                                                                                              | Run even after the build failed (cleanup/teardown).                                               |
@@ -122,8 +123,11 @@ deploy = target().executes(async (ctx) => {
 `` $`…` `` in the body is terminated with `SIGTERM` automatically (the run's
 signal is the shell's ambient signal). Pass `ctx.signal` to `.signal(...)` to
 cancel a command explicitly; it composes with `.killAfter(ms)`. Cancel a run
-programmatically with `execute(build, root, { signal })`. A body that ignores
-its signal and never shells out runs to completion.
+with `zuke cancel <id>`, `Ctrl-C`/`SIGTERM`, the MCP `cancel_run` tool, or
+programmatically with `execute(build, root, { signal })` / `cancelRun(build, {
+runId })`. A body that ignores its signal and never shells out runs to
+completion. Register **compensations** with `.onCancel(...)` (see below) to undo
+a target's effect when the run is cancelled.
 
 ## Durable run state
 
@@ -231,6 +235,34 @@ class Deploy extends Build {
   `zuke resume --check [<id>]` for predicate waits/timeouts). Resumption is
   **exactly-once** (concurrent resumers get `AlreadyResumedError`) and re-runs
   only the not-yet-succeeded targets; `--force-graph` overrides a changed graph.
+
+## Cancellation & compensation — `.onCancel()`
+
+Undo a target's effect when the run is cancelled. `.onCancel(target | () =>
+target)` registers a **compensation** that runs **iff this target succeeded**;
+on cancel, compensations run in **reverse order** of the succeeded targets.
+
+```ts
+class CD extends Build {
+  deploy = target()
+    .executes((ctx) => ctx.state.set({ slot: "sit-7" })) // record what it did
+    .onCancel(() => this.rollback); // thunk → sibling compensation
+  rollback = target().executes((ctx) => tearDown(ctx.state.get().slot));
+  gate = target().dependsOn(this.deploy)
+    .waitsFor((s) => s.on(externalSignal("approved")));
+}
+```
+
+- The compensation body's `ctx.state` exposes **the original target's** persisted
+  metadata (persist what a rollback needs in `ctx.state` when you do the work).
+- Cancel with `zuke cancel <id>`, `Ctrl-C`/`SIGTERM`, or the MCP `cancel_run`
+  tool (all run the same walk). A live run aborts on its next state write.
+- A compensation that throws is recorded but does **not** stop the walk (cleanup
+  is maximal). Cancelling a finished run is a friendly no-op.
+- A timed-out `.waitsFor()` can route here: `.onTimeout(() => "cancel-run")`
+  cancels the run (running compensations); `.onTimeout(() => this.cleanup)` runs
+  that target too. Needs a state store (a build with `.onCancel()` enables
+  `.zuke/runs` by default). See `docs/orchestration.md`.
 
 ## Fan-out over a list — `.forEach()`
 
@@ -465,6 +497,8 @@ is current (`zuke generate-ci --check` is a dedicated gate).
 ./zuke <target> --actor <who> # attribute the run in its state record
 ./zuke runs list [--status s] # list persisted runs (also --target, --since, --json)
 ./zuke runs show <id>         # one run's full per-target status (+ --json)
+./zuke resume <id> --signal <name> [--data <json>]  # continue a suspended run
+./zuke cancel <id>            # cancel a run and run its .onCancel() compensations
 ./zuke mcp [--allow-run]      # serve the build over MCP for an AI client (stdio)
 ./zuke mcp --http 7777        # ...or over HTTP (loopback; token off-loopback)
 ./zuke mcp --allow-run=deploy,checks* --protect deploy --confirm-destructive

--- a/tests/e2e/cancel_e2e.ts
+++ b/tests/e2e/cancel_e2e.ts
@@ -1,0 +1,69 @@
+/**
+ * End-to-end: cross-process cancellation. Process A runs the
+ * {@link file://./fixtures/cancel_build.ts} pipeline to its approval gate and
+ * suspends, persisting the run. Process B — a genuinely separate `zuke cancel`
+ * subprocess — stops it, runs the deploy's compensation (reading the slot the
+ * deploy persisted), and settles the record as `cancelled`. Proves the whole
+ * flow across real OS processes over a shared temp `ZUKE_STATE_DIR`, the thing
+ * the in-process suite cannot. Excluded from the fast unit gate; run by the
+ * `integration` target on the OS matrix.
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import {
+  defaultStateHost,
+  FileSystemStateStore,
+} from "../../packages/core/mod.ts";
+
+const FIXTURE = new URL("./fixtures/cancel_build.ts", import.meta.url);
+
+/** The captured result of one fixture subprocess. */
+interface Run {
+  code: number;
+  out: string;
+}
+
+/** Run the cancel fixture as a real `deno` subprocess against state dir `dir`. */
+async function runFixture(args: string[], dir: string): Promise<Run> {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: ["run", "-A", FIXTURE.href, ...args],
+    env: { ZUKE_STATE_DIR: dir },
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const { code, stdout } = await command.output();
+  return { code, out: new TextDecoder().decode(stdout) };
+}
+
+Deno.test("a separate process cancels a suspended run and runs its compensation", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "zuke-e2e-" });
+  try {
+    // Process 1: run to the gate and suspend, persisting the run.
+    const suspend = await runFixture(["promote"], dir);
+    assertEquals(suspend.code, 0);
+    assertStringIncludes(suspend.out, "DEPLOYED");
+
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    const runs = await store.listRuns({});
+    assertEquals(runs.length, 1);
+    const id = runs[0].id;
+    assertEquals(runs[0].status, "suspended");
+
+    // Process 2: cancel it. The compensation runs, reading the deploy's slot.
+    const cancelled = await runFixture(["cancel", id], dir);
+    assertEquals(cancelled.code, 0);
+    assertStringIncludes(cancelled.out, "ROLLED_BACK:sit-7");
+    // The gate never opened, so promote never ran.
+    assertEquals(cancelled.out.includes("PROMOTED"), false);
+
+    // The record is durably cancelled.
+    const loaded = await store.getRun(id);
+    assertEquals(loaded?.record.status, "cancelled");
+    assertEquals(loaded?.record.events.some((e) => e.tool === "cancel"), true);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/tests/e2e/fixtures/cancel_build.ts
+++ b/tests/e2e/fixtures/cancel_build.ts
@@ -1,0 +1,42 @@
+/**
+ * A real, runnable Zuke build used by the e2e cancellation suite. Run as a
+ * subprocess (`deno run -A cancel_build.ts <target>`), it deploys (recording a
+ * slot in its durable state), then suspends at an approval gate. A separate
+ * `cancel <run-id>` invocation stops it and runs the deploy's compensation — so
+ * two genuine OS processes exercise cross-process cancellation. `run()` reads
+ * `ZUKE_STATE_DIR` from the environment for its durable state.
+ *
+ * @module
+ */
+
+import {
+  Build,
+  externalSignal,
+  run,
+  target,
+} from "../../../packages/core/mod.ts";
+
+/** A deploy → approval-gate → promote pipeline with a rollback compensation. */
+class Cancelable extends Build {
+  /** Deploys, recording the slot in durable state, and registers a rollback. */
+  deploy = target()
+    .executes((ctx) => {
+      console.log("DEPLOYED");
+      return ctx.state.set({ slot: "sit-7" });
+    })
+    .onCancel(() => this.rollback);
+  /** The compensation: prints the slot it read from the deploy's persisted meta. */
+  rollback = target().executes((ctx) =>
+    console.log(`ROLLED_BACK:${ctx.state.get().slot}`)
+  );
+  /** Suspends the run until an `approved` signal is delivered on resume. */
+  gate = target()
+    .dependsOn(this.deploy)
+    .waitsFor((s) => s.on(externalSignal("approved")));
+  /** Prints a marker; a cancelled run must never reach this. */
+  promote = target().dependsOn(this.gate).executes(() =>
+    console.log("PROMOTED")
+  );
+}
+
+await run(Cancelable);

--- a/tests/e2e/mcp_e2e.ts
+++ b/tests/e2e/mcp_e2e.ts
@@ -158,7 +158,7 @@ async function killWithin(
   server: Deno.ChildProcess,
   ms: number,
 ): Promise<void> {
-  let timer: number | undefined;
+  let timer: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<never>((_, reject) => {
     timer = setTimeout(
       () =>

--- a/tests/e2e/mcp_e2e.ts
+++ b/tests/e2e/mcp_e2e.ts
@@ -142,9 +142,38 @@ Deno.test("two MCP sessions: query a suspended run over HTTP and signal it, audi
     assertEquals(event?.outcome, "ok");
   } finally {
     if (server !== undefined) {
+      // SIGTERM (kill's default) must terminate the server promptly. `zuke mcp`
+      // is a long-lived command, so the CLI must not intercept the signal for
+      // graceful build-cancellation and swallow it — fail fast if it does,
+      // rather than hang the whole job.
       server.kill();
-      await server.status;
+      await killWithin(server, 10_000);
     }
     await Deno.remove(dir, { recursive: true });
   }
 });
+
+/** Await a killed process exiting within `ms`, throwing a clear error otherwise. */
+async function killWithin(
+  server: Deno.ChildProcess,
+  ms: number,
+): Promise<void> {
+  let timer: number | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () =>
+        reject(
+          new Error(
+            `mcp server did not exit ${ms}ms after SIGTERM — the CLI is ` +
+              `swallowing the signal instead of terminating.`,
+          ),
+        ),
+      ms,
+    );
+  });
+  try {
+    await Promise.race([server.status, timeout]);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/tests/integration/cancel_test.ts
+++ b/tests/integration/cancel_test.ts
@@ -1,0 +1,123 @@
+/**
+ * Integration: the cancellation flow driven through the real CLI. A build
+ * suspends at a `waitsFor()` gate; a later `zuke cancel <run-id>` command (a
+ * fresh `main()` call — a distinct "process") stops it, runs the compensations
+ * of every target that had succeeded, and settles the record as `cancelled`.
+ * The run id and status are read back from a {@link FileSystemStateStore} over
+ * the same temp `ZUKE_STATE_DIR` the harness set.
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import {
+  Build,
+  defaultStateHost,
+  externalSignal,
+  FileSystemStateStore,
+  type RunRecord,
+  target,
+} from "../../packages/core/mod.ts";
+import { runCli, withStateDir } from "./_harness.ts";
+
+/** The id of the (single non-audit) run the CLI persisted under `dir`. */
+async function onlyRunId(dir: string): Promise<string> {
+  const store = new FileSystemStateStore(dir, defaultStateHost);
+  const runs = await store.listRuns({});
+  assertEquals(runs.length, 1);
+  return runs[0].id;
+}
+
+/** The full persisted record of run `id` under `dir`. */
+async function loadRun(dir: string, id: string): Promise<RunRecord> {
+  const store = new FileSystemStateStore(dir, defaultStateHost);
+  const got = await store.getRun(id);
+  if (got === null) throw new Error(`run ${id} not found`);
+  return got.record;
+}
+
+Deno.test("zuke cancel stops a suspended run and runs its compensations", async () => {
+  await withStateDir(async (dir) => {
+    const log: string[] = [];
+    class CD extends Build {
+      deploy = target()
+        .executes((ctx) => {
+          log.push("deploy");
+          return ctx.state.set({ slot: "sit-7" });
+        })
+        .onCancel(() => this.rollback);
+      rollback = target().executes((ctx) =>
+        void log.push(`rollback:${ctx.state.get().slot}`)
+      );
+      gate = target()
+        .dependsOn(this.deploy)
+        .waitsFor((s) => s.on(externalSignal("approved")));
+      promote = target().dependsOn(this.gate).executes(() =>
+        void log.push("promote")
+      );
+    }
+
+    // First process: deploy runs, then the run suspends at the gate (exit 0).
+    const first = await runCli(CD, ["promote"]);
+    assertEquals(first.code, 0);
+    assertEquals(log, ["deploy"]);
+    const id = await onlyRunId(dir);
+    assertEquals((await loadRun(dir, id)).status, "suspended");
+
+    // Second process: cancel it. The compensation runs, reading deploy's slot.
+    const cancelled = await runCli(CD, ["cancel", id, "--actor", "ops"]);
+    assertEquals(cancelled.code, 0);
+    assertEquals(log, ["deploy", "rollback:sit-7"]);
+    assertStringIncludes(cancelled.out, "cancelled");
+
+    // The record is cancelled, with the cancellation in its audit trail.
+    const record = await loadRun(dir, id);
+    assertEquals(record.status, "cancelled");
+    assertEquals(record.events.some((e) => e.tool === "cancel"), true);
+
+    // `runs show` reconstructs the cancelled status and the audit line.
+    const show = await runCli(CD, ["runs", "show", id]);
+    assertEquals(show.code, 0);
+    assertStringIncludes(show.out, "status:   cancelled");
+    assertStringIncludes(show.out, "cancel");
+
+    // A second cancel is a friendly no-op; the compensation does not run again.
+    const again = await runCli(CD, ["cancel", id]);
+    assertEquals(again.code, 0);
+    assertStringIncludes(again.out, "already cancelled");
+    assertEquals(log, ["deploy", "rollback:sit-7"]);
+  });
+});
+
+Deno.test("zuke cancel of a finished run is a no-op", async () => {
+  await withStateDir(async (dir) => {
+    const log: string[] = [];
+    class B extends Build {
+      work = target().executes(() => void log.push("work"))
+        .onCancel(() => this.undo);
+      undo = target().executes(() => void log.push("undo"));
+    }
+    // A plain run with a durable feature (onCancel) persists to .zuke/runs.
+    const ran = await runCli(B, ["work"]);
+    assertEquals(ran.code, 0);
+    const id = await onlyRunId(dir);
+    assertEquals((await loadRun(dir, id)).status, "succeeded");
+
+    const cancelled = await runCli(B, ["cancel", id]);
+    assertEquals(cancelled.code, 0);
+    assertStringIncludes(cancelled.out, "already succeeded");
+    assertEquals(log, ["work"]); // undo never ran
+  });
+});
+
+Deno.test("zuke cancel with a missing run id fails with usage", async () => {
+  await withStateDir(async () => {
+    class B extends Build {
+      go = target().executes(() => {});
+    }
+    const bad = await runCli(B, ["cancel"]);
+    assertEquals(bad.code, 1);
+    assertStringIncludes(bad.err, "Usage: zuke cancel");
+  });
+});

--- a/zuke.ts
+++ b/zuke.ts
@@ -376,7 +376,11 @@ class ZukeBuild extends Build {
     .description("Run the subprocess e2e suite (real processes, OS matrix)")
     .executes(async () => {
       await DenoTasks.test((s) =>
-        s.allowAll().paths("tests/e2e/race_e2e.ts", "tests/e2e/mcp_e2e.ts")
+        s.allowAll().paths(
+          "tests/e2e/race_e2e.ts",
+          "tests/e2e/mcp_e2e.ts",
+          "tests/e2e/cancel_e2e.ts",
+        )
       );
     });
 


### PR DESCRIPTION
## M6 — Cancellation as a graph concept

Implements milestone **M6** from `plans/orchestrationplan.md`: cancelling a run is always safe and complete — compensations run in reverse order, locks release, and the record settles `cancelled`.

### Authoring
- **`.onCancel(target | () => target)`** on `TargetBuilder` — a compensation that runs **iff its target succeeded**. On cancel, the compensations of the succeeded targets run in **reverse topological order**, each with a normal `TargetContext` whose `ctx.state` exposes **the original target's** persisted metadata (so a rollback reads exactly the slot the deploy recorded). Thunk form for forward references.

### Cancelling — three entry points, one walk
- **`zuke cancel <run-id>`** — cancel any persisted run (idempotent; a finished run is a friendly no-op).
- **Ctrl-C / SIGTERM** — wired in `run()`; the in-process run runs the same walk. A second Ctrl-C force-exits.
- **MCP `cancel_run`** — gated by the allow-list + operator token and audited, exactly like `signal_run`.
- A **live** run being cancelled by another process observes `cancelling` on its next state write and aborts (releasing its locks via the ambient signal); the canceller owns the compensation walk.
- A timed-out `.waitsFor()` routes its `cancel-run` / named-target `onTimeout` disposition through this machinery, closing the stuck-deploy → wait loop.

### New status
- `cancelling` — the transient state between `running`/`suspended` and `cancelled`.

### Robustness (from the adversarial review — see below)
Cleanup is **maximal and safe**: a throwing `onCancel` thunk or compensation body, a hung compensation (bounded by its own `.timeout()`), and a store hiccup mid-finalize are all recorded rather than fatal; a run stranded `cancelling` by an interrupted cancellation is **recoverable** by re-running the cancel; compensation failure messages are **redacted**; and `resume --check` isolates a per-run error instead of aborting the sweep.

### Tests (all three layers)
- **Unit** `packages/core/tests/cancel_test.ts` — reverse-order walk, meta read-back, idempotent no-op, in-process cancel, live observe-hook, recovery, redaction, timeout, throwing thunk, timeout dispositions.
- **Integration** `tests/integration/cancel_test.ts` — the full flow through `main()` (`zuke cancel` → `runs show`).
- **E2E** `tests/e2e/cancel_e2e.ts` — two real processes: one suspends, the other cancels.
- Plus MCP `cancel_run` coverage and the `resumeCheck` isolation regression.

### Adversarial review
An adversarial-review workflow (4 dimensions → per-finding verify) found **13 real defects** the green gate missed — an unguarded `onCancel` thunk that wedged the run, a secret leak through unredacted compensation errors, a double-compensation race, a missing in-process audit event, a silently-stranded `cancelling` run, a sweep-aborting `resume --check`, and a dropped-succeeded-settle. **All fixed with regression tests before this PR.**

### Docs
`docs/orchestration.md` (cancellation section + fan-out limitation), `cli.md`, `authoring.md`, `mcp.md`, `state.md`; skill + cheatsheet; `llms.txt`/`llms-full.txt`/README regenerated.

`deno task ci` green — 98.1% lines / 95.1% branches; `apiDocsCheck` and `deno doc --lint` clean.