### PR TITLE
feat(gh): githubWorkflow wait trigger for cross-repo CI

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -57,6 +57,7 @@
     "endgroup",
     "gcloud",
     "gemini",
+    "GHES",
     "yolo",
     "cowsay",
     "cytoscape",

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -52,12 +52,56 @@ class Deploy extends Build {
   - **`resumeWhen(fn, { interval? })`** — satisfied when an async predicate
     returns `true`. Zuke doesn't poll on its own; the predicate is re-checked on
     each resume, so a cron or webhook drives it.
+  - **`githubWorkflow((g) => …)`** — dispatches a GitHub Actions workflow (often
+    in another repo) and is satisfied when it finishes; see
+    [below](#waiting-for-an-external-github-workflow). A third-party trigger from
+    [`@zuke/gh`](../packages/gh/README.md), built on the exported `WaitTrigger` /
+    `WaitContext` seam — you can write your own the same way.
 - **`s.timeout("72h")`** — an optional deadline. Its purpose and enforcement
   (running `onTimeout`) arrive with the resume half.
 - **`s.onTimeout(() => this.rollback)`** — what a timed-out wait does: a
   **thunk** returning a sibling compensation target, or `"fail"` /
   `"cancel-run"`. A thunk because the compensation is usually declared _below_
   the waiting target, and fields initialise top-to-bottom.
+
+### Waiting for an external GitHub workflow
+
+[`@zuke/gh`](../packages/gh/README.md)'s `githubWorkflow` trigger dispatches a
+GitHub Actions workflow and suspends until it finishes — replacing hand-rolled
+"dispatch, then poll `gh run list`" glue:
+
+```ts
+import { Build, run, target } from "jsr:@zuke/core";
+import { githubWorkflow, readWorkflowResult } from "jsr:@zuke/gh";
+
+class Release extends Build {
+  e2e = target().waitsFor((s) =>
+    s.on(githubWorkflow((g) => g.repo("acme/app").workflow("e2e.yml").ref("main")))
+      .timeout("2h").onTimeout(() => this.rollback)
+  );
+  ship = target().dependsOn(this.e2e).executes((ctx) => {
+    // The gate publishes its result to its own state — read it via stateOf.
+    const result = readWorkflowResult(ctx.stateOf("e2e"));
+    if (!result?.passed) throw new Error("e2e suite failed");
+  });
+  rollback = target().executes(() => rollBack());
+}
+```
+
+- **Dispatch-once, then poll.** On first reach it dispatches, records a
+  correlation marker in the gate's durable state, and suspends. Each
+  `resume --check` polls the run; a resume in a **different process** never
+  re-dispatches, because the marker persisted with the run.
+- **Correlation.** `workflow_dispatch` returns no run id, so the trigger passes a
+  marker input (default `zuke_marker`) and matches it against the run's display
+  title — the dispatched workflow must echo it into `run-name`:
+  `run-name: ${{ inputs.zuke_marker }}`.
+- **Result.** On completion the per-job conclusions (`{ passed, jobs: [{ name,
+  conclusion, url }] }`) are written to the gate target's state; a dependent
+  reads them with `readWorkflowResult(ctx.stateOf("<gate>"))` and branches on a
+  failed suite.
+- **Auth** uses `GH_TOKEN` / `GITHUB_TOKEN`; the GitHub API is an injectable
+  transport, so it is testable without a real GitHub.
 
 ## What suspend does
 

--- a/docs/run-context.md
+++ b/docs/run-context.md
@@ -24,6 +24,8 @@ class Deploy extends Build {
 | `target`     | `string`            | The executing target's dotted name.                                  |
 | `signal`     | `AbortSignal`       | Aborted when the run is cancelled (see below).                       |
 | `state`      | `TargetStateHandle` | Durable per-target metadata — see [Durable run state](./state.md).   |
+| `stateOf`    | `(t) => …`          | The state handle of **another** target — read a dependency's published metadata (e.g. a wait's result). |
+| `signals`    | `ReadonlyMap`       | Payloads of external signals received so far (see [waits](./orchestration.md)). |
 | `dryRun`     | `boolean`           | `true` when the run is a dry run (bodies don't execute in a dry run). |
 
 `runId` is minted once per run (`crypto.randomUUID()`), so it correlates every

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2491,6 +2491,12 @@ interface TargetContext
     signal is delivered by `zuke resume <id> --signal <name>`.
   readonly dryRun: boolean
     True when the run is a dry run (bodies do not execute under a dry run).
+  stateOf(target: string): TargetStateHandle
+    The durable state handle of another target in this run — the seam a body
+    reads a dependency's published metadata through (e.g. the result a
+    `.waitsFor(githubWorkflow(...))` gate recorded to its state). `stateOf(this target)` is equivalent to {@link state}. It reads the run's current
+    record, so it sees writes a dependency made earlier in the run — including
+    across a suspend/resume, since the record is durable.
 
 interface TargetReport
   One row of the end-of-build summary.
@@ -2575,6 +2581,23 @@ interface ValidationContext
   target: string
     The name of the target the validation is attached to.
 
+interface WaitContext
+  The durable context a {@link WaitTrigger} may use while deciding whether its
+  event has occurred. Its {@link WaitContext.state} handle is the awaiting
+  target's persisted metadata — it survives a suspend/resume, even across
+  processes — so a stateful trigger (e.g. "dispatch a GitHub workflow, then poll
+  it") can remember what it started and hand a result to the target's body. The
+  built-in triggers ignore it.
+
+  readonly state: TargetStateHandle
+    The awaiting target's durable state handle (the same one its body receives
+    as `ctx.state`). Reads and writes here persist with the run and are visible
+    to a later resume in another process.
+  readonly runId: string
+    The run id — stable across a resume, so a natural correlation key.
+  readonly target: string
+    The awaiting target's dotted name.
+
 interface WaitState
   The pending wait recorded on a suspended target (see {@link TargetRunState.waitingFor}).
 
@@ -2588,15 +2611,18 @@ interface WaitState
 interface WaitTrigger
   Decides whether the event a target waits for has occurred. `descriptor` is a
   short, JSON-safe label recorded on the suspended target; `isSatisfied` is
-  evaluated against the run's received signals when the target is reached and
-  again on each resume attempt.
+  evaluated against the run's received signals (and a durable {@link
+  WaitContext}) when the target is reached and again on each resume attempt.
 
   readonly descriptor: string
     A short label recorded on the wait (e.g. `signal:approved`).
   readonly pollIntervalMs?: number
     Poll interval hint (ms) for predicate triggers driven by `zuke resume --check`.
-  isSatisfied(signals: ReadonlyMap<string, SignalRecord>): boolean | Promise<boolean>
-    Whether the awaited event has occurred, given the run's received signals.
+  isSatisfied(signals: ReadonlyMap<string, SignalRecord>, context: WaitContext): boolean | Promise<boolean>
+    Whether the awaited event has occurred, given the run's received signals
+    and a durable {@link WaitContext}. The context lets a trigger persist
+    correlation state across a suspend/resume; a trigger that only inspects
+    signals may ignore it (fewer parameters stay assignable).
 
 type AnnouncementLevel = "success" | "failure" | "warning" | "info"
   The outcome an announcement conveys. It drives the accent colour and the icon
@@ -6620,16 +6646,37 @@ type GitRunner = (args: string[]) => Promise<string | null>
 # @zuke/gh
 ========================================================================
 
-`@zuke/gh` — a typed `gh` (GitHub CLI) task wrapper for Zuke builds.
-
-A flexible command builder: name the command with `.command(...)`, set
-`--repo`, and pass anything else with `.flag(...)`.
+`@zuke/gh` — typed GitHub tooling for Zuke builds: the `gh` (GitHub CLI) task
+wrapper plus {@link githubWorkflow}, a wait trigger that dispatches and awaits
+an external GitHub Actions workflow.
 
 ```ts
-import { GhTasks } from "jsr:@zuke/gh";
+import { GhTasks, githubWorkflow } from "jsr:@zuke/gh";
+
 await GhTasks.run((s) => s.command("pr", "list").flag("state", "open"));
+
+// In a build: suspend until an e2e workflow in another repo finishes.
+e2e = target().waitsFor((s) =>
+  s.on(githubWorkflow((g) => g.repo("acme/app").workflow("e2e.yml")))
+);
 ```
 @module
+
+function githubWorkflow(configure: (settings: GithubWorkflowSettings) => GithubWorkflowSettings): WaitTrigger
+  A {@link "@zuke/core".WaitTrigger} that dispatches a GitHub Actions workflow,
+  suspends the run until it finishes, and records its per-job conclusions to the
+  awaiting target's state (read them with {@link readWorkflowResult}). See the
+  module docs for the `run-name` correlation requirement and auth.
+
+  ```ts
+  githubWorkflow((g) => g.repo("acme/app").workflow("e2e.yml").ref("main"))
+  ```
+
+function readWorkflowResult(state: TargetStateHandle): WorkflowResult | undefined
+  Read the {@link WorkflowResult} a completed {@link githubWorkflow} wait wrote
+  to a target's state, or `undefined` if the wait has not completed (or this is
+  not a github-workflow gate). Call it from a dependent target's body with
+  the gate's handle: `readWorkflowResult(ctx.stateOf("<gate-target>"))`.
 
 const GhTasks: GhTasksApi
   Typed task functions for the `gh` GitHub CLI.
@@ -6647,11 +6694,67 @@ class GhSettings extends ToolSettings
     it renders the bare `--name`. Repeatable.
   override protected buildArgs(): string[]
 
+class GithubWorkflowSettings
+  Configuration for {@link githubWorkflow}, set through a settings lambda. Every
+  setter returns `this` so calls chain; `repo` and `workflow` are required.
+
+  repo_?: string
+    The `OWNER/REPO` slug the workflow lives in.
+  workflow_?: string
+    The workflow file name (e.g. `e2e.yml`) or its numeric id.
+  ref_: string
+    The git ref to dispatch against (default `main`).
+  inputs_: Record<string, string>
+    Extra `workflow_dispatch` inputs.
+  markerInput_: string
+    The input name the marker is passed as (default `zuke_marker`).
+  pollIntervalMs_?: number
+    Poll interval hint (ms) for `zuke resume --check`.
+  repo(slug: string): this
+    Set the `OWNER/REPO` the workflow lives in.
+  workflow(idOrFile: string): this
+    Set the workflow file name (e.g. `e2e.yml`) or numeric id.
+  ref(ref: string): this
+    Set the git ref to dispatch against (default `main`).
+  input(name: string, value: string): this
+    Add one `workflow_dispatch` input.
+  inputs(map: Record<string, string>): this
+    Merge a map of `workflow_dispatch` inputs.
+  markerInput(name: string): this
+    Change the input name the correlation marker is dispatched as.
+  pollEvery(duration: string): this
+    Set how often `zuke resume --check` should re-poll (a duration string).
+
 interface GhTasksApi
   The shape of {@link GhTasks}.
 
   run(configure?: Configure<GhSettings>): Promise<CommandOutput>
     Run a `gh` command.
