### PR TITLE
feat(core): add prependPath to put a provisioned dir on PATH

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -422,6 +422,27 @@ function plan(root: TargetBuilder, extra: readonly OrderingEdge[]): TargetBuilde
       if the planned graph contains a cycle (which can happen
       via soft edges even when the hard graph is acyclic).
 
+function prependPath(dir: PathLike, os: typeof Deno.build.os): string
+  Prepend `dir` to the process `PATH`, and return the new value. A tool
+  provisioned into `dir` (e.g. the `bin` directory of an {@link "./install.ts".installTree}
+  runtime) then resolves for the rest of the build: the shell `$`, `Command`,
+  and every tool wrapper spawn subprocesses that inherit `Deno.env`, so the
+  `node_modules/.bin` shims and `NpmTasks` that assume a `node`/`npm` on `PATH`
+  find the provisioned one.
+
+  Idempotent — a directory already on `PATH` is left in place, not duplicated —
+  and uses the platform separator (`;` on Windows, `:` elsewhere).
+
+  @param dir
+      the directory to place first on `PATH`.
+
+  @param os
+      the OS whose `PATH` separator to use; defaults to the host (a test
+      seam, mirroring {@link operatingSystem}).
+
+  @return
+      the resulting `PATH` string.
+
 function remoteCacheKey(name: string, fingerprint: string): string
   The store key for a target's outputs: its name and input `fingerprint`. The
   name is sanitised so the key is safe as a filename and a URL path segment.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -476,6 +476,27 @@ function plan(root: TargetBuilder, extra: readonly OrderingEdge[]): TargetBuilde
       if the planned graph contains a cycle (which can happen
       via soft edges even when the hard graph is acyclic).
 
+function prependPath(dir: PathLike, os: typeof Deno.build.os): string
+  Prepend `dir` to the process `PATH`, and return the new value. A tool
+  provisioned into `dir` (e.g. the `bin` directory of an {@link "./install.ts".installTree}
+  runtime) then resolves for the rest of the build: the shell `$`, `Command`,
+  and every tool wrapper spawn subprocesses that inherit `Deno.env`, so the
+  `node_modules/.bin` shims and `NpmTasks` that assume a `node`/`npm` on `PATH`
+  find the provisioned one.
+
+  Idempotent — a directory already on `PATH` is left in place, not duplicated —
+  and uses the platform separator (`;` on Windows, `:` elsewhere).
+
+  @param dir
+      the directory to place first on `PATH`.
+
+  @param os
+      the OS whose `PATH` separator to use; defaults to the host (a test
+      seam, mirroring {@link operatingSystem}).
+
+  @return
+      the resulting `PATH` string.
+
 function remoteCacheKey(name: string, fingerprint: string): string
   The store key for a target's outputs: its name and input `fingerprint`. The
   name is sanitised so the key is safe as a filename and a URL path segment.

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -289,6 +289,7 @@ export {
   type InstallTreeOptions,
   type Platform,
 } from "./src/install.ts";
