### PR TITLE
feat(core): lazy edge provider for batch ordering

### DIFF
--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -678,6 +678,25 @@ class Monorepo extends Build {
 }
 ```
 
+**Lazy ordering — `override orderWith(targets)`.** Same edges, but **async and
+resolved per run**: use it when the ordering must be *loaded* at run time — read
+the monorepo's `dependency-graph.json`, hit an API — rather than declared
+statically. Return the same `[before, after]` pairs; they merge with
+`extraEdges`, and share its rules (endpoints outside the run's set are ignored,
+cycles reported). Both are honoured by a run and by `zuke cancel`'s reverse-order
+compensation walk, but — being resolved only when a run plans — neither shows in
+the static `graph` / `--list` views nor in `cicd()`-generated CI.
+
+```ts
+override async orderWith(t: Map<string, Target>): Promise<OrderingEdge[]> {
+  const graph = await loadDependencyGraph(); // read it at run time
+  return graph.edges.flatMap(([before, after]) => {
+    const from = t.get(before), to = t.get(after);
+    return from && to ? [[from, to] as OrderingEdge] : [];
+  });
+}
+```
+
 A field literally named `default` is the **default target**, run when no target
 is named on the command line.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -716,6 +716,30 @@ class Build
       }
     }
     ```
+  orderWith(_targets: Map<string, TargetBuilder>): OrderingEdge[] | Promise<OrderingEdge[]>
+    A lazy, per-run provider of soft ordering edges, merged with
+    {@link extraEdges}. Unlike `extraEdges` — synchronous, evaluated at
+    construction — this may be `async` and is evaluated when a run plans, so
+    it can read an external source (a monorepo's `dependency-graph.json`, an
+    API) to decide ordering at run time. The consumer keeps ownership of that
+    graph; Zuke only binds it in. Return `[before, after]` edges over the run's
+    targets; an edge whose endpoints are not both in the execution set is
+    ignored, and cycles are reported with the usual friendly error.
+
+    Like `extraEdges`, these are execution-ordering edges only: they are
+    honoured by a run and by `zuke cancel` (the compensation order), but not by
+    the static `graph`/`--list` views (which never run the provider) nor by
+    `cicd()`-generated CI (whose `needs:` mirrors hard `dependsOn`).
+
+    ```ts
+    override async orderWith(t: Map<string, Target>): Promise<OrderingEdge[]> {
+      const graph = await loadDependencyGraph(); // e.g. dependency-graph.json
+      return graph.edges.flatMap(([before, after]) => {
+        const from = t.get(before), to = t.get(after);
+        return from && to ? [[from, to] as OrderingEdge] : [];
+      });
+    }
+    ```
   registry(): BuildRegistry | undefined
     The {@link "./registry/registry.ts".BuildRegistry} this build registers
     itself in (`zuke register`) and that a registry-backed `zuke mcp` server

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -770,6 +770,30 @@ class Build
       }
     }
     ```
+  orderWith(_targets: Map<string, TargetBuilder>): OrderingEdge[] | Promise<OrderingEdge[]>
+    A lazy, per-run provider of soft ordering edges, merged with
+    {@link extraEdges}. Unlike `extraEdges` — synchronous, evaluated at
+    construction — this may be `async` and is evaluated when a run plans, so
+    it can read an external source (a monorepo's `dependency-graph.json`, an
+    API) to decide ordering at run time. The consumer keeps ownership of that
+    graph; Zuke only binds it in. Return `[before, after]` edges over the run's
+    targets; an edge whose endpoints are not both in the execution set is
+    ignored, and cycles are reported with the usual friendly error.
+
+    Like `extraEdges`, these are execution-ordering edges only: they are
+    honoured by a run and by `zuke cancel` (the compensation order), but not by
+    the static `graph`/`--list` views (which never run the provider) nor by
+    `cicd()`-generated CI (whose `needs:` mirrors hard `dependsOn`).
+
+    ```ts
+    override async orderWith(t: Map<string, Target>): Promise<OrderingEdge[]> {
+      const graph = await loadDependencyGraph(); // e.g. dependency-graph.json
+      return graph.edges.flatMap(([before, after]) => {
+        const from = t.get(before), to = t.get(after);
+        return from && to ? [[from, to] as OrderingEdge] : [];
+      });
+    }
+    ```
   registry(): BuildRegistry | undefined
     The {@link "./registry/registry.ts".BuildRegistry} this build registers
     itself in (`zuke register`) and that a registry-backed `zuke mcp` server

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -198,6 +198,37 @@ export class Build {
   }
 
   /**
+   * A **lazy, per-run** provider of soft ordering edges, merged with
+   * {@link extraEdges}. Unlike `extraEdges` — synchronous, evaluated at
+   * construction — this may be `async` and is evaluated when a run **plans**, so
+   * it can read an external source (a monorepo's `dependency-graph.json`, an
+   * API) to decide ordering at run time. The consumer keeps ownership of that
+   * graph; Zuke only binds it in. Return `[before, after]` edges over the run's
+   * targets; an edge whose endpoints are not both in the execution set is
+   * ignored, and cycles are reported with the usual friendly error.
+   *
+   * Like `extraEdges`, these are **execution-ordering** edges only: they are
+   * honoured by a run and by `zuke cancel` (the compensation order), but not by
+   * the static `graph`/`--list` views (which never run the provider) nor by
+   * `cicd()`-generated CI (whose `needs:` mirrors hard `dependsOn`).
+   *
+   * ```ts
+   * override async orderWith(t: Map<string, Target>): Promise<OrderingEdge[]> {
+   *   const graph = await loadDependencyGraph(); // e.g. dependency-graph.json
+   *   return graph.edges.flatMap(([before, after]) => {
+   *     const from = t.get(before), to = t.get(after);
+   *     return from && to ? [[from, to] as OrderingEdge] : [];
+   *   });
+   * }
+   * ```
+   */
+  orderWith(
+    _targets: Map<string, TargetBuilder>,
+  ): OrderingEdge[] | Promise<OrderingEdge[]> {
+    return [];
+  }
+
+  /**
    * The {@link "./registry/registry.ts".BuildRegistry} this build registers
    * itself in (`zuke register`) and that a registry-backed `zuke mcp` server
    * discovers pipelines from. Override to declare one in code; the default is
@@ -272,6 +303,22 @@ export function discoverTargets(build: Build): Map<string, TargetBuilder> {
     }
   });
   return targets;
+}
+
+/**
+ * Resolve a run's full set of soft ordering edges: the synchronous
+ * {@link Build.extraEdges} plus the lazy {@link Build.orderWith} provider,
+ * evaluated once when the run plans. `orderWith` may be `async` (it can read an
+ * external dependency graph), so this is awaited — which is why the merged edges
+ * are honoured by a run and by `zuke cancel`, but not by the static
+ * `graph`/`--list` views, which never resolve them.
+ */
+export async function resolveOrderingEdges(
+  build: Build,
+  targets: Map<string, TargetBuilder>,
+): Promise<OrderingEdge[]> {
+  const lazy = await build.orderWith(targets);
+  return [...build.extraEdges(targets), ...lazy];
 }
 
 /**

--- a/packages/core/src/cancel.ts
+++ b/packages/core/src/cancel.ts
@@ -24,9 +24,9 @@
  * @module
  */
 
-import { type Build, discoverTargets } from "./build.ts";
+import { type Build, discoverTargets, resolveOrderingEdges } from "./build.ts";
 import type { Reporter } from "./executor.ts";
-import { planGraph } from "./graph.ts";
+import { type OrderingEdge, planGraph } from "./graph.ts";
 import { discoverParameters, resolveParameters } from "./params.ts";
 import { Redactor } from "./redact.ts";
 import type {
@@ -654,10 +654,24 @@ export async function cancelRun(
         `"${record.rootTarget}" — cancelling without compensations.`,
     );
   } else {
-    // Honour the build's soft extraEdges, exactly as execute() does, so
-    // out-of-process cancellation (zuke cancel / MCP / a timed-out wait)
-    // compensates in the same reverse-execution order as an in-process cancel.
-    const order = planGraph(root, build.extraEdges(targets)).order;
+    // Honour the build's soft ordering edges (extraEdges + the lazy orderWith
+    // provider), exactly as execute() does, so out-of-process cancellation
+    // (zuke cancel / MCP / a timed-out wait) compensates in the same
+    // reverse-execution order as an in-process cancel. These edges only affect
+    // the compensation ORDER, so a failing provider (e.g. an unreachable
+    // dependency-graph service during `zuke cancel`) degrades to the base
+    // topological order — never abandoning the walk, which would strand the run
+    // `cancelling` with its rollbacks never run (a re-cancel then skips them).
+    let edges: OrderingEdge[] = [];
+    try {
+      edges = await resolveOrderingEdges(build, targets);
+    } catch (error) {
+      reporter.error(
+        `cancel: ordering provider failed (${messageOf(error)}); ` +
+          `compensating in base topological order.`,
+      );
+    }
+    const order = planGraph(root, edges).order;
     outcome = await runCompensations(order, record, {
       runId,
       signals: new Map(Object.entries(record.signals)),

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -14,8 +14,8 @@
  */
 
 import type { Build, BuildResult, TargetStatus } from "./build.ts";
-import { discoverTargets } from "./build.ts";
-import { planGraph } from "./graph.ts";
+import { discoverTargets, resolveOrderingEdges } from "./build.ts";
+import { type OrderingEdge, planGraph } from "./graph.ts";
 import { withAmbientEcho } from "./ambient_echo.ts";
 import {
   discoverParameters,
@@ -1404,8 +1404,23 @@ export async function execute(
   }
 
   // Soft ordering edges the build declares beyond target-level before/after
-  // (e.g. fed from an external dependency graph); cycle-checked with the rest.
-  const extraEdges = build.extraEdges(discoverTargets(build));
+  // (`extraEdges` plus the lazy per-run `orderWith` provider, e.g. fed from an
+  // external dependency graph); cycle-checked with the rest. The lazy provider
+  // may be async and can fail (an unreachable graph service) — since ordering
+  // can be a correctness requirement, a failure fails the build cleanly rather
+  // than silently running in the base order or crashing with an unhandled
+  // rejection. (No run record exists yet, so nothing is stranded.)
+  let extraEdges: OrderingEdge[];
+  try {
+    extraEdges = await resolveOrderingEdges(build, discoverTargets(build));
+  } catch (error) {
+    reporter.error(
+      `Failed to resolve ordering edges: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return { ok: false, executed: [], error };
+  }
   const { order, predecessors } = planGraph(root, extraEdges);
   // Evaluate up-front conditions for `whenSkipped("skip-dependencies")` targets
   // and skip them plus any dependencies that nothing else needs.

