### PR TITLE
feat(core): per-call identity hook for MCP servers

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -157,11 +157,42 @@ dropped and every `.secret()` parameter's value is masked — before anything is
 persisted.
 
 The trail lives in a store-level record; read it with `zuke runs show mcp-audit`
-(or the `show_run` tool). The actor resolves by precedence: `--actor` →
-`ZUKE_ACTOR` → the CI actor → the connecting client's `initialize` name →
-`"anonymous"`. The client name is an **untrusted label** for the trail only — it
-never influences authorization. On a shared HTTP endpoint it reflects the most
-recent client to connect, so set `--actor` for authoritative attribution there.
+(or the `show_run` tool). The actor resolves by precedence: the **identity
+hook** (below) → `--actor` → `ZUKE_ACTOR` → the CI actor → the connecting
+client's `initialize` name → `"anonymous"`. The client name is an **untrusted
+label** for the trail only — it never influences authorization. On a shared HTTP
+endpoint it reflects the most recent client to connect, so use the identity hook
+(or `--actor`) for authoritative attribution there.
+
+### Trusted per-call identity
+
+On a shared, multi-user endpoint "who did this" must not be self-reported. Front
+the server with an authenticating reverse proxy (e.g. OAuth 2.1) that injects
+the real caller in a header it strips from client input, and resolve it with a
+per-request **identity hook** — `override mcpIdentity()` on the build:
+
+```ts
+class ControlPlane extends Build {
+  override mcpIdentity() {
+    return (ctx: McpRequestContext) => {
+      const sub = ctx.headers.get("x-forwarded-user"); // proxy-injected
+      if (!sub) throw new Error("no identity from proxy"); // any throw rejects
+      return { actor: sub, via: "oauth-proxy" };
+    };
+  }
+}
+```
+
+The hook runs **once per request, before any dispatch**. Its `actor` overrides
+`--actor`, the environment, and the client label for that call, and flows to the
+audit trail, run records, lock-holder identity, and — for a registry-spawned
+build — the child's `ZUKE_ACTOR`. It is **fail-closed**: a hook that throws _or_
+yields no usable actor (an empty string, e.g. from `headers.get(…) ?? ""` when
+the header is missing) **rejects the request** with an auth error — nothing
+executes, nothing is written, and it never falls back to the static actor, so
+the hook's precedence stays absolute. Without a hook, stdio/local behavior is
+unchanged. This is deliberately the _minimal_ seam — TLS, the OAuth flow, and
+header stripping are the proxy's job, not Zuke's.
 
 ## Registry mode (dynamic discovery)
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -733,6 +733,28 @@ class Build
       }
     }
     ```
+  mcpIdentity(): McpIdentityHook | undefined
+    A per-request identity hook for `zuke mcp` — resolve a trusted caller
+    from the request context (an authenticating reverse proxy's header) so a
+    shared, multi-user server attributes each call to the real engineer rather
+    than a client-self-reported label. When set, the resolved actor overrides
+    `--actor`, the environment, and the client label for that call, and flows to
+    the audit trail, run records, lock holders, and (for a registry-spawned
+    build) the child's `ZUKE_ACTOR`; a throwing hook rejects the request before
+    anything runs. Default: none — stdio/local use is unchanged.
+
+    ```ts
+    class ControlPlane extends Build {
+      override mcpIdentity() {
+        return (ctx: McpRequestContext) => {
+          // The proxy strips any client copy of this header and injects its own.
+          const sub = ctx.headers.get("x-forwarded-user");
+          if (!sub) throw new Error("no identity from proxy");
+          return { actor: sub, via: "oauth-proxy" };
+        };
+      }
+    }
+    ```
 
 class CiFile
   A declared CI file. Assign one (via {@link cicd}) to a build field and Zuke
@@ -2263,6 +2285,25 @@ interface LockHolder
   runUrl?: string
     A link to the holding run (e.g. its CI job), when known.
 
+interface McpIdentity
+  A trusted caller identity, resolved per request by a {@link McpIdentityHook}
+  (typically from an authenticating reverse proxy's header). Its
+  {@link McpIdentity.actor} is the highest-precedence attribution — it overrides
+  `--actor`, the environment, and the client's self-reported label for the call.
+
+  actor: string
+    The authenticated actor (e.g. an OAuth subject).
+  via?: string
+    How the identity was established (e.g. `"oauth-proxy"`); informational.
+
+interface McpRequestContext
+  The per-request context a transport hands the message handler. Carries the
+  request's headers, so a server's identity hook can authenticate the caller
+  from a trusted proxy header. Empty on the stdio transport (no headers).
+
+  readonly headers: Headers
+    The request headers; an empty {@link Headers} on stdio.
+
 interface OpenCacheOptions
   Optional extras for {@link openCache}: a remote store and a warning sink.
 
@@ -2909,6 +2950,12 @@ type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string
 type LockResult = { ok: true; token: string; } | { ok: false; holder: LockHolder; }
   The result of {@link StateStore.acquireLock}: a `token` proving ownership, or
   the current `holder` when the lock is already held.
+
+type McpIdentityHook = (ctx: McpRequestContext) => McpIdentity
+  Resolve a trusted {@link McpIdentity} from a request's context. Invoked once
+  per message, before any dispatch; throwing rejects the whole request with
+  an auth error, so nothing executes and nothing is written to state — the seam
+  a proxy in front of the server uses to inject an authenticated identity.
 
 type OnCancel = TargetBuilder | (() => TargetBuilder)
   A compensation registered with {@link TargetBuilder.onCancel}: either a

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -787,6 +787,28 @@ class Build
       }
     }
     ```
