### PR TITLE
feat(core): registry run-tools accept build parameters

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -187,19 +187,31 @@ zuke mcp --registry --allow-run
   the allow-list and `--protect` globs match the **qualified**
   `<buildId>:<target>` name (e.g. `--allow-run=Api:*`, `--protect=Api:deploy`).
   Every mutating or denied call is [audited](#audit-log).
-- **Scope.** A run tool takes no per-parameter inputs yet — only `dryRun`,
-  `confirm`, and `operatorToken`; the spawned build resolves its own parameters
-  from the server's environment. Passing parameters across the spawn boundary
-  (which needs a secret-safe contract) is a follow-up. Because a descriptor does
-  not record whether a target is read-only, every registry run tool is treated
-  as destructive.
+- **Parameters.** A run tool exposes the registered build's declared parameters
+  as its input schema — keyed by the parameter's property name (e.g. `skipE2e`),
+  with the kind, description, enum, and default from the descriptor. Supplied
+  values are validated against their kinds **before** the build spawns (a type
+  mismatch — a bare string where an array is required, a non-numeric number, an
+  out-of-set enum, or an unknown parameter — is a clean tool error, not a failed
+  subprocess), then forwarded to the child as `--flag=value` arguments alongside
+  the target. A value still set in the server's environment applies when the
+  call omits it. Because a descriptor does not record whether a target is
+  read-only, every registry run tool is treated as destructive.
+- **Secrets never cross the boundary.** `.secret()` parameters are omitted from
+  the descriptor entirely (`zuke register` writes the secret-free surface), so a
+  secret can neither be requested nor forwarded — it is rejected as an unknown
+  parameter if a client tries. The spawned build resolves a secret from its own
+  environment / `.from()` source instead. In the [audit log](#audit-log) only a
+  recognised parameter's value is recorded; any unknown argument keeps its name
+  but its value is elided, so a value mistakenly supplied under a secret's name
+  is never written to the durable trail.
 - **Environment.** A spawned build inherits the server's environment (that is
-  how it resolves its parameters), minus the MCP server's own authorization
-  secrets — `ZUKE_OPERATOR_TOKEN` and `ZUKE_MCP_TOKEN` are stripped so a
-  registered build can never read them. It does still see the rest of the
-  server's environment, so run a registry-backed server with **only the
-  environment the registered pipelines should have** — treat it like any host
-  that runs those builds.
+  how it resolves its secrets and any un-supplied parameters), minus the MCP
+  server's own authorization secrets — `ZUKE_OPERATOR_TOKEN` and
+  `ZUKE_MCP_TOKEN` are stripped so a registered build can never read them. It
+  does still see the rest of the server's environment, so run a registry-backed
+  server with **only the environment the registered pipelines should have** —
+  treat it like any host that runs those builds.
 
 The registry resolves like the run store: `ZUKE_REGISTRY_URL`/`_TOKEN` or
 `ZUKE_REGISTRY_DIR`, a build's `registry()` override, else `.zuke/builds`.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -122,7 +122,7 @@ async function createTarGzip(files: PathLike[], dest: PathLike, options: { cwd?:
   Read `files` (relative to `cwd`), pack them into a tar archive named by their
   path relative to `cwd`, gzip it, and write the result to `dest`.
 
-function describeCli(build: Build): CliDescription
+function describeCli(build: Build, options: DescribeCliOptions): CliDescription
   Describe a build's full CLI surface — reserved commands, option flags, targets
   (with descriptions and dependencies), and declared parameters — as a plain
   object ready for JSON. This is the same data `zuke --list --json` prints, made
@@ -133,6 +133,10 @@ function describeCli(build: Build): CliDescription
   const surface = describeCli(new MyBuild());
   console.log(surface.targets.map((t) => t.name));
   ```
+
+  Pass `{ omitSecrets: true }` to drop `.secret()` parameters from the result —
+  the posture the build registry uses, so a secret never becomes a spawnable
+  MCP input or crosses the run boundary (`zuke register` writes this form).
 
 function detectCiHost(env: (name: string) => string | undefined): CiHost
   Detect the CI host from the environment. Recognises GitHub Actions
@@ -1038,6 +1042,10 @@ class Parameter<K extends ParamValue = ParamValue, T extends K | K[] | undefined
     Whether the value is a comma-separated / repeatable list (`.array()`).
   readonly source_?: SecretSource
     A provider that resolves the value when no flag/env supplied one.
+  readonly default_?: string
+    The declared default rendered as a string (an array default is joined with
+    commas), or `undefined` when the parameter has no default or an empty-list
+    one. For display in tool schemas and `--list`; never a secret value.
   get value(): T
     The resolved value. Throws if read before the build resolves parameters.
   isSet_(): boolean
@@ -1652,6 +1660,10 @@ interface AnyParameter
     Whether the value is a comma-separated / repeatable list (`.array()`).
   readonly source_?: SecretSource
     A provider that resolves the value when no flag/env supplied one.
+  readonly default_?: string
+    The declared default rendered as a string (an array default is joined with
+    commas), or `undefined` when the parameter has no default or an empty-list
+    one. For display in tool schemas and `--list`; never a secret value.
   resolve_(raw: string | undefined): void
     Resolve from a raw input (or `undefined` when none was supplied).
   isSet_(): boolean
@@ -1919,18 +1931,26 @@ interface CliFlagInfo
 interface CliParameterInfo
   A parameter declared on the build.
 
+  readonly name: string
+    The parameter's property name — the key an MCP tool call and `execute`'s
+    `params` map use (e.g. `skipE2e`). Distinct from {@link flag}, which is its
+    kebab-case form.
   readonly flag: string
-    The CLI flag (without leading dashes), e.g. `environment`.
+    The CLI flag (without leading dashes), e.g. `skip-e2e`.
   readonly description: string
     The parameter's description, or `""` when none was set.
   readonly required: boolean
     Whether a value is required.
+  readonly kind: "string" | "number" | "boolean"
+    The parameter's value kind.
   readonly boolean: boolean
     Whether the flag is a value-less boolean.
   readonly array: boolean
     Whether repeated flags accumulate into a list.
   readonly options: string[]
     The allowed values, when the parameter is constrained to a set.
+  readonly default?: string
+    The declared default rendered as a string, when the parameter has one.
 
 interface CliTargetInfo
   A target declared on the build.
@@ -1967,6 +1987,12 @@ interface CreateDirectoryOptions
 
   recursive?: boolean
     Create parent directories as needed (default `true`).
+
+interface DescribeCliOptions
+  Options for {@link describeCli}.
+
+  omitSecrets?: boolean
+    Drop `.secret()` parameters from the surface (used for registry descriptors).
 
 interface ExecuteOptions
   Options for {@link execute}.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -176,7 +176,7 @@ async function createTarGzip(files: PathLike[], dest: PathLike, options: { cwd?:
   Read `files` (relative to `cwd`), pack them into a tar archive named by their
   path relative to `cwd`, gzip it, and write the result to `dest`.
 
-function describeCli(build: Build): CliDescription
+function describeCli(build: Build, options: DescribeCliOptions): CliDescription
   Describe a build's full CLI surface — reserved commands, option flags, targets
   (with descriptions and dependencies), and declared parameters — as a plain
   object ready for JSON. This is the same data `zuke --list --json` prints, made
@@ -187,6 +187,10 @@ function describeCli(build: Build): CliDescription
   const surface = describeCli(new MyBuild());
   console.log(surface.targets.map((t) => t.name));
   ```
+
+  Pass `{ omitSecrets: true }` to drop `.secret()` parameters from the result —
+  the posture the build registry uses, so a secret never becomes a spawnable
+  MCP input or crosses the run boundary (`zuke register` writes this form).
 
 function detectCiHost(env: (name: string) => string | undefined): CiHost
   Detect the CI host from the environment. Recognises GitHub Actions
@@ -1092,6 +1096,10 @@ class Parameter<K extends ParamValue = ParamValue, T extends K | K[] | undefined
     Whether the value is a comma-separated / repeatable list (`.array()`).
   readonly source_?: SecretSource
     A provider that resolves the value when no flag/env supplied one.
+  readonly default_?: string
+    The declared default rendered as a string (an array default is joined with
+    commas), or `undefined` when the parameter has no default or an empty-list
+    one. For display in tool schemas and `--list`; never a secret value.
   get value(): T
     The resolved value. Throws if read before the build resolves parameters.
   isSet_(): boolean
@@ -1706,6 +1714,10 @@ interface AnyParameter
     Whether the value is a comma-separated / repeatable list (`.array()`).
   readonly source_?: SecretSource
     A provider that resolves the value when no flag/env supplied one.
+  readonly default_?: string
+    The declared default rendered as a string (an array default is joined with
+    commas), or `undefined` when the parameter has no default or an empty-list
+    one. For display in tool schemas and `--list`; never a secret value.
   resolve_(raw: string | undefined): void
     Resolve from a raw input (or `undefined` when none was supplied).
   isSet_(): boolean
@@ -1973,18 +1985,26 @@ interface CliFlagInfo
 interface CliParameterInfo
   A parameter declared on the build.
 
+  readonly name: string
+    The parameter's property name — the key an MCP tool call and `execute`'s
+    `params` map use (e.g. `skipE2e`). Distinct from {@link flag}, which is its
+    kebab-case form.
   readonly flag: string
-    The CLI flag (without leading dashes), e.g. `environment`.
+    The CLI flag (without leading dashes), e.g. `skip-e2e`.
   readonly description: string
     The parameter's description, or `""` when none was set.
   readonly required: boolean
     Whether a value is required.
+  readonly kind: "string" | "number" | "boolean"
+    The parameter's value kind.
   readonly boolean: boolean
     Whether the flag is a value-less boolean.
   readonly array: boolean
     Whether repeated flags accumulate into a list.
   readonly options: string[]
     The allowed values, when the parameter is constrained to a set.
+  readonly default?: string
+    The declared default rendered as a string, when the parameter has one.
 
 interface CliTargetInfo
   A target declared on the build.
