### PR TITLE
feat(otel): OTLP export plugin for runs, targets, and waits

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -599,6 +599,17 @@
           "jsonpath": "$.version"
         }
       ]
+    },
+    "packages/otel": {
+      "component": "otel",
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "deno.json",
+          "jsonpath": "$.version"
+        }
+      ]
     }
   }
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -52,5 +52,6 @@
   "packages/tofu": "0.1.0",
   "packages/release-please": "1.0.0",
   "packages/security": "0.2.0",
-  "packages/ai": "1.5.0"
+  "packages/ai": "1.5.0",
+  "packages/otel": "0.0.0"
 }

--- a/cspell.json
+++ b/cspell.json
@@ -27,6 +27,7 @@
     "checkpointing",
     "chmods",
     "codegen",
+    "dedup",
     "codecov",
     "codecovcli",
     "gcov",

--- a/deno.json
+++ b/deno.json
@@ -53,7 +53,8 @@
     "packages/tofu",
     "packages/release-please",
     "packages/security",
-    "packages/ai"
+    "packages/ai",
+    "packages/otel"
   ],
   "tasks": {
     "zuke": "deno run -A zuke.ts",

--- a/deno.lock
+++ b/deno.lock
@@ -732,6 +732,11 @@
           "jsr:@zuke/core@1"
         ]
       },
