### PR TITLE
fix(core): executor async-safety and durable wait-timeout

### DIFF
--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -102,6 +102,33 @@ function redactingReporter(inner: Reporter, redactor: Redactor): Reporter {
   };
 }
 
+/**
+ * Wrap a reporter so a failing write can never escape into the run. Output is a
+ * best-effort side effect: a sink that throws — a custom reporter with a bug, or
+ * the default console raising `BrokenPipe`/EPIPE when stdout is piped to a reader
+ * that closed early (`zuke build | head`) — must not turn into a rejection that
+ * unwinds the scheduler and strands the durable run record `running`. A thrown
+ * write is dropped; every other write still lands.
+ */
+function safeReporter(inner: Reporter): Reporter {
+  return {
+    info: (line) => {
+      try {
+        inner.info(line);
+      } catch {
+        // best-effort: a broken output sink must not break the build
+      }
+    },
+    error: (line) => {
+      try {
+        inner.error(line);
+      } catch {
+        // best-effort: a broken output sink must not break the build
+      }
+    },
+  };
+}
+
 /** Options for {@link execute}. */
 export interface ExecuteOptions {
   /** Suppress all banner/summary output (used by tests). */
@@ -239,6 +266,19 @@ export interface ResumeState {
   version: string;
   /** Names of targets recorded `succeeded` — seeded as done, never re-run. */
   done: ReadonlySet<string>;
+}
+
+/**
+ * The still-waiting targets of a resumed run, mapped to the {@link WaitState}
+ * they last recorded — the source of the original timeout deadline that a
+ * re-suspend must preserve (see {@link RunEnv.priorWaits}).
+ */
+function priorWaitsOf(record: RunRecord): ReadonlyMap<string, WaitState> {
+  const waits = new Map<string, WaitState>();
+  for (const [name, state] of Object.entries(record.targets)) {
+    if (state.waitingFor !== undefined) waits.set(name, state.waitingFor);
+  }
+  return waits;
 }
 
 /** Whether the build is running inside a GitHub Actions runner. */
@@ -450,6 +490,13 @@ interface RunEnv {
   signals: ReadonlyMap<string, SignalRecord>;
   /** On a resume, target names already succeeded — seeded done, never re-run. */
   done?: ReadonlySet<string>;
+  /**
+   * On a resume, each still-waiting target's previously recorded {@link WaitState}
+   * — so a re-suspend preserves the original timeout deadline instead of
+   * recomputing `now + timeout` (which would push it forward on every
+   * `resume --check` and mean the timeout never fires).
+   */
+  priorWaits?: ReadonlyMap<string, WaitState>;
 }
 
 /** A failure's message, or `undefined` when there was none — for the state record. */
@@ -525,14 +572,20 @@ async function acquireTargetLock(
   const token = result.token;
   // Renew at half the TTL so a long body keeps its short-TTL lock; cleared on
   // release. The interval is unref'd so it never keeps the process alive.
+  // Renewal is best-effort: `.catch` swallows a rejected renew (store contention
+  // or a transient error) so it can never surface as an unhandled rejection that
+  // crashes the build from a background timer — the lock simply lapses at its
+  // TTL, which is the documented backstop.
   const heartbeat = setInterval(() => {
-    void store.renewLock(key, token, ttlMs);
+    store.renewLock(key, token, ttlMs).catch(() => {});
   }, Math.max(1000, Math.floor(ttlMs / 2)));
   Deno.unrefTimer(heartbeat);
   return {
     release: async () => {
       clearInterval(heartbeat);
-      await store.releaseLock(key, token);
+      // Best-effort release for the same reason: a failed release must not turn
+      // an otherwise-succeeded body into a failure. The TTL reclaims the lock.
+      await store.releaseLock(key, token).catch(() => {});
     },
   };
 }
@@ -584,8 +637,14 @@ async function resolveWait(
     onTimeout: resolveDisposition(settings.onTimeout_),
   };
   if (settings.timeout_ !== undefined) {
-    waitState.deadline = new Date(Date.now() + parseDuration(settings.timeout_))
-      .toISOString();
+    // Preserve the deadline first recorded when this wait suspended: a resume
+    // that re-suspends the same still-unsatisfied gate must not push the
+    // deadline forward, or an hourly `resume --check` cron would reset the
+    // timeout every hour and it would never fire. Only compute a fresh deadline
+    // when there is no prior one (the first suspend).
+    const priorDeadline = env.priorWaits?.get(name)?.deadline;
+    waitState.deadline = priorDeadline ??
+      new Date(Date.now() + parseDuration(settings.timeout_)).toISOString();
   }
   return { satisfied, waitState, descriptor: trigger.descriptor };
 }
