### PR TITLE
fix: default JS-ecosystem wrappers to node_modules binary resolution

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5602,6 +5602,8 @@ class OxlintSettings extends ToolSettings
 
   override protected defaultTool(): string
     The default executable name (`oxlint`).
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — oxlint is an npm-distributed tool.
   paths(...values: PathLike[]): this
     Files or directories to lint (positional); repeatable.
   config(path: PathLike): this
@@ -5664,6 +5666,8 @@ class EslintSettings extends ToolSettings
 
   override protected defaultTool(): string
     The default executable this settings object runs (`eslint`).
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — eslint is an npm-distributed tool.
   paths(...values: PathLike[]): this
     Files, directories, or globs to lint (positional); repeatable.
   config(path: PathLike): this
@@ -5730,6 +5734,8 @@ class CspellSettings extends ToolSettings
 
   override protected defaultTool(): string
     The default executable name (`cspell`).
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — cspell is an npm-distributed tool.
   files(...globs: PathLike[]): this
     Files or globs to check (positional); repeatable.
   config(path: PathLike): this
@@ -5790,6 +5796,8 @@ class JestSettings extends ToolSettings
 
   override protected defaultTool(): string
     The underlying tool binary is `jest`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — jest is an npm-distributed tool.
   paths(...values: PathLike[]): this
     Regex patterns matched against test paths (positional); repeatable.
   config(path: PathLike): this
@@ -5859,6 +5867,8 @@ class VitestSettings extends ToolSettings
 
   override protected defaultTool(): string
     The underlying tool binary (`vitest`).
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — vitest is an npm-distributed tool.
   filters(...values: string[]): this
     Filename filters matched against test files (positional); repeatable.
   watch(): this
@@ -5951,6 +5961,8 @@ abstract class PlaywrightSettings extends ToolSettings
 
   override protected defaultTool(): string
     The tool binary invoked by all Playwright subcommands: `playwright`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — playwright is an npm-distributed tool.
 
 class PlaywrightShowReportSettings extends PlaywrightSettings
   Settings for `playwright show-report`.
@@ -6053,6 +6065,8 @@ abstract class CypressSettings extends ToolSettings
 
   override protected defaultTool(): string
     The default tool binary: `cypress`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — cypress is an npm-distributed tool.
 
 abstract class CypressTestingSettings extends CypressSettings
   Base for the `run`/`open` commands, which share testing-type selection, a
@@ -6150,6 +6164,8 @@ abstract class BiomeSettings extends ToolSettings
 
   override protected defaultTool(): string
     The tool binary: `biome`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — biome is an npm-distributed tool.
   paths(...paths: PathLike[]): this
     Files or directories to operate on; omit to use the configured includes.
   config(path: PathLike): this
@@ -6199,6 +6215,8 @@ class KnipRunSettings extends ToolSettings
 
   override protected defaultTool(): string
     The underlying CLI command: `knip`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — knip is an npm-distributed tool.
   production(): this
     Restrict analysis to production code paths (`--production`).
   strict(): this
@@ -6251,6 +6269,8 @@ class DpdmAnalyzeSettings extends ToolSettings
 
   override protected defaultTool(): string
     The command this settings object runs (`dpdm`).
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — dpdm is an npm-distributed tool.
   transform(): this
     Transform TypeScript modules to JavaScript before analysis (`--transform`).
   noTree(): this
@@ -6447,6 +6467,8 @@ abstract class ViteSettings extends ToolSettings
 
   override protected defaultTool(): string
     The default binary this wrapper invokes: `vite`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — vite is an npm-distributed tool.
   config(path: PathLike): this
     Use an explicit config file (`--config`).
   mode(name: string): this
@@ -6488,6 +6510,8 @@ class TsupBuildSettings extends ToolSettings
 
   override protected defaultTool(): string
     The executable this settings object runs: `tsup`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — tsup is an npm-distributed tool.
   entry(...paths: PathLike[]): this
     Entry point(s) to bundle (positional); repeatable.
   format(...formats: TsupFormat[]): this
@@ -6580,6 +6604,8 @@ abstract class TurboSettings extends ToolSettings
 
   override protected defaultTool(): string
     The tool binary this settings class invokes: `turbo`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — turbo is an npm-distributed tool.
 
 interface TurboTasksApi
   The shape of {@link TurboTasks}.
@@ -6654,6 +6680,8 @@ abstract class NxSettings extends ToolSettings
 
   override protected defaultTool(): string
     The tool binary is `nx`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — nx is an npm-distributed tool.
 
 interface NxTasksApi
   The shape of {@link NxTasks}.
@@ -6689,6 +6717,8 @@ abstract class TsxCommonSettings extends ToolSettings
 
   override protected defaultTool(): string
     The underlying executable: `tsx`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — tsx is an npm-distributed tool.
   script(path: PathLike): this
     The entry point to execute (required).
   scriptArgs(...args: Array<string | number>): this
@@ -6758,6 +6788,8 @@ class TsgoSettings extends ToolSettings
 
   override protected defaultTool(): string
     The executable this settings object drives (`tsgo`).
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — tsgo is an npm-distributed tool.
   paths(...values: PathLike[]): this
     Source files to compile (positional); repeatable.
   project(path: PathLike): this
@@ -6823,6 +6855,8 @@ abstract class TscBaseSettings extends ToolSettings
 
   override protected defaultTool(): string
     The default binary these settings invoke: `tsc`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — tsc is an npm-distributed tool.
 
 class TscBuildSettings extends TscBaseSettings
   Settings for a `tsc --build` project-references run.
@@ -6913,6 +6947,8 @@ class TscAliasRunSettings extends ToolSettings
 
   override protected defaultTool(): string
     The executable this settings object drives (`tsc-alias`).
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — tsc-alias is an npm-distributed tool.
   project(path: PathLike): this
     Path to the `tsconfig.json` to read aliases from (`-p`/`--project`).
   watch(): this
@@ -6970,6 +7006,8 @@ class TsdownBuildSettings extends ToolSettings
 
   override protected defaultTool(): string
     The default executable to run: `tsdown`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — tsdown is an npm-distributed tool.
   entry(...paths: PathLike[]): this
     Entry point(s) to bundle (positional); repeatable.
   format(...formats: TsdownFormat[]): this
@@ -7004,6 +7042,8 @@ class TsdownMigrateSettings extends ToolSettings
 
   override protected defaultTool(): string
     The default executable to run: `tsdown`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — tsdown is an npm-distributed tool.
   from(value: string): this
     The tool to migrate from, e.g. `tsup` (`--from`).
   dryRun(): this
@@ -7121,6 +7161,8 @@ abstract class NestSettings extends ToolSettings
 
   override protected defaultTool(): string
     The tool binary: `nest`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — nest is an npm-distributed tool.
   abstract protected subcommandArgs(): string[]
     The subcommand argv (the verb and its arguments).
   override protected buildArgs(): string[]
@@ -7189,6 +7231,8 @@ class OpenapiTsGenerateSettings extends ToolSettings
 
   override protected defaultTool(): string
     The tool binary this settings object invokes (`openapi-ts`).
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — openapi-ts is an npm-distributed tool.
   input(value: PathLike): this
     OpenAPI specification to read — a file path or URL (`--input`).
   output(value: PathLike): this
