### PR TITLE
fix(ai): cache-key and hash correctness

### DIFF
--- a/packages/ai/src/cache.ts
+++ b/packages/ai/src/cache.ts
@@ -49,14 +49,20 @@ export interface CacheStore {
 }
 
 /**
- * Whether `value` is a well-formed {@link CacheEntry} — it must at least carry a
- * string `text`. Parsed JSON is `unknown`, so this guard narrows it without a
- * cast; a malformed file (hand-edited, truncated, or from an older format) is
- * rejected as a miss rather than handed back as a bad entry.
+ * Whether `value` is a well-formed {@link CacheEntry} — it must carry a string
+ * `text` and a finite numeric `createdAt`. Parsed JSON is `unknown`, so this
+ * guard narrows it without a cast; a malformed file (hand-edited, truncated, or
+ * from an older format) is rejected as a miss rather than handed back as a bad
+ * entry. `createdAt` is required because {@link AiCache.get_} computes the TTL
+ * from it — a missing timestamp would make `now - createdAt` be `NaN`, whose
+ * comparisons are always false, so a stale entry would never expire and be
+ * served forever.
  */
 function isCacheEntry(value: unknown): value is CacheEntry {
-  return typeof value === "object" && value !== null && "text" in value &&
-    typeof value.text === "string";
+  return typeof value === "object" && value !== null &&
+    "text" in value && typeof value.text === "string" &&
+    "createdAt" in value && typeof value.createdAt === "number" &&
+    Number.isFinite(value.createdAt);
 }
 
 /**
@@ -154,7 +160,15 @@ export class AiCache {
   /** INTERNAL: fetch a live (non-expired) entry, or `undefined`. */
   async get_(key: string): Promise<CacheEntry | undefined> {
     if (!this.enabled__) return undefined;
-    const entry = await this.backing_().get(key);
+    let entry: CacheEntry | undefined;
+    try {
+      entry = await this.backing_().get(key);
+    } catch {
+      // Best-effort per the class contract: a throwing store is a miss, never a
+      // build-breaking error. (The file store already swallows its own errors;
+      // this guards an injected store that rejects.)
+      return undefined;
+    }
     if (entry === undefined) return undefined;
     if (this.ttl_ > 0 && this.now_() - entry.createdAt > this.ttl_ * 1_000) {
       return undefined; // expired — treat as a miss

--- a/packages/ai/src/fixer.ts
+++ b/packages/ai/src/fixer.ts
@@ -504,10 +504,12 @@ export class AiFixer implements Remediation {
       },
     };
 
-    // Cost cache: an identical failure (same provider, model, and prompt) reuses
-    // the prior fix instead of paying for another call.
+    // Cost cache: an identical failure (same provider, model, effort, and prompt)
+    // reuses the prior fix instead of paying for another call. `effort` is part
+    // of the key because it changes the model's output — omitting it would serve
+    // a fix computed at a different reasoning effort.
     const cacheKey = this.#cache?.enabled_()
-      ? this.#cache.key_([provider, model, system, user])
+      ? this.#cache.key_([provider, model, this.#effort ?? "", system, user])
       : undefined;
     const cached = cacheKey !== undefined
       ? await this.#cache?.get_(cacheKey)

--- a/packages/ai/src/hash.ts
+++ b/packages/ai/src/hash.ts
@@ -8,25 +8,31 @@
  * @module
  */
 
-/** The 32-bit FNV-1a offset basis. */
-const OFFSET_BASIS = 0x811c9dc5;
+/** The 64-bit FNV-1a offset basis. */
+const OFFSET_BASIS = 0xcbf29ce484222325n;
 
-/** The 32-bit FNV-1a prime. */
-const PRIME = 0x01000193;
+/** The 64-bit FNV-1a prime. */
+const PRIME = 0x00000100000001b3n;
+
+/** Mask that keeps the running hash within 64 bits (BigInt has no fixed width). */
+const MASK_64 = 0xffffffffffffffffn;
 
 /**
- * Hash `input` to a short, stable token (lowercase base-36) via FNV-1a. The
- * same input always yields the same token, on any platform, with no external
+ * Hash `input` to a short, stable token (lowercase base-36) via 64-bit FNV-1a.
+ * The same input always yields the same token, on any platform, with no external
  * dependencies — suitable for cache keys and fingerprints, not for security.
+ *
+ * 64 bits (via BigInt) rather than 32: these tokens key a response cache and a
+ * false-positive suppression set, where a collision would serve a wrong cached
+ * review or silently mute an unrelated finding. A 32-bit space reaches a 50%
+ * birthday-collision chance at only ~77k distinct inputs; 64 bits pushes that
+ * far past any realistic corpus.
  */
 export function stableHash(input: string): string {
   let hash = OFFSET_BASIS;
   for (let i = 0; i < input.length; i++) {
-    hash ^= input.charCodeAt(i);
-    // Multiply mod 2^32 without overflowing the safe-integer range: combine the
-    // 16-bit halves so the product stays exact, then mask back to 32 bits.
-    hash = Math.imul(hash, PRIME);
+    hash ^= BigInt(input.charCodeAt(i));
+    hash = (hash * PRIME) & MASK_64;
   }
-  // `>>> 0` reinterprets the 32-bit result as unsigned before the base-36 cast.
-  return (hash >>> 0).toString(36);
+  return hash.toString(36);
 }

--- a/packages/ai/src/reviewer.ts
+++ b/packages/ai/src/reviewer.ts
@@ -448,10 +448,12 @@ export class Reviewer implements Validation {
         console.warn(retryLine(this.name, info));
       },
     };