@@ -2021,6 +2041,12 @@ interface CreateDirectoryOptions
 
   recursive?: boolean
     Create parent directories as needed (default `true`).
+
+interface DescribeCliOptions
+  Options for {@link describeCli}.
+
+  omitSecrets?: boolean
+    Drop `.secret()` parameters from the surface (used for registry descriptors).
 
 interface ExecuteOptions
   Options for {@link execute}.

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -80,6 +80,7 @@ export {
   type CliParameterInfo,
   type CliTargetInfo,
   describeCli,
+  type DescribeCliOptions,
 } from "./src/describe.ts";
 export type { Plugin, RunInfo, TargetTiming } from "./src/plugin.ts";
 export {

--- a/packages/core/src/describe.ts
+++ b/packages/core/src/describe.ts
@@ -48,18 +48,28 @@ export interface CliTargetInfo {
 
 /** A parameter declared on the build. */
 export interface CliParameterInfo {
-  /** The CLI flag (without leading dashes), e.g. `environment`. */
+  /**
+   * The parameter's property name — the key an MCP tool call and `execute`'s
+   * `params` map use (e.g. `skipE2e`). Distinct from {@link flag}, which is its
+   * kebab-case form.
+   */
+  readonly name: string;
+  /** The CLI flag (without leading dashes), e.g. `skip-e2e`. */
   readonly flag: string;
   /** The parameter's description, or `""` when none was set. */
   readonly description: string;
   /** Whether a value is required. */
   readonly required: boolean;
+  /** The parameter's value kind. */
+  readonly kind: "string" | "number" | "boolean";
   /** Whether the flag is a value-less boolean. */
   readonly boolean: boolean;
   /** Whether repeated flags accumulate into a list. */
   readonly array: boolean;
   /** The allowed values, when the parameter is constrained to a set. */
   readonly options: string[];
+  /** The declared default rendered as a string, when the parameter has one. */
+  readonly default?: string;
 }
 
 /** A build's full CLI surface, suitable for JSON serialization. */
@@ -87,10 +97,12 @@ function targetInfo(name: string, t: TargetBuilder): CliTargetInfo {
 
 /** Describe one parameter. */
 function parameterInfo(name: string, p: AnyParameter): CliParameterInfo {
-  return {
+  const info: CliParameterInfo = {
+    name,
     flag: flagName(name),
     description: p.description_ ?? "",
     required: p.required_,
+    kind: p.kind_,
     boolean: p.kind_ === "boolean",
     array: p.array_,
     // A secret parameter's declared option values could themselves be sensitive
@@ -98,6 +110,10 @@ function parameterInfo(name: string, p: AnyParameter): CliParameterInfo {
     // surfaced — matching how a run record omits secret values entirely.
     options: p.secret_ ? [] : [...(p.options_ ?? [])],
   };
+  // A secret's default could itself be sensitive, so it is never surfaced.
+  return p.default_ !== undefined && !p.secret_
+    ? { ...info, default: p.default_ }
+    : info;
 }
 
 /**
@@ -133,10 +149,24 @@ export function describeBuildSurface(
  * const surface = describeCli(new MyBuild());
  * console.log(surface.targets.map((t) => t.name));
  * ```
+ *
+ * Pass `{ omitSecrets: true }` to drop `.secret()` parameters from the result —
+ * the posture the build registry uses, so a secret never becomes a spawnable
+ * MCP input or crosses the run boundary (`zuke register` writes this form).
  */
-export function describeCli(build: Build): CliDescription {
-  return describeBuildSurface(
-    discoverTargets(build),
-    discoverParameters(build),
-  );
+export function describeCli(
+  build: Build,
+  options: DescribeCliOptions = {},
+): CliDescription {
+  const params = discoverParameters(build);
+  const visible = options.omitSecrets
+    ? new Map([...params].filter(([, p]) => !p.secret_))
+    : params;
+  return describeBuildSurface(discoverTargets(build), visible);
+}
+
+/** Options for {@link describeCli}. */
+export interface DescribeCliOptions {
+  /** Drop `.secret()` parameters from the surface (used for registry descriptors). */
+  omitSecrets?: boolean;
 }

--- a/packages/core/src/mcp/registry_server.ts
+++ b/packages/core/src/mcp/registry_server.ts
@@ -17,11 +17,12 @@
  * allow-list / operator-token / confirmation tiers (keyed on the qualified
  * `<buildId>:<target>` name), and every mutating or denied call is audited.
  *
- * Scope note: a run tool takes no per-parameter inputs yet (only `dryRun`,
- * `confirm`, and `operatorToken`); the spawned build resolves its own parameters
- * from the server's environment. Passing parameters across the spawn boundary —
- * which needs a secret-safe contract the descriptor does not yet carry — is a
- * follow-up.
+ * A run tool exposes the build's declared parameters as its input schema (from
+ * the descriptor's surface), validates supplied values against their kinds
+ * before spawning, and forwards them to the child as `--flag=value` arguments.
+ * Secret parameters are structurally absent from the descriptor (`zuke register`
+ * omits them), so they can neither be requested nor forwarded — the child
+ * resolves a secret from its own environment / `.from()` source.
  *
  * @module
  */
@@ -32,6 +33,7 @@ import { resolveActor } from "../state/record.ts";
 import type { RunEvent, RunEventOutcome } from "../state/types.ts";
 import type { StateStore } from "../state/store.ts";
 import type { RunStateWriter } from "../state/writer.ts";
+import type { CliParameterInfo } from "../describe.ts";
 import type { BuildLocation } from "../registry/descriptor.ts";
 import type { BuildRegistry } from "../registry/registry.ts";
 import { openAuditLog } from "./audit.ts";
@@ -127,9 +129,125 @@ export interface RegistryMcpServerOptions {
   runner?: RegistryRunner;
 }
 
+/** The reserved run-tool control keys — never treated as build parameters. */
+const CONTROL_KEYS: ReadonlySet<string> = new Set([
+  "dryRun",
+  "confirm",
+  "operatorToken",
+]);
+
 /** The MCP result content for a single block of text. */
 function textResult(text: string, isError = false): Record<string, unknown> {
   return { content: [{ type: "text", text }], isError };
+}
+
+/** The JSON-Schema property for one descriptor parameter (kind, enum, default). */
+function schemaForParam(p: CliParameterInfo): Record<string, unknown> {
+  // `options` constrains string parameters only (the fluent `.options()` is
+  // string-typed); an `enum` on a number/boolean would be a malformed schema, so
+  // ignore one from an untrusted descriptor rather than emit it.
+  const enumValues = p.kind === "string" && p.options.length > 0
+    ? [...p.options]
+    : undefined;
+  if (p.array) {
+    const items: Record<string, unknown> = { type: p.kind };
+    if (enumValues !== undefined) items.enum = enumValues;
+    const schema: Record<string, unknown> = { type: "array", items };
+    if (p.description !== "") schema.description = p.description;
+    return schema;
+  }
+  const base: Record<string, unknown> = { type: p.kind };
+  if (p.description !== "") base.description = p.description;
+  if (enumValues !== undefined) base.enum = enumValues;
+  const value = defaultToJson(p);
+  if (value !== undefined) base.default = value;
+  return base;
+}
+
+/**
+ * Render a descriptor parameter's string default back to its JSON-typed value,
+ * or `undefined` when it does not match the declared kind (a malformed default
+ * from an untrusted descriptor is dropped so the advertised schema stays valid).
+ */
+function defaultToJson(p: CliParameterInfo): unknown {
+  if (p.default === undefined) return undefined;
+  if (p.kind === "boolean") {
+    if (p.default === "true") return true;
+    return p.default === "false" ? false : undefined;
+  }
+  if (p.kind === "number") {
+    const n = Number(p.default);
+    return Number.isFinite(n) ? n : undefined;
+  }
+  return p.default;
+}
+
+/** A human phrase for a parameter's expected JSON type, used in error messages. */
+function describeType(p: CliParameterInfo): string {
+  const base = p.array ? `an array of ${p.kind}` : `a ${p.kind}`;
+  return p.options.length > 0 ? `${base} in {${p.options.join(", ")}}` : base;
+}
+
+/** Whether `value` is a scalar of `kind` (and within `options`, when set). */
+function scalarOk(
+  value: unknown,
+  kind: "string" | "number" | "boolean",
+  options: readonly string[],
+): value is string | number | boolean {
+  if (kind === "boolean") return typeof value === "boolean";
+  if (kind === "number") {
+    return typeof value === "number" && Number.isFinite(value);
+  }
+  return typeof value === "string" &&
+    (options.length === 0 || options.includes(value));
+}
+
+/**
+ * Coerce a supplied JSON value to the CLI string a parameter parses, or `null`
+ * when its shape/type is wrong. An array parameter requires a JSON array of
+ * matching scalars (a bare scalar is rejected — the mismatch the requirement
+ * calls out); every other parameter requires a single matching scalar. The
+ * result is joined the way the child's parser splits an array (on commas).
+ */
+function coerceParamValue(value: unknown, p: CliParameterInfo): string | null {
+  if (p.array) {
+    if (!Array.isArray(value)) return null;
+    const parts: string[] = [];
+    for (const element of value) {
+      if (!scalarOk(element, p.kind, p.options)) return null;
+      parts.push(String(element));
+    }
+    return parts.join(",");
+  }
+  return scalarOk(value, p.kind, p.options) ? String(value) : null;
+}
+
+/**
+ * Validate supplied tool arguments against the build's declared parameters and
+ * turn them into `--flag=value` child arguments. Returns the forward argv, or
+ * the list of offending `name (why)` descriptions when any value is the wrong
+ * type or names an unknown parameter — so the caller can reject before spawning.
+ */
+function validateParamArgs(
+  args: Record<string, unknown>,
+  parameters: readonly CliParameterInfo[],
+): { argv: string[] } | { errors: string[] } {
+  const byName = new Map(parameters.map((p) => [p.name, p]));
+  const argv: string[] = [];
+  const errors: string[] = [];
+  for (const [key, value] of Object.entries(args)) {
+    if (CONTROL_KEYS.has(key)) continue;
+    const param = byName.get(key);
+    if (param === undefined) {
+      errors.push(`${key} (unknown parameter)`);
+      continue;
+    }
+    const coerced = coerceParamValue(value, param);
+    if (coerced === null) {
+      errors.push(`${key} (expected ${describeType(param)})`);
+    } else argv.push(`--${param.flag}=${coerced}`);
+  }
+  return errors.length > 0 ? { errors } : { argv };
 }
 
 /** Whether a JSON value is a plain object (a string-keyed record). */
@@ -268,7 +386,12 @@ export class RegistryMcpServer {
         const qualified = `${summary.id}:${target.name}`;
         if (this.#allowMatch(qualified)) {
           tools.push(
-            this.#runTool(summary.id, target.name, target.description),
+            this.#runTool(
+              summary.id,
+              target.name,
+              target.description,
+              loaded.descriptor.surface.parameters,
+            ),
           );
         }
       }
@@ -277,15 +400,25 @@ export class RegistryMcpServer {
   }
 
   /** Build the `run:<buildId>:<target>` tool definition. */
-  #runTool(buildId: string, target: string, description: string): McpTool {
+  #runTool(
+    buildId: string,
+    target: string,
+    description: string,
+    parameters: readonly CliParameterInfo[],
+  ): McpTool {
     const qualified = `${buildId}:${target}`;
-    const properties: Record<string, Record<string, unknown>> = {
-      dryRun: {
-        type: "boolean",
-        description: "Plan without executing any target body.",
-      },
-    };
+    const properties: Record<string, Record<string, unknown>> = {};
     const required: string[] = [];
+    // The build's declared parameters come first, keyed by property name (the
+    // key a tool call supplies), then the reserved execution controls.
+    for (const param of parameters) {
+      properties[param.name] = schemaForParam(param);
+      if (param.required) required.push(param.name);
+    }
+    properties.dryRun = {
+      type: "boolean",
+      description: "Plan without executing any target body.",
+    };
     if (this.#isProtected(qualified)) {
       properties.operatorToken = {
         type: "string",
@@ -420,10 +553,16 @@ export class RegistryMcpServer {
       return ok(id, textResult(`Unknown tool: ${runName}`, true));
     }
 
+    // The build's declared parameter names — the only argument keys whose values
+    // are safe to record in the audit trail from here on.
+    const knownParams = new Set(
+      loaded.descriptor.surface.parameters.map((p) => p.name),
+    );
+
     if (this.#isProtected(qualified)) {
       const denial = this.#checkOperatorToken(args);
       if (denial !== null) {
-        await this.#audit(runName, args, "denied", denial);
+        await this.#audit(runName, args, "denied", denial, knownParams);
         return ok(
           id,
           textResult(
@@ -436,6 +575,30 @@ export class RegistryMcpServer {
           ),
         );
       }
+    }
+
+    // Validate the supplied parameters against the descriptor and turn them into
+    // child `--flag=value` arguments — before any spawn, so a type mismatch is a
+    // clean tool error rather than a subprocess that fails on bad input.
+    const validated = validateParamArgs(
+      args,
+      loaded.descriptor.surface.parameters,
+    );
+    if ("errors" in validated) {
+      await this.#audit(
+        runName,
+        args,
+        "error",
+        "invalid_arguments",
+        knownParams,
+      );
+      return ok(
+        id,
+        textResult(
+          `Invalid argument(s): ${validated.errors.join("; ")}.`,
+          true,
+        ),
+      );
     }
 
     const dryRun = args.dryRun === true;
@@ -461,9 +624,20 @@ export class RegistryMcpServer {
       );
     }
 
-    const launch = this.#launch(loaded.descriptor.location, target, dryRun);
+    const launch = this.#launch(
+      loaded.descriptor.location,
+      target,
+      dryRun,
+      validated.argv,
+    );
     if (launch.argv.length === 0 || launch.argv[0] === "") {
-      await this.#audit(runName, args, "error", "no_launch_command");
+      await this.#audit(
+        runName,
+        args,
+        "error",
+        "no_launch_command",
+        knownParams,
+      );
       return ok(
         id,
         textResult(
@@ -477,14 +651,20 @@ export class RegistryMcpServer {
     try {
       result = await this.#runner(launch.argv, launch.cwd);
     } catch (error) {
-      await this.#audit(runName, args, "error", "spawn_failed");
+      await this.#audit(runName, args, "error", "spawn_failed", knownParams);
       const kind = error instanceof Error ? error.name : "Error";
       return ok(
         id,
         textResult(`Failed to spawn ${qualified} (${kind}).`, true),
       );
     }
-    await this.#audit(runName, args, result.code === 0 ? "ok" : "error");
+    await this.#audit(
+      runName,
+      args,
+      result.code === 0 ? "ok" : "error",
+      undefined,
+      knownParams,
+    );
     const output = [result.stdout, result.stderr].filter((s) => s !== "").join(
       "\n",
     );
@@ -499,8 +679,9 @@ export class RegistryMcpServer {
     location: BuildLocation,
     target: string,
     dryRun: boolean,
+    params: readonly string[],
   ): { argv: string[]; cwd: string } {
-    const trailing = dryRun ? [target, "--dry-run"] : [target];
+    const trailing = [target, ...params, ...(dryRun ? ["--dry-run"] : [])];
     if (location.kind === "command") {
       // An empty command has nothing to launch — return an empty argv so the
       // caller reports it rather than spawning the bare target as a program.
@@ -535,14 +716,18 @@ export class RegistryMcpServer {
 
   /**
    * Append a tool call to the audit log (best-effort; never breaks a call).
-   * No-op without a store. The operator token is dropped from the recorded args
-   * so nothing sensitive reaches the durable trail.
+   * No-op without a store. Only the values of recognised, non-secret arguments
+   * ({@link known} parameters plus the safe control flags) are recorded — the
+   * operator token is dropped, and any unrecognised key's value is elided, so a
+   * value mistakenly supplied under a `.secret()` parameter's name (a secret is
+   * absent from the descriptor, hence "unknown") never reaches the durable trail.
    */
   async #audit(
     tool: string,
     args: Record<string, unknown>,
     outcome: RunEventOutcome,
     detail?: string,
+    known: ReadonlySet<string> = EMPTY_NAMES,
   ): Promise<void> {
     const store = this.#store;
     if (store === undefined) return;
@@ -551,7 +736,7 @@ export class RegistryMcpServer {
       tool,
       actor: this.#resolveActor(),
       outcome,
-      args: auditArgs(args),
+      args: auditArgs(args, known),
     };
     if (detail !== undefined) event.detail = detail;
     try {
@@ -567,15 +752,33 @@ export class RegistryMcpServer {
   }
 }
 
+/** An empty name set — the default when a call is audited before params resolve. */
+const EMPTY_NAMES: ReadonlySet<string> = new Set();
+
+/** Control keys whose values are always safe to record (booleans, never secrets). */
+const AUDIT_SAFE_KEYS: ReadonlySet<string> = new Set(["dryRun", "confirm"]);
+
 /**
- * Sanitise tool arguments for the audit log: drop the operator token entirely,
- * and stringify the rest (registry run tools take only `dryRun`/`confirm`, so
- * there are no secret parameter values to mask).
+ * Sanitise tool arguments for the audit log. The operator token is dropped
+ * entirely; the value of a **recognised** argument — a declared parameter in
+ * `known`, or a safe control flag (`dryRun`/`confirm`) — is stringified and
+ * recorded (build parameters name the deploy's repos, slots, etc. — the point
+ * of the audit trail). Any other key keeps its name but has its value elided to
+ * `"<omitted>"`, so a value mistakenly supplied under a secret parameter's name
+ * (a secret is absent from the descriptor, so it reads as an unknown key) is
+ * never written verbatim to the durable trail.
  */
-function auditArgs(args: Record<string, unknown>): Record<string, string> {
+function auditArgs(
+  args: Record<string, unknown>,
+  known: ReadonlySet<string>,
+): Record<string, string> {
   const out: Record<string, string> = {};
   for (const [key, value] of Object.entries(args)) {
     if (key === "operatorToken") continue;
+    if (!known.has(key) && !AUDIT_SAFE_KEYS.has(key)) {
+      out[key] = "<omitted>";
+      continue;
+    }
     out[key] = typeof value === "object" && value !== null
       ? JSON.stringify(value)
       : String(value);

--- a/packages/core/src/params.ts
+++ b/packages/core/src/params.ts
@@ -39,6 +39,28 @@ export type ParamValue = string | number | boolean;
 /** A parameter's runtime kind tag. */
 export type ParamKind = "string" | "number" | "boolean";
 
+/**
+ * Property names a parameter field may not use: they are the reserved control
+ * keys an MCP `run:<target>` tool adds to its input schema alongside the build's
+ * parameters ({@link "./mcp/server.ts".McpServer}). A build parameter sharing
+ * one of these names would be silently shadowed by the control key, so
+ * {@link discoverParameters} rejects it at discovery.
+ */
+const RESERVED_PARAM_NAMES: ReadonlySet<string> = new Set([
+  "dryRun",
+  "confirm",
+  "operatorToken",
+]);
+
+/** Render a declared default as a display string, or `undefined` when it has none. */
+function defaultToString(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  if (Array.isArray(value)) {
+    return value.length === 0 ? undefined : value.map(String).join(",");
+  }
+  return String(value);
+}
+
 /** Internal resolved state: a value is present only once `ok` is true. */
 type Resolved<T> = { readonly ok: true; readonly value: T } | {
   readonly ok: false;
@@ -108,6 +130,12 @@ export interface AnyParameter {
   readonly array_: boolean;
   /** A provider that resolves the value when no flag/env supplied one. */
   readonly source_?: SecretSource;
+  /**
+   * The declared default rendered as a string (an array default is joined with
+   * commas), or `undefined` when the parameter has no default or an empty-list
+   * one. For display in tool schemas and `--list`; never a secret value.
+   */
+  readonly default_?: string;
   /** Resolve from a raw input (or `undefined` when none was supplied). */
   resolve_(raw: string | undefined): void;
   /** Whether the parameter resolved to a defined value (used by `.requires()`). */
@@ -163,6 +191,12 @@ export class Parameter<
   readonly array_: boolean;
   /** A provider that resolves the value when no flag/env supplied one. */
   readonly source_?: SecretSource;
+  /**
+   * The declared default rendered as a string (an array default is joined with
+   * commas), or `undefined` when the parameter has no default or an empty-list
+   * one. For display in tool schemas and `--list`; never a secret value.
+   */
+  readonly default_?: string;
   readonly #parse: (raw: string) => T;
   readonly #fallback: Fallback<T>;
   #state: Resolved<T> = { ok: false };
@@ -197,6 +231,9 @@ export class Parameter<
     this.secret_ = spec.secret ?? false;
     this.array_ = spec.array ?? false;
     this.source_ = spec.source;
+    this.default_ = spec.fallback.has
+      ? defaultToString(spec.fallback.value)
+      : undefined;
   }
 
   /** The resolved value. Throws if read before the build resolves parameters. */
@@ -440,6 +477,12 @@ export function discoverParameters(build: object): Map<string, AnyParameter> {
   const params = new Map<string, AnyParameter>();
   forEachField(build, (path, value) => {
     if (value instanceof Parameter) {
+      if (RESERVED_PARAM_NAMES.has(path)) {
+        throw new ParameterError(
+          `Parameter "${path}" collides with a reserved MCP control name ` +
+            `(dryRun, confirm, operatorToken). Rename the parameter field.`,
+        );
+      }
       value.name_ = path;
       params.set(path, value);
     }

--- a/packages/core/src/registry/descriptor.ts
+++ b/packages/core/src/registry/descriptor.ts
@@ -204,20 +204,44 @@ function parseTargetInfo(value: unknown): CliTargetInfo {
   };
 }
 
+/**
+ * Read the parameter `kind`, tolerating a pre-M12 descriptor that has no `kind`
+ * field by deriving it from the `boolean` flag (older descriptors only
+ * distinguished boolean from string).
+ */
+function paramKind(
+  object: Record<string, unknown>,
+  boolean: boolean,
+): "string" | "number" | "boolean" {
+  const value = object.kind;
+  if (value === undefined) return boolean ? "boolean" : "string";
+  if (value === "string" || value === "number" || value === "boolean") {
+    return value;
+  }
+  throw new Error(`registry: descriptor field "kind" is not a valid kind`);
+}
+
 /** Validate one {@link CliParameterInfo}. */
 function parseParameterInfo(value: unknown): CliParameterInfo {
   const object = asObject(value);
   if (object === null) {
     throw new Error("registry: surface parameter is not an object");
   }
-  return {
-    flag: str(object, "flag"),
+  const flag = str(object, "flag");
+  const boolean = bool(object, "boolean");
+  const info: CliParameterInfo = {
+    // Pre-M12 descriptors carry no `name`; the flag is the best available key.
+    name: optionalStr(object, "name") ?? flag,
+    flag,
     description: str(object, "description"),
     required: bool(object, "required"),
-    boolean: bool(object, "boolean"),
+    kind: paramKind(object, boolean),
+    boolean,
     array: bool(object, "array"),
     options: strArray(object, "options"),
   };
+  const def = optionalStr(object, "default");
+  return def !== undefined ? { ...info, default: def } : info;
 }
 
 /** Validate and narrow a {@link CliDescription} (the build surface). */

--- a/packages/core/src/registry/register.ts
+++ b/packages/core/src/registry/register.ts
@@ -163,7 +163,10 @@ export async function registerCommand(
     id: options.id ?? build.constructor.name,
     name: build.constructor.name,
     location: options.location ?? deriveLocation(readEnv),
-    surface: describeCli(build),
+    // Omit secret parameters: a registered pipeline's secrets must never become
+    // a spawnable MCP input or cross the spawn boundary — the child resolves
+    // them from its own environment / `.from()` source instead.
+    surface: describeCli(build, { omitSecrets: true }),
     actor: resolveActor(options.actor, readEnv),
   }, now);
 

--- a/packages/core/tests/describe_test.ts
+++ b/packages/core/tests/describe_test.ts
@@ -65,3 +65,39 @@ Deno.test("describeCli hides a secret parameter's option values", () => {
   );
   assertEquals(key?.options, []);
 });
+
+Deno.test("describeCli reports the property name, kind, and default", () => {
+  class Params extends Build {
+    skipE2e = parameter("Skip e2e").boolean();
+    workers = parameter("Workers").number().default(4);
+    region = parameter("Region").default("eu");
+  }
+  const params = describeCli(new Params()).parameters;
+
+  const skip = params.find((p) => p.name === "skipE2e");
+  // The property name is distinct from the kebab flag.
+  assertEquals(skip?.flag, "skip-e2e");
+  assertEquals(skip?.kind, "boolean");
+  assertEquals(skip?.default, "false");
+
+  const workers = params.find((p) => p.name === "workers");
+  assertEquals(workers?.kind, "number");
+  assertEquals(workers?.default, "4");
+
+  // A parameter with no default carries none.
+  assertEquals(params.find((p) => p.name === "region")?.default, "eu");
+});
+
+Deno.test("describeCli omitSecrets drops secret parameters entirely", () => {
+  class WithSecret extends Build {
+    apiKey = parameter("API key").secret();
+    region = parameter("Region");
+  }
+  // By default the secret is present (with masked options).
+  const all = describeCli(new WithSecret()).parameters.map((p) => p.name);
+  assertEquals(all, ["apiKey", "region"]);
+  // With omitSecrets it is gone, so it can never become a spawnable input.
+  const visible = describeCli(new WithSecret(), { omitSecrets: true })
+    .parameters.map((p) => p.name);
+  assertEquals(visible, ["region"]);
+});

--- a/packages/core/tests/params_test.ts
+++ b/packages/core/tests/params_test.ts
@@ -443,3 +443,43 @@ Deno.test("execute emits ::add-mask:: with the real value under GitHub", async (
     true,
   );
 });
+
+Deno.test("discoverParameters rejects a reserved MCP control name", () => {
+  // A parameter field named after a run-tool control key would be shadowed by
+  // that key in the MCP input schema, so discovery refuses it.
+  class BadDryRun extends Build {
+    dryRun = parameter();
+  }
+  class BadConfirm extends Build {
+    confirm = parameter();
+  }
+  class BadOperatorToken extends Build {
+    operatorToken = parameter();
+  }
+  for (
+    const [Bad, name] of [
+      [BadDryRun, "dryRun"],
+      [BadConfirm, "confirm"],
+      [BadOperatorToken, "operatorToken"],
+    ] as const
+  ) {
+    const error = assertThrows(
+      () => discoverParameters(new Bad()),
+      ParameterError,
+    );
+    assertStringIncludes(error.message, name);
+    assertStringIncludes(error.message, "reserved");
+  }
+});
+
+Deno.test("a parameter exposes its default as a display string", () => {
+  const withDefault = parameter().default("eu");
+  assertEquals(withDefault.default_, "eu");
+  const bool = parameter().boolean();
+  assertEquals(bool.default_, "false");
+  const num = parameter().number().default(4);
+  assertEquals(num.default_, "4");
+  // An empty-list array default and an undefined optional carry no default.
+  assertEquals(parameter().array().default_, undefined);
+  assertEquals(parameter().default_, undefined);
+});

--- a/packages/core/tests/register_test.ts
+++ b/packages/core/tests/register_test.ts
@@ -127,7 +127,7 @@ Deno.test("registerCommand writes a descriptor built from the build", async () =
   );
 });
 
-Deno.test("registerCommand excludes secret parameter values from the descriptor", async () => {
+Deno.test("registerCommand excludes secret parameters from the descriptor", async () => {
   const registry = new FakeBuildRegistry();
   // A secret is configured in the environment; it must never reach the record.
   await capture(() =>
@@ -139,10 +139,12 @@ Deno.test("registerCommand excludes secret parameter values from the descriptor"
     })
   );
   const descriptor = registry.builds.get("Sample")?.descriptor;
-  // The surface lists the parameter flags (structure) but no values.
-  const flags = descriptor?.surface.parameters.map((p) => p.flag);
-  assertEquals(flags, ["api-token", "region"]);
-  // The whole serialized descriptor carries no secret value.
+  // The secret parameter is omitted entirely — only the non-secret one remains,
+  // so a secret can never become a spawnable MCP input or cross the boundary.
+  const names = descriptor?.surface.parameters.map((p) => p.name);
+  assertEquals(names, ["region"]);
+  // Neither the secret's flag nor its value appears anywhere in the record.
+  assertEquals(JSON.stringify(descriptor).includes("api-token"), false);
   assertEquals(JSON.stringify(descriptor).includes("s3cr3t-value"), false);
 });
 

--- a/packages/core/tests/registry_server_test.ts
+++ b/packages/core/tests/registry_server_test.ts
@@ -660,3 +660,291 @@ Deno.test("defaultRegistryRunner strips server secrets from the spawned env", as
     else Deno.env.set("ZUKE_OPERATOR_TOKEN", prev);
   }
 });
+
+// ---- M12: build parameters --------------------------------------------------
+
+/** A descriptor for build "Deploy" whose "deploy" target declares parameters. */
+function paramDescriptor(): BuildDescriptor {
+  const base = descriptor("Deploy", ["deploy"]);
+  return {
+    ...base,
+    surface: {
+      ...base.surface,
+      parameters: [
+        {
+          name: "repos",
+          flag: "repos",
+          description: "service repos to deploy",
+          required: true,
+          kind: "string",
+          boolean: false,
+          array: true,
+          options: [],
+        },
+        {
+          name: "sit",
+          flag: "sit",
+          description: "SIT slot",
+          required: false,
+          kind: "string",
+          boolean: false,
+          array: false,
+          options: [],
+        },
+        {
+          name: "skipE2e",
+          flag: "skip-e2e",
+          description: "skip the e2e stage",
+          required: false,
+          kind: "boolean",
+          boolean: true,
+          array: false,
+          options: [],
+          default: "false",
+        },
+        {
+          name: "workers",
+          flag: "workers",
+          description: "worker count",
+          required: false,
+          kind: "number",
+          boolean: false,
+          array: false,
+          options: [],
+        },
+        {
+          name: "env",
+          flag: "env",
+          description: "environment",
+          required: false,
+          kind: "string",
+          boolean: false,
+          array: false,
+          options: ["dev", "prod"],
+        },
+      ],
+    },
+  };
+}
+
+/** The `properties` map of an input schema, or `{}` when absent. */
+function schemaProps(schema: Record<string, unknown>): Record<string, unknown> {
+  return isRec(schema.properties) ? schema.properties : {};
+}
+
+/** The `run:<name>` tool's input schema from a `tools/list` response. */
+function runToolSchema(res: unknown, name: string): Record<string, unknown> {
+  const tools = resultOf(res).tools;
+  if (!Array.isArray(tools)) throw new Error("no tools array");
+  for (const t of tools) {
+    if (isRec(t) && t.name === name && isRec(t.inputSchema)) {
+      return t.inputSchema;
+    }
+  }
+  throw new Error(`no tool ${name}`);
+}
+
+Deno.test("a run tool's inputSchema exposes the build's parameters", async () => {
+  const registry = new FakeRegistry();
+  registry.add(paramDescriptor());
+  const server = new RegistryMcpServer(registry, { allowRun: true });
+  const schema = runToolSchema(
+    await server.handleMessage(req("tools/list")),
+    "run:Deploy:deploy",
+  );
+  const props = schemaProps(schema);
+  // repos: an array of strings, described, and required.
+  assertEquals(props.repos, {
+    type: "array",
+    items: { type: "string" },
+    description: "service repos to deploy",
+  });
+  assertEquals(
+    Array.isArray(schema.required) && schema.required.includes("repos"),
+    true,
+  );
+  // sit: an optional string.
+  assertEquals(props.sit, { type: "string", description: "SIT slot" });
+  // skipE2e: a boolean carrying its declared default.
+  assertEquals(props.skipE2e, {
+    type: "boolean",
+    description: "skip the e2e stage",
+    default: false,
+  });
+  // env: a constrained string (enum).
+  assertEquals(props.env, {
+    type: "string",
+    description: "environment",
+    enum: ["dev", "prod"],
+  });
+  // The reserved control key coexists with the parameters.
+  assertEquals(isRec(props.dryRun), true);
+});
+
+Deno.test("a run tool forwards validated parameters as --flag=value", async () => {
+  const registry = new FakeRegistry();
+  registry.add(paramDescriptor());
+  const { runner, calls } = recordingRunner();
+  const server = new RegistryMcpServer(registry, { allowRun: true, runner });
+  const result = await call(server, "run:Deploy:deploy", {
+    repos: ["expense-service", "web"],
+    skipE2e: true,
+    workers: 4,
+  });
+  assertEquals(result.isError, false);
+  assertEquals(calls.length, 1);
+  const argv = calls[0].argv;
+  assertEquals(argv.includes("--repos=expense-service,web"), true);
+  assertEquals(argv.includes("--skip-e2e=true"), true);
+  assertEquals(argv.includes("--workers=4"), true);
+  // The target name still leads the trailing args.
+  assertEquals(argv.includes("deploy"), true);
+});
+
+Deno.test("a boolean parameter forwards its false value explicitly", async () => {
+  const registry = new FakeRegistry();
+  registry.add(paramDescriptor());
+  const { runner, calls } = recordingRunner();
+  const server = new RegistryMcpServer(registry, { allowRun: true, runner });
+  await call(server, "run:Deploy:deploy", { repos: ["a"], skipE2e: false });
+  assertEquals(calls[0].argv.includes("--skip-e2e=false"), true);
+});
+
+Deno.test("a type-mismatched array parameter is rejected before any spawn", async () => {
+  const registry = new FakeRegistry();
+  registry.add(paramDescriptor());
+  const { runner, calls } = recordingRunner();
+  const server = new RegistryMcpServer(registry, { allowRun: true, runner });
+  // A bare string where an array is required.
+  const result = await call(server, "run:Deploy:deploy", {
+    repos: "expense-service",
+  });
+  assertEquals(result.isError, true);
+  assertStringIncludes(result.text, "repos");
+  assertEquals(calls.length, 0); // never spawned
+});
+
+Deno.test("a non-numeric number and an out-of-set enum are rejected", async () => {
+  const registry = new FakeRegistry();
+  registry.add(paramDescriptor());
+  const { runner, calls } = recordingRunner();
+  const server = new RegistryMcpServer(registry, { allowRun: true, runner });
+  const badNumber = await call(server, "run:Deploy:deploy", {
+    repos: ["a"],
+    workers: "four",
+  });
+  assertEquals(badNumber.isError, true);
+  assertStringIncludes(badNumber.text, "workers");
+  const badEnum = await call(server, "run:Deploy:deploy", {
+    repos: ["a"],
+    env: "staging",
+  });
+  assertEquals(badEnum.isError, true);
+  assertStringIncludes(badEnum.text, "env");
+  assertEquals(calls.length, 0);
+});
+
+Deno.test("an unknown parameter is rejected naming it", async () => {
+  const registry = new FakeRegistry();
+  registry.add(paramDescriptor());
+  const { runner, calls } = recordingRunner();
+  const server = new RegistryMcpServer(registry, { allowRun: true, runner });
+  const result = await call(server, "run:Deploy:deploy", {
+    repos: ["a"],
+    nope: "x",
+  });
+  assertEquals(result.isError, true);
+  assertStringIncludes(result.text, "nope");
+  assertStringIncludes(result.text, "unknown");
+  assertEquals(calls.length, 0);
+});
+
+Deno.test("parameters coexist with the operator token and confirmation", async () => {
+  const registry = new FakeRegistry();
+  registry.add(paramDescriptor());
+  const { runner, calls } = recordingRunner();
+  const server = new RegistryMcpServer(registry, {
+    allowRun: true,
+    runner,
+    confirmDestructive: true,
+    protectPatterns: ["Deploy:*"],
+    operatorToken: "good-token",
+  });
+  const result = await call(server, "run:Deploy:deploy", {
+    repos: ["a"],
+    confirm: true,
+    operatorToken: "good-token",
+  });
+  assertEquals(result.isError, false);
+  assertEquals(calls.length, 1);
+  const argv = calls[0].argv;
+  // The build parameter is forwarded; the control keys never are.
+  assertEquals(argv.includes("--repos=a"), true);
+  assertEquals(argv.some((a) => a.includes("operator")), false);
+  assertEquals(argv.some((a) => a.includes("confirm")), false);
+});
+
+// ---- M12 adversarial-review regressions -------------------------------------
+
+Deno.test("a value supplied under an unknown/secret key is elided from the audit log", async () => {
+  const registry = new FakeRegistry();
+  registry.add(paramDescriptor());
+  const store = new FileSystemStateStore("/state", new FakeStateHost());
+  const { runner } = recordingRunner();
+  const server = new RegistryMcpServer(registry, {
+    allowRun: true,
+    stateStore: store,
+    runner,
+  });
+  // `apiToken` is not a declared parameter (a secret would be absent from the
+  // descriptor); a mistaken value under it must not land verbatim in the trail.
+  await call(server, "run:Deploy:deploy", {
+    repos: ["expense-service"],
+    apiToken: "sk-live-SECRET",
+  });
+
+  const audit = await store.getRun("mcp-audit");
+  const events = audit?.record.events ?? [];
+  const serialized = JSON.stringify(events);
+  // The secret value never appears; the unknown key is recorded but elided.
+  assertEquals(serialized.includes("sk-live-SECRET"), false);
+  assertEquals(serialized.includes("<omitted>"), true);
+  // A declared parameter's value is still recorded (the point of the trail).
+  assertEquals(serialized.includes("expense-service"), true);
+});
+
+Deno.test("a malformed default/enum from an untrusted descriptor is dropped from the schema", async () => {
+  const registry = new FakeRegistry();
+  const base = descriptor("Api", ["deploy"]);
+  registry.add({
+    ...base,
+    surface: {
+      ...base.surface,
+      parameters: [
+        // A number parameter carrying a non-numeric default and a (string) enum
+        // — both invalid for the declared kind, as only an untrusted registry
+        // could produce.
+        {
+          name: "workers",
+          flag: "workers",
+          description: "",
+          required: false,
+          kind: "number",
+          boolean: false,
+          array: false,
+          options: ["1", "2"],
+          default: "abc",
+        },
+      ],
+    },
+  });
+  const server = new RegistryMcpServer(registry, { allowRun: true });
+  const schema = runToolSchema(
+    await server.handleMessage(req("tools/list")),
+    "run:Api:deploy",
+  );
+  const workers = schemaProps(schema).workers;
+  // The schema is well-formed: a number type with neither a string enum nor a
+  // non-numeric default.
+  assertEquals(workers, { type: "number" });
+});

--- a/packages/core/tests/registry_test.ts
+++ b/packages/core/tests/registry_test.ts
@@ -83,9 +83,11 @@ function sampleSurface(): CliDescription {
     ],
     parameters: [
       {
+        name: "environment",
         flag: "environment",
         description: "Deploy target",
         required: true,
+        kind: "string",
         boolean: false,
         array: false,
         options: ["sit", "prod"],
@@ -253,6 +255,71 @@ Deno.test("parseBuildDescriptor validates surface and location shapes", () => {
     () => parseBuildDescriptor(surface({ parameters: [5] })),
     Error,
     "surface parameter",
+  );
+});
+
+Deno.test("parseParameterInfo carries kind/default and tolerates a legacy descriptor", () => {
+  const withParams = (parameters: unknown[]) =>
+    JSON.stringify({
+      ...sampleDescriptor(),
+      surface: { commands: [], flags: [], targets: [], parameters },
+    });
+
+  // A modern parameter round-trips name, kind, and default.
+  const modern = parseBuildDescriptor(withParams([{
+    name: "workers",
+    flag: "workers",
+    description: "n",
+    required: false,
+    kind: "number",
+    boolean: false,
+    array: false,
+    options: [],
+    default: "4",
+  }])).surface.parameters[0];
+  assertEquals(modern.name, "workers");
+  assertEquals(modern.kind, "number");
+  assertEquals(modern.default, "4");
+
+  // A pre-M12 descriptor has no name/kind: derive kind from `boolean` and the
+  // key from `flag`.
+  const legacyBool = parseBuildDescriptor(withParams([{
+    flag: "verbose",
+    description: "",
+    required: false,
+    boolean: true,
+    array: false,
+    options: [],
+  }])).surface.parameters[0];
+  assertEquals(legacyBool.name, "verbose");
+  assertEquals(legacyBool.kind, "boolean");
+  assertEquals(legacyBool.default, undefined);
+
+  const legacyString = parseBuildDescriptor(withParams([{
+    flag: "env",
+    description: "",
+    required: false,
+    boolean: false,
+    array: false,
+    options: [],
+  }])).surface.parameters[0];
+  assertEquals(legacyString.kind, "string");
+
+  // An unrecognised kind is rejected.
+  assertThrows(
+    () =>
+      parseBuildDescriptor(withParams([{
+        name: "x",
+        flag: "x",
+        description: "",
+        required: false,
+        kind: "date",
+        boolean: false,
+        array: false,
+        options: [],
+      }])),
+    Error,
+    "valid kind",
   );
 });
 

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -139,7 +139,12 @@ Before calling any task or settings method, confirm the real shape:
   **redacts** it from all of Zuke's output. See the cheatsheet.
 - **Provisioning tools:** `ToolTasks.install((s) => …)` / `toolchain((t) => …)`
   fetch pinned, checksum-verified tool binaries so a build is hermetic; hand the
-  returned path to a wrapper's `.toolPath(...)`.
+  returned path to a wrapper's `.toolPath(...)`. In a Node monorepo, resolve a
+  wrapper's binary from `node_modules/.bin` npx-style instead —
+  `.fromNodeModules()` on the settings (or `ZUKE_TOOL_RESOLUTION=node_modules`
+  repo-wide) walks up for the local shim and falls back to PATH; `.fromPath()`
+  forces PATH and an explicit `.toolPath(...)` always wins. See the cheatsheet /
+  `docs/tools.md`.
 - **Code-first CI:** `cicd({ provider: "github" })` generates and verifies the
   workflow YAML from the build.
 - **Operate the build from an agent:** `zuke mcp` serves the build over MCP so
@@ -150,6 +155,10 @@ Before calling any task or settings method, confirm the real shape:
   access with `--allow-run=<globs>` (allow-list), `--protect <globs>` +
   `ZUKE_OPERATOR_TOKEN`, and `--confirm-destructive`; mark inspect-only targets
   `.readOnly()`. Mutating/denied calls are audited (`zuke runs show mcp-audit`).
+  A **registry-backed** server (`zuke register` then `zuke mcp --registry`)
+  instead serves every registered pipeline live, each as a
+  `run:<buildId>:<target>` tool that takes the build's declared parameters
+  (secrets excluded, validated, forwarded to the spawn) — see the cheatsheet.
 - **AI review & self-healing (`@zuke/ai`):** gate a target on a structured LLM
   review of the diff (`securityReviewer(...)` etc. via `.validateBefore`), or
   attach `aiFixer(...)` with `.recoverWith(...)` so a failing target is

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -8,32 +8,32 @@ summary, not the source of truth.
 
 Everything is optional except a body (`.executes`).
 
-| Method                                                                                                   | Purpose                                                                                           |
-| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| `.description(text)`                                                                                     | Summary shown in `--list`.                                                                        |
-| `.dependsOn(...t)`                                                                                       | Hard prerequisites; run first, transitively. Pass `this.<field>`.                                 |
-| `.executes(fn)`                                                                                          | The body. Sync or async. **Required.** `fn` may take a `TargetContext` (`(ctx) => …`); see below. |
-| `.before(...t)` / `.after(...t)`                                                                         | Soft ordering — only reorders targets already in the plan; never pulls new ones in.               |
-| `.triggers(...t)`                                                                                        | Pull targets into the plan and run them _after_ this one.                                         |
-| `.dependentFor(...t)`                                                                                    | Reverse of `dependsOn`: make this a prerequisite of others.                                       |
-| `.inputs(...p)` / `.outputs(...p)`                                                                       | Incremental cache: skip when inputs unchanged and outputs exist.                                  |
-| `.cacheKey(fn)`                                                                                          | Add a non-file value (version, git sha, param) to the cache fingerprint.                          |
-| `.onlyWhen(cond)`                                                                                        | Run only when the (possibly async) predicate holds, else skip.                                    |
-| `.requires(...params)`                                                                                   | Fail unless the listed parameters resolved to a value.                                            |
-| `.retry(times, delayMs?)`                                                                                | Retry the body on failure.                                                                        |
-| `.timeout(ms)`                                                                                           | Fail the body if it runs longer than `ms` (per attempt).                                          |
-| `.lock((s) => s.lockKey(...).withTtl(...))`                                                              | Hold a cross-run lock while running; a second run wanting the key fails. See below.               |
-| `.waitsFor((s) => s.on(externalSignal(...)))`                                                            | Gate (no body): suspend the run until an external event; resume later. See below.                 |
-| `.onCancel(() => this.rollback)`                                                                         | Compensation run (reverse order) iff this target succeeded when the run is cancelled. See below.   |
-| `.forEach(() => items, (item) => ({stage: target()…}), (s) => s.concurrency(3).continueOnItemFailure())` | Fan out a pipeline over a runtime list: items concurrent, stages sequential per item. See below.  |
-| `.proceedAfterFailure()`                                                                                 | Keep the build going if this target fails.                                                        |
-| `.always()`                                                                                              | Run even after the build failed (cleanup/teardown).                                               |
-| `.unlisted()`                                                                                            | Hide from `--list`/`--help`; still runnable by name.                                              |
+| Method                                                                                                   | Purpose                                                                                             |
+| -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `.description(text)`                                                                                     | Summary shown in `--list`.                                                                          |
+| `.dependsOn(...t)`                                                                                       | Hard prerequisites; run first, transitively. Pass `this.<field>`.                                   |
+| `.executes(fn)`                                                                                          | The body. Sync or async. **Required.** `fn` may take a `TargetContext` (`(ctx) => …`); see below.   |
+| `.before(...t)` / `.after(...t)`                                                                         | Soft ordering — only reorders targets already in the plan; never pulls new ones in.                 |
+| `.triggers(...t)`                                                                                        | Pull targets into the plan and run them _after_ this one.                                           |
+| `.dependentFor(...t)`                                                                                    | Reverse of `dependsOn`: make this a prerequisite of others.                                         |
+| `.inputs(...p)` / `.outputs(...p)`                                                                       | Incremental cache: skip when inputs unchanged and outputs exist.                                    |
+| `.cacheKey(fn)`                                                                                          | Add a non-file value (version, git sha, param) to the cache fingerprint.                            |
+| `.onlyWhen(cond)`                                                                                        | Run only when the (possibly async) predicate holds, else skip.                                      |
+| `.requires(...params)`                                                                                   | Fail unless the listed parameters resolved to a value.                                              |
+| `.retry(times, delayMs?)`                                                                                | Retry the body on failure.                                                                          |
+| `.timeout(ms)`                                                                                           | Fail the body if it runs longer than `ms` (per attempt).                                            |
+| `.lock((s) => s.lockKey(...).withTtl(...))`                                                              | Hold a cross-run lock while running; a second run wanting the key fails. See below.                 |
+| `.waitsFor((s) => s.on(externalSignal(...)))`                                                            | Gate (no body): suspend the run until an external event; resume later. See below.                   |
+| `.onCancel(() => this.rollback)`                                                                         | Compensation run (reverse order) iff this target succeeded when the run is cancelled. See below.    |
+| `.forEach(() => items, (item) => ({stage: target()…}), (s) => s.concurrency(3).continueOnItemFailure())` | Fan out a pipeline over a runtime list: items concurrent, stages sequential per item. See below.    |
+| `.proceedAfterFailure()`                                                                                 | Keep the build going if this target fails.                                                          |
+| `.always()`                                                                                              | Run even after the build failed (cleanup/teardown).                                                 |
+| `.unlisted()`                                                                                            | Hide from `--list`/`--help`; still runnable by name.                                                |
 | `.dryRunnable()`                                                                                         | Run this body under `--dry-run` with `$` in echo mode (prints argv, no spawn); others stay skipped. |
-| `.validateBefore(...v)` / `.validateAfter(...v)`                                                         | Run `Validation` checks around the body; a throw fails the target.                                |
-| `.recoverWith(...r)` / `.recoverAttempts(n)`                                                             | Run `Remediation`s if the body fails (self-healing); re-run when one asks to. See AI section.     |
-| `.partOf(group)`                                                                                         | Join a parallel batch (see `group()`).                                                            |
-| `.produces(...p)` / `.consumes(...t)`                                                                    | Declare and consume artifact paths.                                                               |
+| `.validateBefore(...v)` / `.validateAfter(...v)`                                                         | Run `Validation` checks around the body; a throw fails the target.                                  |
+| `.recoverWith(...r)` / `.recoverAttempts(n)`                                                             | Run `Remediation`s if the body fails (self-healing); re-run when one asks to. See AI section.       |
+| `.partOf(group)`                                                                                         | Join a parallel batch (see `group()`).                                                              |
+| `.produces(...p)` / `.consumes(...t)`                                                                    | Declare and consume artifact paths.                                                                 |
 
 **External ordering:** `override extraEdges(targets)` on the `Build` returns
 `[before, after]` pairs (from the discovered `targets` map) to impose soft
@@ -133,10 +133,11 @@ deploy = target().executes(async (ctx) => {
 signal is the shell's ambient signal). Pass `ctx.signal` to `.signal(...)` to
 cancel a command explicitly; it composes with `.killAfter(ms)`. Cancel a run
 with `zuke cancel <id>`, `Ctrl-C`/`SIGTERM`, the MCP `cancel_run` tool, or
-programmatically with `execute(build, root, { signal })` / `cancelRun(build, {
-runId })`. A body that ignores its signal and never shells out runs to
-completion. Register **compensations** with `.onCancel(...)` (see below) to undo
-a target's effect when the run is cancelled.
+programmatically with `execute(build, root, { signal })` /
+`cancelRun(build, {
+runId })`. A body that ignores its signal and never shells
+out runs to completion. Register **compensations** with `.onCancel(...)` (see
+below) to undo a target's effect when the run is cancelled.
 
 ## Durable run state
 
@@ -251,9 +252,11 @@ class Deploy extends Build {
 
 ## Cancellation & compensation — `.onCancel()`
 
-Undo a target's effect when the run is cancelled. `.onCancel(target | () =>
-target)` registers a **compensation** that runs **iff this target succeeded**;
-on cancel, compensations run in **reverse order** of the succeeded targets.
+Undo a target's effect when the run is cancelled.
+`.onCancel(target | () =>
+target)` registers a **compensation** that runs **iff
+this target succeeded**; on cancel, compensations run in **reverse order** of
+the succeeded targets.
 
 ```ts
 class CD extends Build {
@@ -266,8 +269,9 @@ class CD extends Build {
 }
 ```
 
-- The compensation body's `ctx.state` exposes **the original target's** persisted
-  metadata (persist what a rollback needs in `ctx.state` when you do the work).
+- The compensation body's `ctx.state` exposes **the original target's**
+  persisted metadata (persist what a rollback needs in `ctx.state` when you do
+  the work).
 - Cancel with `zuke cancel <id>`, `Ctrl-C`/`SIGTERM`, or the MCP `cancel_run`
   tool (all run the same walk). A live run aborts on its next state write.
 - A compensation that throws is recorded but does **not** stop the walk (cleanup
@@ -372,6 +376,16 @@ bin = target().executes(async () =>
 // Many at once:
 tools = toolchain((t) => t.add(/* … */).add(/* … */));
 ```
+
+**Resolve from `node_modules/.bin`** — in a Node monorepo where tool binaries
+are hoisted to the repo root, a wrapper can find its binary npx-style instead of
+needing a `.toolPath(...)`. `.fromNodeModules()` on any settings object walks up
+from the working directory for `node_modules/.bin/<tool>` (the `.cmd`/`.bat`
+shims on Windows, launched via `cmd /c`) and falls back to `PATH` on a miss;
+`.fromPath()` forces `PATH`; and `ZUKE_TOOL_RESOLUTION=node_modules|path` flips
+every wrapper repo-wide without touching call sites (a per-call setting wins
+over it). An explicit `.toolPath(...)` always wins, so a `toolchain()` pin stays
+hermetic. `resolvedArgv()` shows what a run will spawn. See `docs/tools.md`.
 
 ## Tool wrappers — the settings-lambda style
 
@@ -529,10 +543,11 @@ is current (`zuke generate-ci --check` is a dedicated gate).
 
 **Scheduled runs** — `triggers.schedule: [{ cron, tz? }]`. A `tz` (IANA zone) is
 compiled to UTC cron(s); a daylight-saving zone also emits a generated guard job
-so only the correct wall-clock firing proceeds. Full on GitHub; Azure gets native
-`schedules:` for UTC/fixed-offset (DST zone errors); GitLab/Bitbucket schedules
-are UI-side and ignored. Numeric fields + whole-hour offsets only, else a friendly
-error. `cicd({ provider: "github", pipeline: { triggers: { schedule: [{ cron: "30 9 * * 1-5", tz: "Europe/Sofia" }] } } })`.
+so only the correct wall-clock firing proceeds. Full on GitHub; Azure gets
+native `schedules:` for UTC/fixed-offset (DST zone errors); GitLab/Bitbucket
+schedules are UI-side and ignored. Numeric fields + whole-hour offsets only,
+else a friendly error.
+`cicd({ provider: "github", pipeline: { triggers: { schedule: [{ cron: "30 9 * * 1-5", tz: "Europe/Sofia" }] } } })`.
 
 ## Run & inspect
 
@@ -563,11 +578,19 @@ error. `cicd({ provider: "github", pipeline: { triggers: { schedule: [{ cron: "3
 descriptor of this build — its `describeCli()` surface (targets, params) plus a
 launch location — into a pluggable `BuildRegistry`. Resolved like the state
 store: `ZUKE_REGISTRY_URL`/`_TOKEN` (HTTP) or `ZUKE_REGISTRY_DIR` (files), a
-`registry()` build override, else `.zuke/builds`. Separate from the run store; an
-HTTP backend shares the `/builds` REST contract beside `/runs`. **`zuke mcp
---registry`** then serves the whole catalog — re-read live, so a build registered
-by another process appears as a `run:<buildId>:<target>` tool with no restart and
-runs by spawning its launch location (behind `--allow-run` + the same authz).
+`registry()` build override, else `.zuke/builds`. Separate from the run store;
+an HTTP backend shares the `/builds` REST contract beside `/runs`.
+**`zuke mcp
+--registry`** then serves the whole catalog — re-read live, so a
+build registered by another process appears as a `run:<buildId>:<target>` tool
+with no restart and runs by spawning its launch location (behind `--allow-run` +
+the same authz). The run tool exposes the registered build's declared
+**parameters** as its input schema and forwards supplied values to the spawned
+build as `--flag=value` arguments — validated against their kinds first (a type
+mismatch is a clean tool error, never a failed subprocess). `.secret()`
+parameters are omitted from the descriptor entirely, so a secret can neither be
+requested nor forwarded; the child resolves it from its own environment /
+`.from()` source.
 
 **Caching:** a target with `.inputs(...)`/`.outputs(...)` is incremental
 (skipped and reported `cached` when inputs are unchanged and outputs exist). Add

--- a/tests/e2e/fixtures/discoverable_build.ts
+++ b/tests/e2e/fixtures/discoverable_build.ts
@@ -7,14 +7,31 @@
  * @module
  */
 
-import { Build, run, target } from "../../../packages/core/mod.ts";
+import { Build, parameter, run, target } from "../../../packages/core/mod.ts";
 
-/** A one-target pipeline whose output the e2e asserts on. */
+/** A small pipeline whose output the registry-MCP e2e asserts on. */
 class Widget extends Build {
+  /** Repos to deploy — a runtime list forwarded across the spawn boundary. */
+  repos = parameter("service repos to deploy").array();
+  /** Whether to skip the e2e stage — a boolean forwarded as `--skip-e2e`. */
+  skipE2e = parameter("skip the e2e stage").boolean();
+  /** An optional SIT slot; when omitted the build reports it as auto-leased. */
+  sit = parameter("SIT slot");
+
   /** Prints a marker the spawning MCP server captures and returns. */
   hello = target()
     .description("Say hello")
     .executes(() => console.log("HELLO-FROM-REGISTERED"));
+
+  /** Echoes its bound parameters, proving they crossed the spawn boundary. */
+  deploy = target()
+    .description("Deploy the given repos")
+    .executes(() =>
+      console.log(
+        `DEPLOY repos=${this.repos.value.join(",")} ` +
+          `skipE2e=${this.skipE2e.value} sit=${this.sit.value ?? "auto"}`,
+      )
+    );
 }
 
 await run(Widget);

--- a/tests/e2e/registry_e2e.ts
+++ b/tests/e2e/registry_e2e.ts
@@ -63,9 +63,11 @@ Deno.test("two real processes register concurrently; no torn write", async () =>
       loaded?.descriptor.surface.targets.map((t) => t.name),
       ["lint", "build"],
     );
-    // The surface lists the parameter flag (structure) but never its value.
+    // The secret parameter is excluded from the descriptor entirely — neither
+    // its flag nor its value appears, so it can never become a spawnable input.
+    assertEquals(loaded?.descriptor.surface.parameters, []);
     const json = JSON.stringify(loaded?.descriptor);
-    assertEquals(json.includes("api-token"), true);
+    assertEquals(json.includes("api-token"), false);
     assertEquals(json.includes("e2e-secret-xyz"), false);
   } finally {
     await Deno.remove(dir, { recursive: true });

--- a/tests/e2e/registry_mcp_e2e.ts
+++ b/tests/e2e/registry_mcp_e2e.ts
@@ -55,6 +55,28 @@ function toolNames(reply: unknown): string[] {
   return (result?.tools ?? []).map((t) => t.name);
 }
 
+/** Whether a value is a plain object. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** The input schema of a named tool from a `tools/list` reply. */
+function runToolInputSchema(
+  reply: unknown,
+  name: string,
+): Record<string, unknown> {
+  const result = isRecord(reply) ? reply.result : undefined;
+  const tools = isRecord(result) && Array.isArray(result.tools)
+    ? result.tools
+    : [];
+  for (const t of tools) {
+    if (isRecord(t) && t.name === name && isRecord(t.inputSchema)) {
+      return t.inputSchema;
+    }
+  }
+  throw new Error(`no tool ${name}`);
+}
+
 /** The text block of a `tools/call` reply. */
 function toolText(reply: unknown): string {
   const result =
@@ -123,6 +145,37 @@ Deno.test("a build registered after startup appears as a runnable MCP tool", asy
     );
     assertStringIncludes(ran, "HELLO-FROM-REGISTERED");
     assertStringIncludes(ran, "succeeded");
+
+    // The parameterized target advertises its inputs…
+    const schema = runToolInputSchema(
+      await rpc("tools/list"),
+      "run:Widget:deploy",
+    );
+    const props = isRecord(schema.properties) ? schema.properties : {};
+    assertEquals(isRecord(props.repos), true);
+    assertEquals(isRecord(props.skipE2e), true);
+
+    // …and a call binds the supplied values into the spawned build, proving the
+    // values crossed the process boundary as resolved parameters.
+    const deployed = toolText(
+      await rpc("tools/call", {
+        name: "run:Widget:deploy",
+        arguments: { repos: ["expense-service", "web"], skipE2e: true },
+      }),
+    );
+    assertStringIncludes(
+      deployed,
+      "DEPLOY repos=expense-service,web skipE2e=true sit=auto",
+    );
+
+    // A type mismatch is rejected without ever spawning the build.
+    const bad = await rpc("tools/call", {
+      name: "run:Widget:deploy",
+      arguments: { repos: "expense-service" },
+    });
+    const badText = toolText(bad);
+    assertStringIncludes(badText, "repos");
+    assertEquals(badText.includes("DEPLOY"), false);
   } finally {
     if (server !== undefined) {
       server.kill();

--- a/tests/integration/register_test.ts
+++ b/tests/integration/register_test.ts
@@ -53,11 +53,12 @@ Deno.test("zuke register writes a descriptor a reader can load", async () => {
       loaded?.descriptor.surface.targets.map((t) => t.name),
       ["lint", "build"],
     );
-    // The secret parameter's flag is listed, but no value is anywhere in it.
-    assertEquals(
-      loaded?.descriptor.surface.parameters.map((p) => p.flag),
-      ["api-token"],
-    );
+    // The secret parameter is excluded entirely — neither its flag nor a value
+    // appears anywhere in the descriptor, so it can never become an MCP input.
+    assertEquals(loaded?.descriptor.surface.parameters, []);
+    const raw = JSON.stringify(loaded?.descriptor);
+    assertEquals(raw.includes("api-token"), false);
+    assertEquals(raw.includes("apiToken"), false);
     const createdAt = loaded?.descriptor.createdAt;
 
     // Re-registering is idempotent: createdAt is preserved.

--- a/tests/integration/registry_params_test.ts
+++ b/tests/integration/registry_params_test.ts
@@ -1,0 +1,143 @@
+/**
+ * Integration: a build's declared parameters flow all the way from
+ * `zuke register` through a real {@link FileSystemBuildRegistry} (descriptor
+ * serialized to JSON and parsed back) into a {@link RegistryMcpServer}'s run
+ * tool — its input schema, its validation, and the `--flag=value` arguments it
+ * forwards to the spawned build. A secret parameter is proven absent end-to-end.
+ * Unlike the unit tests, nothing here hand-builds a descriptor.
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import { Build, parameter, target } from "../../packages/core/mod.ts";
+import { registerCommand } from "../../packages/core/src/registry/register.ts";
+import { FileSystemBuildRegistry } from "../../packages/core/src/registry/fs_registry.ts";
+import {
+  RegistryMcpServer,
+  type RegistryRunner,
+} from "../../packages/core/src/mcp/registry_server.ts";
+
+/** A parameterized deploy build, including a secret that must never surface. */
+class Deploy extends Build {
+  repos = parameter("service repos to deploy").array();
+  skipE2e = parameter("skip the e2e stage").boolean();
+  sit = parameter("SIT slot");
+  apiToken = parameter("deploy API token").secret();
+  deploy = target().description("Deploy the repos").executes(() => {});
+}
+
+/** Run `fn` with console output suppressed (registerCommand prints a line). */
+async function quietly(fn: () => Promise<void>): Promise<void> {
+  const log = console.log;
+  console.log = () => {};
+  try {
+    await fn();
+  } finally {
+    console.log = log;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** The named tool's input schema from a `tools/list` reply. */
+function inputSchema(reply: unknown, name: string): Record<string, unknown> {
+  const result = isRecord(reply) ? reply.result : undefined;
+  const tools = isRecord(result) && Array.isArray(result.tools)
+    ? result.tools
+    : [];
+  for (const t of tools) {
+    if (isRecord(t) && t.name === name && isRecord(t.inputSchema)) {
+      return t.inputSchema;
+    }
+  }
+  throw new Error(`no tool ${name}`);
+}
+
+/** The text + isError of a `tools/call` reply. */
+function callResult(reply: unknown): { text: string; isError: boolean } {
+  const result = isRecord(reply) ? reply.result : undefined;
+  const content = isRecord(result) ? result.content : undefined;
+  const first = Array.isArray(content) ? content[0] : undefined;
+  const text = isRecord(first) && typeof first.text === "string"
+    ? first.text
+    : "";
+  return { text, isError: isRecord(result) && result.isError === true };
+}
+
+Deno.test("a registered build's parameters flow into the registry run tool", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "zuke-it-registry-params-" });
+  try {
+    const registry = new FileSystemBuildRegistry(dir);
+    await quietly(async () => {
+      const code = await registerCommand(new Deploy(), {
+        registry,
+        location: { kind: "module", module: "file:///r/deploy.ts", cwd: "/r" },
+        readEnv: () => undefined,
+        now: () => "2026-01-01T00:00:00.000Z",
+      });
+      assertEquals(code, 0);
+    });
+
+    const calls: { argv: string[]; cwd: string }[] = [];
+    const runner: RegistryRunner = (argv, cwd) => {
+      calls.push({ argv: [...argv], cwd });
+      return Promise.resolve({ code: 0, stdout: "ok", stderr: "" });
+    };
+    const server = new RegistryMcpServer(registry, { allowRun: true, runner });
+
+    // The run tool advertises the non-secret parameters; the secret is absent.
+    const schema = inputSchema(
+      await server.handleMessage({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+      }),
+      "run:Deploy:deploy",
+    );
+    const props = isRecord(schema.properties) ? schema.properties : {};
+    assertEquals(isRecord(props.repos), true);
+    assertEquals(isRecord(props.skipE2e), true);
+    assertEquals(isRecord(props.sit), true);
+    assertEquals("apiToken" in props, false); // secret excluded end-to-end
+
+    // A call forwards the values to the spawn as --flag=value arguments.
+    const ok = callResult(
+      await server.handleMessage({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: {
+          name: "run:Deploy:deploy",
+          arguments: { repos: ["a", "b"], skipE2e: true },
+        },
+      }),
+    );
+    assertEquals(ok.isError, false);
+    assertEquals(calls.length, 1);
+    assertEquals(calls[0].argv.includes("--repos=a,b"), true);
+    assertEquals(calls[0].argv.includes("--skip-e2e=true"), true);
+
+    // The secret cannot be passed: it is rejected as an unknown parameter and
+    // no second spawn happens.
+    const rejected = callResult(
+      await server.handleMessage({
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: {
+          name: "run:Deploy:deploy",
+          arguments: { apiToken: "s3cr3t" },
+        },
+      }),
+    );
+    assertEquals(rejected.isError, true);
+    assertStringIncludes(rejected.text, "apiToken");
+    assertEquals(calls.length, 1);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});


### PR DESCRIPTION
## What

Round 2 / M12 (P0 #1). A registry MCP `run:<build>:<target>` tool now exposes the registered build's **declared parameters** as its input schema and **forwards** supplied values to the spawned build — the single hardest blocker for the shared control plane, since the requester's deploy build is parameterized (`repos`, `sit`, `skipE2e`).

Before: a registry run tool took only `dryRun`/`confirm`/`operatorToken`; the spawned build could only resolve parameters from the server's environment.

## Design

The in-process `McpServer` already did per-parameter schemas; the registry path lacked it only because the descriptor dropped the metadata. So:

- **Descriptor** (`CliParameterInfo`) gains `name` (property name), `kind`, and `default`. Parsing is tolerant of a pre-M12 descriptor: absent `kind` derives from the `boolean` flag, absent `name` falls back to `flag`.
- **Input schema** is keyed by the parameter's **property name** (`skipE2e`, matching the in-process server and the requirement's example), with kind, description, enum, and default.
- **Validation before spawn**: array-vs-scalar, number, boolean, and enum are checked against the descriptor; a bare string for an array, a non-numeric number, an out-of-set enum, or an unknown parameter is a clean tool error — the subprocess never starts.
- **Forwarding**: validated values become `--flag=value` child arguments (the CLI already parses `--flag=false` for booleans, so no `cli.ts` change).
- **Secrets**: `.secret()` parameters are omitted from the descriptor entirely (`describeCli(build, { omitSecrets: true })`, written by `zuke register`), so a secret can neither be requested nor forwarded — it's rejected as an unknown parameter. The child resolves it from its own env / `.from()` source.
- **Reserved names**: `discoverParameters` rejects a parameter named `dryRun`/`confirm`/`operatorToken` — which also fixes a latent **silent collision** in the in-process server (it would overwrite a same-named parameter with the control key).

## Tests

- **Unit** — `registry_server_test.ts` (schema exposure, forwarding, type/enum/number/unknown rejection before spawn, boolean `false`, control-key coexistence), `describe_test.ts` (name/kind/default, `omitSecrets`), `params_test.ts` (reserved-name guard, `default_`), `registry_test.ts` (tolerant descriptor parse + round-trip).
- **Integration** — `tests/integration/registry_params_test.ts`: the real `register` → `FileSystemBuildRegistry` (JSON round-trip) → `RegistryMcpServer` pipeline; asserts the run tool exposes params, forwards them, and excludes the secret.
- **E2E** — `registry_mcp_e2e.ts` + fixture: a real cross-process spawn binds `repos`/`skipE2e` into the child (which echoes them), and a type mismatch is rejected without spawning.

## Adversarial review

Fanned out attackers across secret-boundary, argv-injection, validation-bypass, schema-evolution, and the discovery guard; verified each finding refute-by-default. Two confirmed defects fixed here with regressions:

- **Audit-log leak (medium):** a value mistakenly supplied under a secret parameter's name (unknown, since secrets are absent from the descriptor) was recorded verbatim in the durable audit trail. Now only recognized (non-secret) argument values are recorded; unknown keys keep their name but their value is elided.
- **Malformed schema from an untrusted descriptor (low):** a `kind:number` parameter with a non-numeric `default` or a string `enum` produced an invalid JSON Schema. Both are now dropped so the advertised schema stays well-formed.

Refuted / out of scope: the inherent `.array()` comma-delimiter contract (identical on the CLI), and a self-contradictory `.options("a,b").array()` declaration that fails cleanly.

## Docs

`docs/mcp.md` (registry run-tool parameters, secret exclusion, audit elision); `llms-full.txt`/README regenerated; `deno doc --lint` clean; `deno task ci` green.