### PR TITLE
fix(ai): cap thrown-fetch backoff and create parent dirs on apply

### DIFF
--- a/packages/ai/src/apply.ts
+++ b/packages/ai/src/apply.ts
@@ -113,17 +113,33 @@ export function checkEdits(edits: FileEdit[], guards: ApplyGuards): string[] {
 }
 
 /**
+ * Default write: create the file's parent directory (if any) then write it, so
+ * a fix that adds a file in a new directory doesn't fail with a missing-parent
+ * error. Paths are already normalised to `/`-separated, repo-relative form by
+ * {@link normalizePath}, so splitting on the last `/` yields the parent.
+ */
+async function writeEnsuringDir(path: string, content: string): Promise<void> {
+  const slash = path.lastIndexOf("/");
+  if (slash > 0) await Deno.mkdir(path.slice(0, slash), { recursive: true });
+  await Deno.writeTextFile(path, content);
+}
+
+/**
  * Validate and apply the edits, writing each file's full new contents. Returns
  * the list of written paths. Throws (writing nothing) when any edit violates a
- * guard. The `write` seam is overridable for tests.
+ * guard. The default write creates missing parent directories; the `write` seam
+ * is overridable for tests.
  */
 export async function applyEdits(
   edits: FileEdit[],
   guards: ApplyGuards,
-  write: (path: string, content: string) => Promise<void> = (p, c) =>
-    Deno.writeTextFile(p, c),
+  write: (path: string, content: string) => Promise<void> = writeEnsuringDir,
 ): Promise<string[]> {
   const paths = checkEdits(edits, guards);
+  // Writes are sequential and not transactional: if a later write fails (e.g. a
+  // permission error), files written earlier stay written. ponytail: no rollback
+  // — the fixer's output is human-reviewed and the run is re-runnable, so atomic
+  // multi-file application (temp + rename) isn't worth the complexity here.
   for (let i = 0; i < edits.length; i++) {
     await write(paths[i], edits[i].content);
   }

--- a/packages/ai/src/retry.ts
+++ b/packages/ai/src/retry.ts
@@ -154,7 +154,10 @@ export async function retryingFetch(
       if (timer !== undefined) clearTimeout(timer);
       lastReason = reasonForThrow(error, timeoutMs);
       if (last) break;
-      const delayMs = baseMs * Math.pow(2, attempt);
+      // Cap the thrown-fetch backoff at MAX_DELAY_MS too — the response path
+      // already caps via delayFor(); without this a large baseDelayMs or a long
+      // attempt run could sleep far past the ceiling on network errors.
+      const delayMs = Math.min(baseMs * Math.pow(2, attempt), MAX_DELAY_MS);
       options.onRetry?.({
         attempt: attempt + 1,
         attempts,

--- a/packages/ai/tests/fixer_test.ts
+++ b/packages/ai/tests/fixer_test.ts
@@ -1,7 +1,7 @@
 import { assertEquals } from "../../core/tests/_assert.ts";
 import { CommandError } from "@zuke/core/shell";
 import { AiFixer, aiFixer, type Fix } from "../mod.ts";
-import { checkEdits, DEFAULT_FIX_EXCLUDES } from "../src/apply.ts";
+import { applyEdits, checkEdits, DEFAULT_FIX_EXCLUDES } from "../src/apply.ts";
 import { parseFix } from "../src/fix.ts";
 import { readTextOrUndefined } from "../src/context.ts";
 import { commitAndPush } from "../src/commit.ts";
@@ -402,6 +402,29 @@ Deno.test("the allowlist is case-sensitive, so a case variant is not silently wi
     checkEdits([{ path: "src/ok.ts", content: "" }], guards),
     ["src/ok.ts"],
   );
+});
+
+Deno.test("applyEdits (default write) creates missing parent directories", async () => {
+  // Exercises the real default write — every other test injects a write seam,
+  // so the mkdir path would otherwise be uncovered. chdir into a temp dir so the
+  // repo-relative write lands there, not in the repo; restored in finally.
+  const dir = await Deno.makeTempDir({ prefix: "zuke-apply-" });
+  const cwd = Deno.cwd();
+  Deno.chdir(dir);
+  try {
+    const written = await applyEdits(
+      [{ path: "nested/new/mod.ts", content: "export const x = 1;\n" }],
+      { allow: ["**"], exclude: [], maxEdits: 10 },
+    );
+    assertEquals(written, ["nested/new/mod.ts"]);
+    assertEquals(
+      await Deno.readTextFile(`${dir}/nested/new/mod.ts`),
+      "export const x = 1;\n",
+    );
+  } finally {
+    Deno.chdir(cwd);
+    await Deno.remove(dir, { recursive: true });
+  }
 });
 
 /** A Claude fix response carrying token usage. */

--- a/packages/ai/tests/retry_test.ts
+++ b/packages/ai/tests/retry_test.ts
@@ -122,6 +122,23 @@ Deno.test("a thrown fetch (network error) is retried, then surfaces an AiReviewE
   assertEquals(sleeps, [5]); // one backoff between the two attempts
 });
 
+Deno.test("thrown-fetch backoff is capped at MAX_DELAY_MS", async () => {
+  const { sleeps, sleep } = recordSleep();
+  const f = scriptedFetch(
+    new TypeError("connection reset"),
+    new TypeError("connection reset"),
+    new Response("ok", { status: 200 }),
+  );
+  await retryingFetch(f.fetch, "https://api.example/x", { method: "POST" }, {
+    attempts: 3,
+    baseDelayMs: 20_000,
+    sleep,
+  });
+  // Attempt 0 → 20_000 (under the cap); attempt 1 → 40_000 uncapped, capped to
+  // the 30_000 ceiling. Without the cap this would sleep 40_000ms.
+  assertEquals(sleeps, [20_000, 30_000]);
+});
+
 Deno.test("a thrown fetch followed by a success returns the success", async () => {
   const { sleep } = recordSleep();
   const f = scriptedFetch(


### PR DESCRIPTION
## What

Two isolated correctness fixes in `@zuke/ai` (the 9.6 tail).

- **Thrown-fetch backoff cap** (`retry.ts`) — `retryingFetch`'s network-error (thrown `fetch`) path now caps its backoff at `MAX_DELAY_MS` (30s), matching the retryable-**response** path which already caps via `delayFor()`. Without it, a large `baseDelayMs` or a long attempt run could sleep far past the ceiling on DNS/TCP/TLS failures.
- **Create parent dirs on apply** (`apply.ts`) — `applyEdits`'s default write now `mkdir -p`s the file's parent directory before writing, so a fix that adds a **new file in a new directory** no longer fails with a missing-parent error. The `mkdir` lives in the default write only, so injected test writes stay hermetic. A comment documents that multi-file writes are sequential and **non-transactional** (no rollback) — deliberate for the human-reviewed, re-runnable fixer.

## Tests

- `retry_test.ts`: a 3-attempt thrown-fetch run with `baseDelayMs: 20_000` sleeps `[20_000, 30_000]` — the second backoff is capped (would be `40_000` uncapped).
- `fixer_test.ts`: `applyEdits` with the **default** write (chdir'd into a temp dir) creates `nested/new/mod.ts` and its parents — the real write path that every other test's injected seam bypassed.

## Scope

This closes two of the three 9.6-tail items. The third — **honouring `DiffSettings.fetchBase()` in the reviewer** (today a silent no-op there, though the fixer honours it) — is its own follow-up PR: it needs a new `.env()` seam on the reviewer for hermetic tests, shares `safeGitArg`, and changes CI diff-resolution behaviour, so it warrants a focused review.

## Gate

`deno task ci` green (coverage 98.3% lines / 95.4% branches); `apiDocsCheck` + `docLint` pass (all edited symbols internal — no public-API/doc change). Adversarial review: 2 attackers (retry cap edge cases, mkdir path safety / hermeticity), **0 confirmed defects**.