### PR TITLE
refactor(ai): share ensureOk and JSON headers across review hosts

### DIFF
--- a/packages/ai/src/hosts/azure.ts
+++ b/packages/ai/src/hosts/azure.ts
@@ -10,12 +10,13 @@
  * @module
  */
 
-import { AiReviewError } from "../errors.ts";
 import { dig } from "../json.ts";
 import {
   commentBody,
   commentMarker,
+  ensureOk,
   type EnvReader,
+  jsonHeaders,
   type ReviewHost,
 } from "./types.ts";
 
@@ -56,24 +57,6 @@ export function resolveAzureContext(
   };
 }
 
-/** Headers for an Azure REST call. */
-function headers(token: string): Record<string, string> {
-  return {
-    "authorization": `Bearer ${token}`,
-    "accept": "application/json",
-    "content-type": "application/json",
-    "user-agent": "zuke-ai",
-  };
-}
-
-/** Throw an {@link AiReviewError} for a non-2xx Azure response. */
-async function ensureOk(response: Response): Promise<void> {
-  if (!response.ok) {
-    await response.body?.cancel();
-    throw new AiReviewError(`Azure DevOps API error: HTTP ${response.status}`);
-  }
-}
-
 /** The root URL for a PR's threads. */
 function threadsUrl(context: AzureContext): string {
   return `${context.collection}${encodeURIComponent(context.project)}` +
@@ -88,8 +71,10 @@ async function findThread(
   doFetch: typeof fetch,
 ): Promise<{ threadId: number; commentId: number } | undefined> {
   const url = `${threadsUrl(context)}?api-version=7.1`;
-  const response = await doFetch(url, { headers: headers(context.token) });
-  await ensureOk(response);
+  const response = await doFetch(url, {
+    headers: jsonHeaders({ "authorization": `Bearer ${context.token}` }),
+  });
+  await ensureOk(response, "Azure DevOps");
   const data: unknown = await response.json();
   const values = dig(data, "value");
   if (!Array.isArray(values)) return undefined;
@@ -124,23 +109,23 @@ export async function upsertPullRequestThread(
   if (existing === undefined) {
     const response = await doFetch(`${threadsUrl(context)}?api-version=7.1`, {
       method: "POST",
-      headers: headers(context.token),
+      headers: jsonHeaders({ "authorization": `Bearer ${context.token}` }),
       body: JSON.stringify({
         comments: [{ parentCommentId: 0, content, commentType: 1 }],
         status: 4, // "closed" — informational thread, not a review blocker.
       }),
     });
-    await ensureOk(response);
+    await ensureOk(response, "Azure DevOps");
     return;
   }
   const url = `${threadsUrl(context)}/${existing.threadId}` +
     `/comments/${existing.commentId}?api-version=7.1`;
   const response = await doFetch(url, {
     method: "PATCH",
-    headers: headers(context.token),
+    headers: jsonHeaders({ "authorization": `Bearer ${context.token}` }),
     body: JSON.stringify({ content, commentType: 1 }),
   });
-  await ensureOk(response);
+  await ensureOk(response, "Azure DevOps");
 }
 
 /** The Azure Pipelines implementation of {@link ReviewHost}. */

--- a/packages/ai/src/hosts/bitbucket.ts
+++ b/packages/ai/src/hosts/bitbucket.ts
@@ -9,12 +9,13 @@
  * @module
  */
 
-import { AiReviewError } from "../errors.ts";
 import { dig } from "../json.ts";
 import {
   commentBody,
   commentMarker,
+  ensureOk,
   type EnvReader,
+  jsonHeaders,
   MAX_COMMENT_PAGES,
   type ReviewHost,
 } from "./types.ts";
@@ -49,24 +50,6 @@ export function resolveBitbucketContext(
   return { token, workspace, repoSlug, prId };
 }
 
-/** Headers for a Bitbucket REST call. */
-function headers(token: string): Record<string, string> {
-  return {
-    "authorization": `Bearer ${token}`,
-    "accept": "application/json",
-    "content-type": "application/json",
-    "user-agent": "zuke-ai",
-  };
-}
-
-/** Throw an {@link AiReviewError} for a non-2xx Bitbucket response. */
-async function ensureOk(response: Response): Promise<void> {
-  if (!response.ok) {
-    await response.body?.cancel();
-    throw new AiReviewError(`Bitbucket API error: HTTP ${response.status}`);
-  }
-}
-
 /** The id of an existing comment carrying `marker`, or `undefined`. */
 async function findComment(
   context: BitbucketContext,
@@ -79,8 +62,10 @@ async function findComment(
   // Bitbucket paginates via a `next` URL in the body; follow it so a marker
   // beyond the first page is found instead of a duplicate comment posted.
   for (let page = 0; url !== undefined && page < MAX_COMMENT_PAGES; page++) {
-    const response = await doFetch(url, { headers: headers(context.token) });
-    await ensureOk(response);
+    const response = await doFetch(url, {
+      headers: jsonHeaders({ "authorization": `Bearer ${context.token}` }),
+    });
+    await ensureOk(response, "Bitbucket");
     const data: unknown = await response.json();
     const values = dig(data, "values");
     if (Array.isArray(values)) {
@@ -116,10 +101,10 @@ export async function upsertBitbucketComment(
   const url = existing === undefined ? root : `${root}/${existing}`;
   const response = await doFetch(url, {
     method: existing === undefined ? "POST" : "PUT",
-    headers: headers(context.token),
+    headers: jsonHeaders({ "authorization": `Bearer ${context.token}` }),
     body: JSON.stringify({ content: { raw } }),
   });
-  await ensureOk(response);
+  await ensureOk(response, "Bitbucket");
 }
 
 /** The Bitbucket Cloud Pipelines implementation of {@link ReviewHost}. */

--- a/packages/ai/src/hosts/github.ts
+++ b/packages/ai/src/hosts/github.ts
@@ -6,11 +6,11 @@
  * @module
  */
 
-import { AiReviewError } from "../errors.ts";
 import { dig } from "../json.ts";
 import {
   commentBody,
   commentMarker,
+  ensureOk,
   type EnvReader,
   MAX_COMMENT_PAGES,
   nextLink,
@@ -74,14 +74,6 @@ export function githubHeaders(token: string): Record<string, string> {
   };
 }
 
-/** Throw an {@link AiReviewError} for a non-2xx GitHub response. */
-export async function ensureGithubOk(response: Response): Promise<void> {
-  if (!response.ok) {
-    await response.body?.cancel();
-    throw new AiReviewError(`GitHub API error: HTTP ${response.status}`);
-  }
-}
-
 /** The id of an existing comment carrying `marker`, or `undefined`. */
 async function findComment(
   context: GithubContext,
@@ -96,7 +88,7 @@ async function findComment(
     const response = await doFetch(url, {
       headers: githubHeaders(context.token),
     });
-    await ensureGithubOk(response);
+    await ensureOk(response, "GitHub");
     const data: unknown = await response.json();
     if (Array.isArray(data)) {
       for (const item of data) {
@@ -137,7 +129,7 @@ export async function upsertPrComment(
     headers: githubHeaders(context.token),
     body: JSON.stringify({ body }),
   });
-  await ensureGithubOk(response);
+  await ensureOk(response, "GitHub");
 }
 
 /** The GitHub Actions implementation of {@link ReviewHost}. */

--- a/packages/ai/src/hosts/github_review.ts
+++ b/packages/ai/src/hosts/github_review.ts
@@ -12,8 +12,8 @@
  */
 
 import { dig } from "../json.ts";
-import { ensureGithubOk, type GithubContext, githubHeaders } from "./github.ts";
-import { MAX_COMMENT_PAGES, nextLink } from "./types.ts";
+import { type GithubContext, githubHeaders } from "./github.ts";
+import { ensureOk, MAX_COMMENT_PAGES, nextLink } from "./types.ts";
 
 /** The GitHub REST API origin. */
 const API = "https://api.github.com";
@@ -47,7 +47,7 @@ async function headSha(
   const response = await doFetch(url, {
     headers: githubHeaders(context.token),
   });
-  await ensureGithubOk(response);
+  await ensureOk(response, "GitHub");
   const data: unknown = await response.json();
   const sha = dig(data, "head", "sha");
   return typeof sha === "string" ? sha : undefined;
@@ -67,7 +67,7 @@ async function existingKeys(
     const response = await doFetch(url, {
       headers: githubHeaders(context.token),
     });
-    await ensureGithubOk(response);
+    await ensureOk(response, "GitHub");
     const data: unknown = await response.json();
     if (Array.isArray(data)) {
       for (const item of data) {

--- a/packages/ai/src/hosts/gitlab.ts
+++ b/packages/ai/src/hosts/gitlab.ts
@@ -10,12 +10,13 @@
  * @module
  */
 
-import { AiReviewError } from "../errors.ts";
 import { dig } from "../json.ts";
 import {
   commentBody,
   commentMarker,
+  ensureOk,
   type EnvReader,
+  jsonHeaders,
   MAX_COMMENT_PAGES,
   nextLink,
   type ReviewHost,
@@ -54,24 +55,6 @@ export function resolveGitlabContext(
   return { token, api: api.replace(/\/+$/, ""), projectId, mrIid };
 }
 
-/** The request headers for a GitLab REST call. */
-function headers(token: string): Record<string, string> {
-  return {
-    "PRIVATE-TOKEN": token,
-    "accept": "application/json",
-    "content-type": "application/json",
-    "user-agent": "zuke-ai",
-  };
-}
-
-/** Throw an {@link AiReviewError} for a non-2xx GitLab response. */
-async function ensureOk(response: Response): Promise<void> {
-  if (!response.ok) {
-    await response.body?.cancel();
-    throw new AiReviewError(`GitLab API error: HTTP ${response.status}`);
-  }
-}
-
 /** The id of an existing note carrying `marker`, or `undefined`. */
 async function findNote(
   context: GitlabContext,
@@ -83,8 +66,10 @@ async function findNote(
   // Newest-first, but still follow `Link: rel="next"` so an older marker on a
   // busy MR (>100 notes) is found rather than re-posted as a duplicate.
   for (let page = 0; url !== undefined && page < MAX_COMMENT_PAGES; page++) {
-    const response = await doFetch(url, { headers: headers(context.token) });
-    await ensureOk(response);
+    const response = await doFetch(url, {
+      headers: jsonHeaders({ "PRIVATE-TOKEN": context.token }),
+    });
+    await ensureOk(response, "GitLab");
     const data: unknown = await response.json();
     if (Array.isArray(data)) {
       for (const item of data) {
@@ -118,10 +103,10 @@ export async function upsertMergeRequestNote(
   const url = existing === undefined ? root : `${root}/${existing}`;
   const response = await doFetch(url, {
     method: existing === undefined ? "POST" : "PUT",
-    headers: headers(context.token),
+    headers: jsonHeaders({ "PRIVATE-TOKEN": context.token }),
     body: JSON.stringify({ body }),
   });
-  await ensureOk(response);
+  await ensureOk(response, "GitLab");
 }
 
 /** The GitLab CI implementation of {@link ReviewHost}. */

--- a/packages/ai/src/hosts/types.ts
+++ b/packages/ai/src/hosts/types.ts
@@ -6,6 +6,8 @@
  * @module
  */
 
+import { AiReviewError } from "../errors.ts";
+
 /** Read an environment variable, tolerating an absent `--allow-env` permission. */
 export type EnvReader = (name: string) => string | undefined;
 
@@ -81,4 +83,36 @@ export function commentMarker(name: string): string {
 /** Compose the final comment body: marker + header + assessment markdown. */
 export function commentBody(name: string, markdown: string): string {
   return `${commentMarker(name)}\n${HEADER}\n\n${markdown}`;
+}
+
+/**
+ * Throw an {@link AiReviewError} for a non-2xx response, naming the host in the
+ * message (e.g. `label` `"GitLab"` → "GitLab API error: HTTP 404"). Cancels the
+ * body first so the connection is released. Shared by every host integration.
+ */
+export async function ensureOk(
+  response: Response,
+  label: string,
+): Promise<void> {
+  if (!response.ok) {
+    await response.body?.cancel();
+    throw new AiReviewError(`${label} API error: HTTP ${response.status}`);
+  }
+}
+
+/**
+ * The common JSON request headers for a host REST call — `accept` and
+ * `content-type` of `application/json`, the `zuke-ai` user-agent — merged with
+ * the host's own `auth` header(s) (a bearer `authorization`, GitLab's
+ * `PRIVATE-TOKEN`, …).
+ */
+export function jsonHeaders(
+  auth: Record<string, string>,
+): Record<string, string> {
+  return {
+    ...auth,
+    "accept": "application/json",
+    "content-type": "application/json",
+    "user-agent": "zuke-ai",
+  };
 }


### PR DESCRIPTION
Remediation plan **8.4** — dedup copy-pasted host helpers in `@zuke/ai`. Pure internal refactor, **behavior identical**.

## What was duplicated

Each per-host integration under `packages/ai/src/hosts/` carried a **verbatim** copy of the non-2xx check (`ensureOk`: cancel the body, throw `AiReviewError` naming the host) — 4 copies across azure/bitbucket/gitlab/github — and 3 of them an identical JSON header builder. GitHub additionally exported its own `ensureGithubOk` that `github_review` re-imported.

## The dedup

Two shared internal helpers now live in `hosts/types.ts`:
- **`ensureOk(response, label)`** — takes the host label, so the error text (`"GitLab API error: HTTP 404"`, etc.) is unchanged.
- **`jsonHeaders(auth)`** — merges a host auth header with the common `accept`/`content-type`/`user-agent`.

Azure, Bitbucket, GitLab, and GitHub call the shared `ensureOk` with their existing label; azure/bitbucket/gitlab use `jsonHeaders`. GitHub keeps its distinct `githubHeaders` (different `accept` + `x-github-api-version` — deliberately **not** folded in). `github_review` imports the shared `ensureOk` in place of the removed `ensureGithubOk`.

## Behavior preservation

Every error message, header value, URL, and control-flow path is unchanged — verified by the existing **248** host+reviewer tests, plus a check that each call site preserves its original label (Azure DevOps / Bitbucket / GitLab / GitHub) and auth header (Bearer / PRIVATE-TOKEN). `hosts/types.ts` is internal (not re-exported from `mod.ts`), so **no public API change** — hence a `refactor:` (no release bump). Net −19 lines; 5 `ensureOk` + 3 `headers` copies collapse to one shared pair.

## Verification

`deno task ci` + `./zuke docLint` + `./zuke apiDocsCheck` green: fmt, lint (no unused imports), spell, type-check, coverage (**98.3% lines / 95.4% branches**).

## Scope note (rest of PR 8)

8.2 shipped (#231). **8.1 declined** (would need Zukes first wrapper→wrapper dependency). **8.3 left as-is** (reusing `DynamicToolSettings` would break 5 packages public API or change argv ordering — not worth it for working, tested code). **8.5** (provider adapter) is the explicitly-lowest-priority refactor, deferred.