### PR TITLE
feat(cli): node-repo ergonomics — npm workspaces, setup collision guard, zuke doc

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,7 +25,15 @@ zuke setup                                  # in your project
 ```
 
 Without installing, the same wizard runs via `deno run -A jsr:@zuke/cli setup`
-(flags: `--dir <path>`, `--name <Class>`, `--force`, `--yes`).
+(flags: `--dir <path>`, `--name <Class>`, `--force`, `--yes`). If a `zuke/`
+directory already occupies the launcher's name, setup stops with an actionable
+error — pass `--launcher-name <name>` to write the launcher (and its `.ps1`)
+under a different name.
+
+Already have a `@zuke/*` package's API in hand? `zuke doc <package>` prints it
+(`zuke doc core`, `zuke doc @scope/pkg`), running `deno doc` in an isolated
+directory so a surrounding Node project's `@types/node` resolution doesn't drown
+the output.
 
 ## Migrate an existing project with `zuke import`
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -126,3 +126,24 @@ await helmUpgrade((s) => s.arg("api", "./chart").flag("install").cwd("infra"));
 `flag`/`option` add a `--` prefix unless the name already starts with a dash (so
 `flag("-v")` stays `-v`). Argv is a discrete array end-to-end, so a `defineTool`
 command is just as injection-free as the built-in wrappers.
+
+## Reading a wrapper's API — `zuke doc`
+
+`deno doc jsr:@zuke/deno` run inside a Node repo drowns the output in
+`@types/node` resolution warnings, because Deno discovers the surrounding
+project's `deno.json` / `node_modules`. `zuke doc <package>` runs `deno doc` from
+an **isolated throwaway directory**, so type resolution starts clean and the API
+prints readably in place:
+
+```sh
+zuke doc core            # jsr:@zuke/core
+zuke doc @scope/pkg      # a scoped package
+zuke doc deno --filter DenoTasks   # extra flags pass through to deno doc
+```
+
+A bare name resolves to `jsr:@zuke/<name>`; an explicit `jsr:`/`npm:`/`https:`
+specifier or a file path is used as-is.
+
+`NpmTasks.run` covers workspaces both ways: `.workspace("app")` for one, and
+`.workspaces()` for every workspace (compose with `.ifPresent()` to skip those
+missing the script) — the two are mutually exclusive.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3508,6 +3508,10 @@ class NpmRunSettings extends NpmSettings
     The package.json script to run (required).
   workspace(name: string): this
     Run in a specific workspace (`--workspace=`).
+  workspaces(): this
+    Run the script in every workspace (`--workspaces`). Pair with
+    {@link ifPresent} to skip workspaces that lack the script. Mutually
+    exclusive with {@link workspace} — setting both is a build error.
   ifPresent(): this
     Do not fail when the script is missing (`--if-present`).
   scriptArgs(...args: Array<string | number>): this
@@ -4049,15 +4053,21 @@ deno install -A -g -n zuke jsr:@zuke/cli
 and scaffold Zuke into any project with `zuke setup`.
 @module
 
-async function main(args: string[], host: SetupHost, prompter: Prompter): Promise<number>
-  The CLI entry point. Returns a process exit code; `host`/`prompter` are
-  injectable for testing.
+async function main(args: string[], host: SetupHost, prompter: Prompter, docRunner: DocRunner): Promise<number>
+  The CLI entry point. Returns a process exit code; `host`/`prompter`/`docRunner`
+  are injectable for testing.
 
 function parseImportFlags(args: string[]): ImportFlags
   Parse the argument list following `zuke import`.
 
 function parseSetupFlags(args: string[]): SetupFlags
   Parse the argument list following `zuke setup`.
+
+function resolveDocSpec(pkg: string | undefined): string | undefined
+  Resolve a `zuke doc` argument to a `deno doc` specifier: a bare package name
+  (`core`) becomes `jsr:@zuke/core`, a scoped name (`@scope/pkg`) becomes
+  `jsr:@scope/pkg`, and an explicit `jsr:`/`npm:`/`https:`/`file:`/path
+  specifier is passed through unchanged. Returns `undefined` for no argument.
 
 const defaultPrompter: Prompter
   The real {@link Prompter}, backed by Deno's `prompt`/`confirm`.
@@ -4089,12 +4099,16 @@ interface SetupFlags
     Build class name for the starter `zuke.ts`.
   dir?: string
     Directory to scaffold into (defaults to the current directory).
+  launcherName?: string
+    Base name for the launcher scripts, when `zuke` is taken by a directory.
 
 interface SetupHost
   Injected side effects, so {@link runSetup} is unit-testable.
 
   exists(path: string): Promise<boolean>
     Whether a path exists.
+  isDirectory(path: string): Promise<boolean>
+    Whether a path exists and is a directory (a reserved-name collision).
   readText(path: string): Promise<string>
     Read a file as UTF-8 text.
   writeText(path: string, content: string): Promise<void>
@@ -4103,6 +4117,10 @@ interface SetupHost
     Set a file's permission bits (may be unsupported on some platforms).
   log(message: string): void
     Emit a line of progress output.
+
+type DocRunner = (denoArgs: string[]) => Promise<number>
+  Runs `deno doc <args>` — the injectable subprocess seam for
+  {@link commandDoc}, so the command is testable without spawning `deno`.
 
 type ImportSource = "package.json" | "Makefile"
   The kinds of project `zuke import` can read.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -25,15 +25,21 @@ deno install -A -g -n zuke jsr:@zuke/cli
 and scaffold Zuke into any project with `zuke setup`.
 @module
 
-async function main(args: string[], host: SetupHost, prompter: Prompter): Promise<number>
-  The CLI entry point. Returns a process exit code; `host`/`prompter` are
-  injectable for testing.
+async function main(args: string[], host: SetupHost, prompter: Prompter, docRunner: DocRunner): Promise<number>
+  The CLI entry point. Returns a process exit code; `host`/`prompter`/`docRunner`
+  are injectable for testing.
 
 function parseImportFlags(args: string[]): ImportFlags
   Parse the argument list following `zuke import`.
 
 function parseSetupFlags(args: string[]): SetupFlags
   Parse the argument list following `zuke setup`.
+
+function resolveDocSpec(pkg: string | undefined): string | undefined
+  Resolve a `zuke doc` argument to a `deno doc` specifier: a bare package name
+  (`core`) becomes `jsr:@zuke/core`, a scoped name (`@scope/pkg`) becomes
+  `jsr:@scope/pkg`, and an explicit `jsr:`/`npm:`/`https:`/`file:`/path
+  specifier is passed through unchanged. Returns `undefined` for no argument.
 
 const defaultPrompter: Prompter
   The real {@link Prompter}, backed by Deno's `prompt`/`confirm`.
@@ -65,12 +71,16 @@ interface SetupFlags
     Build class name for the starter `zuke.ts`.
   dir?: string
     Directory to scaffold into (defaults to the current directory).
+  launcherName?: string
+    Base name for the launcher scripts, when `zuke` is taken by a directory.
 
 interface SetupHost
   Injected side effects, so {@link runSetup} is unit-testable.
 
   exists(path: string): Promise<boolean>
     Whether a path exists.
+  isDirectory(path: string): Promise<boolean>
+    Whether a path exists and is a directory (a reserved-name collision).
   readText(path: string): Promise<string>
     Read a file as UTF-8 text.
   writeText(path: string, content: string): Promise<void>
@@ -79,6 +89,10 @@ interface SetupHost
     Set a file's permission bits (may be unsupported on some platforms).
   log(message: string): void
     Emit a line of progress output.
+
+type DocRunner = (denoArgs: string[]) => Promise<number>
+  Runs `deno doc <args>` — the injectable subprocess seam for
+  {@link commandDoc}, so the command is testable without spawning `deno`.
 
 type ImportSource = "package.json" | "Makefile"
   The kinds of project `zuke import` can read.

--- a/packages/cli/mod.ts
+++ b/packages/cli/mod.ts
@@ -53,6 +53,8 @@ export interface SetupFlags {
   name?: string;
   /** Directory to scaffold into (defaults to the current directory). */
   dir?: string;