@@ -7237,6 +7281,8 @@ class OrvalGenerateSettings extends ToolSettings
 
   override protected defaultTool(): string
     The executable this settings object runs: `orval`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — orval is an npm-distributed tool.
   config(value: PathLike): this
     Configuration file to load settings from (`-c`/`--config`).
   project(value: string): this
@@ -7311,6 +7357,8 @@ abstract class HuskySettings extends ToolSettings
 
   override protected defaultTool(): string
     The tool binary is `husky`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — husky is an npm-distributed tool.
   abstract protected subcommandArgs(): string[]
     The subcommand argv (everything after the binary).
   override protected buildArgs(): string[]
@@ -7460,6 +7508,8 @@ abstract class DprintSettings extends ToolSettings
 
   override protected defaultTool(): string
     The default executable this settings class invokes: `dprint`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — dprint is an npm-distributed tool.
   abstract protected subcommand(): string
     The dprint subcommand this settings class runs.
   config(path: PathLike): this

--- a/packages/biome/README.md
+++ b/packages/biome/README.md
@@ -74,6 +74,8 @@ abstract class BiomeSettings extends ToolSettings
 
   override protected defaultTool(): string
     The tool binary: `biome`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — biome is an npm-distributed tool.
   paths(...paths: PathLike[]): this
     Files or directories to operate on; omit to use the configured includes.
   config(path: PathLike): this

