### PR TITLE
feat(core): npx-style node_modules/.bin tool resolution

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -28,6 +28,30 @@ hand its path to `.toolPath(...)` — see
 through `cmd /c` on Windows (npm ships as a `.cmd` shim there) and otherwise
 raises a `ToolNotFoundError` that names the tool and the fix.
 
+## Resolving from `node_modules/.bin`
+
+By default a wrapper spawns the bare tool name and lets the OS find it on
+`PATH`. In a Node monorepo the tools are usually installed locally and hoisted
+to the repo root instead, so Zuke can resolve them npx-style — walking up from
+the working directory for `node_modules/.bin/<tool>` (the `.cmd`/`.bat` shims,
+launched through `cmd /c`, on Windows) and falling back to `PATH` on a miss. There are three ways to
+turn it on, most specific first:
+
+- **Per call:** `.fromNodeModules()` (or `.fromPath()` to force `PATH`) on any
+  settings object — `OxlintTasks.lint((s) => s.fromNodeModules())`.
+- **Per wrapper:** the JS-ecosystem wrappers default to `node_modules`-first, so
+  in a workspace package whose binaries are hoisted you write no `.toolPath()`
+  and no `.fromNodeModules()` at all.
+- **Repo-wide:** `ZUKE_TOOL_RESOLUTION=node_modules` (or `path`) flips every
+  wrapper without touching call sites. A per-call `.fromNodeModules()`/
+  `.fromPath()` still wins over the ambient value.
+
+An explicit `.toolPath(...)` always wins over resolution — pins from
+`toolchain()` stay hermetic. When resolution walks past a `node_modules`
+directory that lacks the tool, `ToolNotFoundError` adds a hint to run `npm ci`
+or provision it via `toolchain()`. `resolvedArgv()` reports the argv a run will
+actually spawn (the resolved shim or the bare fallback) for diagnostics.
+
 | Package                | Tasks                                                                                                                                 |
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | `@zuke/deno`           | `run`, `test`, `check`, `fmt`, `lint`, `cache`, `coverage`, `task`                                                                    |

--- a/packages/core/src/tooling.ts
+++ b/packages/core/src/tooling.ts
@@ -20,9 +20,105 @@
  */
 
 import { Command, type CommandOutput } from "./shell.ts";
-import type { AbsolutePath, PathLike } from "./path.ts";
+import { type AbsolutePath, absolutePath, type PathLike } from "./path.ts";
 
 export type { PathLike };
