### PR TITLE
feat(gh): created-window workflow correlation and marker fast-fail

### DIFF
--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -92,10 +92,19 @@ class Release extends Build {
   correlation marker in the gate's durable state, and suspends. Each
   `resume --check` polls the run; a resume in a **different process** never
   re-dispatches, because the marker persisted with the run.
-- **Correlation.** `workflow_dispatch` returns no run id, so the trigger passes a
-  marker input (default `zuke_marker`) and matches it against the run's display
-  title — the dispatched workflow must echo it into `run-name`:
-  `run-name: ${{ inputs.zuke_marker }}`.
+- **Correlation.** `workflow_dispatch` returns no run id, so by default the
+  trigger passes a marker input (default `zuke_marker`) and matches it against
+  the run's display title — the dispatched workflow must echo it into `run-name`:
+  `run-name: ${{ inputs.zuke_marker }}`. A workflow you can't modify (the long
+  tail of repos you don't own) correlates **best-effort** with
+  `.correlate("created-window")`: the trigger claims the `workflow_dispatch` run
+  on the dispatch ref created just after dispatch, and fails loudly if two
+  candidates share the window.
+- **Fast-fail.** If no run is identified within a short discovery window
+  (`.discoveryTimeout(...)`, default one minute), the gate fails with guidance
+  instead of eating the whole `.timeout()` — so a workflow that silently never
+  echoes the marker surfaces in ~a minute. The deadline is measured from the
+  persisted dispatch time, so it holds across a suspend/resume.
 - **Result.** On completion the per-job conclusions (`{ passed, jobs: [{ name,
   conclusion, url }] }`) are written to the gate target's state; a dependent
   reads them with `readWorkflowResult(ctx.stateOf("<gate>"))` and branches on a

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -7027,6 +7027,10 @@ class GithubWorkflowSettings
     Extra `workflow_dispatch` inputs.
   markerInput_: string
     The input name the marker is passed as (default `zuke_marker`).
+  correlateMode_: CorrelateMode
+    How the dispatched run is correlated (default `"marker"`); set by {@link correlate}.
+  discoveryTimeoutMs_?: number
+    How long to wait for the run to appear before failing fast (ms); set by {@link discoveryTimeout}.
   pollIntervalMs_?: number
     Poll interval hint (ms) for `zuke resume --check`.
   repo(slug: string): this
@@ -7041,8 +7045,28 @@ class GithubWorkflowSettings
     Merge a map of `workflow_dispatch` inputs.
   markerInput(name: string): this
     Change the input name the correlation marker is dispatched as.
+  correlate(mode: CorrelateMode): this
+    How the dispatched run is correlated: `"marker"` (default) matches the
+    marker echoed into the run's `run-name:`; `"created-window"` claims the
+    `workflow_dispatch` run on the dispatch ref created just after dispatch —
+    a best-effort fallback for a workflow that cannot echo the marker.
+  discoveryTimeout(duration: string): this
+    How long after dispatch to keep looking for the run before failing fast with
+    guidance (a duration string; default one minute). Bounds the "workflow never
+    echoed the marker" failure so it surfaces in ~a minute instead of eating the
+    whole `.timeout()`.
   pollEvery(duration: string): this
     Set how often `zuke resume --check` should re-poll (a duration string).
+
+class WorkflowCorrelationError extends Error
+  A {@link githubWorkflow} correlation failure the wait must not swallow as a
+  transient blip: the dispatched run could not be identified (it never echoed the
+  marker within the discovery window, or created-window correlation found more
+  than one candidate). Thrown from the trigger so the waiting target fails with
+  guidance instead of eating the whole `.timeout()`.
+
+  override name: string
+    The error name, `"WorkflowCorrelationError"`.
 
 interface GhTasksApi
   The shape of {@link GhTasks}.
@@ -7074,6 +7098,15 @@ interface WorkflowResult
     A link to the run on GitHub.
   jobs: WorkflowJob[]
     Each job's conclusion, so a build can branch on which suite failed.
+
+type CorrelateMode = "marker" | "created-window"
+  How {@link githubWorkflow} correlates the run it dispatched:
+
+  - `"marker"` — match the `zuke:<runId>:<target>` marker echoed into the run's
+    `run-name:` (exact, but the target workflow must opt in).
+  - `"created-window"` — claim the `workflow_dispatch` run on the dispatch ref
+    created just after dispatch; best-effort, for workflows that can't echo
+    the marker (fails loudly if two candidates are in the window).
 
 ========================================================================
 # @zuke/codecov

--- a/packages/gh/README.md
+++ b/packages/gh/README.md
@@ -53,10 +53,16 @@ await run(Release);
   correlation marker in the gate's durable state, and suspends. Each
   `zuke resume --check` polls; a resume in a **different process** never
   re-dispatches.
-- **Correlation.** `workflow_dispatch` returns no run id, so the trigger passes
-  a marker input (default `zuke_marker`) and matches it against the run's
-  display title — the dispatched workflow must echo it:
-  `run-name: ${{ inputs.zuke_marker }}`.
+- **Correlation.** `workflow_dispatch` returns no run id, so by default the
+  trigger passes a marker input (default `zuke_marker`) and matches it against
+  the run's display title — the dispatched workflow must echo it:
+  `run-name: ${{ inputs.zuke_marker }}`. For a workflow you can't modify, use
+  `.correlate("created-window")` to claim the run created just after dispatch on
+  the dispatch ref (best-effort; loud on ambiguity).
+- **Fast-fail.** If no run is identified within `.discoveryTimeout(...)`
+  (default one minute), the gate fails with guidance rather than eating the
+  whole `.timeout()` — measured from the persisted dispatch time, so it survives
+  suspend/resume.
 - **Result.** The per-job conclusions are published to the gate target's state;
   a dependent reads them with `readWorkflowResult(ctx.stateOf("<gate>"))`.
 - **Auth** uses `GH_TOKEN` / `GITHUB_TOKEN`; the GitHub API is an injectable
@@ -132,6 +138,10 @@ class GithubWorkflowSettings
     Extra `workflow_dispatch` inputs.
   markerInput_: string
     The input name the marker is passed as (default `zuke_marker`).
+  correlateMode_: CorrelateMode
+    How the dispatched run is correlated (default `"marker"`); set by {@link correlate}.
+  discoveryTimeoutMs_?: number
+    How long to wait for the run to appear before failing fast (ms); set by {@link discoveryTimeout}.
   pollIntervalMs_?: number
     Poll interval hint (ms) for `zuke resume --check`.
   repo(slug: string): this
@@ -146,8 +156,28 @@ class GithubWorkflowSettings
     Merge a map of `workflow_dispatch` inputs.
   markerInput(name: string): this
     Change the input name the correlation marker is dispatched as.
+  correlate(mode: CorrelateMode): this
+    How the dispatched run is correlated: `"marker"` (default) matches the
+    marker echoed into the run's `run-name:`; `"created-window"` claims the
+    `workflow_dispatch` run on the dispatch ref created just after dispatch —
+    a best-effort fallback for a workflow that cannot echo the marker.
+  discoveryTimeout(duration: string): this
+    How long after dispatch to keep looking for the run before failing fast with
+    guidance (a duration string; default one minute). Bounds the "workflow never
+    echoed the marker" failure so it surfaces in ~a minute instead of eating the
+    whole `.timeout()`.
   pollEvery(duration: string): this
     Set how often `zuke resume --check` should re-poll (a duration string).
+
+class WorkflowCorrelationError extends Error
+  A {@link githubWorkflow} correlation failure the wait must not swallow as a
+  transient blip: the dispatched run could not be identified (it never echoed the
+  marker within the discovery window, or created-window correlation found more
+  than one candidate). Thrown from the trigger so the waiting target fails with
+  guidance instead of eating the whole `.timeout()`.
+
+  override name: string
+    The error name, `"WorkflowCorrelationError"`.
 
 interface GhTasksApi
   The shape of {@link GhTasks}.
@@ -179,6 +209,15 @@ interface WorkflowResult
     A link to the run on GitHub.
   jobs: WorkflowJob[]
     Each job's conclusion, so a build can branch on which suite failed.
+
+type CorrelateMode = "marker" | "created-window"
+  How {@link githubWorkflow} correlates the run it dispatched:
+
+  - `"marker"` — match the `zuke:<runId>:<target>` marker echoed into the run's
+    `run-name:` (exact, but the target workflow must opt in).
+  - `"created-window"` — claim the `workflow_dispatch` run on the dispatch ref
+    created just after dispatch; best-effort, for workflows that can't echo
+    the marker (fails loudly if two candidates are in the window).
 ````
 
 </details>

--- a/packages/gh/mod.ts
+++ b/packages/gh/mod.ts
@@ -19,9 +19,11 @@
 
 export * from "./src/gh.ts";
 export {
+  type CorrelateMode,
   githubWorkflow,
   GithubWorkflowSettings,
   readWorkflowResult,
+  WorkflowCorrelationError,
   type WorkflowJob,
   type WorkflowResult,
 } from "./src/workflow.ts";

--- a/packages/gh/src/workflow.ts
+++ b/packages/gh/src/workflow.ts
@@ -41,6 +41,21 @@
  * the awaiting target's durable state, so a resume in a **different process**
  * never re-dispatches — it polls the run it already started.
  *
+ * **Unmodified workflows.** A workflow that can't echo the marker (a long tail
+ * of repos you don't own) correlates **best-effort** with
+ * `.correlate("created-window")`: the trigger snapshots the runs that already
+ * exist at dispatch and then claims the *new* `workflow_dispatch` run on the
+ * dispatch ref created just after — excluding pre-existing runs and failing
+ * loudly if two fresh candidates sit in the window. (The residual ceiling: a
+ * foreign dispatch on the same ref that lands in the window and becomes visible
+ * before ours could still be claimed in error; prefer marker correlation when
+ * the workflow can echo the marker.) Either way, if no run is identified within a
+ * short **discovery window** (`.discoveryTimeout(...)`, default one minute), the
+ * wait fails fast with guidance — a workflow that silently never echoes the
+ * marker surfaces in ~a minute instead of eating the whole `.timeout()`. The
+ * discovery deadline is measured from the persisted dispatch time, so it holds
+ * across a suspend/resume.
+ *
  * **Auth & testing.** The default transport calls the GitHub REST API with
  * `fetch`, authenticated by `GH_TOKEN` / `GITHUB_TOKEN`. The transport is an
  * injectable seam ({@link GhWorkflowApi}), so tests drive the whole state
@@ -95,6 +110,10 @@ export interface WorkflowRun {
   conclusion: string | null;
   /** A link to the run on GitHub. */
   url: string;
+  /** ISO-8601 time the run was created — used by created-window correlation. */
+  createdAt: string;
+  /** The branch the run ran on — matched against the dispatch ref in created-window mode. */
+  headBranch: string;
 }
 
 /**
@@ -115,10 +134,38 @@ export interface GhWorkflowApi {
     workflow: string,
     marker: string,
   ): Promise<WorkflowRun | null>;
+  /**
+   * Recent `workflow_dispatch` runs of `workflow`, newest first — the candidate
+   * pool for created-window correlation (which filters them by branch and
+   * creation time). An implementation must return only `workflow_dispatch` runs.
+   */
+  recentRuns(repo: string, workflow: string): Promise<WorkflowRun[]>;
   /** The current state of run `runId`. */
   getRun(repo: string, runId: number): Promise<WorkflowRun>;
   /** The jobs of run `runId`. */
   listJobs(repo: string, runId: number): Promise<WorkflowJob[]>;
+}
+
+/**
+ * How {@link githubWorkflow} correlates the run it dispatched:
+ * - `"marker"` — match the `zuke:<runId>:<target>` marker echoed into the run's
+ *   `run-name:` (exact, but the target workflow must opt in).
+ * - `"created-window"` — claim the `workflow_dispatch` run on the dispatch ref
+ *   created just after dispatch; **best-effort**, for workflows that can't echo
+ *   the marker (fails loudly if two candidates are in the window).
+ */
+export type CorrelateMode = "marker" | "created-window";
+
+/**
+ * A {@link githubWorkflow} correlation failure the wait must **not** swallow as a
+ * transient blip: the dispatched run could not be identified (it never echoed the
+ * marker within the discovery window, or created-window correlation found more
+ * than one candidate). Thrown from the trigger so the waiting target fails with
+ * guidance instead of eating the whole `.timeout()`.
+ */
+export class WorkflowCorrelationError extends Error {
+  /** The error name, `"WorkflowCorrelationError"`. */
+  override name = "WorkflowCorrelationError";
 }
 
 /**
@@ -136,6 +183,10 @@ export class GithubWorkflowSettings {
   inputs_: Record<string, string> = {};
   /** The input name the marker is passed as (default `zuke_marker`). */
   markerInput_ = "zuke_marker";
