### PR TITLE
docs: list every package in the README and enforce it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,13 +308,14 @@ zuke.ts                   # Zuke's own build (runnable example)
   version is bumped. The repo squash-merges, so the squash body comes from the
   PR description/commits: put illustrative code in the PR discussion, and keep
   commit bodies to prose. See [`RELEASING.md`](RELEASING.md).
-- **A new package must be added everywhere.** Membership is declared in five
+- **A new package must be added everywhere.** Membership is declared in six
   places that must stay in lock-step: the `deno.json` workspace,
   `.release-please-config.json`, `.release-please-manifest.json`, the `PACKAGES`
-  array in `zuke.ts` (the JSR publish loop), and the list in
-  `tests/release_config_test.ts`. `tests/release_config_test.ts` enforces that
-  they agree — run it after adding a package. Omitting `zuke.ts` means the
-  package is released but never published.
+  array in `zuke.ts` (the JSR publish loop), the package table in `README.md`,
+  and the list in `tests/release_config_test.ts`. `tests/release_config_test.ts`
+  enforces that all six agree — run it after adding a package. Omitting
+  `zuke.ts` means the package is released but never published; omitting the
+  `README.md` table means it is invisible to anyone browsing the repo.
 - **Update docs with code.** If behaviour changes, update `README.md`, JSDoc,
   and the spec/acceptance criteria in the same PR.
 - **Always read the reviewer comments on every PR.** This repo runs AI reviewers