--- a/packages/core/tests/cancel_test.ts
+++ b/packages/core/tests/cancel_test.ts
@@ -9,6 +9,7 @@ import {
   runCompensations,
 } from "../src/cancel.ts";
 import { resumeRun } from "../src/resume.ts";
+import type { OrderingEdge } from "../src/graph.ts";
 import { FileSystemStateStore } from "../src/state/fs_store.ts";
 import { defaultStateHost, type StateStore } from "../src/state/store.ts";
 import type { RunRecord } from "../src/state/types.ts";
@@ -1009,6 +1010,47 @@ Deno.test("a fan-out parent's own onCancel runs after its item compensations", a
   });
   // Items unwind first (reverse), then the batch-level compensation.
   assertEquals(seq, ["item:b", "item:a", "parent"]);
+});
+
+Deno.test("cancel degrades to base order when orderWith fails, still compensating", async () => {
+  await withTempStore(async (store) => {
+    const undone: string[] = [];
+    // The ordering provider is reachable at run time, but not at cancel time
+    // (a fresh `zuke cancel` process can't reach the dependency-graph service).
+    let failOrder = false;
+    const makeBuild = () => {
+      class CD extends Build {
+        deploy = target().executes(() => {}).onCancel(() => this.rollback);
+        rollback = target().executes(() => void undone.push("deploy"));
+        gate = target()
+          .dependsOn(this.deploy)
+          .waitsFor((s) => s.on(externalSignal("x")));
+        override orderWith(): Promise<OrderingEdge[]> {
+          return failOrder
+            ? Promise.reject(new Error("graph service down"))
+            : Promise.resolve([]);
+        }
+      }
+      const build = new CD();
+      discoverTargets(build);
+      return build;
+    };
+    const a = makeBuild();
+    await execute(a, a.gate, { silent: true, stateStore: store });
+    const id = (await store.listRuns({}))[0].id;
+
+    failOrder = true; // the provider now rejects
+    const result = await cancelRun(makeBuild(), {
+      runId: id,
+      stateStore: store,
+      silent: true,
+    });
+    // The run still settles cancelled with its compensation run — never stranded
+    // `cancelling` with rollbacks lost.
+    assertEquals(result.status, "cancelled");
+    assertEquals(undone, ["deploy"]);
+    assertEquals((await store.getRun(id))?.record.status, "cancelled");
+  });
 });
 
 /** Force a run to `cancelling`, retrying the CAS until it lands. */

