### PR TITLE
test: harden integration/e2e suite (ports, cleanup, check globs)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -61,7 +61,7 @@
     "test": "GITHUB_STEP_SUMMARY= deno test -A --frozen",
     "cov": "deno run -A zuke.ts coverage",
     "cov:report": "deno coverage cov_profile '--exclude=tests/'",
-    "check": "deno check --frozen zuke.ts tests/*.ts packages/*/mod.ts packages/*/src/*.ts packages/*/tests/*.ts",
+    "check": "deno check --frozen zuke.ts tests/**/*.ts packages/*/mod.ts packages/*/src/**/*.ts packages/*/tests/**/*.ts",
     "fmt": "deno fmt",
     "fmt:check": "deno fmt --check",
     "lint": "deno lint",

--- a/tests/e2e/cancel_e2e.ts
+++ b/tests/e2e/cancel_e2e.ts
@@ -64,6 +64,7 @@ Deno.test("a separate process cancels a suspended run and runs its compensation"
     assertEquals(loaded?.record.status, "cancelled");
     assertEquals(loaded?.record.events.some((e) => e.tool === "cancel"), true);
   } finally {
-    await Deno.remove(dir, { recursive: true });
+    // Best-effort: a cleanup failure must not mask the real assertion error.
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
   }
 });

--- a/tests/e2e/mcp_e2e.ts
+++ b/tests/e2e/mcp_e2e.ts
@@ -20,8 +20,21 @@ import {
 } from "../../packages/core/mod.ts";
 
 const FIXTURE = new URL("./fixtures/gate_build.ts", import.meta.url);
-const PORT = 8799;
+// An OS-assigned free port instead of a fixed constant, removing the port
+// collision-flake class. ponytail: a tiny bind→close→rebind race window
+// remains; the race-free fix is to bind `:0` in the server and report the
+// assigned port, which needs a core CLI change and is out of scope here.
+const PORT = freePort();
 const BASE = `http://127.0.0.1:${PORT}/`;
+
+/** Grab an OS-assigned free TCP port: bind ephemeral, read it, release it. */
+function freePort(): number {
+  const listener = Deno.listen({ port: 0 });
+  const addr = listener.addr;
+  listener.close();
+  if (addr.transport !== "tcp") throw new Error("expected a TCP listener");
+  return addr.port;
+}
 
 /** Run the gate fixture as a real `deno` subprocess against state dir `dir`. */
 async function runFixture(
@@ -149,7 +162,8 @@ Deno.test("two MCP sessions: query a suspended run over HTTP and signal it, audi
       server.kill();
       await killWithin(server, 10_000);
     }
-    await Deno.remove(dir, { recursive: true });
+    // Best-effort: a cleanup failure must not mask the real assertion error.
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
   }
 });
 

--- a/tests/e2e/race_e2e.ts
+++ b/tests/e2e/race_e2e.ts
@@ -64,6 +64,7 @@ Deno.test("two real processes resume the same run; exactly one wins", async () =
     const promotions = [a.out, b.out].filter((o) => o.includes("PROMOTED"));
     assertEquals(promotions.length, 1);
   } finally {
-    await Deno.remove(dir, { recursive: true });
+    // Best-effort: a cleanup failure must not mask the real assertion error.
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
   }
 });

--- a/tests/e2e/registry_mcp_e2e.ts
+++ b/tests/e2e/registry_mcp_e2e.ts
@@ -16,8 +16,21 @@ import {
 } from "../../packages/core/tests/_assert.ts";
 
 const FIXTURE = new URL("./fixtures/discoverable_build.ts", import.meta.url);
-const PORT = 8801;
+// An OS-assigned free port instead of a fixed constant, removing the port
+// collision-flake class. ponytail: a tiny bind→close→rebind race window
+// remains; the race-free fix is to bind `:0` in the server and report the
+// assigned port, which needs a core CLI change and is out of scope here.
+const PORT = freePort();
 const BASE = `http://127.0.0.1:${PORT}/`;
+
+/** Grab an OS-assigned free TCP port: bind ephemeral, read it, release it. */
+function freePort(): number {
+  const listener = Deno.listen({ port: 0 });
+  const addr = listener.addr;
+  listener.close();
+  if (addr.transport !== "tcp") throw new Error("expected a TCP listener");
+  return addr.port;
+}
 
 /** Run the fixture as a real `deno` subprocess against registry dir `dir`. */
 async function runFixture(
@@ -181,7 +194,8 @@ Deno.test("a build registered after startup appears as a runnable MCP tool", asy
       server.kill();
       await killWithin(server, 10_000);
     }
-    await Deno.remove(dir, { recursive: true });
+    // Best-effort: a cleanup failure must not mask the real assertion error.
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
   }
 });
 

