### PR TITLE
feat(core): run-record retention and runs prune

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,8 +18,9 @@
 | `zuke mcp [--allow-run[=<globs>]] [--http <host:port>]` | Run an MCP server over the build for AI agents, on stdio or HTTP ([details](./mcp.md)). |
 | `zuke resume <id> [--signal <n>] [--data <json>]`       | Resume a suspended run, optionally delivering a signal ([details](./orchestration.md)). |
 | `zuke resume --check [<id>]`                            | Re-check suspended runs (predicate waits, timeouts).                                    |
-| `zuke runs list [--status/-target/-since] [--json]`     | List persisted run records, newest first ([details](./state.md)).                       |
+| `zuke runs list [--status/-target/-since/-limit] [--json]` | List persisted run records, newest first ([details](./state.md)).                    |
 | `zuke runs show <id> [--json]`                          | Show one run's full per-target status and metadata.                                     |
+| `zuke runs prune [--keep <age>] [--keep-last <n>] [--dry-run]` | Delete old terminal run records; never touches non-terminal runs.                |
 | `zuke cancel <id> [--actor <name>]`                     | Cancel a run and run its compensations ([details](./orchestration.md#cancellation--compensation-oncancel)). |
 | `zuke --help` / `-h`                                    | Usage.                                                                                  |
 | `zuke` (no target)                                      | Run the `default` target if defined, else print `--list`.                               |
@@ -282,11 +283,18 @@ run's full status survives the process that produced it.
 - `zuke runs list` prints one row per run — id, status, root target, actor, and
   creation time — newest first. Narrow it with `--status <s>` (one of `running`,
   `suspended`, `cancelling`, `succeeded`, `failed`, `cancelled`), `--target <t>` (only runs
-  whose graph contains that target), and `--since <iso>` (only runs created at
-  or after an ISO-8601 timestamp). The filters compose.
+  whose graph contains that target), `--since <iso>` (only runs created at
+  or after an ISO-8601 timestamp), and `--limit <n>` (at most the newest N). The
+  filters compose.
 - `zuke runs show <run-id>` reconstructs one run in full: the header, resolved
   (non-secret) parameters, each target's status with its duration, error, or
   pending wait, and any external signals received.
+- `zuke runs prune` deletes old records. `--keep <age>` (e.g. `90d`) keeps runs
+  newer than that; `--keep-last <n>` always keeps the newest N; a run is deleted
+  only when it is **terminal** and matches neither. **Non-terminal** runs
+  (`suspended`, `running`, `cancelling`) are never pruned. At least one rule is
+  required, and `--dry-run` reports what would go without deleting. See
+  [retention](./state.md#retention) for who owns it on each backend.
 
 Both accept `--json` — `list` emits the summary array, `show` emits the whole
 record — for tools and agents. The store is resolved exactly as a run resolves

--- a/docs/state-api.md
+++ b/docs/state-api.md
@@ -62,7 +62,19 @@ Create or update a run, guarded by a precondition:
 The service is the authority for versioning, which side-steps client clock skew.
 Records are small (kilobytes); whole-document CAS is the intended model.
 
-### `GET /runs?status=&target=&since=`
+### `DELETE /runs/:id`
+
+Delete one run. Backs `zuke runs prune`. **Optional** — a server that manages
+retention itself (see [the retention note](#notes-for-implementers)) may leave
+this unimplemented; the client only calls it from an explicit prune.
+
+| Response | Meaning                                                    |
+| -------- | ---------------------------------------------------------- |
+| `2xx`    | Deleted (or already absent).                               |
+| `404`    | No such run — treated as success (delete is idempotent).   |
+| other    | The client raises an error.                                |
+
+### `GET /runs?status=&target=&since=&limit=`
 
 List runs as an array of **summaries** (a subset of the record):
 
@@ -82,15 +94,18 @@ List runs as an array of **summaries** (a subset of the record):
 
 Query parameters (all optional, combined with AND):
 
-| Param    | Keeps runs where…                                       |
-| -------- | ------------------------------------------------------- |
-| `status` | the run status equals this value                        |
-| `target` | the run's graph contains a target with this dotted name |
-| `since`  | `createdAt` is at or after this ISO-8601 timestamp      |
+| Param    | Keeps runs where…                                                |
+| -------- | ---------------------------------------------------------------- |
+| `status` | the run status equals this value                                 |
+| `target` | the run's graph contains a target with this dotted name          |
+| `since`  | `createdAt` is at or after this ISO-8601 timestamp               |
+| `limit`  | at most this many are returned — the **newest**, so a large store stays listable |
 
 The client validates every summary it receives (an untrusted service is checked,
 not trusted) and expects newest-first ordering is applied server-side where it
-matters; it does not re-sort the list.
+matters; it does not re-sort the list. Ordering is **newest first** (by
+`createdAt`, then `id`); apply `limit` **after** ordering so it returns the most
+recent runs.
 
 ## Build catalog (`/builds`)
 
@@ -146,6 +161,15 @@ client validates every summary and does not re-sort.
   It exits `0` when every scenario passes and `1` (naming the failures) when one
   does not. A backend that passes is compatible with `HttpStateStore` /
   `HttpBuildRegistry`; one that violates CAS fails loudly.
+- **Retention is the server's job.** For a hosted store, **you own retention** —
+  a TTL, a scheduled sweep, a partition drop, whatever fits your storage. The
+  contract's job is to keep the store _listable_ while it grows, which is why
+  `GET /runs` takes `limit` and returns newest-first. `zuke runs prune` exists
+  for the **filesystem** backend (dev-grade, single host, no server to run a
+  sweep); it drives the optional `DELETE /runs/:id`, so implement `DELETE` only
+  if you want the CLI to prune your hosted store too. **Never prune a
+  non-terminal run** (`suspended`, `running`, `cancelling`): a run suspended for
+  days awaiting a human is the point of the system, not stale data.
 - **Never weaker than optimistic 409-retry.** The precondition model above is
   the minimum; a store that already does optimistic concurrency (e.g. a
   k8s-annotation store with resource versions) maps onto it directly.

--- a/docs/state.md
+++ b/docs/state.md
@@ -208,7 +208,34 @@ for (const summary of await store.listRuns({ status: "failed" })) {
 }
 ```
 
-`listRuns` filters by `status`, `target`, and `since`, newest first.
+`listRuns` filters by `status`, `target`, and `since`, newest first, and takes a
+`limit` (the newest N) so a large store stays listable.
+
+## Retention
+
+Records accumulate, so old ones can be pruned:
+
+```sh
+# Delete terminal runs older than 90 days, but always keep the newest 50.
+zuke runs prune --keep 90d --keep-last 50
+
+# Preview what would go, without deleting.
+zuke runs prune --keep 30d --dry-run
+```
+
+A run is removed only when it is **terminal** (`succeeded`, `failed`,
+`cancelled`) **and** matches neither rule — it is both older than `--keep` and
+beyond the newest `--keep-last`. A **non-terminal** run (`suspended`, `running`,
+`cancelling`) is **never** pruned: a run suspended for days awaiting a human is
+the point of the system. At least one of `--keep` / `--keep-last` is required, so
+an accidental bare `prune` never wipes the store.
+
+Who owns retention depends on the backend. The **filesystem** store is
+dev-grade and single-host, so it owns its pruning through this CLI. For the
+**HTTP** backend, retention is the **server's** job (a TTL or scheduled sweep) —
+`GET /runs` takes a `limit` so large stores stay listable, and `DELETE /runs/:id`
+(which `prune` drives) is an optional endpoint a hosted store implements only if
+it wants the CLI to prune it too. See [the state HTTP API](./state-api.md#notes-for-implementers).
 
 ## API stability
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -878,6 +878,8 @@ class FileSystemStateStore implements StateStore
     Publish `record` under an exclusive lock, guarding the expected version.
   async listRuns(query: RunQuery): Promise<RunSummary[]>
     List runs matching `query`, newest first. Unreadable files are skipped.
+  async deleteRun(id: string): Promise<void>
+    Delete a run's file (under its lock); a missing run is a no-op.
   async acquireLock(key: string, holder: LockHolder, ttlMs: number): Promise<LockResult>
     Atomically acquire the lock `key` for `holder`, taking over if expired.
   async renewLock(key: string, token: string, ttlMs: number): Promise<boolean>
@@ -987,6 +989,8 @@ class HttpStateStore implements StateStore
     `PUT /runs/:id` guarded by `If-Match` / `If-None-Match`; `412` → conflict.
   async listRuns(query: RunQuery): Promise<RunSummary[]>
     `GET /runs?status=&target=&since=` → an array of {@link RunSummary}.
+  async deleteRun(id: string): Promise<void>
+    `DELETE /runs/:id`; a missing run (`404`) is not an error.
   async acquireLock(key: string, holder: LockHolder, ttlMs: number): Promise<LockResult>
     `POST /locks/:key` → `201 { token }`, or `409` with the current holder.
   async renewLock(key: string, token: string, ttlMs: number): Promise<boolean>
@@ -2592,6 +2596,9 @@ interface RunQuery
     Keep only runs whose graph contains a target with this dotted name.
   since?: string
     Keep only runs created at or after this ISO-8601 timestamp.
+  limit?: number
+    Return at most this many runs (the newest, since listing is newest-first).
+    Applied server-side so a large store stays listable; `0` returns none.
 
 interface RunRecord
   A versioned snapshot of one run. Persisted as JSON; a store's opaque
@@ -2720,6 +2727,11 @@ interface StateStore
     the stored version has moved on — the caller re-reads and retries.
   listRuns(query: RunQuery): Promise<RunSummary[]>
     List runs matching `query`, newest first (by `createdAt`, then `id`).
+  deleteRun(id: string): Promise<void>
+    Delete a run permanently. A missing run is not an error (delete is
+    idempotent). Backs `zuke runs prune`; on the HTTP backend this maps to a
+    `DELETE /runs/:id` a server may leave unimplemented (retention there is the
+    server's job — see `docs/state-api.md`).
   acquireLock(key: string, holder: LockHolder, ttlMs: number): Promise<LockResult>
     Atomically acquire the lock `key` for `holder`, expiring after `ttlMs`. An
     expired lock is taken over. Returns a `token` on success, or the current

--- a/llms.txt
+++ b/llms.txt
@@ -46,7 +46,7 @@ Reserved commands:
 - `completions` — Print a shell-completion script
 - `mcp` — Run an MCP server over the build (for AI agents)
 - `resume` — Resume a suspended run (or --check all suspended runs)
-- `runs` — List or show persisted run records
+- `runs` — List, show, or prune persisted run records
 - `cancel` — Cancel a run and run its compensations
 - `register` — Register this build in the build registry
 
@@ -71,6 +71,9 @@ Option flags:
 - `--status` — With runs list, keep only runs with this status
 - `--target` — With runs list, keep only runs whose graph has this target
 - `--since` — With runs list, keep only runs created at/after this time
+- `--limit` — With runs list, return at most this many runs (newest)
+- `--keep` — With runs prune, keep runs newer than this age (e.g. 90d)
+- `--keep-last` — With runs prune, always keep the newest N terminal runs
 - `--allow-run` — With mcp, let agents run targets (optional =<glob-list> allow-list)
 - `--protect` — With mcp, require an operator token to run these targets
 - `--confirm-destructive` — With mcp, require confirm:true before a destructive run

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -932,6 +932,8 @@ class FileSystemStateStore implements StateStore
     Publish `record` under an exclusive lock, guarding the expected version.
   async listRuns(query: RunQuery): Promise<RunSummary[]>
     List runs matching `query`, newest first. Unreadable files are skipped.
+  async deleteRun(id: string): Promise<void>
+    Delete a run's file (under its lock); a missing run is a no-op.
   async acquireLock(key: string, holder: LockHolder, ttlMs: number): Promise<LockResult>
     Atomically acquire the lock `key` for `holder`, taking over if expired.
   async renewLock(key: string, token: string, ttlMs: number): Promise<boolean>
@@ -1041,6 +1043,8 @@ class HttpStateStore implements StateStore
     `PUT /runs/:id` guarded by `If-Match` / `If-None-Match`; `412` → conflict.
   async listRuns(query: RunQuery): Promise<RunSummary[]>
     `GET /runs?status=&target=&since=` → an array of {@link RunSummary}.
+  async deleteRun(id: string): Promise<void>
+    `DELETE /runs/:id`; a missing run (`404`) is not an error.
   async acquireLock(key: string, holder: LockHolder, ttlMs: number): Promise<LockResult>
     `POST /locks/:key` → `201 { token }`, or `409` with the current holder.
   async renewLock(key: string, token: string, ttlMs: number): Promise<boolean>
@@ -2646,6 +2650,9 @@ interface RunQuery
     Keep only runs whose graph contains a target with this dotted name.
   since?: string
     Keep only runs created at or after this ISO-8601 timestamp.
+  limit?: number
+    Return at most this many runs (the newest, since listing is newest-first).
+    Applied server-side so a large store stays listable; `0` returns none.
 
 interface RunRecord
   A versioned snapshot of one run. Persisted as JSON; a store's opaque
@@ -2774,6 +2781,11 @@ interface StateStore
     the stored version has moved on — the caller re-reads and retries.
   listRuns(query: RunQuery): Promise<RunSummary[]>
     List runs matching `query`, newest first (by `createdAt`, then `id`).
+  deleteRun(id: string): Promise<void>
+    Delete a run permanently. A missing run is not an error (delete is
+    idempotent). Backs `zuke runs prune`; on the HTTP backend this maps to a
+    `DELETE /runs/:id` a server may leave unimplemented (retention there is the
+    server's job — see `docs/state-api.md`).
   acquireLock(key: string, holder: LockHolder, ttlMs: number): Promise<LockResult>
     Atomically acquire the lock `key` for `holder`, expiring after `ttlMs`. An
     expired lock is taken over. Returns a `token` on success, or the current

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -39,6 +39,7 @@ import { type HttpAddress, serveMcp } from "./mcp/command.ts";
 import { cancelRun } from "./cancel.ts";
 import { resumeCheck, resumeRun } from "./resume.ts";
 import { runsCommand } from "./runs.ts";
+import { parseDuration } from "./duration.ts";
 import { registerCommand } from "./registry/register.ts";
 import { isRunStatus, RUN_STATUS_NAMES, type RunQuery } from "./state/types.ts";
 import {
@@ -152,6 +153,12 @@ export interface ParsedArgs {
   runTarget?: string;
   /** With `runs list`, keep only runs created at/after this ISO-8601 time (`--since`). */
   since?: string;
+  /** With `runs list`, return at most this many runs (`--limit`). */
+  runLimit?: string;
+  /** With `runs prune`, keep runs newer than this age (`--keep`). */
+  keep?: string;
+  /** With `runs prune`, always keep the newest N terminal runs (`--keep-last`). */
+  keepLast?: string;
   /** The `cancel` command was requested (cancel a run and run its compensations). */
   cancel: boolean;
   /** The run id to cancel (the positional after `cancel`). */
@@ -267,6 +274,23 @@ export function parseArgs(
       if (value) parsed.since = value;
     } else if (arg.startsWith("--since=")) {
       parsed.since = arg.slice("--since=".length);
+    } else if (arg === "--limit") {
+      // Capture an explicit empty value (`--limit ""`) so it is validated and
+      // rejected, not silently dropped — only a missing token stays undefined.
+      const value = args[++i];
+      if (value !== undefined) parsed.runLimit = value;
+    } else if (arg.startsWith("--limit=")) {
+      parsed.runLimit = arg.slice("--limit=".length);
+    } else if (arg === "--keep") {
+      const value = args[++i];
+      if (value !== undefined) parsed.keep = value;
+    } else if (arg.startsWith("--keep=")) {
+      parsed.keep = arg.slice("--keep=".length);
+    } else if (arg === "--keep-last") {
+      const value = args[++i];
+      if (value !== undefined) parsed.keepLast = value;
+    } else if (arg.startsWith("--keep-last=")) {
+      parsed.keepLast = arg.slice("--keep-last=".length);
     } else if (arg === "--check") {
       parsed.check = true;
     } else if (arg === "--allow-run") {
@@ -380,8 +404,9 @@ Usage:
   deno run -A zuke.ts mcp [--allow-run] [--registry] [--http <host:port>]
   deno run -A zuke.ts resume <run-id> [--signal <name>] [--data <json>]
   deno run -A zuke.ts resume --check [<run-id>]
-  deno run -A zuke.ts runs list [--status <s>] [--target <t>] [--since <iso>] [--json]
+  deno run -A zuke.ts runs list [--status <s>] [--target <t>] [--since <iso>] [--limit <n>] [--json]
   deno run -A zuke.ts runs show <run-id> [--json]
+  deno run -A zuke.ts runs prune [--keep <age>] [--keep-last <n>] [--dry-run]
   deno run -A zuke.ts cancel <run-id> [--actor <name>]
   deno run -A zuke.ts register [--actor <name>] [--json]
 
@@ -477,6 +502,11 @@ Options:
                     target.
   --since <iso>     With runs list, keep only runs created at or after this
                     ISO-8601 timestamp.
+  --limit <n>       With runs list, return at most this many runs (the newest).
+  --keep <age>      With runs prune, keep runs newer than this age (e.g. 90d);
+                    older terminal runs become eligible for deletion.
+  --keep-last <n>   With runs prune, always keep the newest N terminal runs.
+                    Non-terminal runs (suspended, running) are never pruned.
   --<param> <val>   Set a declared build parameter (see Parameters below).
   --help, -h        Show this help.`;
 
@@ -814,11 +844,49 @@ async function runRuns(build: Build, parsed: ParsedArgs): Promise<number> {
   }
   if (parsed.runTarget !== undefined) query.target = parsed.runTarget;
   if (parsed.since !== undefined) query.since = parsed.since;
+  if (parsed.runLimit !== undefined) {
+    const limit = parsePositiveInt(parsed.runLimit);
+    if (limit === undefined) {
+      console.error(
+        `runs: --limit must be a positive integer (got "${parsed.runLimit}").`,
+      );
+      return 1;
+    }
+    query.limit = limit;
+  }
+
+  let keepMs: number | undefined;
+  if (parsed.keep !== undefined) {
+    try {
+      keepMs = parseDuration(parsed.keep);
+    } catch (error) {
+      console.error(
+        `runs: --keep is ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return 1;
+    }
+  }
+  let keepLast: number | undefined;
+  if (parsed.keepLast !== undefined) {
+    keepLast = parsePositiveInt(parsed.keepLast);
+    if (keepLast === undefined) {
+      console.error(
+        `runs: --keep-last must be a positive integer (got "${parsed.keepLast}").`,
+      );
+      return 1;
+    }
+  }
+
   return await runsCommand(build, {
     action: parsed.runsAction,
     runId: parsed.runsRunId,
     json: parsed.json,
     query,
+    keepMs,
+    keepLast,
+    dryRun: parsed.dryRun,
   });
 }
 

--- a/packages/core/src/cli_spec.ts
+++ b/packages/core/src/cli_spec.ts
@@ -62,7 +62,7 @@ export const RESERVED_COMMANDS: readonly ReservedCommand[] = [
   },
   {
     name: RUNS_COMMAND,
-    description: "List or show persisted run records",
+    description: "List, show, or prune persisted run records",
   },
   {
     name: CANCEL_COMMAND,
@@ -142,6 +142,18 @@ export const BUILTIN_FLAGS: readonly BuiltinFlag[] = [
   {
     name: "--since",
     description: "With runs list, keep only runs created at/after this time",
+  },
+  {
+    name: "--limit",
+    description: "With runs list, return at most this many runs (newest)",
+  },
+  {
+    name: "--keep",
+    description: "With runs prune, keep runs newer than this age (e.g. 90d)",
+  },
+  {
+    name: "--keep-last",
+    description: "With runs prune, always keep the newest N terminal runs",
   },
   {
     name: "--allow-run",

--- a/packages/core/src/conformance.ts
+++ b/packages/core/src/conformance.ts
@@ -177,7 +177,7 @@ const STATE_SCENARIOS: StateScenario[] = [
     },
   },
   {
-    name: "listRuns filters by target and status, newest first",
+    name: "listRuns filters by target, status, since, and limit, newest first",
     async run(store) {
       // A unique graph target isolates this run set on a shared backend.
       const target = uniqueId("t");
@@ -228,6 +228,16 @@ const STATE_SCENARIOS: StateScenario[] = [
       expect(
         since.length === 2,
         `since filter should return the 2 at/after the cutoff, got ${since.length}`,
+      );
+      const limited = await store.listRuns({ target, limit: 2 });
+      expect(
+        limited.length === 2,
+        `limit should cap the result at 2, got ${limited.length}`,
+      );
+      expect(
+        limited.map((r) => r.createdAt).join(",") ===
+          all.slice(0, 2).map((r) => r.createdAt).join(","),
+        "limit should keep the newest runs, in newest-first order",
       );
     },
   },

--- a/packages/core/src/mcp/runtools.ts
+++ b/packages/core/src/mcp/runtools.ts
@@ -58,7 +58,7 @@ const READ_TOOLS: readonly McpTool[] = [
   {
     name: "list_runs",
     description:
-      "List persisted runs (newest first). Optional filters: status, target, since (ISO-8601).",
+      "List persisted runs (newest first). Optional filters: status, target, since (ISO-8601), limit.",
     inputSchema: {
       type: "object",
       properties: {
@@ -73,6 +73,10 @@ const READ_TOOLS: readonly McpTool[] = [
         since: {
           type: "string",
           description: "Keep only runs created at/after this ISO-8601 time.",
+        },
+        limit: {
+          type: "integer",
+          description: "Return at most this many runs (the newest).",
         },
       },
     },
@@ -187,6 +191,17 @@ function stringArg(
   return typeof value === "string" ? value : undefined;
 }
 
+/** A positive-integer argument (a JSON number), or `undefined` when absent/invalid. */
+function positiveIntArg(
+  args: Record<string, unknown>,
+  key: string,
+): number | undefined {
+  const value = args[key];
+  return typeof value === "number" && Number.isInteger(value) && value > 0
+    ? value
+    : undefined;
+}
+
 /** Render a value as a pretty-printed JSON tool result. */
 function jsonResult(value: unknown, isError = false): RunToolResult {
   return { text: JSON.stringify(value, null, 2), isError };
@@ -252,6 +267,8 @@ async function listRuns(
   if (target !== undefined) query.target = target;
   const since = stringArg(args, "since");
   if (since !== undefined) query.since = since;
+  const limit = positiveIntArg(args, "limit");
+  if (limit !== undefined) query.limit = limit;
   return jsonResult(await deps.store.listRuns(query));
 }
 

--- a/packages/core/src/runs.ts
+++ b/packages/core/src/runs.ts
@@ -15,6 +15,7 @@ import { resolveStateStore } from "./state/resolve.ts";
 import type {
   RunQuery,
   RunRecord,
+  RunStatus,
   RunSummary,
   TargetRunState,
   TargetRunStatus,
@@ -23,14 +24,25 @@ import { formatDuration } from "./render.ts";
 
 /** Inputs for {@link runsCommand}. */
 export interface RunsOptions {
-  /** The sub-action: `list` (the default) or `show`. */
+  /** The sub-action: `list` (the default), `show`, or `prune`. */
   action?: string;
   /** The run id to show; required by the `show` sub-action. */
   runId?: string;
   /** Emit JSON (a summary array, or the whole record) instead of a human view. */
   json?: boolean;
-  /** Filters for `list` — status, a target in the run, a creation time. */
+  /** Filters for `list` — status, a target in the run, a creation time, a limit. */
   query?: RunQuery;
+  /**
+   * `prune`: keep runs created within this many milliseconds of now; older
+   * terminal runs become eligible. Omitted means no age rule.
+   */
+  keepMs?: number;
+  /** `prune`: always keep the newest N terminal runs, regardless of age. */
+  keepLast?: number;
+  /** `prune`: report what would be pruned without deleting (CLI `--dry-run`). */
+  dryRun?: boolean;
+  /** The wall clock for `prune`'s age cutoff (epoch ms); defaults to `Date.now`. */
+  now?: () => number;
   /**
    * Store override, resolved like a run (explicit → `stateStore()` → env →
    * `.zuke/runs`); `false` disables state. Tests inject a store here.
@@ -38,6 +50,54 @@ export interface RunsOptions {
   stateStore?: StateStore | false;
   /** Reads an environment variable (injectable for tests). */
   readEnv?: (name: string) => string | undefined;
+}
+
+/** The run statuses past which nothing more happens — the only prunable ones. */
+const TERMINAL_STATUSES: readonly RunStatus[] = [
+  "succeeded",
+  "failed",
+  "cancelled",
+];
+
+/** Whether a run has reached a terminal (prunable) status. */
+function isTerminalStatus(status: RunStatus): boolean {
+  return TERMINAL_STATUSES.includes(status);
+}
+
+/** Options for {@link selectRunsToPrune}. */
+export interface PruneRules {
+  /** Keep runs created within this many ms of `nowMs`; omitted means no age rule. */
+  keepMs?: number;
+  /** Always keep the newest N terminal runs; omitted means no count rule. */
+  keepLast?: number;
+}
+
+/**
+ * From `summaries` (newest first), pick the ids of runs to prune: a run is
+ * removed only if it is **terminal** and matches **neither** retention rule —
+ * it is beyond the newest `keepLast` and older than the `keepMs` window. A
+ * non-terminal run (suspended, running, cancelling) is never selected — a run
+ * waiting days for a human is the point of the system. With no rule given,
+ * every terminal run qualifies, so callers must supply at least one.
+ */
+export function selectRunsToPrune(
+  summaries: readonly RunSummary[],
+  rules: PruneRules,
+  nowMs: number,
+): string[] {
+  const cutoff = rules.keepMs === undefined ? undefined : nowMs - rules.keepMs;
+  const terminal = summaries.filter((s) => isTerminalStatus(s.status));
+  const toPrune: string[] = [];
+  terminal.forEach((s, index) => {
+    if (rules.keepLast !== undefined && index < rules.keepLast) return;
+    if (cutoff !== undefined) {
+      const created = Date.parse(s.createdAt);
+      // An unparseable timestamp is kept, never pruned (fail safe).
+      if (Number.isNaN(created) || created >= cutoff) return;
+    }
+    toPrune.push(s.id);
+  });
+  return toPrune;
 }
 
 /** Read an environment variable, treating missing env access as unset. */
@@ -110,8 +170,57 @@ export async function runsCommand(
     );
     return 0;
   }
-  console.error("Usage: zuke runs <list|show> [<run-id>]");
+  if (action === "prune") return await pruneRuns(store, options);
+  console.error("Usage: zuke runs <list|show|prune> [<run-id>]");
   return 1;
+}
+
+/**
+ * `zuke runs prune`: delete terminal runs that match neither retention rule,
+ * keeping non-terminal runs and everything within `--keep`/`--keep-last`. At
+ * least one rule is required, so an empty `prune` can't wipe the store. With
+ * `--dry-run`, reports what would be pruned without deleting.
+ */
+async function pruneRuns(
+  store: StateStore,
+  options: RunsOptions,
+): Promise<number> {
+  if (options.keepMs === undefined && options.keepLast === undefined) {
+    console.error(
+      "Usage: zuke runs prune [--keep <duration>] [--keep-last <n>]\n" +
+        "  Give at least one retention rule — prune never deletes everything by default.",
+    );
+    return 1;
+  }
+  const now = options.now ?? Date.now;
+  // List everything, newest first (no limit): pruning needs the full set to
+  // apply the newest-N and age rules across all runs.
+  const summaries = await store.listRuns({});
+  const ids = selectRunsToPrune(
+    summaries,
+    { keepMs: options.keepMs, keepLast: options.keepLast },
+    now(),
+  );
+  if (options.dryRun) {
+    console.log(
+      options.json
+        ? JSON.stringify({ wouldPrune: ids }, null, 2)
+        : `Would prune ${ids.length} run(s)${idList(ids)}.`,
+    );
+    return 0;
+  }
+  for (const id of ids) await store.deleteRun(id);
+  console.log(
+    options.json
+      ? JSON.stringify({ pruned: ids }, null, 2)
+      : `Pruned ${ids.length} run(s)${idList(ids)}.`,
+  );
+  return 0;
+}
+
+/** A short trailing ` (id, id, …)` list, or empty when nothing was selected. */
+function idList(ids: readonly string[]): string {
+  return ids.length === 0 ? "" : `: ${ids.join(", ")}`;
 }
 
 /** A single-glyph status marker, kept ASCII so it renders in any terminal/log. */

--- a/packages/core/src/state/fs_store.ts
+++ b/packages/core/src/state/fs_store.ts
@@ -168,7 +168,16 @@ export class FileSystemStateStore implements StateStore {
       }
       if (matches(record, query)) summaries.push(toSummary(record));
     }
-    return sortNewestFirst(summaries);
+    const sorted = sortNewestFirst(summaries);
+    return query.limit === undefined ? sorted : sorted.slice(0, query.limit);
+  }
+
+  /** Delete a run's file (under its lock); a missing run is a no-op. */
+  async deleteRun(id: string): Promise<void> {
+    await this.#ensureDir();
+    await this.#withLock(id, async () => {
+      await this.#host.remove(this.#file(id));
+    });
   }
 
   /** Atomically acquire the lock `key` for `holder`, taking over if expired. */

--- a/packages/core/src/state/http_store.ts
+++ b/packages/core/src/state/http_store.ts
@@ -141,6 +141,7 @@ export class HttpStateStore implements StateStore {
     if (query.status !== undefined) params.set("status", query.status);
     if (query.target !== undefined) params.set("target", query.target);
     if (query.since !== undefined) params.set("since", query.since);
+    if (query.limit !== undefined) params.set("limit", String(query.limit));
     const qs = params.toString();
     const url = `${this.#base}/runs${qs === "" ? "" : `?${qs}`}`;
     const response = await this.#request(url, { headers: this.#headers() });
@@ -153,6 +154,19 @@ export class HttpStateStore implements StateStore {
       throw new Error(`state: ${url} did not return a JSON array`);
     }
     return parsed.map(parseRunSummary);
+  }
+
+  /** `DELETE /runs/:id`; a missing run (`404`) is not an error. */
+  async deleteRun(id: string): Promise<void> {
+    const url = this.#runUrl(id);
+    const response = await this.#request(url, {
+      method: "DELETE",
+      headers: this.#headers(),
+    });
+    await response.body?.cancel();
+    if (!response.ok && response.status !== 404) {
+      throw new HttpError(response.status, url);
+    }
   }
 
   #lockUrl(key: string): string {

--- a/packages/core/src/state/store.ts
+++ b/packages/core/src/state/store.ts
@@ -50,6 +50,13 @@ export interface StateStore {
   /** List runs matching `query`, newest first (by `createdAt`, then `id`). */
   listRuns(query: RunQuery): Promise<RunSummary[]>;
   /**
+   * Delete a run permanently. A missing run is **not** an error (delete is
+   * idempotent). Backs `zuke runs prune`; on the HTTP backend this maps to a
+   * `DELETE /runs/:id` a server may leave unimplemented (retention there is the
+   * server's job — see `docs/state-api.md`).
+   */
+  deleteRun(id: string): Promise<void>;
+  /**
    * Atomically acquire the lock `key` for `holder`, expiring after `ttlMs`. An
    * expired lock is taken over. Returns a `token` on success, or the current
    * holder when the lock is live.

--- a/packages/core/src/state/types.ts
+++ b/packages/core/src/state/types.ts
@@ -170,6 +170,11 @@ export interface RunQuery {
   target?: string;
   /** Keep only runs created at or after this ISO-8601 timestamp. */
   since?: string;
+  /**
+   * Return at most this many runs (the newest, since listing is newest-first).
+   * Applied server-side so a large store stays listable; `0` returns none.
+   */
+  limit?: number;
 }
 
 /** The projection of a {@link RunRecord} down to its {@link RunSummary}. */

--- a/packages/core/tests/cli_test.ts
+++ b/packages/core/tests/cli_test.ts
@@ -240,24 +240,61 @@ Deno.test("parseArgs reads the runs command, sub-action, id, and filters", () =>
     "deploy",
     "--since",
     "2026-01-01",
+    "--limit",
+    "5",
   ]);
   assertEquals(
-    [list.runs, list.runsAction, list.runStatus, list.runTarget, list.since],
-    [true, "list", "failed", "deploy", "2026-01-01"],
+    [
+      list.runs,
+      list.runsAction,
+      list.runStatus,
+      list.runTarget,
+      list.since,
+      list.runLimit,
+    ],
+    [true, "list", "failed", "deploy", "2026-01-01", "5"],
   );
 
   const show = parseArgs(["runs", "show", "run-9"]);
   assertEquals([show.runsAction, show.runsRunId], ["show", "run-9"]);
 
-  // Inline `=` forms of the filters.
+  // prune flags, space form.
+  const prune = parseArgs([
+    "runs",
+    "prune",
+    "--keep",
+    "90d",
+    "--keep-last",
+    "50",
+  ]);
+  assertEquals([prune.runsAction, prune.keep, prune.keepLast], [
+    "prune",
+    "90d",
+    "50",
+  ]);
+
+  // Inline `=` forms of the filters and prune flags.
   const eq = parseArgs([
     "runs",
     "list",
     "--status=succeeded",
     "--target=t",
     "--since=x",
+    "--limit=3",
   ]);
-  assertEquals([eq.runStatus, eq.runTarget, eq.since], ["succeeded", "t", "x"]);
+  assertEquals([eq.runStatus, eq.runTarget, eq.since, eq.runLimit], [
+    "succeeded",
+    "t",
+    "x",
+    "3",
+  ]);
+  const eqPrune = parseArgs(["runs", "prune", "--keep=30d", "--keep-last=10"]);
+  assertEquals([eqPrune.keep, eqPrune.keepLast], ["30d", "10"]);
+
+  // An explicit empty value (e.g. `--keep "$UNSET"`) is captured, not dropped,
+  // so it is validated and rejected rather than silently weakening prune.
+  const empty = parseArgs(["runs", "prune", "--keep", "", "--keep-last", "5"]);
+  assertEquals([empty.keep, empty.keepLast], ["", "5"]);
 });
 
 Deno.test("main: runs list reads persisted runs; --json emits run data", async () => {
@@ -299,6 +336,63 @@ Deno.test("main: runs list rejects an unknown --status", async () => {
   );
   assertEquals(code, 1);
   assertStringIncludes(err.join("\n"), 'unknown --status "bogus"');
+});
+
+Deno.test("main: runs prune validates --limit, --keep, and --keep-last", async () => {
+  const badLimit = await capture(() =>
+    main(Demo, ["runs", "list", "--limit", "nope"])
+  );
+  assertEquals(badLimit.code, 1);
+  assertStringIncludes(badLimit.err.join("\n"), "--limit must be a positive");
+
+  const badKeep = await capture(() =>
+    main(Demo, ["runs", "prune", "--keep", "banana"])
+  );
+  assertEquals(badKeep.code, 1);
+  assertStringIncludes(badKeep.err.join("\n"), "--keep");
+
+  const badKeepLast = await capture(() =>
+    main(Demo, ["runs", "prune", "--keep-last", "-1"])
+  );
+  assertEquals(badKeepLast.code, 1);
+  assertStringIncludes(badKeepLast.err.join("\n"), "--keep-last must be");
+
+  // An empty --keep (an unset CI variable) errors rather than silently pruning
+  // with only the other rule — it must not be treated as "no age window".
+  const emptyKeep = await capture(() =>
+    main(Demo, ["runs", "prune", "--keep", "", "--keep-last", "5"])
+  );
+  assertEquals(emptyKeep.code, 1);
+  assertStringIncludes(emptyKeep.err.join("\n"), "--keep");
+});
+
+Deno.test("main: runs prune deletes eligible runs through the CLI", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    await store.putRun(
+      sampleRunRecord({
+        id: "old",
+        status: "succeeded",
+        createdAt: "2020-01-01T00:00:00.000Z",
+      }),
+      null,
+    );
+    class Stateful extends Build {
+      override stateStore() {
+        return store;
+      }
+      build = target().executes(() => {});
+    }
+    const ok = await capture(() =>
+      main(Stateful, ["runs", "prune", "--keep", "1d"])
+    );
+    assertEquals(ok.code, 0);
+    assertStringIncludes(ok.out.join("\n"), "Pruned 1 run");
+    assertEquals(await store.getRun("old"), null);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
 });
 
 Deno.test("parseArgs reads the mcp --http address", () => {

--- a/packages/core/tests/conformance_test.ts
+++ b/packages/core/tests/conformance_test.ts
@@ -70,6 +70,9 @@ class NoCasStore implements StateStore {
   listRuns(): Promise<RunSummary[]> {
     return Promise.resolve([]);
   }
+  deleteRun(): Promise<void> {
+    return Promise.resolve();
+  }
   acquireLock(): Promise<LockResult> {
     return Promise.resolve({ ok: true, token: "t" }); // never contends
   }

--- a/packages/core/tests/mcp_hardening_test.ts
+++ b/packages/core/tests/mcp_hardening_test.ts
@@ -235,10 +235,17 @@ Deno.test("cancel_run cancels a suspended run, gated by the allow-list and audit
 });
 
 Deno.test("run tools query the store and return structured errors", async () => {
-  await withServer({ allowRun: true }, async (server) => {
+  await withServer({ allowRun: true }, async (server, store) => {
     const list = await call(server, "list_runs");
     assertEquals(list.isError, false);
     assertEquals(JSON.parse(list.text), []);
+
+    // list_runs honours a limit against the store.
+    await seedSuspended(store, "deploy");
+    await seedSuspended(store, "promote");
+    const limited = await call(server, "list_runs", { limit: 1 });
+    assertEquals(limited.isError, false);
+    assertEquals(JSON.parse(limited.text).length, 1);
 
     const missing = await call(server, "show_run", { runId: "nope" });
     assertEquals(missing.isError, true);

--- a/packages/core/tests/runs_test.ts
+++ b/packages/core/tests/runs_test.ts
@@ -1,9 +1,14 @@
 import { assertEquals, assertStringIncludes } from "./_assert.ts";
 import { Build } from "../src/build.ts";
-import { formatRunDetail, formatRunList, runsCommand } from "../src/runs.ts";
+import {
+  formatRunDetail,
+  formatRunList,
+  runsCommand,
+  selectRunsToPrune,
+} from "../src/runs.ts";
 import { FileSystemStateStore } from "../src/state/fs_store.ts";
 import { defaultStateHost } from "../src/state/store.ts";
-import type { RunRecord } from "../src/state/types.ts";
+import type { RunRecord, RunStatus, RunSummary } from "../src/state/types.ts";
 
 /** A trivial build; `runsCommand` only reads `build.stateStore()` from it. */
 class B extends Build {}
@@ -282,6 +287,233 @@ Deno.test("runsCommand rejects an unknown sub-action", async () => {
       runsCommand(new B(), { action: "delete", stateStore: store })
     );
     assertEquals(code, 1);
-    assertStringIncludes(err, "Usage: zuke runs <list|show>");
+    assertStringIncludes(err, "Usage: zuke runs <list|show|prune>");
+  });
+});
+
+// --- M17: run-record retention ---
+
+const DAY = 86_400_000;
+const NOW = Date.parse("2026-07-19T00:00:00.000Z");
+
+/** A run summary at `agoDays` before {@link NOW}, with the given status. */
+function sum(id: string, status: RunStatus, agoDays: number): RunSummary {
+  return {
+    id,
+    build: "CI",
+    rootTarget: "deploy",
+    status,
+    actor: "alice",
+    createdAt: new Date(NOW - agoDays * DAY).toISOString(),
+    updatedAt: new Date(NOW - agoDays * DAY).toISOString(),
+  };
+}
+
+Deno.test("selectRunsToPrune keeps non-terminal runs and honours both rules", () => {
+  // Newest first: a suspended run, then four terminal runs of increasing age.
+  const summaries = [
+    sum("suspended", "suspended", 0), // non-terminal → never pruned
+    sum("t-1d", "succeeded", 1),
+    sum("t-10d", "failed", 10),
+    sum("t-40d", "cancelled", 40),
+    sum("t-50d", "succeeded", 50),
+  ];
+  // keepLast 2 protects the two newest terminal runs; keep 30d protects anything
+  // newer than 30 days. Only runs matching neither are pruned.
+  const ids = selectRunsToPrune(
+    summaries,
+    { keepMs: 30 * DAY, keepLast: 2 },
+    NOW,
+  );
+  assertEquals(ids, ["t-40d", "t-50d"]);
+});
+
+Deno.test("selectRunsToPrune with keep-last only keeps the newest N terminal", () => {
+  const summaries = [
+    sum("t-1d", "succeeded", 1),
+    sum("t-2d", "failed", 2),
+    sum("t-3d", "cancelled", 3),
+  ];
+  assertEquals(selectRunsToPrune(summaries, { keepLast: 1 }, NOW), [
+    "t-2d",
+    "t-3d",
+  ]);
+});
+
+Deno.test("selectRunsToPrune with keep only prunes terminal runs past the window", () => {
+  const summaries = [
+    sum("suspended-old", "suspended", 100), // non-terminal, old → still kept
+    sum("t-5d", "succeeded", 5),
+    sum("t-40d", "failed", 40),
+  ];
+  assertEquals(selectRunsToPrune(summaries, { keepMs: 30 * DAY }, NOW), [
+    "t-40d",
+  ]);
+});
+
+Deno.test("selectRunsToPrune keeps a run with an unparseable timestamp", () => {
+  const bad = sum("t-bad", "succeeded", 0);
+  bad.createdAt = "not-a-date";
+  assertEquals(selectRunsToPrune([bad], { keepMs: DAY }, NOW), []);
+});
+
+Deno.test("runs prune deletes old terminal runs, keeps recent and non-terminal", async () => {
+  await withStore(async (store) => {
+    const iso = (agoDays: number) =>
+      new Date(NOW - agoDays * DAY).toISOString();
+    await store.putRun(
+      sampleRecord({ id: "keep-new", status: "succeeded", createdAt: iso(1) }),
+      null,
+    );
+    await store.putRun(
+      sampleRecord({ id: "prune-old", status: "failed", createdAt: iso(100) }),
+      null,
+    );
+    await store.putRun(
+      sampleRecord({
+        id: "keep-suspended",
+        status: "suspended",
+        createdAt: iso(200),
+      }),
+      null,
+    );
+
+    const { code, out } = await capture(() =>
+      runsCommand(new B(), {
+        action: "prune",
+        keepMs: 30 * DAY,
+        stateStore: store,
+        now: () => NOW,
+      })
+    );
+    assertEquals(code, 0);
+    assertStringIncludes(out, "Pruned 1 run");
+    assertEquals(await store.getRun("prune-old"), null); // deleted
+    assertEquals((await store.getRun("keep-new")) !== null, true);
+    assertEquals((await store.getRun("keep-suspended")) !== null, true);
+  });
+});
+
+Deno.test("runs prune requires at least one retention rule", async () => {
+  await withStore(async (store) => {
+    await store.putRun(sampleRecord({ id: "r1" }), null);
+    const { code, err } = await capture(() =>
+      runsCommand(new B(), { action: "prune", stateStore: store })
+    );
+    assertEquals(code, 1);
+    assertStringIncludes(err, "at least one retention rule");
+    assertEquals((await store.getRun("r1")) !== null, true); // untouched
+  });
+});
+
+Deno.test("runs prune --dry-run reports without deleting", async () => {
+  await withStore(async (store) => {
+    await store.putRun(
+      sampleRecord({
+        id: "old",
+        status: "succeeded",
+        createdAt: "2020-01-01T00:00:00.000Z",
+      }),
+      null,
+    );
+    const { code, out } = await capture(() =>
+      runsCommand(new B(), {
+        action: "prune",
+        keepMs: DAY,
+        stateStore: store,
+        now: () => NOW,
+        dryRun: true,
+      })
+    );
+    assertEquals(code, 0);
+    assertStringIncludes(out, "Would prune 1 run");
+    assertStringIncludes(out, "old");
+    assertEquals((await store.getRun("old")) !== null, true); // not deleted
+  });
+});
+
+Deno.test("runs prune --json emits the pruned and would-prune ids", async () => {
+  await withStore(async (store) => {
+    await store.putRun(
+      sampleRecord({
+        id: "old",
+        status: "succeeded",
+        createdAt: "2020-01-01T00:00:00.000Z",
+      }),
+      null,
+    );
+    const dry = await capture(() =>
+      runsCommand(new B(), {
+        action: "prune",
+        keepMs: DAY,
+        stateStore: store,
+        now: () => NOW,
+        dryRun: true,
+        json: true,
+      })
+    );
+    assertEquals(dry.code, 0);
+    assertEquals(JSON.parse(dry.out).wouldPrune, ["old"]);
+    assertEquals((await store.getRun("old")) !== null, true); // dry-run kept it
+
+    const del = await capture(() =>
+      runsCommand(new B(), {
+        action: "prune",
+        keepMs: DAY,
+        stateStore: store,
+        now: () => NOW,
+        json: true,
+      })
+    );
+    assertEquals(JSON.parse(del.out).pruned, ["old"]);
+  });
+});
+
+Deno.test("runs prune reports zero when nothing matches", async () => {
+  await withStore(async (store) => {
+    await store.putRun(
+      sampleRecord({
+        id: "recent",
+        status: "succeeded",
+        createdAt: new Date(NOW).toISOString(),
+      }),
+      null,
+    );
+    const { code, out } = await capture(() =>
+      runsCommand(new B(), {
+        action: "prune",
+        keepMs: 365 * DAY,
+        stateStore: store,
+        now: () => NOW,
+      })
+    );
+    assertEquals(code, 0);
+    assertStringIncludes(out, "Pruned 0 run");
+    assertEquals((await store.getRun("recent")) !== null, true);
+  });
+});
+
+Deno.test("runs list honours --limit via the query", async () => {
+  await withStore(async (store) => {
+    for (let i = 0; i < 3; i++) {
+      await store.putRun(
+        sampleRecord({
+          id: `r${i}`,
+          createdAt: new Date(NOW - i * DAY).toISOString(),
+        }),
+        null,
+      );
+    }
+    const { code, out } = await capture(() =>
+      runsCommand(new B(), {
+        action: "list",
+        json: true,
+        query: { limit: 2 },
+        stateStore: store,
+      })
+    );
+    assertEquals(code, 0);
+    const rows: RunSummary[] = JSON.parse(out);
+    assertEquals(rows.length, 2);
   });
 });

--- a/packages/core/tests/state_test.ts
+++ b/packages/core/tests/state_test.ts
@@ -379,6 +379,31 @@ Deno.test("FileSystemStateStore listRuns filters, sorts, and skips junk", async 
     ),
     ["r3"],
   );
+  // limit returns the newest N.
+  assertEquals((await store.listRuns({ limit: 2 })).map((s) => s.id), [
+    "r3",
+    "r2",
+  ]);
+  assertEquals((await store.listRuns({ limit: 0 })).length, 0);
+});
+
+Deno.test("FileSystemStateStore deleteRun removes a run; a missing run is a no-op", async () => {
+  const store = new FileSystemStateStore("/runs", new FakeStateHost());
+  await store.putRun(sampleRecord({ id: "r1" }), null);
+  assertEquals((await store.getRun("r1")) !== null, true);
+  await store.deleteRun("r1");
+  assertEquals(await store.getRun("r1"), null);
+  await store.deleteRun("r1"); // idempotent — no throw
+  await store.deleteRun("never-existed");
+});
+
+Deno.test("FileSystemStateStore deleteRun rejects an unsafe run id", async () => {
+  const store = new FileSystemStateStore("/runs", new FakeStateHost());
+  await assertRejects(
+    () => store.deleteRun("../escape"),
+    Error,
+    "unsafe run id",
+  );
 });
 
 Deno.test("FileSystemStateStore rejects an unsafe run id on read and write", async () => {
@@ -525,10 +550,12 @@ Deno.test("HttpStateStore.listRuns builds a query and validates the array", asyn
     status: "running",
     target: "deploy",
     since: "x",
+    limit: 5,
   });
   assertEquals(list.length, 1);
   assertStringIncludes(lastUrl, "status=running");
   assertStringIncludes(lastUrl, "target=deploy");
+  assertStringIncludes(lastUrl, "limit=5");
 
   const emptyQuery = new HttpStateStore({
     url: "https://s.example",
@@ -548,6 +575,34 @@ Deno.test("HttpStateStore.listRuns builds a query and validates the array", asyn
     fetch: fakeFetch(() => new Response(null, { status: 503 })),
   });
   await assertRejects(() => boom.listRuns({}), HttpError);
+});
+
+Deno.test("HttpStateStore.deleteRun sends DELETE; 404 is not an error, others throw", async () => {
+  let method = "";
+  let path = "";
+  const ok = new HttpStateStore({
+    url: "https://s.example",
+    fetch: fakeFetch((url, init) => {
+      method = init?.method ?? "GET";
+      path = url;
+      return new Response(null, { status: 204 });
+    }),
+  });
+  await ok.deleteRun("run-1");
+  assertEquals(method, "DELETE");
+  assertStringIncludes(path, "/runs/run-1");
+
+  const gone = new HttpStateStore({
+    url: "https://s.example",
+    fetch: fakeFetch(() => new Response(null, { status: 404 })),
+  });
+  await gone.deleteRun("missing"); // 404 → no throw
+
+  const boom = new HttpStateStore({
+    url: "https://s.example",
+    fetch: fakeFetch(() => new Response(null, { status: 500 })),
+  });
+  await assertRejects(() => boom.deleteRun("run-1"), HttpError);
 });
 
 // ---------------------------------------------------------------- resolve
@@ -685,6 +740,10 @@ class MemStore implements StateStore {
     this.record = structuredClone(record);
     this.version += 1;
     return Promise.resolve({ ok: true, version: String(this.version) });
+  }
+  deleteRun(): Promise<void> {
+    this.record = null;
+    return Promise.resolve();
   }
   // Locks are exercised against the real backends, not this run-only fake.
   acquireLock(): Promise<never> {

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -97,7 +97,9 @@ Before calling any task or settings method, confirm the real shape:
   `ctx.state.set({ … })` / `ctx.state.get()` records per-target metadata (JSON,
   **never secrets** — secret parameters and redacted values are excluded).
   Inspect persisted runs afterwards with `zuke runs list` (filter by
-  `--status`/`--target`/`--since`) and `zuke runs show <id>` (`--json` on both).
+  `--status`/`--target`/`--since`/`--limit`) and `zuke runs show <id>` (`--json`
+  on both). Prune old ones with `zuke runs prune --keep <age> --keep-last <n>`
+  (only terminal runs; never suspended/running).
   See the cheatsheet.
 - **Cross-run locks:** `.lock((s) => s.lockKey(...).withTtl("4h"))` — a settings
   lambda — gives a target an exclusive claim across runs/machines; a second run

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -172,9 +172,14 @@ class CD extends Build {
   mismatch.
 - The run record holds status, the graph shape, resolved **non-secret**
   parameters, and per-target status/timing/metadata. Inspect it from the CLI
-  with `zuke runs list [--status <s>] [--target <t>] [--since <iso>]` (newest
-  first) and `zuke runs show <id>` (`--json` on both), or programmatically with
-  `store.listRuns({ status?, target?, since? })` and `store.getRun(id)`.
+  with `zuke runs list [--status <s>] [--target <t>] [--since <iso>] [--limit <n>]`
+  (newest first) and `zuke runs show <id>` (`--json` on both), or programmatically
+  with `store.listRuns({ status?, target?, since?, limit? })` and `store.getRun(id)`.
+- **Retention:** `zuke runs prune --keep <age> --keep-last <n>` deletes only
+  **terminal** runs matching neither rule (`--dry-run` to preview); a
+  non-terminal run (suspended/running) is never pruned. The FS store owns
+  pruning via the CLI; for the HTTP backend retention is the server's job
+  (`GET /runs` takes `limit`; `DELETE /runs/:id` is optional). See `docs/state.md`.
 - **Never put secrets in `ctx.state`** — it is stored as plain JSON. Secret
   parameters are excluded from the record and state values are run through the
   redactor, but treat state as a non-secret channel. See `docs/state.md`.
@@ -571,8 +576,9 @@ else a friendly error.
 ./zuke <target> --no-cache    # ignore the incremental cache
 ./zuke <target> --state       # persist run state to .zuke/runs (durable state)
 ./zuke <target> --actor <who> # attribute the run in its state record
-./zuke runs list [--status s] # list persisted runs (also --target, --since, --json)
+./zuke runs list [--status s] # list persisted runs (also --target, --since, --limit, --json)
 ./zuke runs show <id>         # one run's full per-target status (+ --json)
+./zuke runs prune --keep 90d --keep-last 50  # delete old terminal runs (--dry-run to preview)
 ./zuke resume <id> --signal <name> [--data <json>]  # continue a suspended run
 ./zuke cancel <id>            # cancel a run and run its .onCancel() compensations
 ./zuke mcp [--allow-run]      # serve the build over MCP for an AI client (stdio)

--- a/tests/integration/state_test.ts
+++ b/tests/integration/state_test.ts
@@ -12,6 +12,7 @@ import {
 import {
   Build,
   defaultStateHost,
+  externalSignal,
   FileSystemStateStore,
   target,
 } from "../../packages/core/mod.ts";
@@ -62,6 +63,53 @@ Deno.test("a failing run is persisted as a failed record", async () => {
       assertEquals(got.record.status, "failed");
       assertEquals(got.record.targets["boom"].status, "failed");
     }
+  });
+});
+
+Deno.test("zuke runs prune keeps non-terminal runs and the newest terminal, honouring --limit", async () => {
+  await withStateDir(async (dir) => {
+    class Ok extends Build {
+      go = target().executes(() => {});
+    }
+    class Gated extends Build {
+      gate = target().waitsFor((s) => s.on(externalSignal("approve")));
+    }
+    // Two terminal (succeeded) runs and one suspended run.
+    await runCli(Ok, ["go"]);
+    await runCli(Ok, ["go"]);
+    const gated = await runCli(Gated, ["gate"]);
+    assertEquals(gated.code, 0); // suspends and exits 0
+
+    const store = storeAt(dir);
+    assertEquals((await store.listRuns({})).length, 3);
+    const suspended = (await store.listRuns({ status: "suspended" }))[0];
+
+    // --limit caps the listing at the newest run.
+    const listed = await runCli(Ok, ["runs", "list", "--limit", "1", "--json"]);
+    assertEquals(listed.code, 0);
+    assertEquals(JSON.parse(listed.out).length, 1);
+
+    // Keep only the newest terminal run; the suspended one is never counted.
+    const pruned = await runCli(Ok, ["runs", "prune", "--keep-last", "1"]);
+    assertEquals(pruned.code, 0);
+    assertStringIncludes(pruned.out, "Pruned 1 run");
+
+    // One terminal run pruned; the suspended run survives.
+    assertEquals((await store.listRuns({})).length, 2);
+    assertEquals((await store.getRun(suspended.id)) !== null, true);
+  });
+});
+
+Deno.test("zuke runs prune with no retention rule refuses to delete", async () => {
+  await withStateDir(async (dir) => {
+    class Ok extends Build {
+      go = target().executes(() => {});
+    }
+    await runCli(Ok, ["go"]);
+    const refused = await runCli(Ok, ["runs", "prune"]);
+    assertEquals(refused.code, 1);
+    assertStringIncludes(refused.err, "at least one retention rule");
+    assertEquals((await storeAt(dir).listRuns({})).length, 1); // untouched
   });
 });
 


### PR DESCRIPTION
## M17 — Run-record retention (Round 2, P1 #6)

Answers **who owns run-record retention** — then ships the CLI that answer
demands. The requester needs the ownership answer before freezing their backend
schema.

### What changed

- **`StateStore.deleteRun(id)`** — added to the interface. The filesystem backend
  removes the run's file (under its lock; a missing run is a no-op); the HTTP
  backend maps it to `DELETE /runs/:id` (`404` is not an error), a
  **documented-optional** endpoint a hosted store implements only if it wants the
  CLI to prune it.
- **`RunQuery.limit`** — return at most the newest N. Honoured server-side by both
  backends (FS slices after the newest-first sort; HTTP sends `?limit=`), and
  threaded through `zuke runs list --limit` and the `list_runs` MCP tool.
- **`zuke runs prune --keep <age> --keep-last <n> [--dry-run]`** — deletes only
  **terminal** runs (`succeeded`/`failed`/`cancelled`) matching **neither** rule:
  older than the keep window **and** beyond the newest keep-last. A **non-terminal**
  run (`suspended`/`running`/`cancelling`) is **never** pruned — a run suspended
  for days awaiting a human is the point of the system. At least one rule is
  required, so a bare `prune` can't wipe the store; `--dry-run` previews.
- **The ownership answer** (`docs/state-api.md`, `docs/state.md`): the FS store
  owns pruning via the CLI; for the HTTP backend retention is the **server's** job
  (a TTL/scheduled sweep), with `limit` and the optional `DELETE` the only
  contract additions. The conformance kit now certifies the `limit` semantic.

### Acceptance

Prune on a mixed store removes old terminal records, keeps the newest N and
everything non-terminal; `RunQuery.limit` honoured by both backends; the ownership
answer documented. Covered by unit (`runs_test.ts`, `state_test.ts` for both
backends + the conformance limit scenario) and end-to-end CLI integration
(`tests/integration/state_test.ts`).

### Adversarial review

Five attack dimensions (prune-safety, delete-race, limit, cli-parse,
contract-ripple) → refute-by-default verify. **1 confirmed** (the other four
dimensions found nothing):

- **[low, high-confidence] Empty space-form `--keep ""` silently dropped.** From
  `--keep "$KEEP"` with `$KEEP` unset in CI, the `if (value)` guard treated `""`
  as absent, so `prune --keep "" --keep-last 5` proceeded with **only** keep-last
  — deleting recent terminal runs the intended age window would have kept, exit 0.
  Inconsistent with the `--keep=` form, which already errors on empty. **Fixed:**
  the three new flags capture an explicit empty value (`if (value !== undefined)`)
  so it is validated and rejected (exit 1), matching the inline form; regression
  tests on both the parse and the `main` error path.

### Gate

`deno task ci` green (lines 98.2%, branches 95.1%); `apiDocsCheck`,
`generate-ci --check`, and `deno doc --lint` over all five core entrypoints
clean; skill references synced.