+
+interface WorkflowJob
+  One job's outcome within a completed workflow run.
+
+  name: string
+    The job's name.
+  conclusion: string
+    Its conclusion (`success`, `failure`, `cancelled`, `skipped`, …).
+  url: string
+    A link to the job on GitHub.
+
+interface WorkflowResult
+  The payload a completed {@link githubWorkflow} wait writes to the awaiting
+  target's state; read it in a dependent body with {@link readWorkflowResult}.
+
+  passed: boolean
+    True when the run's overall conclusion was `success`.
+  conclusion: string
+    The run's overall conclusion.
+  runId: number
+    The dispatched run's numeric id.
+  url: string
+    A link to the run on GitHub.
+  jobs: WorkflowJob[]
+    Each job's conclusion, so a build can branch on which suite failed.
 
 ========================================================================
 # @zuke/codecov

--- a/llms.txt
+++ b/llms.txt
@@ -124,7 +124,7 @@ Full reference: [docs/cli.md](./docs/cli.md).
 - [@zuke/dprint](https://jsr.io/@zuke/dprint) — typed `dprint` task wrappers for Zuke builds
 - [@zuke/gcloud](https://jsr.io/@zuke/gcloud) — a typed `gcloud` (Google Cloud SDK) task wrapper for Zuke
 - [@zuke/git](https://jsr.io/@zuke/git) — typed `git` task wrappers for Zuke builds
-- [@zuke/gh](https://jsr.io/@zuke/gh) — a typed `gh` (GitHub CLI) task wrapper for Zuke builds
+- [@zuke/gh](https://jsr.io/@zuke/gh) — typed GitHub tooling for Zuke builds: the `gh` (GitHub CLI) task
 - [@zuke/codecov](https://jsr.io/@zuke/codecov) — a typed Codecov CLI (`codecovcli`) task wrapper for Zuke
 - [@zuke/claude](https://jsr.io/@zuke/claude) — a typed Claude Code (https://docs.claude.com/en/docs/claude-code)
 - [@zuke/codex](https://jsr.io/@zuke/codex) — a typed OpenAI Codex (https://developers.openai.com/codex/cli)

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2545,6 +2545,12 @@ interface TargetContext
     signal is delivered by `zuke resume <id> --signal <name>`.
   readonly dryRun: boolean
     True when the run is a dry run (bodies do not execute under a dry run).
+  stateOf(target: string): TargetStateHandle
+    The durable state handle of another target in this run — the seam a body
+    reads a dependency's published metadata through (e.g. the result a
+    `.waitsFor(githubWorkflow(...))` gate recorded to its state). `stateOf(this target)` is equivalent to {@link state}. It reads the run's current
+    record, so it sees writes a dependency made earlier in the run — including
+    across a suspend/resume, since the record is durable.
 
 interface TargetReport
   One row of the end-of-build summary.
@@ -2629,6 +2635,23 @@ interface ValidationContext
   target: string
     The name of the target the validation is attached to.
 
+interface WaitContext
+  The durable context a {@link WaitTrigger} may use while deciding whether its
+  event has occurred. Its {@link WaitContext.state} handle is the awaiting
+  target's persisted metadata — it survives a suspend/resume, even across
+  processes — so a stateful trigger (e.g. "dispatch a GitHub workflow, then poll
+  it") can remember what it started and hand a result to the target's body. The
+  built-in triggers ignore it.
+
+  readonly state: TargetStateHandle
+    The awaiting target's durable state handle (the same one its body receives
+    as `ctx.state`). Reads and writes here persist with the run and are visible
+    to a later resume in another process.
+  readonly runId: string
+    The run id — stable across a resume, so a natural correlation key.
+  readonly target: string
+    The awaiting target's dotted name.
+
 interface WaitState
   The pending wait recorded on a suspended target (see {@link TargetRunState.waitingFor}).
 
@@ -2642,15 +2665,18 @@ interface WaitState
 interface WaitTrigger
   Decides whether the event a target waits for has occurred. `descriptor` is a
   short, JSON-safe label recorded on the suspended target; `isSatisfied` is
-  evaluated against the run's received signals when the target is reached and
-  again on each resume attempt.
+  evaluated against the run's received signals (and a durable {@link
+  WaitContext}) when the target is reached and again on each resume attempt.
 
   readonly descriptor: string
     A short label recorded on the wait (e.g. `signal:approved`).
   readonly pollIntervalMs?: number
     Poll interval hint (ms) for predicate triggers driven by `zuke resume --check`.
-  isSatisfied(signals: ReadonlyMap<string, SignalRecord>): boolean | Promise<boolean>
-    Whether the awaited event has occurred, given the run's received signals.
+  isSatisfied(signals: ReadonlyMap<string, SignalRecord>, context: WaitContext): boolean | Promise<boolean>
+    Whether the awaited event has occurred, given the run's received signals
+    and a durable {@link WaitContext}. The context lets a trigger persist
+    correlation state across a suspend/resume; a trigger that only inspects
+    signals may ignore it (fewer parameters stay assignable).
 
 type AnnouncementLevel = "success" | "failure" | "warning" | "info"
   The outcome an announcement conveys. It drives the accent colour and the icon

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -69,6 +69,7 @@ export {
   externalSignal,
   resumeWhen,
   type ResumeWhenOptions,
+  type WaitContext,
   type WaitTrigger,
 } from "./src/wait.ts";
 export { run, type RunOptions } from "./src/cli.ts";

--- a/packages/core/src/cancel.ts
+++ b/packages/core/src/cancel.ts
@@ -256,6 +256,10 @@ export async function runCompensations(
       target: compName,
       signal: NEVER_ABORTED,
       state: seededStateHandle(step.meta),
+      // A compensation runs off the durable graph, so only its own seeded state
+      // is available; other targets read as empty here.
+      stateOf: (t) =>
+        t === compName ? seededStateHandle(step.meta) : seededStateHandle({}),
       signals: deps.signals,
       dryRun: false,
     };

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -49,6 +49,7 @@ import {
   WaitSettings,
 } from "./target.ts";
 import type { Configure } from "./tooling.ts";
+import type { WaitContext } from "./wait.ts";
 import type {
   RunRecord,
   SignalRecord,
@@ -566,7 +567,15 @@ async function resolveWait(
       `Target "${name}" .waitsFor(...) set no trigger — call s.on(...).`,
     );
   }
-  const satisfied = await trigger.isSatisfied(env.signals);
+  // The trigger gets the target's durable state handle, so a stateful trigger
+  // (e.g. dispatch-then-poll) can persist correlation state across the
+  // suspend/resume boundary and hand a result to the body.
+  const waitCtx: WaitContext = {
+    state: env.writer ? env.writer.stateHandle(name) : inMemoryStateHandle(),
+    runId: env.runId,
+    target: name,
+  };
+  const satisfied = await trigger.isSatisfied(env.signals, waitCtx);
   const waitState: WaitState = {
     trigger: trigger.descriptor,
     onTimeout: resolveDisposition(settings.onTimeout_),
@@ -884,11 +893,21 @@ async function runTarget(
     return { status: "failed", ms: 0, error };
   }
 
+  // One own-state handle, reused for `stateOf(this target)` so the documented
+  // `stateOf(self) === state` invariant holds even store-less (a fresh
+  // inMemoryStateHandle per call would drop writes).
+  const ownState = env.writer
+    ? env.writer.stateHandle(name)
+    : inMemoryStateHandle();
   const ctx: TargetContext = {
     runId: env.runId,
     target: name,
     signal: env.signal,
-    state: env.writer ? env.writer.stateHandle(name) : inMemoryStateHandle(),
+    state: ownState,
+    stateOf: (t) =>
+      t === name
+        ? ownState
+        : (env.writer ? env.writer.stateHandle(t) : inMemoryStateHandle()),
     signals: env.signals,
     dryRun,
   };

--- a/packages/core/src/target.ts
+++ b/packages/core/src/target.ts
@@ -265,6 +265,15 @@ export interface TargetContext {
    */
   readonly state: TargetStateHandle;
   /**
+   * The durable state handle of **another target** in this run — the seam a body
+   * reads a dependency's published metadata through (e.g. the result a
+   * `.waitsFor(githubWorkflow(...))` gate recorded to its state). `stateOf(this
+   * target)` is equivalent to {@link state}. It reads the run's **current**
+   * record, so it sees writes a dependency made earlier in the run — including
+   * across a suspend/resume, since the record is durable.
+   */
+  stateOf(target: string): TargetStateHandle;
+  /**
    * Payloads of the external signals received so far, keyed by name (see
    * `.waitsFor(...)` and {@link "./wait.ts".externalSignal}). Empty until a
    * signal is delivered by `zuke resume <id> --signal <name>`.

--- a/packages/core/src/wait.ts
+++ b/packages/core/src/wait.ts
@@ -13,22 +13,50 @@
  */
 
 import type { SignalRecord } from "./state/types.ts";
+import type { TargetStateHandle } from "./target.ts";
 import { parseDuration } from "./duration.ts";
+
+/**
+ * The durable context a {@link WaitTrigger} may use while deciding whether its
+ * event has occurred. Its {@link WaitContext.state} handle is the awaiting
+ * target's persisted metadata — it **survives a suspend/resume**, even across
+ * processes — so a stateful trigger (e.g. "dispatch a GitHub workflow, then poll
+ * it") can remember what it started and hand a result to the target's body. The
+ * built-in triggers ignore it.
+ */
+export interface WaitContext {
+  /**
+   * The awaiting target's durable state handle (the same one its body receives
+   * as `ctx.state`). Reads and writes here persist with the run and are visible
+   * to a later resume in another process.
+   */
+  readonly state: TargetStateHandle;
+  /** The run id — stable across a resume, so a natural correlation key. */
+  readonly runId: string;
+  /** The awaiting target's dotted name. */
+  readonly target: string;
+}
 
 /**
  * Decides whether the event a target waits for has occurred. `descriptor` is a
  * short, JSON-safe label recorded on the suspended target; `isSatisfied` is
- * evaluated against the run's received signals when the target is reached and
- * again on each resume attempt.
+ * evaluated against the run's received signals (and a durable {@link
+ * WaitContext}) when the target is reached and again on each resume attempt.
  */
 export interface WaitTrigger {
   /** A short label recorded on the wait (e.g. `signal:approved`). */
   readonly descriptor: string;
   /** Poll interval hint (ms) for predicate triggers driven by `zuke resume --check`. */
   readonly pollIntervalMs?: number;
-  /** Whether the awaited event has occurred, given the run's received signals. */
+  /**
+   * Whether the awaited event has occurred, given the run's received signals
+   * and a durable {@link WaitContext}. The context lets a trigger persist
+   * correlation state across a suspend/resume; a trigger that only inspects
+   * signals may ignore it (fewer parameters stay assignable).
+   */
   isSatisfied(
     signals: ReadonlyMap<string, SignalRecord>,
+    context: WaitContext,
   ): boolean | Promise<boolean>;
 }
 

--- a/packages/core/tests/state_test.ts
+++ b/packages/core/tests/state_test.ts
@@ -222,21 +222,31 @@ Deno.test("parseRunRecord defaults missing signals to empty (backwards compat)",
   assertEquals(parseRunRecord(JSON.stringify(withoutSignals)).signals, {});
 });
 
+// A minimal WaitContext for the built-in triggers, which ignore it.
+const WAIT_CTX = { state: inMemoryStateHandle(), runId: "r", target: "t" };
+
 Deno.test("externalSignal is satisfied only when the named signal is present", async () => {
   const trigger = externalSignal("approved");
   assertEquals(trigger.descriptor, "signal:approved");
-  assertEquals(await trigger.isSatisfied(new Map()), false);
+  assertEquals(await trigger.isSatisfied(new Map(), WAIT_CTX), false);
   assertEquals(
     await trigger.isSatisfied(
       new Map([["approved", { data: {}, receivedAt: "t" }]]),
+      WAIT_CTX,
     ),
     true,
   );
 });
 
 Deno.test("resumeWhen evaluates the predicate and carries a poll interval", async () => {
-  assertEquals(await resumeWhen(() => true).isSatisfied(new Map()), true);
-  assertEquals(await resumeWhen(() => false).isSatisfied(new Map()), false);
+  assertEquals(
+    await resumeWhen(() => true).isSatisfied(new Map(), WAIT_CTX),
+    true,
+  );
+  assertEquals(
+    await resumeWhen(() => false).isSatisfied(new Map(), WAIT_CTX),
+    false,
+  );
   assertEquals(
     resumeWhen(() => true, { interval: "30s" }).pollIntervalMs,
     30_000,

--- a/packages/gh/README.md
+++ b/packages/gh/README.md
@@ -20,6 +20,48 @@ await GhTasks.run((s) =>
 await GhTasks.run((s) => s.command("pr", "list").flag("state", "open"));
 ```
 
+## Wait for an external GitHub workflow
+
+`githubWorkflow` is a Zuke
+[wait trigger](https://github.com/zuke-build/zuke/blob/master/docs/orchestration.md):
+it dispatches a GitHub Actions workflow (often in another repo), **suspends the
+run until it finishes**, and resurfaces its per-job conclusions — replacing
+hand-rolled "dispatch, then poll `gh run list`" glue.
+
+```ts
+import { Build, run, target } from "jsr:@zuke/core";
+import { githubWorkflow, readWorkflowResult } from "jsr:@zuke/gh";
+
+class Release extends Build {
+  e2e = target().waitsFor((s) =>
+    s.on(
+      githubWorkflow((g) => g.repo("acme/app").workflow("e2e.yml").ref("main")),
+    )
+      .timeout("2h").onTimeout(() => this.rollback)
+  );
+  ship = target().dependsOn(this.e2e).executes((ctx) => {
+    const result = readWorkflowResult(ctx.stateOf("e2e"));
+    if (!result?.passed) throw new Error("e2e suite failed");
+  });
+  rollback = target().executes(() => rollBack());
+}
+
+await run(Release);
+```
+
+- **Dispatch-once, then poll.** It dispatches on first reach, records a
+  correlation marker in the gate's durable state, and suspends. Each
+  `zuke resume --check` polls; a resume in a **different process** never
+  re-dispatches.
+- **Correlation.** `workflow_dispatch` returns no run id, so the trigger passes
+  a marker input (default `zuke_marker`) and matches it against the run's
+  display title — the dispatched workflow must echo it:
+  `run-name: ${{ inputs.zuke_marker }}`.
+- **Result.** The per-job conclusions are published to the gate target's state;
+  a dependent reads them with `readWorkflowResult(ctx.stateOf("<gate>"))`.
+- **Auth** uses `GH_TOKEN` / `GITHUB_TOKEN`; the GitHub API is an injectable
+  transport, so builds are testable without hitting GitHub.
+
 <!-- ZUKE:API:START -->
 
 ## API
@@ -28,16 +70,37 @@ await GhTasks.run((s) => s.command("pr", "list").flag("state", "open"));
 <summary>Full typed API — generated from <code>deno doc</code></summary>
 
 ````text
-`@zuke/gh` — a typed `gh` (GitHub CLI) task wrapper for Zuke builds.
-
-A flexible command builder: name the command with `.command(...)`, set
-`--repo`, and pass anything else with `.flag(...)`.
+`@zuke/gh` — typed GitHub tooling for Zuke builds: the `gh` (GitHub CLI) task
+wrapper plus {@link githubWorkflow}, a wait trigger that dispatches and awaits
+an external GitHub Actions workflow.
 
 ```ts
-import { GhTasks } from "jsr:@zuke/gh";
+import { GhTasks, githubWorkflow } from "jsr:@zuke/gh";
+
 await GhTasks.run((s) => s.command("pr", "list").flag("state", "open"));
+
+// In a build: suspend until an e2e workflow in another repo finishes.
+e2e = target().waitsFor((s) =>
+  s.on(githubWorkflow((g) => g.repo("acme/app").workflow("e2e.yml")))
+);
 ```
 @module
+
+function githubWorkflow(configure: (settings: GithubWorkflowSettings) => GithubWorkflowSettings): WaitTrigger
+  A {@link "@zuke/core".WaitTrigger} that dispatches a GitHub Actions workflow,
+  suspends the run until it finishes, and records its per-job conclusions to the
+  awaiting target's state (read them with {@link readWorkflowResult}). See the
+  module docs for the `run-name` correlation requirement and auth.
+
+  ```ts
+  githubWorkflow((g) => g.repo("acme/app").workflow("e2e.yml").ref("main"))
+  ```
+
+function readWorkflowResult(state: TargetStateHandle): WorkflowResult | undefined
+  Read the {@link WorkflowResult} a completed {@link githubWorkflow} wait wrote
+  to a target's state, or `undefined` if the wait has not completed (or this is
+  not a github-workflow gate). Call it from a dependent target's body with
+  the gate's handle: `readWorkflowResult(ctx.stateOf("<gate-target>"))`.
 
 const GhTasks: GhTasksApi
   Typed task functions for the `gh` GitHub CLI.
@@ -55,11 +118,67 @@ class GhSettings extends ToolSettings
     it renders the bare `--name`. Repeatable.
   override protected buildArgs(): string[]
 
+class GithubWorkflowSettings
+  Configuration for {@link githubWorkflow}, set through a settings lambda. Every
+  setter returns `this` so calls chain; `repo` and `workflow` are required.
+
+  repo_?: string
+    The `OWNER/REPO` slug the workflow lives in.
+  workflow_?: string
+    The workflow file name (e.g. `e2e.yml`) or its numeric id.
+  ref_: string
+    The git ref to dispatch against (default `main`).
+  inputs_: Record<string, string>
+    Extra `workflow_dispatch` inputs.
+  markerInput_: string
+    The input name the marker is passed as (default `zuke_marker`).
+  pollIntervalMs_?: number
+    Poll interval hint (ms) for `zuke resume --check`.
+  repo(slug: string): this
+    Set the `OWNER/REPO` the workflow lives in.
+  workflow(idOrFile: string): this
+    Set the workflow file name (e.g. `e2e.yml`) or numeric id.
+  ref(ref: string): this
+    Set the git ref to dispatch against (default `main`).
+  input(name: string, value: string): this
+    Add one `workflow_dispatch` input.
+  inputs(map: Record<string, string>): this
+    Merge a map of `workflow_dispatch` inputs.
+  markerInput(name: string): this
+    Change the input name the correlation marker is dispatched as.
+  pollEvery(duration: string): this
+    Set how often `zuke resume --check` should re-poll (a duration string).
+
 interface GhTasksApi
   The shape of {@link GhTasks}.
 
   run(configure?: Configure<GhSettings>): Promise<CommandOutput>
     Run a `gh` command.
+
+interface WorkflowJob
+  One job's outcome within a completed workflow run.
+
+  name: string
+    The job's name.
+  conclusion: string
+    Its conclusion (`success`, `failure`, `cancelled`, `skipped`, …).
+  url: string
+    A link to the job on GitHub.
+
+interface WorkflowResult
+  The payload a completed {@link githubWorkflow} wait writes to the awaiting
+  target's state; read it in a dependent body with {@link readWorkflowResult}.
+
+  passed: boolean
+    True when the run's overall conclusion was `success`.
+  conclusion: string
+    The run's overall conclusion.
+  runId: number
+    The dispatched run's numeric id.
+  url: string
+    A link to the run on GitHub.
+  jobs: WorkflowJob[]
+    Each job's conclusion, so a build can branch on which suite failed.
 ````
 
 </details>

--- a/packages/gh/mod.ts
+++ b/packages/gh/mod.ts
@@ -1,15 +1,27 @@
 /**
- * `@zuke/gh` — a typed `gh` (GitHub CLI) task wrapper for Zuke builds.
- *
- * A flexible command builder: name the command with `.command(...)`, set
- * `--repo`, and pass anything else with `.flag(...)`.
+ * `@zuke/gh` — typed GitHub tooling for Zuke builds: the `gh` (GitHub CLI) task
+ * wrapper plus {@link githubWorkflow}, a wait trigger that dispatches and awaits
+ * an external GitHub Actions workflow.
  *
  * ```ts
- * import { GhTasks } from "jsr:@zuke/gh";
+ * import { GhTasks, githubWorkflow } from "jsr:@zuke/gh";
+ *
  * await GhTasks.run((s) => s.command("pr", "list").flag("state", "open"));
+ *
+ * // In a build: suspend until an e2e workflow in another repo finishes.
+ * e2e = target().waitsFor((s) =>
+ *   s.on(githubWorkflow((g) => g.repo("acme/app").workflow("e2e.yml")))
+ * );
  * ```
  *
  * @module
  */
 
 export * from "./src/gh.ts";
+export {
+  githubWorkflow,
+  GithubWorkflowSettings,
+  readWorkflowResult,
+  type WorkflowJob,
+  type WorkflowResult,
+} from "./src/workflow.ts";

--- a/packages/gh/src/workflow.ts
+++ b/packages/gh/src/workflow.ts
@@ -1,0 +1,561 @@
+/**
+ * {@link githubWorkflow} — a Zuke {@link "@zuke/core".WaitTrigger} that
+ * dispatches a GitHub Actions workflow (often in **another repo**), suspends the
+ * run until it finishes, and resurfaces its per-job conclusions to the target's
+ * body. It replaces the hand-rolled "dispatch, then poll `gh run list`" glue.
+ *
+ * Used inside a `.waitsFor(...)` gate:
+ *
+ * ```ts
+ * import { Build, run, target } from "jsr:@zuke/core";
+ * import { githubWorkflow, readWorkflowResult } from "jsr:@zuke/gh";
+ *
+ * class Release extends Build {
+ *   e2e = target().waitsFor((s) =>
+ *     s.on(
+ *       githubWorkflow((g) =>
+ *         g.repo("acme/app").workflow("e2e.yml").ref("main")
+ *       ),
+ *     ).timeout("2h").onTimeout(() => this.rollback)
+ *   );
+ *   ship = target().dependsOn(this.e2e).executes((ctx) => {
+ *     // The result lives on the gate target's state — read it via stateOf.
+ *     const result = readWorkflowResult(ctx.stateOf("e2e"));
+ *     if (!result?.passed) throw new Error("e2e suite failed");
+ *   });
+ *   rollback = target().executes(() => rollBack());
+ * }
+ * ```
+ *
+ * **Correlation.** GitHub's `workflow_dispatch` API returns no run id, so the
+ * trigger dispatches with a marker input (default `zuke_marker`) and finds the
+ * run by matching that marker against the run's display title. The dispatched
+ * workflow must echo the marker into its `run-name` for this to work:
+ *
+ * ```yaml
+ * on: { workflow_dispatch: { inputs: { zuke_marker: { required: false } } } }
+ * run-name: ${{ inputs.zuke_marker }}
+ * ```
+ *
+ * The marker (`zuke:<runId>:<target>`) and the resolved run id are persisted in
+ * the awaiting target's durable state, so a resume in a **different process**
+ * never re-dispatches — it polls the run it already started.
+ *
+ * **Auth & testing.** The default transport calls the GitHub REST API with
+ * `fetch`, authenticated by `GH_TOKEN` / `GITHUB_TOKEN`. The transport is an
+ * injectable seam ({@link GhWorkflowApi}), so tests drive the whole state
+ * machine with a fake — no network, no real GitHub.
+ *
+ * @module
+ */
+
+import type {
+  JsonValue,
+  SignalRecord,
+  TargetStateHandle,
+  WaitContext,
+  WaitTrigger,
+} from "@zuke/core";
+import { parseDuration } from "@zuke/core";
+
+/** One job's outcome within a completed workflow run. */
+export interface WorkflowJob {
+  /** The job's name. */
+  name: string;
+  /** Its conclusion (`success`, `failure`, `cancelled`, `skipped`, …). */
+  conclusion: string;
+  /** A link to the job on GitHub. */
+  url: string;
+}
+
+/**
+ * The payload a completed {@link githubWorkflow} wait writes to the awaiting
+ * target's state; read it in a dependent body with {@link readWorkflowResult}.
+ */
+export interface WorkflowResult {
+  /** True when the run's overall conclusion was `success`. */
+  passed: boolean;
+  /** The run's overall conclusion. */
+  conclusion: string;
+  /** The dispatched run's numeric id. */
+  runId: number;
+  /** A link to the run on GitHub. */
+  url: string;
+  /** Each job's conclusion, so a build can branch on which suite failed. */
+  jobs: WorkflowJob[];
+}
+
+/** A workflow run's current state, as returned by a {@link GhWorkflowApi}. */
+export interface WorkflowRun {
+  /** The run's numeric id. */
+  id: number;
+  /** Its lifecycle status (`queued`, `in_progress`, `completed`). */
+  status: string;
+  /** Its conclusion once completed, else `null`. */
+  conclusion: string | null;
+  /** A link to the run on GitHub. */
+  url: string;
+}
+
+/**
+ * The slice of the GitHub Actions API {@link githubWorkflow} needs, behind an
+ * interface so tests inject a fake and the trigger stays transport-agnostic.
+ */
+export interface GhWorkflowApi {
+  /** Dispatch `workflow` in `repo` on `ref` with `inputs` (a `workflow_dispatch`). */
+  dispatch(
+    repo: string,
+    workflow: string,
+    ref: string,
+    inputs: Record<string, string>,
+  ): Promise<void>;
+  /** The most recent run of `workflow` whose display title equals `marker`, or `null`. */
+  findRun(
+    repo: string,
+    workflow: string,
+    marker: string,
+  ): Promise<WorkflowRun | null>;
+  /** The current state of run `runId`. */
+  getRun(repo: string, runId: number): Promise<WorkflowRun>;
+  /** The jobs of run `runId`. */
+  listJobs(repo: string, runId: number): Promise<WorkflowJob[]>;
+}
+
+/**
+ * Configuration for {@link githubWorkflow}, set through a settings lambda. Every
+ * setter returns `this` so calls chain; `repo` and `workflow` are required.
+ */
+export class GithubWorkflowSettings {
+  /** The `OWNER/REPO` slug the workflow lives in. */
+  repo_?: string;
+  /** The workflow file name (e.g. `e2e.yml`) or its numeric id. */
+  workflow_?: string;
+  /** The git ref to dispatch against (default `main`). */
+  ref_ = "main";
+  /** Extra `workflow_dispatch` inputs. */
+  inputs_: Record<string, string> = {};
+  /** The input name the marker is passed as (default `zuke_marker`). */
+  markerInput_ = "zuke_marker";
+  /** Poll interval hint (ms) for `zuke resume --check`. */
+  pollIntervalMs_?: number;
+
+  /** Set the `OWNER/REPO` the workflow lives in. */
+  repo(slug: string): this {
+    this.repo_ = slug;
+    return this;
+  }
+
+  /** Set the workflow file name (e.g. `e2e.yml`) or numeric id. */
+  workflow(idOrFile: string): this {
+    this.workflow_ = idOrFile;
+    return this;
+  }
+
+  /** Set the git ref to dispatch against (default `main`). */
+  ref(ref: string): this {
+    this.ref_ = ref;
+    return this;
+  }
+
+  /** Add one `workflow_dispatch` input. */
+  input(name: string, value: string): this {
+    this.inputs_[name] = value;
+    return this;
+  }
+
+  /** Merge a map of `workflow_dispatch` inputs. */
+  inputs(map: Record<string, string>): this {
+    Object.assign(this.inputs_, map);
+    return this;
+  }
+
+  /** Change the input name the correlation marker is dispatched as. */
+  markerInput(name: string): this {
+    this.markerInput_ = name;
+    return this;
+  }
+
+  /** Set how often `zuke resume --check` should re-poll (a duration string). */
+  pollEvery(duration: string): this {
+    this.pollIntervalMs_ = parseDuration(duration);
+    return this;
+  }
+}
+
+/** Narrow a {@link JsonValue} to a JSON object, else `undefined`. */
+function asRecord(
+  value: JsonValue | undefined,
+): Record<string, JsonValue> | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+  return value;
+}
+
+/** Read a string field of a JSON object, or `undefined`. */
+function readStr(
+  object: Record<string, JsonValue>,
+  key: string,
+): string | undefined {
+  const value = object[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+/** Read a number field of a JSON object, or `undefined`. */
+function readNum(
+  object: Record<string, JsonValue>,
+  key: string,
+): number | undefined {
+  const value = object[key];
+  return typeof value === "number" ? value : undefined;
+}
+
+/**
+ * Read the {@link WorkflowResult} a completed {@link githubWorkflow} wait wrote
+ * to a target's state, or `undefined` if the wait has not completed (or this is
+ * not a github-workflow gate). Call it from a **dependent** target's body with
+ * the gate's handle: `readWorkflowResult(ctx.stateOf("<gate-target>"))`.
+ */
+export function readWorkflowResult(
+  state: TargetStateHandle,
+): WorkflowResult | undefined {
+  const entry = asRecord(state.get()[STATE_KEY]);
+  const result = entry === undefined ? undefined : asRecord(entry.result);
+  if (result === undefined) return undefined;
+  const runId = readNum(result, "runId");
+  const conclusion = readStr(result, "conclusion");
+  const url = readStr(result, "url");
+  if (runId === undefined || conclusion === undefined || url === undefined) {
+    return undefined;
+  }
+  const rawJobs = result.jobs;
+  const jobs: WorkflowJob[] = [];
+  if (Array.isArray(rawJobs)) {
+    for (const raw of rawJobs) {
+      const job = asRecord(raw);
+      if (job === undefined) continue;
+      jobs.push({
+        name: readStr(job, "name") ?? "",
+        conclusion: readStr(job, "conclusion") ?? "",
+        url: readStr(job, "url") ?? "",
+      });
+    }
+  }
+  return { passed: result.passed === true, conclusion, runId, url, jobs };
+}
+
+/** The key the trigger's durable correlation state lives under in target meta. */
+const STATE_KEY = "githubWorkflow";
+
+/** Serialise the trigger's correlation state to a JSON patch for `state.set`. */
+function persist(
+  state: TargetStateHandle,
+  data: {
+    marker: string;
+    runId?: number;
+    result?: WorkflowResult;
+  },
+): Promise<void> {
+  const value: Record<string, JsonValue> = {
+    dispatched: true,
+    marker: data.marker,
+  };
+  if (data.runId !== undefined) value.runId = data.runId;
+  if (data.result !== undefined) {
+    value.done = true;
+    value.result = {
+      passed: data.result.passed,
+      conclusion: data.result.conclusion,
+      runId: data.result.runId,
+      url: data.result.url,
+      jobs: data.result.jobs.map((j) => ({
+        name: j.name,
+        conclusion: j.conclusion,
+        url: j.url,
+      })),
+    };
+  }
+  return state.set({ [STATE_KEY]: value });
+}
+
+/** Read a JSON header value from the environment (`GH_TOKEN`, then `GITHUB_TOKEN`). */
+function resolveToken(
+  readEnv: (name: string) => string | undefined,
+): string | undefined {
+  return readEnv("GH_TOKEN") ?? readEnv("GITHUB_TOKEN");
+}
+
+/** The GitHub REST base, overridable for tests/GHES. */
+const API_BASE = "https://api.github.com";
+
+/** The default per-request timeout (ms) — a hung GitHub call must not wedge a poll. */
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/** How many pages of `per_page=100` runs `findRun` scans before giving up. */
+const MAX_RUN_PAGES = 5;
+
+/** The default {@link GhWorkflowApi}: the GitHub REST API over `fetch`. */
+export class RestGhWorkflowApi implements GhWorkflowApi {
+  readonly #fetch: typeof fetch;
+  readonly #token: string | undefined;
+  readonly #base: string;
+  readonly #timeoutMs: number;
+
+  /** Build the transport from a `fetch` seam, a token, and options. */
+  constructor(
+    options: {
+      fetch?: typeof fetch;
+      token?: string;
+      base?: string;
+      timeoutMs?: number;
+    } = {},
+  ) {
+    this.#fetch = options.fetch ?? fetch;
+    this.#token = options.token;
+    this.#base = options.base ?? API_BASE;
+    this.#timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  /** The headers every request carries (auth + the pinned API version). */
+  #headers(): Record<string, string> {
+    const headers: Record<string, string> = {
+      "accept": "application/vnd.github+json",
+      "x-github-api-version": "2022-11-28",
+    };
+    if (this.#token !== undefined) {
+      headers.authorization = `Bearer ${this.#token}`;
+    }
+    return headers;
+  }
+
+  /**
+   * Run `fn` with an {@link AbortSignal} that fires after the request timeout, so
+   * a GitHub endpoint that accepts the connection but never responds aborts
+   * rather than hanging a `resume --check` sweep forever. A manual controller +
+   * cleared timer (not `AbortSignal.timeout`) so no timer lingers past the call.
+   */
+  async #withTimeout<T>(fn: (signal: AbortSignal) => Promise<T>): Promise<T> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.#timeoutMs);
+    try {
+      return await fn(controller.signal);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /** GET a JSON body, throwing on a non-2xx response (bounded by the timeout). */
+  #get(path: string): Promise<Record<string, JsonValue>> {
+    return this.#withTimeout(async (signal) => {
+      const response = await this.#fetch(`${this.#base}${path}`, {
+        headers: this.#headers(),
+        signal,
+      });
+      if (!response.ok) {
+        await response.body?.cancel();
+        throw new Error(`gh workflow: GET ${path} → ${response.status}`);
+      }
+      return asRecord(await response.json()) ?? {};
+    });
+  }
+
+  /** Dispatch a `workflow_dispatch` event (bounded by the timeout). */
+  dispatch(
+    repo: string,
+    workflow: string,
+    ref: string,
+    inputs: Record<string, string>,
+  ): Promise<void> {
+    const path = `/repos/${repo}/actions/workflows/${workflow}/dispatches`;
+    return this.#withTimeout(async (signal) => {
+      const response = await this.#fetch(`${this.#base}${path}`, {
+        method: "POST",
+        headers: { ...this.#headers(), "content-type": "application/json" },
+        body: JSON.stringify({ ref, inputs }),
+        signal,
+      });
+      await response.body?.cancel();
+      if (!response.ok) {
+        throw new Error(
+          `gh workflow: dispatch ${workflow} → ${response.status}`,
+        );
+      }
+    });
+  }
+
+  /**
+   * Find the newest run of `workflow` whose display title equals `marker`,
+   * paginating so a run that has scrolled past the first page in a busy repo is
+   * still correlated (up to {@link MAX_RUN_PAGES} pages of 100).
+   */
+  async findRun(
+    repo: string,
+    workflow: string,
+    marker: string,
+  ): Promise<WorkflowRun | null> {
+    for (let page = 1; page <= MAX_RUN_PAGES; page++) {
+      const body = await this.#get(
+        `/repos/${repo}/actions/workflows/${workflow}/runs?per_page=100&page=${page}`,
+      );
+      const runs = body.workflow_runs;
+      if (!Array.isArray(runs)) return null;
+      for (const raw of runs) {
+        const run = asRecord(raw);
+        if (run === undefined) continue;
+        if (readStr(run, "display_title") === marker) return toRun(run);
+      }
+      if (runs.length < 100) break; // last page reached
+    }
+    return null;
+  }
+
+  /** Fetch a run's current state. */
+  async getRun(repo: string, runId: number): Promise<WorkflowRun> {
+    return toRun(await this.#get(`/repos/${repo}/actions/runs/${runId}`));
+  }
+
+  /** List a run's jobs. */
+  async listJobs(repo: string, runId: number): Promise<WorkflowJob[]> {
+    const body = await this.#get(`/repos/${repo}/actions/runs/${runId}/jobs`);
+    const rawJobs = body.jobs;
+    const jobs: WorkflowJob[] = [];
+    if (Array.isArray(rawJobs)) {
+      for (const raw of rawJobs) {
+        const job = asRecord(raw);
+        if (job === undefined) continue;
+        jobs.push({
+          name: readStr(job, "name") ?? "",
+          conclusion: readStr(job, "conclusion") ?? "",
+          url: readStr(job, "html_url") ?? "",
+        });
+      }
+    }
+    return jobs;
+  }
+}
+
+/** Narrow a GitHub run JSON object into a {@link WorkflowRun}. */
+function toRun(run: Record<string, JsonValue>): WorkflowRun {
+  return {
+    id: readNum(run, "id") ?? 0,
+    status: readStr(run, "status") ?? "unknown",
+    conclusion: readStr(run, "conclusion") ?? null,
+    url: readStr(run, "html_url") ?? "",
+  };
+}
+
+/** Injectable dependencies for {@link githubWorkflowWith} — the test seams. */
+export interface GithubWorkflowDeps {
+  /** A transport to use directly, bypassing the REST implementation (tests). */
+  api?: GhWorkflowApi;
+  /** The `fetch` seam handed to the default REST transport (tests). */
+  fetch?: typeof fetch;
+  /** Environment reader for the token; defaults to `Deno.env.get`. */
+  readEnv?: (name: string) => string | undefined;
+}
+
+/** Read an environment variable, treating missing env access as unset. */
+function defaultReadEnv(name: string): string | undefined {
+  try {
+    return Deno.env.get(name);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * {@link githubWorkflow} with injectable dependencies — the entry point both the
+ * public factory and the tests call.
+ */
+export function githubWorkflowWith(
+  configure: (settings: GithubWorkflowSettings) => GithubWorkflowSettings,
+  deps: GithubWorkflowDeps,
+): WaitTrigger {
+  const settings = configure(new GithubWorkflowSettings());
+  const repo = settings.repo_;
+  const workflow = settings.workflow_;
+  if (repo === undefined || workflow === undefined) {
+    throw new Error(
+      "githubWorkflow(...) needs a repo and a workflow — call s.repo(...).workflow(...).",
+    );
+  }
+  const api = deps.api ??
+    new RestGhWorkflowApi({
+      fetch: deps.fetch,
+      token: resolveToken(deps.readEnv ?? defaultReadEnv),
+    });
+
+  return {
+    descriptor: `github:${repo}:${workflow}`,
+    pollIntervalMs: settings.pollIntervalMs_,
+    async isSatisfied(
+      _signals: ReadonlyMap<string, SignalRecord>,
+      ctx: WaitContext,
+    ): Promise<boolean> {
+      const entry = asRecord(ctx.state.get()[STATE_KEY]);
+      if (entry !== undefined && entry.done === true) return true;
+      const marker = (entry && readStr(entry, "marker")) ??
+        `zuke:${ctx.runId}:${ctx.target}`;
+      const dispatched = entry !== undefined && entry.dispatched === true;
+
+      // 1. Dispatch once, then suspend until a later poll.
+      if (!dispatched) {
+        await api.dispatch(repo, workflow, settings.ref_, {
+          ...settings.inputs_,
+          [settings.markerInput_]: marker,
+        });
+        await persist(ctx.state, { marker });
+        return false;
+      }
+
+      // The run is dispatched; the rest is polling GitHub. A transient error
+      // here (a 5xx, a rate-limit, a network blip, a timeout) must NOT fail the
+      // build — it is treated as "not ready yet", so the wait stays suspended
+      // and retries on the next `zuke resume --check`. The persisted marker/runId
+      // are preserved, so no dispatch or correlation work is lost.
+      try {
+        // 2. Correlate the dispatched run by its marker, once it appears.
+        let runId = entry === undefined ? undefined : readNum(entry, "runId");
+        if (runId === undefined) {
+          const run = await api.findRun(repo, workflow, marker);
+          if (run === null) return false;
+          runId = run.id;
+          await persist(ctx.state, { marker, runId });
+        }
+
+        // 3. Poll until it completes, then record the per-job result.
+        const run = await api.getRun(repo, runId);
+        if (run.status !== "completed") return false;
+        const jobs = await api.listJobs(repo, runId);
+        const result: WorkflowResult = {
+          passed: run.conclusion === "success",
+          conclusion: run.conclusion ?? "unknown",
+          runId,
+          url: run.url,
+          jobs,
+        };
+        await persist(ctx.state, { marker, runId, result });
+        return true;
+      } catch {
+        // Stay suspended and poll again next check.
+        return false;
+      }
+    },
+  };
+}
+
+/**
+ * A {@link "@zuke/core".WaitTrigger} that dispatches a GitHub Actions workflow,
+ * suspends the run until it finishes, and records its per-job conclusions to the
+ * awaiting target's state (read them with {@link readWorkflowResult}). See the
+ * module docs for the `run-name` correlation requirement and auth.
+ *
+ * ```ts
+ * githubWorkflow((g) => g.repo("acme/app").workflow("e2e.yml").ref("main"))
+ * ```
+ */
+export function githubWorkflow(
+  configure: (settings: GithubWorkflowSettings) => GithubWorkflowSettings,
+): WaitTrigger {
+  return githubWorkflowWith(configure, {});
+}

--- a/packages/gh/tests/workflow_test.ts
+++ b/packages/gh/tests/workflow_test.ts
@@ -1,0 +1,495 @@
+import {
+  assertEquals,
+  assertRejects,
+  assertThrows,
+} from "../../core/tests/_assert.ts";
+import type {
+  JsonValue,
+  SignalRecord,
+  TargetStateHandle,
+  WaitContext,
+} from "@zuke/core";
+import {
+  type GhWorkflowApi,
+  githubWorkflow,
+  githubWorkflowWith,
+  readWorkflowResult,
+  RestGhWorkflowApi,
+  type WorkflowJob,
+  type WorkflowRun,
+} from "../src/workflow.ts";
+
+/** The global `fetch` signature, aliased so a local can be annotated. */
+type FetchFn = typeof globalThis.fetch;
+
+const NO_SIGNALS: ReadonlyMap<string, SignalRecord> = new Map();
+
+/** An in-memory {@link TargetStateHandle} for driving the trigger. */
+function fakeState(
+  initial: Record<string, JsonValue> = {},
+): TargetStateHandle {
+  let meta: Record<string, JsonValue> = { ...initial };
+  return {
+    get: () => meta,
+    set: (patch) => {
+      meta = { ...meta, ...patch };
+      return Promise.resolve();
+    },
+  };
+}
+
+/** A wait context over a fresh fake state handle. */
+function ctx(state: TargetStateHandle): WaitContext {
+  return { state, runId: "r1", target: "e2e" };
+}
+
+/** A scripted {@link GhWorkflowApi} whose run status/conclusion the test drives. */
+class ScriptedApi implements GhWorkflowApi {
+  dispatches: Array<{ ref: string; inputs: Record<string, string> }> = [];
+  status = "in_progress";
+  conclusion: string | null = null;
+  appears = true; // whether findRun can locate the dispatched run
+  jobs: WorkflowJob[] = [
+    { name: "build", conclusion: "success", url: "https://gh/j1" },
+  ];
+
+  dispatch(
+    _repo: string,
+    _workflow: string,
+    ref: string,
+    inputs: Record<string, string>,
+  ): Promise<void> {
+    this.dispatches.push({ ref, inputs });
+    return Promise.resolve();
+  }
+  findRun(): Promise<WorkflowRun | null> {
+    return Promise.resolve(
+      this.appears
+        ? {
+          id: 100,
+          status: this.status,
+          conclusion: this.conclusion,
+          url: "https://gh/r100",
+        }
+        : null,
+    );
+  }
+  getRun(): Promise<WorkflowRun> {
+    return Promise.resolve({
+      id: 100,
+      status: this.status,
+      conclusion: this.conclusion,
+      url: "https://gh/r100",
+    });
+  }
+  listJobs(): Promise<WorkflowJob[]> {
+    return Promise.resolve(this.jobs);
+  }
+}
+
+Deno.test("githubWorkflow requires a repo and a workflow", () => {
+  assertThrows(() => githubWorkflow((g) => g), Error, "repo and a workflow");
+  assertThrows(
+    () => githubWorkflow((g) => g.repo("acme/app")),
+    Error,
+    "repo and a workflow",
+  );
+});
+
+Deno.test("descriptor and poll interval reflect the settings", () => {
+  const trigger = githubWorkflow((g) =>
+    g.repo("acme/app").workflow("e2e.yml").pollEvery("30s")
+  );
+  assertEquals(trigger.descriptor, "github:acme/app:e2e.yml");
+  assertEquals(trigger.pollIntervalMs, 30_000);
+});
+
+Deno.test("first evaluation dispatches with a marker and suspends", async () => {
+  const api = new ScriptedApi();
+  const state = fakeState();
+  const trigger = githubWorkflowWith(
+    (g) =>
+      g.repo("acme/app").workflow("e2e.yml").ref("release").input(
+        "env",
+        "prod",
+      ),
+    { api },
+  );
+  assertEquals(await trigger.isSatisfied(NO_SIGNALS, ctx(state)), false);
+  assertEquals(api.dispatches.length, 1);
+  assertEquals(api.dispatches[0].ref, "release");
+  assertEquals(api.dispatches[0].inputs.env, "prod");
+  assertEquals(api.dispatches[0].inputs.zuke_marker, "zuke:r1:e2e");
+});
+
+Deno.test("polls until the run completes, then records the per-job result", async () => {
+  const api = new ScriptedApi();
+  const state = fakeState();
+  const trigger = githubWorkflowWith(
+    (g) => g.repo("acme/app").workflow("e2e.yml"),
+    { api },
+  );
+  const c = ctx(state);
+
+  // Dispatch, then a poll while still running.
+  assertEquals(await trigger.isSatisfied(NO_SIGNALS, c), false); // dispatch
+  assertEquals(await trigger.isSatisfied(NO_SIGNALS, c), false); // in_progress
+  assertEquals(api.dispatches.length, 1); // never re-dispatches
+
+  // Completes successfully.
+  api.status = "completed";
+  api.conclusion = "success";
+  assertEquals(await trigger.isSatisfied(NO_SIGNALS, c), true);
+
+  const result = readWorkflowResult(state);
+  assertEquals(result?.passed, true);
+  assertEquals(result?.conclusion, "success");
+  assertEquals(result?.runId, 100);
+  assertEquals(result?.jobs, [
+    { name: "build", conclusion: "success", url: "https://gh/j1" },
+  ]);
+});
+
+Deno.test("a failed run yields passed:false", async () => {
+  const api = new ScriptedApi();
+  api.status = "completed";
+  api.conclusion = "failure";
+  const state = fakeState();
+  const trigger = githubWorkflowWith((g) => g.repo("a/b").workflow("w"), {
+    api,
+  });
+  const c = ctx(state);
+  await trigger.isSatisfied(NO_SIGNALS, c); // dispatch
+  assertEquals(await trigger.isSatisfied(NO_SIGNALS, c), true);
+  assertEquals(readWorkflowResult(state)?.passed, false);
+});
+
+Deno.test("waits for the run to appear before polling it", async () => {
+  const api = new ScriptedApi();
+  api.appears = false;
+  const state = fakeState();
+  const trigger = githubWorkflowWith((g) => g.repo("a/b").workflow("w"), {
+    api,
+  });
+  const c = ctx(state);
+  await trigger.isSatisfied(NO_SIGNALS, c); // dispatch
+  assertEquals(await trigger.isSatisfied(NO_SIGNALS, c), false); // not found yet
+});
+
+Deno.test("a transient poll error re-suspends instead of failing the run", async () => {
+  let failJobs = true;
+  const api: GhWorkflowApi = {
+    dispatch: () => Promise.resolve(),
+    findRun: () =>
+      Promise.resolve({
+        id: 100,
+        status: "completed",
+        conclusion: "success",
+        url: "u",
+      }),
+    getRun: () =>
+      Promise.resolve({
+        id: 100,
+        status: "completed",
+        conclusion: "success",
+        url: "u",
+      }),
+    listJobs: () =>
+      failJobs
+        ? Promise.reject(new Error("gh workflow: GET /jobs → 502"))
+        : Promise.resolve([{ name: "build", conclusion: "success", url: "j" }]),
+  };
+  const state = fakeState();
+  const trigger = githubWorkflowWith((g) => g.repo("a/b").workflow("w"), {
+    api,
+  });
+  const c = ctx(state);
+  await trigger.isSatisfied(NO_SIGNALS, c); // dispatch
+  // The run completed, but listJobs throws transiently: stay suspended, not fail.
+  assertEquals(await trigger.isSatisfied(NO_SIGNALS, c), false);
+  assertEquals(readWorkflowResult(state), undefined); // nothing recorded yet
+  // The blip clears: the next check completes and records the result.
+  failJobs = false;
+  assertEquals(await trigger.isSatisfied(NO_SIGNALS, c), true);
+  assertEquals(readWorkflowResult(state)?.passed, true);
+});
+
+Deno.test("a satisfied wait stays satisfied and never re-dispatches", async () => {
+  const api = new ScriptedApi();
+  api.status = "completed";
+  api.conclusion = "success";
+  const state = fakeState();
+  const trigger = githubWorkflowWith((g) => g.repo("a/b").workflow("w"), {
+    api,
+  });
+  const c = ctx(state);
+  await trigger.isSatisfied(NO_SIGNALS, c); // dispatch
+  assertEquals(await trigger.isSatisfied(NO_SIGNALS, c), true); // completes
+  assertEquals(await trigger.isSatisfied(NO_SIGNALS, c), true); // idempotent
+  assertEquals(api.dispatches.length, 1);
+});
+
+Deno.test("inputs() and markerInput() feed the dispatch", async () => {
+  const api = new ScriptedApi();
+  const trigger = githubWorkflowWith(
+    (g) =>
+      g.repo("a/b").workflow("w").inputs({ env: "prod" }).markerInput("mark"),
+    { api },
+  );
+  await trigger.isSatisfied(NO_SIGNALS, ctx(fakeState()));
+  assertEquals(api.dispatches[0].inputs.env, "prod");
+  assertEquals(api.dispatches[0].inputs.mark, "zuke:r1:e2e"); // custom marker input
+  assertEquals(api.dispatches[0].inputs.zuke_marker, undefined);
+});
+
+Deno.test("readWorkflowResult returns undefined until the wait completes", () => {
+  assertEquals(readWorkflowResult(fakeState()), undefined);
+  assertEquals(
+    readWorkflowResult(fakeState({ githubWorkflow: { dispatched: true } })),
+    undefined,
+  );
+  // A malformed result (missing fields) is rejected, not partially returned.
+  assertEquals(
+    readWorkflowResult(
+      fakeState({ githubWorkflow: { result: { passed: true } } }),
+    ),
+    undefined,
+  );
+});
+
+Deno.test("readWorkflowResult tolerates malformed jobs", () => {
+  const state = fakeState({
+    githubWorkflow: {
+      result: {
+        runId: 1,
+        conclusion: "success",
+        url: "u",
+        passed: true,
+        jobs: [null, { name: "x" }],
+      },
+    },
+  });
+  // A non-object job is skipped; missing string fields default to "".
+  assertEquals(readWorkflowResult(state)?.jobs, [
+    { name: "x", conclusion: "", url: "" },
+  ]);
+});
+
+// --- The default REST transport, over a fake fetch --------------------------
+
+/** A fake `fetch` routing by `METHOD url` to a canned JSON response. */
+function routerFetch(
+  routes: Record<string, unknown>,
+): { fetch: FetchFn; calls: Array<{ url: string; init?: RequestInit }> } {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fetch: FetchFn = (input, init) => {
+    const url = String(input);
+    calls.push({ url, init });
+    const key = `${init?.method ?? "GET"} ${url}`;
+    const body = routes[key];
+    if (body === undefined) {
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify(body), { status: 200 }),
+    );
+  };
+  return { fetch, calls };
+}
+
+Deno.test("RestGhWorkflowApi.dispatch POSTs ref+inputs with auth", async () => {
+  const { fetch, calls } = routerFetch({
+    "POST https://api.github.com/repos/a/b/actions/workflows/w.yml/dispatches":
+      {},
+  });
+  const api = new RestGhWorkflowApi({ fetch, token: "t0ken" });
+  await api.dispatch("a/b", "w.yml", "main", { zuke_marker: "m" });
+  assertEquals(calls.length, 1);
+  assertEquals(calls[0].init?.method, "POST");
+  assertEquals(
+    new Headers(calls[0].init?.headers).get("authorization"),
+    "Bearer t0ken",
+  );
+  assertEquals(
+    calls[0].init?.body,
+    JSON.stringify({ ref: "main", inputs: { zuke_marker: "m" } }),
+  );
+});
+
+Deno.test("RestGhWorkflowApi.findRun matches the run by display title", async () => {
+  const { fetch } = routerFetch({
+    "GET https://api.github.com/repos/a/b/actions/workflows/w.yml/runs?per_page=100&page=1":
+      {
+        workflow_runs: [
+          {
+            id: 1,
+            display_title: "other",
+            status: "completed",
+            html_url: "u1",
+          },
+          {
+            id: 2,
+            display_title: "zuke:r1:e2e",
+            status: "in_progress",
+            conclusion: null,
+            html_url: "u2",
+          },
+        ],
+      },
+  });
+  const api = new RestGhWorkflowApi({ fetch });
+  const run = await api.findRun("a/b", "w.yml", "zuke:r1:e2e");
+  assertEquals(run?.id, 2);
+  assertEquals(run?.url, "u2");
+});
+
+Deno.test("RestGhWorkflowApi.findRun returns null when no run matches", async () => {
+  const { fetch } = routerFetch({
+    "GET https://api.github.com/repos/a/b/actions/workflows/w.yml/runs?per_page=100&page=1":
+      {
+        workflow_runs: [],
+      },
+  });
+  const api = new RestGhWorkflowApi({ fetch });
+  assertEquals(await api.findRun("a/b", "w.yml", "m"), null);
+});
+
+Deno.test("RestGhWorkflowApi.getRun and listJobs map the GitHub shape", async () => {
+  const { fetch } = routerFetch({
+    "GET https://api.github.com/repos/a/b/actions/runs/9": {
+      id: 9,
+      status: "completed",
+      conclusion: "success",
+      html_url: "run-url",
+    },
+    "GET https://api.github.com/repos/a/b/actions/runs/9/jobs": {
+      jobs: [{ name: "unit", conclusion: "failure", html_url: "job-url" }],
+    },
+  });
+  const api = new RestGhWorkflowApi({ fetch });
+  const run = await api.getRun("a/b", 9);
+  assertEquals(run, {
+    id: 9,
+    status: "completed",
+    conclusion: "success",
+    url: "run-url",
+  });
+  const jobs = await api.listJobs("a/b", 9);
+  assertEquals(jobs, [{ name: "unit", conclusion: "failure", url: "job-url" }]);
+});
+
+Deno.test("RestGhWorkflowApi throws on a non-2xx GET", async () => {
+  const { fetch } = routerFetch({}); // every route 404s
+  const api = new RestGhWorkflowApi({ fetch });
+  await assertRejects(() => api.getRun("a/b", 1), Error, "404");
+});
+
+Deno.test("RestGhWorkflowApi.dispatch throws on a non-2xx", async () => {
+  const { fetch } = routerFetch({}); // dispatch route 404s
+  const api = new RestGhWorkflowApi({ fetch });
+  await assertRejects(
+    () => api.dispatch("a/b", "w.yml", "main", {}),
+    Error,
+    "dispatch",
+  );
+});
+
+Deno.test("RestGhWorkflowApi.findRun tolerates a malformed runs payload", async () => {
+  const base =
+    "https://api.github.com/repos/a/b/actions/workflows/w.yml/runs?per_page=100&page=1";
+  const notArray = routerFetch({ [`GET ${base}`]: { workflow_runs: "nope" } });
+  assertEquals(
+    await new RestGhWorkflowApi({ fetch: notArray.fetch }).findRun(
+      "a/b",
+      "w.yml",
+      "m",
+    ),
+    null,
+  );
+  const withJunk = routerFetch({
+    [`GET ${base}`]: {
+      workflow_runs: [null, 5, {
+        id: 3,
+        display_title: "m",
+        status: "queued",
+        html_url: "u",
+      }],
+    },
+  });
+  assertEquals(
+    (await new RestGhWorkflowApi({ fetch: withJunk.fetch }).findRun(
+      "a/b",
+      "w.yml",
+      "m",
+    ))?.id,
+    3,
+  );
+});
+
+Deno.test("RestGhWorkflowApi.findRun paginates to a run beyond the first page", async () => {
+  const page1 = Array.from({ length: 100 }, (_, i) => ({
+    id: i + 1,
+    display_title: `noise-${i}`,
+    status: "completed",
+    conclusion: "success",
+    html_url: `u${i}`,
+  }));
+  const w = "https://api.github.com/repos/a/b/actions/workflows/w.yml/runs";
+  const { fetch } = routerFetch({
+    [`GET ${w}?per_page=100&page=1`]: { workflow_runs: page1 },
+    [`GET ${w}?per_page=100&page=2`]: {
+      workflow_runs: [{
+        id: 999,
+        display_title: "zuke:r1:e2e",
+        status: "in_progress",
+        conclusion: null,
+        html_url: "u999",
+      }],
+    },
+  });
+  const run = await new RestGhWorkflowApi({ fetch }).findRun(
+    "a/b",
+    "w.yml",
+    "zuke:r1:e2e",
+  );
+  assertEquals(run?.id, 999); // found on page 2, not just the first 100
+});
+
+Deno.test("RestGhWorkflowApi aborts a hung request via its timeout", async () => {
+  // A fetch that never resolves on its own but honours the AbortSignal.
+  const hung: FetchFn = (_input, init) =>
+    new Promise((_resolve, reject) => {
+      init?.signal?.addEventListener(
+        "abort",
+        () => reject(new DOMException("aborted", "AbortError")),
+      );
+    });
+  const api = new RestGhWorkflowApi({
+    fetch: hung,
+    base: "https://api.test",
+    timeoutMs: 5,
+  });
+  await assertRejects(() => api.getRun("a/b", 1)); // aborts, does not hang
+});
+
+Deno.test("RestGhWorkflowApi maps missing run/job fields to defaults", async () => {
+  const { fetch } = routerFetch({
+    "GET https://api.github.com/repos/a/b/actions/runs/9": {}, // no fields
+    "GET https://api.github.com/repos/a/b/actions/runs/9/jobs": {
+      jobs: [null, {}],
+    },
+  });
+  const api = new RestGhWorkflowApi({ fetch });
+  assertEquals(await api.getRun("a/b", 9), {
+    id: 0,
+    status: "unknown",
+    conclusion: null,
+    url: "",
+  });
+  // The null job is skipped; the empty job defaults every field.
+  assertEquals(await api.listJobs("a/b", 9), [{
+    name: "",
+    conclusion: "",
+    url: "",
+  }]);
+});

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -156,6 +156,11 @@ Before calling any task or settings method, confirm the real shape:
   diagnosed and (opt-in) auto-fixed, with a committable PR suggestion. Override
   `recoverWith()` on the build to apply one fixer to every target. See the
   cheatsheet's AI section.
+- **Wait on an external GitHub workflow (`@zuke/gh`):** in a `.waitsFor(...)`
+  gate, `s.on(githubWorkflow((g) => g.repo("o/r").workflow("e2e.yml")))`
+  dispatches a workflow in another repo and suspends until it finishes; read the
+  per-job result with `readWorkflowResult(ctx.stateOf("<gate>"))`. Triggers are
+  extensible — write your own against the exported `WaitTrigger`/`WaitContext`.
 - **OpenTelemetry export (`@zuke/otel`):** register `otel((s) => s.endpoint(…))`
   as a plugin (`run(MyBuild, { plugins: [otel(…)] })`) to ship run/target spans
   and `zuke.run.started` / `zuke.run.suspended` / `zuke.runs` counters as

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -116,6 +116,8 @@ deploy = target().executes(async (ctx) => {
   ctx.signal; // AbortSignal, fired when the run is cancelled
   ctx.dryRun; // true under a dry run
   await ctx.state.set({ where: "sit-7" }); // durable metadata — see below
+  ctx.stateOf("build").get(); // read ANOTHER target's published state
+  ctx.signals.get("approved"); // an external signal's payload (see waits)
 });
 ```
 
@@ -225,8 +227,12 @@ class Deploy extends Build {
 }
 ```
 
-- Triggers: `externalSignal(name)` (payload read via `ctx.signals`) and
-  `resumeWhen(fn, { interval? })` (async predicate, re-checked on resume).
+- Triggers: `externalSignal(name)` (payload read via `ctx.signals`),
+  `resumeWhen(fn, { interval? })` (async predicate, re-checked on resume), and
+  `githubWorkflow((g) => g.repo(...).workflow(...))` from `@zuke/gh` (dispatches
+  an external GitHub Actions workflow, satisfied when it finishes; read its
+  per-job result with `readWorkflowResult(ctx.stateOf("<gate>"))`). Write your
+  own trigger against the exported `WaitTrigger` / `WaitContext` interface.
 - Needs a state store (a build with `.waitsFor()` enables `.zuke/runs` by
   default). A resume is a fresh process, so **only `ctx.state`/`ctx.signals`
   cross the boundary**. See `docs/orchestration.md`.

--- a/tests/e2e/fixtures/gh_workflow_build.ts
+++ b/tests/e2e/fixtures/gh_workflow_build.ts
@@ -1,0 +1,84 @@
+/**
+ * A runnable Zuke build for the githubWorkflow e2e suite. Run as a subprocess
+ * (`deno run -A gh_workflow_build.ts <target|resume ...>`), it waits on a
+ * `githubWorkflow(...)` gate whose GitHub API is a file-backed fake: `dispatch`
+ * appends the marker to `GH_DISPATCH_FILE`, and the run's status/conclusion come
+ * from `GH_RUN_STATUS` / `GH_RUN_CONCLUSION`. Two real processes — dispatch then
+ * `resume --check` — exercise the cross-process correlation state without a real
+ * GitHub. `run()` reads `ZUKE_STATE_DIR` for its durable state.
+ *
+ * @module
+ */
+
+import { Build, run, target } from "../../../packages/core/mod.ts";
+import type {
+  GhWorkflowApi,
+  WorkflowJob,
+  WorkflowRun,
+} from "../../../packages/gh/src/workflow.ts";
+import {
+  githubWorkflowWith,
+  readWorkflowResult,
+} from "../../../packages/gh/src/workflow.ts";
+
+const dispatchFile = Deno.env.get("GH_DISPATCH_FILE");
+const status = Deno.env.get("GH_RUN_STATUS") ?? "in_progress";
+const conclusion = Deno.env.get("GH_RUN_CONCLUSION") ?? "";
+
+/** A file-backed fake: `dispatch` records the marker; status comes from the env. */
+const api: GhWorkflowApi = {
+  dispatch(_repo, _workflow, _ref, inputs): Promise<void> {
+    if (dispatchFile !== undefined) {
+      Deno.writeTextFileSync(dispatchFile, `${inputs.zuke_marker}\n`, {
+        append: true,
+      });
+    }
+    return Promise.resolve();
+  },
+  findRun(): Promise<WorkflowRun | null> {
+    return Promise.resolve({
+      id: 777,
+      status,
+      conclusion: conclusion === "" ? null : conclusion,
+      url: "https://gh/r777",
+    });
+  },
+  getRun(): Promise<WorkflowRun> {
+    return Promise.resolve({
+      id: 777,
+      status,
+      conclusion: conclusion === "" ? null : conclusion,
+      url: "https://gh/r777",
+    });
+  },
+  listJobs(): Promise<WorkflowJob[]> {
+    return Promise.resolve([
+      {
+        name: "e2e",
+        conclusion: conclusion === "" ? "" : conclusion,
+        url: "j",
+      },
+    ]);
+  },
+};
+
+/** A gate that awaits an external workflow, then a ship step that reads its result. */
+class Cd extends Build {
+  /** Dispatches the workflow and suspends until it completes. */
+  e2e = target().waitsFor((s) =>
+    s.on(
+      githubWorkflowWith((g) => g.repo("acme/app").workflow("e2e.yml"), {
+        api,
+      }),
+    )
+  );
+  /** Runs after the gate opens, printing the gate's published result. */
+  ship = target().dependsOn(this.e2e).executes((ctx) => {
+    const result = readWorkflowResult(ctx.stateOf("e2e"));
+    console.log(
+      `SHIPPED:passed=${result?.passed}:conclusion=${result?.conclusion}`,
+    );
+  });
+}
+
+await run(Cd);

--- a/tests/e2e/gh_workflow_e2e.ts
+++ b/tests/e2e/gh_workflow_e2e.ts
@@ -1,0 +1,90 @@
+/**
+ * End-to-end: a `githubWorkflow(...)` wait across two real processes. Process A
+ * reaches the gate, dispatches (recording the marker to a file), and suspends;
+ * process B runs `resume --check`, sees the (env-driven) workflow completed, and
+ * ships — reading the gate's published per-job result. It proves the durable
+ * {@link "@zuke/core".WaitContext} correlation state survives the process
+ * boundary: process B never re-dispatches, because the `dispatched` flag persists
+ * in the run record. Uses a file-backed fake GitHub API — hermetic, no network.
+ *
+ * Excluded from the fast unit gate (`*_e2e.ts`); run by the `integration` target.
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import {
+  defaultStateHost,
+  FileSystemStateStore,
+} from "../../packages/core/mod.ts";
+
+const FIXTURE = new URL("./fixtures/gh_workflow_build.ts", import.meta.url);
+
+/** The captured result of one fixture subprocess. */
+interface Run {
+  code: number;
+  out: string;
+}
+
+/** Run the fixture as a real `deno` subprocess with the given extra env. */
+async function runFixture(
+  args: string[],
+  dir: string,
+  env: Record<string, string>,
+): Promise<Run> {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: ["run", "-A", FIXTURE.href, ...args],
+    env: { ZUKE_STATE_DIR: dir, ...env },
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const { code, stdout } = await command.output();
+  return { code, out: new TextDecoder().decode(stdout) };
+}
+
+/** The number of non-empty lines in the dispatch file (i.e. dispatch count). */
+async function dispatchCount(file: string): Promise<number> {
+  const text = await Deno.readTextFile(file);
+  return text.split("\n").filter((l) => l !== "").length;
+}
+
+Deno.test("a githubWorkflow wait dispatches once and resumes across processes", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "zuke-gh-workflow-e2e-" });
+  const dispatchFile = `${dir}/dispatches.txt`;
+  await Deno.writeTextFile(dispatchFile, "");
+  try {
+    // Process A: reach the gate, dispatch, suspend (the workflow is not done).
+    const first = await runFixture(["ship"], dir, {
+      GH_DISPATCH_FILE: dispatchFile,
+      GH_RUN_STATUS: "in_progress",
+    });
+    assertEquals(first.code, 0);
+    assertEquals(first.out.includes("SHIPPED"), false);
+    assertEquals(await dispatchCount(dispatchFile), 1);
+
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    const runs = await store.listRuns({});
+    assertEquals(runs.length, 1);
+    const id = runs[0].id;
+    assertEquals(runs[0].status, "suspended");
+
+    // Process B: the workflow has completed; resume --check re-evaluates.
+    const second = await runFixture(["resume", id, "--check"], dir, {
+      GH_DISPATCH_FILE: dispatchFile,
+      GH_RUN_STATUS: "completed",
+      GH_RUN_CONCLUSION: "success",
+    });
+    assertEquals(second.code, 0);
+    assertStringIncludes(second.out, "SHIPPED:passed=true:conclusion=success");
+
+    // The dispatched flag persisted across processes: B did NOT re-dispatch.
+    assertEquals(await dispatchCount(dispatchFile), 1);
+    assertEquals(
+      await store.getRun(id).then((g) => g?.record.status),
+      "succeeded",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/tests/integration/gh_workflow_test.ts
+++ b/tests/integration/gh_workflow_test.ts
@@ -1,0 +1,154 @@
+/**
+ * Integration: a `.waitsFor(githubWorkflow(...))` gate driven through the real
+ * CLI. The GitHub API is a fake, but the executor, the durable state writer, the
+ * suspend, and the `resume --check` re-evaluation are all real — so this proves
+ * the core `WaitContext` seam: the trigger dispatches on first reach, persists
+ * its correlation state, suspends, and a later resume reads that state back and
+ * completes without re-dispatching.
+ */
+
+import { assertEquals } from "../../packages/core/tests/_assert.ts";
+import {
+  Build,
+  defaultStateHost,
+  FileSystemStateStore,
+  target,
+} from "../../packages/core/mod.ts";
+import type {
+  GhWorkflowApi,
+  WorkflowJob,
+  WorkflowRun,
+} from "../../packages/gh/src/workflow.ts";
+import {
+  githubWorkflowWith,
+  readWorkflowResult,
+} from "../../packages/gh/src/workflow.ts";
+import { runCli, withStateDir } from "./_harness.ts";
+
+/** A fake GitHub API whose run status/conclusion (and a transient error) the test drives. */
+class FakeApi implements GhWorkflowApi {
+  status = "in_progress";
+  conclusion: string | null = null;
+  dispatched = 0;
+  throwOnGetRun = false;
+
+  dispatch(): Promise<void> {
+    this.dispatched++;
+    return Promise.resolve();
+  }
+  findRun(): Promise<WorkflowRun | null> {
+    return Promise.resolve({
+      id: 55,
+      status: this.status,
+      conclusion: this.conclusion,
+      url: "u",
+    });
+  }
+  getRun(): Promise<WorkflowRun> {
+    if (this.throwOnGetRun) {
+      return Promise.reject(new Error("gh workflow: GET /runs/55 → 502"));
+    }
+    return Promise.resolve({
+      id: 55,
+      status: this.status,
+      conclusion: this.conclusion,
+      url: "u",
+    });
+  }
+  listJobs(): Promise<WorkflowJob[]> {
+    return Promise.resolve([
+      { name: "e2e", conclusion: this.conclusion ?? "", url: "j" },
+    ]);
+  }
+}
+
+Deno.test("a githubWorkflow gate dispatches, suspends, then resumes on completion", async () => {
+  await withStateDir(async (dir) => {
+    const api = new FakeApi();
+    const log: string[] = [];
+    class Ship extends Build {
+      e2e = target().waitsFor((s) =>
+        s.on(
+          githubWorkflowWith(
+            (g) => g.repo("acme/app").workflow("e2e.yml"),
+            { api },
+          ),
+        )
+      );
+      ship = target().dependsOn(this.e2e).executes((ctx) => {
+        // Read the gate target's published result via stateOf.
+        const result = readWorkflowResult(ctx.stateOf("e2e"));
+        log.push(`ship:passed=${result?.passed}`);
+      });
+    }
+
+    // First process: reach the gate, dispatch, suspend (exit 0).
+    const first = await runCli(Ship, ["ship"]);
+    assertEquals(first.code, 0);
+    assertEquals(log, []); // ship did not run
+    assertEquals(api.dispatched, 1);
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    const runs = await store.listRuns({});
+    assertEquals(runs.length, 1);
+    const id = runs[0].id;
+    assertEquals(runs[0].status, "suspended");
+
+    // The external workflow finishes; a resume --check re-evaluates the gate.
+    api.status = "completed";
+    api.conclusion = "success";
+    const resumed = await runCli(Ship, ["resume", id, "--check"]);
+    assertEquals(resumed.code, 0);
+    assertEquals(log, ["ship:passed=true"]);
+    assertEquals(api.dispatched, 1); // never re-dispatched across the resume
+    assertEquals(
+      await store.getRun(id).then((g) => g?.record.status),
+      "succeeded",
+    );
+  });
+});
+
+Deno.test("a transient GitHub error during a resume poll re-suspends, never strands the run", async () => {
+  await withStateDir(async (dir) => {
+    const api = new FakeApi();
+    const log: string[] = [];
+    class Ship extends Build {
+      e2e = target().waitsFor((s) =>
+        s.on(
+          githubWorkflowWith(
+            (g) => g.repo("acme/app").workflow("e2e.yml"),
+            { api },
+          ),
+        )
+      );
+      ship = target().dependsOn(this.e2e).executes((ctx) => {
+        log.push(
+          `ship:passed=${readWorkflowResult(ctx.stateOf("e2e"))?.passed}`,
+        );
+      });
+    }
+
+    const first = await runCli(Ship, ["ship"]); // dispatch + suspend
+    assertEquals(first.code, 0);
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    const id = (await store.listRuns({}))[0].id;
+
+    // A transient 502 on the poll must NOT terminate the run — it stays suspended.
+    api.throwOnGetRun = true;
+    await runCli(Ship, ["resume", id, "--check"]);
+    assertEquals(
+      await store.getRun(id).then((g) => g?.record.status),
+      "suspended",
+    );
+
+    // GitHub recovers and the workflow completes: the run resumes and ships.
+    api.throwOnGetRun = false;
+    api.status = "completed";
+    api.conclusion = "success";
+    await runCli(Ship, ["resume", id, "--check"]);
+    assertEquals(
+      await store.getRun(id).then((g) => g?.record.status),
+      "succeeded",
+    );
+    assertEquals(log, ["ship:passed=true"]);
+  });
+});

--- a/tests/integration/stateof_storeless_test.ts
+++ b/tests/integration/stateof_storeless_test.ts
@@ -1,0 +1,39 @@
+/**
+ * Integration: `ctx.stateOf(ctx.target)` is equivalent to `ctx.state` even for a
+ * **store-less** build (no state store configured). Guards the documented
+ * invariant against a regression where the store-less branch allocated a fresh
+ * empty in-memory handle per `stateOf` call, silently dropping reads and writes.
+ */
+
+import { assertEquals } from "../../packages/core/tests/_assert.ts";
+import { Build, target } from "../../packages/core/mod.ts";
+import { runCli } from "./_harness.ts";
+
+Deno.test("store-less ctx.stateOf(self) is equivalent to ctx.state", async () => {
+  // Ensure no store resolves, so env.writer is undefined (the store-less path).
+  const keys = ["ZUKE_STATE_DIR", "ZUKE_STATE_URL"];
+  const saved = keys.map((k) => [k, Deno.env.get(k)] as const);
+  for (const k of keys) Deno.env.delete(k);
+
+  const log: string[] = [];
+  try {
+    class Solo extends Build {
+      only = target().executes(async (ctx) => {
+        await ctx.state.set({ version: "1.2.3" });
+        // stateOf(self) must see the write ctx.state just made…
+        log.push(JSON.stringify(ctx.stateOf(ctx.target).get()));
+        // …and a write through stateOf(self) must land in ctx.state.
+        await ctx.stateOf(ctx.target).set({ k: 1 });
+        log.push(JSON.stringify(ctx.state.get()));
+      });
+    }
+    const res = await runCli(Solo, ["only"]);
+    assertEquals(res.code, 0);
+    assertEquals(log, [
+      '{"version":"1.2.3"}',
+      '{"version":"1.2.3","k":1}',
+    ]);
+  } finally {
+    for (const [k, v] of saved) if (v !== undefined) Deno.env.set(k, v);
+  }
+});

--- a/zuke.ts
+++ b/zuke.ts
@@ -382,6 +382,7 @@ class ZukeBuild extends Build {
           "tests/e2e/mcp_e2e.ts",
           "tests/e2e/cancel_e2e.ts",
           "tests/e2e/otel_e2e.ts",
+          "tests/e2e/gh_workflow_e2e.ts",
         )
       );
     });


