### PR TITLE
fix(core): honour the ustar prefix field so long tar paths extract correctly

### DIFF
--- a/packages/core/src/compression.ts
+++ b/packages/core/src/compression.ts
@@ -224,13 +224,36 @@ function isZeroBlock(archive: Uint8Array, offset: number): boolean {
   return true;
 }
 
+/**
+ * The full path of the `ustar` header at `offset`. A path longer than the
+ * 100-byte `name` field is stored by POSIX tar **split** across a 155-byte
+ * `prefix` field (bytes 345-499); the real path is `prefix + "/" + name`.
+ * Reading only `name` — as this reader once did — truncated long paths to their
+ * trailing components, scattering e.g. the deeply-nested files in Node's release
+ * tarball (npm's bundled deps) so `npm` could not resolve them. The prefix is
+ * honoured only for the POSIX `ustar\0` magic at byte 257; the older GNU format
+ * reuses that byte region for other fields (and encodes long names via
+ * `@LongLink` pseudo-entries instead), so `readString` there yields `"ustar "`
+ * (trailing space), not `"ustar"`, and the prefix is skipped.
+ *
+ * ponytail: GNU `@LongLink` (typeflag `'L'`) long names are not reconstructed —
+ * the release tarballs Zuke provisions use the ustar prefix split; add LongLink
+ * handling if a consumed archive ever needs it.
+ */
+function entryName(archive: Uint8Array, offset: number): string {
+  const name = readString(archive, offset, 100);
+  if (readString(archive, offset + 257, 6) !== "ustar") return name;
+  const prefix = readString(archive, offset + 345, 155);
+  return prefix === "" ? name : `${prefix}/${name}`;
+}
+
 /** Extract the entries from a `ustar` archive (regular files only). */
 export function untar(archive: Uint8Array): TarEntry[] {
   const entries: TarEntry[] = [];
   let offset = 0;
   while (offset + BLOCK <= archive.length) {
     if (isZeroBlock(archive, offset)) break;
-    const name = readString(archive, offset, 100);
+    const name = entryName(archive, offset);
     // Read the full 12-byte size field; the trailing byte is a NUL terminator.
     const size = readOctal(archive, offset + 124, 12);
     const typeflag = archive[offset + 156];

--- a/packages/core/tests/compression_test.ts
+++ b/packages/core/tests/compression_test.ts
@@ -66,6 +66,92 @@ Deno.test("untar stops at the zero-block trailer and ignores non-files", () => {
   assertEquals(out[0].name, "only.txt");
 });
 
+/**
+ * Build a raw `ustar` archive by hand, splitting long paths across the `prefix`
+ * (bytes 345-499) and `name` (bytes 0-99) fields the way POSIX tar does — the
+ * production `tar()` writer refuses names over 100 bytes, so a long-path archive
+ * (e.g. Node's release tarball) can only be synthesised directly.
+ */
+function ustarArchive(
+  entries: { name: string; prefix: string; data: Uint8Array; magic?: string }[],
+): Uint8Array {
+  const blocks: Uint8Array[] = [];
+  for (const e of entries) {
+    const header = new Uint8Array(512);
+    const put = (offset: number, s: string) =>
+      header.set(new TextEncoder().encode(s), offset);
+    put(0, e.name);
+    put(124, e.data.length.toString(8).padStart(11, "0")); // size, octal
+    header[156] = 0x30; // typeflag '0' — regular file
+    put(257, e.magic ?? "ustar\0"); // POSIX magic (a trailing space → non-ustar)
+    put(263, "00"); // version
+    put(345, e.prefix);
+    blocks.push(header);
+    const body = new Uint8Array(Math.ceil(e.data.length / 512) * 512);
+    body.set(e.data);
+    blocks.push(body);
+  }
+  blocks.push(new Uint8Array(512)); // zero-block trailer
+  const total = blocks.reduce((n, b) => n + b.length, 0);
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const b of blocks) {
+    out.set(b, off);
+    off += b.length;
+  }
+  return out;
+}
+
+Deno.test("untar reconstructs a long path from the ustar prefix field", () => {
+  // A >100-byte path POSIX tar split across prefix + name (as Node's tarball
+  // does for npm's deeply-nested bundled deps).
+  const prefix =
+    "lib/node_modules/npm/node_modules/@npmcli/config/lib/definitions";
+  const out = untar(ustarArchive([
+    { name: "definitions.js", prefix, data: enc("module.exports = {};") },
+    // A short path with the ustar magic but an empty prefix stays unchanged.
+    { name: "short.txt", prefix: "", data: enc("no prefix") },
+  ]));
+  assertEquals(out.map((e) => e.name), [
+    `${prefix}/definitions.js`,
+    "short.txt",
+  ]);
+  assertEquals(dec(out[0].data), "module.exports = {};");
+  assertEquals(dec(out[1].data), "no prefix");
+});
+
+Deno.test("untar ignores the prefix field for a non-ustar (GNU) header", () => {
+  // GNU tar writes "ustar " (trailing space) and reuses the byte-345 region for
+  // other fields, so the prefix must not be treated as a path there.
+  const out = untar(ustarArchive([
+    { name: "short.js", prefix: "not/a/path", data: enc("x"), magic: "ustar " },
+  ]));
+  assertEquals(out.length, 1);
+  assertEquals(out[0].name, "short.js"); // prefix not prepended
+});
+
+Deno.test("extractTarGzip lands a >100-byte prefixed path at its full location", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const prefix =
+      "lib/node_modules/npm/node_modules/@npmcli/config/lib/definitions";
+    const raw = ustarArchive([
+      { name: "definitions.js", prefix, data: enc("ok") },
+    ]);
+    const archive = `${dir}/node.tar.gz`;
+    await Deno.writeFile(archive, await gzip(raw));
+    const outDir = `${dir}/out`;
+    await extractTarGzip(archive, outDir);
+    // The file lands at its full nested path, not truncated under the root.
+    assertEquals(
+      await Deno.readTextFile(`${outDir}/${prefix}/definitions.js`),
+      "ok",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
 Deno.test("createTarGzip then extractTarGzip round-trips files on disk", async () => {
   const dir = await Deno.makeTempDir();
   try {


### PR DESCRIPTION
Remediation plan **PR 0** (found in the field, jumped the queue — it breaks a shipped feature end-to-end).

## The bug

With system Node removed from `PATH` (a real CI scenario), the toolchain provisions Node fine, but `npm ci` then fails with `Cannot find module './definitions.js'`. Root cause is in `@zuke/core`'s tar reader, not the build.

`untar` (`packages/core/src/compression.ts`) read only the **100-byte `name`** field and ignored the **155-byte `prefix`** field at byte offset 345. POSIX tar splits any path longer than 100 bytes across `prefix` + `name` (real path = prefix joined to name). Node's release tarball does this for npm's deeply-nested bundled deps, e.g. `…/lib/node_modules/npm/node_modules/@npmcli/config/lib/definitions/definitions.js` (106 bytes). Ignoring the prefix truncated the path, so **227 files landed under `.zuke/tools/node/node_modules/**`** instead of `…/lib/node_modules/npm/node_modules/**` — npm's bundled modules scattered and it couldn't resolve them. Short paths always worked; only long ones broke.

## The fix

`untar` now reconstructs the full path from the `prefix` field, gated on the POSIX `ustar\0` magic at byte 257 so the older GNU format (which reuses that byte region and encodes long names via `@LongLink`) is not misread. This is a **read-path-only** change — the writer already rejects names over 100 bytes, so Zuke never emits split paths itself. GNU `@LongLink` long names remain out of scope (noted as a ceiling; the tarballs Zuke provisions use the ustar prefix split).

## Tests

New unit + gzip round-trip tests: prefix reconstruction of a >100-byte path, the empty-prefix and non-ustar (GNU) branches, and a full `extractTarGzip` extraction landing a long nested path at its correct on-disk location.

## Verification

- `deno task ci` green: fmt, lint, spell, type-check, coverage (**lines 98.3%, branches 95.3%**).
- `./zuke apiDocsCheck` green — internal function, no public API change.
- **Adversarial review** (security / correctness / tests → verify): **0 findings**. Zip-slip is still caught — the reconstructed `prefix/name` path flows through the existing `assertSafeEntryName` guard, which rejects `..`/absolute paths.