-    // Cost cache: an identical review (same provider, model, and prompt) reuses
-    // the prior response instead of paying for another call.
+    // Cost cache: an identical review (same provider, model, effort, and prompt)
+    // reuses the prior response instead of paying for another call. `effort` is
+    // part of the key because it changes the model's output — omitting it would
+    // serve a response computed at a different reasoning effort.
     const cacheKey = this.#cache?.enabled_()
-      ? this.#cache.key_([provider, model, system, user])
+      ? this.#cache.key_([provider, model, this.#effort ?? "", system, user])
       : undefined;
     const cached = cacheKey !== undefined
       ? await this.#cache?.get_(cacheKey)

--- a/packages/ai/tests/cache_test.ts
+++ b/packages/ai/tests/cache_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
+import { assertEquals } from "../../core/tests/_assert.ts";
 import { AiCache, aiCache } from "../src/cache.ts";
 import type { CacheEntry, CacheStore } from "../src/cache.ts";
 
@@ -149,13 +149,20 @@ Deno.test("the default file store round-trips and misses cleanly", async () => {
     // Valid JSON that is not a well-formed entry is also rejected as a miss.
     await Deno.writeTextFile(`${dir}/${key}.json`, JSON.stringify({ nope: 1 }));
     assertEquals(await cache.get_(key), undefined);
+    // An entry with text but no createdAt (an older format) is a miss too:
+    // without a timestamp the TTL check is NaN and the entry would otherwise be
+    // served forever. isCacheEntry rejects it.
+    await Deno.writeTextFile(
+      `${dir}/${key}.json`,
+      JSON.stringify({ text: "x" }),
+    );
+    assertEquals(await cache.get_(key), undefined);
   } finally {
     await Deno.remove(dir, { recursive: true });
   }
 });
 
