### PR TITLE
feat(core): npm-package tool provisioning in toolchain()

### DIFF
--- a/docs/installing-tools.md
+++ b/docs/installing-tools.md
@@ -10,10 +10,11 @@ Tools are provisioned in Zuke's fluent settings-lambda style — the same
 `(s) => s.method(...)` shape the [tool wrappers](./tools.md) use — through two
 entry points in `@zuke/core`:
 
-| API                                                          | Installs   | Reach for it when                |
-| ------------------------------------------------------------ | ---------- | -------------------------------- |
-| [`ToolTasks.install((s) => …)`](#tooltasksinstall--one-tool) | one tool   | you need a single binary         |
-| [`toolchain()`](#toolchain--many-tools)                      | many tools | a build depends on several tools |
+| API                                                          | Installs      | Reach for it when                    |
+| ------------------------------------------------------------ | ------------- | ------------------------------------ |
+| [`ToolTasks.install((s) => …)`](#tooltasksinstall--one-tool) | one binary    | you need a single release binary     |
+| [`toolchain()`](#toolchain--many-tools)                      | many tools    | a build depends on several tools     |
+| [`ToolTasks.npm(...)` / `.npm(...)`](#npm-package-tools)      | an npm package | the tool ships on the npm registry   |
 
 Both return the installed binary's [`AbsolutePath`](./paths.md); hand it to a
 **[wrapper](./tools.md)** (`.toolPath(...)`), to `CmdTasks`, or to `defineTool`
@@ -190,7 +191,8 @@ class Deploy extends Build {
 - **Custom downloader.** `install({ download })` swaps the downloader for every
   tool — a test seam — and a per-tool `.download(...)` applies when the
   toolchain sets none.
-- **Introspection.** `chain.tools` returns the configured settings in order.
+- **Introspection.** `chain.tools` returns the configured release settings in
+  order; `chain.npmTools` the [npm-package tools](#npm-package-tools).
 - **Cheap to re-run.** Because a matching checksum is a cache hit, calling
   `install()` again (locally or on CI) is a no-op once the tools are present.
 
@@ -201,6 +203,45 @@ const tools = toolchain()
   .tool((s) => s.name("helm").url(helmUrl))
   .tool((s) => s.name("kubectl").url(kubectlUrl));
 ```
+
+## npm-package tools
+
+Not every tool ships a release binary — many (`vitest`, `dprint`,
+`@nestjs/cli`, …) are published on the **npm registry**. `Toolchain.npm(...)`
+provisions one as a version-pinned, cached tool without an ambient `npm ci`:
+
+```ts
+import { Build, target, toolchain } from "jsr:@zuke/core";
+import { VitestTasks } from "jsr:@zuke/vitest";
+
+class Test extends Build {
+  tools = toolchain((t) => t.npm({ name: "vitest", version: "4.1.9" }));
+
+  test = target().executes(async () => {
+    const bins = await this.tools.install();
+    await VitestTasks.run((s) => s.toolPath(bins.get("vitest")));
+  });
+}
+```
+
+Each package installs under `<destDir>/npm/<name>@<version>` via
+`npm install --prefix <dir> --no-save <name>@<version>`, and `install()` returns
+its bin under the same `Map<name, AbsolutePath>` as the release tools. For a
+one-off outside a toolchain, `ToolTasks.npm(spec, options?)` (or the underlying
+`installNpmTool`) does the same for a single package.
+
+- **npm is the one ambient requirement.** It resolves and downloads the package;
+  everything else is Zuke's. Nothing else needs to be on `PATH`.
+- **Pinned and cached.** A marker file records the `{ name, version }`, so a
+  later `install()` whose marker matches — and whose bin is still present — skips
+  npm entirely.
+- **Different bin name.** When a package's bin differs from its name, set `bin`:
+  `{ name: "@nestjs/cli", version: "10.4.0", bin: "nest" }` resolves the `nest`
+  bin.
+- **Hermetic pins compose with `node_modules` resolution.** An explicit
+  `.toolPath(bins.get(...))` always wins over
+  [`node_modules/.bin` resolution](./tools.md#resolving-from-node_modulesbin),
+  so a `toolchain()` pin stays authoritative even inside a Node workspace.
 
 ## Working with an installed tool
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -315,6 +315,28 @@ async function httpJson<T = unknown>(url: string, options: HttpOptions): Promise
 async function httpText(url: string, options: HttpOptions): Promise<string>
   Fetch `url` and return its body as text. Throws {@link HttpError} on non-2xx.
 
+async function installNpmTool(spec: NpmToolSpec, options: InstallNpmToolOptions): Promise<AbsolutePath>
+  Provision an npm-registry package as a version-pinned, cached tool and return
+  the installed bin's {@link AbsolutePath} — hand it straight to a wrapper's
+  `.toolPath(...)`.
+
+  The package installs under `<destDir>/npm/<name>@<version>` via
+  `npm install --prefix <dir> --no-save <name>@<version>`; a marker file records
+  the pinned `{ name, version }`, so a later run whose marker matches and whose
+  bin is still present is reused without invoking npm again. `npm` must be on
+  `PATH` (it resolves and downloads the package).
+
+  Throws — without recording a marker — if `spec` is malformed (an unsafe name,
+  version, or bin), if npm fails, or if npm succeeds but the expected bin is
+  absent (a typo'd `bin`, or a package that ships no executable), so a bad
+  install fails loudly here instead of at a later `.toolPath(...)`.
+
+  The marker is written only after the bin is verified present, so a matching
+  marker always has its bin — a reader never sees a half-written install.
+  Concurrent installs of the same pin into the same directory are not isolated;
+  they just do redundant work (the documented ceiling — a build resolves its
+  toolchain once, and distinct pins use distinct directories).
+
 async function installRelease(options: InstallReleaseOptions): Promise<AbsolutePath>
   Download and install a release binary, returning its {@link AbsolutePath}.
   The path is ready to hand to a wrapper's `.toolPath(...)` (or `CmdTasks`).
@@ -519,7 +541,8 @@ const REDACTED: "[redacted]"
 
 const ToolTasks: ToolTasksApi
   Provision external CLIs from a build. `ToolTasks.install((s) => …)` fetches a
-  single tool; group several with {@link toolchain}.
+  single release binary and `ToolTasks.npm(...)` a single npm package; group
+  several of either with {@link toolchain}.
 
 const defaultRenderer: Renderer
   The built-in renderer: Zuke's ruled headers and summary table.
@@ -1578,13 +1601,20 @@ class Toolchain
   {@link Toolchain.install}. Build one with {@link toolchain}.
 
   tool(configure: Configure<ToolInstallSettings>): this
-    Add a tool, configured through a settings-lambda. Chainable.
+    Add a release tool, configured through a settings-lambda. Chainable.
+  npm(spec: NpmToolSpec): this
+    Add an npm-registry package to provision as a version-pinned tool —
+    installed under `<destDir>/npm/<name>@<version>` and keyed in
+    {@link install}'s result by its {@link NpmToolSpec.name}. See
+    {@link installNpmTool}. Chainable.
   get tools(): readonly ToolInstallSettings[]
-    The configured tools, in declaration order.
+    The configured release tools, in declaration order.
+  get npmTools(): readonly NpmToolSpec[]
+    The configured npm-package tools, in declaration order.
   async install(options: ToolchainInstallOptions): Promise<Map<string, AbsolutePath>>
     Install every declared tool concurrently — reusing a cached copy where a
-    pinned checksum matches — and return a map of tool name to installed
-    {@link AbsolutePath}.
+    release tool's pinned checksum, or an npm tool's `name@version` marker,
+    matches — and return a map of tool name to installed {@link AbsolutePath}.
 
 class WaitSettings
   Fluent configuration for {@link TargetBuilder.waitsFor}:
@@ -2264,6 +2294,19 @@ interface HttpStateStoreOptions
   fetch?: typeof fetch
     The `fetch` implementation; defaults to the global. Overridable for tests.
 
+interface InstallNpmToolOptions
+  Options for {@link installNpmTool}.
+
+  destDir?: PathLike
+    The root tools directory; the package installs under
+    `<destDir>/npm/<name>@<version>`. Defaults to
+    {@link "./tool.ts".DEFAULT_TOOLS_DIR} (`.zuke/tools`).
+  run?: NpmRunner
+    The npm-install runner. Defaults to the ambient `npm`; a test seam.
+  os?: OperatingSystem
+    The OS whose bin-shim filename to return (`.cmd` on Windows). Defaults to
+    the host; a test seam for the Windows shim path.
+
 interface InstallPlatform
   The host identity: a Zuke {@link OperatingSystem} and {@link Architecture}.
 
@@ -2336,6 +2379,18 @@ interface McpRequestContext
 
   readonly headers: Headers
     The request headers; an empty {@link Headers} on stdio.
+
+interface NpmToolSpec
+  A specification of an npm-registry package to provision as a tool.
+
+  name: string
+    The npm package to install, e.g. `"vitest"` or `"@nestjs/cli"`.
+  version: string
+    The exact version to pin, e.g. `"4.1.9"` — installed as `name@version`.
+  bin?: string
+    The bin to resolve, when it differs from the package name — `@nestjs/cli`
+    publishes the `nest` bin, so `{ name: "@nestjs/cli", bin: "nest" }`.
+    Defaults to {@link name}.
 
 interface OpenCacheOptions
   Optional extras for {@link openCache}: a remote store and a warning sink.
@@ -2875,6 +2930,11 @@ interface ToolTasksApi
     Install a single release tool, configured through a
     {@link ToolInstallSettings} lambda, and resolve to its installed path.
     Defaults the install directory to `.zuke/tools`.
+  npm(spec: NpmToolSpec, options?: InstallNpmToolOptions): Promise<AbsolutePath>
+    Provision a single npm-registry package as a version-pinned, cached tool and
+    resolve to its installed bin path. Defaults the install root to
+    `.zuke/tools`. See {@link installNpmTool}; group several with
+    {@link Toolchain.npm}.
 
 interface ToolchainInstallOptions
   Options for {@link Toolchain.install}.
@@ -2882,7 +2942,9 @@ interface ToolchainInstallOptions
   destDir?: PathLike
     Where tools without their own `destDir` install. Defaults to `.zuke/tools`.
   download?: DownloadFn
-    The download implementation for every tool (defaults per {@link installRelease}).
+    The download implementation for every release tool (defaults per {@link installRelease}).
+  npmRun?: NpmRunner
+    The npm-install runner for npm-package tools (defaults to the ambient `npm`; a test seam).
 
 interface Validation
   A check plugged into a target with {@link TargetBuilder.validateBefore} or
@@ -2997,6 +3059,11 @@ type McpIdentityHook = (ctx: McpRequestContext) => McpIdentity
   per message, before any dispatch; throwing rejects the whole request with
   an auth error, so nothing executes and nothing is written to state — the seam
   a proxy in front of the server uses to inject an authenticated identity.
+
+type NpmRunner = (args: string[]) => Promise<void>
+  Runs `npm install <args>` — the injectable subprocess seam. Defaults to
+  spawning the ambient `npm`; a test injects a fake that records the argv and
+  plants the expected bin, so provisioning stays hermetic and network-free.
 
 type OnCancel = TargetBuilder | (() => TargetBuilder)
   A compensation registered with {@link TargetBuilder.onCancel}: either a

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -369,6 +369,28 @@ async function httpJson<T = unknown>(url: string, options: HttpOptions): Promise
 async function httpText(url: string, options: HttpOptions): Promise<string>
   Fetch `url` and return its body as text. Throws {@link HttpError} on non-2xx.
 
+async function installNpmTool(spec: NpmToolSpec, options: InstallNpmToolOptions): Promise<AbsolutePath>
+  Provision an npm-registry package as a version-pinned, cached tool and return
+  the installed bin's {@link AbsolutePath} — hand it straight to a wrapper's
+  `.toolPath(...)`.
+
+  The package installs under `<destDir>/npm/<name>@<version>` via
+  `npm install --prefix <dir> --no-save <name>@<version>`; a marker file records
+  the pinned `{ name, version }`, so a later run whose marker matches and whose
+  bin is still present is reused without invoking npm again. `npm` must be on
+  `PATH` (it resolves and downloads the package).
+
+  Throws — without recording a marker — if `spec` is malformed (an unsafe name,
+  version, or bin), if npm fails, or if npm succeeds but the expected bin is
+  absent (a typo'd `bin`, or a package that ships no executable), so a bad
+  install fails loudly here instead of at a later `.toolPath(...)`.
+
+  The marker is written only after the bin is verified present, so a matching
+  marker always has its bin — a reader never sees a half-written install.
+  Concurrent installs of the same pin into the same directory are not isolated;
+  they just do redundant work (the documented ceiling — a build resolves its
+  toolchain once, and distinct pins use distinct directories).
+
 async function installRelease(options: InstallReleaseOptions): Promise<AbsolutePath>
   Download and install a release binary, returning its {@link AbsolutePath}.
   The path is ready to hand to a wrapper's `.toolPath(...)` (or `CmdTasks`).
@@ -573,7 +595,8 @@ const REDACTED: "[redacted]"
 
 const ToolTasks: ToolTasksApi
   Provision external CLIs from a build. `ToolTasks.install((s) => …)` fetches a
-  single tool; group several with {@link toolchain}.
+  single release binary and `ToolTasks.npm(...)` a single npm package; group
+  several of either with {@link toolchain}.
 
 const defaultRenderer: Renderer
   The built-in renderer: Zuke's ruled headers and summary table.
@@ -1632,13 +1655,20 @@ class Toolchain
   {@link Toolchain.install}. Build one with {@link toolchain}.
 
   tool(configure: Configure<ToolInstallSettings>): this
-    Add a tool, configured through a settings-lambda. Chainable.
+    Add a release tool, configured through a settings-lambda. Chainable.
+  npm(spec: NpmToolSpec): this
+    Add an npm-registry package to provision as a version-pinned tool —
+    installed under `<destDir>/npm/<name>@<version>` and keyed in
+    {@link install}'s result by its {@link NpmToolSpec.name}. See
+    {@link installNpmTool}. Chainable.
   get tools(): readonly ToolInstallSettings[]
-    The configured tools, in declaration order.
+    The configured release tools, in declaration order.
+  get npmTools(): readonly NpmToolSpec[]
+    The configured npm-package tools, in declaration order.
   async install(options: ToolchainInstallOptions): Promise<Map<string, AbsolutePath>>
     Install every declared tool concurrently — reusing a cached copy where a
-    pinned checksum matches — and return a map of tool name to installed
-    {@link AbsolutePath}.
+    release tool's pinned checksum, or an npm tool's `name@version` marker,
+    matches — and return a map of tool name to installed {@link AbsolutePath}.
 
 class WaitSettings
   Fluent configuration for {@link TargetBuilder.waitsFor}:
@@ -2318,6 +2348,19 @@ interface HttpStateStoreOptions
   fetch?: typeof fetch
     The `fetch` implementation; defaults to the global. Overridable for tests.
 
+interface InstallNpmToolOptions
+  Options for {@link installNpmTool}.
+
+  destDir?: PathLike
+    The root tools directory; the package installs under
+    `<destDir>/npm/<name>@<version>`. Defaults to
+    {@link "./tool.ts".DEFAULT_TOOLS_DIR} (`.zuke/tools`).
+  run?: NpmRunner
+    The npm-install runner. Defaults to the ambient `npm`; a test seam.
+  os?: OperatingSystem
+    The OS whose bin-shim filename to return (`.cmd` on Windows). Defaults to
+    the host; a test seam for the Windows shim path.
+
 interface InstallPlatform
   The host identity: a Zuke {@link OperatingSystem} and {@link Architecture}.
 
@@ -2390,6 +2433,18 @@ interface McpRequestContext
 
   readonly headers: Headers
     The request headers; an empty {@link Headers} on stdio.
+
+interface NpmToolSpec
+  A specification of an npm-registry package to provision as a tool.
+
+  name: string
+    The npm package to install, e.g. `"vitest"` or `"@nestjs/cli"`.
+  version: string
+    The exact version to pin, e.g. `"4.1.9"` — installed as `name@version`.
+  bin?: string
+    The bin to resolve, when it differs from the package name — `@nestjs/cli`
+    publishes the `nest` bin, so `{ name: "@nestjs/cli", bin: "nest" }`.
+    Defaults to {@link name}.
 
 interface OpenCacheOptions
   Optional extras for {@link openCache}: a remote store and a warning sink.
@@ -2929,6 +2984,11 @@ interface ToolTasksApi
     Install a single release tool, configured through a
     {@link ToolInstallSettings} lambda, and resolve to its installed path.
     Defaults the install directory to `.zuke/tools`.
+  npm(spec: NpmToolSpec, options?: InstallNpmToolOptions): Promise<AbsolutePath>
+    Provision a single npm-registry package as a version-pinned, cached tool and
+    resolve to its installed bin path. Defaults the install root to
+    `.zuke/tools`. See {@link installNpmTool}; group several with
+    {@link Toolchain.npm}.
 
 interface ToolchainInstallOptions
   Options for {@link Toolchain.install}.
@@ -2936,7 +2996,9 @@ interface ToolchainInstallOptions
   destDir?: PathLike
     Where tools without their own `destDir` install. Defaults to `.zuke/tools`.
   download?: DownloadFn
-    The download implementation for every tool (defaults per {@link installRelease}).
+    The download implementation for every release tool (defaults per {@link installRelease}).
+  npmRun?: NpmRunner
+    The npm-install runner for npm-package tools (defaults to the ambient `npm`; a test seam).
 
 interface Validation
   A check plugged into a target with {@link TargetBuilder.validateBefore} or
@@ -3051,6 +3113,11 @@ type McpIdentityHook = (ctx: McpRequestContext) => McpIdentity
   per message, before any dispatch; throwing rejects the whole request with
   an auth error, so nothing executes and nothing is written to state — the seam
   a proxy in front of the server uses to inject an authenticated identity.
+
+type NpmRunner = (args: string[]) => Promise<void>
+  Runs `npm install <args>` — the injectable subprocess seam. Defaults to
+  spawning the ambient `npm`; a test injects a fake that records the argv and
+  plants the expected bin, so provisioning stays hermetic and network-free.
 
 type OnCancel = TargetBuilder | (() => TargetBuilder)
   A compensation registered with {@link TargetBuilder.onCancel}: either a

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -283,6 +283,12 @@ export {
   type Platform,
 } from "./src/install.ts";
 export {
+  installNpmTool,
+  type InstallNpmToolOptions,
+  type NpmRunner,
+  type NpmToolSpec,
+} from "./src/npm_tool.ts";
+export {
   DEFAULT_TOOLS_DIR,
   Toolchain,
   toolchain,

--- a/packages/core/src/npm_tool.ts
+++ b/packages/core/src/npm_tool.ts
@@ -1,0 +1,256 @@
+/**
+ * Provision an npm-registry package as a runnable, version-pinned tool — the
+ * npm-ecosystem counterpart to {@link "./install.ts".installRelease}.
+ *
+ * `installNpmTool({ name: "vitest", version: "4.1.9" })` runs
+ * `npm install --prefix <dir> --no-save vitest@4.1.9` into a Zuke-managed,
+ * per-version directory and returns the installed bin's {@link AbsolutePath},
+ * ready for a wrapper's `.toolPath(...)` — no ambient `npm ci`, and no
+ * assumption that the tool is already on `PATH`. A marker file records the
+ * pinned `{ name, version }`, so a matching prior install is reused without
+ * re-running npm.
+ *
+ * npm itself is the one ambient requirement — it resolves and downloads the
+ * package; everything else is Zuke's. Group several with
+ * {@link "./tool.ts".Toolchain.npm}, or install one directly through
+ * {@link "./tool.ts".ToolTasks.npm}.
+ *
+ * ```ts
+ * import { installNpmTool } from "jsr:@zuke/core";
+ * import { CmdTasks } from "jsr:@zuke/cmd";
+ *
+ * const vitest = await installNpmTool({ name: "vitest", version: "4.1.9" });
+ * await CmdTasks.exec(String(vitest), (s) => s.args("run"));
+ * ```
+ *
+ * @module
+ */
+
+import { Command } from "./shell.ts";
+import { type AbsolutePath, absolutePath, type PathLike } from "./path.ts";
+import { type OperatingSystem, operatingSystem } from "./host.ts";
+import { DEFAULT_TOOLS_DIR } from "./tool.ts";
+
+/** A specification of an npm-registry package to provision as a tool. */
+export interface NpmToolSpec {
+  /** The npm package to install, e.g. `"vitest"` or `"@nestjs/cli"`. */
+  name: string;
+  /** The exact version to pin, e.g. `"4.1.9"` — installed as `name@version`. */
+  version: string;
+  /**
+   * The bin to resolve, when it differs from the package name — `@nestjs/cli`
+   * publishes the `nest` bin, so `{ name: "@nestjs/cli", bin: "nest" }`.
+   * Defaults to {@link name}.
+   */
+  bin?: string;
+}
+
+/**
+ * Runs `npm install <args>` — the injectable subprocess seam. Defaults to
+ * spawning the ambient `npm`; a test injects a fake that records the argv and
+ * plants the expected bin, so provisioning stays hermetic and network-free.
+ */
+export type NpmRunner = (args: string[]) => Promise<void>;
+
+/** Options for {@link installNpmTool}. */
+export interface InstallNpmToolOptions {
+  /**
+   * The root tools directory; the package installs under
+   * `<destDir>/npm/<name>@<version>`. Defaults to
+   * {@link "./tool.ts".DEFAULT_TOOLS_DIR} (`.zuke/tools`).
+   */
+  destDir?: PathLike;
+  /** The npm-install runner. Defaults to the ambient `npm`; a test seam. */
+  run?: NpmRunner;
+  /**
+   * The OS whose bin-shim filename to return (`.cmd` on Windows). Defaults to
+   * the host; a test seam for the Windows shim path.
+   */
+  os?: OperatingSystem;
+}
+
+/** The default {@link NpmRunner}: spawn the ambient `npm`, throwing on failure. */
+const defaultNpmRun: NpmRunner = async (args) => {
+  await new Command(["npm", ...args]);
+};
+
+/** Resolve a possibly-relative directory to an absolute path (against `cwd`). */
+function resolveDir(dir: string): AbsolutePath {
+  const slashed = dir.replace(/\\/g, "/");
+  const isAbsolute = slashed.startsWith("/") || /^[A-Za-z]:/.test(slashed);
+  return absolutePath(isAbsolute ? slashed : `${Deno.cwd()}/${slashed}`);
+}
+
+/** The pinned package recorded beside an npm-provisioned tool. */
+interface NpmToolMarker {
+  /** The npm package name this install satisfied. */
+  name: string;
+  /** The pinned version this install satisfied. */
+  version: string;
+}
+
+/** The marker file recording the pinned package an install satisfied. */
+function markerPath(prefix: AbsolutePath): string {
+  return String(prefix(".zuke-npm-tool.json"));
+}
+
+/** Parse a marker file's JSON, or `null` if it is absent or malformed. */
+function parseMarker(text: string | null): NpmToolMarker | null {
+  if (text === null) return null;
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (
+      typeof parsed === "object" && parsed !== null &&
+      "name" in parsed && typeof parsed.name === "string" &&
+      "version" in parsed && typeof parsed.version === "string"
+    ) {
+      return { name: parsed.name, version: parsed.version };
+    }
+  } catch {
+    // A corrupt marker is treated as absent — the tool just re-installs.
+  }
+  return null;
+}
+
+/** Read a file's text, or `null` when it does not exist. */
+async function readTextOrNull(path: string): Promise<string | null> {
+  try {
+    return await Deno.readTextFile(path);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return null;
+    throw error;
+  }
+}
+
+/** Whether a filesystem path resolves to an existing file (follows symlinks). */
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await Deno.stat(path);
+    return true;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return false;
+    throw error;
+  }
+}
+
+/** The installed bin path npm plants for `spec`, `.cmd`-shimmed on Windows. */
+function binPathOf(
+  prefix: AbsolutePath,
+  spec: NpmToolSpec,
+  os: OperatingSystem,
+): AbsolutePath {
+  const bin = spec.bin ?? spec.name;
+  return prefix("node_modules", ".bin", os === "windows" ? `${bin}.cmd` : bin);
+}
+
+/** npm package-name grammar: optionally scoped, no path separators or leading dash. */
+const NPM_NAME = /^(?:@[a-z0-9][a-z0-9._~-]*\/)?[a-z0-9][a-z0-9._~-]*$/i;
+/** A bin name: a single path segment — no separators, no leading dash. */
+const BIN_NAME = /^[a-z0-9][a-z0-9._~-]*$/i;
+
+/**
+ * Reject a spec whose `name`, `version`, or `bin` would build an unsafe install
+ * path (a `..` escaping `<destDir>`) or splice an npm flag (a leading-dash name
+ * npm reads as an option) — before npm ever runs. These come from the build
+ * script, so this is a friendly guard-rail that names the offender, not a
+ * trust-boundary defence; a valid scoped name like `@nestjs/cli` passes.
+ */
+function validateNpmSpec(spec: NpmToolSpec): void {
+  if (!NPM_NAME.test(spec.name)) {
+    throw new Error(
+      `invalid npm tool name ${
+        JSON.stringify(spec.name)
+      }: expected a package ` +
+        `name like "vitest" or "@nestjs/cli" — no path separators, spaces, or ` +
+        `leading dash.`,
+    );
+  }
+  if (
+    spec.version === "" || /[\s/\\]/.test(spec.version) ||
+    spec.version.startsWith("-") || spec.version.includes("..")
+  ) {
+    throw new Error(
+      `invalid version ${JSON.stringify(spec.version)} for npm tool ` +
+        `"${spec.name}": expected an exact version like "4.1.9" — no spaces, ` +
+        `slashes, "..", or leading dash.`,
+    );
+  }
+  if (spec.bin !== undefined && !BIN_NAME.test(spec.bin)) {
+    throw new Error(
+      `invalid bin ${JSON.stringify(spec.bin)} for npm tool "${spec.name}": ` +
+        `expected a single bin name like "nest" — no path separators or ` +
+        `leading dash.`,
+    );
+  }
+}
+
+/**
+ * Provision an npm-registry package as a version-pinned, cached tool and return
+ * the installed bin's {@link AbsolutePath} — hand it straight to a wrapper's
+ * `.toolPath(...)`.
+ *
+ * The package installs under `<destDir>/npm/<name>@<version>` via
+ * `npm install --prefix <dir> --no-save <name>@<version>`; a marker file records
+ * the pinned `{ name, version }`, so a later run whose marker matches and whose
+ * bin is still present is reused without invoking npm again. `npm` must be on
+ * `PATH` (it resolves and downloads the package).
+ *
+ * Throws — without recording a marker — if `spec` is malformed (an unsafe name,
+ * version, or bin), if npm fails, or if npm succeeds but the expected bin is
+ * absent (a typo'd `bin`, or a package that ships no executable), so a bad
+ * install fails loudly here instead of at a later `.toolPath(...)`.
+ *
+ * The marker is written only after the bin is verified present, so a matching
+ * marker always has its bin — a reader never sees a half-written install.
+ * Concurrent installs of the same pin into the same directory are not isolated;
+ * they just do redundant work (the documented ceiling — a build resolves its
+ * toolchain once, and distinct pins use distinct directories).
+ */
+export async function installNpmTool(
+  spec: NpmToolSpec,
+  options: InstallNpmToolOptions = {},
+): Promise<AbsolutePath> {
+  validateNpmSpec(spec);
+  const os = options.os ?? operatingSystem();
+  const root = resolveDir(String(options.destDir ?? DEFAULT_TOOLS_DIR));
+  const prefix = root("npm", `${spec.name}@${spec.version}`);
+  const bin = binPathOf(prefix, spec, os);
+
+  // Cache hit: a prior install of the same name@version whose bin is still on
+  // disk is reused without invoking npm again.
+  const marker = parseMarker(await readTextOrNull(markerPath(prefix)));
+  if (
+    marker !== null && marker.name === spec.name &&
+    marker.version === spec.version && await pathExists(String(bin))
+  ) {
+    return bin;
+  }
+
+  await Deno.mkdir(String(prefix), { recursive: true });
+  await (options.run ?? defaultNpmRun)([
+    "install",
+    "--prefix",
+    String(prefix),
+    "--no-save",
+    `${spec.name}@${spec.version}`,
+  ]);
+  // Confirm npm actually produced the bin before recording the install — a
+  // typo'd `bin` or a package that ships no executable exits 0 without planting
+  // it. Fail loudly here (like installRelease) rather than returning a path to a
+  // nonexistent file that only breaks later at `.toolPath(...)`, and never write
+  // a marker for an install that did not land.
+  if (!await pathExists(String(bin))) {
+    throw new Error(
+      `npm installed ${spec.name}@${spec.version}, but its bin was not found ` +
+        `at ${
+          String(bin)
+        }. If the package's bin name differs from the package ` +
+        `name, pass { bin } (e.g. "@nestjs/cli" ships the "nest" bin).`,
+    );
+  }
+  await Deno.writeTextFile(
+    markerPath(prefix),
+    `${JSON.stringify({ name: spec.name, version: spec.version })}\n`,
+  );
+  return bin;
+}

--- a/packages/core/src/tool.ts
+++ b/packages/core/src/tool.ts
@@ -42,6 +42,12 @@ import {
   type InstallReleaseOptions,
   type Platform,
 } from "./install.ts";
+import {
+  installNpmTool,
+  type InstallNpmToolOptions,
+  type NpmRunner,
+  type NpmToolSpec,
+} from "./npm_tool.ts";
 import type { Configure } from "./tooling.ts";
 
 /** The default directory a {@link Toolchain} (and {@link ToolTasks}) installs into. */
@@ -157,16 +163,30 @@ export interface ToolTasksApi {
   install(
     configure: Configure<ToolInstallSettings>,
   ): Promise<AbsolutePath>;
+  /**
+   * Provision a single npm-registry package as a version-pinned, cached tool and
+   * resolve to its installed bin path. Defaults the install root to
+   * `.zuke/tools`. See {@link installNpmTool}; group several with
+   * {@link Toolchain.npm}.
+   */
+  npm(
+    spec: NpmToolSpec,
+    options?: InstallNpmToolOptions,
+  ): Promise<AbsolutePath>;
 }
 
 /**
  * Provision external CLIs from a build. `ToolTasks.install((s) => …)` fetches a
- * single tool; group several with {@link toolchain}.
+ * single release binary and `ToolTasks.npm(...)` a single npm package; group
+ * several of either with {@link toolchain}.
  */
 export const ToolTasks: ToolTasksApi = {
   install(configure) {
     const settings = configure(new ToolInstallSettings());
     return installRelease(settings.options_(DEFAULT_TOOLS_DIR));
+  },
+  npm(spec, options) {
+    return installNpmTool(spec, options);
   },
 };
 
@@ -174,8 +194,10 @@ export const ToolTasks: ToolTasksApi = {
 export interface ToolchainInstallOptions {
   /** Where tools without their own `destDir` install. Defaults to `.zuke/tools`. */
   destDir?: PathLike;
-  /** The download implementation for every tool (defaults per {@link installRelease}). */
+  /** The download implementation for every release tool (defaults per {@link installRelease}). */
   download?: DownloadFn;
+  /** The npm-install runner for npm-package tools (defaults to the ambient `npm`; a test seam). */
+  npmRun?: NpmRunner;
 }
 
 /**
@@ -185,37 +207,63 @@ export interface ToolchainInstallOptions {
  */
 export class Toolchain {
   readonly #tools: ToolInstallSettings[] = [];
+  readonly #npmTools: NpmToolSpec[] = [];
 
-  /** Add a tool, configured through a settings-lambda. Chainable. */
+  /** Add a release tool, configured through a settings-lambda. Chainable. */
   tool(configure: Configure<ToolInstallSettings>): this {
     this.#tools.push(configure(new ToolInstallSettings()));
     return this;
   }
 
-  /** The configured tools, in declaration order. */
+  /**
+   * Add an npm-registry package to provision as a version-pinned tool —
+   * installed under `<destDir>/npm/<name>@<version>` and keyed in
+   * {@link install}'s result by its {@link NpmToolSpec.name}. See
+   * {@link installNpmTool}. Chainable.
+   */
+  npm(spec: NpmToolSpec): this {
+    this.#npmTools.push(spec);
+    return this;
+  }
+
+  /** The configured release tools, in declaration order. */
   get tools(): readonly ToolInstallSettings[] {
     return this.#tools;
   }
 
+  /** The configured npm-package tools, in declaration order. */
+  get npmTools(): readonly NpmToolSpec[] {
+    return this.#npmTools;
+  }
+
   /**
    * Install every declared tool concurrently — reusing a cached copy where a
-   * pinned checksum matches — and return a map of tool name to installed
-   * {@link AbsolutePath}.
+   * release tool's pinned checksum, or an npm tool's `name@version` marker,
+   * matches — and return a map of tool name to installed {@link AbsolutePath}.
    */
   async install(
     options: ToolchainInstallOptions = {},
   ): Promise<Map<string, AbsolutePath>> {
     const destDir = options.destDir ?? DEFAULT_TOOLS_DIR;
     const installed = new Map<string, AbsolutePath>();
-    await Promise.all(this.#tools.map(async (settings) => {
-      const spec = settings.options_(destDir);
-      const path = await installRelease(
-        options.download === undefined
-          ? spec
-          : { ...spec, download: options.download },
-      );
-      installed.set(spec.name, path);
-    }));
+    await Promise.all([
+      ...this.#tools.map(async (settings) => {
+        const spec = settings.options_(destDir);
+        const path = await installRelease(
+          options.download === undefined
+            ? spec
+            : { ...spec, download: options.download },
+        );
+        installed.set(spec.name, path);
+      }),
+      ...this.#npmTools.map(async (spec) => {
+        const path = await installNpmTool(spec, {
+          destDir,
+          run: options.npmRun,
+        });
+        installed.set(spec.name, path);
+      }),
+    ]);
     return installed;
   }
 }