### PR DESCRIPTION
## What

M9 — a `.waitsFor(...)` gate can now **await an external GitHub Actions workflow**.

```ts
import { githubWorkflow, readWorkflowResult } from "jsr:@zuke/gh";

class Release extends Build {
  e2e = target().waitsFor((s) =>
    s.on(githubWorkflow((g) => g.repo("acme/app").workflow("e2e.yml").ref("main")))
      .timeout("2h").onTimeout(() => this.rollback)
  );
  ship = target().dependsOn(this.e2e).executes((ctx) => {
    const result = readWorkflowResult(ctx.stateOf("e2e"));
    if (!result?.passed) throw new Error("e2e suite failed");
  });
  rollback = target().executes(() => rollBack());
}
```

`githubWorkflow` dispatches the workflow, **suspends** the run until it finishes,
correlates the dispatched run by a `run-name` marker, and publishes its per-job
conclusions to the gate's state. Dispatch-once is durable across suspend/resume
— a resume in a different process never re-dispatches. Auth via
`GH_TOKEN`/`GITHUB_TOKEN`; the GitHub API is an injectable transport (hermetic
tests, no real GitHub).

## Core seam (small, backward-compatible)

- `WaitTrigger.isSatisfied` now also receives a **`WaitContext`** (`state` /
  `runId` / `target`), so a stateful trigger can persist correlation state across
  the suspend boundary. Built-in triggers ignore it (fewer params stay
  assignable). Only the executor calls it.