+  /** How the dispatched run is correlated (default `"marker"`); set by {@link correlate}. */
+  correlateMode_: CorrelateMode = "marker";
+  /** How long to wait for the run to appear before failing fast (ms); set by {@link discoveryTimeout}. */
+  discoveryTimeoutMs_?: number;
   /** Poll interval hint (ms) for `zuke resume --check`. */
   pollIntervalMs_?: number;
 
@@ -175,6 +226,28 @@ export class GithubWorkflowSettings {
     return this;
   }
 
+  /**
+   * How the dispatched run is correlated: `"marker"` (default) matches the
+   * marker echoed into the run's `run-name:`; `"created-window"` claims the
+   * `workflow_dispatch` run on the dispatch ref created just after dispatch —
+   * a **best-effort** fallback for a workflow that cannot echo the marker.
+   */
+  correlate(mode: CorrelateMode): this {
+    this.correlateMode_ = mode;
+    return this;
+  }
+
+  /**
+   * How long after dispatch to keep looking for the run before failing fast with
+   * guidance (a duration string; default one minute). Bounds the "workflow never
+   * echoed the marker" failure so it surfaces in ~a minute instead of eating the
+   * whole `.timeout()`.
+   */
+  discoveryTimeout(duration: string): this {
+    this.discoveryTimeoutMs_ = parseDuration(duration);
+    return this;
+  }
+
   /** Set how often `zuke resume --check` should re-poll (a duration string). */
   pollEvery(duration: string): this {
     this.pollIntervalMs_ = parseDuration(duration);
@@ -208,6 +281,16 @@ function readNum(
 ): number | undefined {
   const value = object[key];
   return typeof value === "number" ? value : undefined;
+}
+
+/** Read a numeric array field of a JSON object, or `[]` when absent/malformed. */
+function readNumArray(
+  object: Record<string, JsonValue> | undefined,
+  key: string,
+): number[] {
+  const value = object?.[key];
+  if (!Array.isArray(value)) return [];
+  return value.filter((v): v is number => typeof v === "number");
 }
 
 /**
@@ -252,6 +335,8 @@ function persist(
   state: TargetStateHandle,
   data: {
     marker: string;
+    dispatchedAt?: number;
+    baselineIds?: number[];
     runId?: number;
     result?: WorkflowResult;
   },
@@ -260,6 +345,11 @@ function persist(
     dispatched: true,
     marker: data.marker,
   };
+  // The dispatch timestamp anchors the discovery window and the created-window
+  // filter, and the baseline excludes pre-existing runs — so every write must
+  // carry them forward (a persist replaces the entry).
+  if (data.dispatchedAt !== undefined) value.dispatchedAt = data.dispatchedAt;
+  if (data.baselineIds !== undefined) value.baselineIds = data.baselineIds;
   if (data.runId !== undefined) value.runId = data.runId;
   if (data.result !== undefined) {
     value.done = true;
@@ -293,6 +383,16 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 
 /** How many pages of `per_page=100` runs `findRun` scans before giving up. */
 const MAX_RUN_PAGES = 5;
+
+/** Default discovery window: fail fast if the run has not appeared within this. */
+const DEFAULT_DISCOVERY_TIMEOUT_MS = 60_000;
+
+/**
+ * Clock-skew allowance for created-window correlation: a run whose GitHub
+ * `created_at` is up to this far *before* our dispatch timestamp still counts, so
+ * modest skew between this host and GitHub doesn't drop the run.
+ */
+const CREATED_WINDOW_SKEW_MS = 30_000;
 
 /** The default {@link GhWorkflowApi}: the GitHub REST API over `fetch`. */
 export class RestGhWorkflowApi implements GhWorkflowApi {
@@ -409,6 +509,25 @@ export class RestGhWorkflowApi implements GhWorkflowApi {
     return null;
   }
 
+  /**
+   * The newest page of `workflow_dispatch` runs of `workflow` (the API returns
+   * them newest first). One page suffices for created-window correlation — the
+   * run being sought was created seconds ago, so it is at the top.
+   */
+  async recentRuns(repo: string, workflow: string): Promise<WorkflowRun[]> {
+    const body = await this.#get(
+      `/repos/${repo}/actions/workflows/${workflow}/runs?event=workflow_dispatch&per_page=100`,
+    );
+    const runs = body.workflow_runs;
+    if (!Array.isArray(runs)) return [];
+    const out: WorkflowRun[] = [];
+    for (const raw of runs) {
+      const run = asRecord(raw);
+      if (run !== undefined) out.push(toRun(run));
+    }
+    return out;
+  }
+
   /** Fetch a run's current state. */
   async getRun(repo: string, runId: number): Promise<WorkflowRun> {
     return toRun(await this.#get(`/repos/${repo}/actions/runs/${runId}`));
@@ -441,6 +560,8 @@ function toRun(run: Record<string, JsonValue>): WorkflowRun {
     status: readStr(run, "status") ?? "unknown",
     conclusion: readStr(run, "conclusion") ?? null,
     url: readStr(run, "html_url") ?? "",
+    createdAt: readStr(run, "created_at") ?? "",
+    headBranch: readStr(run, "head_branch") ?? "",
   };
 }
 
@@ -452,6 +573,83 @@ export interface GithubWorkflowDeps {
   fetch?: typeof fetch;
   /** Environment reader for the token; defaults to `Deno.env.get`. */
   readEnv?: (name: string) => string | undefined;
+  /** The clock (epoch ms) for the discovery window; defaults to `Date.now` (tests inject it). */
+  now?: () => number;
+}
+
+/**
+ * Pick the one `workflow_dispatch` run this dispatch produced from `runs`: same
+ * branch as the dispatch `ref`, created at/after the dispatch time (minus a small
+ * skew allowance), and **not** one of the `baseline` runs that already existed
+ * when we dispatched (so a run someone else started just before ours is never
+ * claimed). Returns the sole match, `null` when none has appeared yet, or throws
+ * {@link WorkflowCorrelationError} when two or more sit in the window —
+ * best-effort correlation deliberately refuses to guess between them.
+ */
+function correlateByWindow(
+  runs: readonly WorkflowRun[],
+  ref: string,
+  dispatchedAtMs: number,
+  workflow: string,
+  baseline: readonly number[],
+): WorkflowRun | null {
+  const floor = dispatchedAtMs - CREATED_WINDOW_SKEW_MS;
+  const candidates = runs.filter((r) => {
+    if (r.headBranch !== ref || baseline.includes(r.id)) return false;
+    const created = Date.parse(r.createdAt);
+    return !Number.isNaN(created) && created >= floor;
+  });
+  if (candidates.length === 0) return null;
+  if (candidates.length > 1) {
+    const urls = candidates.map((r) => r.url).join(", ");
+    throw new WorkflowCorrelationError(
+      `githubWorkflow: created-window correlation for "${workflow}" on "${ref}" ` +
+        `is ambiguous — ${candidates.length} workflow_dispatch runs in the ` +
+        `window (${urls}). Echo the marker into run-name: and use marker ` +
+        `correlation, or dispatch on a dedicated ref.`,
+    );
+  }
+  return candidates[0];
+}
+
+/**
+ * The ids of the `workflow_dispatch` runs that already exist just before we
+ * dispatch — the baseline created-window correlation excludes so it never claims
+ * a pre-existing run. Best-effort: a transient error yields an empty baseline,
+ * and correlation then leans on the ambiguity guard.
+ */
+async function snapshotBaseline(
+  api: GhWorkflowApi,
+  repo: string,
+  workflow: string,
+): Promise<number[]> {
+  try {
+    return (await api.recentRuns(repo, workflow)).map((r) => r.id);
+  } catch {
+    return [];
+  }
+}
+
+/** Build the fast-fail guidance message for a run that never appeared, per mode. */
+function discoveryFailure(
+  mode: CorrelateMode,
+  ctx: {
+    workflow: string;
+    ref: string;
+    markerInput: string;
+    discoveryTimeoutMs: number;
+  },
+): string {
+  const secs = Math.round(ctx.discoveryTimeoutMs / 1000);
+  if (mode === "created-window") {
+    return `githubWorkflow: no workflow_dispatch run of "${ctx.workflow}" on ` +
+      `"${ctx.ref}" appeared within ${secs}s of dispatch — can "${ctx.workflow}" ` +
+      `be dispatched on that ref?`;
+  }
+  return `githubWorkflow: no run of "${ctx.workflow}" matched the marker within ` +
+    `${secs}s of dispatch. Does "${ctx.workflow}" echo the "${ctx.markerInput}" ` +
+    `input into its run-name:? (run-name: \${{ inputs.${ctx.markerInput} }}) — ` +
+    `or switch to .correlate("created-window").`;
 }
 
 /** Read an environment variable, treating missing env access as unset. */
@@ -484,6 +682,10 @@ export function githubWorkflowWith(
       fetch: deps.fetch,
       token: resolveToken(deps.readEnv ?? defaultReadEnv),
     });
+  const now = deps.now ?? (() => Date.now());
+  const mode = settings.correlateMode_;
+  const discoveryTimeoutMs = settings.discoveryTimeoutMs_ ??
+    DEFAULT_DISCOVERY_TIMEOUT_MS;
 
   return {
     descriptor: `github:${repo}:${workflow}`,
@@ -497,30 +699,80 @@ export function githubWorkflowWith(
       const marker = (entry && readStr(entry, "marker")) ??
         `zuke:${ctx.runId}:${ctx.target}`;
       const dispatched = entry !== undefined && entry.dispatched === true;
+      const baselineIds = readNumArray(entry, "baselineIds");
 
-      // 1. Dispatch once, then suspend until a later poll.
+      // Throw the fast-fail guidance error — hoisted so both the "no run" and the
+      // "API threw during discovery" paths can invoke it.
+      const failDiscovery = (): never => {
+        throw new WorkflowCorrelationError(discoveryFailure(mode, {
+          workflow,
+          ref: settings.ref_,
+          markerInput: settings.markerInput_,
+          discoveryTimeoutMs,
+        }));
+      };
+
+      // 1. Dispatch once. In created-window mode, snapshot the runs that already
+      //    exist **before** dispatching, so correlation never claims one that
+      //    was already there (e.g. a nightly cron or a colleague's run on the
+      //    same branch). Then stamp the dispatch time and suspend.
       if (!dispatched) {
+        const baseline = mode === "created-window"
+          ? await snapshotBaseline(api, repo, workflow)
+          : undefined;
         await api.dispatch(repo, workflow, settings.ref_, {
           ...settings.inputs_,
           [settings.markerInput_]: marker,
         });
-        await persist(ctx.state, { marker });
+        await persist(ctx.state, {
+          marker,
+          dispatchedAt: now(),
+          baselineIds: baseline,
+        });
         return false;
       }
 
-      // The run is dispatched; the rest is polling GitHub. A transient error
-      // here (a 5xx, a rate-limit, a network blip, a timeout) must NOT fail the
-      // build — it is treated as "not ready yet", so the wait stays suspended
-      // and retries on the next `zuke resume --check`. The persisted marker/runId
-      // are preserved, so no dispatch or correlation work is lost.
+      // Anchor the discovery clock. A record predating M18 has no dispatchedAt;
+      // backfill and persist it **once** so the deadline is stable across
+      // resumes (recomputing it every poll would reset the window forever).
+      let runId = entry === undefined ? undefined : readNum(entry, "runId");
+      let dispatchedAt = entry ? readNum(entry, "dispatchedAt") : undefined;
+      if (dispatchedAt === undefined) {
+        dispatchedAt = now();
+        await persist(ctx.state, { marker, dispatchedAt, runId, baselineIds });
+      }
+      const anchor = dispatchedAt;
+
+      // The run is dispatched; the rest is polling GitHub. A transient error here
+      // (a 5xx, a rate-limit, a network blip) must NOT fail the build — it is
+      // "not ready yet", so the wait stays suspended and retries next check. Two
+      // exceptions: a WorkflowCorrelationError is fatal (re-thrown), and while
+      // the run is still uncorrelated the discovery deadline applies even to a
+      // thrown error — a bad token or renamed workflow must fail fast, not eat
+      // the whole `.timeout()`.
       try {
-        // 2. Correlate the dispatched run by its marker, once it appears.
-        let runId = entry === undefined ? undefined : readNum(entry, "runId");
+        // 2. Correlate the dispatched run, once it appears.
         if (runId === undefined) {
-          const run = await api.findRun(repo, workflow, marker);
-          if (run === null) return false;
+          const run = mode === "created-window"
+            ? correlateByWindow(
+              await api.recentRuns(repo, workflow),
+              settings.ref_,
+              anchor,
+              workflow,
+              baselineIds,
+            )
+            : await api.findRun(repo, workflow, marker);
+          if (run === null) {
+            if (now() - anchor > discoveryTimeoutMs) failDiscovery();
+            return false;
+          }
           runId = run.id;
-          await persist(ctx.state, { marker, runId });
+          await persist(ctx.state, {
+            marker,
+            runId,
+            dispatchedAt: anchor,
+            baselineIds,
+          });
         }
 
         // 3. Poll until it completes, then record the per-job result.
@@ -534,11 +786,22 @@ export function githubWorkflowWith(
           url: run.url,
           jobs,
         };
-        await persist(ctx.state, { marker, runId, result });
+        await persist(ctx.state, {
+          marker,
+          runId,
+          result,
+          dispatchedAt: anchor,
+          baselineIds,
+        });
         return true;
-      } catch {
-        // Stay suspended and poll again next check.
-        return false;
+      } catch (error) {
+        if (error instanceof WorkflowCorrelationError) throw error; // fatal
+        // A discovery-phase error (run not yet correlated) also honours the
+        // deadline, so a persistent correlation failure fails fast.
+        if (runId === undefined && now() - anchor > discoveryTimeoutMs) {
+          failDiscovery();
+        }
+        return false; // transient → stay suspended, poll again next check
       }
     },
   };

--- a/packages/gh/tests/workflow_test.ts
+++ b/packages/gh/tests/workflow_test.ts
@@ -15,9 +15,18 @@ import {
   githubWorkflowWith,
   readWorkflowResult,
   RestGhWorkflowApi,
+  WorkflowCorrelationError,
   type WorkflowJob,
   type WorkflowRun,
 } from "../src/workflow.ts";
+
+/** A controllable monotonic clock (epoch ms) for driving the discovery window. */
+function clock(
+  start: number,
+): { now: () => number; advance: (ms: number) => void } {
+  let t = start;
+  return { now: () => t, advance: (ms) => void (t += ms) };
+}
 
 /** The global `fetch` signature, aliased so a local can be annotated. */
 type FetchFn = typeof globalThis.fetch;
@@ -48,10 +57,23 @@ class ScriptedApi implements GhWorkflowApi {
   dispatches: Array<{ ref: string; inputs: Record<string, string> }> = [];
   status = "in_progress";
   conclusion: string | null = null;
-  appears = true; // whether findRun can locate the dispatched run
+  appears = true; // whether findRun/recentRuns can locate the dispatched run
+  createdAt = "2026-07-19T00:00:00.000Z";
+  headBranch = "main";
   jobs: WorkflowJob[] = [
     { name: "build", conclusion: "success", url: "https://gh/j1" },
   ];
+
+  #run(): WorkflowRun {
+    return {
+      id: 100,
+      status: this.status,
+      conclusion: this.conclusion,
+      url: "https://gh/r100",
+      createdAt: this.createdAt,
+      headBranch: this.headBranch,
+    };
+  }
 
   dispatch(
     _repo: string,
@@ -63,24 +85,16 @@ class ScriptedApi implements GhWorkflowApi {
     return Promise.resolve();
   }
   findRun(): Promise<WorkflowRun | null> {
-    return Promise.resolve(
-      this.appears
-        ? {
-          id: 100,
-          status: this.status,
-          conclusion: this.conclusion,
-          url: "https://gh/r100",
-        }
-        : null,
-    );
+    return Promise.resolve(this.appears ? this.#run() : null);
+  }
+  recentRuns(): Promise<WorkflowRun[]> {
+    // Before dispatch the run does not exist yet (an empty created-window
+    // baseline); after dispatch it appears if `appears` is set.
+    const exists = this.appears && this.dispatches.length > 0;
+    return Promise.resolve(exists ? [this.#run()] : []);
   }
   getRun(): Promise<WorkflowRun> {
-    return Promise.resolve({
-      id: 100,
-      status: this.status,
-      conclusion: this.conclusion,
-      url: "https://gh/r100",
-    });
+    return Promise.resolve(this.#run());
   }
   listJobs(): Promise<WorkflowJob[]> {
     return Promise.resolve(this.jobs);
@@ -178,22 +192,19 @@ Deno.test("waits for the run to appear before polling it", async () => {
 
 Deno.test("a transient poll error re-suspends instead of failing the run", async () => {
   let failJobs = true;
+  const run: WorkflowRun = {
+    id: 100,
+    status: "completed",
+    conclusion: "success",
+    url: "u",
+    createdAt: "2026-07-19T00:00:00.000Z",
+    headBranch: "main",
+  };
   const api: GhWorkflowApi = {
     dispatch: () => Promise.resolve(),
-    findRun: () =>
-      Promise.resolve({
-        id: 100,
-        status: "completed",
-        conclusion: "success",
-        url: "u",
-      }),
-    getRun: () =>
-      Promise.resolve({
-        id: 100,
-        status: "completed",
-        conclusion: "success",
-        url: "u",
-      }),
+    findRun: () => Promise.resolve(run),
+    recentRuns: () => Promise.resolve([run]),
+    getRun: () => Promise.resolve(run),
     listJobs: () =>
       failJobs
         ? Promise.reject(new Error("gh workflow: GET /jobs → 502"))
@@ -275,6 +286,273 @@ Deno.test("readWorkflowResult tolerates malformed jobs", () => {
   ]);
 });
 
+// --- M18: created-window correlation and marker fast-fail -------------------
+
+const DISPATCH_AT = Date.parse("2026-07-19T00:00:00.000Z");
+
+Deno.test("created-window mode correlates the single matching run", async () => {
+  const api = new ScriptedApi();
+  api.status = "completed";
+  api.conclusion = "success";
+  api.createdAt = "2026-07-19T00:00:30.000Z"; // 30s after dispatch
+  api.headBranch = "release";
+  const c = clock(DISPATCH_AT);
+  const state = fakeState();
+  const trigger = githubWorkflowWith(
+    (g) =>
+      g.repo("a/b").workflow("w").ref("release").correlate("created-window"),
+    { api, now: c.now },
+  );
+  const cv = ctx(state);
+  assertEquals(await trigger.isSatisfied(NO_SIGNALS, cv), false); // dispatch
+  assertEquals(await trigger.isSatisfied(NO_SIGNALS, cv), true); // correlate + done
+  assertEquals(readWorkflowResult(state)?.runId, 100);
+});
+
+Deno.test("created-window mode fails loudly on two candidates in the window", async () => {
+  const created = "2026-07-19T00:00:10.000Z";
+  let dispatched = false;
+  const api: GhWorkflowApi = {
+    dispatch: () => {
+      dispatched = true;
+      return Promise.resolve();
+    },
+    findRun: () => Promise.resolve(null),
+    recentRuns: () =>
+      Promise.resolve(
+        dispatched
+          ? [
+            {
+              id: 1,
+              status: "in_progress",
+              conclusion: null,
+              url: "u1",
+              createdAt: created,
+              headBranch: "main",
+            },
+            {
+              id: 2,
+              status: "in_progress",
+              conclusion: null,
+              url: "u2",
+              createdAt: created,
+              headBranch: "main",
+            },
+          ]
+          : [], // empty baseline before dispatch, so both are fresh candidates
+      ),
+    getRun: () =>
+      Promise.reject(new Error("should not poll an ambiguous match")),
+    listJobs: () => Promise.resolve([]),
+  };
+  const c = clock(DISPATCH_AT);
+  const trigger = githubWorkflowWith(
+    (g) => g.repo("a/b").workflow("w").correlate("created-window"),
+    { api, now: c.now },
+  );
+  const cv = ctx(fakeState());
+  await trigger.isSatisfied(NO_SIGNALS, cv); // dispatch
+  await assertRejects(
+    () => Promise.resolve(trigger.isSatisfied(NO_SIGNALS, cv)),
+    WorkflowCorrelationError,
+    "ambiguous",
+  );
+});
+
+Deno.test("created-window ignores a run on another branch or created before dispatch", async () => {
+  let dispatched = false;
+  const api: GhWorkflowApi = {
+    dispatch: () => {
+      dispatched = true;
+      return Promise.resolve();
+    },
+    findRun: () => Promise.resolve(null),
+    recentRuns: () =>
+      Promise.resolve(
+        dispatched
+          ? [
+            // right window, wrong branch:
+            {
+              id: 1,
+              status: "in_progress",
+              conclusion: null,
+              url: "u1",
+              createdAt: "2026-07-19T00:01:00.000Z",
+              headBranch: "other",
+            },
+            // right branch, created a day before dispatch (beyond the skew):
+            {
+              id: 2,
+              status: "in_progress",
+              conclusion: null,
+              url: "u2",
+              createdAt: "2026-07-18T00:00:00.000Z",
+              headBranch: "main",
+            },
+          ]
+          : [], // empty baseline before dispatch
+      ),
+    getRun: () => Promise.reject(new Error("no candidate should be polled")),
+    listJobs: () => Promise.resolve([]),
+  };
+  const c = clock(DISPATCH_AT);
+  const trigger = githubWorkflowWith(
+    (g) => g.repo("a/b").workflow("w").correlate("created-window"),
+    { api, now: c.now },
+  );
+  const cv = ctx(fakeState());
+  await trigger.isSatisfied(NO_SIGNALS, cv); // dispatch
+  assertEquals(await trigger.isSatisfied(NO_SIGNALS, cv), false); // no candidate → suspended
+});
+
+Deno.test("marker mode fails fast with guidance once the discovery window elapses", async () => {
+  const api = new ScriptedApi();
+  api.appears = false; // the run never echoes the marker
+  const c = clock(DISPATCH_AT);
+  const state = fakeState();
+  const trigger = githubWorkflowWith(
+    (g) => g.repo("a/b").workflow("e2e.yml").discoveryTimeout("60s"),
+    { api, now: c.now },
+  );
+  const cv = ctx(state);
+  assertEquals(await trigger.isSatisfied(NO_SIGNALS, cv), false); // dispatch
+  assertEquals(await trigger.isSatisfied(NO_SIGNALS, cv), false); // within window → suspended
+  c.advance(61_000); // past the 60s discovery window
+  const error = await assertRejects(
+    () => Promise.resolve(trigger.isSatisfied(NO_SIGNALS, cv)),
+    WorkflowCorrelationError,
+    "run-name",
+  );
+  // The guidance names the workflow and the marker input.
+  assertEquals(error.message.includes("e2e.yml"), true);
+  assertEquals(error.message.includes("zuke_marker"), true);
+});
+
+Deno.test("created-window mode fails fast when no run appears in the window", async () => {
+  const api = new ScriptedApi();
+  api.appears = false; // recentRuns → []
+  const c = clock(DISPATCH_AT);
+  const trigger = githubWorkflowWith(
+    (g) =>
+      g.repo("a/b").workflow("w").correlate("created-window").discoveryTimeout(
+        "30s",
+      ),
+    { api, now: c.now },
+  );
+  const cv = ctx(fakeState());
+  await trigger.isSatisfied(NO_SIGNALS, cv); // dispatch
+  c.advance(31_000);
+  await assertRejects(
+    () => Promise.resolve(trigger.isSatisfied(NO_SIGNALS, cv)),
+    WorkflowCorrelationError,
+    "appeared within",
+  );
+});
+
+Deno.test("a discovery error suspends within the window, but fails fast past it", async () => {
+  // recentRuns keeps throwing (a bad token / renamed workflow / long outage):
+  // within the window the wait stays suspended, but past the window it fails
+  // fast — a permanent correlation error must not eat the whole .timeout().
+  const api: GhWorkflowApi = {
+    dispatch: () => Promise.resolve(),
+    findRun: () => Promise.resolve(null),
+    recentRuns: () =>
+      Promise.reject(
+        new Error("gh workflow: GET /runs → 403 (no actions:read)"),
+      ),
+    getRun: () => Promise.reject(new Error("uncorrelated, never polled")),
+    listJobs: () => Promise.resolve([]),
+  };
+  const c = clock(DISPATCH_AT);
+  const trigger = githubWorkflowWith(
+    (g) =>
+      g.repo("a/b").workflow("w").correlate("created-window").discoveryTimeout(
+        "60s",
+      ),
+    { api, now: c.now },
+  );
+  const cv = ctx(fakeState());
+  await trigger.isSatisfied(NO_SIGNALS, cv); // dispatch (baseline snapshot swallows the throw)
+  assertEquals(await trigger.isSatisfied(NO_SIGNALS, cv), false); // within window → suspended
+  c.advance(61_000); // past the window
+  await assertRejects(
+    () => Promise.resolve(trigger.isSatisfied(NO_SIGNALS, cv)),
+    WorkflowCorrelationError,
+  );
+});
+
+Deno.test("a persisted record without dispatchedAt (pre-M18) fails fast after backfilling", async () => {
+  const api = new ScriptedApi();
+  api.appears = false; // never correlates
+  const c = clock(DISPATCH_AT);
+  // A record from before M18: dispatched, but no dispatchedAt anchor.
+  const state = fakeState({
+    githubWorkflow: { dispatched: true, marker: "zuke:r1:e2e" },
+  });
+  const trigger = githubWorkflowWith(
+    (g) => g.repo("a/b").workflow("e2e.yml").discoveryTimeout("60s"),
+    { api, now: c.now },
+  );
+  const cv = ctx(state);
+  // First observation backfills and persists the anchor at the current time.
+  assertEquals(await trigger.isSatisfied(NO_SIGNALS, cv), false);
+  assertEquals(
+    typeof (state.get().githubWorkflow as { dispatchedAt?: number })
+      .dispatchedAt,
+    "number",
+  );
+  // The anchor is now stable, so advancing past the window fails fast (it would
+  // never elapse if each resume re-stamped the anchor).
+  c.advance(61_000);
+  await assertRejects(
+    () => Promise.resolve(trigger.isSatisfied(NO_SIGNALS, cv)),
+    WorkflowCorrelationError,
+    "run-name",
+  );
+});
+
+Deno.test("created-window excludes a run that already existed before dispatch", async () => {
+  // A foreign workflow_dispatch run on the same branch, created 15s before our
+  // dispatch, is in the baseline — so it is never claimed as ours.
+  const foreign: WorkflowRun = {
+    id: 100,
+    status: "completed",
+    conclusion: "success",
+    url: "u-foreign",
+    createdAt: "2026-07-18T23:59:45.000Z", // 15s before DISPATCH_AT
+    headBranch: "main",
+  };
+  let dispatched = false;
+  const api: GhWorkflowApi = {
+    dispatch: () => {
+      dispatched = true;
+      return Promise.resolve();
+    },
+    findRun: () => Promise.resolve(null),
+    // The foreign run exists both before and after dispatch; ours never appears.
+    recentRuns: () => Promise.resolve(dispatched ? [foreign] : [foreign]),
+    getRun: () =>
+      Promise.reject(new Error("a baseline run must never be polled")),
+    listJobs: () => Promise.resolve([]),
+  };
+  const c = clock(DISPATCH_AT);
+  const trigger = githubWorkflowWith(
+    (g) =>
+      g.repo("a/b").workflow("w").correlate("created-window").discoveryTimeout(
+        "60s",
+      ),
+    { api, now: c.now },
+  );
+  const cv = ctx(fakeState());
+  await trigger.isSatisfied(NO_SIGNALS, cv); // dispatch — snapshots [100] as baseline
+  assertEquals(await trigger.isSatisfied(NO_SIGNALS, cv), false); // #100 excluded → suspended
+  c.advance(61_000);
+  await assertRejects( // ours never appeared → fast-fail, never claims #100
+    () => Promise.resolve(trigger.isSatisfied(NO_SIGNALS, cv)),
+    WorkflowCorrelationError,
+  );
+});
+
 // --- The default REST transport, over a fake fetch --------------------------
 
 /** A fake `fetch` routing by `METHOD url` to a canned JSON response. */
@@ -354,6 +632,61 @@ Deno.test("RestGhWorkflowApi.findRun returns null when no run matches", async ()
   assertEquals(await api.findRun("a/b", "w.yml", "m"), null);
 });
 
+Deno.test("RestGhWorkflowApi.recentRuns maps workflow_dispatch runs", async () => {
+  const url =
+    "https://api.github.com/repos/a/b/actions/workflows/w.yml/runs?event=workflow_dispatch&per_page=100";
+  const { fetch } = routerFetch({
+    [`GET ${url}`]: {
+      workflow_runs: [
+        {
+          id: 7,
+          status: "in_progress",
+          conclusion: null,
+          html_url: "u7",
+          created_at: "2026-07-19T00:00:05.000Z",
+          head_branch: "main",
+        },
+      ],
+    },
+  });
+  const runs = await new RestGhWorkflowApi({ fetch }).recentRuns(
+    "a/b",
+    "w.yml",
+  );
+  assertEquals(runs.length, 1);
+  assertEquals(runs[0].id, 7);
+  assertEquals(runs[0].createdAt, "2026-07-19T00:00:05.000Z");
+  assertEquals(runs[0].headBranch, "main");
+});
+
+Deno.test("RestGhWorkflowApi.recentRuns tolerates a malformed payload", async () => {
+  const url =
+    "https://api.github.com/repos/a/b/actions/workflows/w.yml/runs?event=workflow_dispatch&per_page=100";
+  const { fetch } = routerFetch({ [`GET ${url}`]: { workflow_runs: "nope" } });
+  assertEquals(
+    await new RestGhWorkflowApi({ fetch }).recentRuns("a/b", "w.yml"),
+    [],
+  );
+  // A null/non-object element is skipped, not fatal.
+  const withJunk = routerFetch({
+    [`GET ${url}`]: {
+      workflow_runs: [null, {
+        id: 3,
+        status: "queued",
+        html_url: "u",
+        created_at: "t",
+        head_branch: "main",
+      }],
+    },
+  });
+  const runs = await new RestGhWorkflowApi({ fetch: withJunk.fetch })
+    .recentRuns(
+      "a/b",
+      "w.yml",
+    );
+  assertEquals(runs.map((r) => r.id), [3]);
+});
+
 Deno.test("RestGhWorkflowApi.getRun and listJobs map the GitHub shape", async () => {
   const { fetch } = routerFetch({
     "GET https://api.github.com/repos/a/b/actions/runs/9": {
@@ -361,6 +694,8 @@ Deno.test("RestGhWorkflowApi.getRun and listJobs map the GitHub shape", async ()
       status: "completed",
       conclusion: "success",
       html_url: "run-url",
+      created_at: "2026-07-19T10:00:00.000Z",
+      head_branch: "release",
     },
     "GET https://api.github.com/repos/a/b/actions/runs/9/jobs": {
       jobs: [{ name: "unit", conclusion: "failure", html_url: "job-url" }],
@@ -373,6 +708,8 @@ Deno.test("RestGhWorkflowApi.getRun and listJobs map the GitHub shape", async ()
     status: "completed",
     conclusion: "success",
     url: "run-url",
+    createdAt: "2026-07-19T10:00:00.000Z",
+    headBranch: "release",
   });
   const jobs = await api.listJobs("a/b", 9);
   assertEquals(jobs, [{ name: "unit", conclusion: "failure", url: "job-url" }]);
@@ -485,6 +822,8 @@ Deno.test("RestGhWorkflowApi maps missing run/job fields to defaults", async () 
     status: "unknown",
     conclusion: null,
     url: "",
+    createdAt: "",
+    headBranch: "",
   });
   // The null job is skipped; the empty job defaults every field.
   assertEquals(await api.listJobs("a/b", 9), [{

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -175,8 +175,11 @@ Before calling any task or settings method, confirm the real shape:
 - **Wait on an external GitHub workflow (`@zuke/gh`):** in a `.waitsFor(...)`
   gate, `s.on(githubWorkflow((g) => g.repo("o/r").workflow("e2e.yml")))`
   dispatches a workflow in another repo and suspends until it finishes; read the
-  per-job result with `readWorkflowResult(ctx.stateOf("<gate>"))`. Triggers are
-  extensible — write your own against the exported `WaitTrigger`/`WaitContext`.
+  per-job result with `readWorkflowResult(ctx.stateOf("<gate>"))`. Correlates by
+  a `run-name:` marker by default, or `.correlate("created-window")` for a
+  workflow you can't modify; fails fast (`.discoveryTimeout(...)`) if the run
+  never correlates. Triggers are extensible — write your own against the exported
+  `WaitTrigger`/`WaitContext`.
 - **OpenTelemetry export (`@zuke/otel`):** register `otel((s) => s.endpoint(…))`
   as a plugin (`run(MyBuild, { plugins: [otel(…)] })`) to ship run/target spans
   and `zuke.run.started` / `zuke.run.suspended` / `zuke.runs` counters as

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -250,8 +250,12 @@ class Deploy extends Build {
   `resumeWhen(fn, { interval? })` (async predicate, re-checked on resume), and
   `githubWorkflow((g) => g.repo(...).workflow(...))` from `@zuke/gh` (dispatches
   an external GitHub Actions workflow, satisfied when it finishes; read its
-  per-job result with `readWorkflowResult(ctx.stateOf("<gate>"))`). Write your
-  own trigger against the exported `WaitTrigger` / `WaitContext` interface.
+  per-job result with `readWorkflowResult(ctx.stateOf("<gate>"))`). By default it
+  correlates via a marker echoed into the run's `run-name:`; for a workflow you
+  can't modify use `.correlate("created-window")` (best-effort). Either way it
+  **fails fast** (`.discoveryTimeout(...)`, default 1m) if the run never
+  correlates, instead of eating the whole `.timeout()`. Write your own trigger
+  against the exported `WaitTrigger` / `WaitContext` interface.
 - Needs a state store (a build with `.waitsFor()` enables `.zuke/runs` by
   default). A resume is a fresh process, so **only `ctx.state`/`ctx.signals`
   cross the boundary**. See `docs/orchestration.md`.

--- a/tests/e2e/fixtures/gh_workflow_build.ts
+++ b/tests/e2e/fixtures/gh_workflow_build.ts
@@ -25,6 +25,18 @@ const dispatchFile = Deno.env.get("GH_DISPATCH_FILE");
 const status = Deno.env.get("GH_RUN_STATUS") ?? "in_progress";
 const conclusion = Deno.env.get("GH_RUN_CONCLUSION") ?? "";
 
+/** The dispatched run, as the file-backed fake reports it. */
+function fakeRun(): WorkflowRun {
+  return {
+    id: 777,
+    status,
+    conclusion: conclusion === "" ? null : conclusion,
+    url: "https://gh/r777",
+    createdAt: "2026-07-19T00:00:05.000Z",
+    headBranch: "main",
+  };
+}
+
 /** A file-backed fake: `dispatch` records the marker; status comes from the env. */
 const api: GhWorkflowApi = {
   dispatch(_repo, _workflow, _ref, inputs): Promise<void> {
@@ -36,20 +48,13 @@ const api: GhWorkflowApi = {
     return Promise.resolve();
   },
   findRun(): Promise<WorkflowRun | null> {
-    return Promise.resolve({
-      id: 777,
-      status,
-      conclusion: conclusion === "" ? null : conclusion,
-      url: "https://gh/r777",
-    });
+    return Promise.resolve(fakeRun());
+  },
+  recentRuns(): Promise<WorkflowRun[]> {
+    return Promise.resolve([fakeRun()]);
   },
   getRun(): Promise<WorkflowRun> {
-    return Promise.resolve({
-      id: 777,
-      status,
-      conclusion: conclusion === "" ? null : conclusion,
-      url: "https://gh/r777",
-    });
+    return Promise.resolve(fakeRun());
   },
   listJobs(): Promise<WorkflowJob[]> {
     return Promise.resolve([

--- a/tests/integration/gh_workflow_test.ts
+++ b/tests/integration/gh_workflow_test.ts
@@ -31,29 +31,34 @@ class FakeApi implements GhWorkflowApi {
   conclusion: string | null = null;
   dispatched = 0;
   throwOnGetRun = false;
+  appears = true; // whether the dispatched run can be correlated
+
+  #run(): WorkflowRun {
+    return {
+      id: 55,
+      status: this.status,
+      conclusion: this.conclusion,
+      url: "u",
+      createdAt: "2026-07-19T00:00:05.000Z",
+      headBranch: "main",
+    };
+  }
 
   dispatch(): Promise<void> {
     this.dispatched++;
     return Promise.resolve();
   }
   findRun(): Promise<WorkflowRun | null> {
-    return Promise.resolve({
-      id: 55,
-      status: this.status,
-      conclusion: this.conclusion,
-      url: "u",
-    });
+    return Promise.resolve(this.appears ? this.#run() : null);
+  }
+  recentRuns(): Promise<WorkflowRun[]> {
+    return Promise.resolve(this.appears ? [this.#run()] : []);
   }
   getRun(): Promise<WorkflowRun> {
     if (this.throwOnGetRun) {
       return Promise.reject(new Error("gh workflow: GET /runs/55 → 502"));
     }
-    return Promise.resolve({
-      id: 55,
-      status: this.status,
-      conclusion: this.conclusion,
-      url: "u",
-    });
+    return Promise.resolve(this.#run());
   }
   listJobs(): Promise<WorkflowJob[]> {
     return Promise.resolve([
@@ -104,6 +109,40 @@ Deno.test("a githubWorkflow gate dispatches, suspends, then resumes on completio
       await store.getRun(id).then((g) => g?.record.status),
       "succeeded",
     );
+  });
+});
+
+Deno.test("a githubWorkflow gate fails fast when the run never correlates", async () => {
+  await withStateDir(async (dir) => {
+    const api = new FakeApi();
+    api.appears = false; // the target workflow never echoes the marker
+    let t = Date.parse("2026-07-19T00:00:00.000Z");
+    const now = () => t;
+    class Ship extends Build {
+      e2e = target().waitsFor((s) =>
+        s.on(
+          githubWorkflowWith(
+            (g) =>
+              g.repo("acme/app").workflow("e2e.yml").discoveryTimeout("60s"),
+            { api, now },
+          ),
+        )
+      );
+      ship = target().dependsOn(this.e2e).executes(() => {});
+    }
+
+    // First process: dispatch + suspend.
+    const first = await runCli(Ship, ["ship"]);
+    assertEquals(first.code, 0);
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    const id = (await store.listRuns({}))[0].id;
+    assertEquals((await store.getRun(id))?.record.status, "suspended");
+
+    // Advance past the discovery window; the resume fails fast (not a timeout).
+    t += 61_000;
+    const resumed = await runCli(Ship, ["resume", id, "--check"]);
+    assertEquals(resumed.code, 1);
+    assertEquals((await store.getRun(id))?.record.status, "failed");
   });
 });
 


### PR DESCRIPTION
## M18 — `githubWorkflow` correlation without the marker (Round 2, P1 #7)

Unmodified target workflows (the ~100-repo long tail you don't own) can't echo
the correlation marker into their `run-name:`. This adds a **best-effort
fallback** and makes both modes **fail fast** instead of eating the whole
`.timeout()`.

### What changed

- **`.correlate("created-window")`** — snapshots the runs that already exist at
  dispatch, then claims the *new* `workflow_dispatch` run on the dispatch ref
  created just after (excluding pre-existing runs; **loud** on two fresh
  candidates in the window). Marker correlation stays the exact default.
- **`.discoveryTimeout(...)` fast-fail** — if no run is identified within a short
  window (default one minute), the gate fails with guidance
  (`does "<workflow>" echo "<marker>" into run-name:?`) rather than hanging until
  the wait's `.timeout()`. Anchored to the **persisted dispatch time**, so it
  holds across a suspend/resume, and it applies even when the correlation call
  keeps erroring (bad token / renamed workflow fails fast).
- `WorkflowRun` gains `createdAt`/`headBranch` (parsed from `created_at`/
  `head_branch`); `WorkflowCorrelationError` + `CorrelateMode` are exported.

### Acceptance

An unmodified workflow + the fallback resolves the single-dispatch case and
errors distinctly on two dispatches; marker mode against a non-echoing workflow
fails within ~a minute with the guidance message. Covered by unit tests
(`workflow_test.ts`) and an end-to-end CLI fast-fail across a resume
(`tests/integration/gh_workflow_test.ts`).

### Adversarial review

Five attack dimensions → refute-by-default verify. **3 confirmed** (all
high-confidence), each **fixed with a regression test**:

- **[medium] created-window could claim a foreign run.** A `workflow_dispatch`
  run someone else started on the same branch just before ours — visible before
  ours propagates — was claimed as ours (the 2+ ambiguity guard misses it when
  only one is visible). **Fixed:** snapshot the existing run ids at dispatch and
  exclude them. The narrow residual (a foreign dispatch landing after the
  snapshot yet visible before ours) is documented as the best-effort ceiling.
- **[low] Pre-M18 records re-stamped the discovery clock.** A record predating
  `dispatchedAt`, resumed under M18, recomputed the anchor every poll (the
  `?? now()` fallback wasn't persisted on the not-found path), so the window
  never elapsed. **Fixed:** backfill and persist the anchor once on first
  observation.
- **[medium] Fast-fail bypassed when the correlation API threw.** A permanent
  correlation error (missing `actions:read`, a renamed workflow, a long outage)
  jumped to the catch and returned "suspended", never reaching the deadline —
  so it ate the full `.timeout()`. **Fixed:** the discovery deadline is enforced
  on the error path too, while the run is still uncorrelated.

### Gate

`deno task ci` green (lines 98.2%, branches 95.1%); `apiDocsCheck`,
`generate-ci --check`, and `deno doc --lint` over all five core entrypoints
clean; gh unit + integration + e2e green; skills synced.