--- a/packages/core/tests/npm_tool_test.ts
+++ b/packages/core/tests/npm_tool_test.ts
@@ -1,0 +1,361 @@
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "./_assert.ts";
+import { withAmbientEcho } from "../src/ambient_echo.ts";
+import { type OperatingSystem, operatingSystem } from "../src/host.ts";
+import { installNpmTool, type NpmRunner } from "../src/npm_tool.ts";
+
+const HOST_OS = operatingSystem();
+/** The npm bin-shim suffix on the host (`.cmd` on Windows, else none). */
+const EXE = HOST_OS === "windows" ? ".cmd" : "";
+
+/**
+ * A fake npm runner that records each argv and plants the package's bin file
+ * under the `--prefix` it was given — the hermetic stand-in for a real
+ * `npm install`, with no network and no ambient npm.
+ */
+function fakeNpm(
+  bin: string,
+  os: OperatingSystem = HOST_OS,
+): { run: NpmRunner; calls: string[][] } {
+  const calls: string[][] = [];
+  const run: NpmRunner = async (args) => {
+    calls.push(args);
+    const prefix = args[args.indexOf("--prefix") + 1];
+    const dir = `${prefix}/node_modules/.bin`;
+    await Deno.mkdir(dir, { recursive: true });
+    const file = os === "windows" ? `${bin}.cmd` : bin;
+    await Deno.writeTextFile(`${dir}/${file}`, "#!/bin/sh\n");
+  };
+  return { run, calls };
+}
+
+Deno.test("installNpmTool installs, returns the bin path, and records the argv", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const { run, calls } = fakeNpm("vitest", "linux");
+    const bin = await installNpmTool(
+      { name: "vitest", version: "4.1.9" },
+      { destDir: dir, run, os: "linux" },
+    );
+    assertEquals(bin.name, "vitest");
+    assertEquals(
+      bin.path.endsWith("/npm/vitest@4.1.9/node_modules/.bin/vitest"),
+      true,
+    );
+    assertEquals(calls.length, 1);
+    assertEquals(calls[0][0], "install");
+    assertEquals(calls[0][1], "--prefix");
+    assertEquals(calls[0][2].endsWith("/npm/vitest@4.1.9"), true);
+    assertEquals(calls[0][3], "--no-save");
+    assertEquals(calls[0][4], "vitest@4.1.9");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("installNpmTool returns the .cmd shim path on Windows", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const { run } = fakeNpm("vitest", "windows");
+    const bin = await installNpmTool(
+      { name: "vitest", version: "1.0.0" },
+      { destDir: dir, run, os: "windows" },
+    );
+    assertEquals(bin.name, "vitest.cmd");
+    assertEquals(bin.path.endsWith("/node_modules/.bin/vitest.cmd"), true);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("installNpmTool resolves a bin that differs from the package name", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const { run, calls } = fakeNpm("nest", "linux");
+    const bin = await installNpmTool(
+      { name: "@nestjs/cli", version: "10.0.0", bin: "nest" },
+      { destDir: dir, run, os: "linux" },
+    );
+    assertEquals(bin.name, "nest");
+    assertEquals(
+      bin.path.endsWith("/npm/@nestjs/cli@10.0.0/node_modules/.bin/nest"),
+      true,
+    );
+    assertEquals(calls[0][4], "@nestjs/cli@10.0.0"); // scoped name@version
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("a matching marker with the bin present is reused without re-running npm", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const { run, calls } = fakeNpm("vitest", "linux");
+    const spec = { name: "vitest", version: "4.1.9" };
+    const first = await installNpmTool(spec, {
+      destDir: dir,
+      run,
+      os: "linux",
+    });
+    const second = await installNpmTool(spec, {
+      destDir: dir,
+      run,
+      os: "linux",
+    });
+    assertEquals(first.path, second.path);
+    assertEquals(calls.length, 1); // the second call short-circuited on the marker
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("a different version misses the cache and re-installs", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const { run, calls } = fakeNpm("vitest", "linux");
+    await installNpmTool({ name: "vitest", version: "1.0.0" }, {
+      destDir: dir,
+      run,
+      os: "linux",
+    });
+    await installNpmTool({ name: "vitest", version: "2.0.0" }, {
+      destDir: dir,
+      run,
+      os: "linux",
+    });
+    assertEquals(calls.length, 2);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("a marker recording a different package is ignored (re-installs)", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const { run, calls } = fakeNpm("vitest", "linux");
+    const spec = { name: "vitest", version: "4.1.9" };
+    const bin = await installNpmTool(spec, { destDir: dir, run, os: "linux" });
+    const prefix = bin.parent().parent().parent();
+    await Deno.writeTextFile(
+      String(prefix(".zuke-npm-tool.json")),
+      JSON.stringify({ name: "vitest", version: "9.9.9" }),
+    );
+    await installNpmTool(spec, { destDir: dir, run, os: "linux" });
+    assertEquals(calls.length, 2);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("a malformed marker is treated as absent (re-installs)", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const { run, calls } = fakeNpm("vitest", "linux");
+    const spec = { name: "vitest", version: "4.1.9" };
+    const bin = await installNpmTool(spec, { destDir: dir, run, os: "linux" });
+    const marker = String(
+      bin.parent().parent().parent()(".zuke-npm-tool.json"),
+    );
+    // Unparseable JSON, then valid JSON of the wrong shape — both re-install.
+    await Deno.writeTextFile(marker, "{not json");
+    await installNpmTool(spec, { destDir: dir, run, os: "linux" });
+    await Deno.writeTextFile(marker, JSON.stringify({ name: 123 }));
+    await installNpmTool(spec, { destDir: dir, run, os: "linux" });
+    assertEquals(calls.length, 3);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("a valid marker whose bin has gone re-installs", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const { run, calls } = fakeNpm("vitest", "linux");
+    const spec = { name: "vitest", version: "4.1.9" };
+    const bin = await installNpmTool(spec, { destDir: dir, run, os: "linux" });
+    await Deno.remove(String(bin)); // marker stays, but the bin is gone
+    await installNpmTool(spec, { destDir: dir, run, os: "linux" });
+    assertEquals(calls.length, 2);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("installNpmTool rejects an unsafe name, version, or bin", async () => {
+  let ran = 0;
+  const noop: NpmRunner = () => {
+    ran++;
+    return Promise.resolve();
+  };
+  for (const name of ["", "../evil", "--registry=x", "a/b/c", "foo bar"]) {
+    await assertRejects(
+      () => installNpmTool({ name, version: "1.0.0" }, { run: noop }),
+      Error,
+      "invalid npm tool name",
+    );
+  }
+  for (const version of ["", "-1", "../x", "1 2", "a/b"]) {
+    await assertRejects(
+      () => installNpmTool({ name: "vitest", version }, { run: noop }),
+      Error,
+      "invalid version",
+    );
+  }
+  await assertRejects(
+    () =>
+      installNpmTool({ name: "x", version: "1.0.0", bin: "../evil" }, {
+        run: noop,
+      }),
+    Error,
+    "invalid bin",
+  );
+  assertEquals(ran, 0); // validation rejects before npm is ever invoked
+});
+
+Deno.test("installNpmTool throws when npm plants no bin, writing no marker", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const calls: string[][] = [];
+    // A runner that "succeeds" but plants nothing — a typo'd bin, or a package
+    // that ships no executable: npm exits 0 without creating node_modules/.bin.
+    const emptyRun: NpmRunner = async (args) => {
+      calls.push(args);
+      await Deno.mkdir(args[args.indexOf("--prefix") + 1], { recursive: true });
+    };
+    const spec = { name: "vitest", version: "4.1.9" };
+    await assertRejects(
+      () => installNpmTool(spec, { destDir: dir, run: emptyRun, os: "linux" }),
+      Error,
+      "its bin was not found",
+    );
+    // No marker was written, so a retry re-runs npm (no false cache hit).
+    await assertRejects(
+      () => installNpmTool(spec, { destDir: dir, run: emptyRun, os: "linux" }),
+      Error,
+      "its bin was not found",
+    );
+    assertEquals(calls.length, 2);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("a rejecting npm runner propagates and writes no marker", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    let calls = 0;
+    const failing: NpmRunner = () => {
+      calls++;
+      return Promise.reject(new Error("npm exploded"));
+    };
+    const spec = { name: "vitest", version: "4.1.9" };
+    await assertRejects(
+      () => installNpmTool(spec, { destDir: dir, run: failing, os: "linux" }),
+      Error,
+      "npm exploded",
+    );
+    // A failed install must not poison the cache — the retry re-runs.
+    await assertRejects(
+      () => installNpmTool(spec, { destDir: dir, run: failing, os: "linux" }),
+      Error,
+      "npm exploded",
+    );
+    assertEquals(calls, 2);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("a non-NotFound error reading the marker surfaces (not swallowed)", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const { run } = fakeNpm("vitest", "linux");
+    const spec = { name: "vitest", version: "4.1.9" };
+    const bin = await installNpmTool(spec, { destDir: dir, run, os: "linux" });
+    // Replace the marker file with a directory → readTextFile throws EISDIR,
+    // which is not NotFound and must propagate, not be treated as "no marker".
+    const marker = String(
+      bin.parent().parent().parent()(".zuke-npm-tool.json"),
+    );
+    await Deno.remove(marker);
+    await Deno.mkdir(marker);
+    await assertRejects(
+      () => installNpmTool(spec, { destDir: dir, run, os: "linux" }),
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("a non-NotFound error stat-ing the bin surfaces (not swallowed)", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const { run } = fakeNpm("vitest", "linux");
+    const spec = { name: "vitest", version: "4.1.9" };
+    const bin = await installNpmTool(spec, { destDir: dir, run, os: "linux" });
+    // Turn node_modules into a file: stat-ing the bin path now traverses through
+    // a non-directory → NotADirectory, which is not NotFound and must propagate.
+    const prefix = bin.parent().parent().parent();
+    await Deno.remove(String(prefix("node_modules")), { recursive: true });
+    await Deno.writeTextFile(String(prefix("node_modules")), "not a dir");
+    await assertRejects(
+      () => installNpmTool(spec, { destDir: dir, run, os: "linux" }),
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("installNpmTool runs the ambient npm by default", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const echoed: string[] = [];
+    // With no injected runner, the default runner spawns `npm` via the Command
+    // class. Under a deep-dry-run echo sink it echoes the argv instead of
+    // spawning — so npm plants no bin and the post-install check then reports
+    // it, which proves the default runner (and its exact argv) was invoked.
+    await assertRejects(
+      () =>
+        withAmbientEcho(
+          (line) => echoed.push(line),
+          () =>
+            installNpmTool({ name: "vitest", version: "4.1.9" }, {
+              destDir: dir,
+              os: "linux",
+            }),
+        ),
+      Error,
+      "its bin was not found",
+    );
+    assertEquals(echoed.length, 1);
+    assertStringIncludes(echoed[0], "npm install --prefix");
+    assertStringIncludes(echoed[0], "--no-save vitest@4.1.9");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("installNpmTool defaults the install root to .zuke/tools and the host OS", async () => {
+  const dir = await Deno.makeTempDir();
+  const original = Deno.cwd();
+  try {
+    Deno.chdir(dir);
+    const { run } = fakeNpm("vitest"); // host OS
+    const bin = await installNpmTool(
+      { name: "vitest", version: "4.1.9" },
+      { run }, // no destDir, no os → .zuke/tools + host OS
+    );
+    assertEquals(
+      bin.path.endsWith(
+        `/.zuke/tools/npm/vitest@4.1.9/node_modules/.bin/vitest${EXE}`,
+      ),
+      true,
+    );
+  } finally {
+    Deno.chdir(original);
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/packages/core/tests/tool_test.ts
+++ b/packages/core/tests/tool_test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertThrows } from "./_assert.ts";
 import type { DownloadFn } from "../src/install.ts";
+import type { NpmRunner } from "../src/npm_tool.ts";
 import {
   DEFAULT_TOOLS_DIR,
   Toolchain,
@@ -9,12 +10,30 @@ import {
 } from "../src/tool.ts";
 
 const EXE = Deno.build.os === "windows" ? ".exe" : "";
+/** The npm bin-shim suffix on the host (`.cmd` on Windows, else none). */
+const NPM_EXE = Deno.build.os === "windows" ? ".cmd" : "";
 
 /** A download seam that writes the URL's own text, recording each URL fetched. */
 function recordingDownload(seen: string[]): DownloadFn {
   return async (url, dest) => {
     seen.push(url);
     await Deno.writeFile(String(dest), new TextEncoder().encode(url));
+  };
+}
+
+/** A fake npm runner that records argv and plants the named bin under `--prefix`. */
+function recordingNpm(
+  bin: string,
+  calls: string[][],
+): NpmRunner {
+  return async (args) => {
+    calls.push(args);
+    const prefix = args[args.indexOf("--prefix") + 1];
+    await Deno.mkdir(`${prefix}/node_modules/.bin`, { recursive: true });
+    await Deno.writeTextFile(
+      `${prefix}/node_modules/.bin/${bin}${NPM_EXE}`,
+      "x",
+    );
   };
 }
 
@@ -68,6 +87,58 @@ Deno.test("toolchain exposes its configured tools in order", () => {
     .tool((s) => s.name("a").url(() => "a"))
     .tool((s) => s.name("b").url(() => "b"));
   assertEquals(chain.tools.map((s) => s.name_), ["a", "b"]);
+});
+
+Deno.test("toolchain provisions npm tools alongside release tools", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const seen: string[] = [];
+    const npmCalls: string[][] = [];
+    const tools = toolchain((t) =>
+      t.tool((s) => s.name("helm").url(() => "https://tools.test/helm"))
+        .npm({ name: "vitest", version: "4.1.9" })
+    );
+    const bins = await tools.install({
+      destDir: dir,
+      download: recordingDownload(seen),
+      npmRun: recordingNpm("vitest", npmCalls),
+    });
+
+    assertEquals([...bins.keys()].sort(), ["helm", "vitest"]);
+    assertEquals(
+      bins.get("vitest")?.path.endsWith(
+        `/npm/vitest@4.1.9/node_modules/.bin/vitest${NPM_EXE}`,
+      ),
+      true,
+    );
+    assertEquals(npmCalls.length, 1);
+    assertEquals(npmCalls[0][4], "vitest@4.1.9");
+    assertEquals(seen, ["https://tools.test/helm"]);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("toolchain exposes its npm tools in declaration order", () => {
+  const chain = new Toolchain()
+    .npm({ name: "a", version: "1" })
+    .npm({ name: "b", version: "2" });
+  assertEquals(chain.npmTools.map((s) => s.name), ["a", "b"]);
+});
+
+Deno.test("ToolTasks.npm provisions a single npm package with a distinct bin", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const npmCalls: string[][] = [];
+    const bin = await ToolTasks.npm(
+      { name: "@nestjs/cli", version: "10.0.0", bin: "nest" },
+      { destDir: dir, run: recordingNpm("nest", npmCalls) },
+    );
+    assertEquals(bin.name, `nest${NPM_EXE}`);
+    assertEquals(npmCalls[0][4], "@nestjs/cli@10.0.0");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
 });
 
 Deno.test("a per-tool destDir overrides the toolchain default", async () => {

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -141,7 +141,9 @@ Before calling any task or settings method, confirm the real shape:
   value at run time (e.g. `execSecret(...)` shelling out to a secret CLI) and
   **redacts** it from all of Zuke's output. See the cheatsheet.
 - **Provisioning tools:** `ToolTasks.install((s) => …)` / `toolchain((t) => …)`
-  fetch pinned, checksum-verified tool binaries so a build is hermetic; hand the
+  fetch pinned, checksum-verified release binaries so a build is hermetic, and
+  `t.npm({ name, version, bin? })` / `ToolTasks.npm(...)` provision a
+  version-pinned, cached npm-registry package (needs `npm` on `PATH`); hand the
   returned path to a wrapper's `.toolPath(...)`. In a Node monorepo, resolve a
   wrapper's binary from `node_modules/.bin` npx-style instead —
   `.fromNodeModules()` on the settings (or `ZUKE_TOOL_RESOLUTION=node_modules`

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -387,15 +387,19 @@ hand it to a wrapper's `.toolPath(...)`, to `CmdTasks`, or to `defineTool`.
 ```ts
 import { toolchain, ToolTasks } from "jsr:@zuke/core";
 
-// One tool:
+// One release binary:
 bin = target().executes(async () =>
   await ToolTasks.install((s) =>
-    s.name("shellcheck").version("0.10.0" /* …checksum */)
+    s.name("shellcheck").url(shellcheckUrl).checksum(shellcheckSum)
   )
 );
 
-// Many at once:
-tools = toolchain((t) => t.add(/* … */).add(/* … */));
+// Many at once — release binaries via .tool(), npm packages via .npm():
+tools = toolchain((t) =>
+  t.tool((s) => s.name("helm").url(helmUrl))
+    .npm({ name: "vitest", version: "4.1.9" })
+);
+// install() returns Map<name, AbsolutePath>; npm packages need `npm` on PATH.
 ```
 
 **Resolve from `node_modules/.bin`** — in a Node monorepo where tool binaries

--- a/tests/integration/toolchain_npm_test.ts
+++ b/tests/integration/toolchain_npm_test.ts
@@ -1,0 +1,62 @@
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import { Build, target, toolchain } from "../../packages/core/mod.ts";
+import type { NpmRunner } from "../../packages/core/mod.ts";
+import { runCli } from "./_harness.ts";
+
+// A build that provisions an npm-package tool. The fake npm runner and the
+// install root are module-scoped so the target's body (captured at field-init)
+// reads them at execution time — set before each run.
+let npmCalls: string[][] = [];
+let toolsDir = "";
+
+/** Plants the expected bin under `--prefix`, recording argv — no real npm. */
+const fakeNpm: NpmRunner = async (args) => {
+  npmCalls.push(args);
+  const prefix = args[args.indexOf("--prefix") + 1];
+  await Deno.mkdir(`${prefix}/node_modules/.bin`, { recursive: true });
+  const exe = Deno.build.os === "windows" ? ".cmd" : "";
+  await Deno.writeTextFile(`${prefix}/node_modules/.bin/vitest${exe}`, "x");
+};
+
+class ProvisionBuild extends Build {
+  tools = toolchain((t) => t.npm({ name: "vitest", version: "4.1.9" }));
+
+  provision = target()
+    .description("provision an npm-package tool")
+    .executes(async () => {
+      const bins = await this.tools.install({
+        destDir: toolsDir,
+        npmRun: fakeNpm,
+      });
+      console.log(`vitest=${bins.get("vitest")}`);
+    });
+}
+
+Deno.test("a build provisions an npm-package tool end-to-end via the CLI", async () => {
+  npmCalls = [];
+  toolsDir = await Deno.makeTempDir({ prefix: "zuke-npm-it-" });
+  try {
+    const { code, out } = await runCli(ProvisionBuild, ["provision"]);
+    assertEquals(code, 0);
+    assertStringIncludes(out, "/npm/vitest@4.1.9/node_modules/.bin/vitest");
+    assertEquals(npmCalls.length, 1);
+    assertEquals(npmCalls[0][4], "vitest@4.1.9");
+  } finally {
+    await Deno.remove(toolsDir, { recursive: true });
+  }
+});
+
+Deno.test("re-provisioning the same pin reuses the cache (npm runs once)", async () => {
+  npmCalls = [];
+  toolsDir = await Deno.makeTempDir({ prefix: "zuke-npm-it-" });
+  try {
+    await runCli(ProvisionBuild, ["provision"]);
+    await runCli(ProvisionBuild, ["provision"]); // second run hits the marker
+    assertEquals(npmCalls.length, 1);
+  } finally {
+    await Deno.remove(toolsDir, { recursive: true });
+  }
+});


### PR DESCRIPTION
## Track B T2 — provision npm-package tools via `toolchain()`

Not every tool ships a release binary — many (`vitest`, `dprint`, `@nestjs/cli`,
…) live on the **npm registry**. This adds npm-package provisioning next to the
existing release-binary toolchain, so a build can pin and cache them without an
ambient `npm ci`.

### What's new

- **`installNpmTool(spec, options)`** (the npm counterpart of `installRelease`):
  runs a scoped, version-pinned `npm install --prefix <dir> --no-save
  <name>@<version>` into `<destDir>/npm/<name>@<version>` and returns the
  installed bin's `AbsolutePath` (`.cmd`-shimmed on Windows). A marker file
  records the pinned `{ name, version }`; a matching marker whose bin is still
  present **skips npm** on a later run.
- **`Toolchain.npm(spec)` / `ToolTasks.npm(spec, options?)`** — group npm tools
  in a toolchain (installed concurrently with release tools, keyed into the same
  `Map<name, AbsolutePath>`) or provision one directly. `bin` covers packages
  whose bin name differs from the package (`@nestjs/cli` → `nest`).
- **npm is the one ambient requirement** — it resolves and downloads the
  package; the subprocess goes through an injectable runner so tests are
  hermetic and network-free. An explicit `.toolPath(...)` pin still wins over
  `node_modules/.bin` resolution (composes with T1).

### Fails loudly, never poisons the cache

Mirroring `installRelease`, the install throws — **and records no marker** —
when the spec is malformed (an unsafe name, version, or bin), when npm fails, or
when npm exits 0 but the expected bin is absent (a typo'd `bin`, or a package
that ships no executable). A bad install errors once, here, instead of returning
a path to a nonexistent file that only breaks later at `.toolPath(...)` and
re-runs npm on every invocation forever.

### Tests

Unit (`packages/core/tests/npm_tool_test.ts`, + `tool_test.ts` for the
`Toolchain`/`ToolTasks` wiring) and integration
(`tests/integration/toolchain_npm_test.ts`, a real build provisioning a tool
end-to-end via the CLI) — all through a fake npm runner. `npm_tool.ts` is at
100% line/branch coverage.

### Adversarial review

Ran a 6-dimension adversarial pass (cache/marker correctness, path/argv safety,
concurrency, error handling, cross-platform, test adequacy) → refute-by-default
verify. **6 confirmed findings, all fixed with a regression test each:**

- **Returned a bin path without verifying npm produced it** — a typo'd `bin` or
  a bin-less package returned a phantom path and re-ran npm forever. Fixed with
  the post-install bin check above.
- **`..` in name/bin could escape `<destDir>`, and a leading-dash name could be
  parsed by npm as a flag** (both trusted-author-gated). Fixed with front-door
  name/version/bin validation that rejects the offender with a friendly error
  *before* npm runs (a valid scoped `@nestjs/cli` still passes).
- **Untested error paths** — a rejecting npm runner propagating without writing
  a marker, and the non-`NotFound` re-throw arms — now have regression tests
  (the coverage lift to 100%).

The one finding left as-is by design: a missing-`npm` spawn surfaces the raw
Deno error, exactly as `installRelease` leaves its download/copy errors
unwrapped — consistent sibling behavior, not a regression.

### Gate

`deno task ci` green (lines 98.2%, branches 95.1%); `apiDocsCheck`,
`generate-ci --check`, and `deno doc --lint` over all five core entrypoints
clean; `docs/installing-tools.md` and the `zuke-write-build` skill updated.