- **`TargetContext.stateOf(name)`** lets a body read another target's published
  state (reads the live record) — how a dependent reads the gate's result.

## Testing (three layers)
- **Unit** — the trigger state machine (dispatch/correlate/poll/complete, idempotency, transient re-suspend) and the REST transport (dispatch/find/get/list, pagination, timeout, malformed payloads).
- **Integration** — a real build via `main()` → dispatch + suspend → `resume --check` completes (only `fetch`/api faked); plus the store-less `stateOf` invariant.
- **E2E** — two real processes prove the dispatched flag persists (dispatch-once across the boundary).

`@zuke/gh` coverage 96% branch / 99% line. Full `deno task ci` green; `apiDocsCheck` clean. Docs (`orchestration.md`, `run-context.md`, gh README) + agent skill updated.

## Adversarial review

A fan-out review (5 dimensions → per-finding verify) confirmed 4 distinct issues; all fixed here with regression tests:

| # | Fix | Sev |
|---|-----|-----|
| 1 | A **transient GitHub error during a poll** now re-suspends and retries next `resume --check`, instead of throwing out of the gate and **terminally failing the run** (a poll-based feature turning one 5xx/rate-limit into permanent, unrecoverable loss). | high |
| 2 | `findRun` **paginates** (up to 5×100) so a dispatched run that scrolled off page 1 in a busy repo is still correlated. | med |
| 3 | The REST transport bounds **every request with a timeout**, so a hung GitHub endpoint can't wedge a `resume --check` sweep forever. | med |
| 4 | Store-less **`ctx.stateOf(self)` is now equivalent to `ctx.state`** (was a fresh empty handle per call, dropping writes). | low |

This PR touches `packages/core` (the `WaitContext` / `stateOf` seam and fixes 1/4) and `packages/gh` (the trigger). Part of the M9 milestone; depends only on M3 (waits/resume), already merged.