### PR TITLE
feat(core): registry-backed dynamic MCP tool discovery

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -162,6 +162,40 @@ The trail lives in a store-level record; read it with `zuke runs show mcp-audit`
 never influences authorization. On a shared HTTP endpoint it reflects the most
 recent client to connect, so set `--actor` for authoritative attribution there.
 
+## Registry mode (dynamic discovery)
+
+By default `zuke mcp` serves the single build its process was launched with. With
+`--registry` it instead serves the [build registry](./registry.md) — the catalog
+`zuke register` writes to — and **re-reads it on every `tools/list` and
+`tools/call`**. So a pipeline registered by another process appears as a tool in
+an already-running server with **no restart**:
+
+```sh
+# Serve every registered pipeline, execution enabled:
+zuke mcp --registry --allow-run
+```
+
+- **Discovery.** `list_builds` returns the catalog; `describe_build` (with a
+  `build` id) returns one build's surface. Each registered target is exposed as a
+  `run:<buildId>:<target>` tool, re-read live.
+- **Execution is a spawn.** A registered build has no live instance in the
+  server, so a run tool **spawns the build's registered launch location** (the
+  `deno run <module> <target>` `zuke register` recorded, or an explicit command)
+  and returns its captured output. This is code execution, so it is off unless
+  `--allow-run`, and it honours the same [authorization](#authorization) tiers —
+  the allow-list and `--protect` globs match the **qualified** `<buildId>:<target>`
+  name (e.g. `--allow-run=Api:*`, `--protect=Api:deploy`). Every mutating or
+  denied call is [audited](#audit-log).
+- **Scope.** A run tool takes no per-parameter inputs yet — only `dryRun`,
+  `confirm`, and `operatorToken`; the spawned build resolves its own parameters
+  from the server's environment. Passing parameters across the spawn boundary
+  (which needs a secret-safe contract) is a follow-up. Because a descriptor does
+  not record whether a target is read-only, every registry run tool is treated as
+  destructive.
+
+The registry resolves like the run store: `ZUKE_REGISTRY_URL`/`_TOKEN` or
+`ZUKE_REGISTRY_DIR`, a build's `registry()` override, else `.zuke/builds`.
+
 ## Safety
 
 **Trust model.** On the default stdio transport the server has no network

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -150,10 +150,11 @@ ZUKE_OPERATOR_TOKEN=… zuke mcp --http 7777 \
 ## Audit log
 
 With a store configured, **every mutating or denied tool call** (`run:<target>`,
-`signal_run`, `resume_check`, `cancel_run`) is appended to an audit trail: the time, the tool,
-the resolved **actor**, the outcome (`ok` / `denied` / `error`), and the call's
-arguments. Arguments are **redacted** — the operator token is dropped and every
-`.secret()` parameter's value is masked — before anything is persisted.
+`signal_run`, `resume_check`, `cancel_run`) is appended to an audit trail: the
+time, the tool, the resolved **actor**, the outcome (`ok` / `denied` / `error`),
+and the call's arguments. Arguments are **redacted** — the operator token is
+dropped and every `.secret()` parameter's value is masked — before anything is
+persisted.
 
 The trail lives in a store-level record; read it with `zuke runs show mcp-audit`
 (or the `show_run` tool). The actor resolves by precedence: `--actor` →
@@ -164,9 +165,9 @@ recent client to connect, so set `--actor` for authoritative attribution there.
 
 ## Registry mode (dynamic discovery)
 
-By default `zuke mcp` serves the single build its process was launched with. With
-`--registry` it instead serves the [build registry](./registry.md) — the catalog
-`zuke register` writes to — and **re-reads it on every `tools/list` and
+By default `zuke mcp` serves the single build its process was launched with.
+With `--registry` it instead serves the [build registry](./registry.md) — the
+catalog `zuke register` writes to — and **re-reads it on every `tools/list` and
 `tools/call`**. So a pipeline registered by another process appears as a tool in
 an already-running server with **no restart**:
 
@@ -176,22 +177,29 @@ zuke mcp --registry --allow-run
 ```
 
 - **Discovery.** `list_builds` returns the catalog; `describe_build` (with a
-  `build` id) returns one build's surface. Each registered target is exposed as a
-  `run:<buildId>:<target>` tool, re-read live.
+  `build` id) returns one build's surface. Each registered target is exposed as
+  a `run:<buildId>:<target>` tool, re-read live.
 - **Execution is a spawn.** A registered build has no live instance in the
   server, so a run tool **spawns the build's registered launch location** (the
   `deno run <module> <target>` `zuke register` recorded, or an explicit command)
   and returns its captured output. This is code execution, so it is off unless
   `--allow-run`, and it honours the same [authorization](#authorization) tiers —
-  the allow-list and `--protect` globs match the **qualified** `<buildId>:<target>`
-  name (e.g. `--allow-run=Api:*`, `--protect=Api:deploy`). Every mutating or
-  denied call is [audited](#audit-log).
+  the allow-list and `--protect` globs match the **qualified**
+  `<buildId>:<target>` name (e.g. `--allow-run=Api:*`, `--protect=Api:deploy`).
+  Every mutating or denied call is [audited](#audit-log).
 - **Scope.** A run tool takes no per-parameter inputs yet — only `dryRun`,
   `confirm`, and `operatorToken`; the spawned build resolves its own parameters
   from the server's environment. Passing parameters across the spawn boundary
   (which needs a secret-safe contract) is a follow-up. Because a descriptor does
-  not record whether a target is read-only, every registry run tool is treated as
-  destructive.
+  not record whether a target is read-only, every registry run tool is treated
+  as destructive.
+- **Environment.** A spawned build inherits the server's environment (that is
+  how it resolves its parameters), minus the MCP server's own authorization
+  secrets — `ZUKE_OPERATOR_TOKEN` and `ZUKE_MCP_TOKEN` are stripped so a
+  registered build can never read them. It does still see the rest of the
+  server's environment, so run a registry-backed server with **only the
+  environment the registered pipelines should have** — treat it like any host
+  that runs those builds.
 
 The registry resolves like the run store: `ZUKE_REGISTRY_URL`/`_TOKEN` or
 `ZUKE_REGISTRY_DIR`, a build's `registry()` override, else `.zuke/builds`.

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -6,12 +6,11 @@ registry records *builds*: each build registers a small **descriptor** — its i
 its CLI surface (targets, parameters, commands), and how to launch it — into a
 pluggable store.
 
-Its purpose is agentic discovery driven by the store: an MCP server pointed at
-the registry can expose newly-registered pipelines as tools **without a redeploy
-or new instructions**. A build that registers itself for the first time becomes
-discoverable through an already-running server. (That dynamic `zuke mcp`
-integration is the next milestone; this page covers the registry and
-`zuke register` that back it.)
+Its purpose is agentic discovery driven by the store: a `zuke mcp --registry`
+server exposes newly-registered pipelines as tools **without a redeploy or new
+instructions**. A build that registers itself for the first time becomes
+discoverable — and runnable — through an already-running server (see
+[Registry mode](./mcp.md#registry-mode-dynamic-discovery)).
 
 The registry is a **separate concern** from the run [`StateStore`](./state.md) —
 a run history and a build catalog are different things — but it is configured the

--- a/llms.txt
+++ b/llms.txt
@@ -74,6 +74,7 @@ Option flags:
 - `--allow-run` — With mcp, let agents run targets (optional =<glob-list> allow-list)
 - `--protect` — With mcp, require an operator token to run these targets
 - `--confirm-destructive` — With mcp, require confirm:true before a destructive run
+- `--registry` — With mcp, serve the build registry (dynamic pipeline discovery)
 - `--http` — With mcp, serve over HTTP on <host:port> instead of stdio
 - `--help` — Show usage
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -98,6 +98,8 @@ export interface ParsedArgs {
   protectPatterns?: string[];
   /** Require `confirm:true` before a destructive `mcp` run (`--confirm-destructive`). */
   confirmDestructive: boolean;
+  /** Serve `mcp` over the build registry (dynamic discovery) rather than one build (`--registry`). */
+  mcpRegistry: boolean;
   /** Serve `mcp` over HTTP on this `<host:port>` instead of stdio (`--http`). */
   httpAddr?: string;
   /** The `completions` sub-action (`install` or `print`); the first positional. */
@@ -197,6 +199,7 @@ export function parseArgs(
     cancel: false,
     register: false,
     confirmDestructive: false,
+    mcpRegistry: false,
     help: false,
   };
   const byFlag = new Map<string, ParamFlag>();
@@ -269,6 +272,8 @@ export function parseArgs(
       parsed.protectPatterns = splitList(arg.slice("--protect=".length));
     } else if (arg === "--confirm-destructive") {
       parsed.confirmDestructive = true;
+    } else if (arg === "--registry") {
+      parsed.mcpRegistry = true;
     } else if (arg === "--http") {
       const value = args[++i];
       if (value) parsed.httpAddr = value;
@@ -357,7 +362,7 @@ Usage:
   deno run -A zuke.ts graph [--output=html] [--no-open]
   deno run -A zuke.ts generate-ci [--check]
   deno run -A zuke.ts completions <install|print> <bash|zsh|fish>
-  deno run -A zuke.ts mcp [--allow-run] [--http <host:port>]
+  deno run -A zuke.ts mcp [--allow-run] [--registry] [--http <host:port>]
   deno run -A zuke.ts resume <run-id> [--signal <name>] [--data <json>]
   deno run -A zuke.ts resume --check [<run-id>]
   deno run -A zuke.ts runs list [--status <s>] [--target <t>] [--since <iso>] [--json]
@@ -416,6 +421,11 @@ Options:
   --confirm-destructive
                     With mcp, make a destructive run tool return its plan unless
                     called with confirm:true (a .readOnly() target is exempt).
+  --registry        With mcp, serve the build registry instead of this one build:
+                    expose every registered pipeline's targets as tools, re-read
+                    live so a newly-registered build appears with no restart. A
+                    run tool spawns the registered build's launch command (behind
+                    --allow-run + the same authz). See docs/registry.md.
   --http <host:port>
                     With mcp, serve the streamable-HTTP transport on the given
                     address instead of stdio. Just <port> binds 127.0.0.1. A
@@ -730,6 +740,7 @@ async function runMcp(build: Build, parsed: ParsedArgs): Promise<number> {
     allowRunPatterns: parsed.allowRunPatterns,
     protectPatterns: parsed.protectPatterns,
     confirmDestructive: parsed.confirmDestructive,
+    useRegistry: parsed.mcpRegistry,
     actor: parsed.actor,
     http,
   });

--- a/packages/core/src/cli_spec.ts
+++ b/packages/core/src/cli_spec.ts
@@ -157,6 +157,11 @@ export const BUILTIN_FLAGS: readonly BuiltinFlag[] = [
     description: "With mcp, require confirm:true before a destructive run",
   },
   {
+    name: "--registry",
+    description:
+      "With mcp, serve the build registry (dynamic pipeline discovery)",
+  },
+  {
     name: "--http",
     description: "With mcp, serve over HTTP on <host:port> instead of stdio",
   },

--- a/packages/core/src/mcp/command.ts
+++ b/packages/core/src/mcp/command.ts
@@ -10,9 +10,22 @@ import { absolutePath } from "../path.ts";
 import { findConfigDir, pathExists } from "../config.ts";
 import { defaultStateHost, type StateStore } from "../state/store.ts";
 import { resolveStateStore } from "../state/resolve.ts";
-import { type ByteWriter, serveStdio } from "./jsonrpc.ts";
+import type { BuildRegistry } from "../registry/registry.ts";
+import { resolveBuildRegistry } from "../registry/resolve.ts";
+import {
+  type ByteWriter,
+  type JsonRpcResponse,
+  serveStdio,
+} from "./jsonrpc.ts";
 import { serveHttp } from "./http.ts";
 import { McpServer, type McpServerOptions } from "./server.ts";
+import { RegistryMcpServer, type RegistryRunner } from "./registry_server.ts";
+
+/** A thing that answers MCP messages — either server flavour drives a transport. */
+interface McpHandler {
+  /** Handle one parsed JSON-RPC message, or return `null` for a notification. */
+  handleMessage(message: unknown): Promise<JsonRpcResponse | null>;
+}
 
 /** A parsed `--http` bind address. */
 export interface HttpAddress {
@@ -24,6 +37,18 @@ export interface HttpAddress {
 
 /** Options for {@link serveMcp}. */
 export interface ServeMcpOptions extends McpServerOptions {
+  /**
+   * Serve the whole {@link "../registry/registry.ts".BuildRegistry} (dynamic
+   * pipeline discovery) instead of the single launched build. When set, the
+   * server exposes each registered pipeline's targets, re-read live. Tests inject
+   * a registry here; the CLI sets {@link useRegistry} and the registry is
+   * resolved from the environment / build override / default `.zuke/builds`.
+   */
+  registry?: BuildRegistry;
+  /** Resolve a {@link BuildRegistry} and serve it (the `--registry` CLI flag). */
+  useRegistry?: boolean;
+  /** Spawns a registered build in registry mode; injectable for tests. */
+  runner?: RegistryRunner;
   /** The message stream to read (defaults to stdin); injectable for tests. */
   input?: ReadableStream<Uint8Array>;
   /** The sink to write responses to (defaults to stdout); injectable for tests. */
@@ -56,6 +81,21 @@ function isLoopback(host: string): boolean {
   return host === "127.0.0.1" || host === "::1" || host === "localhost";
 }
 
+/** Resolve the build registry for `zuke mcp --registry` — defaulting on `.zuke/builds`. */
+function resolveMcpRegistry(
+  build: Build,
+  readEnv: (name: string) => string | undefined,
+): BuildRegistry | undefined {
+  return resolveBuildRegistry(undefined, build.registry(), {
+    readEnv,
+    host: defaultStateHost,
+    defaultDir: absolutePath(
+      findConfigDir(Deno.cwd(), pathExists) ?? Deno.cwd(),
+    )(".zuke", "builds").path,
+    enableDefault: true,
+  });
+}
+
 /** Resolve the store for MCP — like a run, always defaulting on so run tools work. */
 function resolveMcpStore(
   build: Build,
@@ -83,21 +123,42 @@ export async function serveMcp(
   options: ServeMcpOptions = {},
 ): Promise<number> {
   const readEnv = options.readEnv ?? defaultReadEnv;
-  // Resolve the durable store (so the run tools work) and the operator token
-  // once, then hand them to the server alongside the caller's options.
-  const server = new McpServer(build, {
-    ...options,
-    readEnv,
-    stateStore: resolveMcpStore(build, options.stateStore, readEnv),
-    operatorToken: options.operatorToken ?? readEnv("ZUKE_OPERATOR_TOKEN"),
-  });
+  // Resolve the durable store (audit + run tools) and the operator token once,
+  // then hand them to the server alongside the caller's options.
+  const store = resolveMcpStore(build, options.stateStore, readEnv);
+  const operatorToken = options.operatorToken ?? readEnv("ZUKE_OPERATOR_TOKEN");
+  // An injected registry (tests) wins; otherwise `--registry` resolves one.
+  const registry = options.registry ??
+    (options.useRegistry ? resolveMcpRegistry(build, readEnv) : undefined);
+  // In registry mode the server serves the catalog (spawning registered builds);
+  // otherwise it serves the single launched build in-process.
+  const server: McpHandler = registry !== undefined
+    ? new RegistryMcpServer(registry, {
+      allowRun: options.allowRun,
+      allowRunPatterns: options.allowRunPatterns,
+      protectPatterns: options.protectPatterns,
+      confirmDestructive: options.confirmDestructive,
+      operatorToken,
+      stateStore: store,
+      actor: options.actor,
+      readEnv,
+      version: options.version,
+      runner: options.runner,
+    })
+    : new McpServer(build, {
+      ...options,
+      readEnv,
+      stateStore: store,
+      operatorToken,
+    });
   if (options.http !== undefined) {
     return await serveMcpHttp(server, options.http, options);
   }
   if (!options.quiet) {
     const mode = options.allowRun ? "run enabled" : "read-only";
+    const source = registry !== undefined ? "registry, " : "";
     console.error(
-      `zuke mcp: serving on stdio (${mode}). Press Ctrl-C to stop.`,
+      `zuke mcp: serving on stdio (${source}${mode}). Press Ctrl-C to stop.`,
     );
   }
   await serveStdio(
@@ -115,7 +176,7 @@ export async function serveMcp(
  * unauthenticated endpoint. A loopback bind may run without one.
  */
 async function serveMcpHttp(
-  server: McpServer,
+  server: McpHandler,
   address: HttpAddress,
   options: ServeMcpOptions,
 ): Promise<number> {
@@ -132,10 +193,14 @@ async function serveMcpHttp(
   }
   if (!options.quiet) {
     const mode = options.allowRun ? "run enabled" : "read-only";
+    const source =
+      options.registry !== undefined || options.useRegistry === true
+        ? "registry, "
+        : "";
     const auth = hasToken ? "bearer token required" : "no auth (loopback only)";
     console.error(
       `zuke mcp: serving on http://${address.host}:${address.port} ` +
-        `(${mode}, ${auth}). Press Ctrl-C to stop.`,
+        `(${source}${mode}, ${auth}). Press Ctrl-C to stop.`,
     );
   }
   await serveHttp((message) => server.handleMessage(message), {

--- a/packages/core/src/mcp/registry_server.ts
+++ b/packages/core/src/mcp/registry_server.ts
@@ -1,0 +1,595 @@
+/**
+ * A registry-backed MCP server — dynamic pipeline discovery.
+ *
+ * Where {@link "./server.ts".McpServer} serves the single build its process was
+ * launched with, {@link RegistryMcpServer} serves a whole
+ * {@link "../registry/registry.ts".BuildRegistry}: it reads the catalog **fresh
+ * on every `tools/list` and `tools/call`**, so a pipeline registered by another
+ * process (`zuke register`) shows up as a tool in an already-running server with
+ * no redeploy.
+ *
+ * A registered build has no live instance here — only a
+ * {@link "../registry/descriptor.ts".BuildDescriptor}. So a run tool does not
+ * `execute()` in-process; it **spawns the descriptor's launch location** (the
+ * `deno run <module> <target>` the operator registered, or an explicit command),
+ * captures its output, and returns it. That is a code-execution surface, so it
+ * rides entirely on M5's gates: it is off unless `--allow-run`, honours the
+ * allow-list / operator-token / confirmation tiers (keyed on the qualified
+ * `<buildId>:<target>` name), and every mutating or denied call is audited.
+ *
+ * Scope note: a run tool takes no per-parameter inputs yet (only `dryRun`,
+ * `confirm`, and `operatorToken`); the spawned build resolves its own parameters
+ * from the server's environment. Passing parameters across the spawn boundary —
+ * which needs a secret-safe contract the descriptor does not yet carry — is a
+ * follow-up.
+ *
+ * @module
+ */
+
+import { absolutePath } from "../path.ts";
+import { Redactor } from "../redact.ts";
+import { resolveActor } from "../state/record.ts";
+import type { RunEvent, RunEventOutcome } from "../state/types.ts";
+import type { StateStore } from "../state/store.ts";
+import type { RunStateWriter } from "../state/writer.ts";
+import type { BuildLocation } from "../registry/descriptor.ts";
+import type { BuildRegistry } from "../registry/registry.ts";
+import { openAuditLog } from "./audit.ts";
+import { targetMatcher, timingSafeEqual } from "./authz.ts";
+import {
+  type McpTool,
+  PROTOCOL_VERSION,
+  SUPPORTED_PROTOCOL_VERSIONS,
+} from "./server.ts";
+import {
+  err,
+  INTERNAL_ERROR,
+  INVALID_PARAMS,
+  type JsonRpcResponse,
+  METHOD_NOT_FOUND,
+  ok,
+} from "./jsonrpc.ts";
+
+/** The `run:` prefix that names a per-target execution tool. */
+const RUN_PREFIX = "run:";
+
+/** The captured result of spawning a registered build. */
+export interface RegistryRunResult {
+  /** The subprocess exit code (0 on success). */
+  code: number;
+  /** Everything the build wrote to stdout. */
+  stdout: string;
+  /** Everything the build wrote to stderr. */
+  stderr: string;
+}
+
+/**
+ * Spawns a registered build and captures its output. The default
+ * ({@link defaultRegistryRunner}) uses {@link Deno.Command}; tests inject a fake
+ * so no real subprocess runs.
+ */
+export type RegistryRunner = (
+  argv: readonly string[],
+  cwd: string,
+) => Promise<RegistryRunResult>;
+
+/** The real, `Deno`-backed {@link RegistryRunner}. */
+export const defaultRegistryRunner: RegistryRunner = async (argv, cwd) => {
+  // The build inherits the server's environment (that is how it resolves its own
+  // parameters), but the MCP server's *authorization* secrets are stripped — a
+  // spawned pipeline must not be able to read the operator or HTTP bearer token.
+  const env = Deno.env.toObject();
+  delete env.ZUKE_OPERATOR_TOKEN;
+  delete env.ZUKE_MCP_TOKEN;
+  const command = new Deno.Command(argv[0], {
+    args: [...argv.slice(1)],
+    cwd,
+    env,
+    clearEnv: true,
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const { code, stdout, stderr } = await command.output();
+  const decoder = new TextDecoder();
+  return {
+    code,
+    stdout: decoder.decode(stdout),
+    stderr: decoder.decode(stderr),
+  };
+};
+
+/** Options for {@link RegistryMcpServer}. */
+export interface RegistryMcpServerOptions {
+  /** Expose `run:<buildId>:<target>` tools that spawn build code. Off by default. */
+  allowRun?: boolean;
+  /**
+   * Restrict the exposed run tools to **qualified** names (`<buildId>:<target>`)
+   * matching these globs (from `--allow-run=a,b*`). `undefined` (a bare
+   * `--allow-run`) exposes every registered target; a non-matched target is
+   * neither advertised nor runnable.
+   */
+  allowRunPatterns?: readonly string[];
+  /** Qualified names (globs, from `--protect`) whose run tool needs an operator token. */
+  protectPatterns?: readonly string[];
+  /** The operator token a protected call must carry (from `ZUKE_OPERATOR_TOKEN`). */
+  operatorToken?: string;
+  /** Require `confirm: true` before a run tool spawns (from `--confirm-destructive`). */
+  confirmDestructive?: boolean;
+  /** The durable store; when set, every mutating/denied call is audited. */
+  stateStore?: StateStore;
+  /** Who to attribute audited calls to (`--actor`), highest precedence. */
+  actor?: string;
+  /** Reads an environment variable (injectable for tests). */
+  readEnv?: (name: string) => string | undefined;
+  /** The server version reported in `initialize`. Defaults to `"0.0.0"`. */
+  version?: string;
+  /** Spawns a registered build; defaults to {@link defaultRegistryRunner}. */
+  runner?: RegistryRunner;
+}
+
+/** The MCP result content for a single block of text. */
+function textResult(text: string, isError = false): Record<string, unknown> {
+  return { content: [{ type: "text", text }], isError };
+}
+
+/** Whether a JSON value is a plain object (a string-keyed record). */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * An MCP server bound to a {@link "../registry/registry.ts".BuildRegistry}.
+ * Construct it once, then feed each incoming JSON-RPC message to
+ * {@link RegistryMcpServer.handleMessage}. Every tool list and call re-reads the
+ * registry, so the exposed pipelines track the catalog live.
+ */
+export class RegistryMcpServer {
+  readonly #registry: BuildRegistry;
+  readonly #allowRun: boolean;
+  readonly #version: string;
+  /** Matches a qualified `<buildId>:<target>` allowed to run (allow-list glob, or all). */
+  readonly #allowMatch: (name: string) => boolean;
+  /** Matches a qualified name that needs an operator token to run. */
+  readonly #isProtected: (name: string) => boolean;
+  readonly #operatorToken?: string;
+  readonly #confirmDestructive: boolean;
+  readonly #store?: StateStore;
+  readonly #actor?: string;
+  readonly #readEnv: (name: string) => string | undefined;
+  readonly #runner: RegistryRunner;
+  /** The connecting client's `initialize` name, a low-priority audit actor. */
+  #clientLabel?: string;
+  /** The audit-log writer, opened lazily on the first audited call. */
+  #auditLog?: RunStateWriter;
+
+  /** Build the server over `registry`, applying the authz/audit options. */
+  constructor(registry: BuildRegistry, options: RegistryMcpServerOptions = {}) {
+    this.#registry = registry;
+    this.#allowRun = options.allowRun ?? false;
+    this.#allowMatch = targetMatcher(options.allowRunPatterns);
+    // An empty/absent protect list protects nothing; targetMatcher(undefined)
+    // matches everything, so map that case to a never-match.
+    this.#isProtected = options.protectPatterns === undefined ||
+        options.protectPatterns.length === 0
+      ? () => false
+      : targetMatcher(options.protectPatterns);
+    this.#operatorToken = options.operatorToken;
+    this.#confirmDestructive = options.confirmDestructive ?? false;
+    this.#store = options.stateStore;
+    this.#actor = options.actor;
+    this.#readEnv = options.readEnv ?? (() => undefined);
+    this.#version = options.version ?? "0.0.0";
+    this.#runner = options.runner ?? defaultRegistryRunner;
+  }
+
+  /**
+   * Handle one parsed JSON-RPC message. Returns the response to send, or `null`
+   * for a notification (which takes no reply).
+   */
+  async handleMessage(message: unknown): Promise<JsonRpcResponse | null> {
+    if (
+      typeof message !== "object" || message === null ||
+      !("method" in message) || typeof message.method !== "string"
+    ) {
+      return err(idOf(message), INVALID_PARAMS, "Invalid Request");
+    }
+    const method = message.method;
+    const id = idOf(message);
+    const params = "params" in message ? message.params : undefined;
+
+    if (id === null && method.startsWith("notifications/")) return null;
+
+    switch (method) {
+      case "initialize":
+        return ok(id, this.#initialize(params));
+      case "ping":
+        return ok(id, {});
+      case "tools/list":
+        // Listing reads the registry live (a hosted backend can throw on a
+        // transient fault or a malformed descriptor). Guard it — like tools/call
+        // below — so one registry hiccup returns an error instead of tearing
+        // down the transport for every client.
+        try {
+          return ok(id, { tools: await this.tools() });
+        } catch {
+          return err(id, INTERNAL_ERROR, "Internal error listing tools");
+        }
+      case "tools/call":
+        // Backstop: no tool call may crash the transport. Anything unforeseen
+        // becomes a generic error so no raw detail escapes.
+        try {
+          return await this.#callTool(id, params);
+        } catch {
+          return err(
+            id,
+            INTERNAL_ERROR,
+            "Internal error handling the tool call",
+          );
+        }
+      default:
+        if (id === null) return null;
+        return err(id, METHOD_NOT_FOUND, `Unknown method: ${method}`);
+    }
+  }
+
+  /**
+   * The tools advertised to the client, read from the registry live: two read
+   * tools always, plus one `run:<buildId>:<target>` per registered target when
+   * execution is enabled and the target is allow-listed.
+   */
+  async tools(): Promise<McpTool[]> {
+    const tools: McpTool[] = [
+      {
+        name: "list_builds",
+        description:
+          "List the pipelines registered in the build registry (id, name, actor).",
+        inputSchema: { type: "object", properties: {} },
+        annotations: { readOnlyHint: true },
+      },
+      {
+        name: "describe_build",
+        description:
+          "Describe one registered build's surface: its targets and parameters.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            build: { type: "string", description: "The registered build id." },
+          },
+          required: ["build"],
+        },
+        annotations: { readOnlyHint: true },
+      },
+    ];
+    if (!this.#allowRun) return tools;
+    for (const summary of await this.#registry.listBuilds({})) {
+      const loaded = await this.#registry.getBuild(summary.id);
+      if (loaded === null) continue; // deregistered between list and read
+      for (const target of loaded.descriptor.surface.targets) {
+        const qualified = `${summary.id}:${target.name}`;
+        if (this.#allowMatch(qualified)) {
+          tools.push(
+            this.#runTool(summary.id, target.name, target.description),
+          );
+        }
+      }
+    }
+    return tools;
+  }
+
+  /** Build the `run:<buildId>:<target>` tool definition. */
+  #runTool(buildId: string, target: string, description: string): McpTool {
+    const qualified = `${buildId}:${target}`;
+    const properties: Record<string, Record<string, unknown>> = {
+      dryRun: {
+        type: "boolean",
+        description: "Plan without executing any target body.",
+      },
+    };
+    const required: string[] = [];
+    if (this.#isProtected(qualified)) {
+      properties.operatorToken = {
+        type: "string",
+        description:
+          "Operator token (ZUKE_OPERATOR_TOKEN) required to run this protected target.",
+      };
+      required.push("operatorToken");
+    }
+    // A registered target's read-only-ness is not carried in the descriptor, so
+    // every registry run tool is treated as destructive (the safe default).
+    if (this.#confirmDestructive) {
+      properties.confirm = {
+        type: "boolean",
+        description:
+          "Set true to spawn this target; otherwise a confirmation is returned.",
+      };
+    }
+    const schema: Record<string, unknown> = { type: "object", properties };
+    if (required.length > 0) schema.required = required;
+    return {
+      name: `${RUN_PREFIX}${qualified}`,
+      description: description === ""
+        ? `Run the "${target}" target of registered build "${buildId}".`
+        : `Run the "${target}" target of registered build "${buildId}": ${description}`,
+      inputSchema: schema,
+      annotations: { title: `Run ${qualified}`, destructiveHint: true },
+    };
+  }
+
+  /**
+   * The `initialize` result: negotiate the protocol version (echo the client's
+   * only when supported), and remember the client's self-reported name as a
+   * low-priority audit actor (an untrusted label, never an authorization input).
+   */
+  #initialize(params: unknown): Record<string, unknown> {
+    if (
+      isRecord(params) && isRecord(params.clientInfo) &&
+      typeof params.clientInfo.name === "string"
+    ) {
+      this.#clientLabel = params.clientInfo.name;
+    }
+    const requested = isRecord(params) &&
+        typeof params.protocolVersion === "string"
+      ? params.protocolVersion
+      : undefined;
+    const protocolVersion = requested !== undefined &&
+        SUPPORTED_PROTOCOL_VERSIONS.includes(requested)
+      ? requested
+      : PROTOCOL_VERSION;
+    return {
+      protocolVersion,
+      capabilities: { tools: { listChanged: false } },
+      serverInfo: { name: "zuke", version: this.#version },
+    };
+  }
+
+  /** Dispatch a `tools/call`. */
+  async #callTool(
+    id: string | number | null,
+    params: unknown,
+  ): Promise<JsonRpcResponse> {
+    if (!isRecord(params) || !("name" in params)) {
+      return err(id, INVALID_PARAMS, "tools/call requires a tool name");
+    }
+    const name = params.name;
+    if (typeof name !== "string") {
+      return err(id, INVALID_PARAMS, "tool name must be a string");
+    }
+    const args = isRecord(params.arguments) ? params.arguments : {};
+
+    if (name === "list_builds") {
+      return ok(id, textResult(await this.#listBuilds()));
+    }
+    if (name === "describe_build") {
+      return ok(id, await this.#describeBuild(args));
+    }
+    if (name.startsWith(RUN_PREFIX)) {
+      return await this.#run(id, name.slice(RUN_PREFIX.length), args);
+    }
+    return ok(id, textResult(`Unknown tool: ${name}`, true));
+  }
+
+  /** The registry catalog as pretty JSON. */
+  async #listBuilds(): Promise<string> {
+    return JSON.stringify(await this.#registry.listBuilds({}), null, 2);
+  }
+
+  /** Describe one registered build's surface, or an error when it is unknown. */
+  async #describeBuild(
+    args: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const buildId = args.build;
+    if (typeof buildId !== "string") {
+      return textResult("describe_build requires a string `build` id.", true);
+    }
+    const loaded = await this.#registry.getBuild(buildId);
+    if (loaded === null) {
+      return textResult(`No registered build "${buildId}".`, true);
+    }
+    return textResult(JSON.stringify(loaded.descriptor.surface, null, 2));
+  }
+
+  /** Spawn a registered target: enforce the allow-list, protection, and confirmation. */
+  async #run(
+    id: string | number | null,
+    qualified: string,
+    args: Record<string, unknown>,
+  ): Promise<JsonRpcResponse> {
+    const runName = `${RUN_PREFIX}${qualified}`;
+    if (!this.#allowRun) {
+      await this.#audit(runName, args, "denied", "run_disabled");
+      return ok(
+        id,
+        textResult(
+          "Running targets is disabled. Start the server with " +
+            "`zuke mcp --registry --allow-run` to enable execution.",
+          true,
+        ),
+      );
+    }
+
+    const colon = qualified.indexOf(":");
+    const buildId = colon === -1 ? qualified : qualified.slice(0, colon);
+    const target = colon === -1 ? "" : qualified.slice(colon + 1);
+    const loaded = colon === -1 ? null : await this.#registry.getBuild(buildId);
+    const known = loaded !== null &&
+      loaded.descriptor.surface.targets.some((t) => t.name === target);
+    // Unknown build/target and a non-allow-listed one are reported identically,
+    // so a denial never reveals which protected pipelines exist.
+    if (!known || !this.#allowMatch(qualified)) {
+      await this.#audit(runName, args, "denied", "not_allowed");
+      return ok(id, textResult(`Unknown tool: ${runName}`, true));
+    }
+
+    if (this.#isProtected(qualified)) {
+      const denial = this.#checkOperatorToken(args);
+      if (denial !== null) {
+        await this.#audit(runName, args, "denied", denial);
+        return ok(
+          id,
+          textResult(
+            JSON.stringify(
+              { error: "unauthorized", tool: runName, reason: denial },
+              null,
+              2,
+            ),
+            true,
+          ),
+        );
+      }
+    }
+
+    const dryRun = args.dryRun === true;
+    // Unlike the in-process server, a spawn can't enforce dry-run — `--dry-run`
+    // is only appended to the child argv, and a command-form wrapper may ignore
+    // it and execute for real. So confirmation is required before *any* spawn,
+    // dry run included; it is not exempt the way an in-process dry run is.
+    if (this.#confirmDestructive && args.confirm !== true) {
+      return ok(
+        id,
+        textResult(
+          JSON.stringify(
+            {
+              status: "confirmation_required",
+              tool: runName,
+              hint: "Re-call with confirm:true to spawn this target.",
+            },
+            null,
+            2,
+          ),
+          false,
+        ),
+      );
+    }
+
+    const launch = this.#launch(loaded.descriptor.location, target, dryRun);
+    if (launch.argv.length === 0 || launch.argv[0] === "") {
+      await this.#audit(runName, args, "error", "no_launch_command");
+      return ok(
+        id,
+        textResult(
+          `Registered build "${buildId}" has no runnable launch command.`,
+          true,
+        ),
+      );
+    }
+
+    let result: RegistryRunResult;
+    try {
+      result = await this.#runner(launch.argv, launch.cwd);
+    } catch (error) {
+      await this.#audit(runName, args, "error", "spawn_failed");
+      const kind = error instanceof Error ? error.name : "Error";
+      return ok(
+        id,
+        textResult(`Failed to spawn ${qualified} (${kind}).`, true),
+      );
+    }
+    await this.#audit(runName, args, result.code === 0 ? "ok" : "error");
+    const output = [result.stdout, result.stderr].filter((s) => s !== "").join(
+      "\n",
+    );
+    const status = result.code === 0
+      ? `\n\n✔ ${qualified} succeeded.`
+      : `\n\n✘ ${qualified} exited ${result.code}.`;
+    return ok(id, textResult(output + status, result.code !== 0));
+  }
+
+  /** Build the launch argv and working directory for a target's location. */
+  #launch(
+    location: BuildLocation,
+    target: string,
+    dryRun: boolean,
+  ): { argv: string[]; cwd: string } {
+    const trailing = dryRun ? [target, "--dry-run"] : [target];
+    if (location.kind === "command") {
+      // An empty command has nothing to launch — return an empty argv so the
+      // caller reports it rather than spawning the bare target as a program.
+      if (location.command.length === 0) return { argv: [], cwd: location.cwd };
+      return { argv: [...location.command, ...trailing], cwd: location.cwd };
+    }
+    return {
+      argv: [Deno.execPath(), "run", "-A", location.module, ...trailing],
+      cwd: absolutePath(location.cwd).path,
+    };
+  }
+
+  /**
+   * Validate a protected target's operator token, returning a denial reason (for
+   * the structured error and audit) or `null` when the token is valid.
+   */
+  #checkOperatorToken(args: Record<string, unknown>): string | null {
+    if (this.#operatorToken === undefined || this.#operatorToken === "") {
+      return "operator_token_unconfigured";
+    }
+    const provided = args.operatorToken;
+    if (typeof provided !== "string") return "missing_operator_token";
+    return timingSafeEqual(provided, this.#operatorToken)
+      ? null
+      : "invalid_operator_token";
+  }
+
+  /** Resolve the actor for audited calls: --actor → env → the client label. */
+  #resolveActor(): string {
+    return resolveActor(this.#actor, this.#readEnv, [this.#clientLabel]);
+  }
+
+  /**
+   * Append a tool call to the audit log (best-effort; never breaks a call).
+   * No-op without a store. The operator token is dropped from the recorded args
+   * so nothing sensitive reaches the durable trail.
+   */
+  async #audit(
+    tool: string,
+    args: Record<string, unknown>,
+    outcome: RunEventOutcome,
+    detail?: string,
+  ): Promise<void> {
+    const store = this.#store;
+    if (store === undefined) return;
+    const event: RunEvent = {
+      at: new Date().toISOString(),
+      tool,
+      actor: this.#resolveActor(),
+      outcome,
+      args: auditArgs(args),
+    };
+    if (detail !== undefined) event.detail = detail;
+    try {
+      this.#auditLog ??= await openAuditLog(
+        store,
+        () => new Date().toISOString(),
+        new Redactor(),
+      );
+      await this.#auditLog.appendEvent(event);
+    } catch {
+      // Auditing is best-effort: a store hiccup must not fail the tool call.
+    }
+  }
+}
+
+/**
+ * Sanitise tool arguments for the audit log: drop the operator token entirely,
+ * and stringify the rest (registry run tools take only `dryRun`/`confirm`, so
+ * there are no secret parameter values to mask).
+ */
+function auditArgs(args: Record<string, unknown>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(args)) {
+    if (key === "operatorToken") continue;
+    out[key] = typeof value === "object" && value !== null
+      ? JSON.stringify(value)
+      : String(value);
+  }
+  return out;
+}
+
+/** Extract a JSON-RPC id from a message, defaulting to `null`. */
+function idOf(message: unknown): string | number | null {
+  if (
+    typeof message === "object" && message !== null && "id" in message &&
+    (typeof message.id === "string" || typeof message.id === "number")
+  ) {
+    return message.id;
+  }
+  return null;
+}

