### PR TITLE
feat(core): install multi-file runtime trees via installTree

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -88,6 +88,13 @@ function assertSafeEntryName(name: string): void
   absolute path or one with a `..` segment (a "zip slip"). A downloaded or
   poisoned archive must never place files outside where it is being unpacked.
 
+function assertSafeLinkTarget(entryName: string, target: string): void
+  Reject a symlink whose target would resolve outside the destination directory
+  — an absolute target, or a relative one that climbs (with `..`) above the
+  extraction root once resolved against the link's own directory. A file entry's
+  name is bounded by {@link assertSafeEntryName}; a symlink adds a second escape
+  vector (its target), so a poisoned tarball can't plant `bin/x -> ../../etc`.
+
 async function cancelRun(build: Build, options: CancelOptions): Promise<CancelResult>
   Cancel the run `options.runId` for `build`: transition it to `cancelling`
   (exactly one canceller drives the walk; a live owning process observes the
@@ -220,11 +227,13 @@ function externalSignal(name: string): WaitTrigger
   (via `zuke resume <id> --signal <name>`). The signal's payload is exposed to
   target bodies through {@link "./target.ts".TargetContext} `signals`.
 
-async function extractTarGzip(src: PathLike, destDir: PathLike): Promise<void>
+async function extractTarGzip(src: PathLike, destDir: PathLike, options: ExtractOptions): Promise<void>
   Read the `.tar.gz` at `src`, gunzip and unpack it, and write each entry under
-  `destDir` (creating parent directories as needed).
+  `destDir` (creating parent directories as needed). Symlink entries are
+  recreated as symlinks; pass {@link ExtractOptions.strip} to drop leading path
+  components.
 
-async function extractZip(src: PathLike, destDir: PathLike): Promise<void>
+async function extractZip(src: PathLike, destDir: PathLike, options: ExtractOptions): Promise<void>
   Read the `.zip` at `src`, unpack it, and write each entry under `destDir`
   (creating parent directories as needed) — the zip counterpart of
   {@link extractTarGzip}. Entry names are validated so a malicious archive
@@ -356,6 +365,19 @@ async function installRelease(options: InstallReleaseOptions): Promise<AbsoluteP
   anything is installed, and a matching prior install is reused without
   downloading again — so pinning a checksum makes the install both hermetic
   (tamper-evident) and cached.
+
+async function installTree(options: InstallTreeOptions): Promise<AbsolutePath>
+  Download and unpack a whole archive tree — a multi-file runtime such as
+  Node.js, which ships `bin/node`, `bin/npm`, `bin/npx`, and
+  `lib/node_modules/**` in one tarball — and return the {@link AbsolutePath} of
+  its (stripped) root. `installRelease` extracts a single binary; `installTree`
+  keeps the entire directory, symlinks included.
+
+  Because {@link AbsolutePath} is callable, the root doubles as an accessor:
+  `root("bin", "node")` is the node binary and `root("bin")` is the directory to
+  put on `PATH` (with `prependPath`). Declared {@link InstallTreeOptions.bins}
+  are marked executable on POSIX. With a {@link InstallTreeOptions.checksum} the
+  archive is verified before unpacking and a matching prior install is reused.
 
 function isCI(): boolean
   Whether the build appears to be running in a CI environment.
@@ -1588,6 +1610,10 @@ class ToolInstallSettings
     Download format. Set by {@link archive}.
   binaryPath_?: string
     The binary's path within a `tar.gz`. Set by {@link binaryPath}.
+  strip_?: number
+    Leading path components to strip on a tree install. Set by {@link strip}.
+  bins_?: string[]
+    Executable bins within a tree install. Set by {@link bins}.
   checksum_?: string | ((platform: Platform) => string)
     Expected SHA-256 (or a per-platform resolver). Set by {@link checksum}.
   platform_?: InstallPlatform
@@ -1605,6 +1631,14 @@ class ToolInstallSettings
     the bare binary). Pair with {@link binaryPath} for the binary inside.
   binaryPath(path: string): this
     For an archive, the binary's path within it (defaults to the name).
+  strip(components: number): this
+    For a tree install ({@link ToolTasksApi.installTree} / {@link Toolchain.tree}),
+    drop this many leading path components while unpacking — `1` unwraps a
+    release tarball's `tool-v1.2.3/` directory. Ignored by a single-binary install.
+  bins(...paths: string[]): this
+    For a tree install, the paths (relative to the stripped root) to mark
+    executable on POSIX — a runtime's `bin/node`, `bin/npm`, … Ignored by a
+    single-binary install.
   checksum(sha256: string | ((platform: Platform) => string)): this
     The expected SHA-256 (hex) of the downloaded artifact — verifies and caches
     the install. Pass a `({ os, arch }) => string` resolver to pin it per
@@ -1616,6 +1650,11 @@ class ToolInstallSettings
   options_(fallbackDestDir: PathLike): InstallReleaseOptions
     Build the {@link InstallReleaseOptions}, using `fallbackDestDir` when no
     {@link destDir} was set. Throws if a required field is missing.
