### PR TITLE
feat(gcloud): typed gcloud subcommands, GCS + Secret Manager REST, kubectl annotate/label

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -62,7 +62,7 @@ actually spawn (the resolved shim or the bare fallback) for diagnostics.
 | `@zuke/yarn`           | `install`, `add`, `remove`, `run`, `dlx`                                                                                              |
 | `@zuke/docker`         | `build`, `run`, `exec`, `push`, `pull`, `tag`, `login`, `images`, `ps`, `stop`, `start`, `rm`, `rmi`, `save`, `load`                  |
 | `@zuke/docker-compose` | `up`, `down`, `build`, `pull`, `push`, `run`, `exec`, `logs`, `ps`, `config`, `start`, `stop`, `restart`, `rm`                        |
-| `@zuke/kubectl`        | `apply`, `create`, `delete`, `get`, `describe`, `logs`, `exec`, `rollout`, `scale`, `setImage`, `patch`, `portForward`, `wait`, `top` |
+| `@zuke/kubectl`        | `apply`, `create`, `delete`, `get`, `describe`, `logs`, `exec`, `rollout`, `scale`, `setImage`, `patch`, `portForward`, `wait`, `top`, `annotate`, `label` |
 | `@zuke/helm`           | `install`, `upgrade`, `uninstall`, `template`, `lint`, `dependencyUpdate`, `repoAdd`, `package`                                       |
 | `@zuke/kustomize`      | `build`, `editSetImage`                                                                                                               |
 | `@zuke/oxlint`         | `lint`                                                                                                                                |
@@ -91,7 +91,7 @@ actually spawn (the resolved shim or the bare fallback) for diagnostics.
 | `@zuke/husky`          | `init`, `install`                                                                                                                     |
 | `@zuke/node`           | `run`, `eval`, `test`                                                                                                                 |
 | `@zuke/dprint`         | `fmt`, `check`                                                                                                                        |