@@ -1129,20 +1188,30 @@ async function runSequential(
       void env.writer?.markTargetSettled(name, "skipped");
       continue;
     }
-    const outcome = await runTarget(
-      life,
-      reporter,
-      renderer,
-      style,
-      t,
-      opened,
-      cache,
-      dryRun,
-      globalRecovery,
-      services,
-      env,
-    );
-    await life.targetEnd(name, outcome.status, outcome.ms);
+    let outcome: TargetOutcome;
+    try {
+      outcome = await runTarget(
+        life,
+        reporter,
+        renderer,
+        style,
+        t,
+        opened,
+        cache,
+        dryRun,
+        globalRecovery,
+        services,
+        env,
+      );
+      await life.targetEnd(name, outcome.status, outcome.ms);
+    } catch (error) {
+      // A reject from outside runTarget's own try/catch (an `onlyWhen`/`cacheKey`
+      // thunk, a lifecycle hook, or `life.targetEnd`) becomes a failed target so
+      // the run finalizes here instead of rejecting out of `execute()` and
+      // stranding the record `running`.
+      failTarget(reporter, renderer, style, name, 0, error);
+      outcome = { status: "failed", ms: 0, error };
+    }
     void env.writer?.markTargetSettled(
       name,
       outcome.status,
@@ -1286,7 +1355,34 @@ async function runScheduled(
               }
               pump();
             },
