### PR TITLE
fix: align kubectl/jest/git wrapper argv with the real CLIs

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -100,6 +100,7 @@
     "oxlint",
     "oxlintrc",
     "pagelen",
+    "pathspec",
     "pathspecs",
     "patriksvensson",
     "pedantic",

--- a/packages/git/src/git.ts
+++ b/packages/git/src/git.ts
@@ -167,7 +167,9 @@ export class GitAddSettings extends GitSettings {
     const argv = ["add"];
     if (this.#all) argv.push("--all");
     if (this.#update) argv.push("--update");
-    argv.push(...this.#paths);
+    // `--` so a pathspec beginning with `-` (e.g. `-weird.txt`) is treated as a
+    // path, not parsed by git as a flag. `add` positionals are always pathspecs.
+    if (this.#paths.length > 0) argv.push("--", ...this.#paths);
     return argv;
   }
 }

--- a/packages/git/tests/git_test.ts
+++ b/packages/git/tests/git_test.ts
@@ -63,6 +63,7 @@ Deno.test("add and commit render their options", () => {
     "git",
     "add",
     "--all",
+    "--",
     "src",
     "mod.ts",
   ]);
@@ -70,6 +71,13 @@ Deno.test("add and commit render their options", () => {
     "git",
     "add",
     "--update",
+  ]);
+  // A pathspec beginning with `-` goes after `--`, not parsed by git as a flag.
+  assertEquals(new GitAddSettings().paths("-weird.txt").argv(), [
+    "git",
+    "add",
+    "--",
+    "-weird.txt",
   ]);
   assertEquals(
     new GitCommitSettings().all().amend().noEdit().allowEmpty()

--- a/packages/jest/src/jest.ts
+++ b/packages/jest/src/jest.ts
@@ -152,7 +152,7 @@ export class JestSettings extends ToolSettings {
 
   /** Use the named reporters (`--reporters`); repeatable. */
   reporters(...names: string[]): this {
-    for (const name of names) this.#reporters.push("--reporters", name);
+    this.#reporters.push(...names);
     return this;
   }
 
@@ -177,10 +177,11 @@ export class JestSettings extends ToolSettings {
     if (this.#onlyChanged) argv.push("-o");
     if (this.#passWithNoTests) argv.push("--passWithNoTests");
     if (this.#detectOpenHandles) argv.push("--detectOpenHandles");
-    if (this.#selectProjects.length > 0) {
-      argv.push("--selectProjects", ...this.#selectProjects);
-    }
-    argv.push(...this.#reporters);
+    // Array flags use `--flag=value` form so jest's yargs parser binds exactly
+    // one value per flag; the space-separated form is greedy and swallows the
+    // trailing positional test-path patterns into the array instead.
+    for (const p of this.#selectProjects) argv.push(`--selectProjects=${p}`);
+    for (const r of this.#reporters) argv.push(`--reporters=${r}`);
     argv.push(...this.#patterns);
     return argv;
   }

--- a/packages/jest/tests/jest_test.ts
+++ b/packages/jest/tests/jest_test.ts
@@ -34,16 +34,27 @@ Deno.test("jest: every option renders, patterns last", () => {
     "-o",
     "--passWithNoTests",
     "--detectOpenHandles",
-    "--selectProjects",
-    "web",
-    "api",
-    "--reporters",
-    "default",
-    "--reporters",
-    "jest-junit",
+    "--selectProjects=web",
+    "--selectProjects=api",
+    "--reporters=default",
+    "--reporters=jest-junit",
     "src/",
     "test/",
   ]);
+});
+
+Deno.test("jest: array flags use = form so positional patterns survive", () => {
+  // Space-separated array flags let jest's yargs parser greedily swallow the
+  // trailing `src/` into --reporters; the `=` form binds one value per flag so
+  // the positional test-path pattern survives.
+  assertEquals(
+    new JestSettings().reporters("default", "jest-junit").paths("src/").argv(),
+    ["jest", "--reporters=default", "--reporters=jest-junit", "src/"],
+  );
+  assertEquals(
+    new JestSettings().selectProjects("web", "api").paths("test/").argv(),
+    ["jest", "--selectProjects=web", "--selectProjects=api", "test/"],
+  );
 });
 
 Deno.test("jest: bail defaults to one suite", () => {

--- a/packages/kubectl/src/kubectl.ts
+++ b/packages/kubectl/src/kubectl.ts
@@ -144,6 +144,18 @@ export class KubectlApplySettings extends KubectlSettings {
         "KubectlTasks.apply: .file() or .kustomize() is required.",
       );
     }
+    // kubectl apply accepts EITHER -f or -k, never both.
+    if (this.#files.length > 0 && this.#kustomize !== undefined) {
+      throw new Error(
+        "KubectlTasks.apply: .file() and .kustomize() are mutually exclusive.",
+      );
+    }
+    // -k also rejects -R: kubectl errors "the -k flag can't be used with -f or -R".
+    if (this.#kustomize !== undefined && this.#recursive) {
+      throw new Error(
+        "KubectlTasks.apply: .kustomize() cannot be combined with .recursive().",
+      );
+    }
     const argv = ["apply", ...this.globalArgs()];
     for (const f of this.#files) argv.push("-f", f);
     if (this.#kustomize !== undefined) argv.push("-k", this.#kustomize);
@@ -378,9 +390,11 @@ export class KubectlDescribeSettings extends KubectlSettings {
   }
 
   protected override buildArgs(): string[] {
-    if (this.#resources.length === 0 && this.#selector === undefined) {
+    // kubectl describe needs a resource type even with a selector; a bare
+    // `describe -l ...` is rejected ("You must specify the type of resource").
+    if (this.#resources.length === 0) {
       throw new Error(
-        "KubectlTasks.describe: specify .resource(...) or .selector().",
+        "KubectlTasks.describe: specify a resource type with .resource(...).",
       );
     }
     const argv = ["describe", ...this.globalArgs(), ...this.#resources];
@@ -458,6 +472,12 @@ export class KubectlLogsSettings extends KubectlSettings {
   protected override buildArgs(): string[] {
     if (this.#resource === undefined && this.#selector === undefined) {
       throw new Error("KubectlTasks.logs: specify .resource() or .selector().");
+    }
+    // kubectl logs takes a pod name OR a selector, never both.
+    if (this.#resource !== undefined && this.#selector !== undefined) {
+      throw new Error(
+        "KubectlTasks.logs: .resource() and .selector() are mutually exclusive.",
+      );
     }
     const argv = ["logs", ...this.globalArgs()];
     if (this.#resource !== undefined) argv.push(this.#resource);
@@ -764,12 +784,11 @@ export class KubectlAnnotateSettings extends KubectlSettings {
   }
 
   protected override buildArgs(): string[] {
-    if (
-      this.#resources.length === 0 && this.#selector === undefined &&
-      !this.#all
-    ) {
+    // kubectl annotate always needs a resource type; `.all()`/`.selector()`
+    // are modifiers on top of it, not substitutes for it.
+    if (this.#resources.length === 0) {
       throw new Error(
-        "KubectlTasks.annotate: a target is required — .resource(...), .selector(), or .all().",
+        "KubectlTasks.annotate: a resource type is required — .resource(...).",
       );
     }
     if (this.#annotations.length === 0 && this.#removals.length === 0) {
@@ -837,12 +856,11 @@ export class KubectlLabelSettings extends KubectlSettings {
   }
 
   protected override buildArgs(): string[] {
-    if (
-      this.#resources.length === 0 && this.#selector === undefined &&
-      !this.#all
-    ) {
+    // kubectl label always needs a resource type; `.all()`/`.selector()` are
+    // modifiers on top of it, not substitutes for it.
+    if (this.#resources.length === 0) {
       throw new Error(
-        "KubectlTasks.label: a target is required — .resource(...), .selector(), or .all().",
+        "KubectlTasks.label: a resource type is required — .resource(...).",
       );
     }
     if (this.#labels.length === 0 && this.#removals.length === 0) {
@@ -1055,6 +1073,18 @@ export class KubectlTopSettings extends KubectlSettings {
   protected override buildArgs(): string[] {
     if (this.#kind === undefined) {
       throw new Error("KubectlTasks.top: choose .pods() or .nodes().");
+    }
+    // `--containers` and `-A`/`--all-namespaces` are `top pod`-only; kubectl
+    // rejects them on `top node` ("unknown flag"). `-l`/selector stays valid.
+    if (this.#containers && this.#kind !== "pods") {
+      throw new Error(
+        "KubectlTasks.top: .containers() is only valid with .pods().",
+      );
+    }
+    if (this.#allNamespaces && this.#kind !== "pods") {
+      throw new Error(
+        "KubectlTasks.top: .allNamespaces() is only valid with .pods().",
+      );
     }
     const argv = ["top", this.#kind, ...this.globalArgs()];
     if (this.#name !== undefined) argv.push(this.#name);

--- a/packages/kubectl/tests/kubectl_test.ts
+++ b/packages/kubectl/tests/kubectl_test.ts
@@ -59,16 +59,34 @@ Deno.test("apply: requires file or kustomize; all options", () => {
     Error,
     "KubectlTasks.apply: .file() or .kustomize() is required",
   );
+  // -f and -k are mutually exclusive (kubectl rejects both together).
+  assertThrows(
+    () =>
+      new KubectlApplySettings().file("a.yaml").kustomize("overlays/prod")
+        .argv(),
+    Error,
+    "mutually exclusive",
+  );
+  // -k also rejects -R (recursive).
+  assertThrows(
+    () =>
+      new KubectlApplySettings().kustomize("overlays/prod").recursive().argv(),
+    Error,
+    "cannot be combined with .recursive()",
+  );
   assertEquals(new KubectlApplySettings().file("a.yaml").argv().slice(1), [
     "apply",
     "-f",
     "a.yaml",
   ]);
   assertEquals(
+    new KubectlApplySettings().kustomize("overlays/prod").argv().slice(1),
+    ["apply", "-k", "overlays/prod"],
+  );
+  assertEquals(
     new KubectlApplySettings()
       .file("a.yaml")
       .file("b.yaml")
-      .kustomize("overlays/prod")
       .recursive()
       .prune()
       .serverSide()
@@ -83,8 +101,6 @@ Deno.test("apply: requires file or kustomize; all options", () => {
       "a.yaml",
       "-f",
       "b.yaml",
-      "-k",
-      "overlays/prod",
       "-R",
       "--prune",
       "--server-side",
@@ -342,19 +358,26 @@ Deno.test("KubectlGetSettings.watch(false) disables an earlier watch", () => {
   );
 });
 
-Deno.test("describe: requires resource or selector; both forms", () => {
+Deno.test("describe: requires a resource type; selector is a filter", () => {
   assertThrows(
     () => new KubectlDescribeSettings().argv(),
     Error,
-    "KubectlTasks.describe: specify .resource(...) or .selector()",
+    "specify a resource type",
+  );
+  // A bare selector with no resource type is rejected by kubectl.
+  assertThrows(
+    () => new KubectlDescribeSettings().selector("app=api").argv(),
+    Error,
+    "specify a resource type",
   );
   assertEquals(
     new KubectlDescribeSettings().resource("deployment/api").argv().slice(1),
     ["describe", "deployment/api"],
   );
   assertEquals(
-    new KubectlDescribeSettings().selector("app=api").argv().slice(1),
-    ["describe", "-l", "app=api"],
+    new KubectlDescribeSettings().resource("pods").selector("app=api").argv()
+      .slice(1),
+    ["describe", "pods", "-l", "app=api"],
   );
 });
 
@@ -393,6 +416,13 @@ Deno.test("logs: requires resource or selector; all options", () => {
   assertEquals(
     new KubectlLogsSettings().selector("app=api").argv().slice(1),
     ["logs", "-l", "app=api"],
+  );
+  // A pod name and a selector are mutually exclusive.
+  assertThrows(
+    () =>
+      new KubectlLogsSettings().resource("web-0").selector("app=api").argv(),
+    Error,
+    "mutually exclusive",
   );
 });
 
@@ -621,14 +651,26 @@ Deno.test("annotate and label honour the shared cluster flags", () => {
   );
 });
 
-Deno.test("annotate and label require both a target and a payload", () => {
-  // A payload but no target.
+Deno.test("annotate and label require a resource type and a payload", () => {
+  // A payload but no resource type — a bare selector or --all is not enough.
   assertThrows(
     () => new KubectlAnnotateSettings().annotation("a", "b").argv(),
     Error,
-    "a target is required",
+    "a resource type is required",
   );
-  // A target but no annotation/removal.
+  assertThrows(
+    () =>
+      new KubectlAnnotateSettings().selector("app=web").annotation("a", "b")
+        .argv(),
+    Error,
+    "a resource type is required",
+  );
+  assertThrows(
+    () => new KubectlAnnotateSettings().all().annotation("a", "b").argv(),
+    Error,
+    "a resource type is required",
+  );
+  // A resource type but no annotation/removal.
   assertThrows(
     () => new KubectlAnnotateSettings().resource("deploy").argv(),
     Error,
@@ -637,7 +679,12 @@ Deno.test("annotate and label require both a target and a payload", () => {
   assertThrows(
     () => new KubectlLabelSettings().label("a", "b").argv(),
     Error,
-    "a target is required",
+    "a resource type is required",
+  );
+  assertThrows(
+    () => new KubectlLabelSettings().all().label("a", "b").argv(),
+    Error,
+    "a resource type is required",
   );
   assertThrows(
     () => new KubectlLabelSettings().resource("deploy").argv(),
@@ -753,6 +800,22 @@ Deno.test("top: requires pods or nodes; all options", () => {
   assertEquals(
     new KubectlTopSettings().nodes().argv().slice(1),
     ["top", "nodes"],
+  );
+  // --containers and -A are pod-only; kubectl rejects them on `top node`.
+  assertThrows(
+    () => new KubectlTopSettings().nodes().containers().argv(),
+    Error,
+    "only valid with .pods()",
+  );
+  assertThrows(
+    () => new KubectlTopSettings().nodes().allNamespaces().argv(),
+    Error,
+    "only valid with .pods()",
+  );
+  // A selector stays valid on `top nodes`.
+  assertEquals(
+    new KubectlTopSettings().nodes().selector("role=worker").argv().slice(1),
+    ["top", "nodes", "-l", "role=worker"],
   );
 });
 


### PR DESCRIPTION
Remediation plan **PR 7** — the correctness half (**7.1–7.4**). These are argv bugs a single snapshot test can't catch; each wrapper emitted a command the real CLI rejects, or dropped a positional. Every fix ships an **interaction** test.

## Fixes

**kubectl** (`packages/kubectl`)
- **7.1** `apply`: `-f` and `-k` are now mutually exclusive; `-k` also rejects `-R` (kubectl: *"only one of -f or -k"* and *"the -k flag can't be used with -f or -R"*).
- **7.3(a)** `describe`: requires a resource type — a bare selector (`describe -l …`) is rejected by kubectl.
- **7.3(b)** `annotate`/`label`: require a resource type; `--all`/`--selector` are modifiers on a type, not substitutes.
- **7.3(c)** `logs`: rejects a pod name together with a selector (kubectl allows only one).
- **7.3(d)** `top`: `--containers` and `-A`/`--all-namespaces` are `top pod`-only and rejected on `top node`; a selector stays valid on nodes.
- **7.3(e)** `scale --current-replicas`: **no change** — the understand pass verified it is *not* deprecated (it is a documented precondition flag), so the plan item was refuted.

**jest** (`packages/jest`) — **7.2**: array flags (`--reporters`, `--selectProjects`) now emit `--flag=value` form, so jest's yargs parser binds one value per flag instead of greedily swallowing the trailing positional test-path patterns.

**git** (`packages/git`) — **7.4**: `add` emits `--` before pathspecs, so a path beginning with `-` is treated as a path, not parsed as a flag.

## Scope note

**7.5** (house-wide `deno doc --lint` first-party `private-type-ref` cleanup + wiring the lint into the gate) is a large, mechanical, ~50-package change of a different character — it ships as a **separate follow-up** so this PR stays reviewable and release attribution stays clean (like the earlier PR 2a/2b split).

## Verification

- `deno task ci` green: fmt, lint, spell, type-check, coverage (**lines 98.3%, branches 95.4%**); `./zuke apiDocsCheck` clean (guard-only changes, no public API drift).
- **Adversarial review** (too-strict guards + regressions → verify against real kubectl v1.36.1): **0 too-strict / 0 regressions**; it surfaced one adjacent too-loose case (the `-k`/`-R` combo) which is now guarded + tested.