### PR TITLE
feat(core): richer plugin lifecycle payloads

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -20,23 +20,36 @@ import { type Plugin, run } from "jsr:@zuke/core";
 
 const timing: Plugin = {
   name: "timing",
-  onTargetEnd: (target, status) => console.log(`${target}: ${status}`),
+  onTargetEnd: (target, status, { runId, durationMs }) =>
+    console.log(`${runId} ${target}: ${status} in ${durationMs}ms`),
   onFinish: (result) => console.log(`done: ${result.ok ? "ok" : "failed"}`),
 };
 
 await run(MyBuild, { plugins: [timing] });
 ```
 
-| Hook                       | When it runs                                          |
-| -------------------------- | ----------------------------------------------------- |
-| `onStart()`                | Once, before any target runs.                         |
-| `onTargetStart(target)`    | Before a target's body executes (not skipped/cached). |
-| `onTargetEnd(target, s)`   | After each target settles, with its status.           |
-| `onFinish(result)`         | Once, after the run (success or failure).             |
+| Hook                                  | When it runs                                                        |
+| ------------------------------------- | ------------------------------------------------------------------- |
+| `onStart(run)`                        | Once, before any target runs.                                       |
+| `onTargetStart(target, run)`          | Before a target's body executes (not skipped/cached).               |
+| `onTargetEnd(target, status, timing)` | After each target settles, with its status and duration.            |
+| `onFinish(result, run)`               | Once, after the run (success or failure).                           |
+| `onRunStateChange(record)`            | On each run-level status change; needs a [state store](./state.md). |
 
-Every hook is optional and may be async — the executor awaits each before
-continuing. Hooks mirror the `Build` lifecycle methods (`onStart`,
-`onTargetStart`, `onTargetEnd`, `onFinish`), so anything a build can observe by
+Each hook carries context beyond the bare names: `run` is a `RunInfo`
+(`{ runId, dryRun }`) whose `runId` is **stable across a suspend/resume
+boundary**, so an exporter can group a run's events (e.g. under one trace id);
+`timing` is a `TargetTiming` (`{ runId, durationMs }`). `onRunStateChange`
+receives the full [`RunRecord`](./state.md) whenever the run goes `running`,
+`suspended`, `succeeded`, `failed`, `cancelling`, or `cancelled` — per-target
+timings, waits, and the audit trail in one payload — and only fires when a state
+store is configured (a plain build with no store never produces a record).
+
+The extra arguments are **additive**: a plugin written against the old
+signatures (`onTargetEnd: (target, status) => …`) keeps working unchanged, since
+a function that ignores its trailing arguments is still assignable. Every hook
+is optional and may be async — the executor awaits each before continuing. Hooks
+mirror the `Build` lifecycle methods, so anything a build can observe by
 overriding those, a plugin can observe without subclassing — and several plugins
 can observe at once.
 
@@ -61,7 +74,11 @@ Wrap a CLI as a typed, fluent task in the settings-lambda style. For a one-off,
 distributable package extends `ToolSettings` from `@zuke/core/tooling`.
 
 ```ts