+  /** Base name for the launcher scripts, when `zuke` is taken by a directory. */
+  launcherName?: string;
 }
 
 /** Parse the argument list following `zuke setup`. */
@@ -78,6 +80,13 @@ export function parseSetupFlags(args: string[]): SetupFlags {
       }
     } else if (arg.startsWith("--dir=")) {
       flags.dir = arg.slice("--dir=".length);
+    } else if (arg === "--launcher-name") {
+      if (i + 1 < args.length) {
+        i++;
+        flags.launcherName = args[i];
+      }
+    } else if (arg.startsWith("--launcher-name=")) {
+      flags.launcherName = arg.slice("--launcher-name=".length);
     }
   }
   return flags;
@@ -88,14 +97,16 @@ const HELP = `zuke ${VERSION} — code-first build automation for Deno
 Usage:
   zuke setup [options]    Scaffold Zuke into a directory
   zuke import [options]   Generate a build from package.json scripts or a Makefile
+  zuke doc <package>      Show a @zuke/* package's API docs (isolated resolution)
   zuke --help             Show this help
   zuke --version          Show the version
 
 Setup options:
-  --dir <path>     Directory to scaffold into (default: .)
-  --name <Class>   Build class name for zuke.ts (default: MyBuild)
-  --force, -f      Overwrite existing files
-  --yes, -y        Accept defaults without prompting
+  --dir <path>            Directory to scaffold into (default: .)
+  --name <Class>          Build class name for zuke.ts (default: MyBuild)
+  --launcher-name <name>  Launcher base name when a zuke/ directory is in the way
+  --force, -f             Overwrite existing files
+  --yes, -y               Accept defaults without prompting
 
 Import options:
   --dir <path>     Directory to read from and scaffold into (default: .)
@@ -103,6 +114,10 @@ Import options:
   --from <source>  Force a source: package.json or makefile (default: auto-detect)
   --force, -f      Overwrite existing files
   --yes, -y        Accept defaults without prompting
+
+Doc:
+  zuke doc core           API of @zuke/core
+  zuke doc @scope/pkg      API of a scoped package (or pass jsr:/npm:/https: as-is)
 
 Run your build with the scaffolded launcher: ./zuke <target>`;
 
