### PR TITLE
feat(core): state/registry conformance kit and protocol version

### DIFF
--- a/docs/state-api.md
+++ b/docs/state-api.md
@@ -22,6 +22,13 @@ The client is dependency-free and talks plain HTTP, so any stack can serve it.
   returns it as an `ETag` response header and honours it in `If-Match` /
   `If-None-Match` request headers. Any stable per-write token works (a row
   version, a content hash, a monotonic counter).
+- **Protocol version.** This document describes wire protocol **`1`**. Every
+  client request carries `x-zuke-state-protocol: 1`. A service **may** echo its
+  own version in that response header; when it does and the value differs, the
+  client fails loudly rather than risk a silent mis-parse. A service that omits
+  the header is treated as compatible, so adopting it is optional — but echoing
+  it lets a version bump be detected immediately. A breaking change to this
+  contract bumps the number.
 
 ## Endpoints
 
@@ -30,10 +37,10 @@ The client is dependency-free and talks plain HTTP, so any stack can serve it.
 Fetch one run.
 
 | Response | Meaning                                                         |
-| -------- | -------------------------------------------------------------- |
-| `200`    | Body is the run record; **`ETag` header is required**.         |
+| -------- | --------------------------------------------------------------- |
+| `200`    | Body is the run record; **`ETag` header is required**.          |
 | `404`    | No such run (the client treats this as "not found", not error). |
-| other    | The client raises an error.                                    |
+| other    | The client raises an error.                                     |
 
 The client **requires** the `ETag` header on a `200`; omitting it is an error.
 
@@ -46,14 +53,14 @@ Create or update a run, guarded by a precondition:
 - **Update** — the client sends `If-Match: <etag>`. The service must store the
   record only if the current version equals `<etag>`, else respond `412`.
 
-| Response      | Meaning                                                       |
-| ------------- | ------------------------------------------------------------- |
-| `200`/`201`   | Stored; **`ETag` header (the new version) is required**.      |
-| `412`         | Precondition failed → the client reports a compare-and-swap conflict and retries. |
-| other         | The client raises an error.                                   |
+| Response    | Meaning                                                                           |
+| ----------- | --------------------------------------------------------------------------------- |
+| `200`/`201` | Stored; **`ETag` header (the new version) is required**.                          |
+| `412`       | Precondition failed → the client reports a compare-and-swap conflict and retries. |
+| other       | The client raises an error.                                                       |
 
-The service is the authority for versioning, which side-steps client clock
-skew. Records are small (kilobytes); whole-document CAS is the intended model.
+The service is the authority for versioning, which side-steps client clock skew.
+Records are small (kilobytes); whole-document CAS is the intended model.
 
 ### `GET /runs?status=&target=&since=`
 
@@ -75,11 +82,11 @@ List runs as an array of **summaries** (a subset of the record):
 
 Query parameters (all optional, combined with AND):
 
-| Param    | Keeps runs where…                                        |
-| -------- | -------------------------------------------------------- |
-| `status` | the run status equals this value                         |
-| `target` | the run's graph contains a target with this dotted name  |
-| `since`  | `createdAt` is at or after this ISO-8601 timestamp       |
+| Param    | Keeps runs where…                                       |
+| -------- | ------------------------------------------------------- |
+| `status` | the run status equals this value                        |
+| `target` | the run's graph contains a target with this dotted name |
+| `since`  | `createdAt` is at or after this ISO-8601 timestamp      |
 
 The client validates every summary it receives (an untrusted service is checked,
 not trusted) and expects newest-first ordering is applied server-side where it
