### PR TITLE
feat(deno): make the coverage gate trustworthy

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3335,6 +3335,11 @@ class DenoCoverageSettings extends DenoSettings
     Fail the gate if branch coverage is below `percent` (see {@link linesThreshold}).
   threshold(percent: number): this
     Fail the gate if either line or branch coverage is below `percent`.
+  perFileThreshold(percent: number): this
+    Fail the gate if any single instrumented file's line coverage is below
+    `percent` — a per-file floor, so an under-tested file can't hide inside a
+    healthy aggregate (see {@link CoverageThresholds.perFile}, which notes the
+    `deno coverage` limit for files no test loads).
   get thresholds(): CoverageThresholds
     The configured thresholds; read by {@link DenoTasks.coverage}.
   get outputPath(): string | undefined
@@ -3437,6 +3442,14 @@ interface CoverageThresholds
     Minimum line-coverage percentage (0–100).
   branches?: number
     Minimum branch-coverage percentage (0–100).
+  perFile?: number
+    Minimum per-file line-coverage percentage (0–100). Unlike {@link lines}
+    (an aggregate over the whole report), this fails the gate when any single
+    instrumented file falls below the floor — so an under-tested file can't
+    hide inside a healthy repo-wide average. Files with no measurable lines are
+    skipped. Note the coverage tool's limit: `deno coverage` only reports files
+    that were loaded, so a source file no test imports at all is invisible to
+    this check (as it is to every coverage metric).
 
 interface DenoTasksApi
   The shape of {@link DenoTasks}.

--- a/packages/deno/README.md
+++ b/packages/deno/README.md
@@ -81,6 +81,11 @@ class DenoCoverageSettings extends DenoSettings
     Fail the gate if branch coverage is below `percent` (see {@link linesThreshold}).
   threshold(percent: number): this
     Fail the gate if either line or branch coverage is below `percent`.
+  perFileThreshold(percent: number): this
+    Fail the gate if any single instrumented file's line coverage is below
+    `percent` — a per-file floor, so an under-tested file can't hide inside a
+    healthy aggregate (see {@link CoverageThresholds.perFile}, which notes the
+    `deno coverage` limit for files no test loads).
   get thresholds(): CoverageThresholds
     The configured thresholds; read by {@link DenoTasks.coverage}.
   get outputPath(): string | undefined
@@ -183,6 +188,14 @@ interface CoverageThresholds
     Minimum line-coverage percentage (0–100).
   branches?: number
     Minimum branch-coverage percentage (0–100).
+  perFile?: number
+    Minimum per-file line-coverage percentage (0–100). Unlike {@link lines}
+    (an aggregate over the whole report), this fails the gate when any single
+    instrumented file falls below the floor — so an under-tested file can't
+    hide inside a healthy repo-wide average. Files with no measurable lines are
+    skipped. Note the coverage tool's limit: `deno coverage` only reports files
+    that were loaded, so a source file no test imports at all is invisible to
+    this check (as it is to every coverage metric).
 
 interface DenoTasksApi
   The shape of {@link DenoTasks}.

