### PR TITLE
feat(core): pluggable BuildRegistry and zuke register

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -1,0 +1,125 @@
+# The build registry
+
+The **build registry** is a catalog of the pipelines (builds) that exist and
+where they live. Where [durable run state](./state.md) records *runs*, the
+registry records *builds*: each build registers a small **descriptor** — its id,
+its CLI surface (targets, parameters, commands), and how to launch it — into a
+pluggable store.
+
+Its purpose is agentic discovery driven by the store: an MCP server pointed at
+the registry can expose newly-registered pipelines as tools **without a redeploy
+or new instructions**. A build that registers itself for the first time becomes
+discoverable through an already-running server. (That dynamic `zuke mcp`
+integration is the next milestone; this page covers the registry and
+`zuke register` that back it.)
+
+The registry is a **separate concern** from the run [`StateStore`](./state.md) —
+a run history and a build catalog are different things — but it is configured the
+same way and, over HTTP, rides the same [REST contract](./state-api.md#build-catalog-builds)
+with a `/builds` collection beside `/runs`, so one service can host both.
+
+## Quick start
+
+```sh
+# Record this build in the registry (writes .zuke/builds/<id>.json by default).
+deno run -A zuke.ts register
+
+# Print the descriptor that was written.
+deno run -A zuke.ts register --json
+```
+
+Registration is **idempotent**: re-running `register` refreshes the descriptor
+(and its `updatedAt`) while preserving the original `createdAt`. Concurrent
+registrations converge on one record via compare-and-swap.
+
+## The build descriptor
+
+A descriptor is a versioned JSON snapshot of one build. It carries only static,
+structural metadata — never parameter *values* — so, like a run record, it
+excludes secrets by construction.
+
+| Field       | What it is                                                        |
+| ----------- | ---------------------------------------------------------------- |
+| `id`        | Stable build id (the build class name, unless overridden).       |
+| `name`      | Human-facing build name (the class name).                        |
+| `location`  | How to launch the build (see below).                             |
+| `surface`   | The CLI surface — the exact output of `describeCli(build)`: commands, flags, targets (with deps), and parameters (flags only, no values). |
+| `actor`     | Who registered it (resolved from `--actor` / `ZUKE_ACTOR` / CI). |
+| `createdAt` | ISO-8601 first-registration time (preserved across updates).     |
+| `updatedAt` | ISO-8601 time of the latest registration.                        |
+
+The **location** is one of two forms:
+
+- `{ kind: "module", module, cwd, repo? }` — the entry module `deno run`
+  executes (a `file:`/`https:` URL or path), the working directory, and — in CI
+  — the `owner/name` repo slug. This is what `zuke register` writes, derived from
+  the running module, `Deno.cwd()`, and `GITHUB_REPOSITORY`.
+- `{ kind: "command", command, cwd, repo? }` — an explicit tokenised launch argv
+  (for a build fronted by a wrapper script). Hand-authored or produced by a
+  custom registry; the runner honours it in the same way.
+
+## Backends
+
+Two dependency-free backends ship, mirroring the state layer.
+
+### `FileSystemBuildRegistry` — dev default
+
+Writes one `<id>.json` file per build under a directory (default
+`<repo root>/.zuke/builds`, a sibling of `.zuke/runs` — never colliding).
+Compare-and-swap uses an `O_EXCL` lock marker plus an atomic temp-file rename, so
+two processes registering at once cannot tear a write. Single-host by design.
+
+### `HttpBuildRegistry` — hosted service
+
+Talks to a hosted service over the [`/builds` REST contract](./state-api.md#build-catalog-builds):
+`GET/PUT/DELETE /builds/:id` and `GET /builds`, with `ETag`/`If-Match`
+compare-and-swap and bearer auth. Its options mirror the state client —
+`{ url, token?, fetch? }` — and it is the production path. Point it only at a
+service you control.
+
+## Configuration
+
+The registry is resolved by the same precedence as the run store:
+
+1. an explicit registry passed in code (or `false` to disable);
+2. a build's `registry()` override;
+3. the environment — `ZUKE_REGISTRY_URL` (with an optional
+   `ZUKE_REGISTRY_TOKEN`) selects the HTTP backend, else `ZUKE_REGISTRY_DIR`
+   selects the filesystem backend;
+4. for `zuke register`, a filesystem registry under `.zuke/builds` as the
+   default, so the command works out of the box.
+
+```ts
+class CD extends Build {
+  registryUrl = parameter("registry URL").required();
+  registryToken = parameter("registry token").secret();
+  override registry() {
+    return new HttpBuildRegistry({
+      url: this.registryUrl.value,
+      token: this.registryToken.value,
+    });
+  }
+}
+```
+
+## Secrets
+
+A descriptor is secret-free by construction: it is built from
+`describeCli(build)`, which emits only parameter **flags** and their static
+metadata (required, kind, …) — never resolved values — plus a launch location
+and an actor name. `zuke register` resolves no parameter values at all. Two extra
+guards keep declared-but-sensitive strings out: a **secret** parameter's declared
+`.options(...)` values are omitted (they could be real keys), and credentials
+embedded in a remote module URL (`https://user:token@host/build.ts`) are stripped
+from the stored `location.module`. Treat the store as sensitive configuration
+nonetheless (it names your pipelines and where they run), and front an HTTP
+backend with TLS and authn as you would any internal API.
+
+## Extensibility
+
+The whole thing sits behind the `BuildRegistry` interface
+(`getBuild` / `register` / `deregister` / `listBuilds`). A consumer can implement
+it against their own catalog service or database and plug it in via
+`Build.registry()` — the richer catalog stays a plugin, exactly as the pluggable
+`StateStore` and `RemoteCacheStore` do. Core ships the interface, the two
+reference backends, and (next) the `zuke mcp` integration point.

--- a/docs/state-api.md
+++ b/docs/state-api.md
@@ -85,6 +85,46 @@ The client validates every summary it receives (an untrusted service is checked,
 not trusted) and expects newest-first ordering is applied server-side where it
 matters; it does not re-sort the list.
 
+## Build catalog (`/builds`)
+
+The [build registry](./registry.md) rides the **same** contract — same base URL,
+same bearer auth, same `ETag`/`If-Match` compare-and-swap — with a `/builds`
+collection beside `/runs`, so one service can host both (they stay separate
+concerns in the client:
+[`HttpBuildRegistry`](./registry.md#httpbuildregistry--hosted-service) is not the
+run store). A build **descriptor** is JSON, exactly the shape in
+[the registry docs](./registry.md#the-build-descriptor); the service stores and
+returns it verbatim. Descriptors never contain secrets.
+
+### `GET /builds/:id`
+
+Fetch one registered build.
+
+| Response | Meaning                                                          |
+| -------- | --------------------------------------------------------------- |
+| `200`    | Body is the descriptor; **`ETag` header is required**.          |
+| `404`    | No such build (the client treats this as "not registered").     |
+| other    | The client raises an error.                                     |
+
+### `PUT /builds/:id`
+
+Register (create or update) a build, guarded exactly like `PUT /runs/:id`:
+`If-None-Match: *` to create, `If-Match: <etag>` to update, `412` on a version
+mismatch (the client re-reads and retries, so concurrent registrations converge).
+A `200`/`201` must return the new version as an `ETag`.
+
+### `DELETE /builds/:id`
+
+Deregister a build. `404` (already gone) is **not** an error; any other non-`2xx`
+is. No body.
+
+### `GET /builds?name=&since=`
+
+List registered builds as an array of **summaries**
+(`id`, `name`, `actor`, `createdAt`, `updatedAt`). Query parameters (optional,
+AND-combined): `name` (exact match) and `since` (`createdAt` at or after an
+ISO-8601 timestamp). The client validates every summary and does not re-sort.
+
 ## Notes for implementers
 
 - **Never weaker than optimistic 409-retry.** The precondition model above is

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -162,6 +162,12 @@ function discoverTargets(build: Build): Map<string, TargetBuilder>
       if two properties reference the same builder instance under different
       names (a programming error that would corrupt naming).
 
+function envBuildRegistry(readEnv: (name: string) => string | undefined, host: StateHost): BuildRegistry | undefined
+  Resolve a {@link BuildRegistry} from the environment, or `undefined` when none
+  is configured. `ZUKE_REGISTRY_URL` (with an optional `ZUKE_REGISTRY_TOKEN`)
+  selects an {@link HttpBuildRegistry}; otherwise `ZUKE_REGISTRY_DIR` selects a
+  {@link FileSystemBuildRegistry}.
+
 function envCacheStore(readEnv: (name: string) => string | undefined): RemoteCacheStore | undefined
   Resolve a {@link RemoteCacheStore} from the environment, or `undefined` when
   none is configured. `ZUKE_REMOTE_CACHE_URL` (with an optional
@@ -377,6 +383,13 @@ function repoRoot(...segments: string[]): AbsolutePath
 
   @throws
       if no {@link CONFIG_FILE} is found in the cwd or any ancestor.
+
+function resolveBuildRegistry(option: BuildRegistry | false | undefined, declared: BuildRegistry | undefined, options: ResolveRegistryOptions): BuildRegistry | undefined
+  Pick the build registry by precedence: an explicit `option` wins (`false`
+  disables the registry entirely), then a `declared` registry (a build's
+  `registry()` override), then the {@link envBuildRegistry} environment
+  fallback, then — only when {@link ResolveRegistryOptions.enableDefault} — a
+  filesystem registry under `<root>/.zuke/builds`.
 
 function resolveRemoteStore(option: RemoteCacheStore | false | undefined, declared: RemoteCacheStore | undefined, readEnv: (name: string) => string | undefined): RemoteCacheStore | undefined
   Pick the remote store for a run by precedence: an explicit `option` wins
@@ -699,6 +712,23 @@ class Build
       }
     }
     ```
+  registry(): BuildRegistry | undefined
+    The {@link "./registry/registry.ts".BuildRegistry} this build registers
+    itself in (`zuke register`) and that a registry-backed `zuke mcp` server
+    discovers pipelines from. Override to declare one in code; the default is
+    none, and — unless overridden — the resolution falls back to the
+    `ZUKE_REGISTRY_URL` / `ZUKE_REGISTRY_DIR` environment variables, then (for
+    `zuke register`) a filesystem registry under `<root>/.zuke/builds`. Kept a
+    separate concern from {@link stateStore} (a run history and a build catalog
+    are different things), so a consumer can host a richer catalog as a plugin.
+
+    ```ts
+    class CD extends Build {
+      override registry() {
+        return new HttpBuildRegistry({ url: this.registryUrl.value, token: this.registryToken.value });
+      }
+    }
+    ```
 
 class CiFile
   A declared CI file. Assign one (via {@link cicd}) to a build field and Zuke
@@ -764,6 +794,29 @@ class FileSecretSettings
   async resolve_(): Promise<string>
     Read the file and return its content as the secret. A missing or
     unreadable file throws a {@link SecretError} naming the path.
+
+class FileSystemBuildRegistry implements BuildRegistry
+  A {@link BuildRegistry} that writes one `<id>.json` file per build under a
+  directory.
+
+  Security. `dir` is trusted configuration — the location you choose to
+  store the build catalog (from `ZUKE_REGISTRY_DIR` or an explicit registry),
+  the same posture as {@link "../state/fs_store.ts".FileSystemStateStore}. The
+  only untrusted value that reaches a path is the build id, validated at
+  every point a path is built, so a traversal cannot be smuggled in via an id.
+
+  constructor(dir: string, host: StateHost)
+    Build the registry over `dir` (created on first write). Filesystem access
+    goes through `host`, which defaults to
+    {@link "../state/store.ts".defaultStateHost}.
+  async getBuild(id: string): Promise<{ descriptor: BuildDescriptor; version: string; } | null>
+    Fetch a build and the content-hash version of its stored file.
+  async register(descriptor: BuildDescriptor, expectedVersion: string | null): Promise<PutBuildResult>
+    Publish `descriptor` under an exclusive lock, guarding the expected version.
+  async deregister(id: string): Promise<void>
+    Remove a registered build under an exclusive lock; a missing file is a no-op.
+  async listBuilds(query: BuildQuery): Promise<BuildSummary[]>
+    List builds matching `query`, newest first. Unreadable files are skipped.
 
 class FileSystemCacheStore implements RemoteCacheStore
   A {@link RemoteCacheStore} backed by a shared or mounted directory.
@@ -842,6 +895,25 @@ class Group
     Members that declared themselves part of this group, in declaration order.
   name_?: string
     Property name, assigned during discovery. Undefined until then.
+
+class HttpBuildRegistry implements BuildRegistry
+  A {@link BuildRegistry} backed by HTTP.
+
+  Security. The `url` and `token` are trusted configuration — build
+  descriptors (structural CLI metadata plus a launch location) are sent to that
+  host, so point it only at a service you control and prefer a secret parameter
+  or environment variable over a hard-coded value.
+
+  constructor(options: HttpBuildRegistryOptions)
+    Build the registry from its URL, optional token, and `fetch` seam.
+  async getBuild(id: string): Promise<{ descriptor: BuildDescriptor; version: string; } | null>
+    `GET /builds/:id` → descriptor + `ETag`; a `404` is a miss.
+  async register(descriptor: BuildDescriptor, expectedVersion: string | null): Promise<PutBuildResult>
+    `PUT /builds/:id` guarded by `If-Match` / `If-None-Match`; `412` → conflict.
+  async deregister(id: string): Promise<void>
+    `DELETE /builds/:id`; a missing build (`404`) is not an error.
+  async listBuilds(query: BuildQuery): Promise<BuildSummary[]>
+    `GET /builds?name=&since=` → an array of {@link BuildSummary}.
 
 class HttpCacheStore implements RemoteCacheStore
   A {@link RemoteCacheStore} backed by HTTP: `GET <url>/<key>` fetches an
@@ -1598,6 +1670,51 @@ interface BuildCache
   save(): Promise<void>
     Persist the store if anything changed.
 
+interface BuildDescriptor
+  A versioned snapshot of one registered build. Persisted as JSON; a registry's
+  opaque `version` (an ETag / content hash) drives compare-and-swap writes so
+  two registrations racing at the same version cannot both win.
+
+  id: string
+    Stable id of the build (its class name, unless overridden).
+  name: string
+    Human-facing build name (the build class name).
+  location: BuildLocation
+    Where the build lives, so a runner can launch it.
+  surface: CliDescription
+    The build's CLI surface, exactly as {@link "../describe.ts".describeCli} produces it.
+  actor: string
+    Who registered the build (a resolved actor; secrets never appear here).
+  createdAt: string
+    ISO-8601 timestamp when the build was first registered.
+  updatedAt: string
+    ISO-8601 timestamp of the last registration write.
+
+interface BuildQuery
+  Filters for {@link "./registry.ts".BuildRegistry.listBuilds}; all fields optional.
+
+  name?: string
+    Keep only builds whose `name` equals this.
+  since?: string
+    Keep only builds registered at or after this ISO-8601 timestamp.
+
+interface BuildRegistry
+  Pluggable persistence for {@link BuildDescriptor}s. `version` is an opaque
+  token (an ETag or content hash) used for optimistic concurrency: a write only
+  lands if the stored version still matches the one the writer last read, so two
+  registrations racing at the same version cannot both win.
+
+  getBuild(id: string): Promise<{ descriptor: BuildDescriptor; version: string; } | null>
+    Fetch a build and its current version, or `null` if it is not registered.
+  register(descriptor: BuildDescriptor, expectedVersion: string | null): Promise<PutBuildResult>
+    Write `descriptor` only if the stored version equals `expectedVersion`
+    (`null` meaning "must not exist yet"). Returns the new version, or a conflict
+    when the stored version has moved on — the caller re-reads and retries.
+  deregister(id: string): Promise<void>
+    Remove a registered build by id; a missing build is not an error.
+  listBuilds(query: BuildQuery): Promise<BuildSummary[]>
+    List registered builds matching `query`, newest first (by `createdAt`, then `id`).
+
 interface BuildResult
   Result passed to the {@link Build.onFinish} lifecycle hook.
 
@@ -1619,6 +1736,20 @@ interface BuildResult
     The run's id, when a run identity was established (always, in practice —
     every {@link "./executor.ts".execute} generates one). Lets the caller point
     a follow-up (`zuke runs show`, `zuke cancel`) at this run.
+
+interface BuildSummary
+  A compact registry listing row, returned by {@link "./registry.ts".BuildRegistry.listBuilds}.
+
+  id: string
+    The build id.
+  name: string
+    The build name.
+  actor: string
+    Who last registered the build.
+  createdAt: string
+    ISO-8601 first-registration timestamp.
+  updatedAt: string
+    ISO-8601 timestamp of the last registration write.
 
 interface CancelOptions
   Options for {@link cancelRun}.
@@ -2006,6 +2137,16 @@ interface GlobOptions
   cwd?: string
     Directory to resolve the pattern against (default: `Deno.cwd()`).
 
+interface HttpBuildRegistryOptions
+  Configuration for an {@link HttpBuildRegistry}.
+
+  url: string
+    The base URL build endpoints are built under (any trailing slash is ignored).
+  token?: string
+    A bearer token sent as `Authorization: Bearer <token>`, if set.
+  fetch?: typeof fetch
+    The `fetch` implementation; defaults to the global. Overridable for tests.
+
 interface HttpCacheStoreOptions
   Configuration for an {@link HttpCacheStore}.
 
@@ -2240,6 +2381,19 @@ interface Reporter
     Write an informational line.
   error(line: string): void
     Write an error line.
+
+interface ResolveRegistryOptions
+  Inputs {@link resolveBuildRegistry} needs to build the default filesystem registry.
+
+  readEnv: (name: string) => string | undefined
+    Reads an environment variable (injectable for tests).
+  host: StateHost
+    Filesystem effects for the default/env filesystem registry.
+  defaultDir: string
+    Directory the default filesystem registry writes to (`<root>/.zuke/builds`).
+  enableDefault: boolean
+    Fall back to the default filesystem registry when nothing else is
+    configured. `zuke register` sets this so the command works out of the box.
 
 interface ResolveStateOptions
   Inputs {@link resolveStateStore} needs to build the default filesystem store.
@@ -2674,6 +2828,12 @@ type AnnouncementLevel = "success" | "failure" | "warning" | "info"
 type Architecture = "x86_64" | "aarch64"
   The CPU architectures Zuke recognises.
 
+type BuildLocation = { kind: "module"; module: string; cwd: string; repo?: string; } | { kind: "command"; command: string[]; cwd: string; repo?: string; }
+  Where a registered build lives, so a runner can launch it. Two forms: a
+  `module` (the entry file `deno run` executes — the form `zuke register`
+  writes) or an explicit `command` (a launch argv, for a build fronted by a
+  wrapper script). Both carry the working directory and, in CI, the repository.
+
 type ChangedFilesFn = (base: string) => Promise<string[]>
   Lists the files changed since `base` (a git revision), each path relative to
   the repository root. The seam behind {@link ExecuteOptions.affected}; defaults
@@ -2739,6 +2899,9 @@ type PathLike = string | AbsolutePath
   A filesystem path accepted by Zuke APIs: either a plain string or an
   {@link AbsolutePath}. Anywhere a tool wrapper or build helper takes a path,
   it accepts a `PathLike` and coerces it to a string.
+
+type PutBuildResult = { ok: true; version: string; } | { ok: false; conflict: true; }
+  The result of a {@link BuildRegistry.register} compare-and-swap write.
 
 type PutResult = { ok: true; version: string; } | { ok: false; conflict: true; }
   The result of a {@link StateStore.putRun} compare-and-swap write.

--- a/llms.txt
+++ b/llms.txt
@@ -48,6 +48,7 @@ Reserved commands:
 - `resume` — Resume a suspended run (or --check all suspended runs)
 - `runs` — List or show persisted run records
 - `cancel` — Cancel a run and run its compensations
+- `register` — Register this build in the build registry
 
 Option flags:
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -216,6 +216,12 @@ function discoverTargets(build: Build): Map<string, TargetBuilder>
       if two properties reference the same builder instance under different
       names (a programming error that would corrupt naming).
 
+function envBuildRegistry(readEnv: (name: string) => string | undefined, host: StateHost): BuildRegistry | undefined
+  Resolve a {@link BuildRegistry} from the environment, or `undefined` when none
+  is configured. `ZUKE_REGISTRY_URL` (with an optional `ZUKE_REGISTRY_TOKEN`)
+  selects an {@link HttpBuildRegistry}; otherwise `ZUKE_REGISTRY_DIR` selects a
+  {@link FileSystemBuildRegistry}.
+
 function envCacheStore(readEnv: (name: string) => string | undefined): RemoteCacheStore | undefined
   Resolve a {@link RemoteCacheStore} from the environment, or `undefined` when
   none is configured. `ZUKE_REMOTE_CACHE_URL` (with an optional
@@ -431,6 +437,13 @@ function repoRoot(...segments: string[]): AbsolutePath
 
   @throws
       if no {@link CONFIG_FILE} is found in the cwd or any ancestor.
+
+function resolveBuildRegistry(option: BuildRegistry | false | undefined, declared: BuildRegistry | undefined, options: ResolveRegistryOptions): BuildRegistry | undefined
+  Pick the build registry by precedence: an explicit `option` wins (`false`
+  disables the registry entirely), then a `declared` registry (a build's
+  `registry()` override), then the {@link envBuildRegistry} environment
+  fallback, then — only when {@link ResolveRegistryOptions.enableDefault} — a
+  filesystem registry under `<root>/.zuke/builds`.
 
 function resolveRemoteStore(option: RemoteCacheStore | false | undefined, declared: RemoteCacheStore | undefined, readEnv: (name: string) => string | undefined): RemoteCacheStore | undefined
   Pick the remote store for a run by precedence: an explicit `option` wins
@@ -753,6 +766,23 @@ class Build
       }
     }
     ```
+  registry(): BuildRegistry | undefined
+    The {@link "./registry/registry.ts".BuildRegistry} this build registers
+    itself in (`zuke register`) and that a registry-backed `zuke mcp` server
+    discovers pipelines from. Override to declare one in code; the default is
+    none, and — unless overridden — the resolution falls back to the
+    `ZUKE_REGISTRY_URL` / `ZUKE_REGISTRY_DIR` environment variables, then (for
+    `zuke register`) a filesystem registry under `<root>/.zuke/builds`. Kept a
+    separate concern from {@link stateStore} (a run history and a build catalog
+    are different things), so a consumer can host a richer catalog as a plugin.
+
+    ```ts
+    class CD extends Build {
+      override registry() {
+        return new HttpBuildRegistry({ url: this.registryUrl.value, token: this.registryToken.value });
+      }
+    }
+    ```
 
 class CiFile
   A declared CI file. Assign one (via {@link cicd}) to a build field and Zuke
@@ -818,6 +848,29 @@ class FileSecretSettings
   async resolve_(): Promise<string>
     Read the file and return its content as the secret. A missing or
     unreadable file throws a {@link SecretError} naming the path.
+
+class FileSystemBuildRegistry implements BuildRegistry
+  A {@link BuildRegistry} that writes one `<id>.json` file per build under a
+  directory.
+
+  Security. `dir` is trusted configuration — the location you choose to
+  store the build catalog (from `ZUKE_REGISTRY_DIR` or an explicit registry),
+  the same posture as {@link "../state/fs_store.ts".FileSystemStateStore}. The
+  only untrusted value that reaches a path is the build id, validated at
+  every point a path is built, so a traversal cannot be smuggled in via an id.
+
+  constructor(dir: string, host: StateHost)
+    Build the registry over `dir` (created on first write). Filesystem access
+    goes through `host`, which defaults to
+    {@link "../state/store.ts".defaultStateHost}.
+  async getBuild(id: string): Promise<{ descriptor: BuildDescriptor; version: string; } | null>
+    Fetch a build and the content-hash version of its stored file.
+  async register(descriptor: BuildDescriptor, expectedVersion: string | null): Promise<PutBuildResult>
+    Publish `descriptor` under an exclusive lock, guarding the expected version.
+  async deregister(id: string): Promise<void>
+    Remove a registered build under an exclusive lock; a missing file is a no-op.
+  async listBuilds(query: BuildQuery): Promise<BuildSummary[]>
+    List builds matching `query`, newest first. Unreadable files are skipped.
 
 class FileSystemCacheStore implements RemoteCacheStore
   A {@link RemoteCacheStore} backed by a shared or mounted directory.
@@ -896,6 +949,25 @@ class Group
     Members that declared themselves part of this group, in declaration order.
   name_?: string
     Property name, assigned during discovery. Undefined until then.
+
+class HttpBuildRegistry implements BuildRegistry
+  A {@link BuildRegistry} backed by HTTP.
+
+  Security. The `url` and `token` are trusted configuration — build
+  descriptors (structural CLI metadata plus a launch location) are sent to that
+  host, so point it only at a service you control and prefer a secret parameter
+  or environment variable over a hard-coded value.
+
+  constructor(options: HttpBuildRegistryOptions)
+    Build the registry from its URL, optional token, and `fetch` seam.
+  async getBuild(id: string): Promise<{ descriptor: BuildDescriptor; version: string; } | null>
+    `GET /builds/:id` → descriptor + `ETag`; a `404` is a miss.
+  async register(descriptor: BuildDescriptor, expectedVersion: string | null): Promise<PutBuildResult>
+    `PUT /builds/:id` guarded by `If-Match` / `If-None-Match`; `412` → conflict.
+  async deregister(id: string): Promise<void>
+    `DELETE /builds/:id`; a missing build (`404`) is not an error.
+  async listBuilds(query: BuildQuery): Promise<BuildSummary[]>
+    `GET /builds?name=&since=` → an array of {@link BuildSummary}.
 
 class HttpCacheStore implements RemoteCacheStore
   A {@link RemoteCacheStore} backed by HTTP: `GET <url>/<key>` fetches an
@@ -1652,6 +1724,51 @@ interface BuildCache
   save(): Promise<void>
     Persist the store if anything changed.
 
+interface BuildDescriptor
+  A versioned snapshot of one registered build. Persisted as JSON; a registry's
+  opaque `version` (an ETag / content hash) drives compare-and-swap writes so
+  two registrations racing at the same version cannot both win.
+
+  id: string
+    Stable id of the build (its class name, unless overridden).
+  name: string
+    Human-facing build name (the build class name).
+  location: BuildLocation
+    Where the build lives, so a runner can launch it.
+  surface: CliDescription
+    The build's CLI surface, exactly as {@link "../describe.ts".describeCli} produces it.
+  actor: string
+    Who registered the build (a resolved actor; secrets never appear here).
+  createdAt: string
+    ISO-8601 timestamp when the build was first registered.
+  updatedAt: string
+    ISO-8601 timestamp of the last registration write.
+
+interface BuildQuery
+  Filters for {@link "./registry.ts".BuildRegistry.listBuilds}; all fields optional.
+
+  name?: string
+    Keep only builds whose `name` equals this.
+  since?: string
+    Keep only builds registered at or after this ISO-8601 timestamp.
+
+interface BuildRegistry
+  Pluggable persistence for {@link BuildDescriptor}s. `version` is an opaque
+  token (an ETag or content hash) used for optimistic concurrency: a write only
+  lands if the stored version still matches the one the writer last read, so two
+  registrations racing at the same version cannot both win.
+
+  getBuild(id: string): Promise<{ descriptor: BuildDescriptor; version: string; } | null>
+    Fetch a build and its current version, or `null` if it is not registered.
+  register(descriptor: BuildDescriptor, expectedVersion: string | null): Promise<PutBuildResult>
+    Write `descriptor` only if the stored version equals `expectedVersion`
+    (`null` meaning "must not exist yet"). Returns the new version, or a conflict
+    when the stored version has moved on — the caller re-reads and retries.
+  deregister(id: string): Promise<void>
+    Remove a registered build by id; a missing build is not an error.
+  listBuilds(query: BuildQuery): Promise<BuildSummary[]>
+    List registered builds matching `query`, newest first (by `createdAt`, then `id`).
+
 interface BuildResult
   Result passed to the {@link Build.onFinish} lifecycle hook.
 
@@ -1673,6 +1790,20 @@ interface BuildResult
     The run's id, when a run identity was established (always, in practice —
     every {@link "./executor.ts".execute} generates one). Lets the caller point
     a follow-up (`zuke runs show`, `zuke cancel`) at this run.
+
+interface BuildSummary
+  A compact registry listing row, returned by {@link "./registry.ts".BuildRegistry.listBuilds}.
+
+  id: string
+    The build id.
+  name: string
+    The build name.
+  actor: string
+    Who last registered the build.
+  createdAt: string
+    ISO-8601 first-registration timestamp.
+  updatedAt: string
+    ISO-8601 timestamp of the last registration write.
 
 interface CancelOptions
   Options for {@link cancelRun}.
@@ -2060,6 +2191,16 @@ interface GlobOptions
   cwd?: string
     Directory to resolve the pattern against (default: `Deno.cwd()`).
 
+interface HttpBuildRegistryOptions
+  Configuration for an {@link HttpBuildRegistry}.
+
+  url: string
+    The base URL build endpoints are built under (any trailing slash is ignored).
+  token?: string
+    A bearer token sent as `Authorization: Bearer <token>`, if set.
+  fetch?: typeof fetch
+    The `fetch` implementation; defaults to the global. Overridable for tests.
+
 interface HttpCacheStoreOptions
   Configuration for an {@link HttpCacheStore}.
 
@@ -2294,6 +2435,19 @@ interface Reporter
     Write an informational line.
   error(line: string): void
     Write an error line.
+
+interface ResolveRegistryOptions
+  Inputs {@link resolveBuildRegistry} needs to build the default filesystem registry.
+
+  readEnv: (name: string) => string | undefined
+    Reads an environment variable (injectable for tests).
+  host: StateHost
+    Filesystem effects for the default/env filesystem registry.
+  defaultDir: string
+    Directory the default filesystem registry writes to (`<root>/.zuke/builds`).
+  enableDefault: boolean
+    Fall back to the default filesystem registry when nothing else is
+    configured. `zuke register` sets this so the command works out of the box.
 
 interface ResolveStateOptions
   Inputs {@link resolveStateStore} needs to build the default filesystem store.
@@ -2728,6 +2882,12 @@ type AnnouncementLevel = "success" | "failure" | "warning" | "info"
 type Architecture = "x86_64" | "aarch64"
   The CPU architectures Zuke recognises.
 
+type BuildLocation = { kind: "module"; module: string; cwd: string; repo?: string; } | { kind: "command"; command: string[]; cwd: string; repo?: string; }
+  Where a registered build lives, so a runner can launch it. Two forms: a
+  `module` (the entry file `deno run` executes — the form `zuke register`
+  writes) or an explicit `command` (a launch argv, for a build fronted by a
+  wrapper script). Both carry the working directory and, in CI, the repository.
+
 type ChangedFilesFn = (base: string) => Promise<string[]>
   Lists the files changed since `base` (a git revision), each path relative to
   the repository root. The seam behind {@link ExecuteOptions.affected}; defaults
@@ -2793,6 +2953,9 @@ type PathLike = string | AbsolutePath
   A filesystem path accepted by Zuke APIs: either a plain string or an
   {@link AbsolutePath}. Anywhere a tool wrapper or build helper takes a path,
   it accepts a `PathLike` and coerces it to a string.
+
+type PutBuildResult = { ok: true; version: string; } | { ok: false; conflict: true; }
+  The result of a {@link BuildRegistry.register} compare-and-swap write.
 
 type PutResult = { ok: true; version: string; } | { ok: false; conflict: true; }
   The result of a {@link StateStore.putRun} compare-and-swap write.

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -162,6 +162,26 @@ export {
   type ResolveStateOptions,
   resolveStateStore,
 } from "./src/state/resolve.ts";
+export {
+  type BuildDescriptor,
+  type BuildLocation,
+  type BuildQuery,
+  type BuildSummary,
+} from "./src/registry/descriptor.ts";
+export {
+  type BuildRegistry,
+  type PutBuildResult,
+} from "./src/registry/registry.ts";
+export { FileSystemBuildRegistry } from "./src/registry/fs_registry.ts";
+export {
+  HttpBuildRegistry,
+  type HttpBuildRegistryOptions,
+} from "./src/registry/http_registry.ts";
+export {
+  envBuildRegistry,
+  resolveBuildRegistry,
+  type ResolveRegistryOptions,
+} from "./src/registry/resolve.ts";
 export { type AbsolutePath, absolutePath, type PathLike } from "./src/path.ts";
 export { CONFIG_FILE, repoRoot } from "./src/config.ts";
 export {

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -13,6 +13,7 @@ import { Group, type Remediation, TargetBuilder } from "./target.ts";
 import type { OrderingEdge } from "./graph.ts";
 import type { RemoteCacheStore } from "./remote_cache.ts";
 import type { StateStore } from "./state/store.ts";
+import type { BuildRegistry } from "./registry/registry.ts";
 
 /** Whether a value is a plain object (a component bundle), not a class instance. */
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -193,6 +194,28 @@ export class Build {
    */
   extraEdges(_targets: Map<string, TargetBuilder>): OrderingEdge[] {
     return [];
+  }
+
+  /**
+   * The {@link "./registry/registry.ts".BuildRegistry} this build registers
+   * itself in (`zuke register`) and that a registry-backed `zuke mcp` server
+   * discovers pipelines from. Override to declare one in code; the default is
+   * none, and — unless overridden — the resolution falls back to the
+   * `ZUKE_REGISTRY_URL` / `ZUKE_REGISTRY_DIR` environment variables, then (for
+   * `zuke register`) a filesystem registry under `<root>/.zuke/builds`. Kept a
+   * separate concern from {@link stateStore} (a run history and a build catalog
+   * are different things), so a consumer can host a richer catalog as a plugin.
+   *
+   * ```ts
+   * class CD extends Build {
+   *   override registry() {
+   *     return new HttpBuildRegistry({ url: this.registryUrl.value, token: this.registryToken.value });
+   *   }
+   * }
+   * ```
+   */
+  registry(): BuildRegistry | undefined {
+    return undefined;
   }
 }
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -31,6 +31,7 @@ import {
   GENERATE_CI_COMMAND,
   GRAPH_COMMAND,
   MCP_COMMAND,
+  REGISTER_COMMAND,
   RESUME_COMMAND,
   RUNS_COMMAND,
 } from "./cli_spec.ts";
@@ -38,6 +39,7 @@ import { type HttpAddress, serveMcp } from "./mcp/command.ts";
 import { cancelRun } from "./cancel.ts";
 import { resumeCheck, resumeRun } from "./resume.ts";
 import { runsCommand } from "./runs.ts";
+import { registerCommand } from "./registry/register.ts";
 import { isRunStatus, RUN_STATUS_NAMES, type RunQuery } from "./state/types.ts";
 import {
   installCompletions,
@@ -150,6 +152,8 @@ export interface ParsedArgs {
   cancel: boolean;
   /** The run id to cancel (the positional after `cancel`). */
   cancelRunId?: string;
+  /** The `register` command was requested (record this build in the registry). */
+  register: boolean;
   /** Raw parameter values from declared flags, keyed by property name. */
   values: Record<string, string>;
   help: boolean;
@@ -191,6 +195,7 @@ export function parseArgs(
     forceGraph: false,
     runs: false,
     cancel: false,
+    register: false,
     confirmDestructive: false,
     help: false,
   };
@@ -323,7 +328,7 @@ export function parseArgs(
     } else if (
       parsed.target === undefined && !parsed.graph && !parsed.generateCi &&
       !parsed.completions && !parsed.mcp && !parsed.resume && !parsed.runs &&
-      !parsed.cancel
+      !parsed.cancel && !parsed.register
     ) {
       if (arg === GRAPH_COMMAND) parsed.graph = true;
       else if (arg === GENERATE_CI_COMMAND) parsed.generateCi = true;
@@ -332,6 +337,7 @@ export function parseArgs(
       else if (arg === RESUME_COMMAND) parsed.resume = true;
       else if (arg === RUNS_COMMAND) parsed.runs = true;
       else if (arg === CANCEL_COMMAND) parsed.cancel = true;
+      else if (arg === REGISTER_COMMAND) parsed.register = true;
       else parsed.target = arg;
     }
   }
@@ -357,6 +363,7 @@ Usage:
   deno run -A zuke.ts runs list [--status <s>] [--target <t>] [--since <iso>] [--json]
   deno run -A zuke.ts runs show <run-id> [--json]
   deno run -A zuke.ts cancel <run-id> [--actor <name>]
+  deno run -A zuke.ts register [--actor <name>] [--json]
 
 Options:
   <target>          Run the target and its transitive dependencies.
@@ -430,6 +437,11 @@ Options:
                     compensations of every target that had succeeded — in
                     reverse order — and mark the record cancelled. Idempotent:
                     cancelling a finished run is a no-op. See docs/orchestration.md.
+  register          Record this build in the build registry (its targets,
+                    parameters, and launch location) so a registry-backed MCP
+                    server can discover it. Idempotent; excludes secrets. Writes
+                    to .zuke/builds unless ZUKE_REGISTRY_URL/DIR or the build's
+                    registry() configures a store. See docs/registry.md.
   --status <s>      With runs list, keep only runs with this status (running,
                     suspended, succeeded, failed, cancelled).
   --target <t>      With runs list, keep only runs whose graph contains this
@@ -743,6 +755,19 @@ async function runCancel(build: Build, parsed: ParsedArgs): Promise<number> {
   }
 }
 
+/** Run the `register` command: record this build in the build registry. */
+async function runRegister(build: Build, parsed: ParsedArgs): Promise<number> {
+  try {
+    return await registerCommand(build, {
+      actor: parsed.actor,
+      json: parsed.json,
+    });
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}
+
 /** Run the `runs` command: build the query (validating `--status`) and dispatch. */
 async function runRuns(build: Build, parsed: ParsedArgs): Promise<number> {
   const query: RunQuery = {};
@@ -800,8 +825,9 @@ export async function main(
   }
 
   // `--json` prints the build surface, except when a command consumes it
-  // itself (`runs list/show --json` emits run data, not the build surface).
-  if (parsed.json && !parsed.runs) {
+  // itself (`runs list/show --json` emits run data; `register --json` emits the
+  // written descriptor).
+  if (parsed.json && !parsed.runs && !parsed.register) {
     const surface = describeBuildSurface(targets, params);
     console.log(JSON.stringify(surface, null, 2));
     return 0;
@@ -847,6 +873,9 @@ export async function main(
   }
   if (parsed.cancel) {
     return await runCancel(build, parsed);
+  }
+  if (parsed.register) {
+    return await runRegister(build, parsed);
   }
 
   let name = parsed.target;

--- a/packages/core/src/cli_spec.ts
+++ b/packages/core/src/cli_spec.ts
@@ -41,6 +41,9 @@ export const RUNS_COMMAND = "runs";
 /** The `cancel` command: cancel a run and run its compensations. */
 export const CANCEL_COMMAND = "cancel";
 
+/** The `register` command: record this build in the build registry. */
+export const REGISTER_COMMAND = "register";
+
 /** Every reserved command, in help and completion order. */
 export const RESERVED_COMMANDS: readonly ReservedCommand[] = [
   { name: GRAPH_COMMAND, description: "Show the dependency graph" },
@@ -64,6 +67,10 @@ export const RESERVED_COMMANDS: readonly ReservedCommand[] = [
   {
     name: CANCEL_COMMAND,
     description: "Cancel a run and run its compensations",
+  },
+  {
+    name: REGISTER_COMMAND,
+    description: "Register this build in the build registry",
   },
 ];
 

--- a/packages/core/src/describe.ts
+++ b/packages/core/src/describe.ts
@@ -93,7 +93,10 @@ function parameterInfo(name: string, p: AnyParameter): CliParameterInfo {
     required: p.required_,
     boolean: p.kind_ === "boolean",
     array: p.array_,
-    options: [...(p.options_ ?? [])],
+    // A secret parameter's declared option values could themselves be sensitive
+    // (e.g. `.secret().options(...)` listing real keys), so they are never
+    // surfaced — matching how a run record omits secret values entirely.
+    options: p.secret_ ? [] : [...(p.options_ ?? [])],
   };
 }
 

--- a/packages/core/src/registry/descriptor.ts
+++ b/packages/core/src/registry/descriptor.ts
@@ -1,0 +1,304 @@
+/**
+ * The build-registry vocabulary: a {@link BuildDescriptor} — a small, versioned
+ * record describing one pipeline (build) that has registered itself — and its
+ * parts.
+ *
+ * A descriptor says **which** build exists, **where** it lives (so a runner can
+ * launch it), and **what** its CLI surface is (the same {@link CliDescription}
+ * `describeCli(build)` produces, so an MCP host can expose its targets as tools
+ * without loading the build). It carries no parameter *values* and no run data —
+ * only static structural metadata — so, like a run record, it excludes secrets
+ * by construction.
+ *
+ * The record's shape is validated on read (a registry's HTTP backend reads
+ * descriptors from a service Zuke does not control), mirroring
+ * {@link "../state/types.ts".parseRunRecord}.
+ *
+ * @module
+ */
+
+import type {
+  CliCommandInfo,
+  CliDescription,
+  CliFlagInfo,
+  CliParameterInfo,
+  CliTargetInfo,
+} from "../describe.ts";
+
+/**
+ * Where a registered build lives, so a runner can launch it. Two forms: a
+ * `module` (the entry file `deno run` executes — the form `zuke register`
+ * writes) or an explicit `command` (a launch argv, for a build fronted by a
+ * wrapper script). Both carry the working directory and, in CI, the repository.
+ */
+export type BuildLocation =
+  | {
+    /** A build launched by running its entry module. */
+    kind: "module";
+    /** The entry module `deno run` executes (a `file:`/`https:` URL or path). */
+    module: string;
+    /** The working directory the build expects to run in. */
+    cwd: string;
+    /** The `owner/name` repository slug, when known (from `GITHUB_REPOSITORY`). */
+    repo?: string;
+  }
+  | {
+    /** A build launched by an explicit command (e.g. a wrapper script). */
+    kind: "command";
+    /** The launch argv, already tokenised (never a shell string). */
+    command: string[];
+    /** The working directory the command runs in. */
+    cwd: string;
+    /** The `owner/name` repository slug, when known. */
+    repo?: string;
+  };
+
+/**
+ * A versioned snapshot of one registered build. Persisted as JSON; a registry's
+ * opaque `version` (an ETag / content hash) drives compare-and-swap writes so
+ * two registrations racing at the same version cannot both win.
+ */
+export interface BuildDescriptor {
+  /** Stable id of the build (its class name, unless overridden). */
+  id: string;
+  /** Human-facing build name (the build class name). */
+  name: string;
+  /** Where the build lives, so a runner can launch it. */
+  location: BuildLocation;
+  /** The build's CLI surface, exactly as {@link "../describe.ts".describeCli} produces it. */
+  surface: CliDescription;
+  /** Who registered the build (a resolved actor; secrets never appear here). */
+  actor: string;
+  /** ISO-8601 timestamp when the build was first registered. */
+  createdAt: string;
+  /** ISO-8601 timestamp of the last registration write. */
+  updatedAt: string;
+}
+
+/** A compact registry listing row, returned by {@link "./registry.ts".BuildRegistry.listBuilds}. */
+export interface BuildSummary {
+  /** The build id. */
+  id: string;
+  /** The build name. */
+  name: string;
+  /** Who last registered the build. */
+  actor: string;
+  /** ISO-8601 first-registration timestamp. */
+  createdAt: string;
+  /** ISO-8601 timestamp of the last registration write. */
+  updatedAt: string;
+}
+
+/** Filters for {@link "./registry.ts".BuildRegistry.listBuilds}; all fields optional. */
+export interface BuildQuery {
+  /** Keep only builds whose `name` equals this. */
+  name?: string;
+  /** Keep only builds registered at or after this ISO-8601 timestamp. */
+  since?: string;
+}
+
+/** The projection of a {@link BuildDescriptor} down to its {@link BuildSummary}. */
+export function toBuildSummary(descriptor: BuildDescriptor): BuildSummary {
+  return {
+    id: descriptor.id,
+    name: descriptor.name,
+    actor: descriptor.actor,
+    createdAt: descriptor.createdAt,
+    updatedAt: descriptor.updatedAt,
+  };
+}
+
+/** Serialise a descriptor to the canonical stored form (pretty JSON + newline). */
+export function stringifyBuildDescriptor(descriptor: BuildDescriptor): string {
+  return `${JSON.stringify(descriptor, null, 2)}\n`;
+}
+
+// --- Hardened parsing (untrusted JSON in, no casts) --------------------------
+
+/** Narrow an unknown value to a plain object without casting, else `null`. */
+function asObject(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  const out: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value)) out[key] = val;
+  return out;
+}
+
+/** Read a required string field, throwing a descriptive error if it is not one. */
+function str(object: Record<string, unknown>, field: string): string {
+  const value = object[field];
+  if (typeof value !== "string") {
+    throw new Error(`registry: descriptor field "${field}" is not a string`);
+  }
+  return value;
+}
+
+/** Read an optional string field, throwing if present but not a string. */
+function optionalStr(
+  object: Record<string, unknown>,
+  field: string,
+): string | undefined {
+  const value = object[field];
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") {
+    throw new Error(`registry: descriptor field "${field}" is not a string`);
+  }
+  return value;
+}
+
+/** Read a required boolean field, throwing if it is not one. */
+function bool(object: Record<string, unknown>, field: string): boolean {
+  const value = object[field];
+  if (typeof value !== "boolean") {
+    throw new Error(`registry: descriptor field "${field}" is not a boolean`);
+  }
+  return value;
+}
+
+/** Read a required array-of-strings field, throwing if it is not one. */
+function strArray(object: Record<string, unknown>, field: string): string[] {
+  const value = object[field];
+  if (!Array.isArray(value) || value.some((v) => typeof v !== "string")) {
+    throw new Error(
+      `registry: descriptor field "${field}" is not a string array`,
+    );
+  }
+  return value.filter((v): v is string => typeof v === "string");
+}
+
+/** Read a required array field and map each element through `parse`. */
+function arrayOf<T>(
+  object: Record<string, unknown>,
+  field: string,
+  parse: (value: unknown) => T,
+): T[] {
+  const value = object[field];
+  if (!Array.isArray(value)) {
+    throw new Error(`registry: descriptor field "${field}" is not an array`);
+  }
+  return value.map(parse);
+}
+
+/** Validate one `{ name, description }` entry (a command or a flag). */
+function parseNamed(value: unknown): CliCommandInfo & CliFlagInfo {
+  const object = asObject(value);
+  if (object === null) {
+    throw new Error("registry: surface entry is not an object");
+  }
+  return { name: str(object, "name"), description: str(object, "description") };
+}
+
+/** Validate one {@link CliTargetInfo}. */
+function parseTargetInfo(value: unknown): CliTargetInfo {
+  const object = asObject(value);
+  if (object === null) {
+    throw new Error("registry: surface target is not an object");
+  }
+  return {
+    name: str(object, "name"),
+    description: str(object, "description"),
+    dependsOn: strArray(object, "dependsOn"),
+    default: bool(object, "default"),
+    unlisted: bool(object, "unlisted"),
+  };
+}
+
+/** Validate one {@link CliParameterInfo}. */
+function parseParameterInfo(value: unknown): CliParameterInfo {
+  const object = asObject(value);
+  if (object === null) {
+    throw new Error("registry: surface parameter is not an object");
+  }
+  return {
+    flag: str(object, "flag"),
+    description: str(object, "description"),
+    required: bool(object, "required"),
+    boolean: bool(object, "boolean"),
+    array: bool(object, "array"),
+    options: strArray(object, "options"),
+  };
+}
+
+/** Validate and narrow a {@link CliDescription} (the build surface). */
+function parseCliDescription(value: unknown): CliDescription {
+  const object = asObject(value);
+  if (object === null) {
+    throw new Error('registry: descriptor field "surface" is not an object');
+  }
+  return {
+    commands: arrayOf(object, "commands", parseNamed),
+    flags: arrayOf(object, "flags", parseNamed),
+    targets: arrayOf(object, "targets", parseTargetInfo),
+    parameters: arrayOf(object, "parameters", parseParameterInfo),
+  };
+}
+
+/** Validate and narrow a {@link BuildLocation}. */
+function parseBuildLocation(value: unknown): BuildLocation {
+  const object = asObject(value);
+  if (object === null) {
+    throw new Error('registry: descriptor field "location" is not an object');
+  }
+  const cwd = str(object, "cwd");
+  const repo = optionalStr(object, "repo");
+  if (object.kind === "command") {
+    const command = strArray(object, "command");
+    return repo === undefined
+      ? { kind: "command", command, cwd }
+      : { kind: "command", command, cwd, repo };
+  }
+  if (object.kind === "module") {
+    const module = str(object, "module");
+    return repo === undefined
+      ? { kind: "module", module, cwd }
+      : { kind: "module", module, cwd, repo };
+  }
+  throw new Error(
+    `registry: unknown location kind "${String(object.kind)}"`,
+  );
+}
+
+/**
+ * Parse and validate a stored {@link BuildDescriptor}. Throws a descriptive
+ * error when the text is not JSON or does not match the shape — the HTTP backend
+ * reads descriptors from a service Zuke does not control, so the shape is checked
+ * rather than trusted (mirroring {@link "../state/types.ts".parseRunRecord}).
+ */
+export function parseBuildDescriptor(text: string): BuildDescriptor {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error("registry: descriptor is not valid JSON");
+  }
+  const object = asObject(parsed);
+  if (object === null) throw new Error("registry: descriptor is not an object");
+  return {
+    id: str(object, "id"),
+    name: str(object, "name"),
+    location: parseBuildLocation(object.location),
+    surface: parseCliDescription(object.surface),
+    actor: str(object, "actor"),
+    createdAt: str(object, "createdAt"),
+    updatedAt: str(object, "updatedAt"),
+  };
+}
+
+/**
+ * Parse and validate a {@link BuildSummary} from an untrusted value (an element
+ * of the HTTP list response). Throws when a field is missing or the wrong type.
+ */
+export function parseBuildSummary(value: unknown): BuildSummary {
+  const object = asObject(value);
+  if (object === null) {
+    throw new Error("registry: build summary is not an object");
+  }
+  return {
+    id: str(object, "id"),
+    name: str(object, "name"),
+    actor: str(object, "actor"),
+    createdAt: str(object, "createdAt"),
+    updatedAt: str(object, "updatedAt"),
+  };
+}

--- a/packages/core/src/registry/fs_registry.ts
+++ b/packages/core/src/registry/fs_registry.ts
@@ -1,0 +1,196 @@
+/**
+ * {@link FileSystemBuildRegistry} — a {@link BuildRegistry} backed by one JSON
+ * file per build under a directory (default `<repo root>/.zuke/builds`).
+ *
+ * It is single-host by design (fine for dev, per the requirement); production
+ * uses {@link "./http_registry.ts".HttpBuildRegistry}. Compare-and-swap is
+ * enforced with an `O_EXCL` lock marker plus an atomic temp-file rename — the
+ * same trick as {@link "../state/fs_store.ts".FileSystemStateStore} — so two
+ * registrations racing at the same version cannot both win. The version is a
+ * content hash, mirroring the ETag the HTTP backend uses.
+ *
+ * @module
+ */
+
+import { defaultStateHost, type StateHost } from "../state/store.ts";
+import {
+  type BuildDescriptor,
+  type BuildQuery,
+  type BuildSummary,
+  parseBuildDescriptor,
+  stringifyBuildDescriptor,
+  toBuildSummary,
+} from "./descriptor.ts";
+import type { BuildRegistry, PutBuildResult } from "./registry.ts";
+
+const encoder = new TextEncoder();
+
+/** Hex SHA-256 of a UTF-8 string — the opaque CAS version of a stored descriptor. */
+async function hashText(text: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", encoder.encode(text));
+  return Array.from(
+    new Uint8Array(digest),
+    (b) => b.toString(16).padStart(2, "0"),
+  ).join("");
+}
+
+/**
+ * Reject a build id that could escape the builds directory. Ids are build class
+ * names in normal use; this guards the case where one arrives from the CLI or a
+ * query.
+ */
+function assertSafeId(id: string): void {
+  if (!/^[A-Za-z0-9._-]+$/.test(id)) {
+    throw new Error(`registry: unsafe build id "${id}"`);
+  }
+}
+
+/** How long to wait for a contended lock before giving up. */
+const LOCK_ATTEMPTS = 100;
+const LOCK_DELAY_MS = 10;
+
+/** Resolve after `ms` milliseconds. */
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * A {@link BuildRegistry} that writes one `<id>.json` file per build under a
+ * directory.
+ *
+ * **Security.** `dir` is *trusted configuration* — the location you choose to
+ * store the build catalog (from `ZUKE_REGISTRY_DIR` or an explicit registry),
+ * the same posture as {@link "../state/fs_store.ts".FileSystemStateStore}. The
+ * only untrusted value that reaches a path is the build **id**, validated at
+ * every point a path is built, so a traversal cannot be smuggled in via an id.
+ */
+export class FileSystemBuildRegistry implements BuildRegistry {
+  readonly #dir: string;
+  readonly #host: StateHost;
+  #ensured = false;
+
+  /**
+   * Build the registry over `dir` (created on first write). Filesystem access
+   * goes through `host`, which defaults to
+   * {@link "../state/store.ts".defaultStateHost}.
+   */
+  constructor(dir: string, host: StateHost = defaultStateHost) {
+    this.#dir = dir.replace(/\/+$/, "");
+    this.#host = host;
+  }
+
+  // Both id-derived paths are built through these helpers, and both validate the
+  // id — so a traversal can't slip in via a caller that forgets to check.
+  #file(id: string): string {
+    assertSafeId(id);
+    return `${this.#dir}/${id}.json`;
+  }
+
+  #lock(id: string): string {
+    assertSafeId(id);
+    return `${this.#dir}/${id}.json.lock`;
+  }
+
+  async #ensureDir(): Promise<void> {
+    if (this.#ensured) return;
+    await this.#host.mkdirp(this.#dir);
+    this.#ensured = true;
+  }
+
+  /** Fetch a build and the content-hash version of its stored file. */
+  async getBuild(
+    id: string,
+  ): Promise<{ descriptor: BuildDescriptor; version: string } | null> {
+    const text = await this.#host.readText(this.#file(id));
+    if (text === null) return null;
+    return {
+      descriptor: parseBuildDescriptor(text),
+      version: await hashText(text),
+    };
+  }
+
+  /** Publish `descriptor` under an exclusive lock, guarding the expected version. */
+  async register(
+    descriptor: BuildDescriptor,
+    expectedVersion: string | null,
+  ): Promise<PutBuildResult> {
+    // #lock/#file validate descriptor.id before any path is used below.
+    await this.#ensureDir();
+    return await this.#withLock(descriptor.id, async () => {
+      const current = await this.#host.readText(this.#file(descriptor.id));
+      const currentVersion = current === null ? null : await hashText(current);
+      if (currentVersion !== expectedVersion) {
+        return { ok: false, conflict: true };
+      }
+      const content = stringifyBuildDescriptor(descriptor);
+      const tmp = `${this.#file(descriptor.id)}.tmp-${crypto.randomUUID()}`;
+      await this.#host.writeText(tmp, content);
+      await this.#host.rename(tmp, this.#file(descriptor.id));
+      return { ok: true, version: await hashText(content) };
+    });
+  }
+
+  /** Remove a registered build under an exclusive lock; a missing file is a no-op. */
+  async deregister(id: string): Promise<void> {
+    await this.#ensureDir();
+    await this.#withLock(id, () => this.#host.remove(this.#file(id)));
+  }
+
+  /** List builds matching `query`, newest first. Unreadable files are skipped. */
+  async listBuilds(query: BuildQuery): Promise<BuildSummary[]> {
+    const names = await this.#host.listDir(this.#dir);
+    const summaries: BuildSummary[] = [];
+    for (const name of names) {
+      if (!name.endsWith(".json")) continue; // skip .lock / .tmp-* markers
+      const text = await this.#host.readText(`${this.#dir}/${name}`);
+      if (text === null) continue;
+      let descriptor: BuildDescriptor;
+      try {
+        descriptor = parseBuildDescriptor(text);
+      } catch {
+        continue; // a corrupt/partial file must not break listing the rest
+      }
+      if (matches(descriptor, query)) {
+        summaries.push(toBuildSummary(descriptor));
+      }
+    }
+    return sortNewestFirst(summaries);
+  }
+
+  /** Take the build's lock (spinning briefly on contention), run `fn`, release. */
+  async #withLock<T>(id: string, fn: () => Promise<T>): Promise<T> {
+    const marker = this.#lock(id);
+    for (let attempt = 0; attempt < LOCK_ATTEMPTS; attempt++) {
+      if (await this.#host.createExclusive(marker)) {
+        try {
+          return await fn();
+        } finally {
+          await this.#host.remove(marker);
+        }
+      }
+      await delay(LOCK_DELAY_MS);
+    }
+    throw new Error(
+      `registry: could not acquire the mutex for build "${id}" — ` +
+        `a stale ${marker} may need removing.`,
+    );
+  }
+}
+
+/** Whether a descriptor passes a {@link BuildQuery}. */
+function matches(descriptor: BuildDescriptor, query: BuildQuery): boolean {
+  if (query.name !== undefined && descriptor.name !== query.name) return false;
+  if (query.since !== undefined && descriptor.createdAt < query.since) {
+    return false;
+  }
+  return true;
+}
+
+/** Sort by `createdAt` descending, then `id` descending, for stable output. */
+function sortNewestFirst(summaries: BuildSummary[]): BuildSummary[] {
+  return summaries.sort((a, b) =>
+    a.createdAt !== b.createdAt
+      ? (a.createdAt < b.createdAt ? 1 : -1)
+      : (a.id < b.id ? 1 : a.id > b.id ? -1 : 0)
+  );
+}