+
+/**
+ * How {@link ToolSettings.run} locates a wrapper's binary when no explicit
+ * {@link ToolSettings.toolPath} is set:
+ *
+ * - `"path"` — spawn the bare tool name and let the OS resolve it on `PATH`
+ *   (the default, matching a native/global install);
+ * - `"node_modules"` — npx-style: walk up from the working directory looking
+ *   for `node_modules/.bin/<tool>`, falling back to `PATH` on a miss (so a
+ *   package hoisted to a monorepo root runs with no `.toolPath()`).
+ */
+export type ToolResolution = "node_modules" | "path";
+
+/** Process-lifetime memo of `node_modules/.bin` lookups, keyed by os+tool+cwd. */
+const NODE_BIN_MEMO = new Map<string, NodeBinLookup>();
+
+/** The outcome of a `node_modules/.bin` walk. */
+interface NodeBinLookup {
+  /** The resolved absolute shim path, or `null` when none was found. */
+  bin: string | null;
+  /** Whether any `node_modules` directory was seen during the walk. */
+  sawNodeModules: boolean;
+}
+
+/** The ambient `ZUKE_TOOL_RESOLUTION` override, or `null` when unset/invalid. */
+function envResolution(): ToolResolution | null {
+  let value: string | undefined;
+  try {
+    value = Deno.env.get("ZUKE_TOOL_RESOLUTION");
+  } catch {
+    return null; // no --allow-env: behave as if unset
+  }
+  return value === "node_modules" || value === "path" ? value : null;
+}
+
+/** Whether `path` names an existing file (following symlinks). */
+function isFile(path: string): boolean {
+  try {
+    return Deno.statSync(path).isFile;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Search `node_modules/.bin` for `tool`, walking up from `cwd` to the
+ * filesystem root. On Windows the spawnable `.cmd`/`.bat` shim variants are
+ * matched (a batch shim is launched via {@link windowsCmdShim}). The result is
+ * memoized for the process, keyed by os+tool+cwd.
+ */
+function findNodeModulesBin(
+  tool: string,
+  cwd: string,
+  os: typeof Deno.build.os,
+): NodeBinLookup {
+  const key = `${os}\0${tool}\0${cwd}`;
+  const cached = NODE_BIN_MEMO.get(key);
+  if (cached !== undefined) return cached;
+  // On Windows only the batch shims can be spawned (via `cmd /c`); the bare
+  // shim (no extension) is a POSIX shell script and the `.ps1` needs PowerShell,
+  // so resolving to either would return a path Windows cannot launch — skip
+  // them and let the PATH fallback handle those (rare) cases.
+  const names = os === "windows" ? [`${tool}.cmd`, `${tool}.bat`] : [tool];
+  let dir = /^(\/|[A-Za-z]:)/.test(cwd)
+    ? absolutePath(cwd)
+    : absolutePath(Deno.cwd(), cwd);
+  let sawNodeModules = false;
+  while (true) {
+    const binDir = dir("node_modules", ".bin");
+    if (existsDir(dir("node_modules").path)) sawNodeModules = true;
+    for (const name of names) {
+      const candidate = binDir(name);
+      if (isFile(candidate.path)) {
+        return remember(key, { bin: candidate.path, sawNodeModules: true });
+      }
+    }
+    if (dir.isRoot) break;
+    dir = dir.parent();
+  }
+  return remember(key, { bin: null, sawNodeModules });
+}
+
+/** Whether `path` names an existing directory. */
+function existsDir(path: string): boolean {
+  try {
+    return Deno.statSync(path).isDirectory;
+  } catch {
+    return false;
+  }
+}
+
+/** Store `lookup` under `key` and return it. */
+function remember(key: string, lookup: NodeBinLookup): NodeBinLookup {
+  NODE_BIN_MEMO.set(key, lookup);
+  return lookup;
+}
 
 /** Raised when a tool's binary cannot be found on the system. */
 export class ToolNotFoundError extends Error {
@@ -32,10 +128,19 @@ export class ToolNotFoundError extends Error {
   constructor(
     /** The binary that could not be resolved. */
     readonly tool: string,
+    /**
+     * Whether a `node_modules` directory was seen during resolution but lacked
+     * the binary — when `true`, the message suggests `npm ci` / `toolchain()`.
+     */
+    sawNodeModules = false,
   ) {
     super(
       `Tool not found: "${tool}". Install it and make sure it is on PATH, ` +
-        `or point at the binary explicitly with .toolPath(...).`,
+        `or point at the binary explicitly with .toolPath(...).` +
+        (sawNodeModules
+          ? ` A node_modules directory was found but did not contain ` +
+            `"${tool}" — run \`npm ci\`, or provision it via toolchain().`
+          : ""),
     );
   }
 }
@@ -49,6 +154,22 @@ export function shimFallbackArgv(
   os: typeof Deno.build.os,
 ): string[] | null {
   return os === "windows" ? ["cmd", "/c", ...argv] : null;
+}
+
+/**
+ * On Windows, spawn a resolved `.cmd`/`.bat` shim (such as npm's `node_modules`
+ * shims) through `cmd /c` — a batch shim is not a PE executable, so
+ * `Deno.Command` cannot launch it directly. Returns `argv` unchanged on other
+ * platforms or when the binary is not a batch shim.
+ */
+export function windowsCmdShim(
+  argv: ReadonlyArray<string>,
+  os: typeof Deno.build.os,
+): string[] {
+  const first = argv[0];
+  return os === "windows" && first !== undefined && /\.(cmd|bat)$/i.test(first)
+    ? ["cmd", "/c", ...argv]
+    : [...argv];
 }
 
 /** A lambda that configures a settings instance and returns it. */
@@ -85,6 +206,7 @@ export abstract class ToolSettings {
   #quiet = false;
   #timeoutMs?: number;
   #toolPath?: string;
+  #resolution?: ToolResolution;
   #extraArgs: string[] = [];
 
   /** The binary to spawn when {@link toolPath} is not set. */
@@ -92,6 +214,17 @@ export abstract class ToolSettings {
 
   /** The subcommand argv. Must be pure — no I/O, no environment reads. */
   protected abstract buildArgs(): string[];
+
+  /**
+   * The wrapper's default binary-resolution strategy. The base returns
+   * `"path"` (bare name on `PATH`); a JS-ecosystem wrapper whose binary is
+   * almost always installed under `node_modules` overrides this to
+   * `"node_modules"`. A per-call {@link fromNodeModules}/{@link fromPath} and
+   * the ambient `ZUKE_TOOL_RESOLUTION` both take precedence over this default.
+   */
+  protected defaultResolution(): ToolResolution {
+    return "path";
+  }
 
   /** Merge additional environment variables for the process. */
   env(record: Record<string, string>): this {
@@ -142,6 +275,23 @@ export abstract class ToolSettings {
     return this;
   }
 
+  /**
+   * Resolve the binary npx-style: walk up from the working directory looking
+   * for `node_modules/.bin/<tool>`, falling back to `PATH` on a miss. Overrides
+   * both the wrapper default and the ambient `ZUKE_TOOL_RESOLUTION`. Has no
+   * effect once {@link toolPath} is set (an explicit path always wins).
+   */
+  fromNodeModules(): this {
+    this.#resolution = "node_modules";
+    return this;
+  }
+
+  /** Resolve the binary from `PATH` only, ignoring any `node_modules/.bin`. */
+  fromPath(): this {
+    this.#resolution = "path";
+    return this;
+  }
+
   /** Escape hatch: append raw arguments after all typed options. */
   args(...extra: Array<string | number | AbsolutePath>): this {
     this.#extraArgs.push(...extra.map(String));
@@ -155,6 +305,45 @@ export abstract class ToolSettings {
       ...this.buildArgs(),
       ...this.#extraArgs,
     ];
+  }
+
+  /** The effective resolution: per-call override, else ambient, else default. */
+  #effectiveResolution(): ToolResolution {
+    return this.#resolution ?? envResolution() ?? this.defaultResolution();
+  }
+
+  /**
+   * The argv {@link run} will actually spawn — like {@link argv}, but with the
+   * `node_modules/.bin` resolution applied (so it performs I/O). Useful for
+   * tests and diagnostics: it reveals whether a wrapper resolved to a local
+   * shim or fell back to the bare name on `PATH`.
+   */
+  resolvedArgv(): string[] {
+    return this.#resolveBinary().argv;
+  }
+
+  /**
+   * The argv to spawn, plus whether a `node_modules` directory was seen. When
+   * no explicit {@link toolPath} is set and resolution is `"node_modules"`,
+   * argv[0] is rewritten to the resolved `node_modules/.bin` shim (or left as
+   * the bare name to fall back to `PATH`).
+   */
+  #resolveBinary(): { argv: string[]; sawNodeModules: boolean } {
+    const base = this.argv();
+    if (this.#toolPath !== undefined || base[0] === undefined) {
+      return { argv: base, sawNodeModules: false };
+    }
+    if (this.#effectiveResolution() !== "node_modules") {
+      return { argv: base, sawNodeModules: false };
+    }
+    const cwd = this.#cwd ?? Deno.cwd();
+    const { bin, sawNodeModules } = findNodeModulesBin(
+      this.defaultTool(),
+      cwd,
+      this.os_,
+    );
+    const argv = bin === null ? base : [bin, ...base.slice(1)];
+    return { argv, sawNodeModules };
   }
 
   #command(argv: string[]): Command {
@@ -172,19 +361,23 @@ export abstract class ToolSettings {
    * otherwise raise a {@link ToolNotFoundError} naming the tool.
    */
   async run(): Promise<CommandOutput> {
-    const argv = this.argv();
+    const { argv, sawNodeModules } = this.#resolveBinary();
     const tool = argv[0] ?? "";
+    // A resolved `node_modules/.bin/*.cmd` shim must go through `cmd /c` up
+    // front — it is not directly spawnable — rather than relying on the
+    // NotFound retry below (which only fires for a bare name missing on PATH).
+    const primary = windowsCmdShim(argv, this.os_);
     try {
-      return await this.#command(argv);
+      return await this.#command(primary);
     } catch (error) {
       if (!(error instanceof Deno.errors.NotFound)) throw error;
       const fallback = shimFallbackArgv(argv, this.os_);
-      if (fallback === null) throw new ToolNotFoundError(tool);
+      if (fallback === null) throw new ToolNotFoundError(tool, sawNodeModules);
       try {
         return await this.#command(fallback);
       } catch (retryError) {
         if (retryError instanceof Deno.errors.NotFound) {
-          throw new ToolNotFoundError(tool);
+          throw new ToolNotFoundError(tool, sawNodeModules);
         }
         throw retryError;
       }

--- a/packages/core/tests/tooling_test.ts
+++ b/packages/core/tests/tooling_test.ts
@@ -11,6 +11,7 @@ import {
   shimFallbackArgv,
   ToolNotFoundError,
   ToolSettings,
+  windowsCmdShim,
 } from "../src/tooling.ts";
 import { CommandError, CommandTimeoutError } from "../src/shell.ts";
 
@@ -131,6 +132,186 @@ Deno.test("non-NotFound spawn errors propagate unchanged", async () => {
     }
   }
   await assertRejects(() => new EmptySettings().run(), Error, "empty");
+});
+
+/** Create `node_modules/.bin/<name>` under `dir` and return its path. */
+function plantBin(dir: string, name: string): string {
+  const binDir = `${dir}/node_modules/.bin`;
+  Deno.mkdirSync(binDir, { recursive: true });
+  const path = `${binDir}/${name}`;
+  Deno.writeTextFileSync(path, "#!/bin/sh\n");
+  return path.replace(/\\/g, "/");
+}
+
+/** A wrapper whose binary is resolved from `node_modules` by default. */
+class NodeToolSettings extends ToolSettings {
+  protected override defaultTool(): string {
+    return "mytool";
+  }
+  protected override buildArgs(): string[] {
+    return ["run"];
+  }
+  protected override defaultResolution(): "node_modules" | "path" {
+    return "node_modules";
+  }
+}
+
+Deno.test("fromNodeModules resolves a hoisted bin by walking up", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    const bin = plantBin(root, "mytool");
+    Deno.mkdirSync(`${root}/a/b`, { recursive: true });
+    // The bin lives at the root; the cwd is two levels down → the walk finds it.
+    const node = new NodeToolSettings().cwd(`${root}/a/b`);
+    assertEquals(node.resolvedArgv(), [bin, "run"]);
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("resolution falls back to the bare name on a miss", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    const s = new NodeToolSettings().cwd(root);
+    assertEquals(s.resolvedArgv(), ["mytool", "run"]);
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("fromPath ignores a present node_modules/.bin", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    plantBin(root, "mytool");
+    const s = new NodeToolSettings().cwd(root).fromPath();
+    assertEquals(s.resolvedArgv(), ["mytool", "run"]);
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("an explicit toolPath wins over node_modules resolution", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    plantBin(root, "mytool");
+    const s = new NodeToolSettings().cwd(root).toolPath("/custom/mytool");
+    assertEquals(s.resolvedArgv(), ["/custom/mytool", "run"]);
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("ZUKE_TOOL_RESOLUTION flips a path-default wrapper repo-wide", () => {
+  const root = Deno.makeTempDirSync();
+  const prev = Deno.env.get("ZUKE_TOOL_RESOLUTION");
+  try {
+    const bin = plantBin(root, "mytool");
+    // EvalSettings defaults to "path"; the ambient override switches it on.
+    class MyTool extends ToolSettings {
+      protected override defaultTool(): string {
+        return "mytool";
+      }
+      protected override buildArgs(): string[] {
+        return [];
+      }
+    }
+    Deno.env.set("ZUKE_TOOL_RESOLUTION", "node_modules");
+    assertEquals(new MyTool().cwd(root).resolvedArgv(), [bin]);
+    // A per-call .fromPath() still beats the ambient override.
+    assertEquals(new MyTool().cwd(root).fromPath().resolvedArgv(), ["mytool"]);
+    // And "path" turns a node_modules-default wrapper back off.
+    Deno.env.set("ZUKE_TOOL_RESOLUTION", "path");
+    assertEquals(new NodeToolSettings().cwd(root).resolvedArgv(), [
+      "mytool",
+      "run",
+    ]);
+    // An unrecognised value is ignored (default wins).
+    Deno.env.set("ZUKE_TOOL_RESOLUTION", "bogus");
+    assertEquals(new NodeToolSettings().cwd(root).resolvedArgv(), [bin, "run"]);
+  } finally {
+    if (prev === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prev);
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("windows resolution matches the .cmd shim, not the bare shim", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    const cmd = plantBin(root, "mytool.cmd");
+    plantBin(root, "mytool"); // the bare shim (no extension) is ignored
+    const s = new NodeToolSettings().cwd(root);
+    s.os_ = "windows";
+    assertEquals(s.resolvedArgv(), [cmd, "run"]);
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("windows resolution ignores a bare-only shim", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    plantBin(root, "mytool"); // no .cmd/.bat → Windows cannot launch it
+    const s = new NodeToolSettings().cwd(root);
+    s.os_ = "windows";
+    assertEquals(s.resolvedArgv(), ["mytool", "run"]); // falls back to PATH
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("windowsCmdShim wraps .cmd/.bat via cmd /c on windows only", () => {
+  assertEquals(windowsCmdShim(["C:/x/foo.cmd", "-v"], "windows"), [
+    "cmd",
+    "/c",
+    "C:/x/foo.cmd",
+    "-v",
+  ]);
+  assertEquals(windowsCmdShim(["C:/x/foo.BAT"], "windows"), [
+    "cmd",
+    "/c",
+    "C:/x/foo.BAT",
+  ]);
+  // A plain executable is left alone, and non-windows never wraps.
+  assertEquals(windowsCmdShim(["foo.exe", "-v"], "windows"), ["foo.exe", "-v"]);
+  assertEquals(windowsCmdShim(["/n/foo.cmd"], "linux"), ["/n/foo.cmd"]);
+  assertEquals(windowsCmdShim([], "windows"), []);
+});
+
+Deno.test("the lookup is memoized per (tool, cwd)", () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    const s = new NodeToolSettings().cwd(root);
+    assertEquals(s.resolvedArgv(), ["mytool", "run"]); // miss, memoized
+    plantBin(root, "mytool"); // planted *after* the first lookup
+    assertEquals(s.resolvedArgv(), ["mytool", "run"]); // still the cached miss
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
+});
+
+Deno.test("ToolNotFoundError hints at npm ci when node_modules lacked the bin", async () => {
+  const root = Deno.makeTempDirSync();
+  try {
+    Deno.mkdirSync(`${root}/node_modules`, { recursive: true });
+    // A bare tool name that does not exist, so the spawn fails NotFound while
+    // a node_modules directory was seen during the walk.
+    class Missing extends ToolSettings {
+      protected override defaultTool(): string {
+        return "zuke-no-such-tool-xyz";
+      }
+      protected override buildArgs(): string[] {
+        return [];
+      }
+    }
+    const miss = new Missing().cwd(root).fromNodeModules();
+    miss.os_ = "linux";
+    const err = await assertRejects(() => miss.run(), ToolNotFoundError);
+    assertEquals(messageOf(err).includes("node_modules"), true);
+    assertEquals(messageOf(err).includes("npm ci"), true);
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+  }
 });
 
 Deno.test("shimFallbackArgv wraps with cmd /c on windows only", () => {

--- a/packages/core/tests/tooling_test.ts
+++ b/packages/core/tests/tooling_test.ts
@@ -143,8 +143,14 @@ function plantBin(dir: string, name: string): string {
   return path.replace(/\\/g, "/");
 }
 
-/** A wrapper whose binary is resolved from `node_modules` by default. */
+/**
+ * A wrapper whose binary is resolved from `node_modules` by default. The
+ * platform is pinned to `linux` so the walk/precedence tests match a planted
+ * bare shim regardless of the host OS; the Windows `.cmd`/`.bat` matching has
+ * its own tests that set `os_ = "windows"` explicitly.
+ */
 class NodeToolSettings extends ToolSettings {
+  override os_: typeof Deno.build.os = "linux";
   protected override defaultTool(): string {
     return "mytool";
   }
@@ -206,8 +212,10 @@ Deno.test("ZUKE_TOOL_RESOLUTION flips a path-default wrapper repo-wide", () => {
   const prev = Deno.env.get("ZUKE_TOOL_RESOLUTION");
   try {
     const bin = plantBin(root, "mytool");
-    // EvalSettings defaults to "path"; the ambient override switches it on.
+    // A "path"-default wrapper; the ambient override switches it on. Pinned to
+    // linux so the planted bare shim matches regardless of the host OS.
     class MyTool extends ToolSettings {
+      override os_: typeof Deno.build.os = "linux";
       protected override defaultTool(): string {
         return "mytool";
       }

--- a/tests/integration/tool_resolution_test.ts
+++ b/tests/integration/tool_resolution_test.ts
@@ -1,0 +1,50 @@
+/**
+ * Integration: npx-style `node_modules/.bin` tool resolution driven through a
+ * real build. A target runs a `defineTool` wrapper with `.fromNodeModules()`;
+ * the only copy of the binary lives under a planted `node_modules/.bin`, so a
+ * successful run proves the walk resolved it (it is not on `PATH`). Skipped on
+ * Windows, where a bare-named copy of the Deno binary is not directly
+ * spawnable — the resolution logic itself is unit-covered on every platform.
+ */
+
+import { assertEquals } from "../../packages/core/tests/_assert.ts";
+import { Build, target } from "../../packages/core/mod.ts";
+import { defineTool } from "../../packages/core/src/tooling.ts";
+import { runCli } from "./_harness.ts";
+
+/** Copy the running Deno binary to `node_modules/.bin/<name>`, executable. */
+function plantLocalDeno(dir: string, name: string): void {
+  const binDir = `${dir}/node_modules/.bin`;
+  Deno.mkdirSync(binDir, { recursive: true });
+  Deno.copyFileSync(Deno.execPath(), `${binDir}/${name}`);
+  Deno.chmodSync(`${binDir}/${name}`, 0o755);
+}
+
+Deno.test({
+  name: "a build resolves a wrapper's binary from node_modules/.bin",
+  ignore: Deno.build.os === "windows",
+  fn: async () => {
+    const dir = await Deno.makeTempDir({ prefix: "zuke-it-node-bin-" });
+    const prev = Deno.cwd();
+    try {
+      plantLocalDeno(dir, "local-deno");
+      Deno.chdir(dir);
+      // `local-deno` is not on PATH: the run only succeeds via node_modules.
+      const localDeno = defineTool("local-deno");
+      class ToolBuild extends Build {
+        run = target().executes(async () => {
+          await localDeno((s) =>
+            s.fromNodeModules().quiet().arg("eval").arg(
+              "console.log('from-local')",
+            )
+          );
+        });
+      }
+      const { code } = await runCli(ToolBuild, ["run"]);
+      assertEquals(code, 0);
+    } finally {
+      Deno.chdir(prev);
+      await Deno.remove(dir, { recursive: true });
+    }
+  },
+});


### PR DESCRIPTION
## What

Track B / T1 (FR-1). Resolve a wrapper's binary from `node_modules/.bin`, walking up from the working directory before falling back to `PATH` — so in a Node monorepo where the tools are hoisted to the repo root, `OxlintTasks.lint(...)` runs with no `.toolPath()`.

## Design

Resolution happens in `ToolSettings.run()` (I/O belongs there; `buildArgs()`/`argv()` stay pure). Opt-in three ways, most specific first:

- **per call** — `.fromNodeModules()` / `.fromPath()` on any settings object;
- **ambient** — `ZUKE_TOOL_RESOLUTION=node_modules|path` for a repo-wide flip without touching call sites (a per-call override still wins);
- **per wrapper** — `protected defaultResolution()` (base returns `"path"`; the JS-ecosystem wrappers will override to `"node_modules"` in the follow-up PR).

An explicit `.toolPath(...)` always wins over resolution, so `toolchain()` pins stay hermetic. Lookups are memoized per `(os, tool, cwd)` for the process. `ToolNotFoundError` grows an `npm ci` / `toolchain()` hint when a `node_modules` directory was seen but lacked the binary. `resolvedArgv()` exposes the argv a run will actually spawn (resolved shim or bare fallback) for diagnostics.

On Windows only the spawnable `.cmd`/`.bat` shims are matched and launched through `cmd /c` (via the new exported `windowsCmdShim`) — a batch shim is not a PE executable, so relying on the `NotFound` retry would be fragile.

## Tests

- **Unit** (`tooling_test.ts`): walk-up resolution, PATH fallback on miss, `.fromPath()`/`.toolPath()` precedence, the ambient override + precedence, Windows `.cmd`-only matching, memoization, the `npm ci` error hint, and `windowsCmdShim` wrapping.
- **Integration** (`tests/integration/tool_resolution_test.ts`): a real build resolves a planted `node_modules/.bin` shim (not on PATH) through the CLI — skipped on Windows where a bare-named copy of the Deno binary is not directly spawnable.

## Docs

`docs/tools.md` gains a "Resolving from node_modules/.bin" section. `deno doc --lint` clean; `deno task ci` green.

## Adversarial review

An adversarial pass attacked the walk, cwd normalization, memoization, the precedence chain, and the Windows spawn path. It surfaced the Windows `.cmd` direct-spawn fragility, which is fixed here (proactive `cmd /c` wrap + only matching spawnable shim variants). The process-lifetime negative-memo and the ancestor-`node_modules` hint are deliberate, documented behaviors.

## Follow-up

A small PR flips the JS-ecosystem wrappers' `defaultResolution()` to `node_modules` (touches each wrapper package → release-please bumps them, intended).