--- a/packages/core/tests/registry_server_test.ts
+++ b/packages/core/tests/registry_server_test.ts
@@ -1,0 +1,662 @@
+/**
+ * Unit tests for {@link RegistryMcpServer}: live discovery from the registry,
+ * spawn-based execution through an injected runner (no real subprocess), the M5
+ * authz tiers keyed on the qualified `<buildId>:<target>` name, and auditing.
+ */
+
+import { assertEquals, assertStringIncludes } from "./_assert.ts";
+import { Build } from "../src/build.ts";
+import { type ByteWriter, METHOD_NOT_FOUND } from "../src/mcp/jsonrpc.ts";
+import { PROTOCOL_VERSION } from "../src/mcp/server.ts";
+import { serveMcp } from "../src/mcp/command.ts";
+import {
+  defaultRegistryRunner,
+  RegistryMcpServer,
+  type RegistryRunner,
+  type RegistryRunResult,
+} from "../src/mcp/registry_server.ts";
+import {
+  type BuildDescriptor,
+  type BuildLocation,
+  toBuildSummary,
+} from "../src/registry/descriptor.ts";
+import type {
+  BuildRegistry,
+  PutBuildResult,
+} from "../src/registry/registry.ts";
+import { FileSystemStateStore } from "../src/state/fs_store.ts";
+import type { StateHost } from "../src/state/store.ts";
+
+// ---- fakes ------------------------------------------------------------------
+
+/** An in-memory {@link BuildRegistry}. */
+class FakeRegistry implements BuildRegistry {
+  readonly map = new Map<string, BuildDescriptor>();
+  add(descriptor: BuildDescriptor): void {
+    this.map.set(descriptor.id, descriptor);
+  }
+  getBuild(id: string) {
+    const descriptor = this.map.get(id);
+    return Promise.resolve(
+      descriptor ? { descriptor, version: "v1" } : null,
+    );
+  }
+  register(descriptor: BuildDescriptor): Promise<PutBuildResult> {
+    this.map.set(descriptor.id, descriptor);
+    return Promise.resolve({ ok: true, version: "v1" });
+  }
+  deregister(id: string): Promise<void> {
+    this.map.delete(id);
+    return Promise.resolve();
+  }
+  listBuilds() {
+    return Promise.resolve([...this.map.values()].map(toBuildSummary));
+  }
+}
+
+/** An in-memory {@link StateHost} for a real FileSystemStateStore (audit trail). */
+class FakeStateHost implements StateHost {
+  readonly files = new Map<string, string>();
+  readonly locks = new Set<string>();
+  readText(path: string): Promise<string | null> {
+    return Promise.resolve(this.files.get(path) ?? null);
+  }
+  writeText(path: string, content: string): Promise<void> {
+    this.files.set(path, content);
+    return Promise.resolve();
+  }
+  rename(from: string, to: string): Promise<void> {
+    const content = this.files.get(from);
+    if (content !== undefined) {
+      this.files.set(to, content);
+      this.files.delete(from);
+    }
+    return Promise.resolve();
+  }
+  createExclusive(path: string): Promise<boolean> {
+    if (this.locks.has(path)) return Promise.resolve(false);
+    this.locks.add(path);
+    return Promise.resolve(true);
+  }
+  remove(path: string): Promise<void> {
+    this.files.delete(path);
+    this.locks.delete(path);
+    return Promise.resolve();
+  }
+  listDir(): Promise<string[]> {
+    return Promise.resolve([]);
+  }
+  mkdirp(): Promise<void> {
+    return Promise.resolve();
+  }
+  now(): number {
+    return 1_000_000;
+  }
+}
+
+/** A descriptor with the given id, target names, and (optional) launch location. */
+function descriptor(
+  id: string,
+  targets: string[],
+  location?: BuildLocation,
+): BuildDescriptor {
+  return {
+    id,
+    name: id,
+    location: location ??
+      { kind: "module", module: `file:///r/${id}.ts`, cwd: "/r" },
+    surface: {
+      commands: [],
+      flags: [],
+      targets: targets.map((name) => ({
+        name,
+        description: "",
+        dependsOn: [],
+        default: false,
+        unlisted: false,
+      })),
+      parameters: [],
+    },
+    actor: "me",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+/** A runner that records every spawn and returns a fixed result. */
+function recordingRunner(
+  result: RegistryRunResult = { code: 0, stdout: "ran", stderr: "" },
+): { runner: RegistryRunner; calls: { argv: string[]; cwd: string }[] } {
+  const calls: { argv: string[]; cwd: string }[] = [];
+  const runner: RegistryRunner = (argv, cwd) => {
+    calls.push({ argv: [...argv], cwd });
+    return Promise.resolve(result);
+  };
+  return { runner, calls };
+}
+
+/** A build whose `registry()` returns a fixed registry (for the serveMcp path). */
+class RegistryBuild extends Build {
+  constructor(private readonly reg: BuildRegistry) {
+    super();
+  }
+  override registry(): BuildRegistry {
+    return this.reg;
+  }
+}
+
+/** A ReadableStream that emits the given string chunks, then closes. */
+function streamOf(...chunks: string[]): ReadableStream<Uint8Array> {
+  const enc = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(enc.encode(chunk));
+      controller.close();
+    },
+  });
+}
+
+/** A ByteWriter that records everything written. */
+function capturingWriter(): { output: ByteWriter; text(): string } {
+  const parts: string[] = [];
+  const dec = new TextDecoder();
+  return {
+    output: {
+      write(p) {
+        parts.push(dec.decode(p));
+        return Promise.resolve(p.length);
+      },
+    },
+    text: () => parts.join(""),
+  };
+}
+
+// ---- response helpers (no casts) -------------------------------------------
+
+function isRec(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function req(method: string, params?: unknown): Record<string, unknown> {
+  return { jsonrpc: "2.0", id: 1, method, ...(params ? { params } : {}) };
+}
+function resultOf(res: unknown): Record<string, unknown> {
+  if (isRec(res) && isRec(res.result)) return res.result;
+  throw new Error(`expected a result: ${JSON.stringify(res)}`);
+}
+function toolNames(res: unknown): string[] {
+  const tools = resultOf(res).tools;
+  if (!Array.isArray(tools)) throw new Error("no tools array");
+  return tools.map((
+    t,
+  ) => (isRec(t) && typeof t.name === "string" ? t.name : ""));
+}
+function callText(res: unknown): { text: string; isError: boolean } {
+  const result = resultOf(res);
+  const content = result.content;
+  if (
+    !Array.isArray(content) || !isRec(content[0]) ||
+    typeof content[0].text !== "string"
+  ) {
+    throw new Error("not a tool result");
+  }
+  return { text: content[0].text, isError: result.isError === true };
+}
+
+/** Call a tool and return its text block. */
+async function call(
+  server: RegistryMcpServer,
+  name: string,
+  args: Record<string, unknown> = {},
+): Promise<{ text: string; isError: boolean }> {
+  const res = await server.handleMessage(
+    req("tools/call", { name, arguments: args }),
+  );
+  return callText(res);
+}
+
+// ---- tests ------------------------------------------------------------------
+
+Deno.test("initialize negotiates the version; ping is empty", async () => {
+  const server = new RegistryMcpServer(new FakeRegistry());
+  const res = await server.handleMessage(
+    req("initialize", { protocolVersion: "2024-11-05" }),
+  );
+  assertEquals(resultOf(res).protocolVersion, "2024-11-05");
+  const res2 = await server.handleMessage(req("initialize", {}));
+  assertEquals(resultOf(res2).protocolVersion, PROTOCOL_VERSION);
+  assertEquals((await server.handleMessage(req("ping")))?.result, {});
+});
+
+Deno.test("tools/list is read-only until running is allowed, and re-reads live", async () => {
+  const registry = new FakeRegistry();
+  registry.add(descriptor("Api", ["deploy"]));
+
+  const readOnly = new RegistryMcpServer(registry);
+  assertEquals(toolNames(await readOnly.handleMessage(req("tools/list"))), [
+    "list_builds",
+    "describe_build",
+  ]);
+
+  const server = new RegistryMcpServer(registry, { allowRun: true });
+  assertEquals(
+    toolNames(await server.handleMessage(req("tools/list"))).includes(
+      "run:Api:deploy",
+    ),
+    true,
+  );
+
+  // A build registered later appears without reconstructing the server.
+  registry.add(descriptor("Web", ["build", "release"]));
+  const names = toolNames(await server.handleMessage(req("tools/list")));
+  assertEquals(names.includes("run:Web:build"), true);
+  assertEquals(names.includes("run:Web:release"), true);
+});
+
+Deno.test("describe_build returns a surface or a friendly miss", async () => {
+  const registry = new FakeRegistry();
+  registry.add(descriptor("Api", ["deploy"]));
+  const server = new RegistryMcpServer(registry);
+
+  const ok = await call(server, "describe_build", { build: "Api" });
+  assertEquals(ok.isError, false);
+  assertStringIncludes(ok.text, "deploy");
+
+  assertEquals(
+    (await call(server, "describe_build", { build: "Nope" })).isError,
+    true,
+  );
+  assertEquals((await call(server, "describe_build", {})).isError, true);
+});
+
+Deno.test("list_builds returns the catalog", async () => {
+  const registry = new FakeRegistry();
+  registry.add(descriptor("Api", ["deploy"]));
+  const server = new RegistryMcpServer(registry);
+  const { text } = await call(server, "list_builds");
+  assertStringIncludes(text, "Api");
+});
+
+Deno.test("a run tool is disabled without --allow-run", async () => {
+  const registry = new FakeRegistry();
+  registry.add(descriptor("Api", ["deploy"]));
+  const { runner, calls } = recordingRunner();
+  const server = new RegistryMcpServer(registry, { runner });
+  const result = await call(server, "run:Api:deploy");
+  assertEquals(result.isError, true);
+  assertStringIncludes(result.text, "disabled");
+  assertEquals(calls.length, 0);
+});
+
+Deno.test("a run tool spawns the descriptor's module location", async () => {
+  const registry = new FakeRegistry();
+  registry.add(descriptor("Api", ["deploy"]));
+  const { runner, calls } = recordingRunner({
+    code: 0,
+    stdout: "DEPLOYED",
+    stderr: "",
+  });
+  const server = new RegistryMcpServer(registry, { allowRun: true, runner });
+
+  const result = await call(server, "run:Api:deploy");
+  assertEquals(result.isError, false);
+  assertStringIncludes(result.text, "DEPLOYED");
+  assertStringIncludes(result.text, "succeeded");
+  assertEquals(calls.length, 1);
+  // deno run -A <module> deploy
+  assertEquals(calls[0].argv.slice(1), [
+    "run",
+    "-A",
+    "file:///r/Api.ts",
+    "deploy",
+  ]);
+});
+
+Deno.test("a non-zero exit is reported as an error", async () => {
+  const registry = new FakeRegistry();
+  registry.add(descriptor("Api", ["deploy"]));
+  const { runner } = recordingRunner({
+    code: 2,
+    stdout: "boom",
+    stderr: "bad",
+  });
+  const server = new RegistryMcpServer(registry, { allowRun: true, runner });
+  const result = await call(server, "run:Api:deploy");
+  assertEquals(result.isError, true);
+  assertStringIncludes(result.text, "exited 2");
+});
+
+Deno.test("dryRun appends --dry-run to the spawn argv", async () => {
+  const registry = new FakeRegistry();
+  registry.add(descriptor("Api", ["deploy"]));
+  const { runner, calls } = recordingRunner();
+  const server = new RegistryMcpServer(registry, { allowRun: true, runner });
+  await call(server, "run:Api:deploy", { dryRun: true });
+  assertEquals(calls[0].argv.includes("--dry-run"), true);
+});
+
+Deno.test("the allow-list glob restricts by qualified name", async () => {
+  const registry = new FakeRegistry();
+  registry.add(descriptor("Api", ["deploy", "check"]));
+  registry.add(descriptor("Web", ["deploy"]));
+  const { runner, calls } = recordingRunner();
+  const server = new RegistryMcpServer(registry, {
+    allowRun: true,
+    allowRunPatterns: ["Api:*"],
+    runner,
+  });
+  const names = toolNames(await server.handleMessage(req("tools/list")));
+  assertEquals(names.includes("run:Api:deploy"), true);
+  assertEquals(names.includes("run:Web:deploy"), false);
+
+  // A call to a non-allow-listed build is indistinguishable from unknown.
+  const denied = await call(server, "run:Web:deploy");
+  assertEquals(denied.isError, true);
+  assertStringIncludes(denied.text, "Unknown tool");
+  assertEquals(calls.length, 0);
+});
+
+Deno.test("a protected target requires a valid operator token", async () => {
+  const registry = new FakeRegistry();
+  registry.add(descriptor("Api", ["deploy"]));
+  const { runner, calls } = recordingRunner();
+  const server = new RegistryMcpServer(registry, {
+    allowRun: true,
+    protectPatterns: ["Api:deploy"],
+    operatorToken: "good-token",
+    runner,
+  });
+  // Missing token → denied, no spawn.
+  assertStringIncludes(
+    (await call(server, "run:Api:deploy")).text,
+    "missing_operator_token",
+  );
+  // Wrong token → denied.
+  assertStringIncludes(
+    (await call(server, "run:Api:deploy", { operatorToken: "nope" })).text,
+    "invalid_operator_token",
+  );
+  assertEquals(calls.length, 0);
+  // Right token → runs.
+  const okd = await call(server, "run:Api:deploy", {
+    operatorToken: "good-token",
+  });
+  assertEquals(okd.isError, false);
+  assertEquals(calls.length, 1);
+});
+
+Deno.test("a protected target with no server token is fail-closed", async () => {
+  const registry = new FakeRegistry();
+  registry.add(descriptor("Api", ["deploy"]));
+  const server = new RegistryMcpServer(registry, {
+    allowRun: true,
+    protectPatterns: ["Api:deploy"],
+    runner: recordingRunner().runner,
+  });
+  assertStringIncludes(
+    (await call(server, "run:Api:deploy", { operatorToken: "x" })).text,
+    "operator_token_unconfigured",
+  );
+});
+
+Deno.test("--confirm-destructive returns a confirmation unless confirmed", async () => {
+  const registry = new FakeRegistry();
+  registry.add(descriptor("Api", ["deploy"]));
+  const { runner, calls } = recordingRunner();
+  const server = new RegistryMcpServer(registry, {
+    allowRun: true,
+    confirmDestructive: true,
+    runner,
+  });
+  const gated = await call(server, "run:Api:deploy");
+  assertStringIncludes(gated.text, "confirmation_required");
+  assertEquals(calls.length, 0);
+  // A dry run is NOT exempt: a spawn can't enforce dry-run, so it still gates.
+  const gatedDry = await call(server, "run:Api:deploy", { dryRun: true });
+  assertStringIncludes(gatedDry.text, "confirmation_required");
+  assertEquals(calls.length, 0);
+  // confirm:true runs it.
+  await call(server, "run:Api:deploy", { confirm: true });
+  assertEquals(calls.length, 1);
+});
+
+Deno.test("an unknown build/target run is a plain unknown tool", async () => {
+  const registry = new FakeRegistry();
+  const server = new RegistryMcpServer(registry, {
+    allowRun: true,
+    runner: recordingRunner().runner,
+  });
+  assertStringIncludes(
+    (await call(server, "run:Ghost:deploy")).text,
+    "Unknown tool",
+  );
+  // A name with no colon is also unknown, not a crash.
+  assertStringIncludes((await call(server, "run:bare")).text, "Unknown tool");
+});
+
+Deno.test("a command location spawns the command; an empty one errors", async () => {
+  const registry = new FakeRegistry();
+  registry.add(
+    descriptor("Api", ["deploy"], {
+      kind: "command",
+      command: ["make", "deploy-it"],
+      cwd: "/w",
+    }),
+  );
+  registry.add(
+    descriptor("Broke", ["deploy"], {
+      kind: "command",
+      command: [],
+      cwd: "/w",
+    }),
+  );
+  const { runner, calls } = recordingRunner();
+  const server = new RegistryMcpServer(registry, { allowRun: true, runner });
+
+  await call(server, "run:Api:deploy");
+  assertEquals(calls[0].argv, ["make", "deploy-it", "deploy"]);
+  assertEquals(calls[0].cwd, "/w");
+
+  const broke = await call(server, "run:Broke:deploy");
+  assertEquals(broke.isError, true);
+  assertStringIncludes(broke.text, "no runnable launch command");
+});
+
+Deno.test("a runner that throws is caught, not crashed", async () => {
+  const registry = new FakeRegistry();
+  registry.add(descriptor("Api", ["deploy"]));
+  const runner: RegistryRunner = () => Promise.reject(new Error("no exec"));
+  const server = new RegistryMcpServer(registry, { allowRun: true, runner });
+  const result = await call(server, "run:Api:deploy");
+  assertEquals(result.isError, true);
+  assertStringIncludes(result.text, "Failed to spawn");
+});
+
+Deno.test("unknown methods and malformed calls are handled", async () => {
+  const server = new RegistryMcpServer(new FakeRegistry());
+  const unknown = await server.handleMessage(req("does/not/exist"));
+  assertEquals(
+    isRec(unknown) && isRec(unknown.error) ? unknown.error.code : 0,
+    METHOD_NOT_FOUND,
+  );
+  const noName = await server.handleMessage(
+    req("tools/call", { arguments: {} }),
+  );
+  assertEquals(isRec(noName) && "error" in noName, true);
+  // A message with no method is an invalid request (an error response).
+  const invalid = await server.handleMessage({ jsonrpc: "2.0", id: 5 });
+  assertEquals(isRec(invalid) && "error" in invalid, true);
+  // A notification (no id) is silently accepted with no reply.
+  assertEquals(
+    await server.handleMessage({
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    }),
+    null,
+  );
+});
+
+Deno.test("mutating and denied calls are written to the audit log", async () => {
+  const registry = new FakeRegistry();
+  registry.add(descriptor("Api", ["deploy"]));
+  const store = new FileSystemStateStore("/state", new FakeStateHost());
+  const { runner } = recordingRunner();
+  const server = new RegistryMcpServer(registry, {
+    allowRun: true,
+    stateStore: store,
+    runner,
+  });
+  await call(server, "run:Api:deploy"); // ok
+  await call(server, "run:Ghost:deploy"); // denied
+
+  const audit = await store.getRun("mcp-audit");
+  const events = audit?.record.events ?? [];
+  assertEquals(
+    events.some((e) => e.tool === "run:Api:deploy" && e.outcome === "ok"),
+    true,
+  );
+  assertEquals(
+    events.some((e) => e.tool === "run:Ghost:deploy" && e.outcome === "denied"),
+    true,
+  );
+  // The operator token never reaches the trail.
+  assertEquals(events.every((e) => !("operatorToken" in e.args)), true);
+});
+
+/** Find one tool definition by name from a `tools/list` reply. */
+function toolDef(res: unknown, name: string): Record<string, unknown> {
+  const tools = resultOf(res).tools;
+  if (!Array.isArray(tools)) throw new Error("no tools array");
+  const found = tools.find((t) => isRec(t) && t.name === name);
+  if (!isRec(found)) throw new Error(`no tool ${name}`);
+  return found;
+}
+
+Deno.test("a protected/confirmable target advertises its extra inputs", async () => {
+  const registry = new FakeRegistry();
+  registry.add(descriptor("Api", ["deploy"]));
+  const server = new RegistryMcpServer(registry, {
+    allowRun: true,
+    protectPatterns: ["Api:deploy"],
+    confirmDestructive: true,
+  });
+  const tool = toolDef(
+    await server.handleMessage(req("tools/list")),
+    "run:Api:deploy",
+  );
+  const schema = isRec(tool.inputSchema) ? tool.inputSchema : {};
+  const properties = isRec(schema.properties) ? schema.properties : {};
+  assertEquals("operatorToken" in properties, true);
+  assertEquals("confirm" in properties, true);
+  assertEquals(
+    Array.isArray(schema.required) && schema.required.includes("operatorToken"),
+    true,
+  );
+});
+
+Deno.test("a build deregistered between list and read is skipped, not crashed", async () => {
+  // listBuilds names a build that getBuild can no longer load.
+  class GhostRegistry extends FakeRegistry {
+    override getBuild() {
+      return Promise.resolve(null);
+    }
+  }
+  const registry = new GhostRegistry();
+  registry.add(descriptor("Ghost", ["x"]));
+  const server = new RegistryMcpServer(registry, { allowRun: true });
+  assertEquals(toolNames(await server.handleMessage(req("tools/list"))), [
+    "list_builds",
+    "describe_build",
+  ]);
+});
+
+Deno.test("a registry error during a call is a JSON-RPC error, not a crash", async () => {
+  class BrokenRegistry extends FakeRegistry {
+    override getBuild(): Promise<never> {
+      return Promise.reject(new Error("store down"));
+    }
+  }
+  const server = new RegistryMcpServer(new BrokenRegistry(), {
+    allowRun: true,
+  });
+  const res = await server.handleMessage(
+    req("tools/call", { name: "run:Api:deploy", arguments: {} }),
+  );
+  assertEquals(
+    isRec(res) && isRec(res.error) ? typeof res.error.code : "none",
+    "number",
+  );
+});
+
+Deno.test("serveMcp --registry resolves the registry and serves the catalog", async () => {
+  const registry = new FakeRegistry();
+  registry.add(descriptor("Api", ["deploy"]));
+  const { output, text } = capturingWriter();
+  const banner: string[] = [];
+  const origErr = console.error;
+  console.error = (...a: unknown[]) => void banner.push(a.join(" "));
+  try {
+    const code = await serveMcp(new RegistryBuild(registry), {
+      useRegistry: true,
+      allowRun: true,
+      runner: recordingRunner().runner,
+      input: streamOf('{"jsonrpc":"2.0","id":1,"method":"tools/list"}\n'),
+      output,
+    });
+    assertEquals(code, 0);
+  } finally {
+    console.error = origErr;
+  }
+  assertStringIncludes(banner.join("\n"), "registry");
+  assertStringIncludes(text(), "run:Api:deploy");
+});
+
+Deno.test("a throwing registry on tools/list is a JSON-RPC error, not a crash", async () => {
+  class BrokenListRegistry extends FakeRegistry {
+    override listBuilds(): Promise<never> {
+      return Promise.reject(new Error("registry down"));
+    }
+  }
+  const server = new RegistryMcpServer(new BrokenListRegistry(), {
+    allowRun: true,
+  });
+  const res = await server.handleMessage(req("tools/list"));
+  // An error response, not a rejected promise that would kill the transport.
+  assertEquals(
+    isRec(res) && isRec(res.error) ? typeof res.error.code : "none",
+    "number",
+  );
+  // The server keeps answering afterwards.
+  assertEquals((await server.handleMessage(req("ping")))?.result, {});
+});
+
+Deno.test("defaultRegistryRunner spawns a real process and captures its output", async () => {
+  const result = await defaultRegistryRunner(
+    [Deno.execPath(), "eval", "console.log('spawned-ok')"],
+    Deno.cwd(),
+  );
+  assertEquals(result.code, 0);
+  assertStringIncludes(result.stdout, "spawned-ok");
+});
+
+Deno.test("defaultRegistryRunner strips server secrets from the spawned env", async () => {
+  const prev = Deno.env.get("ZUKE_OPERATOR_TOKEN");
+  Deno.env.set("ZUKE_OPERATOR_TOKEN", "server-secret");
+  try {
+    const result = await defaultRegistryRunner(
+      [
+        Deno.execPath(),
+        "eval",
+        "console.log(Deno.env.get('ZUKE_OPERATOR_TOKEN') ?? 'STRIPPED', " +
+        "Deno.env.get('PATH') ? 'HAS_PATH' : 'NO_PATH')",
+      ],
+      Deno.cwd(),
+    );
+    assertEquals(result.code, 0);
+    // The operator token is gone, but the rest of the environment is intact.
+    assertStringIncludes(result.stdout, "STRIPPED");
+    assertStringIncludes(result.stdout, "HAS_PATH");
+  } finally {
+    if (prev === undefined) Deno.env.delete("ZUKE_OPERATOR_TOKEN");
+    else Deno.env.set("ZUKE_OPERATOR_TOKEN", prev);
+  }
+});

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -549,15 +549,18 @@ is current (`zuke generate-ci --check` is a dedicated gate).
                               # authz tiers: allow-list, operator token, confirm
 ./zuke runs show mcp-audit    # the MCP tool-call audit trail
 ./zuke register [--json]      # record this build in the build registry (idempotent)
+./zuke mcp --registry --allow-run  # serve the registry: registered builds as tools, spawned
 ```
 
 **Build registry** (`docs/registry.md`): `zuke register` writes a secret-free
 descriptor of this build — its `describeCli()` surface (targets, params) plus a
-launch location — into a pluggable `BuildRegistry`, so a registry-backed MCP
-server can discover new pipelines without a redeploy. Resolved like the state
+launch location — into a pluggable `BuildRegistry`. Resolved like the state
 store: `ZUKE_REGISTRY_URL`/`_TOKEN` (HTTP) or `ZUKE_REGISTRY_DIR` (files), a
 `registry()` build override, else `.zuke/builds`. Separate from the run store; an
-HTTP backend shares the `/builds` REST contract beside `/runs`.
+HTTP backend shares the `/builds` REST contract beside `/runs`. **`zuke mcp
+--registry`** then serves the whole catalog — re-read live, so a build registered
+by another process appears as a `run:<buildId>:<target>` tool with no restart and
+runs by spawning its launch location (behind `--allow-run` + the same authz).
 
 **Caching:** a target with `.inputs(...)`/`.outputs(...)` is incremental
 (skipped and reported `cached` when inputs are unchanged and outputs exist). Add

--- a/tests/e2e/fixtures/discoverable_build.ts
+++ b/tests/e2e/fixtures/discoverable_build.ts
@@ -1,0 +1,20 @@
+/**
+ * A tiny runnable build used by the registry-MCP e2e. It registers itself
+ * (`register`) into `ZUKE_REGISTRY_DIR`, and its one target prints a marker so a
+ * registry-backed `zuke mcp` server that spawns it can be shown to have captured
+ * real subprocess output.
+ *
+ * @module
+ */
+
+import { Build, run, target } from "../../../packages/core/mod.ts";
+
+/** A one-target pipeline whose output the e2e asserts on. */
+class Widget extends Build {
+  /** Prints a marker the spawning MCP server captures and returns. */
+  hello = target()
+    .description("Say hello")
+    .executes(() => console.log("HELLO-FROM-REGISTERED"));
+}
+
+await run(Widget);

--- a/tests/e2e/registry_mcp_e2e.ts
+++ b/tests/e2e/registry_mcp_e2e.ts
@@ -1,0 +1,158 @@
+/**
+ * End-to-end: the M11 acceptance across real processes. A `zuke mcp --registry`
+ * server starts over an empty build registry; a separate process registers a new
+ * build; **without restarting the server**, that build's target appears as an
+ * MCP tool and is runnable — the server spawns the registered build and returns
+ * its captured output. Proves live registry discovery and spawn-based execution
+ * between genuinely separate processes.
+ *
+ * Excluded from the fast unit gate (`*_e2e.ts`); run by the `integration` target
+ * / integration.yml on the OS matrix.
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+
+const FIXTURE = new URL("./fixtures/discoverable_build.ts", import.meta.url);
+const PORT = 8801;
+const BASE = `http://127.0.0.1:${PORT}/`;
+
+/** Run the fixture as a real `deno` subprocess against registry dir `dir`. */
+async function runFixture(
+  args: string[],
+  dir: string,
+): Promise<{ code: number; out: string }> {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: ["run", "-A", FIXTURE.href, ...args],
+    env: { ZUKE_REGISTRY_DIR: dir },
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const { code, stdout } = await command.output();
+  return { code, out: new TextDecoder().decode(stdout) };
+}
+
+/** Post a JSON-RPC message to the running MCP server and return the parsed reply. */
+async function rpc(method: string, params?: unknown): Promise<unknown> {
+  const res = await fetch(BASE, {
+    method: "POST",
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method,
+      ...(params ? { params } : {}),
+    }),
+  });
+  return await res.json();
+}
+
+/** The tool names from a `tools/list` reply. */
+function toolNames(reply: unknown): string[] {
+  const result = (reply as { result?: { tools?: Array<{ name: string }> } })
+    .result;
+  return (result?.tools ?? []).map((t) => t.name);
+}
+
+/** The text block of a `tools/call` reply. */
+function toolText(reply: unknown): string {
+  const result =
+    (reply as { result?: { content?: Array<{ text: string }> } }).result;
+  const text = result?.content?.[0]?.text;
+  if (typeof text !== "string") throw new Error("no tool text");
+  return text;
+}
+
+/** Poll the server until it answers `ping`, or throw past `deadline`. */
+async function waitReady(deadline: number): Promise<void> {
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(BASE, {
+        method: "POST",
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+      });
+      const ok = res.ok;
+      await res.body?.cancel();
+      if (ok) return;
+    } catch {
+      // Not listening yet.
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error("MCP server did not become ready in time");
+}
+
+Deno.test("a build registered after startup appears as a runnable MCP tool", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "zuke-reg-mcp-e2e-" });
+  let server: Deno.ChildProcess | undefined;
+  try {
+    // A registry-backed MCP server over an initially-empty registry.
+    server = new Deno.Command(Deno.execPath(), {
+      args: [
+        "run",
+        "-A",
+        FIXTURE.href,
+        "mcp",
+        "--registry",
+        "--http",
+        `127.0.0.1:${PORT}`,
+        "--allow-run",
+      ],
+      env: { ZUKE_REGISTRY_DIR: dir },
+      stdout: "null",
+      stderr: "null",
+    }).spawn();
+    await waitReady(Date.now() + 10_000);
+
+    // No pipelines registered yet: only the read tools are exposed.
+    const before = toolNames(await rpc("tools/list"));
+    assertEquals(before.includes("run:Widget:hello"), false);
+
+    // A separate process registers the build.
+    const registered = await runFixture(["register"], dir);
+    assertEquals(registered.code, 0);
+
+    // Without restarting the server, the new target is now a tool…
+    const after = toolNames(await rpc("tools/list"));
+    assertEquals(after.includes("run:Widget:hello"), true);
+
+    // …and running it spawns the registered build and returns its output.
+    const ran = toolText(
+      await rpc("tools/call", { name: "run:Widget:hello", arguments: {} }),
+    );
+    assertStringIncludes(ran, "HELLO-FROM-REGISTERED");
+    assertStringIncludes(ran, "succeeded");
+  } finally {
+    if (server !== undefined) {
+      server.kill();
+      await killWithin(server, 10_000);
+    }
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+/** Await a killed process exiting within `ms`, throwing a clear error otherwise. */
+async function killWithin(
+  server: Deno.ChildProcess,
+  ms: number,
+): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () =>
+        reject(
+          new Error(
+            `mcp server did not exit ${ms}ms after SIGTERM — the CLI is ` +
+              `swallowing the signal instead of terminating.`,
+          ),
+        ),
+      ms,
+    );
+  });
+  try {
+    await Promise.race([server.status, timeout]);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/zuke.ts
+++ b/zuke.ts
@@ -384,6 +384,7 @@ class ZukeBuild extends Build {
           "tests/e2e/otel_e2e.ts",
           "tests/e2e/gh_workflow_e2e.ts",
           "tests/e2e/registry_e2e.ts",
+          "tests/e2e/registry_mcp_e2e.ts",
         )
       );
     });