--- a/packages/core/src/registry/http_registry.ts
+++ b/packages/core/src/registry/http_registry.ts
@@ -1,0 +1,158 @@
+/**
+ * {@link HttpBuildRegistry} — a {@link BuildRegistry} backed by a hosted HTTP
+ * service, the production path for the build catalog. It rides the same REST
+ * contract as {@link "../state/http_store.ts".HttpStateStore} (see
+ * `docs/state-api.md`), adding a `/builds` collection beside `/runs`, so one
+ * service can host both.
+ *
+ * Compare-and-swap rides on HTTP preconditions: `GET /builds/:id` returns the
+ * descriptor and an `ETag`; `PUT /builds/:id` sends `If-Match: <etag>` (or
+ * `If-None-Match: *` to create), and the server answers `412 Precondition
+ * Failed` when the version has moved on. The option shape mirrors the state
+ * backend — `{ url, token?, fetch? }`, the `fetch` seam keeping tests hermetic.
+ *
+ * @module
+ */
+
+import { HttpError } from "../http.ts";
+import {
+  type BuildDescriptor,
+  type BuildQuery,
+  type BuildSummary,
+  parseBuildDescriptor,
+  parseBuildSummary,
+  stringifyBuildDescriptor,
+} from "./descriptor.ts";
+import type { BuildRegistry, PutBuildResult } from "./registry.ts";
+
+/** Configuration for an {@link HttpBuildRegistry}. */
+export interface HttpBuildRegistryOptions {
+  /** The base URL build endpoints are built under (any trailing slash is ignored). */
+  url: string;
+  /** A bearer token sent as `Authorization: Bearer <token>`, if set. */
+  token?: string;
+  /** The `fetch` implementation; defaults to the global. Overridable for tests. */
+  fetch?: typeof fetch;
+}
+
+/**
+ * A {@link BuildRegistry} backed by HTTP.
+ *
+ * **Security.** The `url` and `token` are *trusted configuration* — build
+ * descriptors (structural CLI metadata plus a launch location) are sent to that
+ * host, so point it only at a service you control and prefer a secret parameter
+ * or environment variable over a hard-coded value.
+ */
+export class HttpBuildRegistry implements BuildRegistry {
+  readonly #base: string;
+  readonly #token?: string;
+  readonly #fetch: typeof fetch;
+
+  /** Build the registry from its URL, optional token, and `fetch` seam. */
+  constructor(options: HttpBuildRegistryOptions) {
+    this.#base = options.url.replace(/\/+$/, "");
+    this.#token = options.token;
+    this.#fetch = options.fetch ?? fetch;
+  }
+
+  #buildUrl(id: string): string {
+    return `${this.#base}/builds/${encodeURIComponent(id)}`;
+  }
+
+  #headers(extra?: Record<string, string>): Record<string, string> {
+    const headers: Record<string, string> = { ...extra };
+    if (this.#token !== undefined && this.#token !== "") {
+      headers.Authorization = `Bearer ${this.#token}`;
+    }
+    return headers;
+  }
+
+  /** `GET /builds/:id` → descriptor + `ETag`; a `404` is a miss. */
+  async getBuild(
+    id: string,
+  ): Promise<{ descriptor: BuildDescriptor; version: string } | null> {
+    const url = this.#buildUrl(id);
+    const response = await this.#fetch(url, { headers: this.#headers() });
+    if (response.status === 404) {
+      await response.body?.cancel();
+      return null;
+    }
+    if (!response.ok) {
+      await response.body?.cancel();
+      throw new HttpError(response.status, url);
+    }
+    const version = response.headers.get("etag");
+    const text = await response.text();
+    if (version === null) {
+      throw new Error(`registry: ${url} did not return an ETag`);
+    }
+    return { descriptor: parseBuildDescriptor(text), version };
+  }
+
+  /** `PUT /builds/:id` guarded by `If-Match` / `If-None-Match`; `412` → conflict. */
+  async register(
+    descriptor: BuildDescriptor,
+    expectedVersion: string | null,
+  ): Promise<PutBuildResult> {
+    const url = this.#buildUrl(descriptor.id);
+    const precondition: Record<string, string> = expectedVersion === null
+      ? { "If-None-Match": "*" }
+      : { "If-Match": expectedVersion };
+    const response = await this.#fetch(url, {
+      method: "PUT",
+      headers: this.#headers({
+        "content-type": "application/json",
+        ...precondition,
+      }),
+      body: stringifyBuildDescriptor(descriptor),
+    });
+    if (response.status === 412) {
+      await response.body?.cancel();
+      return { ok: false, conflict: true };
+    }
+    await response.body?.cancel();
+    if (!response.ok) throw new HttpError(response.status, url);
+    const version = response.headers.get("etag");
+    if (version === null) {
+      throw new Error(`registry: ${url} did not return an ETag on write`);
+    }
+    return { ok: true, version };
+  }
+
+  /** `DELETE /builds/:id`; a missing build (`404`) is not an error. */
+  async deregister(id: string): Promise<void> {
+    const url = this.#buildUrl(id);
+    const response = await this.#fetch(url, {
+      method: "DELETE",
+      headers: this.#headers(),
+    });
+    await response.body?.cancel();
+    if (!response.ok && response.status !== 404) {
+      throw new HttpError(response.status, url);
+    }
+  }
+
+  /** `GET /builds?name=&since=` → an array of {@link BuildSummary}. */
+  async listBuilds(query: BuildQuery): Promise<BuildSummary[]> {
+    const params = new URLSearchParams();
+    if (query.name !== undefined) params.set("name", query.name);
+    if (query.since !== undefined) params.set("since", query.since);
+    const qs = params.toString();
+    const url = `${this.#base}/builds${qs === "" ? "" : `?${qs}`}`;
+    const response = await this.#fetch(url, { headers: this.#headers() });
+    if (!response.ok) {
+      await response.body?.cancel();
+      throw new HttpError(response.status, url);
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(await response.text());
+    } catch {
+      throw new Error(`registry: ${url} did not return valid JSON`);
+    }
+    if (!Array.isArray(parsed)) {
+      throw new Error(`registry: ${url} did not return a JSON array`);
+    }
+    return parsed.map(parseBuildSummary);
+  }
+}