-import { type Configure, runSettings, ToolSettings } from "jsr:@zuke/core/tooling";
+import {
+  type Configure,
+  runSettings,
+  ToolSettings,
+} from "jsr:@zuke/core/tooling";
 
 class MyToolSettings extends ToolSettings {
   #args: string[] = [];
@@ -95,8 +112,9 @@ existing `@zuke/*` wrappers are the template.
 
 A **component** is a function that returns an object of related targets.
 Assigned to a build field, discovery recurses into the bundle and names each
-target with a dotted path (`release.publish`), runnable as `zuke release.publish`
-and shown in the graph. Components compose, nest, and take options.
+target with a dotted path (`release.publish`), runnable as
+`zuke release.publish` and shown in the graph. Components compose, nest, and
+take options.
 
 ```ts
 // @acme/zuke-release

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2088,14 +2088,31 @@ interface Plugin
 
   name?: string
     A name for diagnostics (optional).
-  onStart?(): void | Promise<void>
-    Called once before any target runs.
-  onTargetStart?(target: string): void | Promise<void>
-    Called just before a target's body executes (not for skipped/cached).
-  onTargetEnd?(target: string, status: TargetStatus): void | Promise<void>
-    Called after each target settles, with its final status.
-  onFinish?(result: BuildResult): void | Promise<void>
-    Called once after the run completes (success or failure).
+  onStart?(run: RunInfo): void | Promise<void>
+    Called once before any target runs, with the run's {@link RunInfo}.
+  onTargetStart?(target: string, run: RunInfo): void | Promise<void>
+    Called just before a target's body executes (not for skipped/cached), with
+    the target name and the run's {@link RunInfo}.
+  onTargetEnd?(target: string, status: TargetStatus, timing: TargetTiming): void | Promise<void>
+    Called after each target settles, with its final status and its
+    {@link TargetTiming} (run id + duration).
+  onFinish?(result: BuildResult, run: RunInfo): void | Promise<void>
+    Called once after the run completes (success or failure), with the result
+    and the run's {@link RunInfo}.
+  onRunStateChange?(record: RunRecord): void | Promise<void>
+    Called on each run-level durable status change — the run going
+    `running`, `suspended`, `succeeded`, `failed`, `cancelling`, or `cancelled`
+    — with the current {@link "./state/types.ts".RunRecord}. It carries the full
+    record (per-target timings, waits, the audit trail), so a metrics exporter
+    can derive spans, wait durations, and counters from a single source.
+    Only fires when a state store is configured (the record's home); a plain
+    build with no store never produces one, and this hook stays silent.
+
+    A run cancelled in-process (Ctrl-C / its `signal`) is observed as
+    `running` → `cancelling` → `cancelled`. When another process cancels the
+    run (`zuke cancel`), this process observes it through `cancelling` and stops
+    — the canceller's process owns the final `cancelled` — so treat `cancelling`
+    as run-ended for the owning process.
 
 interface Remediation
   A recovery step plugged into a target with {@link TargetBuilder.recoverWith}.
@@ -2215,6 +2232,10 @@ interface ResumeOptions
     Suppress banner/summary output.
   reporter?: Reporter
     Custom reporter; overrides `silent`.
+  plugins?: Plugin[]
+    Lifecycle observers for the resumed run. Because a resume keeps the original
+    run id, a plugin sees the continuation under the same identity — so an
+    exporter's spans join one trace across the suspend/resume boundary.
 
 interface ResumeState
   The continuation state {@link resumeRun} hands to {@link execute} on a resume.
@@ -2258,6 +2279,16 @@ interface RunGraphNode
     The target's dotted name.
   dependsOn: string[]
     The dotted names of its direct dependencies.
+
+interface RunInfo
+  Run identity passed to a plugin's lifecycle hooks, so an observer can group a
+  run's events (e.g. under one trace id) — stable across a suspend/resume
+  boundary, since a resumed run keeps the original id.
+
+  readonly runId: string
+    The run id, stable for every target in the run (and across a resume).
+  readonly dryRun: boolean
+    True when the run is a dry run (no target body executes).
 
 interface RunOptions
   Options for {@link run}.
@@ -2496,6 +2527,14 @@ interface TargetStateHandle
     Merge a JSON patch into this target's persisted metadata (awaits the write).
   get(): Record<string, JsonValue>
     Read this target's persisted metadata (from prior attempts/runs too).
+
+interface TargetTiming
+  Timing for a settled target, passed to {@link Plugin.onTargetEnd}.
+
+  readonly runId: string
+    The run id (see {@link RunInfo}).
+  readonly durationMs: number
+    The target's wall-clock duration in milliseconds (0 for skipped/cached).
 
 interface ToolTasksApi
   The task surface of {@link ToolTasks}.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2108,6 +2108,11 @@ interface Plugin
     Only fires when a state store is configured (the record's home); a plain
     build with no store never produces one, and this hook stays silent.
 
+    The record is the secret-free projection: `secret()` parameters are
+    omitted, and `ctx.state` metadata, target errors, and audit arguments are
+    run through the redactor before they reach it — the same data already
+    persisted to the store and shown by `zuke runs show`. It is safe to export.
+
     A run cancelled in-process (Ctrl-C / its `signal`) is observed as
     `running` → `cancelling` → `cancelled`. When another process cancels the
     run (`zuke cancel`), this process observes it through `cancelling` and stops

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2142,14 +2142,31 @@ interface Plugin
 
   name?: string
     A name for diagnostics (optional).
-  onStart?(): void | Promise<void>
-    Called once before any target runs.
-  onTargetStart?(target: string): void | Promise<void>
-    Called just before a target's body executes (not for skipped/cached).
-  onTargetEnd?(target: string, status: TargetStatus): void | Promise<void>
-    Called after each target settles, with its final status.
-  onFinish?(result: BuildResult): void | Promise<void>
-    Called once after the run completes (success or failure).
+  onStart?(run: RunInfo): void | Promise<void>
+    Called once before any target runs, with the run's {@link RunInfo}.
+  onTargetStart?(target: string, run: RunInfo): void | Promise<void>
+    Called just before a target's body executes (not for skipped/cached), with
+    the target name and the run's {@link RunInfo}.
+  onTargetEnd?(target: string, status: TargetStatus, timing: TargetTiming): void | Promise<void>
+    Called after each target settles, with its final status and its
+    {@link TargetTiming} (run id + duration).
+  onFinish?(result: BuildResult, run: RunInfo): void | Promise<void>
+    Called once after the run completes (success or failure), with the result
+    and the run's {@link RunInfo}.
+  onRunStateChange?(record: RunRecord): void | Promise<void>
+    Called on each run-level durable status change — the run going
+    `running`, `suspended`, `succeeded`, `failed`, `cancelling`, or `cancelled`
+    — with the current {@link "./state/types.ts".RunRecord}. It carries the full
+    record (per-target timings, waits, the audit trail), so a metrics exporter
+    can derive spans, wait durations, and counters from a single source.
+    Only fires when a state store is configured (the record's home); a plain
+    build with no store never produces one, and this hook stays silent.
+
+    A run cancelled in-process (Ctrl-C / its `signal`) is observed as
+    `running` → `cancelling` → `cancelled`. When another process cancels the
+    run (`zuke cancel`), this process observes it through `cancelling` and stops
+    — the canceller's process owns the final `cancelled` — so treat `cancelling`
+    as run-ended for the owning process.
 
 interface Remediation
   A recovery step plugged into a target with {@link TargetBuilder.recoverWith}.
@@ -2269,6 +2286,10 @@ interface ResumeOptions
     Suppress banner/summary output.
   reporter?: Reporter
     Custom reporter; overrides `silent`.
+  plugins?: Plugin[]
+    Lifecycle observers for the resumed run. Because a resume keeps the original
+    run id, a plugin sees the continuation under the same identity — so an
+    exporter's spans join one trace across the suspend/resume boundary.
 
 interface ResumeState
   The continuation state {@link resumeRun} hands to {@link execute} on a resume.
@@ -2312,6 +2333,16 @@ interface RunGraphNode
     The target's dotted name.
   dependsOn: string[]
     The dotted names of its direct dependencies.
+
+interface RunInfo
+  Run identity passed to a plugin's lifecycle hooks, so an observer can group a
+  run's events (e.g. under one trace id) — stable across a suspend/resume
+  boundary, since a resumed run keeps the original id.
+
+  readonly runId: string
+    The run id, stable for every target in the run (and across a resume).
+  readonly dryRun: boolean
+    True when the run is a dry run (no target body executes).
 
 interface RunOptions
   Options for {@link run}.
@@ -2550,6 +2581,14 @@ interface TargetStateHandle
     Merge a JSON patch into this target's persisted metadata (awaits the write).
   get(): Record<string, JsonValue>
     Read this target's persisted metadata (from prior attempts/runs too).
+
+interface TargetTiming
+  Timing for a settled target, passed to {@link Plugin.onTargetEnd}.
+
+  readonly runId: string
+    The run id (see {@link RunInfo}).
+  readonly durationMs: number
+    The target's wall-clock duration in milliseconds (0 for skipped/cached).
 
 interface ToolTasksApi
   The task surface of {@link ToolTasks}.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2162,6 +2162,11 @@ interface Plugin
     Only fires when a state store is configured (the record's home); a plain
     build with no store never produces one, and this hook stays silent.
 
+    The record is the secret-free projection: `secret()` parameters are
+    omitted, and `ctx.state` metadata, target errors, and audit arguments are
+    run through the redactor before they reach it — the same data already
+    persisted to the store and shown by `zuke runs show`. It is safe to export.
+
     A run cancelled in-process (Ctrl-C / its `signal`) is observed as
     `running` → `cancelling` → `cancelled`. When another process cancels the
     run (`zuke cancel`), this process observes it through `cancelling` and stops

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -80,7 +80,7 @@ export {
   type CliTargetInfo,
   describeCli,
 } from "./src/describe.ts";
-export type { Plugin } from "./src/plugin.ts";
+export type { Plugin, RunInfo, TargetTiming } from "./src/plugin.ts";
 export {
   type AffectedOptions,
   affectedTargets,

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -640,7 +640,11 @@ function parseSignalData(raw: string | undefined): JsonValue | undefined {
 }
 
 /** Run the `resume` command: continue a suspended run, or `--check` all of them. */
-async function runResume(build: Build, parsed: ParsedArgs): Promise<number> {
+async function runResume(
+  build: Build,
+  parsed: ParsedArgs,
+  plugins?: Plugin[],
+): Promise<number> {
   try {
     if (parsed.check) {
       const { checked, failed } = await resumeCheck(build, {
@@ -648,6 +652,7 @@ async function runResume(build: Build, parsed: ParsedArgs): Promise<number> {
         params: parsed.values,
         actor: parsed.actor,
         forceGraph: parsed.forceGraph,
+        plugins,
       });
       console.log(`Checked ${checked} suspended run(s); ${failed} failed.`);
       return failed > 0 ? 1 : 0;
@@ -666,6 +671,7 @@ async function runResume(build: Build, parsed: ParsedArgs): Promise<number> {
       params: parsed.values,
       actor: parsed.actor,
       forceGraph: parsed.forceGraph,
+      plugins,
     });
     return result.ok ? 0 : 1;
   } catch (error) {
@@ -834,7 +840,7 @@ export async function main(
     return await runMcp(build, parsed);
   }
   if (parsed.resume) {
-    return await runResume(build, parsed);
+    return await runResume(build, parsed, options.plugins);
   }
   if (parsed.runs) {
     return await runRuns(build, parsed);

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -63,7 +63,7 @@ import { inMemoryStateHandle, RunStateWriter } from "./state/writer.ts";
 import { cancelEvent, runCompensations } from "./cancel.ts";
 import { LockConflictError, type LockHolder } from "./state/lock.ts";
 import { parseDuration } from "./duration.ts";
-import type { Plugin } from "./plugin.ts";
+import type { Plugin, RunInfo, TargetTiming } from "./plugin.ts";
 import {
   detectWidth,
   type Style,
@@ -586,28 +586,72 @@ async function resolveWait(
 interface Lifecycle {
   start(): Promise<void>;
   targetStart(name: string): Promise<void>;
-  targetEnd(name: string, status: TargetStatus): Promise<void>;
+  targetEnd(
+    name: string,
+    status: TargetStatus,
+    durationMs: number,
+  ): Promise<void>;
   finish(result: BuildResult): Promise<void>;
+  /** Notify plugins of a run-level durable status change (no-op without a store). */
+  runStateChange(record: RunRecord): Promise<void>;
 }
 
-/** Compose a build and its plugins into one {@link Lifecycle}. */
-function makeLifecycle(build: Build, plugins: Plugin[]): Lifecycle {
+/**
+ * Compose a build and its plugins into one {@link Lifecycle}. The run's
+ * {@link RunInfo} is bound in, so it enriches every plugin hook without threading
+ * it through each call site; the build's own hooks keep their original
+ * signatures. Plugin hooks that ignore the extra arguments stay compatible.
+ *
+ * A plugin is an **observer** — its contract is to report, time, or notify, not
+ * to change a target's result — so a throwing plugin hook is caught and reported
+ * through `warn`, never allowed to break the run. The build's own hooks are the
+ * build's logic and still propagate.
+ */
+function makeLifecycle(
+  build: Build,
+  plugins: Plugin[],
+  run: RunInfo,
+  warn: (message: string) => void,
+): Lifecycle {
+  const observe = async (
+    hook: string,
+    call: (p: Plugin) => void | Promise<void>,
+  ): Promise<void> => {
+    for (const p of plugins) {
+      try {
+        await call(p);
+      } catch (error) {
+        warn(
+          `plugin "${p.name ?? "?"}" threw in ${hook}: ${
+            errorMessage(error) ?? "unknown error"
+          } (ignored — plugins observe, they do not change the run)`,
+        );
+      }
+    }
+  };
   return {
     async start() {
       await build.onStart();
-      for (const p of plugins) await p.onStart?.();
+      await observe("onStart", (p) => p.onStart?.(run));
     },
     async targetStart(name) {
       await build.onTargetStart(name);
-      for (const p of plugins) await p.onTargetStart?.(name);
+      await observe("onTargetStart", (p) => p.onTargetStart?.(name, run));
     },
-    async targetEnd(name, status) {
+    async targetEnd(name, status, durationMs) {
       await build.onTargetEnd(name, status);
-      for (const p of plugins) await p.onTargetEnd?.(name, status);
+      const timing: TargetTiming = { runId: run.runId, durationMs };
+      await observe(
+        "onTargetEnd",
+        (p) => p.onTargetEnd?.(name, status, timing),
+      );
     },
     async finish(result) {
       await build.onFinish(result);
-      for (const p of plugins) await p.onFinish?.(result);
+      await observe("onFinish", (p) => p.onFinish?.(result, run));
+    },
+    async runStateChange(record) {
+      await observe("onRunStateChange", (p) => p.onRunStateChange?.(record));
     },
   };
 }
@@ -1037,7 +1081,7 @@ async function runSequential(
       services,
       env,
     );
-    await life.targetEnd(name, outcome.status);
+    await life.targetEnd(name, outcome.status, outcome.ms);
     void env.writer?.markTargetSettled(
       name,
       outcome.status,
@@ -1141,7 +1185,11 @@ async function runScheduled(
         )
           .then(
             async (outcome) => {
-              await life.targetEnd(t.name_ ?? "<unnamed>", outcome.status);
+              await life.targetEnd(
+                t.name_ ?? "<unnamed>",
+                outcome.status,
+                outcome.ms,
+              );
               // A waiting gate already recorded its `waitingFor` via
               // markTargetWaiting; settling it here would clobber that.
               if (outcome.status !== "waiting") {
@@ -1335,18 +1383,27 @@ export async function execute(
   );
   const overallStart = performance.now();
 
-  const life = makeLifecycle(build, options.plugins ?? []);
+  // One run identity per run (stable across a resume), established before the
+  // lifecycle so every plugin hook can carry it.
+  const runId = options.resume ? options.resume.record.id : crypto.randomUUID();
+  const runInfo: RunInfo = { runId, dryRun };
+
+  const life = makeLifecycle(
+    build,
+    options.plugins ?? [],
+    runInfo,
+    (message) => reporter.info(message),
+  );
   await life.start();
 
   // Build-level remediations apply to every target (after each target's own),
   // resolved once before the run.
   const globalRecovery = dryRun ? [] : build.recoverWith();
 
-  // One run identity and one cancellation controller per run. The controller
-  // aborts when the caller's `options.signal` does; its signal is handed to
-  // every target's context and installed as the shell's ambient signal, so a
-  // cancelled run terminates in-flight `$` child processes.
-  const runId = options.resume ? options.resume.record.id : crypto.randomUUID();
+  // One cancellation controller per run. The controller aborts when the caller's
+  // `options.signal` does; its signal is handed to every target's context and
+  // installed as the shell's ambient signal, so a cancelled run terminates
+  // in-flight `$` child processes.
   const runController = new AbortController();
   const onCancel = () => runController.abort();
   if (options.signal !== undefined) {
@@ -1445,6 +1502,10 @@ export async function execute(
     done: options.resume?.done,
   };
 
+  // Announce the run's initial durable state (`running`) to plugins — a no-op
+  // without a store. Terminal transitions are announced once the plan settles.
+  if (writer !== undefined) await life.runStateChange(writer.snapshot());
+
   // Services started during the run are held here and torn down in reverse
   // order once it finishes — in a `finally`, so a failure never leaks a process.
   const services = new ServiceRegistry();
@@ -1540,6 +1601,10 @@ export async function execute(
           `Run ${runId} cancelled by another process — stopping.`,
         );
       } else {
+        // Announce the intermediate `cancelling` transition (the record was just
+        // moved there) before compensations run, so a plugin sees the full
+        // running → cancelling → cancelled sequence.
+        await life.runStateChange(writer.snapshot());
         // Run the succeeded targets' compensations in reverse order, record the
         // cancellation in the audit trail (as `zuke cancel` does), then settle.
         const comp = await runCompensations(order, writer.snapshot(), {
@@ -1569,6 +1634,10 @@ export async function execute(
     if (run.suspended) await writer?.markRunSuspended();
     else await writer?.markRunFinished(result.ok);
   }
+
+  // Announce the run's terminal durable state (succeeded/failed/suspended/
+  // cancelling) to plugins, now that the transition above has landed.
+  if (writer !== undefined) await life.runStateChange(writer.snapshot());
 
   const totalMs = performance.now() - overallStart;
   for (

--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -88,6 +88,11 @@ export interface Plugin {
    * **Only fires when a state store is configured** (the record's home); a plain
    * build with no store never produces one, and this hook stays silent.
    *
+   * The record is the **secret-free projection**: `secret()` parameters are
+   * omitted, and `ctx.state` metadata, target errors, and audit arguments are
+   * run through the redactor before they reach it — the same data already
+   * persisted to the store and shown by `zuke runs show`. It is safe to export.
+   *
    * A run cancelled in-process (Ctrl-C / its `signal`) is observed as
    * `running` → `cancelling` → `cancelled`. When **another process** cancels the
    * run (`zuke cancel`), this process observes it through `cancelling` and stops

--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -13,16 +13,43 @@
  *
  * const timing: Plugin = {
  *   name: "timing",
- *   onTargetEnd: (target, status) => console.log(`${target}: ${status}`),
+ *   // The enriched form carries the run id and the target's duration…
+ *   onTargetEnd: (target, status, timing) =>
+ *     console.log(`${timing.runId} ${target}: ${status} in ${timing.durationMs}ms`),
  * };
  *
  * await run(MyBuild, { plugins: [timing] });
  * ```
  *
+ * Every hook's extra arguments are additive: a plugin written against the old
+ * signatures (`onTargetEnd: (target, status) => …`) keeps working unchanged,
+ * because a function that ignores the trailing arguments is still assignable.
+ *
  * @module
  */
 
 import type { BuildResult, TargetStatus } from "./build.ts";
+import type { RunRecord } from "./state/types.ts";
+
+/**
+ * Run identity passed to a plugin's lifecycle hooks, so an observer can group a
+ * run's events (e.g. under one trace id) — stable across a suspend/resume
+ * boundary, since a resumed run keeps the original id.
+ */
+export interface RunInfo {
+  /** The run id, stable for every target in the run (and across a resume). */
+  readonly runId: string;
+  /** True when the run is a dry run (no target body executes). */
+  readonly dryRun: boolean;
+}
+
+/** Timing for a settled target, passed to {@link Plugin.onTargetEnd}. */
+export interface TargetTiming {
+  /** The run id (see {@link RunInfo}). */
+  readonly runId: string;
+  /** The target's wall-clock duration in milliseconds (0 for skipped/cached). */
+  readonly durationMs: number;
+}
 
 /**
  * A lifecycle observer. Every hook is optional; implement only the ones you
@@ -31,12 +58,41 @@ import type { BuildResult, TargetStatus } from "./build.ts";
 export interface Plugin {
   /** A name for diagnostics (optional). */
   name?: string;
-  /** Called once before any target runs. */
-  onStart?(): void | Promise<void>;
-  /** Called just before a target's body executes (not for skipped/cached). */
-  onTargetStart?(target: string): void | Promise<void>;
-  /** Called after each target settles, with its final status. */
-  onTargetEnd?(target: string, status: TargetStatus): void | Promise<void>;
-  /** Called once after the run completes (success or failure). */
-  onFinish?(result: BuildResult): void | Promise<void>;
+  /** Called once before any target runs, with the run's {@link RunInfo}. */
+  onStart?(run: RunInfo): void | Promise<void>;
+  /**
+   * Called just before a target's body executes (not for skipped/cached), with
+   * the target name and the run's {@link RunInfo}.
+   */
+  onTargetStart?(target: string, run: RunInfo): void | Promise<void>;
+  /**
+   * Called after each target settles, with its final status and its
+   * {@link TargetTiming} (run id + duration).
+   */
+  onTargetEnd?(
+    target: string,
+    status: TargetStatus,
+    timing: TargetTiming,
+  ): void | Promise<void>;
+  /**
+   * Called once after the run completes (success or failure), with the result
+   * and the run's {@link RunInfo}.
+   */
+  onFinish?(result: BuildResult, run: RunInfo): void | Promise<void>;
+  /**
+   * Called on each **run-level** durable status change — the run going
+   * `running`, `suspended`, `succeeded`, `failed`, `cancelling`, or `cancelled`
+   * — with the current {@link "./state/types.ts".RunRecord}. It carries the full
+   * record (per-target timings, waits, the audit trail), so a metrics exporter
+   * can derive spans, wait durations, and counters from a single source.
+   * **Only fires when a state store is configured** (the record's home); a plain
+   * build with no store never produces one, and this hook stays silent.
+   *
+   * A run cancelled in-process (Ctrl-C / its `signal`) is observed as
+   * `running` → `cancelling` → `cancelled`. When **another process** cancels the
+   * run (`zuke cancel`), this process observes it through `cancelling` and stops
+   * — the canceller's process owns the final `cancelled` — so treat `cancelling`
+   * as run-ended for the owning process.
+   */
+  onRunStateChange?(record: RunRecord): void | Promise<void>;
 }