@@ -91,8 +98,8 @@ The [build registry](./registry.md) rides the **same** contract — same base UR
 same bearer auth, same `ETag`/`If-Match` compare-and-swap — with a `/builds`
 collection beside `/runs`, so one service can host both (they stay separate
 concerns in the client:
-[`HttpBuildRegistry`](./registry.md#httpbuildregistry--hosted-service) is not the
-run store). A build **descriptor** is JSON, exactly the shape in
+[`HttpBuildRegistry`](./registry.md#httpbuildregistry--hosted-service) is not
+the run store). A build **descriptor** is JSON, exactly the shape in
 [the registry docs](./registry.md#the-build-descriptor); the service stores and
 returns it verbatim. Descriptors never contain secrets.
 
@@ -100,33 +107,45 @@ returns it verbatim. Descriptors never contain secrets.
 
 Fetch one registered build.
 
-| Response | Meaning                                                          |
-| -------- | --------------------------------------------------------------- |
-| `200`    | Body is the descriptor; **`ETag` header is required**.          |
-| `404`    | No such build (the client treats this as "not registered").     |
-| other    | The client raises an error.                                     |
+| Response | Meaning                                                     |
+| -------- | ----------------------------------------------------------- |
+| `200`    | Body is the descriptor; **`ETag` header is required**.      |
+| `404`    | No such build (the client treats this as "not registered"). |
+| other    | The client raises an error.                                 |
 
 ### `PUT /builds/:id`
 
 Register (create or update) a build, guarded exactly like `PUT /runs/:id`:
 `If-None-Match: *` to create, `If-Match: <etag>` to update, `412` on a version
-mismatch (the client re-reads and retries, so concurrent registrations converge).
-A `200`/`201` must return the new version as an `ETag`.
+mismatch (the client re-reads and retries, so concurrent registrations
+converge). A `200`/`201` must return the new version as an `ETag`.
 
 ### `DELETE /builds/:id`
 
-Deregister a build. `404` (already gone) is **not** an error; any other non-`2xx`
-is. No body.
+Deregister a build. `404` (already gone) is **not** an error; any other
+non-`2xx` is. No body.
 
 ### `GET /builds?name=&since=`
 
-List registered builds as an array of **summaries**
-(`id`, `name`, `actor`, `createdAt`, `updatedAt`). Query parameters (optional,
-AND-combined): `name` (exact match) and `since` (`createdAt` at or after an
-ISO-8601 timestamp). The client validates every summary and does not re-sort.
+List registered builds as an array of **summaries** (`id`, `name`, `actor`,
+`createdAt`, `updatedAt`). Query parameters (optional, AND-combined): `name`
+(exact match) and `since` (`createdAt` at or after an ISO-8601 timestamp). The
+client validates every summary and does not re-sort.
 
 ## Notes for implementers
 
+- **Conformance kit.** Do not re-derive correctness from this prose. Point the
+  kit at your running service and it verifies every semantic the core relies on
+  — CAS stale-write rejection, one-writer-wins, listing filter/sort, TTL lock
+  takeover, append-only events, and the `/builds` register/deregister CAS:
+
+  ```sh
+  deno run -A jsr:@zuke/core/conformance --url http://localhost:8080 [--token …]
+  ```
+
+  It exits `0` when every scenario passes and `1` (naming the failures) when one
+  does not. A backend that passes is compatible with `HttpStateStore` /
+  `HttpBuildRegistry`; one that violates CAS fails loudly.
 - **Never weaker than optimistic 409-retry.** The precondition model above is
   the minimum; a store that already does optimistic concurrency (e.g. a
   k8s-annotation store with resource versions) maps onto it directly.

--- a/docs/state.md
+++ b/docs/state.md
@@ -148,7 +148,10 @@ const store = new FileSystemStateStore(".zuke/runs");
 Talks to an HTTP service you host, using ETags for optimistic concurrency. This
 is the production path: point several machines (CI, developers) at one service
 and they share run state. The one-page contract is in
-[the state HTTP API](./state-api.md).
+[the state HTTP API](./state-api.md), and the
+[conformance kit](./state-api.md#notes-for-implementers)
+(`deno run -A jsr:@zuke/core/conformance --url …`) verifies your backend against
+it — don't re-derive correctness from the prose.
 
 ```ts
 import { HttpStateStore } from "jsr:@zuke/core";
@@ -206,3 +209,20 @@ for (const summary of await store.listRuns({ status: "failed" })) {
 ```
 
 `listRuns` filters by `status`, `target`, and `since`, newest first.
+
+## API stability
+
+The durable-state surface — the `StateStore` interface, `resumeRun`,
+`acquireLock`/`renewLock`/`releaseLock`, and the `RunRecord` / `RunEvent` shapes
+— is **stable with a deprecation cycle**: a breaking change ships with the old
+form kept working for one minor version, emitting a warning, before removal. The
+`RunRecord` JSON is versioned by tolerant parsing (an older record still loads,
+its missing fields defaulted), and that tolerance is a stated guarantee, not an
+accident — the schema-evolution tests enforce it.
+
+The HTTP wire contract carries an explicit
+[protocol version](./state-api.md#conventions) (`x-zuke-state-protocol`); a
+breaking change to the contract bumps the number, and a client fails loudly
+against a server that declares a different one rather than mis-parsing silently.
+Build the [conformance kit](./state-api.md#notes-for-implementers) into your
+backend's CI so a contract change surfaces the moment it lands.

--- a/packages/core/deno.json
+++ b/packages/core/deno.json
@@ -6,7 +6,8 @@
     ".": "./mod.ts",
     "./shell": "./src/shell.ts",
     "./tooling": "./src/tooling.ts",
-    "./render": "./src/render.ts"
+    "./render": "./src/render.ts",
+    "./conformance": "./src/conformance.ts"
   },
   "publish": {
     "exclude": [

--- a/packages/core/src/conformance.ts
+++ b/packages/core/src/conformance.ts
@@ -1,0 +1,559 @@
+/**
+ * A backend conformance kit for the state-api (`docs/state-api.md`).
+ *
+ * A hosted {@link "./state/store.ts".StateStore} / {@link
+ * "./registry/registry.ts".BuildRegistry} backend must implement the same
+ * compare-and-swap, listing, and TTL-lock semantics the filesystem backend
+ * does — the exactly-once resume, lock takeover, and one-writer-wins guarantees
+ * the core relies on ride on them. This module extracts those semantics into
+ * store-agnostic scenarios you can point at any implementation: Zuke's own test
+ * lane runs them against the filesystem store, and a backend author runs them
+ * against a live service:
+ *
+ * ```sh
+ * deno run -A jsr:@zuke/core/conformance --url http://localhost:8080 [--token …]
+ * ```
+ *
+ * Every scenario uses freshly-generated ids, so it is safe to run against a
+ * shared, persistent service; the lock-takeover scenario uses a short real TTL
+ * and a brief sleep, so it takes a beat of wall-clock time. A backend that
+ * passes is compatible with
+ * {@link "./state/http_store.ts".HttpStateStore} /
+ * {@link "./registry/http_registry.ts".HttpBuildRegistry}; one that violates
+ * CAS fails loudly.
+ *
+ * @module
+ */
+
+import type { RunEvent, RunRecord } from "./state/types.ts";
+import type { StateStore } from "./state/store.ts";
+import type { LockHolder } from "./state/lock.ts";
+import { HttpStateStore } from "./state/http_store.ts";
+import type { BuildDescriptor } from "./registry/descriptor.ts";
+import type { BuildRegistry } from "./registry/registry.ts";
+import { HttpBuildRegistry } from "./registry/http_registry.ts";
+
+/** The outcome of one conformance scenario. */
+export interface ConformanceResult {
+  /** The scenario's name. */
+  readonly name: string;
+  /** Whether the backend satisfied it. */
+  readonly ok: boolean;
+  /** The failure detail when `ok` is false. */
+  readonly error?: string;
+}
+
+/** Tuning options for the conformance scenarios. */
+export interface ConformanceOptions {
+  /**
+   * The lock TTL (ms) the takeover scenario acquires with; it then waits a bit
+   * longer than this for the lock to expire. Raise it for a slow backend.
+   * Default 200.
+   */
+  lockTtlMs?: number;
+}
+
+/** A `() =>` factory the kit calls once to obtain the store under test. */
+export type StateStoreFactory = () => StateStore | Promise<StateStore>;
+
+/** A `() =>` factory the kit calls once to obtain the registry under test. */
+export type BuildRegistryFactory = () => BuildRegistry | Promise<BuildRegistry>;
+
+/** The message of an unknown thrown value, without casting. */
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** Assert `condition`, throwing `message` (a scenario failure) otherwise. */
+function expect(condition: boolean, message: string): void {
+  if (!condition) throw new Error(message);
+}
+
+/** A unique id for a scenario's records, safe on a shared, persistent backend. */
+function uniqueId(prefix: string): string {
+  return `${prefix}-${crypto.randomUUID()}`;
+}
+
+/** Sleep for `ms` milliseconds. */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** A TTL long enough that a live-lock scenario never races the expiry (1 hour). */
+const LIVE_TTL_MS = 3_600_000;
+
+/** A minimal valid {@link RunRecord} with the given id and overrides. */
+function record(id: string, over: Partial<RunRecord> = {}): RunRecord {
+  const now = new Date().toISOString();
+  return {
+    id,
+    build: "Conformance",
+    rootTarget: "deploy",
+    status: "running",
+    actor: "conformance",
+    createdAt: now,
+    updatedAt: now,
+    graph: [{ name: "deploy", dependsOn: [] }],
+    params: {},
+    targets: { deploy: { status: "pending", meta: {} } },
+    signals: {},
+    events: [],
+    ...over,
+  };
+}
+
+/** A minimal {@link RunEvent}. */
+function event(tool: string): RunEvent {
+  return {
+    at: new Date().toISOString(),
+    tool,
+    actor: "conformance",
+    outcome: "ok",
+    args: {},
+  };
+}
+
+/** A {@link LockHolder} for the given actor and run. */
+function holder(actor: string, runId: string): LockHolder {
+  return { actor, runId, since: new Date().toISOString() };
+}
+
+/** One named scenario over a store. */
+interface StateScenario {
+  name: string;
+  run(store: StateStore, options: Required<ConformanceOptions>): Promise<void>;
+}
+
+/** The state-store semantic scenarios (store-agnostic). */
+const STATE_SCENARIOS: StateScenario[] = [
+  {
+    name: "putRun creates a record getRun round-trips",
+    async run(store) {
+      const id = uniqueId("run");
+      const put = await store.putRun(record(id), null);
+      expect(put.ok, "create putRun should succeed");
+      const loaded = await store.getRun(id);
+      expect(loaded !== null, "getRun should find the created record");
+      expect(loaded?.record.id === id, "getRun should return the same id");
+    },
+  },
+  {
+    name: "putRun CAS rejects a stale version",
+    async run(store) {
+      const id = uniqueId("run");
+      const created = await store.putRun(record(id), null);
+      expect(created.ok, "create should succeed");
+      const first = created.ok ? created.version : "";
+      // The update changes the record's content, so the version genuinely
+      // advances on any versioning scheme (content hash, ETag, counter).
+      const updated = await store.putRun(
+        record(id, { status: "succeeded" }),
+        first,
+      );
+      expect(updated.ok, "an in-order update should succeed");
+      // Writing again at the now-stale first version must conflict, not clobber.
+      const stale = await store.putRun(record(id, { status: "failed" }), first);
+      expect(!stale.ok, "a write at a stale version must be a conflict");
+    },
+  },
+  {
+    name: "concurrent writers at one version: exactly one wins",
+    async run(store) {
+      const id = uniqueId("run");
+      const created = await store.putRun(record(id), null);
+      const version = created.ok ? created.version : "";
+      // Distinct content per writer, so the winner's write really changes the
+      // version and the loser's compare-and-swap sees the change (a
+      // content-hash backend would otherwise let two identical writes both win).
+      const [a, b] = await Promise.all([
+        store.putRun(record(id, { status: "succeeded" }), version),
+        store.putRun(record(id, { status: "failed" }), version),
+      ]);
+      const winners = [a, b].filter((r) => r.ok).length;
+      expect(
+        winners === 1,
+        `exactly one concurrent writer must win, got ${winners}`,
+      );
+    },
+  },
+  {
+    name: "listRuns filters by target and status, newest first",
+    async run(store) {
+      // A unique graph target isolates this run set on a shared backend.
+      const target = uniqueId("t");
+      const graph = [{ name: target, dependsOn: [] }];
+      await store.putRun(
+        record(uniqueId("run"), {
+          graph,
+          status: "failed",
+          createdAt: "2020-01-01T00:00:00.000Z",
+        }),
+        null,
+      );
+      await store.putRun(
+        record(uniqueId("run"), {
+          graph,
+          status: "succeeded",
+          createdAt: "2020-01-03T00:00:00.000Z",
+        }),
+        null,
+      );
+      await store.putRun(
+        record(uniqueId("run"), {
+          graph,
+          status: "failed",
+          createdAt: "2020-01-02T00:00:00.000Z",
+        }),
+        null,
+      );
+      const all = await store.listRuns({ target });
+      expect(
+        all.length === 3,
+        `listRuns should return the 3 runs, got ${all.length}`,
+      );
+      const order = all.map((r) => r.createdAt);
+      expect(
+        order[0] >= order[1] && order[1] >= order[2],
+        `listRuns should sort newest first, got ${order.join(",")}`,
+      );
+      const failed = await store.listRuns({ target, status: "failed" });
+      expect(
+        failed.length === 2,
+        `status filter should return 2, got ${failed.length}`,
+      );
+      const since = await store.listRuns({
+        target,
+        since: "2020-01-02T00:00:00.000Z",
+      });
+      expect(
+        since.length === 2,
+        `since filter should return the 2 at/after the cutoff, got ${since.length}`,
+      );
+    },
+  },
+  {
+    name: "run events round-trip and preserve order",
+    async run(store) {
+      const id = uniqueId("run");
+      const created = await store.putRun(
+        record(id, { events: [event("a")] }),
+        null,
+      );
+      const v1 = created.ok ? created.version : "";
+      const appended = await store.putRun(
+        record(id, { events: [event("a"), event("b")] }),
+        v1,
+      );
+      expect(appended.ok, "appending an event should succeed");
+      const loaded = await store.getRun(id);
+      const tools = loaded?.record.events.map((e) => e.tool) ?? [];
+      expect(
+        tools.length === 2 && tools[0] === "a" && tools[1] === "b",
+        `events should round-trip in order, got ${tools.join(",")}`,
+      );
+    },
+  },
+  {
+    name:
+      "acquireLock grants a token; a second acquire conflicts with the holder",
+    async run(store) {
+      const key = uniqueId("lock");
+      // A long TTL so the lock is unambiguously live when the second acquire
+      // runs — the conflict check must not race the expiry, even on a slow
+      // remote backend (the takeover scenario is where expiry is exercised).
+      const first = await store.acquireLock(
+        key,
+        holder("alice", "r1"),
+        LIVE_TTL_MS,
+      );
+      expect(first.ok, "the first acquire should grant a token");
+      const second = await store.acquireLock(
+        key,
+        holder("bob", "r2"),
+        LIVE_TTL_MS,
+      );
+      expect(!second.ok, "a second acquire on a live lock must conflict");
+      expect(
+        !second.ok && second.holder.actor === "alice",
+        "the conflict must name the current holder",
+      );
+      if (first.ok) await store.releaseLock(key, first.token);
+    },
+  },
+  {
+    name: "an expired lock is taken over; the old token loses it",
+    async run(store, options) {
+      const key = uniqueId("lock");
+      const first = await store.acquireLock(
+        key,
+        holder("alice", "r1"),
+        options.lockTtlMs,
+      );
+      expect(first.ok, "the first acquire should succeed");
+      await sleep(options.lockTtlMs + 150);
+      const takeover = await store.acquireLock(
+        key,
+        holder("bob", "r2"),
+        options.lockTtlMs,
+      );
+      expect(takeover.ok, "an expired lock must be taken over");
+      if (first.ok) {
+        const renewed = await store.renewLock(
+          key,
+          first.token,
+          options.lockTtlMs,
+        );
+        expect(!renewed, "the evicted token must fail to renew");
+      }
+      if (takeover.ok) await store.releaseLock(key, takeover.token);
+    },
+  },
+  {
+    name: "concurrent acquire: exactly one wins",
+    async run(store) {
+      const key = uniqueId("lock");
+      const [a, b] = await Promise.all([
+        store.acquireLock(key, holder("alice", "r1"), LIVE_TTL_MS),
+        store.acquireLock(key, holder("bob", "r2"), LIVE_TTL_MS),
+      ]);
+      const winners = [a, b].filter((r) => r.ok).length;
+      expect(
+        winners === 1,
+        `exactly one concurrent acquire must win, got ${winners}`,
+      );
+      if (a.ok) await store.releaseLock(key, a.token);
+      if (b.ok) await store.releaseLock(key, b.token);
+    },
+  },
+  {
+    name: "renew and release of an absent lock are safe",
+    async run(store) {
+      const key = uniqueId("lock");
+      const renewed = await store.renewLock(key, "nope", LIVE_TTL_MS);
+      expect(!renewed, "renewing a lock nobody holds must return false");
+      await store.releaseLock(key, "nope"); // must not throw
+    },
+  },
+];
+
+/** Run the state-store conformance scenarios against the store `make` builds. */
+export async function checkStateStore(
+  make: StateStoreFactory,
+  options: ConformanceOptions = {},
+): Promise<ConformanceResult[]> {
+  const store = await make();
+  const resolved: Required<ConformanceOptions> = {
+    lockTtlMs: options.lockTtlMs ?? 200,
+  };
+  const results: ConformanceResult[] = [];
+  for (const scenario of STATE_SCENARIOS) {
+    try {
+      await scenario.run(store, resolved);
+      results.push({ name: scenario.name, ok: true });
+    } catch (error) {
+      results.push({ name: scenario.name, ok: false, error: messageOf(error) });
+    }
+  }
+  return results;
+}
+
+/** A minimal valid {@link BuildDescriptor} with the given id. */
+function descriptor(
+  id: string,
+  over: Partial<BuildDescriptor> = {},
+): BuildDescriptor {
+  const now = new Date().toISOString();
+  return {
+    id,
+    name: id,
+    location: { kind: "module", module: `file:///${id}.ts`, cwd: "/" },
+    surface: { commands: [], flags: [], targets: [], parameters: [] },
+    actor: "conformance",
+    createdAt: now,
+    updatedAt: now,
+    ...over,
+  };
+}
+
+/** One named scenario over a registry. */
+interface RegistryScenario {
+  name: string;
+  run(registry: BuildRegistry): Promise<void>;
+}
+
+/** The build-registry semantic scenarios (store-agnostic). */
+const REGISTRY_SCENARIOS: RegistryScenario[] = [
+  {
+    name: "register creates a descriptor getBuild round-trips",
+    async run(registry) {
+      const id = uniqueId("build");
+      const put = await registry.register(descriptor(id), null);
+      expect(put.ok, "create register should succeed");
+      const loaded = await registry.getBuild(id);
+      expect(
+        loaded?.descriptor.id === id,
+        "getBuild should return the descriptor",
+      );
+    },
+  },
+  {
+    name: "register CAS rejects a stale version",
+    async run(registry) {
+      const id = uniqueId("build");
+      const created = await registry.register(descriptor(id), null);
+      const first = created.ok ? created.version : "";
+      // Distinct content, so the version advances on any versioning scheme.
+      const updated = await registry.register(
+        descriptor(id, { actor: "updated" }),
+        first,
+      );
+      expect(updated.ok, "an in-order update should succeed");
+      const stale = await registry.register(
+        descriptor(id, { actor: "stale" }),
+        first,
+      );
+      expect(!stale.ok, "a register at a stale version must be a conflict");
+    },
+  },
+  {
+    name: "deregister removes a build",
+    async run(registry) {
+      const id = uniqueId("build");
+      await registry.register(descriptor(id), null);
+      await registry.deregister(id);
+      const loaded = await registry.getBuild(id);
+      expect(loaded === null, "getBuild after deregister must be a miss");
+    },
+  },
+  {
+    name: "listBuilds filters by name and since, newest first",
+    async run(registry) {
+      // A shared name (distinct ids) isolates this set on a shared backend.
+      const name = uniqueId("app");
+      await registry.register(
+        descriptor(uniqueId("build"), {
+          name,
+          createdAt: "2020-01-01T00:00:00.000Z",
+        }),
+        null,
+      );
+      await registry.register(
+        descriptor(uniqueId("build"), {
+          name,
+          createdAt: "2020-01-03T00:00:00.000Z",
+        }),
+        null,
+      );
+      await registry.register(
+        descriptor(uniqueId("build"), {
+          name,
+          createdAt: "2020-01-02T00:00:00.000Z",
+        }),
+        null,
+      );
+      const all = await registry.listBuilds({ name });
+      expect(
+        all.length === 3,
+        `name filter should return 3, got ${all.length}`,
+      );
+      const order = all.map((b) => b.createdAt);
+      expect(
+        order[0] >= order[1] && order[1] >= order[2],
+        `listBuilds should sort newest first, got ${order.join(",")}`,
+      );
+      const since = await registry.listBuilds({
+        name,
+        since: "2020-01-02T00:00:00.000Z",
+      });
+      expect(
+        since.length === 2,
+        `since filter should return the 2 at/after the cutoff, got ${since.length}`,
+      );
+    },
+  },
+];
+
+/** Run the build-registry conformance scenarios against the registry `make` builds. */
+export async function checkBuildRegistry(
+  make: BuildRegistryFactory,
+): Promise<ConformanceResult[]> {
+  const registry = await make();
+  const results: ConformanceResult[] = [];
+  for (const scenario of REGISTRY_SCENARIOS) {
+    try {
+      await scenario.run(registry);
+      results.push({ name: scenario.name, ok: true });
+    } catch (error) {
+      results.push({ name: scenario.name, ok: false, error: messageOf(error) });
+    }
+  }
+  return results;
+}
+
+/** Injectable dependencies for {@link runConformanceCli} (tests override them). */
+export interface ConformanceCliDeps {
+  /** Build the {@link StateStore} for a url/token (default {@link HttpStateStore}). */
+  makeStateStore?: (url: string, token?: string) => StateStore;
+  /** Build the {@link BuildRegistry} for a url/token (default {@link HttpBuildRegistry}). */
+  makeBuildRegistry?: (url: string, token?: string) => BuildRegistry;
+  /** Emit a line of output (default `console.log`). */
+  log?: (line: string) => void;
+}
+
+/**
+ * Run the conformance kit as a CLI: `--url <base>` (required) and `--token
+ * <bearer>` (optional) name the backend, then both suites run against it. Prints
+ * a `PASS`/`FAIL` line per scenario and resolves to a process exit code — `0`
+ * when every scenario passes, `1` when any fails or `--url` is missing.
+ */
+export async function runConformanceCli(
+  args: string[],
+  deps: ConformanceCliDeps = {},
+): Promise<number> {
+  const log = deps.log ?? ((line: string) => console.log(line));
+  const url = flag(args, "--url");
+  const token = flag(args, "--token");
+  if (url === undefined) {
+    log("conformance: --url <base> is required.");
+    return 1;
+  }
+  const makeState = deps.makeStateStore ??
+    ((u: string, t?: string) => new HttpStateStore({ url: u, token: t }));
+  const makeRegistry = deps.makeBuildRegistry ??
+    ((u: string, t?: string) => new HttpBuildRegistry({ url: u, token: t }));
+
+  const results: ConformanceResult[] = [];
+  try {
+    results.push(...await checkStateStore(() => makeState(url, token)));
+    results.push(...await checkBuildRegistry(() => makeRegistry(url, token)));
+  } catch (error) {
+    // A transport/protocol failure (e.g. a version mismatch) aborts the run.
+    log(`conformance: aborted — ${messageOf(error)}`);
+    return 1;
+  }
+
+  let failures = 0;
+  for (const result of results) {
+    if (result.ok) {
+      log(`PASS  ${result.name}`);
+    } else {
+      failures++;
+      log(`FAIL  ${result.name}\n        ${result.error ?? ""}`);
+    }
+  }
+  log(`\n${results.length - failures}/${results.length} scenarios passed.`);
+  return failures === 0 ? 0 : 1;
+}
+
+/** Read `--name value` or `--name=value` from `args`, or `undefined`. */
+function flag(args: string[], name: string): string | undefined {
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === name) return args[i + 1];
+    if (args[i].startsWith(`${name}=`)) return args[i].slice(name.length + 1);
+  }
+  return undefined;
+}
+
+if (import.meta.main) {
+  Deno.exit(await runConformanceCli(Deno.args));
+}

--- a/packages/core/src/registry/http_registry.ts
+++ b/packages/core/src/registry/http_registry.ts
@@ -16,6 +16,11 @@
 
 import { HttpError } from "../http.ts";
 import {
+  assertProtocol,
+  STATE_PROTOCOL_HEADER,
+  STATE_PROTOCOL_VERSION,
+} from "../state/protocol.ts";
+import {
   type BuildDescriptor,
   type BuildQuery,
   type BuildSummary,
@@ -60,11 +65,21 @@ export class HttpBuildRegistry implements BuildRegistry {
   }
 
   #headers(extra?: Record<string, string>): Record<string, string> {
-    const headers: Record<string, string> = { ...extra };
+    const headers: Record<string, string> = {
+      ...extra,
+      [STATE_PROTOCOL_HEADER]: STATE_PROTOCOL_VERSION,
+    };
     if (this.#token !== undefined && this.#token !== "") {
       headers.Authorization = `Bearer ${this.#token}`;
     }
     return headers;
+  }
+
+  /** Fetch and reject a response that declares an incompatible protocol version. */
+  async #request(url: string, init?: RequestInit): Promise<Response> {
+    const response = await this.#fetch(url, init);
+    assertProtocol(response, "registry");
+    return response;
   }
 
   /** `GET /builds/:id` → descriptor + `ETag`; a `404` is a miss. */
@@ -72,7 +87,7 @@ export class HttpBuildRegistry implements BuildRegistry {
     id: string,
   ): Promise<{ descriptor: BuildDescriptor; version: string } | null> {
     const url = this.#buildUrl(id);
-    const response = await this.#fetch(url, { headers: this.#headers() });
+    const response = await this.#request(url, { headers: this.#headers() });
     if (response.status === 404) {
       await response.body?.cancel();
       return null;
@@ -98,7 +113,7 @@ export class HttpBuildRegistry implements BuildRegistry {
     const precondition: Record<string, string> = expectedVersion === null
       ? { "If-None-Match": "*" }
       : { "If-Match": expectedVersion };
-    const response = await this.#fetch(url, {
+    const response = await this.#request(url, {
       method: "PUT",
       headers: this.#headers({
         "content-type": "application/json",
@@ -122,7 +137,7 @@ export class HttpBuildRegistry implements BuildRegistry {
   /** `DELETE /builds/:id`; a missing build (`404`) is not an error. */
   async deregister(id: string): Promise<void> {
     const url = this.#buildUrl(id);
-    const response = await this.#fetch(url, {
+    const response = await this.#request(url, {
       method: "DELETE",
       headers: this.#headers(),
     });
@@ -139,7 +154,7 @@ export class HttpBuildRegistry implements BuildRegistry {
     if (query.since !== undefined) params.set("since", query.since);
     const qs = params.toString();
     const url = `${this.#base}/builds${qs === "" ? "" : `?${qs}`}`;
-    const response = await this.#fetch(url, { headers: this.#headers() });
+    const response = await this.#request(url, { headers: this.#headers() });
     if (!response.ok) {
       await response.body?.cancel();
       throw new HttpError(response.status, url);

--- a/packages/core/src/state/http_store.ts
+++ b/packages/core/src/state/http_store.ts
@@ -14,6 +14,11 @@
  */
 
 import { HttpError } from "../http.ts";
+import {
+  assertProtocol,
+  STATE_PROTOCOL_HEADER,
+  STATE_PROTOCOL_VERSION,
+} from "./protocol.ts";
 import type { LockResult, PutResult, StateStore } from "./store.ts";
 import {
   parseRunRecord,
@@ -61,11 +66,21 @@ export class HttpStateStore implements StateStore {
   }
 
   #headers(extra?: Record<string, string>): Record<string, string> {
-    const headers: Record<string, string> = { ...extra };
+    const headers: Record<string, string> = {
+      ...extra,
+      [STATE_PROTOCOL_HEADER]: STATE_PROTOCOL_VERSION,
+    };
     if (this.#token !== undefined && this.#token !== "") {
       headers.Authorization = `Bearer ${this.#token}`;
     }
     return headers;
+  }
+
+  /** Fetch and reject a response that declares an incompatible protocol version. */
+  async #request(url: string, init?: RequestInit): Promise<Response> {
+    const response = await this.#fetch(url, init);
+    assertProtocol(response, "state");
+    return response;
   }
 
   /** `GET /runs/:id` → record + `ETag`; a `404` is a miss. */
@@ -73,7 +88,7 @@ export class HttpStateStore implements StateStore {
     id: string,
   ): Promise<{ record: RunRecord; version: string } | null> {
     const url = this.#runUrl(id);
-    const response = await this.#fetch(url, { headers: this.#headers() });
+    const response = await this.#request(url, { headers: this.#headers() });
     if (response.status === 404) {
       await response.body?.cancel();
       return null;
@@ -99,7 +114,7 @@ export class HttpStateStore implements StateStore {
     const precondition: Record<string, string> = expectedVersion === null
       ? { "If-None-Match": "*" }
       : { "If-Match": expectedVersion };
-    const response = await this.#fetch(url, {
+    const response = await this.#request(url, {
       method: "PUT",
       headers: this.#headers({
         "content-type": "application/json",
@@ -128,7 +143,7 @@ export class HttpStateStore implements StateStore {
     if (query.since !== undefined) params.set("since", query.since);
     const qs = params.toString();
     const url = `${this.#base}/runs${qs === "" ? "" : `?${qs}`}`;
-    const response = await this.#fetch(url, { headers: this.#headers() });
+    const response = await this.#request(url, { headers: this.#headers() });
     if (!response.ok) {
       await response.body?.cancel();
       throw new HttpError(response.status, url);
@@ -151,7 +166,7 @@ export class HttpStateStore implements StateStore {
     ttlMs: number,
   ): Promise<LockResult> {
     const url = this.#lockUrl(key);
-    const response = await this.#fetch(url, {
+    const response = await this.#request(url, {
       method: "POST",
       headers: this.#headers({ "content-type": "application/json" }),
       body: JSON.stringify({ holder, ttlMs }),
@@ -170,7 +185,7 @@ export class HttpStateStore implements StateStore {
   /** `PUT /locks/:key` renews; a `409`/`404` means the token lost the lock. */
   async renewLock(key: string, token: string, ttlMs: number): Promise<boolean> {
     const url = this.#lockUrl(key);
-    const response = await this.#fetch(url, {
+    const response = await this.#request(url, {
       method: "PUT",
       headers: this.#headers({ "content-type": "application/json" }),
       body: JSON.stringify({ token, ttlMs }),
@@ -184,7 +199,7 @@ export class HttpStateStore implements StateStore {
   /** `DELETE /locks/:key` releases; a missing lock (`404`) is not an error. */
   async releaseLock(key: string, token: string): Promise<void> {
     const url = this.#lockUrl(key);
-    const response = await this.#fetch(url, {
+    const response = await this.#request(url, {
       method: "DELETE",
       headers: this.#headers({ "content-type": "application/json" }),
       body: JSON.stringify({ token }),

--- a/packages/core/src/state/protocol.ts
+++ b/packages/core/src/state/protocol.ts
@@ -1,0 +1,36 @@
+/**
+ * The state-api wire-protocol version — the single contract shared by the HTTP
+ * {@link "./http_store.ts".HttpStateStore} run/lock endpoints and the
+ * {@link "../registry/http_registry.ts".HttpBuildRegistry} `/builds` endpoints
+ * (one service hosts both — see `docs/state-api.md`).
+ *
+ * Each client stamps every request with `x-zuke-state-protocol: <version>` and,
+ * on a response that declares a **different** version, fails loudly rather than
+ * risk a silent mis-parse. A server that omits the header is treated as
+ * compatible (legacy/tolerant), so the check only fires on a declared mismatch.
+ *
+ * @module
+ */
+
+/** The wire-contract version this client speaks (`docs/state-api.md`). */
+export const STATE_PROTOCOL_VERSION = "1";
+
+/** The request/response header carrying the {@link STATE_PROTOCOL_VERSION}. */
+export const STATE_PROTOCOL_HEADER = "x-zuke-state-protocol";
+
+/**
+ * Throw a descriptive error when `response` declares a state-api protocol
+ * version this client does not speak. A response with no version header passes
+ * (a server that predates the header is assumed compatible). `context`
+ * (`"state"` / `"registry"`) prefixes the message.
+ */
+export function assertProtocol(response: Response, context: string): void {
+  const declared = response.headers.get(STATE_PROTOCOL_HEADER);
+  if (declared !== null && declared !== STATE_PROTOCOL_VERSION) {
+    throw new Error(
+      `${context}: state-api protocol mismatch — the server declared ` +
+        `"${declared}" but this client speaks "${STATE_PROTOCOL_VERSION}". ` +
+        `Upgrade the client or the backend so both agree on the wire contract.`,
+    );
+  }
+}

--- a/packages/core/tests/conformance_test.ts
+++ b/packages/core/tests/conformance_test.ts
@@ -1,0 +1,191 @@
+/**
+ * The state-api conformance kit, run against Zuke's own filesystem backend (it
+ * must pass), a deliberately CAS-violating fake (it must fail loudly), and the
+ * CLI runner — plus the wire protocol-version handshake on the HTTP client.
+ */
+
+import { assertEquals, assertRejects } from "./_assert.ts";
+import {
+  checkBuildRegistry,
+  checkStateStore,
+  type ConformanceResult,
+  runConformanceCli,
+} from "../src/conformance.ts";
+import { FileSystemStateStore } from "../src/state/fs_store.ts";
+import { FileSystemBuildRegistry } from "../src/registry/fs_registry.ts";
+import { defaultStateHost } from "../src/state/store.ts";
+import type { LockResult, PutResult, StateStore } from "../src/state/store.ts";
+import type { RunSummary } from "../src/state/types.ts";
+import { HttpStateStore } from "../src/state/http_store.ts";
+import type { BuildRegistry } from "../src/registry/registry.ts";
+import {
+  type BuildDescriptor,
+  type BuildQuery,
+  toBuildSummary,
+} from "../src/registry/descriptor.ts";
+
+/** A short TTL keeps the lock-takeover scenarios fast in the test lane. */
+const FAST = { lockTtlMs: 50 };
+
+/** The names of failing scenarios in a result set. */
+function failures(results: ConformanceResult[]): string[] {
+  return results.filter((r) => !r.ok).map((r) => r.name);
+}
+
+Deno.test("the kit passes against the filesystem state store", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "zuke-conf-state-" });
+  try {
+    const results = await checkStateStore(
+      () => new FileSystemStateStore(`${dir}/runs`, defaultStateHost),
+      FAST,
+    );
+    assertEquals(failures(results), []);
+    assertEquals(results.length > 0, true);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("the kit passes against the filesystem build registry", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "zuke-conf-reg-" });
+  try {
+    const results = await checkBuildRegistry(
+      () => new FileSystemBuildRegistry(`${dir}/builds`, defaultStateHost),
+    );
+    assertEquals(failures(results), []);
+    assertEquals(results.length > 0, true);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+/** A store that never enforces CAS: every write "succeeds", nothing persists. */
+class NoCasStore implements StateStore {
+  getRun(): Promise<{ record: never; version: string } | null> {
+    return Promise.resolve(null);
+  }
+  putRun(): Promise<PutResult> {
+    return Promise.resolve({ ok: true, version: "v" }); // never conflicts
+  }
+  listRuns(): Promise<RunSummary[]> {
+    return Promise.resolve([]);
+  }
+  acquireLock(): Promise<LockResult> {
+    return Promise.resolve({ ok: true, token: "t" }); // never contends
+  }
+  renewLock(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+  releaseLock(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+Deno.test("the kit fails loudly against a CAS-violating store", async () => {
+  const results = await checkStateStore(() => new NoCasStore(), FAST);
+  const failed = failures(results);
+  // The CAS scenario in particular must be reported as a failure.
+  assertEquals(
+    results.find((r) => r.name.includes("CAS"))?.ok,
+    false,
+  );
+  assertEquals(failed.length > 0, true);
+});
+
+Deno.test("runConformanceCli passes over injected FS backends, fails on violations", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "zuke-conf-cli-" });
+  const lines: string[] = [];
+  try {
+    // Missing --url is a usage error.
+    assertEquals(await runConformanceCli([], { log: (l) => lines.push(l) }), 1);
+
+    // A good FS-backed run exits 0 and reports every scenario.
+    const ok = await runConformanceCli(["--url", "unused"], {
+      makeStateStore: () =>
+        new FileSystemStateStore(`${dir}/a`, defaultStateHost),
+      makeBuildRegistry: () =>
+        new FileSystemBuildRegistry(`${dir}/b`, defaultStateHost),
+      log: (l) => lines.push(l),
+    });
+    assertEquals(ok, 0);
+    assertEquals(lines.some((l) => l.startsWith("PASS")), true);
+
+    // A CAS-violating backend exits 1.
+    const bad = await runConformanceCli(["--url=unused"], {
+      makeStateStore: () => new NoCasStore(),
+      makeBuildRegistry: () =>
+        new FileSystemBuildRegistry(`${dir}/c`, defaultStateHost),
+      log: (l) => lines.push(l),
+    });
+    assertEquals(bad, 1);
+    assertEquals(lines.some((l) => l.startsWith("FAIL")), true);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("the HTTP client rejects a server that declares a mismatched protocol", async () => {
+  const store = new HttpStateStore({
+    url: "https://s.example",
+    fetch: () =>
+      Promise.resolve(
+        new Response("{}", {
+          status: 200,
+          headers: { etag: "v1", "x-zuke-state-protocol": "999" },
+        }),
+      ),
+  });
+  await assertRejects(() => store.getRun("run-1"), Error, "protocol mismatch");
+});
+
+Deno.test("the HTTP client tolerates a server that omits the protocol header", async () => {
+  // A backend predating the header is assumed compatible (no version declared).
+  const store = new HttpStateStore({
+    url: "https://s.example",
+    fetch: (_url, _init) =>
+      Promise.resolve(new Response(null, { status: 404 })),
+  });
+  assertEquals(await store.getRun("missing"), null);
+});
+
+/** A registry correct at CAS but returning listBuilds in insertion (not newest-first) order. */
+class BadOrderRegistry implements BuildRegistry {
+  #map = new Map<string, { descriptor: BuildDescriptor; version: number }>();
+  getBuild(id: string) {
+    const held = this.#map.get(id);
+    return Promise.resolve(
+      held
+        ? { descriptor: held.descriptor, version: String(held.version) }
+        : null,
+    );
+  }
+  register(descriptor: BuildDescriptor, expected: string | null) {
+    const held = this.#map.get(descriptor.id);
+    const current = held ? String(held.version) : null;
+    if (current !== expected) {
+      return Promise.resolve({ ok: false as const, conflict: true as const });
+    }
+    const version = (held?.version ?? 0) + 1;
+    this.#map.set(descriptor.id, { descriptor, version });
+    return Promise.resolve({ ok: true as const, version: String(version) });
+  }
+  deregister(id: string) {
+    this.#map.delete(id);
+    return Promise.resolve();
+  }
+  listBuilds(query: BuildQuery) {
+    // Correct filtering, but WRONG order (insertion order, not newest-first).
+    const rows = [...this.#map.values()]
+      .map((h) => toBuildSummary(h.descriptor))
+      .filter((b) => query.name === undefined || b.name === query.name)
+      .filter((b) => query.since === undefined || b.createdAt >= query.since);
+    return Promise.resolve(rows);
+  }
+}
+
+Deno.test("the kit catches a registry that violates listBuilds ordering", async () => {
+  const results = await checkBuildRegistry(() => new BadOrderRegistry());
+  // CAS/round-trip/deregister pass; only the ordering+filter scenario fails.
+  assertEquals(results.find((r) => r.name.includes("newest first"))?.ok, false);
+  assertEquals(results.find((r) => r.name.includes("CAS"))?.ok, true);
+});

--- a/packages/core/tests/registry_http_test.ts
+++ b/packages/core/tests/registry_http_test.ts
@@ -64,7 +64,10 @@ Deno.test("HttpBuildRegistry.getBuild returns descriptor + ETag, or null on 404"
     url: "https://r.example/",
     token: "t",
     fetch: fakeFetch((url, init) => {
-      assertEquals(init?.headers, { Authorization: "Bearer t" });
+      assertEquals(init?.headers, {
+        Authorization: "Bearer t",
+        "x-zuke-state-protocol": "1",
+      });
       if (url.endsWith("/builds/missing")) {
         return new Response(null, { status: 404 });
       }

--- a/packages/core/tests/state_test.ts
+++ b/packages/core/tests/state_test.ts
@@ -426,7 +426,10 @@ Deno.test("HttpStateStore.getRun returns record + ETag, or null on 404", async (
     url: "https://s.example/",
     token: "t",
     fetch: fakeFetch((url, init) => {
-      assertEquals(init?.headers, { Authorization: "Bearer t" });
+      assertEquals(init?.headers, {
+        Authorization: "Bearer t",
+        "x-zuke-state-protocol": "1",
+      });
       if (url.endsWith("/runs/missing")) {
         return new Response(null, { status: 404 });
       }

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -164,6 +164,12 @@ class CD extends Build {
 - Backends: `FileSystemStateStore(dir)` (single host, dev) and
   `HttpStateStore({ url, token? })` (hosted, production — see
   `docs/state-api.md`). Both dependency-free and pluggable behind `StateStore`.
+  A hosted backend is verified with the **conformance kit**
+  (`deno run -A jsr:@zuke/core/conformance --url <base> [--token …]`, or
+  `checkStateStore`/`checkBuildRegistry` from `@zuke/core/conformance`) — it
+  exercises CAS, listing, and TTL-lock semantics. The HTTP clients stamp every
+  request with `x-zuke-state-protocol: 1` and fail loudly on a server-declared
+  mismatch.
 - The run record holds status, the graph shape, resolved **non-secret**
   parameters, and per-target status/timing/metadata. Inspect it from the CLI
   with `zuke runs list [--status <s>] [--target <t>] [--since <iso>]` (newest


### PR DESCRIPTION
## What

Round 2 / M16 (P1 #5 + P2 #9). A hosted state-api backend must implement the same CAS, listing, and TTL-lock semantics the filesystem backend does — the exactly-once resume, lock takeover, and one-writer-wins guarantees the core relies on ride on them. The requester is building a Deno+Postgres backend and chose option (b): a conformance kit over a reference server.

## Design

- **Conformance kit** — a new `@zuke/core/conformance` entrypoint with store-agnostic scenarios: CAS stale-write rejection, concurrent-writers-one-wins, `listRuns`/`listBuilds` filter+sort, run-event round-trip, and the full lock lifecycle (acquire, holder-named conflict, TTL takeover, concurrent-one-wins). Zuke's own test lane runs them against the FS store (no coverage loss); a backend author runs them against a live URL:

  ```sh
  deno run -A jsr:@zuke/core/conformance --url http://localhost:8080 [--token …]
  ```

  Exposed as `checkStateStore(factory)` / `checkBuildRegistry(factory)` (programmatic) and `runConformanceCli(args, deps)` (the CLI, injectable for tests). Every scenario uses fresh `crypto.randomUUID()` ids, so it is safe against a shared, persistent service.
- **Protocol version** — every HTTP client request stamps `x-zuke-state-protocol: 1` (via a shared `state/protocol.ts`, wired through both clients' `#headers()`/a new `#request()` wrapper). A response that declares a *different* version fails loudly rather than mis-parse; a server that omits the header is treated as compatible, so adoption is optional.
- **Docs** — `docs/state-api.md` documents the protocol version + the kit; `docs/state.md` adds an API-stability policy (the state surface is stable-with-deprecation-cycle; the `RunRecord` schema-evolution tolerance is a stated guarantee).

## Tests

`conformance_test.ts`: the kit passes against the FS state store and FS registry, fails loudly against a CAS-violating fake (CAS scenario flagged specifically), catches an order-violating registry, and the CLI runner exits 0/1 correctly. The protocol handshake rejects a mismatched-version server and tolerates an omitting one. The two HTTP-client header deep-equal asserts were updated for the new request header.

## Adversarial review

A 5-dimension workflow (false-pass, false-fail/flake, protocol, isolation, CLI/types) with refute-by-default verification found **4 confirmed**, all fixed with regressions:

- **Two HIGH false-flakes** (verified with a 400-iteration repro; the committed test already flaked 1/20): the CAS-stale and concurrent-writer scenarios false-failed a *content-hash* backend (the FS store!) when create and update landed in the same millisecond — identical content yielded an identical version, so the "stale" write correctly succeeded. Fixed: each write now carries distinct content, so the version genuinely advances on any versioning scheme.
- **listBuilds ordering was uncertified** (medium) and the **`since`/`name` filters were never exercised** (low) — a filter/order-violating backend passed. Fixed: the registry listing scenario now checks newest-first ordering and both filters; a regression test proves the kit catches an order-violating registry. The live-lock scenarios were also decoupled from the short takeover TTL (a 1-hour TTL) so a slow backend never races the expiry.

## Gates

`deno task ci` green (5× flake-check on the kit clean); `apiDocsCheck`, `generate-ci --check`, and `deno doc --lint` over all 5 entrypoints clean. Skill cheatsheet updated with the kit + protocol note.