+      "packages/otel": {
+        "dependencies": [
+          "jsr:@zuke/core@^1.18.0"
+        ]
+      },
       "packages/oxlint": {
         "dependencies": [
           "jsr:@zuke/core@1"

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,9 @@
   CLIs from a build with `installRelease()` and `toolchain()`.
 - [Extending Zuke](./extending.md) — the plugin contract: lifecycle plugins,
   tool wrappers, and reusable target bundles.
+- [Observability (OpenTelemetry)](./observability.md) — `@zuke/otel` exports run
+  and target spans plus counters as OTLP/HTTP JSON, with trace continuity across
+  suspend/resume.
 - [MCP server](./mcp.md) — `zuke mcp` exposes the build to AI agents as typed
   tools over the Model Context Protocol.
 - [AI review](./ai-review.md) — model-assessed review gates as build

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -67,6 +67,11 @@ export function slack(opts: { webhook: string }): Plugin {
 }
 ```
 
+[`@zuke/otel`](./observability.md) is a full worked example of this pattern: a
+factory returning a `Plugin` that turns `onRunStateChange` records into
+OpenTelemetry spans and counters — including trace continuity across a
+suspend/resume — with no runtime dependencies.
+
 ## 2. Tool wrappers — typed CLI tasks
 
 Wrap a CLI as a typed, fluent task in the settings-lambda style. For a one-off,

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,110 @@
+# Observability (OpenTelemetry)
+
+`@zuke/otel` exports a build's run as [OpenTelemetry](https://opentelemetry.io/)
+traces and metrics, so a CI pipeline shows up in your existing Grafana / Tempo /
+Prometheus stack next to everything else. It is a [plugin](./extending.md):
+register it on a run and every run/target transition is shipped to your
+collector as **OTLP/HTTP JSON**. Core stays OpenTelemetry-free — the package has
+**no runtime dependencies** and hand-rolls the OTLP payloads.
+
+```ts
+import { run } from "jsr:@zuke/core";
+import { otel } from "jsr:@zuke/otel";
+
+await run(MyBuild, {
+  plugins: [
+    otel((s) =>
+      s.endpoint("http://localhost:4318")
+        .serviceName("my-build")
+        .header("authorization", "Bearer …")
+    ),
+  ],
+});
+```
+
+## What it exports
+
+The plugin observes each run-level transition (via
+[`onRunStateChange`](./extending.md), which delivers the durable
+[`RunRecord`](./state.md)) and emits:
+
+| Signal               | When                                     | Shape                                                                          |
+| -------------------- | ---------------------------------------- | ------------------------------------------------------------------------------ |
+| **trace**            | the run settles                          | a run span (`createdAt` → `updatedAt`) with one child span per executed target |
+| `zuke.run.started`   | a *fresh* run begins                     | counter, tagged `zuke.build` / `zuke.root_target`                              |
+| `zuke.run.suspended` | the run parks at a `.waitsFor(...)` gate | counter per waiting target, tagged with its `trigger`                          |
+| `zuke.runs`          | the run settles                          | counter, tagged `outcome` = `succeeded` / `failed` / `cancelled`               |
+
+The **run span** carries `zuke.run.id`, `zuke.build`, `zuke.root_target`,
+`zuke.actor`, and `zuke.run.status`. Each **target span** carries `zuke.target`
+and `zuke.target.status`; a failed target's span is marked `error` with its
+(redacted) message, so a broken build is a red span, not just a log line. Metric
+data points are OTLP delta `Sum`s (`aggregationTemporality = 1`).
+
+Only targets that actually executed (they have a start timestamp) get a span; a
+skipped or never-reached target is omitted.
+
+## Trace continuity across suspend/resume
+
+A run that [suspends at a `.waitsFor(...)` gate](./orchestration.md) and resumes
+later — often in a **different process**, minutes or days on — still shows up as
+**one trace**. Two things make that work with no cross-process handoff:
+
+- The trace id is `SHA-256(runId)` truncated to 16 bytes, and each target's span
+  id is a stable hash of `(runId, target)`. Every process for the run derives
+  the same ids from the same run id.
+- The durable run record accumulates every target's **absolute** timestamps —
+  including the ones that ran before the suspend. So the finishing process
+  exports a single, complete, gap-spanning trace: the pre-suspend `deploy` span
+  and the post-resume `promote` span sit under one run span, with the wait
+  visible as the gap between them.
+
+The run's `zuke.run.suspended` counter (emitted when it parks) and the terminal
+`zuke.runs{outcome}` counter bracket that wait for dashboards.
+
+## Configuration
+
+Configure through the settings lambda, or lean entirely on the standard `OTEL_*`
+environment variables the OpenTelemetry ecosystem already uses:
+
+| Setter                          | Environment fallback                  |
+| ------------------------------- | ------------------------------------- |
+| `.endpoint(url)`                | `OTEL_EXPORTER_OTLP_ENDPOINT`         |
+| `.tracesEndpoint(url)`          | `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`  |
+| `.metricsEndpoint(url)`         | `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` |
+| `.serviceName(name)`            | `OTEL_SERVICE_NAME` (else `zuke`)     |
+| `.header(k, v)` / `.headers(m)` | `OTEL_EXPORTER_OTLP_HEADERS`          |
+| `.resourceAttribute(k, v)`      | `OTEL_RESOURCE_ATTRIBUTES`            |
+| `.timeout("5s")`                | — (default 10s)                       |
+
+An explicit setter wins over the environment. A base `.endpoint(...)` has
+`/v1/traces` and `/v1/metrics` appended; a per-signal endpoint is used verbatim
+(the OTLP convention). Because the whole config can come from the environment,
+the same registration works locally and in CI:
+
+```ts
+// Reads OTEL_EXPORTER_OTLP_ENDPOINT / OTEL_SERVICE_NAME / OTEL_EXPORTER_OTLP_HEADERS.
+await run(MyBuild, { plugins: [otel()] });
+```
+
+**With no endpoint configured by either route, the plugin is inert** — it
+registers but does nothing — so it is safe to add unconditionally and light up
+only where a collector is configured.
+
+## Requirements & guarantees
+
+- **A [state store](./state.md) is required.** The plugin's records come from
+  Zuke's durable run state, so a plain store-less build exports nothing. Turn
+  state on with `--state`, `ZUKE_STATE_DIR` / `ZUKE_STATE_URL`, or a
+  `stateStore()` override; a build that already uses locks, waits, or
+  compensations enables it automatically.
+- **Export is best-effort.** A collector that is down, slow, or rejecting is
+  never allowed to fail — or stall, beyond the timeout — the build. Export
+  failures are swallowed, the OpenTelemetry-SDK convention.
+- **The record is secret-free.** It is the same redacted projection
+  `zuke runs show` prints: [`secret()`](./secrets.md) parameters are omitted,
+  and errors and state metadata are run through the redactor before they reach
+  the plugin. It is safe to ship to a collector.
+
+See the [`@zuke/otel` README](../packages/otel/README.md) for the generated API
+reference.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8083,3 +8083,87 @@ type Provider = "claude" | "openai" | "gemini"
 
 type Severity = "none" | "low" | "medium" | "high" | "critical"
   A severity level, ordered `none` < `low` < `medium` < `high` < `critical`.
+
+========================================================================
+# @zuke/otel
+========================================================================
+
+`@zuke/otel` — an OpenTelemetry (OTLP/HTTP JSON) export plugin for Zuke
+builds. Register {@link otel} on a run and every run/target transition is
+exported to a collector: a run span with one child span per target, plus
+`zuke.run.started` / `zuke.run.suspended` / `zuke.runs` counters. The trace id
+is derived from the run id, so a run that suspends in one process and resumes
+in another lands its spans under a single trace with no handoff.
+
+```ts
+import { run } from "jsr:@zuke/core";
+import { otel } from "jsr:@zuke/otel";
+
+await run(MyBuild, {
+  plugins: [otel((s) => s.endpoint("http://localhost:4318").serviceName("ci"))],
+});
+```
+
+Configuration falls back to the standard `OTEL_EXPORTER_OTLP_ENDPOINT`,
+`OTEL_SERVICE_NAME`, and `OTEL_EXPORTER_OTLP_HEADERS` environment variables;
+with no endpoint the plugin is inert. Core stays OpenTelemetry-free — this
+package has no runtime dependencies and hand-rolls the OTLP JSON.
+@module
+
+function otel(configure?: Configure<OtelSettings>): Plugin
+  Create the OpenTelemetry export plugin. Register it on a run and every
+  run/target transition is exported as OTLP/HTTP JSON:
+
+  ```ts
+  import { run } from "jsr:@zuke/core";
+  import { otel } from "jsr:@zuke/otel";
+
+  await run(MyBuild, {
+    plugins: [otel((s) => s.endpoint("http://localhost:4318").serviceName("ci"))],
+  });
+  ```
+
+  With no argument it reads the standard `OTEL_EXPORTER_OTLP_ENDPOINT` /
+  `OTEL_SERVICE_NAME` / `OTEL_EXPORTER_OTLP_HEADERS` environment variables. If
+  no endpoint is configured by either route the plugin is inert, so it is safe
+  to register unconditionally. Telemetry needs a state store (the plugin's
+  records come from durable run state); a store-less build exports nothing.
+
+class OtelSettings
+  Configuration for the OTLP exporter, set through a lambda passed to
+  {@link "./plugin.ts".otel}. Every setter returns `this` so calls chain, and
+  each value falls back to the matching `OTEL_*` environment variable when left
+  unset (see {@link resolveOtel}).
+
+  endpoint_?: string
+    The base OTLP/HTTP endpoint (e.g. `http://localhost:4318`).
+  tracesEndpoint_?: string
+    A full endpoint for the trace signal, overriding {@link endpoint_} + `/v1/traces`.
+  metricsEndpoint_?: string
+    A full endpoint for the metric signal, overriding {@link endpoint_} + `/v1/metrics`.
+  serviceName_?: string
+    The `service.name` resource attribute.
+  headers_: Record<string, string>
+    Extra HTTP headers sent on every export (e.g. an auth token).
+  resourceAttributes_: Record<string, string>
+    Extra OTLP resource attributes (e.g. `deployment.environment`).
+  timeoutMs_: number
+    Per-request timeout in milliseconds (default 10s).
+  endpoint(url: string): this
+    Set the base OTLP/HTTP endpoint; `/v1/traces` and `/v1/metrics` are appended.
+  tracesEndpoint(url: string): this
+    Set a full endpoint URL for the trace signal (no path is appended).
+  metricsEndpoint(url: string): this
+    Set a full endpoint URL for the metric signal (no path is appended).
+  serviceName(name: string): this
+    Set the `service.name` reported to the collector.
+  header(name: string, value: string): this
+    Add one HTTP header to every export request.
+  headers(map: Record<string, string>): this
+    Merge a map of HTTP headers into the export requests.
+  resourceAttribute(name: string, value: string): this
+    Add one OTLP resource attribute.
+  resourceAttributes(map: Record<string, string>): this
+    Merge a map of OTLP resource attributes.
+  timeout(duration: string): this
+    Set the per-request timeout (a duration string like `"5s"`).

--- a/llms.txt
+++ b/llms.txt
@@ -134,3 +134,4 @@ Full reference: [docs/cli.md](./docs/cli.md).
 - [@zuke/release-please](https://jsr.io/@zuke/release-please) — typed `ReleasePleaseTasks` wrappers for the
 - [@zuke/security](https://jsr.io/@zuke/security) — typed task wrappers for free, open-source security scanners
 - [@zuke/ai](https://jsr.io/@zuke/ai) — AI-powered code review for Zuke builds
+- [@zuke/otel](https://jsr.io/@zuke/otel) — an OpenTelemetry (OTLP/HTTP JSON) export plugin for Zuke

--- a/packages/core/src/resume.ts
+++ b/packages/core/src/resume.ts
@@ -135,7 +135,7 @@ export async function resumeRun(
   if (initial.record.status === "suspended" && expired !== null) {
     const disposition = expired.waitingFor.onTimeout;
     if (disposition === "fail") {
-      return await failTimedOut(store, initial, expired, now);
+      return await failTimedOut(store, initial, expired, now, options.plugins);
     }
     return await cancelTimedOut(
       build,
@@ -319,6 +319,26 @@ function expiredWait(
 }
 
 /**
+ * Best-effort: announce a settled run's record to each plugin's
+ * `onRunStateChange`. The resume-timeout paths settle a run directly (without
+ * running {@link execute}, which normally dispatches the lifecycle), so this is
+ * how an observer — e.g. the `@zuke/otel` exporter — sees a timed-out run's
+ * terminal transition. Plugins observe; a throw must never break the resume.
+ */
+async function announceRunState(
+  plugins: Plugin[] | undefined,
+  record: RunRecord,
+): Promise<void> {
+  for (const p of plugins ?? []) {
+    try {
+      await p.onRunStateChange?.(record);
+    } catch {
+      // Ignored — plugins observe, they do not change the run.
+    }
+  }
+}
+
+/**
  * Mark a timed-out wait's target `failed` and the run `failed` (CAS-retry), and
  * return a failing result. The onTimeout disposition is left recorded for the
  * cancellation milestone to act on.
@@ -328,9 +348,11 @@ async function failTimedOut(
   initial: { record: RunRecord; version: string },
   expired: { name: string; waitingFor: WaitState },
   now: () => string,
+  plugins: Plugin[] | undefined,
 ): Promise<BuildResult> {
   let record = initial.record;
   let version = initial.version;
+  let settled = initial.record;
   const message = `wait "${expired.name}" timed out (deadline ` +
     `${expired.waitingFor.deadline})`;
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
@@ -345,12 +367,19 @@ async function failTimedOut(
     next.status = "failed";
     next.updatedAt = now();
     const result = await store.putRun(next, version);
-    if (result.ok) break;
+    if (result.ok) {
+      settled = next;
+      break;
+    }
     const fresh = await store.getRun(record.id);
     if (fresh === null) break;
     record = fresh.record;
     version = fresh.version;
+    settled = fresh.record;
   }
+  // Let observers (e.g. @zuke/otel) see the terminal transition this fast-path
+  // settled without going through execute()'s lifecycle.
+  await announceRunState(plugins, settled);
   return {
     ok: false,
     executed: [],
@@ -386,6 +415,10 @@ async function cancelTimedOut(
     reporter: options.reporter,
     also,
   });
+  // cancelRun settles the record directly (no execute() lifecycle), so re-read
+  // the terminal record and let observers (e.g. @zuke/otel) see it.
+  const final = await store.getRun(options.runId);
+  if (final !== null) await announceRunState(options.plugins, final.record);
   return {
     ok: false,
     executed: [],

--- a/packages/core/src/state/writer.ts
+++ b/packages/core/src/state/writer.ts
@@ -200,7 +200,14 @@ export class RunStateWriter {
     return this.#update((record) => {
       const target = ensureTarget(record, name);
       target.status = "waiting";
-      target.waitingFor = wait;
+      // Redact the trigger descriptor like every other stored string (errors,
+      // audit args, meta): a secret routed into a signal name — e.g.
+      // `externalSignal(this.token.value)` → `signal:<secret>` — must not be
+      // persisted or exported (via @zuke/otel) or printed in the clear.
+      target.waitingFor = {
+        ...wait,
+        trigger: this.#redactor.redact(wait.trigger),
+      };
     });
   }
 

--- a/packages/core/tests/state_test.ts
+++ b/packages/core/tests/state_test.ts
@@ -727,6 +727,28 @@ Deno.test("RunStateWriter records a failure message, redacted", async () => {
   assertEquals(store.record?.targets.deploy.error, "bad password [redacted]");
 });
 
+Deno.test("RunStateWriter redacts a secret in a wait trigger descriptor", async () => {
+  const store = new MemStore();
+  const redactor = new Redactor();
+  redactor.add("swordfish"); // a secret routed into a signal name
+  const writer = await RunStateWriter.open(
+    store,
+    sampleRecord(),
+    () => "t",
+    redactor,
+  );
+  await writer.markTargetWaiting("deploy", {
+    trigger: "signal:swordfish",
+    onTimeout: "fail",
+  });
+  // The descriptor is masked in the persisted record (so @zuke/otel, the fs
+  // store on disk, and `zuke runs show` all see the redacted form).
+  assertEquals(
+    store.record?.targets.deploy.waitingFor?.trigger,
+    "signal:[redacted]",
+  );
+});
+
 Deno.test("RunStateWriter survives a store error without throwing", async () => {
   const store = new MemStore();
   const warnings: string[] = [];

--- a/packages/otel/README.md
+++ b/packages/otel/README.md
@@ -1,0 +1,177 @@
+# @zuke/otel
+
+An [OpenTelemetry](https://opentelemetry.io/) export plugin for
+[Zuke](https://github.com/zuke-build/zuke#readme) builds. Register it on a run
+and every run/target transition is exported to your collector as **OTLP/HTTP
+JSON** — a run span with one child span per target, plus run counters. The trace
+id is derived from the run id, so a run that **suspends in one process and
+resumes in another lands its spans under a single trace**, with no handoff.
+
+No runtime dependencies: the OTLP JSON is hand-rolled, and `@zuke/core` stays
+OpenTelemetry-free.
+
+```ts
+import { run } from "jsr:@zuke/core";
+import { otel } from "jsr:@zuke/otel";
+
+await run(MyBuild, {
+  plugins: [
+    otel((s) =>
+      s.endpoint("http://localhost:4318")
+        .serviceName("my-build")
+        .header("authorization", "Bearer …")
+    ),
+  ],
+});
+```
+
+## What it exports
+
+Registered on a run with a durable state store, the plugin observes each
+run-level transition and emits:
+
+| Signal               | When                                     | Shape                                                                          |
+| -------------------- | ---------------------------------------- | ------------------------------------------------------------------------------ |
+| **trace**            | the run settles                          | a run span (`createdAt` → `updatedAt`) with one child span per executed target |
+| `zuke.run.started`   | a _fresh_ run begins                     | counter, tagged `zuke.build` / `zuke.root_target`                              |
+| `zuke.run.suspended` | the run parks at a `.waitsFor(...)` gate | counter per waiting target, tagged with its `trigger`                          |
+| `zuke.runs`          | the run settles                          | counter, tagged `outcome` = `succeeded` / `failed` / `cancelled`               |
+
+A target span carries `zuke.target` / `zuke.target.status`, and a failed
+target's span is marked `error` with its (redacted) message. The run span
+carries `zuke.build`, `zuke.root_target`, `zuke.actor`, and `zuke.run.status`.
+
+## Trace continuity across resume
+
+The trace id is `SHA-256(runId)` truncated to 16 bytes, and each target's span
+id is a stable hash of `(runId, target)`. The durable run record accumulates
+every target's absolute timestamps — including targets that ran **before** a
+suspend — so the finishing process exports one complete, gap-spanning trace on
+its own. Because the id is derived, not handed off, that trace is exactly the
+one every process for the run would produce.
+
+## Configuration
+
+Configure through the settings lambda, or leave it to the standard `OTEL_*`
+environment variables:
+
+| Setter                          | Environment fallback                  |
+| ------------------------------- | ------------------------------------- |
+| `.endpoint(url)`                | `OTEL_EXPORTER_OTLP_ENDPOINT`         |
+| `.tracesEndpoint(url)`          | `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`  |
+| `.metricsEndpoint(url)`         | `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` |
+| `.serviceName(name)`            | `OTEL_SERVICE_NAME` (else `zuke`)     |
+| `.header(k, v)` / `.headers(m)` | `OTEL_EXPORTER_OTLP_HEADERS`          |
+| `.resourceAttribute(k, v)`      | `OTEL_RESOURCE_ATTRIBUTES`            |
+| `.timeout("5s")`                | — (default 10s)                       |
+
+An explicit setter wins over the environment; a base `.endpoint(...)` has
+`/v1/traces` and `/v1/metrics` appended, while a per-signal endpoint is used
+verbatim. **With no endpoint configured by either route, the plugin is inert**,
+so it is safe to register unconditionally.
+
+## Notes
+
+- **A state store is required.** The plugin's records come from Zuke's durable
+  run state, so a plain store-less build exports nothing. Enable state with
+  `--state`, `ZUKE_STATE_DIR` / `ZUKE_STATE_URL`, or a `stateStore()` override;
+  a build that uses locks/waits/compensations turns it on automatically.
+- **Export is best-effort.** A collector that is down, slow, or rejecting is
+  never allowed to fail (or stall, beyond the timeout) the build — telemetry
+  failures are swallowed, the OpenTelemetry-SDK convention.
+- **The record is secret-free.** It is the same redacted projection
+  `zuke runs show` prints — `secret()` parameters are omitted and errors/state
+  are run through the redactor — so it is safe to export.
+
+<!-- ZUKE:API:START -->
+
+## API
+
+<details>
+<summary>Full typed API — generated from <code>deno doc</code></summary>
+
+````text
+`@zuke/otel` — an OpenTelemetry (OTLP/HTTP JSON) export plugin for Zuke
+builds. Register {@link otel} on a run and every run/target transition is
+exported to a collector: a run span with one child span per target, plus
+`zuke.run.started` / `zuke.run.suspended` / `zuke.runs` counters. The trace id
+is derived from the run id, so a run that suspends in one process and resumes
+in another lands its spans under a single trace with no handoff.
+
+```ts
+import { run } from "jsr:@zuke/core";
+import { otel } from "jsr:@zuke/otel";
+
+await run(MyBuild, {
+  plugins: [otel((s) => s.endpoint("http://localhost:4318").serviceName("ci"))],
+});
+```
+
+Configuration falls back to the standard `OTEL_EXPORTER_OTLP_ENDPOINT`,
+`OTEL_SERVICE_NAME`, and `OTEL_EXPORTER_OTLP_HEADERS` environment variables;
+with no endpoint the plugin is inert. Core stays OpenTelemetry-free — this
+package has no runtime dependencies and hand-rolls the OTLP JSON.
+@module
+
+function otel(configure?: Configure<OtelSettings>): Plugin
+  Create the OpenTelemetry export plugin. Register it on a run and every
+  run/target transition is exported as OTLP/HTTP JSON:
+
+  ```ts
+  import { run } from "jsr:@zuke/core";
+  import { otel } from "jsr:@zuke/otel";
+
+  await run(MyBuild, {
+    plugins: [otel((s) => s.endpoint("http://localhost:4318").serviceName("ci"))],
+  });
+  ```
+
+  With no argument it reads the standard `OTEL_EXPORTER_OTLP_ENDPOINT` /
+  `OTEL_SERVICE_NAME` / `OTEL_EXPORTER_OTLP_HEADERS` environment variables. If
+  no endpoint is configured by either route the plugin is inert, so it is safe
+  to register unconditionally. Telemetry needs a state store (the plugin's
+  records come from durable run state); a store-less build exports nothing.
+
+class OtelSettings
+  Configuration for the OTLP exporter, set through a lambda passed to
+  {@link "./plugin.ts".otel}. Every setter returns `this` so calls chain, and
+  each value falls back to the matching `OTEL_*` environment variable when left
+  unset (see {@link resolveOtel}).
+
+  endpoint_?: string
+    The base OTLP/HTTP endpoint (e.g. `http://localhost:4318`).
+  tracesEndpoint_?: string
+    A full endpoint for the trace signal, overriding {@link endpoint_} + `/v1/traces`.
+  metricsEndpoint_?: string
+    A full endpoint for the metric signal, overriding {@link endpoint_} + `/v1/metrics`.
+  serviceName_?: string
+    The `service.name` resource attribute.
+  headers_: Record<string, string>
+    Extra HTTP headers sent on every export (e.g. an auth token).
+  resourceAttributes_: Record<string, string>
+    Extra OTLP resource attributes (e.g. `deployment.environment`).
+  timeoutMs_: number
+    Per-request timeout in milliseconds (default 10s).
+  endpoint(url: string): this
+    Set the base OTLP/HTTP endpoint; `/v1/traces` and `/v1/metrics` are appended.
+  tracesEndpoint(url: string): this
+    Set a full endpoint URL for the trace signal (no path is appended).
+  metricsEndpoint(url: string): this
+    Set a full endpoint URL for the metric signal (no path is appended).
+  serviceName(name: string): this
+    Set the `service.name` reported to the collector.
+  header(name: string, value: string): this
+    Add one HTTP header to every export request.
+  headers(map: Record<string, string>): this
+    Merge a map of HTTP headers into the export requests.
+  resourceAttribute(name: string, value: string): this
+    Add one OTLP resource attribute.
+  resourceAttributes(map: Record<string, string>): this
+    Merge a map of OTLP resource attributes.
+  timeout(duration: string): this
+    Set the per-request timeout (a duration string like `"5s"`).
+````
+
+</details>
+
+<!-- ZUKE:API:END -->

--- a/packages/otel/deno.json
+++ b/packages/otel/deno.json
@@ -1,0 +1,16 @@
+{
+  "name": "@zuke/otel",
+  "version": "0.0.0",
+  "description": "OpenTelemetry (OTLP/HTTP JSON) export plugin for Zuke builds — per-target spans linked across resume boundaries by run id, plus run counters, with no runtime dependencies.",
+  "exports": {
+    ".": "./mod.ts"
+  },
+  "imports": {
+    "@zuke/core": "jsr:@zuke/core@^1.18.0"
+  },
+  "publish": {
+    "exclude": [
+      "tests/"
+    ]
+  }
+}

--- a/packages/otel/mod.ts
+++ b/packages/otel/mod.ts
@@ -1,0 +1,27 @@
+/**
+ * `@zuke/otel` — an OpenTelemetry (OTLP/HTTP **JSON**) export plugin for Zuke
+ * builds. Register {@link otel} on a run and every run/target transition is
+ * exported to a collector: a run span with one child span per target, plus
+ * `zuke.run.started` / `zuke.run.suspended` / `zuke.runs` counters. The trace id
+ * is derived from the run id, so a run that suspends in one process and resumes
+ * in another lands its spans under a single trace with no handoff.
+ *
+ * ```ts
+ * import { run } from "jsr:@zuke/core";
+ * import { otel } from "jsr:@zuke/otel";
+ *
+ * await run(MyBuild, {
+ *   plugins: [otel((s) => s.endpoint("http://localhost:4318").serviceName("ci"))],
+ * });
+ * ```
+ *
+ * Configuration falls back to the standard `OTEL_EXPORTER_OTLP_ENDPOINT`,
+ * `OTEL_SERVICE_NAME`, and `OTEL_EXPORTER_OTLP_HEADERS` environment variables;
+ * with no endpoint the plugin is inert. Core stays OpenTelemetry-free — this
+ * package has no runtime dependencies and hand-rolls the OTLP JSON.
+ *
+ * @module
+ */
+
+export { otel } from "./src/plugin.ts";
+export { OtelSettings } from "./src/settings.ts";

--- a/packages/otel/src/exporter.ts
+++ b/packages/otel/src/exporter.ts
@@ -1,0 +1,95 @@
+/**
+ * The OTLP/HTTP JSON transport: POSTs a trace or metrics payload to a
+ * collector. Kept behind the {@link OtlpTransport} interface so the plugin can
+ * be driven by a capturing fake in tests, and built on the same `fetch` seam
+ * the rest of Zuke's HTTP code uses (default: the global `fetch`).
+ *
+ * Export is **best-effort**: a dead collector, a timeout, or a non-2xx response
+ * is swallowed, never surfaced as a build failure — telemetry must never break
+ * the build (the OpenTelemetry SDK convention). The payload builders are pure
+ * and independently tested, so silence here does not hide a shape bug.
+ *
+ * @module
+ */
+
+import type { OtlpMetricsPayload, OtlpTracePayload } from "./otlp.ts";
+
+/**
+ * Where the plugin sends OTLP payloads. The real implementation is
+ * {@link OtlpHttpExporter}; tests pass a fake that records what it was handed.
+ */
+export interface OtlpTransport {
+  /** Export a trace payload (best-effort). */
+  traces(payload: OtlpTracePayload): Promise<void>;
+  /** Export a metrics payload (best-effort). */
+  metrics(payload: OtlpMetricsPayload): Promise<void>;
+}
+
+/** Construction options for {@link OtlpHttpExporter}. */
+export interface OtlpHttpExporterOptions {
+  /** The URL trace payloads are POSTed to; `undefined` skips the trace signal. */
+  tracesUrl: string | undefined;
+  /** The URL metrics payloads are POSTed to; `undefined` skips the metric signal. */
+  metricsUrl: string | undefined;
+  /** HTTP headers added to every request (e.g. an auth token). */
+  headers: Record<string, string>;
+  /** Per-request timeout in milliseconds. */
+  timeoutMs: number;
+  /** The `fetch` implementation; defaults to the global. Overridable for tests. */
+  fetch?: typeof fetch;
+}
+
+/** POSTs OTLP/HTTP JSON payloads to a collector, best-effort. */
+export class OtlpHttpExporter implements OtlpTransport {
+  readonly #tracesUrl: string | undefined;
+  readonly #metricsUrl: string | undefined;
+  readonly #headers: Record<string, string>;
+  readonly #timeoutMs: number;
+  readonly #fetch: typeof fetch;
+
+  /** Build the exporter from its resolved URLs, headers, timeout, and `fetch` seam. */
+  constructor(options: OtlpHttpExporterOptions) {
+    this.#tracesUrl = options.tracesUrl;
+    this.#metricsUrl = options.metricsUrl;
+    this.#headers = options.headers;
+    this.#timeoutMs = options.timeoutMs;
+    this.#fetch = options.fetch ?? fetch;
+  }
+
+  /** Export a trace payload to the traces endpoint (best-effort; skipped if none). */
+  async traces(payload: OtlpTracePayload): Promise<void> {
+    if (this.#tracesUrl === undefined) return;
+    await this.#post(this.#tracesUrl, payload);
+  }
+
+  /** Export a metrics payload to the metrics endpoint (best-effort; skipped if none). */
+  async metrics(payload: OtlpMetricsPayload): Promise<void> {
+    if (this.#metricsUrl === undefined) return;
+    await this.#post(this.#metricsUrl, payload);
+  }
+
+  /** POST one JSON payload, swallowing every failure (telemetry is best-effort). */
+  async #post(url: string, payload: unknown): Promise<void> {
+    // A manual controller + cleared timer (rather than `AbortSignal.timeout`) so
+    // the timer is always released when the request settles — no pending timer
+    // lingers past the export.
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.#timeoutMs);
+    try {
+      const response = await this.#fetch(url, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...this.#headers },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      });
+      // Consume the body so the connection is freed / no resource leaks in tests;
+      // the response content is irrelevant to a best-effort export.
+      await response.body?.cancel();
+    } catch {
+      // Best-effort: a collector that is down, slow, or rejecting must not fail
+      // (or even slow, beyond the timeout) the build.
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/packages/otel/src/ids.ts
+++ b/packages/otel/src/ids.ts
@@ -1,0 +1,50 @@
+/**
+ * Deterministic OpenTelemetry trace and span ids, derived from a run id by
+ * hashing. Determinism is the whole point: a run that suspends in one process
+ * and resumes in another must land its spans under the **same** trace id, with
+ * no handoff — every process recomputes the id from the shared run id. Target
+ * span ids are likewise stable per `(runId, target)`, so a resumed run's spans
+ * slot into the same trace tree.
+ *
+ * OTLP/HTTP JSON encodes trace ids as 16-byte and span ids as 8-byte
+ * lowercase-hex strings; that is exactly what these helpers produce.
+ *
+ * @module
+ */
+
+/** Lowercase-hex-encode a byte slice (OTLP/JSON ids are hex strings). */
+function toHex(bytes: Uint8Array): string {
+  let out = "";
+  for (const b of bytes) out += b.toString(16).padStart(2, "0");
+  return out;
+}
+
+/** SHA-256 of `input` as a byte array. */
+async function sha256(input: string): Promise<Uint8Array> {
+  const data = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return new Uint8Array(digest);
+}
+
+/**
+ * The 16-byte (32-hex-char) trace id for a run — the first half of
+ * `SHA-256("zuke.trace:" + runId)`. Deterministic, so every process that
+ * touches this run (a fresh execute, a resume, a cancel) derives the same id
+ * and their spans join one trace.
+ */
+export async function traceIdFor(runId: string): Promise<string> {
+  const digest = await sha256(`zuke.trace:${runId}`);
+  return toHex(digest.slice(0, 16));
+}
+
+/**
+ * An 8-byte (16-hex-char) span id, unique per `(runId, key)` and stable across
+ * processes. `key` is the sentinel `"run"` for a run's root span, or a target's
+ * dotted name for its span — so a resumed run reuses the same ids. The `/`
+ * separator never appears in a run id (a UUID) or a target name, so distinct
+ * pairs never collide on the hashed input.
+ */
+export async function spanIdFor(runId: string, key: string): Promise<string> {
+  const digest = await sha256(`zuke.span:${runId}/${key}`);
+  return toHex(digest.slice(0, 8));
+}

--- a/packages/otel/src/otlp.ts
+++ b/packages/otel/src/otlp.ts
@@ -1,0 +1,306 @@
+/**
+ * Pure builders that turn a Zuke {@link RunRecord} into OTLP/HTTP **JSON**
+ * payloads — one for the trace signal (`resourceSpans`) and one for metrics
+ * (`resourceMetrics`). No I/O and no clock: everything is derived from the
+ * record's own ISO-8601 timestamps, so the same record always yields the same
+ * bytes and the functions are trivially unit-testable. The transport
+ * ({@link "./exporter.ts".OtlpHttpExporter}) POSTs whatever these return.
+ *
+ * Only the small slice of the OTLP JSON schema this exporter actually emits is
+ * modelled here (string/int/bool attribute values, `Sum` metrics); the shapes
+ * mirror the [OTLP JSON encoding](https://opentelemetry.io/docs/specs/otlp/).
+ *
+ * @module
+ */
+
+import type { RunRecord, TargetRunState } from "@zuke/core";
+
+/** An OTLP `AnyValue` — only the kinds this exporter emits. */
+export interface OtlpAnyValue {
+  /** A string attribute value. */
+  stringValue?: string;
+  /** An integer attribute value (uint64/int64 encoded as a decimal string). */
+  intValue?: string;
+  /** A boolean attribute value. */
+  boolValue?: boolean;
+}
+
+/** An OTLP key/value attribute. */
+export interface OtlpAttribute {
+  /** The attribute key. */
+  key: string;
+  /** The attribute value. */
+  value: OtlpAnyValue;
+}
+
+/** An OTLP `Status` on a span (`code` 0 unset, 1 ok, 2 error). */
+export interface OtlpStatus {
+  /** The status code: 0 = unset, 1 = ok, 2 = error. */
+  code: number;
+  /** A human-readable error message (present only for an error status). */
+  message?: string;
+}
+
+/** An OTLP span (a run's root span or one of its target spans). */
+export interface OtlpSpan {
+  /** The trace id (16-byte hex). */
+  traceId: string;
+  /** This span's id (8-byte hex). */
+  spanId: string;
+  /** The parent span's id (omitted on a root span). */
+  parentSpanId?: string;
+  /** The span name (the target's dotted name, or the build name for a run). */
+  name: string;
+  /** The span kind — always 1 (internal) for a build's spans. */
+  kind: number;
+  /** Start time, nanoseconds since the Unix epoch, as a decimal string. */
+  startTimeUnixNano: string;
+  /** End time, nanoseconds since the Unix epoch, as a decimal string. */
+  endTimeUnixNano: string;
+  /** The span's attributes. */
+  attributes: OtlpAttribute[];
+  /** The span's status. */
+  status: OtlpStatus;
+}
+
+/** The instrumentation scope stamped on every emitted span and metric. */
+export interface OtlpScope {
+  /** The scope name (`@zuke/otel`). */
+  name: string;
+  /** The scope version (the plugin's package version). */
+  version: string;
+}
+
+/** An OTLP `NumberDataPoint` of a `Sum` metric. */
+export interface OtlpNumberDataPoint {
+  /** The point's attributes (the metric's label set). */
+  attributes: OtlpAttribute[];
+  /** The series' start time, nanoseconds since the epoch, as a string. */
+  startTimeUnixNano: string;
+  /** The point's time, nanoseconds since the epoch, as a string. */
+  timeUnixNano: string;
+  /** The integer value (a delta increment), as a decimal string. */
+  asInt: string;
+}
+
+/** An OTLP `Sum` metric (a monotonic delta counter). */
+export interface OtlpSum {
+  /** The metric name (e.g. `zuke.runs`). */
+  name: string;
+  /** The unit (`1` for a dimensionless count, `ms` for a duration). */
+  unit: string;
+  /** The `Sum` body. */
+  sum: {
+    /** The metric's data points. */
+    dataPoints: OtlpNumberDataPoint[];
+    /** Temporality: 1 = delta (each export is an increment). */
+    aggregationTemporality: number;
+    /** Whether the counter only ever increases. */
+    isMonotonic: boolean;
+  };
+}
+
+/** The top-level OTLP trace-export payload (`POST /v1/traces` body). */
+export interface OtlpTracePayload {
+  /** The resource-scoped spans (a single resource per export). */
+  resourceSpans: [{
+    /** The resource these spans describe (its `service.name`, etc.). */
+    resource: { attributes: OtlpAttribute[] };
+    /** The scope-grouped spans. */
+    scopeSpans: [{ scope: OtlpScope; spans: OtlpSpan[] }];
+  }];
+}
+
+/** The top-level OTLP metrics-export payload (`POST /v1/metrics` body). */
+export interface OtlpMetricsPayload {
+  /** The resource-scoped metrics (a single resource per export). */
+  resourceMetrics: [{
+    /** The resource these metrics describe. */
+    resource: { attributes: OtlpAttribute[] };
+    /** The scope-grouped metrics. */
+    scopeMetrics: [{ scope: OtlpScope; metrics: OtlpSum[] }];
+  }];
+}
+
+/** The pre-computed span ids for a run — its root span plus one per target. */
+export interface RunSpanIds {
+  /** The run's trace id (16-byte hex). */
+  traceId: string;
+  /** The run's root span id (8-byte hex). */
+  runSpanId: string;
+  /** Each target's span id, keyed by dotted target name. */
+  targetSpanIds: ReadonlyMap<string, string>;
+}
+
+/** The resource/scope identity shared by every export from one plugin. */
+export interface OtlpResource {
+  /** The `service.name` stamped on the OTLP resource. */
+  serviceName: string;
+  /** Extra resource attributes (e.g. `deployment.environment`). */
+  attributes: Record<string, string>;
+  /** The scope version (the plugin package's version). */
+  scopeVersion: string;
+}
+
+/** One counter increment to render as an OTLP `Sum` data point. */
+export interface MetricPoint {
+  /** The metric name (e.g. `zuke.runs`). */
+  name: string;
+  /** The unit (`1` for a count). */
+  unit: string;
+  /** The increment (usually 1). */
+  value: number;
+  /** The point's label set. */
+  attributes: Record<string, string>;
+  /** ISO-8601 series start (the run's `createdAt`). */
+  startIso: string;
+  /** ISO-8601 event time (the record's `updatedAt`). */
+  atIso: string;
+}
+
+/** The instrumentation scope name for every span and metric this package emits. */
+export const SCOPE_NAME = "@zuke/otel";
+
+/** Convert an ISO-8601 timestamp to nanoseconds-since-epoch (a decimal string). */
+export function isoToNano(iso: string): string {
+  const ms = Date.parse(iso);
+  // Millisecond precision times 1e6 overflows Number.MAX_SAFE_INTEGER, so widen
+  // to BigInt for an exact nanosecond value. A malformed timestamp → "0".
+  if (Number.isNaN(ms)) return "0";
+  return (BigInt(ms) * 1_000_000n).toString();
+}
+
+/** Encode a string→string map as OTLP attributes, in insertion order. */
+function attributes(map: Record<string, string>): OtlpAttribute[] {
+  return Object.entries(map).map(([key, value]) => ({
+    key,
+    value: { stringValue: value },
+  }));
+}
+
+/** The OTLP resource for an export (its `service.name` plus extra attributes). */
+function resource(res: OtlpResource): { attributes: OtlpAttribute[] } {
+  return {
+    attributes: attributes({
+      "service.name": res.serviceName,
+      ...res.attributes,
+    }),
+  };
+}
+
+/** The instrumentation scope for an export. */
+function scope(res: OtlpResource): OtlpScope {
+  return { name: SCOPE_NAME, version: res.scopeVersion };
+}
+
+/** Map a run's terminal status to the outcome label used on spans/metrics. */
+export function runOutcome(status: RunRecord["status"]): string {
+  // A process that only observes `cancelling` (another process owns the final
+  // `cancelled`) still reports the run as cancelled from its own vantage point.
+  return status === "cancelling" ? "cancelled" : status;
+}
+
+/** The span for one target, or `null` when it never ran (no start timestamp). */
+function targetSpan(
+  runId: string,
+  name: string,
+  state: TargetRunState,
+  ids: RunSpanIds,
+): OtlpSpan | null {
+  const startedAt = state.startedAt;
+  if (startedAt === undefined) return null; // pending/skipped/waiting — no span
+  const spanId = ids.targetSpanIds.get(name);
+  if (spanId === undefined) return null;
+  const endedAt = state.endedAt ?? startedAt;
+  const status: OtlpStatus = state.status === "failed"
+    ? { code: 2, message: state.error ?? "target failed" }
+    : { code: 0 };
+  return {
+    traceId: ids.traceId,
+    spanId,
+    parentSpanId: ids.runSpanId,
+    name,
+    kind: 1,
+    startTimeUnixNano: isoToNano(startedAt),
+    endTimeUnixNano: isoToNano(endedAt),
+    attributes: attributes({
+      "zuke.run.id": runId,
+      "zuke.target": name,
+      "zuke.target.status": state.status,
+    }),
+    status,
+  };
+}
+
+/**
+ * Build the OTLP trace payload for a settled run: one root span covering the
+ * whole run (`createdAt` → `updatedAt`, which spans any suspend/resume gap) and
+ * one child span per target that executed. The record carries every target's
+ * absolute timestamps — including targets that ran before a suspend — so a
+ * single export from the finishing process is a complete trace.
+ */
+export function buildTraces(
+  record: RunRecord,
+  ids: RunSpanIds,
+  res: OtlpResource,
+): OtlpTracePayload {
+  const runFailed = record.status === "failed";
+  const runCancelled = runOutcome(record.status) === "cancelled";
+  const runStatus: OtlpStatus = runFailed || runCancelled
+    ? { code: 2, message: runFailed ? "run failed" : "run cancelled" }
+    : { code: 0 };
+  const runSpan: OtlpSpan = {
+    traceId: ids.traceId,
+    spanId: ids.runSpanId,
+    name: record.build,
+    kind: 1,
+    startTimeUnixNano: isoToNano(record.createdAt),
+    endTimeUnixNano: isoToNano(record.updatedAt),
+    attributes: attributes({
+      "zuke.run.id": record.id,
+      "zuke.build": record.build,
+      "zuke.root_target": record.rootTarget,
+      "zuke.actor": record.actor,
+      "zuke.run.status": record.status,
+    }),
+    status: runStatus,
+  };
+  const spans: OtlpSpan[] = [runSpan];
+  for (const [name, state] of Object.entries(record.targets)) {
+    const span = targetSpan(record.id, name, state, ids);
+    if (span !== null) spans.push(span);
+  }
+  return {
+    resourceSpans: [{
+      resource: resource(res),
+      scopeSpans: [{ scope: scope(res), spans }],
+    }],
+  };
+}
+
+/** Build an OTLP metrics payload from a set of counter increments. */
+export function buildMetrics(
+  points: MetricPoint[],
+  res: OtlpResource,
+): OtlpMetricsPayload {
+  const metrics: OtlpSum[] = points.map((p) => ({
+    name: p.name,
+    unit: p.unit,
+    sum: {
+      dataPoints: [{
+        attributes: attributes(p.attributes),
+        startTimeUnixNano: isoToNano(p.startIso),
+        timeUnixNano: isoToNano(p.atIso),
+        asInt: String(Math.trunc(p.value)),
+      }],
+      aggregationTemporality: 1, // delta: each export is an increment
+      isMonotonic: true,
+    },
+  }));
+  return {
+    resourceMetrics: [{
+      resource: resource(res),
+      scopeMetrics: [{ scope: scope(res), metrics }],
+    }],
+  };
+}

--- a/packages/otel/src/plugin.ts
+++ b/packages/otel/src/plugin.ts
@@ -1,0 +1,244 @@
+/**
+ * The {@link otel} plugin factory and its emission logic. The plugin observes a
+ * build through one hook — `onRunStateChange`, delivered the run's durable
+ * {@link RunRecord} at each run-level transition — and turns those records into
+ * OTLP exports:
+ *
+ * - **`running`** (a *fresh* start only, not a resume): a `zuke.run.started`
+ *   counter.
+ * - **`suspended`** (parked at a `.waitsFor(...)` gate): a `zuke.run.suspended`
+ *   counter per waiting target, tagged with its trigger.
+ * - **terminal** (`succeeded` / `failed` / `cancelled`, or `cancelling` when
+ *   another process owns the final settle): the complete trace — a run span plus
+ *   one span per target that executed — and a `zuke.runs` counter tagged with the
+ *   outcome. The record accumulates every target's absolute timings across a
+ *   suspend/resume, so this single export is a whole, gap-spanning trace, and the
+ *   trace id is derived from the run id so it is the *same* trace the pre-suspend
+ *   process would have produced.
+ *
+ * A run is exported **once**: the emitted-run set guards against the in-process
+ * cancel sequence (`cancelling` then `cancelled`) double-emitting. The hook only
+ * fires when a state store is configured, so a store-less build produces no
+ * telemetry — which is the intended scope (durable/CI runs are the target).
+ *
+ * @module
+ */
+
+import type { Configure } from "@zuke/core/tooling";
+import type { Plugin, RunRecord } from "@zuke/core";
+import { spanIdFor, traceIdFor } from "./ids.ts";
+import {
+  buildMetrics,
+  buildTraces,
+  type MetricPoint,
+  type OtlpResource,
+  runOutcome,
+  type RunSpanIds,
+} from "./otlp.ts";
+import { OtlpHttpExporter, type OtlpTransport } from "./exporter.ts";
+import { OtelSettings, resolveOtel } from "./settings.ts";
+
+/**
+ * Whether a `running` record is a *fresh* start rather than a resume — true when
+ * no target has progressed past `pending` yet (a resumed run's record already
+ * carries the targets it settled before suspending).
+ */
+function isFreshStart(record: RunRecord): boolean {
+  for (const state of Object.values(record.targets)) {
+    if (state.status !== "pending") return false;
+  }
+  return true;
+}
+
+/** Derive the trace id, run span id, and each target's span id for a record. */
+async function runSpanIds(record: RunRecord): Promise<RunSpanIds> {
+  const runId = record.id;
+  const traceId = await traceIdFor(runId);
+  const runSpanId = await spanIdFor(runId, "run");
+  const targetSpanIds = new Map<string, string>();
+  for (const name of Object.keys(record.targets)) {
+    targetSpanIds.set(name, await spanIdFor(runId, name));
+  }
+  return { traceId, runSpanId, targetSpanIds };
+}
+
+/** The `zuke.run.started` counter increment for a fresh run. */
+function startedPoint(record: RunRecord): MetricPoint {
+  return {
+    name: "zuke.run.started",
+    unit: "1",
+    value: 1,
+    attributes: {
+      "zuke.build": record.build,
+      "zuke.root_target": record.rootTarget,
+    },
+    startIso: record.createdAt,
+    atIso: record.updatedAt,
+  };
+}
+
+/** The `zuke.runs` counter increment for a settled run, tagged by outcome. */
+function outcomePoint(record: RunRecord): MetricPoint {
+  return {
+    name: "zuke.runs",
+    unit: "1",
+    value: 1,
+    attributes: {
+      outcome: runOutcome(record.status),
+      "zuke.build": record.build,
+      "zuke.root_target": record.rootTarget,
+    },
+    startIso: record.createdAt,
+    atIso: record.updatedAt,
+  };
+}
+
+/**
+ * Cap on the deduped-run set. Dedup only needs to guard the in-process
+ * `cancelling` → `cancelled` double-fire for the current run, so a bound this
+ * large never evicts an active run, yet keeps a long-lived plugin instance
+ * (reused across many runs by a server/daemon) from growing without bound.
+ */
+export const DEDUP_CAP = 1024;
+
+/** Record a run id in the bounded dedup set, evicting the oldest when full. */
+function remember(emitted: Set<string>, id: string): void {
+  emitted.add(id);
+  if (emitted.size > DEDUP_CAP) {
+    const oldest = emitted.values().next().value;
+    if (oldest !== undefined) emitted.delete(oldest);
+  }
+}
+
+/** One `zuke.run.suspended` counter per target currently parked on a wait. */
+function suspendedPoints(record: RunRecord): MetricPoint[] {
+  const points: MetricPoint[] = [];
+  for (const [name, state] of Object.entries(record.targets)) {
+    if (state.status !== "waiting") continue;
+    points.push({
+      name: "zuke.run.suspended",
+      unit: "1",
+      value: 1,
+      attributes: {
+        "zuke.build": record.build,
+        "zuke.target": name,
+        trigger: state.waitingFor?.trigger ?? "unknown",
+      },
+      startIso: record.createdAt,
+      atIso: record.updatedAt,
+    });
+  }
+  return points;
+}
+
+/**
+ * Build the OTel plugin from an already-resolved resource identity and an
+ * explicit {@link OtlpTransport}. {@link otel} wraps this with settings/env
+ * resolution and the HTTP transport; tests call it directly with a capturing
+ * fake to assert the exported payloads.
+ */
+export function createOtelPlugin(
+  transport: OtlpTransport,
+  resource: OtlpResource,
+): Plugin {
+  const emitted = new Set<string>(); // run ids whose trace has been exported
+  return {
+    name: "otel",
+    async onRunStateChange(record: RunRecord): Promise<void> {
+      const status = record.status;
+      if (status === "running") {
+        if (isFreshStart(record)) {
+          await transport.metrics(
+            buildMetrics([startedPoint(record)], resource),
+          );
+        }
+        return;
+      }
+      if (status === "suspended") {
+        const points = suspendedPoints(record);
+        if (points.length > 0) {
+          await transport.metrics(buildMetrics(points, resource));
+        }
+        return;
+      }
+      // Any other status is terminal: succeeded / failed / cancelled, or
+      // cancelling when another process owns the final settle. Export the trace
+      // once — the in-process cancel fires `cancelling` then `cancelled`.
+      if (emitted.has(record.id)) return;
+      remember(emitted, record.id);
+      const ids = await runSpanIds(record);
+      // Fire both signals concurrently: a hung collector stalls the terminal
+      // transition by at most one timeout, not two. Both are best-effort and
+      // never reject, so Promise.all cannot reject either.
+      await Promise.all([
+        transport.traces(buildTraces(record, ids, resource)),
+        transport.metrics(buildMetrics([outcomePoint(record)], resource)),
+      ]);
+    },
+  };
+}
+
+/** Injectable dependencies for {@link otelWith} — the seams tests reach for. */
+export interface OtelDeps {
+  /** Environment reader; defaults to `Deno.env.get`. */
+  readEnv?: (name: string) => string | undefined;
+  /** A transport to use directly, bypassing the HTTP exporter (tests). */
+  transport?: OtlpTransport;
+  /** The `fetch` seam handed to the default HTTP exporter (tests). */
+  fetch?: typeof fetch;
+}
+
+/** Read an environment variable, treating missing env access as unset. */
+function defaultReadEnv(name: string): string | undefined {
+  try {
+    return Deno.env.get(name);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * {@link otel} with injectable dependencies — the entry point that both the
+ * public factory and the tests call. When no endpoint resolves (neither a
+ * setter nor `OTEL_EXPORTER_OTLP_ENDPOINT`), the returned plugin is inert.
+ */
+export function otelWith(
+  configure: Configure<OtelSettings> | undefined,
+  deps: OtelDeps,
+): Plugin {
+  const settings = (configure ?? ((s) => s))(new OtelSettings());
+  const resolved = resolveOtel(settings, deps.readEnv ?? defaultReadEnv);
+  if (resolved === null) return { name: "otel" }; // no endpoint → do nothing
+  const transport = deps.transport ??
+    new OtlpHttpExporter({
+      tracesUrl: resolved.tracesUrl,
+      metricsUrl: resolved.metricsUrl,
+      headers: resolved.headers,
+      timeoutMs: resolved.timeoutMs,
+      fetch: deps.fetch,
+    });
+  return createOtelPlugin(transport, resolved.resource);
+}
+
+/**
+ * Create the OpenTelemetry export plugin. Register it on a run and every
+ * run/target transition is exported as OTLP/HTTP JSON:
+ *
+ * ```ts
+ * import { run } from "jsr:@zuke/core";
+ * import { otel } from "jsr:@zuke/otel";
+ *
+ * await run(MyBuild, {
+ *   plugins: [otel((s) => s.endpoint("http://localhost:4318").serviceName("ci"))],
+ * });
+ * ```
+ *
+ * With no argument it reads the standard `OTEL_EXPORTER_OTLP_ENDPOINT` /
+ * `OTEL_SERVICE_NAME` / `OTEL_EXPORTER_OTLP_HEADERS` environment variables. If
+ * no endpoint is configured by either route the plugin is inert, so it is safe
+ * to register unconditionally. Telemetry needs a state store (the plugin's
+ * records come from durable run state); a store-less build exports nothing.
+ */
+export function otel(configure?: Configure<OtelSettings>): Plugin {
+  return otelWith(configure, {});
+}

--- a/packages/otel/src/settings.ts
+++ b/packages/otel/src/settings.ts
@@ -1,0 +1,196 @@
+/**
+ * The fluent {@link OtelSettings} the {@link "./plugin.ts".otel} factory is
+ * configured with, and {@link resolveOtel}, which folds those settings together
+ * with the standard `OTEL_*` environment variables into a {@link ResolvedOtel}
+ * the exporter can use — or `null` when no endpoint is configured, which makes
+ * the plugin inert (safe to always register).
+ *
+ * Precedence follows the OpenTelemetry spec's spirit: an explicit setter wins
+ * over the environment, and a per-signal endpoint (`.tracesEndpoint(...)` /
+ * `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`) wins over the base endpoint with the
+ * signal path appended.
+ *
+ * @module
+ */
+
+import { parseDuration } from "@zuke/core";
+import type { OtlpResource } from "./otlp.ts";
+
+/** The plugin package version, stamped as the OTLP instrumentation-scope version. */
+export const SCOPE_VERSION = "0.0.0";
+
+/**
+ * Configuration for the OTLP exporter, set through a lambda passed to
+ * {@link "./plugin.ts".otel}. Every setter returns `this` so calls chain, and
+ * each value falls back to the matching `OTEL_*` environment variable when left
+ * unset (see {@link resolveOtel}).
+ */
+export class OtelSettings {
+  /** The base OTLP/HTTP endpoint (e.g. `http://localhost:4318`). */
+  endpoint_?: string;
+  /** A full endpoint for the trace signal, overriding {@link endpoint_} + `/v1/traces`. */
+  tracesEndpoint_?: string;
+  /** A full endpoint for the metric signal, overriding {@link endpoint_} + `/v1/metrics`. */
+  metricsEndpoint_?: string;
+  /** The `service.name` resource attribute. */
+  serviceName_?: string;
+  /** Extra HTTP headers sent on every export (e.g. an auth token). */
+  headers_: Record<string, string> = {};
+  /** Extra OTLP resource attributes (e.g. `deployment.environment`). */
+  resourceAttributes_: Record<string, string> = {};
+  /** Per-request timeout in milliseconds (default 10s). */
+  timeoutMs_ = 10_000;
+
+  /** Set the base OTLP/HTTP endpoint; `/v1/traces` and `/v1/metrics` are appended. */
+  endpoint(url: string): this {
+    this.endpoint_ = url;
+    return this;
+  }
+
+  /** Set a full endpoint URL for the trace signal (no path is appended). */
+  tracesEndpoint(url: string): this {
+    this.tracesEndpoint_ = url;
+    return this;
+  }
+
+  /** Set a full endpoint URL for the metric signal (no path is appended). */
+  metricsEndpoint(url: string): this {
+    this.metricsEndpoint_ = url;
+    return this;
+  }
+
+  /** Set the `service.name` reported to the collector. */
+  serviceName(name: string): this {
+    this.serviceName_ = name;
+    return this;
+  }
+
+  /** Add one HTTP header to every export request. */
+  header(name: string, value: string): this {
+    this.headers_[name] = value;
+    return this;
+  }
+
+  /** Merge a map of HTTP headers into the export requests. */
+  headers(map: Record<string, string>): this {
+    Object.assign(this.headers_, map);
+    return this;
+  }
+
+  /** Add one OTLP resource attribute. */
+  resourceAttribute(name: string, value: string): this {
+    this.resourceAttributes_[name] = value;
+    return this;
+  }
+
+  /** Merge a map of OTLP resource attributes. */
+  resourceAttributes(map: Record<string, string>): this {
+    Object.assign(this.resourceAttributes_, map);
+    return this;
+  }
+
+  /** Set the per-request timeout (a duration string like `"5s"`). */
+  timeout(duration: string): this {
+    this.timeoutMs_ = parseDuration(duration);
+    return this;
+  }
+}
+
+/** A fully resolved exporter configuration (settings merged with the environment). */
+export interface ResolvedOtel {
+  /** The URL the trace signal is POSTed to, or `undefined` to skip traces. */
+  tracesUrl: string | undefined;
+  /** The URL the metric signal is POSTed to, or `undefined` to skip metrics. */
+  metricsUrl: string | undefined;
+  /** The HTTP headers sent on every export. */
+  headers: Record<string, string>;
+  /** The per-request timeout in milliseconds. */
+  timeoutMs: number;
+  /** The OTLP resource/scope identity for every export. */
+  resource: OtlpResource;
+}
+
+/** Join a base endpoint and a signal path, tolerating a trailing slash. */
+function joinEndpoint(base: string, path: string): string {
+  return `${base.replace(/\/+$/, "")}${path}`;
+}
+
+/** Normalise a blank or whitespace-only endpoint value to `undefined` (unset). */
+function cleanEndpoint(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const trimmed = value.trim();
+  return trimmed === "" ? undefined : trimmed;
+}
+
+/**
+ * Parse an `OTEL_EXPORTER_OTLP_HEADERS`-style value (`k1=v1,k2=v2`) into a map.
+ * Whitespace around keys/values is trimmed; malformed entries are skipped.
+ */
+export function parseHeaderList(value: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const pair of value.split(",")) {
+    const eq = pair.indexOf("=");
+    if (eq <= 0) continue;
+    const key = pair.slice(0, eq).trim();
+    const val = pair.slice(eq + 1).trim();
+    if (key !== "") out[key] = val;
+  }
+  return out;
+}
+
+/**
+ * Resolve {@link OtelSettings} plus the environment into a {@link ResolvedOtel},
+ * or `null` when no endpoint is configured at all (neither an explicit setter
+ * nor `OTEL_EXPORTER_OTLP_ENDPOINT` / a per-signal endpoint variable) — in which
+ * case the plugin does nothing. A blank or whitespace-only endpoint counts as
+ * unset (so `OTEL_EXPORTER_OTLP_ENDPOINT=` disables rather than resolving to a
+ * relative URL), and the two signals resolve **independently**: one per-signal
+ * endpoint on its own enables just that signal, and only that one is exported.
+ *
+ * `readEnv` is the environment seam (defaults to `Deno.env.get`), kept injectable
+ * so resolution is unit-testable without touching the process environment.
+ */
+export function resolveOtel(
+  settings: OtelSettings,
+  readEnv: (name: string) => string | undefined,
+): ResolvedOtel | null {
+  const base = cleanEndpoint(
+    settings.endpoint_ ?? readEnv("OTEL_EXPORTER_OTLP_ENDPOINT"),
+  );
+  const tracesRaw = cleanEndpoint(
+    settings.tracesEndpoint_ ?? readEnv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"),
+  );
+  const metricsRaw = cleanEndpoint(
+    settings.metricsEndpoint_ ?? readEnv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"),
+  );
+
+  const tracesUrl = tracesRaw ??
+    (base !== undefined ? joinEndpoint(base, "/v1/traces") : undefined);
+  const metricsUrl = metricsRaw ??
+    (base !== undefined ? joinEndpoint(base, "/v1/metrics") : undefined);
+  // Inert only when neither signal has an endpoint; one alone enables that one.
+  if (tracesUrl === undefined && metricsUrl === undefined) return null;
+
+  const envHeaders = readEnv("OTEL_EXPORTER_OTLP_HEADERS");
+  const headers: Record<string, string> = {
+    ...(envHeaders !== undefined ? parseHeaderList(envHeaders) : {}),
+    ...settings.headers_, // an explicit setter overrides the environment
+  };
+
+  const envAttrs = readEnv("OTEL_RESOURCE_ATTRIBUTES");
+  const attributes: Record<string, string> = {
+    ...(envAttrs !== undefined ? parseHeaderList(envAttrs) : {}),
+    ...settings.resourceAttributes_,
+  };
+
+  const serviceName = settings.serviceName_ ?? readEnv("OTEL_SERVICE_NAME") ??
+    "zuke";
+
+  return {
+    tracesUrl,
+    metricsUrl,
+    headers,
+    timeoutMs: settings.timeoutMs_,
+    resource: { serviceName, attributes, scopeVersion: SCOPE_VERSION },
+  };
+}

--- a/packages/otel/tests/_fixtures.ts
+++ b/packages/otel/tests/_fixtures.ts
@@ -1,0 +1,75 @@
+/**
+ * Shared test fixtures: a {@link RunRecord} builder, a {@link TargetRunState}
+ * builder, a fixed {@link OtlpResource}, and a capturing {@link OtlpTransport}
+ * fake — so the unit tests assert exported payloads without any network.
+ */
+
+import type { RunRecord, TargetRunState } from "@zuke/core";
+import type {
+  OtlpMetricsPayload,
+  OtlpResource,
+  OtlpTracePayload,
+} from "../src/otlp.ts";
+import type { OtlpTransport } from "../src/exporter.ts";
+
+/** A fixed resource/scope identity for tests. */
+export const RESOURCE: OtlpResource = {
+  serviceName: "test-svc",
+  attributes: {},
+  scopeVersion: "0.0.0",
+};
+
+/** Build a {@link TargetRunState} over the `pending`/empty-meta defaults. */
+export function target(
+  overrides: Partial<TargetRunState> = {},
+): TargetRunState {
+  return { status: "pending", meta: {}, ...overrides };
+}
+
+/** Build a {@link RunRecord} over sensible defaults, overriding any field. */
+export function makeRecord(overrides: Partial<RunRecord> = {}): RunRecord {
+  return {
+    id: "run-1",
+    build: "MyBuild",
+    rootTarget: "deploy",
+    status: "running",
+    actor: "alice",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:10.000Z",
+    graph: [],
+    params: {},
+    targets: {},
+    signals: {},
+    events: [],
+    ...overrides,
+  };
+}
+
+/** What a {@link fakeTransport} recorded. */
+export interface Captured {
+  /** Trace payloads handed to the transport, in order. */
+  traces: OtlpTracePayload[];
+  /** Metrics payloads handed to the transport, in order. */
+  metrics: OtlpMetricsPayload[];
+}
+
+/** A capturing {@link OtlpTransport} plus the {@link Captured} record it fills. */
+export function fakeTransport(): {
+  transport: OtlpTransport;
+  captured: Captured;
+} {
+  const captured: Captured = { traces: [], metrics: [] };
+  return {
+    captured,
+    transport: {
+      traces(payload) {
+        captured.traces.push(payload);
+        return Promise.resolve();
+      },
+      metrics(payload) {
+        captured.metrics.push(payload);
+        return Promise.resolve();
+      },
+    },
+  };
+}

--- a/packages/otel/tests/exporter_test.ts
+++ b/packages/otel/tests/exporter_test.ts
@@ -1,0 +1,138 @@
+import { assertEquals } from "../../core/tests/_assert.ts";
+import { OtlpHttpExporter } from "../src/exporter.ts";
+import { buildMetrics, buildTraces, type RunSpanIds } from "../src/otlp.ts";
+import { makeRecord, RESOURCE } from "./_fixtures.ts";
+
+const IDS: RunSpanIds = {
+  traceId: "0123456789abcdef0123456789abcdef",
+  runSpanId: "1111111111111111",
+  targetSpanIds: new Map(),
+};
+
+/** The global `fetch` signature, aliased so a local `fetch` param can be typed. */
+type FetchFn = typeof globalThis.fetch;
+
+/** A captured fetch call. */
+interface Call {
+  url: string;
+  method: string | undefined;
+  headers: Headers;
+  body: string;
+}
+
+/** A fake `fetch` that records calls and returns a canned response. */
+function recordingFetch(
+  respond: () => Response = () => new Response("{}", { status: 200 }),
+): { fetch: FetchFn; calls: Call[] } {
+  const calls: Call[] = [];
+  const fetch: FetchFn = (input, init) => {
+    calls.push({
+      url: String(input),
+      method: init?.method,
+      headers: new Headers(init?.headers),
+      body: typeof init?.body === "string" ? init.body : "",
+    });
+    return Promise.resolve(respond());
+  };
+  return { fetch, calls };
+}
+
+function exporter(fetch: FetchFn): OtlpHttpExporter {
+  return new OtlpHttpExporter({
+    tracesUrl: "http://c:4318/v1/traces",
+    metricsUrl: "http://c:4318/v1/metrics",
+    headers: { authorization: "Bearer t" },
+    timeoutMs: 10_000,
+    fetch,
+  });
+}
+
+Deno.test("traces() POSTs JSON to the traces URL with headers", async () => {
+  const { fetch, calls } = recordingFetch();
+  const payload = buildTraces(
+    makeRecord({ status: "succeeded" }),
+    IDS,
+    RESOURCE,
+  );
+  await exporter(fetch).traces(payload);
+
+  assertEquals(calls.length, 1);
+  assertEquals(calls[0].url, "http://c:4318/v1/traces");
+  assertEquals(calls[0].method, "POST");
+  assertEquals(calls[0].headers.get("content-type"), "application/json");
+  assertEquals(calls[0].headers.get("authorization"), "Bearer t");
+  assertEquals(calls[0].body, JSON.stringify(payload));
+});
+
+Deno.test("metrics() POSTs JSON to the metrics URL", async () => {
+  const { fetch, calls } = recordingFetch();
+  const payload = buildMetrics([], RESOURCE);
+  await exporter(fetch).metrics(payload);
+
+  assertEquals(calls[0].url, "http://c:4318/v1/metrics");
+  assertEquals(calls[0].body, JSON.stringify(payload));
+});
+
+Deno.test("a thrown fetch is swallowed (best-effort)", async () => {
+  const failing: FetchFn = () => Promise.reject(new Error("ECONNREFUSED"));
+  // Resolves without throwing.
+  await exporter(failing).metrics(buildMetrics([], RESOURCE));
+});
+
+Deno.test("a non-2xx response is swallowed (best-effort)", async () => {
+  const { fetch } = recordingFetch(() => new Response("nope", { status: 500 }));
+  await exporter(fetch).metrics(buildMetrics([], RESOURCE));
+});
+
+Deno.test("a response with no body is tolerated", async () => {
+  const { fetch } = recordingFetch(() => new Response(null, { status: 202 }));
+  await exporter(fetch).traces(
+    buildTraces(makeRecord({ status: "succeeded" }), IDS, RESOURCE),
+  );
+});
+
+Deno.test("skips a signal whose URL is absent", async () => {
+  const { fetch, calls } = recordingFetch();
+  const tracesOnly = new OtlpHttpExporter({
+    tracesUrl: "http://c:4318/v1/traces",
+    metricsUrl: undefined, // metrics not configured
+    headers: {},
+    timeoutMs: 10_000,
+    fetch,
+  });
+  await tracesOnly.metrics(buildMetrics([], RESOURCE)); // no-op, no request
+  assertEquals(calls.length, 0);
+  await tracesOnly.traces(
+    buildTraces(makeRecord({ status: "succeeded" }), IDS, RESOURCE),
+  );
+  assertEquals(calls.length, 1);
+  assertEquals(calls[0].url, "http://c:4318/v1/traces");
+
+  // Symmetric: a metrics-only exporter skips the trace signal.
+  const { fetch: fetch2, calls: calls2 } = recordingFetch();
+  const metricsOnly = new OtlpHttpExporter({
+    tracesUrl: undefined,
+    metricsUrl: "http://c:4318/v1/metrics",
+    headers: {},
+    timeoutMs: 10_000,
+    fetch: fetch2,
+  });
+  await metricsOnly.traces(
+    buildTraces(makeRecord({ status: "succeeded" }), IDS, RESOURCE),
+  );
+  assertEquals(calls2.length, 0);
+  await metricsOnly.metrics(buildMetrics([], RESOURCE));
+  assertEquals(calls2.length, 1);
+  assertEquals(calls2[0].url, "http://c:4318/v1/metrics");
+});
+
+Deno.test("defaults to the global fetch when none is injected", () => {
+  // Construction alone exercises the `?? fetch` default (never called).
+  const built = new OtlpHttpExporter({
+    tracesUrl: "http://c/v1/traces",
+    metricsUrl: "http://c/v1/metrics",
+    headers: {},
+    timeoutMs: 1000,
+  });
+  assertEquals(built instanceof OtlpHttpExporter, true);
+});

--- a/packages/otel/tests/ids_test.ts
+++ b/packages/otel/tests/ids_test.ts
@@ -1,0 +1,46 @@
+import { assertEquals } from "../../core/tests/_assert.ts";
+import { spanIdFor, traceIdFor } from "../src/ids.ts";
+
+const HEX = /^[0-9a-f]+$/;
+
+Deno.test("traceIdFor is 16 bytes of lowercase hex", async () => {
+  const id = await traceIdFor("run-abc");
+  assertEquals(id.length, 32);
+  assertEquals(HEX.test(id), true);
+});
+
+Deno.test("spanIdFor is 8 bytes of lowercase hex", async () => {
+  const id = await spanIdFor("run-abc", "run");
+  assertEquals(id.length, 16);
+  assertEquals(HEX.test(id), true);
+});
+
+Deno.test("ids are deterministic — the same inputs give the same id", async () => {
+  // This is the whole cross-process story: two processes hashing the same run
+  // id land the same trace id, with no handoff.
+  assertEquals(await traceIdFor("run-1"), await traceIdFor("run-1"));
+  assertEquals(
+    await spanIdFor("run-1", "build"),
+    await spanIdFor("run-1", "build"),
+  );
+});
+
+Deno.test("different runs get different trace ids", async () => {
+  const a = await traceIdFor("run-1");
+  const b = await traceIdFor("run-2");
+  assertEquals(a === b, false);
+});
+
+Deno.test("different targets get different span ids within a run", async () => {
+  const run = await spanIdFor("run-1", "run");
+  const lint = await spanIdFor("run-1", "lint");
+  const test = await spanIdFor("run-1", "test");
+  assertEquals(run === lint, false);
+  assertEquals(lint === test, false);
+});
+
+Deno.test("the same target key in different runs gets different span ids", async () => {
+  const a = await spanIdFor("run-1", "lint");
+  const b = await spanIdFor("run-2", "lint");
+  assertEquals(a === b, false);
+});

--- a/packages/otel/tests/otlp_test.ts
+++ b/packages/otel/tests/otlp_test.ts
@@ -1,0 +1,164 @@
+import { assertEquals } from "../../core/tests/_assert.ts";
+import {
+  buildMetrics,
+  buildTraces,
+  isoToNano,
+  type MetricPoint,
+  runOutcome,
+  type RunSpanIds,
+  SCOPE_NAME,
+} from "../src/otlp.ts";
+import { makeRecord, RESOURCE, target } from "./_fixtures.ts";
+
+const IDS: RunSpanIds = {
+  traceId: "0123456789abcdef0123456789abcdef",
+  runSpanId: "1111111111111111",
+  targetSpanIds: new Map([
+    ["lint", "2222222222222222"],
+    ["test", "3333333333333333"],
+    ["skipped", "4444444444444444"],
+  ]),
+};
+
+Deno.test("isoToNano converts millisecond timestamps exactly", () => {
+  assertEquals(isoToNano("1970-01-01T00:00:00.000Z"), "0");
+  assertEquals(isoToNano("1970-01-01T00:00:01.000Z"), "1000000000");
+  // Millisecond precision is preserved without float overflow.
+  assertEquals(isoToNano("2026-01-01T00:00:00.000Z"), "1767225600000000000");
+});
+
+Deno.test("isoToNano returns 0 for an unparseable timestamp", () => {
+  assertEquals(isoToNano("not-a-date"), "0");
+});
+
+Deno.test("runOutcome maps cancelling to cancelled, else passes through", () => {
+  assertEquals(runOutcome("cancelling"), "cancelled");
+  assertEquals(runOutcome("cancelled"), "cancelled");
+  assertEquals(runOutcome("succeeded"), "succeeded");
+  assertEquals(runOutcome("failed"), "failed");
+});
+
+Deno.test("buildTraces emits a run span plus one span per executed target", () => {
+  const record = makeRecord({
+    status: "succeeded",
+    targets: {
+      lint: target({
+        status: "succeeded",
+        startedAt: "2026-01-01T00:00:01.000Z",
+        endedAt: "2026-01-01T00:00:03.000Z",
+      }),
+      test: target({
+        status: "failed",
+        startedAt: "2026-01-01T00:00:03.000Z",
+        endedAt: "2026-01-01T00:00:05.000Z",
+        error: "1 test failed",
+      }),
+      // No startedAt → never ran → no span.
+      skipped: target({ status: "skipped" }),
+    },
+  });
+
+  const payload = buildTraces(record, IDS, RESOURCE);
+  const { resource, scopeSpans } = payload.resourceSpans[0];
+  assertEquals(
+    resource.attributes[0],
+    { key: "service.name", value: { stringValue: "test-svc" } },
+  );
+  const scope = scopeSpans[0].scope;
+  assertEquals(scope.name, SCOPE_NAME);
+
+  const spans = scopeSpans[0].spans;
+  assertEquals(spans.length, 3); // run + lint + test (skipped omitted)
+
+  const run = spans[0];
+  assertEquals(run.name, "MyBuild");
+  assertEquals(run.spanId, IDS.runSpanId);
+  assertEquals(run.parentSpanId, undefined);
+  assertEquals(run.traceId, IDS.traceId);
+  assertEquals(run.startTimeUnixNano, isoToNano("2026-01-01T00:00:00.000Z"));
+  assertEquals(run.endTimeUnixNano, isoToNano("2026-01-01T00:00:10.000Z"));
+
+  const lint = spans[1];
+  assertEquals(lint.name, "lint");
+  assertEquals(lint.spanId, "2222222222222222");
+  assertEquals(lint.parentSpanId, IDS.runSpanId);
+  assertEquals(lint.status.code, 0); // ok/unset
+
+  const test = spans[2];
+  assertEquals(test.name, "test");
+  assertEquals(test.status.code, 2); // error
+  assertEquals(test.status.message, "1 test failed");
+});
+
+Deno.test("buildTraces marks a failed run span as error", () => {
+  const record = makeRecord({ status: "failed" });
+  const run = buildTraces(record, IDS, RESOURCE).resourceSpans[0]
+    .scopeSpans[0].spans[0];
+  assertEquals(run.status.code, 2);
+  assertEquals(run.status.message, "run failed");
+});
+
+Deno.test("buildTraces marks a cancelling run span as cancelled error", () => {
+  const record = makeRecord({ status: "cancelling" });
+  const run = buildTraces(record, IDS, RESOURCE).resourceSpans[0]
+    .scopeSpans[0].spans[0];
+  assertEquals(run.status.code, 2);
+  assertEquals(run.status.message, "run cancelled");
+});
+
+Deno.test("buildTraces omits a started target with no span id and defaults a missing end", () => {
+  const ids: RunSpanIds = {
+    traceId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    runSpanId: "bbbbbbbbbbbbbbbb",
+    targetSpanIds: new Map([["running", "cccccccccccccccc"]]),
+  };
+  const record = makeRecord({
+    status: "succeeded",
+    targets: {
+      // Started, still running (no endedAt) → span ends where it started.
+      running: target({
+        status: "running",
+        startedAt: "2026-01-01T00:00:01.000Z",
+      }),
+      // Ran, but absent from the id map → no span emitted.
+      orphan: target({
+        status: "succeeded",
+        startedAt: "2026-01-01T00:00:02.000Z",
+      }),
+    },
+  });
+  const spans = buildTraces(record, ids, RESOURCE).resourceSpans[0]
+    .scopeSpans[0].spans;
+  assertEquals(spans.map((s) => s.name).sort(), ["MyBuild", "running"]);
+  const runningSpan = spans.find((s) => s.name === "running");
+  assertEquals(
+    runningSpan?.endTimeUnixNano,
+    runningSpan?.startTimeUnixNano,
+  );
+});
+
+Deno.test("buildMetrics renders a delta Sum data point per point", () => {
+  const points: MetricPoint[] = [{
+    name: "zuke.runs",
+    unit: "1",
+    value: 1,
+    attributes: { outcome: "succeeded", "zuke.build": "MyBuild" },
+    startIso: "2026-01-01T00:00:00.000Z",
+    atIso: "2026-01-01T00:00:10.000Z",
+  }];
+  const payload = buildMetrics(points, RESOURCE);
+  const metrics = payload.resourceMetrics[0].scopeMetrics[0].metrics;
+  assertEquals(metrics.length, 1);
+  const metric = metrics[0];
+  assertEquals(metric.name, "zuke.runs");
+  assertEquals(metric.unit, "1");
+  assertEquals(metric.sum.aggregationTemporality, 1); // delta
+  assertEquals(metric.sum.isMonotonic, true);
+  const dp = metric.sum.dataPoints[0];
+  assertEquals(dp.asInt, "1");
+  assertEquals(dp.timeUnixNano, isoToNano("2026-01-01T00:00:10.000Z"));
+  assertEquals(dp.attributes, [
+    { key: "outcome", value: { stringValue: "succeeded" } },
+    { key: "zuke.build", value: { stringValue: "MyBuild" } },
+  ]);
+});

--- a/packages/otel/tests/plugin_test.ts
+++ b/packages/otel/tests/plugin_test.ts
@@ -1,0 +1,211 @@
+import { assertEquals } from "../../core/tests/_assert.ts";
+import type { Plugin, RunRecord } from "@zuke/core";
+import { createOtelPlugin, DEDUP_CAP, otel, otelWith } from "../src/plugin.ts";
+import type { OtlpTransport } from "../src/exporter.ts";
+import { fakeTransport, makeRecord, RESOURCE, target } from "./_fixtures.ts";
+
+/** Deliver a record to the plugin's `onRunStateChange`, failing if it has none. */
+async function deliver(plugin: Plugin, record: RunRecord): Promise<void> {
+  const hook = plugin.onRunStateChange;
+  if (hook === undefined) throw new Error("plugin has no onRunStateChange");
+  await hook(record);
+}
+
+/** The metric names inside a captured metrics payload. */
+function metricNames(payload: {
+  resourceMetrics: [{ scopeMetrics: [{ metrics: { name: string }[] }] }];
+}): string[] {
+  return payload.resourceMetrics[0].scopeMetrics[0].metrics.map((m) => m.name);
+}
+
+Deno.test("a fresh running record emits zuke.run.started only", async () => {
+  const { transport, captured } = fakeTransport();
+  const plugin = createOtelPlugin(transport, RESOURCE);
+  await deliver(
+    plugin,
+    makeRecord({ status: "running", targets: { lint: target() } }),
+  );
+  assertEquals(captured.traces.length, 0);
+  assertEquals(captured.metrics.length, 1);
+  assertEquals(metricNames(captured.metrics[0]), ["zuke.run.started"]);
+});
+
+Deno.test("a resumed running record emits nothing (not a fresh start)", async () => {
+  const { transport, captured } = fakeTransport();
+  const plugin = createOtelPlugin(transport, RESOURCE);
+  await deliver(
+    plugin,
+    makeRecord({
+      status: "running",
+      targets: {
+        lint: target({
+          status: "succeeded",
+          startedAt: "2026-01-01T00:00:01.000Z",
+        }),
+        test: target({ status: "pending" }),
+      },
+    }),
+  );
+  assertEquals(captured.metrics.length, 0);
+  assertEquals(captured.traces.length, 0);
+});
+
+Deno.test("a suspended record emits zuke.run.suspended per waiting target", async () => {
+  const { transport, captured } = fakeTransport();
+  const plugin = createOtelPlugin(transport, RESOURCE);
+  await deliver(
+    plugin,
+    makeRecord({
+      status: "suspended",
+      targets: {
+        approve: target({
+          status: "waiting",
+          waitingFor: { trigger: "signal:approved", onTimeout: "fail" },
+        }),
+      },
+    }),
+  );
+  assertEquals(captured.traces.length, 0);
+  assertEquals(metricNames(captured.metrics[0]), ["zuke.run.suspended"]);
+  const dp = captured.metrics[0].resourceMetrics[0].scopeMetrics[0].metrics[0]
+    .sum.dataPoints[0];
+  assertEquals(
+    dp.attributes.find((a) => a.key === "trigger")?.value.stringValue,
+    "signal:approved",
+  );
+});
+
+Deno.test("suspended emits only for waiting targets, defaulting an unknown trigger", async () => {
+  const { transport, captured } = fakeTransport();
+  const plugin = createOtelPlugin(transport, RESOURCE);
+  await deliver(
+    plugin,
+    makeRecord({
+      status: "suspended",
+      targets: {
+        done: target({
+          status: "succeeded",
+          startedAt: "2026-01-01T00:00:01.000Z",
+        }),
+        // A waiting target with no waitingFor → trigger falls back to "unknown".
+        gate: target({ status: "waiting" }),
+      },
+    }),
+  );
+  const metrics =
+    captured.metrics[0].resourceMetrics[0].scopeMetrics[0].metrics;
+  assertEquals(metrics.length, 1); // only the waiting target, not `done`
+  const trigger = metrics[0].sum.dataPoints[0].attributes.find(
+    (a) => a.key === "trigger",
+  );
+  assertEquals(trigger?.value.stringValue, "unknown");
+});
+
+Deno.test("a terminal record emits one trace and a zuke.runs metric", async () => {
+  const { transport, captured } = fakeTransport();
+  const plugin = createOtelPlugin(transport, RESOURCE);
+  await deliver(
+    plugin,
+    makeRecord({
+      status: "succeeded",
+      targets: {
+        lint: target({
+          status: "succeeded",
+          startedAt: "2026-01-01T00:00:01.000Z",
+          endedAt: "2026-01-01T00:00:02.000Z",
+        }),
+      },
+    }),
+  );
+  assertEquals(captured.traces.length, 1);
+  assertEquals(metricNames(captured.metrics[0]), ["zuke.runs"]);
+});
+
+Deno.test("cancelling then cancelled exports the trace exactly once", async () => {
+  const { transport, captured } = fakeTransport();
+  const plugin = createOtelPlugin(transport, RESOURCE);
+  // In-process cancel drives running → cancelling → cancelled; the plugin must
+  // not double-export.
+  await deliver(plugin, makeRecord({ status: "cancelling" }));
+  await deliver(plugin, makeRecord({ status: "cancelled" }));
+  assertEquals(captured.traces.length, 1);
+  assertEquals(captured.metrics.length, 1);
+  const outcome = captured.metrics[0].resourceMetrics[0].scopeMetrics[0]
+    .metrics[0].sum.dataPoints[0].attributes.find((a) => a.key === "outcome");
+  assertEquals(outcome?.value.stringValue, "cancelled");
+});
+
+Deno.test("otelWith is inert when no endpoint resolves", () => {
+  const plugin = otelWith(undefined, { readEnv: () => undefined });
+  assertEquals(plugin.name, "otel");
+  assertEquals(plugin.onRunStateChange, undefined);
+});
+
+Deno.test("terminal traces and metrics are exported concurrently", async () => {
+  // traces() resolves only once metrics() has been entered. Serial
+  // (await traces; await metrics) would deadlock; Promise.all completes.
+  let metricsEntered = false;
+  let releaseTraces: () => void = () => {};
+  const tracesGate = new Promise<void>((resolve) => {
+    releaseTraces = resolve;
+  });
+  const transport: OtlpTransport = {
+    traces: () => tracesGate,
+    metrics: () => {
+      metricsEntered = true;
+      releaseTraces();
+      return Promise.resolve();
+    },
+  };
+  const plugin = createOtelPlugin(transport, RESOURCE);
+  await deliver(plugin, makeRecord({ status: "succeeded" }));
+  assertEquals(metricsEntered, true);
+});
+
+Deno.test("the dedup set is bounded — old run ids are evicted", async () => {
+  const { transport, captured } = fakeTransport();
+  const plugin = createOtelPlugin(transport, RESOURCE);
+  // Deliver DEDUP_CAP + 1 distinct terminal runs; each emits once, and the
+  // oldest (run-0) is evicted when the set overflows.
+  for (let i = 0; i <= DEDUP_CAP; i++) {
+    await deliver(plugin, makeRecord({ id: `run-${i}`, status: "succeeded" }));
+  }
+  const afterFill = captured.traces.length;
+  assertEquals(afterFill, DEDUP_CAP + 1);
+  // run-0 was evicted → re-delivering it re-emits (bounded, not leaking).
+  await deliver(plugin, makeRecord({ id: "run-0", status: "succeeded" }));
+  assertEquals(captured.traces.length, afterFill + 1);
+  // A still-remembered run is NOT re-emitted.
+  await deliver(
+    plugin,
+    makeRecord({ id: `run-${DEDUP_CAP}`, status: "succeeded" }),
+  );
+  assertEquals(captured.traces.length, afterFill + 1);
+});
+
+Deno.test("otel() reads the environment and is inert with no endpoint", () => {
+  // Exercises the public factory and its default `Deno.env.get` reader; clear
+  // the OTLP endpoint vars so the assertion holds regardless of the host env.
+  const keys = [
+    "OTEL_EXPORTER_OTLP_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+  ];
+  const saved = keys.map((k) => [k, Deno.env.get(k)] as const);
+  for (const k of keys) Deno.env.delete(k);
+  try {
+    assertEquals(otel().onRunStateChange, undefined);
+  } finally {
+    for (const [k, v] of saved) if (v !== undefined) Deno.env.set(k, v);
+  }
+});
+
+Deno.test("otelWith wires settings through to the transport", async () => {
+  const { transport, captured } = fakeTransport();
+  const plugin = otelWith((s) => s.endpoint("http://h:4318"), {
+    transport,
+    readEnv: () => undefined,
+  });
+  await deliver(plugin, makeRecord({ status: "succeeded" }));
+  assertEquals(captured.traces.length, 1);
+});

--- a/packages/otel/tests/settings_test.ts
+++ b/packages/otel/tests/settings_test.ts
@@ -1,0 +1,155 @@
+import { assertEquals } from "../../core/tests/_assert.ts";
+import { OtelSettings, parseHeaderList, resolveOtel } from "../src/settings.ts";
+
+/** A `readEnv` backed by a fixed map. */
+function env(
+  map: Record<string, string>,
+): (name: string) => string | undefined {
+  return (name) => map[name];
+}
+
+const NONE = env({});
+
+Deno.test("resolveOtel returns null when no endpoint is configured", () => {
+  assertEquals(resolveOtel(new OtelSettings(), NONE), null);
+});
+
+Deno.test("resolveOtel appends the signal paths to a base endpoint", () => {
+  const resolved = resolveOtel(
+    new OtelSettings().endpoint("http://localhost:4318"),
+    NONE,
+  );
+  assertEquals(resolved?.tracesUrl, "http://localhost:4318/v1/traces");
+  assertEquals(resolved?.metricsUrl, "http://localhost:4318/v1/metrics");
+  assertEquals(resolved?.resource.serviceName, "zuke");
+});
+
+Deno.test("resolveOtel tolerates a trailing slash on the endpoint", () => {
+  const resolved = resolveOtel(
+    new OtelSettings().endpoint("http://localhost:4318/"),
+    NONE,
+  );
+  assertEquals(resolved?.tracesUrl, "http://localhost:4318/v1/traces");
+});
+
+Deno.test("resolveOtel falls back to OTEL_EXPORTER_OTLP_ENDPOINT", () => {
+  const resolved = resolveOtel(
+    new OtelSettings(),
+    env({ OTEL_EXPORTER_OTLP_ENDPOINT: "http://collector:4318" }),
+  );
+  assertEquals(resolved?.tracesUrl, "http://collector:4318/v1/traces");
+});
+
+Deno.test("a per-signal endpoint wins and is used verbatim", () => {
+  const resolved = resolveOtel(
+    new OtelSettings()
+      .endpoint("http://base:4318")
+      .tracesEndpoint("http://traces:9999/ingest"),
+    NONE,
+  );
+  assertEquals(resolved?.tracesUrl, "http://traces:9999/ingest");
+  assertEquals(resolved?.metricsUrl, "http://base:4318/v1/metrics");
+});
+
+Deno.test("a per-signal endpoint alone enables that signal", () => {
+  // Only OTEL_EXPORTER_OTLP_METRICS_ENDPOINT set (no base) still resolves,
+  // because both URLs are derivable.
+  const resolved = resolveOtel(
+    new OtelSettings().tracesEndpoint("http://t/1").metricsEndpoint(
+      "http://m/1",
+    ),
+    NONE,
+  );
+  assertEquals(resolved?.tracesUrl, "http://t/1");
+  assertEquals(resolved?.metricsUrl, "http://m/1");
+});
+
+Deno.test("a lone traces endpoint enables just the trace signal", () => {
+  const resolved = resolveOtel(
+    new OtelSettings().tracesEndpoint("http://t/1"),
+    NONE,
+  );
+  assertEquals(resolved?.tracesUrl, "http://t/1");
+  assertEquals(resolved?.metricsUrl, undefined);
+});
+
+Deno.test("a lone metrics env endpoint enables just the metric signal", () => {
+  const resolved = resolveOtel(
+    new OtelSettings(),
+    env({ OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "http://m/1" }),
+  );
+  assertEquals(resolved?.tracesUrl, undefined);
+  assertEquals(resolved?.metricsUrl, "http://m/1");
+});
+
+Deno.test("a blank endpoint counts as unset (setter and env)", () => {
+  assertEquals(resolveOtel(new OtelSettings().endpoint(""), NONE), null);
+  assertEquals(resolveOtel(new OtelSettings().endpoint("   "), NONE), null);
+  assertEquals(
+    resolveOtel(new OtelSettings(), env({ OTEL_EXPORTER_OTLP_ENDPOINT: "" })),
+    null,
+  );
+});
+
+Deno.test("headers merge env then setter, setter winning on conflict", () => {
+  const resolved = resolveOtel(
+    new OtelSettings()
+      .endpoint("http://h:4318")
+      .header("authorization", "Bearer set")
+      .headers({ "x-tenant": "acme" }),
+    env({ OTEL_EXPORTER_OTLP_HEADERS: "authorization=Bearer env,x-region=eu" }),
+  );
+  assertEquals(resolved?.headers, {
+    authorization: "Bearer set", // setter overrides env
+    "x-region": "eu",
+    "x-tenant": "acme",
+  });
+});
+
+Deno.test("serviceName: setter > OTEL_SERVICE_NAME > default", () => {
+  assertEquals(
+    resolveOtel(
+      new OtelSettings().endpoint("http://h").serviceName("explicit"),
+      env({ OTEL_SERVICE_NAME: "from-env" }),
+    )?.resource.serviceName,
+    "explicit",
+  );
+  assertEquals(
+    resolveOtel(
+      new OtelSettings().endpoint("http://h"),
+      env({ OTEL_SERVICE_NAME: "from-env" }),
+    )?.resource.serviceName,
+    "from-env",
+  );
+});
+
+Deno.test("resource attributes merge env (OTEL_RESOURCE_ATTRIBUTES) and setters", () => {
+  const resolved = resolveOtel(
+    new OtelSettings()
+      .endpoint("http://h")
+      .resourceAttribute("k", "setter")
+      .resourceAttributes({ team: "core" }),
+    env({ OTEL_RESOURCE_ATTRIBUTES: "k=env,deployment.environment=ci" }),
+  );
+  assertEquals(resolved?.resource.attributes, {
+    k: "setter",
+    "deployment.environment": "ci",
+    team: "core",
+  });
+});
+
+Deno.test("timeout parses a duration string into milliseconds", () => {
+  assertEquals(
+    resolveOtel(new OtelSettings().endpoint("http://h").timeout("5s"), NONE)
+      ?.timeoutMs,
+    5000,
+  );
+});
+
+Deno.test("parseHeaderList trims and skips malformed entries", () => {
+  assertEquals(parseHeaderList("a=1, b = 2 ,nope,=x,c="), {
+    a: "1",
+    b: "2",
+    c: "",
+  });
+});

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -156,3 +156,9 @@ Before calling any task or settings method, confirm the real shape:
   diagnosed and (opt-in) auto-fixed, with a committable PR suggestion. Override
   `recoverWith()` on the build to apply one fixer to every target. See the
   cheatsheet's AI section.
+- **OpenTelemetry export (`@zuke/otel`):** register `otel((s) => s.endpoint(…))`
+  as a plugin (`run(MyBuild, { plugins: [otel(…)] })`) to ship run/target spans
+  and `zuke.run.started` / `zuke.run.suspended` / `zuke.runs` counters as
+  OTLP/HTTP JSON. Needs a state store; the trace id is derived from the run id,
+  so a suspend/resume across processes is one trace. Config falls back to the
+  standard `OTEL_*` env vars, and it is inert with no endpoint. Dependency-free.

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -463,6 +463,37 @@ test = target()
   );
 ```
 
+## OpenTelemetry export — `@zuke/otel`
+
+A plugin that ships run/target spans and counters to an OTLP/HTTP JSON
+collector. Register it on the run, not the build — it observes durable run
+state, so a **state store is required**.
+
+```ts
+import { run } from "jsr:@zuke/core";
+import { otel } from "jsr:@zuke/otel";
+
+await run(MyBuild, {
+  plugins: [
+    otel((s) =>
+      s.endpoint("http://localhost:4318") // else OTEL_EXPORTER_OTLP_ENDPOINT
+        .serviceName("my-build") // else OTEL_SERVICE_NAME
+        .header("authorization", "Bearer …") // else OTEL_EXPORTER_OTLP_HEADERS
+    ),
+  ],
+});
+// Or fully env-driven: run(MyBuild, { plugins: [otel()] })
+```
+
+- Exports a **trace** (run span + one child span per executed target) when the
+  run settles, plus `zuke.run.started` / `zuke.run.suspended` /
+  `zuke.runs{outcome}` counters.
+- The trace id is `SHA-256(runId)`, so a **suspend/resume across processes is
+  one trace** — the finishing process exports the complete, gap-spanning run.
+- **Inert with no endpoint** (safe to always register); **best-effort** (a dead
+  collector never fails the build); the record is **secret-free**. No runtime
+  deps. See `docs/observability.md`.
+
 ## Helpers from `@zuke/core`
 
 - `glob(pattern, { cwd? })` — expand a glob to sorted paths.

--- a/tests/e2e/fixtures/otel_build.ts
+++ b/tests/e2e/fixtures/otel_build.ts
@@ -1,0 +1,58 @@
+/**
+ * A real, runnable Zuke build for the OTel e2e suite. Run as a subprocess
+ * (`deno run -A otel_build.ts <target>`), it deploys, suspends at an approval
+ * gate, and on `resume` promotes — with the `@zuke/otel` plugin registered.
+ * The plugin's HTTP transport is redirected (via the internal `otelWith` seam)
+ * to a `fetch` that appends every OTLP request to the file named by
+ * `OTEL_CAPTURE_FILE`, so a hermetic test can inspect what two genuine
+ * processes exported without a running collector. `run()` reads `ZUKE_STATE_DIR`
+ * for its durable state.
+ *
+ * @module
+ */
+
+import {
+  Build,
+  externalSignal,
+  run,
+  target,
+} from "../../../packages/core/mod.ts";
+import { otelWith } from "../../../packages/otel/src/plugin.ts";
+
+/** The global `fetch` signature, aliased for the capturing seam. */
+type FetchFn = typeof globalThis.fetch;
+
+const captureFile = Deno.env.get("OTEL_CAPTURE_FILE");
+
+/** A `fetch` that appends each OTLP request (url + raw body) to the capture file. */
+const capturingFetch: FetchFn = (input, init) => {
+  if (captureFile !== undefined && typeof init?.body === "string") {
+    Deno.writeTextFileSync(
+      captureFile,
+      `${JSON.stringify({ url: String(input), body: init.body })}\n`,
+      { append: true },
+    );
+  }
+  return Promise.resolve(new Response("{}", { status: 200 }));
+};
+
+const plugin = otelWith((s) => s.endpoint("http://collector:4318"), {
+  fetch: capturingFetch,
+  readEnv: () => undefined,
+});
+
+/** A deploy → approval-gate → promote pipeline, observed by the OTel plugin. */
+class Cd extends Build {
+  /** Deploys (a real body, so it earns a span with timing). */
+  deploy = target().executes(() => console.log("DEPLOYED"));
+  /** Suspends the run until an `approved` signal is delivered on resume. */
+  gate = target()
+    .dependsOn(this.deploy)
+    .waitsFor((s) => s.on(externalSignal("approved")));
+  /** Runs only after the gate opens on resume (in the second process). */
+  promote = target().dependsOn(this.gate).executes(() =>
+    console.log("PROMOTED")
+  );
+}
+
+await run(Cd, { plugins: [plugin] });

--- a/tests/e2e/otel_e2e.ts
+++ b/tests/e2e/otel_e2e.ts
@@ -1,0 +1,133 @@
+/**
+ * End-to-end: cross-process trace continuity. Process A runs the
+ * {@link file://./fixtures/otel_build.ts} pipeline to its approval gate and
+ * suspends; process B — a genuinely separate `resume` subprocess — delivers the
+ * signal and finishes it. The `@zuke/otel` plugin in each process exports to a
+ * shared capture file, and the test proves that:
+ *
+ * - process A exports `zuke.run.started` (a fresh run) and no trace;
+ * - process B exports the run's **complete** trace exactly once, carrying the
+ *   `deploy` span (which ran in process A) *and* the `promote` span (process B),
+ *   because the durable record accumulates every target's absolute timings; and
+ * - that trace's id is the deterministic hash of the run id — the same id both
+ *   processes would derive, so their telemetry joins one trace with no handoff.
+ *
+ * Excluded from the fast unit gate (`*_e2e.ts`); run by the `integration` target.
+ */
+
+import { assertEquals } from "../../packages/core/tests/_assert.ts";
+import {
+  defaultStateHost,
+  FileSystemStateStore,
+} from "../../packages/core/mod.ts";
+import { traceIdFor } from "../../packages/otel/src/ids.ts";
+
+const FIXTURE = new URL("./fixtures/otel_build.ts", import.meta.url);
+
+/** The captured result of one fixture subprocess. */
+interface Run {
+  code: number;
+  out: string;
+}
+
+/** Run the OTel fixture as a real `deno` subprocess against `dir` + capture file. */
+async function runFixture(
+  args: string[],
+  dir: string,
+  captureFile: string,
+): Promise<Run> {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: ["run", "-A", FIXTURE.href, ...args],
+    env: { ZUKE_STATE_DIR: dir, OTEL_CAPTURE_FILE: captureFile },
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const { code, stdout } = await command.output();
+  return { code, out: new TextDecoder().decode(stdout) };
+}
+
+/** Parse the capture file into `{ url, payload }` records (one per exported POST). */
+async function readCaptured(
+  file: string,
+): Promise<{ url: string; payload: unknown }[]> {
+  const text = await Deno.readTextFile(file);
+  return text.split("\n").filter((l) => l !== "").map((line) => {
+    const record = JSON.parse(line);
+    return { url: record.url, payload: JSON.parse(record.body) };
+  });
+}
+
+Deno.test("two processes export one complete trace under a shared trace id", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "zuke-otel-e2e-" });
+  const captureFile = `${dir}/otlp.ndjson`;
+  await Deno.writeTextFile(captureFile, "");
+  try {
+    // Process A: run to the gate and suspend.
+    const suspend = await runFixture(["promote"], dir, captureFile);
+    assertEquals(suspend.code, 0);
+    assertEquals(suspend.out.includes("DEPLOYED"), true);
+    assertEquals(suspend.out.includes("PROMOTED"), false);
+
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    const runs = await store.listRuns({});
+    assertEquals(runs.length, 1);
+    const id = runs[0].id;
+    assertEquals(runs[0].status, "suspended");
+
+    // After process A: a started counter and a suspended counter, but no trace.
+    const afterA = await readCaptured(captureFile);
+    assertEquals(afterA.some((r) => r.url.endsWith("/v1/traces")), false);
+    assertEquals(
+      afterA.filter((r) => r.url.endsWith("/v1/metrics")).length >= 1,
+      true,
+    );
+
+    // Process B: deliver the signal and finish.
+    const resumed = await runFixture(
+      ["resume", id, "--signal", "approved"],
+      dir,
+      captureFile,
+    );
+    assertEquals(resumed.code, 0);
+    assertEquals(resumed.out.includes("PROMOTED"), true);
+    assertEquals(
+      await store.getRun(id).then((g) => g?.record.status),
+      "succeeded",
+    );
+
+    const all = await readCaptured(captureFile);
+    const traces = all.filter((r) => r.url.endsWith("/v1/traces"));
+    // Exactly one trace, exported by the finishing process.
+    assertEquals(traces.length, 1);
+
+    const payload = traces[0].payload as {
+      resourceSpans: [{
+        scopeSpans: [{
+          spans: {
+            name: string;
+            traceId: string;
+            startTimeUnixNano: string;
+          }[];
+        }];
+      }];
+    };
+    const spans = payload.resourceSpans[0].scopeSpans[0].spans;
+    const names = spans.map((s) => s.name).sort();
+    // The trace spans both processes: deploy (process A) and promote (process B).
+    assertEquals(names, ["Cd", "deploy", "promote"]);
+
+    // The trace id is the deterministic hash of the run id.
+    assertEquals(spans[0].traceId, await traceIdFor(id));
+
+    // deploy (process A) started strictly before promote (process B) — real gap.
+    const deploy = spans.find((s) => s.name === "deploy");
+    const promote = spans.find((s) => s.name === "promote");
+    assertEquals(
+      BigInt(deploy?.startTimeUnixNano ?? "0") <
+        BigInt(promote?.startTimeUnixNano ?? "0"),
+      true,
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/tests/integration/otel_test.ts
+++ b/tests/integration/otel_test.ts
@@ -1,0 +1,169 @@
+/**
+ * Integration: drive a real build through the CLI `main()` with the `@zuke/otel`
+ * plugin registered, against a capturing `fetch` (the only faked seam — the
+ * executor, the durable state writer, the plugin, and the HTTP exporter are all
+ * real). Proves the whole path: a run/target transition becomes a genuine
+ * OTLP/HTTP JSON request body.
+ */
+
+import { assertEquals } from "../../packages/core/tests/_assert.ts";
+import {
+  Build,
+  defaultStateHost,
+  externalSignal,
+  FileSystemStateStore,
+  target,
+} from "../../packages/core/mod.ts";
+import { otelWith } from "../../packages/otel/src/plugin.ts";
+import { runCli, withStateDir } from "./_harness.ts";
+
+/** The global `fetch` signature, aliased so a local can be annotated. */
+type FetchFn = typeof globalThis.fetch;
+
+/** One captured export request. */
+interface Request {
+  url: string;
+  body: unknown;
+}
+
+/** A `fetch` that records the URL and parsed JSON body of every request. */
+function capturingFetch(): { fetch: FetchFn; requests: Request[] } {
+  const requests: Request[] = [];
+  const fetch: FetchFn = (input, init) => {
+    const body = typeof init?.body === "string" ? JSON.parse(init.body) : null;
+    requests.push({ url: String(input), body });
+    return Promise.resolve(new Response("{}", { status: 200 }));
+  };
+  return { fetch, requests };
+}
+
+/** The span names inside a captured trace request body. */
+function spanNames(body: unknown): string[] {
+  const payload = body as {
+    resourceSpans: [{ scopeSpans: [{ spans: { name: string }[] }] }];
+  };
+  return payload.resourceSpans[0].scopeSpans[0].spans.map((s) => s.name);
+}
+
+/** A metric's single data-point attribute value, by key. */
+function metricAttr(body: unknown, key: string): string | undefined {
+  const payload = body as {
+    resourceMetrics: [{
+      scopeMetrics: [{
+        metrics: [{
+          sum: {
+            dataPoints: [
+              {
+                attributes: { key: string; value: { stringValue?: string } }[];
+              },
+            ];
+          };
+        }];
+      }];
+    }];
+  };
+  const attrs = payload.resourceMetrics[0].scopeMetrics[0].metrics[0].sum
+    .dataPoints[0].attributes;
+  return attrs.find((a) => a.key === key)?.value.stringValue;
+}
+
+class OtelDemo extends Build {
+  lint = target().executes(() => {});
+  test = target().dependsOn(this.lint).executes(() => {});
+}
+
+class OtelFails extends Build {
+  build = target().executes(() => {
+    throw new Error("boom");
+  });
+}
+
+class OtelWaits extends Build {
+  gate = target().waitsFor((s) => s.on(externalSignal("never")).timeout("1ms"));
+  done = target().dependsOn(this.gate).executes(() => {});
+}
+
+Deno.test("otel exports a run trace and counters for a successful build", async () => {
+  await withStateDir(async () => {
+    const { fetch, requests } = capturingFetch();
+    const plugin = otelWith((s) => s.endpoint("http://collector:4318"), {
+      fetch,
+      readEnv: () => undefined,
+    });
+    const result = await runCli(OtelDemo, ["test"], { plugins: [plugin] });
+    assertEquals(result.code, 0);
+
+    const traces = requests.filter((r) => r.url.endsWith("/v1/traces"));
+    const metrics = requests.filter((r) => r.url.endsWith("/v1/metrics"));
+    assertEquals(traces.length, 1);
+    // Run span + one span per executed target (lint, test).
+    assertEquals(spanNames(traces[0].body).sort(), [
+      "OtelDemo",
+      "lint",
+      "test",
+    ]);
+
+    // A fresh start counter, then the terminal outcome counter.
+    assertEquals(metrics.length, 2);
+    assertEquals(metricAttr(metrics[1].body, "outcome"), "succeeded");
+  });
+});
+
+Deno.test("otel reports a failed run and marks the failing target span", async () => {
+  await withStateDir(async () => {
+    const { fetch, requests } = capturingFetch();
+    const plugin = otelWith((s) => s.endpoint("http://collector:4318"), {
+      fetch,
+      readEnv: () => undefined,
+    });
+    const result = await runCli(OtelFails, ["build"], { plugins: [plugin] });
+    assertEquals(result.code, 1);
+
+    const traces = requests.filter((r) => r.url.endsWith("/v1/traces"));
+    assertEquals(traces.length, 1);
+    const spans = (traces[0].body as {
+      resourceSpans: [{
+        scopeSpans: [{ spans: { name: string; status: { code: number } }[] }];
+      }];
+    }).resourceSpans[0].scopeSpans[0].spans;
+    const buildSpan = spans.find((s) => s.name === "build");
+    assertEquals(buildSpan?.status.code, 2); // error
+
+    const metrics = requests.filter((r) => r.url.endsWith("/v1/metrics"));
+    const outcome = metrics.at(-1);
+    assertEquals(metricAttr(outcome?.body, "outcome"), "failed");
+  });
+});
+
+Deno.test("otel exports a terminal trace when a wait times out on resume", async () => {
+  await withStateDir(async (dir) => {
+    const { fetch, requests } = capturingFetch();
+    // One plugin instance across both CLI calls (dedup is per instance).
+    const plugin = otelWith((s) => s.endpoint("http://collector:4318"), {
+      fetch,
+      readEnv: () => undefined,
+    });
+
+    // First: run to the gate and suspend (deadline 1ms in the future).
+    const first = await runCli(OtelWaits, ["done"], { plugins: [plugin] });
+    assertEquals(first.code, 0);
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    const runs = await store.listRuns({});
+    assertEquals(runs.length, 1);
+    const id = runs[0].id;
+
+    // Let the deadline pass, then resume — the timeout fast-path settles the
+    // run `failed` without execute()'s lifecycle, so the terminal telemetry
+    // must come from the resume path announcing the record to the plugin.
+    await new Promise((r) => setTimeout(r, 25));
+    const resumed = await runCli(OtelWaits, ["resume", id], {
+      plugins: [plugin],
+    });
+    assertEquals(resumed.code, 1); // a timed-out run fails
+
+    const traces = requests.filter((r) => r.url.endsWith("/v1/traces"));
+    assertEquals(traces.length, 1); // the terminal trace, from the timeout path
+    const metrics = requests.filter((r) => r.url.endsWith("/v1/metrics"));
+    assertEquals(metricAttr(metrics.at(-1)?.body, "outcome"), "failed");
+  });
+});

--- a/tests/release_config_test.ts
+++ b/tests/release_config_test.ts
@@ -55,6 +55,7 @@ const PACKAGES = [
   "packages/release-please",
   "packages/security",
   "packages/ai",
+  "packages/otel",
 ];
 
 async function readJson(path: string): Promise<Record<string, unknown>> {

--- a/zuke.ts
+++ b/zuke.ts
@@ -106,6 +106,7 @@ const PACKAGES = [
   "release-please",
   "security",
   "ai",
+  "otel",
 ];
 
 /** Project framing for the generated API docs (`@zuke/docs`). */
@@ -380,6 +381,7 @@ class ZukeBuild extends Build {
           "tests/e2e/race_e2e.ts",
           "tests/e2e/mcp_e2e.ts",
           "tests/e2e/cancel_e2e.ts",
+          "tests/e2e/otel_e2e.ts",
         )
       );
     });


### PR DESCRIPTION
## What

A new dependency-free package **`@zuke/otel`** (M7 PR2): an OpenTelemetry export
`Plugin` that turns Zuke's durable run records into **OTLP/HTTP JSON** traces and
metrics. Register it on a run and every run/target transition ships to a
collector.

```ts
await run(MyBuild, {
  plugins: [otel((s) => s.endpoint("http://localhost:4318").serviceName("ci"))],
});
```

### What it exports
- **Trace** at run settle: a run span + one child span per executed target (a
  failed target span is `error` with its redacted message).
- **Counters**: `zuke.run.started` (fresh run), `zuke.run.suspended` (per waiting
  target, tagged with its trigger), `zuke.runs` (tagged `outcome`).

### Trace continuity across suspend/resume
Trace id = `SHA-256(runId)`; each target span id is a stable hash of
`(runId, target)`. The durable record accumulates every target's absolute
timings across a suspend, so the finishing process exports **one complete,
gap-spanning trace** — no cross-process handoff. Proven by the e2e (two real
processes → one trace).

### Config
Fluent settings lambda with `OTEL_*` environment-variable fallbacks; the two
signals resolve independently (a lone `tracesEndpoint` exports just traces).
**Inert with no endpoint** (safe to always register). Export is **best-effort**
— a dead/slow collector never fails or stalls the build beyond the timeout. A
state store is required (records come from durable run state).

## Testing (three layers)
- **Unit** — ids, OTLP payload builders, settings/env resolution, exporter
  transport, emission rules (fresh/resume/suspend/terminal, dedup, concurrency,
  bounded dedup).
- **Integration** — real build via `main()` → real executor/writer/plugin/HTTP
  exporter (only `fetch` faked): success, failure, and **timeout-resume**.
- **E2E** — two real subprocesses suspend/resume → one complete cross-process
  trace under the shared derived trace id (added to the `integration` target).

`@zuke/otel` coverage: 98.1% branches / 99.5% lines. Full `deno task ci` green;
`apiDocsCheck` clean. Registered in all five required places; docs
(`docs/observability.md` + index + extending) and the agent skill updated.

## Adversarial review

Ran a fan-out adversarial review (5 dimensions → per-finding verify). It
confirmed 7 findings (6 distinct); all are fixed here with regression tests:

| # | Fix | Where |
|---|-----|-------|
| 1 | Terminal traces+metrics exported **concurrently** (`Promise.all`), so a hung collector stalls at most one timeout, not two | `packages/otel` |
| 2 | Dedup set is **bounded** (evicts oldest past a cap) — no slow leak under plugin-instance reuse | `packages/otel` |
| 3 | A **lone per-signal endpoint** now enables that signal instead of making the plugin inert | `packages/otel` |
| 4 | A **blank/whitespace endpoint** counts as unset (was resolving to a relative URL) | `packages/otel` |
| 5 | **Secret redaction gap**: `markTargetWaiting` now redacts the wait trigger descriptor at the write-site choke point — a secret routed into a signal name is masked for the exporter, `zuke runs show`, and on-disk state alike | `packages/core` |
| 6 | **Timeout telemetry gap**: the resume timeout fast-paths now announce their terminal record to plugins, so a timed-out run still emits its terminal trace + counter | `packages/core` |

Findings 5 and 6 have root causes in core that the exporter surfaced; both are
small, choke-point fixes with regression tests. This PR therefore also touches
`packages/core` (a redaction fix and a resume-path improvement).

Part of the M7 OpenTelemetry milestone (follows #179, richer plugin payloads).