### PR DESCRIPTION
## What

Milestone **M11 PR2** (the second half of M11) — **registry-backed dynamic MCP discovery**. `zuke mcp --registry` serves the whole [build registry](./docs/registry.md) instead of the single build its process was launched with, and **re-reads it on every `tools/list` and `tools/call`**. A pipeline registered by another process (`zuke register`, PR1) appears as a tool in an already-running server with **no restart** — the M11 acceptance.

## How

A registered build has no live instance in the server — only a descriptor — so a run tool cannot `execute()` in-process. It **spawns the descriptor's launch location** (`deno run <module> <target>`, or an explicit command) through an injectable runner and returns the captured output. This is the plan's resolved crux: the MCP host runs the location/command itself.

- **Discovery:** `list_builds` (catalog) and `describe_build {build}` read tools; each registered target becomes a `run:<buildId>:<target>` tool.
- **Execution** is off unless `--allow-run` and rides the **M5 authz tiers**, keyed on the qualified `<buildId>:<target>` name — allow-list (`--allow-run=Api:*`), operator token (`--protect=Api:deploy`), confirmation (`--confirm-destructive`). Every mutating or denied call is **audited**.
- **Scope:** a run tool takes only `dryRun`/`confirm`/`operatorToken` — the spawned build resolves its own parameters from the server environment. Per-parameter passthrough (which needs a secret-safe cross-spawn contract) is a documented follow-up. The single-build `McpServer` is **untouched** (zero regression).

