### PR TITLE
feat(core): concurrent registry MCP serving with a run cap

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -53,9 +53,12 @@ Each request is a `POST` whose body is one JSON-RPC message; the response is
 that message's JSON-RPC reply. A notification (no `id`) is answered
 `202 Accepted` with no body. Zuke never initiates server→client messages, so the
 optional server-sent-events stream is not implemented — a `GET` is answered
-`405`, and clients fall back to POST-only (which is spec-compliant). Messages
-are processed **one at a time**, mirroring stdio, so two concurrent runs of the
-one build can't race.
+`405`, and clients fall back to POST-only (which is spec-compliant). For the
+single-build server, messages are processed **one at a time**, mirroring stdio,
+so two concurrent runs of the one build can't race. The
+[registry server](#registry-mode-dynamic-discovery) — which has no shared
+in-process run state — instead handles requests **concurrently** (see its cap
+below), so one long `run:` never head-of-line-blocks another client's read.
 
 **Security defaults — a bridge, not an internet gateway:**
 
@@ -243,6 +246,14 @@ zuke mcp --registry --allow-run
   does still see the rest of the server's environment, so run a registry-backed
   server with **only the environment the registered pipelines should have** —
   treat it like any host that runs those builds.
+- **Concurrency.** Unlike the single-build server, the registry server handles
+  requests **concurrently** — a read tool (`list_builds`, `describe_build`) is
+  never blocked behind a running `run:` call, and independent runs proceed in
+  parallel. Concurrent run-tool **spawns** are capped (default 4,
+  `--max-concurrent-runs <n>`); a call past the cap gets an immediate structured
+  `at_capacity` busy error (`{ running, cap, hint }`) rather than an unbounded
+  queue. Read tools are never counted against the cap. Cross-process state
+  safety rides the store's CAS, so no new coordination is introduced.
 
 The registry resolves like the run store: `ZUKE_REGISTRY_URL`/`_TOKEN` or
 `ZUKE_REGISTRY_DIR`, a build's `registry()` override, else `.zuke/builds`.

--- a/llms.txt
+++ b/llms.txt
@@ -75,6 +75,7 @@ Option flags:
 - `--protect` — With mcp, require an operator token to run these targets
 - `--confirm-destructive` — With mcp, require confirm:true before a destructive run
 - `--registry` — With mcp, serve the build registry (dynamic pipeline discovery)
+- `--max-concurrent-runs` — With mcp --registry, cap concurrent run-tool spawns (default 4)
 - `--http` — With mcp, serve over HTTP on <host:port> instead of stdio
 - `--help` — Show usage
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -100,6 +100,8 @@ export interface ParsedArgs {
   confirmDestructive: boolean;
   /** Serve `mcp` over the build registry (dynamic discovery) rather than one build (`--registry`). */
   mcpRegistry: boolean;
+  /** Cap on concurrent registry run-tool spawns (`--max-concurrent-runs`). */
+  maxConcurrentRuns?: number;
   /** Serve `mcp` over HTTP on this `<host:port>` instead of stdio (`--http`). */
   httpAddr?: string;
   /** The `completions` sub-action (`install` or `print`); the first positional. */
@@ -166,6 +168,13 @@ function parseParallel(value: string | undefined): boolean | number {
   if (value === undefined || value === "") return true;
   const n = Number(value);
   return Number.isFinite(n) && n > 0 ? Math.floor(n) : true;
+}
+
+/** Parse a positive-integer flag value, or `undefined` when absent/invalid. */
+function parsePositiveInt(value: string | undefined): number | undefined {
+  if (value === undefined || value === "") return undefined;
+  const n = Number(value);
+  return Number.isInteger(n) && n > 0 ? n : undefined;
 }
 
 /**
@@ -274,6 +283,12 @@ export function parseArgs(
       parsed.confirmDestructive = true;
     } else if (arg === "--registry") {
       parsed.mcpRegistry = true;
+    } else if (arg.startsWith("--max-concurrent-runs=")) {
+      parsed.maxConcurrentRuns = parsePositiveInt(
+        arg.slice("--max-concurrent-runs=".length),
+      );
+    } else if (arg === "--max-concurrent-runs") {
+      parsed.maxConcurrentRuns = parsePositiveInt(args[++i]);
     } else if (arg === "--http") {
       const value = args[++i];
       if (value) parsed.httpAddr = value;
@@ -426,6 +441,10 @@ Options:
                     live so a newly-registered build appears with no restart. A
                     run tool spawns the registered build's launch command (behind
                     --allow-run + the same authz). See docs/registry.md.
+  --max-concurrent-runs <n>
+                    With mcp --registry, the most run-tool spawns allowed at
+                    once (default 4). A call past the cap gets an immediate busy
+                    error; read tools are never blocked or counted.
   --http <host:port>
                     With mcp, serve the streamable-HTTP transport on the given
                     address instead of stdio. Just <port> binds 127.0.0.1. A
@@ -741,6 +760,7 @@ async function runMcp(build: Build, parsed: ParsedArgs): Promise<number> {
     protectPatterns: parsed.protectPatterns,
     confirmDestructive: parsed.confirmDestructive,
     useRegistry: parsed.mcpRegistry,
+    maxConcurrentRuns: parsed.maxConcurrentRuns,
     actor: parsed.actor,
     http,
   });

--- a/packages/core/src/cli_spec.ts
+++ b/packages/core/src/cli_spec.ts
@@ -162,6 +162,11 @@ export const BUILTIN_FLAGS: readonly BuiltinFlag[] = [
       "With mcp, serve the build registry (dynamic pipeline discovery)",
   },
   {
+    name: "--max-concurrent-runs",
+    description:
+      "With mcp --registry, cap concurrent run-tool spawns (default 4)",
+  },
+  {
     name: "--http",
     description: "With mcp, serve over HTTP on <host:port> instead of stdio",
   },

--- a/packages/core/src/mcp/command.ts
+++ b/packages/core/src/mcp/command.ts
@@ -32,6 +32,12 @@ interface McpHandler {
     message: unknown,
     ctx?: McpRequestContext,
   ): Promise<JsonRpcResponse | null>;
+  /**
+   * Whether messages may be handled concurrently. The registry server sets this
+   * (each run is its own subprocess); the single-build server leaves it unset so
+   * the HTTP transport serialises its handling.
+   */
+  readonly concurrent?: boolean;
 }
 
 /** A parsed `--http` bind address. */
@@ -56,6 +62,8 @@ export interface ServeMcpOptions extends McpServerOptions {
   useRegistry?: boolean;
   /** Spawns a registered build in registry mode; injectable for tests. */
   runner?: RegistryRunner;
+  /** Cap on concurrent run-tool spawns in registry mode (`--max-concurrent-runs`). */
+  maxConcurrentRuns?: number;
   /** The message stream to read (defaults to stdin); injectable for tests. */
   input?: ReadableStream<Uint8Array>;
   /** The sink to write responses to (defaults to stdout); injectable for tests. */
@@ -155,6 +163,7 @@ export async function serveMcp(
       readEnv,
       version: options.version,
       runner: options.runner,
+      maxConcurrentRuns: options.maxConcurrentRuns,
     })
     : new McpServer(build, {
       ...options,
@@ -221,6 +230,7 @@ async function serveMcpHttp(
     token: hasToken ? token : undefined,
     signal: options.signal,
     onListen: options.onListen,
+    concurrent: server.concurrent,
   });
   return 0;
 }

--- a/packages/core/src/mcp/http.ts
+++ b/packages/core/src/mcp/http.ts
@@ -44,6 +44,14 @@ export interface HttpTransportOptions {
   signal?: AbortSignal;
   /** Called once the listener is bound, with the actual address (test hook). */
   onListen?: (address: { hostname: string; port: number }) => void;
+  /**
+   * Handle requests **concurrently** instead of one at a time. Off by default:
+   * the single-build server mutates per-run parameter state on the shared build
+   * instance, so its handling must serialise. A handler with no shared in-process
+   * state (the registry server — each run is its own subprocess, reads only hit
+   * the CAS store) opts in, so a long run never head-of-line-blocks a read.
+   */
+  concurrent?: boolean;
 }
 
 /** A JSON `Response` with the given status and `application/json` content type. */
@@ -89,11 +97,12 @@ export async function serveHttp(
   ) => Promise<JsonRpcResponse | null>,
   options: HttpTransportOptions,
 ): Promise<void> {
-  const { host, port, token, signal, onListen } = options;
+  const { host, port, token, signal, onListen, concurrent } = options;
 
-  // Process messages one at a time: the server/execute path mutates per-run
-  // parameter state, so concurrent handling of two POSTs would race. Requests
-  // still arrive concurrently; this chain resolves them in arrival order.
+  // By default, process messages one at a time: the single-build server/execute
+  // path mutates per-run parameter state, so concurrent handling of two POSTs
+  // would race. Requests still arrive concurrently; this chain resolves them in
+  // arrival order. A `concurrent` handler bypasses the queue entirely.
   let queue: Promise<unknown> = Promise.resolve();
   const serial = (
     message: unknown,
@@ -103,6 +112,7 @@ export async function serveHttp(
     queue = result.then(() => {}, () => {});
     return result;
   };
+  const dispatch = concurrent === true ? handle : serial;
 
   const onRequest = async (request: Request): Promise<Response> => {
     if (request.method !== "POST") {
@@ -132,7 +142,7 @@ export async function serveHttp(
     } catch {
       return jsonResponse(err(null, PARSE_ERROR, "Parse error"), 400);
     }
-    const response = await serial(message, { headers: request.headers });
+    const response = await dispatch(message, { headers: request.headers });
     if (response === null) return new Response(null, { status: 202 });
     return jsonResponse(response, 200);
   };

--- a/packages/core/src/mcp/registry_server.ts
+++ b/packages/core/src/mcp/registry_server.ts
@@ -159,7 +159,16 @@ export interface RegistryMcpServerOptions {
   version?: string;
   /** Spawns a registered build; defaults to {@link defaultRegistryRunner}. */
   runner?: RegistryRunner;
+  /**
+   * The most run-tool spawns allowed in flight at once (default
+   * {@link DEFAULT_MAX_CONCURRENT_RUNS}). A call past the cap gets an immediate
+   * structured busy error rather than queueing; read tools are never counted.
+   */
+  maxConcurrentRuns?: number;
 }
+
+/** The default {@link RegistryMcpServerOptions.maxConcurrentRuns} cap. */
+export const DEFAULT_MAX_CONCURRENT_RUNS = 4;
 
 /** The reserved run-tool control keys — never treated as build parameters. */
 const CONTROL_KEYS: ReadonlySet<string> = new Set([
@@ -311,10 +320,23 @@ export class RegistryMcpServer {
   readonly #identity?: McpIdentityHook;
   readonly #readEnv: (name: string) => string | undefined;
   readonly #runner: RegistryRunner;
+  readonly #maxConcurrentRuns: number;
+  /**
+   * Requests may be handled concurrently: each run tool spawns its own
+   * subprocess and read tools only hit the CAS store, so there is no shared
+   * in-process run state to serialise (unlike the single-build server).
+   */
+  readonly concurrent = true;
+  /** Run-tool spawns currently in flight, capped by {@link #maxConcurrentRuns}. */
+  #inFlightRuns = 0;
   /** The connecting client's `initialize` name, a low-priority audit actor. */
   #clientLabel?: string;
-  /** The audit-log writer, opened lazily on the first audited call. */
-  #auditLog?: RunStateWriter;
+  /**
+   * The audit-log writer, opened lazily and memoized as a promise so concurrent
+   * first calls share a single open (and one serialising writer) rather than
+   * racing to create two.
+   */
+  #auditLog?: Promise<RunStateWriter>;
 
   /** Build the server over `registry`, applying the authz/audit options. */
   constructor(registry: BuildRegistry, options: RegistryMcpServerOptions = {}) {
@@ -335,6 +357,8 @@ export class RegistryMcpServer {
     this.#readEnv = options.readEnv ?? (() => undefined);
     this.#version = options.version ?? "0.0.0";
     this.#runner = options.runner ?? defaultRegistryRunner;
+    this.#maxConcurrentRuns = options.maxConcurrentRuns ??
+      DEFAULT_MAX_CONCURRENT_RUNS;
   }
 
   /**
@@ -703,6 +727,40 @@ export class RegistryMcpServer {
       );
     }
 
+    // Concurrency cap: refuse a spawn past the limit immediately with a
+    // structured busy error, rather than queueing it. The check and the
+    // increment are adjacent (no await between), so two concurrent calls can
+    // never both claim the last slot. Read tools never reach here.
+    if (this.#inFlightRuns >= this.#maxConcurrentRuns) {
+      await this.#audit(
+        runName,
+        args,
+        "denied",
+        actor,
+        "at_capacity",
+        knownParams,
+      );
+      return ok(
+        id,
+        textResult(
+          JSON.stringify(
+            {
+              error: "at_capacity",
+              tool: runName,
+              running: this.#inFlightRuns,
+              cap: this.#maxConcurrentRuns,
+              hint:
+                "The registry server is at its concurrent-run cap; retry shortly.",
+            },
+            null,
+            2,
+          ),
+          true,
+        ),
+      );
+    }
+
+    this.#inFlightRuns++;
     let result: RegistryRunResult;
     try {
       result = await this.#runner(launch.argv, launch.cwd, { actor });
@@ -720,6 +778,8 @@ export class RegistryMcpServer {
         id,
         textResult(`Failed to spawn ${qualified} (${kind}).`, true),
       );
+    } finally {
+      this.#inFlightRuns--;
     }
     await this.#audit(
       runName,
@@ -805,14 +865,18 @@ export class RegistryMcpServer {
     };
     if (detail !== undefined) event.detail = detail;
     try {
-      this.#auditLog ??= await openAuditLog(
+      // Memoize the open as a promise so concurrent first calls share one writer
+      // (whose #chain serialises appends) instead of racing to create two.
+      this.#auditLog ??= openAuditLog(
         store,
         () => new Date().toISOString(),
         new Redactor(),
       );
-      await this.#auditLog.appendEvent(event);
+      await (await this.#auditLog).appendEvent(event);
     } catch {
       // Auditing is best-effort: a store hiccup must not fail the tool call.
+      // Drop a failed open so a later call can retry instead of a poisoned one.
+      this.#auditLog = undefined;
     }
   }
 }

--- a/packages/core/tests/cli_test.ts
+++ b/packages/core/tests/cli_test.ts
@@ -310,6 +310,28 @@ Deno.test("parseArgs reads the mcp --http address", () => {
   assertEquals(parseArgs(["mcp"]).httpAddr, undefined);
 });
 
+Deno.test("parseArgs reads --max-concurrent-runs as a positive integer", () => {
+  assertEquals(
+    parseArgs(["mcp", "--registry", "--max-concurrent-runs", "8"])
+      .maxConcurrentRuns,
+    8,
+  );
+  assertEquals(
+    parseArgs(["mcp", "--max-concurrent-runs=2"]).maxConcurrentRuns,
+    2,
+  );
+  // Absent, or an invalid value, leaves it unset (the server default applies).
+  assertEquals(parseArgs(["mcp"]).maxConcurrentRuns, undefined);
+  assertEquals(
+    parseArgs(["mcp", "--max-concurrent-runs=0"]).maxConcurrentRuns,
+    undefined,
+  );
+  assertEquals(
+    parseArgs(["mcp", "--max-concurrent-runs=x"]).maxConcurrentRuns,
+    undefined,
+  );
+});
+
 Deno.test("main: mcp --http rejects an invalid address", async () => {
   const { code, err } = await capture(() =>
     main(Demo, ["mcp", "--http", "nope"])

--- a/packages/core/tests/registry_server_test.ts
+++ b/packages/core/tests/registry_server_test.ts
@@ -1066,3 +1066,127 @@ Deno.test("a hook yielding an empty actor is rejected, never a spawn", async () 
   assertEquals(calls.length, 0);
   assertEquals(await store.getRun("mcp-audit"), null);
 });
+
+// ---- M14: concurrent registry serving + run cap ----------------------------
+
+/** A runner whose spawns block until released, exposing the in-flight count. */
+function gatedRunner(): {
+  runner: RegistryRunner;
+  active: () => number;
+  release: () => void;
+} {
+  let active = 0;
+  let open = () => {};
+  const gate = new Promise<void>((resolve) => {
+    open = resolve;
+  });
+  const runner: RegistryRunner = async () => {
+    active++;
+    try {
+      await gate;
+    } finally {
+      active--;
+    }
+    return { code: 0, stdout: "ok", stderr: "" };
+  };
+  return { runner, active: () => active, release: () => open() };
+}
+
+/** Wait until `predicate` holds (bounded), so we observe in-flight spawns. */
+async function until(predicate: () => boolean): Promise<void> {
+  for (let i = 0; i < 1000 && !predicate(); i++) {
+    await new Promise((r) => setTimeout(r, 1));
+  }
+}
+
+Deno.test("the concurrency cap refuses a spawn past the limit, immediately", async () => {
+  const registry = new FakeRegistry();
+  registry.add(descriptor("Api", ["deploy"]));
+  const { runner, active, release } = gatedRunner();
+  const server = new RegistryMcpServer(registry, {
+    allowRun: true,
+    runner,
+    maxConcurrentRuns: 2,
+  });
+
+  // Two runs start and block in the runner — both in flight.
+  const r1 = server.handleMessage(
+    req("tools/call", { name: "run:Api:deploy" }),
+  );
+  const r2 = server.handleMessage(
+    req("tools/call", { name: "run:Api:deploy" }),
+  );
+  await until(() => active() === 2);
+
+  // A third is refused at once with the structured busy error (not queued).
+  const third = callText(
+    await server.handleMessage(req("tools/call", { name: "run:Api:deploy" })),
+  );
+  assertEquals(third.isError, true);
+  const body = JSON.parse(third.text);
+  assertEquals(body.error, "at_capacity");
+  assertEquals(body.cap, 2);
+  assertEquals(body.running, 2);
+
+  // A read tool is never counted or blocked, even at capacity.
+  const list = await call(server, "list_builds");
+  assertEquals(list.isError, false);
+  assertStringIncludes(list.text, "Api");
+
+  // Releasing the two lets them finish and frees the slots.
+  release();
+  await Promise.all([r1, r2]);
+  assertEquals(active(), 0);
+  // A run tool works again once below the cap.
+  assertEquals((await call(server, "run:Api:deploy")).isError, false);
+});
+
+Deno.test("registry HTTP serving does not head-of-line-block a read behind a run", async () => {
+  const registry = new FakeRegistry();
+  registry.add(descriptor("Api", ["deploy"]));
+  const { runner, active, release } = gatedRunner();
+  const ac = new AbortController();
+  let setPort = (_: number) => {};
+  const portReady = new Promise<number>((r) => (setPort = r));
+  const finished = serveMcp(new RegistryBuild(registry), {
+    useRegistry: true,
+    allowRun: true,
+    runner,
+    http: { host: "127.0.0.1", port: 0 },
+    quiet: true,
+    signal: ac.signal,
+    onListen: (a) => setPort(a.port),
+  });
+  const url = `http://127.0.0.1:${await portReady}/`;
+  const post = (body: unknown) =>
+    fetch(url, { method: "POST", body: JSON.stringify(body) });
+  try {
+    // Start a run that blocks in the runner; do not await it.
+    const running = post({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: "run:Api:deploy", arguments: {} },
+    });
+    await until(() => active() === 1);
+
+    // A read returns while the run is still blocked — proving no serialization.
+    const list = await post({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/call",
+      params: { name: "list_builds", arguments: {} },
+    });
+    assertEquals(list.status, 200);
+    assertStringIncludes(JSON.stringify(await list.json()), "Api");
+    assertEquals(active(), 1); // the run is still in flight, untouched
+
+    // Release the run and drain it.
+    release();
+    const ran = await running;
+    await ran.json();
+  } finally {
+    ac.abort();
+    await finished;
+  }
+});

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -572,6 +572,7 @@ else a friendly error.
 ./zuke runs show mcp-audit    # the MCP tool-call audit trail
 ./zuke register [--json]      # record this build in the build registry (idempotent)
 ./zuke mcp --registry --allow-run  # serve the registry: registered builds as tools, spawned
+./zuke mcp --registry --max-concurrent-runs 4  # cap concurrent run-tool spawns (default 4)
 ```
 
 **Build registry** (`docs/registry.md`): `zuke register` writes a secret-free


### PR DESCRIPTION
## What

Round 2 / M14 (P0 #3). The shared MCP endpoint must not let one engineer's 30-minute `run:deploy` head-of-line-block another engineer's read. HTTP request serialization is now **handler-declared** instead of a transport constant.

Before: `serveHttp` serialized every request through one global promise-chain — correct for the single-build server (its `execute` mutates per-run parameter state on the shared build instance), fatal for a shared registry endpoint.

## Design

- **Serialization is a policy, not a constant.** `serveHttp` gains a `concurrent` option; the `McpHandler` contract a `concurrent` flag. `RegistryMcpServer` sets it (each run is its own subprocess; reads only hit the CAS store — no shared in-process run state); `McpServer` leaves it unset, so **stdio and the single-build HTTP path are byte-for-byte unchanged**.
- **Run cap.** Concurrent run-tool **spawns** are capped (default 4, `--max-concurrent-runs <n>`). A call past the cap gets an **immediate structured `at_capacity` busy error** (`{ running, cap, hint }`) rather than joining an unbounded queue. The cap check and the in-flight increment are adjacent (no `await` between) so two concurrent calls can never both claim the last slot. Read tools and confirm/validation-rejected calls are never counted.
- **Audit under concurrency.** The audit-log open is memoized as a promise so concurrent first calls share one serialising writer (`RunStateWriter.#chain` + CAS) instead of racing to create two.
- No new state machinery — cross-process safety already rides the store's CAS. Rate limiting / total-request bounding stays the reverse proxy's job (declared non-goal).

## Tests

- **Unit** — `registry_server_test.ts`: a gated (blocking) runner proves the cap refuses the 3rd of three concurrent runs (cap 2) with `at_capacity` while two are in flight, read tools stay uncounted, and slots free on completion. `cli_test.ts`: `--max-concurrent-runs` parses a positive integer and rejects `0`/non-integers to `undefined` (server default).
- **Integration** — `registry_server_test.ts`: a real `serveMcp` HTTP registry server serves a `list_builds` **while** a `run:deploy` is blocked in the runner — proving the transport no longer serializes.
- The existing single-build MCP/HTTP suites are unchanged (serial behavior preserved).

## Adversarial review

A 5-dimension workflow — cap TOCTOU, single-build serialization regression, audit-open race, other shared mutable state, and the CLI flag — with refute-by-default verification found **no defects**.

## Docs

`docs/mcp.md` (HTTP concurrency split + the registry `Concurrency` bullet); the cheatsheet gains the `--max-concurrent-runs` example. `llms.txt` regenerated (CLI surface); `deno task ci` + `apiDocsCheck` + `generate-ci --check` + e2e all green.