### PR TITLE
test(core): make deepEqual compare Set/Map/Date structurally

### DIFF
--- a/packages/core/tests/_assert.ts
+++ b/packages/core/tests/_assert.ts
@@ -11,23 +11,101 @@ export function messageOf(value: unknown): string {
   return value instanceof Error ? value.message : String(value);
 }
 
-/** Structural equality via JSON-ish deep comparison. */
+/** A plain data object (`{...}`) — not a class instance with an opaque shape. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/** A readable type name for an unknown value, for a clear failure message. */
+function typeName(value: unknown): string {
+  if (value === null) return "null";
+  if (typeof value !== "object") return typeof value;
+  return Object.getPrototypeOf(value)?.constructor?.name ?? "object";
+}
+
+/**
+ * Deep-equal two `Set`s: same size and a one-to-one matching of members (a
+ * bijection, not a subset). Each `b` member is consumed once, so
+ * `Set([{n:1},{n:1}])` does not match `Set([{n:1},{n:2}])` — the object-member
+ * form of the very false positive (unequal Sets comparing equal) this helper
+ * exists to catch.
+ */
+function setsEqual(a: Set<unknown>, b: Set<unknown>): boolean {
+  if (a.size !== b.size) return false;
+  const bs = [...b];
+  const used = bs.map(() => false);
+  return [...a].every((av) => {
+    const i = bs.findIndex((bv, j) => !used[j] && deepEqual(av, bv));
+    if (i === -1) return false;
+    used[i] = true;
+    return true;
+  });
+}
+
+/**
+ * Deep-equal two `Map`s: same size, every key present with a deep-equal value.
+ * Keys are matched by `Map.has` (SameValueZero / reference identity), so two
+ * maps keyed by equal-but-distinct objects read as unequal — an over-strict
+ * (safe) limit; the suite only ever uses primitive keys.
+ */
+function mapsEqual(
+  a: Map<unknown, unknown>,
+  b: Map<unknown, unknown>,
+): boolean {
+  if (a.size !== b.size) return false;
+  for (const [key, value] of a) {
+    if (!b.has(key) || !deepEqual(value, b.get(key))) return false;
+  }
+  return true;
+}
+
+/**
+ * Structural equality. Handles primitives, arrays, plain objects, and the
+ * built-ins whose data is invisible to `Object.keys` — `Date`, `Set`, `Map` —
+ * which a naive key-only compare treats as always-equal (any two Sets have zero
+ * keys). Any other object type (a class instance with an opaque shape, a RegExp,
+ * …) throws rather than silently returning a vacuous `true`: add an explicit
+ * handler here if the suite needs to compare one.
+ */
 function deepEqual(a: unknown, b: unknown): boolean {
   if (a === b) return true;
-  if (typeof a !== typeof b || a === null || b === null) return false;
-  if (typeof a !== "object") return false;
+  if (a instanceof Date || b instanceof Date) {
+    return a instanceof Date && b instanceof Date &&
+      a.getTime() === b.getTime();
+  }
+  if (a instanceof Set || b instanceof Set) {
+    return a instanceof Set && b instanceof Set && setsEqual(a, b);
+  }
+  if (a instanceof Map || b instanceof Map) {
+    return a instanceof Map && b instanceof Map && mapsEqual(a, b);
+  }
+  if (a instanceof Uint8Array || b instanceof Uint8Array) {
+    return a instanceof Uint8Array && b instanceof Uint8Array &&
+      a.length === b.length && a.every((v, i) => v === b[i]);
+  }
   if (Array.isArray(a) || Array.isArray(b)) {
     if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) {
       return false;
     }
     return a.every((v, i) => deepEqual(v, b[i]));
   }
-  const ao = a as Record<string, unknown>;
-  const bo = b as Record<string, unknown>;
-  const ak = Object.keys(ao);
-  const bk = Object.keys(bo);
+  if (
+    typeof a !== "object" || typeof b !== "object" || a === null || b === null
+  ) {
+    return false; // a primitive (not `===`) or a null/object mismatch
+  }
+  if (!isRecord(a) || !isRecord(b)) {
+    throw new Error(
+      `deepEqual: cannot structurally compare ${typeName(a)} with ` +
+        `${typeName(b)} — add an explicit handler in tests/_assert.ts.`,
+    );
+  }
+  const ak = Object.keys(a);
+  const bk = Object.keys(b);
   if (ak.length !== bk.length) return false;
-  return ak.every((k) => deepEqual(ao[k], bo[k]));
+  return ak.every((k) => k in b && deepEqual(a[k], b[k]));
 }
 
 /** Assert deep equality. */