--- a/packages/deno/src/coverage.ts
+++ b/packages/deno/src/coverage.ts
@@ -26,6 +26,16 @@ export interface CoverageThresholds {
   lines?: number;
   /** Minimum branch-coverage percentage (0–100). */
   branches?: number;
+  /**
+   * Minimum **per-file** line-coverage percentage (0–100). Unlike {@link lines}
+   * (an aggregate over the whole report), this fails the gate when any single
+   * **instrumented** file falls below the floor — so an under-tested file can't
+   * hide inside a healthy repo-wide average. Files with no measurable lines are
+   * skipped. Note the coverage tool's limit: `deno coverage` only reports files
+   * that were *loaded*, so a source file no test imports at all is invisible to
+   * this check (as it is to every coverage metric).
+   */
+  perFile?: number;
 }
 
 interface CoverageTotals {
@@ -33,6 +43,12 @@ interface CoverageTotals {
   linesHit: number;
   branchesFound: number;
   branchesHit: number;
+}
+
+/** One source file's coverage totals, from its LCOV `SF:`…`end_of_record` block. */
+export interface FileCoverage extends CoverageTotals {
+  /** The source file path (the LCOV `SF:` record). */
+  file: string;
 }
 
 /** Sum the LF/LH/BRF/BRH records across every file in an LCOV report. */
@@ -65,6 +81,42 @@ export function parseLcov(lcov: string): CoverageTotals {
   return totals;
 }
 
+/**
+ * Parse an LCOV report into per-file totals, one entry per `SF:`…`end_of_record`
+ * block. `SF` paths are read literally (they may contain a Windows drive
+ * `C:`), so only the numeric records are colon-split.
+ */
+export function parseLcovPerFile(lcov: string): FileCoverage[] {
+  const files: FileCoverage[] = [];
+  let current: FileCoverage | null = null;
+  for (const line of lcov.split("\n")) {
+    if (line.startsWith("SF:")) {
+      current = {
+        file: line.slice(3),
+        linesFound: 0,
+        linesHit: 0,
+        branchesFound: 0,
+        branchesHit: 0,
+      };
+      continue;
+    }
+    if (line.startsWith("end_of_record")) {
+      if (current !== null) files.push(current);
+      current = null;
+      continue;
+    }
+    if (current === null) continue;
+    const [tag, value] = line.split(":", 2);
+    const n = Number(value);
+    if (Number.isNaN(n)) continue;
+    if (tag === "LF") current.linesFound += n;
+    else if (tag === "LH") current.linesHit += n;
+    else if (tag === "BRF") current.branchesFound += n;
+    else if (tag === "BRH") current.branchesHit += n;
+  }
+  return files;
+}
+
 /** Percentage hit/found; 100 when nothing was found (vacuously covered). */
 function pct(hit: number, found: number): number {
   return found === 0 ? 100 : (hit / found) * 100;
@@ -92,13 +144,41 @@ export function enforceCoverage(
   );
 
   const failures: string[] = [];
-  if (thresholds.lines !== undefined && lines < thresholds.lines) {
-    failures.push(`line coverage ${fmt(lines)}% < ${thresholds.lines}%`);
-  }
-  if (thresholds.branches !== undefined && branches < thresholds.branches) {
-    failures.push(
-      `branch coverage ${fmt(branches)}% < ${thresholds.branches}%`,
-    );
+  const gated = thresholds.lines !== undefined ||
+    thresholds.branches !== undefined || thresholds.perFile !== undefined;
+  if (gated && t.linesFound === 0 && t.branchesFound === 0) {
+    // An empty report is not 100% covered — nothing was instrumented. A gate
+    // that passed here would go green on a run that measured no code at all.
+    // (Branchless-but-measured code — linesFound > 0, branchesFound === 0 — is a
+    // legitimate vacuous 100% branch score, handled below, not an empty report.)
+    failures.push("no coverage data measured; gate cannot pass");
+  } else {
+    if (thresholds.lines !== undefined && lines < thresholds.lines) {
+      failures.push(`line coverage ${fmt(lines)}% < ${thresholds.lines}%`);
+    }
+    // Only enforce branches when some were found: a branchless file is 100%.
+    if (
+      thresholds.branches !== undefined && t.branchesFound > 0 &&
+      branches < thresholds.branches
+    ) {
+      failures.push(
+        `branch coverage ${fmt(branches)}% < ${thresholds.branches}%`,
+      );
+    }
+    if (thresholds.perFile !== undefined) {
+      const floor = thresholds.perFile;
+      const under = parseLcovPerFile(lcov)
+        .filter((f) =>
+          f.linesFound > 0 && pct(f.linesHit, f.linesFound) < floor
+        )
+        .map((f) => `${f.file} (${fmt(pct(f.linesHit, f.linesFound))}%)`);
+      if (under.length > 0) {
+        failures.push(
+          `${under.length} file(s) below the ${floor}% per-file line floor: ` +
+            under.join(", "),
+        );
+      }
+    }
   }
 
   if (failures.length === 0) {

--- a/packages/deno/src/coverage.ts
+++ b/packages/deno/src/coverage.ts
@@ -59,7 +59,7 @@ export function parseLcov(lcov: string): CoverageTotals {
     branchesFound: 0,
     branchesHit: 0,
   };
-  for (const line of lcov.split("\n")) {
+  for (const line of lcov.split(/\r?\n/)) {
     const [tag, value] = line.split(":", 2);
     const n = Number(value);
     if (Number.isNaN(n)) continue;
@@ -89,7 +89,10 @@ export function parseLcov(lcov: string): CoverageTotals {
 export function parseLcovPerFile(lcov: string): FileCoverage[] {
   const files: FileCoverage[] = [];
   let current: FileCoverage | null = null;
-  for (const line of lcov.split("\n")) {
+  // Split on CRLF or LF so a Windows-authored report doesn't leave a trailing
+  // `\r` on the `SF:` path (the numeric records tolerate it — `Number` trims —
+  // but the path would carry it into a failure message).
+  for (const line of lcov.split(/\r?\n/)) {
     if (line.startsWith("SF:")) {
       current = {
         file: line.slice(3),

--- a/packages/deno/src/deno.ts
+++ b/packages/deno/src/deno.ts
@@ -326,6 +326,7 @@ export class DenoCoverageSettings extends DenoSettings {
   #exclude?: string;
   #linesThreshold?: number;
   #branchesThreshold?: number;
+  #perFileThreshold?: number;
 
   /** The coverage profile directory to report on. */
   dir(path: PathLike): this {
@@ -374,9 +375,24 @@ export class DenoCoverageSettings extends DenoSettings {
     return this;
   }
 
+  /**
+   * Fail the gate if any single instrumented file's line coverage is below
+   * `percent` — a per-file floor, so an under-tested file can't hide inside a
+   * healthy aggregate (see {@link CoverageThresholds.perFile}, which notes the
+   * `deno coverage` limit for files no test loads).
+   */
+  perFileThreshold(percent: number): this {
+    this.#perFileThreshold = percent;
+    return this;
+  }
+
   /** The configured thresholds; read by {@link DenoTasks.coverage}. */
   get thresholds(): CoverageThresholds {
-    return { lines: this.#linesThreshold, branches: this.#branchesThreshold };
+    return {
+      lines: this.#linesThreshold,
+      branches: this.#branchesThreshold,
+      perFile: this.#perFileThreshold,
+    };
   }
 
   /** The `--output` file path, if {@link output} was set; read by the task. */
@@ -386,7 +402,8 @@ export class DenoCoverageSettings extends DenoSettings {
 
   #hasThreshold(): boolean {
     return this.#linesThreshold !== undefined ||
-      this.#branchesThreshold !== undefined;
+      this.#branchesThreshold !== undefined ||
+      this.#perFileThreshold !== undefined;
   }
 
   protected override buildArgs(): string[] {
@@ -606,8 +623,10 @@ export const DenoTasks: DenoTasksApi = {
   ): Promise<CommandOutput> {
     const settings = new DenoCoverageSettings();
     const s = configure ? configure(settings) : settings;
-    const { lines, branches } = s.thresholds;
-    if (lines === undefined && branches === undefined) {
+    const { lines, branches, perFile } = s.thresholds;
+    if (
+      lines === undefined && branches === undefined && perFile === undefined
+    ) {
       return await s.run(); // plain `deno coverage`, no gate
     }
     // Read the lcov from the output file when one is set, else capture it from
@@ -618,7 +637,7 @@ export const DenoTasks: DenoTasksApi = {
     const lcov = output === undefined
       ? result.stdout
       : await Deno.readTextFile(output);
-    enforceCoverage(lcov, { lines, branches }, s.throwsOnError);
+    enforceCoverage(lcov, { lines, branches, perFile }, s.throwsOnError);
     return result;
   },
   /** Install a script or executable: `deno install`. */

--- a/packages/deno/tests/coverage_test.ts
+++ b/packages/deno/tests/coverage_test.ts
@@ -127,6 +127,15 @@ Deno.test("parseLcovPerFile splits totals per file, keeping colon-bearing paths"
   assertEquals(files[1].linesHit, 4);
 });
 
+Deno.test("parseLcovPerFile strips CRLF so paths carry no trailing carriage return", () => {
+  const lcov = ["SF:win.ts", "LF:4", "LH:2", "end_of_record", ""].join("\r\n");
+  const files = parseLcovPerFile(lcov);
+  assertEquals(files.length, 1);
+  assertEquals(files[0].file, "win.ts"); // no trailing "\r"
+  assertEquals(files[0].linesFound, 4);
+  assertEquals(files[0].linesHit, 2);
+});
+
 Deno.test("the per-file floor fails a single low file even when the aggregate passes", () => {
   // Aggregate is 90/100 = 90% (passes a 90 line gate), but one file is at 20%.
   const lcov = [

--- a/packages/deno/tests/coverage_test.ts
+++ b/packages/deno/tests/coverage_test.ts
@@ -1,12 +1,14 @@
 import {
   assertEquals,
   assertRejects,
+  assertStringIncludes,
   assertThrows,
 } from "../../core/tests/_assert.ts";
 import {
   CoverageThresholdError,
   enforceCoverage,
   parseLcov,
+  parseLcovPerFile,
 } from "../src/coverage.ts";
 import { DenoTasks } from "../src/deno.ts";
 
@@ -46,9 +48,33 @@ Deno.test("enforceCoverage passes when metrics meet the thresholds", () => {
   );
 });
 
-Deno.test("enforceCoverage treats zero-found as fully covered", () => {
+Deno.test("enforceCoverage fails when no data was measured (an empty report)", () => {
+  // An empty report is not 100% covered — nothing ran. A gated metric with zero
+  // found must fail, not pass vacuously.
+  const err = assertThrows(
+    () =>
+      enforceCoverage(
+        "LF:0\nLH:0\nBRF:0\nBRH:0\n",
+        { lines: 95, branches: 95 },
+        true,
+      ),
+    CoverageThresholdError,
+    "no coverage data measured",
+  );
+  if (err instanceof CoverageThresholdError) {
+    assertEquals(err.failures.length, 1); // one clear "nothing measured" message
+  }
+});
+
+Deno.test("enforceCoverage passes branchless code that is fully line-covered", () => {
+  // A module with no conditionals reports BRF:0. Under a combined threshold that
+  // must NOT fail as "no branch data" — the branch score is vacuously 100%.
   assertEquals(
-    enforceCoverage("LF:0\nLH:0\n", { lines: 100, branches: 100 }, true),
+    enforceCoverage(
+      "SF:a.ts\nLF:5\nLH:5\nBRF:0\nBRH:0\nend_of_record\n",
+      { lines: 95, branches: 95 },
+      true,
+    ),
     [],
   );
 });
@@ -77,6 +103,66 @@ Deno.test("enforceCoverage returns failures instead of throwing when not enforci
     false,
   );
   assertEquals(failures.length, 2);
+});
+
+Deno.test("parseLcovPerFile splits totals per file, keeping colon-bearing paths", () => {
+  const lcov = [
+    "SF:C:/win/a.ts", // a Windows drive path — the colon must survive
+    "LF:10",
+    "LH:9",
+    "BRF:2",
+    "BRH:1",
+    "end_of_record",
+    "SF:b.ts",
+    "LF:4",
+    "LH:4",
+    "end_of_record",
+  ].join("\n");
+  const files = parseLcovPerFile(lcov);
+  assertEquals(files.length, 2);
+  assertEquals(files[0].file, "C:/win/a.ts");
+  assertEquals(files[0].linesFound, 10);
+  assertEquals(files[0].linesHit, 9);
+  assertEquals(files[1].file, "b.ts");
+  assertEquals(files[1].linesHit, 4);
+});
+
+Deno.test("the per-file floor fails a single low file even when the aggregate passes", () => {
+  // Aggregate is 90/100 = 90% (passes a 90 line gate), but one file is at 20%.
+  const lcov = [
+    "SF:good.ts",
+    "LF:90",
+    "LH:88",
+    "end_of_record",
+    "SF:bad.ts",
+    "LF:10",
+    "LH:2",
+    "end_of_record",
+  ].join("\n");
+  const err = assertThrows(
+    () => enforceCoverage(lcov, { lines: 90, perFile: 50 }, true),
+    CoverageThresholdError,
+    "per-file line floor",
+  );
+  if (err instanceof CoverageThresholdError) {
+    // Only the aggregate-passing-but-file-failing case trips: bad.ts (20%).
+    assertEquals(err.failures.length, 1);
+    assertStringIncludes(err.failures[0], "bad.ts");
+  }
+});
+
+Deno.test("the per-file floor skips files with no measurable lines", () => {
+  const lcov = [
+    "SF:types.ts", // a declaration-only file: zero lines found
+    "LF:0",
+    "LH:0",
+    "end_of_record",
+    "SF:code.ts",
+    "LF:10",
+    "LH:10",
+    "end_of_record",
+  ].join("\n");
+  assertEquals(enforceCoverage(lcov, { perFile: 80 }, true), []); // no failure
 });
 
 /**
@@ -144,6 +230,21 @@ Deno.test("coverage with noThrow reports a shortfall without throwing", async ()
       s.dir(profile).threshold(100).noThrow().quiet()
     );
     assertEquals(out.code, 0); // deno coverage itself succeeded
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("a per-file floor alone gates the run and fails a low file", async () => {
+  // No aggregate threshold — only .perFileThreshold(). It must still force
+  // --lcov and enforce, so the under-covered single file trips the gate.
+  const { dir, profile } = await makeProfile(false);
+  try {
+    await assertRejects(
+      () => DenoTasks.coverage((s) => s.dir(profile).perFileThreshold(100)),
+      CoverageThresholdError,
+      "per-file line floor",
+    );
   } finally {
     await Deno.remove(dir, { recursive: true });
   }

--- a/packages/deno/tests/deno_test.ts
+++ b/packages/deno/tests/deno_test.ts
@@ -201,13 +201,28 @@ Deno.test("coverage: a threshold forces --lcov and stays off the argv", () => {
   const s = new DenoCoverageSettings().dir("cov_profile").threshold(95);
   // The threshold is enforced by the task, not a `deno coverage` flag.
   assertEquals(s.argv().slice(1), ["coverage", "cov_profile", "--lcov"]);
-  assertEquals(s.thresholds, { lines: 95, branches: 95 });
+  assertEquals(s.thresholds, {
+    lines: 95,
+    branches: 95,
+    perFile: undefined,
+  });
 });
 
 Deno.test("coverage: line and branch thresholds can differ", () => {
   const s = new DenoCoverageSettings().linesThreshold(90).branchesThreshold(80);
-  assertEquals(s.thresholds, { lines: 90, branches: 80 });
+  assertEquals(s.thresholds, { lines: 90, branches: 80, perFile: undefined });
   assertEquals(s.outputPath, undefined);
+  assertEquals(s.argv().slice(1), ["coverage", "--lcov"]);
+});
+
+Deno.test("coverage: a per-file floor alone forces --lcov and is exposed", () => {
+  const s = new DenoCoverageSettings().perFileThreshold(50);
+  assertEquals(s.thresholds, {
+    lines: undefined,
+    branches: undefined,
+    perFile: 50,
+  });
+  // A per-file floor still needs an lcov report to parse, so --lcov is forced.
   assertEquals(s.argv().slice(1), ["coverage", "--lcov"]);
 });
 

--- a/zuke.ts
+++ b/zuke.ts
@@ -438,8 +438,13 @@ class ZukeBuild extends Build {
     .description("Enforce the 95% coverage gate")
     .dependsOn(this.test)
     .executes(async () => {
+      // A 95% aggregate gate, plus a per-file floor so a wholly-untested file or
+      // package can't hide inside the average. The floor (50%) sits well below
+      // the current lowest src file (~82%), so it flags only a genuinely
+      // neglected file rather than churning on the existing spread.
       await DenoTasks.coverage((s) =>
-        s.dir("cov_profile").exclude("tests/").output("cov.lcov").threshold(95)
+        s.dir("cov_profile").exclude("tests/").output("cov.lcov")
+          .threshold(95).perFileThreshold(50)
       );
     });
 


### PR DESCRIPTION
Remediation plan PR 2, part 2 (items 2.2 + 2.3) — split from the `deepEqual` fix (#220) because this is a `feat(deno)` (new API + `@zuke/deno` bump), whereas that was test-only.

## Fixes

**2.2 — the gate passed vacuously on an empty report (M1).** `pct` returned `100` for `0/0`, so a run that instrumented **no code at all** went green at "100%". `enforceCoverage` now fails a gated run whose report is empty (no lines *and* no branches measured) with a clear `no coverage data measured` message.

**2.3 — the threshold was aggregate-only (M2).** A wholly-untested file could dilute into a healthy repo-wide average. New **`.perFileThreshold(percent)`** (+ `CoverageThresholds.perFile`) fails the gate when any single **instrumented** file's line coverage is below the floor. Zuke wires a **50%** floor into its own gate — well below the current lowest src file (~82%), so it flags a genuinely neglected file without churning on the existing spread.

## Adversarial review

A reviewer confirmed two MEDIUM issues in my first cut, both fixed here:

1. **Branchless code spuriously failed.** `threshold(95)` sets both lines and branches, and my initial unconditional `branchesFound===0` failure would fail a real, 100%-line-covered but **branchless** module ("no branch data"). The true "nothing measured" signal is `linesFound===0`; branchless-but-measured code is now correctly a vacuous 100% branch pass (regression test added). Zuke's own gate was never affected (thousands of branches) — it was a downstream footgun.
2. **The per-file floor is blind to never-imported files.** `deno coverage` only reports *loaded* files, so a source file no test imports is invisible to any coverage metric. The JSDoc previously overclaimed ("a wholly-untested file or package can't hide"); it now states the tool's limit plainly. The floor still catches the common regression — an imported-but-under-tested file (reported at 0%). A src-tree glob for a stronger guarantee is noted as a possible follow-up.

Refuted: LCOV per-file segmentation (Windows `C:` paths preserved), malformed-LCOV crash, double-count, per-file false positives, test-file leakage — all clean.

## Tests

`parseLcovPerFile` segmentation (incl. colon paths); empty-report fail; branchless-pass; per-file floor flags a low file while the aggregate passes; per-file skips zero-line files; a per-file floor alone gates and forces `--lcov`; the getter/argv wiring. The old "zero-found as fully covered" test was inverted to assert the new fail-on-empty behaviour.

All green: `deno task ci` (the gate now runs with the new floor on this repo), `apiDocsCheck`, `generate-ci --check`. Pre-existing `deno doc --lint` errors are unchanged (that's plan PR 7.5); this PR adds none. Commit signed.