+  mcpIdentity(): McpIdentityHook | undefined
+    A per-request identity hook for `zuke mcp` — resolve a trusted caller
+    from the request context (an authenticating reverse proxy's header) so a
+    shared, multi-user server attributes each call to the real engineer rather
+    than a client-self-reported label. When set, the resolved actor overrides
+    `--actor`, the environment, and the client label for that call, and flows to
+    the audit trail, run records, lock holders, and (for a registry-spawned
+    build) the child's `ZUKE_ACTOR`; a throwing hook rejects the request before
+    anything runs. Default: none — stdio/local use is unchanged.
+
+    ```ts
+    class ControlPlane extends Build {
+      override mcpIdentity() {
+        return (ctx: McpRequestContext) => {
+          // The proxy strips any client copy of this header and injects its own.
+          const sub = ctx.headers.get("x-forwarded-user");
+          if (!sub) throw new Error("no identity from proxy");
+          return { actor: sub, via: "oauth-proxy" };
+        };
+      }
+    }
+    ```
 
 class CiFile
   A declared CI file. Assign one (via {@link cicd}) to a build field and Zuke
@@ -2317,6 +2339,25 @@ interface LockHolder
   runUrl?: string
     A link to the holding run (e.g. its CI job), when known.
 
+interface McpIdentity
+  A trusted caller identity, resolved per request by a {@link McpIdentityHook}
+  (typically from an authenticating reverse proxy's header). Its
+  {@link McpIdentity.actor} is the highest-precedence attribution — it overrides
+  `--actor`, the environment, and the client's self-reported label for the call.
+
+  actor: string
+    The authenticated actor (e.g. an OAuth subject).
+  via?: string
+    How the identity was established (e.g. `"oauth-proxy"`); informational.
+
+interface McpRequestContext
+  The per-request context a transport hands the message handler. Carries the
+  request's headers, so a server's identity hook can authenticate the caller
+  from a trusted proxy header. Empty on the stdio transport (no headers).
+
+  readonly headers: Headers
+    The request headers; an empty {@link Headers} on stdio.
+
 interface OpenCacheOptions
   Optional extras for {@link openCache}: a remote store and a warning sink.
 
@@ -2963,6 +3004,12 @@ type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string
 type LockResult = { ok: true; token: string; } | { ok: false; holder: LockHolder; }
   The result of {@link StateStore.acquireLock}: a `token` proving ownership, or
   the current `holder` when the lock is already held.
+
+type McpIdentityHook = (ctx: McpRequestContext) => McpIdentity
+  Resolve a trusted {@link McpIdentity} from a request's context. Invoked once
+  per message, before any dispatch; throwing rejects the whole request with
+  an auth error, so nothing executes and nothing is written to state — the seam
+  a proxy in front of the server uses to inject an authenticated identity.
 
 type OnCancel = TargetBuilder | (() => TargetBuilder)
   A compensation registered with {@link TargetBuilder.onCancel}: either a

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -183,6 +183,11 @@ export {
   resolveBuildRegistry,
   type ResolveRegistryOptions,
 } from "./src/registry/resolve.ts";
+export {
+  type McpIdentity,
+  type McpIdentityHook,
+  type McpRequestContext,
+} from "./src/mcp/jsonrpc.ts";
 export { type AbsolutePath, absolutePath, type PathLike } from "./src/path.ts";
 export { CONFIG_FILE, repoRoot } from "./src/config.ts";
 export {

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -14,6 +14,7 @@ import type { OrderingEdge } from "./graph.ts";
 import type { RemoteCacheStore } from "./remote_cache.ts";
 import type { StateStore } from "./state/store.ts";
 import type { BuildRegistry } from "./registry/registry.ts";
+import type { McpIdentityHook } from "./mcp/jsonrpc.ts";
 
 /** Whether a value is a plain object (a component bundle), not a class instance. */
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -215,6 +216,33 @@ export class Build {
    * ```
    */
   registry(): BuildRegistry | undefined {
+    return undefined;
+  }
+
+  /**
+   * A per-request identity hook for `zuke mcp` — resolve a **trusted** caller
+   * from the request context (an authenticating reverse proxy's header) so a
+   * shared, multi-user server attributes each call to the real engineer rather
+   * than a client-self-reported label. When set, the resolved actor overrides
+   * `--actor`, the environment, and the client label for that call, and flows to
+   * the audit trail, run records, lock holders, and (for a registry-spawned
+   * build) the child's `ZUKE_ACTOR`; a throwing hook rejects the request before
+   * anything runs. Default: none — stdio/local use is unchanged.
+   *
+   * ```ts
+   * class ControlPlane extends Build {
+   *   override mcpIdentity() {
+   *     return (ctx: McpRequestContext) => {
+   *       // The proxy strips any client copy of this header and injects its own.
+   *       const sub = ctx.headers.get("x-forwarded-user");
+   *       if (!sub) throw new Error("no identity from proxy");
+   *       return { actor: sub, via: "oauth-proxy" };
+   *     };
+   *   }
+   * }
+   * ```
+   */
+  mcpIdentity(): McpIdentityHook | undefined {
     return undefined;
   }
 }

--- a/packages/core/src/mcp/command.ts
+++ b/packages/core/src/mcp/command.ts
@@ -15,6 +15,7 @@ import { resolveBuildRegistry } from "../registry/resolve.ts";
 import {
   type ByteWriter,
   type JsonRpcResponse,
+  type McpRequestContext,
   serveStdio,
 } from "./jsonrpc.ts";
 import { serveHttp } from "./http.ts";
@@ -23,8 +24,14 @@ import { RegistryMcpServer, type RegistryRunner } from "./registry_server.ts";
 
 /** A thing that answers MCP messages — either server flavour drives a transport. */
 interface McpHandler {
-  /** Handle one parsed JSON-RPC message, or return `null` for a notification. */
-  handleMessage(message: unknown): Promise<JsonRpcResponse | null>;
+  /**
+   * Handle one parsed JSON-RPC message with its per-request context (headers on
+   * HTTP; empty on stdio), or return `null` for a notification.
+   */
+  handleMessage(
+    message: unknown,
+    ctx?: McpRequestContext,
+  ): Promise<JsonRpcResponse | null>;
 }
 
 /** A parsed `--http` bind address. */
@@ -127,6 +134,9 @@ export async function serveMcp(
   // then hand them to the server alongside the caller's options.
   const store = resolveMcpStore(build, options.stateStore, readEnv);
   const operatorToken = options.operatorToken ?? readEnv("ZUKE_OPERATOR_TOKEN");
+  // The trusted identity hook: an explicit option wins, else the build declares
+  // one via `override mcpIdentity()` (the CLI-reachable seam).
+  const identity = options.identity ?? build.mcpIdentity();
   // An injected registry (tests) wins; otherwise `--registry` resolves one.
   const registry = options.registry ??
     (options.useRegistry ? resolveMcpRegistry(build, readEnv) : undefined);
@@ -141,6 +151,7 @@ export async function serveMcp(
       operatorToken,
       stateStore: store,
       actor: options.actor,
+      identity,
       readEnv,
       version: options.version,
       runner: options.runner,
@@ -150,6 +161,7 @@ export async function serveMcp(
       readEnv,
       stateStore: store,
       operatorToken,
+      identity,
     });
   if (options.http !== undefined) {
     return await serveMcpHttp(server, options.http, options);
@@ -162,7 +174,7 @@ export async function serveMcp(
     );
   }
   await serveStdio(
-    (message) => server.handleMessage(message),
+    (message, ctx) => server.handleMessage(message, ctx),
     options.input,
     options.output,
   );
@@ -203,7 +215,7 @@ async function serveMcpHttp(
         `(${source}${mode}, ${auth}). Press Ctrl-C to stop.`,
     );
   }
-  await serveHttp((message) => server.handleMessage(message), {
+  await serveHttp((message, ctx) => server.handleMessage(message, ctx), {
     host: address.host,
     port: address.port,
     token: hasToken ? token : undefined,

--- a/packages/core/src/mcp/http.ts
+++ b/packages/core/src/mcp/http.ts
@@ -23,6 +23,7 @@ import {
   err,
   INVALID_REQUEST,
   type JsonRpcResponse,
+  type McpRequestContext,
   PARSE_ERROR,
 } from "./jsonrpc.ts";
 import { timingSafeEqual } from "./authz.ts";
@@ -82,7 +83,10 @@ function bearerToken(header: string | null): string | undefined {
  * Resolves when the server closes (abort {@link HttpTransportOptions.signal}).
  */
 export async function serveHttp(
-  handle: (message: unknown) => Promise<JsonRpcResponse | null>,
+  handle: (
+    message: unknown,
+    ctx: McpRequestContext,
+  ) => Promise<JsonRpcResponse | null>,
   options: HttpTransportOptions,
 ): Promise<void> {
   const { host, port, token, signal, onListen } = options;
@@ -91,8 +95,11 @@ export async function serveHttp(
   // parameter state, so concurrent handling of two POSTs would race. Requests
   // still arrive concurrently; this chain resolves them in arrival order.
   let queue: Promise<unknown> = Promise.resolve();
-  const serial = (message: unknown): Promise<JsonRpcResponse | null> => {
-    const result = queue.then(() => handle(message));
+  const serial = (
+    message: unknown,
+    ctx: McpRequestContext,
+  ): Promise<JsonRpcResponse | null> => {
+    const result = queue.then(() => handle(message, ctx));
     queue = result.then(() => {}, () => {});
     return result;
   };
@@ -125,7 +132,7 @@ export async function serveHttp(
     } catch {
       return jsonResponse(err(null, PARSE_ERROR, "Parse error"), 400);
     }
-    const response = await serial(message);
+    const response = await serial(message, { headers: request.headers });
     if (response === null) return new Response(null, { status: 202 });
     return jsonResponse(response, 200);
   };

--- a/packages/core/src/mcp/jsonrpc.ts
+++ b/packages/core/src/mcp/jsonrpc.ts
@@ -73,13 +73,72 @@ export interface ByteWriter {
 }
 
 /**
+ * The per-request context a transport hands the message handler. Carries the
+ * request's headers, so a server's identity hook can authenticate the caller
+ * from a trusted proxy header. Empty on the stdio transport (no headers).
+ */
+export interface McpRequestContext {
+  /** The request headers; an empty {@link Headers} on stdio. */
+  readonly headers: Headers;
+}
+
+/**
+ * A trusted caller identity, resolved per request by a {@link McpIdentityHook}
+ * (typically from an authenticating reverse proxy's header). Its
+ * {@link McpIdentity.actor} is the highest-precedence attribution — it overrides
+ * `--actor`, the environment, and the client's self-reported label for the call.
+ */
+export interface McpIdentity {
+  /** The authenticated actor (e.g. an OAuth subject). */
+  actor: string;
+  /** How the identity was established (e.g. `"oauth-proxy"`); informational. */
+  via?: string;
+}
+
+/**
+ * Resolve a trusted {@link McpIdentity} from a request's context. Invoked once
+ * per message, before any dispatch; **throwing rejects the whole request** with
+ * an auth error, so nothing executes and nothing is written to state — the seam
+ * a proxy in front of the server uses to inject an authenticated identity.
+ */
+export type McpIdentityHook = (ctx: McpRequestContext) => McpIdentity;
+
+/**
+ * Run an identity `hook` and return its trusted actor, or `null` when the hook
+ * throws or yields an unusable actor (empty, or not a string). A caller must
+ * reject the request on `null` rather than fall back to a static actor — the
+ * hook's precedence is absolute and fail-closed, so a missing identity is a
+ * rejection, never an anonymous/spoofable attribution.
+ */
+export function resolveIdentity(
+  hook: McpIdentityHook,
+  ctx: McpRequestContext,
+): string | null {
+  let actor: unknown;
+  try {
+    // Guard both the call and the property read: a hook returning `undefined`
+    // (looser JS typing) must be rejected, not throw out of the dispatch loop.
+    actor = hook(ctx).actor;
+  } catch {
+    return null;
+  }
+  return typeof actor === "string" && actor !== "" ? actor : null;
+}
+
+/** The stdio transport's request context — no headers. */
+const STDIO_CONTEXT: McpRequestContext = { headers: new Headers() };
+
+/**
  * Read newline-delimited JSON-RPC messages from `input`, pass each parsed
  * message to `handle`, and write any non-null response back to `output`
  * (newline-framed). A line that is not valid JSON yields a parse-error response
  * with a null id, per JSON-RPC. Returns when the input stream ends.
  */
 export async function serveStdio(
-  handle: (message: unknown) => Promise<JsonRpcResponse | null>,
+  handle: (
+    message: unknown,
+    ctx: McpRequestContext,
+  ) => Promise<JsonRpcResponse | null>,
   input: ReadableStream<Uint8Array> = Deno.stdin.readable,
   output: ByteWriter = Deno.stdout,
 ): Promise<void> {
@@ -98,7 +157,7 @@ export async function serveStdio(
       await send(err(null, PARSE_ERROR, "Parse error"));
       return;
     }
-    const response = await handle(message);
+    const response = await handle(message, STDIO_CONTEXT);
     if (response !== null) await send(response);
   };
 

--- a/packages/core/src/mcp/registry_server.ts
+++ b/packages/core/src/mcp/registry_server.ts
@@ -47,9 +47,13 @@ import {
   err,
   INTERNAL_ERROR,
   INVALID_PARAMS,
+  INVALID_REQUEST,
   type JsonRpcResponse,
+  type McpIdentityHook,
+  type McpRequestContext,
   METHOD_NOT_FOUND,
   ok,
+  resolveIdentity,
 } from "./jsonrpc.ts";
 
 /** The `run:` prefix that names a per-target execution tool. */
@@ -65,6 +69,16 @@ export interface RegistryRunResult {
   stderr: string;
 }
 
+/** Extra context a {@link RegistryRunner} may honour when spawning a build. */
+export interface RegistryRunOptions {
+  /**
+   * The resolved caller actor. The default runner exports it as `ZUKE_ACTOR` in
+   * the child environment so the spawned build attributes its run to the same
+   * (trusted, when an identity hook is active) actor as the MCP audit trail.
+   */
+  actor?: string;
+}
+
 /**
  * Spawns a registered build and captures its output. The default
  * ({@link defaultRegistryRunner}) uses {@link Deno.Command}; tests inject a fake
@@ -73,16 +87,26 @@ export interface RegistryRunResult {
 export type RegistryRunner = (
   argv: readonly string[],
   cwd: string,
+  options?: RegistryRunOptions,
 ) => Promise<RegistryRunResult>;
 
 /** The real, `Deno`-backed {@link RegistryRunner}. */
-export const defaultRegistryRunner: RegistryRunner = async (argv, cwd) => {
+export const defaultRegistryRunner: RegistryRunner = async (
+  argv,
+  cwd,
+  options,
+) => {
   // The build inherits the server's environment (that is how it resolves its own
   // parameters), but the MCP server's *authorization* secrets are stripped — a
   // spawned pipeline must not be able to read the operator or HTTP bearer token.
   const env = Deno.env.toObject();
   delete env.ZUKE_OPERATOR_TOKEN;
   delete env.ZUKE_MCP_TOKEN;
+  // Attribute the child run to the resolved caller (a trusted identity when a
+  // hook is active), overriding any inherited ZUKE_ACTOR.
+  if (options?.actor !== undefined && options.actor !== "") {
+    env.ZUKE_ACTOR = options.actor;
+  }
   const command = new Deno.Command(argv[0], {
     args: [...argv.slice(1)],
     cwd,
@@ -119,8 +143,16 @@ export interface RegistryMcpServerOptions {
   confirmDestructive?: boolean;
   /** The durable store; when set, every mutating/denied call is audited. */
   stateStore?: StateStore;
-  /** Who to attribute audited calls to (`--actor`), highest precedence. */
+  /** Who to attribute audited calls to (`--actor`); below {@link identity}. */
   actor?: string;
+  /**
+   * Resolve a trusted caller identity per request (e.g. from an authenticating
+   * reverse proxy's header). When set, its actor overrides `--actor`, the
+   * environment, and the client label for every call — flowing to the audit
+   * trail and to the spawned build (as `ZUKE_ACTOR`) — and a throwing hook
+   * rejects the request before anything spawns. Off by default.
+   */
+  identity?: McpIdentityHook;
   /** Reads an environment variable (injectable for tests). */
   readEnv?: (name: string) => string | undefined;
   /** The server version reported in `initialize`. Defaults to `"0.0.0"`. */
@@ -135,6 +167,9 @@ const CONTROL_KEYS: ReadonlySet<string> = new Set([
   "confirm",
   "operatorToken",
 ]);
+
+/** The request context handed to {@link RegistryMcpServer.handleMessage} on stdio. */
+const EMPTY_CONTEXT: McpRequestContext = { headers: new Headers() };
 
 /** The MCP result content for a single block of text. */
 function textResult(text: string, isError = false): Record<string, unknown> {
@@ -273,6 +308,7 @@ export class RegistryMcpServer {
   readonly #confirmDestructive: boolean;
   readonly #store?: StateStore;
   readonly #actor?: string;
+  readonly #identity?: McpIdentityHook;
   readonly #readEnv: (name: string) => string | undefined;
   readonly #runner: RegistryRunner;
   /** The connecting client's `initialize` name, a low-priority audit actor. */
@@ -295,6 +331,7 @@ export class RegistryMcpServer {
     this.#confirmDestructive = options.confirmDestructive ?? false;
     this.#store = options.stateStore;
     this.#actor = options.actor;
+    this.#identity = options.identity;
     this.#readEnv = options.readEnv ?? (() => undefined);
     this.#version = options.version ?? "0.0.0";
     this.#runner = options.runner ?? defaultRegistryRunner;
@@ -304,7 +341,10 @@ export class RegistryMcpServer {
    * Handle one parsed JSON-RPC message. Returns the response to send, or `null`
    * for a notification (which takes no reply).
    */
-  async handleMessage(message: unknown): Promise<JsonRpcResponse | null> {
+  async handleMessage(
+    message: unknown,
+    ctx: McpRequestContext = EMPTY_CONTEXT,
+  ): Promise<JsonRpcResponse | null> {
     if (
       typeof message !== "object" || message === null ||
       !("method" in message) || typeof message.method !== "string"
@@ -316,6 +356,17 @@ export class RegistryMcpServer {
     const params = "params" in message ? message.params : undefined;
 
     if (id === null && method.startsWith("notifications/")) return null;
+
+    // Resolve the trusted caller identity once, before any dispatch. A throwing
+    // hook — or one that yields no usable actor — rejects the whole request:
+    // nothing spawns, nothing is written, and it never falls back to the
+    // (untrusted) static actor, so the hook's precedence stays absolute.
+    let identityActor: string | undefined;
+    if (this.#identity !== undefined) {
+      const resolved = resolveIdentity(this.#identity, ctx);
+      if (resolved === null) return err(id, INVALID_REQUEST, "Unauthorized");
+      identityActor = resolved;
+    }
 
     switch (method) {
       case "initialize":
@@ -336,7 +387,7 @@ export class RegistryMcpServer {
         // Backstop: no tool call may crash the transport. Anything unforeseen
         // becomes a generic error so no raw detail escapes.
         try {
-          return await this.#callTool(id, params);
+          return await this.#callTool(id, params, identityActor);
         } catch {
           return err(
             id,
@@ -475,10 +526,11 @@ export class RegistryMcpServer {
     };
   }
 
-  /** Dispatch a `tools/call`. */
+  /** Dispatch a `tools/call`, attributed to `actor` (the resolved caller). */
   async #callTool(
     id: string | number | null,
     params: unknown,
+    actor: string | undefined,
   ): Promise<JsonRpcResponse> {
     if (!isRecord(params) || !("name" in params)) {
       return err(id, INVALID_PARAMS, "tools/call requires a tool name");
@@ -496,7 +548,7 @@ export class RegistryMcpServer {
       return ok(id, await this.#describeBuild(args));
     }
     if (name.startsWith(RUN_PREFIX)) {
-      return await this.#run(id, name.slice(RUN_PREFIX.length), args);
+      return await this.#run(id, name.slice(RUN_PREFIX.length), args, actor);
     }
     return ok(id, textResult(`Unknown tool: ${name}`, true));
   }
@@ -526,10 +578,12 @@ export class RegistryMcpServer {
     id: string | number | null,
     qualified: string,
     args: Record<string, unknown>,
+    identityActor: string | undefined,
   ): Promise<JsonRpcResponse> {
     const runName = `${RUN_PREFIX}${qualified}`;
+    const actor = identityActor ?? this.#resolveActor();
     if (!this.#allowRun) {
-      await this.#audit(runName, args, "denied", "run_disabled");
+      await this.#audit(runName, args, "denied", actor, "run_disabled");
       return ok(
         id,
         textResult(
@@ -549,7 +603,7 @@ export class RegistryMcpServer {
     // Unknown build/target and a non-allow-listed one are reported identically,
     // so a denial never reveals which protected pipelines exist.
     if (!known || !this.#allowMatch(qualified)) {
-      await this.#audit(runName, args, "denied", "not_allowed");
+      await this.#audit(runName, args, "denied", actor, "not_allowed");
       return ok(id, textResult(`Unknown tool: ${runName}`, true));
     }
 
@@ -562,7 +616,7 @@ export class RegistryMcpServer {
     if (this.#isProtected(qualified)) {
       const denial = this.#checkOperatorToken(args);
       if (denial !== null) {
-        await this.#audit(runName, args, "denied", denial, knownParams);
+        await this.#audit(runName, args, "denied", actor, denial, knownParams);
         return ok(
           id,
           textResult(
@@ -589,6 +643,7 @@ export class RegistryMcpServer {
         runName,
         args,
         "error",
+        actor,
         "invalid_arguments",
         knownParams,
       );
@@ -635,6 +690,7 @@ export class RegistryMcpServer {
         runName,
         args,
         "error",
+        actor,
         "no_launch_command",
         knownParams,
       );
@@ -649,9 +705,16 @@ export class RegistryMcpServer {
 
     let result: RegistryRunResult;
     try {
-      result = await this.#runner(launch.argv, launch.cwd);
+      result = await this.#runner(launch.argv, launch.cwd, { actor });
     } catch (error) {
-      await this.#audit(runName, args, "error", "spawn_failed", knownParams);
+      await this.#audit(
+        runName,
+        args,
+        "error",
+        actor,
+        "spawn_failed",
+        knownParams,
+      );
       const kind = error instanceof Error ? error.name : "Error";
       return ok(
         id,
@@ -662,6 +725,7 @@ export class RegistryMcpServer {
       runName,
       args,
       result.code === 0 ? "ok" : "error",
+      actor,
       undefined,
       knownParams,
     );
@@ -726,6 +790,7 @@ export class RegistryMcpServer {
     tool: string,
     args: Record<string, unknown>,
     outcome: RunEventOutcome,
+    actor: string,
     detail?: string,
     known: ReadonlySet<string> = EMPTY_NAMES,
   ): Promise<void> {
@@ -734,7 +799,7 @@ export class RegistryMcpServer {
     const event: RunEvent = {
       at: new Date().toISOString(),
       tool,
-      actor: this.#resolveActor(),
+      actor,
       outcome,
       args: auditArgs(args, known),
     };

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -40,9 +40,13 @@ import {
   err,
   INTERNAL_ERROR,
   INVALID_PARAMS,
+  INVALID_REQUEST,
   type JsonRpcResponse,
+  type McpIdentityHook,
+  type McpRequestContext,
   METHOD_NOT_FOUND,
   ok,
+  resolveIdentity,
 } from "./jsonrpc.ts";
 
 /**
@@ -61,6 +65,9 @@ export const PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSIONS[0];
 
 /** The `run:` prefix that names a per-target execution tool. */
 const RUN_PREFIX = "run:";
+
+/** The request context handed to {@link McpServer.handleMessage} on stdio (no headers). */
+const EMPTY_CONTEXT: McpRequestContext = { headers: new Headers() };
 
 /** A JSON Schema fragment (kept loose — MCP only needs plain JSON Schema). */
 type JsonSchema = Record<string, unknown>;
@@ -116,8 +123,16 @@ export interface McpServerOptions {
    * tool call is written to the audit log.
    */
   stateStore?: StateStore;
-  /** Who to attribute audited calls to (`--actor`), highest precedence. */
+  /** Who to attribute audited calls to (`--actor`); below {@link identity}. */
   actor?: string;
+  /**
+   * Resolve a trusted caller identity per request (e.g. from an authenticating
+   * reverse proxy's header). When set, its actor overrides `--actor`, the
+   * environment, and the client's self-reported label for every call, and a
+   * throwing hook rejects the request before anything runs. Off by default, so
+   * stdio/local use is unchanged.
+   */
+  identity?: McpIdentityHook;
   /** Reads an environment variable (injectable for tests). */
   readEnv?: (name: string) => string | undefined;
   /** The server version reported in `initialize`. Defaults to `"0.0.0"`. */
@@ -196,6 +211,7 @@ export class McpServer {
   readonly #confirmDestructive: boolean;
   readonly #store?: StateStore;
   readonly #actor?: string;
+  readonly #identity?: McpIdentityHook;
   readonly #readEnv: (name: string) => string | undefined;
   /** The connecting client's `initialize` name, a low-priority audit actor. */
   #clientLabel?: string;
@@ -223,6 +239,7 @@ export class McpServer {
     this.#confirmDestructive = options.confirmDestructive ?? false;
     this.#store = options.stateStore;
     this.#actor = options.actor;
+    this.#identity = options.identity;
     this.#readEnv = options.readEnv ?? (() => undefined);
     this.#version = options.version ?? "0.0.0";
   }
@@ -322,7 +339,10 @@ export class McpServer {
    * Handle one parsed JSON-RPC message. Returns the response to send, or `null`
    * for a notification (which takes no reply).
    */
-  async handleMessage(message: unknown): Promise<JsonRpcResponse | null> {
+  async handleMessage(
+    message: unknown,
+    ctx: McpRequestContext = EMPTY_CONTEXT,
+  ): Promise<JsonRpcResponse | null> {
     if (
       typeof message !== "object" || message === null ||
       !("method" in message) || typeof message.method !== "string"
@@ -336,6 +356,17 @@ export class McpServer {
     // Notifications (no id) never receive a response.
     if (id === null && method.startsWith("notifications/")) return null;
 
+    // Resolve the trusted caller identity once, before any dispatch. A throwing
+    // hook — or one that yields no usable actor — rejects the whole request:
+    // nothing runs, nothing is written, and it never falls back to the
+    // (untrusted) static actor, so the hook's precedence stays absolute.
+    let identityActor: string | undefined;
+    if (this.#identity !== undefined) {
+      const resolved = resolveIdentity(this.#identity, ctx);
+      if (resolved === null) return err(id, INVALID_REQUEST, "Unauthorized");
+      identityActor = resolved;
+    }
+
     switch (method) {
       case "initialize":
         return ok(id, this.#initialize(params));
@@ -348,7 +379,7 @@ export class McpServer {
         // already structured tool results; this catches anything unforeseen and
         // returns a JSON-RPC error (generic, so no raw detail can escape).
         try {
-          return await this.#callTool(id, params);
+          return await this.#callTool(id, params, identityActor);
         } catch {
           return err(
             id,
@@ -396,10 +427,11 @@ export class McpServer {
     };
   }
 
-  /** Dispatch a `tools/call`. */
+  /** Dispatch a `tools/call`, attributed to `actor` (the resolved caller). */
   async #callTool(
     id: string | number | null,
     params: unknown,
+    actor: string | undefined,
   ): Promise<JsonRpcResponse> {
     if (!isRecord(params) || !("name" in params)) {
       return err(id, INVALID_PARAMS, "tools/call requires a tool name");
@@ -420,9 +452,9 @@ export class McpServer {
       return ok(id, textResult(this.#describe().graph));
     }
     if (name.startsWith(RUN_PREFIX)) {
-      return await this.#run(id, name.slice(RUN_PREFIX.length), args);
+      return await this.#run(id, name.slice(RUN_PREFIX.length), args, actor);
     }
-    const runStateResult = await this.#callRunStateTool(name, args);
+    const runStateResult = await this.#callRunStateTool(name, args, actor);
     if (runStateResult !== null) return ok(id, runStateResult);
     // An unknown tool is reported through the result (isError), per MCP, so the
     // model sees it rather than a transport-level failure.
@@ -438,9 +470,11 @@ export class McpServer {
   async #callRunStateTool(
     name: string,
     args: Record<string, unknown>,
+    identityActor: string | undefined,
   ): Promise<Record<string, unknown> | null> {
     const store = this.#store;
     if (store === undefined) return null;
+    const actor = identityActor ?? this.#resolveActor();
     const mutating = isMutatingRunTool(name);
     if (mutating && !this.#allowRun) {
       return textResult(
@@ -453,7 +487,7 @@ export class McpServer {
       {
         store,
         build: this.build,
-        actor: this.#resolveActor(),
+        actor,
         readEnv: this.#readEnv,
         authorize: (targetName, callArgs) =>
           this.#authorizeTarget(targetName, callArgs),
@@ -463,7 +497,7 @@ export class McpServer {
     );
     if (result === null) return null;
     if (mutating) {
-      await this.#audit(name, args, result.isError ? "error" : "ok");
+      await this.#audit(name, args, result.isError ? "error" : "ok", actor);
     }
     return textResult(result.text, result.isError);
   }
@@ -490,11 +524,13 @@ export class McpServer {
     id: string | number | null,
     targetName: string,
     args: Record<string, unknown>,
+    identityActor: string | undefined,
   ): Promise<JsonRpcResponse> {
     const runName = `${RUN_PREFIX}${targetName}`;
+    const actor = identityActor ?? this.#resolveActor();
     // Execution off entirely: a generic message (reveals no specific target).
     if (!this.#allowRun) {
-      await this.#audit(runName, args, "denied", "run_disabled");
+      await this.#audit(runName, args, "denied", actor, "run_disabled");
       return ok(
         id,
         textResult(
@@ -508,7 +544,7 @@ export class McpServer {
     // A target that is unknown OR not in the allow-list is reported identically,
     // so a denial never reveals which protected targets exist.
     if (root === undefined || !this.#allowMatch(targetName)) {
-      await this.#audit(runName, args, "denied", "not_allowed");
+      await this.#audit(runName, args, "denied", actor, "not_allowed");
       return ok(id, textResult(`Unknown tool: ${runName}`, true));
     }
 
@@ -517,7 +553,7 @@ export class McpServer {
     if (this.#isProtected(targetName)) {
       const denial = this.#checkOperatorToken(args);
       if (denial !== null) {
-        await this.#audit(runName, args, "denied", denial);
+        await this.#audit(runName, args, "denied", actor, denial);
         return ok(
           id,
           textResult(
@@ -576,7 +612,7 @@ export class McpServer {
       else values[paramName] = coerced;
     }
     if (badArgs.length > 0) {
-      await this.#audit(runName, args, "error", "invalid_arguments");
+      await this.#audit(runName, args, "error", actor, "invalid_arguments");
       return ok(
         id,
         textResult(
@@ -602,11 +638,11 @@ export class McpServer {
         reporter: buffer.reporter,
         dryRun,
         github: false,
-        actor: this.#resolveActor(),
+        actor,
         readEnv: this.#readEnv,
       });
     } catch (error) {
-      await this.#audit(runName, args, "error", "execute_threw");
+      await this.#audit(runName, args, "error", actor, "execute_threw");
       const kind = error instanceof Error ? error.name : "Error";
       return ok(
         id,
@@ -616,7 +652,7 @@ export class McpServer {
         ),
       );
     }
-    await this.#audit(runName, args, result.ok ? "ok" : "error");
+    await this.#audit(runName, args, result.ok ? "ok" : "error", actor);
     const status = result.ok
       ? `\n\n✔ ${targetName} succeeded.`
       : `\n\n✘ ${targetName} failed.`;
@@ -660,14 +696,16 @@ export class McpServer {
 
   /**
    * Append a tool call to the audit log (best-effort; never breaks a call).
-   * No-op without a store. `args` are sanitised by {@link "#auditArgs"} first —
-   * the operator token dropped, secret values masked wherever they appear — so
-   * nothing sensitive reaches the durable trail.
+   * No-op without a store. Attributed to `actor` — the trusted per-call identity
+   * when a hook is configured, else the resolved `--actor`/env/label. `args` are
+   * sanitised by {@link "#auditArgs"} first — the operator token dropped, secret
+   * values masked wherever they appear — so nothing sensitive reaches the trail.
    */
   async #audit(
     tool: string,
     args: Record<string, unknown>,
     outcome: RunEventOutcome,
+    actor: string,
     detail?: string,
   ): Promise<void> {
     const store = this.#store;
@@ -675,7 +713,7 @@ export class McpServer {
     const event: RunEvent = {
       at: new Date().toISOString(),
       tool,
-      actor: this.#resolveActor(),
+      actor,
       outcome,
       args: this.#auditArgs(args),
     };

--- a/packages/core/tests/mcp_hardening_test.ts
+++ b/packages/core/tests/mcp_hardening_test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertStringIncludes } from "./_assert.ts";
 import { Build, parameter, target } from "../mod.ts";
 import { McpServer, type McpServerOptions } from "../src/mcp/server.ts";
+import type { JsonRpcResponse } from "../src/mcp/jsonrpc.ts";
 import { FileSystemStateStore } from "../src/state/fs_store.ts";
 import { defaultStateHost } from "../src/state/store.ts";
 import { AUDIT_RUN_ID } from "../src/mcp/audit.ts";
@@ -424,4 +425,110 @@ Deno.test("a thrown framework error returns a structured result, not a crash", a
   } finally {
     await Deno.remove(dir, { recursive: true });
   }
+});
+
+// ---- M13: trusted per-call identity ----------------------------------------
+
+/** Send a tools/call with request headers (the transport's per-call context). */
+function callWith(
+  server: McpServer,
+  name: string,
+  headers: Record<string, string>,
+  args: Record<string, unknown> = {},
+): Promise<JsonRpcResponse | null> {
+  return server.handleMessage(
+    req("tools/call", { name, arguments: args }),
+    { headers: new Headers(headers) },
+  );
+}
+
+/** An identity hook that reads `x-user` and rejects a request that lacks it. */
+const xUser = (ctx: { headers: Headers }): { actor: string } => {
+  const sub = ctx.headers.get("x-user");
+  if (sub === null) throw new Error("no identity from proxy");
+  return { actor: sub };
+};
+
+Deno.test("an identity hook overrides --actor and the client label", async () => {
+  await withServer({ allowRun: true, actor: "ci-bot", identity: xUser }, async (
+    server,
+    store,
+  ) => {
+    // The client self-reports a name; the hook (and its header) must win.
+    await server.handleMessage(
+      req("initialize", { clientInfo: { name: "spoofed" } }),
+      { headers: new Headers({ "x-user": "engineer-a" }) },
+    );
+    await callWith(server, "run:deploy", { "x-user": "engineer-a" }, {
+      environment: "dev",
+    });
+    const deploy = (await auditEvents(store)).find((e) =>
+      e.tool === "run:deploy"
+    );
+    assertEquals(deploy?.actor, "engineer-a");
+  });
+});
+
+Deno.test("a run and a later signal are attributed to their own callers", async () => {
+  await withServer(
+    { allowRun: true, identity: xUser },
+    async (server, store) => {
+      // Engineer A runs deploy…
+      await callWith(server, "run:deploy", { "x-user": "engineer-a" }, {
+        environment: "dev",
+      });
+      // …and engineer B signals a suspended run.
+      const id = await seedSuspended(store, "deploy");
+      await callWith(server, "signal_run", { "x-user": "engineer-b" }, {
+        runId: id,
+        signal: "go",
+      });
+      const events = await auditEvents(store);
+      assertEquals(
+        events.find((e) => e.tool === "run:deploy")?.actor,
+        "engineer-a",
+      );
+      assertEquals(
+        events.find((e) => e.tool === "signal_run")?.actor,
+        "engineer-b",
+      );
+    },
+  );
+});
+
+Deno.test("a throwing identity hook rejects the request and writes nothing", async () => {
+  await withServer(
+    { allowRun: true, identity: xUser },
+    async (server, store) => {
+      // No `x-user` header → the hook throws → a JSON-RPC auth error.
+      const res = await callWith(server, "run:deploy", {}, {
+        environment: "dev",
+      });
+      assertEquals(res?.result, undefined);
+      assertEquals(res?.error?.message, "Unauthorized");
+      // Nothing was audited.
+      assertEquals((await auditEvents(store)).length, 0);
+    },
+  );
+});
+
+Deno.test("a hook yielding an empty actor is rejected, never the static fallback", async () => {
+  // The natural idiom `headers.get(...) ?? ""` yields `{ actor: "" }` — a valid
+  // string, no throw — when the header is missing. It must reject (fail-closed),
+  // NOT silently attribute the call to the static `--actor`/env.
+  await withServer(
+    {
+      allowRun: true,
+      actor: "ci-bot",
+      identity: (ctx) => ({ actor: ctx.headers.get("x-user") ?? "" }),
+    },
+    async (server, store) => {
+      const res = await callWith(server, "run:deploy", {}, {
+        environment: "dev",
+      });
+      assertEquals(res?.error?.message, "Unauthorized");
+      // Neither audited nor attributed to the untrusted static actor.
+      assertEquals((await auditEvents(store)).length, 0);
+    },
+  );
 });

--- a/packages/core/tests/mcp_http_test.ts
+++ b/packages/core/tests/mcp_http_test.ts
@@ -1,9 +1,11 @@
 import { assertEquals, assertStringIncludes } from "./_assert.ts";
-import { Build, target } from "../mod.ts";
+import { Build, type McpRequestContext, target } from "../mod.ts";
 import type { JsonRpcResponse } from "../src/mcp/jsonrpc.ts";
 import { McpServer } from "../src/mcp/server.ts";
 import { serveHttp } from "../src/mcp/http.ts";
 import { serveMcp } from "../src/mcp/command.ts";
+import { FileSystemStateStore } from "../src/state/fs_store.ts";
+import { defaultStateHost } from "../src/state/store.ts";
 
 /** A minimal build for the transport tests. */
 class Demo extends Build {
@@ -199,5 +201,64 @@ Deno.test("serveMcp refuses a non-loopback HTTP bind without a token", async () 
     assertStringIncludes(errs.join("\n"), "must be authenticated");
   } finally {
     console.error = origErr;
+  }
+});
+
+Deno.test("serveMcp applies the build's identity hook to HTTP requests", async () => {
+  // A build declaring a per-call identity hook via the override seam.
+  class Guarded extends Build {
+    deploy = target().description("Deploy").executes(() => {});
+    override mcpIdentity() {
+      return (ctx: McpRequestContext) => {
+        const user = ctx.headers.get("x-user");
+        if (user === null) throw new Error("no identity from proxy");
+        return { actor: user, via: "test-proxy" };
+      };
+    }
+  }
+  const dir = await Deno.makeTempDir();
+  const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+  const ac = new AbortController();
+  let setPort = (_: number) => {};
+  const portReady = new Promise<number>((r) => (setPort = r));
+  const finished = serveMcp(new Guarded(), {
+    http: { host: "127.0.0.1", port: 0 },
+    allowRun: true,
+    stateStore: store,
+    quiet: true,
+    signal: ac.signal,
+    onListen: (a) => setPort(a.port),
+  });
+  const url = `http://127.0.0.1:${await portReady}/`;
+  try {
+    // A request carrying the trusted header runs and is audited to that actor.
+    const ok = await fetch(url, {
+      method: "POST",
+      headers: { "x-user": "engineer-a" },
+      body: rpc("tools/call", 1, { name: "run:deploy", arguments: {} }),
+    });
+    assertEquals(ok.status, 200);
+    await ok.json();
+
+    // A request WITHOUT the header is rejected — the hook throws, nothing runs.
+    const denied = await fetch(url, {
+      method: "POST",
+      body: rpc("tools/call", 2, { name: "run:deploy", arguments: {} }),
+    });
+    assertEquals(denied.status, 200); // JSON-RPC error travels in the 200 body
+    const deniedBody = await denied.json();
+    assertEquals(deniedBody.error.message, "Unauthorized");
+
+    // The audit trail names the trusted actor for the successful call only.
+    const events = (await store.getRun("mcp-audit"))?.record.events ?? [];
+    assertEquals(
+      events.some((e) => e.tool === "run:deploy" && e.actor === "engineer-a"),
+      true,
+    );
+    assertEquals(events.every((e) => e.actor !== "anonymous"), true);
+  } finally {
+    ac.abort();
+    await finished;
+    await Deno.remove(dir, { recursive: true });
   }
 });

--- a/packages/core/tests/registry_server_test.ts
+++ b/packages/core/tests/registry_server_test.ts
@@ -6,7 +6,11 @@
 
 import { assertEquals, assertStringIncludes } from "./_assert.ts";
 import { Build } from "../src/build.ts";
-import { type ByteWriter, METHOD_NOT_FOUND } from "../src/mcp/jsonrpc.ts";
+import {
+  type ByteWriter,
+  type JsonRpcResponse,
+  METHOD_NOT_FOUND,
+} from "../src/mcp/jsonrpc.ts";
 import { PROTOCOL_VERSION } from "../src/mcp/server.ts";
 import { serveMcp } from "../src/mcp/command.ts";
 import {
@@ -123,13 +127,16 @@ function descriptor(
   };
 }
 
-/** A runner that records every spawn and returns a fixed result. */
+/** A runner that records every spawn (argv, cwd, actor) and returns a fixed result. */
 function recordingRunner(
   result: RegistryRunResult = { code: 0, stdout: "ran", stderr: "" },
-): { runner: RegistryRunner; calls: { argv: string[]; cwd: string }[] } {
-  const calls: { argv: string[]; cwd: string }[] = [];
-  const runner: RegistryRunner = (argv, cwd) => {
-    calls.push({ argv: [...argv], cwd });
+): {
+  runner: RegistryRunner;
+  calls: { argv: string[]; cwd: string; actor?: string }[];
+} {
+  const calls: { argv: string[]; cwd: string; actor?: string }[] = [];
+  const runner: RegistryRunner = (argv, cwd, options) => {
+    calls.push({ argv: [...argv], cwd, actor: options?.actor });
     return Promise.resolve(result);
   };
   return { runner, calls };
@@ -947,4 +954,115 @@ Deno.test("a malformed default/enum from an untrusted descriptor is dropped from
   // The schema is well-formed: a number type with neither a string enum nor a
   // non-numeric default.
   assertEquals(workers, { type: "number" });
+});
+
+// ---- M13: trusted per-call identity ----------------------------------------
+
+/** Send a tools/call with the given request headers. */
+function callWith(
+  server: RegistryMcpServer,
+  name: string,
+  headers: Record<string, string>,
+  args: Record<string, unknown> = {},
+): Promise<JsonRpcResponse | null> {
+  return server.handleMessage(
+    req("tools/call", { name, arguments: args }),
+    { headers: new Headers(headers) },
+  );
+}
+
+Deno.test("an identity hook attributes the call to the trusted actor, not the label", async () => {
+  const registry = new FakeRegistry();
+  registry.add(descriptor("Api", ["deploy"]));
+  const store = new FileSystemStateStore("/state", new FakeStateHost());
+  const { runner, calls } = recordingRunner();
+  const server = new RegistryMcpServer(registry, {
+    allowRun: true,
+    runner,
+    stateStore: store,
+    actor: "config-actor", // even an explicit --actor is overridden by the hook
+    identity: (ctx) => {
+      const sub = ctx.headers.get("x-user");
+      if (sub === null) throw new Error("no identity from proxy");
+      return { actor: sub, via: "oauth-proxy" };
+    },
+  });
+
+  // The client self-reports a name; the hook must win over it.
+  await server.handleMessage(
+    req("initialize", { clientInfo: { name: "spoofed-client" } }),
+    { headers: new Headers({ "x-user": "engineer-a" }) },
+  );
+  const res = await callWith(server, "run:Api:deploy", {
+    "x-user": "engineer-a",
+  });
+  assertEquals(res?.result !== undefined, true);
+
+  // The audit trail and the spawned child both name the trusted actor.
+  const events = (await store.getRun("mcp-audit"))?.record.events ?? [];
+  assertEquals(events.length > 0, true);
+  assertEquals(events.every((e) => e.actor === "engineer-a"), true);
+  assertEquals(calls.length, 1);
+  assertEquals(calls[0].actor, "engineer-a");
+});
+
+Deno.test("a throwing identity hook rejects the request and writes nothing", async () => {
+  const registry = new FakeRegistry();
+  registry.add(descriptor("Api", ["deploy"]));
+  const store = new FileSystemStateStore("/state", new FakeStateHost());
+  const { runner, calls } = recordingRunner();
+  const server = new RegistryMcpServer(registry, {
+    allowRun: true,
+    runner,
+    stateStore: store,
+    identity: (ctx) => {
+      const sub = ctx.headers.get("x-user");
+      if (sub === null) throw new Error("no identity from proxy");
+      return { actor: sub };
+    },
+  });
+
+  // No `x-user` header → the hook throws → a JSON-RPC auth error, no dispatch.
+  const res = await callWith(server, "run:Api:deploy", {});
+  assertEquals(res?.result, undefined);
+  assertEquals(res?.error?.message, "Unauthorized");
+  // Nothing executed and nothing was written to the audit trail.
+  assertEquals(calls.length, 0);
+  assertEquals(await store.getRun("mcp-audit"), null);
+});
+
+Deno.test("without an identity hook, attribution is unchanged (stdio/local)", async () => {
+  const registry = new FakeRegistry();
+  registry.add(descriptor("Api", ["deploy"]));
+  const store = new FileSystemStateStore("/state", new FakeStateHost());
+  const { runner } = recordingRunner();
+  const server = new RegistryMcpServer(registry, {
+    allowRun: true,
+    runner,
+    stateStore: store,
+    actor: "ci-bot",
+  });
+  await call(server, "run:Api:deploy");
+  const events = (await store.getRun("mcp-audit"))?.record.events ?? [];
+  assertEquals(events.every((e) => e.actor === "ci-bot"), true);
+});
+
+Deno.test("a hook yielding an empty actor is rejected, never a spawn", async () => {
+  const registry = new FakeRegistry();
+  registry.add(descriptor("Api", ["deploy"]));
+  const store = new FileSystemStateStore("/state", new FakeStateHost());
+  const { runner, calls } = recordingRunner();
+  const server = new RegistryMcpServer(registry, {
+    allowRun: true,
+    runner,
+    stateStore: store,
+    actor: "ci-bot", // the static fallback that must NOT be used
+    // `headers.get(...) ?? ""` yields `{ actor: "" }` on a missing header.
+    identity: (ctx) => ({ actor: ctx.headers.get("x-user") ?? "" }),
+  });
+  const res = await callWith(server, "run:Api:deploy", {});
+  assertEquals(res?.error?.message, "Unauthorized");
+  // No spawn (so no child ZUKE_ACTOR), and nothing audited.
+  assertEquals(calls.length, 0);
+  assertEquals(await store.getRun("mcp-audit"), null);
 });

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -159,6 +159,10 @@ Before calling any task or settings method, confirm the real shape:
   instead serves every registered pipeline live, each as a
   `run:<buildId>:<target>` tool that takes the build's declared parameters
   (secrets excluded, validated, forwarded to the spawn) — see the cheatsheet.
+  For a shared, multi-user endpoint, `override mcpIdentity()` resolves a
+  **trusted** caller per request from an authenticating proxy's header (it
+  overrides the client-reported actor and flows to the audit trail, run records,
+  and lock holders; a throwing hook rejects the request).
 - **AI review & self-healing (`@zuke/ai`):** gate a target on a structured LLM
   review of the diff (`securityReviewer(...)` etc. via `.validateBefore`), or
   attach `aiFixer(...)` with `.recoverWith(...)` so a failing target is

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -592,6 +592,16 @@ parameters are omitted from the descriptor entirely, so a secret can neither be
 requested nor forwarded; the child resolves it from its own environment /
 `.from()` source.
 
+**Trusted per-call identity** (`docs/mcp.md`): on a shared, multi-user endpoint,
+`override mcpIdentity()` returns a hook `(ctx) => ({ actor, via? })` that
+resolves the **real** caller from a request header an authenticating reverse
+proxy injects (`ctx.headers.get("x-forwarded-user")`). It runs once per request
+before any dispatch; its actor overrides `--actor`/env/the client label and
+flows to the audit trail, run records, lock holders, and a registry-spawned
+child's `ZUKE_ACTOR`. A **throwing hook rejects the request** (nothing runs,
+nothing is written). The minimal seam — TLS/OAuth/header-stripping is the
+proxy's job.
+
 **Caching:** a target with `.inputs(...)`/`.outputs(...)` is incremental
 (skipped and reported `cached` when inputs are unchanged and outputs exist). Add
 a **remote store** to share results across machines — a fresh CI checkout or a


### PR DESCRIPTION
## What

Round 2 / M13 (P0 #2). A per-request **identity hook** so a shared, multi-user MCP endpoint attributes each call to the *real* engineer (from an authenticating reverse proxy's header) instead of a client-self-reported label.

Before: attribution was `--actor` → `ZUKE_ACTOR` → `GITHUB_ACTOR` → the client's `initialize` name → `anonymous`. On a shared endpoint the client name is self-reported and worthless. The blocker was the transport: `serveHttp` discarded the request headers.

## Design

- **Transport ctx.** Each message now carries an `McpRequestContext` (the request headers on HTTP; empty on stdio). `serveStdio`/`serveHttp` and the `McpHandler` contract widen to `(message, ctx)`.
- **The hook.** Both `McpServer` and `RegistryMcpServer` gain an identity hook, reachable via the new **`Build.mcpIdentity()`** override (the CLI-reachable seam — `serveMcp` reads it) or the server option:

  ```ts
  class ControlPlane extends Build {
    override mcpIdentity() {
      return (ctx: McpRequestContext) => {
        const sub = ctx.headers.get("x-forwarded-user"); // proxy-injected
        if (!sub) throw new Error("no identity from proxy");
        return { actor: sub, via: "oauth-proxy" };
      };
    }
  }
  ```

  It runs **once per message, before any dispatch**. Its actor has **absolute precedence** over `--actor`/env/label and flows to the audit trail, run records, lock-holder identity, resume/signal attribution, and — for a registry-spawned build — the child's `ZUKE_ACTOR`.
- **Fail-closed.** A hook that throws *or* yields no usable actor rejects the request with an auth error — nothing executes, nothing is written, never a fallback to the static actor. Without a hook, stdio/local behavior is unchanged.
- The per-call actor is **threaded**, not stored on the instance, so it stays correct once the registry path is parallelized (M14). This is deliberately the *minimal* seam — TLS/OAuth/header-stripping is the proxy's job.

## Tests

- **Unit** — `mcp_hardening_test.ts` (in-process: hook overrides `--actor`/label; **A runs / B signals → event log shows A then B**; throwing hook rejects + writes nothing; empty-actor rejected, no static fallback); `registry_server_test.ts` (hook actor → audit **and** child `ZUKE_ACTOR`; throw/empty rejected, no spawn; no-hook unchanged).
- **Integration** — `mcp_http_test.ts`: `serveMcp` applies `Build.mcpIdentity()` to real HTTP requests — a header-carrying request is audited to that actor; a header-less one is rejected `Unauthorized`.

## Adversarial review

A 5-dimension workflow (auth-bypass, attribution-integrity, spoofing, crash/DoS, transport) with refute-by-default verification found **one confirmed medium**: the natural idiom `headers.get(…) ?? ""` yields `{ actor: "" }` (a valid string, no throw), and `"" ?? staticActor` let the untrusted static actor through — the audit recorded `""` while the run record/child fell back to `ZUKE_ACTOR`, silently breaking the fail-closed invariant. Fixed by a shared `resolveIdentity` that rejects an empty/non-string/undefined actor exactly like a throw, with regression tests on both servers.

## Docs

`docs/mcp.md` gains a "Trusted per-call identity" section; the `zuke-write-build` skill + cheatsheet document `mcpIdentity()`. `deno doc --lint` clean; `deno task ci` green; e2e suite green.