--- a/packages/core/tests/assert_helper_test.ts
+++ b/packages/core/tests/assert_helper_test.ts
@@ -1,0 +1,96 @@
+/**
+ * Self-tests for the local assertion helper. `deepEqual` once compared only
+ * `Object.keys`, so any two `Set`s / `Map`s / `Date`s (which expose no
+ * enumerable keys) were treated as equal — a silent blind spot that let
+ * Set-comparing tests pass vacuously. These lock in structural comparison of
+ * those built-ins and a loud failure for any type the helper can't compare.
+ */
+
+import { assertEquals, assertThrows } from "./_assert.ts";
+
+Deno.test("assertEquals compares Sets by membership, not vacuously", () => {
+  assertEquals(new Set(["a", "b"]), new Set(["b", "a"])); // order-independent
+  assertThrows(
+    () => assertEquals(new Set(["a"]), new Set(["b", "c"])),
+    Error,
+    "not equal",
+  );
+  assertThrows(
+    () => assertEquals(new Set(["a"]), new Set(["b"])),
+    Error,
+    "not equal",
+  );
+  // Object members: a one-to-one matching, not a subset. Two distinct `{n:1}`
+  // refs must not both match the single `{n:1}` in the other set.
+  assertEquals(new Set([{ n: 1 }, { n: 2 }]), new Set([{ n: 2 }, { n: 1 }]));
+  assertThrows(
+    () =>
+      assertEquals(
+        new Set([{ n: 1 }, { n: 1 }]),
+        new Set([{ n: 1 }, { n: 2 }]),
+      ),
+    Error,
+    "not equal",
+  );
+});
+
+Deno.test("assertEquals compares Maps by key and deep value", () => {
+  assertEquals(new Map([["k", { n: 1 }]]), new Map([["k", { n: 1 }]]));
+  assertThrows(
+    () => assertEquals(new Map([["k", 1]]), new Map([["k", 2]])),
+    Error,
+    "not equal",
+  );
+  assertThrows(
+    () => assertEquals(new Map([["k", 1]]), new Map([["j", 1]])),
+    Error,
+    "not equal",
+  );
+});
+
+Deno.test("assertEquals compares Dates by instant", () => {
+  assertEquals(
+    new Date("2026-01-01T00:00:00Z"),
+    new Date("2026-01-01T00:00:00Z"),
+  );
+  assertThrows(
+    () => assertEquals(new Date(0), new Date(1000)),
+    Error,
+    "not equal",
+  );
+});
+
+Deno.test("assertEquals compares Uint8Arrays element-wise", () => {
+  assertEquals(new Uint8Array([1, 2, 3]), new Uint8Array([1, 2, 3]));
+  assertThrows(
+    () => assertEquals(new Uint8Array([1, 2]), new Uint8Array([1, 3])),
+    Error,
+    "not equal",
+  );
+  assertThrows(
+    () => assertEquals(new Uint8Array([1]), new Uint8Array([1, 2])),
+    Error,
+    "not equal",
+  );
+});
+
+Deno.test("assertEquals throws on an opaque type it cannot structurally compare", () => {
+  assertThrows(
+    () => assertEquals(/a/, /a/),
+    Error,
+    "cannot structurally compare",
+  );
+});
+
+Deno.test("assertEquals compares plain objects and arrays structurally", () => {
+  assertEquals({ a: 1, b: { c: 2 } }, { a: 1, b: { c: 2 } });
+  assertEquals({}, {});
+  assertEquals([1, [2, 3]], [1, [2, 3]]);
+  assertThrows(
+    () => assertEquals({ a: 1 }, { a: 1, b: 2 }),
+    Error,
+    "not equal",
+  );
+  assertThrows(() => assertEquals({ a: 1 }, { a: 2 }), Error, "not equal");
+  assertThrows(() => assertEquals({ a: 1 }, { b: 1 }), Error, "not equal");
+});

--- a/packages/jsr/tests/registry_test.ts
+++ b/packages/jsr/tests/registry_test.ts
@@ -5,19 +5,27 @@ import {
   publishedVersions,
 } from "../src/registry.ts";
 