+export { prependPath } from "./src/env.ts";
 export {
   installNpmTool,
   type InstallNpmToolOptions,

--- a/packages/core/src/env.ts
+++ b/packages/core/src/env.ts
@@ -1,0 +1,47 @@
+/**
+ * Process-environment helpers for a build. Right now that is {@link prependPath}
+ * — put a provisioned tool's directory on `PATH` so every subprocess the build
+ * spawns can find it.
+ *
+ * ```ts
+ * import { installTree, prependPath } from "jsr:@zuke/core";
+ *
+ * const node = await installTree({ name: "node", ...  });
+ * prependPath(node("bin")); // now `node`, `npm`, `npx` resolve on PATH
+ * ```
+ *
+ * @module
+ */
+
+import { operatingSystem } from "./host.ts";
+import type { PathLike } from "./path.ts";
+
+/**
+ * Prepend `dir` to the process `PATH`, and return the new value. A tool
+ * provisioned into `dir` (e.g. the `bin` directory of an {@link "./install.ts".installTree}
+ * runtime) then resolves for the rest of the build: the shell `$`, `Command`,
+ * and every tool wrapper spawn subprocesses that inherit `Deno.env`, so the
+ * `node_modules/.bin` shims and `NpmTasks` that assume a `node`/`npm` on `PATH`
+ * find the provisioned one.
+ *
+ * Idempotent — a directory already on `PATH` is left in place, not duplicated —
+ * and uses the platform separator (`;` on Windows, `:` elsewhere).
+ *
+ * @param dir the directory to place first on `PATH`.
+ * @param os the OS whose `PATH` separator to use; defaults to the host (a test
+ * seam, mirroring {@link operatingSystem}).
+ * @returns the resulting `PATH` string.
+ */
+export function prependPath(
+  dir: PathLike,
+  os: typeof Deno.build.os = Deno.build.os,
+): string {
+  const separator = operatingSystem(os) === "windows" ? ";" : ":";
+  const entry = String(dir);
+  const current = Deno.env.get("PATH") ?? "";
+  const parts = current.split(separator).filter((part) => part !== "");
+  if (parts.includes(entry)) return current; // already present — unchanged
+  const next = current === "" ? entry : `${entry}${separator}${current}`;
+  Deno.env.set("PATH", next);
+  return next;
+}

--- a/packages/core/tests/env_test.ts
+++ b/packages/core/tests/env_test.ts
@@ -1,0 +1,70 @@
+import { assertEquals } from "./_assert.ts";
+import { prependPath } from "../src/env.ts";
+
+/** Run `fn` with `PATH` set to `value`, restoring the real `PATH` afterwards. */
+async function withPath(
+  value: string,
+  fn: () => void | Promise<void>,
+): Promise<void> {
+  const saved = Deno.env.get("PATH");
+  Deno.env.set("PATH", value);
+  try {
+    await fn();
+  } finally {
+    if (saved === undefined) Deno.env.delete("PATH");
+    else Deno.env.set("PATH", saved);
+  }
+}
+
+Deno.test("prependPath puts a directory first (POSIX separator)", async () => {
+  await withPath("/usr/bin:/bin", () => {
+    const next = prependPath("/tools/bin", "linux");
+    assertEquals(next, "/tools/bin:/usr/bin:/bin");
+    assertEquals(Deno.env.get("PATH"), "/tools/bin:/usr/bin:/bin");
+  });
+});
+
+Deno.test("prependPath uses the Windows separator", async () => {
+  await withPath("C:\\Windows;C:\\bin", () => {
+    const next = prependPath("C:\\tools", "windows");
+    assertEquals(next, "C:\\tools;C:\\Windows;C:\\bin");
+    assertEquals(Deno.env.get("PATH"), "C:\\tools;C:\\Windows;C:\\bin");
+  });
+});
+
+Deno.test("prependPath is idempotent — an already-present dir is not duplicated", async () => {
+  await withPath("/a:/b", () => {
+    const next = prependPath("/a", "linux");
+    assertEquals(next, "/a:/b"); // unchanged
+    assertEquals(Deno.env.get("PATH"), "/a:/b");
+  });
+});
+
+Deno.test("prependPath handles an empty PATH", async () => {
+  await withPath("", () => {
+    assertEquals(prependPath("/only", "linux"), "/only");
+    assertEquals(Deno.env.get("PATH"), "/only");
+  });
+});
+
+Deno.test("prependPath treats an unset PATH as empty", () => {
+  // Distinct from an empty-string PATH: this exercises the `?? ""` fallback for
+  // a PATH that is genuinely unset.
+  const saved = Deno.env.get("PATH");
+  Deno.env.delete("PATH");
+  try {
+    assertEquals(prependPath("/x", "linux"), "/x");
+    assertEquals(Deno.env.get("PATH"), "/x");
+  } finally {
+    if (saved === undefined) Deno.env.delete("PATH");
+    else Deno.env.set("PATH", saved);
+  }
+});
+
+Deno.test("prependPath defaults to the host separator", async () => {
+  await withPath("HOST", () => {
+    const next = prependPath("FIRST"); // host os
+    assertEquals(next.startsWith("FIRST"), true);
+    assertEquals(next.endsWith("HOST"), true);
+  });
+});

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -408,6 +408,27 @@ tools = toolchain((t) =>
 blocks zip-slip. `.checksum(sha256)` verifies (the archive's SHA-256 for an
 archive, the binary's for `"raw"`) and doubles as the install cache key.
 
+**Multi-file runtimes (Node.js, a JDK, …)** — `ToolTasks.installTree((s) => …)`
+(or `toolchain().tree((s) => …)`) keeps the *whole* extracted tree instead of one
+binary, for a runtime that ships several bins plus `lib/`. `.strip(1)` unwraps the
+`tool-v1.2.3/` top directory, `.bins("bin/node", "bin/npm")` marks executables
+(symlinks preserved). It returns the tree root as a callable `AbsolutePath`, so
+`root("bin", "node")` is a binary and `root("bin")` the directory to put on PATH:
+
+```ts
+import { prependPath, ToolTasks } from "jsr:@zuke/core";
+
+const node = await ToolTasks.installTree((s) =>
+  s.name("node").archive("tar.gz").strip(1).bins("bin/node", "bin/npm")
+    .url(nodeUrl).checksum(nodeSum)
+);
+prependPath(node("bin")); // node/npm (and node_modules/.bin shims) now on PATH
+```
+
+`prependPath(dir)` puts `dir` first on the process `PATH` (idempotent, platform
+separator) so every subprocess Zuke spawns — the shell `$`, `Command`, and the
+tool wrappers, which inherit `Deno.env` — finds the provisioned tool.
+
 **Resolve from `node_modules/.bin`** — in a Node monorepo where tool binaries
 are hoisted to the repo root, a wrapper can find its binary npx-style instead of
 needing a `.toolPath(...)`. `.fromNodeModules()` on any settings object walks up

--- a/tests/integration/prepend_path_test.ts
+++ b/tests/integration/prepend_path_test.ts
@@ -1,0 +1,48 @@
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import { Build, prependPath, target } from "../../packages/core/mod.ts";
+import { runCli } from "./_harness.ts";
+
+// The bin directory to put on PATH is module-scoped so the target body (captured
+// at field-init) reads it at execution time — set before the run.
+let binDir = "";
+
+class PathBuild extends Build {
+  run = target()
+    .description("resolve a provisioned tool by bare name via PATH")
+    .executes(async () => {
+      prependPath(binDir);
+      // A bare command name must now resolve through the prepended directory,
+      // proving the mutation reaches spawned subprocesses.
+      const cmd = new Deno.Command("zuke-fixture-tool", { stdout: "piped" });
+      const { success, stdout } = await cmd.output();
+      console.log(
+        `resolved=${success} out=${new TextDecoder().decode(stdout).trim()}`,
+      );
+    });
+}
+
+Deno.test("prependPath makes a provisioned bin resolve by bare name via the CLI", async () => {
+  if (Deno.build.os === "windows") return; // bare-name shell scripts are POSIX
+  const dir = await Deno.makeTempDir({ prefix: "zuke-path-it-" });
+  const savedPath = Deno.env.get("PATH");
+  try {
+    binDir = `${dir}/bin`;
+    await Deno.mkdir(binDir);
+    const tool = `${binDir}/zuke-fixture-tool`;
+    await Deno.writeTextFile(tool, "#!/bin/sh\necho PATH-RESOLVED\n");
+    await Deno.chmod(tool, 0o755);
+
+    const { code, out } = await runCli(PathBuild, ["run"]);
+    assertEquals(code, 0);
+    assertStringIncludes(out, "resolved=true"); // the subprocess spawned…
+    assertStringIncludes(out, "out=PATH-RESOLVED"); // …and it was the provisioned one
+  } finally {
+    // Restore the real PATH the in-process run mutated.
+    if (savedPath === undefined) Deno.env.delete("PATH");
+    else Deno.env.set("PATH", savedPath);
+    await Deno.remove(dir, { recursive: true });
+  }
+});


### PR DESCRIPTION
## What

`installTree` (PR #215) provisions a multi-file runtime, but its bins land in `.zuke/tools/<name>/bin` and aren't discoverable to other processes — so `node_modules/.bin` shims (`#!/usr/bin/env node`) and `NpmTasks` couldn't find a provisioned `node`/`npm` without a manual `Deno.env.set("PATH", …)`. This is the other half of FR-8: **`prependPath(dir)`**.

```ts
import { installTree, prependPath } from "jsr:@zuke/core";

const node = await installTree({ name: "node", archive: "tar.gz", strip: 1,
  bins: ["bin/node", "bin/npm"], url: nodeUrl, checksum: nodeSum });
prependPath(node("bin")); // node, npm, npx now resolve for the rest of the build
```

## How

`prependPath(dir, os?)` prepends `dir` to the process `PATH` and returns the new value:
- **Idempotent** — a directory already on `PATH` is left in place, not duplicated.
- **Platform separator** — `;` on Windows, `:` elsewhere (the `os` param is a test seam mirroring `operatingSystem(os?)`).
- Every subprocess Zuke spawns — the shell `$`, `Command`, and the tool wrappers — inherits `Deno.env`, so the mutation reaches all of them.

## Tests

- **Unit** — POSIX/Windows separators, empty PATH, unset PATH (`?? ""` fallback), idempotent hit, default-host. `env.ts` is 100% line/branch/function.
- **Integration** — a build `prependPath`s a temp bin dir, then a bare command name resolves to the provisioned tool through the CLI (POSIX; bare-name shell scripts are POSIX).

## Adversarial review

An independent reviewer attacked correctness, coverage, injection, and global-state safety. **Verdict APPROVE.** One confirmed LOW — the unset-`PATH` branch was untested — now closed with a regression test (100% branch). Accepted as trusted-input ceilings: a `dir` containing the separator, and case/trailing-slash de-dup — `dir` comes from the build script, the same trust boundary as the rest of the build. Tests save/restore `PATH`; the suite runs non-parallel (`deno test` without `--parallel`), so there's no contamination.

Also brought the `zuke-write-build` skill cheatsheet current with `installTree` + `prependPath` (the runtime-provisioning story).

All gates green: `deno task ci`, `apiDocsCheck`, `generate-ci --check`, `deno doc --lint`. Commit signed.