-| `@zuke/gcloud`         | `run` (any command)                                                                                                                   |
+| `@zuke/gcloud`         | `run` (any command; typed `containerImagesAddTag` / `sqlInstancesDescribe` / `sqlOperationsWait`), plus `GcsTasks` and `SecretManagerTasks` REST groups |
 | `@zuke/git`            | `init`, `clone`, `add`, `commit`, `status`, `checkout`, `branch`, `tag`, `push`, `pull`, `fetch`, `run` (+ `gitInfo()` helper)        |
 | `@zuke/gh`             | `run` (any command)                                                                                                                   |
 | `@zuke/codecov`        | `upload` (`codecovcli upload-process`)                                                                                                |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4566,6 +4566,23 @@ await KubectlTasks.rollout((s) =>
 const KubectlTasks: KubectlTasksApi
   Typed task functions for the `kubectl` CLI.
 
+class KubectlAnnotateSettings extends KubectlSettings
+  Settings for `kubectl annotate`.
+
+  resource(...tokens: string[]): this
+    Resource tokens, e.g. `("deploy", "api")` or `("pods", "-l", "app=web")`; repeatable.
+  annotation(key: string, value: string): this
+    Set an annotation as a `key=value` token; repeatable.
+  remove(key: string): this
+    Remove an annotation, rendered as kubectl's `key-` syntax; repeatable.
+  overwrite(): this
+    Overwrite existing annotations (`--overwrite`).
+  all(): this
+    Apply to all resources of the given type (`--all`).
+  selector(query: string): this
+    Restrict to resources matching a label selector (`-l`).
+  override protected buildArgs(): string[]
+
 class KubectlApplySettings extends KubectlSettings
   Settings for `kubectl apply`.
 
@@ -4665,6 +4682,23 @@ class KubectlGetSettings extends KubectlSettings
     Watch for changes instead of returning once (`-w`).
   showLabels(): this
     Include resource labels as columns (`--show-labels`).
+  override protected buildArgs(): string[]
+
+class KubectlLabelSettings extends KubectlSettings
+  Settings for `kubectl label`.
+
+  resource(...tokens: string[]): this
+    Resource tokens, e.g. `("deploy", "api")` or `("pods", "-l", "app=web")`; repeatable.
+  label(key: string, value: string): this
+    Set a label as a `key=value` token; repeatable.
+  remove(key: string): this
+    Remove a label, rendered as kubectl's `key-` syntax; repeatable.
+  overwrite(): this
+    Overwrite existing labels (`--overwrite`).
+  all(): this
+    Apply to all resources of the given type (`--all`).
+  selector(query: string): this
+    Restrict to resources matching a label selector (`-l`).
   override protected buildArgs(): string[]
 
 class KubectlLogsSettings extends KubectlSettings
@@ -4818,6 +4852,10 @@ interface KubectlTasksApi
     Scale a workload: `kubectl scale`.
   setImage(configure?: Configure<KubectlSetImageSettings>): Promise<CommandOutput>
     Update a container image: `kubectl set image`.
+  annotate(configure?: Configure<KubectlAnnotateSettings>): Promise<CommandOutput>
+    Annotate resources: `kubectl annotate`.
+  label(configure?: Configure<KubectlLabelSettings>): Promise<CommandOutput>
+    Label resources: `kubectl label`.
   patch(configure?: Configure<KubectlPatchSettings>): Promise<CommandOutput>
     Patch a resource: `kubectl patch`.
   portForward(configure?: Configure<KubectlPortForwardSettings>): Promise<CommandOutput>
@@ -6709,20 +6747,42 @@ interface DprintTasksApi
 # @zuke/gcloud
 ========================================================================
 
-`@zuke/gcloud` — a typed `gcloud` (Google Cloud SDK) task wrapper for Zuke
-builds.
-
-A flexible command builder: name the command with `.command(...)`, set common
-global flags fluently, and pass anything else with `.flag(...)`.
+`@zuke/gcloud` — typed Google Cloud tooling for Zuke builds: the `gcloud`
+(Google Cloud SDK) CLI wrapper, plus GCS and Secret Manager REST task
+groups that share `gcloud`-based auth (no Google SDK dependency).
 
 ```ts
-import { GcloudTasks } from "jsr:@zuke/gcloud";
-await GcloudTasks.run((s) => s.command("auth", "list").format("json"));
+import { GcloudTasks, GcsTasks, SecretManagerTasks } from "jsr:@zuke/gcloud";
+
+await GcloudTasks.run((s) => s.containerImagesAddTag(src, dst)); // CLI
+await GcsTasks.writeJson("bucket", "state.json", { slot: "sit-7" }); // REST
+const pw = await SecretManagerTasks.access("db-password", { project }); // REST
 ```
+
+The CLI wrapper builds a discrete argv array (never a shell string), and the
+REST groups take an injectable `fetch`, so both are testable without network
+or a real cluster.
 @module
+
+function gcloudAccessToken(run: GcloudRunner): Promise<string>
+  The default {@link AccessTokenProvider}: the trimmed stdout of
+  `gcloud auth print-access-token`, run with `--quiet` so the token never
+  streams to the build log. `run` defaults to {@link "./gcloud.ts".GcloudTasks}
+  `.run` and is injectable for tests.
+
+function resolveAccessToken(options: { token?: string; tokenProvider?: AccessTokenProvider; }): Promise<string>
+  Resolve a bearer token from an explicit `token` or, when it is omitted, the
+  `tokenProvider` (defaulting to {@link gcloudAccessToken}). Shared by the REST
+  task groups so every call resolves auth the same way.
 
 const GcloudTasks: GcloudTasksApi
   Typed task functions for the `gcloud` CLI.
+
+const GcsTasks: GcsTasksApi
+  Typed Google Cloud Storage JSON operations.
+
+const SecretManagerTasks: SecretManagerTasksApi
+  Typed Google Secret Manager operations.
 
 class GcloudSettings extends ToolSettings
   Settings for a `gcloud` invocation.
@@ -6730,6 +6790,20 @@ class GcloudSettings extends ToolSettings
   override protected defaultTool(): string
   command(...parts: Array<string | number>): this
     The command path and verb, e.g. `command("run", "deploy", "api")`.
+  containerImagesAddTag(source: string, ...destinations: string[]): this
+    Add tags to a container image across registries:
+    `gcloud container images add-tag <source> <destination…>`. Each argument is
+    a discrete argv token, so an image reference can't inject flags. Runs with
+    `--quiet` (the re-tag is non-interactive automation; `add-tag` otherwise
+    prompts for confirmation).
+  sqlInstancesDescribe(instance: string): this
+    Describe a Cloud SQL instance:
+    `gcloud sql instances describe <instance>`. Add `.format("json")` to get a
+    machine-readable body to parse from the command's stdout.
+  sqlOperationsWait(operation: string): this
+    Block until a Cloud SQL operation completes:
+    `gcloud sql operations wait <operation>` — the typed form of the
+    poll-an-operation shell loop.
   project(id: string): this
     Target Google Cloud project (`--project`).
   account(email: string): this
@@ -6754,6 +6828,79 @@ interface GcloudTasksApi
 
   run(configure?: Configure<GcloudSettings>): Promise<CommandOutput>
     Run a `gcloud` command.
+
+interface GcpRestOptions
+  Common options for a Google REST call: the bearer token and an injectable `fetch`.
+
+  token: string
+    The OAuth access token (see {@link "./auth.ts".gcloudAccessToken}).
+  fetch?: typeof fetch
+    The `fetch` implementation; defaults to the global. Overridable for tests.
+
+interface GcsListOptions extends GcsOptions
+  Options for {@link GcsTasksApi.list}: the auth/transport plus an object-name prefix.
+
+  prefix?: string
+    Keep only objects whose name starts with this prefix.
+
+interface GcsOptions
+  Auth + transport options common to every {@link GcsTasks} call.
+
+  token?: string
+    A pre-resolved OAuth token; when omitted, {@link tokenProvider} supplies one.
+  tokenProvider?: AccessTokenProvider
+    Resolves the token when `token` is omitted (default: {@link "./auth.ts".gcloudAccessToken}).
+  fetch?: typeof fetch
+    The `fetch` implementation; defaults to the global. Overridable for tests.
+
+interface GcsTasksApi
+  The shape of {@link GcsTasks}.
+
+  readJson(bucket: string, object: string, options?: GcsOptions): Promise<T>
+    Read object `object` from `bucket` and parse its body as JSON.
+  writeJson(bucket: string, object: string, data: unknown, options?: GcsOptions): Promise<void>
+    Write `data` (JSON-serialised) as object `object` in `bucket`.
+  list(bucket: string, options?: GcsListOptions): Promise<string[]>
+    List object names in `bucket` (optionally filtered by `prefix`).
+
+interface SecretManagerAccessOptions extends SecretManagerOptions
+  Options for {@link SecretManagerTasksApi.access}: the common options plus a version.
+
+  version?: string
+    The version to access; defaults to `"latest"`.
+
+interface SecretManagerOptions
+  Auth + transport + project options common to every {@link SecretManagerTasks} call.
+
+  project?: string
+    The Google Cloud project id; when omitted, resolved from the environment.
+  token?: string
+    A pre-resolved OAuth token; when omitted, {@link tokenProvider} supplies one.
+  tokenProvider?: AccessTokenProvider
+    Resolves the token when `token` is omitted (default: {@link "./auth.ts".gcloudAccessToken}).
+  fetch?: typeof fetch
+    The `fetch` implementation; defaults to the global. Overridable for tests.
+  readEnv?: (name: string) => string | undefined
+    Reads an environment variable for project resolution; defaults to `Deno.env.get`.
+
+interface SecretManagerTasksApi
+  The shape of {@link SecretManagerTasks}.
+
+  access(name: string, options?: SecretManagerAccessOptions): Promise<string>
+    Access secret `name`'s payload as a string (version defaults to `"latest"`).
+  addVersion(name: string, value: string, options?: SecretManagerOptions): Promise<string>
+    Add a new version holding `value` to secret `name`, creating the secret
+    first if it does not exist (an already-exists `409` is ignored) — the
+    write-before-create idempotency a deploy relies on. Returns the new version's
+    resource name.
+
+type AccessTokenProvider = () => Promise<string>
+  Supplies a Google Cloud OAuth access token for a REST call.
+
+type GcloudRunner = (configure?: Configure<GcloudSettings>) => Promise<CommandOutput>
+  Runs a `gcloud` command — the seam {@link gcloudAccessToken} resolves the
+  token through. Defaults to {@link "./gcloud.ts".GcloudTasks} `.run`; injectable
+  so the default provider is unit-testable without invoking `gcloud`.
 
 ========================================================================
 # @zuke/git

--- a/llms.txt
+++ b/llms.txt
@@ -128,7 +128,7 @@ Full reference: [docs/cli.md](./docs/cli.md).
 - [@zuke/husky](https://jsr.io/@zuke/husky) — typed `husky` task wrappers for Zuke builds
 - [@zuke/node](https://jsr.io/@zuke/node) — typed Node.js task wrappers for Zuke builds
 - [@zuke/dprint](https://jsr.io/@zuke/dprint) — typed `dprint` task wrappers for Zuke builds
-- [@zuke/gcloud](https://jsr.io/@zuke/gcloud) — a typed `gcloud` (Google Cloud SDK) task wrapper for Zuke
+- [@zuke/gcloud](https://jsr.io/@zuke/gcloud) — typed Google Cloud tooling for Zuke builds: the `gcloud`
 - [@zuke/git](https://jsr.io/@zuke/git) — typed `git` task wrappers for Zuke builds
 - [@zuke/gh](https://jsr.io/@zuke/gh) — typed GitHub tooling for Zuke builds: the `gh` (GitHub CLI) task
 - [@zuke/codecov](https://jsr.io/@zuke/codecov) — a typed Codecov CLI (`codecovcli`) task wrapper for Zuke

--- a/packages/gcloud/README.md
+++ b/packages/gcloud/README.md
@@ -21,6 +21,45 @@ await GcloudTasks.run((s) =>
 await GcloudTasks.run((s) => s.command("auth", "list").format("json"));
 ```
 
+Typed methods cover the ugliest shells directly — cross-registry image tagging
+and Cloud SQL:
+
+```ts
+await GcloudTasks.run((s) =>
+  s.containerImagesAddTag("gcr.io/p/img:sha", "eu.gcr.io/p/img:prod")
+);
+await GcloudTasks.run((s) => s.sqlInstancesDescribe("prod-db").format("json"));
+await GcloudTasks.run((s) => s.sqlOperationsWait("op-123"));
+```
+
+## GCS and Secret Manager (REST)
+
+Two REST task groups reach Google Cloud Storage and Secret Manager **without a
+Google SDK** — auth is a bearer token from an injected provider (default:
+`gcloud auth print-access-token`), and the transport is an injectable `fetch`,
+so both are testable without network:
+
+```ts
+import { GcsTasks, SecretManagerTasks } from "jsr:@zuke/gcloud";
+
+// GCS: read/write/list JSON blobs.
+await GcsTasks.writeJson("my-bucket", "state/deploy.json", { slot: "sit-7" });
+const state = await GcsTasks.readJson<{ slot: string }>(
+  "my-bucket",
+  "state/deploy.json",
+);
+const keys = await GcsTasks.list("my-bucket", { prefix: "state/" });
+
+// Secret Manager: create-if-absent, then add a version (idempotent).
+await SecretManagerTasks.addVersion("db-password", pw, { project: "my-proj" });
+const secret = await SecretManagerTasks.access("db-password", {
+  project: "my-proj",
+});
+```
+
+`access` returns the plaintext secret — route it into a `.secret()` parameter or
+the run's redactor; never log it.
+
 <!-- ZUKE:API:START -->
 
 ## API
@@ -29,20 +68,42 @@ await GcloudTasks.run((s) => s.command("auth", "list").format("json"));
 <summary>Full typed API — generated from <code>deno doc</code></summary>
 
 ````text
-`@zuke/gcloud` — a typed `gcloud` (Google Cloud SDK) task wrapper for Zuke
-builds.
-
-A flexible command builder: name the command with `.command(...)`, set common
-global flags fluently, and pass anything else with `.flag(...)`.
+`@zuke/gcloud` — typed Google Cloud tooling for Zuke builds: the `gcloud`
+(Google Cloud SDK) CLI wrapper, plus GCS and Secret Manager REST task
+groups that share `gcloud`-based auth (no Google SDK dependency).
 
 ```ts
-import { GcloudTasks } from "jsr:@zuke/gcloud";
-await GcloudTasks.run((s) => s.command("auth", "list").format("json"));
+import { GcloudTasks, GcsTasks, SecretManagerTasks } from "jsr:@zuke/gcloud";
+
+await GcloudTasks.run((s) => s.containerImagesAddTag(src, dst)); // CLI
+await GcsTasks.writeJson("bucket", "state.json", { slot: "sit-7" }); // REST
+const pw = await SecretManagerTasks.access("db-password", { project }); // REST
 ```
+
+The CLI wrapper builds a discrete argv array (never a shell string), and the
+REST groups take an injectable `fetch`, so both are testable without network
+or a real cluster.
 @module
+
+function gcloudAccessToken(run: GcloudRunner): Promise<string>
+  The default {@link AccessTokenProvider}: the trimmed stdout of
+  `gcloud auth print-access-token`, run with `--quiet` so the token never
+  streams to the build log. `run` defaults to {@link "./gcloud.ts".GcloudTasks}
+  `.run` and is injectable for tests.
+
+function resolveAccessToken(options: { token?: string; tokenProvider?: AccessTokenProvider; }): Promise<string>
+  Resolve a bearer token from an explicit `token` or, when it is omitted, the
+  `tokenProvider` (defaulting to {@link gcloudAccessToken}). Shared by the REST
+  task groups so every call resolves auth the same way.
 
 const GcloudTasks: GcloudTasksApi
   Typed task functions for the `gcloud` CLI.
+
+const GcsTasks: GcsTasksApi
+  Typed Google Cloud Storage JSON operations.
+
+const SecretManagerTasks: SecretManagerTasksApi
+  Typed Google Secret Manager operations.
 
 class GcloudSettings extends ToolSettings
   Settings for a `gcloud` invocation.
@@ -50,6 +111,20 @@ class GcloudSettings extends ToolSettings
   override protected defaultTool(): string
   command(...parts: Array<string | number>): this
     The command path and verb, e.g. `command("run", "deploy", "api")`.
+  containerImagesAddTag(source: string, ...destinations: string[]): this
+    Add tags to a container image across registries:
+    `gcloud container images add-tag <source> <destination…>`. Each argument is
+    a discrete argv token, so an image reference can't inject flags. Runs with
+    `--quiet` (the re-tag is non-interactive automation; `add-tag` otherwise
+    prompts for confirmation).
+  sqlInstancesDescribe(instance: string): this
+    Describe a Cloud SQL instance:
+    `gcloud sql instances describe <instance>`. Add `.format("json")` to get a
+    machine-readable body to parse from the command's stdout.
+  sqlOperationsWait(operation: string): this
+    Block until a Cloud SQL operation completes:
+    `gcloud sql operations wait <operation>` — the typed form of the
+    poll-an-operation shell loop.
   project(id: string): this
     Target Google Cloud project (`--project`).
   account(email: string): this
@@ -74,6 +149,79 @@ interface GcloudTasksApi
 
   run(configure?: Configure<GcloudSettings>): Promise<CommandOutput>
     Run a `gcloud` command.
+
+interface GcpRestOptions
+  Common options for a Google REST call: the bearer token and an injectable `fetch`.
+
+  token: string
+    The OAuth access token (see {@link "./auth.ts".gcloudAccessToken}).
+  fetch?: typeof fetch
+    The `fetch` implementation; defaults to the global. Overridable for tests.
+
+interface GcsListOptions extends GcsOptions
+  Options for {@link GcsTasksApi.list}: the auth/transport plus an object-name prefix.
+
+  prefix?: string
+    Keep only objects whose name starts with this prefix.
+
+interface GcsOptions
+  Auth + transport options common to every {@link GcsTasks} call.
+
+  token?: string
+    A pre-resolved OAuth token; when omitted, {@link tokenProvider} supplies one.
+  tokenProvider?: AccessTokenProvider
+    Resolves the token when `token` is omitted (default: {@link "./auth.ts".gcloudAccessToken}).
+  fetch?: typeof fetch
+    The `fetch` implementation; defaults to the global. Overridable for tests.
+
+interface GcsTasksApi
+  The shape of {@link GcsTasks}.
+
+  readJson(bucket: string, object: string, options?: GcsOptions): Promise<T>
+    Read object `object` from `bucket` and parse its body as JSON.
+  writeJson(bucket: string, object: string, data: unknown, options?: GcsOptions): Promise<void>
+    Write `data` (JSON-serialised) as object `object` in `bucket`.
+  list(bucket: string, options?: GcsListOptions): Promise<string[]>
+    List object names in `bucket` (optionally filtered by `prefix`).
+
+interface SecretManagerAccessOptions extends SecretManagerOptions
+  Options for {@link SecretManagerTasksApi.access}: the common options plus a version.
+
+  version?: string
+    The version to access; defaults to `"latest"`.
+
+interface SecretManagerOptions
+  Auth + transport + project options common to every {@link SecretManagerTasks} call.
+
+  project?: string
+    The Google Cloud project id; when omitted, resolved from the environment.
+  token?: string
+    A pre-resolved OAuth token; when omitted, {@link tokenProvider} supplies one.
+  tokenProvider?: AccessTokenProvider
+    Resolves the token when `token` is omitted (default: {@link "./auth.ts".gcloudAccessToken}).
+  fetch?: typeof fetch
+    The `fetch` implementation; defaults to the global. Overridable for tests.
+  readEnv?: (name: string) => string | undefined
+    Reads an environment variable for project resolution; defaults to `Deno.env.get`.
+
+interface SecretManagerTasksApi
+  The shape of {@link SecretManagerTasks}.
+
+  access(name: string, options?: SecretManagerAccessOptions): Promise<string>
+    Access secret `name`'s payload as a string (version defaults to `"latest"`).
+  addVersion(name: string, value: string, options?: SecretManagerOptions): Promise<string>
+    Add a new version holding `value` to secret `name`, creating the secret
+    first if it does not exist (an already-exists `409` is ignored) — the
+    write-before-create idempotency a deploy relies on. Returns the new version's
+    resource name.
+
+type AccessTokenProvider = () => Promise<string>
+  Supplies a Google Cloud OAuth access token for a REST call.
+
+type GcloudRunner = (configure?: Configure<GcloudSettings>) => Promise<CommandOutput>
+  Runs a `gcloud` command — the seam {@link gcloudAccessToken} resolves the
+  token through. Defaults to {@link "./gcloud.ts".GcloudTasks} `.run`; injectable
+  so the default provider is unit-testable without invoking `gcloud`.
 ````
 
 </details>

--- a/packages/gcloud/deno.json
+++ b/packages/gcloud/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@zuke/gcloud",
   "version": "0.1.0",
-  "description": "Typed gcloud (Google Cloud SDK) task wrapper for Zuke builds — a flexible, injection-free command builder with the common global flags via a settings-lambda API.",
+  "description": "Typed Google Cloud tooling for Zuke builds — the gcloud (Google Cloud SDK) CLI wrapper plus GCS and Secret Manager REST task groups sharing gcloud-based auth, all injection-free and testable without network.",
   "exports": {
     ".": "./mod.ts"
   },

--- a/packages/gcloud/mod.ts
+++ b/packages/gcloud/mod.ts
@@ -1,16 +1,40 @@
 /**
- * `@zuke/gcloud` — a typed `gcloud` (Google Cloud SDK) task wrapper for Zuke
- * builds.
- *
- * A flexible command builder: name the command with `.command(...)`, set common
- * global flags fluently, and pass anything else with `.flag(...)`.
+ * `@zuke/gcloud` — typed Google Cloud tooling for Zuke builds: the `gcloud`
+ * (Google Cloud SDK) CLI wrapper, plus **GCS** and **Secret Manager** REST task
+ * groups that share `gcloud`-based auth (no Google SDK dependency).
  *
  * ```ts
- * import { GcloudTasks } from "jsr:@zuke/gcloud";
- * await GcloudTasks.run((s) => s.command("auth", "list").format("json"));
+ * import { GcloudTasks, GcsTasks, SecretManagerTasks } from "jsr:@zuke/gcloud";
+ *
+ * await GcloudTasks.run((s) => s.containerImagesAddTag(src, dst)); // CLI
+ * await GcsTasks.writeJson("bucket", "state.json", { slot: "sit-7" }); // REST
+ * const pw = await SecretManagerTasks.access("db-password", { project }); // REST
  * ```
+ *
+ * The CLI wrapper builds a discrete argv array (never a shell string), and the
+ * REST groups take an injectable `fetch`, so both are testable without network
+ * or a real cluster.
  *
  * @module
  */
 
 export * from "./src/gcloud.ts";
+export {
+  type AccessTokenProvider,
+  gcloudAccessToken,
+  type GcloudRunner,
+  resolveAccessToken,
+} from "./src/auth.ts";
+export {
+  type GcsListOptions,
+  type GcsOptions,
+  GcsTasks,
+  type GcsTasksApi,
+} from "./src/gcs.ts";
+export {
+  type SecretManagerAccessOptions,
+  type SecretManagerOptions,
+  SecretManagerTasks,
+  type SecretManagerTasksApi,
+} from "./src/secret_manager.ts";
+export { type GcpRestOptions } from "./src/rest.ts";

--- a/packages/gcloud/src/auth.ts
+++ b/packages/gcloud/src/auth.ts
@@ -1,0 +1,53 @@
+/**
+ * Google Cloud access-token resolution for the REST task groups
+ * ({@link "./gcs.ts".GcsTasks} and {@link "./secret_manager.ts".SecretManagerTasks}).
+ *
+ * The default provider shells out to `gcloud auth print-access-token`, so no
+ * Google SDK — and no extra dependency — is needed: the token comes from the
+ * same credentials `gcloud` already uses. Inject a different {@link AccessTokenProvider}
+ * (a secret parameter, a metadata-server fetch, a workload-identity exchange)
+ * wherever that fits better.
+ *
+ * @module
+ */
+
+import type { Configure } from "@zuke/core/tooling";
+import type { CommandOutput } from "@zuke/core/shell";
+import { type GcloudSettings, GcloudTasks } from "./gcloud.ts";
+
+/** Supplies a Google Cloud OAuth access token for a REST call. */
+export type AccessTokenProvider = () => Promise<string>;
+
+/**
+ * Runs a `gcloud` command — the seam {@link gcloudAccessToken} resolves the
+ * token through. Defaults to {@link "./gcloud.ts".GcloudTasks} `.run`; injectable
+ * so the default provider is unit-testable without invoking `gcloud`.
+ */
+export type GcloudRunner = (
+  configure?: Configure<GcloudSettings>,
+) => Promise<CommandOutput>;
+
+/**
+ * The default {@link AccessTokenProvider}: the trimmed stdout of
+ * `gcloud auth print-access-token`, run with `--quiet` so the token never
+ * streams to the build log. `run` defaults to {@link "./gcloud.ts".GcloudTasks}
+ * `.run` and is injectable for tests.
+ */
+export function gcloudAccessToken(
+  run: GcloudRunner = GcloudTasks.run,
+): Promise<string> {
+  return run((s) => s.command("auth", "print-access-token").quiet())
+    .then((out) => out.text());
+}
+
+/**
+ * Resolve a bearer token from an explicit `token` or, when it is omitted, the
+ * `tokenProvider` (defaulting to {@link gcloudAccessToken}). Shared by the REST
+ * task groups so every call resolves auth the same way.
+ */
+export function resolveAccessToken(
+  options: { token?: string; tokenProvider?: AccessTokenProvider },
+): Promise<string> {
+  if (options.token !== undefined) return Promise.resolve(options.token);
+  return (options.tokenProvider ?? gcloudAccessToken)();
+}

--- a/packages/gcloud/src/gcloud.ts
+++ b/packages/gcloud/src/gcloud.ts
@@ -45,6 +45,36 @@ export class GcloudSettings extends ToolSettings {
     return this;
   }
 
+  /**
+   * Add tags to a container image across registries:
+   * `gcloud container images add-tag <source> <destination…>`. Each argument is
+   * a discrete argv token, so an image reference can't inject flags. Runs with
+   * `--quiet` (the re-tag is non-interactive automation; `add-tag` otherwise
+   * prompts for confirmation).
+   */
+  containerImagesAddTag(source: string, ...destinations: string[]): this {
+    this.command("container", "images", "add-tag", source, ...destinations);
+    return this.noPrompt();
+  }
+
+  /**
+   * Describe a Cloud SQL instance:
+   * `gcloud sql instances describe <instance>`. Add `.format("json")` to get a
+   * machine-readable body to parse from the command's stdout.
+   */
+  sqlInstancesDescribe(instance: string): this {
+    return this.command("sql", "instances", "describe", instance);
+  }
+
+  /**
+   * Block until a Cloud SQL operation completes:
+   * `gcloud sql operations wait <operation>` — the typed form of the
+   * poll-an-operation shell loop.
+   */
+  sqlOperationsWait(operation: string): this {
+    return this.command("sql", "operations", "wait", operation);
+  }
+
   /** Target Google Cloud project (`--project`). */
   project(id: string): this {
     this.#project = id;

--- a/packages/gcloud/src/gcs.ts
+++ b/packages/gcloud/src/gcs.ts
@@ -1,0 +1,118 @@
+/**
+ * `GcsTasks` — read, write, and list JSON objects in Google Cloud Storage over
+ * its JSON REST API, without a Google SDK. Auth is a bearer token from an
+ * injected {@link "./auth.ts".AccessTokenProvider} (default:
+ * `gcloud auth print-access-token`).
+ *
+ * ```ts
+ * import { GcsTasks } from "jsr:@zuke/gcloud";
+ *
+ * await GcsTasks.writeJson("my-bucket", "state/deploy.json", { slot: "sit-7" });
+ * const state = await GcsTasks.readJson<{ slot: string }>(
+ *   "my-bucket",
+ *   "state/deploy.json",
+ * );
+ * const keys = await GcsTasks.list("my-bucket", { prefix: "state/" });
+ * ```
+ *
+ * @module
+ */
+
+import { httpJson } from "@zuke/core";
+import { type AccessTokenProvider, resolveAccessToken } from "./auth.ts";
+import { gcpJson, isRecord, readArray, readString } from "./rest.ts";
+
+/** The GCS JSON/upload API roots (overridable only via the `fetch` seam in tests). */
+const STORAGE_BASE = "https://storage.googleapis.com/storage/v1";
+const UPLOAD_BASE = "https://storage.googleapis.com/upload/storage/v1";
+
+/** Auth + transport options common to every {@link GcsTasks} call. */
+export interface GcsOptions {
+  /** A pre-resolved OAuth token; when omitted, {@link tokenProvider} supplies one. */
+  token?: string;
+  /** Resolves the token when `token` is omitted (default: {@link "./auth.ts".gcloudAccessToken}). */
+  tokenProvider?: AccessTokenProvider;
+  /** The `fetch` implementation; defaults to the global. Overridable for tests. */
+  fetch?: typeof fetch;
+}
+
+/** Options for {@link GcsTasksApi.list}: the auth/transport plus an object-name prefix. */
+export interface GcsListOptions extends GcsOptions {
+  /** Keep only objects whose name starts with this prefix. */
+  prefix?: string;
+}
+
+/** The shape of {@link GcsTasks}. */
+export interface GcsTasksApi {
+  /** Read object `object` from `bucket` and parse its body as JSON. */
+  readJson<T = unknown>(
+    bucket: string,
+    object: string,
+    options?: GcsOptions,
+  ): Promise<T>;
+  /** Write `data` (JSON-serialised) as object `object` in `bucket`. */
+  writeJson(
+    bucket: string,
+    object: string,
+    data: unknown,
+    options?: GcsOptions,
+  ): Promise<void>;
+  /** List object names in `bucket` (optionally filtered by `prefix`). */
+  list(bucket: string, options?: GcsListOptions): Promise<string[]>;
+}
+
+/** Typed Google Cloud Storage JSON operations. */
+export const GcsTasks: GcsTasksApi = {
+  async readJson<T = unknown>(
+    bucket: string,
+    object: string,
+    options: GcsOptions = {},
+  ): Promise<T> {
+    const token = await resolveAccessToken(options);
+    const url = `${STORAGE_BASE}/b/${encodeURIComponent(bucket)}/o/${
+      encodeURIComponent(object)
+    }?alt=media`;
+    return await httpJson<T>(url, {
+      headers: { authorization: `Bearer ${token}` },
+      fetch: options.fetch,
+    });
+  },
+
+  async writeJson(
+    bucket: string,
+    object: string,
+    data: unknown,
+    options: GcsOptions = {},
+  ): Promise<void> {
+    const token = await resolveAccessToken(options);
+    const url = `${UPLOAD_BASE}/b/${
+      encodeURIComponent(bucket)
+    }/o?uploadType=media&name=${encodeURIComponent(object)}`;
+    await gcpJson(
+      url,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(data),
+      },
+      { token, fetch: options.fetch },
+    );
+  },
+
+  async list(bucket: string, options: GcsListOptions = {}): Promise<string[]> {
+    const token = await resolveAccessToken(options);
+    const query = options.prefix === undefined
+      ? ""
+      : `?prefix=${encodeURIComponent(options.prefix)}`;
+    const url = `${STORAGE_BASE}/b/${encodeURIComponent(bucket)}/o${query}`;
+    const body = await gcpJson(url, { method: "GET" }, {
+      token,
+      fetch: options.fetch,
+    });
+    const root = isRecord(body) ? body : {};
+    return readArray(root, "items").flatMap((item) => {
+      const name = isRecord(item) ? readString(item, "name") : undefined;
+      return name === undefined ? [] : [name];
+    });
+  },
+};

--- a/packages/gcloud/src/rest.ts
+++ b/packages/gcloud/src/rest.ts
@@ -1,0 +1,67 @@
+/**
+ * The small authenticated-JSON transport the Google REST task groups share
+ * ({@link "./gcs.ts".GcsTasks}, {@link "./secret_manager.ts".SecretManagerTasks}):
+ * a bearer-token request over an injectable `fetch`, plus a few guards for
+ * narrowing an untrusted response body without a type assertion.
+ *
+ * @module
+ */
+
+import { HttpError } from "@zuke/core";
+
+/** Common options for a Google REST call: the bearer token and an injectable `fetch`. */
+export interface GcpRestOptions {
+  /** The OAuth access token (see {@link "./auth.ts".gcloudAccessToken}). */
+  token: string;
+  /** The `fetch` implementation; defaults to the global. Overridable for tests. */
+  fetch?: typeof fetch;
+}
+
+/**
+ * Perform an authenticated Google REST request and return its parsed JSON body
+ * (`null` for an empty body). Throws {@link "@zuke/core".HttpError} on a non-2xx
+ * status **unless** the status is listed in `tolerate` — the seam an idempotent
+ * create uses to treat an already-exists `409` as success.
+ */
+export async function gcpJson(
+  url: string,
+  init: RequestInit,
+  options: GcpRestOptions,
+  tolerate: readonly number[] = [],
+): Promise<unknown> {
+  const doFetch = options.fetch ?? fetch;
+  const headers = new Headers(init.headers);
+  headers.set("authorization", `Bearer ${options.token}`);
+  const response = await doFetch(url, { ...init, headers });
+  if (!response.ok && !tolerate.includes(response.status)) {
+    await response.body?.cancel();
+    throw new HttpError(response.status, url);
+  }
+  const text = await response.text();
+  if (text === "") return null;
+  const parsed: unknown = JSON.parse(text);
+  return parsed;
+}
+
+/** Narrow an unknown JSON value to a plain object. */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Read a string field of a JSON object, or `undefined`. */
+export function readString(
+  object: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const value = object[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+/** The array elements of a JSON object's field, or `[]` when absent/not an array. */
+export function readArray(
+  object: Record<string, unknown>,
+  key: string,
+): unknown[] {
+  const value = object[key];
+  return Array.isArray(value) ? value : [];
+}

--- a/packages/gcloud/src/secret_manager.ts
+++ b/packages/gcloud/src/secret_manager.ts
@@ -1,0 +1,181 @@
+/**
+ * `SecretManagerTasks` — read and write Google Secret Manager secrets over its
+ * REST API, without a Google SDK. Auth is a bearer token from an injected
+ * {@link "./auth.ts".AccessTokenProvider} (default: `gcloud auth print-access-token`).
+ *
+ * ```ts
+ * import { SecretManagerTasks } from "jsr:@zuke/gcloud";
+ *
+ * // Create-if-absent, then add a version (idempotent, write-before-create):
+ * await SecretManagerTasks.addVersion("db-password", secret, { project: "p" });
+ * const value = await SecretManagerTasks.access("db-password", { project: "p" });
+ * ```
+ *
+ * **Handling.** `access` returns the plaintext secret — route it straight into a
+ * `.secret()` parameter or the run's redactor; never log it.
+ *
+ * @module
+ */
+
+import { type AccessTokenProvider, resolveAccessToken } from "./auth.ts";
+import { gcpJson, isRecord, readString } from "./rest.ts";
+
+/** The Secret Manager v1 API root (overridable only via the `fetch` seam in tests). */
+const SECRET_MANAGER_BASE = "https://secretmanager.googleapis.com/v1";
+
+/** The `409 Conflict` a create returns when the secret already exists (tolerated). */
+const ALREADY_EXISTS = 409;
+
+/** Auth + transport + project options common to every {@link SecretManagerTasks} call. */
+export interface SecretManagerOptions {
+  /** The Google Cloud project id; when omitted, resolved from the environment. */
+  project?: string;
+  /** A pre-resolved OAuth token; when omitted, {@link tokenProvider} supplies one. */
+  token?: string;
+  /** Resolves the token when `token` is omitted (default: {@link "./auth.ts".gcloudAccessToken}). */
+  tokenProvider?: AccessTokenProvider;
+  /** The `fetch` implementation; defaults to the global. Overridable for tests. */
+  fetch?: typeof fetch;
+  /** Reads an environment variable for project resolution; defaults to `Deno.env.get`. */
+  readEnv?: (name: string) => string | undefined;
+}
+
+/** Options for {@link SecretManagerTasksApi.access}: the common options plus a version. */
+export interface SecretManagerAccessOptions extends SecretManagerOptions {
+  /** The version to access; defaults to `"latest"`. */
+  version?: string;
+}
+
+/** Read an environment variable, treating missing env access as unset. */
+function defaultReadEnv(name: string): string | undefined {
+  try {
+    return Deno.env.get(name);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Resolve the target project from the option or the standard gcloud env vars. */
+function resolveProject(options: SecretManagerOptions): string {
+  if (options.project !== undefined) return options.project;
+  const readEnv = options.readEnv ?? defaultReadEnv;
+  const project = readEnv("GOOGLE_CLOUD_PROJECT") ?? readEnv("GCLOUD_PROJECT");
+  if (project === undefined || project === "") {
+    throw new Error(
+      "secret manager: no project — pass { project } or set GOOGLE_CLOUD_PROJECT.",
+    );
+  }
+  return project;
+}
+
+/** Base64-encode a UTF-8 string (the payload wire format), dependency-free. */
+function base64Encode(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+/**
+ * Decode a base64 payload back to its UTF-8 string. Uses a **fatal** decoder, so
+ * a non-UTF-8 (binary) payload throws rather than being silently mangled into
+ * U+FFFD replacement characters — {@link SecretManagerTasks} `access` turns that
+ * into a friendly error naming the secret.
+ */
+function base64Decode(encoded: string): string {
+  const binary = atob(encoded);
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+}
+
+/** The shape of {@link SecretManagerTasks}. */
+export interface SecretManagerTasksApi {
+  /** Access secret `name`'s payload as a string (version defaults to `"latest"`). */
+  access(
+    name: string,
+    options?: SecretManagerAccessOptions,
+  ): Promise<string>;
+  /**
+   * Add a new version holding `value` to secret `name`, **creating the secret
+   * first if it does not exist** (an already-exists `409` is ignored) — the
+   * write-before-create idempotency a deploy relies on. Returns the new version's
+   * resource name.
+   */
+  addVersion(
+    name: string,
+    value: string,
+    options?: SecretManagerOptions,
+  ): Promise<string>;
+}
+
+/** Typed Google Secret Manager operations. */
+export const SecretManagerTasks: SecretManagerTasksApi = {
+  async access(
+    name: string,
+    options: SecretManagerAccessOptions = {},
+  ): Promise<string> {
+    const project = resolveProject(options);
+    const token = await resolveAccessToken(options);
+    const version = options.version ?? "latest";
+    const url = `${SECRET_MANAGER_BASE}/projects/${
+      encodeURIComponent(project)
+    }/secrets/${encodeURIComponent(name)}/versions/${
+      encodeURIComponent(version)
+    }:access`;
+    const body = await gcpJson(url, { method: "GET" }, {
+      token,
+      fetch: options.fetch,
+    });
+    const payload = isRecord(body) && isRecord(body.payload)
+      ? readString(body.payload, "data")
+      : undefined;
+    if (payload === undefined) {
+      throw new Error(`secret manager: ${url} returned no payload data`);
+    }
+    try {
+      return base64Decode(payload);
+    } catch {
+      throw new Error(
+        `secret manager: secret "${name}" version "${version}" is not valid ` +
+          `UTF-8 text — access() returns strings, not binary secrets.`,
+      );
+    }
+  },
+
+  async addVersion(
+    name: string,
+    value: string,
+    options: SecretManagerOptions = {},
+  ): Promise<string> {
+    const project = resolveProject(options);
+    const token = await resolveAccessToken(options);
+    const rest = { token, fetch: options.fetch };
+    const projectPath = `${SECRET_MANAGER_BASE}/projects/${
+      encodeURIComponent(project)
+    }`;
+
+    // Create the secret (the container) first; an already-existing one is fine.
+    await gcpJson(
+      `${projectPath}/secrets?secretId=${encodeURIComponent(name)}`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ replication: { automatic: {} } }),
+      },
+      rest,
+      [ALREADY_EXISTS],
+    );
+
+    // Then add the version holding the value.
+    const added = await gcpJson(
+      `${projectPath}/secrets/${encodeURIComponent(name)}:addVersion`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ payload: { data: base64Encode(value) } }),
+      },
+      rest,
+    );
+    return (isRecord(added) ? readString(added, "name") : undefined) ?? "";
+  },
+};

--- a/packages/gcloud/tests/auth_test.ts
+++ b/packages/gcloud/tests/auth_test.ts
@@ -1,0 +1,27 @@
+import { assertEquals } from "../../core/tests/_assert.ts";
+import { CommandOutput } from "@zuke/core/shell";
+import type { Configure } from "@zuke/core/tooling";
+import { gcloudAccessToken, resolveAccessToken } from "../src/auth.ts";
+import { GcloudSettings } from "../src/gcloud.ts";
+
+Deno.test("gcloudAccessToken returns the trimmed print-access-token stdout", async () => {
+  let argv: string[] = [];
+  const run = (configure?: Configure<GcloudSettings>) => {
+    argv = (configure ? configure(new GcloudSettings()) : new GcloudSettings())
+      .argv();
+    return Promise.resolve(new CommandOutput(0, "ya29.a-token\n", ""));
+  };
+  assertEquals(await gcloudAccessToken(run), "ya29.a-token");
+  // Runs `gcloud auth print-access-token` (quiet keeps the token out of logs).
+  assertEquals(argv, ["gcloud", "auth", "print-access-token"]);
+});
+
+Deno.test("resolveAccessToken prefers an explicit token, else the provider", async () => {
+  assertEquals(await resolveAccessToken({ token: "explicit" }), "explicit");
+  assertEquals(
+    await resolveAccessToken({
+      tokenProvider: () => Promise.resolve("from-provider"),
+    }),
+    "from-provider",
+  );
+});

--- a/packages/gcloud/tests/gcloud_test.ts
+++ b/packages/gcloud/tests/gcloud_test.ts
@@ -54,3 +54,48 @@ Deno.test("GcloudTasks.run reaches execution", async () => {
     ToolNotFoundError,
   );
 });
+
+Deno.test("containerImagesAddTag tags across registries, quietly", () => {
+  assertEquals(
+    new GcloudSettings()
+      .containerImagesAddTag("gcr.io/p/img:sha", "eu.gcr.io/p/img:prod")
+      .argv(),
+    [
+      "gcloud",
+      "container",
+      "images",
+      "add-tag",
+      "gcr.io/p/img:sha",
+      "eu.gcr.io/p/img:prod",
+      "--quiet",
+    ],
+  );
+});
+
+Deno.test("containerImagesAddTag accepts multiple destination tags", () => {
+  const argv = new GcloudSettings()
+    .containerImagesAddTag("src:sha", "a:prod", "b:latest")
+    .argv();
+  assertEquals(argv.slice(1, 6), [
+    "container",
+    "images",
+    "add-tag",
+    "src:sha",
+    "a:prod",
+  ]);
+  assertEquals(argv.includes("b:latest"), true);
+});
+
+Deno.test("sqlInstancesDescribe builds the describe command", () => {
+  assertEquals(
+    new GcloudSettings().sqlInstancesDescribe("prod-db").format("json").argv(),
+    ["gcloud", "sql", "instances", "describe", "prod-db", "--format", "json"],
+  );
+});
+
+Deno.test("sqlOperationsWait builds the wait command", () => {
+  assertEquals(
+    new GcloudSettings().sqlOperationsWait("op-123").project("p").argv(),
+    ["gcloud", "sql", "operations", "wait", "op-123", "--project", "p"],
+  );
+});

--- a/packages/gcloud/tests/gcs_test.ts
+++ b/packages/gcloud/tests/gcs_test.ts
@@ -1,0 +1,99 @@
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "../../core/tests/_assert.ts";
+import { HttpError } from "@zuke/core";
+import { GcsTasks } from "../src/gcs.ts";
+
+/** A `fetch` double that records calls and answers from a handler. */
+function fakeFetch(
+  handler: (url: string, init?: RequestInit) => Response,
+): { fetch: typeof fetch; calls: Array<{ url: string; init?: RequestInit }> } {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fetch: typeof globalThis.fetch = (input, init) => {
+    const url = String(input);
+    calls.push({ url, init });
+    return Promise.resolve(handler(url, init));
+  };
+  return { fetch, calls };
+}
+
+Deno.test("GcsTasks.readJson GETs the object media with a bearer token", async () => {
+  const { fetch, calls } = fakeFetch(() =>
+    new Response(JSON.stringify({ slot: "sit-7" }), { status: 200 })
+  );
+  const object = "state/deploy.json";
+  const data = await GcsTasks.readJson<{ slot: string }>(
+    "my-bucket",
+    object,
+    { token: "t0", fetch },
+  );
+  assertEquals(data.slot, "sit-7");
+  // The object name is percent-encoded (its slash becomes %2F) in the path.
+  assertStringIncludes(
+    calls[0].url,
+    `/b/my-bucket/o/${encodeURIComponent(object)}`,
+  );
+  assertStringIncludes(calls[0].url, "alt=media");
+  assertEquals(
+    new Headers(calls[0].init?.headers).get("authorization"),
+    "Bearer t0",
+  );
+});
+
+Deno.test("GcsTasks.writeJson POSTs the JSON body to the upload endpoint", async () => {
+  // An empty write response (no body) is fine — exercises the null-body path.
+  const { fetch, calls } = fakeFetch(() => new Response(null, { status: 204 }));
+  await GcsTasks.writeJson("b", "k.json", { a: 1 }, { token: "t0", fetch });
+  assertEquals(calls[0].init?.method, "POST");
+  assertStringIncludes(calls[0].url, "/upload/storage/v1/b/b/o");
+  assertStringIncludes(calls[0].url, "uploadType=media");
+  assertStringIncludes(calls[0].url, "name=k.json");
+  assertEquals(calls[0].init?.body, JSON.stringify({ a: 1 }));
+});
+
+Deno.test("GcsTasks.list returns object names, honouring a prefix", async () => {
+  const { fetch, calls } = fakeFetch(() =>
+    new Response(
+      JSON.stringify({
+        items: [{ name: "state/a.json" }, { name: "state/b.json" }, {}],
+      }),
+      { status: 200 },
+    )
+  );
+  const names = await GcsTasks.list("b", {
+    token: "t0",
+    fetch,
+    prefix: "state/",
+  });
+  // The nameless entry is skipped, not a crash.
+  assertEquals(names, ["state/a.json", "state/b.json"]);
+  assertStringIncludes(calls[0].url, "prefix=state%2F");
+});
+
+Deno.test("GcsTasks.list tolerates a body with no items array", async () => {
+  const { fetch } = fakeFetch(() => new Response("{}", { status: 200 }));
+  assertEquals(await GcsTasks.list("b", { token: "t0", fetch }), []);
+});
+
+Deno.test("GcsTasks surfaces a non-2xx response as an HttpError", async () => {
+  const { fetch } = fakeFetch(() => new Response("nope", { status: 404 }));
+  await assertRejects(
+    () => GcsTasks.readJson("b", "missing", { token: "t0", fetch }),
+    HttpError,
+  );
+});
+
+Deno.test("GcsTasks resolves the token via the provider when none is given", async () => {
+  let used = "";
+  const { fetch } = fakeFetch((_url, init) => {
+    used = new Headers(init?.headers).get("authorization") ?? "";
+    return new Response("{}", { status: 200 });
+  });
+  await GcsTasks.list("b", {
+    fetch,
+    tokenProvider: () => Promise.resolve("provided"),
+  });
+  assertEquals(used, "Bearer provided");
+});

--- a/packages/gcloud/tests/secret_manager_test.ts
+++ b/packages/gcloud/tests/secret_manager_test.ts
@@ -1,0 +1,195 @@
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "../../core/tests/_assert.ts";
+import { HttpError } from "@zuke/core";
+import { SecretManagerTasks } from "../src/secret_manager.ts";
+
+/** A `fetch` double that records calls and answers from a handler. */
+function fakeFetch(
+  handler: (url: string, init?: RequestInit) => Response,
+): { fetch: typeof fetch; calls: Array<{ url: string; init?: RequestInit }> } {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fetch: typeof globalThis.fetch = (input, init) => {
+    const url = String(input);
+    calls.push({ url, init });
+    return Promise.resolve(handler(url, init));
+  };
+  return { fetch, calls };
+}
+
+/** Base64-encode a UTF-8 string, matching the payload wire format. */
+function b64(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+Deno.test("access decodes the latest payload of a secret", async () => {
+  const { fetch, calls } = fakeFetch(() =>
+    new Response(JSON.stringify({ payload: { data: b64("s3cr3t-ü") } }), {
+      status: 200,
+    })
+  );
+  const value = await SecretManagerTasks.access("db-password", {
+    project: "p",
+    token: "t0",
+    fetch,
+  });
+  assertEquals(value, "s3cr3t-ü"); // round-trips UTF-8
+  assertStringIncludes(
+    calls[0].url,
+    "/projects/p/secrets/db-password/versions/latest:access",
+  );
+  assertEquals(
+    new Headers(calls[0].init?.headers).get("authorization"),
+    "Bearer t0",
+  );
+});
+
+Deno.test("access honours an explicit version", async () => {
+  const { fetch, calls } = fakeFetch(() =>
+    new Response(JSON.stringify({ payload: { data: b64("v3") } }), {
+      status: 200,
+    })
+  );
+  assertEquals(
+    await SecretManagerTasks.access("s", {
+      project: "p",
+      token: "t0",
+      fetch,
+      version: "3",
+    }),
+    "v3",
+  );
+  assertStringIncludes(calls[0].url, "/versions/3:access");
+});
+
+Deno.test("access throws when the response carries no payload", async () => {
+  const { fetch } = fakeFetch(() => new Response("{}", { status: 200 }));
+  await assertRejects(
+    () => SecretManagerTasks.access("s", { project: "p", token: "t0", fetch }),
+    Error,
+    "no payload",
+  );
+});
+
+Deno.test("access rejects a non-UTF-8 (binary) payload instead of corrupting it", async () => {
+  // Base64 of raw bytes that are not valid UTF-8 (e.g. key material).
+  let binary = "";
+  for (const byte of [0xff, 0xfe, 0x80]) binary += String.fromCharCode(byte);
+  const { fetch } = fakeFetch(() =>
+    new Response(JSON.stringify({ payload: { data: btoa(binary) } }), {
+      status: 200,
+    })
+  );
+  await assertRejects(
+    () =>
+      SecretManagerTasks.access("bin", { project: "p", token: "t0", fetch }),
+    Error,
+    "not valid UTF-8",
+  );
+});
+
+Deno.test("addVersion creates the secret then adds the version (idempotent on 409)", async () => {
+  const seen: Array<{ url: string; method: string; body: string }> = [];
+  const { fetch } = fakeFetch((url, init) => {
+    seen.push({ url, method: init?.method ?? "GET", body: String(init?.body) });
+    if (url.includes(":addVersion")) {
+      return new Response(
+        JSON.stringify({ name: "projects/p/secrets/s/versions/5" }),
+        { status: 200 },
+      );
+    }
+    // The secret already exists → 409, which addVersion must tolerate.
+    return new Response(JSON.stringify({ error: "exists" }), { status: 409 });
+  });
+  const name = await SecretManagerTasks.addVersion("s", "hunter2", {
+    project: "p",
+    token: "t0",
+    fetch,
+  });
+  assertEquals(name, "projects/p/secrets/s/versions/5");
+  assertEquals(seen.length, 2); // create (tolerated 409) then addVersion
+  assertStringIncludes(seen[0].url, "/secrets?secretId=s");
+  assertEquals(seen[0].method, "POST");
+  assertStringIncludes(seen[1].url, "/secrets/s:addVersion");
+  assertStringIncludes(seen[1].body, b64("hunter2")); // value base64-encoded
+});
+
+Deno.test("addVersion works when the secret is created fresh", async () => {
+  const { fetch } = fakeFetch((url) =>
+    url.includes(":addVersion")
+      ? new Response(JSON.stringify({ name: "n" }), { status: 200 })
+      : new Response("{}", { status: 200 })
+  );
+  assertEquals(
+    await SecretManagerTasks.addVersion("s", "v", {
+      project: "p",
+      token: "t0",
+      fetch,
+    }),
+    "n",
+  );
+});
+
+Deno.test("addVersion propagates a real create failure (non-409)", async () => {
+  const { fetch } = fakeFetch((url) =>
+    url.includes(":addVersion")
+      ? new Response("{}", { status: 200 })
+      : new Response("boom", { status: 500 })
+  );
+  await assertRejects(
+    () =>
+      SecretManagerTasks.addVersion("s", "v", {
+        project: "p",
+        token: "t0",
+        fetch,
+      }),
+    HttpError,
+  );
+});
+
+Deno.test("the project falls back to the ambient GOOGLE_CLOUD_PROJECT env var", async () => {
+  const { fetch } = fakeFetch(() =>
+    new Response(JSON.stringify({ payload: { data: b64("x") } }), {
+      status: 200,
+    })
+  );
+  // No project and no injected readEnv → the default reader reads the real env.
+  Deno.env.set("GOOGLE_CLOUD_PROJECT", "ambient-proj");
+  try {
+    assertEquals(
+      await SecretManagerTasks.access("s", { token: "t0", fetch }),
+      "x",
+    );
+  } finally {
+    Deno.env.delete("GOOGLE_CLOUD_PROJECT");
+  }
+});
+
+Deno.test("the project resolves from the environment, else errors", async () => {
+  const { fetch } = fakeFetch(() =>
+    new Response(JSON.stringify({ payload: { data: b64("x") } }), {
+      status: 200,
+    })
+  );
+  const readEnv = (name: string) =>
+    name === "GOOGLE_CLOUD_PROJECT" ? "env-proj" : undefined;
+  assertEquals(
+    await SecretManagerTasks.access("s", { token: "t0", fetch, readEnv }),
+    "x",
+  );
+  await assertRejects(
+    () =>
+      SecretManagerTasks.access("s", {
+        token: "t0",
+        fetch,
+        readEnv: () => undefined,
+      }),
+    Error,
+    "no project",
+  );
+});

--- a/packages/kubectl/README.md
+++ b/packages/kubectl/README.md
@@ -51,6 +51,23 @@ await KubectlTasks.rollout((s) =>
 const KubectlTasks: KubectlTasksApi
   Typed task functions for the `kubectl` CLI.
 
+class KubectlAnnotateSettings extends KubectlSettings
+  Settings for `kubectl annotate`.
+
+  resource(...tokens: string[]): this
+    Resource tokens, e.g. `("deploy", "api")` or `("pods", "-l", "app=web")`; repeatable.
+  annotation(key: string, value: string): this
+    Set an annotation as a `key=value` token; repeatable.
+  remove(key: string): this
+    Remove an annotation, rendered as kubectl's `key-` syntax; repeatable.
+  overwrite(): this
+    Overwrite existing annotations (`--overwrite`).
+  all(): this
+    Apply to all resources of the given type (`--all`).
+  selector(query: string): this
+    Restrict to resources matching a label selector (`-l`).
+  override protected buildArgs(): string[]
+
 class KubectlApplySettings extends KubectlSettings
   Settings for `kubectl apply`.
 
@@ -150,6 +167,23 @@ class KubectlGetSettings extends KubectlSettings
     Watch for changes instead of returning once (`-w`).
   showLabels(): this
     Include resource labels as columns (`--show-labels`).
+  override protected buildArgs(): string[]
+
+class KubectlLabelSettings extends KubectlSettings
+  Settings for `kubectl label`.
+
+  resource(...tokens: string[]): this
+    Resource tokens, e.g. `("deploy", "api")` or `("pods", "-l", "app=web")`; repeatable.
+  label(key: string, value: string): this
+    Set a label as a `key=value` token; repeatable.
+  remove(key: string): this
+    Remove a label, rendered as kubectl's `key-` syntax; repeatable.
+  overwrite(): this
+    Overwrite existing labels (`--overwrite`).
+  all(): this
+    Apply to all resources of the given type (`--all`).
+  selector(query: string): this
+    Restrict to resources matching a label selector (`-l`).
   override protected buildArgs(): string[]
 
 class KubectlLogsSettings extends KubectlSettings
@@ -303,6 +337,10 @@ interface KubectlTasksApi
     Scale a workload: `kubectl scale`.
   setImage(configure?: Configure<KubectlSetImageSettings>): Promise<CommandOutput>
     Update a container image: `kubectl set image`.
+  annotate(configure?: Configure<KubectlAnnotateSettings>): Promise<CommandOutput>
+    Annotate resources: `kubectl annotate`.
+  label(configure?: Configure<KubectlLabelSettings>): Promise<CommandOutput>
+    Label resources: `kubectl label`.
   patch(configure?: Configure<KubectlPatchSettings>): Promise<CommandOutput>
     Patch a resource: `kubectl patch`.
   portForward(configure?: Configure<KubectlPortForwardSettings>): Promise<CommandOutput>

--- a/packages/kubectl/src/kubectl.ts
+++ b/packages/kubectl/src/kubectl.ts
@@ -718,6 +718,152 @@ export class KubectlSetImageSettings extends KubectlSettings {
   }
 }
 
+/** Settings for `kubectl annotate`. */
+export class KubectlAnnotateSettings extends KubectlSettings {
+  #resources: string[] = [];
+  #annotations: string[] = [];
+  #removals: string[] = [];
+  #overwrite = false;
+  #all = false;
+  #selector?: string;
+
+  /** Resource tokens, e.g. `("deploy", "api")` or `("pods", "-l", "app=web")`; repeatable. */
+  resource(...tokens: string[]): this {
+    this.#resources.push(...tokens);
+    return this;
+  }
+
+  /** Set an annotation as a `key=value` token; repeatable. */
+  annotation(key: string, value: string): this {
+    this.#annotations.push(`${key}=${value}`);
+    return this;
+  }
+
+  /** Remove an annotation, rendered as kubectl's `key-` syntax; repeatable. */
+  remove(key: string): this {
+    this.#removals.push(`${key}-`);
+    return this;
+  }
+
+  /** Overwrite existing annotations (`--overwrite`). */
+  overwrite(): this {
+    this.#overwrite = true;
+    return this;
+  }
+
+  /** Apply to all resources of the given type (`--all`). */
+  all(): this {
+    this.#all = true;
+    return this;
+  }
+
+  /** Restrict to resources matching a label selector (`-l`). */
+  selector(query: string): this {
+    this.#selector = query;
+    return this;
+  }
+
+  protected override buildArgs(): string[] {
+    if (
+      this.#resources.length === 0 && this.#selector === undefined &&
+      !this.#all
+    ) {
+      throw new Error(
+        "KubectlTasks.annotate: a target is required — .resource(...), .selector(), or .all().",
+      );
+    }
+    if (this.#annotations.length === 0 && this.#removals.length === 0) {
+      throw new Error(
+        "KubectlTasks.annotate: at least one .annotation() or .remove() is required.",
+      );
+    }
+    const argv = [
+      "annotate",
+      ...this.#resources,
+      ...this.#annotations,
+      ...this.#removals,
+    ];
+    if (this.#overwrite) argv.push("--overwrite");
+    if (this.#all) argv.push("--all");
+    if (this.#selector !== undefined) argv.push("-l", this.#selector);
+    argv.push(...this.globalArgs());
+    return argv;
+  }
+}
+
+/** Settings for `kubectl label`. */
+export class KubectlLabelSettings extends KubectlSettings {
+  #resources: string[] = [];
+  #labels: string[] = [];
+  #removals: string[] = [];
+  #overwrite = false;
+  #all = false;
+  #selector?: string;
+
+  /** Resource tokens, e.g. `("deploy", "api")` or `("pods", "-l", "app=web")`; repeatable. */
+  resource(...tokens: string[]): this {
+    this.#resources.push(...tokens);
+    return this;
+  }
+
+  /** Set a label as a `key=value` token; repeatable. */
+  label(key: string, value: string): this {
+    this.#labels.push(`${key}=${value}`);
+    return this;
+  }
+
+  /** Remove a label, rendered as kubectl's `key-` syntax; repeatable. */
+  remove(key: string): this {
+    this.#removals.push(`${key}-`);
+    return this;
+  }
+
+  /** Overwrite existing labels (`--overwrite`). */
+  overwrite(): this {
+    this.#overwrite = true;
+    return this;
+  }
+
+  /** Apply to all resources of the given type (`--all`). */
+  all(): this {
+    this.#all = true;
+    return this;
+  }
+
+  /** Restrict to resources matching a label selector (`-l`). */
+  selector(query: string): this {
+    this.#selector = query;
+    return this;
+  }
+
+  protected override buildArgs(): string[] {
+    if (
+      this.#resources.length === 0 && this.#selector === undefined &&
+      !this.#all
+    ) {
+      throw new Error(
+        "KubectlTasks.label: a target is required — .resource(...), .selector(), or .all().",
+      );
+    }
+    if (this.#labels.length === 0 && this.#removals.length === 0) {
+      throw new Error(
+        "KubectlTasks.label: at least one .label() or .remove() is required.",
+      );
+    }
+    const argv = [
+      "label",
+      ...this.#resources,
+      ...this.#labels,
+      ...this.#removals,
+    ];
+    if (this.#overwrite) argv.push("--overwrite");
+    if (this.#all) argv.push("--all");
+    if (this.#selector !== undefined) argv.push("-l", this.#selector);
+    argv.push(...this.globalArgs());
+    return argv;
+  }
+}
+
 /** A patch strategy accepted by `kubectl patch --type`. */
 export type PatchType = "strategic" | "merge" | "json";
 
@@ -947,6 +1093,12 @@ export interface KubectlTasksApi {
   setImage(
     configure?: Configure<KubectlSetImageSettings>,
   ): Promise<CommandOutput>;
+  /** Annotate resources: `kubectl annotate`. */
+  annotate(
+    configure?: Configure<KubectlAnnotateSettings>,
+  ): Promise<CommandOutput>;
+  /** Label resources: `kubectl label`. */
+  label(configure?: Configure<KubectlLabelSettings>): Promise<CommandOutput>;
   /** Patch a resource: `kubectl patch`. */
   patch(configure?: Configure<KubectlPatchSettings>): Promise<CommandOutput>;
   /** Forward local ports: `kubectl port-forward`. */
@@ -996,6 +1148,14 @@ export const KubectlTasks: KubectlTasksApi = {
     configure?: Configure<KubectlSetImageSettings>,
   ): Promise<CommandOutput> {
     return runSettings(new KubectlSetImageSettings(), configure);
+  },
+  annotate(
+    configure?: Configure<KubectlAnnotateSettings>,
+  ): Promise<CommandOutput> {
+    return runSettings(new KubectlAnnotateSettings(), configure);
+  },
+  label(configure?: Configure<KubectlLabelSettings>): Promise<CommandOutput> {
+    return runSettings(new KubectlLabelSettings(), configure);
   },
   patch(configure?: Configure<KubectlPatchSettings>): Promise<CommandOutput> {
     return runSettings(new KubectlPatchSettings(), configure);

--- a/packages/kubectl/tests/kubectl_test.ts
+++ b/packages/kubectl/tests/kubectl_test.ts
@@ -5,12 +5,14 @@ import {
 } from "../../core/tests/_assert.ts";
 import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
 import {
+  KubectlAnnotateSettings,
   KubectlApplySettings,
   KubectlCreateSettings,
   KubectlDeleteSettings,
   KubectlDescribeSettings,
   KubectlExecSettings,
   KubectlGetSettings,
+  KubectlLabelSettings,
   KubectlLogsSettings,
   KubectlPatchSettings,
   KubectlPortForwardSettings,
@@ -376,6 +378,121 @@ Deno.test("setImage: requires resource and image; all options", () => {
   );
 });
 
+Deno.test("annotate: resource + annotations, remove, and flags", () => {
+  // Resource tokens + one annotation + --overwrite.
+  assertEquals(
+    new KubectlAnnotateSettings()
+      .resource("deploy", "api")
+      .annotation("team", "payments")
+      .overwrite()
+      .argv()
+      .slice(1),
+    ["annotate", "deploy", "api", "team=payments", "--overwrite"],
+  );
+  // remove(key) renders kubectl's `key-` syntax.
+  assertEquals(
+    new KubectlAnnotateSettings()
+      .resource("deploy", "api")
+      .remove("team")
+      .argv()
+      .slice(1),
+    ["annotate", "deploy", "api", "team-"],
+  );
+  // Everything together, incl. --all and the label selector.
+  assertEquals(
+    new KubectlAnnotateSettings()
+      .resource("pods")
+      .annotation("team", "payments")
+      .remove("old")
+      .overwrite()
+      .all()
+      .selector("app=web")
+      .argv()
+      .slice(1),
+    [
+      "annotate",
+      "pods",
+      "team=payments",
+      "old-",
+      "--overwrite",
+      "--all",
+      "-l",
+      "app=web",
+    ],
+  );
+});
+
+Deno.test("label: resource + labels, remove, and flags", () => {
+  // Resource + a label + -l selector.
+  assertEquals(
+    new KubectlLabelSettings()
+      .resource("pods")
+      .label("team", "payments")
+      .selector("app=web")
+      .argv()
+      .slice(1),
+    ["label", "pods", "team=payments", "-l", "app=web"],
+  );
+  // Everything together, incl. remove(key), --overwrite, and --all.
+  assertEquals(
+    new KubectlLabelSettings()
+      .resource("deploy", "api")
+      .label("team", "payments")
+      .remove("old")
+      .overwrite()
+      .all()
+      .argv()
+      .slice(1),
+    ["label", "deploy", "api", "team=payments", "old-", "--overwrite", "--all"],
+  );
+});
+
+Deno.test("annotate and label honour the shared cluster flags", () => {
+  assertEquals(
+    new KubectlAnnotateSettings()
+      .resource("deploy", "api")
+      .annotation("team", "payments")
+      .namespace("prod")
+      .argv()
+      .slice(1),
+    ["annotate", "deploy", "api", "team=payments", "--namespace", "prod"],
+  );
+  assertEquals(
+    new KubectlLabelSettings()
+      .resource("deploy", "api")
+      .label("team", "payments")
+      .namespace("prod")
+      .argv()
+      .slice(1),
+    ["label", "deploy", "api", "team=payments", "--namespace", "prod"],
+  );
+});
+
+Deno.test("annotate and label require both a target and a payload", () => {
+  // A payload but no target.
+  assertThrows(
+    () => new KubectlAnnotateSettings().annotation("a", "b").argv(),
+    Error,
+    "a target is required",
+  );
+  // A target but no annotation/removal.
+  assertThrows(
+    () => new KubectlAnnotateSettings().resource("deploy").argv(),
+    Error,
+    "at least one .annotation()",
+  );
+  assertThrows(
+    () => new KubectlLabelSettings().label("a", "b").argv(),
+    Error,
+    "a target is required",
+  );
+  assertThrows(
+    () => new KubectlLabelSettings().resource("deploy").argv(),
+    Error,
+    "at least one .label()",
+  );
+});
+
 Deno.test("patch: requires resource and patch; --type ordering", () => {
   assertThrows(
     () => new KubectlPatchSettings().patch("{}").argv(),
@@ -536,6 +653,20 @@ Deno.test("every KubectlTasks function reaches execution", async () => {
     () =>
       KubectlTasks.setImage((s) =>
         missing(s).resource("deploy/api").image("api", "api:1")
+      ),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () =>
+      KubectlTasks.annotate((s) =>
+        missing(s).resource("deploy", "api").annotation("team", "payments")
+      ),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () =>
+      KubectlTasks.label((s) =>
+        missing(s).resource("deploy", "api").label("team", "payments")
       ),
     ToolNotFoundError,
   );


### PR DESCRIPTION
## M19 (P2 #8) — cloud + kubectl wrappers, all in one PR

The wrapper batch consumers were dropping to raw shell for. Two packages:

### `@zuke/gcloud` — typed CLI methods + GCS/Secret Manager REST

- **Typed gcloud CLI methods** (their ugliest shells): `containerImagesAddTag`
  (cross-registry image tagging, runs `--quiet`), `sqlInstancesDescribe`,
  `sqlOperationsWait` — each a discrete, injection-free argv.
- **`GcsTasks`** (REST): `readJson` / `writeJson` / `list` JSON objects in Cloud
  Storage.
- **`SecretManagerTasks`** (REST): `access` a secret's payload and `addVersion`
  (create-if-absent, so the write is idempotent — "write-before-create").
- **No Google SDK.** Both REST groups share `gcloud`-based auth — a bearer token
  from an injected provider (default `gcloud auth print-access-token`, run
  `--quiet` so the token never streams) — over an **injectable `fetch`**, so
  they're testable without network. Untrusted responses are narrowed (no `as`),
  non-2xx throws `HttpError`. `access` returns the plaintext secret with a note
  to route it through a `.secret()` param or the redactor.

### `@zuke/kubectl` — `annotate` / `label`

New subcommand wrappers with `key=value` / `key-` tokens, `--overwrite`/`--all`/
`-l`, and the same shared cluster flags and required-arg guards as the siblings.

### Acceptance

Every operation is unit-tested: the CLI methods assert their exact argv; the REST
groups drive `readJson`/`writeJson`/`list` and `access`/`addVersion` (including
the idempotent 409-tolerate and UTF-8 base64 round-trip) over a fake `fetch`.

### Adversarial review

Five attack dimensions (injection, secret-idempotency, secret-logging,
rest-errors, kubectl-cli) → refute-by-default verify. **2 confirmed** (both low,
high-confidence), each **fixed with a regression test**:

- **`access` silently corrupted a non-UTF-8 (binary) secret** — the non-fatal
  `TextDecoder` returned U+FFFD replacement chars, so a caller could use a wrong
  key. **Fixed:** a fatal decoder, turned into a friendly error naming the secret
  ("not valid UTF-8 — access() returns strings, not binary secrets").
- **`kubectl annotate`/`label` lacked the required-arg guards** every sibling
  subcommand has (a bare `annotate()` produced a confusing raw kubectl error).
  **Fixed:** both now throw a friendly error when a target or a payload is
  missing, matching the siblings.

The three no-finding dimensions confirmed argv/URL injection-safety
(`encodeURIComponent` on every path/query value), the 409 idempotency, and that
no secret or token reaches a log or an `HttpError` URL.

### Gate

`deno task ci` green (lines 98.2%, branches 95.1%); `apiDocsCheck`,
`generate-ci --check`, and `deno doc --lint` over all five core entrypoints
clean; docs/skills synced.

*(This finishes the M19 P2 batch: `orderWith` shipped in #203, these wrappers
here.)*