--- a/packages/biome/src/biome.ts
+++ b/packages/biome/src/biome.ts
@@ -19,6 +19,7 @@ import {
   type Configure,
   type PathLike,
   runSettings,
+  type ToolResolution,
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
@@ -38,6 +39,11 @@ export abstract class BiomeSettings extends ToolSettings {
   /** The tool binary: `biome`. */
   protected override defaultTool(): string {
     return "biome";
+  }
+
+  /** Resolve the binary from `node_modules/.bin` by default — biome is an npm-distributed tool. */
+  protected override defaultResolution(): ToolResolution {
+    return "node_modules";
   }
 
   /** Files or directories to operate on; omit to use the configured includes. */

--- a/packages/biome/tests/biome_test.ts
+++ b/packages/biome/tests/biome_test.ts
@@ -65,6 +65,25 @@ const missing = <S extends ToolSettings>(s: S): S => {
   return s.toolPath("zuke-no-such-biome-xyz");
 };
 
+Deno.test("biome: resolves its binary from node_modules by default", () => {
+  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
+  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+  const root = Deno.makeTempDirSync();
+  try {
+    const binDir = `${root}/node_modules/.bin`;
+    Deno.mkdirSync(binDir, { recursive: true });
+    const bin = `${binDir}/biome`;
+    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
+    const s = new BiomeCheckSettings();
+    s.os_ = "linux";
+    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
+  }
+});
+
 Deno.test("every BiomeTasks function reaches execution", async () => {
   await assertRejects(() => BiomeTasks.check(missing), ToolNotFoundError);
   await assertRejects(() => BiomeTasks.format(missing), ToolNotFoundError);

--- a/packages/cspell/README.md
+++ b/packages/cspell/README.md
@@ -45,6 +45,8 @@ class CspellSettings extends ToolSettings
 
   override protected defaultTool(): string
     The default executable name (`cspell`).
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — cspell is an npm-distributed tool.
   files(...globs: PathLike[]): this
     Files or globs to check (positional); repeatable.
   config(path: PathLike): this

--- a/packages/cspell/src/cspell.ts
+++ b/packages/cspell/src/cspell.ts
@@ -19,6 +19,7 @@ import {
   type Configure,
   type PathLike,
   runSettings,
+  type ToolResolution,
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
@@ -43,6 +44,11 @@ export class CspellSettings extends ToolSettings {
   /** The default executable name (`cspell`). */
   protected override defaultTool(): string {
     return "cspell";
+  }
+
+  /** Resolve the binary from `node_modules/.bin` by default — cspell is an npm-distributed tool. */
+  protected override defaultResolution(): ToolResolution {
+    return "node_modules";
   }
 
   /** Files or globs to check (positional); repeatable. */

--- a/packages/cspell/tests/cspell_test.ts
+++ b/packages/cspell/tests/cspell_test.ts
@@ -55,3 +55,22 @@ const missing = <S extends ToolSettings>(s: S): S => {
 Deno.test("CspellTasks.lint reaches execution", async () => {
   await assertRejects(() => CspellTasks.lint(missing), ToolNotFoundError);
 });
+
+Deno.test("cspell: resolves its binary from node_modules by default", () => {
+  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
+  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+  const root = Deno.makeTempDirSync();
+  try {
+    const binDir = `${root}/node_modules/.bin`;
+    Deno.mkdirSync(binDir, { recursive: true });
+    const bin = `${binDir}/cspell`;
+    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
+    const s = new CspellSettings();
+    s.os_ = "linux"; // pin so the planted bare shim matches on any host
+    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
+  }
+});

--- a/packages/cypress/README.md
+++ b/packages/cypress/README.md
@@ -75,6 +75,8 @@ abstract class CypressSettings extends ToolSettings
 
   override protected defaultTool(): string
     The default tool binary: `cypress`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — cypress is an npm-distributed tool.
 
 abstract class CypressTestingSettings extends CypressSettings
   Base for the `run`/`open` commands, which share testing-type selection, a

--- a/packages/cypress/src/cypress.ts
+++ b/packages/cypress/src/cypress.ts
@@ -18,6 +18,7 @@ import {
   type Configure,
   type PathLike,
   runSettings,
+  type ToolResolution,
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
@@ -27,6 +28,11 @@ export abstract class CypressSettings extends ToolSettings {
   /** The default tool binary: `cypress`. */
   protected override defaultTool(): string {
     return "cypress";
+  }
+
+  /** Resolve the binary from `node_modules/.bin` by default — cypress is an npm-distributed tool. */
+  protected override defaultResolution(): ToolResolution {
+    return "node_modules";
   }
 }
 

--- a/packages/cypress/tests/cypress_test.ts
+++ b/packages/cypress/tests/cypress_test.ts
@@ -13,6 +13,25 @@ Deno.test("the default binary is cypress", () => {
   assertEquals(new CypressRunSettings().argv()[0], "cypress");
 });
 
+Deno.test("cypress: resolves its binary from node_modules by default", () => {
+  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
+  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+  const root = Deno.makeTempDirSync();
+  try {
+    const binDir = `${root}/node_modules/.bin`;
+    Deno.mkdirSync(binDir, { recursive: true });
+    const bin = `${binDir}/cypress`;
+    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
+    const s = new CypressRunSettings();
+    s.os_ = "linux"; // pin so the planted bare shim matches on any host
+    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
+  }
+});
+
 Deno.test("run: bare and all options (shared + run-specific)", () => {
   assertEquals(new CypressRunSettings().argv().slice(1), ["run"]);
   assertEquals(

--- a/packages/dpdm/README.md
+++ b/packages/dpdm/README.md
@@ -46,6 +46,8 @@ class DpdmAnalyzeSettings extends ToolSettings
 
   override protected defaultTool(): string
     The command this settings object runs (`dpdm`).
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — dpdm is an npm-distributed tool.
   transform(): this
     Transform TypeScript modules to JavaScript before analysis (`--transform`).
   noTree(): this

--- a/packages/dpdm/src/dpdm.ts
+++ b/packages/dpdm/src/dpdm.ts
@@ -26,6 +26,7 @@ import {
   type Configure,
   type PathLike,
   runSettings,
+  type ToolResolution,
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
@@ -52,6 +53,11 @@ export class DpdmAnalyzeSettings extends ToolSettings {
   /** The command this settings object runs (`dpdm`). */
   protected override defaultTool(): string {
     return "dpdm";
+  }
+
+  /** Resolve the binary from `node_modules/.bin` by default — dpdm is an npm-distributed tool. */
+  protected override defaultResolution(): ToolResolution {
+    return "node_modules";
   }
 
   /** Transform TypeScript modules to JavaScript before analysis (`--transform`). */

--- a/packages/dpdm/tests/dpdm_test.ts
+++ b/packages/dpdm/tests/dpdm_test.ts
@@ -81,3 +81,22 @@ const missing = <S extends ToolSettings>(s: S): S => {
 Deno.test("DpdmTasks.analyze reaches execution", async () => {
   await assertRejects(() => DpdmTasks.analyze(missing), ToolNotFoundError);
 });
+
+Deno.test("dpdm: resolves its binary from node_modules by default", () => {
+  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
+  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+  const root = Deno.makeTempDirSync();
+  try {
+    const binDir = `${root}/node_modules/.bin`;
+    Deno.mkdirSync(binDir, { recursive: true });
+    const bin = `${binDir}/dpdm`;
+    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
+    const s = new DpdmAnalyzeSettings();
+    s.os_ = "linux";
+    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
+  }
+});

--- a/packages/dprint/README.md
+++ b/packages/dprint/README.md
@@ -56,6 +56,8 @@ abstract class DprintSettings extends ToolSettings
 
   override protected defaultTool(): string
     The default executable this settings class invokes: `dprint`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — dprint is an npm-distributed tool.
   abstract protected subcommand(): string
     The dprint subcommand this settings class runs.
   config(path: PathLike): this

--- a/packages/dprint/src/dprint.ts
+++ b/packages/dprint/src/dprint.ts
@@ -20,6 +20,7 @@ import {
   type Configure,
   type PathLike,
   runSettings,
+  type ToolResolution,
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
@@ -35,6 +36,11 @@ export abstract class DprintSettings extends ToolSettings {
   /** The default executable this settings class invokes: `dprint`. */
   protected override defaultTool(): string {
     return "dprint";
+  }
+
+  /** Resolve the binary from `node_modules/.bin` by default — dprint is an npm-distributed tool. */
+  protected override defaultResolution(): ToolResolution {
+    return "node_modules";
   }
 
   /** The dprint subcommand this settings class runs. */

--- a/packages/dprint/tests/dprint_test.ts
+++ b/packages/dprint/tests/dprint_test.ts
@@ -40,6 +40,25 @@ const missing = <S extends ToolSettings>(s: S): S => {
   return s.toolPath("zz-no-such-dprint-zz");
 };
 
+Deno.test("dprint: resolves its binary from node_modules by default", () => {
+  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
+  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+  const root = Deno.makeTempDirSync();
+  try {
+    const binDir = `${root}/node_modules/.bin`;
+    Deno.mkdirSync(binDir, { recursive: true });
+    const bin = `${binDir}/dprint`;
+    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
+    const s = new DprintFmtSettings();
+    s.os_ = "linux";
+    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
+  }
+});
+
 Deno.test("DprintTasks.fmt and .check reach execution", async () => {
   await assertRejects(() => DprintTasks.fmt(missing), ToolNotFoundError);
   await assertRejects(() => DprintTasks.check(missing), ToolNotFoundError);

--- a/packages/eslint/README.md
+++ b/packages/eslint/README.md
@@ -45,6 +45,8 @@ class EslintSettings extends ToolSettings
 
   override protected defaultTool(): string
     The default executable this settings object runs (`eslint`).
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — eslint is an npm-distributed tool.
   paths(...values: PathLike[]): this
     Files, directories, or globs to lint (positional); repeatable.
   config(path: PathLike): this

--- a/packages/eslint/src/eslint.ts
+++ b/packages/eslint/src/eslint.ts
@@ -19,6 +19,7 @@ import {
   type Configure,
   type PathLike,
   runSettings,
+  type ToolResolution,
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
@@ -46,6 +47,11 @@ export class EslintSettings extends ToolSettings {
   /** The default executable this settings object runs (`eslint`). */
   protected override defaultTool(): string {
     return "eslint";
+  }
+
+  /** Resolve the binary from `node_modules/.bin` by default — eslint is an npm-distributed tool. */
+  protected override defaultResolution(): ToolResolution {
+    return "node_modules";
   }
 
   /** Files, directories, or globs to lint (positional); repeatable. */

--- a/packages/eslint/tests/eslint_test.ts
+++ b/packages/eslint/tests/eslint_test.ts
@@ -62,3 +62,22 @@ const missing = <S extends ToolSettings>(s: S): S => {
 Deno.test("EslintTasks.lint reaches execution", async () => {
   await assertRejects(() => EslintTasks.lint(missing), ToolNotFoundError);
 });
+
+Deno.test("eslint: resolves its binary from node_modules by default", () => {
+  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
+  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+  const root = Deno.makeTempDirSync();
+  try {
+    const binDir = `${root}/node_modules/.bin`;
+    Deno.mkdirSync(binDir, { recursive: true });
+    const bin = `${binDir}/eslint`;
+    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
+    const s = new EslintSettings();
+    s.os_ = "linux";
+    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
+  }
+});

--- a/packages/husky/README.md
+++ b/packages/husky/README.md
@@ -73,6 +73,8 @@ abstract class HuskySettings extends ToolSettings
 
   override protected defaultTool(): string
     The tool binary is `husky`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — husky is an npm-distributed tool.
   abstract protected subcommandArgs(): string[]
     The subcommand argv (everything after the binary).
   override protected buildArgs(): string[]

--- a/packages/husky/src/husky.ts
+++ b/packages/husky/src/husky.ts
@@ -23,6 +23,7 @@ import {
   type Configure,
   type PathLike,
   runSettings,
+  type ToolResolution,
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
@@ -32,6 +33,11 @@ export abstract class HuskySettings extends ToolSettings {
   /** The tool binary is `husky`. */
   protected override defaultTool(): string {
     return "husky";
+  }
+
+  /** Resolve the binary from `node_modules/.bin` by default — husky is an npm-distributed tool. */
+  protected override defaultResolution(): ToolResolution {
+    return "node_modules";
   }
 
   /** The subcommand argv (everything after the binary). */

--- a/packages/husky/tests/husky_test.ts
+++ b/packages/husky/tests/husky_test.ts
@@ -37,3 +37,22 @@ Deno.test("HuskyTasks.init reaches execution", async () => {
 Deno.test("HuskyTasks.install reaches execution", async () => {
   await assertRejects(() => HuskyTasks.install(missing), ToolNotFoundError);
 });
+
+Deno.test("husky: resolves its binary from node_modules by default", () => {
+  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
+  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+  const root = Deno.makeTempDirSync();
+  try {
+    const binDir = `${root}/node_modules/.bin`;
+    Deno.mkdirSync(binDir, { recursive: true });
+    const bin = `${binDir}/husky`;
+    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
+    const s = new HuskyInstallSettings();
+    s.os_ = "linux";
+    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
+  }
+});

--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -43,6 +43,8 @@ class JestSettings extends ToolSettings
 
   override protected defaultTool(): string
     The underlying tool binary is `jest`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — jest is an npm-distributed tool.
   paths(...values: PathLike[]): this
     Regex patterns matched against test paths (positional); repeatable.
   config(path: PathLike): this

--- a/packages/jest/src/jest.ts
+++ b/packages/jest/src/jest.ts
@@ -19,6 +19,7 @@ import {
   type Configure,
   type PathLike,
   runSettings,
+  type ToolResolution,
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
@@ -47,6 +48,11 @@ export class JestSettings extends ToolSettings {
   /** The underlying tool binary is `jest`. */
   protected override defaultTool(): string {
     return "jest";
+  }
+
+  /** Resolve the binary from `node_modules/.bin` by default — jest is an npm-distributed tool. */
+  protected override defaultResolution(): ToolResolution {
+    return "node_modules";
   }
 
   /** Regex patterns matched against test paths (positional); repeatable. */

--- a/packages/jest/tests/jest_test.ts
+++ b/packages/jest/tests/jest_test.ts
@@ -73,3 +73,22 @@ const missing = <S extends ToolSettings>(s: S): S => {
 Deno.test("JestTasks.run reaches execution", async () => {
   await assertRejects(() => JestTasks.run(missing), ToolNotFoundError);
 });
+
+Deno.test("jest: resolves its binary from node_modules by default", () => {
+  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
+  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+  const root = Deno.makeTempDirSync();
+  try {
+    const binDir = `${root}/node_modules/.bin`;
+    Deno.mkdirSync(binDir, { recursive: true });
+    const bin = `${binDir}/jest`;
+    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
+    const s = new JestSettings();
+    s.os_ = "linux"; // pin so the planted bare shim matches on any host
+    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
+  }
+});

--- a/packages/knip/README.md
+++ b/packages/knip/README.md
@@ -36,6 +36,8 @@ class KnipRunSettings extends ToolSettings
 
   override protected defaultTool(): string
     The underlying CLI command: `knip`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — knip is an npm-distributed tool.
   production(): this
     Restrict analysis to production code paths (`--production`).
   strict(): this

--- a/packages/knip/src/knip.ts
+++ b/packages/knip/src/knip.ts
@@ -21,6 +21,7 @@ import {
   type Configure,
   type PathLike,
   runSettings,
+  type ToolResolution,
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
@@ -40,6 +41,11 @@ export class KnipRunSettings extends ToolSettings {
   /** The underlying CLI command: `knip`. */
   protected override defaultTool(): string {
     return "knip";
+  }
+
+  /** Resolve the binary from `node_modules/.bin` by default — knip is an npm-distributed tool. */
+  protected override defaultResolution(): ToolResolution {
+    return "node_modules";
   }
 
   /** Restrict analysis to production code paths (`--production`). */

--- a/packages/knip/tests/knip_test.ts
+++ b/packages/knip/tests/knip_test.ts
@@ -50,3 +50,22 @@ const missing = <S extends ToolSettings>(s: S): S => {
 Deno.test("KnipTasks.run reaches execution", async () => {
   await assertRejects(() => KnipTasks.run(missing), ToolNotFoundError);
 });
+
+Deno.test("knip: resolves its binary from node_modules by default", () => {
+  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
+  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+  const root = Deno.makeTempDirSync();
+  try {
+    const binDir = `${root}/node_modules/.bin`;
+    Deno.mkdirSync(binDir, { recursive: true });
+    const bin = `${binDir}/knip`;
+    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
+    const s = new KnipRunSettings();
+    s.os_ = "linux"; // pin so the planted bare shim matches on any host
+    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
+  }
+});

--- a/packages/nest/README.md
+++ b/packages/nest/README.md
@@ -122,6 +122,8 @@ abstract class NestSettings extends ToolSettings
 
   override protected defaultTool(): string
     The tool binary: `nest`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — nest is an npm-distributed tool.
   abstract protected subcommandArgs(): string[]
     The subcommand argv (the verb and its arguments).
   override protected buildArgs(): string[]

--- a/packages/nest/src/nest.ts
+++ b/packages/nest/src/nest.ts
@@ -22,6 +22,7 @@ import {
   type Configure,
   type PathLike,
   runSettings,
+  type ToolResolution,
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
@@ -31,6 +32,11 @@ export abstract class NestSettings extends ToolSettings {
   /** The tool binary: `nest`. */
   protected override defaultTool(): string {
     return "nest";
+  }
+
+  /** Resolve the binary from `node_modules/.bin` by default — nest is an npm-distributed tool. */
+  protected override defaultResolution(): ToolResolution {
+    return "node_modules";
   }
 
   /** The subcommand argv (the verb and its arguments). */

--- a/packages/nest/tests/nest_test.ts
+++ b/packages/nest/tests/nest_test.ts
@@ -17,6 +17,25 @@ Deno.test("the default binary is nest and the subcommand follows", () => {
   assertEquals(new NestInfoSettings().argv(), ["nest", "info"]);
 });
 
+Deno.test("nest: resolves its binary from node_modules by default", () => {
+  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
+  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+  const root = Deno.makeTempDirSync();
+  try {
+    const binDir = `${root}/node_modules/.bin`;
+    Deno.mkdirSync(binDir, { recursive: true });
+    const bin = `${binDir}/nest`;
+    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
+    const s = new NestInfoSettings();
+    s.os_ = "linux";
+    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
+  }
+});
+
 Deno.test("new renders every option and requires a name", () => {
   assertEquals(new NestNewSettings().name("my-app").argv(), [
     "nest",

--- a/packages/nx/README.md
+++ b/packages/nx/README.md
@@ -83,6 +83,8 @@ abstract class NxSettings extends ToolSettings
 
   override protected defaultTool(): string
     The tool binary is `nx`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — nx is an npm-distributed tool.
 
 interface NxTasksApi
   The shape of {@link NxTasks}.

--- a/packages/nx/src/nx.ts
+++ b/packages/nx/src/nx.ts
@@ -15,7 +15,12 @@
  * @module
  */
 
-import { type Configure, runSettings, ToolSettings } from "@zuke/core/tooling";
+import {
+  type Configure,
+  runSettings,
+  type ToolResolution,
+  ToolSettings,
+} from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
 
 /** Base for all `nx` subcommand settings: the binary is `nx`. */
@@ -23,6 +28,11 @@ export abstract class NxSettings extends ToolSettings {
   /** The tool binary is `nx`. */
   protected override defaultTool(): string {
     return "nx";
+  }
+
+  /** Resolve the binary from `node_modules/.bin` by default — nx is an npm-distributed tool. */
+  protected override defaultResolution(): ToolResolution {
+    return "node_modules";
   }
 }
 

--- a/packages/nx/tests/nx_test.ts
+++ b/packages/nx/tests/nx_test.ts
@@ -15,6 +15,28 @@ Deno.test("the default binary is nx", () => {
   assertEquals(new NxRunSettings().target("web:build").argv()[0], "nx");
 });
 
+Deno.test("nx: resolves its binary from node_modules by default", () => {
+  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
+  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+  const root = Deno.makeTempDirSync();
+  try {
+    const binDir = `${root}/node_modules/.bin`;
+    Deno.mkdirSync(binDir, { recursive: true });
+    const bin = `${binDir}/nx`;
+    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
+    const s = new NxRunSettings();
+    s.os_ = "linux";
+    assertEquals(
+      s.cwd(root).target("web:build").resolvedArgv()[0],
+      bin.replace(/\\/g, "/"),
+    );
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
+  }
+});
+
 Deno.test("run: requires a target; configuration", () => {
   assertThrows(
     () => new NxRunSettings().argv(),

--- a/packages/openapi-ts/README.md
+++ b/packages/openapi-ts/README.md
@@ -56,6 +56,8 @@ class OpenapiTsGenerateSettings extends ToolSettings
 
   override protected defaultTool(): string
     The tool binary this settings object invokes (`openapi-ts`).
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — openapi-ts is an npm-distributed tool.
   input(value: PathLike): this
     OpenAPI specification to read — a file path or URL (`--input`).
   output(value: PathLike): this

--- a/packages/openapi-ts/src/openapi_ts.ts
+++ b/packages/openapi-ts/src/openapi_ts.ts
@@ -28,6 +28,7 @@ import {
   type Configure,
   type PathLike,
   runSettings,
+  type ToolResolution,
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
@@ -45,6 +46,11 @@ export class OpenapiTsGenerateSettings extends ToolSettings {
   /** The tool binary this settings object invokes (`openapi-ts`). */
   protected override defaultTool(): string {
     return "openapi-ts";
+  }
+
+  /** Resolve the binary from `node_modules/.bin` by default — openapi-ts is an npm-distributed tool. */
+  protected override defaultResolution(): ToolResolution {
+    return "node_modules";
   }
 
   /** OpenAPI specification to read — a file path or URL (`--input`). */

--- a/packages/openapi-ts/tests/openapi_ts_test.ts
+++ b/packages/openapi-ts/tests/openapi_ts_test.ts
@@ -52,3 +52,22 @@ Deno.test("OpenapiTsTasks.generate reaches execution", async () => {
     ToolNotFoundError,
   );
 });
+
+Deno.test("openapi-ts: resolves its binary from node_modules by default", () => {
+  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
+  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+  const root = Deno.makeTempDirSync();
+  try {
+    const binDir = `${root}/node_modules/.bin`;
+    Deno.mkdirSync(binDir, { recursive: true });
+    const bin = `${binDir}/openapi-ts`;
+    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
+    const s = new OpenapiTsGenerateSettings();
+    s.os_ = "linux";
+    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
+  }
+});

--- a/packages/orval/README.md
+++ b/packages/orval/README.md
@@ -46,6 +46,8 @@ class OrvalGenerateSettings extends ToolSettings
 
   override protected defaultTool(): string
     The executable this settings object runs: `orval`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — orval is an npm-distributed tool.
   config(value: PathLike): this
     Configuration file to load settings from (`-c`/`--config`).
   project(value: string): this

--- a/packages/orval/src/orval.ts
+++ b/packages/orval/src/orval.ts
@@ -26,6 +26,7 @@ import {
   type Configure,
   type PathLike,
   runSettings,
+  type ToolResolution,
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
@@ -45,6 +46,11 @@ export class OrvalGenerateSettings extends ToolSettings {
   /** The executable this settings object runs: `orval`. */
   protected override defaultTool(): string {
     return "orval";
+  }
+
+  /** Resolve the binary from `node_modules/.bin` by default — orval is an npm-distributed tool. */
+  protected override defaultResolution(): ToolResolution {
+    return "node_modules";
   }
 
   /** Configuration file to load settings from (`-c`/`--config`). */

--- a/packages/orval/tests/orval_test.ts
+++ b/packages/orval/tests/orval_test.ts
@@ -44,3 +44,22 @@ const missing = <S extends ToolSettings>(s: S): S => {
 Deno.test("OrvalTasks.generate reaches execution", async () => {
   await assertRejects(() => OrvalTasks.generate(missing), ToolNotFoundError);
 });
+
+Deno.test("orval: resolves its binary from node_modules by default", () => {
+  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
+  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+  const root = Deno.makeTempDirSync();
+  try {
+    const binDir = `${root}/node_modules/.bin`;
+    Deno.mkdirSync(binDir, { recursive: true });
+    const bin = `${binDir}/orval`;
+    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
+    const s = new OrvalGenerateSettings();
+    s.os_ = "linux"; // pin so the planted bare shim matches on any host
+    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
+  }
+});

--- a/packages/oxlint/README.md
+++ b/packages/oxlint/README.md
@@ -45,6 +45,8 @@ class OxlintSettings extends ToolSettings
 
   override protected defaultTool(): string
     The default executable name (`oxlint`).
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — oxlint is an npm-distributed tool.
   paths(...values: PathLike[]): this
     Files or directories to lint (positional); repeatable.
   config(path: PathLike): this

--- a/packages/oxlint/src/oxlint.ts
+++ b/packages/oxlint/src/oxlint.ts
@@ -19,6 +19,7 @@ import {
   type Configure,
   type PathLike,
   runSettings,
+  type ToolResolution,
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
@@ -42,6 +43,11 @@ export class OxlintSettings extends ToolSettings {
   /** The default executable name (`oxlint`). */
   protected override defaultTool(): string {
     return "oxlint";
+  }
+
+  /** Resolve the binary from `node_modules/.bin` by default — oxlint is an npm-distributed tool. */
+  protected override defaultResolution(): ToolResolution {
+    return "node_modules";
   }
 
   /** Files or directories to lint (positional); repeatable. */

--- a/packages/oxlint/tests/oxlint_test.ts
+++ b/packages/oxlint/tests/oxlint_test.ts
@@ -56,3 +56,22 @@ const missing = <S extends ToolSettings>(s: S): S => {
 Deno.test("OxlintTasks.lint reaches execution", async () => {
   await assertRejects(() => OxlintTasks.lint(missing), ToolNotFoundError);
 });
+
+Deno.test("oxlint: resolves its binary from node_modules by default", () => {
+  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
+  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+  const root = Deno.makeTempDirSync();
+  try {
+    const binDir = `${root}/node_modules/.bin`;
+    Deno.mkdirSync(binDir, { recursive: true });
+    const bin = `${binDir}/oxlint`;
+    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
+    const s = new OxlintSettings();
+    s.os_ = "linux"; // pin so the planted bare shim matches on any host
+    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
+  }
+});

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -60,6 +60,8 @@ abstract class PlaywrightSettings extends ToolSettings
 
   override protected defaultTool(): string
     The tool binary invoked by all Playwright subcommands: `playwright`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — playwright is an npm-distributed tool.
 
 class PlaywrightShowReportSettings extends PlaywrightSettings
   Settings for `playwright show-report`.

--- a/packages/playwright/src/playwright.ts
+++ b/packages/playwright/src/playwright.ts
@@ -15,7 +15,12 @@
  * spawning fails.
  */
 
-import { type Configure, runSettings, ToolSettings } from "@zuke/core/tooling";
+import {
+  type Configure,
+  runSettings,
+  type ToolResolution,
+  ToolSettings,
+} from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
 
 /** Base for all Playwright subcommand settings: binary is `playwright`. */
@@ -23,6 +28,11 @@ export abstract class PlaywrightSettings extends ToolSettings {
   /** The tool binary invoked by all Playwright subcommands: `playwright`. */
   protected override defaultTool(): string {
     return "playwright";
+  }
+
+  /** Resolve the binary from `node_modules/.bin` by default — playwright is an npm-distributed tool. */
+  protected override defaultResolution(): ToolResolution {
+    return "node_modules";
   }
 }
 

--- a/packages/playwright/tests/playwright_test.ts
+++ b/packages/playwright/tests/playwright_test.ts
@@ -85,6 +85,25 @@ const missing = <S extends ToolSettings>(s: S): S => {
   return s.toolPath("zuke-no-such-playwright-xyz");
 };
 
+Deno.test("playwright: resolves its binary from node_modules by default", () => {
+  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
+  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+  const root = Deno.makeTempDirSync();
+  try {
+    const binDir = `${root}/node_modules/.bin`;
+    Deno.mkdirSync(binDir, { recursive: true });
+    const bin = `${binDir}/playwright`;
+    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
+    const s = new PlaywrightTestSettings();
+    s.os_ = "linux"; // pin so the planted bare shim matches on any host
+    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
+  }
+});
+
 Deno.test("every PlaywrightTasks function reaches execution", async () => {
   await assertRejects(() => PlaywrightTasks.test(missing), ToolNotFoundError);
   await assertRejects(

--- a/packages/tsc-alias/README.md
+++ b/packages/tsc-alias/README.md
@@ -51,6 +51,8 @@ class TscAliasRunSettings extends ToolSettings
 
   override protected defaultTool(): string
     The executable this settings object drives (`tsc-alias`).
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — tsc-alias is an npm-distributed tool.
   project(path: PathLike): this
     Path to the `tsconfig.json` to read aliases from (`-p`/`--project`).
   watch(): this

--- a/packages/tsc-alias/src/tsc_alias.ts
+++ b/packages/tsc-alias/src/tsc_alias.ts
@@ -24,6 +24,7 @@ import {
   type Configure,
   type PathLike,
   runSettings,
+  type ToolResolution,
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
@@ -46,6 +47,11 @@ export class TscAliasRunSettings extends ToolSettings {
   /** The executable this settings object drives (`tsc-alias`). */
   protected override defaultTool(): string {
     return "tsc-alias";
+  }
+
+  /** Resolve the binary from `node_modules/.bin` by default — tsc-alias is an npm-distributed tool. */
+  protected override defaultResolution(): ToolResolution {
+    return "node_modules";
   }
 
   /** Path to the `tsconfig.json` to read aliases from (`-p`/`--project`). */

--- a/packages/tsc-alias/tests/tsc_alias_test.ts
+++ b/packages/tsc-alias/tests/tsc_alias_test.ts
@@ -54,3 +54,22 @@ const missing = <S extends ToolSettings>(s: S): S => {
 Deno.test("TscAliasTasks.run reaches execution", async () => {
   await assertRejects(() => TscAliasTasks.run(missing), ToolNotFoundError);
 });
+
+Deno.test("tsc-alias: resolves its binary from node_modules by default", () => {
+  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
+  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+  const root = Deno.makeTempDirSync();
+  try {
+    const binDir = `${root}/node_modules/.bin`;
+    Deno.mkdirSync(binDir, { recursive: true });
+    const bin = `${binDir}/tsc-alias`;
+    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
+    const s = new TscAliasRunSettings();
+    s.os_ = "linux";
+    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
+  }
+});

--- a/packages/tsc/README.md
+++ b/packages/tsc/README.md
@@ -56,6 +56,8 @@ abstract class TscBaseSettings extends ToolSettings
 
   override protected defaultTool(): string
     The default binary these settings invoke: `tsc`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — tsc is an npm-distributed tool.
 
 class TscBuildSettings extends TscBaseSettings
   Settings for a `tsc --build` project-references run.

--- a/packages/tsc/src/tsc.ts
+++ b/packages/tsc/src/tsc.ts
@@ -25,6 +25,7 @@ import {
   type Configure,
   type PathLike,
   runSettings,
+  type ToolResolution,
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
@@ -34,6 +35,11 @@ export abstract class TscBaseSettings extends ToolSettings {
   /** The default binary these settings invoke: `tsc`. */
   protected override defaultTool(): string {
     return "tsc";
+  }
+
+  /** Resolve the binary from `node_modules/.bin` by default — tsc is an npm-distributed tool. */
+  protected override defaultResolution(): ToolResolution {
+    return "node_modules";
   }
 }
 

--- a/packages/tsc/tests/tsc_test.ts
+++ b/packages/tsc/tests/tsc_test.ts
@@ -72,3 +72,22 @@ Deno.test("TscTasks.tsc reaches execution", async () => {
 Deno.test("TscTasks.build reaches execution", async () => {
   await assertRejects(() => TscTasks.build(missing), ToolNotFoundError);
 });
+
+Deno.test("tsc: resolves its binary from node_modules by default", () => {
+  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
+  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+  const root = Deno.makeTempDirSync();
+  try {
+    const binDir = `${root}/node_modules/.bin`;
+    Deno.mkdirSync(binDir, { recursive: true });
+    const bin = `${binDir}/tsc`;
+    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
+    const s = new TscSettings();
+    s.os_ = "linux"; // pin so the planted bare shim matches on any host
+    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
+  }
+});

--- a/packages/tsdown/README.md
+++ b/packages/tsdown/README.md
@@ -54,6 +54,8 @@ class TsdownBuildSettings extends ToolSettings
 
   override protected defaultTool(): string
     The default executable to run: `tsdown`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — tsdown is an npm-distributed tool.
   entry(...paths: PathLike[]): this
     Entry point(s) to bundle (positional); repeatable.
   format(...formats: TsdownFormat[]): this
@@ -88,6 +90,8 @@ class TsdownMigrateSettings extends ToolSettings
 
   override protected defaultTool(): string
     The default executable to run: `tsdown`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — tsdown is an npm-distributed tool.
   from(value: string): this
     The tool to migrate from, e.g. `tsup` (`--from`).
   dryRun(): this

--- a/packages/tsdown/src/tsdown.ts
+++ b/packages/tsdown/src/tsdown.ts
@@ -24,6 +24,7 @@ import {
   type Configure,
   type PathLike,
   runSettings,
+  type ToolResolution,
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
@@ -50,6 +51,11 @@ export class TsdownBuildSettings extends ToolSettings {
   /** The default executable to run: `tsdown`. */
   protected override defaultTool(): string {
     return "tsdown";
+  }
+
+  /** Resolve the binary from `node_modules/.bin` by default — tsdown is an npm-distributed tool. */
+  protected override defaultResolution(): ToolResolution {
+    return "node_modules";
   }
 
   /** Entry point(s) to bundle (positional); repeatable. */
@@ -159,6 +165,11 @@ export class TsdownMigrateSettings extends ToolSettings {
   /** The default executable to run: `tsdown`. */
   protected override defaultTool(): string {
     return "tsdown";
+  }
+
+  /** Resolve the binary from `node_modules/.bin` by default — tsdown is an npm-distributed tool. */
+  protected override defaultResolution(): ToolResolution {
+    return "node_modules";
   }
 
   /** The tool to migrate from, e.g. `tsup` (`--from`). */

--- a/packages/tsdown/tests/tsdown_test.ts
+++ b/packages/tsdown/tests/tsdown_test.ts
@@ -87,3 +87,22 @@ Deno.test("TsdownTasks.build reaches execution", async () => {
 Deno.test("TsdownTasks.migrate reaches execution", async () => {
   await assertRejects(() => TsdownTasks.migrate(missing), ToolNotFoundError);
 });
+
+Deno.test("tsdown: resolves its binary from node_modules by default", () => {
+  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
+  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+  const root = Deno.makeTempDirSync();
+  try {
+    const binDir = `${root}/node_modules/.bin`;
+    Deno.mkdirSync(binDir, { recursive: true });
+    const bin = `${binDir}/tsdown`;
+    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
+    const s = new TsdownBuildSettings();
+    s.os_ = "linux"; // pin so the planted bare shim matches on any host
+    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
+  }
+});

--- a/packages/tsgo/README.md
+++ b/packages/tsgo/README.md
@@ -52,6 +52,8 @@ class TsgoSettings extends ToolSettings
 
   override protected defaultTool(): string
     The executable this settings object drives (`tsgo`).
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — tsgo is an npm-distributed tool.
   paths(...values: PathLike[]): this
     Source files to compile (positional); repeatable.
   project(path: PathLike): this

--- a/packages/tsgo/src/tsgo.ts
+++ b/packages/tsgo/src/tsgo.ts
@@ -25,6 +25,7 @@ import {
   type Configure,
   type PathLike,
   runSettings,
+  type ToolResolution,
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
@@ -50,6 +51,11 @@ export class TsgoSettings extends ToolSettings {
   /** The executable this settings object drives (`tsgo`). */
   protected override defaultTool(): string {
     return "tsgo";
+  }
+
+  /** Resolve the binary from `node_modules/.bin` by default — tsgo is an npm-distributed tool. */
+  protected override defaultResolution(): ToolResolution {
+    return "node_modules";
   }
 
   /** Source files to compile (positional); repeatable. */

--- a/packages/tsgo/tests/tsgo_test.ts
+++ b/packages/tsgo/tests/tsgo_test.ts
@@ -49,3 +49,22 @@ const missing = <S extends ToolSettings>(s: S): S => {
 Deno.test("TsgoTasks.tsgo reaches execution", async () => {
   await assertRejects(() => TsgoTasks.tsgo(missing), ToolNotFoundError);
 });
+
+Deno.test("tsgo: resolves its binary from node_modules by default", () => {
+  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
+  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+  const root = Deno.makeTempDirSync();
+  try {
+    const binDir = `${root}/node_modules/.bin`;
+    Deno.mkdirSync(binDir, { recursive: true });
+    const bin = `${binDir}/tsgo`;
+    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
+    const s = new TsgoSettings();
+    s.os_ = "linux"; // pin so the planted bare shim matches on any host
+    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
+  }
+});

--- a/packages/tsup/README.md
+++ b/packages/tsup/README.md
@@ -40,6 +40,8 @@ class TsupBuildSettings extends ToolSettings
 
   override protected defaultTool(): string
     The executable this settings object runs: `tsup`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — tsup is an npm-distributed tool.
   entry(...paths: PathLike[]): this
     Entry point(s) to bundle (positional); repeatable.
   format(...formats: TsupFormat[]): this

--- a/packages/tsup/src/tsup.ts
+++ b/packages/tsup/src/tsup.ts
@@ -23,6 +23,7 @@ import {
   type Configure,
   type PathLike,
   runSettings,
+  type ToolResolution,
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
@@ -47,6 +48,11 @@ export class TsupBuildSettings extends ToolSettings {
   /** The executable this settings object runs: `tsup`. */
   protected override defaultTool(): string {
     return "tsup";
+  }
+
+  /** Resolve the binary from `node_modules/.bin` by default — tsup is an npm-distributed tool. */
+  protected override defaultResolution(): ToolResolution {
+    return "node_modules";
   }
 
   /** Entry point(s) to bundle (positional); repeatable. */

--- a/packages/tsup/tests/tsup_test.ts
+++ b/packages/tsup/tests/tsup_test.ts
@@ -56,3 +56,22 @@ const missing = <S extends ToolSettings>(s: S): S => {
 Deno.test("TsupTasks.build reaches execution", async () => {
   await assertRejects(() => TsupTasks.build(missing), ToolNotFoundError);
 });
+
+Deno.test("tsup: resolves its binary from node_modules by default", () => {
+  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
+  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+  const root = Deno.makeTempDirSync();
+  try {
+    const binDir = `${root}/node_modules/.bin`;
+    Deno.mkdirSync(binDir, { recursive: true });
+    const bin = `${binDir}/tsup`;
+    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
+    const s = new TsupBuildSettings();
+    s.os_ = "linux"; // pin so the planted bare shim matches on any host
+    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
+  }
+});

--- a/packages/tsx/README.md
+++ b/packages/tsx/README.md
@@ -50,6 +50,8 @@ abstract class TsxCommonSettings extends ToolSettings
 
   override protected defaultTool(): string
     The underlying executable: `tsx`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — tsx is an npm-distributed tool.
   script(path: PathLike): this
     The entry point to execute (required).
   scriptArgs(...args: Array<string | number>): this

--- a/packages/tsx/src/tsx.ts
+++ b/packages/tsx/src/tsx.ts
@@ -24,6 +24,7 @@ import {
   type Configure,
   type PathLike,
   runSettings,
+  type ToolResolution,
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
@@ -42,6 +43,11 @@ export abstract class TsxCommonSettings extends ToolSettings {
   /** The underlying executable: `tsx`. */
   protected override defaultTool(): string {
     return "tsx";
+  }
+
+  /** Resolve the binary from `node_modules/.bin` by default — tsx is an npm-distributed tool. */
+  protected override defaultResolution(): ToolResolution {
+    return "node_modules";
   }
 
   /** The entry point to execute (required). */

--- a/packages/tsx/tests/tsx_test.ts
+++ b/packages/tsx/tests/tsx_test.ts
@@ -93,3 +93,25 @@ Deno.test("TsxTasks.watch reaches execution", async () => {
     ToolNotFoundError,
   );
 });
+
+Deno.test("tsx: resolves its binary from node_modules by default", () => {
+  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
+  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+  const root = Deno.makeTempDirSync();
+  try {
+    const binDir = `${root}/node_modules/.bin`;
+    Deno.mkdirSync(binDir, { recursive: true });
+    const bin = `${binDir}/tsx`;
+    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
+    const s = new TsxSettings();
+    s.os_ = "linux";
+    assertEquals(
+      s.cwd(root).script("main.ts").resolvedArgv()[0],
+      bin.replace(/\\/g, "/"),
+    );
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
+  }
+});

--- a/packages/turbo/README.md
+++ b/packages/turbo/README.md
@@ -72,6 +72,8 @@ abstract class TurboSettings extends ToolSettings
 
   override protected defaultTool(): string
     The tool binary this settings class invokes: `turbo`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — turbo is an npm-distributed tool.
 
 interface TurboTasksApi
   The shape of {@link TurboTasks}.

--- a/packages/turbo/src/turbo.ts
+++ b/packages/turbo/src/turbo.ts
@@ -18,6 +18,7 @@ import {
   type Configure,
   type PathLike,
   runSettings,
+  type ToolResolution,
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
@@ -27,6 +28,11 @@ export abstract class TurboSettings extends ToolSettings {
   /** The tool binary this settings class invokes: `turbo`. */
   protected override defaultTool(): string {
     return "turbo";
+  }
+
+  /** Resolve the binary from `node_modules/.bin` by default — turbo is an npm-distributed tool. */
+  protected override defaultResolution(): ToolResolution {
+    return "node_modules";
   }
 }
 

--- a/packages/turbo/tests/turbo_test.ts
+++ b/packages/turbo/tests/turbo_test.ts
@@ -14,6 +14,28 @@ Deno.test("the default binary is turbo", () => {
   assertEquals(new TurboRunSettings().tasks("build").argv()[0], "turbo");
 });
 
+Deno.test("turbo: resolves its binary from node_modules by default", () => {
+  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
+  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+  const root = Deno.makeTempDirSync();
+  try {
+    const binDir = `${root}/node_modules/.bin`;
+    Deno.mkdirSync(binDir, { recursive: true });
+    const bin = `${binDir}/turbo`;
+    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
+    const s = new TurboRunSettings();
+    s.os_ = "linux"; // pin so the planted bare shim matches on any host
+    assertEquals(
+      s.cwd(root).tasks("build").resolvedArgv()[0],
+      bin.replace(/\\/g, "/"),
+    );
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
+  }
+});
+
 Deno.test("run: requires a task; tasks first, then flags", () => {
   assertThrows(
     () => new TurboRunSettings().argv(),

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -79,6 +79,8 @@ abstract class ViteSettings extends ToolSettings
 
   override protected defaultTool(): string
     The default binary this wrapper invokes: `vite`.
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — vite is an npm-distributed tool.
   config(path: PathLike): this
     Use an explicit config file (`--config`).
   mode(name: string): this

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -19,6 +19,7 @@ import {
   type Configure,
   type PathLike,
   runSettings,
+  type ToolResolution,
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
@@ -34,6 +35,11 @@ export abstract class ViteSettings extends ToolSettings {
   /** The default binary this wrapper invokes: `vite`. */
   protected override defaultTool(): string {
     return "vite";
+  }
+
+  /** Resolve the binary from `node_modules/.bin` by default — vite is an npm-distributed tool. */
+  protected override defaultResolution(): ToolResolution {
+    return "node_modules";
   }
 
   /** Use an explicit config file (`--config`). */

--- a/packages/vite/tests/vite_test.ts
+++ b/packages/vite/tests/vite_test.ts
@@ -79,6 +79,25 @@ const missing = <S extends ToolSettings>(s: S): S => {
   return s.toolPath("zuke-no-such-vite-xyz");
 };
 
+Deno.test("vite: resolves its binary from node_modules by default", () => {
+  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
+  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+  const root = Deno.makeTempDirSync();
+  try {
+    const binDir = `${root}/node_modules/.bin`;
+    Deno.mkdirSync(binDir, { recursive: true });
+    const bin = `${binDir}/vite`;
+    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
+    const s = new ViteDevSettings();
+    s.os_ = "linux";
+    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
+  }
+});
+
 Deno.test("every ViteTasks function reaches execution", async () => {
   await assertRejects(() => ViteTasks.dev(missing), ToolNotFoundError);
   await assertRejects(() => ViteTasks.build(missing), ToolNotFoundError);

--- a/packages/vitest/README.md
+++ b/packages/vitest/README.md
@@ -48,6 +48,8 @@ class VitestSettings extends ToolSettings
 
   override protected defaultTool(): string
     The underlying tool binary (`vitest`).
+  override protected defaultResolution(): ToolResolution
+    Resolve the binary from `node_modules/.bin` by default — vitest is an npm-distributed tool.
   filters(...values: string[]): this
     Filename filters matched against test files (positional); repeatable.
   watch(): this

--- a/packages/vitest/src/vitest.ts
+++ b/packages/vitest/src/vitest.ts
@@ -23,6 +23,7 @@ import {
   type Configure,
   type PathLike,
   runSettings,
+  type ToolResolution,
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
@@ -52,6 +53,11 @@ export class VitestSettings extends ToolSettings {
   /** The underlying tool binary (`vitest`). */
   protected override defaultTool(): string {
     return "vitest";
+  }
+
+  /** Resolve the binary from `node_modules/.bin` by default — vitest is an npm-distributed tool. */
+  protected override defaultResolution(): ToolResolution {
+    return "node_modules";
   }
 
   /** Filename filters matched against test files (positional); repeatable. */

--- a/packages/vitest/tests/vitest_test.ts
+++ b/packages/vitest/tests/vitest_test.ts
@@ -61,3 +61,22 @@ const missing = <S extends ToolSettings>(s: S): S => {
 Deno.test("VitestTasks.run reaches execution", async () => {
   await assertRejects(() => VitestTasks.run(missing), ToolNotFoundError);
 });
+
+Deno.test("vitest: resolves its binary from node_modules by default", () => {
+  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
+  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+  const root = Deno.makeTempDirSync();
+  try {
+    const binDir = `${root}/node_modules/.bin`;
+    Deno.mkdirSync(binDir, { recursive: true });
+    const bin = `${binDir}/vitest`;
+    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
+    const s = new VitestSettings();
+    s.os_ = "linux";
+    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
+  }
+});


### PR DESCRIPTION
Remediation plan **8.2** (the behavior-fix half of PR 8; the dedup/refactor items ship separately).

## The bug

`ToolSettings` documents that a JS-ecosystem wrapper whose binary lives under `node_modules` overrides `defaultResolution()` to `"node_modules"` — but **no wrapper actually did** (`grep defaultResolution packages/*/src` matched only core). So in a normal npm project, `jest`/`vitest`/`eslint`/`tsup`/`tsx`/`knip`/`playwright` and siblings threw `ToolNotFoundError` unless **every call site** added `.fromNodeModules()`.

## The fix

The **24 npm-distributed dev-tool wrappers** now override `defaultResolution()` → `"node_modules"`, so the common case works without ceremony:

`biome, cypress, cspell, dpdm, dprint, eslint, jest, knip, nest, nx, openapi-ts, orval, oxlint, playwright, tsc, tsc-alias, tsdown, tsgo, tsup, tsx, turbo, vite, vitest, husky`

Deliberately **left on `PATH`**: runtimes/package managers (`deno`, `node`, `bun`, `npm`, `npx`, `pnpm`, `yarn`), system/standalone binaries (`docker`, `kubectl`, `helm`, `terraform`, `git`, `gh`, `gcloud`, …), the AI CLIs (`claude`, `codex`, `gemini`), and `release-please`.

**Behavior-safe:** node_modules resolution walks up for `node_modules/.bin/<tool>` and **falls back to PATH on a miss**; a per-call `.fromPath()` and the ambient `ZUKE_TOOL_RESOLUTION` still override it. Pure `buildArgs()`/argv is unchanged.

## Tests

Each wrapper adds a **hermetic** test proving its binary resolves from a planted `node_modules/.bin` **by default** (no `.fromNodeModules()`), with the ambient `ZUKE_TOOL_RESOLUTION` snapshotted/cleared/restored so it cant pass or fail for the wrong reason.

## Adversarial review

Attack→verify across classification / per-subcommand coverage / test-adequacy. Classification and coverage came back **clean** (all 24 correctly classified; every subcommand covered — abstract-base packages via one override, multi-class packages per-class). It surfaced **one low** finding — the tests didnt neutralize ambient `ZUKE_TOOL_RESOLUTION` (a guideline-5 hermeticity gap vs the repos own `tooling_test.ts`) — now **fixed across all 24**.

## Verification

- `deno task ci` + `./zuke docLint` + `./zuke apiDocsCheck` green: fmt, lint, spell, type-check, coverage (**lines 98.3%, branches 95.4%**), 1856 tests. Generated docs regenerated for the new member.

Bumps the 24 touched packages (patch).