-// Reference assertRejects so the shared import stays exercised under no-unused.
-Deno.test("a rejecting store get surfaces when not guarded by the cache", async () => {
+Deno.test("get_ swallows a throwing store and reports a miss (its contract)", async () => {
   const throwing: CacheStore = {
     get() {
       return Promise.reject(new Error("boom"));
@@ -164,5 +171,8 @@ Deno.test("a rejecting store get surfaces when not guarded by the cache", async 
       return Promise.resolve();
     },
   };
-  await assertRejects(() => throwing.get("k"), Error, "boom");
+  const cache = new AiCache().store(throwing);
+  // The class promises a store error is treated as a miss, never surfaced —
+  // a broken cache must not break the build it caches for.
+  assertEquals(await cache.get_("k"), undefined);
 });

--- a/packages/ai/tests/cost_controls_test.ts
+++ b/packages/ai/tests/cost_controls_test.ts
@@ -172,6 +172,25 @@ Deno.test("reviewer caches a response and reuses it on a repeat run", async () =
   assertEquals(store.map.size, 1);
 });
 
+Deno.test("reviewer cache key is effort-sensitive (no cross-effort reuse)", async () => {
+  const store = memStore();
+  const c = aiCache((x) => x.store(store));
+  const { fetch, calls } = recordFetch(
+    claude({ score: 1, severity: "low", summary: "s", findings: [] }),
+  );
+  const runAt = (effort: "low" | "high") =>
+    securityReviewer((r) =>
+      r.provider("claude").apiKey("k").quiet().diff((d) => d.text(DIFF))
+        .fetch(fetch).cache(c).effort(effort)
+    ).validate({ target: "t" });
+  await runAt("low");
+  await runAt("high");
+  // Different effort changes the model's output, so it must not reuse the
+  // low-effort response: two real calls, two distinct cache entries.
+  assertEquals(calls.length, 2);
+  assertEquals(store.map.size, 2);
+});
+
 Deno.test("a cached review notes it served from cache", async () => {
   const store = memStore();
   const c = aiCache((x) => x.store(store));
@@ -428,4 +447,20 @@ Deno.test("fixer reuses a cached fix on a repeat failure", async () => {
   await run();
   assertEquals(calls.length, 1);
   assertEquals(store.map.size, 1);
+});
+
+Deno.test("fixer cache key is effort-sensitive (no cross-effort reuse)", async () => {
+  const store = memStore();
+  const c = aiCache((x) => x.store(store));
+  const { fetch, calls } = recordFetch(claudeFix(ONE_EDIT));
+  const runAt = (effort: "low" | "high") =>
+    hermetic(
+      aiFixer((f) => f.provider("claude").apiKey("k").cache(c).effort(effort)),
+    ).fetch(fetch).remediate(CTX);
+  await runAt("low");
+  await runAt("high");
+  // Effort changes the fix the model produces, so the high-effort run must not
+  // replay the low-effort cache: two real calls, two distinct entries.
+  assertEquals(calls.length, 2);
+  assertEquals(store.map.size, 2);
 });

--- a/packages/ai/tests/hash_test.ts
+++ b/packages/ai/tests/hash_test.ts
@@ -1,0 +1,40 @@
+import { assertEquals } from "../../core/tests/_assert.ts";
+import { stableHash } from "../src/hash.ts";
+
+Deno.test("stableHash is deterministic for the same input", () => {
+  assertEquals(stableHash("hello world"), stableHash("hello world"));
+});
+
+Deno.test("stableHash distinguishes different inputs", () => {
+  assertEquals(stableHash("a") === stableHash("b"), false);
+  // A single-character change must change the token.
+  assertEquals(
+    stableHash("definitions.js") === stableHash("definitions.ts"),
+    false,
+  );
+});
+
+Deno.test("stableHash emits a lowercase base-36 token", () => {
+  const token = stableHash("some cache key\0with a nul");
+  assertEquals(token.length > 0, true);
+  assertEquals(/^[0-9a-z]+$/.test(token), true);
+});
+
+Deno.test("stableHash handles the empty string and unicode without throwing", () => {
+  assertEquals(stableHash(""), stableHash(""));
+  assertEquals(stableHash("café — ☕") === stableHash("cafe — ☕"), false);
+});
+
+Deno.test("stableHash uses the full 64-bit space (tokens exceed 32-bit width)", () => {
+  // A 32-bit FNV-1a token is at most 7 base-36 chars (2^32 < 36^7). Across a
+  // spread of inputs, a 64-bit hash must produce tokens longer than that,
+  // proving the widened space is actually in use.
+  let sawWide = false;
+  for (let i = 0; i < 200; i++) {
+    if (stableHash(`input-${i}-payload`).length > 7) {
+      sawWide = true;
+      break;
+    }
+  }
+  assertEquals(sawWide, true);
+});


### PR DESCRIPTION
## What

Four correctness fixes in the `@zuke/ai` response cache and its hash (remediation item 9.6, cache/hash cluster).

- **64-bit hash** — `stableHash` moves from 32-bit FNV-1a (`Math.imul`) to 64-bit FNV-1a via `BigInt`. The token keys both the response cache and the false-positive **suppression** set, where a collision would serve a wrong cached review or **silently mute an unrelated finding** (a security concern). A 32-bit space reaches a 50% birthday-collision chance at only ~77k distinct inputs; 64 bits pushes that far past any realistic corpus.
- **`createdAt` validation** — `isCacheEntry` now requires a finite numeric `createdAt`. Without it, the TTL check `now - createdAt` was `NaN`, whose comparisons are always false, so a timestamp-less entry (older format / hand-edited) **never expired and was served forever**.
- **`get_` throwing-store guard** — the backing-store read is wrapped in try/catch, honouring the class's documented contract that a store error is a *miss*, not a build-breaking throw. `put_` already did this; `get_` did not. (The prior test papered over the gap by asserting the throw *outside* the cache — now rewritten to assert `get_` returns `undefined`.)
- **effort in the cache key** — the reviewer and fixer add `this.#effort` to the key. `effort` changes the model's output but was absent from the key, so switching `.effort()` replayed a response computed at a different reasoning effort.

## Tests

- New `hash_test.ts` (determinism, distinctness, base-36 shape, unicode, 64-bit width).
- `cache_test.ts`: rewrote the papered-over throwing-store test to assert the real contract; added a file-store `createdAt`-missing → miss case (fails on pre-change code).
- `cost_controls_test.ts`: added effort-sensitivity tests for both reviewer and fixer (different effort → 2 calls, 2 distinct cache entries).

## Migration note

Widening the hash changes every derived token, so existing on-disk `.zuke/ai-cache` files miss once (harmless — best-effort) and any recorded suppression fingerprints in `.zuke/ai-suppress.json` must be **re-recorded**. Fingerprints are opaque tokens, not public API.

## Scope

This is the cache/hash cluster of 9.6. The tail — retry backoff cap on the thrown-fetch path, `applyEdits` `mkdir -p` for new-file fixes, `DiffSettings.fetchBase()` honour-or-error — is a separate follow-up PR (distinct modules).

## Gate

`deno task ci` green (coverage 98.3% lines / 95.4% branches); `apiDocsCheck` + `docLint` pass (no public-API/doc change — all edited symbols are internal). Adversarial review pass: 4 independent attackers (hash sign/precedence, `createdAt`, `get_` guard, effort-key collisions), **0 confirmed defects**.