### PR TITLE
fix: pin @zuke/core ^1.25.0 across wrappers so fromNodeModules resolves

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -565,267 +565,267 @@
     "members": {
       "packages/ai": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/biome": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/bun": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/claude": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/cmd": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/codecov": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/codex": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/console": {
         "dependencies": [
-          "jsr:@zuke/core@^1.9.0"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/cspell": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/cypress": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/deno": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/docker": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/docker-compose": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/docs": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/dpdm": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/dprint": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/eslint": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/gcloud": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/gemini": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/gh": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/git": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/helm": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/husky": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/jest": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/jsr": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/knip": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/kubectl": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/kustomize": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/nest": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/node": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/npm": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/npx": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/nx": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/openapi-ts": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/orval": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/otel": {
         "dependencies": [
-          "jsr:@zuke/core@^1.18.0"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/oxlint": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/playwright": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/pnpm": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/release-please": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/security": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/terraform": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/tofu": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/tsc": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/tsc-alias": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/tsdown": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/tsgo": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/tsup": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/tsx": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/turbo": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/vite": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/vitest": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       },
       "packages/yarn": {
         "dependencies": [
-          "jsr:@zuke/core@1"
+          "jsr:@zuke/core@^1.25.0"
         ]
       }
     }

--- a/packages/ai/deno.json
+++ b/packages/ai/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/biome/deno.json
+++ b/packages/biome/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/bun/deno.json
+++ b/packages/bun/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/claude/deno.json
+++ b/packages/claude/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/cmd/deno.json
+++ b/packages/cmd/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/codecov/deno.json
+++ b/packages/codecov/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/codex/deno.json
+++ b/packages/codex/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/console/deno.json
+++ b/packages/console/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1.9.0"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/cspell/deno.json
+++ b/packages/cspell/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/cypress/deno.json
+++ b/packages/cypress/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/deno/deno.json
+++ b/packages/deno/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/docker-compose/deno.json
+++ b/packages/docker-compose/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/docker/deno.json
+++ b/packages/docker/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/docs/deno.json
+++ b/packages/docs/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/dpdm/deno.json
+++ b/packages/dpdm/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/dprint/deno.json
+++ b/packages/dprint/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/eslint/deno.json
+++ b/packages/eslint/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/gcloud/deno.json
+++ b/packages/gcloud/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/gemini/deno.json
+++ b/packages/gemini/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/gh/deno.json
+++ b/packages/gh/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/git/deno.json
+++ b/packages/git/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/helm/deno.json
+++ b/packages/helm/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/husky/deno.json
+++ b/packages/husky/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/jest/deno.json
+++ b/packages/jest/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/jsr/deno.json
+++ b/packages/jsr/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/knip/deno.json
+++ b/packages/knip/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/kubectl/deno.json
+++ b/packages/kubectl/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/kustomize/deno.json
+++ b/packages/kustomize/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/nest/deno.json
+++ b/packages/nest/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/node/deno.json
+++ b/packages/node/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/npm/deno.json
+++ b/packages/npm/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/npx/deno.json
+++ b/packages/npx/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/nx/deno.json
+++ b/packages/nx/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/openapi-ts/deno.json
+++ b/packages/openapi-ts/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/orval/deno.json
+++ b/packages/orval/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/otel/deno.json
+++ b/packages/otel/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1.18.0"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/oxlint/deno.json
+++ b/packages/oxlint/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/playwright/deno.json
+++ b/packages/playwright/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/pnpm/deno.json
+++ b/packages/pnpm/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/release-please/deno.json
+++ b/packages/release-please/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/security/deno.json
+++ b/packages/security/deno.json
@@ -5,7 +5,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/terraform/deno.json
+++ b/packages/terraform/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/tofu/deno.json
+++ b/packages/tofu/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/tsc-alias/deno.json
+++ b/packages/tsc-alias/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/tsc/deno.json
+++ b/packages/tsc/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/tsdown/deno.json
+++ b/packages/tsdown/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/tsgo/deno.json
+++ b/packages/tsgo/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/tsup/deno.json
+++ b/packages/tsup/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/tsx/deno.json
+++ b/packages/tsx/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/turbo/deno.json
+++ b/packages/turbo/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/vite/deno.json
+++ b/packages/vite/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/vitest/deno.json
+++ b/packages/vitest/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [

--- a/packages/yarn/deno.json
+++ b/packages/yarn/deno.json
@@ -6,7 +6,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1"
+    "@zuke/core": "jsr:@zuke/core@^1.25.0"
   },
   "publish": {
     "exclude": [


### PR DESCRIPTION
## Problem

`.fromNodeModules()` fails at runtime (`s.fromNodeModules is not a function`) on six published wrappers — oxlint, dprint, cspell, vitest, dpdm, vite.

Verified against JSR: those six are published with `@zuke/core@^0` (excludes 1.x), while tsc/nest/npm ship `@zuke/core@^1`. The method lives on core's `ToolSettings` and landed in **core 1.25.0**, so a wrapper resolving pre-1.x core simply doesn't have it.

## Root cause

PR #93 tightened the local dep to `^1`, but as a `chore:` commit — release-please never bumped those package versions, so JSR keeps serving the old `^0` range under the current version (JSR versions are immutable).

## Fix

Bump the core dependency floor to `^1.25.0` for all 53 core-dependent packages. This:
- guarantees `fromNodeModules` (and every other `ToolSettings` chainer) exists at runtime, even under a consumer lockfile / `minimumDependencyAge` that would otherwise resolve pre-1.25 core;
- gives release-please a `fix:` to attribute to every package, re-releasing them with a correct range.

Consumers importing wrappers at `@^0` will pick up the patched versions automatically once released.

## Verification

`deno task ci` green: check, test, coverage (98.3% lines / 95.2% branches) all pass.