+/** A Set's members as a sorted array — an order-independent comparison that does
+ * not depend on the assert helper's Set support (so it can't pass vacuously). */
+function sortedMembers(set: Set<string>): string[] {
+  return [...set].sort();
+}
+
 Deno.test("publishedVersions extracts version keys", () => {
   assertEquals(
-    publishedVersions({ versions: { "1.0.0": {}, "1.1.0": {} } }),
-    new Set(["1.0.0", "1.1.0"]),
+    sortedMembers(
+      publishedVersions({ versions: { "1.0.0": {}, "1.1.0": {} } }),
+    ),
+    ["1.0.0", "1.1.0"],
   );
 });
 
 Deno.test("publishedVersions tolerates malformed payloads", () => {
-  assertEquals(publishedVersions(null), new Set<string>());
-  assertEquals(publishedVersions("nope"), new Set<string>());
-  assertEquals(publishedVersions({}), new Set<string>());
-  assertEquals(publishedVersions({ versions: null }), new Set<string>());
-  assertEquals(publishedVersions({ versions: 7 }), new Set<string>());
+  assertEquals(sortedMembers(publishedVersions(null)), []);
+  assertEquals(sortedMembers(publishedVersions("nope")), []);
+  assertEquals(sortedMembers(publishedVersions({})), []);
+  assertEquals(sortedMembers(publishedVersions({ versions: null })), []);
+  assertEquals(sortedMembers(publishedVersions({ versions: 7 })), []);
 });
 
 /** A `fetch` stub returning the given JSON body with a controllable status. */
@@ -35,14 +43,14 @@ Deno.test("jsrVersions returns the published set on a 2xx", async () => {
   const versions = await jsrVersions("@zuke/core", {
     fetch: stubFetch({ versions: { "0.13.0": {} } }),
   });
-  assertEquals(versions, new Set(["0.13.0"]));
+  assertEquals(sortedMembers(versions), ["0.13.0"]);
 });
 
 Deno.test("jsrVersions resolves to an empty set on a non-2xx", async () => {
   const versions = await jsrVersions("@zuke/nope", {
     fetch: stubFetch({}, false),
   });
-  assertEquals(versions, new Set<string>());
+  assertEquals(sortedMembers(versions), []);
 });
 
 Deno.test("jsrVersions requests the package meta.json", async () => {
@@ -54,7 +62,7 @@ Deno.test("jsrVersions requests the package meta.json", async () => {
     },
   });
   assertEquals(requested, "https://jsr.io/@zuke/core/meta.json");
-  assertEquals(versions, new Set<string>());
+  assertEquals(sortedMembers(versions), []);
 });
 
 Deno.test("isPublished reflects membership in the published set", async () => {


### PR DESCRIPTION
Remediation plan PR 2, part 1 — the 🔴 test-infrastructure defect (H1). Split out from the coverage-gate work (2.2/2.3) because this is **test-only** (no shipped code, no release bump), whereas the coverage changes are a `feat(deno)`; combining them would make release-please spuriously bump `@zuke/core`/`@zuke/jsr` for test-file changes.

## Problem

`deepEqual` in `packages/core/tests/_assert.ts` compared only `Object.keys`, which `Set`/`Map`/`Date` don't expose — so **any two Sets/Maps/Dates compared equal**. Verified: `assertEquals(new Set(["a"]), new Set(["b","c"]))` did not throw. The `@zuke/jsr` registry tests that compared `publishedVersions` Sets were therefore passing vacuously. It also used two banned `as` casts.

## Fix

`deepEqual` now handles the built-ins whose data is invisible to `Object.keys`:
- **Date** — by instant (`getTime`).
- **Set** — same size + a **one-to-one member matching** (a bijection, not a subset, so `Set([{n:1},{n:1}])` ≠ `Set([{n:1},{n:2}])`).
- **Map** — same size + every key present with a deep-equal value (primitive keys; the reference-identity limit for object keys is documented).
- **Uint8Array** — length + element-wise.

Any *other* object type (a class instance, RegExp, …) now **throws** with a clear message rather than silently returning a vacuous `true`, so a future blind spot fails loudly. The `as` casts are replaced by an `isRecord` type guard, and a `k in b` check closes a second latent false positive (`{a:undefined}` vs `{b:undefined}` used to compare equal).

The `@zuke/jsr` registry Set assertions are rewritten as sorted-array comparisons (order-independent, and immune to any future regression in the helper).

## Tests

New `packages/core/tests/assert_helper_test.ts` self-tests every branch: Set membership + object-member bijection, Map key/value, Date instant, Uint8Array element-wise, the opaque-type throw, and plain object/array structure.

## Adversarial review

A reviewer confirmed the aggressive throw is safe (the full 1800+ test suite passes; only `Uint8Array` legitimately needed a handler, which was added) and found one real latent false positive — `setsEqual` was a subset check, not a bijection — now fixed with a consumed-member matching and a regression test. NaN / `-0` / object-Map-key concerns were refuted (no regression / safe over-strictness).

All green: `deno task ci`, `apiDocsCheck`. Commit signed. No public API or shipped code changed.