## Adversarial review

A security pass (5 dimensions, each finding verified against the code) confirmed and fixed three issues, each with a regression test:

- **DoS:** `tools/list` did live registry I/O unguarded, so a transient HTTP-backend fault or one malformed descriptor would reject out of the stdio read loop and kill the server for all clients. Now guarded like `tools/call` — a registry hiccup returns a JSON-RPC error and the server keeps serving.
- **Confirmation bypass:** `dryRun:true` skipped `--confirm-destructive`. Sound for the in-process server (which enforces dry-run structurally), but the registry server only *appends* `--dry-run` and spawns — a command-wrapper that ignores it would execute for real. Confirmation is now required before **any** spawn, dry run included.
- **Secret leak:** a spawned build inherited the server's full environment, including the operator and HTTP bearer tokens. Those authorization secrets are now stripped from the child environment (the rest is preserved so the build still resolves its params).

Two candidates were refuted: argv ordering is safe (the target follows the module, so it's a script argument, never a `deno` runtime flag), and run output is already redacted by the spawned build's own reporter.

## Tests & docs

Unit (`registry_server_test.ts`: live discovery, spawn via a fake runner, the authz tiers, audit, the three fixes, the real `defaultRegistryRunner`), and a cross-process **e2e** that starts the server over an empty registry, registers a build from another process, and runs it — asserting the tool appears live and its spawned output comes back. `docs/mcp.md` gains a Registry-mode section; `docs/registry.md` and the cheatsheet updated.

Full `deno task ci` green (coverage 95.1% branches), `apiDocsCheck` and `generate-ci --check` clean.

Completes **M11**. Next: **M8** (timezone-aware schedules in `cicd()`).
