### PR TITLE
feat(core): add a doc command to print a package's API in isolation

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,29 +1,30 @@
 # CLI reference
 
-| Command                                                 | Behaviour                                                                               |
-| ------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| `zuke <target>`                                         | Run the target and all its transitive dependencies, in order.                           |
-| `zuke <target> --skip <dep>`                            | Run the target but skip the named dependency (repeatable).                              |
-| `zuke <target> --parallel`                              | Run independent targets concurrently (`--parallel=N` caps it).                          |
-| `zuke <target> --no-cache`                              | Ignore the incremental cache; re-run every target.                                      |
-| `zuke <target> --affected[=<base>]`                     | Run only targets affected by files changed since a git base.                            |
-| `zuke <target> --dry-run`                               | Print the plan without executing any target body.                                       |
-| `zuke <target> --state`                                 | Persist [durable run state](./state.md) under `.zuke/runs`.                             |
-| `zuke <target> --actor <name>`                          | Attribute the run to `<name>` in its state record.                                      |
-| `zuke --list` / `-l`                                    | List all targets with descriptions and dependencies.                                    |
-| `zuke graph`                                            | Print the dependency graph (`target → deps`).                                           |
-| `zuke graph --output=html`                              | Render an interactive HTML graph into `.zuke/` and open it.                             |
-| `zuke completions print <shell>`                        | Print a shell-completion script (`bash`, `zsh`, or `fish`).                             |
-| `zuke completions install <shell>`                      | Write the script and wire it into the shell's startup.                                  |
-| `zuke mcp [--allow-run[=<globs>]] [--http <host:port>]` | Run an MCP server over the build for AI agents, on stdio or HTTP ([details](./mcp.md)). |
-| `zuke resume <id> [--signal <n>] [--data <json>]`       | Resume a suspended run, optionally delivering a signal ([details](./orchestration.md)). |
-| `zuke resume --check [<id>]`                            | Re-check suspended runs (predicate waits, timeouts).                                    |
-| `zuke runs list [--status/-target/-since/-limit] [--counts] [--json]` | List persisted run records (or `--counts` for a status tally), newest first ([details](./state.md)). |
-| `zuke runs show <id> [--json]`                          | Show one run's full per-target status and metadata.                                     |
-| `zuke runs prune [--keep <age>] [--keep-last <n>] [--dry-run]` | Delete old terminal run records; never touches non-terminal runs.                |
-| `zuke cancel <id> [--actor <name>]`                     | Cancel a run and run its compensations ([details](./orchestration.md#cancellation--compensation-oncancel)). |
-| `zuke --help` / `-h`                                    | Usage.                                                                                  |
-| `zuke` (no target)                                      | Run the `default` target if defined, else print `--list`.                               |
+| Command                                                               | Behaviour                                                                                                   |
+| --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `zuke <target>`                                                       | Run the target and all its transitive dependencies, in order.                                               |
+| `zuke <target> --skip <dep>`                                          | Run the target but skip the named dependency (repeatable).                                                  |
+| `zuke <target> --parallel`                                            | Run independent targets concurrently (`--parallel=N` caps it).                                              |
+| `zuke <target> --no-cache`                                            | Ignore the incremental cache; re-run every target.                                                          |
+| `zuke <target> --affected[=<base>]`                                   | Run only targets affected by files changed since a git base.                                                |
+| `zuke <target> --dry-run`                                             | Print the plan without executing any target body.                                                           |
+| `zuke <target> --state`                                               | Persist [durable run state](./state.md) under `.zuke/runs`.                                                 |
+| `zuke <target> --actor <name>`                                        | Attribute the run to `<name>` in its state record.                                                          |
+| `zuke --list` / `-l`                                                  | List all targets with descriptions and dependencies.                                                        |
+| `zuke graph`                                                          | Print the dependency graph (`target → deps`).                                                               |
+| `zuke graph --output=html`                                            | Render an interactive HTML graph into `.zuke/` and open it.                                                 |
+| `zuke completions print <shell>`                                      | Print a shell-completion script (`bash`, `zsh`, or `fish`).                                                 |
+| `zuke completions install <shell>`                                    | Write the script and wire it into the shell's startup.                                                      |
+| `zuke mcp [--allow-run[=<globs>]] [--http <host:port>]`               | Run an MCP server over the build for AI agents, on stdio or HTTP ([details](./mcp.md)).                     |
+| `zuke resume <id> [--signal <n>] [--data <json>]`                     | Resume a suspended run, optionally delivering a signal ([details](./orchestration.md)).                     |
+| `zuke resume --check [<id>]`                                          | Re-check suspended runs (predicate waits, timeouts).                                                        |
+| `zuke runs list [--status/-target/-since/-limit] [--counts] [--json]` | List persisted run records (or `--counts` for a status tally), newest first ([details](./state.md)).        |
+| `zuke runs show <id> [--json]`                                        | Show one run's full per-target status and metadata.                                                         |
+| `zuke runs prune [--keep <age>] [--keep-last <n>] [--dry-run]`        | Delete old terminal run records; never touches non-terminal runs.                                           |
+| `zuke cancel <id> [--actor <name>]`                                   | Cancel a run and run its compensations ([details](./orchestration.md#cancellation--compensation-oncancel)). |
+| `zuke doc <spec>`                                                     | Print a package's API docs (`deno doc <spec>`) from an isolated empty directory.                            |
+| `zuke --help` / `-h`                                                  | Usage.                                                                                                      |
+| `zuke` (no target)                                                    | Run the `default` target if defined, else print `--list`.                                                   |
 
 (Read `zuke` as `deno run -A zuke.ts` until the launcher binary ships.)
 
@@ -122,6 +123,20 @@ mutating or denied call is written to an audit trail
 transport instead of stdio (loopback by default; a non-loopback bind requires a
 `ZUKE_MCP_TOKEN` bearer token). `mcp` is a reserved command name. See the full
 guide: [MCP server](./mcp.md).
+
+## `zuke doc`
+
+`zuke doc <spec>` prints a package's API by running `deno doc <spec>` (e.g.
+`zuke doc jsr:@zuke/deno`) — but from a fresh empty directory instead of the
+current one. Run inside a Node repository, a bare `deno doc jsr:@zuke/...`
+resolves the repo's `node_modules/@types/*` and buries the API under dozens of
+`Failed resolving types …` warnings; the isolated empty working directory has
+nothing to resolve, so the output is just the API. Any relative file path
+(`zuke doc ./mod.ts` or `zuke doc mod.ts`) is resolved against the real working
+directory before the isolated `deno doc` runs; `jsr:`/`npm:`/`https:` specifiers
+and absolute paths are passed through unchanged. `doc` is a reserved command
+name. (This complements the generated [`llms-full.txt`](../llms-full.txt) and
+each package's README `## API` block.)
 
 ## Parallel execution
 
@@ -268,12 +283,13 @@ build graph changed since the run was suspended. See
 
 `zuke cancel <run-id>` cancels a run and runs its
 [compensations](./orchestration.md#cancellation--compensation-oncancel): every
-target that had **succeeded** and declared `.onCancel(...)` is unwound in reverse
-order, then the record settles `cancelled`. `--actor <name>` attributes the
-cancellation in the audit trail. Cancelling a run another process is executing
-stops it (a live run aborts on its next state write); cancelling an
-already-finished run is a friendly no-op. `Ctrl-C` (or `SIGTERM`) cancels the run
-in the current process the same way — a second `Ctrl-C` forces an immediate exit.
+target that had **succeeded** and declared `.onCancel(...)` is unwound in
+reverse order, then the record settles `cancelled`. `--actor <name>` attributes
+the cancellation in the audit trail. Cancelling a run another process is
+executing stops it (a live run aborts on its next state write); cancelling an
+already-finished run is a friendly no-op. `Ctrl-C` (or `SIGTERM`) cancels the
+run in the current process the same way — a second `Ctrl-C` forces an immediate
+exit.
 
 ## Inspecting runs
 
@@ -282,11 +298,11 @@ run's full status survives the process that produced it.
 
 - `zuke runs list` prints one row per run — id, status, root target, actor, and
   creation time — newest first. Narrow it with `--status <s>` (one of `running`,
-  `suspended`, `cancelling`, `succeeded`, `failed`, `cancelled`), `--target <t>` (only runs
-  whose graph contains that target), `--since <iso>` (only runs created at
-  or after an ISO-8601 timestamp), and `--limit <n>` (at most the newest N). The
-  filters compose. Add `--counts` to print aggregate counts (a total and one
-  line per status) instead of rows — with `--json` it emits
+  `suspended`, `cancelling`, `succeeded`, `failed`, `cancelled`), `--target <t>`
+  (only runs whose graph contains that target), `--since <iso>` (only runs
+  created at or after an ISO-8601 timestamp), and `--limit <n>` (at most the
+  newest N). The filters compose. Add `--counts` to print aggregate counts (a
+  total and one line per status) instead of rows — with `--json` it emits
   `{ total, byStatus }` (status keys sorted for stable output), honouring the
   same filters.
 - `zuke runs show <run-id>` reconstructs one run in full: the header, resolved

--- a/llms.txt
+++ b/llms.txt
@@ -49,6 +49,7 @@ Reserved commands:
 - `runs` — List, show, or prune persisted run records
 - `cancel` — Cancel a run and run its compensations
 - `register` — Register this build in the build registry
+- `doc` — Print a package's API docs (deno doc), isolated from the repo
 
 Option flags:
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -28,6 +28,7 @@ import {
   CANCEL_COMMAND,
   COMPLETIONS_COMMAND,
   DEFAULT_TARGET,
+  DOC_COMMAND,
   GENERATE_CI_COMMAND,
   GRAPH_COMMAND,
   MCP_COMMAND,
@@ -167,6 +168,10 @@ export interface ParsedArgs {
   cancelRunId?: string;
   /** The `register` command was requested (record this build in the registry). */
   register: boolean;
+  /** The `doc` command was requested (print a package's API docs, isolated). */
+  doc: boolean;
+  /** The spec to document (the positional after `doc`): a `jsr:`/`npm:` URL or a path. */
+  docSpec?: string;
   /** Raw parameter values from declared flags, keyed by property name. */
   values: Record<string, string>;
   help: boolean;
@@ -216,6 +221,7 @@ export function parseArgs(
     runs: false,
     cancel: false,
     register: false,
+    doc: false,
     confirmDestructive: false,
     mcpRegistry: false,
     help: false,
@@ -373,10 +379,13 @@ export function parseArgs(
     } else if (parsed.cancel && parsed.cancelRunId === undefined) {
       // `cancel` takes the run id as its positional.
       parsed.cancelRunId = arg;
+    } else if (parsed.doc && parsed.docSpec === undefined) {
+      // `doc` takes the spec to document as its positional.
+      parsed.docSpec = arg;
     } else if (
       parsed.target === undefined && !parsed.graph && !parsed.generateCi &&
       !parsed.completions && !parsed.mcp && !parsed.resume && !parsed.runs &&
-      !parsed.cancel && !parsed.register
+      !parsed.cancel && !parsed.register && !parsed.doc
     ) {
       if (arg === GRAPH_COMMAND) parsed.graph = true;
       else if (arg === GENERATE_CI_COMMAND) parsed.generateCi = true;
@@ -386,6 +395,7 @@ export function parseArgs(
       else if (arg === RUNS_COMMAND) parsed.runs = true;
       else if (arg === CANCEL_COMMAND) parsed.cancel = true;
       else if (arg === REGISTER_COMMAND) parsed.register = true;
+      else if (arg === DOC_COMMAND) parsed.doc = true;
       else parsed.target = arg;
     }
   }
@@ -413,6 +423,7 @@ Usage:
   deno run -A zuke.ts runs prune [--keep <age>] [--keep-last <n>] [--dry-run]
   deno run -A zuke.ts cancel <run-id> [--actor <name>]
   deno run -A zuke.ts register [--actor <name>] [--json]
+  deno run -A zuke.ts doc <spec>
 
 Options:
   <target>          Run the target and its transitive dependencies.
@@ -500,6 +511,12 @@ Options:
                     server can discover it. Idempotent; excludes secrets. Writes
                     to .zuke/builds unless ZUKE_REGISTRY_URL/DIR or the build's
                     registry() configures a store. See docs/registry.md.
+  doc <spec>        Print a package's API docs by running 'deno doc <spec>' from
+                    an isolated empty directory (e.g. doc jsr:@zuke/deno). Run in
+                    a Node repo, deno doc otherwise resolves node_modules/@types
+                    and buries the API under type-resolution warnings; the empty
+                    cwd has nothing to resolve. A relative path (./mod.ts) is
+                    resolved against the real working directory first.
   --status <s>      With runs list, keep only runs with this status (running,
                     suspended, succeeded, failed, cancelled).
   --target <t>      With runs list, keep only runs whose graph contains this
@@ -628,6 +645,8 @@ export async function syncCiConfig(
 export interface MainOptions {
   /** Host used to render and open the HTML graph (injected in tests). */
   graphHost?: GraphHost;
+  /** Runner for the `doc` command's `deno doc` spawn (injected in tests). */
+  docRunner?: DocRunner;
   /** Lifecycle observers to run alongside the build's own hooks. */
   plugins?: Plugin[];
   /** Overrides for `completions install` (home/config dir), injected in tests. */
@@ -834,6 +853,79 @@ async function runRegister(build: Build, parsed: ParsedArgs): Promise<number> {
   }
 }
 
+/**
+ * Runs `deno doc <spec>` for the {@link runDoc} command — the injectable seam a
+ * test swaps for a fake. Returns the process exit code.
+ */
+export type DocRunner = (spec: string) => Promise<number>;
+
+/**
+ * The default {@link DocRunner}: spawn the running `deno` (via
+ * {@link Deno.execPath}, so no ambient `deno` on `PATH` is assumed) as
+ * `deno doc <spec>` with the working directory set to a fresh empty temp dir.
+ * That isolation is the whole point — run from a Node repo, `deno doc` otherwise
+ * resolves the repo's `node_modules/@types/*` and buries the API under dozens of
+ * "Failed resolving types" warnings; an empty cwd has nothing to resolve.
+ */
+const defaultDocRunner: DocRunner = async (spec) => {
+  const cwd = await Deno.makeTempDir({ prefix: "zuke-doc-" });
+  try {
+    const command = new Deno.Command(Deno.execPath(), {
+      args: ["doc", spec],
+      cwd,
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+    const { code } = await command.output();
+    return code;
+  } finally {
+    await Deno.remove(cwd, { recursive: true });
+  }
+};
+
+/**
+ * Whether a `deno doc` spec is a URL or an absolute path — i.e. not something to
+ * resolve against the working directory. A URL has a multi-character scheme
+ * (`jsr:`, `npm:`, `https:`, …); a lone drive letter (`C:`) is a Windows
+ * absolute path, not a scheme; a leading `/` is a POSIX absolute path.
+ */
+function isUrlOrAbsolute(spec: string): boolean {
+  const normalized = spec.replace(/\\/g, "/");
+  if (normalized.startsWith("/")) return true; // POSIX absolute
+  if (/^[A-Za-z]:/.test(normalized)) return true; // Windows drive absolute
+  return /^[a-z][a-z0-9+.-]+:/i.test(normalized); // URL scheme (2+ chars)
+}
+
+/**
+ * Run the `doc` command: print a package's API docs via `deno doc`, isolated
+ * from the repo so type-resolution noise doesn't bury the output. Any relative
+ * spec (a file path, not a `jsr:`/`npm:`/`https:` URL or absolute path) is
+ * resolved against the real working directory first, since the runner documents
+ * from a different (empty) directory. Errors resolve to a non-zero exit with a
+ * friendly message, matching the other commands.
+ */
+async function runDoc(
+  parsed: ParsedArgs,
+  runner: DocRunner = defaultDocRunner,
+): Promise<number> {
+  let spec = parsed.docSpec;
+  if (spec === undefined) {
+    console.error(
+      "Usage: zuke doc <spec>   (e.g. zuke doc jsr:@zuke/deno, or ./mod.ts)",
+    );
+    return 1;
+  }
+  // A file path is relative to the caller's cwd, but the runner documents from
+  // an isolated empty directory — resolve it to absolute before it changes.
+  if (!isUrlOrAbsolute(spec)) spec = `${Deno.cwd()}/${spec}`;
+  try {
+    return await runner(spec);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}
+
 /** Run the `runs` command: build the query (validating `--status`) and dispatch. */
 async function runRuns(build: Build, parsed: ParsedArgs): Promise<number> {
   const query: RunQuery = {};
@@ -981,6 +1073,9 @@ export async function main(
   }
   if (parsed.register) {
     return await runRegister(build, parsed);
+  }
+  if (parsed.doc) {
+    return await runDoc(parsed, options.docRunner);
   }
 
   let name = parsed.target;

--- a/packages/core/src/cli_spec.ts
+++ b/packages/core/src/cli_spec.ts
@@ -44,6 +44,9 @@ export const CANCEL_COMMAND = "cancel";
 /** The `register` command: record this build in the build registry. */
 export const REGISTER_COMMAND = "register";
 
+/** The `doc` command: print a package's API docs, isolated from the repo. */
+export const DOC_COMMAND = "doc";
+
 /** Every reserved command, in help and completion order. */
 export const RESERVED_COMMANDS: readonly ReservedCommand[] = [
   { name: GRAPH_COMMAND, description: "Show the dependency graph" },
@@ -71,6 +74,11 @@ export const RESERVED_COMMANDS: readonly ReservedCommand[] = [
   {
     name: REGISTER_COMMAND,
     description: "Register this build in the build registry",
+  },
+  {
+    name: DOC_COMMAND,
+    description:
+      "Print a package's API docs (deno doc), isolated from the repo",
   },
 ];
 

--- a/packages/core/tests/cli_test.ts
+++ b/packages/core/tests/cli_test.ts
@@ -170,6 +170,71 @@ Deno.test("every reserved command is honoured by the parser and help", () => {
   for (const flag of BUILTIN_FLAGS) assertStringIncludes(help, flag.name);
 });
 
+Deno.test("parseArgs recognises the doc command and its spec", () => {
+  const p = parseArgs(["doc", "jsr:@zuke/deno"]);
+  assertEquals(p.doc, true);
+  assertEquals(p.docSpec, "jsr:@zuke/deno");
+  assertEquals(p.target, undefined); // a command, not a target
+});
+
+Deno.test("main doc runs the doc runner with the spec and passes its exit code", async () => {
+  const seen: string[] = [];
+  const runner = (spec: string) => {
+    seen.push(spec);
+    return Promise.resolve(0);
+  };
+  const { code } = await capture(() =>
+    main(Demo, ["doc", "jsr:@zuke/deno"], { docRunner: runner })
+  );
+  assertEquals(code, 0);
+  assertEquals(seen, ["jsr:@zuke/deno"]);
+});
+
+Deno.test("main doc resolves a relative spec to an absolute path before running", async () => {
+  const seen: string[] = [];
+  const runner = (spec: string) => {
+    seen.push(spec);
+    return Promise.resolve(0);
+  };
+  // Both a dot-prefixed and a bare relative file path resolve against cwd…
+  await capture(() => main(Demo, ["doc", "./mod.ts"], { docRunner: runner }));
+  await capture(() => main(Demo, ["doc", "src/lib.ts"], { docRunner: runner }));
+  // …while a URL and an absolute path pass through unchanged.
+  await capture(() => main(Demo, ["doc", "npm:cowsay"], { docRunner: runner }));
+  await capture(() =>
+    main(Demo, ["doc", "/abs/mod.ts"], { docRunner: runner })
+  );
+  assertEquals(seen, [
+    `${Deno.cwd()}/./mod.ts`,
+    `${Deno.cwd()}/src/lib.ts`,
+    "npm:cowsay",
+    "/abs/mod.ts",
+  ]);
+});
+
+Deno.test("main doc returns a friendly non-zero exit when the runner throws", async () => {
+  const { code, err } = await capture(() =>
+    main(Demo, ["doc", "jsr:@zuke/deno"], {
+      docRunner: () => Promise.reject(new Error("deno doc exploded")),
+    })
+  );
+  assertEquals(code, 1);
+  assertStringIncludes(err.join("\n"), "deno doc exploded"); // not a raw stack
+});
+
+Deno.test("main doc propagates the runner's non-zero exit code", async () => {
+  const { code } = await capture(() =>
+    main(Demo, ["doc", "jsr:@zuke/x"], { docRunner: () => Promise.resolve(3) })
+  );
+  assertEquals(code, 3);
+});
+
+Deno.test("main doc without a spec prints usage and fails", async () => {
+  const { code, err } = await capture(() => main(Demo, ["doc"]));
+  assertEquals(code, 1);
+  assertStringIncludes(err.join("\n"), "Usage: zuke doc");
+});
+
 Deno.test("parseArgs collects declared parameter flags", () => {
   const valued = parseArgs(
     ["greet", "--environment", "prod", "--verbose"],

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -624,6 +624,7 @@ else a friendly error.
                               # authz tiers: allow-list, operator token, confirm
 ./zuke runs show mcp-audit    # the MCP tool-call audit trail
 ./zuke register [--json]      # record this build in the build registry (idempotent)
+./zuke doc jsr:@zuke/deno     # print a package's API (deno doc) from an isolated empty dir
 ./zuke mcp --registry --allow-run  # serve the registry: registered builds as tools, spawned
 ./zuke mcp --registry --max-concurrent-runs 4  # cap concurrent run-tool spawns (default 4)
 ```

--- a/tests/integration/doc_test.ts
+++ b/tests/integration/doc_test.ts
@@ -1,0 +1,30 @@
+import { assertEquals } from "../../packages/core/tests/_assert.ts";
+import { Build, target } from "../../packages/core/mod.ts";
+import { runCli } from "./_harness.ts";
+
+// The `doc` command is build-independent; any build serves to reach it.
+class Noop extends Build {
+  noop = target().executes(() => {});
+}
+
+Deno.test("zuke doc runs deno doc for a local module in an isolated cwd", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "zuke-doc-it-" });
+  try {
+    const mod = `${dir}/lib.ts`;
+    await Deno.writeTextFile(
+      mod,
+      '/** A documented greeting. */\nexport function greet(): string {\n  return "hi";\n}\n',
+    );
+    // The default runner spawns a real `deno doc` (offline for a self-contained
+    // local module) from a fresh empty temp dir; success proves the isolation
+    // path end-to-end. Output goes to inherited stdout, so assert the exit code.
+    const ok = await runCli(Noop, ["doc", mod]);
+    assertEquals(ok.code, 0);
+
+    // A spec deno doc cannot resolve fails, and that failure is propagated.
+    const missing = await runCli(Noop, ["doc", `${dir}/does-not-exist.ts`]);
+    assertEquals(missing.code !== 0, true);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});


### PR DESCRIPTION
## What

Running `deno doc jsr:@zuke/<pkg>` inside a **Node repository** floods the output with dozens of `Failed resolving types …` warnings from the repo's `node_modules/@types/*`, burying the API. Clean output only came from an empty directory. This adds a reserved **`zuke doc <spec>`** command:

```
zuke doc jsr:@zuke/deno     # the API, nothing else
zuke doc ./mod.ts           # a local module (relative path resolved for you)
```

It runs `deno doc <spec>` from a fresh empty temp directory (via `Deno.execPath()`, no ambient `deno` assumed) — the isolated cwd has no `node_modules`, so there's nothing to resolve and the output is just the API. This complements the generated `llms-full.txt` and each package's README `## API` block, directly serving the repo's "read the typed API, don't guess" principle.

## Behaviour

- A relative **file path** (`./mod.ts` or `mod.ts`) is resolved against the real working directory before the isolated `deno doc` runs; `jsr:`/`npm:`/`https:` specifiers and absolute paths pass through unchanged.
- The spec reaches `deno doc` as a discrete `args` entry (no shell) — injection-free.
- The spawn is an injectable `docRunner` seam (`MainOptions.docRunner`) so tests stay hermetic.
- Errors resolve to a friendly non-zero exit, matching the other commands.
- Wired into `cli_spec.ts` (so it appears in help and completions), `docs/cli.md`, and the `zuke-write-build` skill cheatsheet.

## Tests

- **Unit** — parsing (`doc` is a command, captures its spec), runner invocation + exit-code passthrough, relative/bare-relative resolution vs URL/absolute passthrough, missing-spec usage error, and a friendly exit when the runner throws.
- **Integration** — the real default runner runs `deno doc` on a local module (offline) in an isolated cwd: success returns 0, an unresolvable spec propagates non-zero.

## Adversarial review

An independent reviewer verdict was **REQUEST CHANGES** with two confirmed items, both fixed here with regression tests: (1) `runDoc` now wraps the spawn in try/catch so an unexpected throw becomes a friendly exit 1 instead of a raw stack trace (matching `runRegister`/`runCancel`/…); (2) bare relative specs (`mod.ts`, not just `./mod.ts`) are now resolved, so they don't silently fail from the isolated cwd. Declined as out-of-contract: `doc` takes only a spec and forwards no flags, so `--json` is not plumbed through. Parsing/precedence, injection, temp-dir cleanup, coverage, and JSDoc dimensions were refuted.

All gates green: `deno task ci`, `apiDocsCheck`, `generate-ci --check`, `deno doc --lint`. Commit signed.