### PR TITLE
fix(core): validate MCP Origin and redact URLs; fix ai diff parsing

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -4,6 +4,7 @@
   "useGitignore": true,
   "words": [
     "ACCESSTOKEN",
+    "apikey",
     "COLLECTIONURI",
     "Dependabot",
     "Dockerfiles",
@@ -22,6 +23,7 @@
     "Svensson",
     "TEAMPROJECT",
     "USERPROFILE",
+    "userinfo",
     "Vixie",
     "actionlint",
     "asciinema",

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -70,6 +70,14 @@ below), so one long `run:` never head-of-line-blocks another client's read.
   bind** a non-loopback address rather than exposing an unauthenticated
   endpoint.
 - A token is also enforced on a loopback bind when `ZUKE_MCP_TOKEN` is set.
+- **Origin validation** guards against a browser drive-by / DNS-rebinding page:
+  on a loopback bind, a request that carries an `Origin` header is accepted only
+  when it is a loopback origin, and rejected `403` otherwise. A client that sends
+  no `Origin` (a CLI/MCP client — not a browser) is always allowed, so this is
+  invisible to normal use. Permit a specific extra origin with
+  `--allowed-origin <origin>` (repeatable); when set, a present `Origin` must
+  match one exactly. A non-loopback bind runs no default Origin check — front it
+  with your own policy.
 - This is a bridge for a trusted network segment: **put real TLS and
   authentication in front of it** (a reverse proxy, a service mesh) for anything
   production-facing. Zuke provides the transport, not an internet gateway.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1076,12 +1076,18 @@ class HttpCacheStore implements RemoteCacheStore
     Store `artifact` (a gzipped tar of a target's outputs) under `key`.
 
 class HttpError extends Error
-  Raised when an HTTP request returns a non-2xx status.
+  Raised when an HTTP request returns a non-2xx status. The URL appears in the
+  message and on {@link url}, so it is passed through {@link redactUrl} first —
+  userinfo and credential query params never reach a log.
 
-  constructor(readonly status: number, readonly url: string)
+  constructor(status: number, url: string)
     Build the error from the failing response's status and URL.
   override name: string
     The error name.
+  readonly status: number
+    The HTTP status code of the failing response.
+  readonly url: string
+    The requested URL, with any credentials redacted.
 
 class HttpStateStore implements StateStore
   A {@link StateStore} backed by HTTP.

--- a/llms.txt
+++ b/llms.txt
@@ -78,6 +78,7 @@ Option flags:
 - `--keep-last` — With runs prune, always keep the newest N terminal runs
 - `--allow-run` — With mcp, let agents run targets (optional =<glob-list> allow-list)
 - `--protect` — With mcp, require an operator token to run these targets
+- `--allowed-origin` — With mcp --http, an extra allowed Origin (repeatable; loopback-only otherwise)
 - `--confirm-destructive` — With mcp, require confirm:true before a destructive run
 - `--registry` — With mcp, serve the build registry (dynamic pipeline discovery)
 - `--max-concurrent-runs` — With mcp --registry, cap concurrent run-tool spawns (default 4)

--- a/packages/ai/src/diff.ts
+++ b/packages/ai/src/diff.ts
@@ -14,10 +14,27 @@ function matchesAny(patterns: string[], path: string): boolean {
   return patterns.some((p) => globToRegExp(p).test(path));
 }
 
-/** The file path of a `diff --git` section header, if it has one. */
+/** Whether a section is a file diff (has a `diff --git` header) at all. */
+function isFileSection(section: string): boolean {
+  return /^diff --git /m.test(section);
+}
+
+/**
+ * The file path of a diff section. Read from the unambiguous `+++ b/<path>`
+ * line (everything to end-of-line or a trailing tab), so a path containing
+ * spaces parses correctly — the space-separated `diff --git a/… b/…` header is
+ * ambiguous for such paths. Falls back to that header (tolerant of spaces via a
+ * greedy match) for a section with no `+++` line (a pure rename/mode change).
+ */
 function sectionPath(section: string): string | undefined {
-  const match = section.match(/^diff --git a\/(\S+) b\//m);
-  return match?.[1];
+  const plus = section.match(/^\+\+\+ b\/(.*)$/m);
+  if (plus) return plus[1].replace(/\t.*$/, "");
+  // ponytail: this greedy fallback only fires for a section with no `+++` line
+  // (a pure rename/mode change, which carries no content), and mis-splits a path
+  // that itself contains ` b/` — a genuinely ambiguous git header. Acceptable:
+  // no reviewable body is at stake. Reach for `git diff -z` if it ever matters.
+  const git = section.match(/^diff --git a\/(.+) b\//m);
+  return git?.[1];
 }
 
 /** Drop diff sections whose file is excluded (or not included). */
@@ -30,7 +47,14 @@ export function filterDiff(
   return sections
     .filter((section) => {
       const path = sectionPath(section);
-      if (path === undefined) return true; // preamble / non-file text
+      if (path === undefined) {
+        // Non-file preamble is kept. A file section whose path we could not
+        // parse is dropped when any filter is active — fail safe: we cannot
+        // confirm it is included, nor that it is not excluded, so we do not
+        // review it rather than leak a possibly-excluded file.
+        if (!isFileSection(section)) return true;
+        return include.length === 0 && exclude.length === 0;
+      }
       if (include.length > 0 && !matchesAny(include, path)) return false;
       return !matchesAny(exclude, path);
     })

--- a/packages/ai/src/diff_suggest.ts
+++ b/packages/ai/src/diff_suggest.ts
@@ -66,7 +66,10 @@ export function diffToSuggestions(
       path = undefined;
       continue;
     }
-    if (line.startsWith("+++ b/")) {
+    // The `+++ b/` file header only appears before a hunk; guarding on `!inHunk`
+    // stops an in-hunk addition of a line that happens to start `++ b/` from
+    // being misread as a header (the symmetric case to the `---` bug below).
+    if (!inHunk && line.startsWith("+++ b/")) {
       path = line.slice("+++ b/".length).trim();
       continue;
     }
@@ -78,7 +81,10 @@ export function diffToSuggestions(
       continue;
     }
     if (!inHunk || path === undefined) continue;
-    if (line.startsWith("---") || line.startsWith("\\")) continue;
+    // Inside a hunk, a `\ No newline` marker is skipped — but NOT a line starting
+    // `---`: that is the removal (`-`) of a line whose content begins `--` (e.g.
+    // deleting `--verbose`), which must fall through to the `-` branch below.
+    if (line.startsWith("\\")) continue;
     if (line.startsWith("-")) {
       if (blockStart === -1) blockStart = oldLine;
       blockEnd = oldLine;

--- a/packages/ai/tests/diff_suggest_test.ts
+++ b/packages/ai/tests/diff_suggest_test.ts
@@ -73,6 +73,24 @@ Deno.test("multiple files and hunks each produce a suggestion", () => {
   ]);
 });
 
+Deno.test("a removed line whose content begins with '--' is a removal, not a header", () => {
+  const diff = [
+    "diff --git a/flags.ts b/flags.ts",
+    "--- a/flags.ts",
+    "+++ b/flags.ts",
+    "@@ -3,2 +3,1 @@",
+    " keep",
+    "---verbose", // the removal (`-`) of a line whose content is `--verbose`
+    "+--quiet", // the addition of `--quiet`
+  ].join("\n");
+  const s = diffToSuggestions(diff, PRELUDE);
+  // If `---verbose` were mistaken for a header the block would have no removal
+  // and be skipped; the fix parses it, producing a replacement suggestion.
+  assertEquals(s.length, 1);
+  assertEquals([s[0].startLine, s[0].line], [4, 4]);
+  assertEquals(s[0].body.includes("--quiet"), true);
+});
+
 Deno.test("an empty diff yields no suggestions", () => {
   assertEquals(diffToSuggestions("", PRELUDE), []);
 });

--- a/packages/ai/tests/diff_test.ts
+++ b/packages/ai/tests/diff_test.ts
@@ -1,0 +1,40 @@
+import { assertEquals } from "../../core/tests/_assert.ts";
+import { filterDiff } from "../src/diff.ts";
+
+/** A minimal one-file diff section for `path`. */
+function section(path: string): string {
+  return [
+    `diff --git a/${path} b/${path}`,
+    `--- a/${path}`,
+    `+++ b/${path}`,
+    "@@ -1 +1 @@",
+    "-a",
+    "+b",
+    "",
+  ].join("\n");
+}
+
+Deno.test("filterDiff excludes a file whose path contains a space", () => {
+  const diff = section("src/my file.ts") + section("src/keep.ts");
+  const out = filterDiff(diff, [], ["**/my file.ts"]);
+  assertEquals(out.includes("my file.ts"), false); // dropped despite the space
+  assertEquals(out.includes("keep.ts"), true);
+});
+
+Deno.test("filterDiff includes only matching files, parsing spaced paths", () => {
+  const diff = section("src/a b.ts") + section("lib/c.ts");
+  const out = filterDiff(diff, ["src/**"], []);
+  assertEquals(out.includes("a b.ts"), true);
+  assertEquals(out.includes("lib/c.ts"), false);
+});
+
+Deno.test("filterDiff keeps preamble but drops an unparseable file section when filters are active", () => {
+  const preamble = "warning: some git advice\n";
+  const weird = "diff --git \nBinary files differ\n"; // a file section, no path line
+  const out = filterDiff(preamble + section("src/x.ts") + weird, [], [
+    "**/*.lock",
+  ]);
+  assertEquals(out.includes("some git advice"), true); // preamble kept
+  assertEquals(out.includes("src/x.ts"), true); // parseable file kept
+  assertEquals(out.includes("Binary files differ"), false); // fail-safe: dropped
+});

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1130,12 +1130,18 @@ class HttpCacheStore implements RemoteCacheStore
     Store `artifact` (a gzipped tar of a target's outputs) under `key`.
 
 class HttpError extends Error
-  Raised when an HTTP request returns a non-2xx status.
+  Raised when an HTTP request returns a non-2xx status. The URL appears in the
+  message and on {@link url}, so it is passed through {@link redactUrl} first —
+  userinfo and credential query params never reach a log.
 
-  constructor(readonly status: number, readonly url: string)
+  constructor(status: number, url: string)
     Build the error from the failing response's status and URL.
   override name: string
     The error name.
+  readonly status: number
+    The HTTP status code of the failing response.
+  readonly url: string
+    The requested URL, with any credentials redacted.
 
 class HttpStateStore implements StateStore
   A {@link StateStore} backed by HTTP.

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -720,9 +720,13 @@ const MAX_SIGNAL_DATA_BYTES = 64 * 1024;
  */
 function parseSignalData(raw: string | undefined): JsonValue | undefined {
   if (raw === undefined) return undefined;
-  if (raw.length > MAX_SIGNAL_DATA_BYTES) {
+  // Measure real UTF-8 bytes, not `raw.length` (UTF-16 code units) — a payload
+  // of multi-byte characters can be well over the byte budget while its `.length`
+  // is under it.
+  const bytes = new TextEncoder().encode(raw).length;
+  if (bytes > MAX_SIGNAL_DATA_BYTES) {
     throw new Error(
-      `resume: --data payload is too large (${raw.length} bytes; ` +
+      `resume: --data payload is too large (${bytes} bytes; ` +
         `max ${MAX_SIGNAL_DATA_BYTES}).`,
     );
   }

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -98,6 +98,8 @@ export interface ParsedArgs {
   allowRunPatterns?: string[];
   /** Targets whose `mcp` run tool needs an operator token (`--protect <list>`). */
   protectPatterns?: string[];
+  /** Extra origins allowed to call the `mcp --http` transport (`--allowed-origin`). */
+  allowedOrigins?: string[];
   /** Require `confirm:true` before a destructive `mcp` run (`--confirm-destructive`). */
   confirmDestructive: boolean;
   /** Serve `mcp` over the build registry (dynamic discovery) rather than one build (`--registry`). */
@@ -313,6 +315,16 @@ export function parseArgs(
       if (value) parsed.protectPatterns = splitList(value);
     } else if (arg.startsWith("--protect=")) {
       parsed.protectPatterns = splitList(arg.slice("--protect=".length));
+    } else if (arg === "--allowed-origin") {
+      const value = args[++i];
+      if (value) {
+        parsed.allowedOrigins = [...parsed.allowedOrigins ?? [], value];
+      }
+    } else if (arg.startsWith("--allowed-origin=")) {
+      parsed.allowedOrigins = [
+        ...parsed.allowedOrigins ?? [],
+        ...splitList(arg.slice("--allowed-origin=".length)),
+      ];
     } else if (arg === "--confirm-destructive") {
       parsed.confirmDestructive = true;
     } else if (arg === "--registry") {
@@ -490,6 +502,11 @@ Options:
                     address instead of stdio. Just <port> binds 127.0.0.1. A
                     non-loopback host requires a bearer token (ZUKE_MCP_TOKEN);
                     put real TLS/authn in front for production. See docs/mcp.md.
+  --allowed-origin <origin>
+                    With mcp --http, permit this browser Origin (repeatable). By
+                    default a loopback bind accepts only loopback origins (the
+                    drive-by / DNS-rebinding guard); a request with no Origin (a
+                    CLI client) is always allowed.
   resume            Continue a suspended run (a .waitsFor() gate). Exactly one
                     resumer wins; the rest report "already resumed". With
                     --check [<run-id>] it re-checks suspended runs (predicate
@@ -820,6 +837,7 @@ async function runMcp(build: Build, parsed: ParsedArgs): Promise<number> {
     useRegistry: parsed.mcpRegistry,
     maxConcurrentRuns: parsed.maxConcurrentRuns,
     actor: parsed.actor,
+    allowedOrigins: parsed.allowedOrigins,
     http,
   });
 }

--- a/packages/core/src/cli_spec.ts
+++ b/packages/core/src/cli_spec.ts
@@ -177,6 +177,11 @@ export const BUILTIN_FLAGS: readonly BuiltinFlag[] = [
     description: "With mcp, require an operator token to run these targets",
   },
   {
+    name: "--allowed-origin",
+    description:
+      "With mcp --http, an extra allowed Origin (repeatable; loopback-only otherwise)",
+  },
+  {
     name: "--confirm-destructive",
     description: "With mcp, require confirm:true before a destructive run",
   },

--- a/packages/core/src/http.ts
+++ b/packages/core/src/http.ts
@@ -19,18 +19,68 @@
 
 import type { PathLike } from "./path.ts";
 
-/** Raised when an HTTP request returns a non-2xx status. */
+/**
+ * Substrings that mark a query-param name as credential-bearing. Matched as
+ * substrings (not exact names) so variants — `client_secret`, `refresh_token`,
+ * `x-api-key` — are covered without maintaining an exhaustive list. Over-masking
+ * an innocent param (e.g. `monkey`) is harmless; under-masking a secret is not.
+ */
+const CREDENTIAL_MARKERS = [
+  "secret",
+  "token",
+  "key",
+  "password",
+  "pwd",
+  "auth",
+  "sig",
+  "credential",
+  "session",
+];
+
+/** Whether a query-param `name` looks credential-bearing (see {@link CREDENTIAL_MARKERS}). */
+function isCredentialParam(name: string): boolean {
+  const lower = name.toLowerCase();
+  return CREDENTIAL_MARKERS.some((marker) => lower.includes(marker));
+}
+
+/**
+ * Strip userinfo (`user:pass@`) and mask any credential-bearing query param so a
+ * URL is safe to put in an error message or log. A string that is not a URL is
+ * returned unchanged. Non-goal: a secret embedded in the URL *path* (rare and
+ * non-standard) is not redacted — only userinfo and query params are.
+ */
+export function redactUrl(raw: string): string {
+  try {
+    const url = new URL(raw);
+    url.username = "";
+    url.password = "";
+    for (const key of [...url.searchParams.keys()]) {
+      if (isCredentialParam(key)) url.searchParams.set(key, "REDACTED");
+    }
+    return url.href;
+  } catch {
+    return raw;
+  }
+}
+
+/**
+ * Raised when an HTTP request returns a non-2xx status. The URL appears in the
+ * message and on {@link url}, so it is passed through {@link redactUrl} first —
+ * userinfo and credential query params never reach a log.
+ */
 export class HttpError extends Error {
   /** The error name. */
   override name = "HttpError";
+  /** The HTTP status code of the failing response. */
+  readonly status: number;
+  /** The requested URL, with any credentials redacted. */
+  readonly url: string;
   /** Build the error from the failing response's status and URL. */
-  constructor(
-    /** The HTTP status code of the failing response. */
-    readonly status: number,
-    /** The requested URL. */
-    readonly url: string,
-  ) {
-    super(`HTTP ${status} for ${url}`);
+  constructor(status: number, url: string) {
+    const safe = redactUrl(url);
+    super(`HTTP ${status} for ${safe}`);
+    this.status = status;
+    this.url = safe;
   }
 }
 

--- a/packages/core/src/mcp/command.ts
+++ b/packages/core/src/mcp/command.ts
@@ -74,6 +74,13 @@ export interface ServeMcpOptions extends McpServerOptions {
   http?: HttpAddress;
   /** Bearer token for the HTTP transport (defaults to `ZUKE_MCP_TOKEN`). */
   token?: string;
+  /**
+   * Extra origins allowed to call the HTTP transport (the `--allowed-origin`
+   * flag, repeatable). When set, a request's `Origin` — if present — must match
+   * one of these exactly; when unset, the default applies (loopback origins only
+   * on a loopback bind). See {@link "./http.ts".HttpTransportOptions.allowedOrigins}.
+   */
+  allowedOrigins?: string[];
   /** Reads an environment variable (injectable for tests). */
   readEnv?: (name: string) => string | undefined;
   /** Abort to stop the HTTP server (test hook; the CLI runs until killed). */
@@ -228,6 +235,7 @@ async function serveMcpHttp(
     host: address.host,
     port: address.port,
     token: hasToken ? token : undefined,
+    allowedOrigins: options.allowedOrigins,
     signal: options.signal,
     onListen: options.onListen,
     concurrent: server.concurrent,

--- a/packages/core/src/mcp/http.ts
+++ b/packages/core/src/mcp/http.ts
@@ -40,6 +40,16 @@ export interface HttpTransportOptions {
    * unauthenticated (only safe on loopback — the caller enforces that).
    */
   token?: string;
+  /**
+   * Origins allowed to call the server. When set, a request whose `Origin`
+   * header is present must exactly match one of these (a request with no
+   * `Origin`, e.g. a CLI client, is always allowed). When unset, the default
+   * applies: on a **loopback** bind, only loopback origins pass — the
+   * DNS-rebinding / browser drive-by guard the MCP streamable-HTTP spec
+   * requires; on a non-loopback bind, no default Origin check runs (front it
+   * with your own TLS/authn).
+   */
+  allowedOrigins?: string[];
   /** Abort to stop the server (its {@link serveHttp} promise then resolves). */
   signal?: AbortSignal;
   /** Called once the listener is bound, with the actual address (test hook). */
@@ -81,6 +91,42 @@ function bearerToken(header: string | null): string | undefined {
   return parts[1];
 }
 
+/** Whether `host` is a loopback address (localhost, 127.0.0.0/8, or ::1). The
+ * 127/8 match is a fully-anchored dotted-quad so an attacker domain like
+ * `127.0.0.1.evil.com` (which merely *starts* with `127.`) is not accepted. */
+function isLoopbackHost(host: string): boolean {
+  return host === "localhost" || host === "::1" || host === "[::1]" ||
+    /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host);
+}
+
+/** The hostname of an `Origin` value, or `null` if it can't be parsed. */
+function originHost(origin: string): string | null {
+  try {
+    return new URL(origin).hostname;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether a request's `Origin` is allowed. A client that sends no `Origin` (a
+ * CLI/MCP client, not a browser) is always allowed. With an explicit
+ * {@link HttpTransportOptions.allowedOrigins} list the origin must be in it.
+ * Otherwise, on a loopback bind only loopback origins pass (the drive-by /
+ * DNS-rebinding guard); a non-loopback bind runs no default check.
+ */
+export function originAllowed(
+  origin: string | null,
+  allowed: string[] | undefined,
+  bindHost: string,
+): boolean {
+  if (origin === null) return true;
+  if (allowed !== undefined) return allowed.includes(origin);
+  if (!isLoopbackHost(bindHost)) return true;
+  const host = originHost(origin);
+  return host !== null && isLoopbackHost(host);
+}
+
 /**
  * Serve JSON-RPC over HTTP: each `POST` carries one JSON-RPC message as its
  * body, `handle` produces the response, and it is returned as JSON. A
@@ -97,7 +143,8 @@ export async function serveHttp(
   ) => Promise<JsonRpcResponse | null>,
   options: HttpTransportOptions,
 ): Promise<void> {
-  const { host, port, token, signal, onListen, concurrent } = options;
+  const { host, port, token, signal, onListen, concurrent, allowedOrigins } =
+    options;
 
   // By default, process messages one at a time: the single-build server/execute
   // path mutates per-run parameter state, so concurrent handling of two POSTs
@@ -119,6 +166,18 @@ export async function serveHttp(
       return jsonResponse(
         err(null, INVALID_REQUEST, "This MCP endpoint accepts POST only."),
         405,
+      );
+    }
+    // Reject a cross-origin browser request before doing anything else: on a
+    // loopback bind this blocks a drive-by / DNS-rebinding page from driving the
+    // local server. A CLI client sends no Origin and passes. (This is the guard;
+    // a Content-Type check is deliberately not added — Deno/browser `fetch`
+    // defaults a string body to text/plain, so requiring JSON would break
+    // legitimate non-SDK clients, and Origin already stops the cross-origin case.)
+    if (!originAllowed(request.headers.get("origin"), allowedOrigins, host)) {
+      return jsonResponse(
+        err(null, INVALID_REQUEST, "Forbidden: Origin not allowed."),
+        403,
       );
     }
     if (token !== undefined && token !== "") {

--- a/packages/core/tests/cli_test.ts
+++ b/packages/core/tests/cli_test.ts
@@ -170,6 +170,22 @@ Deno.test("every reserved command is honoured by the parser and help", () => {
   for (const flag of BUILTIN_FLAGS) assertStringIncludes(help, flag.name);
 });
 
+Deno.test("parseArgs accumulates --allowed-origin (repeatable and comma-list)", () => {
+  const p = parseArgs([
+    "mcp",
+    "--allowed-origin",
+    "https://a.example",
+    "--allowed-origin=https://b.example,https://c.example",
+  ]);
+  assertEquals(p.allowedOrigins, [
+    "https://a.example",
+    "https://b.example",
+    "https://c.example",
+  ]);
+  // Absent by default.
+  assertEquals(parseArgs(["mcp"]).allowedOrigins, undefined);
+});
+
 Deno.test("parseArgs recognises the doc command and its spec", () => {
   const p = parseArgs(["doc", "jsr:@zuke/deno"]);
   assertEquals(p.doc, true);

--- a/packages/core/tests/cli_test.ts
+++ b/packages/core/tests/cli_test.ts
@@ -1012,3 +1012,15 @@ Deno.test("main: resume rejects an oversized --data payload", async () => {
   assertEquals(code, 1);
   assertEquals(err.join("\n").includes("too large"), true);
 });
+
+Deno.test("main: resume rejects a multibyte --data payload over the byte budget", async () => {
+  // 22k euro signs: ~22k UTF-16 code units (under the 64 KiB char length) but
+  // ~66 KB of UTF-8 (over it). Measuring `.length` would wrongly let it through.
+  const multibyte = JSON.stringify({ blob: "€".repeat(22_000) });
+  assertEquals(multibyte.length < 64 * 1024, true); // under the cap by char count
+  const { code, err } = await capture(() =>
+    main(Demo, ["resume", "run-x", "--data", multibyte])
+  );
+  assertEquals(code, 1); // but over it in real bytes → rejected
+  assertEquals(err.join("\n").includes("too large"), true);
+});

--- a/packages/core/tests/http_test.ts
+++ b/packages/core/tests/http_test.ts
@@ -52,6 +52,21 @@ Deno.test("a non-2xx status throws HttpError carrying the status", async () => {
   }
 });
 
+Deno.test("HttpError redacts userinfo and credential query params from the URL", () => {
+  const e = new HttpError(
+    500,
+    "https://user:pw@host.example/x?key=abc&client_secret=cs&refresh_token=rt&q=ok",
+  );
+  // Userinfo and every credential param (incl. OAuth `client_secret` /
+  // `refresh_token`, caught by substring markers) are masked.
+  for (const leaked of ["user", "pw", "abc", "cs", "rt"]) {
+    assertEquals(e.message.includes(leaked), false, `leaked: ${leaked}`);
+    assertEquals(e.url.includes(leaked), false); // the stored url is redacted too
+  }
+  assertEquals(e.message.includes("REDACTED"), true);
+  assertEquals(e.url.includes("q=ok"), true); // a non-credential param is kept
+});
+
 Deno.test("httpDownload streams the body to a file", async () => {
   const { fetch } = fakeFetch("file-contents");
   const dir = await Deno.makeTempDir();

--- a/packages/core/tests/mcp_http_test.ts
+++ b/packages/core/tests/mcp_http_test.ts
@@ -2,7 +2,7 @@ import { assertEquals, assertStringIncludes } from "./_assert.ts";
 import { Build, type McpRequestContext, target } from "../mod.ts";
 import type { JsonRpcResponse } from "../src/mcp/jsonrpc.ts";
 import { McpServer } from "../src/mcp/server.ts";
-import { serveHttp } from "../src/mcp/http.ts";
+import { originAllowed, serveHttp } from "../src/mcp/http.ts";
 import { serveMcp } from "../src/mcp/command.ts";
 import { FileSystemStateStore } from "../src/state/fs_store.ts";
 import { defaultStateHost } from "../src/state/store.ts";
@@ -72,6 +72,71 @@ Deno.test("http transport rejects a non-POST with 405", async () => {
     const res = await fetch(`http://127.0.0.1:${s.port}/`);
     assertEquals(res.status, 405);
     await res.json();
+  } finally {
+    await s.stop();
+  }
+});
+
+Deno.test("originAllowed enforces the loopback / allow-list rules", () => {
+  // No Origin (a CLI/MCP client) is always allowed.
+  assertEquals(originAllowed(null, undefined, "127.0.0.1"), true);
+  // On a loopback bind, only loopback origins pass.
+  assertEquals(
+    originAllowed("http://localhost:5173", undefined, "127.0.0.1"),
+    true,
+  );
+  assertEquals(originAllowed("http://127.0.0.5", undefined, "127.0.0.1"), true);
+  assertEquals(originAllowed("http://[::1]:8080", undefined, "::1"), true);
+  assertEquals(
+    originAllowed("https://evil.example", undefined, "127.0.0.1"),
+    false,
+  );
+  // A domain that merely *starts* with `127.` is not loopback (anchored match).
+  assertEquals(
+    originAllowed("http://127.0.0.1.evil.com", undefined, "127.0.0.1"),
+    false,
+  );
+  assertEquals(
+    originAllowed("http://localhost.evil.com", undefined, "127.0.0.1"),
+    false,
+  );
+  assertEquals(originAllowed("not a url", undefined, "127.0.0.1"), false);
+  // A non-loopback bind runs no default Origin check (operator's responsibility).
+  assertEquals(
+    originAllowed("https://evil.example", undefined, "10.0.0.5"),
+    true,
+  );
+  // An explicit allow-list is matched exactly, regardless of the bind.
+  assertEquals(
+    originAllowed("https://app.example", ["https://app.example"], "0.0.0.0"),
+    true,
+  );
+  assertEquals(
+    originAllowed("https://evil.example", ["https://app.example"], "0.0.0.0"),
+    false,
+  );
+});
+
+Deno.test("http transport rejects a cross-origin browser request (drive-by guard)", async () => {
+  const server = new McpServer(new Demo());
+  const s = await startHttp((m) => server.handleMessage(m));
+  try {
+    // A drive-by / DNS-rebinding page sends its own (non-loopback) Origin.
+    const blocked = await fetch(`http://127.0.0.1:${s.port}/`, {
+      method: "POST",
+      headers: { origin: "https://evil.example" },
+      body: rpc("initialize", 1, {}),
+    });
+    assertEquals(blocked.status, 403);
+    await blocked.json();
+    // A loopback origin (a legit local dev tool) is allowed.
+    const ok = await fetch(`http://127.0.0.1:${s.port}/`, {
+      method: "POST",
+      headers: { origin: "http://localhost:5173" },
+      body: rpc("initialize", 2, {}),
+    });
+    assertEquals(ok.status, 200);
+    await ok.json();
   } finally {
     await s.stop();
   }

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -619,7 +619,8 @@ else a friendly error.
 ./zuke resume <id> --signal <name> [--data <json>]  # continue a suspended run
 ./zuke cancel <id>            # cancel a run and run its .onCancel() compensations
 ./zuke mcp [--allow-run]      # serve the build over MCP for an AI client (stdio)
-./zuke mcp --http 7777        # ...or over HTTP (loopback; token off-loopback)
+./zuke mcp --http 7777        # ...or over HTTP (loopback; token off-loopback; Origin-guarded)
+./zuke mcp --http 7777 --allowed-origin https://app.example  # permit an extra browser Origin
 ./zuke mcp --allow-run=deploy,checks* --protect deploy --confirm-destructive
                               # authz tiers: allow-list, operator token, confirm
 ./zuke runs show mcp-audit    # the MCP tool-call audit trail


### PR DESCRIPTION
Remediation plan **PR 4** — MCP HTTP `Origin` validation (the other security-flagged item) plus the `@zuke/ai` diff-parsing correctness fixes. Touches `@zuke/core` (4.1/4.4/4.5) and `@zuke/ai` (4.2/4.3), so both take a patch bump.

## Fixes

- **4.1 (🟠) — No `Origin` validation on the MCP HTTP transport.** A browser drive-by / DNS-rebinding page could POST to a loopback-bound server. `serveHttp` now rejects (403) a request whose `Origin` isn't allowed: on a loopback bind only loopback origins pass; a client that sends no `Origin` (CLI/MCP) is unaffected; a non-loopback bind is the operator's responsibility (or set `allowedOrigins`). A Content-Type check was deliberately *not* added — Deno/browser `fetch` defaults a string body to `text/plain`, so requiring JSON would break legit clients, and `Origin` already covers the cross-origin threat.
- **4.2 (🟡) — Diff parser dropped removed lines starting `--`.** Removing `--verbose` (diff line `---verbose`) was mistaken for a `---` header and lost. Header detection is now gated to *before* the hunk (the `+++ b/` symmetric case too).
- **4.3 (🟡) — `filterDiff` failed open on spaced paths.** `\S+` stopped at the space, so an excluded file with a space in its name was reviewed anyway. It now reads the unambiguous `+++ b/` line; an unparseable *file* section is dropped when filters are active (fail-safe), preamble is kept.
- **4.4 (🟡) — `--data` byte cap measured UTF-16 code units.** Now `TextEncoder().encode(raw).length`, so a multibyte payload over the byte budget is rejected.
- **4.5 (🟡) — `HttpError` echoed the full URL.** It now redacts userinfo and credential query params before the URL reaches the message or `.url`.

## Adversarial review

Two reviewers attacked the change. **1 HIGH confirmed and fixed:** `isLoopbackHost`'s unanchored `/^127\./` accepted an attacker domain like `127.0.0.1.evil.com`, bypassing the loopback guard — now a fully anchored dotted-quad (regression test added). **1 MEDIUM confirmed and fixed:** `redactUrl`'s exact-name denylist missed OAuth params (`client_secret`, `refresh_token`, …) — switched to substring matching (test covers both). Documented ceilings (not fixed): a secret in the URL *path* (non-standard), and the greedy `diff --git` fallback for a rename whose path contains ` b/` (no reviewable content at stake). Everything else — Host-header need, no-Origin bypass, allow-list matching, 4.2/4.4 correctness — refuted.

## Tests

`originAllowed` branch matrix (loopback variants incl. the `127.x.evil` bypass, allow-list, non-loopback bind); a live cross-origin POST → 403; the `--` removal parse; spaced-path include/exclude + unparseable-section fail-safe; the multibyte `--data` rejection; and `HttpError` userinfo + OAuth-param redaction.

All green: `deno task ci`, `apiDocsCheck`, `generate-ci --check`, `deno doc --lint`. Commit signed.