--- a/packages/core/src/resume.ts
+++ b/packages/core/src/resume.ts
@@ -19,6 +19,7 @@
 import { type Build, type BuildResult, discoverTargets } from "./build.ts";
 import { cancelRun } from "./cancel.ts";
 import { execute, type Reporter } from "./executor.ts";
+import type { Plugin } from "./plugin.ts";
 import { planGraph } from "./graph.ts";
 import type { JsonValue, TargetBuilder } from "./target.ts";
 import { absolutePath } from "./path.ts";
@@ -76,6 +77,12 @@ export interface ResumeOptions {
   silent?: boolean;
   /** Custom reporter; overrides `silent`. */
   reporter?: Reporter;
+  /**
+   * Lifecycle observers for the resumed run. Because a resume keeps the original
+   * run id, a plugin sees the continuation under the **same** identity — so an
+   * exporter's spans join one trace across the suspend/resume boundary.
+   */
+  plugins?: Plugin[];
 }
 
 /** How many times a conflicting resume CAS is re-read and retried. */
@@ -183,6 +190,7 @@ export async function resumeRun(
     actor: resumerActor,
     silent: options.silent,
     reporter: options.reporter,
+    plugins: options.plugins,
     resume: { record, version, done },
   });
 }

--- a/packages/core/tests/executor_test.ts
+++ b/packages/core/tests/executor_test.ts
@@ -1317,6 +1317,181 @@ Deno.test("execute supports multiple plugins and partial hook sets", async () =>
   assertEquals(calls, ["p1:a:passed", "p2:finish"]);
 });
 