@@ -126,9 +141,12 @@ async function commandSetup(
 
   const where = dir === "." ? "the current directory" : dir;
   host.log(`Scaffolding Zuke into ${where}:`);
-  const result = await runSetup({ dir, force, name }, host);
+  const launcherName = flags.launcherName;
+  const result = await runSetup({ dir, force, name, launcherName }, host);
   const written = result.files.filter((f) => f.status !== "skipped").length;
-  host.log(`Done — ${written} file(s) written. Next: ./zuke`);
+  host.log(
+    `Done — ${written} file(s) written. Next: ./${launcherName ?? "zuke"}`,
+  );
   return 0;
 }
 
@@ -195,13 +213,76 @@ async function commandImport(
 }
 
 /**
- * The CLI entry point. Returns a process exit code; `host`/`prompter` are
- * injectable for testing.
+ * Runs `deno doc <args>` — the injectable subprocess seam for
+ * {@link commandDoc}, so the command is testable without spawning `deno`.
+ */
+export type DocRunner = (denoArgs: string[]) => Promise<number>;
+
+/** The default {@link DocRunner}: spawn `deno doc …` in an isolated temp dir. */
+const defaultDocRunner: DocRunner = async (denoArgs) => {
+  // Run from a throwaway directory so the surrounding repo's deno.json /
+  // node_modules / tsconfig don't drag @types/node resolution noise into the
+  // output — the whole point of `zuke doc` inside a Node project.
+  const cwd = await Deno.makeTempDir({ prefix: "zuke-doc-" });
+  try {
+    const { code } = await new Deno.Command(Deno.execPath(), {
+      args: denoArgs,
+      cwd,
+      stdout: "inherit",
+      stderr: "inherit",
+    }).output();
+    return code;
+  } finally {
+    await Deno.remove(cwd, { recursive: true });
+  }
+};
+
+/**
+ * Resolve a `zuke doc` argument to a `deno doc` specifier: a bare package name
+ * (`core`) becomes `jsr:@zuke/core`, a scoped name (`@scope/pkg`) becomes
+ * `jsr:@scope/pkg`, and an explicit `jsr:`/`npm:`/`https:`/`file:`/path
+ * specifier is passed through unchanged. Returns `undefined` for no argument.
+ */
+export function resolveDocSpec(pkg: string | undefined): string | undefined {
+  if (pkg === undefined || pkg === "") return undefined;
+  // Pass through anything already a specifier: a URI scheme (`jsr:`, `npm:`,
+  // `https:`, `file:`, and a Windows `C:` drive), or a slash/dot path.
+  if (/^([a-z][a-z0-9+.-]*:|[\\/]|\.)/i.test(pkg)) return pkg;
+  return `jsr:${pkg.startsWith("@") ? pkg : `@zuke/${pkg}`}`;
+}
+
+/** Run the `doc` subcommand: `deno doc <spec>` in an isolated directory. */
+async function commandDoc(
+  args: string[],
+  host: SetupHost,
+  runner: DocRunner,
+): Promise<number> {
+  const [pkg, ...extra] = args;
+  let spec = pkg === undefined || pkg.startsWith("-")
+    ? undefined
+    : resolveDocSpec(pkg);
+  if (spec === undefined) {
+    host.log(
+      "zuke doc: name a package, e.g. `zuke doc core` or `zuke doc @scope/pkg`.",
+    );
+    return 1;
+  }
+  // A relative path would resolve against the runner's throwaway cwd — pin it to
+  // the user's directory now, while cwd is still theirs. (Absolute paths and
+  // `jsr:`/`npm:`/`https:` specifiers are already location-independent.)
+  if (spec.startsWith(".")) spec = `${Deno.cwd()}/${spec}`;
+  return await runner(["doc", ...extra, spec]);
+}
+
+/**
+ * The CLI entry point. Returns a process exit code; `host`/`prompter`/`docRunner`
+ * are injectable for testing.
  */
 export async function main(
   args: string[],
   host: SetupHost = defaultHost,
   prompter: Prompter = defaultPrompter,
+  docRunner: DocRunner = defaultDocRunner,
 ): Promise<number> {
   if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
     host.log(HELP);
@@ -214,11 +295,21 @@ export async function main(
     host.log(VERSION);
     return 0;
   }
-  if (command === "setup") {
-    return await commandSetup(rest, host, prompter);
-  }
-  if (command === "import") {
-    return await commandImport(rest, host, prompter);
+  try {
+    if (command === "setup") {
+      return await commandSetup(rest, host, prompter);
+    }
+    if (command === "import") {
+      return await commandImport(rest, host, prompter);
+    }
+    if (command === "doc") {
+      return await commandDoc(rest, host, docRunner);
+    }
+  } catch (error) {
+    // Surface a command's own friendly error (e.g. a setup directory collision)
+    // as a clean message and non-zero exit, not an uncaught stack trace.
+    host.log(error instanceof Error ? error.message : String(error));
+    return 1;
   }
   host.log(`Unknown command: ${command}\n`);
   host.log(HELP);

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -135,6 +135,8 @@ export function zukeTaskState(text: string): DenoJsonState {
 export interface SetupHost {
   /** Whether a path exists. */
   exists(path: string): Promise<boolean>;
+  /** Whether a path exists and is a directory (a reserved-name collision). */
+  isDirectory(path: string): Promise<boolean>;
   /** Read a file as UTF-8 text. */
   readText(path: string): Promise<string>;
   /** Write UTF-8 text to a file, creating or truncating it. */
@@ -151,6 +153,14 @@ export const defaultHost: SetupHost = {
     try {
       await Deno.lstat(path);
       return true;
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) return false;
+      throw error;
+    }
+  },
+  async isDirectory(path: string): Promise<boolean> {
+    try {
+      return (await Deno.lstat(path)).isDirectory;
     } catch (error) {
       if (error instanceof Deno.errors.NotFound) return false;
       throw error;
@@ -178,6 +188,12 @@ export interface SetupOptions {
   force: boolean;
   /** Build class name for the starter `zuke.ts`. */
   name: string;
+  /**
+   * The base name for the launcher scripts (`<name>` and `<name>.ps1`).
+   * Defaults to `"zuke"`; override it when a `zuke/` directory already occupies
+   * that name in the target directory.
+   */
+  launcherName?: string;
   /**
    * The `zuke.ts` contents to write. Defaults to {@link starterBuild}; `zuke
    * import` passes a build generated from an existing project's tasks instead.
@@ -212,29 +228,94 @@ interface ScaffoldFile {
   name: string;
   content: string;
   mode?: number;
+  /** Whether this file is a launcher (its name comes from `launcherName`). */
+  launcher?: boolean;
+}
+
+/** The default launcher base name. */
+export const DEFAULT_LAUNCHER = "zuke";
+
+/** Scaffold file names a launcher must not shadow (the build file and config). */
+const RESERVED_NON_LAUNCHER = new Set([
+  "zuke.ts",
+  "zuke.json",
+  "deno.json",
+  ".gitignore",
+]);
+
+/**
+ * Validate a `--launcher-name`: a single path segment (so the launcher can't be
+ * written outside the target directory) that doesn't shadow another file setup
+ * writes. Throws a friendly error otherwise.
+ */
+function assertLauncherName(name: string): void {
+  // Reject path separators and a colon (a Windows drive/ADS separator), so the
+  // launcher can only be a plain file in the target directory.
+  if (name === "" || /[\\/:]/.test(name) || name === "." || name === "..") {
+    throw new Error(
+      `zuke setup: invalid --launcher-name "${name}" — it must be a plain file ` +
+        `name (no path separators or ":").`,
+    );
+  }
+  // Compare case-insensitively: a case-insensitive filesystem (macOS, Windows)
+  // would let `Zuke.ts` shadow the `zuke.ts` setup writes.
+  if (RESERVED_NON_LAUNCHER.has(name.toLowerCase())) {
+    throw new Error(
+      `zuke setup: --launcher-name "${name}" would overwrite a file setup ` +
+        `writes (the build file or config) — choose a different name.`,
+    );
+  }
 }
 
 /**
- * Scaffold Zuke into `options.dir`: a starter `zuke.ts`, the `./zuke` and
- * `./zuke.ps1` launchers, and a `deno.json` task block. Existing files are
- * skipped unless `options.force` is set; `deno.json` is always merged (never
- * clobbered).
+ * Scaffold Zuke into `options.dir`: a starter `zuke.ts`, the launcher scripts,
+ * and a `deno.json` task block. Existing files are skipped unless
+ * `options.force` is set; `deno.json` is always merged (never clobbered). Fails
+ * up front if a target name is occupied by a directory (see
+ * {@link SetupOptions.launcherName}).
  */
 export async function runSetup(
   options: SetupOptions,
   host: SetupHost = defaultHost,
 ): Promise<SetupResult> {
   const files: FileResult[] = [];
+  const launcher = options.launcherName ?? DEFAULT_LAUNCHER;
+  assertLauncherName(launcher);
 
   const scaffold: readonly ScaffoldFile[] = [
     {
       name: "zuke.ts",
       content: options.buildContent ?? starterBuild(options.name),
     },
-    { name: "zuke", content: launcherBash(), mode: 0o755 },
-    { name: "zuke.ps1", content: launcherPwsh() },
+    { name: launcher, content: launcherBash(), mode: 0o755, launcher: true },
+    { name: `${launcher}.ps1`, content: launcherPwsh(), launcher: true },
     { name: "zuke.json", content: starterConfig(options.name) },
   ];
+
+  // Fail before writing anything if a target name is occupied by a directory —
+  // a scaffolded file can't be written over a directory, and silently skipping
+  // it (the old behaviour) produced a launcher-less setup. Covers every name
+  // setup writes, including the separately-written deno.json and .gitignore.
+  const collisionTargets: ReadonlyArray<{ name: string; launcher: boolean }> = [
+    ...scaffold.map((s) => ({ name: s.name, launcher: s.launcher === true })),
+    { name: "deno.json", launcher: false },
+    { name: ".gitignore", launcher: false },
+  ];
+  for (const item of collisionTargets) {
+    const path = joinPath(options.dir, item.name);
+    if (await host.isDirectory(path)) {
+      throw new Error(
+        `zuke setup: cannot write "${item.name}" — a directory exists at ` +
+          `${path}. ` +
+          (item.launcher
+            ? `Pass --launcher-name <name> to write the launcher under a ` +
+              `different name`
+            : `Move or rename that directory (${item.name} is reserved by ` +
+              `Zuke)`) +
+          `, then re-run setup.`,
+      );
+    }
+  }
 
   for (const item of scaffold) {
     const path = joinPath(options.dir, item.name);

--- a/packages/cli/tests/_fakes.ts
+++ b/packages/cli/tests/_fakes.ts
@@ -7,6 +7,8 @@ import type { Prompter } from "../mod.ts";
 export class FakeHost implements SetupHost {
   /** Virtual filesystem: path → contents. */
   readonly files = new Map<string, string>();
+  /** Paths that exist as directories (for reserved-name collision tests). */
+  readonly directories = new Set<string>();
   /** Lines passed to {@link log}. */
   readonly logs: string[] = [];
   /** `[path, mode]` pairs passed to {@link chmod}. */
@@ -23,7 +25,11 @@ export class FakeHost implements SetupHost {
   }
 
   exists(path: string): Promise<boolean> {
-    return Promise.resolve(this.files.has(path));
+    return Promise.resolve(this.files.has(path) || this.directories.has(path));
+  }
+
+  isDirectory(path: string): Promise<boolean> {
+    return Promise.resolve(this.directories.has(path));
   }
 
   readText(path: string): Promise<string> {

--- a/packages/cli/tests/cli_test.ts
+++ b/packages/cli/tests/cli_test.ts
@@ -1,5 +1,10 @@
 import { assertEquals } from "../../core/tests/_assert.ts";
-import { defaultPrompter, main, parseSetupFlags } from "../mod.ts";
+import {
+  defaultPrompter,
+  main,
+  parseSetupFlags,
+  resolveDocSpec,
+} from "../mod.ts";
 import { VERSION } from "../src/version.ts";
 import { FakeHost, FakePrompter } from "./_fakes.ts";
 
@@ -15,7 +20,134 @@ Deno.test("parseSetupFlags reads every flag form", () => {
   assertEquals(parseSetupFlags(["--dir", "app"]).dir, "app");
   assertEquals(parseSetupFlags(["--dir=pkg"]).dir, "pkg");
   assertEquals(parseSetupFlags(["--dir"]).dir, undefined);
+  assertEquals(
+    parseSetupFlags(["--launcher-name", "build"]).launcherName,
+    "build",
+  );
+  assertEquals(parseSetupFlags(["--launcher-name=go"]).launcherName, "go");
+  assertEquals(parseSetupFlags(["--launcher-name"]).launcherName, undefined);
   assertEquals(parseSetupFlags(["whatever"]).name, undefined);
+});
+
+Deno.test("main setup surfaces a directory collision as a friendly exit 1", async () => {
+  const host = new FakeHost();
+  host.directories.add("zuke"); // a zuke/ directory is in the way
+  const code = await main(["setup", "--yes"], host, new FakePrompter(false));
+  assertEquals(code, 1);
+  assertEquals(host.logs.some((l) => l.includes("--launcher-name")), true);
+  assertEquals(host.files.size, 0); // nothing scaffolded
+});
+
+Deno.test("main setup --launcher-name renames the launcher and reports it", async () => {
+  const host = new FakeHost();
+  const code = await main(
+    ["setup", "--yes", "--launcher-name", "build"],
+    host,
+    new FakePrompter(false),
+  );
+  assertEquals(code, 0);
+  assertEquals(host.files.has("build"), true);
+  assertEquals(host.logs.some((l) => l.includes("./build")), true);
+});
+
+Deno.test("resolveDocSpec resolves bare, scoped, and explicit specifiers", () => {
+  assertEquals(resolveDocSpec("core"), "jsr:@zuke/core");
+  assertEquals(resolveDocSpec("@scope/pkg"), "jsr:@scope/pkg");
+  assertEquals(resolveDocSpec("jsr:@zuke/deno"), "jsr:@zuke/deno");
+  assertEquals(resolveDocSpec("npm:cowsay"), "npm:cowsay");
+  assertEquals(resolveDocSpec("https://x/y.ts"), "https://x/y.ts");
+  assertEquals(resolveDocSpec("./local.ts"), "./local.ts");
+  assertEquals(resolveDocSpec(""), undefined);
+  assertEquals(resolveDocSpec(undefined), undefined);
+});
+
+Deno.test("main doc runs `deno doc <spec>` in an isolated temp-dir cwd", async () => {
+  const host = new FakeHost();
+  let seen: string[] = [];
+  const code = await main(["doc", "core"], host, defaultPrompter, (args) => {
+    seen = args;
+    return Promise.resolve(0);
+  });
+  assertEquals(code, 0);
+  assertEquals(seen, ["doc", "jsr:@zuke/core"]);
+});
+
+Deno.test("main doc pins a relative path to an absolute spec (cwd changes under it)", async () => {
+  const host = new FakeHost();
+  let seen: string[] = [];
+  const code = await main(
+    ["doc", "./lib.ts"],
+    host,
+    defaultPrompter,
+    (args) => {
+      seen = args;
+      return Promise.resolve(0);
+    },
+  );
+  assertEquals(code, 0);
+  // The relative path was resolved against the user's cwd, not left relative
+  // (which would resolve against the runner's throwaway directory).
+  assertEquals(seen[0], "doc");
+  assertEquals(seen[1].startsWith("."), false);
+  assertEquals(seen[1].endsWith("/lib.ts"), true);
+});
+
+Deno.test("main doc forwards extra flags and propagates the exit code", async () => {
+  const host = new FakeHost();
+  let seen: string[] = [];
+  const code = await main(
+    ["doc", "deno", "--filter", "DenoTasks"],
+    host,
+    defaultPrompter,
+    (args) => {
+      seen = args;
+      return Promise.resolve(3);
+    },
+  );
+  assertEquals(code, 3);
+  assertEquals(seen, ["doc", "--filter", "DenoTasks", "jsr:@zuke/deno"]);
+});
+
+Deno.test("main doc without a package prints usage and never spawns", async () => {
+  const host = new FakeHost();
+  let called = false;
+  const runner = () => {
+    called = true;
+    return Promise.resolve(0);
+  };
+  assertEquals(await main(["doc"], host, defaultPrompter, runner), 1);
+  assertEquals(
+    await main(["doc", "--filter"], host, defaultPrompter, runner),
+    1,
+  );
+  assertEquals(called, false);
+  assertEquals(host.logs.some((l) => l.includes("name a package")), true);
+});
+
+Deno.test("main doc runs a real `deno doc` via the default runner (end-to-end)", async () => {
+  const host = new FakeHost();
+  const dir = await Deno.makeTempDir();
+  try {
+    const fixture = `${dir}/lib.ts`;
+    await Deno.writeTextFile(
+      fixture,
+      '/** A documented greeting. */\nexport const hello = "hi";\n',
+    );
+    // No injected runner → the real defaultDocRunner spawns `deno doc` in its
+    // own throwaway directory against the fixture's absolute path.
+    const code = await main(["doc", fixture], host);
+    assertEquals(code, 0);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("main doc propagates a non-zero exit from the real runner", async () => {
+  const host = new FakeHost();
+  // A missing file → `deno doc` exits non-zero. No injected runner, so the real
+  // defaultDocRunner runs and its temp dir is still cleaned up on failure.
+  const code = await main(["doc", "/no/such/zuke-doc-fixture.ts"], host);
+  assertEquals(code !== 0, true);
 });
 
 Deno.test("main setup honours --dir", async () => {

--- a/packages/cli/tests/setup_test.ts
+++ b/packages/cli/tests/setup_test.ts
@@ -100,6 +100,111 @@ Deno.test("runSetup scaffolds an empty project", async () => {
   assertEquals(host.chmods[0], ["zuke", 0o755]);
 });
 
+Deno.test("runSetup writes the launcher under a custom --launcher-name", async () => {
+  const host = new FakeHost();
+  await runSetup(
+    { dir: ".", force: false, name: "Foo", launcherName: "build" },
+    host,
+  );
+  assertEquals(host.files.has("build"), true);
+  assertEquals(host.files.has("build.ps1"), true);
+  assertEquals(host.files.has("zuke"), false); // the default launcher isn't written
+  assertEquals(host.files.has("zuke.ts"), true); // the build file keeps its name
+  assertEquals(host.chmods[0], ["build", 0o755]);
+});
+
+Deno.test("runSetup fails when the launcher name is a directory, suggesting --launcher-name", async () => {
+  const host = new FakeHost();
+  host.directories.add("zuke"); // a zuke/ package directory occupies the name
+  await assertRejects(
+    () => runSetup({ dir: ".", force: false, name: "Foo" }, host),
+    Error,
+    "--launcher-name",
+  );
+  // Nothing was written — the guard aborts before any scaffolding.
+  assertEquals(host.files.size, 0);
+});
+
+Deno.test("runSetup fails when a reserved non-launcher name is a directory", async () => {
+  const host = new FakeHost();
+  host.directories.add("zuke.ts");
+  const err = await assertRejects(
+    () => runSetup({ dir: ".", force: false, name: "Foo" }, host),
+    Error,
+    "reserved by Zuke",
+  );
+  assertEquals(err.message.includes("--launcher-name"), false); // not a launcher
+});
+
+Deno.test("runSetup rejects a launcher name with a path separator", async () => {
+  const host = new FakeHost();
+  await assertRejects(
+    () =>
+      runSetup(
+        { dir: ".", force: false, name: "Foo", launcherName: "../evil" },
+        host,
+      ),
+    Error,
+    "invalid --launcher-name",
+  );
+});
+
+Deno.test("runSetup fails when deno.json is a directory", async () => {
+  const host = new FakeHost();
+  host.directories.add("deno.json"); // a deno.json/ directory, not a file
+  await assertRejects(
+    () => runSetup({ dir: ".", force: false, name: "Foo" }, host),
+    Error,
+    "reserved by Zuke",
+  );
+  assertEquals(host.files.size, 0);
+});
+
+Deno.test("runSetup rejects a launcher name that shadows a scaffolded file", async () => {
+  const host = new FakeHost();
+  await assertRejects(
+    () =>
+      runSetup(
+        { dir: ".", force: false, name: "Foo", launcherName: "zuke.ts" },
+        host,
+      ),
+    Error,
+    "would overwrite a file",
+  );
+});
+
+Deno.test("runSetup rejects a case-variant launcher name that shadows a file", async () => {
+  // On a case-insensitive filesystem `Zuke.ts` would clobber the `zuke.ts`
+  // build file, so it must be rejected regardless of case.
+  const host = new FakeHost();
+  for (const shadow of ["Zuke.ts", "ZUKE.JSON", "Deno.json", ".GITIGNORE"]) {
+    await assertRejects(
+      () =>
+        runSetup(
+          { dir: ".", force: false, name: "Foo", launcherName: shadow },
+          host,
+        ),
+      Error,
+      "would overwrite a file",
+    );
+  }
+});
+
+Deno.test("runSetup rejects a launcher name containing a colon", async () => {
+  const host = new FakeHost();
+  for (const bad of ["C:evil", "foo:bar"]) {
+    await assertRejects(
+      () =>
+        runSetup(
+          { dir: ".", force: false, name: "Foo", launcherName: bad },
+          host,
+        ),
+      Error,
+      "invalid --launcher-name",
+    );
+  }
+});
+
 Deno.test("runSetup skips a .gitignore that already ignores .zuke/", async () => {
   const host = new FakeHost({ ".gitignore": "node_modules/\n.zuke/\n" });
   const result = await runSetup({ dir: ".", force: false, name: "Foo" }, host);
@@ -191,5 +296,22 @@ Deno.test("defaultHost.exists rethrows non-NotFound errors", async () => {
     await assertRejects(() => defaultHost.exists(`${file}/child`));
   } finally {
     await Deno.remove(file);
+  }
+});
+
+Deno.test("defaultHost.isDirectory distinguishes dirs, files, and missing paths", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    assertEquals(await defaultHost.isDirectory(dir), true);
+    const file = `${dir}/f.txt`;
+    await Deno.writeTextFile(file, "x");
+    assertEquals(await defaultHost.isDirectory(file), false);
+    assertEquals(await defaultHost.isDirectory(`${dir}/missing`), false);
+    if (Deno.build.os !== "windows") {
+      // A non-NotFound error (NotADirectory) must propagate, not be swallowed.
+      await assertRejects(() => defaultHost.isDirectory(`${file}/child`));
+    }
+  } finally {
+    await Deno.remove(dir, { recursive: true });
   }
 });

--- a/packages/npm/README.md
+++ b/packages/npm/README.md
@@ -84,6 +84,10 @@ class NpmRunSettings extends NpmSettings
     The package.json script to run (required).
   workspace(name: string): this
     Run in a specific workspace (`--workspace=`).
+  workspaces(): this
+    Run the script in every workspace (`--workspaces`). Pair with
+    {@link ifPresent} to skip workspaces that lack the script. Mutually
+    exclusive with {@link workspace} — setting both is a build error.
   ifPresent(): this
     Do not fail when the script is missing (`--if-present`).
   scriptArgs(...args: Array<string | number>): this

--- a/packages/npm/src/npm.ts
+++ b/packages/npm/src/npm.ts
@@ -80,6 +80,7 @@ export class NpmCiSettings extends NpmSettings {
 export class NpmRunSettings extends NpmSettings {
   #script?: string;
   #workspace?: string;
+  #workspaces = false;
   #ifPresent = false;
   #scriptArgs: string[] = [];
 
@@ -92,6 +93,16 @@ export class NpmRunSettings extends NpmSettings {
   /** Run in a specific workspace (`--workspace=`). */
   workspace(name: string): this {
     this.#workspace = name;
+    return this;
+  }
+
+  /**
+   * Run the script in **every** workspace (`--workspaces`). Pair with
+   * {@link ifPresent} to skip workspaces that lack the script. Mutually
+   * exclusive with {@link workspace} — setting both is a build error.
+   */
+  workspaces(): this {
+    this.#workspaces = true;
     return this;
   }
 
@@ -111,10 +122,17 @@ export class NpmRunSettings extends NpmSettings {
     if (this.#script === undefined) {
       throw new Error("NpmTasks.run: .script() is required.");
     }
+    if (this.#workspace !== undefined && this.#workspaces) {
+      throw new Error(
+        "NpmTasks.run: .workspace() and .workspaces() are mutually exclusive — " +
+          "pick one workspace or all of them, not both.",
+      );
+    }
     const argv = ["run"];
     if (this.#workspace !== undefined) {
       argv.push(`--workspace=${this.#workspace}`);
     }
+    if (this.#workspaces) argv.push("--workspaces");
     if (this.#ifPresent) argv.push("--if-present");
     argv.push(this.#script);
     if (this.#scriptArgs.length > 0) argv.push("--", ...this.#scriptArgs);

--- a/packages/npm/tests/npm_test.ts
+++ b/packages/npm/tests/npm_test.ts
@@ -64,6 +64,28 @@ Deno.test("run: no -- separator when there are no script args", () => {
   ]);
 });
 
+Deno.test("run: --workspaces runs every workspace and composes with --if-present", () => {
+  assertEquals(
+    new NpmRunSettings().script("build").workspaces().argv().slice(1),
+    ["run", "--workspaces", "build"],
+  );
+  assertEquals(
+    new NpmRunSettings().script("test").workspaces().ifPresent().argv().slice(
+      1,
+    ),
+    ["run", "--workspaces", "--if-present", "test"],
+  );
+});
+
+Deno.test("run: .workspace() and .workspaces() are mutually exclusive", () => {
+  assertThrows(
+    () =>
+      new NpmRunSettings().script("build").workspace("app").workspaces().argv(),
+    Error,
+    "mutually exclusive",
+  );
+});
+
 Deno.test("exec: command required; --yes, --package, forwarded args", () => {
   assertThrows(
     () => new NpmExecSettings().argv(),

--- a/skills/zuke-setup/SKILL.md
+++ b/skills/zuke-setup/SKILL.md
@@ -27,7 +27,14 @@ deno run -A jsr:@zuke/cli setup
 ```
 
 `setup` flags: `--dir <path>`, `--name <ClassName>`, `--force` (overwrite
-existing files), `--yes` (non-interactive).
+existing files), `--yes` (non-interactive), `--launcher-name <name>` (write the
+launcher under a different name when a `zuke/` directory already occupies it — a
+directory collision now fails with an actionable error instead of silently
+skipping the launcher).
+
+To read a `@zuke/*` package's API without a Node repo's `@types/node` noise, run
+`zuke doc <package>` (e.g. `zuke doc core`) — it runs `deno doc` in an isolated
+directory.
 
 ### Migrating an existing project: `zuke import`
 


### PR DESCRIPTION
## Track B T4 — Node-repo ergonomics batch (FR-5, FR-6, FR-7)

Three small, independent DX fixes for driving Zuke inside a Node monorepo.

### FR-5 — `NpmTasks.run().workspaces()`

`.workspaces()` runs a script in **every** npm workspace (`--workspaces`),
composing with `.ifPresent()` to skip those missing the script. It's mutually
exclusive with `.workspace(name)` — setting both throws a friendly build error
instead of silently emitting a contradictory command. Pure argv change.

### FR-6 — `zuke setup` directory-collision guard + `--launcher-name`

`zuke setup` used to **silently skip** any existing path — including a `zuke/`
**directory** — producing a launcher-less setup (a real footgun in package
monorepos). Now setup does a pre-pass over every name it writes (`zuke.ts`, the
launchers, `zuke.json`, `deno.json`, `.gitignore`) and, if one is a directory,
**fails up front with an actionable error before writing anything**. The new
`--launcher-name <name>` writes the launcher scripts under a different base name
for repos that must keep the `zuke/` directory. A thrown setup error surfaces as
a clean message and a non-zero exit, not an uncaught stack trace. `zuke import`
(which reuses the scaffolder) inherits the guard.

### FR-7 — `zuke doc <package>`

`deno doc jsr:@zuke/deno` inside a Node repo drowns in `@types/node` resolution
warnings. `zuke doc <package>` runs `deno doc` from an **isolated throwaway
directory**, so type resolution starts clean. A bare name resolves to
`jsr:@zuke/<name>`, a scoped name to `jsr:<name>`, an explicit
`jsr:`/`npm:`/`https:` specifier passes through, and a relative path is pinned to
the caller's directory before the isolation kicks in. Extra flags pass through to
`deno doc`.

### Tests

Unit (npm argv, setup scaffolding, `resolveDocSpec`) and CLI-driven tests through
the real `main()` entry point (collision → friendly exit 1, `--launcher-name`
rename, `zuke doc` argv + a real `deno doc` subprocess end-to-end). All hermetic:
fake host / fake runner, no real npm, no network. npm 100% / setup.ts 100% line /
cli mod.ts 98% line.

### Adversarial review

Ran a 5-dimension pass (npm argv, setup collision, launcher-name escape, doc
spec/spawn, test adequacy) → refute-by-default verify. Confirmed findings fixed
with regression tests:

- **`--launcher-name` shadow check was case-sensitive** (medium) — on a
  case-insensitive filesystem (macOS/Windows) `--launcher-name Zuke.ts` slipped
  past the guard and, with `--force`, overwrote the `zuke.ts` build file. Now the
  check is case-insensitive.
- **`--launcher-name` allowed a colon** (low) — `C:evil` (Windows drive-relative)
  and `foo:bar` (NTFS alternate data stream) passed the separator guard. Now
  rejected.
- **`zuke doc ./relative.ts` was broken** by the temp-dir cwd change — a relative
  path resolved against the throwaway directory. Now pinned to the caller's cwd
  first.
- Test-adequacy gaps closed: the real doc runner's non-zero-exit path, the
  case-variant shadow, and the colon guard now have regression tests.

The one refuted finding: the setup directory-collision guard already covers
setup directory-collision guard already covers `deno.json`/`.gitignore` (a
finding claiming otherwise was refuted against the real code).

### Gate

`deno task ci` green (lines 98.2%, branches 95.1%); `apiDocsCheck`,
`generate-ci --check`, and `deno doc --lint` over the core entrypoints clean;
`docs/tools.md`, `docs/getting-started.md`, and the `zuke-setup` skill updated.