--- a/README.md
+++ b/README.md
@@ -104,9 +104,12 @@ latest release on JSR.
 | [`@zuke/docs`](https://jsr.io/@zuke/docs)         | [![JSR](https://jsr.io/badges/@zuke/docs)](https://jsr.io/@zuke/docs) [![JSR score](https://jsr.io/badges/@zuke/docs/score)](https://jsr.io/@zuke/docs)                 |
 | [`@zuke/npm`](https://jsr.io/@zuke/npm)           | [![JSR](https://jsr.io/badges/@zuke/npm)](https://jsr.io/@zuke/npm) [![JSR score](https://jsr.io/badges/@zuke/npm/score)](https://jsr.io/@zuke/npm)                     |
 | [`@zuke/security`](https://jsr.io/@zuke/security) | [![JSR](https://jsr.io/badges/@zuke/security)](https://jsr.io/@zuke/security) [![JSR score](https://jsr.io/badges/@zuke/security/score)](https://jsr.io/@zuke/security) |
+| [`@zuke/ai`](https://jsr.io/@zuke/ai)             | [![JSR](https://jsr.io/badges/@zuke/ai)](https://jsr.io/@zuke/ai) [![JSR score](https://jsr.io/badges/@zuke/ai/score)](https://jsr.io/@zuke/ai)                         |
+| [`@zuke/console`](https://jsr.io/@zuke/console)   | [![JSR](https://jsr.io/badges/@zuke/console)](https://jsr.io/@zuke/console) [![JSR score](https://jsr.io/badges/@zuke/console/score)](https://jsr.io/@zuke/console)     |
+| [`@zuke/otel`](https://jsr.io/@zuke/otel)         | [![JSR](https://jsr.io/badges/@zuke/otel)](https://jsr.io/@zuke/otel) [![JSR score](https://jsr.io/badges/@zuke/otel/score)](https://jsr.io/@zuke/otel)                 |
 
 <details>
-<summary><strong>All tool wrappers</strong> (30+ packages)</summary>
+<summary><strong>All tool wrappers</strong> (40+ packages)</summary>
 
 | Package                                                       | Version                                                                                                                                                                                         |
 | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -142,6 +145,7 @@ latest release on JSR.
 | [`@zuke/oxlint`](https://jsr.io/@zuke/oxlint)                 | [![JSR](https://jsr.io/badges/@zuke/oxlint)](https://jsr.io/@zuke/oxlint) [![JSR score](https://jsr.io/badges/@zuke/oxlint/score)](https://jsr.io/@zuke/oxlint)                                 |
 | [`@zuke/playwright`](https://jsr.io/@zuke/playwright)         | [![JSR](https://jsr.io/badges/@zuke/playwright)](https://jsr.io/@zuke/playwright) [![JSR score](https://jsr.io/badges/@zuke/playwright/score)](https://jsr.io/@zuke/playwright)                 |
 | [`@zuke/pnpm`](https://jsr.io/@zuke/pnpm)                     | [![JSR](https://jsr.io/badges/@zuke/pnpm)](https://jsr.io/@zuke/pnpm) [![JSR score](https://jsr.io/badges/@zuke/pnpm/score)](https://jsr.io/@zuke/pnpm)                                         |
+| [`@zuke/release-please`](https://jsr.io/@zuke/release-please) | [![JSR](https://jsr.io/badges/@zuke/release-please)](https://jsr.io/@zuke/release-please) [![JSR score](https://jsr.io/badges/@zuke/release-please/score)](https://jsr.io/@zuke/release-please) |
 | [`@zuke/terraform`](https://jsr.io/@zuke/terraform)           | [![JSR](https://jsr.io/badges/@zuke/terraform)](https://jsr.io/@zuke/terraform) [![JSR score](https://jsr.io/badges/@zuke/terraform/score)](https://jsr.io/@zuke/terraform)                     |
 | [`@zuke/tofu`](https://jsr.io/@zuke/tofu)                     | [![JSR](https://jsr.io/badges/@zuke/tofu)](https://jsr.io/@zuke/tofu) [![JSR score](https://jsr.io/badges/@zuke/tofu/score)](https://jsr.io/@zuke/tofu)                                         |
 | [`@zuke/tsc`](https://jsr.io/@zuke/tsc)                       | [![JSR](https://jsr.io/badges/@zuke/tsc)](https://jsr.io/@zuke/tsc) [![JSR score](https://jsr.io/badges/@zuke/tsc/score)](https://jsr.io/@zuke/tsc)                                             |
@@ -366,9 +370,10 @@ Zuke stands on the shoulders of giants:
   **[Matthias Koch](https://github.com/matkoch)** — the code-first,
   strongly-typed build model that inspired Zuke. If you build for .NET, use
   NUKE; Zuke is an homage to its ideas in the Deno/TypeScript world.
-- **[Spectre.Console](https://spectreconsole.net/)** and its creator **[Patrik Svensson](https://github.com/patriksvensson)** — the .NET console library
-  whose markup, themes, and rich widgets (rules, panels, tables) inspired the
-  output model of `@zuke/console`.
+- **[Spectre.Console](https://spectreconsole.net/)** and its creator
+  **[Patrik Svensson](https://github.com/patriksvensson)** — the .NET console
+  library whose markup, themes, and rich widgets (rules, panels, tables)
+  inspired the output model of `@zuke/console`.
 - **[Deno](https://deno.com/)** — the runtime and toolchain (test runner,
   formatter, linter, type-checker, coverage) that makes a zero-dependency,
   hermetic build tool possible.

--- a/tests/release_config_test.ts
+++ b/tests/release_config_test.ts
@@ -101,6 +101,24 @@ Deno.test("the deno workspace lists exactly the configured packages", async () =
   assertEquals(workspace.map(String).sort(), [...PACKAGES].sort());
 });
 
+Deno.test("the README package table lists every workspace package", async () => {
+  // The README's package tables are the human-facing catalog; a package missing
+  // there is invisible to anyone browsing the repo. Enforce it so the six
+  // membership lists (workspace, release-please config/manifest, zuke.ts publish
+  // loop, this test, and the README) never drift apart.
+  const readme = await Deno.readTextFile("README.md");
+  const missing = PACKAGES
+    .map((path) => path.replace("packages/", ""))
+    .filter((name) =>
+      !readme.includes(`[\`@zuke/${name}\`](https://jsr.io/@zuke/${name})`)
+    );
+  assertEquals(
+    missing,
+    [],
+    `README.md package tables are missing: ${missing.join(", ")}`,
+  );
+});
+
 Deno.test("the zuke.ts JSR publish list covers every workspace package", async () => {
   // `publishJsr` only iterates this array, so a package missing here is silently
   // never published — guard against that drift (it is what stranded the AI CLI


### PR DESCRIPTION
## Complete the README package list (and keep it complete)

The README package tables had drifted — **four published packages were missing**
from the catalog: `@zuke/ai`, `@zuke/console`, `@zuke/otel`, and
`@zuke/release-please`.

### What changed

- **Added the four missing packages** to the README package tables — the three
  first-party feature packages (`ai`, `console`, `otel`) to the top table, and
  the `release-please` CLI wrapper to the tool-wrappers list.
- **Made the README a first-class membership place.** A new package must now be
  registered in **six** lock-step places (the `deno.json` workspace, the two
  release-please files, the `zuke.ts` publish loop, `release_config_test.ts`,
  and the `README.md` table). `AGENTS.md` documents this.
- **Enforced it.** `tests/release_config_test.ts` now asserts every workspace
  package has a row in the README, so the catalog can't silently drift again —
  the same guard style that already keeps the other five lists in sync.

### Why

The drift was invisible because the README wasn't one of the enforced places.
Rather than just patch the list, this closes the loop so it stays correct.

### Gate

`deno task ci` green (fmt, lint, spell, type-check, tests + coverage). Docs-only
plus one guard test — no package code changed, so nothing is released.