### PR TITLE
fix(core): harden executor cancellation, graph validation, and state edge cases

### DIFF
--- a/packages/core/src/cancel.ts
+++ b/packages/core/src/cancel.ts
@@ -40,6 +40,7 @@ import { absolutePath } from "./path.ts";
 import { findConfigDir, pathExists } from "./config.ts";
 import { defaultStateHost, type StateStore } from "./state/store.ts";
 import { resolveStateStore } from "./state/resolve.ts";
+import { acquireCancelLock } from "./state/cancel_lock.ts";
 import { resolveActor } from "./state/record.ts";
 import type {
   RunEvent,
@@ -483,7 +484,7 @@ function collectForEachInto(
  * when the cancel landed — an item mid-flight may have partial side effects
  * (a started deploy) its `.onCancel(...)` needs to unwind.
  *
- * ponytail: an out-of-process `zuke cancel` compensates a `running` item from a
+ * An out-of-process `zuke cancel` compensates a `running` item from a
  * record snapshot, so if that item's body is still live in the owning process
  * (which aborts only on its next state write / lock heartbeat), the compensation
  * can overlap the body's tail. Bodies that checkpoint via `ctx.state.set(...)`
@@ -600,101 +601,128 @@ export async function cancelRun(
     };
   }
 
-  // Transition running/suspended → cancelling.
-  const transitioned = await transitionToCancelling(store, runId, initial, now);
-  if (transitioned === "noop") {
+  // Hold the per-run cancel lock so exactly one process drives the compensation
+  // walk. A live holder (another `zuke cancel`, or the in-process executor)
+  // blocks us with a friendly no-op; a crashed holder's lock lapses via the TTL,
+  // so we can then safely recover the stranded `cancelling` record (F7).
+  const cancelLock = await acquireCancelLock(store, runId, actor, now);
+  if (cancelLock === null) {
     const fresh = await store.getRun(runId);
-    const status = fresh?.record.status ?? "cancelled";
-    reporter.info(`Run ${runId} is already ${status}; nothing to cancel.`);
+    const status = fresh?.record.status ?? "cancelling";
+    reporter.info(
+      `Run ${runId} is already being cancelled by another process; ` +
+        `nothing to do.`,
+    );
     return { runId, status, noop: true, compensated: [], failures: [] };
   }
-  if (transitioned === "recover") {
-    // The run was left `cancelling` by an interrupted cancellation (a crashed
-    // canceller, or a store hiccup mid-finalize). Settle it to `cancelled`
-    // without re-running compensations — they may not be idempotent, so a second
-    // pass is more dangerous than the small chance an interrupted first pass
-    // left some cleanup undone. `zuke cancel` becomes retryable, not a dead end.
-    reporter.info(`Run ${runId} was mid-cancellation; finalizing it.`);
-    await finalizeCancelled(store, runId, actor, EMPTY_OUTCOME, now);
+  try {
+    // Transition running/suspended → cancelling.
+    const transitioned = await transitionToCancelling(
+      store,
+      runId,
+      initial,
+      now,
+    );
+    if (transitioned === "noop") {
+      const fresh = await store.getRun(runId);
+      const status = fresh?.record.status ?? "cancelled";
+      reporter.info(`Run ${runId} is already ${status}; nothing to cancel.`);
+      return { runId, status, noop: true, compensated: [], failures: [] };
+    }
+    if (transitioned === "recover") {
+      // The run was left `cancelling` by an interrupted cancellation. Because we
+      // hold the cancel lock, no other process is compensating it right now (a
+      // live one would still hold the lock; a crashed one's lock lapsed via the
+      // TTL). Settle it to `cancelled` without re-running compensations — they may
+      // not be idempotent, so a second pass is more dangerous than the small
+      // chance an interrupted first pass left some cleanup undone. `zuke cancel`
+      // becomes retryable, not a dead end.
+      reporter.info(`Run ${runId} was mid-cancellation; finalizing it.`);
+      await finalizeCancelled(store, runId, actor, EMPTY_OUTCOME, now);
+      return {
+        runId,
+        status: "cancelled",
+        noop: false,
+        compensated: [],
+        failures: [],
+      };
+    }
+    const record = transitioned.record;
+
+    // Resolve compensation targets by reference, and make `this.<param>.value`
+    // available to their bodies (from the record's non-secret params; secrets
+    // re-resolve from the environment, exactly as a resume does). Retain the
+    // seeded redactor so a compensation's failure message can't leak a secret.
+    const targets = discoverTargets(build);
+    const params = discoverParameters(build);
+    const redactor = new Redactor();
+    await resolveParameters(
+      params,
+      record.params,
+      readEnv,
+      () => undefined,
+      redactor,
+    );
+    for (const p of params.values()) {
+      if (!p.secret_) continue;
+      const value = p.stringValue_();
+      if (value !== undefined && value !== "") redactor.add(value);
+    }
+
+    let outcome: CompensationOutcome = EMPTY_OUTCOME;
+    const root = targets.get(record.rootTarget);
+    if (root === undefined) {
+      reporter.info(
+        `cancel: build "${build.constructor.name}" has no target ` +
+          `"${record.rootTarget}" — cancelling without compensations.`,
+      );
+    } else {
+      // Honour the build's soft ordering edges (extraEdges + the lazy orderWith
+      // provider), exactly as execute() does, so out-of-process cancellation
+      // (zuke cancel / MCP / a timed-out wait) compensates in the same
+      // reverse-execution order as an in-process cancel. These edges only affect
+      // the compensation ORDER, so a failing provider (e.g. an unreachable
+      // dependency-graph service during `zuke cancel`) degrades to the base
+      // topological order — never abandoning the walk, which would strand the run
+      // `cancelling` with its rollbacks never run (a re-cancel then skips them).
+      let edges: OrderingEdge[] = [];
+      try {
+        edges = await resolveOrderingEdges(build, targets);
+      } catch (error) {
+        reporter.error(
+          `cancel: ordering provider failed (${messageOf(error)}); ` +
+            `compensating in base topological order.`,
+        );
+      }
+      const order = planGraph(root, edges).order;
+      outcome = await runCompensations(order, record, {
+        runId,
+        signals: new Map(Object.entries(record.signals)),
+        reporter,
+        redactor,
+        extra: resolveExtra(options.also, targets, record),
+      });
+    }
+
+    await finalizeCancelled(store, runId, actor, outcome, now);
+    reporter.info(
+      `Run ${runId} cancelled — ${outcome.compensated.length} compensation(s) ` +
+        `ran${
+          outcome.failures.length > 0
+            ? `, ${outcome.failures.length} failed`
+            : ""
+        }.`,
+    );
     return {
       runId,
       status: "cancelled",
       noop: false,
-      compensated: [],
-      failures: [],
+      compensated: outcome.compensated,
+      failures: outcome.failures,
     };
+  } finally {
+    await cancelLock.release();
   }
-  const record = transitioned.record;
-
-  // Resolve compensation targets by reference, and make `this.<param>.value`
-  // available to their bodies (from the record's non-secret params; secrets
-  // re-resolve from the environment, exactly as a resume does). Retain the
-  // seeded redactor so a compensation's failure message can't leak a secret.
-  const targets = discoverTargets(build);
-  const params = discoverParameters(build);
-  const redactor = new Redactor();
-  await resolveParameters(
-    params,
-    record.params,
-    readEnv,
-    () => undefined,
-    redactor,
-  );
-  for (const p of params.values()) {
-    if (!p.secret_) continue;
-    const value = p.stringValue_();
-    if (value !== undefined && value !== "") redactor.add(value);
-  }
-
-  let outcome: CompensationOutcome = EMPTY_OUTCOME;
-  const root = targets.get(record.rootTarget);
-  if (root === undefined) {
-    reporter.info(
-      `cancel: build "${build.constructor.name}" has no target ` +
-        `"${record.rootTarget}" — cancelling without compensations.`,
-    );
-  } else {
-    // Honour the build's soft ordering edges (extraEdges + the lazy orderWith
-    // provider), exactly as execute() does, so out-of-process cancellation
-    // (zuke cancel / MCP / a timed-out wait) compensates in the same
-    // reverse-execution order as an in-process cancel. These edges only affect
-    // the compensation ORDER, so a failing provider (e.g. an unreachable
-    // dependency-graph service during `zuke cancel`) degrades to the base
-    // topological order — never abandoning the walk, which would strand the run
-    // `cancelling` with its rollbacks never run (a re-cancel then skips them).
-    let edges: OrderingEdge[] = [];
-    try {
-      edges = await resolveOrderingEdges(build, targets);
-    } catch (error) {
-      reporter.error(
-        `cancel: ordering provider failed (${messageOf(error)}); ` +
-          `compensating in base topological order.`,
-      );
-    }
-    const order = planGraph(root, edges).order;
-    outcome = await runCompensations(order, record, {
-      runId,
-      signals: new Map(Object.entries(record.signals)),
-      reporter,
-      redactor,
-      extra: resolveExtra(options.also, targets, record),
-    });
-  }
-
-  await finalizeCancelled(store, runId, actor, outcome, now);
-  reporter.info(
-    `Run ${runId} cancelled — ${outcome.compensated.length} compensation(s) ` +
-      `ran${
-        outcome.failures.length > 0 ? `, ${outcome.failures.length} failed` : ""
-      }.`,
-  );
-  return {
-    runId,
-    status: "cancelled",
-    noop: false,
-    compensated: outcome.compensated,
-    failures: outcome.failures,
-  };
 }
 
 /** Resolve the store for a cancel — like a run, but always defaulting on. */

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -777,6 +777,9 @@ async function runBody(t: TargetBuilder, ctx: TargetContext): Promise<void> {
       return;
     } catch (error) {
       if (attempt >= attempts) throw error;
+      // A cancelled run (Ctrl-C / SIGTERM / an aborted signal) must not burn
+      // further retries: surface the failure now instead of re-running the body.
+      if (ctx.signal.aborted) throw error;
       if (t.retryDelay_ > 0) await delay(t.retryDelay_);
     }
   }
@@ -805,6 +808,9 @@ async function runBodyWithRecovery(
     if (remediations.length === 0) throw error;
     let lastError = error;
     for (let attempt = 1; attempt <= t.recoverAttempts_; attempt++) {
+      // A cancelled run must not trigger (possibly paid) remediations: stop and
+      // let the original failure propagate (falls through to `throw lastError`).
+      if (ctx.signal.aborted) break;
       let willRetry = false;
       for (const r of remediations) {
         try {
@@ -1389,9 +1395,12 @@ async function runScheduled(
           if (!started.has(t)) {
             outcomes.set(t, { status: "skipped", ms: 0 });
             started.add(t);
-            // When the run suspends, targets blocked behind the wait are left
-            // `pending` in the record (a resume runs them) rather than skipped.
-            if (!anyWaiting) {
+            // When the run *suspends* (a wait parked and nothing failed),
+            // targets blocked behind the wait are left `pending` so a resume
+            // runs them. A run that also failed will never resume, so settle
+            // them `skipped` — otherwise they linger `pending` inside a terminal
+            // `failed` record that no resume sweep reaches (F8).
+            if (!anyWaiting || anyFailed) {
               void env.writer?.markTargetSettled(
                 t.name_ ?? "<unnamed>",
                 "skipped",
@@ -1404,6 +1413,20 @@ async function runScheduled(
     };
     pump();
   });
+
+  // A failed run does not suspend, so any target parked at a `.waitsFor(...)`
+  // gate — recorded `waiting` and normally left for a resume — will never be
+  // resumed. Settle those rows to a terminal `skipped` so the `failed` record
+  // has no permanently-`waiting` target that `runs show` and the resume sweep
+  // would otherwise see forever (F8).
+  if (anyFailed && anyWaiting) {
+    for (const [t, outcome] of outcomes) {
+      if (outcome.status === "waiting") {
+        outcomes.set(t, { status: "skipped", ms: outcome.ms });
+        void env.writer?.markTargetSettled(t.name_ ?? "<unnamed>", "skipped");
+      }
+    }
+  }
 
   const reports: TargetReport[] = [];
   const executed: string[] = [];
@@ -1777,43 +1800,65 @@ export async function execute(
         `Run ${runId} cancelled by another process — stopping.`,
       );
     } else if (writer !== undefined) {
-      // We initiated it (Ctrl-C / options.signal): mark cancelling (which also
-      // drains every pending per-target write, so the snapshot is current).
-      await writer.markRunCancelling();
-      // markRunCancelling drains the write chain, so if another process's
-      // `zuke cancel` won the race in the meantime, the conflict has already
-      // fired onExternalCancel. Re-check before walking, so we never run the
-      // compensations twice (that canceller owns them now).
-      if (externallyCancelled) {
+      // Hold the per-run cancel lock while we compensate, so a concurrent
+      // `zuke cancel` can't settle the run (declaring "no compensations") over
+      // our live cleanup. We only reach here with `externallyCancelled` false
+      // (the true case stopped above), so always attempt the acquire; a `null`
+      // result means another process already holds the lock and owns the walk —
+      // we stop and drain (F7).
+      const cancelLock = await writer.acquireCancelLock(actor);
+      if (cancelLock === null) {
         await writer.drain();
         reporter.info(
           `Run ${runId} cancelled by another process — stopping.`,
         );
       } else {
-        // Announce the intermediate `cancelling` transition (the record was just
-        // moved there) before compensations run, so a plugin sees the full
-        // running → cancelling → cancelled sequence.
-        await life.runStateChange(writer.snapshot());
-        // Run the succeeded targets' compensations in reverse order, record the
-        // cancellation in the audit trail (as `zuke cancel` does), then settle.
-        const comp = await runCompensations(order, writer.snapshot(), {
-          runId,
-          signals: env.signals,
-          reporter,
-          redactor,
-        });
-        const at = nowIso();
-        for (const event of compensationEvents(comp.attempts, actor, at)) {
-          await writer.appendEvent(event);
+        try {
+          // We initiated it (Ctrl-C / options.signal): mark cancelling (which
+          // also drains every pending per-target write, so the snapshot is
+          // current).
+          await writer.markRunCancelling();
+          // markRunCancelling drains the write chain, so if another process's
+          // `zuke cancel` won the race in the meantime, the conflict has already
+          // fired onExternalCancel. Re-check before walking, so we never run the
+          // compensations twice (that canceller owns them now).
+          if (externallyCancelled) {
+            await writer.drain();
+            reporter.info(
+              `Run ${runId} cancelled by another process — stopping.`,
+            );
+          } else {
+            // Announce the intermediate `cancelling` transition (the record was
+            // just moved there) before compensations run, so a plugin sees the
+            // full running → cancelling → cancelled sequence.
+            await life.runStateChange(writer.snapshot());
+            // Run the succeeded targets' compensations in reverse order, record
+            // the cancellation in the audit trail (as `zuke cancel` does), then
+            // settle.
+            const comp = await runCompensations(order, writer.snapshot(), {
+              runId,
+              signals: env.signals,
+              reporter,
+              redactor,
+            });
+            const at = nowIso();
+            for (const event of compensationEvents(comp.attempts, actor, at)) {
+              await writer.appendEvent(event);
+            }
+            await writer.appendEvent(cancelEvent(actor, comp, at));
+            await writer.markRunCancelled();
+            reporter.info(
+              `Run ${runId} cancelled — ${comp.compensated.length} ` +
+                `compensation(s) ran${
+                  comp.failures.length > 0
+                    ? `, ${comp.failures.length} failed`
+                    : ""
+                }.`,
+            );
+          }
+        } finally {
+          await cancelLock?.release();
         }
-        await writer.appendEvent(cancelEvent(actor, comp, at));
-        await writer.markRunCancelled();
-        reporter.info(
-          `Run ${runId} cancelled — ${comp.compensated.length} ` +
-            `compensation(s) ran${
-              comp.failures.length > 0 ? `, ${comp.failures.length} failed` : ""
-            }.`,
-        );
       }
     }
   } else {

--- a/packages/core/src/graph.ts
+++ b/packages/core/src/graph.ts
@@ -25,6 +25,21 @@ function label(t: TargetBuilder | undefined): string {
 }
 
 /**
+ * The friendly error for a `this.x` reference to a target declared *after* the
+ * referrer: class fields initialise top-to-bottom, so the reference read
+ * `undefined`. Shared by {@link validateReferences} (the CLI pre-check) and
+ * {@link executionSet} (the backstop every programmatic entry point hits).
+ */
+function undefinedRefError(name: string, verb: string): GraphError {
+  return new GraphError(
+    `Target "${name}" ${verb} an undefined target. This usually means it ` +
+      `references a sibling via this.x that is declared *after* it — ` +
+      `class fields initialise top-to-bottom, so referenced targets must ` +
+      `be declared before the targets that reference them.`,
+  );
+}
+
+/**
  * Validate that every `.dependsOn(...)` reference is a discovered target.
  *
  * A reference is "unknown" if the builder was never assigned to a property of
@@ -42,14 +57,7 @@ export function validateReferences(
     verb: string,
   ) => {
     for (const ref of refs) {
-      if (ref === undefined) {
-        throw new GraphError(
-          `Target "${name}" ${verb} an undefined target. This usually means it ` +
-            `references a sibling via this.x that is declared *after* it — ` +
-            `class fields initialise top-to-bottom, so referenced targets must ` +
-            `be declared before the targets that reference them.`,
-        );
-      }
+      if (ref === undefined) throw undefinedRefError(name, verb);
       if (!known.has(ref)) {
         throw new GraphError(
           `Target "${name}" ${verb} a target that was not discovered ` +
@@ -129,13 +137,24 @@ export function validateGraph(targets: Map<string, TargetBuilder>): void {
  */
 export function executionSet(root: TargetBuilder): Set<TargetBuilder> {
   const set = new Set<TargetBuilder>();
-  const walk = (node: TargetBuilder) => {
+  // Guard against a forward reference (a `this.x` to a target declared below,
+  // so the array holds `undefined`). Walking into it would throw a raw
+  // `TypeError`; instead every entry point that plans a graph — execute(),
+  // resumeRun(), cancelRun(), the CLI — surfaces the friendly `GraphError`
+  // here. On the CLI path `validateReferences` already caught it, so the guard
+  // is a no-op there (F10).
+  const walk = (
+    node: TargetBuilder | undefined,
+    from: TargetBuilder | undefined,
+    verb: string,
+  ) => {
+    if (node === undefined) throw undefinedRefError(label(from), verb);
     if (set.has(node)) return;
     set.add(node);
-    for (const dep of node.dependsOn_) walk(dep);
-    for (const trigger of node.triggers_) walk(trigger);
+    for (const dep of node.dependsOn_) walk(dep, node, "depends on");
+    for (const trigger of node.triggers_) walk(trigger, node, "triggers");
   };
-  walk(root);
+  walk(root, undefined, "depends on");
   return set;
 }
 

--- a/packages/core/src/state/cancel_lock.ts
+++ b/packages/core/src/state/cancel_lock.ts
@@ -1,0 +1,69 @@
+/**
+ * The per-run cancellation lock. Exactly one process may drive a run's
+ * compensation walk at a time — an in-process executor handling Ctrl-C/SIGTERM,
+ * or an out-of-process `zuke cancel`. Holding this lock while compensating stops
+ * a second canceller from settling the run `cancelled` (declaring "no
+ * compensations") over a still-running cleanup; and its TTL lets a *crashed*
+ * holder's lock lapse, so a later canceller can safely recover the stranded
+ * `cancelling` record.
+ *
+ * @module
+ */
+
+import { lockKey } from "./lock.ts";
+import type { StateStore } from "./store.ts";
+
+/**
+ * How long a cancel lock lives before a crashed holder's grip lapses. The
+ * holder renews at half this interval, so a live canceller keeps the lock
+ * indefinitely while a dead one becomes reclaimable within the TTL.
+ */
+export const CANCEL_LOCK_TTL_MS = 30_000;
+
+/** A held cancellation lock; call {@link CancelLock.release} when the walk ends. */
+export interface CancelLock {
+  /** Stop the renewal heartbeat and release the lock (best-effort). */
+  release(): Promise<void>;
+}
+
+/**
+ * Try to acquire the cancellation lock for `runId`. Returns the held lock, or
+ * `null` when another live canceller holds it (a crashed holder's lock lapses
+ * via `ttlMs`, so a later caller reclaims it). While held, the lock renews on a
+ * background, unref'd heartbeat until {@link CancelLock.release}. `ttlMs`
+ * defaults to {@link CANCEL_LOCK_TTL_MS}; a shorter value is for tests that need
+ * the heartbeat to fire quickly.
+ */
+export async function acquireCancelLock(
+  store: StateStore,
+  runId: string,
+  actor: string,
+  now: () => string,
+  ttlMs: number = CANCEL_LOCK_TTL_MS,
+): Promise<CancelLock | null> {
+  const key = lockKey("zuke-cancel", runId);
+  const result = await store.acquireLock(
+    key,
+    { actor, runId, since: now() },
+    ttlMs,
+  );
+  if (!result.ok) return null;
+  const token = result.token;
+  // Renew at half the TTL so a long compensation walk keeps its lock. The timer
+  // is unref'd so it never keeps the process alive, and renewal is best-effort:
+  // a dropped renew just lets the lock lapse at its TTL (the documented
+  // backstop) rather than crashing on an unhandled rejection from a background
+  // timer.
+  const heartbeat = setInterval(() => {
+    store.renewLock(key, token, ttlMs).catch(() => {});
+  }, Math.max(1000, Math.floor(ttlMs / 2)));
+  Deno.unrefTimer(heartbeat);
+  return {
+    release: async () => {
+      clearInterval(heartbeat);
+      // Best-effort release for the same reason: a failed release must not turn
+      // a completed cancellation into a failure. The TTL reclaims the lock.
+      await store.releaseLock(key, token).catch(() => {});
+    },
+  };
+}

--- a/packages/core/src/state/writer.ts
+++ b/packages/core/src/state/writer.ts
@@ -26,6 +26,7 @@ import type {
   WaitState,
 } from "./types.ts";
 import { recordStatusOf } from "./record.ts";
+import { acquireCancelLock, type CancelLock } from "./cancel_lock.ts";
 
 /** Extract a message from an unknown thrown value without casting. */
 function messageOf(value: unknown): string {
@@ -233,6 +234,16 @@ export class RunStateWriter {
   }
 
   /**
+   * Try to hold this run's per-run cancellation lock (see
+   * {@link "./cancel_lock.ts".acquireCancelLock}) so the executor's in-process
+   * compensation walk and an out-of-process `zuke cancel` cannot both drive it.
+   * Returns the held lock, or `null` if another live canceller holds it.
+   */
+  acquireCancelLock(actor: string): Promise<CancelLock | null> {
+    return acquireCancelLock(this.#store, this.#record.id, actor, this.#now);
+  }
+
+  /**
    * Append an {@link RunEvent} to the run's audit trail (the MCP tool-call log).
    * Its `args` values and `detail` are run through the redactor first, so a
    * secret that reached a tool argument is masked before it is persisted.
@@ -302,10 +313,22 @@ export class RunStateWriter {
           this.#version = result.version;
           return;
         }
-        // Another writer moved the record on: re-read and re-apply the mutator.
+        // Another writer moved the record on: re-read a FRESH base and re-apply
+        // the mutator to it on the next iteration. If the run has vanished
+        // (deleted/pruned mid-write) there is no clean base to CAS onto — and
+        // the in-memory record already carries this mutation, so re-running the
+        // mutator on it would double-apply (e.g. push an audit event twice).
+        // Drop this best-effort write instead (F12).
         const fresh = await this.#store.getRun(this.#record.id);
-        this.#record = fresh?.record ?? this.#record;
-        this.#version = fresh?.version ?? null;
+        if (fresh === null) {
+          this.#warn?.(
+            `state: run "${this.#record.id}" vanished from the store ` +
+              `mid-write; dropping one update`,
+          );
+          return;
+        }
+        this.#record = fresh.record;
+        this.#version = fresh.version;
         // The other writer may be a `zuke cancel` in another process. If it has
         // moved the run to cancelling/cancelled, re-apply our (target-level)
         // change onto its record — so a just-settled `succeeded` target isn't
@@ -314,9 +337,8 @@ export class RunStateWriter {
         // canceller's responsibility now. Best-effort (a conflict here is
         // harmless; the canceller owns finalisation).
         if (
-          fresh !== null &&
-          (fresh.record.status === "cancelling" ||
-            fresh.record.status === "cancelled")
+          fresh.record.status === "cancelling" ||
+          fresh.record.status === "cancelled"
         ) {
           const cancelStatus = fresh.record.status;
           mutator(this.#record);

--- a/packages/core/tests/cancel_test.ts
+++ b/packages/core/tests/cancel_test.ts
@@ -12,6 +12,7 @@ import { resumeRun } from "../src/resume.ts";
 import type { OrderingEdge } from "../src/graph.ts";
 import { FileSystemStateStore } from "../src/state/fs_store.ts";
 import { defaultStateHost, type StateStore } from "../src/state/store.ts";
+import { lockKey } from "../src/state/lock.ts";
 import type { RunRecord } from "../src/state/types.ts";
 import type { Reporter } from "../src/executor.ts";
 import { externalSignal } from "../src/wait.ts";
@@ -1069,3 +1070,182 @@ async function forceCancelling(
   }
   throw new Error(`could not move run ${runId} to cancelling`);
 }
+
+/** Poll until `ready()` or the bound elapses (keeps a wedged test from hanging). */
+async function until(ready: () => boolean): Promise<void> {
+  for (let i = 0; !ready() && i < 400; i++) {
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+Deno.test("a second cancelRun is a no-op while the first holds the cancel lock", async () => {
+  await withTempStore(async (store) => {
+    let release!: () => void;
+    const blocked = new Promise<void>((r) => {
+      release = r;
+    });
+    const undone: string[] = [];
+    const makeBuild = (blocking: boolean) => {
+      class B extends Build {
+        deploy = target().executes(() => {}).onCancel(() => this.rollback);
+        rollback = target().executes(async () => {
+          undone.push("deploy");
+          if (blocking) await blocked; // hold the cancel lock mid-walk
+        });
+        gate = target()
+          .dependsOn(this.deploy)
+          .waitsFor((s) => s.on(externalSignal("x")));
+      }
+      const b = new B();
+      discoverTargets(b);
+      return b;
+    };
+    const a = makeBuild(true);
+    await execute(a, a.gate, { silent: true, stateStore: store });
+    const id = (await store.listRuns({}))[0].id;
+
+    // Canceller A starts and blocks mid-compensation, holding the cancel lock.
+    const first = cancelRun(makeBuild(true), {
+      runId: id,
+      stateStore: store,
+      silent: true,
+      actor: "a",
+    });
+    await until(() => undone.length > 0);
+
+    // Canceller B arrives while A holds the lock → friendly no-op, no walk, no
+    // premature settlement (F7).
+    const second = await cancelRun(makeBuild(false), {
+      runId: id,
+      stateStore: store,
+      silent: true,
+      actor: "b",
+    });
+    assertEquals(second.noop, true);
+    assertEquals(second.status, "cancelling");
+    assertEquals((await store.getRun(id))?.record.status, "cancelling");
+
+    // Release A; it settles the run, having compensated exactly once.
+    release();
+    const firstResult = await first;
+    assertEquals(firstResult.noop, false);
+    assertEquals(firstResult.status, "cancelled");
+    assertEquals(undone, ["deploy"]);
+    assertEquals((await store.getRun(id))?.record.status, "cancelled");
+  });
+});
+
+Deno.test("a concurrent cancelRun is a no-op while the executor compensates in-process", async () => {
+  await withTempStore(async (store) => {
+    let release!: () => void;
+    const blocked = new Promise<void>((r) => {
+      release = r;
+    });
+    let workStarted!: () => void;
+    const workRunning = new Promise<void>((r) => {
+      workStarted = r;
+    });
+    const undone: string[] = [];
+    const controller = new AbortController();
+    class B extends Build {
+      deploy = target().executes(() => {}).onCancel(() => this.rollback);
+      rollback = target().executes(async () => {
+        undone.push("deploy");
+        await blocked; // hold the executor's cancel lock mid-walk
+      });
+      work = target()
+        .dependsOn(this.deploy)
+        .executes((ctx) => {
+          workStarted();
+          return new Promise<void>((resolve) => {
+            ctx.signal.addEventListener("abort", () => resolve(), {
+              once: true,
+            });
+          });
+        });
+    }
+    const b = new B();
+    discoverTargets(b);
+
+    // Start the run; once `work` is running, abort to trigger the executor's own
+    // in-process compensation (which holds the cancel lock while rolling back).
+    const runP = execute(b, b.work, {
+      silent: true,
+      stateStore: store,
+      signal: controller.signal,
+    });
+    await workRunning;
+    controller.abort();
+    await until(() => undone.length > 0);
+
+    // A `zuke cancel` racing the live in-process compensation is a no-op — it
+    // must not settle the run (declaring "no compensations") over the walk (F7).
+    const b2 = new B();
+    discoverTargets(b2);
+    const id = (await store.listRuns({}))[0].id;
+    const other = await cancelRun(b2, {
+      runId: id,
+      stateStore: store,
+      silent: true,
+      actor: "ops",
+    });
+    assertEquals(other.noop, true);
+    assertEquals((await store.getRun(id))?.record.status, "cancelling");
+
+    // Release the executor's compensation; it settles the run once.
+    release();
+    const runResult = await runP;
+    assertEquals(runResult.cancelled, true);
+    assertEquals(undone, ["deploy"]); // compensation ran exactly once
+    assertEquals((await store.getRun(id))?.record.status, "cancelled");
+  });
+});
+
+Deno.test("the executor defers when another process already holds the cancel lock", async () => {
+  await withTempStore(async (store) => {
+    const undone: string[] = [];
+    let workStarted!: () => void;
+    const workRunning = new Promise<void>((r) => {
+      workStarted = r;
+    });
+    const controller = new AbortController();
+    class B extends Build {
+      deploy = target().executes(() => {}).onCancel(() => this.rollback);
+      rollback = target().executes(() => void undone.push("deploy"));
+      work = target()
+        .dependsOn(this.deploy)
+        .executes((ctx) => {
+          workStarted();
+          return new Promise<void>((resolve) => {
+            ctx.signal.addEventListener("abort", () => resolve(), {
+              once: true,
+            });
+          });
+        });
+    }
+    const b = new B();
+    discoverTargets(b);
+    const runP = execute(b, b.work, {
+      silent: true,
+      stateStore: store,
+      signal: controller.signal,
+    });
+    await workRunning;
+    // A separate process grabs the run's cancel lock first.
+    const id = (await store.listRuns({}))[0].id;
+    const held = await store.acquireLock(
+      lockKey("zuke-cancel", id),
+      { actor: "other", runId: id, since: new Date().toISOString() },
+      30_000,
+    );
+    if (!held.ok) throw new Error("expected to acquire the cancel lock");
+
+    // The executor self-cancels but cannot get the lock, so it defers to the
+    // holder: it drains and runs NO compensations (F7).
+    controller.abort();
+    const runResult = await runP;
+    assertEquals(runResult.cancelled, true);
+    assertEquals(undone, []); // the lock holder owns the compensation walk
+    await store.releaseLock(lockKey("zuke-cancel", id), held.token);
+  });
+});

--- a/packages/core/tests/executor_test.ts
+++ b/packages/core/tests/executor_test.ts
@@ -1,4 +1,10 @@
-import { assertEquals, assertStringIncludes, messageOf } from "./_assert.ts";
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+  messageOf,
+} from "./_assert.ts";
+import { GraphError } from "../src/graph.ts";
 import {
   Build,
   type BuildResult,
@@ -2467,4 +2473,103 @@ Deno.test("a throwing predicate on a lenient target does not halt its siblings",
   // the independent `sib` still runs (root stays blocked behind bad).
   assertEquals(result.ok, false);
   assertEquals(result.executed.includes("sib"), true);
+});
+
+// --- Cancellation stops retries and remediations (F6) ---
+
+Deno.test("a cancelled run stops retrying immediately", async () => {
+  let attempts = 0;
+  const controller = new AbortController();
+  class B extends Build {
+    doomed = target()
+      .retry(5, 1)
+      .executes(() => {
+        attempts++;
+        controller.abort(); // cancel synchronously mid-run
+        throw new Error("boom");
+      });
+  }
+  const b = new B();
+  discoverTargets(b);
+  const result = await execute(b, b.doomed, {
+    silent: true,
+    signal: controller.signal,
+  });
+  assertEquals(result.ok, false);
+  assertEquals(attempts, 1); // no further retries after the cancel (pre-fix: 6)
+});
+
+Deno.test("a cancelled run does not invoke recoverWith remediations", async () => {
+  let fixes = 0;
+  const controller = new AbortController();
+  class B extends Build {
+    doomed = target()
+      .recoverWith({
+        remediate: () => {
+          fixes++;
+          return { retry: true };
+        },
+      })
+      .recoverAttempts(3)
+      .executes(() => {
+        controller.abort();
+        throw new Error("boom");
+      });
+  }
+  const b = new B();
+  discoverTargets(b);
+  const result = await execute(b, b.doomed, {
+    silent: true,
+    signal: controller.signal,
+  });
+  assertEquals(result.ok, false);
+  assertEquals(fixes, 0); // remediations skipped on cancel (pre-fix: 3)
+});
+
+// --- Public API validates the graph, emitting GraphError not TypeError (F10) ---
+
+Deno.test("execute rejects a forward-referenced dependency with GraphError", async () => {
+  class B extends Build {
+    // @ts-expect-error -- deliberately forward-references a later field
+    early = target().dependsOn(this.later).executes(() => {});
+    later = target().executes(() => {});
+  }
+  const b = new B();
+  discoverTargets(b);
+  await assertRejects(
+    () => execute(b, b.early, silent),
+    GraphError,
+    "undefined target",
+  );
+});
+
+// --- A failed run strands no `waiting` target row (F8) ---
+
+Deno.test("a failed run leaves no waiting target stranded in the record", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    class B extends Build {
+      // Independent branches: one parks at a wait gate, the other fails.
+      gate = target().waitsFor((s) => s.on(externalSignal("go")));
+      boom = target().executes(() => {
+        throw new Error("boom");
+      });
+      all = target().dependsOn(this.gate, this.boom).executes(() => {});
+    }
+    const b = new B();
+    discoverTargets(b);
+    const result = await execute(b, b.all, { silent: true, stateStore: store });
+    assertEquals(result.ok, false); // failed, not suspended
+    const runId = (await store.listRuns({}))[0].id;
+    const loaded = await store.getRun(runId);
+    assertEquals(loaded?.record.status, "failed");
+    // No target row is left `waiting` in the terminal `failed` record (F8).
+    const statuses = Object.values(loaded?.record.targets ?? {}).map(
+      (t) => t.status,
+    );
+    assertEquals(statuses.includes("waiting"), false);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
 });

--- a/packages/core/tests/graph_test.ts
+++ b/packages/core/tests/graph_test.ts
@@ -313,3 +313,16 @@ Deno.test("resolveOrderingEdges merges extraEdges with an async orderWith", asyn
   assertEquals(order.indexOf("a") < order.indexOf("b"), true);
   assertEquals(order.indexOf("b") < order.indexOf("c"), true);
 });
+
+Deno.test("planGraph rejects a forward-referenced (undefined) dependency", () => {
+  class B extends Build {
+    // @ts-expect-error -- deliberately forward-references a later field
+    early = target().dependsOn(this.later).executes(() => {});
+    later = target().executes(() => {});
+  }
+  const b = new B();
+  discover(b);
+  // The friendly GraphError (not a raw TypeError) surfaces for every entry
+  // point that plans a graph, not just the CLI's `validateGraph` pre-check (F10).
+  assertThrows(() => planGraph(b.early), GraphError, "undefined target");
+});

--- a/packages/core/tests/state_test.ts
+++ b/packages/core/tests/state_test.ts
@@ -26,6 +26,7 @@ import {
   resolveActor,
 } from "../src/state/record.ts";
 import { inMemoryStateHandle, RunStateWriter } from "../src/state/writer.ts";
+import { acquireCancelLock } from "../src/state/cancel_lock.ts";
 import { Redactor } from "../src/redact.ts";
 import { LockSettings, target } from "../src/target.ts";
 import { externalSignal, resumeWhen } from "../src/wait.ts";
@@ -1122,4 +1123,60 @@ Deno.test("HttpStateStore locks: a 201 without a token is an error", async () =>
     Error,
     "did not return a token",
   );
+});
+
+Deno.test("RunStateWriter drops a write when the run vanishes after a conflict", async () => {
+  const store = new MemStore();
+  const warnings: string[] = [];
+  const writer = await RunStateWriter.open(
+    store,
+    sampleRecord(),
+    () => "t",
+    new Redactor(),
+    (m) => warnings.push(m),
+  );
+  // Simulate the run being deleted/pruned between the conflicting put and the
+  // re-read: the next put conflicts, and getRun then returns null. The mutator
+  // must NOT be re-applied to the already-mutated in-memory copy (which, pre-fix,
+  // re-ran it and a version-null create resurrected the run) (F12).
+  store.forceConflicts = 1;
+  store.record = null;
+  await writer.markRunFinished(true);
+  assertEquals(warnings.some((w) => w.includes("vanished")), true);
+  assertEquals(store.record, null); // vanished run is not resurrected
+});
+
+Deno.test("acquireCancelLock renews on a heartbeat and blocks a second holder", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    // A store that counts the heartbeat's renewals but still renews for real.
+    class CountingStore extends FileSystemStateStore {
+      renewCalls = 0;
+      override renewLock(
+        key: string,
+        token: string,
+        ttlMs: number,
+      ): Promise<boolean> {
+        this.renewCalls++;
+        return super.renewLock(key, token, ttlMs);
+      }
+    }
+    const store = new CountingStore(`${dir}/runs`, defaultStateHost);
+    const now = () => new Date().toISOString();
+    // A short TTL → a 1s renewal heartbeat that fires within the test.
+    const lock = await acquireCancelLock(store, "run-1", "a", now, 2000);
+    if (lock === null) throw new Error("expected to acquire the cancel lock");
+    // A second holder is blocked while the lock is held.
+    assertEquals(await acquireCancelLock(store, "run-1", "b", now, 2000), null);
+    // Outlive the 1s renewal interval so the heartbeat fires at least once.
+    await new Promise((r) => setTimeout(r, 1200));
+    assertEquals(store.renewCalls >= 1, true);
+    await lock.release();
+    // After release, a fresh holder can take it.
+    const next = await acquireCancelLock(store, "run-1", "c", now, 2000);
+    assertEquals(next !== null, true);
+    await next?.release();
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
 });


### PR DESCRIPTION
Remediation plan **PR 6** — five executor/cancel/state edge cases in `@zuke/core`. All internal; no public API change.

## Fixes

- **F6 — retries/remediations ignore cancellation.** On a cancelled run (Ctrl-C / SIGTERM / aborted signal), `runBody` kept retrying and `runBodyWithRecovery` still fired `recoverWith` remediations — including a **paid AI-fixer** the user had just cancelled. Both now stop the moment `ctx.signal.aborted` is true.
- **F7 — `cancelling` double-settle over a live cleanup.** A second `zuke cancel`, or one racing the in-process executor, could finalize a run `cancelled` with `EMPTY_OUTCOME` ("no compensations") while another process was mid-compensation. Introduced a **per-run cancel lock** (`state/cancel_lock.ts`) — a store lock with a heartbeat and a 30s TTL crash backstop, held by whoever drives the walk. `cancelRun` and the executor both acquire it before compensating; a contender is a friendly no-op. The `recover` path (settle a stranded `cancelling` record) now only runs **while holding the lock**, so no live canceller exists.
- **F8 — waiting target stranded in a failed record.** A run that both failed *and* parked at a `.waitsFor()` gate left the gate row `waiting` forever in a terminal `failed` record no resume sweep reaches. Waiting rows + blocked deps now settle `skipped`.
- **F10 — graph validation only on the CLI path.** A forward-referenced dependency crashed `execute()`/`resumeRun()`/`cancelRun()` with a raw `TypeError`. The shared planning walk (`executionSet`) now raises the friendly `GraphError` for every entry point.
- **F12 — non-idempotent CAS double-apply.** On a conflict where `getRun` returned `null` (run vanished/pruned), the writer re-applied the mutator to the already-mutated copy — double-pushing an audit event and resurrecting a deleted run. It now drops the best-effort write.
- **F11** — removed a stray `ponytail:` placeholder token from a cancel comment.

## Tests

New tests per fix, incl. the **cancel-vs-cancel** and **cancel-vs-live-body** races, the executor lock-loss deferral, the CAS-vanish drop, the forward-ref `GraphError`, and the cancel-lock heartbeat renewal.

## Adversarial review

Ran an attack→verify pass across concurrency/regression/coverage dimensions. **No correctness defects survived.** Two confirmed **test-coverage** findings were fixed: added the executor lock-loss test + made the cancel-lock TTL injectable to exercise the heartbeat; also removed a dead ternary arm the review flagged.

## Verification

- `deno task ci` green: fmt, lint, spell, type-check, coverage (**lines 98.3%, branches 95.3%**).
- `./zuke apiDocsCheck` and `generate-ci --check` green — no drift, no public API change.