+  treeOptions_(fallbackDestDir: PathLike): InstallTreeOptions
+    Build the {@link InstallTreeOptions} for a tree install, using
+    `fallbackDestDir` when no {@link destDir} was set. A tree always ships
+    packed, so the archive defaults to `"tar.gz"` and `"raw"` is rejected. Throws
+    if a required field is missing.
 
 class Toolchain
   A declared set of external tools. Add tools with {@link Toolchain.tool} (a
@@ -1624,6 +1663,12 @@ class Toolchain
 
   tool(configure: Configure<ToolInstallSettings>): this
     Add a release tool, configured through a settings-lambda. Chainable.
+  tree(configure: Configure<ToolInstallSettings>): this
+    Add a multi-file runtime tree (see {@link ToolTasksApi.installTree}),
+    configured through a settings-lambda with `.strip(...)`/`.bins(...)`. In
+    {@link install}'s result its entry is the extracted tree's root — a callable
+    {@link AbsolutePath}, so `root("bin")` is the directory to put on `PATH`.
+    Chainable.
   npm(spec: NpmToolSpec): this
     Add an npm-registry package to provision as a version-pinned tool —
     installed under `<destDir>/npm/<name>@<version>` and keyed in
@@ -1631,12 +1676,15 @@ class Toolchain
     {@link installNpmTool}. Chainable.
   get tools(): readonly ToolInstallSettings[]
     The configured release tools, in declaration order.
+  get trees(): readonly ToolInstallSettings[]
+    The configured runtime trees, in declaration order.
   get npmTools(): readonly NpmToolSpec[]
     The configured npm-package tools, in declaration order.
   async install(options: ToolchainInstallOptions): Promise<Map<string, AbsolutePath>>
     Install every declared tool concurrently — reusing a cached copy where a
-    release tool's pinned checksum, or an npm tool's `name@version` marker,
-    matches — and return a map of tool name to installed {@link AbsolutePath}.
+    release tool's or tree's pinned checksum, or an npm tool's `name@version`
+    marker, matches — and return a map of tool name to installed
+    {@link AbsolutePath}. A {@link tree}'s entry is its extracted root directory.
 
 class WaitSettings
   Fluent configuration for {@link TargetBuilder.waitsFor}:
@@ -2193,6 +2241,15 @@ interface ExecuteOptions
     already succeeded (which are not re-run). Not for direct use — call
     `resumeRun`.
 
+interface ExtractOptions
+  Options common to {@link extractTarGzip} and {@link extractZip}.
+
+  strip?: number
+    Drop this many leading path components from every entry (like tar's
+    `--strip-components`). An entry left with no path — e.g. the archive's
+    single top-level directory — is skipped. Defaults to `0`. Use `1` to unpack
+    a release tarball that wraps everything in a `tool-v1.2.3/` directory.
+
 interface FanOutOptions
   Options for {@link fanOutPipeline}: how a build's targets become parallel CI
   jobs.
@@ -2371,6 +2428,37 @@ interface InstallReleaseOptions
     Because {@link url} resolves a different artifact per platform, each has its
     own hash — so pass a resolver `(platform) => string` (like `url`) to pin a
     checksum per platform, or a plain string when a single artifact is installed.
+
+interface InstallTreeOptions
+  Options for {@link installTree}.
+
+  name: string
+    The tool name; the extracted tree lands in `<destDir>/<name>`.
+  url: (platform: Platform) => string
+    Resolve the download URL for the target {@link Platform}.
+  destDir: PathLike
+    The directory the tree is installed under (created if missing).
+  archive: "tar.gz" | "zip"
+    The archive format — a multi-file runtime always ships packed.
+  strip?: number
+    Leading path components to drop while unpacking (tar's `--strip-components`).
+    A release tarball wraps everything in a `tool-v1.2.3/` directory, so `1`
+    unwraps it; {@link bins} and the returned tree root are then relative to the
+    stripped tree. Defaults to `0`.
+  bins?: readonly string[]
+    Paths (relative to the stripped tree root) to mark executable on POSIX — the
+    tar reader does not preserve mode bits, so a runtime's `bin/node`,
+    `bin/npm`, … need it. Chmod follows a symlink to its real target, so listing
+    a symlinked bin makes the script it points at executable too.
+  platform?: InstallPlatform
+    The platform to resolve for. Defaults to {@link hostPlatform}.
+  download?: DownloadFn
+    The download implementation. Defaults to {@link httpDownload}; a test seam.
+  checksum?: string | ((platform: Platform) => string)
+    The expected SHA-256 (hex) of the downloaded archive — verified before
+    anything is unpacked, and used as the cache key (see
+    {@link InstallReleaseOptions.checksum}). Omit it and the tree is downloaded
+    every time and not verified.
 
 interface LockHolder
   Who holds a lock — surfaced to the loser of a conflict so it can act.
@@ -2856,12 +2944,16 @@ interface Style
     Width of horizontal rules and boxes, in characters.
 
 interface TarEntry
-  A single file entry within a tar archive.
+  A single entry within a tar archive — a regular file or a symbolic link.
 
   name: string
     The entry's path inside the archive (≤ 100 bytes).
   data: Uint8Array
-    The file contents.
+    The file contents (empty for a symlink entry).
+  linkname?: string
+    For a symbolic-link entry, its target (≤ 100 bytes); absent for a regular
+    file. Node's release tarballs, for one, ship `bin/npm`/`bin/npx` as symlinks
+    into `lib/node_modules`, so extracting a runtime tree must preserve them.
 
 interface TargetContext
   The context passed to every target body. Optional to receive — an existing
@@ -2953,6 +3045,14 @@ interface ToolTasksApi
     Install a single release tool, configured through a
     {@link ToolInstallSettings} lambda, and resolve to its installed path.
     Defaults the install directory to `.zuke/tools`.
+  installTree(configure: Configure<ToolInstallSettings>): Promise<AbsolutePath>
+    Install a multi-file runtime tree (Node.js, a JDK, …) from one archive,
+    configured through a {@link ToolInstallSettings} lambda, and resolve to the
+    extracted tree's root {@link AbsolutePath}. Because that path is callable,
+    `root("bin", "node")` is a binary and `root("bin")` a directory to put on
+    `PATH`. Use `.strip(...)` and `.bins(...)`; defaults the install directory to
+    `.zuke/tools`. See {@link installTree}; group several with
+    {@link Toolchain.tree}.
   npm(spec: NpmToolSpec, options?: InstallNpmToolOptions): Promise<AbsolutePath>
     Provision a single npm-registry package as a version-pinned, cached tool and
     resolve to its installed bin path. Defaults the install root to

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -142,6 +142,13 @@ function assertSafeEntryName(name: string): void
   absolute path or one with a `..` segment (a "zip slip"). A downloaded or
   poisoned archive must never place files outside where it is being unpacked.
 
+function assertSafeLinkTarget(entryName: string, target: string): void
+  Reject a symlink whose target would resolve outside the destination directory
+  — an absolute target, or a relative one that climbs (with `..`) above the
+  extraction root once resolved against the link's own directory. A file entry's
+  name is bounded by {@link assertSafeEntryName}; a symlink adds a second escape
+  vector (its target), so a poisoned tarball can't plant `bin/x -> ../../etc`.
+
 async function cancelRun(build: Build, options: CancelOptions): Promise<CancelResult>
   Cancel the run `options.runId` for `build`: transition it to `cancelling`
   (exactly one canceller drives the walk; a live owning process observes the
@@ -274,11 +281,13 @@ function externalSignal(name: string): WaitTrigger
   (via `zuke resume <id> --signal <name>`). The signal's payload is exposed to
   target bodies through {@link "./target.ts".TargetContext} `signals`.
 
-async function extractTarGzip(src: PathLike, destDir: PathLike): Promise<void>
+async function extractTarGzip(src: PathLike, destDir: PathLike, options: ExtractOptions): Promise<void>
   Read the `.tar.gz` at `src`, gunzip and unpack it, and write each entry under
-  `destDir` (creating parent directories as needed).
+  `destDir` (creating parent directories as needed). Symlink entries are
+  recreated as symlinks; pass {@link ExtractOptions.strip} to drop leading path
+  components.
 
-async function extractZip(src: PathLike, destDir: PathLike): Promise<void>
+async function extractZip(src: PathLike, destDir: PathLike, options: ExtractOptions): Promise<void>
   Read the `.zip` at `src`, unpack it, and write each entry under `destDir`
   (creating parent directories as needed) — the zip counterpart of
   {@link extractTarGzip}. Entry names are validated so a malicious archive
@@ -410,6 +419,19 @@ async function installRelease(options: InstallReleaseOptions): Promise<AbsoluteP
   anything is installed, and a matching prior install is reused without
   downloading again — so pinning a checksum makes the install both hermetic
   (tamper-evident) and cached.
+
+async function installTree(options: InstallTreeOptions): Promise<AbsolutePath>
+  Download and unpack a whole archive tree — a multi-file runtime such as
+  Node.js, which ships `bin/node`, `bin/npm`, `bin/npx`, and
+  `lib/node_modules/**` in one tarball — and return the {@link AbsolutePath} of
+  its (stripped) root. `installRelease` extracts a single binary; `installTree`
+  keeps the entire directory, symlinks included.
+
+  Because {@link AbsolutePath} is callable, the root doubles as an accessor:
+  `root("bin", "node")` is the node binary and `root("bin")` is the directory to
+  put on `PATH` (with `prependPath`). Declared {@link InstallTreeOptions.bins}
+  are marked executable on POSIX. With a {@link InstallTreeOptions.checksum} the
+  archive is verified before unpacking and a matching prior install is reused.
 
 function isCI(): boolean
   Whether the build appears to be running in a CI environment.
@@ -1642,6 +1664,10 @@ class ToolInstallSettings
     Download format. Set by {@link archive}.
   binaryPath_?: string
     The binary's path within a `tar.gz`. Set by {@link binaryPath}.
+  strip_?: number
+    Leading path components to strip on a tree install. Set by {@link strip}.
+  bins_?: string[]
+    Executable bins within a tree install. Set by {@link bins}.
   checksum_?: string | ((platform: Platform) => string)
     Expected SHA-256 (or a per-platform resolver). Set by {@link checksum}.
   platform_?: InstallPlatform
@@ -1659,6 +1685,14 @@ class ToolInstallSettings
     the bare binary). Pair with {@link binaryPath} for the binary inside.
   binaryPath(path: string): this
     For an archive, the binary's path within it (defaults to the name).
+  strip(components: number): this
+    For a tree install ({@link ToolTasksApi.installTree} / {@link Toolchain.tree}),
+    drop this many leading path components while unpacking — `1` unwraps a
+    release tarball's `tool-v1.2.3/` directory. Ignored by a single-binary install.
+  bins(...paths: string[]): this
+    For a tree install, the paths (relative to the stripped root) to mark
+    executable on POSIX — a runtime's `bin/node`, `bin/npm`, … Ignored by a
+    single-binary install.
   checksum(sha256: string | ((platform: Platform) => string)): this
     The expected SHA-256 (hex) of the downloaded artifact — verifies and caches
     the install. Pass a `({ os, arch }) => string` resolver to pin it per
@@ -1670,6 +1704,11 @@ class ToolInstallSettings
   options_(fallbackDestDir: PathLike): InstallReleaseOptions
     Build the {@link InstallReleaseOptions}, using `fallbackDestDir` when no
     {@link destDir} was set. Throws if a required field is missing.
+  treeOptions_(fallbackDestDir: PathLike): InstallTreeOptions
+    Build the {@link InstallTreeOptions} for a tree install, using
+    `fallbackDestDir` when no {@link destDir} was set. A tree always ships
+    packed, so the archive defaults to `"tar.gz"` and `"raw"` is rejected. Throws
+    if a required field is missing.
 
 class Toolchain
   A declared set of external tools. Add tools with {@link Toolchain.tool} (a
@@ -1678,6 +1717,12 @@ class Toolchain
 
   tool(configure: Configure<ToolInstallSettings>): this
     Add a release tool, configured through a settings-lambda. Chainable.
+  tree(configure: Configure<ToolInstallSettings>): this
+    Add a multi-file runtime tree (see {@link ToolTasksApi.installTree}),
+    configured through a settings-lambda with `.strip(...)`/`.bins(...)`. In
+    {@link install}'s result its entry is the extracted tree's root — a callable
+    {@link AbsolutePath}, so `root("bin")` is the directory to put on `PATH`.
+    Chainable.
   npm(spec: NpmToolSpec): this
     Add an npm-registry package to provision as a version-pinned tool —
     installed under `<destDir>/npm/<name>@<version>` and keyed in
@@ -1685,12 +1730,15 @@ class Toolchain
     {@link installNpmTool}. Chainable.
   get tools(): readonly ToolInstallSettings[]
     The configured release tools, in declaration order.
+  get trees(): readonly ToolInstallSettings[]
+    The configured runtime trees, in declaration order.
   get npmTools(): readonly NpmToolSpec[]
     The configured npm-package tools, in declaration order.
   async install(options: ToolchainInstallOptions): Promise<Map<string, AbsolutePath>>
     Install every declared tool concurrently — reusing a cached copy where a
-    release tool's pinned checksum, or an npm tool's `name@version` marker,
-    matches — and return a map of tool name to installed {@link AbsolutePath}.
+    release tool's or tree's pinned checksum, or an npm tool's `name@version`
+    marker, matches — and return a map of tool name to installed
+    {@link AbsolutePath}. A {@link tree}'s entry is its extracted root directory.
 
 class WaitSettings
   Fluent configuration for {@link TargetBuilder.waitsFor}:
@@ -2247,6 +2295,15 @@ interface ExecuteOptions
     already succeeded (which are not re-run). Not for direct use — call
     `resumeRun`.
 
+interface ExtractOptions
+  Options common to {@link extractTarGzip} and {@link extractZip}.
+
+  strip?: number
+    Drop this many leading path components from every entry (like tar's
+    `--strip-components`). An entry left with no path — e.g. the archive's
+    single top-level directory — is skipped. Defaults to `0`. Use `1` to unpack
+    a release tarball that wraps everything in a `tool-v1.2.3/` directory.
+
 interface FanOutOptions
   Options for {@link fanOutPipeline}: how a build's targets become parallel CI
   jobs.
@@ -2425,6 +2482,37 @@ interface InstallReleaseOptions
     Because {@link url} resolves a different artifact per platform, each has its
     own hash — so pass a resolver `(platform) => string` (like `url`) to pin a
     checksum per platform, or a plain string when a single artifact is installed.
+
+interface InstallTreeOptions
+  Options for {@link installTree}.
+
+  name: string
+    The tool name; the extracted tree lands in `<destDir>/<name>`.
+  url: (platform: Platform) => string
+    Resolve the download URL for the target {@link Platform}.
+  destDir: PathLike
+    The directory the tree is installed under (created if missing).
+  archive: "tar.gz" | "zip"
+    The archive format — a multi-file runtime always ships packed.
+  strip?: number
+    Leading path components to drop while unpacking (tar's `--strip-components`).
+    A release tarball wraps everything in a `tool-v1.2.3/` directory, so `1`
+    unwraps it; {@link bins} and the returned tree root are then relative to the
+    stripped tree. Defaults to `0`.
+  bins?: readonly string[]
+    Paths (relative to the stripped tree root) to mark executable on POSIX — the
+    tar reader does not preserve mode bits, so a runtime's `bin/node`,
+    `bin/npm`, … need it. Chmod follows a symlink to its real target, so listing
+    a symlinked bin makes the script it points at executable too.
+  platform?: InstallPlatform
+    The platform to resolve for. Defaults to {@link hostPlatform}.
+  download?: DownloadFn
+    The download implementation. Defaults to {@link httpDownload}; a test seam.
+  checksum?: string | ((platform: Platform) => string)
+    The expected SHA-256 (hex) of the downloaded archive — verified before
+    anything is unpacked, and used as the cache key (see
+    {@link InstallReleaseOptions.checksum}). Omit it and the tree is downloaded
+    every time and not verified.
 
 interface LockHolder
   Who holds a lock — surfaced to the loser of a conflict so it can act.
@@ -2910,12 +2998,16 @@ interface Style
     Width of horizontal rules and boxes, in characters.
 
 interface TarEntry
-  A single file entry within a tar archive.
+  A single entry within a tar archive — a regular file or a symbolic link.
 
   name: string
     The entry's path inside the archive (≤ 100 bytes).
   data: Uint8Array
-    The file contents.
+    The file contents (empty for a symlink entry).
+  linkname?: string
+    For a symbolic-link entry, its target (≤ 100 bytes); absent for a regular
+    file. Node's release tarballs, for one, ship `bin/npm`/`bin/npx` as symlinks
+    into `lib/node_modules`, so extracting a runtime tree must preserve them.
 
 interface TargetContext
   The context passed to every target body. Optional to receive — an existing
@@ -3007,6 +3099,14 @@ interface ToolTasksApi
     Install a single release tool, configured through a
     {@link ToolInstallSettings} lambda, and resolve to its installed path.
     Defaults the install directory to `.zuke/tools`.
+  installTree(configure: Configure<ToolInstallSettings>): Promise<AbsolutePath>
+    Install a multi-file runtime tree (Node.js, a JDK, …) from one archive,
+    configured through a {@link ToolInstallSettings} lambda, and resolve to the
+    extracted tree's root {@link AbsolutePath}. Because that path is callable,
+    `root("bin", "node")` is a binary and `root("bin")` a directory to put on
+    `PATH`. Use `.strip(...)` and `.bins(...)`; defaults the install directory to
+    `.zuke/tools`. See {@link installTree}; group several with
+    {@link Toolchain.tree}.
   npm(spec: NpmToolSpec, options?: InstallNpmToolOptions): Promise<AbsolutePath>
     Provision a single npm-registry package as a version-pinned, cached tool and
     resolve to its installed bin path. Defaults the install root to

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -267,7 +267,9 @@ export {
 } from "./src/announce.ts";
 export {
   assertSafeEntryName,
+  assertSafeLinkTarget,
   createTarGzip,
+  type ExtractOptions,
   extractTarGzip,
   extractZip,
   gunzip,
@@ -283,6 +285,8 @@ export {
   type InstallPlatform,
   installRelease,
   type InstallReleaseOptions,
+  installTree,
+  type InstallTreeOptions,
   type Platform,
 } from "./src/install.ts";
 export {

--- a/packages/core/src/compression.ts
+++ b/packages/core/src/compression.ts
@@ -330,7 +330,11 @@ async function writeEntries(
       // a malformed archive is "last one wins" (like a file) rather than a raw
       // AlreadyExists crash.
       await Deno.remove(path).catch(() => {});
-      await Deno.symlink(entry.linkname, path);
+      // Windows requires an explicit link `type`; POSIX ignores it. Runtime bins
+      // (Node's bin/npm → npm-cli.js) are file symlinks.
+      // ponytail: assume "file"; a directory symlink in a tar unpacked on Windows
+      // would get the wrong type — rare (runtimes ship .zip on Windows).
+      await Deno.symlink(entry.linkname, path, { type: "file" });
     } else {
       await Deno.writeFile(path, entry.data);
     }

--- a/packages/core/src/compression.ts
+++ b/packages/core/src/compression.ts
@@ -42,6 +42,40 @@ export function assertSafeEntryName(name: string): void {
   }
 }
 
+/**
+ * Reject a symlink whose target would resolve outside the destination directory
+ * — an absolute target, or a relative one that climbs (with `..`) above the
+ * extraction root once resolved against the link's own directory. A file entry's
+ * name is bounded by {@link assertSafeEntryName}; a symlink adds a second escape
+ * vector (its target), so a poisoned tarball can't plant `bin/x -> ../../etc`.
+ */
+export function assertSafeLinkTarget(entryName: string, target: string): void {
+  const normalized = target.replace(/\\/g, "/");
+  if (normalized.startsWith("/") || /^[A-Za-z]:/.test(normalized)) {
+    throw new Error(
+      `archive: refusing a symlink "${entryName}" to an absolute path: ` +
+        `"${target}".`,
+    );
+  }
+  // Resolve the target relative to the symlink's own directory; it must never
+  // climb above the extraction root.
+  const parts = entryName.replace(/\\/g, "/").split("/").slice(0, -1);
+  for (const segment of normalized.split("/")) {
+    if (segment === "" || segment === ".") continue;
+    if (segment === "..") {
+      if (parts.length === 0) {
+        throw new Error(
+          `archive: refusing a symlink "${entryName}" whose target escapes ` +
+            `the destination: "${target}".`,
+        );
+      }
+      parts.pop();
+    } else {
+      parts.push(segment);
+    }
+  }
+}
+
 /** Gzip-compress `data` using the platform `CompressionStream`. */
 export async function gzip(data: Uint8Array): Promise<Uint8Array> {
   // Copy into a fresh ArrayBuffer-backed view so the Blob accepts it.
@@ -59,12 +93,18 @@ export async function gunzip(data: Uint8Array): Promise<Uint8Array> {
   return new Uint8Array(await new Response(stream).arrayBuffer());
 }
 
-/** A single file entry within a tar archive. */
+/** A single entry within a tar archive — a regular file or a symbolic link. */
 export interface TarEntry {
   /** The entry's path inside the archive (≤ 100 bytes). */
   name: string;
-  /** The file contents. */
+  /** The file contents (empty for a symlink entry). */
   data: Uint8Array;
+  /**
+   * For a symbolic-link entry, its target (≤ 100 bytes); absent for a regular
+   * file. Node's release tarballs, for one, ship `bin/npm`/`bin/npx` as symlinks
+   * into `lib/node_modules`, so extracting a runtime tree must preserve them.
+   */
+  linkname?: string;
 }
 
 /** The tar block size; headers and data are padded to a multiple of this. */
@@ -92,22 +132,30 @@ function writeOctal(
   writeString(block, offset, text);
 }
 
-/** Build the 512-byte `ustar` header for one entry. */
-function tarHeader(name: string, size: number): Uint8Array {
+/** Build the 512-byte `ustar` header for one entry (a file, or a symlink when
+ * `linkname` is given). */
+function tarHeader(name: string, size: number, linkname?: string): Uint8Array {
   const nameBytes = new TextEncoder().encode(name);
   if (nameBytes.length > 100) {
     throw new Error(
       `tar: entry name exceeds 100 bytes (ustar limit): "${name}"`,
     );
   }
+  const isLink = linkname !== undefined;
+  if (isLink && new TextEncoder().encode(linkname).length > 100) {
+    throw new Error(
+      `tar: symlink target exceeds 100 bytes (ustar limit): "${linkname}"`,
+    );
+  }
   const header = new Uint8Array(BLOCK);
   writeString(header, 0, name);
-  writeOctal(header, 100, 7, 0o644); // mode
+  writeOctal(header, 100, 7, isLink ? 0o777 : 0o644); // mode
   writeOctal(header, 108, 7, 0); // uid
   writeOctal(header, 116, 7, 0); // gid
-  writeOctal(header, 124, 11, size); // size
+  writeOctal(header, 124, 11, isLink ? 0 : size); // size (a symlink carries none)
   writeOctal(header, 136, 11, 0); // mtime (fixed for reproducibility)
-  header[156] = 0x30; // typeflag '0' (regular file)
+  header[156] = isLink ? 0x32 : 0x30; // typeflag '2' (symlink) | '0' (file)
+  if (isLink) writeString(header, 157, linkname); // linkname field
   writeString(header, 257, "ustar\0"); // magic
   header[263] = 0x30; // version "00"
   header[264] = 0x30;
@@ -126,11 +174,13 @@ export function tar(entries: TarEntry[]): Uint8Array {
   const blocks: Uint8Array[] = [];
   let total = 0;
   for (const entry of entries) {
-    const header = tarHeader(entry.name, entry.data.length);
+    const header = tarHeader(entry.name, entry.data.length, entry.linkname);
     blocks.push(header);
     total += BLOCK;
-    const body = new Uint8Array(padded(entry.data.length));
-    body.set(entry.data);
+    // A symlink entry carries no data blocks; a file's data is block-padded.
+    const size = entry.linkname === undefined ? entry.data.length : 0;
+    const body = new Uint8Array(padded(size));
+    if (entry.linkname === undefined) body.set(entry.data);
     blocks.push(body);
     total += body.length;
   }
@@ -184,9 +234,13 @@ export function untar(archive: Uint8Array): TarEntry[] {
     // Read the full 12-byte size field; the trailing byte is a NUL terminator.
     const size = readOctal(archive, offset + 124, 12);
     const typeflag = archive[offset + 156];
+    const linkname = readString(archive, offset + 157, 100);
     offset += BLOCK;
-    // Only regular files ('0' or legacy '\0') carry extractable data.
-    if (typeflag === 0x30 || typeflag === 0) {
+    if (typeflag === 0x32) {
+      // '2' → a symbolic link: the target is the linkname; it carries no data.
+      entries.push({ name, data: new Uint8Array(0), linkname });
+    } else if (typeflag === 0x30 || typeflag === 0) {
+      // Regular files ('0' or legacy '\0') carry extractable data.
       entries.push({ name, data: archive.slice(offset, offset + size) });
     }
     offset += padded(size);
@@ -213,36 +267,73 @@ export async function createTarGzip(
   await Deno.writeFile(String(dest), await gzip(tar(entries)));
 }
 
+/** Options common to {@link extractTarGzip} and {@link extractZip}. */
+export interface ExtractOptions {
+  /**
+   * Drop this many leading path components from every entry (like tar's
+   * `--strip-components`). An entry left with no path — e.g. the archive's
+   * single top-level directory — is skipped. Defaults to `0`. Use `1` to unpack
+   * a release tarball that wraps everything in a `tool-v1.2.3/` directory.
+   */
+  strip?: number;
+}
+
 /**
  * Read the `.tar.gz` at `src`, gunzip and unpack it, and write each entry under
- * `destDir` (creating parent directories as needed).
+ * `destDir` (creating parent directories as needed). Symlink entries are
+ * recreated as symlinks; pass {@link ExtractOptions.strip} to drop leading path
+ * components.
  */
 export async function extractTarGzip(
   src: PathLike,
   destDir: PathLike,
+  options: ExtractOptions = {},
 ): Promise<void> {
   const archive = untar(await gunzip(await Deno.readFile(String(src))));
-  await writeEntries(archive, destDir);
+  await writeEntries(archive, destDir, options);
+}
+
+/** Drop the first `n` path components from `name`, returning "" if none remain. */
+function stripComponents(name: string, n: number): string {
+  if (n <= 0) return name;
+  return name.replace(/\\/g, "/").split("/").slice(n).join("/");
 }
 
 /**
  * Write each archive `entry` under `destDir`, creating parent directories as
- * needed. Every entry name is validated first ({@link assertSafeEntryName}), so
- * a malicious archive cannot plant a file outside `destDir` (a "zip slip").
+ * needed. Every entry name is validated first ({@link assertSafeEntryName}), and
+ * a symlink's target is validated ({@link assertSafeLinkTarget}), so a malicious
+ * archive cannot plant or point a file outside `destDir` (a "zip slip"). With
+ * {@link ExtractOptions.strip}, leading path components are dropped and any entry
+ * left with an empty path is skipped.
  */
 async function writeEntries(
   entries: TarEntry[],
   destDir: PathLike,
+  options: ExtractOptions = {},
 ): Promise<void> {
+  const strip = options.strip ?? 0;
   for (const entry of entries) assertSafeEntryName(entry.name);
   const root = String(destDir);
   for (const entry of entries) {
-    const path = `${root}/${entry.name}`;
+    const name = stripComponents(entry.name, strip);
+    if (name === "") continue; // fully stripped (e.g. the top-level directory)
+    const path = `${root}/${name}`;
     const slash = path.lastIndexOf("/");
     if (slash !== -1) {
       await Deno.mkdir(path.slice(0, slash), { recursive: true });
     }
-    await Deno.writeFile(path, entry.data);
+    if (entry.linkname !== undefined) {
+      assertSafeLinkTarget(name, entry.linkname);
+      // `Deno.symlink` throws if the path already exists, whereas a file write
+      // silently overwrites; remove any prior entry first so a duplicate name in
+      // a malformed archive is "last one wins" (like a file) rather than a raw
+      // AlreadyExists crash.
+      await Deno.remove(path).catch(() => {});
+      await Deno.symlink(entry.linkname, path);
+    } else {
+      await Deno.writeFile(path, entry.data);
+    }
   }
 }
 
@@ -401,6 +492,11 @@ export async function unzip(archive: Uint8Array): Promise<TarEntry[]> {
 export async function extractZip(
   src: PathLike,
   destDir: PathLike,
+  options: ExtractOptions = {},
 ): Promise<void> {
-  await writeEntries(await unzip(await Deno.readFile(String(src))), destDir);
+  await writeEntries(
+    await unzip(await Deno.readFile(String(src))),
+    destDir,
+    options,
+  );
 }

--- a/packages/core/src/install.ts
+++ b/packages/core/src/install.ts
@@ -7,6 +7,8 @@
  * {@link httpDownload}), unpacks a `.tar.gz` (reusing {@link extractTarGzip}) or
  * a `.zip` (reusing {@link extractZip}) or takes a raw single binary, drops it
  * into a directory, marks it executable, and returns its {@link AbsolutePath}.
+ * {@link installTree} is its multi-file sibling: it keeps the whole extracted
+ * tree (symlinks included) for a runtime like Node.js that ships several bins.
  *
  * ```ts
  * import { installRelease } from "jsr:@zuke/core";
@@ -343,4 +345,159 @@ export async function installRelease(
   // skip the download only when the binary on disk still matches.
   if (checksum !== undefined) await writeMarker(target, checksum);
   return target;
+}
+
+/** Whether a filesystem path exists (follows symlinks, so a bin symlink counts). */
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await Deno.stat(path);
+    return true;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return false;
+    throw error;
+  }
+}
+
+/** The marker file recording the checksum an installed tree satisfied. */
+function treeMarkerPath(treeRoot: AbsolutePath): string {
+  return `${String(treeRoot)}.tree.json`;
+}
+
+/**
+ * Whether `treeRoot` is a valid cache hit for `checksum`: the recorded install
+ * satisfied the same checksum, and every declared bin is still present. Unlike a
+ * single-binary install, a tree is not re-hashed file-by-file — the pinned
+ * archive checksum is the integrity boundary, and a present-bins check catches a
+ * half-deleted directory. (ponytail: no whole-tree re-hash; the download's
+ * checksum already gates integrity, re-verify by re-pinning a new checksum.)
+ */
+async function cachedTree(
+  treeRoot: AbsolutePath,
+  checksum: string,
+  bins: readonly string[],
+): Promise<boolean> {
+  const recorded = await readFileOrNull(treeMarkerPath(treeRoot));
+  if (recorded === null) return false;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(new TextDecoder().decode(recorded));
+  } catch {
+    return false; // a corrupt marker is treated as no marker — re-install.
+  }
+  if (
+    typeof parsed !== "object" || parsed === null ||
+    !("checksum" in parsed) || parsed.checksum !== checksum
+  ) {
+    return false;
+  }
+  for (const bin of bins) {
+    if (!await pathExists(String(treeRoot(...bin.split("/"))))) return false;
+  }
+  return true;
+}
+
+/** Options for {@link installTree}. */
+export interface InstallTreeOptions {
+  /** The tool name; the extracted tree lands in `<destDir>/<name>`. */
+  name: string;
+  /** Resolve the download URL for the target {@link Platform}. */
+  url: (platform: Platform) => string;
+  /** The directory the tree is installed under (created if missing). */
+  destDir: PathLike;
+  /** The archive format — a multi-file runtime always ships packed. */
+  archive: "tar.gz" | "zip";
+  /**
+   * Leading path components to drop while unpacking (tar's `--strip-components`).
+   * A release tarball wraps everything in a `tool-v1.2.3/` directory, so `1`
+   * unwraps it; {@link bins} and the returned tree root are then relative to the
+   * stripped tree. Defaults to `0`.
+   */
+  strip?: number;
+  /**
+   * Paths (relative to the stripped tree root) to mark executable on POSIX — the
+   * tar reader does not preserve mode bits, so a runtime's `bin/node`,
+   * `bin/npm`, … need it. Chmod follows a symlink to its real target, so listing
+   * a symlinked bin makes the script it points at executable too.
+   */
+  bins?: readonly string[];
+  /** The platform to resolve for. Defaults to {@link hostPlatform}. */
+  platform?: InstallPlatform;
+  /** The download implementation. Defaults to {@link httpDownload}; a test seam. */
+  download?: DownloadFn;
+  /**
+   * The expected **SHA-256** (hex) of the downloaded archive — verified before
+   * anything is unpacked, and used as the cache key (see
+   * {@link InstallReleaseOptions.checksum}). Omit it and the tree is downloaded
+   * every time and not verified.
+   */
+  checksum?: string | ((platform: Platform) => string);
+}
+
+/**
+ * Download and unpack a **whole archive tree** — a multi-file runtime such as
+ * Node.js, which ships `bin/node`, `bin/npm`, `bin/npx`, and
+ * `lib/node_modules/**` in one tarball — and return the {@link AbsolutePath} of
+ * its (stripped) root. `installRelease` extracts a single binary; `installTree`
+ * keeps the entire directory, symlinks included.
+ *
+ * Because {@link AbsolutePath} is callable, the root doubles as an accessor:
+ * `root("bin", "node")` is the node binary and `root("bin")` is the directory to
+ * put on `PATH` (with `prependPath`). Declared {@link InstallTreeOptions.bins}
+ * are marked executable on POSIX. With a {@link InstallTreeOptions.checksum} the
+ * archive is verified before unpacking and a matching prior install is reused.
+ */
+export async function installTree(
+  options: InstallTreeOptions,
+): Promise<AbsolutePath> {
+  const platform = options.platform !== undefined
+    ? platformOf(options.platform)
+    : hostPlatform();
+  const download = options.download ?? httpDownload;
+  const checksum = resolveChecksum(options.checksum, platform);
+  const root = resolveDir(String(options.destDir));
+  const treeRoot = root(options.name);
+  const bins = options.bins ?? [];
+
+  // Cache hit: a prior install verified against the same checksum, bins intact.
+  if (checksum !== undefined && await cachedTree(treeRoot, checksum, bins)) {
+    return treeRoot;
+  }
+
+  const url = options.url(platform);
+  const scratch = await Deno.makeTempDir();
+  try {
+    const archivePath = `${scratch}/download.${options.archive}`;
+    await download(url, archivePath);
+    if (checksum !== undefined) {
+      await verifyChecksum(
+        options.name,
+        await Deno.readFile(archivePath),
+        checksum,
+      );
+    }
+    // Clear any stale or partial prior tree before unpacking a fresh one, so a
+    // re-install never collides with leftover files (or symlinks).
+    await Deno.remove(String(treeRoot), { recursive: true }).catch(() => {});
+    await Deno.mkdir(String(treeRoot), { recursive: true });
+    const extract = options.archive === "zip" ? extractZip : extractTarGzip;
+    await extract(archivePath, String(treeRoot), { strip: options.strip });
+  } finally {
+    await Deno.remove(scratch, { recursive: true });
+  }
+
+  // The tar reader drops mode bits, so make the declared bins executable —
+  // skipped for a Windows target, whose `.exe`/`.cmd` bins need no POSIX mode
+  // (mirrors installRelease, and keeps the skip branch testable via `platform`).
+  if (platform.os !== "windows") {
+    for (const bin of bins) {
+      await Deno.chmod(String(treeRoot(...bin.split("/"))), 0o755);
+    }
+  }
+  if (checksum !== undefined) {
+    await Deno.writeTextFile(
+      treeMarkerPath(treeRoot),
+      `${JSON.stringify({ checksum })}\n`,
+    );
+  }
+  return treeRoot;
 }

--- a/packages/core/src/tool.ts
+++ b/packages/core/src/tool.ts
@@ -40,6 +40,8 @@ import {
   type InstallPlatform,
   installRelease,
   type InstallReleaseOptions,
+  installTree,
+  type InstallTreeOptions,
   type Platform,
 } from "./install.ts";
 import {
@@ -70,6 +72,10 @@ export class ToolInstallSettings {
   archive_?: "raw" | "tar.gz" | "zip";
   /** The binary's path within a `tar.gz`. Set by {@link binaryPath}. */
   binaryPath_?: string;
+  /** Leading path components to strip on a tree install. Set by {@link strip}. */
+  strip_?: number;
+  /** Executable bins within a tree install. Set by {@link bins}. */
+  bins_?: string[];
   /** Expected SHA-256 (or a per-platform resolver). Set by {@link checksum}. */
   checksum_?: string | ((platform: Platform) => string);
   /** The platform to resolve for. Set by {@link platform}. */
@@ -107,6 +113,26 @@ export class ToolInstallSettings {
   /** For an archive, the binary's path within it (defaults to the name). */
   binaryPath(path: string): this {
     this.binaryPath_ = path;
+    return this;
+  }
+
+  /**
+   * For a tree install ({@link ToolTasksApi.installTree} / {@link Toolchain.tree}),
+   * drop this many leading path components while unpacking — `1` unwraps a
+   * release tarball's `tool-v1.2.3/` directory. Ignored by a single-binary install.
+   */
+  strip(components: number): this {
+    this.strip_ = components;
+    return this;
+  }
+
+  /**
+   * For a tree install, the paths (relative to the stripped root) to mark
+   * executable on POSIX — a runtime's `bin/node`, `bin/npm`, … Ignored by a
+   * single-binary install.
+   */
+  bins(...paths: string[]): this {
+    this.bins_ = paths;
     return this;
   }
 
@@ -154,6 +180,38 @@ export class ToolInstallSettings {
       download: this.download_,
     };
   }
+
+  /**
+   * Build the {@link InstallTreeOptions} for a tree install, using
+   * `fallbackDestDir` when no {@link destDir} was set. A tree always ships
+   * packed, so the archive defaults to `"tar.gz"` and `"raw"` is rejected. Throws
+   * if a required field is missing.
+   */
+  treeOptions_(fallbackDestDir: PathLike): InstallTreeOptions {
+    if (this.name_ === undefined) {
+      throw new Error("a tool tree install requires .name(...).");
+    }
+    if (this.url_ === undefined) {
+      throw new Error(`tool "${this.name_}" requires .url(...).`);
+    }
+    if (this.archive_ === "raw") {
+      throw new Error(
+        `tool "${this.name_}": a tree install needs an archive ` +
+          `("tar.gz" or "zip"), not "raw".`,
+      );
+    }
+    return {
+      name: this.name_,
+      url: this.url_,
+      destDir: this.destDir_ ?? fallbackDestDir,
+      archive: this.archive_ ?? "tar.gz",
+      strip: this.strip_,
+      bins: this.bins_,
+      checksum: this.checksum_,
+      platform: this.platform_,
+      download: this.download_,
+    };
+  }
 }
 
 /** The task surface of {@link ToolTasks}. */
@@ -164,6 +222,18 @@ export interface ToolTasksApi {
    * Defaults the install directory to `.zuke/tools`.
    */
   install(
+    configure: Configure<ToolInstallSettings>,
+  ): Promise<AbsolutePath>;
+  /**
+   * Install a multi-file runtime tree (Node.js, a JDK, …) from one archive,
+   * configured through a {@link ToolInstallSettings} lambda, and resolve to the
+   * extracted tree's root {@link AbsolutePath}. Because that path is callable,
+   * `root("bin", "node")` is a binary and `root("bin")` a directory to put on
+   * `PATH`. Use `.strip(...)` and `.bins(...)`; defaults the install directory to
+   * `.zuke/tools`. See {@link installTree}; group several with
+   * {@link Toolchain.tree}.
+   */
+  installTree(
     configure: Configure<ToolInstallSettings>,
   ): Promise<AbsolutePath>;
   /**
@@ -188,6 +258,10 @@ export const ToolTasks: ToolTasksApi = {
     const settings = configure(new ToolInstallSettings());
     return installRelease(settings.options_(DEFAULT_TOOLS_DIR));
   },
+  installTree(configure) {
+    const settings = configure(new ToolInstallSettings());
+    return installTree(settings.treeOptions_(DEFAULT_TOOLS_DIR));
+  },
   npm(spec, options) {
     return installNpmTool(spec, options);
   },
@@ -210,11 +284,24 @@ export interface ToolchainInstallOptions {
  */
 export class Toolchain {
   readonly #tools: ToolInstallSettings[] = [];
+  readonly #trees: ToolInstallSettings[] = [];
   readonly #npmTools: NpmToolSpec[] = [];
 
   /** Add a release tool, configured through a settings-lambda. Chainable. */
   tool(configure: Configure<ToolInstallSettings>): this {
     this.#tools.push(configure(new ToolInstallSettings()));
+    return this;
+  }
+
+  /**
+   * Add a multi-file runtime tree (see {@link ToolTasksApi.installTree}),
+   * configured through a settings-lambda with `.strip(...)`/`.bins(...)`. In
+   * {@link install}'s result its entry is the extracted tree's root — a callable
+   * {@link AbsolutePath}, so `root("bin")` is the directory to put on `PATH`.
+   * Chainable.
+   */
+  tree(configure: Configure<ToolInstallSettings>): this {
+    this.#trees.push(configure(new ToolInstallSettings()));
     return this;
   }
 
@@ -234,6 +321,11 @@ export class Toolchain {
     return this.#tools;
   }
 
+  /** The configured runtime trees, in declaration order. */
+  get trees(): readonly ToolInstallSettings[] {
+    return this.#trees;
+  }
+
   /** The configured npm-package tools, in declaration order. */
   get npmTools(): readonly NpmToolSpec[] {
     return this.#npmTools;
@@ -241,8 +333,9 @@ export class Toolchain {
 
   /**
    * Install every declared tool concurrently — reusing a cached copy where a
-   * release tool's pinned checksum, or an npm tool's `name@version` marker,
-   * matches — and return a map of tool name to installed {@link AbsolutePath}.
+   * release tool's or tree's pinned checksum, or an npm tool's `name@version`
+   * marker, matches — and return a map of tool name to installed
+   * {@link AbsolutePath}. A {@link tree}'s entry is its extracted root directory.
    */
   async install(
     options: ToolchainInstallOptions = {},
@@ -258,6 +351,15 @@ export class Toolchain {
             : { ...spec, download: options.download },
         );
         installed.set(spec.name, path);
+      }),
+      ...this.#trees.map(async (settings) => {
+        const spec = settings.treeOptions_(destDir);
+        const root = await installTree(
+          options.download === undefined
+            ? spec
+            : { ...spec, download: options.download },
+        );
+        installed.set(spec.name, root);
       }),
       ...this.#npmTools.map(async (spec) => {
         const path = await installNpmTool(spec, {

--- a/packages/core/tests/compression_test.ts
+++ b/packages/core/tests/compression_test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertRejects, assertThrows } from "./_assert.ts";
 import {
   assertSafeEntryName,
+  assertSafeLinkTarget,
   createTarGzip,
   extractTarGzip,
   extractZip,
@@ -306,6 +307,149 @@ Deno.test("unzip uses the local header's extra length, not the central directory
   ]);
   const out = await unzip(zip);
   assertEquals(dec(out[0].data), "payload");
+});
+
+Deno.test("tar/untar round-trips a symlink entry (linkname, no data)", () => {
+  const archive = tar([
+    { name: "bin/node", data: enc("ELF-binary") },
+    {
+      name: "bin/npm",
+      data: new Uint8Array(0),
+      linkname: "../lib/node_modules/npm/bin/npm-cli.js",
+    },
+  ]);
+  assertEquals(archive.length % 512, 0);
+  const out = untar(archive);
+  assertEquals(out.map((e) => e.name), ["bin/node", "bin/npm"]);
+  assertEquals(out[0].linkname, undefined); // a regular file
+  assertEquals(dec(out[0].data), "ELF-binary");
+  assertEquals(out[1].linkname, "../lib/node_modules/npm/bin/npm-cli.js");
+  assertEquals(out[1].data.length, 0); // a symlink carries no data
+});
+
+Deno.test("tar rejects a symlink target longer than the ustar limit", () => {
+  let message = "";
+  try {
+    tar([{ name: "l", data: new Uint8Array(0), linkname: "x/".repeat(60) }]);
+  } catch (error) {
+    message = error instanceof Error ? error.message : String(error);
+  }
+  assertEquals(message.includes("symlink target exceeds 100 bytes"), true);
+});
+
+Deno.test("extractTarGzip strips leading path components", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const archive = `${dir}/a.tar.gz`;
+    await Deno.writeFile(
+      archive,
+      await gzip(tar([
+        { name: "pkg-1.0/bin/tool", data: enc("BIN") },
+        { name: "pkg-1.0/README", data: enc("hi") },
+        { name: "pkg-1.0", data: new Uint8Array(0) }, // top dir → fully stripped
+      ])),
+    );
+    await extractTarGzip(archive, `${dir}/out`, { strip: 1 });
+    assertEquals(await Deno.readTextFile(`${dir}/out/bin/tool`), "BIN");
+    assertEquals(await Deno.readTextFile(`${dir}/out/README`), "hi");
+    // The stripped-to-nothing top-level entry left no stray file.
+    assertEquals(
+      await Deno.stat(`${dir}/out`).then((s) => s.isDirectory),
+      true,
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("extractTarGzip recreates an in-tree symlink on disk (POSIX)", async () => {
+  if (Deno.build.os === "windows") return; // symlink creation is privileged there
+  const dir = await Deno.makeTempDir();
+  try {
+    const archive = `${dir}/a.tar.gz`;
+    await Deno.writeFile(
+      archive,
+      await gzip(tar([
+        { name: "lib/real.txt", data: enc("payload") },
+        { name: "link", data: new Uint8Array(0), linkname: "lib/real.txt" },
+      ])),
+    );
+    await extractTarGzip(archive, `${dir}/out`);
+    const info = await Deno.lstat(`${dir}/out/link`);
+    assertEquals(info.isSymlink, true);
+    assertEquals(await Deno.readTextFile(`${dir}/out/link`), "payload"); // resolves
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("extractTarGzip lets a later symlink overwrite an earlier entry (no AlreadyExists crash)", async () => {
+  if (Deno.build.os === "windows") return; // symlink creation is privileged there
+  const dir = await Deno.makeTempDir();
+  try {
+    const archive = `${dir}/dup.tar.gz`;
+    // A duplicate name: first a file, then a symlink. A raw Deno.symlink would
+    // throw AlreadyExists; extraction must instead be "last one wins".
+    await Deno.writeFile(
+      archive,
+      await gzip(tar([
+        { name: "real.txt", data: enc("target") },
+        { name: "x", data: enc("first-as-file") },
+        { name: "x", data: new Uint8Array(0), linkname: "real.txt" },
+      ])),
+    );
+    await extractTarGzip(archive, `${dir}/out`);
+    const info = await Deno.lstat(`${dir}/out/x`);
+    assertEquals(info.isSymlink, true); // the symlink won
+    assertEquals(await Deno.readTextFile(`${dir}/out/x`), "target");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("extractTarGzip refuses a symlink whose target escapes the destination", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const archive = `${dir}/evil.tar.gz`;
+    await Deno.writeFile(
+      archive,
+      await gzip(tar([
+        {
+          name: "bin/pwn",
+          data: new Uint8Array(0),
+          linkname: "../../../../etc/passwd",
+        },
+      ])),
+    );
+    await assertRejects(
+      () => extractTarGzip(archive, `${dir}/out`),
+      Error,
+      "escapes the destination",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("assertSafeLinkTarget accepts in-tree targets and rejects escapes", () => {
+  assertSafeLinkTarget("bin/npm", "../lib/npm-cli.js"); // resolves inside the tree
+  assertSafeLinkTarget("bin/x", "./sibling");
+  assertSafeLinkTarget("a/b/c", "../../top"); // climbs to root, not above
+  assertThrows(
+    () => assertSafeLinkTarget("bin/x", "/etc/passwd"),
+    Error,
+    "absolute path",
+  );
+  assertThrows(
+    () => assertSafeLinkTarget("bin/x", "C:/win"),
+    Error,
+    "absolute path",
+  );
+  assertThrows(
+    () => assertSafeLinkTarget("bin/x", "../../etc"),
+    Error,
+    "escapes",
+  );
 });
 
 Deno.test("assertSafeEntryName accepts safe names and rejects escapes", () => {

--- a/packages/core/tests/install_tree_test.ts
+++ b/packages/core/tests/install_tree_test.ts
@@ -34,16 +34,23 @@ async function sha256Hex(bytes: Uint8Array): Promise<string> {
 function nodeTarball(): Promise<Uint8Array> {
   const entries: TarEntry[] = [
     { name: "node-v1/bin/node", data: enc("#!/bin/sh\necho node\n") },
-    {
-      name: "node-v1/lib/node_modules/npm/bin/npm-cli.js",
-      data: enc("#!/bin/sh\necho npm\n"),
-    },
-    {
-      name: "node-v1/bin/npm",
-      data: new Uint8Array(0),
-      linkname: "../lib/node_modules/npm/bin/npm-cli.js",
-    },
   ];
+  if (POSIX) {
+    // Plant the symlinked bin only on POSIX: Windows symlink creation is
+    // privileged (and Windows runtimes ship .zip of real bins, not symlinks), so
+    // the symlink-preservation path is exercised on macOS/Linux runners.
+    entries.push(
+      {
+        name: "node-v1/lib/node_modules/npm/bin/npm-cli.js",
+        data: enc("#!/bin/sh\necho npm\n"),
+      },
+      {
+        name: "node-v1/bin/npm",
+        data: new Uint8Array(0),
+        linkname: "../lib/node_modules/npm/bin/npm-cli.js",
+      },
+    );
+  }
   return gzip(tar(entries));
 }
 

--- a/packages/core/tests/install_tree_test.ts
+++ b/packages/core/tests/install_tree_test.ts
@@ -1,0 +1,251 @@
+import { assertEquals, assertRejects } from "./_assert.ts";
+import { type DownloadFn, installTree } from "../src/install.ts";
+import { gzip, tar, type TarEntry } from "../src/compression.ts";
+import { makeZip, STORED } from "./_zip.ts";
+
+const enc = (s: string) => new TextEncoder().encode(s);
+const POSIX = Deno.build.os !== "windows";
+
+/** A download seam that writes fixed bytes to `dest`, counting its calls. */
+function fakeDownload(
+  bytes: Uint8Array,
+  counter?: { calls: number },
+): DownloadFn {
+  return async (_url, dest) => {
+    if (counter) counter.calls++;
+    await Deno.writeFile(String(dest), bytes);
+  };
+}
+
+/** Hex SHA-256 of bytes, matching installTree's own hashing. */
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new Uint8Array(bytes));
+  return Array.from(
+    new Uint8Array(digest),
+    (b) => b.toString(16).padStart(2, "0"),
+  ).join("");
+}
+
+/**
+ * A Node-like release tarball: a `node-v1/` top directory, a real `bin/node`, a
+ * `lib/` script, and a `bin/npm` symlink into it — the exact shape (top-dir wrap
+ * + symlinked bins) that `installRelease` cannot handle but `installTree` can.
+ */
+function nodeTarball(): Promise<Uint8Array> {
+  const entries: TarEntry[] = [
+    { name: "node-v1/bin/node", data: enc("#!/bin/sh\necho node\n") },
+    {
+      name: "node-v1/lib/node_modules/npm/bin/npm-cli.js",
+      data: enc("#!/bin/sh\necho npm\n"),
+    },
+    {
+      name: "node-v1/bin/npm",
+      data: new Uint8Array(0),
+      linkname: "../lib/node_modules/npm/bin/npm-cli.js",
+    },
+  ];
+  return gzip(tar(entries));
+}
+
+Deno.test("installTree unpacks a runtime tree, strips, and returns the root", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const root = await installTree({
+      name: "node",
+      destDir: dir,
+      archive: "tar.gz",
+      strip: 1,
+      bins: ["bin/node", "bin/npm"],
+      url: () => "https://example.com/node.tar.gz",
+      download: fakeDownload(await nodeTarball()),
+    });
+    assertEquals(root.path.endsWith("/node"), true);
+    // The `node-v1/` wrapper is stripped: files sit directly under the root.
+    assertEquals(
+      await Deno.readTextFile(String(root("bin", "node"))),
+      "#!/bin/sh\necho node\n",
+    );
+    if (POSIX) {
+      const mode = (await Deno.stat(String(root("bin", "node")))).mode ?? 0;
+      assertEquals(mode & 0o111, 0o111); // bin/node is executable
+      // bin/npm is a real symlink; reading follows it to the lib script.
+      const link = await Deno.lstat(String(root("bin", "npm")));
+      assertEquals(link.isSymlink, true);
+      assertEquals(
+        await Deno.readTextFile(String(root("bin", "npm"))),
+        "#!/bin/sh\necho npm\n",
+      );
+      // chmod of the symlinked bin follows to its target, so npm-cli.js is +x.
+      const targetMode = (await Deno.stat(String(root("bin", "npm")))).mode ??
+        0;
+      assertEquals(targetMode & 0o111, 0o111);
+    }
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("installTree verifies the archive checksum and reuses a cached tree", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const bytes = await nodeTarball();
+    const counter = { calls: 0 };
+    const spec = {
+      name: "node",
+      destDir: dir,
+      archive: "tar.gz" as const,
+      strip: 1,
+      bins: ["bin/node"],
+      url: () => "u",
+      download: fakeDownload(bytes, counter),
+      checksum: await sha256Hex(bytes),
+    };
+    const first = await installTree(spec);
+    const second = await installTree(spec);
+    assertEquals(counter.calls, 1); // the second call is a cache hit
+    assertEquals(String(first), String(second));
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("installTree rejects a checksum mismatch and installs nothing", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const err = await assertRejects(() =>
+      installTree({
+        name: "node",
+        destDir: dir,
+        archive: "tar.gz",
+        strip: 1,
+        url: () => "u",
+        download: fakeDownload(new TextEncoder().encode("nodeTarballBytes")),
+        checksum: "0".repeat(64),
+      })
+    );
+    assertEquals(err.message.includes("checksum mismatch"), true);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("installTree re-installs on a missing bin or a corrupt marker", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const bytes = await nodeTarball();
+    const counter = { calls: 0 };
+    const spec = {
+      name: "node",
+      destDir: dir,
+      archive: "tar.gz" as const,
+      strip: 1,
+      bins: ["bin/node"],
+      url: () => "u",
+      download: fakeDownload(bytes, counter),
+      checksum: await sha256Hex(bytes),
+    };
+    const root = await installTree(spec);
+    // A deleted declared bin invalidates the cache → re-download and re-extract.
+    await Deno.remove(String(root("bin", "node")));
+    await installTree(spec);
+    assertEquals(counter.calls, 2);
+    // A corrupt marker is treated as no marker → re-install again.
+    await Deno.writeTextFile(`${String(root)}.tree.json`, "not json{");
+    await installTree(spec);
+    assertEquals(counter.calls, 3);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("installTree re-installs when the pinned checksum changes", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const v1 = await nodeTarball();
+    // A second, distinct tarball (different bin contents → a different checksum).
+    const v2 = await gzip(tar([
+      { name: "node-v1/bin/node", data: enc("#!/bin/sh\necho node-v2\n") },
+    ]));
+    const counter = { calls: 0 };
+    await installTree({
+      name: "node",
+      destDir: dir,
+      archive: "tar.gz",
+      strip: 1,
+      bins: ["bin/node"],
+      url: () => "u",
+      download: fakeDownload(v1, counter),
+      checksum: await sha256Hex(v1),
+    });
+    const root = await installTree({
+      name: "node",
+      destDir: dir,
+      archive: "tar.gz",
+      strip: 1,
+      bins: ["bin/node"],
+      url: () => "u",
+      download: fakeDownload(v2, counter),
+      checksum: await sha256Hex(v2), // a valid but different pin → cache miss
+    });
+    assertEquals(counter.calls, 2);
+    assertEquals(
+      await Deno.readTextFile(String(root("bin", "node"))),
+      "#!/bin/sh\necho node-v2\n",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("installTree unpacks a zip tree and skips chmod for a windows target", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    // Windows Node ships a .zip of real .exe/.cmd files (no symlinks). A windows
+    // target skips chmod — which exercises that branch on a POSIX CI runner too.
+    const bytes = await makeZip([
+      { name: "node-v1/node.exe", data: enc("MZ"), method: STORED },
+      { name: "node-v1/npm.cmd", data: enc("@echo off"), method: STORED },
+    ]);
+    const root = await installTree({
+      name: "node",
+      destDir: dir,
+      archive: "zip",
+      strip: 1,
+      bins: ["node.exe"],
+      platform: { os: "windows", arch: "x86_64" },
+      url: () => "https://example.com/node.zip",
+      download: fakeDownload(bytes),
+    });
+    assertEquals(await Deno.readTextFile(String(root("node.exe"))), "MZ");
+    assertEquals(await Deno.readTextFile(String(root("npm.cmd"))), "@echo off");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("installTree without a checksum downloads every time and writes no marker", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const counter = { calls: 0 };
+    const spec = {
+      name: "node",
+      destDir: dir,
+      archive: "tar.gz" as const,
+      strip: 1,
+      bins: ["bin/node"],
+      url: () => "u",
+      download: fakeDownload(await nodeTarball(), counter),
+    };
+    const root = await installTree(spec);
+    await installTree(spec);
+    assertEquals(counter.calls, 2); // no checksum → no cache
+    assertEquals(
+      await Deno.stat(`${String(root)}.tree.json`).then(() => true).catch(
+        () => false,
+      ),
+      false, // no marker recorded without a checksum
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/packages/core/tests/tool_test.ts
+++ b/packages/core/tests/tool_test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertThrows } from "./_assert.ts";
 import type { DownloadFn } from "../src/install.ts";
 import type { NpmRunner } from "../src/npm_tool.ts";
+import { gzip, tar } from "../src/compression.ts";
 import {
   DEFAULT_TOOLS_DIR,
   Toolchain,
@@ -8,6 +9,20 @@ import {
   ToolInstallSettings,
   ToolTasks,
 } from "../src/tool.ts";
+
+/** A tiny release tarball wrapping a `pkg/bin/tool` under a top directory. */
+function toolTarball(): Promise<Uint8Array> {
+  return gzip(tar([
+    { name: "pkg/bin/tool", data: new TextEncoder().encode("TREE-BIN") },
+  ]));
+}
+
+/** A download seam that writes prepared archive bytes to `dest`. */
+function bytesDownload(bytes: Uint8Array): DownloadFn {
+  return async (_url, dest) => {
+    await Deno.writeFile(String(dest), bytes);
+  };
+}
 
 const EXE = Deno.build.os === "windows" ? ".exe" : "";
 /** The npm bin-shim suffix on the host (`.cmd` on Windows, else none). */
@@ -237,6 +252,122 @@ Deno.test("ToolInstallSettings carries every option through to the install spec"
   assertEquals(spec.binaryPath, "dir/t");
   assertEquals(spec.platform, platform);
   assertEquals(spec.checksum, checksum);
+});
+
+Deno.test("ToolTasks.installTree unpacks a runtime tree via a settings-lambda", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const tarball = await toolTarball();
+    const root = await ToolTasks.installTree((s) =>
+      s.name("node").destDir(dir).archive("tar.gz").strip(1).bins("bin/tool")
+        .url(() => "https://tools.test/node.tar.gz")
+        .download(bytesDownload(tarball))
+    );
+    assertEquals(root.path.endsWith("/node"), true);
+    assertEquals(
+      await Deno.readTextFile(String(root("bin", "tool"))),
+      "TREE-BIN",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("toolchain installs a runtime tree alongside release tools", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const seen: string[] = [];
+    const tarball = await toolTarball();
+    // Each tool carries its own download seam (a tree needs a real archive, not
+    // the URL-text a toolchain-level seam would write), so set none globally.
+    const tools = toolchain((t) =>
+      t.tool((s) =>
+        s.name("helm").url(() => "https://tools.test/helm")
+          .download(recordingDownload(seen))
+      )
+        .tree((s) =>
+          s.name("node").archive("tar.gz").strip(1).bins("bin/tool")
+            .url(() => "https://tools.test/node.tar.gz")
+            .download(bytesDownload(tarball))
+        )
+    );
+    const bins = await tools.install({ destDir: dir });
+    assertEquals([...bins.keys()].sort(), ["helm", "node"]);
+    // The tree's entry is its extracted root directory (a callable path).
+    const root = bins.get("node");
+    assertEquals(root?.path.endsWith("/node"), true);
+    assertEquals(
+      await Deno.readTextFile(String(root?.("bin", "tool"))),
+      "TREE-BIN",
+    );
+    // The tree carried its own download seam; the toolchain default fetched helm.
+    assertEquals(seen, ["https://tools.test/helm"]);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("a toolchain-level download seam is applied to a tree without its own", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const tarball = await toolTarball();
+    // The tree sets no .download(), so the toolchain-level seam must be used.
+    const bins = await toolchain()
+      .tree((s) =>
+        s.name("node").archive("tar.gz").strip(1).bins("bin/tool").url(() =>
+          "u"
+        )
+      )
+      .install({ destDir: dir, download: bytesDownload(tarball) });
+    const root = bins.get("node");
+    assertEquals(
+      await Deno.readTextFile(String(root?.("bin", "tool"))),
+      "TREE-BIN",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("toolchain exposes its configured trees in order", () => {
+  const chain = new Toolchain()
+    .tree((s) => s.name("node").url(() => "n"))
+    .tree((s) => s.name("bun").url(() => "b"));
+  assertEquals(chain.trees.map((s) => s.name_), ["node", "bun"]);
+});
+
+Deno.test("treeOptions_ requires name and url and rejects a raw archive", () => {
+  assertThrows(
+    () => new ToolInstallSettings().treeOptions_(DEFAULT_TOOLS_DIR),
+    Error,
+    "requires .name",
+  );
+  assertThrows(
+    () => new ToolInstallSettings().name("x").treeOptions_(DEFAULT_TOOLS_DIR),
+    Error,
+    "requires .url",
+  );
+  assertThrows(
+    () =>
+      new ToolInstallSettings().name("x").url(() => "u").archive("raw")
+        .treeOptions_(DEFAULT_TOOLS_DIR),
+    Error,
+    'not "raw"',
+  );
+});
+
+Deno.test("treeOptions_ carries strip/bins and defaults the archive to tar.gz", () => {
+  const spec = new ToolInstallSettings()
+    .name("node")
+    .url(() => "u")
+    .strip(1)
+    .bins("bin/node", "bin/npm")
+    .treeOptions_(".fallback");
+  assertEquals(spec.name, "node");
+  assertEquals(spec.destDir, ".fallback");
+  assertEquals(spec.archive, "tar.gz"); // defaulted, since a tree ships packed
+  assertEquals(spec.strip, 1);
+  assertEquals(spec.bins, ["bin/node", "bin/npm"]);
 });
 
 Deno.test("the default tools directory is .zuke/tools", () => {

--- a/tests/integration/install_tree_test.ts
+++ b/tests/integration/install_tree_test.ts
@@ -1,0 +1,97 @@
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import {
+  Build,
+  gzip,
+  tar,
+  target,
+  toolchain,
+} from "../../packages/core/mod.ts";
+import type { DownloadFn, TarEntry } from "../../packages/core/mod.ts";
+import { runCli } from "./_harness.ts";
+
+// A build that provisions a multi-file runtime tree. The fixture tarball and
+// install root are module-scoped so the target body (captured at field-init)
+// reads them at execution time — set before the run.
+let tarballBytes: Uint8Array = new Uint8Array(0);
+let toolsDir = "";
+const POSIX = Deno.build.os !== "windows";
+
+/** A download seam that writes the prepared fixture tarball to `dest`. */
+const fixtureDownload: DownloadFn = async (_url, dest) => {
+  await Deno.writeFile(String(dest), tarballBytes);
+};
+
+class TreeBuild extends Build {
+  tools = toolchain((t) =>
+    t.tree((s) =>
+      s.name("node").archive("tar.gz").strip(1).bins("bin/node", "bin/npm")
+        .url(() => "https://example.test/node.tar.gz")
+        .download(fixtureDownload)
+    )
+  );
+
+  install = target()
+    .description("install a multi-file runtime tree")
+    .executes(async () => {
+      const roots = await this.tools.install({ destDir: toolsDir });
+      const root = roots.get("node");
+      if (root === undefined) throw new Error("node tree not installed");
+      if (Deno.build.os !== "windows") {
+        // The symlinked bin resolves to the lib script it points at…
+        const npm = await Deno.readTextFile(String(root("bin", "npm")));
+        console.log(`npm-via-symlink=${npm.trim()}`);
+        // …and chmod made the real bin executable, so it actually runs.
+        const cmd = new Deno.Command(String(root("bin", "node")), {
+          stdout: "piped",
+        });
+        const { stdout } = await cmd.output();
+        console.log(`ran=${new TextDecoder().decode(stdout).trim()}`);
+      } else {
+        const node = await Deno.stat(String(root("bin", "node")));
+        console.log(`node-exists=${node.isFile}`);
+      }
+    });
+}
+
+Deno.test("a build installs a multi-file runtime tree end-to-end via the CLI", async () => {
+  const entries: TarEntry[] = [
+    {
+      name: "node-v1/bin/node",
+      data: new TextEncoder().encode("#!/bin/sh\necho NODE-RAN\n"),
+    },
+  ];
+  if (POSIX) {
+    // Only plant the symlink on POSIX; Windows symlink creation is privileged
+    // and Windows runtimes ship real .exe bins, not symlinks.
+    entries.push(
+      {
+        name: "node-v1/lib/npm-cli.js",
+        data: new TextEncoder().encode("#!/bin/sh\necho NPM\n"),
+      },
+      {
+        name: "node-v1/bin/npm",
+        data: new Uint8Array(0),
+        linkname: "../lib/npm-cli.js",
+      },
+    );
+  }
+  tarballBytes = await gzip(tar(entries));
+  toolsDir = await Deno.makeTempDir({ prefix: "zuke-tree-it-" });
+  try {
+    const { code, out } = await runCli(TreeBuild, ["install"]);
+    assertEquals(code, 0);
+    if (POSIX) {
+      // Reading the symlinked bin returns the lib script it points at.
+      assertStringIncludes(out, "npm-via-symlink=#!/bin/sh");
+      assertStringIncludes(out, "echo NPM"); // symlink resolved to npm-cli.js
+      assertStringIncludes(out, "ran=NODE-RAN"); // bin made executable, so it ran
+    } else {
+      assertStringIncludes(out, "node-exists=true"); // tree extracted
+    }
+  } finally {
+    await Deno.remove(toolsDir, { recursive: true });
+  }
+});


### PR DESCRIPTION
## What

`installRelease` extracts exactly one binary, so a multi-file runtime such as **Node.js** — which ships `bin/node`, `bin/npm`, `bin/npx`, and `lib/node_modules/**` in one tarball — could not be toolchain-provisioned (installing left only `.zuke/tools/node`; npm/npx were discarded). This adds **`installTree`**, which keeps the whole extracted archive tree and returns its root as a callable `AbsolutePath`:

- `root("bin", "node")` — a binary to invoke
- `root("bin")` — the directory to put on `PATH` (the FR-9 follow-up)

Surfaced through `ToolTasks.installTree((s) => …)`, `Toolchain.tree(...)`, and `ToolInstallSettings.strip()/.bins()`.

## How it works

- **Tar symlink support** — the tar reader (`untar`/`tar`/`TarEntry.linkname`) now preserves symbolic-link entries, because Node's `bin/npm`/`bin/npx` are symlinks into `lib/node_modules`. A new **`assertSafeLinkTarget`** rejects absolute or `..`-escaping targets (the second escape vector a symlink adds beyond the existing name check).
- **`strip` option** on `extractTarGzip`/`extractZip` drops the leading `tool-v1.2.3/` directory a release tarball wraps everything in.
- Declared `bins` are marked executable on POSIX (the tar reader does not preserve mode bits; `chmod` follows a symlinked bin to its real target).
- Cached by the pinned archive checksum plus a declared-bins-present check.

## Tests

- **Unit** — tar symlink round-trip, `strip`, `assertSafeLinkTarget` (accept/reject), duplicate-entry overwrite, and `installTree` (extract/strip/chmod/symlink-resolve, checksum verify + cache reuse, checksum mismatch, version-bump re-install, missing-bin/corrupt-marker re-install, zip tree, no-checksum path), plus `ToolTasks.installTree` / `Toolchain.tree` / `treeOptions_`.
- **Integration** — a build provisions a runtime tree end-to-end via the CLI, proving the symlinked bin resolves and the real bin is executable (POSIX) / the tree extracts (Windows).

## Adversarial review

Two independent reviewers attacked the change. **Confirmed & fixed:** a duplicate archive entry crashed extraction with a raw `AlreadyExists` (now last-one-wins, with a regression test); two branch-coverage gaps closed. **Refuted:** symlink escape (incl. directory-traversal), strip×safety ordering, and zip-slip are all bounded within the destination root. **Declined (documented ceiling):** the tree cache is keyed on the pinned download checksum rather than re-hashing the whole tree — the download checksum is the integrity boundary, and re-hashing an ~80MB runtime every build is the cost a single-binary install avoids.

All gates green: `deno task ci` (lines 98.3%, branches 95.3%), `apiDocsCheck`, `generate-ci --check`, and `deno doc --lint`.