--- a/tests/integration/_harness.ts
+++ b/tests/integration/_harness.ts
@@ -65,6 +65,12 @@ export async function withStateDir(
   } finally {
     if (prev === undefined) Deno.env.delete("ZUKE_STATE_DIR");
     else Deno.env.set("ZUKE_STATE_DIR", prev);
-    await Deno.remove(dir, { recursive: true });
+    // Best-effort cleanup: a removal error (e.g. a Windows file lock) must never
+    // replace the test's own assertion failure, which is the error worth seeing.
+    try {
+      await Deno.remove(dir, { recursive: true });
+    } catch {
+      // ignore — the temp dir is throwaway; masking the real error is worse.
+    }
   }
 }

--- a/tests/integration/harness_test.ts
+++ b/tests/integration/harness_test.ts
@@ -1,0 +1,41 @@
+/**
+ * Regression tests for the integration harness itself: its throwaway temp-dir
+ * cleanup must never mask the failure a test actually cares about. A `finally`
+ * that lets `Deno.remove` throw would replace the real assertion error with a
+ * removal error (e.g. a Windows file lock), so the cleanup is best-effort.
+ *
+ * @module
+ */
+
+import { assertEquals } from "../../packages/core/tests/_assert.ts";
+import { withStateDir } from "./_harness.ts";
+
+Deno.test("withStateDir surfaces the body error even when cleanup fails", async () => {
+  const marker = new Error("body failure");
+  let caught: unknown;
+  try {
+    await withStateDir(async (dir) => {
+      // Delete the dir out from under the finally so its Deno.remove throws
+      // (NotFound) — proving the removal error is swallowed, not the body's.
+      await Deno.remove(dir, { recursive: true });
+      throw marker;
+    });
+  } catch (error) {
+    caught = error;
+  }
+  assertEquals(caught, marker);
+});
+
+Deno.test("withStateDir resolves when cleanup fails after a successful body", async () => {
+  // The body succeeds but removes the dir itself, so the finally's own
+  // Deno.remove throws NotFound. On the old (unwrapped) code that rejected
+  // withStateDir even though nothing meaningful failed; the best-effort catch
+  // means a clean body now resolves — this is the behaviour the PR adds, and
+  // this call throwing would fail the test on a revert.
+  const prev = Deno.env.get("ZUKE_STATE_DIR");
+  await withStateDir(async (dir) => {
+    await Deno.remove(dir, { recursive: true });
+  });
+  // The env var is still restored on the success-with-failed-cleanup path.
+  assertEquals(Deno.env.get("ZUKE_STATE_DIR"), prev);
+});


### PR DESCRIPTION
## What

Test-infrastructure robustness from the remediation plan (PR 9). No published-package source changes — this is `test:` and does not bump any version.

- **`check` globs (9.5)** — `deno.json`'s `check` task previously matched only `tests/*.ts`, `packages/*/src/*.ts`, `packages/*/tests/*.ts`, so subdir sources (`packages/core/src/{mcp,state,registry}/*.ts`) and the whole `tests/integration/` + `tests/e2e/` trees were **not** type-checked by `deno task check` — only transitively. Broadened to `tests/**/*.ts`, `packages/*/src/**/*.ts`, `packages/*/tests/**/*.ts` (a strict superset). Confirmed clean under `--frozen`.
- **Cleanup no longer masks failures (9.2)** — `withStateDir` and the four `*_e2e.ts` suites made their `finally` `Deno.remove` best-effort. A removal error (e.g. a Windows file lock) could previously replace the test's own assertion error, which is the one worth seeing.
- **Free e2e ports (9.3)** — `mcp_e2e.ts` / `registry_mcp_e2e.ts` bind an OS-assigned free port (`Deno.listen({port:0})`) instead of the fixed `8799`/`8801`, removing a port-collision flake class.

## Tests

New `tests/integration/harness_test.ts` with two regression tests for the best-effort cleanup; one (`resolves when cleanup fails after a successful body`) throws on the pre-change harness and passes now — verified directly.

## Scope note

9.1 (harness `%s` format substitution / direct `Deno.stdout` capture) was skipped: no test uses `%s` or asserts raw subprocess stdout through the harness, so the gap is latent. 9.4 (sleep-based timing in `executor_test.ts`) was skipped: the concurrency test is deterministic and the 50 ms SIGTERM-listener wait has no clean readiness signal through the `$` abstraction. 9.6 (`@zuke/ai` hash/cache correctness) is deferred to its own `fix(ai): …` PR — different package, real behaviour fixes.

## Gate

`deno task ci` green (coverage 98.3% lines / 95.4% branches); `apiDocsCheck` and `docLint` unchanged. Adversarial review pass run: 0 confirmed defects; one test-quality finding surfaced and fixed pre-PR (strengthened the second regression test to actually guard the change).