-          );
+          )
+          .catch((error: unknown) => {
+            // `runTarget` handles a thrown body itself, but paths outside its
+            // try/catch can still reject — an `onlyWhen`/`cacheKey` thunk, a
+            // lifecycle hook, or `life.targetEnd` in the fulfilment handler
+            // above. Route any such rejection into the normal failure path so
+            // the scheduler settles (and finalizes the record) instead of
+            // hanging with the target stuck in `runningSet`, or dying on an
+            // unhandled rejection.
+            //
+            // Free the slot and record the failure BEFORE emitting output, so
+            // even a throwing reporter (already made best-effort by
+            // safeReporter) can never leave `t` in `runningSet` — which would
+            // wedge the scheduler's completion `Promise` forever.
+            const targetName = t.name_ ?? "<unnamed>";
+            outcomes.set(t, { status: "failed", ms: 0, error });
+            runningSet.delete(t);
+            anyFailed = true;
+            failure ??= error;
+            if (!t.proceedAfterFailure_) halted = true;
+            failTarget(reporter, renderer, style, targetName, 0, error);
+            void env.writer?.markTargetSettled(
+              targetName,
+              "failed",
+              errorMessage(error),
+            );
+            pump();
+          });
       }
       if (runningSet.size === 0) {
         for (const t of order) {
@@ -1349,7 +1445,10 @@ export async function execute(
   // parameter resolution below; since nothing meaningful is reported before
   // then, wrapping the reporter up-front is safe.
   const redactor = new Redactor();
-  const reporter = redactingReporter(baseReporter, redactor);
+  // …and every write is best-effort (see safeReporter): a throwing sink (a buggy
+  // custom reporter, or EPIPE on a piped stdout) must never escape `failTarget`
+  // and reject out of a scheduler, which would strand the run record `running`.
+  const reporter = safeReporter(redactingReporter(baseReporter, redactor));
   // The GitHub job summary is a real-world output side effect (it appends to a
   // shared file named by GITHUB_STEP_SUMMARY). Only write it when output goes to
   // the default console — i.e. neither silenced nor redirected to a custom
@@ -1384,12 +1483,18 @@ export async function execute(
   }
   // Under GitHub Actions, also emit `::add-mask::` with the real value so the
   // runner masks it in its own logs. This goes through the base reporter, which
-  // is not wrapped in the redactor — a masked directive would hide nothing.
-  if (style.github) {
+  // is not wrapped in the redactor — a masked directive would hide nothing. Gate
+  // it on `writesToConsole` too: when a custom reporter is supplied it *is* the
+  // base reporter, so an embedded `execute()` must never be handed the raw
+  // secret — only the real runner stdout should receive the directive.
+  if (style.github && writesToConsole) {
+    const maskReporter = safeReporter(baseReporter);
     for (const p of params.values()) {
       const value = p.secret_ ? p.stringValue_() : undefined;
       if (value !== undefined && value !== "") {
-        baseReporter.info(`::add-mask::${value}`);
+        // Straight to the base reporter (not redacted, so the directive works),
+        // but best-effort: an EPIPE here must not abort the run either.
+        maskReporter.info(`::add-mask::${value}`);
       }
     }
   }
@@ -1579,6 +1684,9 @@ export async function execute(
     runUrl,
     signals: writer ? writer.signals() : new Map<string, SignalRecord>(),
     done: options.resume?.done,
+    priorWaits: options.resume
+      ? priorWaitsOf(options.resume.record)
+      : undefined,
   };
 
   // Announce the run's initial durable state (`running`) to plugins — a no-op
@@ -1634,7 +1742,9 @@ export async function execute(
   try {
     // Run the plan inside the ambient-signal scope so a plain `$` in a target
     // body is cancelled with the run; the binding unwinds on its own, even if
-    // the plan throws — nothing to restore.
+    // the plan throws — nothing to restore. Both schedulers convert every
+    // target-path reject into a failed outcome (never rejecting themselves), so
+    // the run always settles here rather than stranding the record `running`.
     run = await withAmbientSignal(runController.signal, runPlan);
   } finally {
     if (options.signal !== undefined) {

--- a/packages/core/tests/executor_test.ts
+++ b/packages/core/tests/executor_test.ts
@@ -1039,7 +1039,29 @@ Deno.test("onTargetStart and onTargetEnd fire around each target", async () => {
   ]);
 });
 
-Deno.test("secret parameter values are masked under GitHub Actions", async () => {
+Deno.test("secret parameter values are masked to the real console under GitHub Actions", async () => {
+  class B extends Build {
+    token = parameter("token").secret();
+    go = target().executes(() => {});
+  }
+  const b = new B();
+  discoverTargets(b);
+  const printed: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => void printed.push(args.join(" "));
+  try {
+    await withEnv("GITHUB_STEP_SUMMARY", undefined, async () => {
+      // No custom reporter and not silent → output goes to the real console
+      // (the GitHub runner's stdout), which is where ::add-mask:: belongs.
+      await execute(b, b.go, { github: true, params: { token: "s3cr3t" } });
+    });
+  } finally {
+    console.log = origLog;
+  }
+  assertEquals(printed.includes("::add-mask::s3cr3t"), true);
+});
+
+Deno.test("a custom reporter never receives a raw ::add-mask:: secret", async () => {
   const { lines, reporter } = recorder();
   class B extends Build {
     token = parameter("token").secret();
@@ -1048,13 +1070,17 @@ Deno.test("secret parameter values are masked under GitHub Actions", async () =>
   const b = new B();
   discoverTargets(b);
   await withEnv("GITHUB_STEP_SUMMARY", undefined, async () => {
+    // A custom reporter *is* the base reporter (not redacted), so the add-mask
+    // directive — which bypasses redaction — must not be emitted to it: an
+    // embedded execute() would otherwise be handed the plaintext secret.
     await execute(b, b.go, {
       reporter,
       github: true,
       params: { token: "s3cr3t" },
     });
   });
-  assertEquals(lines.includes("::add-mask::s3cr3t"), true);
+  assertEquals(lines.some((l) => l.includes("s3cr3t")), false); // no leak at all
+  assertEquals(lines.some((l) => l.startsWith("::add-mask::")), false);
 });
 
 Deno.test("execute prompts for a missing required parameter", async () => {
@@ -2267,4 +2293,178 @@ Deno.test("waitsFor with no trigger fails with a friendly error", async () => {
   } finally {
     await Deno.remove(dir, { recursive: true });
   }
+});
+
+Deno.test("a throwing onlyWhen predicate fails the target, not the process (sequential)", async () => {
+  const { lines, reporter } = recorder();
+  class B extends Build {
+    setup = target().executes(() => {});
+    boom = target()
+      .dependsOn(this.setup)
+      .onlyWhen(() => {
+        throw new Error("predicate boom");
+      })
+      .executes(() => {});
+  }
+  const b = new B();
+  discoverTargets(b);
+  // The predicate rejects outside runTarget's own try/catch; the run must still
+  // finalize as failed (no unhandled rejection crashes the test process).
+  const result = await execute(b, b.boom, { reporter, github: false });
+  assertEquals(result.ok, false);
+  assertEquals(lines.some((l) => l.includes("predicate boom")), true);
+});
+
+Deno.test("a throwing predicate settles the parallel scheduler without hanging", async () => {
+  const { reporter } = recorder();
+  class B extends Build {
+    good = target().executes(() => {});
+    bad = target()
+      .onlyWhen(() => {
+        throw new Error("predicate boom");
+      })
+      .executes(() => {});
+    all = target().dependsOn(this.good, this.bad).executes(() => {});
+  }
+  const b = new B();
+  discoverTargets(b);
+  // If the scheduler's `.then` had no `.catch`, `bad` would reject unobserved:
+  // its slot never frees and the run would hang (or die). It must instead settle
+  // as failed while the independent `good` still completes.
+  const result = await execute(b, b.all, {
+    reporter,
+    parallel: true,
+    github: false,
+  });
+  assertEquals(result.ok, false);
+  assertEquals(result.executed.includes("good"), true);
+});
+
+Deno.test("a rejected lock renewal never crashes the build", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    // A store whose lock renewal always rejects, counting the heartbeat's calls.
+    class RenewFails extends FileSystemStateStore {
+      renewCalls = 0;
+      override renewLock(
+        _key: string,
+        _token: string,
+        _ttlMs: number,
+      ): Promise<boolean> {
+        this.renewCalls++;
+        return Promise.reject(new Error("renew boom"));
+      }
+    }
+    const store = new RenewFails(`${dir}/runs`, defaultStateHost);
+    class B extends Build {
+      work = target()
+        .lock((s) => s.key("build-lock").withTtl("2s"))
+        // Outlive the 1s renewal heartbeat so it fires (and rejects) mid-body.
+        .executes(() => new Promise<void>((r) => setTimeout(r, 1200)));
+    }
+    const b = new B();
+    discoverTargets(b);
+    const result = await execute(b, b.work, {
+      silent: true,
+      stateStore: store,
+    });
+    // The heartbeat fired and its rejection was swallowed: the build still won.
+    assertEquals(result.ok, true);
+    assertEquals(store.renewCalls >= 1, true);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+/** A reporter whose every write throws — a buggy sink, or EPIPE on piped stdout. */
+const throwingReporter: Reporter = {
+  info: () => {
+    throw new Error("EPIPE");
+  },
+  error: () => {
+    throw new Error("EPIPE");
+  },
+};
+
+Deno.test("a throwing reporter never strands the run record (sequential)", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    class B extends Build {
+      // A reject from outside runTarget's own try/catch, so failTarget prints
+      // through the (throwing) reporter on the settle path.
+      boom = target()
+        .onlyWhen(() => {
+          throw new Error("predicate boom");
+        })
+        .executes(() => {});
+    }
+    const b = new B();
+    discoverTargets(b);
+    const result = await execute(b, b.boom, {
+      reporter: throwingReporter,
+      stateStore: store,
+    });
+    assertEquals(result.ok, false);
+    const runs = await store.listRuns({});
+    // The record is finalized, not left stranded `running` (un-resumable).
+    assertEquals((await store.getRun(runs[0].id))?.record.status, "failed");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("a throwing reporter never hangs the parallel scheduler or strands the record", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    class B extends Build {
+      good = target().executes(() => {});
+      bad = target()
+        .onlyWhen(() => {
+          throw new Error("predicate boom");
+        })
+        .executes(() => {});
+      all = target().dependsOn(this.good, this.bad).executes(() => {});
+    }
+    const b = new B();
+    discoverTargets(b);
+    // The `.catch` prints the failure through the throwing reporter; it must
+    // still free the slot, pump, and finalize — never hang or leak a rejection.
+    const result = await execute(b, b.all, {
+      reporter: throwingReporter,
+      parallel: true,
+      stateStore: store,
+    });
+    assertEquals(result.ok, false);
+    const runs = await store.listRuns({});
+    assertEquals((await store.getRun(runs[0].id))?.record.status, "failed");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("a throwing predicate on a lenient target does not halt its siblings", async () => {
+  const { reporter } = recorder();
+  class B extends Build {
+    bad = target()
+      .proceedAfterFailure()
+      .onlyWhen(() => {
+        throw new Error("predicate boom");
+      })
+      .executes(() => {});
+    sib = target().executes(() => {});
+    root = target().dependsOn(this.bad, this.sib).executes(() => {});
+  }
+  const b = new B();
+  discoverTargets(b);
+  const result = await execute(b, b.root, {
+    reporter,
+    parallel: true,
+    github: false,
+  });
+  // `bad` fails via the `.catch`, but being lenient it does not set `halted`, so
+  // the independent `sib` still runs (root stays blocked behind bad).
+  assertEquals(result.ok, false);
+  assertEquals(result.executed.includes("sib"), true);
 });

--- a/packages/core/tests/params_test.ts
+++ b/packages/core/tests/params_test.ts
@@ -422,7 +422,7 @@ Deno.test("execute redacts a secret's invalid value from the parameter error", a
   assertStringIncludes(joined, REDACTED);
 });
 
-Deno.test("execute emits ::add-mask:: with the real value under GitHub", async () => {
+Deno.test("a custom reporter is never handed the raw secret via ::add-mask::", async () => {
   const { reporter, lines } = recordingReporter();
   class Deploy extends Build {
     token = parameter("Token").secret().from(fixedSource("real-value-123"));
@@ -436,12 +436,12 @@ Deno.test("execute emits ::add-mask:: with the real value under GitHub", async (
     github: true,
     readEnv: () => undefined,
   });
-  // The add-mask directive carries the true value so the runner can mask it;
-  // redacting it would defeat the purpose.
-  assertEquals(
-    lines.some((l) => l === "::add-mask::real-value-123"),
-    true,
-  );
+  // The add-mask directive bypasses redaction (a masked directive hides
+  // nothing), so it must reach only the real runner stdout — never a custom
+  // reporter, which an embedded execute() supplies. The raw value must not leak
+  // in any form. (The positive real-console case is covered in executor_test.)
+  assertEquals(lines.some((l) => l.includes("real-value-123")), false);
+  assertEquals(lines.some((l) => l.startsWith("::add-mask::")), false);
 });
 
 Deno.test("discoverParameters rejects a reserved MCP control name", () => {

--- a/tests/integration/waiting_test.ts
+++ b/tests/integration/waiting_test.ts
@@ -134,6 +134,34 @@ Deno.test("a wait past its deadline times out on resume --check", async () => {
   });
 });
 
+Deno.test("a re-suspend preserves the original timeout deadline", async () => {
+  await withStateDir(async (dir) => {
+    const ready = false; // never satisfied here: the gate only ever re-suspends
+    class B extends Build {
+      gate = target().waitsFor((s) =>
+        s.on(resumeWhen(() => ready)).timeout("1h")
+      );
+    }
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    const deadlineOf = async (id: string): Promise<string | undefined> =>
+      (await store.getRun(id))?.record.targets["gate"].waitingFor?.deadline;
+
+    const first = await runCli(B, ["gate"]);
+    assertEquals(first.code, 0);
+    const id = await onlyRunId(dir);
+    const d1 = await deadlineOf(id);
+    assertEquals(typeof d1, "string");
+
+    // A `resume --check` while the predicate is still false re-suspends the gate.
+    // The recorded deadline must stay put — recomputing `now + 1h` on every check
+    // would push it forward forever, so the timeout could never fire.
+    const again = await runCli(B, ["resume", "--check"]);
+    assertEquals(again.code, 0);
+    assertEquals(await runStatus(dir, id), "suspended");
+    assertEquals(await deadlineOf(id), d1); // preserved, not moved
+  });
+});
+
 Deno.test("a service starts, gates its dependent on readiness, and is stopped", async () => {
   const log: string[] = [];
   let probes = 0;


### PR DESCRIPTION
First PR of the remediation plan (`plans/REMEDIATION_PLAN.md`, PR 1 — the 🔴 critical async-safety items). Four defects that all undermined the framework's core promise of durable, resumable runs.

## Fixes

**1.1 — Wait `.timeout()` never fires (C1).** Every re-suspend recomputed `deadline = now + timeout`, so an hourly `resume --check` pushed the deadline forward forever. The deadline is now recorded once (first suspend) and preserved across re-suspends via `env.priorWaits` (seeded from the resumed record). The timeout finally arrives.

**1.2 — Unobserved rejection in the schedulers (C2/F2).** `onlyWhen`/`cacheKey` thunks and lifecycle hooks reject *outside* `runTarget`'s try/catch. The parallel scheduler's `.then` had no `.catch` (→ unhandled rejection + a wedged slot that hangs the run); the sequential path let the reject unwind out of `execute()`, stranding the record `running`. Both now route such a reject into the normal failure path so the run finalizes.

**1.3 — Lock-renewal heartbeat could crash the build (C2/F3).** `void store.renewLock(...)` in a `setInterval` didn't swallow rejections. Renewal and release are now best-effort (`.catch`) — a failed heartbeat just lets the lock lapse at its TTL (the documented backstop) instead of crashing from a background timer.

**1.4 — Raw secret emitted to a caller's reporter (F4).** The GitHub `::add-mask::<secret>` directive (raw value, deliberately un-redacted) was gated only on `style.github`. A caller-supplied reporter *is* the base reporter, so an embedded `execute()` was handed the plaintext. Now gated on `writesToConsole` too — the directive reaches only the real runner stdout.

## Adversarial review

Two independent reviewers attacked the change (the plan flags PR 1 for this). The **security** pass found nothing (the mask fix is complete). The **async-safety** pass found a defect my first cut introduced: a **throwing reporter** — a buggy custom sink, or **EPIPE when stdout is piped to a reader that closes** (`zuke build | head`) — makes `failTarget → reporter.error` throw, which still escaped the schedulers and stranded the record `running`. Fixed at the root: reporter output is now **best-effort** (`safeReporter`), so a broken sink can never break the build; the parallel failure handler also frees its slot *before* printing. The lenient-target failure arm got a dedicated test.

## Tests

Integration (`waiting_test.ts`): a re-suspend preserves the original deadline. Unit (`executor_test.ts`): throwing `onlyWhen` fails the target without crashing (sequential + parallel); a rejected lock renewal never crashes the build; a **throwing reporter** never strands the record (sequential) nor hangs the parallel scheduler; a lenient target's failure doesn't halt its siblings. Existing mask tests updated to assert the no-leak property + a real-console positive.

All green: `deno task ci` (lines/branches gate), `apiDocsCheck`, `generate-ci --check`, `deno doc --lint`. Commit signed. No public API change.