### PR TITLE
feat(core): zip archive support in installRelease

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -57,6 +57,7 @@
     "dprint",
     "effectful",
     "endgroup",
+    "eocd",
     "esac",
     "exfiltrate",
     "fpath",

--- a/docs/installing-tools.md
+++ b/docs/installing-tools.md
@@ -61,25 +61,27 @@ await CmdTasks.exec(String(bin), (s) => s.args("--version"));
 | `.name(name)`                | The tool name, and the installed filename (`.exe` is appended on Windows). **Required.**                           |
 | `.url((platform) => string)` | Resolve the download URL for the target platform (see [platforms](#cross-platform-url-resolution)). **Required.**  |
 | `.destDir(dir)`              | Directory to install into (created if missing). Defaults to `.zuke/tools`.                                         |
-| `.archive("tar.gz")`         | Unpack a gzipped tarball; the default `"raw"` treats the download as the binary.                                   |
-| `.binaryPath(path)`          | For a `tar.gz`, the binary's path _inside_ the archive. Defaults to the name.                                      |
+| `.archive("tar.gz" \| "zip")` | Unpack a gzipped tarball or a zip; the default `"raw"` treats the download as the binary.                         |
+| `.binaryPath(path)`          | For an archive, the binary's path _inside_ it. Defaults to the name.                                               |
 | `.checksum(sha256)`          | Expected SHA-256, or a `(platform) => string` resolver — [verifies and caches](#pinning-verification-and-caching). |
 | `.platform({ os, arch })`    | Resolve for a specific platform instead of the host.                                                               |
 | `.download(fn)`              | Override the downloader (defaults to an HTTPS download); mainly a test seam.                                       |
 
-### Raw binaries vs. tarballs
+### Raw binaries vs. archives
 
 - **`"raw"`** (default) — the URL points straight at the executable; it's saved
   as `<destDir>/<name>` and `chmod +x`'d.
-- **`.archive("tar.gz")`** — the URL points at a gzipped tarball; Zuke unpacks
-  it to a scratch directory, copies `.binaryPath(...)` (default the name) out to
-  `<destDir>/<name>`, then discards the scratch. Set `.binaryPath(...)` when the
-  binary lives in a subdirectory of the archive (e.g. Helm ships it under
-  `linux-amd64/helm`).
+- **`.archive("tar.gz")` / `.archive("zip")`** — the URL points at a gzipped
+  tarball or a zip; Zuke unpacks it to a scratch directory, copies
+  `.binaryPath(...)` (default the name) out to `<destDir>/<name>`, then discards
+  the scratch. Set `.binaryPath(...)` when the binary lives in a subdirectory of
+  the archive (e.g. Helm ships it under `linux-amd64/helm`). Zip reading covers
+  the `stored` and `deflate` methods release assets use (dprint et al. ship
+  zip-only); encrypted or zip64 archives are rejected with a clear error, and no
+  archive entry may escape the destination directory (a "zip slip").
 
-Zip archives are not yet supported, so this targets the Unix runners where most
-release tarballs are published. On Windows the installed filename gains an
-`.exe` suffix and the executable bit is skipped.
+On Windows the installed filename gains an `.exe` suffix and the executable bit
+is skipped.
 
 ## Pinning, verification, and caching
 
@@ -106,9 +108,10 @@ publish — and it does three jobs at once:
    re-downloaded and re-verified, never silently reused. Bumping the checksum
    for a new version is a natural miss that re-fetches.
 
-What the checksum covers depends on the format: for `"tar.gz"` it's the SHA-256
-of the **archive** (what projects list in their `checksums.txt`/`sha256sum`
-files); for `"raw"` it's the SHA-256 of the **binary** itself.
+What the checksum covers depends on the format: for `"tar.gz"` and `"zip"` it's
+the SHA-256 of the **archive** (what projects list in their
+`checksums.txt`/`sha256sum` files); for `"raw"` it's the SHA-256 of the
+**binary** itself.
 
 Without a checksum, the tool is downloaded every run and left unverified — fine
 for a quick spike, but pin one for anything real.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -83,6 +83,11 @@ function assertExists<T>(value: T, message: string): NonNullable<T>
 async function assertFileExists(path: PathLike): Promise<void>
   Assert that `path` exists and is a file. Async (stats the filesystem).
 
+function assertSafeEntryName(name: string): void
+  Reject an archive entry whose name would escape the destination directory — an
+  absolute path or one with a `..` segment (a "zip slip"). A downloaded or
+  poisoned archive must never place files outside where it is being unpacked.
+
 async function cancelRun(build: Build, options: CancelOptions): Promise<CancelResult>
   Cancel the run `options.runId` for `build`: transition it to `cancelling`
   (exactly one canceller drives the walk; a live owning process observes the
@@ -218,6 +223,12 @@ function externalSignal(name: string): WaitTrigger
 async function extractTarGzip(src: PathLike, destDir: PathLike): Promise<void>
   Read the `.tar.gz` at `src`, gunzip and unpack it, and write each entry under
   `destDir` (creating parent directories as needed).
+
+async function extractZip(src: PathLike, destDir: PathLike): Promise<void>
+  Read the `.zip` at `src`, unpack it, and write each entry under `destDir`
+  (creating parent directories as needed) — the zip counterpart of
+  {@link extractTarGzip}. Entry names are validated so a malicious archive
+  cannot escape `destDir`.
 
 function fail(message: string): never
   Throw an {@link AssertionError} with `message`. Never returns.
@@ -511,6 +522,16 @@ function toolchain(configure?: (t: Toolchain) => void): Toolchain
 
 function untar(archive: Uint8Array): TarEntry[]
   Extract the entries from a `ustar` archive (regular files only).
+
+async function unzip(archive: Uint8Array): Promise<TarEntry[]>
+  Read the entries of a `.zip` archive, decompressing `stored` and `deflate`
+  members. The central directory is the source of truth. Directory entries (a
+  trailing `/`) are skipped. Encrypted, zip64, or otherwise-compressed entries
+  throw a friendly error naming the offending entry, and a header or data field
+  that runs past the archive is reported as a malformed zip (not a raw
+  out-of-bounds error). Every offset read from the archive is bounds-checked;
+  for integrity against a tampered download, pin a `.checksum(...)`, which is
+  verified before the archive is ever parsed.
 
 function validateGraph(targets: Map<string, TargetBuilder>): void
   Validate the whole graph: unknown references first, then cycles.
@@ -1563,7 +1584,7 @@ class ToolInstallSettings
     Resolves the per-platform download URL. Set by {@link url}.
   destDir_?: PathLike
     Install directory (overrides the toolchain's). Set by {@link destDir}.
-  archive_?: "raw" | "tar.gz"
+  archive_?: "raw" | "tar.gz" | "zip"
     Download format. Set by {@link archive}.
   binaryPath_?: string
     The binary's path within a `tar.gz`. Set by {@link binaryPath}.
@@ -1579,10 +1600,11 @@ class ToolInstallSettings
     Resolve the download URL for the target {@link Platform}.
   destDir(dir: PathLike): this
     The directory to install the binary into (created if missing).
-  archive(format: "raw" | "tar.gz"): this
-    Treat the download as a `"tar.gz"` (default `"raw"`, the bare binary).
+  archive(format: "raw" | "tar.gz" | "zip"): this
+    Treat the download as a `"tar.gz"` or `"zip"` to unpack (default `"raw"`,
+    the bare binary). Pair with {@link binaryPath} for the binary inside.
   binaryPath(path: string): this
-    For a `tar.gz`, the binary's path within the archive (defaults to the name).
+    For an archive, the binary's path within it (defaults to the name).
   checksum(sha256: string | ((platform: Platform) => string)): this
     The expected SHA-256 (hex) of the downloaded artifact — verifies and caches
     the install. Pass a `({ os, arch }) => string` resolver to pin it per
@@ -2324,12 +2346,13 @@ interface InstallReleaseOptions
     Resolve the download URL for the target {@link Platform}.
   destDir: PathLike
     The directory to install the binary into (created if missing).
-  archive?: "raw" | "tar.gz"
+  archive?: "raw" | "tar.gz" | "zip"
     The download format. `"raw"` (default) treats the download as the binary
-    itself; `"tar.gz"` unpacks it and takes {@link binaryPath} from inside.
+    itself; `"tar.gz"` and `"zip"` unpack it and take {@link binaryPath} from
+    inside. Many release assets ship one or the other.
   binaryPath?: string
-    For a `"tar.gz"` archive, the binary's path within the archive. Defaults to
-    {@link name}.
+    For a `"tar.gz"` or `"zip"` archive, the binary's path within the archive.
+    Defaults to {@link name}.
   platform?: InstallPlatform
     The platform to resolve the URL for. Defaults to {@link hostPlatform}.
     Override it to install a foreign binary or to unit-test URL resolution.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -137,6 +137,11 @@ function assertExists<T>(value: T, message: string): NonNullable<T>
 async function assertFileExists(path: PathLike): Promise<void>
   Assert that `path` exists and is a file. Async (stats the filesystem).
 
+function assertSafeEntryName(name: string): void
+  Reject an archive entry whose name would escape the destination directory — an
+  absolute path or one with a `..` segment (a "zip slip"). A downloaded or
+  poisoned archive must never place files outside where it is being unpacked.
+
 async function cancelRun(build: Build, options: CancelOptions): Promise<CancelResult>
   Cancel the run `options.runId` for `build`: transition it to `cancelling`
   (exactly one canceller drives the walk; a live owning process observes the
@@ -272,6 +277,12 @@ function externalSignal(name: string): WaitTrigger
 async function extractTarGzip(src: PathLike, destDir: PathLike): Promise<void>
   Read the `.tar.gz` at `src`, gunzip and unpack it, and write each entry under
   `destDir` (creating parent directories as needed).
+
+async function extractZip(src: PathLike, destDir: PathLike): Promise<void>
+  Read the `.zip` at `src`, unpack it, and write each entry under `destDir`
+  (creating parent directories as needed) — the zip counterpart of
+  {@link extractTarGzip}. Entry names are validated so a malicious archive
+  cannot escape `destDir`.
 
 function fail(message: string): never
   Throw an {@link AssertionError} with `message`. Never returns.
@@ -565,6 +576,16 @@ function toolchain(configure?: (t: Toolchain) => void): Toolchain
 
 function untar(archive: Uint8Array): TarEntry[]
   Extract the entries from a `ustar` archive (regular files only).
+
+async function unzip(archive: Uint8Array): Promise<TarEntry[]>
+  Read the entries of a `.zip` archive, decompressing `stored` and `deflate`
+  members. The central directory is the source of truth. Directory entries (a
+  trailing `/`) are skipped. Encrypted, zip64, or otherwise-compressed entries
+  throw a friendly error naming the offending entry, and a header or data field
+  that runs past the archive is reported as a malformed zip (not a raw
+  out-of-bounds error). Every offset read from the archive is bounds-checked;
+  for integrity against a tampered download, pin a `.checksum(...)`, which is
+  verified before the archive is ever parsed.
 
 function validateGraph(targets: Map<string, TargetBuilder>): void
   Validate the whole graph: unknown references first, then cycles.
@@ -1617,7 +1638,7 @@ class ToolInstallSettings
     Resolves the per-platform download URL. Set by {@link url}.
   destDir_?: PathLike
     Install directory (overrides the toolchain's). Set by {@link destDir}.
-  archive_?: "raw" | "tar.gz"
+  archive_?: "raw" | "tar.gz" | "zip"
     Download format. Set by {@link archive}.
   binaryPath_?: string
     The binary's path within a `tar.gz`. Set by {@link binaryPath}.
@@ -1633,10 +1654,11 @@ class ToolInstallSettings
     Resolve the download URL for the target {@link Platform}.
   destDir(dir: PathLike): this
     The directory to install the binary into (created if missing).
-  archive(format: "raw" | "tar.gz"): this
-    Treat the download as a `"tar.gz"` (default `"raw"`, the bare binary).
+  archive(format: "raw" | "tar.gz" | "zip"): this
+    Treat the download as a `"tar.gz"` or `"zip"` to unpack (default `"raw"`,
+    the bare binary). Pair with {@link binaryPath} for the binary inside.
   binaryPath(path: string): this
-    For a `tar.gz`, the binary's path within the archive (defaults to the name).
+    For an archive, the binary's path within it (defaults to the name).
   checksum(sha256: string | ((platform: Platform) => string)): this
     The expected SHA-256 (hex) of the downloaded artifact — verifies and caches
     the install. Pass a `({ os, arch }) => string` resolver to pin it per
@@ -2378,12 +2400,13 @@ interface InstallReleaseOptions
     Resolve the download URL for the target {@link Platform}.
   destDir: PathLike
     The directory to install the binary into (created if missing).
-  archive?: "raw" | "tar.gz"
+  archive?: "raw" | "tar.gz" | "zip"
     The download format. `"raw"` (default) treats the download as the binary
-    itself; `"tar.gz"` unpacks it and takes {@link binaryPath} from inside.
+    itself; `"tar.gz"` and `"zip"` unpack it and take {@link binaryPath} from
+    inside. Many release assets ship one or the other.
   binaryPath?: string
-    For a `"tar.gz"` archive, the binary's path within the archive. Defaults to
-    {@link name}.
+    For a `"tar.gz"` or `"zip"` archive, the binary's path within the archive.
+    Defaults to {@link name}.
   platform?: InstallPlatform
     The platform to resolve the URL for. Defaults to {@link hostPlatform}.
     Override it to install a foreign binary or to unit-test URL resolution.

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -266,13 +266,16 @@ export {
   TeamsAnnouncementSettings,
 } from "./src/announce.ts";
 export {
+  assertSafeEntryName,
   createTarGzip,
   extractTarGzip,
+  extractZip,
   gunzip,
   gzip,
   tar,
   type TarEntry,
   untar,
+  unzip,
 } from "./src/compression.ts";
 export {
   type DownloadFn,

--- a/packages/core/src/compression.ts
+++ b/packages/core/src/compression.ts
@@ -1,24 +1,46 @@
 /**
- * Compression helpers for build scripts: gzip/gunzip byte streams and read or
- * write `tar` / `.tar.gz` archives. Dependency-free — gzip uses the platform
- * `CompressionStream`, and the tar reader/writer implements the POSIX `ustar`
- * format directly.
+ * Compression helpers for build scripts: gzip/gunzip byte streams, read or write
+ * `tar` / `.tar.gz` archives, and read `.zip` archives. Dependency-free — gzip
+ * and deflate use the platform `CompressionStream`/`DecompressionStream`, and
+ * the tar reader/writer and the zip reader implement the formats directly.
  *
  * ```ts
- * import { createTarGzip, extractTarGzip } from "jsr:@zuke/core";
+ * import { createTarGzip, extractTarGzip, extractZip } from "jsr:@zuke/core";
  *
  * await createTarGzip(["dist/app.js", "README.md"], "artifact.tar.gz");
  * await extractTarGzip("artifact.tar.gz", "out");
+ * await extractZip("tool.zip", "out"); // read-only: many release assets ship zip
  * ```
  *
  * `tar` entry names are limited to 100 bytes (the `ustar` name field); longer
  * names throw. Archives are written with a fixed mtime so output is
- * reproducible.
+ * reproducible. Zip reading supports the two methods release assets use —
+ * `stored` and `deflate` — and rejects encrypted or zip64 archives with a
+ * friendly error; every extractor rejects an entry name that would escape the
+ * destination directory (a "zip slip").
  *
  * @module
  */
 
 import type { PathLike } from "./path.ts";
+
+/**
+ * Reject an archive entry whose name would escape the destination directory — an
+ * absolute path or one with a `..` segment (a "zip slip"). A downloaded or
+ * poisoned archive must never place files outside where it is being unpacked.
+ */
+export function assertSafeEntryName(name: string): void {
+  const normalized = name.replace(/\\/g, "/");
+  if (normalized.startsWith("/") || /^[A-Za-z]:/.test(normalized)) {
+    throw new Error(`archive: refusing to unpack an absolute path: "${name}".`);
+  }
+  if (normalized.split("/").some((segment) => segment === "..")) {
+    throw new Error(
+      `archive: refusing to unpack a path that escapes the destination: ` +
+        `"${name}".`,
+    );
+  }
+}
 
 /** Gzip-compress `data` using the platform `CompressionStream`. */
 export async function gzip(data: Uint8Array): Promise<Uint8Array> {
@@ -200,8 +222,21 @@ export async function extractTarGzip(
   destDir: PathLike,
 ): Promise<void> {
   const archive = untar(await gunzip(await Deno.readFile(String(src))));
+  await writeEntries(archive, destDir);
+}
+
+/**
+ * Write each archive `entry` under `destDir`, creating parent directories as
+ * needed. Every entry name is validated first ({@link assertSafeEntryName}), so
+ * a malicious archive cannot plant a file outside `destDir` (a "zip slip").
+ */
+async function writeEntries(
+  entries: TarEntry[],
+  destDir: PathLike,
+): Promise<void> {
+  for (const entry of entries) assertSafeEntryName(entry.name);
   const root = String(destDir);
-  for (const entry of archive) {
+  for (const entry of entries) {
     const path = `${root}/${entry.name}`;
     const slash = path.lastIndexOf("/");
     if (slash !== -1) {
@@ -209,4 +244,163 @@ export async function extractTarGzip(
     }
     await Deno.writeFile(path, entry.data);
   }
+}
+
+// --- ZIP reading -----------------------------------------------------------
+// Many release assets (dprint, deno, …) ship a `.zip`, so installing a tool
+// needs to read one. This is a *reader* only — the central directory is the
+// authoritative index — supporting the two methods release zips use.
+
+/** The End Of Central Directory record signature. */
+const ZIP_EOCD_SIG = 0x06054b50;
+/** The central-directory file-header signature. */
+const ZIP_CD_SIG = 0x02014b50;
+/** The local file-header signature. */
+const ZIP_LOCAL_SIG = 0x04034b50;
+/** Compression method: stored (no compression). */
+const ZIP_STORED = 0;
+/** Compression method: DEFLATE. */
+const ZIP_DEFLATE = 8;
+/** The 32-bit sentinel a field carries when its real value lives in a zip64 record. */
+const ZIP64_SENTINEL = 0xffffffff;
+
+/** Inflate a raw DEFLATE stream via the platform `DecompressionStream`. */
+async function inflateRaw(data: Uint8Array): Promise<Uint8Array> {
+  const stream = new Blob([new Uint8Array(data)]).stream().pipeThrough(
+    new DecompressionStream("deflate-raw"),
+  );
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+/**
+ * Find the offset of the End Of Central Directory record, scanning back from the
+ * end past a possible trailing comment (≤ 65535 bytes). Throws if none is found.
+ */
+function findEocd(view: DataView, length: number): number {
+  const earliest = Math.max(0, length - 22 - 0xffff);
+  for (let i = length - 22; i >= earliest; i--) {
+    if (view.getUint32(i, true) === ZIP_EOCD_SIG) return i;
+  }
+  throw new Error(
+    "zip: no end-of-central-directory record found (not a zip archive?).",
+  );
+}
+
+/** Read one entry's bytes from its local header, decompressing per `method`. */
+async function readLocalEntry(
+  view: DataView,
+  archive: Uint8Array,
+  offset: number,
+  compressedSize: number,
+  method: number,
+  name: string,
+): Promise<Uint8Array> {
+  if (
+    offset + 30 > archive.length ||
+    view.getUint32(offset, true) !== ZIP_LOCAL_SIG
+  ) {
+    throw new Error(`zip: malformed local header for entry "${name}".`);
+  }
+  // The local header's own name/extra lengths can differ from the central
+  // directory's, so re-read them here to locate the compressed data.
+  const nameLen = view.getUint16(offset + 26, true);
+  const extraLen = view.getUint16(offset + 28, true);
+  const start = offset + 30 + nameLen + extraLen;
+  if (start + compressedSize > archive.length) {
+    throw new Error(
+      `zip: entry "${name}" data runs past the archive (malformed).`,
+    );
+  }
+  const raw = archive.subarray(start, start + compressedSize);
+  if (method === ZIP_STORED) return raw.slice();
+  if (method === ZIP_DEFLATE) return await inflateRaw(raw);
+  throw new Error(
+    `zip: unsupported compression method ${method} for entry "${name}".`,
+  );
+}
+
+/**
+ * Read the entries of a `.zip` archive, decompressing `stored` and `deflate`
+ * members. The central directory is the source of truth. Directory entries (a
+ * trailing `/`) are skipped. Encrypted, zip64, or otherwise-compressed entries
+ * throw a friendly error naming the offending entry, and a header or data field
+ * that runs past the archive is reported as a malformed zip (not a raw
+ * out-of-bounds error). Every offset read from the archive is bounds-checked;
+ * for integrity against a tampered download, pin a `.checksum(...)`, which is
+ * verified before the archive is ever parsed.
+ */
+export async function unzip(archive: Uint8Array): Promise<TarEntry[]> {
+  const view = new DataView(
+    archive.buffer,
+    archive.byteOffset,
+    archive.byteLength,
+  );
+  const eocd = findEocd(view, archive.length);
+  const count = view.getUint16(eocd + 10, true);
+  const cdOffset = view.getUint32(eocd + 16, true);
+  if (count === 0xffff || cdOffset === ZIP64_SENTINEL) {
+    throw new Error("zip: unsupported zip feature (zip64).");
+  }
+  const entries: TarEntry[] = [];
+  let p = cdOffset;
+  for (let i = 0; i < count; i++) {
+    // Bounds-check every field read from the untrusted archive: a header
+    // running past the end is a malformed zip, not a raw DataView RangeError.
+    if (p + 46 > archive.length || view.getUint32(p, true) !== ZIP_CD_SIG) {
+      throw new Error("zip: malformed central directory.");
+    }
+    const flags = view.getUint16(p + 8, true);
+    const method = view.getUint16(p + 10, true);
+    const compressedSize = view.getUint32(p + 20, true);
+    const uncompressedSize = view.getUint32(p + 24, true);
+    const nameLen = view.getUint16(p + 28, true);
+    const extraLen = view.getUint16(p + 30, true);
+    const commentLen = view.getUint16(p + 32, true);
+    const localOffset = view.getUint32(p + 42, true);
+    if (p + 46 + nameLen > archive.length) {
+      throw new Error("zip: malformed central directory (name runs past end).");
+    }
+    const name = new TextDecoder().decode(
+      archive.subarray(p + 46, p + 46 + nameLen),
+    );
+    if ((flags & 0x0001) !== 0) {
+      throw new Error(
+        `zip: unsupported zip feature (encrypted entry "${name}").`,
+      );
+    }
+    if (
+      compressedSize === ZIP64_SENTINEL ||
+      uncompressedSize === ZIP64_SENTINEL || localOffset === ZIP64_SENTINEL
+    ) {
+      throw new Error(`zip: unsupported zip feature (zip64 entry "${name}").`);
+    }
+    if (!name.endsWith("/")) {
+      entries.push({
+        name,
+        data: await readLocalEntry(
+          view,
+          archive,
+          localOffset,
+          compressedSize,
+          method,
+          name,
+        ),
+      });
+    }
+    p += 46 + nameLen + extraLen + commentLen;
+  }
+  return entries;
+}
+
+/**
+ * Read the `.zip` at `src`, unpack it, and write each entry under `destDir`
+ * (creating parent directories as needed) — the zip counterpart of
+ * {@link extractTarGzip}. Entry names are validated so a malicious archive
+ * cannot escape `destDir`.
+ */
+export async function extractZip(
+  src: PathLike,
+  destDir: PathLike,
+): Promise<void> {
+  await writeEntries(await unzip(await Deno.readFile(String(src))), destDir);
 }

--- a/packages/core/src/install.ts
+++ b/packages/core/src/install.ts
@@ -5,8 +5,8 @@
  *
  * {@link installRelease} resolves a per-platform URL, downloads it (reusing
  * {@link httpDownload}), unpacks a `.tar.gz` (reusing {@link extractTarGzip}) or
- * takes a raw single binary, drops it into a directory, marks it executable, and
- * returns its {@link AbsolutePath}.
+ * a `.zip` (reusing {@link extractZip}) or takes a raw single binary, drops it
+ * into a directory, marks it executable, and returns its {@link AbsolutePath}.
  *
  * ```ts
  * import { installRelease } from "jsr:@zuke/core";
@@ -25,14 +25,11 @@
  * await CmdTasks.exec(String(bin), (s) => s.args("version"));
  * ```
  *
- * Zip archives are not yet supported (only raw binaries and `.tar.gz`), so this
- * targets the Unix CI runners where most release tarballs are published.
- *
  * @module
  */
 
 import { httpDownload } from "./http.ts";
-import { extractTarGzip } from "./compression.ts";
+import { extractTarGzip, extractZip } from "./compression.ts";
 import { type AbsolutePath, absolutePath, type PathLike } from "./path.ts";
 import {
   type Architecture,
@@ -122,12 +119,13 @@ export interface InstallReleaseOptions {
   destDir: PathLike;
   /**
    * The download format. `"raw"` (default) treats the download as the binary
-   * itself; `"tar.gz"` unpacks it and takes {@link binaryPath} from inside.
+   * itself; `"tar.gz"` and `"zip"` unpack it and take {@link binaryPath} from
+   * inside. Many release assets ship one or the other.
    */
-  archive?: "raw" | "tar.gz";
+  archive?: "raw" | "tar.gz" | "zip";
   /**
-   * For a `"tar.gz"` archive, the binary's path within the archive. Defaults to
-   * {@link name}.
+   * For a `"tar.gz"` or `"zip"` archive, the binary's path within the archive.
+   * Defaults to {@link name}.
    */
   binaryPath?: string;
   /**
@@ -300,10 +298,11 @@ export async function installRelease(
   const url = options.url(platform);
   await Deno.mkdir(String(dir), { recursive: true });
 
-  if ((options.archive ?? "raw") === "tar.gz") {
+  const archive = options.archive ?? "raw";
+  if (archive === "tar.gz" || archive === "zip") {
     const scratch = await Deno.makeTempDir();
     try {
-      const archivePath = `${scratch}/download.tar.gz`;
+      const archivePath = `${scratch}/download.${archive}`;
       await download(url, archivePath);
       if (checksum !== undefined) {
         await verifyChecksum(
@@ -313,7 +312,8 @@ export async function installRelease(
         );
       }
       const unpacked = `${scratch}/unpacked`;
-      await extractTarGzip(archivePath, unpacked);
+      if (archive === "zip") await extractZip(archivePath, unpacked);
+      else await extractTarGzip(archivePath, unpacked);
       await Deno.copyFile(
         `${unpacked}/${options.binaryPath ?? options.name}`,
         String(target),

--- a/packages/core/src/tool.ts
+++ b/packages/core/src/tool.ts
@@ -67,7 +67,7 @@ export class ToolInstallSettings {
   /** Install directory (overrides the toolchain's). Set by {@link destDir}. */
   destDir_?: PathLike;
   /** Download format. Set by {@link archive}. */
-  archive_?: "raw" | "tar.gz";
+  archive_?: "raw" | "tar.gz" | "zip";
   /** The binary's path within a `tar.gz`. Set by {@link binaryPath}. */
   binaryPath_?: string;
   /** Expected SHA-256 (or a per-platform resolver). Set by {@link checksum}. */
@@ -95,13 +95,16 @@ export class ToolInstallSettings {
     return this;
   }
 
-  /** Treat the download as a `"tar.gz"` (default `"raw"`, the bare binary). */
-  archive(format: "raw" | "tar.gz"): this {
+  /**
+   * Treat the download as a `"tar.gz"` or `"zip"` to unpack (default `"raw"`,
+   * the bare binary). Pair with {@link binaryPath} for the binary inside.
+   */
+  archive(format: "raw" | "tar.gz" | "zip"): this {
     this.archive_ = format;
     return this;
   }
 
-  /** For a `tar.gz`, the binary's path within the archive (defaults to the name). */
+  /** For an archive, the binary's path within it (defaults to the name). */
   binaryPath(path: string): this {
     this.binaryPath_ = path;
     return this;

--- a/packages/core/tests/_zip.ts
+++ b/packages/core/tests/_zip.ts
@@ -1,0 +1,114 @@
+/**
+ * Build a `.zip` archive in memory for the compression/install tests — no
+ * network, no ambient tools. Supports the two methods a release asset uses
+ * (`stored` and `deflate`) plus the knobs the adversarial tests need
+ * (encryption flag, zip64 sentinels, a bogus method), so a fixture is a plain
+ * value the reader can be driven against.
+ */
+
+/** Compression method: stored (no compression). */
+export const STORED = 0;
+/** Compression method: DEFLATE. */
+export const DEFLATE = 8;
+
+/** One entry to place in a fixture zip. */
+export interface ZipEntrySpec {
+  /** The entry name (a trailing `/` marks a directory entry, which carries no data). */
+  name: string;
+  /** The uncompressed contents (omitted for a directory entry). */
+  data?: Uint8Array;
+  /** The compression method (default {@link STORED}). */
+  method?: number;
+  /** General-purpose flags (set `0x0001` to mark the entry encrypted). */
+  flags?: number;
+  /** Force the zip64 sentinels in the central directory (compressed/uncompressed size + offset). */
+  zip64?: boolean;
+  /**
+   * Bytes for the LOCAL header's extra field (the central directory's stays
+   * empty) — so a reader that uses the central-directory extra length instead of
+   * the local one lands on the wrong data offset.
+   */
+  localExtra?: Uint8Array;
+}
+
+/** Raw-DEFLATE `data` via the platform `CompressionStream` (matches the reader). */
+async function deflateRaw(data: Uint8Array): Promise<Uint8Array> {
+  const stream = new Blob([new Uint8Array(data)]).stream().pipeThrough(
+    new CompressionStream("deflate-raw"),
+  );
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+const SENTINEL = 0xffffffff;
+
+/** Assemble a valid `.zip` byte array from `specs` (local headers → central dir → EOCD). */
+export async function makeZip(specs: ZipEntrySpec[]): Promise<Uint8Array> {
+  const enc = new TextEncoder();
+  const local: Uint8Array[] = [];
+  const central: Uint8Array[] = [];
+  let offset = 0;
+
+  for (const spec of specs) {
+    const method = spec.method ?? STORED;
+    const flags = spec.flags ?? 0;
+    const data = spec.data ?? new Uint8Array(0);
+    const localExtra = spec.localExtra ?? new Uint8Array(0);
+    const nameBytes = enc.encode(spec.name);
+    const comp = method === DEFLATE ? await deflateRaw(data) : data;
+
+    const lh = new Uint8Array(
+      30 + nameBytes.length + localExtra.length + comp.length,
+    );
+    const lv = new DataView(lh.buffer);
+    lv.setUint32(0, 0x04034b50, true);
+    lv.setUint16(4, 20, true); // version needed
+    lv.setUint16(6, flags, true);
+    lv.setUint16(8, method, true);
+    lv.setUint32(14, 0, true); // crc (the reader does not validate it)
+    lv.setUint32(18, comp.length, true); // real sizes so the data is locatable
+    lv.setUint32(22, data.length, true);
+    lv.setUint16(26, nameBytes.length, true);
+    lv.setUint16(28, localExtra.length, true); // local extra field (CD's stays 0)
+    lh.set(nameBytes, 30);
+    lh.set(localExtra, 30 + nameBytes.length);
+    lh.set(comp, 30 + nameBytes.length + localExtra.length);
+    local.push(lh);
+
+    const ch = new Uint8Array(46 + nameBytes.length);
+    const cv = new DataView(ch.buffer);
+    cv.setUint32(0, 0x02014b50, true);
+    cv.setUint16(4, 20, true); // version made by
+    cv.setUint16(6, 20, true); // version needed
+    cv.setUint16(8, flags, true);
+    cv.setUint16(10, method, true);
+    cv.setUint32(16, 0, true); // crc
+    cv.setUint32(20, spec.zip64 ? SENTINEL : comp.length, true);
+    cv.setUint32(24, spec.zip64 ? SENTINEL : data.length, true);
+    cv.setUint16(28, nameBytes.length, true);
+    cv.setUint32(42, spec.zip64 ? SENTINEL : offset, true); // local header offset
+    ch.set(nameBytes, 46);
+    central.push(ch);
+
+    offset += lh.length;
+  }
+
+  const cdStart = offset;
+  const cdSize = central.reduce((n, c) => n + c.length, 0);
+  const eocd = new Uint8Array(22);
+  const ev = new DataView(eocd.buffer);
+  ev.setUint32(0, 0x06054b50, true);
+  ev.setUint16(8, specs.length, true); // records on this disk
+  ev.setUint16(10, specs.length, true); // total records
+  ev.setUint32(12, cdSize, true);
+  ev.setUint32(16, cdStart, true);
+
+  const chunks = [...local, ...central, eocd];
+  const total = chunks.reduce((n, c) => n + c.length, 0);
+  const out = new Uint8Array(total);
+  let o = 0;
+  for (const c of chunks) {
+    out.set(c, o);
+    o += c.length;
+  }
+  return out;
+}

--- a/packages/core/tests/compression_test.ts
+++ b/packages/core/tests/compression_test.ts
@@ -1,13 +1,17 @@
-import { assertEquals, assertRejects } from "./_assert.ts";
+import { assertEquals, assertRejects, assertThrows } from "./_assert.ts";
 import {
+  assertSafeEntryName,
   createTarGzip,
   extractTarGzip,
+  extractZip,
   gunzip,
   gzip,
   tar,
   type TarEntry,
   untar,
+  unzip,
 } from "../src/compression.ts";
+import { DEFLATE, makeZip, STORED } from "./_zip.ts";
 
 const enc = (s: string) => new TextEncoder().encode(s);
 const dec = (b: Uint8Array) => new TextDecoder().decode(b);
@@ -106,4 +110,217 @@ Deno.test("createTarGzip fails clearly when a file is missing", async () => {
   } finally {
     await Deno.remove(dir, { recursive: true });
   }
+});
+
+Deno.test("extractTarGzip refuses a path that escapes the destination", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    // A hand-built archive with a traversing entry — a poisoned tarball.
+    const archive = `${dir}/evil.tar.gz`;
+    await Deno.writeFile(
+      String(archive),
+      await gzip(tar([
+        { name: "../escape.txt", data: enc("pwned") },
+      ])),
+    );
+    await assertRejects(
+      () => extractTarGzip(archive, `${dir}/out`),
+      Error,
+      "escapes the destination",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("unzip round-trips a stored and a deflate entry", async () => {
+  const compressible = enc("deflate ".repeat(200));
+  const zip = await makeZip([
+    { name: "raw.txt", data: enc("stored-bytes"), method: STORED },
+    { name: "packed.txt", data: compressible, method: DEFLATE },
+  ]);
+  const out = await unzip(zip);
+  assertEquals(out.map((e) => e.name), ["raw.txt", "packed.txt"]);
+  assertEquals(dec(out[0].data), "stored-bytes");
+  assertEquals(dec(out[1].data), dec(compressible));
+});
+
+Deno.test("unzip skips directory entries and keeps nested files", async () => {
+  const zip = await makeZip([
+    { name: "bin/" }, // directory entry — no data
+    { name: "bin/tool", data: enc("#!/bin/sh\n"), method: DEFLATE },
+  ]);
+  const out = await unzip(zip);
+  assertEquals(out.map((e) => e.name), ["bin/tool"]);
+  assertEquals(dec(out[0].data), "#!/bin/sh\n");
+});
+
+Deno.test("extractZip writes files (stored + deflate + nested) to disk", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const zip = `${dir}/tool.zip`;
+    await Deno.writeFile(
+      zip,
+      await makeZip([
+        { name: "dprint", data: enc("BINARY"), method: STORED },
+        {
+          name: "lib/notes.txt",
+          data: enc("read me".repeat(50)),
+          method: DEFLATE,
+        },
+      ]),
+    );
+    await extractZip(zip, `${dir}/out`);
+    assertEquals(await Deno.readTextFile(`${dir}/out/dprint`), "BINARY");
+    assertEquals(
+      await Deno.readTextFile(`${dir}/out/lib/notes.txt`),
+      "read me".repeat(50),
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("extractZip refuses a traversing or absolute entry (zip slip)", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const evil = `${dir}/evil.zip`;
+    await Deno.writeFile(
+      evil,
+      await makeZip([{ name: "../escape", data: enc("x") }]),
+    );
+    await assertRejects(
+      () => extractZip(evil, `${dir}/out`),
+      Error,
+      "escapes the destination",
+    );
+    const abs = `${dir}/abs.zip`;
+    await Deno.writeFile(
+      abs,
+      await makeZip([{ name: "/etc/x", data: enc("x") }]),
+    );
+    await assertRejects(
+      () => extractZip(abs, `${dir}/out`),
+      Error,
+      "absolute path",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("unzip rejects an encrypted entry", async () => {
+  const zip = await makeZip([
+    { name: "secret", data: enc("x"), flags: 0x0001 },
+  ]);
+  await assertRejects(() => unzip(zip), Error, "encrypted");
+});
+
+Deno.test("unzip rejects a zip64 archive", async () => {
+  const zip = await makeZip([{ name: "big", data: enc("x"), zip64: true }]);
+  await assertRejects(() => unzip(zip), Error, "zip64");
+});
+
+Deno.test("unzip rejects an unsupported compression method", async () => {
+  const zip = await makeZip([{ name: "bz", data: enc("x"), method: 12 }]);
+  await assertRejects(
+    () => unzip(zip),
+    Error,
+    "unsupported compression method",
+  );
+});
+
+Deno.test("unzip rejects bytes that are not a zip", async () => {
+  await assertRejects(
+    () => unzip(enc("not a zip at all, no signature here")),
+    Error,
+    "not a zip archive",
+  );
+});
+
+Deno.test("unzip rejects a corrupt local file header", async () => {
+  const zip = await makeZip([{ name: "x", data: enc("data") }]);
+  zip[0] = 0; // corrupt the local file-header signature
+  await assertRejects(() => unzip(zip), Error, "malformed local header");
+});
+
+Deno.test("unzip rejects a zip64 end-of-central-directory", async () => {
+  const zip = await makeZip([{ name: "x", data: enc("data") }]);
+  const view = new DataView(zip.buffer, zip.byteOffset, zip.byteLength);
+  // Point the central-directory offset at the zip64 sentinel.
+  view.setUint32(zip.length - 22 + 16, 0xffffffff, true);
+  await assertRejects(() => unzip(zip), Error, "zip64");
+});
+
+Deno.test("unzip rejects a corrupt central directory", async () => {
+  const zip = await makeZip([{ name: "x", data: enc("data") }]);
+  const view = new DataView(zip.buffer, zip.byteOffset, zip.byteLength);
+  const cdOffset = view.getUint32(zip.length - 22 + 16, true);
+  view.setUint32(cdOffset, 0, true); // corrupt the central-directory signature
+  await assertRejects(() => unzip(zip), Error, "malformed central directory");
+});
+
+Deno.test("unzip reports an out-of-range central-directory offset as malformed, not a RangeError", async () => {
+  const zip = await makeZip([{ name: "x", data: enc("data") }]);
+  const view = new DataView(zip.buffer, zip.byteOffset, zip.byteLength);
+  view.setUint32(zip.length - 22 + 16, zip.length + 100, true); // cdOffset past end
+  const err = await assertRejects(() => unzip(zip), Error);
+  assertEquals(err.message.includes("malformed central directory"), true);
+  assertEquals(err.message.includes("RangeError"), false);
+});
+
+Deno.test("unzip rejects a central-directory name that runs past the end", async () => {
+  const zip = await makeZip([{ name: "x", data: enc("data") }]);
+  const view = new DataView(zip.buffer, zip.byteOffset, zip.byteLength);
+  const cdOffset = view.getUint32(zip.length - 22 + 16, true);
+  view.setUint16(cdOffset + 28, 5000, true); // absurd name length
+  await assertRejects(() => unzip(zip), Error, "name runs past end");
+});
+
+Deno.test("unzip reports an out-of-range local-header offset as malformed", async () => {
+  const zip = await makeZip([{ name: "x", data: enc("data") }]);
+  const view = new DataView(zip.buffer, zip.byteOffset, zip.byteLength);
+  const cdOffset = view.getUint32(zip.length - 22 + 16, true);
+  view.setUint32(cdOffset + 42, zip.length + 100, true); // localOffset past end
+  await assertRejects(() => unzip(zip), Error, "malformed local header");
+});
+
+Deno.test("unzip rejects an entry whose data runs past the archive", async () => {
+  const zip = await makeZip([{ name: "x", data: enc("data") }]);
+  const view = new DataView(zip.buffer, zip.byteOffset, zip.byteLength);
+  const cdOffset = view.getUint32(zip.length - 22 + 16, true);
+  view.setUint32(cdOffset + 20, zip.length * 10, true); // absurd compressed size
+  await assertRejects(() => unzip(zip), Error, "runs past the archive");
+});
+
+Deno.test("unzip uses the local header's extra length, not the central directory's", async () => {
+  // The local header carries a 5-byte extra field the central directory omits.
+  // A reader that used the central-directory extra length would land 5 bytes
+  // early and decode garbage; this proves it reads the local length.
+  const zip = await makeZip([
+    {
+      name: "x",
+      data: enc("payload"),
+      localExtra: new Uint8Array([1, 2, 3, 4, 5]),
+    },
+  ]);
+  const out = await unzip(zip);
+  assertEquals(dec(out[0].data), "payload");
+});
+
+Deno.test("assertSafeEntryName accepts safe names and rejects escapes", () => {
+  assertSafeEntryName("bin/tool"); // no throw
+  assertSafeEntryName("a/b/c.txt");
+  assertThrows(() => assertSafeEntryName("/abs"), Error, "absolute path");
+  assertThrows(() => assertSafeEntryName("C:/win"), Error, "absolute path");
+  assertThrows(
+    () => assertSafeEntryName("a/../b"),
+    Error,
+    "escapes the destination",
+  );
+  assertThrows(
+    () => assertSafeEntryName("..\\win"),
+    Error,
+    "escapes the destination",
+  );
 });

--- a/packages/core/tests/install_test.ts
+++ b/packages/core/tests/install_test.ts
@@ -8,6 +8,7 @@ import {
 } from "../src/install.ts";
 import { operatingSystem } from "../src/host.ts";
 import { createTarGzip } from "../src/compression.ts";
+import { makeZip, STORED } from "./_zip.ts";
 
 /**
  * The suffix `installRelease` adds to the installed filename for the host
@@ -185,6 +186,77 @@ Deno.test("installRelease (tar.gz) defaults binaryPath to the tool name", async 
     });
     const contents = new TextDecoder().decode(await Deno.readFile(String(bin)));
     assertEquals(contents, "flat-binary");
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("installRelease (zip) unpacks and installs the inner binary", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    // A zip carrying bin/dprint (dprint et al. ship zip-only), served via the seam.
+    const bytes = await makeZip([
+      { name: "bin/dprint", data: new TextEncoder().encode("zipped-binary") },
+    ]);
+    const dest = `${root}/install`;
+    const bin = await installRelease({
+      name: "dprint",
+      destDir: dest,
+      archive: "zip",
+      binaryPath: "bin/dprint",
+      url: () => "https://example.com/dprint.zip",
+      download: fakeDownload(bytes),
+    });
+    assertEquals(bin.path.endsWith(`/dprint${EXE}`), true);
+    const contents = new TextDecoder().decode(await Deno.readFile(String(bin)));
+    assertEquals(contents, "zipped-binary");
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("installRelease (zip) defaults binaryPath to the tool name and verifies a checksum", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    const bytes = await makeZip([
+      {
+        name: "flat",
+        data: new TextEncoder().encode("flat-zip"),
+        method: STORED,
+      },
+    ]);
+    const sha = await crypto.subtle.digest("SHA-256", new Uint8Array(bytes));
+    const checksum = Array.from(
+      new Uint8Array(sha),
+      (b) => b.toString(16).padStart(2, "0"),
+    ).join("");
+
+    const dest = `${root}/install`;
+    const bin = await installRelease({
+      name: "flat",
+      destDir: dest,
+      archive: "zip",
+      checksum,
+      url: () => "https://example.com/flat.zip",
+      download: fakeDownload(bytes),
+    });
+    const contents = new TextDecoder().decode(await Deno.readFile(String(bin)));
+    assertEquals(contents, "flat-zip");
+
+    // A wrong checksum on the same archive fails, installing nothing new.
+    await assertRejects(
+      () =>
+        installRelease({
+          name: "flat",
+          destDir: `${root}/install2`,
+          archive: "zip",
+          checksum: "0".repeat(64),
+          url: () => "https://example.com/flat.zip",
+          download: fakeDownload(bytes),
+        }),
+      Error,
+      "checksum mismatch",
+    );
   } finally {
     await Deno.remove(root, { recursive: true });
   }

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -402,6 +402,12 @@ tools = toolchain((t) =>
 // install() returns Map<name, AbsolutePath>; npm packages need `npm` on PATH.
 ```
 
+`.archive("tar.gz")` or `.archive("zip")` unpacks an archive and copies
+`.binaryPath(...)` (default the name) out — zip reading covers the `stored`/
+`deflate` methods release assets use, rejects encrypted/zip64 archives, and
+blocks zip-slip. `.checksum(sha256)` verifies (the archive's SHA-256 for an
+archive, the binary's for `"raw"`) and doubles as the install cache key.
+
 **Resolve from `node_modules/.bin`** — in a Node monorepo where tool binaries
 are hoisted to the repo root, a wrapper can find its binary npx-style instead of
 needing a `.toolPath(...)`. `.fromNodeModules()` on any settings object walks up

--- a/tests/integration/install_zip_test.ts
+++ b/tests/integration/install_zip_test.ts
@@ -1,0 +1,52 @@
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import { Build, target, toolchain } from "../../packages/core/mod.ts";
+import type { DownloadFn } from "../../packages/core/mod.ts";
+import { makeZip } from "../../packages/core/tests/_zip.ts";
+import { runCli } from "./_harness.ts";
+
+// A build that provisions a zip-packaged tool. The fixture zip and install root
+// are module-scoped so the target body (captured at field-init) reads them at
+// execution time — set before each run.
+let zipBytes: Uint8Array = new Uint8Array(0);
+let toolsDir = "";
+
+/** A download seam that writes the prepared fixture zip to `dest`. */
+const fixtureDownload: DownloadFn = async (_url, dest) => {
+  await Deno.writeFile(String(dest), zipBytes);
+};
+
+class ZipToolBuild extends Build {
+  tools = toolchain((t) =>
+    t.tool((s) =>
+      s.name("dprint").archive("zip").binaryPath("bin/dprint")
+        .url(() => "https://example.test/dprint.zip")
+        .download(fixtureDownload)
+    )
+  );
+
+  install = target()
+    .description("install a zip-packaged tool")
+    .executes(async () => {
+      const bins = await this.tools.install({ destDir: toolsDir });
+      const bin = bins.get("dprint");
+      console.log(`dprint=${bin} :: ${await Deno.readTextFile(String(bin))}`);
+    });
+}
+
+Deno.test("a build installs a zip-packaged tool end-to-end via the CLI", async () => {
+  zipBytes = await makeZip([
+    { name: "bin/dprint", data: new TextEncoder().encode("ZIP-TOOL") },
+  ]);
+  toolsDir = await Deno.makeTempDir({ prefix: "zuke-zip-it-" });
+  try {
+    const { code, out } = await runCli(ZipToolBuild, ["install"]);
+    assertEquals(code, 0);
+    assertStringIncludes(out, "/dprint");
+    assertStringIncludes(out, ":: ZIP-TOOL"); // the unpacked binary's contents
+  } finally {
+    await Deno.remove(toolsDir, { recursive: true });
+  }
+});


### PR DESCRIPTION
## Track B T3 — `.zip` archive support in `installRelease`

Many release assets ship as a **zip** rather than a tarball (dprint, deno, …),
so `installRelease` couldn't install them — the archive union was `raw`/`tar.gz`
only. This adds zip reading.

### What's new

- **A dependency-free zip reader** in `compression.ts`:
  - `unzip(bytes)` parses the end-of-central-directory and central directory
    (the authoritative index), reads each member from its local header, and
    decompresses the two methods release assets use — **`stored`** (verbatim) and
    **`deflate`** (via the platform `DecompressionStream("deflate-raw")`).
    Directory entries are skipped.
  - `extractZip(src, destDir)` unpacks to disk — the zip counterpart of
    `extractTarGzip`.
- **`installRelease({ archive: "zip", binaryPath, url })`** unpacks a downloaded
  zip and copies the binary out, with the same `binaryPath`/`checksum` semantics
  as `tar.gz`. `.archive("zip")` is also available on the `toolchain()` settings.
- **Shared zip-slip guard.** `assertSafeEntryName` rejects an entry whose name is
  absolute or contains `..`, and it's applied to **both** the zip and tar.gz
  extractors — which also **fixes a pre-existing zip-slip gap** in the tar.gz
  extractor.

### Fails loudly, safely

Encrypted, zip64, unsupported-method, and structurally-malformed archives each
throw a **friendly error naming the offender**. Every offset read from the
untrusted archive is **bounds-checked**, so a crafted zip is reported as a
malformed archive rather than surfacing a raw `RangeError`. When a `.checksum()`
is pinned it is verified **before** the archive is parsed.

### Tests

Unit (`compression_test.ts` — round-trips, directory entries, and the reject
paths: encrypted / zip64 / bad method / not-a-zip / corrupt or out-of-range
headers / a local extra-field that differs from the central directory), install
(`install_test.ts` — zip unpack + `binaryPath` + checksum verify/mismatch), and
integration (`install_zip_test.ts` — a real build installs a zip tool end-to-end
via the CLI). Fixtures are built in memory (`tests/_zip.ts`), no network.
`compression.ts` is at 100% line / 97% branch.

### Adversarial review

Ran a 5-dimension pass (parser bounds/memory, zip-slip + copy, decompression
correctness, reject paths, test adequacy) → refute-by-default verify. **3
confirmed, 2 refuted:**

- **Out-of-bounds offsets surfaced a raw `RangeError`** — an untrusted
  `cdOffset`/`localOffset`/size pointing past the buffer hit a bare
  `DataView` error instead of the parser's friendly messages. **Fixed:** every
  such offset is now bounds-checked and reported as a malformed zip, with
  regression tests for each path.
- **The local-vs-central extra-field correctness point was untested** — the
  reader correctly re-reads the *local* header's extra length, but the fixture
  always set it to zero. **Fixed:** the fixture can now emit a differing local
  extra field, with a regression test that would fail if the reader used the
  central-directory length.
- **Unbounded inflate (zip bomb)** — a deflate member can inflate hugely and the
  checksum is optional. **Left as-is by design:** the identical unbounded pattern
  already ships in `gunzip`/`extractTarGzip` (and `gunzip` also feeds the remote
  build cache, where legitimately-large payloads must not be rejected), so a
  zip-only cap would be inconsistent. The all-format integrity boundary is
  `.checksum()` — verified before parsing and documented — and a malicious source
  can ship a trojan binary regardless, which a decompression cap would not
  address. The reader's docs point to the checksum for untrusted downloads.

### Gate

`deno task ci` green (lines 98.2%, branches 95.1%); `apiDocsCheck`,
`generate-ci --check`, and `deno doc --lint` over all five core entrypoints
clean; `docs/installing-tools.md` and the `zuke-write-build` skill updated (incl.
the FR-4 checksum-claim sweep).