--- a/packages/core/src/registry/register.ts
+++ b/packages/core/src/registry/register.ts
@@ -1,0 +1,179 @@
+/**
+ * The `zuke register` command: write (or refresh) this build's
+ * {@link BuildDescriptor} into a {@link BuildRegistry}, so an MCP host driven by
+ * the registry can discover the pipeline without a redeploy (see M11 / PR2).
+ *
+ * The descriptor is derived entirely from static metadata —
+ * {@link "../describe.ts".describeCli} for the surface, the running module for
+ * the location — so it carries no parameter values and no secrets, exactly like
+ * a run record. Registration is idempotent: it re-reads the current descriptor
+ * and compare-and-swaps, retrying on a conflict, so concurrent registrations
+ * converge instead of corrupting the record.
+ *
+ * @module
+ */
+
+import type { Build } from "../build.ts";
+import { describeCli } from "../describe.ts";
+import { absolutePath } from "../path.ts";
+import { findConfigDir, pathExists } from "../config.ts";
+import { defaultStateHost } from "../state/store.ts";
+import { resolveActor } from "../state/record.ts";
+import type { BuildDescriptor, BuildLocation } from "./descriptor.ts";
+import type { BuildRegistry } from "./registry.ts";
+import { resolveBuildRegistry } from "./resolve.ts";
+
+/** How many times a conflicting registration CAS is re-read and retried. */
+const MAX_RETRIES = 10;
+
+/** Read an environment variable, treating missing env access as unset. */
+function defaultReadEnv(name: string): string | undefined {
+  try {
+    return Deno.env.get(name);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Inputs for {@link registerCommand}. */
+export interface RegisterOptions {
+  /** The build id to register under; defaults to the build class name. */
+  id?: string;
+  /** Who to attribute the registration to (else `ZUKE_ACTOR`, CI, `anonymous`). */
+  actor?: string;
+  /** Emit the written descriptor as JSON instead of a human confirmation. */
+  json?: boolean;
+  /**
+   * Registry override, resolved like a run store (explicit → `registry()` → env
+   * → `.zuke/builds`); `false` disables the registry. Tests inject one here.
+   */
+  registry?: BuildRegistry | false;
+  /** Reads an environment variable (injectable for tests). */
+  readEnv?: (name: string) => string | undefined;
+  /** The build's launch location; derived from the running module when absent. */
+  location?: BuildLocation;
+  /** Clock for `createdAt`/`updatedAt` (injectable for tests). */
+  now?: () => string;
+}
+
+/** Resolve the registry for a `register` — like a run store, but always defaulting on. */
+function resolveRegisterRegistry(
+  option: BuildRegistry | false | undefined,
+  build: Build,
+  readEnv: (name: string) => string | undefined,
+): BuildRegistry | undefined {
+  return resolveBuildRegistry(option, build.registry(), {
+    readEnv,
+    host: defaultStateHost,
+    defaultDir: absolutePath(
+      findConfigDir(Deno.cwd(), pathExists) ?? Deno.cwd(),
+    )(".zuke", "builds").path,
+    enableDefault: true,
+  });
+}
+
+/**
+ * Strip embedded credentials from a module URL before it is persisted — a build
+ * launched from a remote entrypoint like `https://user:token@host/build.ts`
+ * carries basic-auth userinfo in {@link Deno.mainModule} that must not land in
+ * the descriptor. A plain filesystem path (not a URL) is returned unchanged, and
+ * Deno's remote auth uses `DENO_AUTH_TOKENS`, so stripping userinfo does not
+ * break a runner relaunch.
+ */
+export function redactModuleUrl(module: string): string {
+  try {
+    const url = new URL(module);
+    if (url.username === "" && url.password === "") return module;
+    url.username = "";
+    url.password = "";
+    return url.href;
+  } catch {
+    return module; // a bare filesystem path is not a URL — leave it as-is
+  }
+}
+
+/** Derive the launch location from the running module, cwd, and CI repo slug. */
+function deriveLocation(
+  readEnv: (name: string) => string | undefined,
+): BuildLocation {
+  const repo = readEnv("GITHUB_REPOSITORY");
+  const location: BuildLocation = {
+    kind: "module",
+    module: redactModuleUrl(Deno.mainModule),
+    cwd: Deno.cwd(),
+  };
+  if (repo !== undefined && repo !== "") location.repo = repo;
+  return location;
+}
+
+/**
+ * Write `descriptor` fields into `registry`, preserving the original
+ * `createdAt` on an update, and compare-and-swapping so two concurrent
+ * registrations converge on one record. Retries on conflict.
+ *
+ * @throws if the write cannot land after {@link MAX_RETRIES} conflicts.
+ */
+async function writeDescriptor(
+  registry: BuildRegistry,
+  fields: Omit<BuildDescriptor, "createdAt" | "updatedAt">,
+  now: () => string,
+): Promise<BuildDescriptor> {
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    const current = await registry.getBuild(fields.id);
+    const descriptor: BuildDescriptor = {
+      ...fields,
+      createdAt: current?.descriptor.createdAt ?? now(),
+      updatedAt: now(),
+    };
+    const result = await registry.register(
+      descriptor,
+      current?.version ?? null,
+    );
+    if (result.ok) return descriptor;
+  }
+  throw new Error(
+    `register: gave up registering "${fields.id}" after repeated conflicts.`,
+  );
+}
+
+/**
+ * Run `zuke register`: build this build's descriptor and write it to the
+ * resolved registry — an idempotent, retrying compare-and-swap — printing a
+ * confirmation (or the JSON descriptor) and resolving to a process exit code
+ * (0 success, 1 when no registry is configured).
+ *
+ * @throws if the registry write fails (a store outage); the caller reports it.
+ */
+export async function registerCommand(
+  build: Build,
+  options: RegisterOptions = {},
+): Promise<number> {
+  const readEnv = options.readEnv ?? defaultReadEnv;
+  const registry = resolveRegisterRegistry(options.registry, build, readEnv);
+  if (registry === undefined) {
+    console.error(
+      "register: no build registry is configured. Set ZUKE_REGISTRY_DIR / " +
+        "ZUKE_REGISTRY_URL, or override registry() on the build.",
+    );
+    return 1;
+  }
+
+  const now = options.now ?? (() => new Date().toISOString());
+  const descriptor = await writeDescriptor(registry, {
+    id: options.id ?? build.constructor.name,
+    name: build.constructor.name,
+    location: options.location ?? deriveLocation(readEnv),
+    surface: describeCli(build),
+    actor: resolveActor(options.actor, readEnv),
+  }, now);
+
+  if (options.json) {
+    console.log(JSON.stringify(descriptor, null, 2));
+  } else {
+    console.log(
+      `Registered build "${descriptor.id}" ` +
+        `(${descriptor.surface.targets.length} target(s)) to the registry.`,
+    );
+  }
+  return 0;
+}

--- a/packages/core/src/registry/registry.ts
+++ b/packages/core/src/registry/registry.ts
@@ -1,0 +1,56 @@
+/**
+ * The pluggable {@link BuildRegistry} — a catalog of the builds (pipelines) that
+ * exist and where they live — kept **separate** from the run
+ * {@link "../state/store.ts".StateStore} (a run history and a build catalog are
+ * different concerns) but resolved the same way (see
+ * {@link "./resolve.ts".resolveBuildRegistry}).
+ *
+ * Two backends ship, both dependency-free and mirroring the state layer:
+ * {@link "./fs_registry.ts".FileSystemBuildRegistry} for a single host (fine for
+ * dev) and {@link "./http_registry.ts".HttpBuildRegistry} for a hosted service
+ * (the production path — the `/builds` collection of `docs/state-api.md`). A
+ * consumer can implement this interface against their own catalog and plug it in
+ * via `Build.registry()`, so a richer catalog stays a plugin rather than core.
+ *
+ * The filesystem effects a backend needs are the same as the state layer's, so
+ * the {@link "../state/store.ts".StateHost} is reused rather than re-declared.
+ *
+ * @module
+ */
+
+import type {
+  BuildDescriptor,
+  BuildQuery,
+  BuildSummary,
+} from "./descriptor.ts";
+
+/** The result of a {@link BuildRegistry.register} compare-and-swap write. */
+export type PutBuildResult =
+  | { ok: true; version: string }
+  | { ok: false; conflict: true };
+
+/**
+ * Pluggable persistence for {@link BuildDescriptor}s. `version` is an opaque
+ * token (an ETag or content hash) used for optimistic concurrency: a write only
+ * lands if the stored version still matches the one the writer last read, so two
+ * registrations racing at the same version cannot both win.
+ */
+export interface BuildRegistry {
+  /** Fetch a build and its current version, or `null` if it is not registered. */
+  getBuild(
+    id: string,
+  ): Promise<{ descriptor: BuildDescriptor; version: string } | null>;
+  /**
+   * Write `descriptor` only if the stored version equals `expectedVersion`
+   * (`null` meaning "must not exist yet"). Returns the new version, or a conflict
+   * when the stored version has moved on — the caller re-reads and retries.
+   */
+  register(
+    descriptor: BuildDescriptor,
+    expectedVersion: string | null,
+  ): Promise<PutBuildResult>;
+  /** Remove a registered build by id; a missing build is not an error. */
+  deregister(id: string): Promise<void>;
+  /** List registered builds matching `query`, newest first (by `createdAt`, then `id`). */
+  listBuilds(query: BuildQuery): Promise<BuildSummary[]>;
+}

--- a/packages/core/src/registry/resolve.ts
+++ b/packages/core/src/registry/resolve.ts
@@ -1,0 +1,76 @@
+/**
+ * Selection of the {@link BuildRegistry} for a command, by precedence — the
+ * registry analogue of {@link "../state/resolve.ts".resolveStateStore}. Kept a
+ * separate concern from the run store, so it reads its own `ZUKE_REGISTRY_*`
+ * environment variables and defaults to its own directory
+ * (`<root>/.zuke/builds`), never colliding with `.zuke/runs`.
+ *
+ * @module
+ */
+
+import type { StateHost } from "../state/store.ts";
+import { FileSystemBuildRegistry } from "./fs_registry.ts";
+import { HttpBuildRegistry } from "./http_registry.ts";
+import type { BuildRegistry } from "./registry.ts";
+
+/**
+ * Resolve a {@link BuildRegistry} from the environment, or `undefined` when none
+ * is configured. `ZUKE_REGISTRY_URL` (with an optional `ZUKE_REGISTRY_TOKEN`)
+ * selects an {@link HttpBuildRegistry}; otherwise `ZUKE_REGISTRY_DIR` selects a
+ * {@link FileSystemBuildRegistry}.
+ */
+export function envBuildRegistry(
+  readEnv: (name: string) => string | undefined,
+  host: StateHost,
+): BuildRegistry | undefined {
+  const url = readEnv("ZUKE_REGISTRY_URL");
+  if (url !== undefined && url !== "") {
+    return new HttpBuildRegistry({
+      url,
+      token: readEnv("ZUKE_REGISTRY_TOKEN"),
+    });
+  }
+  const dir = readEnv("ZUKE_REGISTRY_DIR");
+  if (dir !== undefined && dir !== "") {
+    return new FileSystemBuildRegistry(dir, host);
+  }
+  return undefined;
+}
+
+/** Inputs {@link resolveBuildRegistry} needs to build the default filesystem registry. */
+export interface ResolveRegistryOptions {
+  /** Reads an environment variable (injectable for tests). */
+  readEnv: (name: string) => string | undefined;
+  /** Filesystem effects for the default/env filesystem registry. */
+  host: StateHost;
+  /** Directory the default filesystem registry writes to (`<root>/.zuke/builds`). */
+  defaultDir: string;
+  /**
+   * Fall back to the default filesystem registry when nothing else is
+   * configured. `zuke register` sets this so the command works out of the box.
+   */
+  enableDefault: boolean;
+}
+
+/**
+ * Pick the build registry by precedence: an explicit `option` wins (`false`
+ * disables the registry entirely), then a `declared` registry (a build's
+ * `registry()` override), then the {@link envBuildRegistry} environment
+ * fallback, then — only when {@link ResolveRegistryOptions.enableDefault} — a
+ * filesystem registry under `<root>/.zuke/builds`.
+ */
+export function resolveBuildRegistry(
+  option: BuildRegistry | false | undefined,
+  declared: BuildRegistry | undefined,
+  options: ResolveRegistryOptions,
+): BuildRegistry | undefined {
+  if (option === false) return undefined;
+  if (option !== undefined) return option;
+  if (declared !== undefined) return declared;
+  const fromEnv = envBuildRegistry(options.readEnv, options.host);
+  if (fromEnv !== undefined) return fromEnv;
+  if (options.enableDefault) {
+    return new FileSystemBuildRegistry(options.defaultDir, options.host);
+  }
+  return undefined;
+}

--- a/packages/core/tests/describe_test.ts
+++ b/packages/core/tests/describe_test.ts
@@ -54,3 +54,14 @@ Deno.test("describeCli reports parameter flags, kinds, and options", () => {
   assertEquals(params.find((p) => p.flag === "tags")?.array, true);
   assertEquals(params.find((p) => p.flag === "verbose")?.boolean, true);
 });
+
+Deno.test("describeCli hides a secret parameter's option values", () => {
+  class WithSecret extends Build {
+    // A secret whose declared options are real credentials must not surface.
+    apiKey = parameter("API key").secret().options("sk-live-a", "sk-live-b");
+  }
+  const key = describeCli(new WithSecret()).parameters.find((p) =>
+    p.flag === "api-key"
+  );
+  assertEquals(key?.options, []);
+});

--- a/packages/core/tests/register_test.ts
+++ b/packages/core/tests/register_test.ts
@@ -1,0 +1,263 @@
+/**
+ * Unit tests for the `zuke register` command ({@link registerCommand}): the
+ * descriptor it builds, its secret-free surface, idempotent compare-and-swap
+ * with conflict retry, `--json` output, and the no-registry error path.
+ */
+
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "./_assert.ts";
+import { Build } from "../src/build.ts";
+import { target } from "../src/target.ts";
+import { parameter } from "../src/params.ts";
+import {
+  type BuildDescriptor,
+  type BuildLocation,
+  toBuildSummary,
+} from "../src/registry/descriptor.ts";
+import type {
+  BuildRegistry,
+  PutBuildResult,
+} from "../src/registry/registry.ts";
+import { redactModuleUrl, registerCommand } from "../src/registry/register.ts";
+
+/** Run `fn` with `console.log`/`console.error` captured instead of printed. */
+async function capture(
+  fn: () => Promise<number> | number,
+): Promise<{ code: number; out: string; err: string }> {
+  const out: string[] = [];
+  const err: string[] = [];
+  const origLog = console.log;
+  const origErr = console.error;
+  console.log = (...args: unknown[]) => void out.push(args.join(" "));
+  console.error = (...args: unknown[]) => void err.push(args.join(" "));
+  try {
+    const code = await fn();
+    return { code, out: out.join("\n"), err: err.join("\n") };
+  } finally {
+    console.log = origLog;
+    console.error = origErr;
+  }
+}
+
+/** An in-memory {@link BuildRegistry} that can force a set number of conflicts. */
+class FakeBuildRegistry implements BuildRegistry {
+  readonly builds = new Map<
+    string,
+    { descriptor: BuildDescriptor; version: string }
+  >();
+  #version = 0;
+  #conflictsLeft: number;
+
+  constructor(conflicts = 0) {
+    this.#conflictsLeft = conflicts;
+  }
+
+  getBuild(
+    id: string,
+  ): Promise<{ descriptor: BuildDescriptor; version: string } | null> {
+    return Promise.resolve(this.builds.get(id) ?? null);
+  }
+
+  register(
+    descriptor: BuildDescriptor,
+    expectedVersion: string | null,
+  ): Promise<PutBuildResult> {
+    if (this.#conflictsLeft > 0) {
+      this.#conflictsLeft--;
+      return Promise.resolve({ ok: false, conflict: true });
+    }
+    const current = this.builds.get(descriptor.id);
+    if ((current?.version ?? null) !== expectedVersion) {
+      return Promise.resolve({ ok: false, conflict: true });
+    }
+    const version = `v${++this.#version}`;
+    this.builds.set(descriptor.id, { descriptor, version });
+    return Promise.resolve({ ok: true, version });
+  }
+
+  deregister(id: string): Promise<void> {
+    this.builds.delete(id);
+    return Promise.resolve();
+  }
+
+  listBuilds() {
+    return Promise.resolve(
+      [...this.builds.values()].map((b) => toBuildSummary(b.descriptor)),
+    );
+  }
+}
+
+/** A fixture build with a secret parameter, to prove secrets stay out. */
+class Sample extends Build {
+  apiToken = parameter("api token").secret();
+  region = parameter("Region").options("eu", "us");
+  compile = target().description("Compile the app").executes(() => {});
+}
+
+/** A fixed launch location, so tests never depend on the running module. */
+const LOCATION: BuildLocation = {
+  kind: "module",
+  module: "file:///repo/zuke.ts",
+  cwd: "/repo",
+};
+
+Deno.test("registerCommand writes a descriptor built from the build", async () => {
+  const registry = new FakeBuildRegistry();
+  const { code } = await capture(() =>
+    registerCommand(new Sample(), {
+      registry,
+      location: LOCATION,
+      actor: "alice",
+      readEnv: () => undefined,
+      now: () => "2026-03-01T00:00:00.000Z",
+    })
+  );
+  assertEquals(code, 0);
+  const stored = registry.builds.get("Sample");
+  assertEquals(stored?.descriptor.id, "Sample");
+  assertEquals(stored?.descriptor.name, "Sample");
+  assertEquals(stored?.descriptor.actor, "alice");
+  assertEquals(stored?.descriptor.location, LOCATION);
+  assertEquals(
+    stored?.descriptor.surface.targets.map((t) => t.name),
+    ["compile"],
+  );
+});
+
+Deno.test("registerCommand excludes secret parameter values from the descriptor", async () => {
+  const registry = new FakeBuildRegistry();
+  // A secret is configured in the environment; it must never reach the record.
+  await capture(() =>
+    registerCommand(new Sample(), {
+      registry,
+      location: LOCATION,
+      readEnv: (name) => (name === "API_TOKEN" ? "s3cr3t-value" : undefined),
+      now: () => "2026-03-01T00:00:00.000Z",
+    })
+  );
+  const descriptor = registry.builds.get("Sample")?.descriptor;
+  // The surface lists the parameter flags (structure) but no values.
+  const flags = descriptor?.surface.parameters.map((p) => p.flag);
+  assertEquals(flags, ["api-token", "region"]);
+  // The whole serialized descriptor carries no secret value.
+  assertEquals(JSON.stringify(descriptor).includes("s3cr3t-value"), false);
+});
+
+Deno.test("registerCommand --json prints the written descriptor", async () => {
+  const registry = new FakeBuildRegistry();
+  const { code, out } = await capture(() =>
+    registerCommand(new Sample(), {
+      registry,
+      location: LOCATION,
+      json: true,
+      readEnv: () => undefined,
+      now: () => "2026-03-01T00:00:00.000Z",
+    })
+  );
+  assertEquals(code, 0);
+  const parsed: unknown = JSON.parse(out);
+  assertEquals(parsed !== null && typeof parsed === "object", true);
+  assertStringIncludes(out, '"id": "Sample"');
+});
+
+Deno.test("registerCommand is idempotent and preserves createdAt on update", async () => {
+  const registry = new FakeBuildRegistry();
+  const times = ["2026-03-01T00:00:00.000Z", "2026-03-02T00:00:00.000Z"];
+  let i = 0;
+  const now = () => times[Math.min(i++, times.length - 1)];
+  const opts = { registry, location: LOCATION, readEnv: () => undefined, now };
+  await capture(() => registerCommand(new Sample(), opts));
+  await capture(() => registerCommand(new Sample(), opts));
+  const descriptor = registry.builds.get("Sample")?.descriptor;
+  assertEquals(descriptor?.createdAt, times[0]); // preserved
+  assertEquals(descriptor?.updatedAt, times[1]); // refreshed
+});
+
+Deno.test("registerCommand retries on a registry conflict", async () => {
+  const registry = new FakeBuildRegistry(1); // one forced conflict, then succeeds
+  const { code } = await capture(() =>
+    registerCommand(new Sample(), {
+      registry,
+      location: LOCATION,
+      readEnv: () => undefined,
+      now: () => "2026-03-01T00:00:00.000Z",
+    })
+  );
+  assertEquals(code, 0);
+  assertEquals(registry.builds.has("Sample"), true);
+});
+
+Deno.test("registerCommand accepts an explicit id override", async () => {
+  const registry = new FakeBuildRegistry();
+  await capture(() =>
+    registerCommand(new Sample(), {
+      registry,
+      id: "sample-prod",
+      location: LOCATION,
+      readEnv: () => undefined,
+      now: () => "2026-03-01T00:00:00.000Z",
+    })
+  );
+  assertEquals(registry.builds.get("sample-prod")?.descriptor.name, "Sample");
+});
+
+Deno.test("registerCommand derives a module location with the CI repo", async () => {
+  const registry = new FakeBuildRegistry();
+  // No location injected, so deriveLocation runs against the running module.
+  await capture(() =>
+    registerCommand(new Sample(), {
+      registry,
+      readEnv: (
+        name,
+      ) => (name === "GITHUB_REPOSITORY" ? "acme/app" : undefined),
+      now: () => "2026-03-01T00:00:00.000Z",
+    })
+  );
+  const location = registry.builds.get("Sample")?.descriptor.location;
+  assertEquals(location?.kind, "module");
+  assertEquals(location?.repo, "acme/app");
+});
+
+Deno.test("registerCommand throws after repeated registry conflicts", async () => {
+  const registry = new FakeBuildRegistry(999); // never stops conflicting
+  await assertRejects(
+    () =>
+      registerCommand(new Sample(), {
+        registry,
+        location: LOCATION,
+        readEnv: () => undefined,
+        now: () => "2026-03-01T00:00:00.000Z",
+      }),
+    Error,
+    "gave up registering",
+  );
+});
+
+Deno.test("redactModuleUrl strips credentials but leaves plain URLs and paths", () => {
+  // Embedded basic-auth userinfo is stripped from a remote entrypoint.
+  assertEquals(
+    redactModuleUrl("https://user:token@host/build.ts"),
+    "https://host/build.ts",
+  );
+  // A credential-free URL and a bare path are returned unchanged.
+  assertEquals(
+    redactModuleUrl("file:///repo/zuke.ts"),
+    "file:///repo/zuke.ts",
+  );
+  assertEquals(redactModuleUrl("/repo/zuke.ts"), "/repo/zuke.ts");
+});
+
+Deno.test("registerCommand errors when no registry is configured", async () => {
+  const { code, err } = await capture(() =>
+    registerCommand(new Sample(), {
+      registry: false,
+      location: LOCATION,
+      readEnv: () => undefined,
+    })
+  );
+  assertEquals(code, 1);
+  assertStringIncludes(err, "no build registry is configured");
+});

--- a/packages/core/tests/registry_http_test.ts
+++ b/packages/core/tests/registry_http_test.ts
@@ -1,0 +1,216 @@
+/**
+ * Unit tests for {@link HttpBuildRegistry}: the REST verbs, ETag/If-Match
+ * compare-and-swap, and untrusted-response validation, all driven through the
+ * injectable `fetch` seam (no network). Mirrors the HttpStateStore tests.
+ */
+
+import { assertEquals, assertRejects } from "./_assert.ts";
+import { HttpError } from "../src/http.ts";
+import type { CliDescription } from "../src/describe.ts";
+import {
+  type BuildDescriptor,
+  stringifyBuildDescriptor,
+  toBuildSummary,
+} from "../src/registry/descriptor.ts";
+import { HttpBuildRegistry } from "../src/registry/http_registry.ts";
+
+/** A minimal, valid CLI surface. */
+function surface(): CliDescription {
+  return { commands: [], flags: [], targets: [], parameters: [] };
+}
+
+/** A sample descriptor. */
+function descriptor(overrides: Partial<BuildDescriptor> = {}): BuildDescriptor {
+  return {
+    id: "CI",
+    name: "CI",
+    location: { kind: "module", module: "file:///x/zuke.ts", cwd: "/x" },
+    surface: surface(),
+    actor: "me",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+/** Wrap a synchronous handler as a `fetch` implementation. */
+function fakeFetch(
+  handler: (url: string, init: RequestInit | undefined) => Response,
+): typeof fetch {
+  return (input: string | URL | Request, init?: RequestInit) =>
+    Promise.resolve(handler(String(input), init));
+}
+
+/** Read one request header without casting, whatever `HeadersInit` shape it is. */
+function headerOf(
+  init: RequestInit | undefined,
+  name: string,
+): string | undefined {
+  const headers = init?.headers;
+  if (headers === undefined) return undefined;
+  if (headers instanceof Headers) return headers.get(name) ?? undefined;
+  if (Array.isArray(headers)) {
+    for (const [key, value] of headers) if (key === name) return value;
+    return undefined;
+  }
+  for (const [key, value] of Object.entries(headers)) {
+    if (key === name) return value;
+  }
+  return undefined;
+}
+
+Deno.test("HttpBuildRegistry.getBuild returns descriptor + ETag, or null on 404", async () => {
+  const registry = new HttpBuildRegistry({
+    url: "https://r.example/",
+    token: "t",
+    fetch: fakeFetch((url, init) => {
+      assertEquals(init?.headers, { Authorization: "Bearer t" });
+      if (url.endsWith("/builds/missing")) {
+        return new Response(null, { status: 404 });
+      }
+      return new Response(stringifyBuildDescriptor(descriptor()), {
+        status: 200,
+        headers: { etag: "v1" },
+      });
+    }),
+  });
+  const loaded = await registry.getBuild("CI");
+  assertEquals(loaded?.version, "v1");
+  assertEquals(loaded?.descriptor.id, "CI");
+  assertEquals(await registry.getBuild("missing"), null);
+});
+
+Deno.test("HttpBuildRegistry.getBuild errors without an ETag or on failure", async () => {
+  const noEtag = new HttpBuildRegistry({
+    url: "https://r.example",
+    fetch: fakeFetch(() =>
+      new Response(stringifyBuildDescriptor(descriptor()), { status: 200 })
+    ),
+  });
+  await assertRejects(
+    () => noEtag.getBuild("CI"),
+    Error,
+    "did not return an ETag",
+  );
+
+  const failing = new HttpBuildRegistry({
+    url: "https://r.example",
+    fetch: fakeFetch(() => new Response(null, { status: 500 })),
+  });
+  await assertRejects(() => failing.getBuild("CI"), HttpError);
+});
+
+Deno.test("HttpBuildRegistry.register sends preconditions and maps 412 to a conflict", async () => {
+  const registry = new HttpBuildRegistry({
+    url: "https://r.example",
+    fetch: fakeFetch((_url, init) => {
+      // A create (null version) sends If-None-Match:*.
+      if (headerOf(init, "If-None-Match") === "*") {
+        return new Response(null, { status: 200, headers: { etag: "v1" } });
+      }
+      // A stale If-Match version is rejected.
+      if (headerOf(init, "If-Match") === "stale") {
+        return new Response(null, { status: 412 });
+      }
+      return new Response(null, { status: 200, headers: { etag: "v2" } });
+    }),
+  });
+  const created = await registry.register(descriptor(), null);
+  assertEquals(created, { ok: true, version: "v1" });
+
+  const conflict = await registry.register(descriptor(), "stale");
+  assertEquals(conflict, { ok: false, conflict: true });
+
+  const updated = await registry.register(descriptor(), "v1");
+  assertEquals(updated, { ok: true, version: "v2" });
+});
+
+Deno.test("HttpBuildRegistry.register errors without an ETag or on failure", async () => {
+  const noEtag = new HttpBuildRegistry({
+    url: "https://r.example",
+    fetch: fakeFetch(() => new Response(null, { status: 200 })),
+  });
+  await assertRejects(
+    () => noEtag.register(descriptor(), null),
+    Error,
+    "did not return an ETag on write",
+  );
+
+  const failing = new HttpBuildRegistry({
+    url: "https://r.example",
+    fetch: fakeFetch(() => new Response(null, { status: 500 })),
+  });
+  await assertRejects(() => failing.register(descriptor(), null), HttpError);
+});
+
+Deno.test("HttpBuildRegistry.deregister tolerates 404 and reports other errors", async () => {
+  let method: string | undefined;
+  const ok = new HttpBuildRegistry({
+    url: "https://r.example",
+    fetch: fakeFetch((_url, init) => {
+      method = init?.method;
+      return new Response(null, { status: 204 });
+    }),
+  });
+  await ok.deregister("CI");
+  assertEquals(method, "DELETE");
+
+  const missing = new HttpBuildRegistry({
+    url: "https://r.example",
+    fetch: fakeFetch(() => new Response(null, { status: 404 })),
+  });
+  await missing.deregister("CI"); // 404 is not an error
+
+  const failing = new HttpBuildRegistry({
+    url: "https://r.example",
+    fetch: fakeFetch(() => new Response(null, { status: 500 })),
+  });
+  await assertRejects(() => failing.deregister("CI"), HttpError);
+});
+
+Deno.test("HttpBuildRegistry.listBuilds builds a query and validates the array", async () => {
+  let seenUrl = "";
+  const registry = new HttpBuildRegistry({
+    url: "https://r.example",
+    fetch: fakeFetch((url) => {
+      seenUrl = url;
+      return new Response(
+        JSON.stringify([toBuildSummary(descriptor())]),
+        { status: 200 },
+      );
+    }),
+  });
+  const summaries = await registry.listBuilds({
+    name: "CI",
+    since: "2026-01-01T00:00:00.000Z",
+  });
+  assertEquals(summaries.map((s) => s.id), ["CI"]);
+  assertEquals(seenUrl.includes("name=CI"), true);
+  assertEquals(seenUrl.includes("since=2026-01-01"), true);
+
+  const notArray = new HttpBuildRegistry({
+    url: "https://r.example",
+    fetch: fakeFetch(() => new Response("{}", { status: 200 })),
+  });
+  await assertRejects(() => notArray.listBuilds({}), Error, "JSON array");
+
+  // A 200 with a non-JSON body (e.g. a proxy HTML page) is a friendly error,
+  // not a raw SyntaxError.
+  const notJson = new HttpBuildRegistry({
+    url: "https://r.example",
+    fetch: fakeFetch(() =>
+      new Response("<html>Bad Gateway</html>", { status: 200 })
+    ),
+  });
+  await assertRejects(
+    () => notJson.listBuilds({}),
+    Error,
+    "did not return valid JSON",
+  );
+
+  const failing = new HttpBuildRegistry({
+    url: "https://r.example",
+    fetch: fakeFetch(() => new Response(null, { status: 500 })),
+  });
+  await assertRejects(() => failing.listBuilds({}), HttpError);
+});

--- a/packages/core/tests/registry_test.ts
+++ b/packages/core/tests/registry_test.ts
@@ -1,0 +1,492 @@
+/**
+ * Unit tests for the build-registry vocabulary and the filesystem backend:
+ * descriptor parse/round-trip, {@link FileSystemBuildRegistry} compare-and-swap,
+ * and {@link resolveBuildRegistry} precedence. Mirrors the state-layer tests.
+ */
+
+import { assertEquals, assertRejects, assertThrows } from "./_assert.ts";
+import { defaultStateHost, type StateHost } from "../src/state/store.ts";
+import type { CliDescription } from "../src/describe.ts";
+import {
+  type BuildDescriptor,
+  parseBuildDescriptor,
+  parseBuildSummary,
+  stringifyBuildDescriptor,
+  toBuildSummary,
+} from "../src/registry/descriptor.ts";
+import { FileSystemBuildRegistry } from "../src/registry/fs_registry.ts";
+import { HttpBuildRegistry } from "../src/registry/http_registry.ts";
+import {
+  envBuildRegistry,
+  resolveBuildRegistry,
+} from "../src/registry/resolve.ts";
+
+/** An in-memory {@link StateHost}: a flat file map plus a lock set. */
+class FakeStateHost implements StateHost {
+  readonly files = new Map<string, string>();
+  readonly locks = new Set<string>();
+
+  readText(path: string): Promise<string | null> {
+    return Promise.resolve(this.files.get(path) ?? null);
+  }
+  writeText(path: string, content: string): Promise<void> {
+    this.files.set(path, content);
+    return Promise.resolve();
+  }
+  rename(from: string, to: string): Promise<void> {
+    const content = this.files.get(from);
+    if (content !== undefined) {
+      this.files.set(to, content);
+      this.files.delete(from);
+    }
+    return Promise.resolve();
+  }
+  createExclusive(path: string): Promise<boolean> {
+    if (this.locks.has(path)) return Promise.resolve(false);
+    this.locks.add(path);
+    return Promise.resolve(true);
+  }
+  remove(path: string): Promise<void> {
+    this.files.delete(path);
+    this.locks.delete(path);
+    return Promise.resolve();
+  }
+  listDir(path: string): Promise<string[]> {
+    const prefix = `${path}/`;
+    const names: string[] = [];
+    for (const key of this.files.keys()) {
+      if (key.startsWith(prefix)) names.push(key.slice(prefix.length));
+    }
+    return Promise.resolve(names);
+  }
+  mkdirp(): Promise<void> {
+    return Promise.resolve();
+  }
+  now(): number {
+    return 1_000_000;
+  }
+}
+
+/** A minimal CLI surface for a descriptor. */
+function sampleSurface(): CliDescription {
+  return {
+    commands: [{ name: "graph", description: "Show the dependency graph" }],
+    flags: [{ name: "--list", description: "List all targets" }],
+    targets: [
+      {
+        name: "build",
+        description: "Compile",
+        dependsOn: ["lint"],
+        default: false,
+        unlisted: false,
+      },
+    ],
+    parameters: [
+      {
+        flag: "environment",
+        description: "Deploy target",
+        required: true,
+        boolean: false,
+        array: false,
+        options: ["sit", "prod"],
+      },
+    ],
+  };
+}
+
+/** A sample descriptor, with overridable fields. */
+function sampleDescriptor(
+  overrides: Partial<BuildDescriptor> = {},
+): BuildDescriptor {
+  return {
+    id: "CI",
+    name: "CI",
+    location: { kind: "module", module: "file:///x/zuke.ts", cwd: "/x" },
+    surface: sampleSurface(),
+    actor: "me",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+// ------------------------------------------------------------- descriptor
+
+Deno.test("stringify then parse round-trips a descriptor", () => {
+  const descriptor = sampleDescriptor();
+  assertEquals(
+    parseBuildDescriptor(stringifyBuildDescriptor(descriptor)),
+    descriptor,
+  );
+});
+
+Deno.test("parseBuildDescriptor round-trips a command location with a repo", () => {
+  const descriptor = sampleDescriptor({
+    location: {
+      kind: "command",
+      command: ["deno", "run", "-A", "zuke.ts"],
+      cwd: "/w",
+      repo: "acme/app",
+    },
+  });
+  assertEquals(
+    parseBuildDescriptor(stringifyBuildDescriptor(descriptor)),
+    descriptor,
+  );
+});
+
+Deno.test("toBuildSummary projects the summary fields", () => {
+  assertEquals(toBuildSummary(sampleDescriptor()), {
+    id: "CI",
+    name: "CI",
+    actor: "me",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  });
+});
+
+Deno.test("parseBuildDescriptor rejects malformed descriptors", () => {
+  assertThrows(() => parseBuildDescriptor("not json"), Error, "not valid JSON");
+  assertThrows(() => parseBuildDescriptor("[]"), Error, "not an object");
+  // Missing required field.
+  const noId = JSON.stringify({ ...sampleDescriptor(), id: undefined });
+  assertThrows(() => parseBuildDescriptor(noId), Error, '"id"');
+  // Unknown location kind.
+  const badKind = JSON.stringify({
+    ...sampleDescriptor(),
+    location: { kind: "carrier-pigeon", cwd: "/x" },
+  });
+  assertThrows(() => parseBuildDescriptor(badKind), Error, "location kind");
+  // Surface is not an object.
+  const badSurface = JSON.stringify({ ...sampleDescriptor(), surface: 7 });
+  assertThrows(() => parseBuildDescriptor(badSurface), Error, '"surface"');
+  // A surface target with a non-boolean flag.
+  const badTarget = JSON.stringify({
+    ...sampleDescriptor(),
+    surface: {
+      commands: [],
+      flags: [],
+      targets: [{
+        name: "x",
+        description: "",
+        dependsOn: [],
+        default: false,
+        unlisted: "no",
+      }],
+      parameters: [],
+    },
+  });
+  assertThrows(() => parseBuildDescriptor(badTarget), Error, "not a boolean");
+});
+
+/** Serialize the sample descriptor with malformed fields spliced in. */
+function mangled(overrides: Record<string, unknown>): string {
+  return JSON.stringify({ ...sampleDescriptor(), ...overrides });
+}
+
+Deno.test("parseBuildDescriptor validates surface and location shapes", () => {
+  // A non-string field that is not `id`.
+  assertThrows(
+    () => parseBuildDescriptor(mangled({ name: 5 })),
+    Error,
+    "not a string",
+  );
+  // A location that is not an object, and one whose repo is the wrong type.
+  assertThrows(
+    () => parseBuildDescriptor(mangled({ location: 5 })),
+    Error,
+    "location",
+  );
+  assertThrows(
+    () =>
+      parseBuildDescriptor(
+        mangled({
+          location: { kind: "module", module: "m", cwd: "/c", repo: 5 },
+        }),
+      ),
+    Error,
+    "not a string",
+  );
+  // A surface whose collections are the wrong shape.
+  const surface = (over: Record<string, unknown>) =>
+    mangled({
+      surface: {
+        commands: [],
+        flags: [],
+        targets: [],
+        parameters: [],
+        ...over,
+      },
+    });
+  assertThrows(
+    () => parseBuildDescriptor(surface({ commands: 5 })),
+    Error,
+    "not an array",
+  );
+  assertThrows(
+    () => parseBuildDescriptor(surface({ commands: [5] })),
+    Error,
+    "surface entry",
+  );
+  assertThrows(
+    () => parseBuildDescriptor(surface({ targets: [5] })),
+    Error,
+    "surface target",
+  );
+  assertThrows(
+    () =>
+      parseBuildDescriptor(
+        surface({
+          targets: [{
+            name: "x",
+            description: "",
+            dependsOn: "no",
+            default: false,
+            unlisted: false,
+          }],
+        }),
+      ),
+    Error,
+    "not a string array",
+  );
+  assertThrows(
+    () => parseBuildDescriptor(surface({ parameters: [5] })),
+    Error,
+    "surface parameter",
+  );
+});
+
+Deno.test("parseBuildDescriptor round-trips a module location with a repo", () => {
+  const descriptor = sampleDescriptor({
+    location: {
+      kind: "module",
+      module: "file:///x/zuke.ts",
+      cwd: "/x",
+      repo: "acme/app",
+    },
+  });
+  assertEquals(
+    parseBuildDescriptor(stringifyBuildDescriptor(descriptor)),
+    descriptor,
+  );
+});
+
+Deno.test("parseBuildSummary validates untrusted summaries", () => {
+  assertThrows(() => parseBuildSummary(42), Error, "not an object");
+  assertThrows(() => parseBuildSummary({ id: 1 }), Error, '"id"');
+  assertEquals(parseBuildSummary(toBuildSummary(sampleDescriptor())).id, "CI");
+});
+
+// ----------------------------------------------------- filesystem backend
+
+Deno.test("FileSystemBuildRegistry persists and reconstructs a descriptor", async () => {
+  const host = new FakeStateHost();
+  const registry = new FileSystemBuildRegistry("/builds", host);
+  const created = await registry.register(sampleDescriptor(), null);
+  if (!created.ok) throw new Error("expected create to succeed");
+  const loaded = await registry.getBuild("CI");
+  assertEquals(loaded?.descriptor.name, "CI");
+  assertEquals(loaded?.version, created.version);
+  assertEquals(await registry.getBuild("missing"), null);
+});
+
+Deno.test("FileSystemBuildRegistry CAS rejects a stale write", async () => {
+  const host = new FakeStateHost();
+  const registry = new FileSystemBuildRegistry("/builds", host);
+  const created = await registry.register(sampleDescriptor(), null);
+  if (!created.ok) throw new Error("expected create to succeed");
+  // A second create at null (must-not-exist) now conflicts.
+  assertEquals(await registry.register(sampleDescriptor(), null), {
+    ok: false,
+    conflict: true,
+  });
+  // A write at a stale version conflicts too.
+  assertEquals(await registry.register(sampleDescriptor(), "stale"), {
+    ok: false,
+    conflict: true,
+  });
+  // A write at the current version succeeds.
+  const ok = await registry.register(
+    sampleDescriptor({ actor: "you" }),
+    created.version,
+  );
+  assertEquals(ok.ok, true);
+});
+
+Deno.test("FileSystemBuildRegistry: concurrent registrations — exactly one wins", async () => {
+  const host = new FakeStateHost();
+  const registry = new FileSystemBuildRegistry("/builds", host);
+  const created = await registry.register(sampleDescriptor(), null);
+  if (!created.ok) throw new Error("expected create to succeed");
+  const results = await Promise.all([
+    registry.register(sampleDescriptor({ actor: "b" }), created.version),
+    registry.register(sampleDescriptor({ actor: "c" }), created.version),
+  ]);
+  assertEquals(results.filter((r) => r.ok).length, 1);
+  assertEquals(results.filter((r) => !r.ok).length, 1);
+});
+
+Deno.test("FileSystemBuildRegistry deregister removes a build", async () => {
+  const host = new FakeStateHost();
+  const registry = new FileSystemBuildRegistry("/builds", host);
+  await registry.register(sampleDescriptor(), null);
+  await registry.deregister("CI");
+  assertEquals(await registry.getBuild("CI"), null);
+  // Deregistering a missing build is a no-op.
+  await registry.deregister("CI");
+});
+
+Deno.test("FileSystemBuildRegistry listBuilds filters, sorts, and skips junk", async () => {
+  const host = new FakeStateHost();
+  const registry = new FileSystemBuildRegistry("/builds", host);
+  await registry.register(
+    sampleDescriptor({
+      id: "a",
+      name: "a",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    }),
+    null,
+  );
+  await registry.register(
+    sampleDescriptor({
+      id: "b",
+      name: "b",
+      createdAt: "2026-02-01T00:00:00.000Z",
+    }),
+    null,
+  );
+  // A corrupt file and a non-json marker must not break listing.
+  host.files.set("/builds/corrupt.json", "{ not json");
+  host.files.set("/builds/note.txt", "ignore me");
+
+  const all = await registry.listBuilds({});
+  assertEquals(all.map((s) => s.id), ["b", "a"]); // newest first
+
+  const byName = await registry.listBuilds({ name: "a" });
+  assertEquals(byName.map((s) => s.id), ["a"]);
+
+  const since = await registry.listBuilds({
+    since: "2026-01-15T00:00:00.000Z",
+  });
+  assertEquals(since.map((s) => s.id), ["b"]);
+});
+
+Deno.test("FileSystemBuildRegistry rejects an unsafe build id", async () => {
+  const registry = new FileSystemBuildRegistry("/builds", new FakeStateHost());
+  await assertRejects(
+    () => registry.getBuild("../escape"),
+    Error,
+    "unsafe build id",
+  );
+  await assertRejects(
+    () => registry.register(sampleDescriptor({ id: "../escape" }), null),
+    Error,
+    "unsafe build id",
+  );
+  await assertRejects(
+    () => registry.deregister("a/b"),
+    Error,
+    "unsafe build id",
+  );
+});
+
+Deno.test("FileSystemBuildRegistry listBuilds skips a vanished file", async () => {
+  // A file listed by the directory but gone by the time it is read (deleted
+  // between listing and reading) is skipped, not an error.
+  class PhantomHost extends FakeStateHost {
+    override listDir(): Promise<string[]> {
+      return Promise.resolve(["ghost.json"]);
+    }
+  }
+  const registry = new FileSystemBuildRegistry("/builds", new PhantomHost());
+  assertEquals(await registry.listBuilds({}), []);
+});
+
+Deno.test("FileSystemBuildRegistry gives up on a permanently held mutex", async () => {
+  const host = new FakeStateHost();
+  // Pre-hold the lock marker so createExclusive never succeeds.
+  host.locks.add("/builds/CI.json.lock");
+  const registry = new FileSystemBuildRegistry("/builds", host);
+  await assertRejects(
+    () => registry.register(sampleDescriptor(), null),
+    Error,
+    "could not acquire the mutex",
+  );
+});
+
+Deno.test("FileSystemBuildRegistry round-trips through the real filesystem", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const registry = new FileSystemBuildRegistry(
+      `${dir}/builds`,
+      defaultStateHost,
+    );
+    const created = await registry.register(sampleDescriptor(), null);
+    if (!created.ok) throw new Error("expected create to succeed");
+    const loaded = await registry.getBuild("CI");
+    assertEquals(loaded?.descriptor.surface.targets[0].name, "build");
+    assertEquals((await registry.listBuilds({})).length, 1);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+// --------------------------------------------------------------- resolve
+
+Deno.test("resolveBuildRegistry follows its precedence", () => {
+  const host = new FakeStateHost();
+  const explicit = new FileSystemBuildRegistry("/explicit", host);
+  const declared = new FileSystemBuildRegistry("/declared", host);
+  const opts = {
+    readEnv: () => undefined,
+    host,
+    defaultDir: "/default",
+    enableDefault: false,
+  };
+
+  // `false` disables entirely.
+  assertEquals(resolveBuildRegistry(false, declared, opts), undefined);
+  // An explicit option wins.
+  assertEquals(resolveBuildRegistry(explicit, declared, opts), explicit);
+  // Then a declared (build.registry()) override.
+  assertEquals(resolveBuildRegistry(undefined, declared, opts), declared);
+  // Then nothing, unless enableDefault.
+  assertEquals(resolveBuildRegistry(undefined, undefined, opts), undefined);
+  const defaulted = resolveBuildRegistry(undefined, undefined, {
+    ...opts,
+    enableDefault: true,
+  });
+  assertEquals(defaulted instanceof FileSystemBuildRegistry, true);
+});
+
+Deno.test("resolveBuildRegistry reads the environment when nothing is declared", () => {
+  const host = new FakeStateHost();
+  const env = new Map<string, string>([["ZUKE_REGISTRY_DIR", "/env-builds"]]);
+  const fromDir = resolveBuildRegistry(undefined, undefined, {
+    readEnv: (name) => env.get(name),
+    host,
+    defaultDir: "/default",
+    enableDefault: false,
+  });
+  assertEquals(fromDir instanceof FileSystemBuildRegistry, true);
+});
+
+Deno.test("envBuildRegistry prefers URL over DIR", () => {
+  const host = new FakeStateHost();
+  const env = new Map<string, string>([
+    ["ZUKE_REGISTRY_URL", "https://registry.example"],
+    ["ZUKE_REGISTRY_TOKEN", "t"],
+    ["ZUKE_REGISTRY_DIR", "/ignored"],
+  ]);
+  const http = envBuildRegistry((name) => env.get(name), host);
+  assertEquals(http instanceof HttpBuildRegistry, true);
+
+  const dirOnly = new Map<string, string>([["ZUKE_REGISTRY_DIR", "/only"]]);
+  assertEquals(
+    envBuildRegistry((name) => dirOnly.get(name), host) instanceof
+      FileSystemBuildRegistry,
+    true,
+  );
+
+  assertEquals(envBuildRegistry(() => undefined, host), undefined);
+});

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -548,7 +548,16 @@ is current (`zuke generate-ci --check` is a dedicated gate).
 ./zuke mcp --allow-run=deploy,checks* --protect deploy --confirm-destructive
                               # authz tiers: allow-list, operator token, confirm
 ./zuke runs show mcp-audit    # the MCP tool-call audit trail
+./zuke register [--json]      # record this build in the build registry (idempotent)
 ```
+
+**Build registry** (`docs/registry.md`): `zuke register` writes a secret-free
+descriptor of this build — its `describeCli()` surface (targets, params) plus a
+launch location — into a pluggable `BuildRegistry`, so a registry-backed MCP
+server can discover new pipelines without a redeploy. Resolved like the state
+store: `ZUKE_REGISTRY_URL`/`_TOKEN` (HTTP) or `ZUKE_REGISTRY_DIR` (files), a
+`registry()` build override, else `.zuke/builds`. Separate from the run store; an
+HTTP backend shares the `/builds` REST contract beside `/runs`.
 
 **Caching:** a target with `.inputs(...)`/`.outputs(...)` is incremental
 (skipped and reported `cached` when inputs are unchanged and outputs exist). Add

--- a/tests/e2e/fixtures/register_build.ts
+++ b/tests/e2e/fixtures/register_build.ts
@@ -1,0 +1,22 @@
+/**
+ * A real, runnable Zuke build used by the registry e2e race. Run as a subprocess
+ * (`deno run -A register_build.ts register`), it records itself in the build
+ * registry `ZUKE_REGISTRY_DIR` points at — so two genuine OS processes can race
+ * the same descriptor's compare-and-swap and prove no torn write results.
+ *
+ * @module
+ */
+
+import { Build, parameter, run, target } from "../../../packages/core/mod.ts";
+
+/** A tiny pipeline with a secret parameter (which must stay out of the record). */
+class Catalog extends Build {
+  /** A secret; the registered descriptor must never carry its value. */
+  apiToken = parameter("api token").secret();
+  /** A leaf target. */
+  lint = target().description("Lint").executes(() => {});
+  /** A target depending on the leaf, so the surface has an edge. */
+  build = target().dependsOn(this.lint).executes(() => {});
+}
+
+await run(Catalog);

--- a/tests/e2e/registry_e2e.ts
+++ b/tests/e2e/registry_e2e.ts
@@ -1,0 +1,73 @@
+/**
+ * End-to-end: two real, separate OS processes racing `zuke register` against one
+ * shared build registry converge on a single, uncorrupted descriptor — the
+ * cross-process compare-and-swap the in-process suite cannot prove. Runs the
+ * {@link file://./fixtures/register_build.ts} build as `deno` subprocesses over a
+ * shared temp `ZUKE_REGISTRY_DIR`. Excluded from the fast unit gate; runs on the
+ * `integration` OS matrix where Windows filesystem-lock semantics get coverage.
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import {
+  defaultStateHost,
+  FileSystemBuildRegistry,
+} from "../../packages/core/mod.ts";
+
+const FIXTURE = new URL("./fixtures/register_build.ts", import.meta.url);
+
+/** The captured result of one fixture subprocess. */
+interface Run {
+  code: number;
+  out: string;
+}
+
+/** Run the register fixture as a real `deno` subprocess against registry `dir`. */
+async function runFixture(args: string[], dir: string): Promise<Run> {
+  const command = new Deno.Command(Deno.execPath(), {
+    // Pass the fixture as a `file://` URL (deno's native module specifier)
+    // rather than URL.pathname, which is `/C:/…` on Windows.
+    args: ["run", "-A", FIXTURE.href, ...args],
+    // A secret is present in the environment; the descriptor must not carry it.
+    env: { ZUKE_REGISTRY_DIR: dir, API_TOKEN: "e2e-secret-xyz" },
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const { code, stdout } = await command.output();
+  return { code, out: new TextDecoder().decode(stdout) };
+}
+
+Deno.test("two real processes register concurrently; no torn write", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "zuke-reg-e2e-" });
+  try {
+    // Two processes register the same build at once. Idempotent CAS: both
+    // succeed (one creates, the other retries onto the created version).
+    const [a, b] = await Promise.all([
+      runFixture(["register"], dir),
+      runFixture(["register"], dir),
+    ]);
+    assertEquals(a.code, 0);
+    assertEquals(b.code, 0);
+    assertStringIncludes(a.out, "Registered build");
+
+    // A separate reader loads exactly one, well-formed descriptor — proving the
+    // file was never left half-written under the cross-process mutex.
+    const registry = new FileSystemBuildRegistry(dir, defaultStateHost);
+    const builds = await registry.listBuilds({});
+    assertEquals(builds.length, 1);
+    const loaded = await registry.getBuild("Catalog");
+    assertEquals(loaded?.descriptor.id, "Catalog");
+    assertEquals(
+      loaded?.descriptor.surface.targets.map((t) => t.name),
+      ["lint", "build"],
+    );
+    // The surface lists the parameter flag (structure) but never its value.
+    const json = JSON.stringify(loaded?.descriptor);
+    assertEquals(json.includes("api-token"), true);
+    assertEquals(json.includes("e2e-secret-xyz"), false);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/tests/integration/register_test.ts
+++ b/tests/integration/register_test.ts
@@ -1,0 +1,80 @@
+/**
+ * Integration: `zuke register` driven through the real CLI `main()`. Proves the
+ * command resolves a registry from `ZUKE_REGISTRY_DIR`, writes a descriptor a
+ * separate reader can load, keeps secrets out, and is idempotent.
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import {
+  Build,
+  FileSystemBuildRegistry,
+  parameter,
+  target,
+} from "../../packages/core/mod.ts";
+import { runCli } from "./_harness.ts";
+
+/** A build with a secret parameter and one target, registered by the tests. */
+class RegBuild extends Build {
+  apiToken = parameter("api token").secret();
+  lint = target().description("Lint").executes(() => {});
+  build = target().dependsOn(this.lint).executes(() => {});
+}
+
+/** Run `fn` with a fresh temporary `ZUKE_REGISTRY_DIR`, cleaned up afterwards. */
+async function withRegistryDir(
+  fn: (dir: string) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "zuke-reg-it-" });
+  const prev = Deno.env.get("ZUKE_REGISTRY_DIR");
+  Deno.env.set("ZUKE_REGISTRY_DIR", dir);
+  try {
+    await fn(dir);
+  } finally {
+    if (prev === undefined) Deno.env.delete("ZUKE_REGISTRY_DIR");
+    else Deno.env.set("ZUKE_REGISTRY_DIR", prev);
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+Deno.test("zuke register writes a descriptor a reader can load", async () => {
+  await withRegistryDir(async (dir) => {
+    const first = await runCli(RegBuild, ["register"]);
+    assertEquals(first.code, 0);
+    assertStringIncludes(first.out, "Registered build");
+
+    // A separate reader reconstructs the descriptor from the same directory.
+    const registry = new FileSystemBuildRegistry(dir);
+    const loaded = await registry.getBuild("RegBuild");
+    assertEquals(loaded?.descriptor.id, "RegBuild");
+    assertEquals(
+      loaded?.descriptor.surface.targets.map((t) => t.name),
+      ["lint", "build"],
+    );
+    // The secret parameter's flag is listed, but no value is anywhere in it.
+    assertEquals(
+      loaded?.descriptor.surface.parameters.map((p) => p.flag),
+      ["api-token"],
+    );
+    const createdAt = loaded?.descriptor.createdAt;
+
+    // Re-registering is idempotent: createdAt is preserved.
+    const second = await runCli(RegBuild, ["register"]);
+    assertEquals(second.code, 0);
+    const reloaded = await registry.getBuild("RegBuild");
+    assertEquals(reloaded?.descriptor.createdAt, createdAt);
+    assertEquals((await registry.listBuilds({})).length, 1);
+  });
+});
+
+Deno.test("zuke register --json prints the written descriptor", async () => {
+  await withRegistryDir(async () => {
+    const res = await runCli(RegBuild, ["register", "--json"]);
+    assertEquals(res.code, 0);
+    const parsed: unknown = JSON.parse(res.out);
+    assertEquals(parsed !== null && typeof parsed === "object", true);
+    assertStringIncludes(res.out, '"id": "RegBuild"');
+  });
+});

--- a/zuke.ts
+++ b/zuke.ts
@@ -383,6 +383,7 @@ class ZukeBuild extends Build {
           "tests/e2e/cancel_e2e.ts",
           "tests/e2e/otel_e2e.ts",
           "tests/e2e/gh_workflow_e2e.ts",
+          "tests/e2e/registry_e2e.ts",
         )
       );
     });


### PR DESCRIPTION
## What

Milestone **M11 PR1** — a pluggable **build registry**: a catalog of the pipelines (builds) that exist and where they live. Where durable run state records *runs*, the registry records *builds*, so a later registry-backed `zuke mcp` server (PR2) can discover newly-registered pipelines without a redeploy.

Kept a **separate concern** from the run `StateStore` but configured the same way; over HTTP it rides the same `docs/state-api.md` contract with a `/builds` collection beside `/runs`, so one service can host both.

## Surface

- **`BuildRegistry`** interface — `getBuild` / `register` / `deregister` / `listBuilds`, with whole-record compare-and-swap.
- **`BuildDescriptor`** — a versioned, secret-free snapshot: id, name, launch `location` (module or command form), the `describeCli(build)` surface, actor, timestamps.
- Two dependency-free reference backends, mirroring the state layer:
  - `FileSystemBuildRegistry` — one `<id>.json` under `.zuke/builds` (a sibling of `.zuke/runs`, never colliding), `O_EXCL` marker + atomic rename CAS.
  - `HttpBuildRegistry` — `GET/PUT/DELETE /builds/:id`, `GET /builds`, `ETag`/`If-Match` CAS, `{ url, token?, fetch? }`.
- **`zuke register`** — idempotent CAS write of this build's descriptor; `--json` prints it. Resolution precedence: explicit → `Build.registry()` override → `ZUKE_REGISTRY_URL`/`_TOKEN` or `ZUKE_REGISTRY_DIR` → default `.zuke/builds`.
- **`Build.registry()`** override, mirroring `stateStore()`.

## Secrets

Descriptors are secret-free by construction — built from `describeCli(build)`, which emits only structural metadata; `register` resolves no parameter values. Two extra guards (added in the adversarial pass below): a secret parameter's declared `.options(...)` values are omitted, and credentials embedded in a remote module URL are stripped from `location.module`.

## Adversarial review

An adversarial pass attacked path-safety, secret leakage, CAS/concurrency, crash/parse hardening, and CLI wiring; each finding was verified against the real code. Three confirmed issues were fixed here, each with a regression test:

- secret parameter `.options(...)` values were flowing into `describeCli` output (and thus the descriptor, `--list --json`, and MCP) — now omitted at the source;
- a credentialed remote module URL was persisted verbatim — userinfo is now stripped;
- `HttpBuildRegistry.listBuilds` parsed an untrusted body with an unguarded `JSON.parse` — now a friendly error.

Two low-severity findings were assessed and deliberately not changed: a defensive "no registry configured" guard reachable only via the `registry: false` API (tested, correct), and `register --list` being shadowed by the global `--list` (pre-existing and consistent with `runs`/`cancel`/`resume`; the root-cause fix is cross-cutting and out of scope).

## Tests & docs

- Unit (descriptor round-trip + hardened parse, FS CAS/deregister/listBuilds, HTTP verbs, resolve precedence, register command), integration (`zuke register` through `main()`), and a cross-process e2e (two real processes race a register — no torn write).
- `docs/registry.md` (new), the `/builds` section of `docs/state-api.md`, the skill cheatsheet, and regenerated `llms.txt` / `llms-full.txt` / README.

Full `deno task ci` green (coverage 95.2% branches), `apiDocsCheck` and `generate-ci --check` clean, `deno doc --lint` clean.

Dynamic MCP discovery over this registry is **PR2**.
