### PR TITLE
feat(core): fan-out items run their own onCancel compensation

### DIFF
--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -239,11 +239,36 @@ to whoever cancelled it, so `zuke runs show <id>` shows what was unwound.
 Cancellation needs a state store, so a build that uses `.onCancel()` turns on
 the `.zuke/runs` filesystem store by default (like `.lock()` and `.waitsFor()`).
 
-> **Limitation:** the cancel walk considers only the static plan, so an
-> `.onCancel()` on a [`.forEach()`](#fan-out-over-a-list--foreach)
-> **sub-target** is not run (sub-targets are materialised at run time and don't
-> exist at cancel time). Put a compensation on an ordinary target, or on the
-> parent fan-out target itself.
+An `.onCancel()` on a [`.forEach()`](#fan-out-over-a-list--foreach) **sub-target**
+runs too. Cancel re-materialises the fan-out, matches each item's sub-targets by
+name against the record, and runs the compensation of every item that had
+**succeeded — or was still in-flight when the cancel landed** (a mid-deploy item
+has partial work to undo). Items unwind before the parent's own compensation, in
+reverse order; a throwing item compensation is recorded and the walk continues,
+exactly as for an ordinary target. Each item's cleanup reads that item's own
+persisted state (`ctx.state`), and lands its own `compensate` entry in the
+[audit trail](./state.md) (naming the runtime sub-target, e.g.
+`deployBatch[repo-a].deploy`) alongside the summary.
+
+Nested fan-out works too: a `.forEach()` stage that is itself a `.forEach()` has
+its inner items' `.onCancel()` run, matched by the same nested
+`parent[item].stage[inner].stage` names.
+
+> **Caveat:** for per-item compensation to find its items, the `.forEach()`
+> item list must be **deterministic** — cancel re-evaluates it (from the
+> record's parameters) and matches by the same `parent[item].stage` names. A
+> non-deterministic list leaves a recorded item with no re-materialised twin;
+> its compensation is reported as skipped, never a crash.
+
+> **In-flight items and out-of-process cancel.** An out-of-process
+> `zuke cancel` compensates an item that was still **running** from the run
+> record's snapshot. The owning process aborts a live body only when it next
+> writes state (a `ctx.state.set(...)` checkpoint, or a `.lock()` heartbeat), so
+> a body doing one long uninterrupted command may keep running while its
+> compensation begins — the two can briefly overlap. Have item bodies
+> **checkpoint via `ctx.state.set(...)`** (or hold a `.lock()`) so a cancel
+> propagates promptly and closes that window; an in-process cancel (Ctrl-C) has
+> no such window, since bodies are aborted and settled before the walk runs.
 
 ## Fan-out over a list — `.forEach()`
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1451,6 +1451,11 @@ class TargetBuilder
     rolled back from exactly that slot. Compensation failures are recorded but do
     not stop the walk (cleanup is maximal). Requires a state store.
 
+    On a {@link forEach} sub-target, the compensation is per item: cancel
+    runs it for every item that had succeeded (or was still in-flight), each with
+    its own item-scoped context — see the fan-out section of
+    `docs/orchestration.md`.
+
     ```ts
     deploy = target()
       .executes((ctx) => ctx.state.set({ slot: "sit-7" }))

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1505,6 +1505,11 @@ class TargetBuilder
     rolled back from exactly that slot. Compensation failures are recorded but do
     not stop the walk (cleanup is maximal). Requires a state store.
 
+    On a {@link forEach} sub-target, the compensation is per item: cancel
+    runs it for every item that had succeeded (or was still in-flight), each with
+    its own item-scoped context — see the fan-out section of
+    `docs/orchestration.md`.
+
     ```ts
     deploy = target()
       .executes((ctx) => ctx.state.set({ slot: "sit-7" }))

--- a/packages/core/src/cancel.ts
+++ b/packages/core/src/cancel.ts
@@ -30,6 +30,7 @@ import { planGraph } from "./graph.ts";
 import { discoverParameters, resolveParameters } from "./params.ts";
 import { Redactor } from "./redact.ts";
 import type {
+  ForEachSpec,
   JsonValue,
   TargetBuilder,
   TargetContext,
@@ -115,7 +116,11 @@ function isTerminal(status: RunStatus): boolean {
 }
 
 /** An empty compensation outcome (nothing ran, nothing failed). */
-const EMPTY_OUTCOME: CompensationOutcome = { compensated: [], failures: [] };
+const EMPTY_OUTCOME: CompensationOutcome = {
+  compensated: [],
+  failures: [],
+  attempts: [],
+};
 
 /** One compensation to run: the target undoing an original, plus that original's meta. */
 interface CompensationStep {
@@ -137,12 +142,24 @@ export interface CompensationFailure {
   error: string;
 }
 
+/** One attempted compensation, for the run's audit trail (see {@link compensationEvents}). */
+export interface CompensationAttempt {
+  /** The succeeded/in-flight target this compensation undid (e.g. a fan-out item `deploy[repo-a].push`). */
+  forTarget: string;
+  /** The name of the compensation target that ran. */
+  compensation: string;
+  /** True when the body completed, false when it threw or timed out. */
+  ok: boolean;
+}
+
 /** What a compensation walk did: which cleanups ran, and which threw. */
 export interface CompensationOutcome {
   /** Names of compensation targets whose bodies completed. */
   compensated: string[];
   /** Compensations that threw (the walk continued past each). */
   failures: CompensationFailure[];
+  /** Every attempted compensation in run order, for per-target audit events. */
+  attempts: CompensationAttempt[];
 }
 
 /** Dependencies for {@link runCompensations}. */
@@ -197,16 +214,29 @@ export async function runCompensations(
     deps.redactor ? deps.redactor.redact(message) : message;
   const compensated: string[] = [];
   const failures: CompensationFailure[] = [];
+  const attempts: CompensationAttempt[] = [];
   const steps: CompensationStep[] = [...(deps.extra ?? [])];
   // Reverse topological order: undo the work that ran last before the work it
   // was built on.
-  // ponytail: walks the static plan `order` only, so a `.forEach(...)` fan-out
-  // sub-target's `.onCancel(...)` is not run (sub-targets are materialised at
-  // run time and aren't in `order`). Put compensations on ordinary targets or
-  // the parent fan-out target; re-materialising the fan-out here would need the
-  // runtime item list, which cancel doesn't have. Documented in docs/orchestration.md.
   for (const t of [...order].reverse()) {
     const name = t.name_ ?? "";
+    // A `.forEach(...)` fan-out parent's per-item sub-targets are materialised at
+    // run time — they aren't in the static `order`, so the walk can't reach their
+    // `.onCancel(...)` directly. Re-materialise the parent and collect each
+    // succeeded/in-flight item's own compensation, matched by name against the
+    // record. Item compensations run before the parent's own (batch-level) one.
+    if (t.forEach_ !== undefined) {
+      steps.push(
+        ...collectForEachSteps(
+          t,
+          t.forEach_,
+          record,
+          failures,
+          attempts,
+          deps.reporter,
+        ),
+      );
+    }
     if (record.targets[name]?.status !== "succeeded") continue;
     if (t.onCancel_ === undefined) continue;
     // The thunk is user code: a throw here must be recorded, not allowed to
@@ -220,6 +250,13 @@ export async function runCompensations(
         target: `${name}.onCancel`,
         forTarget: name,
         error: message,
+      });
+      // Record the resolution failure as an attempt too, so the per-target
+      // `compensate` events match the summary event's failed count.
+      attempts.push({
+        forTarget: name,
+        compensation: `${name}.onCancel`,
+        ok: false,
       });
       deps.reporter.error(
         `✘ .onCancel() thunk for "${name}" threw: ${message}`,
@@ -269,6 +306,11 @@ export async function runCompensations(
       // the walk (and leave the record non-terminal); no default, like a body.
       await withTimeout(() => body(ctx), step.compensation.timeout_);
       compensated.push(compName);
+      attempts.push({
+        forTarget: step.forTarget,
+        compensation: compName,
+        ok: true,
+      });
     } catch (error) {
       const message = redact(messageOf(error));
       failures.push({
@@ -276,10 +318,203 @@ export async function runCompensations(
         forTarget: step.forTarget,
         error: message,
       });
+      attempts.push({
+        forTarget: step.forTarget,
+        compensation: compName,
+        ok: false,
+      });
       deps.reporter.error(`✘ compensation ${compName} failed: ${message}`);
     }
   }
-  return { compensated, failures };
+  return { compensated, failures, attempts };
+}
+
+/**
+ * Collect the per-item compensation steps of a `.forEach(...)` fan-out parent.
+ * The sub-targets live on ephemeral builders materialised at run time, so cancel
+ * — which may be a fresh process with no live builders — re-runs
+ * {@link ForEachSpec.materialize} and matches each stage sub-target **by name**
+ * (`parent[key].stage`) against the record. A sub-target that succeeded, or was
+ * still in-flight when the cancel landed (an item mid-deploy has partial work to
+ * undo), whose re-materialised twin declared `.onCancel(...)`, contributes a
+ * step. A stage that is itself a fan-out is recursed into, so nested items'
+ * compensations are reached too. Steps come back newest-first so later
+ * stages/items unwind before earlier ones. A `materialize()` that throws is
+ * recorded as a failure and skipped — never a crash; a record row with no
+ * re-materialised twin (a non-deterministic item list) is reported as skipped
+ * rather than silently dropped.
+ */
+function collectForEachSteps(
+  parent: TargetBuilder,
+  spec: ForEachSpec,
+  record: RunRecord,
+  failures: CompensationFailure[],
+  attempts: CompensationAttempt[],
+  reporter: Reporter,
+): CompensationStep[] {
+  const steps: CompensationStep[] = [];
+  const materialised = new Set<string>();
+  collectForEachInto(
+    parent,
+    spec,
+    record,
+    failures,
+    attempts,
+    reporter,
+    materialised,
+    steps,
+  );
+  // A non-deterministic item list can leave a recorded item with no
+  // re-materialised twin: its compensation can't be found. Flag it rather than
+  // silently dropping it. Run once, at the top level, against the full set of
+  // every descendant sub-target name (so nested items don't false-warn).
+  const prefix = `${parent.name_ ?? ""}[`;
+  for (const [rowName, row] of Object.entries(record.targets)) {
+    if (!rowName.startsWith(prefix) || materialised.has(rowName)) continue;
+    if (!isItemCompensable(row.status)) continue;
+    reporter.error(
+      `cancel: fan-out item "${rowName}" has no matching re-materialised item ` +
+        `— its compensation is skipped (is the item list deterministic?).`,
+    );
+  }
+  // Reverse once at the top: later stages/items (and nested items) unwind first.
+  return steps.reverse();
+}
+
+/**
+ * Recursive worker for {@link collectForEachSteps}: materialise `parent`, append
+ * each eligible item's compensation step to `out` in forward order, recurse into
+ * any stage that is itself a fan-out, and register every descendant sub-target
+ * name in `materialised`. A resolution failure (materialize or a thunk throwing)
+ * is recorded in both `failures` and `attempts` so the audit trail stays
+ * consistent, and never escapes.
+ */
+function collectForEachInto(
+  parent: TargetBuilder,
+  spec: ForEachSpec,
+  record: RunRecord,
+  failures: CompensationFailure[],
+  attempts: CompensationAttempt[],
+  reporter: Reporter,
+  materialised: Set<string>,
+  out: CompensationStep[],
+): void {
+  const parentName = parent.name_ ?? "";
+  let items: ReturnType<ForEachSpec["materialize"]>;
+  try {
+    items = spec.materialize();
+  } catch (error) {
+    failures.push({
+      target: `${parentName}.forEach`,
+      forTarget: parentName,
+      error: messageOf(error),
+    });
+    attempts.push({
+      forTarget: parentName,
+      compensation: `${parentName}.forEach`,
+      ok: false,
+    });
+    reporter.error(
+      `✘ cancel: re-materialising "${parentName}" for per-item ` +
+        `compensation threw: ${messageOf(error)}`,
+    );
+    return;
+  }
+  for (const { key, stages } of items) {
+    for (const [stage, sub] of Object.entries(stages)) {
+      const subName = `${parentName}[${key}].${stage}`;
+      // Name the sub as the executor does, so a nested fan-out reconstructs its
+      // grandchildren under the same `parent[key].stage[innerKey].innerStage`
+      // names.
+      sub.name_ = subName;
+      materialised.add(subName);
+      // A stage that is itself a fan-out: recurse so nested items' onCancel runs.
+      if (sub.forEach_ !== undefined) {
+        collectForEachInto(
+          sub,
+          sub.forEach_,
+          record,
+          failures,
+          attempts,
+          reporter,
+          materialised,
+          out,
+        );
+      }
+      if (!isItemCompensable(record.targets[subName]?.status)) continue;
+      if (sub.onCancel_ === undefined) continue;
+      let compensation: TargetBuilder | undefined;
+      try {
+        compensation = sub.onCancel_();
+      } catch (error) {
+        failures.push({
+          target: `${subName}.onCancel`,
+          forTarget: subName,
+          error: messageOf(error),
+        });
+        attempts.push({
+          forTarget: subName,
+          compensation: `${subName}.onCancel`,
+          ok: false,
+        });
+        reporter.error(
+          `✘ .onCancel() thunk for "${subName}" threw: ${messageOf(error)}`,
+        );
+        continue;
+      }
+      if (compensation === undefined) {
+        reporter.error(
+          `cancel: fan-out item "${subName}" .onCancel() resolved to ` +
+            `undefined — skipping.`,
+        );
+        continue;
+      }
+      out.push({
+        compensation,
+        forTarget: subName,
+        meta: record.targets[subName]?.meta ?? {},
+      });
+    }
+  }
+}
+
+/**
+ * A fan-out item is worth compensating if it succeeded, or was still running
+ * when the cancel landed — an item mid-flight may have partial side effects
+ * (a started deploy) its `.onCancel(...)` needs to unwind.
+ *
+ * ponytail: an out-of-process `zuke cancel` compensates a `running` item from a
+ * record snapshot, so if that item's body is still live in the owning process
+ * (which aborts only on its next state write / lock heartbeat), the compensation
+ * can overlap the body's tail. Bodies that checkpoint via `ctx.state.set(...)`
+ * or hold a `.lock()` propagate the cancel promptly and close the window; the
+ * full fix is prompt abort-propagation in the executor (background run-status
+ * poll) — a cancellation-hardening follow-up, out of this milestone's scope.
+ */
+function isItemCompensable(status: string | undefined): boolean {
+  return status === "succeeded" || status === "running";
+}
+
+/**
+ * Turn a compensation walk's {@link CompensationAttempt}s into audit events
+ * (`tool: "compensate"`), one per attempted cleanup, naming the target it undid
+ * (e.g. a fan-out item `deploy[repo-a].push`). Appended alongside the summary
+ * {@link cancelEvent} so the trail shows each item's outcome, not just a count.
+ * Target names are static identifiers, so nothing here needs redaction.
+ */
+export function compensationEvents(
+  attempts: CompensationAttempt[],
+  actor: string,
+  at: string,
+): RunEvent[] {
+  return attempts.map((a) => ({
+    at,
+    tool: "compensate",
+    actor,
+    outcome: a.ok ? "ok" : "error",
+    args: { target: a.forTarget },
+    detail: `${a.forTarget} → ${a.compensation}`,
+  }));
 }
 
 /** Options for {@link cancelRun}. */
@@ -531,10 +766,14 @@ async function finalizeCancelled(
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     const loaded = await store.getRun(id);
     if (loaded === null || loaded.record.status === "cancelled") return;
+    const at = now();
     const next = structuredClone(loaded.record);
     next.status = "cancelled";
-    next.updatedAt = now();
-    next.events.push(cancelEvent(actor, outcome, now()));
+    next.updatedAt = at;
+    for (const event of compensationEvents(outcome.attempts, actor, at)) {
+      next.events.push(event);
+    }
+    next.events.push(cancelEvent(actor, outcome, at));
     const result = await store.putRun(next, loaded.version);
     if (result.ok) return;
   }

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -41,6 +41,7 @@ import { ServiceBuilder, ServiceRegistry } from "./service.ts";
 import { Redactor } from "./redact.ts";
 import { absolutePath } from "./path.ts";
 import {
+  type ForEachItem,
   ForEachSettings,
   type ForEachSpec,
   LockSettings,
@@ -63,7 +64,7 @@ import { defaultStateHost, type StateStore } from "./state/store.ts";
 import { resolveStateStore } from "./state/resolve.ts";
 import { buildRunRecord, ciRunUrl, resolveActor } from "./state/record.ts";
 import { inMemoryStateHandle, RunStateWriter } from "./state/writer.ts";
-import { cancelEvent, runCompensations } from "./cancel.ts";
+import { cancelEvent, compensationEvents, runCompensations } from "./cancel.ts";
 import { LockConflictError, type LockHolder } from "./state/lock.ts";
 import { parseDuration } from "./duration.ts";
 import type { Plugin, RunInfo, TargetTiming } from "./plugin.ts";
@@ -1002,35 +1003,44 @@ async function runForEachTarget(
   const settings = spec.configure
     ? spec.configure(new ForEachSettings())
     : new ForEachSettings();
-  const items = spec.materialize();
-
-  // Materialise each item's stages into named, chained sub-targets.
-  const order: TargetBuilder[] = [];
-  const predecessors = new Map<TargetBuilder, TargetBuilder[]>();
-  for (const { key, stages } of items) {
-    let prev: TargetBuilder | undefined;
-    for (const [stage, sub] of Object.entries(stages)) {
-      sub.name_ = `${name}[${key}].${stage}`;
-      // Isolating item failures means a failed stage stays lenient: its
-      // siblings keep running, only this item's later stages are blocked.
-      if (settings.continueOnItemFailure_) sub.proceedAfterFailure_ = true;
-      const deps = prev === undefined ? [] : [prev];
-      if (prev !== undefined) sub.dependsOn_.push(prev);
-      order.push(sub);
-      predecessors.set(sub, deps);
-      prev = sub;
-    }
-  }
-
   openTarget(reporter, renderer, style, name, opened);
   await life.targetStart(name);
   void env.writer?.markTargetRunning(name);
+  const start = performance.now();
+
+  // Materialise each item's stages into named, chained sub-targets. The items
+  // thunk and factory are user code (they read params and build targets), so a
+  // throw here must fail the fan-out target cleanly — not escape as an uncaught
+  // rejection that crashes the run and leaves the record non-terminal.
+  const order: TargetBuilder[] = [];
+  const predecessors = new Map<TargetBuilder, TargetBuilder[]>();
+  let items: ForEachItem[];
+  try {
+    items = spec.materialize();
+    for (const { key, stages } of items) {
+      let prev: TargetBuilder | undefined;
+      for (const [stage, sub] of Object.entries(stages)) {
+        sub.name_ = `${name}[${key}].${stage}`;
+        // Isolating item failures means a failed stage stays lenient: its
+        // siblings keep running, only this item's later stages are blocked.
+        if (settings.continueOnItemFailure_) sub.proceedAfterFailure_ = true;
+        const deps = prev === undefined ? [] : [prev];
+        if (prev !== undefined) sub.dependsOn_.push(prev);
+        order.push(sub);
+        predecessors.set(sub, deps);
+        prev = sub;
+      }
+    }
+  } catch (error) {
+    const ms = performance.now() - start;
+    failTarget(reporter, renderer, style, name, ms, error);
+    return { status: "failed", ms, error };
+  }
   reporter.info(
     items.length === 0
       ? `${name}: fan-out over 0 items — nothing to run.`
       : `${name}: fan-out over ${items.length} item(s).`,
   );
-  const start = performance.now();
   const run = await runScheduled(
     life,
     order,
@@ -1667,7 +1677,11 @@ export async function execute(
           reporter,
           redactor,
         });
-        await writer.appendEvent(cancelEvent(actor, comp, nowIso()));
+        const at = nowIso();
+        for (const event of compensationEvents(comp.attempts, actor, at)) {
+          await writer.appendEvent(event);
+        }
+        await writer.appendEvent(cancelEvent(actor, comp, at));
         await writer.markRunCancelled();
         reporter.info(
           `Run ${runId} cancelled — ${comp.compensated.length} ` +

--- a/packages/core/src/target.ts
+++ b/packages/core/src/target.ts
@@ -791,6 +791,11 @@ export class TargetBuilder {
    * rolled back from exactly that slot. Compensation failures are recorded but do
    * not stop the walk (cleanup is maximal). Requires a state store.
    *
+   * On a {@link forEach} **sub-target**, the compensation is per item: cancel
+   * runs it for every item that had succeeded (or was still in-flight), each with
+   * its own item-scoped context — see the fan-out section of
+   * `docs/orchestration.md`.
+   *
    * ```ts
    * deploy = target()
    *   .executes((ctx) => ctx.state.set({ slot: "sit-7" }))

--- a/packages/core/tests/cancel_test.ts
+++ b/packages/core/tests/cancel_test.ts
@@ -3,11 +3,44 @@ import { Build, discoverTargets } from "../src/build.ts";
 import { parameter } from "../src/params.ts";
 import { target } from "../src/target.ts";
 import { execute } from "../src/executor.ts";
-import { cancelRun } from "../src/cancel.ts";
+import {
+  cancelRun,
+  compensationEvents,
+  runCompensations,
+} from "../src/cancel.ts";
 import { resumeRun } from "../src/resume.ts";
 import { FileSystemStateStore } from "../src/state/fs_store.ts";
 import { defaultStateHost, type StateStore } from "../src/state/store.ts";
+import type { RunRecord } from "../src/state/types.ts";
+import type { Reporter } from "../src/executor.ts";
 import { externalSignal } from "../src/wait.ts";
+
+/** A run record scaffold for driving {@link runCompensations} directly. */
+function craftRecord(
+  rootTarget: string,
+  targets: RunRecord["targets"],
+): RunRecord {
+  return {
+    id: "run",
+    build: "B",
+    rootTarget,
+    status: "cancelling",
+    actor: "ops",
+    createdAt: "t",
+    updatedAt: "t",
+    graph: [],
+    params: {},
+    targets,
+    signals: {},
+    events: [],
+  };
+}
+
+/** A reporter that captures error lines (for asserting cancel diagnostics). */
+function capturingReporter(): { reporter: Reporter; errors: string[] } {
+  const errors: string[] = [];
+  return { reporter: { info: () => {}, error: (l) => errors.push(l) }, errors };
+}
 
 /** Run `fn` with a temp filesystem store, cleaned up afterwards. */
 async function withTempStore(
@@ -621,6 +654,361 @@ Deno.test("a hung compensation is bounded by its .timeout()", async () => {
     assertEquals(result.failures.length, 1);
     assertEquals(result.failures[0].error.includes("timed out"), true);
   });
+});
+
+Deno.test("fan-out sub-target compensations run per item, in reverse, on cancel", async () => {
+  await withTempStore(async (store) => {
+    const undone: string[] = [];
+    const makeBuild = () => {
+      class CD extends Build {
+        deployBatch = target().forEach(
+          () => ["a", "b", "c"],
+          (repo) => ({
+            deploy: target()
+              .executes((ctx) => ctx.state.set({ slot: `slot-${repo}` }))
+              .onCancel(() =>
+                target().executes((ctx) => {
+                  undone.push(`${repo}:${ctx.state.get().slot}`);
+                })
+              ),
+          }),
+          (s) => s.continueOnItemFailure(),
+        );
+        gate = target()
+          .dependsOn(this.deployBatch)
+          .waitsFor((s) => s.on(externalSignal("x")));
+      }
+      const build = new CD();
+      discoverTargets(build);
+      return build;
+    };
+    const a = makeBuild();
+    const res = await execute(a, a.gate, { silent: true, stateStore: store });
+    assertEquals(res.suspended, true);
+    const runId = (await store.listRuns({}))[0].id;
+
+    const result = await cancelRun(makeBuild(), {
+      runId,
+      stateStore: store,
+      silent: true,
+      actor: "ops",
+    });
+    assertEquals(result.status, "cancelled");
+    // Reverse item order; each read its own item-scoped persisted slot.
+    assertEquals(undone, ["c:slot-c", "b:slot-b", "a:slot-a"]);
+
+    const loaded = await store.getRun(runId);
+    const events = (loaded?.record.events ?? []).filter(
+      (e) => e.tool === "compensate",
+    );
+    assertEquals(events.length, 3);
+    assertEquals(
+      events.map((e) => e.args.target).sort(),
+      [
+        "deployBatch[a].deploy",
+        "deployBatch[b].deploy",
+        "deployBatch[c].deploy",
+      ],
+    );
+    assertEquals(events.every((e) => e.outcome === "ok"), true);
+  });
+});
+
+Deno.test("a throwing fan-out item compensation is recorded; the others still run", async () => {
+  await withTempStore(async (store) => {
+    const undone: string[] = [];
+    const makeBuild = () => {
+      class CD extends Build {
+        deployBatch = target().forEach(
+          () => ["a", "b", "c"],
+          (repo) => ({
+            deploy: target().executes(() => {}).onCancel(() =>
+              target().executes(() => {
+                if (repo === "a") throw new Error("boom-a");
+                undone.push(repo);
+              })
+            ),
+          }),
+          (s) => s.continueOnItemFailure(),
+        );
+        gate = target()
+          .dependsOn(this.deployBatch)
+          .waitsFor((s) => s.on(externalSignal("x")));
+      }
+      const build = new CD();
+      discoverTargets(build);
+      return build;
+    };
+    const a = makeBuild();
+    await execute(a, a.gate, { silent: true, stateStore: store });
+    const runId = (await store.listRuns({}))[0].id;
+
+    const result = await cancelRun(makeBuild(), {
+      runId,
+      stateStore: store,
+      silent: true,
+    });
+    assertEquals(result.status, "cancelled"); // never wedged
+    // c and b ran (reverse order) despite a throwing.
+    assertEquals(undone, ["c", "b"]);
+    assertEquals(
+      result.failures.some((f) => f.forTarget === "deployBatch[a].deploy"),
+      true,
+    );
+    const loaded = await store.getRun(runId);
+    const errored = (loaded?.record.events ?? []).filter(
+      (e) => e.tool === "compensate" && e.outcome === "error",
+    );
+    assertEquals(errored.length, 1);
+    assertEquals(errored[0].args.target, "deployBatch[a].deploy");
+  });
+});
+
+Deno.test("an in-flight (running) fan-out item is compensated; a stage with no onCancel is skipped", async () => {
+  const undone: string[] = [];
+  class CD extends Build {
+    deployBatch = target().forEach(
+      () => ["a", "b"],
+      (repo) => ({
+        deploy: target().executes(() => {}).onCancel(() =>
+          target().executes(() => void undone.push(repo))
+        ),
+        // A second stage with no compensation — nothing to undo.
+        verify: target().executes(() => {}),
+      }),
+    );
+  }
+  const build = new CD();
+  discoverTargets(build);
+  // "a" succeeded, "b" was still running when the cancel landed — both undo;
+  // the verify stages have no onCancel, so they are skipped even when succeeded.
+  const record = craftRecord("deployBatch", {
+    "deployBatch[a].deploy": { status: "succeeded", meta: {} },
+    "deployBatch[a].verify": { status: "succeeded", meta: {} },
+    "deployBatch[b].deploy": { status: "running", meta: {} },
+    "deployBatch[b].verify": { status: "pending", meta: {} },
+  });
+  const outcome = await runCompensations([build.deployBatch], record, {
+    runId: "run",
+    signals: new Map(),
+    reporter: { info: () => {}, error: () => {} },
+  });
+  assertEquals(undone, ["b", "a"]); // reverse order, deploy stages only
+  assertEquals(outcome.attempts.length, 2);
+  assertEquals(outcome.attempts.every((a) => a.ok), true);
+});
+
+Deno.test("a pending fan-out item (never started) is not compensated", async () => {
+  const undone: string[] = [];
+  class CD extends Build {
+    deployBatch = target().forEach(
+      () => ["a", "b"],
+      (repo) => ({
+        deploy: target().executes(() => {}).onCancel(() =>
+          target().executes(() => void undone.push(repo))
+        ),
+      }),
+    );
+  }
+  const build = new CD();
+  discoverTargets(build);
+  const record = craftRecord("deployBatch", {
+    "deployBatch[a].deploy": { status: "succeeded", meta: {} },
+    "deployBatch[b].deploy": { status: "pending", meta: {} },
+  });
+  const outcome = await runCompensations([build.deployBatch], record, {
+    runId: "run",
+    signals: new Map(),
+    reporter: { info: () => {}, error: () => {} },
+  });
+  assertEquals(undone, ["a"]); // b never ran → nothing to undo
+  assertEquals(outcome.attempts.length, 1);
+});
+
+Deno.test("a non-deterministic forEach list reports an unmatched recorded item", async () => {
+  class CD extends Build {
+    deployBatch = target().forEach(
+      () => ["a"], // cancel-time list no longer includes "z"
+      (_repo) => ({
+        deploy: target().executes(() => {}).onCancel(() =>
+          target().executes(() => {})
+        ),
+      }),
+    );
+  }
+  const build = new CD();
+  discoverTargets(build);
+  const record = craftRecord("deployBatch", {
+    "deployBatch[z].deploy": { status: "succeeded", meta: {} },
+    // An unmatched, non-compensable row (failed) is silently skipped — no warning.
+    "deployBatch[gone].deploy": { status: "failed", meta: {} },
+  });
+  const { reporter, errors } = capturingReporter();
+  const outcome = await runCompensations([build.deployBatch], record, {
+    runId: "run",
+    signals: new Map(),
+    reporter,
+  });
+  assertEquals(outcome.failures, []); // not a crash
+  assertEquals(
+    errors.some((e) =>
+      e.includes("deployBatch[z].deploy") &&
+      e.includes("no matching re-materialised item")
+    ),
+    true,
+  );
+  // The non-compensable unmatched row does not warn.
+  assertEquals(errors.some((e) => e.includes("deployBatch[gone]")), false);
+});
+
+Deno.test("a forEach item list that throws at cancel is recorded, not fatal", async () => {
+  class CD extends Build {
+    deployBatch = target().forEach(
+      () => {
+        throw new Error("list boom");
+      },
+      (_repo) => ({ deploy: target().executes(() => {}) }),
+    );
+  }
+  const build = new CD();
+  discoverTargets(build);
+  const record = craftRecord("deployBatch", {
+    "deployBatch[a].deploy": { status: "succeeded", meta: {} },
+  });
+  const { reporter } = capturingReporter();
+  const outcome = await runCompensations([build.deployBatch], record, {
+    runId: "run",
+    signals: new Map(),
+    reporter,
+  });
+  assertEquals(
+    outcome.failures.some((f) => f.error.includes("list boom")),
+    true,
+  );
+  assertEquals(outcome.failures[0].forTarget, "deployBatch");
+});
+
+Deno.test("an item .onCancel() thunk that throws or returns undefined is skipped", async () => {
+  const undone: string[] = [];
+  class CD extends Build {
+    deployBatch = target().forEach(
+      () => ["boom", "undef", "ok"],
+      (repo) => ({
+        // @ts-expect-error the "undef" branch returns undefined to exercise the skip
+        deploy: target().executes(() => {}).onCancel(() => {
+          if (repo === "boom") throw new Error("thunk boom");
+          if (repo === "undef") return undefined;
+          return target().executes(() => void undone.push(repo));
+        }),
+      }),
+    );
+  }
+  const build = new CD();
+  discoverTargets(build);
+  const record = craftRecord("deployBatch", {
+    "deployBatch[boom].deploy": { status: "succeeded", meta: {} },
+    "deployBatch[undef].deploy": { status: "succeeded", meta: {} },
+    "deployBatch[ok].deploy": { status: "succeeded", meta: {} },
+  });
+  const { reporter } = capturingReporter();
+  const outcome = await runCompensations([build.deployBatch], record, {
+    runId: "run",
+    signals: new Map(),
+    reporter,
+  });
+  assertEquals(undone, ["ok"]); // only the valid item compensated
+  // The throwing thunk is a recorded failure; undefined is silently skipped.
+  assertEquals(
+    outcome.failures.some((f) => f.forTarget === "deployBatch[boom].deploy"),
+    true,
+  );
+  // The thrown thunk is also an attempt (ok:false), so it yields a per-target
+  // `compensate` event matching the summary's failed count.
+  assertEquals(
+    outcome.attempts.some((a) =>
+      a.forTarget === "deployBatch[boom].deploy" && !a.ok
+    ),
+    true,
+  );
+  const events = compensationEvents(outcome.attempts, "ops", "t");
+  assertEquals(
+    events.some((e) =>
+      e.args.target === "deployBatch[boom].deploy" && e.outcome === "error"
+    ),
+    true,
+  );
+});
+
+Deno.test("cancel runs a nested fan-out item's onCancel without false-warning", async () => {
+  const undone: string[] = [];
+  class CD extends Build {
+    // deployBatch fans out over ["a"]; each item's `inner` stage is itself a
+    // fan-out over ["g1"], whose `push` grandchild declares its own onCancel.
+    deployBatch = target().forEach(
+      () => ["a"],
+      (repo) => ({
+        inner: target().forEach(
+          () => ["g1"],
+          (g) => ({
+            push: target().executes(() => {}).onCancel(() =>
+              target().executes(() => void undone.push(`${repo}/${g}`))
+            ),
+          }),
+        ),
+      }),
+    );
+  }
+  const build = new CD();
+  discoverTargets(build);
+  const record = craftRecord("deployBatch", {
+    "deployBatch": { status: "succeeded", meta: {} },
+    "deployBatch[a].inner": { status: "succeeded", meta: {} },
+    "deployBatch[a].inner[g1].push": { status: "succeeded", meta: {} },
+  });
+  const { reporter, errors } = capturingReporter();
+  const outcome = await runCompensations([build.deployBatch], record, {
+    runId: "run",
+    signals: new Map(),
+    reporter,
+  });
+  assertEquals(undone, ["a/g1"]); // the grandchild's compensation ran
+  assertEquals(outcome.attempts.length, 1);
+  // Every descendant row is recognised, so no spurious "no matching" warning.
+  assertEquals(
+    errors.some((e) => e.includes("no matching re-materialised")),
+    false,
+  );
+});
+
+Deno.test("a fan-out parent's own onCancel runs after its item compensations", async () => {
+  const seq: string[] = [];
+  class CD extends Build {
+    deployBatch = target()
+      .forEach(
+        () => ["a", "b"],
+        (repo) => ({
+          deploy: target().executes(() => {}).onCancel(() =>
+            target().executes(() => void seq.push(`item:${repo}`))
+          ),
+        }),
+      )
+      .onCancel(() => this.batchRollback);
+    batchRollback = target().executes(() => void seq.push("parent"));
+  }
+  const build = new CD();
+  discoverTargets(build);
+  const record = craftRecord("deployBatch", {
+    "deployBatch": { status: "succeeded", meta: {} },
+    "deployBatch[a].deploy": { status: "succeeded", meta: {} },
+    "deployBatch[b].deploy": { status: "succeeded", meta: {} },
+  });
+  await runCompensations([build.deployBatch], record, {
+    runId: "run",
+    signals: new Map(),
+    reporter: { info: () => {}, error: () => {} },
+  });
+  // Items unwind first (reverse), then the batch-level compensation.
+  assertEquals(seq, ["item:b", "item:a", "parent"]);
 });
 
 /** Force a run to `cancelling`, retrying the CAS until it lands. */

--- a/packages/core/tests/foreach_test.ts
+++ b/packages/core/tests/foreach_test.ts
@@ -224,6 +224,49 @@ Deno.test("forEach records per-item sub-target status and metadata in the run", 
   });
 });
 
+Deno.test("a throwing forEach items thunk fails the target, not the process", async () => {
+  class Batch extends Build {
+    deployBatch = target().forEach(
+      () => {
+        throw new Error("bad item list");
+      },
+      (_repo) => ({ deploy: target().executes(() => {}) }),
+    );
+  }
+  // Both the sequential and the parallel dispatch paths must settle to a failed
+  // result — never escape as an uncaught rejection.
+  for (const parallel of [false, true]) {
+    const b = new Batch();
+    discoverTargets(b);
+    const result = await execute(b, b.deployBatch, { silent: true, parallel });
+    assertEquals(result.ok, false);
+  }
+});
+
+Deno.test("a throwing forEach items thunk settles the run record to failed", async () => {
+  await withStore(async (store) => {
+    class Batch extends Build {
+      deployBatch = target().forEach(
+        () => {
+          throw new Error("boom list");
+        },
+        (_repo) => ({ deploy: target().executes(() => {}) }),
+      );
+    }
+    const b = new Batch();
+    discoverTargets(b);
+    const result = await execute(b, b.deployBatch, {
+      silent: true,
+      stateStore: store,
+    });
+    assertEquals(result.ok, false);
+    const runId = (await store.listRuns({}))[0].id;
+    const loaded = await store.getRun(runId);
+    assertEquals(loaded?.record.status, "failed"); // settled, not stuck running
+    assertEquals(loaded?.record.targets["deployBatch"].status, "failed");
+  });
+});
+
 Deno.test("--list and graph annotate a fan-out target", () => {
   class Batch extends Build {
     plain = target().description("plain").executes(() => {});

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -128,8 +128,9 @@ Before calling any task or settings method, confirm the real shape:
   runs the same pipeline over a runtime list — items concurrent, each item's
   stages sequential. Sub-targets are materialised at run time
   (`parent[item].stage`), each a first-class row in the summary and the run
-  record; `continueOnItemFailure()` isolates a failed item. See
-  `docs/orchestration.md`.
+  record; `continueOnItemFailure()` isolates a failed item. An `.onCancel(...)`
+  on a fan-out stage runs per item on cancel (item-scoped `ctx.state`, reverse
+  order). See `docs/orchestration.md`.
 - **Typed inputs:** `parameter("...")` (with `.secret()` / `.required()`), read
   as `this.x.value`, gated with `.requires(this.x)`. `.array()` composes:
   `.options(...).array()` validates each element, `.number().array()` →

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -319,6 +319,10 @@ class CD extends Build {
   a first-class row in the summary and the [run record](#durable-run-state) (so
   `zuke runs show` reports per-item verdicts). `--list`/`graph` show the one
   node, annotated `[fan-out]`.
+- **Per-item compensation:** an `.onCancel(...)` on a fan-out **stage** runs on
+  cancel for each item that had succeeded — or was still in-flight — with its own
+  item-scoped `ctx.state`, in reverse order, before the parent's own `.onCancel`.
+  The item list must be deterministic (cancel re-materialises it to find items).
 - Pairs with array params: `.options(...).array()` / `.number().array()` type
   and validate the list before the batch runs.
 

--- a/tests/integration/cancel_test.ts
+++ b/tests/integration/cancel_test.ts
@@ -90,6 +90,53 @@ Deno.test("zuke cancel stops a suspended run and runs its compensations", async 
   });
 });
 
+Deno.test("zuke cancel runs each fan-out item's own onCancel compensation", async () => {
+  await withStateDir(async (dir) => {
+    const undone: string[] = [];
+    class CD extends Build {
+      deployBatch = target().forEach(
+        () => ["repo-a", "repo-b"],
+        (repo) => ({
+          deploy: target()
+            .executes((ctx) => ctx.state.set({ slot: `slot-${repo}` }))
+            .onCancel(() =>
+              target().executes((ctx) =>
+                void undone.push(`${repo}:${ctx.state.get().slot}`)
+              )
+            ),
+        }),
+        (s) => s.continueOnItemFailure(),
+      );
+      gate = target()
+        .dependsOn(this.deployBatch)
+        .waitsFor((s) => s.on(externalSignal("approved")));
+    }
+
+    // First process: the batch deploys, then the run suspends at the gate.
+    const first = await runCli(CD, ["gate"]);
+    assertEquals(first.code, 0);
+    const id = await onlyRunId(dir);
+    assertEquals((await loadRun(dir, id)).status, "suspended");
+
+    // Second process: cancel it. Each item's own compensation runs, reading that
+    // item's persisted slot — reverse order.
+    const cancelled = await runCli(CD, ["cancel", id]);
+    assertEquals(cancelled.code, 0);
+    assertEquals(undone, ["repo-b:slot-repo-b", "repo-a:slot-repo-a"]);
+
+    // Each item's compensation is its own audit entry naming the runtime target.
+    const record = await loadRun(dir, id);
+    const compensated = record.events
+      .filter((e) => e.tool === "compensate")
+      .map((e) => e.args.target)
+      .sort();
+    assertEquals(compensated, [
+      "deployBatch[repo-a].deploy",
+      "deployBatch[repo-b].deploy",
+    ]);
+  });
+});
+
 Deno.test("zuke cancel of a finished run is a no-op", async () => {
   await withStateDir(async (dir) => {
     const log: string[] = [];


### PR DESCRIPTION
## M15 — Fan-out per-item compensation on cancel (Round 2, P1 #4)

On cancel, a `.forEach()` fan-out target's per-item sub-targets now run **their
own** `.onCancel()` compensation — the requester's most common compensation
scenario (their deploys are fan-out-first, each item leasing per-repo
resources).

### What changed

- **Per-item compensation.** The cancel walk re-materialises each fan-out parent
  (`spec.materialize()`), matches each item's stage sub-targets by name
  (`parent[item].stage`) against the run record, and runs the compensation of
  every item that had **succeeded or was still in-flight**, each with its own
  item-scoped `TargetContext` and persisted `ctx.state`. Reverse order (later
  items/stages unwind first); a throwing item compensation is recorded and the
  walk continues (cleanup stays maximal).
- **Per-item audit events.** Each compensation lands its own `compensate`
  `RunEvent` naming the runtime sub-target (e.g. `deployBatch[repo-a].deploy`),
  alongside the existing summary `cancel` event, on both `zuke cancel` and the
  in-process (Ctrl-C) path.
- **Nested fan-out** is handled by recursion; the unmatched-item scan runs once
  against the full descendant-name set, so nested items don't false-warn.
- Retires the previous "sub-target `.onCancel()` is not run" limitation from
  `docs/orchestration.md`, the JSDoc, and the skill references.

### Acceptance

Batch of 3, cancel after item 1 finished and item 2 mid-flight → items 1 and 2
compensate with their own contexts, item 3 never does; the event log shows
per-item `compensate` entries; a throwing compensation on item 1 doesn't stop
item 2's. Covered by unit tests (`cancel_test.ts`) and an end-to-end CLI
integration test (`tests/integration/cancel_test.ts`).

### Adversarial review

A fan-out adversarial pass (5 attack dimensions → refute-by-default verify)
surfaced **4 confirmed** findings; each verified against the real code:

- **[high] Unguarded `spec.materialize()` in `runForEachTarget`** — a throwing
  item-list thunk/factory escaped as an uncaught rejection, crashing the run and
  leaving the record non-terminal. **Fixed:** wrapped so it fails the target
  cleanly on both the sequential and parallel dispatch paths; regression tests
  assert a failed result and a `failed` record.
- **[low] Nested fan-out** dropped grandchildren compensations and emitted a
  spurious "no matching re-materialised item" warning. **Fixed:** recurse with a
  shared name set and a single top-level unmatched-item scan; regression test
  asserts the grandchild compensates with no false warning.
- **[low] Resolution failures** (a throwing `.onCancel()` thunk / a throwing
  item list) inflated the summary's failed count but produced no per-item
  `compensate` event. **Fixed:** they are now recorded as attempts, so per-item
  events agree with the summary; regression test asserts the error event.
- **[medium] Out-of-process in-flight window** — `zuke cancel` compensates a
  `running` item from the record snapshot, and the owning process aborts a live
  body only on its next state write, so the two can briefly overlap. This is
  inherent to the requirement's "compensate in-flight items" design (the
  acceptance has no live process), and fully closing it needs prompt
  abort-propagation in the executor — a cancellation-hardening follow-up beyond
  this milestone. **Dispositioned:** documented with the `ctx.state.set(...)` /
  `.lock()` mitigations that close the window, plus a ceiling comment naming the
  upgrade path. In-process cancel has no such window (bodies settle before the
  walk).

### Gate

`deno task ci` green (lines 98.2%, branches 95.1%); `apiDocsCheck`,
`generate-ci --check`, and `deno doc --lint` over all five core entrypoints
clean; skill references synced.