--- a/packages/core/tests/graph_test.ts
+++ b/packages/core/tests/graph_test.ts
@@ -1,10 +1,11 @@
 import { assertEquals, assertThrows } from "./_assert.ts";
-import { Build, discoverTargets } from "../src/build.ts";
-import { target } from "../src/target.ts";
+import { Build, discoverTargets, resolveOrderingEdges } from "../src/build.ts";
+import { target, type TargetBuilder } from "../src/target.ts";
 import {
   executionSet,
   findCycle,
   GraphError,
+  type OrderingEdge,
   plan,
   planGraph,
   validateGraph,
@@ -277,4 +278,38 @@ Deno.test("an extra edge that forms a cycle is reported", () => {
 Deno.test("Build.extraEdges defaults to no edges", () => {
   class B extends Build {}
   assertEquals(new B().extraEdges(new Map()), []);
+});
+
+Deno.test("Build.orderWith defaults to no edges", async () => {
+  class B extends Build {}
+  assertEquals(await new B().orderWith(new Map()), []);
+});
+
+Deno.test("resolveOrderingEdges merges extraEdges with an async orderWith", async () => {
+  class B extends Build {
+    a = target().executes(() => {});
+    b = target().executes(() => {});
+    c = target().executes(() => {});
+    all = target().dependsOn(this.a, this.b, this.c).executes(() => {});
+    override extraEdges(t: Map<string, TargetBuilder>): OrderingEdge[] {
+      const a = t.get("a"), b = t.get("b");
+      return a && b ? [[a, b]] : [];
+    }
+    override async orderWith(
+      t: Map<string, TargetBuilder>,
+    ): Promise<OrderingEdge[]> {
+      await Promise.resolve(); // a genuinely async provider (e.g. a fetch)
+      const b = t.get("b"), c = t.get("c");
+      return b && c ? [[b, c]] : [];
+    }
+  }
+  const build = new B();
+  const targets = discoverTargets(build);
+  const edges = await resolveOrderingEdges(build, targets);
+  // One edge from extraEdges (a→b) and one from orderWith (b→c).
+  assertEquals(edges.length, 2);
+  const order = planGraph(build.all, edges).order.map((t) => t.name_);
+  // The merged edges chain a → b → c within the run's execution set.
+  assertEquals(order.indexOf("a") < order.indexOf("b"), true);
+  assertEquals(order.indexOf("b") < order.indexOf("c"), true);
 });

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -38,8 +38,10 @@ Everything is optional except a body (`.executes`).
 **External ordering:** `override extraEdges(targets)` on the `Build` returns
 `[before, after]` pairs (from the discovered `targets` map) to impose soft
 ordering beyond per-target `.before()`/`.after()` — the seam for feeding an
-external dependency graph in. Cycle-checked; edges outside the run's set are
-ignored.
+external dependency graph in. `override orderWith(targets)` is the same, but
+**async and resolved per run** (load the graph at run time); its edges merge
+with `extraEdges`. Cycle-checked; edges outside the run's set are ignored; both
+are honoured by a run and `zuke cancel`, but not by static `graph`/`--list`.
 
 ## `group()` — parallel batches
 

--- a/tests/integration/orderwith_test.ts
+++ b/tests/integration/orderwith_test.ts
@@ -1,0 +1,134 @@
+/**
+ * Integration: `Build.orderWith` — the lazy, per-run soft-ordering provider
+ * (M19 P2 #10) — driven through the real CLI `main()`. Unlike `extraEdges`, the
+ * provider is `async` and evaluated when the run plans (it can read an external
+ * dependency graph), and it is honoured both by a run and by `zuke cancel`'s
+ * reverse-order compensation walk.
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import {
+  Build,
+  defaultStateHost,
+  externalSignal,
+  FileSystemStateStore,
+  type OrderingEdge,
+  target,
+} from "../../packages/core/mod.ts";
+import type { TargetBuilder } from "../../packages/core/mod.ts";
+import { runCli, withStateDir } from "./_harness.ts";
+
+/** A fake "load the dependency graph" step: async, resolves to `[before, after]` names. */
+function loadDependencyGraph(): Promise<Array<[string, string]>> {
+  return Promise.resolve([["web", "api"]]); // web must build before api
+}
+
+Deno.test("orderWith imposes lazy per-run ordering", async () => {
+  const log: string[] = [];
+  class Mono extends Build {
+    web = target().executes(() => void log.push("web"));
+    api = target().executes(() => void log.push("api"));
+    all = target()
+      .dependsOn(this.web, this.api)
+      .executes(() => void log.push("all"));
+    // Resolved at run time from an external graph — the opposite of the default
+    // sibling order.
+    override async orderWith(
+      t: Map<string, TargetBuilder>,
+    ): Promise<OrderingEdge[]> {
+      const graph = await loadDependencyGraph();
+      return graph.flatMap(([before, after]) => {
+        const from = t.get(before), to = t.get(after);
+        return from && to ? [[from, to] as OrderingEdge] : [];
+      });
+    }
+  }
+  const res = await runCli(Mono, ["all"]);
+  assertEquals(res.code, 0);
+  assertEquals(log.indexOf("web") < log.indexOf("api"), true);
+});
+
+Deno.test("orderWith and extraEdges merge into one edge set", async () => {
+  const log: string[] = [];
+  class Mono extends Build {
+    a = target().executes(() => void log.push("a"));
+    b = target().executes(() => void log.push("b"));
+    c = target().executes(() => void log.push("c"));
+    all = target()
+      .dependsOn(this.a, this.b, this.c)
+      .executes(() => {});
+    // extraEdges: a → b (static).
+    override extraEdges(t: Map<string, TargetBuilder>): OrderingEdge[] {
+      const a = t.get("a"), b = t.get("b");
+      return a && b ? [[a, b]] : [];
+    }
+    // orderWith: b → c (lazy). Together they chain a → b → c.
+    override orderWith(t: Map<string, TargetBuilder>): OrderingEdge[] {
+      const b = t.get("b"), c = t.get("c");
+      return b && c ? [[b, c]] : [];
+    }
+  }
+  const res = await runCli(Mono, ["all"]);
+  assertEquals(res.code, 0);
+  assertEquals(log.indexOf("a") < log.indexOf("b"), true);
+  assertEquals(log.indexOf("b") < log.indexOf("c"), true);
+});
+
+Deno.test("a failing orderWith fails the run cleanly, not with an unhandled rejection", async () => {
+  class B extends Build {
+    a = target().executes(() => {});
+    // The dependency-graph service is unreachable at plan time.
+    override orderWith(): Promise<OrderingEdge[]> {
+      return Promise.reject(new Error("dependency graph unavailable"));
+    }
+  }
+  const res = await runCli(B, ["a"]);
+  assertEquals(res.code, 1);
+  assertStringIncludes(res.err, "Failed to resolve ordering edges");
+  assertStringIncludes(res.err, "dependency graph unavailable");
+});
+
+Deno.test("out-of-process cancel unwinds in orderWith execution order", async () => {
+  await withStateDir(async (dir) => {
+    const log: string[] = [];
+    class CD extends Build {
+      web = target()
+        .executes(() => void log.push("web"))
+        .onCancel(() => this.webDown);
+      api = target()
+        .executes(() => void log.push("api"))
+        .onCancel(() => this.apiDown);
+      webDown = target().executes(() => void log.push("webDown"));
+      apiDown = target().executes(() => void log.push("apiDown"));
+      gate = target()
+        .dependsOn(this.web, this.api)
+        .waitsFor((s) => s.on(externalSignal("go")));
+      done = target().dependsOn(this.gate).executes(() => {});
+      // Lazy edge: web before api — so api is the "later" work, unwound first.
+      override async orderWith(
+        t: Map<string, TargetBuilder>,
+      ): Promise<OrderingEdge[]> {
+        await Promise.resolve();
+        const web = t.get("web"), api = t.get("api");
+        return web && api ? [[web, api]] : [];
+      }
+    }
+
+    // Run to the gate: web then api succeed, then suspend.
+    const first = await runCli(CD, ["done"]);
+    assertEquals(first.code, 0);
+    assertEquals(log, ["web", "api"]);
+    const id =
+      (await new FileSystemStateStore(dir, defaultStateHost).listRuns({}))[0]
+        .id;
+
+    // Cancel out-of-process: compensations run in reverse execution order, so
+    // api (which ran after web, per the lazy edge) is unwound before web.
+    const cancelled = await runCli(CD, ["cancel", id]);
+    assertEquals(cancelled.code, 0);
+    assertEquals(log.indexOf("apiDown") < log.indexOf("webDown"), true);
+  });
+});


### PR DESCRIPTION
## M19 (P2 #10) — `build.orderWith()` lazy edge provider

The requester keeps ownership of their cross-repo `dependency-graph.json`; Zuke
gains only the **binding seam** to feed it into ordering at run time.

### What changed

- **`Build.orderWith(targets)`** — a **lazy, per-run** provider of soft ordering
  edges (`[before, after]`), merged with the synchronous `extraEdges`. Unlike
  `extraEdges` (declaration-time), it may be **`async`** and is resolved when a
  run plans, so it can *load* the ordering — read `dependency-graph.json`, hit an
  API. Shares `extraEdges`' rules (endpoints outside the run's set ignored,
  cycles reported). Defaults to `[]`, so every existing build is unchanged.
- Honoured by a run and by `zuke cancel`'s reverse-order compensation walk (via a
  new `resolveOrderingEdges` helper wired into both planning points), but — being
  resolved only when a run plans — **not** by the static `graph`/`--list` views
  nor by `cicd()`-generated CI (whose `needs:` mirrors hard `dependsOn`).

### Acceptance

An async `orderWith` imposes ordering through a real run; it merges with
`extraEdges` into one edge set; `zuke cancel` unwinds compensations in the
`orderWith` execution order. Covered by unit (`graph_test.ts`) + end-to-end CLI
integration (`tests/integration/orderwith_test.ts`).

### Adversarial review

Four attack dimensions → refute-by-default verify. **1 confirmed** (high
confidence, medium severity), **fixed with a regression test**:

- **A failing `orderWith` during cancel stranded the run.** Because the provider
  can be async and reach an external graph service, an *unreachable* service
  during `zuke cancel` made `resolveOrderingEdges` reject **after** the run was
  CAS'd to `cancelling` — so the compensation walk and the settle never ran, and
  a retry `cancel` took the "recover" path that **skips** compensations, losing
  the rollbacks permanently. **Fixed:** the cancel path now degrades a failed
  provider to the base topological order and still compensates and settles
  (the edges only affect *order*). On the run path — where ordering can be a
  correctness requirement — a failed provider now fails the build **cleanly**
  with a friendly message rather than crashing with an unhandled rejection or
  silently running in the base order; both paths have regression tests.

### Gate

`deno task ci` green (lines 98.2%, branches 95.1%); `build.ts` 100% covered;
`apiDocsCheck`, `generate-ci --check`, and `deno doc --lint` over all five core
entrypoints clean; skills synced.

*(M19 is a P2 batch — this is the `orderWith` slice. The gcloud/kubectl/GCS
wrapper slices remain, each its own small PR when demand warrants.)*
