### PR TITLE
feat(core): runs list --counts and typed kubectl getNamespaces

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,7 +18,7 @@
 | `zuke mcp [--allow-run[=<globs>]] [--http <host:port>]` | Run an MCP server over the build for AI agents, on stdio or HTTP ([details](./mcp.md)). |
 | `zuke resume <id> [--signal <n>] [--data <json>]`       | Resume a suspended run, optionally delivering a signal ([details](./orchestration.md)). |
 | `zuke resume --check [<id>]`                            | Re-check suspended runs (predicate waits, timeouts).                                    |
-| `zuke runs list [--status/-target/-since/-limit] [--json]` | List persisted run records, newest first ([details](./state.md)).                    |
+| `zuke runs list [--status/-target/-since/-limit] [--counts] [--json]` | List persisted run records (or `--counts` for a status tally), newest first ([details](./state.md)). |
 | `zuke runs show <id> [--json]`                          | Show one run's full per-target status and metadata.                                     |
 | `zuke runs prune [--keep <age>] [--keep-last <n>] [--dry-run]` | Delete old terminal run records; never touches non-terminal runs.                |
 | `zuke cancel <id> [--actor <name>]`                     | Cancel a run and run its compensations ([details](./orchestration.md#cancellation--compensation-oncancel)). |
@@ -285,7 +285,10 @@ run's full status survives the process that produced it.
   `suspended`, `cancelling`, `succeeded`, `failed`, `cancelled`), `--target <t>` (only runs
   whose graph contains that target), `--since <iso>` (only runs created at
   or after an ISO-8601 timestamp), and `--limit <n>` (at most the newest N). The
-  filters compose.
+  filters compose. Add `--counts` to print aggregate counts (a total and one
+  line per status) instead of rows — with `--json` it emits
+  `{ total, byStatus }` (status keys sorted for stable output), honouring the
+  same filters.
 - `zuke runs show <run-id>` reconstructs one run in full: the header, resolved
   (non-secret) parameters, each target's status with its duration, error, or
   pending wait, and any external signals received.

--- a/docs/state.md
+++ b/docs/state.md
@@ -188,6 +188,9 @@ zuke runs list
 # Just the failed ones touching a given target, since a cutoff.
 zuke runs list --status failed --target deploy --since 2026-07-01
 
+# Aggregate counts instead of rows (total + per status); honours the filters.
+zuke runs list --counts          # add --json for { total, byStatus }
+
 # One run in full: header, parameters, per-target status, and signals.
 zuke runs show 6f1c…             # add --json to emit the raw record
 ```

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -62,7 +62,7 @@ actually spawn (the resolved shim or the bare fallback) for diagnostics.
 | `@zuke/yarn`           | `install`, `add`, `remove`, `run`, `dlx`                                                                                              |
 | `@zuke/docker`         | `build`, `run`, `exec`, `push`, `pull`, `tag`, `login`, `images`, `ps`, `stop`, `start`, `rm`, `rmi`, `save`, `load`                  |
 | `@zuke/docker-compose` | `up`, `down`, `build`, `pull`, `push`, `run`, `exec`, `logs`, `ps`, `config`, `start`, `stop`, `restart`, `rm`                        |
-| `@zuke/kubectl`        | `apply`, `create`, `delete`, `get`, `describe`, `logs`, `exec`, `rollout`, `scale`, `setImage`, `patch`, `portForward`, `wait`, `top`, `annotate`, `label` |
+| `@zuke/kubectl`        | `apply`, `create`, `delete`, `get`, `getNamespaces` (typed), `describe`, `logs`, `exec`, `rollout`, `scale`, `setImage`, `patch`, `portForward`, `wait`, `top`, `annotate`, `label` |
 | `@zuke/helm`           | `install`, `upgrade`, `uninstall`, `template`, `lint`, `dependencyUpdate`, `repoAdd`, `package`                                       |
 | `@zuke/kustomize`      | `build`, `editSetImage`                                                                                                               |
 | `@zuke/oxlint`         | `lint`                                                                                                                                |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4671,6 +4671,12 @@ await KubectlTasks.rollout((s) =>
 ```
 @module
 
+function parseNamespaces(json: string): KubernetesNamespace[]
+  Parse the JSON text of `kubectl get namespaces -o json` — a `List`, or a
+  single namespace object — into {@link KubernetesNamespace} records. Items
+  without a `metadata.name` are skipped; empty input yields `[]`. Throws if the
+  text is non-empty and not valid JSON.
+
 const KubectlTasks: KubectlTasksApi
   Typed task functions for the `kubectl` CLI.
 
@@ -4786,8 +4792,8 @@ class KubectlGetSettings extends KubectlSettings
     Restrict by field selector (`--field-selector`).
   allNamespaces(): this
     List across all namespaces (`-A`).
-  watch(): this
-    Watch for changes instead of returning once (`-w`).
+  watch(on: boolean): this
+    Watch for changes instead of returning once (`-w`); pass `false` to disable.
   showLabels(): this
     Include resource labels as columns (`--show-labels`).
   override protected buildArgs(): string[]
@@ -4948,6 +4954,10 @@ interface KubectlTasksApi
     Delete resources: `kubectl delete`.
   get(configure?: Configure<KubectlGetSettings>): Promise<CommandOutput>
     List resources: `kubectl get`.
+  getNamespaces(configure?: Configure<KubectlGetSettings>): Promise<KubernetesNamespace[]>
+    List namespaces as typed {@link KubernetesNamespace} records: runs
+    `kubectl get namespaces -o json` (forcing JSON output, quietly) and parses
+    the result. Use the lambda for cluster flags or a label `.selector(...)`.
   describe(configure?: Configure<KubectlDescribeSettings>): Promise<CommandOutput>
     Describe resources: `kubectl describe`.
   logs(configure?: Configure<KubectlLogsSettings>): Promise<CommandOutput>
@@ -4972,6 +4982,20 @@ interface KubectlTasksApi
     Wait for a condition: `kubectl wait`.
   top(configure?: Configure<KubectlTopSettings>): Promise<CommandOutput>
     Show resource usage: `kubectl top`.
+
+interface KubernetesNamespace
+  A Kubernetes namespace, parsed from `kubectl get namespaces -o json` — the
+  typed result of {@link KubectlTasksApi.getNamespaces}.
+
+  name: string
+    The namespace name (`metadata.name`).
+  status: string
+    The lifecycle phase (`status.phase`), e.g. `"Active"` or `"Terminating"`;
+    `""` when the field is absent.
+  labels: Record<string, string>
+    The namespace labels (`metadata.labels`), string-valued; `{}` when none.
+  createdAt?: string
+    When the namespace was created (`metadata.creationTimestamp`), if present.
 
 type DryRunMode = "none" | "client" | "server"
   The `--dry-run` strategies kubectl accepts.

--- a/llms.txt
+++ b/llms.txt
@@ -72,6 +72,7 @@ Option flags:
 - `--target` — With runs list, keep only runs whose graph has this target
 - `--since` — With runs list, keep only runs created at/after this time
 - `--limit` — With runs list, return at most this many runs (newest)
+- `--counts` — With runs list, print aggregate counts (total + per status)
 - `--keep` — With runs prune, keep runs newer than this age (e.g. 90d)
 - `--keep-last` — With runs prune, always keep the newest N terminal runs
 - `--allow-run` — With mcp, let agents run targets (optional =<glob-list> allow-list)

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -155,6 +155,8 @@ export interface ParsedArgs {
   since?: string;
   /** With `runs list`, return at most this many runs (`--limit`). */
   runLimit?: string;
+  /** With `runs list`, report aggregate counts instead of rows (`--counts`). */
+  runCounts?: boolean;
   /** With `runs prune`, keep runs newer than this age (`--keep`). */
   keep?: string;
   /** With `runs prune`, always keep the newest N terminal runs (`--keep-last`). */
@@ -274,6 +276,8 @@ export function parseArgs(
       if (value) parsed.since = value;
     } else if (arg.startsWith("--since=")) {
       parsed.since = arg.slice("--since=".length);
+    } else if (arg === "--counts") {
+      parsed.runCounts = true;
     } else if (arg === "--limit") {
       // Capture an explicit empty value (`--limit ""`) so it is validated and
       // rejected, not silently dropped — only a missing token stays undefined.
@@ -404,7 +408,7 @@ Usage:
   deno run -A zuke.ts mcp [--allow-run] [--registry] [--http <host:port>]
   deno run -A zuke.ts resume <run-id> [--signal <name>] [--data <json>]
   deno run -A zuke.ts resume --check [<run-id>]
-  deno run -A zuke.ts runs list [--status <s>] [--target <t>] [--since <iso>] [--limit <n>] [--json]
+  deno run -A zuke.ts runs list [--status <s>] [--target <t>] [--since <iso>] [--limit <n>] [--counts] [--json]
   deno run -A zuke.ts runs show <run-id> [--json]
   deno run -A zuke.ts runs prune [--keep <age>] [--keep-last <n>] [--dry-run]
   deno run -A zuke.ts cancel <run-id> [--actor <name>]
@@ -503,6 +507,7 @@ Options:
   --since <iso>     With runs list, keep only runs created at or after this
                     ISO-8601 timestamp.
   --limit <n>       With runs list, return at most this many runs (the newest).
+  --counts          With runs list, print aggregate counts (total + per status).
   --keep <age>      With runs prune, keep runs newer than this age (e.g. 90d);
                     older terminal runs become eligible for deletion.
   --keep-last <n>   With runs prune, always keep the newest N terminal runs.
@@ -883,6 +888,7 @@ async function runRuns(build: Build, parsed: ParsedArgs): Promise<number> {
     action: parsed.runsAction,
     runId: parsed.runsRunId,
     json: parsed.json,
+    counts: parsed.runCounts,
     query,
     keepMs,
     keepLast,

--- a/packages/core/src/cli_spec.ts
+++ b/packages/core/src/cli_spec.ts
@@ -148,6 +148,10 @@ export const BUILTIN_FLAGS: readonly BuiltinFlag[] = [
     description: "With runs list, return at most this many runs (newest)",
   },
   {
+    name: "--counts",
+    description: "With runs list, print aggregate counts (total + per status)",
+  },
+  {
     name: "--keep",
     description: "With runs prune, keep runs newer than this age (e.g. 90d)",
   },

--- a/packages/core/src/runs.ts
+++ b/packages/core/src/runs.ts
@@ -30,6 +30,8 @@ export interface RunsOptions {
   runId?: string;
   /** Emit JSON (a summary array, or the whole record) instead of a human view. */
   json?: boolean;
+  /** With `list`, report aggregate counts (total + per status) instead of rows. */
+  counts?: boolean;
   /** Filters for `list` — status, a target in the run, a creation time, a limit. */
   query?: RunQuery;
   /**
@@ -146,6 +148,15 @@ export async function runsCommand(
   const action = options.action ?? "list";
   if (action === "list") {
     const summaries = await store.listRuns(options.query ?? {});
+    if (options.counts) {
+      const counts = aggregateRunCounts(summaries);
+      console.log(
+        options.json
+          ? JSON.stringify(counts, null, 2)
+          : formatRunCounts(counts),
+      );
+      return 0;
+    }
     console.log(
       options.json
         ? JSON.stringify(summaries, null, 2)
@@ -232,6 +243,42 @@ const STATUS_MARK: Record<TargetRunStatus, string> = {
   failed: "x",
   skipped: "-",
 };
+
+/** Aggregate run counts for `runs list --counts`. */
+export interface RunCounts {
+  /** The total number of runs matched by the query. */
+  total: number;
+  /** The count per run status, keyed in ascending status-name order. */
+  byStatus: Record<string, number>;
+}
+
+/**
+ * Tally `summaries` into a total and per-status counts. The `byStatus` keys are
+ * inserted in ascending status-name order, so the JSON output is deterministic.
+ */
+export function aggregateRunCounts(
+  summaries: readonly RunSummary[],
+): RunCounts {
+  const tally = new Map<string, number>();
+  for (const s of summaries) {
+    tally.set(s.status, (tally.get(s.status) ?? 0) + 1);
+  }
+  const byStatus: Record<string, number> = {};
+  const sorted = [...tally].sort((a, b) =>
+    a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0
+  );
+  for (const [status, count] of sorted) byStatus[status] = count;
+  return { total: summaries.length, byStatus };
+}
+
+/** Render `runs list --counts`: a total and one line per present status. */
+export function formatRunCounts(counts: RunCounts): string {
+  if (counts.total === 0) return "No runs found.";
+  const entries = Object.entries(counts.byStatus);
+  const width = Math.max(...entries.map(([status]) => status.length));
+  const lines = entries.map(([status, n]) => `  ${status.padEnd(width)}  ${n}`);
+  return [`Total: ${counts.total}`, ...lines].join("\n");
+}
 
 /** Render `runs list`: one row per run, newest first (as the store returns them). */
 export function formatRunList(summaries: readonly RunSummary[]): string {

--- a/packages/core/tests/runs_test.ts
+++ b/packages/core/tests/runs_test.ts
@@ -1,6 +1,8 @@
 import { assertEquals, assertStringIncludes } from "./_assert.ts";
 import { Build } from "../src/build.ts";
 import {
+  aggregateRunCounts,
+  formatRunCounts,
   formatRunDetail,
   formatRunList,
   runsCommand,
@@ -183,6 +185,92 @@ Deno.test("runsCommand list --json emits a summary array", async () => {
     const summaries = JSON.parse(out);
     assertEquals(Array.isArray(summaries), true);
     assertEquals(summaries[0].id, "run-a");
+  });
+});
+
+Deno.test("aggregateRunCounts tallies total and per-status, in stable order", () => {
+  const summary = (id: string, status: RunStatus): RunSummary => ({
+    id,
+    build: "CI",
+    rootTarget: "deploy",
+    status,
+    actor: "alice",
+    createdAt: "2026-07-17T10:00:00.000Z",
+    updatedAt: "2026-07-17T10:05:00.000Z",
+  });
+  const counts = aggregateRunCounts([
+    summary("1", "succeeded"),
+    summary("2", "failed"),
+    summary("3", "succeeded"),
+    summary("4", "running"),
+  ]);
+  assertEquals(counts.total, 4);
+  // Keys are sorted ascending, so the JSON is deterministic.
+  assertEquals(Object.keys(counts.byStatus), [
+    "failed",
+    "running",
+    "succeeded",
+  ]);
+  assertEquals(counts.byStatus.succeeded, 2);
+  assertEquals(counts.byStatus.failed, 1);
+  assertEquals(aggregateRunCounts([]), { total: 0, byStatus: {} });
+});
+
+Deno.test("formatRunCounts renders a total and per-status lines, or an empty note", () => {
+  const text = formatRunCounts({
+    total: 3,
+    byStatus: { failed: 1, succeeded: 2 },
+  });
+  assertStringIncludes(text, "Total: 3");
+  assertStringIncludes(text, "succeeded");
+  assertStringIncludes(text, "2");
+  assertEquals(formatRunCounts({ total: 0, byStatus: {} }), "No runs found.");
+});
+
+Deno.test("runsCommand list --counts prints aggregate counts, and --json emits them", async () => {
+  await withStore(async (store) => {
+    await store.putRun(sampleRecord({ id: "a", status: "succeeded" }), null);
+    await store.putRun(sampleRecord({ id: "b", status: "succeeded" }), null);
+    await store.putRun(sampleRecord({ id: "c", status: "failed" }), null);
+
+    const human = await capture(() =>
+      runsCommand(new B(), { action: "list", counts: true, stateStore: store })
+    );
+    assertEquals(human.code, 0);
+    assertStringIncludes(human.out, "Total: 3");
+    assertStringIncludes(human.out, "succeeded");
+
+    const json = await capture(() =>
+      runsCommand(new B(), {
+        action: "list",
+        counts: true,
+        json: true,
+        stateStore: store,
+      })
+    );
+    assertEquals(json.code, 0);
+    assertEquals(JSON.parse(json.out), {
+      total: 3,
+      byStatus: { failed: 1, succeeded: 2 },
+    });
+  });
+});
+
+Deno.test("runsCommand list --counts honours the query filter", async () => {
+  await withStore(async (store) => {
+    await store.putRun(sampleRecord({ id: "ok", status: "succeeded" }), null);
+    await store.putRun(sampleRecord({ id: "bad", status: "failed" }), null);
+    const { code, out } = await capture(() =>
+      runsCommand(new B(), {
+        action: "list",
+        counts: true,
+        json: true,
+        query: { status: "failed" },
+        stateStore: store,
+      })
+    );
+    assertEquals(code, 0);
+    assertEquals(JSON.parse(out), { total: 1, byStatus: { failed: 1 } });
   });
 });
 

--- a/packages/kubectl/README.md
+++ b/packages/kubectl/README.md
@@ -48,6 +48,12 @@ await KubectlTasks.rollout((s) =>
 ```
 @module
 
+function parseNamespaces(json: string): KubernetesNamespace[]
+  Parse the JSON text of `kubectl get namespaces -o json` — a `List`, or a
+  single namespace object — into {@link KubernetesNamespace} records. Items
+  without a `metadata.name` are skipped; empty input yields `[]`. Throws if the
+  text is non-empty and not valid JSON.
+
 const KubectlTasks: KubectlTasksApi
   Typed task functions for the `kubectl` CLI.
 
@@ -163,8 +169,8 @@ class KubectlGetSettings extends KubectlSettings
     Restrict by field selector (`--field-selector`).
   allNamespaces(): this
     List across all namespaces (`-A`).
-  watch(): this
-    Watch for changes instead of returning once (`-w`).
+  watch(on: boolean): this
+    Watch for changes instead of returning once (`-w`); pass `false` to disable.
   showLabels(): this
     Include resource labels as columns (`--show-labels`).
   override protected buildArgs(): string[]
@@ -325,6 +331,10 @@ interface KubectlTasksApi
     Delete resources: `kubectl delete`.
   get(configure?: Configure<KubectlGetSettings>): Promise<CommandOutput>
     List resources: `kubectl get`.
+  getNamespaces(configure?: Configure<KubectlGetSettings>): Promise<KubernetesNamespace[]>
+    List namespaces as typed {@link KubernetesNamespace} records: runs
+    `kubectl get namespaces -o json` (forcing JSON output, quietly) and parses
+    the result. Use the lambda for cluster flags or a label `.selector(...)`.
   describe(configure?: Configure<KubectlDescribeSettings>): Promise<CommandOutput>
     Describe resources: `kubectl describe`.
   logs(configure?: Configure<KubectlLogsSettings>): Promise<CommandOutput>
@@ -349,6 +359,20 @@ interface KubectlTasksApi
     Wait for a condition: `kubectl wait`.
   top(configure?: Configure<KubectlTopSettings>): Promise<CommandOutput>
     Show resource usage: `kubectl top`.
+
+interface KubernetesNamespace
+  A Kubernetes namespace, parsed from `kubectl get namespaces -o json` — the
+  typed result of {@link KubectlTasksApi.getNamespaces}.
+
+  name: string
+    The namespace name (`metadata.name`).
+  status: string
+    The lifecycle phase (`status.phase`), e.g. `"Active"` or `"Terminating"`;
+    `""` when the field is absent.
+  labels: Record<string, string>
+    The namespace labels (`metadata.labels`), string-valued; `{}` when none.
+  createdAt?: string
+    When the namespace was created (`metadata.creationTimestamp`), if present.
 
 type DryRunMode = "none" | "client" | "server"
   The `--dry-run` strategies kubectl accepts.

--- a/packages/kubectl/src/kubectl.ts
+++ b/packages/kubectl/src/kubectl.ts
@@ -329,9 +329,9 @@ export class KubectlGetSettings extends KubectlSettings {
     return this;
   }
 
-  /** Watch for changes instead of returning once (`-w`). */
-  watch(): this {
-    this.#watch = true;
+  /** Watch for changes instead of returning once (`-w`); pass `false` to disable. */
+  watch(on = true): this {
+    this.#watch = on;
     return this;
   }
 
@@ -1065,6 +1065,76 @@ export class KubectlTopSettings extends KubectlSettings {
   }
 }
 
+/**
+ * A Kubernetes namespace, parsed from `kubectl get namespaces -o json` — the
+ * typed result of {@link KubectlTasksApi.getNamespaces}.
+ */
+export interface KubernetesNamespace {
+  /** The namespace name (`metadata.name`). */
+  name: string;
+  /**
+   * The lifecycle phase (`status.phase`), e.g. `"Active"` or `"Terminating"`;
+   * `""` when the field is absent.
+   */
+  status: string;
+  /** The namespace labels (`metadata.labels`), string-valued; `{}` when none. */
+  labels: Record<string, string>;
+  /** When the namespace was created (`metadata.creationTimestamp`), if present. */
+  createdAt?: string;
+}
+
+/** Narrow an unknown value to a plain JSON object. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Narrow a value to a `Record<string, string>`, dropping non-string entries. */
+function stringMap(value: unknown): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (isRecord(value)) {
+    for (const [key, v] of Object.entries(value)) {
+      if (typeof v === "string") out[key] = v;
+    }
+  }
+  return out;
+}
+
+/** Narrow one `kubectl get` item into a {@link KubernetesNamespace}, or `null`. */
+function parseNamespace(item: unknown): KubernetesNamespace | null {
+  if (!isRecord(item)) return null;
+  const metadata = isRecord(item.metadata) ? item.metadata : {};
+  const name = typeof metadata.name === "string" ? metadata.name : undefined;
+  if (name === undefined) return null;
+  const status = isRecord(item.status) && typeof item.status.phase === "string"
+    ? item.status.phase
+    : "";
+  const createdAt = typeof metadata.creationTimestamp === "string"
+    ? metadata.creationTimestamp
+    : undefined;
+  return { name, status, labels: stringMap(metadata.labels), createdAt };
+}
+
+/**
+ * Parse the JSON text of `kubectl get namespaces -o json` — a `List`, or a
+ * single namespace object — into {@link KubernetesNamespace} records. Items
+ * without a `metadata.name` are skipped; empty input yields `[]`. Throws if the
+ * text is non-empty and not valid JSON.
+ */
+export function parseNamespaces(json: string): KubernetesNamespace[] {
+  const text = json.trim();
+  if (text === "") return [];
+  const parsed: unknown = JSON.parse(text);
+  const items = isRecord(parsed) && Array.isArray(parsed.items)
+    ? parsed.items
+    : [parsed];
+  const namespaces: KubernetesNamespace[] = [];
+  for (const item of items) {
+    const namespace = parseNamespace(item);
+    if (namespace !== null) namespaces.push(namespace);
+  }
+  return namespaces;
+}
+
 /** The shape of {@link KubectlTasks}. */
 export interface KubectlTasksApi {
   /** Apply manifests: `kubectl apply`. */
@@ -1075,6 +1145,14 @@ export interface KubectlTasksApi {
   delete(configure?: Configure<KubectlDeleteSettings>): Promise<CommandOutput>;
   /** List resources: `kubectl get`. */
   get(configure?: Configure<KubectlGetSettings>): Promise<CommandOutput>;
+  /**
+   * List namespaces as typed {@link KubernetesNamespace} records: runs
+   * `kubectl get namespaces -o json` (forcing JSON output, quietly) and parses
+   * the result. Use the lambda for cluster flags or a label `.selector(...)`.
+   */
+  getNamespaces(
+    configure?: Configure<KubectlGetSettings>,
+  ): Promise<KubernetesNamespace[]>;
   /** Describe resources: `kubectl describe`. */
   describe(
     configure?: Configure<KubectlDescribeSettings>,
@@ -1124,6 +1202,17 @@ export const KubectlTasks: KubectlTasksApi = {
   },
   get(configure?: Configure<KubectlGetSettings>): Promise<CommandOutput> {
     return runSettings(new KubectlGetSettings(), configure);
+  },
+  async getNamespaces(
+    configure?: Configure<KubectlGetSettings>,
+  ): Promise<KubernetesNamespace[]> {
+    const settings = new KubectlGetSettings().resource("namespaces");
+    configure?.(settings);
+    // Force a single JSON snapshot regardless of the caller's config: JSON output
+    // to parse, `.watch(false)` so it returns once instead of streaming forever,
+    // and `.quiet()` so the raw JSON isn't echoed to the terminal.
+    const out = await settings.output("json").watch(false).quiet().run();
+    return parseNamespaces(out.text());
   },
   describe(
     configure?: Configure<KubectlDescribeSettings>,

--- a/packages/kubectl/tests/kubectl_test.ts
+++ b/packages/kubectl/tests/kubectl_test.ts
@@ -1,9 +1,11 @@
 import {
   assertEquals,
   assertRejects,
+  assertStringIncludes,
   assertThrows,
 } from "../../core/tests/_assert.ts";
 import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { withAmbientEcho } from "../../core/src/ambient_echo.ts";
 import {
   KubectlAnnotateSettings,
   KubectlApplySettings,
@@ -22,6 +24,7 @@ import {
   KubectlTasks,
   KubectlTopSettings,
   KubectlWaitSettings,
+  parseNamespaces,
 } from "../src/kubectl.ts";
 
 Deno.test("the default binary is kubectl", () => {
@@ -186,6 +189,156 @@ Deno.test("get: requires a resource; all options", () => {
       "-w",
       "--show-labels",
     ],
+  );
+});
+
+Deno.test("getNamespaces forces `get namespaces -o json`", () => {
+  // getNamespaces builds this argv internally (the forced `.quiet()` adds no arg).
+  assertEquals(
+    new KubectlGetSettings().resource("namespaces").output("json").argv().slice(
+      1,
+    ),
+    ["get", "namespaces", "-o", "json"],
+  );
+});
+
+Deno.test("parseNamespaces narrows a List, a single object, and skips bad items", () => {
+  const list = parseNamespaces(JSON.stringify({
+    items: [
+      {
+        metadata: {
+          name: "a",
+          labels: { x: "1", n: 2 },
+          creationTimestamp: "t",
+        },
+        status: { phase: "Active" },
+      },
+      { metadata: { name: "b" } }, // no status, no labels
+      { metadata: {} }, // no name → skipped
+      { spec: {} }, // no metadata → skipped
+      "nope", // not a record → skipped
+    ],
+  }));
+  assertEquals(list.map((n) => n.name), ["a", "b"]);
+  // A non-string label value (n: 2) is dropped, not coerced.
+  assertEquals(list[0], {
+    name: "a",
+    status: "Active",
+    labels: { x: "1" },
+    createdAt: "t",
+  });
+  assertEquals(list[1], {
+    name: "b",
+    status: "",
+    labels: {},
+    createdAt: undefined,
+  });
+
+  // A single namespace object (kubectl get ns <name> -o json) → one-element array.
+  assertEquals(
+    parseNamespaces(
+      JSON.stringify({
+        metadata: { name: "solo" },
+        status: { phase: "Terminating" },
+      }),
+    ),
+    [{ name: "solo", status: "Terminating", labels: {}, createdAt: undefined }],
+  );
+  assertEquals(parseNamespaces(JSON.stringify({ items: [] })), []);
+  assertEquals(parseNamespaces(JSON.stringify({})), []); // no name → dropped
+  assertEquals(parseNamespaces("  "), []); // empty/whitespace → no rows
+  assertThrows(() => parseNamespaces("{not json"), Error);
+});
+
+Deno.test("getNamespaces runs kubectl and parses the JSON (POSIX fake binary)", async () => {
+  if (Deno.build.os === "windows") return; // shebang script; argv is covered above.
+  const dir = await Deno.makeTempDir();
+  try {
+    const argvFile = `${dir}/argv`;
+    const jsonFile = `${dir}/ns.json`;
+    await Deno.writeTextFile(
+      jsonFile,
+      JSON.stringify({
+        items: [
+          {
+            metadata: {
+              name: "default",
+              labels: { env: "prod" },
+              creationTimestamp: "2026-01-01T00:00:00Z",
+            },
+            status: { phase: "Active" },
+          },
+          { metadata: { name: "kube-system" } },
+        ],
+      }),
+    );
+    const fake = `${dir}/kubectl`;
+    await Deno.writeTextFile(
+      fake,
+      `#!/bin/sh\nprintf '%s' "$*" > "${argvFile}"\ncat "${jsonFile}"\n`,
+    );
+    await Deno.chmod(fake, 0o755);
+
+    // The caller sets `.output("yaml")` and a `.selector()`: getNamespaces must
+    // FORCE `-o json` over the caller's yaml (or parsing would fail) while still
+    // threading the caller's selector through.
+    const namespaces = await KubectlTasks.getNamespaces((s) =>
+      s.toolPath(fake).output("yaml").selector("team=web")
+    );
+    assertEquals(namespaces.map((n) => n.name), ["default", "kube-system"]);
+    assertEquals(namespaces[0].status, "Active");
+    assertEquals(namespaces[0].labels, { env: "prod" });
+    assertEquals(namespaces[0].createdAt, "2026-01-01T00:00:00Z");
+    assertEquals(namespaces[1].status, ""); // no status.phase
+    assertEquals(
+      await Deno.readTextFile(argvFile),
+      "get namespaces -o json -l team=web",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("getNamespaces with no configure runs the command (dry run yields no rows)", async () => {
+  // Under a deep-dry-run echo sink the command is echoed, not spawned; the
+  // empty output parses to no rows. Exercises the no-configure path.
+  const echoed: string[] = [];
+  const result = await withAmbientEcho(
+    (line) => echoed.push(line),
+    () => KubectlTasks.getNamespaces(),
+  );
+  assertEquals(result, []);
+  assertStringIncludes(echoed[0], "kubectl get namespaces -o json");
+});
+
+Deno.test("getNamespaces reaches execution", async () => {
+  await assertRejects(
+    () =>
+      KubectlTasks.getNamespaces((s) => {
+        s.os_ = "linux";
+        return s.toolPath("zuke-no-such-kubectl-xyz");
+      }),
+    ToolNotFoundError,
+  );
+});
+
+Deno.test("getNamespaces neutralizes a caller's .watch() so it never streams", async () => {
+  // A watch (`-w`) would stream forever and never yield parseable JSON; the
+  // helper must force it off. Echoed under a dry run so nothing spawns.
+  const echoed: string[] = [];
+  await withAmbientEcho(
+    (line) => echoed.push(line),
+    () => KubectlTasks.getNamespaces((s) => s.watch()),
+  );
+  assertStringIncludes(echoed[0], "get namespaces -o json");
+  assertEquals(echoed[0].includes("-w"), false);
+});
+
+Deno.test("KubectlGetSettings.watch(false) disables an earlier watch", () => {
+  assertEquals(
+    new KubectlGetSettings().resource("pods").watch().watch(false).argv()
+      .includes("-w"),
+    false,
   );
 });
 

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -174,7 +174,7 @@ class CD extends Build {
   mismatch.
 - The run record holds status, the graph shape, resolved **non-secret**
   parameters, and per-target status/timing/metadata. Inspect it from the CLI
-  with `zuke runs list [--status <s>] [--target <t>] [--since <iso>] [--limit <n>]`
+  with `zuke runs list [--status <s>] [--target <t>] [--since <iso>] [--limit <n>] [--counts]`
   (newest first) and `zuke runs show <id>` (`--json` on both), or programmatically
   with `store.listRuns({ status?, target?, since?, limit? })` and `store.getRun(id)`.
 - **Retention:** `zuke runs prune --keep <age> --keep-last <n>` deletes only
@@ -592,7 +592,7 @@ else a friendly error.
 ./zuke <target> --no-cache    # ignore the incremental cache
 ./zuke <target> --state       # persist run state to .zuke/runs (durable state)
 ./zuke <target> --actor <who> # attribute the run in its state record
-./zuke runs list [--status s] # list persisted runs (also --target, --since, --limit, --json)
+./zuke runs list [--status s] # list persisted runs (also --target, --since, --limit, --counts, --json)
 ./zuke runs show <id>         # one run's full per-target status (+ --json)
 ./zuke runs prune --keep 90d --keep-last 50  # delete old terminal runs (--dry-run to preview)
 ./zuke resume <id> --signal <name> [--data <json>]  # continue a suspended run

--- a/tests/integration/state_test.ts
+++ b/tests/integration/state_test.ts
@@ -100,6 +100,32 @@ Deno.test("zuke runs prune keeps non-terminal runs and the newest terminal, hono
   });
 });
 
+Deno.test("zuke runs list --counts aggregates by status end-to-end", async () => {
+  await withStateDir(async () => {
+    class Ok extends Build {
+      go = target().executes(() => {});
+    }
+    class Boom extends Build {
+      go = target().executes(() => {
+        throw new Error("nope");
+      });
+    }
+    await runCli(Ok, ["go"]);
+    await runCli(Ok, ["go"]);
+    await runCli(Boom, ["go"]); // one failed run
+
+    const counts = await runCli(Ok, ["runs", "list", "--counts", "--json"]);
+    assertEquals(counts.code, 0);
+    assertEquals(JSON.parse(counts.out), {
+      total: 3,
+      byStatus: { failed: 1, succeeded: 2 },
+    });
+
+    const human = await runCli(Ok, ["runs", "list", "--counts"]);
+    assertStringIncludes(human.out, "Total: 3");
+  });
+});
+
 Deno.test("zuke runs prune with no retention rule refuses to delete", async () => {
   await withStateDir(async (dir) => {
     class Ok extends Build {


### PR DESCRIPTION
## `runs list --counts` + typed `kubectl getNamespaces`

The two P2 items you asked for, batched.

### 1 — `zuke runs list --counts`

Aggregate counts instead of one row per run: a **total** and one line per
**status**. With `--json` it emits `{ total, byStatus }`, where `byStatus`
keys are **sorted** so the output is deterministic (scriptable). It composes
with the existing filters, so `runs list --status failed --since … --counts`
tallies just the matching set.

```
$ zuke runs list --counts
Total: 3
  failed     1
  succeeded  2

$ zuke runs list --counts --json
{ "total": 3, "byStatus": { "failed": 1, "succeeded": 2 } }
```

### 2 — `KubectlTasks.getNamespaces()` (typed output)

`get ns` typed output: instead of raw text, `getNamespaces()` returns
`KubernetesNamespace[]` (`{ name, status, labels, createdAt? }`). It runs
`kubectl get namespaces -o json` and narrows the **untrusted** cluster JSON with
type guards (no `as`) — skipping items without a `metadata.name`, defaulting a
missing `status.phase` to `""`, and dropping non-string labels. The exported
`parseNamespaces(text)` is the pure parser behind it.

It **forces** JSON output and a single non-watching snapshot regardless of the
caller's config (so it always returns parseable records, never a stream), while
still threading a caller's cluster flags / label `.selector(...)` through.
`KubectlGetSettings.watch` now takes an optional boolean so a watch can be
turned back off.

### Tests

Unit (aggregate/format counts; `parseNamespaces` edge cases: List vs single
object, missing name, non-string labels, empty/invalid input), integration
(`runs list --counts` end-to-end via the CLI; a POSIX fake-kubectl proving the
real run → JSON → typed result, the output-format override, and selector
threading), plus a cross-platform dry-run path. `kubectl.ts` 100% coverage.

### Adversarial review

5-dimension pass (namespace JSON parsing, output forcing, counts correctness,
test adequacy) → refute-by-default verify. **3 confirmed, all fixed with a
regression test:**

- **`getNamespaces` didn't neutralize a caller's `.watch()`** — `-w` would
  stream forever and hang. Now forced off (and `watch()` is toggleable).
- **The "force `-o json` over the caller" guarantee was untested** — a reorder
  bug could let a caller's `.output("yaml")` win and crash the parser. Now a
  test passes `.output("yaml") + .selector(...)` and asserts the forced json +
  threaded selector.
- **A dead `?? 0` fallback** in `aggregateRunCounts` (an uncoverable branch) —
  removed by iterating the tally entries directly.

### Gate

`deno task ci` green (lines 98.2%, branches 95.1%); `apiDocsCheck`,
`generate-ci --check`, and core `deno doc --lint` clean; `docs/state.md`,
`docs/cli.md`, `docs/tools.md`, and the build skill updated.