+Deno.test("plugin hooks carry the run id, dry-run flag, and target timing (M7)", async () => {
+  const seen: {
+    startRunId?: string;
+    tsRunId?: string;
+    teRunId?: string;
+    teDuration?: number;
+    finishRunId?: string;
+    dryRun?: boolean;
+  } = {};
+  class B extends Build {
+    a = target().executes(() => {});
+  }
+  const plugin: Plugin = {
+    onStart: (run) => {
+      seen.startRunId = run.runId;
+      seen.dryRun = run.dryRun;
+    },
+    onTargetStart: (_n, run) => void (seen.tsRunId = run.runId),
+    onTargetEnd: (_n, _s, timing) => {
+      seen.teRunId = timing.runId;
+      seen.teDuration = timing.durationMs;
+    },
+    onFinish: (_r, run) => void (seen.finishRunId = run.runId),
+  };
+  const b = new B();
+  discoverTargets(b);
+  const result = await execute(b, b.a, { silent: true, plugins: [plugin] });
+  // Every hook sees the same, non-empty run id — the run's identity.
+  assertEquals(seen.startRunId, result.runId);
+  assertEquals(seen.startRunId !== undefined && seen.startRunId !== "", true);
+  assertEquals(seen.tsRunId, seen.startRunId);
+  assertEquals(seen.teRunId, seen.startRunId);
+  assertEquals(seen.finishRunId, seen.startRunId);
+  assertEquals(seen.dryRun, false);
+  assertEquals(typeof seen.teDuration, "number");
+
+  // A dry run reports dryRun: true through the same RunInfo.
+  const dry: boolean[] = [];
+  const b2 = new B();
+  discoverTargets(b2);
+  await execute(b2, b2.a, {
+    silent: true,
+    dryRun: true,
+    plugins: [{ onStart: (run) => void dry.push(run.dryRun) }],
+  });
+  assertEquals(dry, [true]);
+});
+
+Deno.test("old-style plugin hooks (fewer args) still compile and run (M7)", async () => {
+  const calls: string[] = [];
+  class B extends Build {
+    a = target().executes(() => {});
+  }
+  // The pre-M7 signatures — no run/timing arguments — remain valid.
+  const legacy: Plugin = {
+    onStart: () => void calls.push("start"),
+    onTargetStart: (n) => void calls.push(`ts:${n}`),
+    onTargetEnd: (n, s) => void calls.push(`te:${n}:${s}`),
+    onFinish: (r) => void calls.push(`finish:${r.ok}`),
+  };
+  const b = new B();
+  discoverTargets(b);
+  await execute(b, b.a, { silent: true, plugins: [legacy] });
+  assertEquals(calls, ["start", "ts:a", "te:a:passed", "finish:true"]);
+});
+
+Deno.test("onRunStateChange fires with the record on run-level transitions (M7)", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    const statuses: string[] = [];
+    const runIds = new Set<string>();
+    class B extends Build {
+      a = target().executes(() => {});
+    }
+    const plugin: Plugin = {
+      onRunStateChange: (record) => {
+        statuses.push(record.status);
+        runIds.add(record.id);
+      },
+    };
+    const b = new B();
+    discoverTargets(b);
+    const result = await execute(b, b.a, {
+      silent: true,
+      stateStore: store,
+      plugins: [plugin],
+    });
+    // Fires at start (running) and at the terminal transition (succeeded), both
+    // carrying the same run record.
+    assertEquals(statuses, ["running", "succeeded"]);
+    assertEquals(runIds.size, 1);
+    assertEquals([...runIds][0], result.runId);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("onRunStateChange stays silent without a state store (M7)", async () => {
+  const calls: string[] = [];
+  class B extends Build {
+    a = target().executes(() => {});
+  }
+  const b = new B();
+  discoverTargets(b);
+  await execute(b, b.a, {
+    silent: true,
+    stateStore: false,
+    plugins: [{ onRunStateChange: (r) => void calls.push(r.status) }],
+  });
+  assertEquals(calls, []); // no store → no record → no run-state events
+});
+
+Deno.test("onRunStateChange delivers running → cancelling → cancelled on self-cancel (M7)", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    const statuses: string[] = [];
+    let started: () => void = () => {};
+    const ready = new Promise<void>((resolve) => (started = resolve));
+    const controller = new AbortController();
+    class B extends Build {
+      hang = target().executes((ctx) =>
+        new Promise<void>((resolve) => {
+          ctx.signal.addEventListener("abort", () => resolve(), { once: true });
+          started();
+        })
+      );
+    }
+    const b = new B();
+    discoverTargets(b);
+    const runPromise = execute(b, b.hang, {
+      silent: true,
+      stateStore: store,
+      signal: controller.signal,
+      plugins: [{ onRunStateChange: (r) => void statuses.push(r.status) }],
+    });
+    await ready;
+    controller.abort();
+    const result = await runPromise;
+    assertEquals(result.cancelled, true);
+    // The full cancellation sequence is delivered, not just the terminal state.
+    assertEquals(statuses, ["running", "cancelling", "cancelled"]);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("a throwing plugin hook is isolated and never breaks the run (M7)", async () => {
+  const events: string[] = [];
+  class B extends Build {
+    a = target().executes(() => void events.push("body"));
+  }
+  // A buggy observer that throws in every hook must not break the build, and
+  // must not stop a well-behaved plugin registered after it.
+  const bad: Plugin = {
+    name: "bad",
+    onStart: () => {
+      throw new Error("boom-start");
+    },
+    onTargetEnd: () => {
+      throw new Error("boom-te");
+    },
+    onFinish: () => {
+      throw new Error("boom-finish");
+    },
+  };
+  const good: Plugin = { onFinish: () => void events.push("good:finish") };
+  const b = new B();
+  discoverTargets(b);
+  const result = await execute(b, b.a, { silent: true, plugins: [bad, good] });
+  assertEquals(result.ok, true); // the run completes despite the throwing observer
+  assertEquals(events, ["body", "good:finish"]); // the good plugin still ran
+});
+
 Deno.test("validateBefore runs before the body; validateAfter runs after", async () => {
   const log: string[] = [];
   class B extends Build {

--- a/packages/core/tests/resume_test.ts
+++ b/packages/core/tests/resume_test.ts
@@ -231,6 +231,41 @@ Deno.test("resuming a run already running gives AlreadyResumedError", async () =
   });
 });
 
+Deno.test("a resumed run's plugins observe it under the original run id (M7)", async () => {
+  await withTempStore(async (store) => {
+    const makeBuild = () => {
+      class B extends Build {
+        gate = target().waitsFor((s) => s.on(externalSignal("go")));
+        done = target().dependsOn(this.gate).executes(() => {});
+      }
+      const build = new B();
+      discoverTargets(build);
+      return build;
+    };
+    // Original run: suspends at the gate.
+    const a = makeBuild();
+    const first = await execute(a, a.done, { silent: true, stateStore: store });
+    assertEquals(first.suspended, true);
+    const runId = (await store.listRuns({}))[0].id;
+
+    // Resume with a plugin: it sees the SAME run id and the run-state changes.
+    const seen: { start?: string; states: string[] } = { states: [] };
+    const resumed = await resumeRun(makeBuild(), {
+      runId,
+      signal: "go",
+      stateStore: store,
+      silent: true,
+      plugins: [{
+        onStart: (run) => void (seen.start = run.runId),
+        onRunStateChange: (record) => void seen.states.push(record.status),
+      }],
+    });
+    assertEquals(resumed.ok, true);
+    assertEquals(seen.start, runId); // one identity across the suspend/resume
+    assertEquals(seen.states, ["running", "succeeded"]);
+  });
+});
+
 Deno.test("resumeCheck isolates a per-run error and keeps sweeping", async () => {
   await withTempStore(async (store) => {
     let ready = false;

--- a/tests/integration/plugin_test.ts
+++ b/tests/integration/plugin_test.ts
@@ -1,0 +1,43 @@
+/**
+ * Integration: the enriched plugin lifecycle (M7) driven through the real CLI.
+ * A plugin passed to `main()` receives the run id and dry-run flag on every
+ * hook, the per-target duration on `onTargetEnd`, and — because `--state` turns
+ * on a durable store — `onRunStateChange` on each run-level transition.
+ */
+
+import { assertEquals } from "../../packages/core/tests/_assert.ts";
+import { Build, type Plugin, target } from "../../packages/core/mod.ts";
+import { runCli, withStateDir } from "./_harness.ts";
+
+Deno.test("a plugin driven through the CLI gets run id, timing, and run-state changes", async () => {
+  await withStateDir(async () => {
+    const events: string[] = [];
+    let runId: string | undefined;
+    class B extends Build {
+      compile = target().executes(() => {});
+    }
+    const plugin: Plugin = {
+      onStart: (run) => {
+        runId = run.runId;
+        events.push(`start:${run.dryRun}`);
+      },
+      onTargetEnd: (n, s, timing) =>
+        void events.push(`te:${n}:${s}:${typeof timing.durationMs}`),
+      onRunStateChange: (record) => void events.push(`state:${record.status}`),
+      onFinish: (_r, run) => void events.push(`finish:${run.runId === runId}`),
+    };
+    // `--state` turns on the `.zuke/runs` store, so onRunStateChange fires.
+    const { code } = await runCli(B, ["compile", "--state"], {
+      plugins: [plugin],
+    });
+    assertEquals(code, 0);
+    assertEquals(runId !== undefined && runId !== "", true);
+    assertEquals(events, [
+      "start:false",
+      "state:running",
+      "te:compile:passed:number",
+      "state:succeeded",
+      "finish:true",
+    ]);
+  });
+});


### PR DESCRIPTION
## M7 PR1 — richer plugin lifecycle payloads

The first of two PRs for **M7 (OpenTelemetry export)**. This one enriches the core plugin lifecycle so an observer can group, time, and count a run — the foundation the `@zuke/otel` exporter (PR2) builds on. No new package; core stays dependency-free.

### Enriched `Plugin` hooks
- `onStart(run)` / `onTargetStart(target, run)` / `onFinish(result, run)` carry a **`RunInfo`** (`{ runId, dryRun }`).
- `onTargetEnd(target, status, timing)` carries a **`TargetTiming`** (`{ runId, durationMs }`).
- New **`onRunStateChange(record)`** fires on each run-level durable status change (`running` → … → terminal) with the full [`RunRecord`](docs/state.md) — per-target timings, waits, and the audit trail in one payload. Fires only when a state store is configured.
- The **run id is stable across a suspend/resume boundary**, so an exporter's spans join one trace; `resumeRun`/`resume --check` forward plugins so a resumed run is observed under the same identity.

### Backwards compatible
The extra arguments are **additive** — a plugin written against the old signatures (`onTargetEnd: (target, status) => …`) keeps working unchanged, since a function that ignores its trailing arguments stays assignable. Existing plugin tests pass untouched.

### Robustness (from the adversarial review)
A plugin is an **observer** (the contract is "report/time/notify, don't change the run), so a **throwing plugin hook is now caught and reported** rather than breaking the run — the build's own hooks still propagate. `onRunStateChange` delivers the full `running → cancelling → cancelled` sequence on an in-process cancel; the cross-process cancel case (the owning process observes through `cancelling`) is documented on the hook.

### Tests
- **Unit** (`executor_test.ts`): run id / dry-run / timing on every hook, `onRunStateChange` running→terminal (and the cancel sequence), no-store silence, throwing-hook isolation, and old-signature compatibility.
- **Integration** (`tests/integration/plugin_test.ts`): the enriched lifecycle through the real CLI (`--state`).
- **Resume continuity** (`resume_test.ts`): a resumed run observed under the original run id.

### Adversarial review
A focused adversarial-review workflow (2 lenses → verify) surfaced 5 low-severity findings — all in the `onRunStateChange`/plugin-isolation area — each addressed before opening: `cancelling` is now delivered, plugin hooks are isolated, and the cross-process terminal-status nuance is documented.

`deno task ci` green — 98.x% lines / 95%+ branches; `apiDocsCheck` + `deno doc --lint` clean. Next: PR2 `feat(otel): OTLP export plugin`.