### PR TITLE
feat(ai): honour DiffSettings.fetchBase in the reviewer

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9405,6 +9405,10 @@ class Reviewer implements Validation
     The `fetch` implementation for the API call (test seam).
   exec(run: (argv: string[]) => Promise<string>): this
     The `git` runner used to produce the diff (test seam).
+  env(reader: EnvReader): this
+    Environment reader used to auto-detect the base branch for
+    {@link "./diff.ts".DiffSettings.fetchBase} (reads `GITHUB_BASE_REF`). A test
+    seam; defaults to the process environment.
   budget(budget: Budget): this
     Attach a shared {@link Budget} that caps spend by an exact token count
     (a USD cap is opt-in, computed from prices you supply to the budget). Pass

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -522,6 +522,10 @@ class Reviewer implements Validation
     The `fetch` implementation for the API call (test seam).
   exec(run: (argv: string[]) => Promise<string>): this
     The `git` runner used to produce the diff (test seam).
+  env(reader: EnvReader): this
+    Environment reader used to auto-detect the base branch for
+    {@link "./diff.ts".DiffSettings.fetchBase} (reads `GITHUB_BASE_REF`). A test
+    seam; defaults to the process environment.
   budget(budget: Budget): this
     Attach a shared {@link Budget} that caps spend by an exact token count
     (a USD cap is opt-in, computed from prices you supply to the budget). Pass

--- a/packages/ai/src/diff.ts
+++ b/packages/ai/src/diff.ts
@@ -146,3 +146,42 @@ export class DiffSettings {
     return argv;
   }
 }
+
+/**
+ * Whether a value is safe to pass as a positional `git` argument: non-empty and
+ * not option-like (a leading `-` could be misread as a flag — e.g. an injected
+ * `--upload-pack=...` — so such values are rejected rather than fetched).
+ */
+function safeGitArg(value: string): boolean {
+  return value !== "" && !value.startsWith("-");
+}
+
+/**
+ * Honour a {@link DiffSettings.fetchBase} request: fetch the base branch
+ * ourselves (a shallow, tag-less `git fetch`, auto-detecting the branch from
+ * `GITHUB_BASE_REF` when unset) and return the diff against `FETCH_HEAD`, so a
+ * CI job needs no manual `git fetch` step. Returns `undefined` — leaving the
+ * caller to fall back to its normal diff source — when no fetch was requested,
+ * the branch can't be determined, a `remote`/`branch` argument is unsafe, or the
+ * fetch/diff fails (offline, not a PR, ref unavailable). Shared by the reviewer
+ * and the {@link "./fixer.ts".AiFixer} so both resolve `fetchBase` identically.
+ */
+export async function fetchBaseDiff(
+  diff: DiffSettings,
+  run: (argv: string[]) => Promise<string>,
+  env: (name: string) => string | undefined,
+): Promise<string | undefined> {
+  const fetch = diff.fetch_();
+  if (fetch === undefined) return undefined;
+  const branch = fetch.branch ?? env("GITHUB_BASE_REF");
+  const remote = fetch.remote;
+  if (branch === undefined || !safeGitArg(branch) || !safeGitArg(remote)) {
+    return undefined;
+  }
+  try {
+    await run(["git", "fetch", "--no-tags", "--depth=1", remote, branch]);
+    return await run(["git", "diff", "FETCH_HEAD"]);
+  } catch {
+    return undefined; // offline, not a PR, or the ref is unavailable
+  }
+}

--- a/packages/ai/src/fixer.ts
+++ b/packages/ai/src/fixer.ts
@@ -29,6 +29,7 @@ import { postSuggestions } from "./hosts/github_review.ts";
 import {
   DEFAULT_EXCLUDES,
   DiffSettings,
+  fetchBaseDiff,
   filterDiff,
   truncate,
 } from "./diff.ts";
@@ -66,15 +67,6 @@ function suggestionBody(diagnosis: string, loc: FixLocation): string {
     ? ["```suggestion", "```"]
     : ["```suggestion", suggestion, "```"];
   return [diagnosis, "", ...block].join("\n");
-}
-
-/**
- * Whether a value is safe to pass as a positional `git` argument: non-empty and
- * not option-like (a leading `-` could be misread as a flag — e.g. an injected
- * `--upload-pack=...` — so such values are rejected rather than fetched).
- */
-function safeGitArg(value: string): boolean {
-  return value !== "" && !value.startsWith("-");
 }
 
 /**
@@ -349,22 +341,10 @@ export class AiFixer implements Remediation {
     const text = this.#diff.text_();
     if (text !== undefined) return text;
     const run = this.#git();
-    // When `.fetchBase()` is set, fetch the base branch ourselves (auto-detecting
-    // it from the CI env when unspecified) so no manual `git fetch` step is
-    // needed; fall back to the working-tree diff if the fetch can't be done.
-    const fetch = this.#diff.fetch_();
-    if (fetch) {
-      const branch = fetch.branch ?? this.#env("GITHUB_BASE_REF");
-      const remote = fetch.remote;
-      if (branch !== undefined && safeGitArg(branch) && safeGitArg(remote)) {
-        try {
-          await run(["git", "fetch", "--no-tags", "--depth=1", remote, branch]);
-          return await run(["git", "diff", "FETCH_HEAD"]);
-        } catch {
-          // Offline, not a PR, or the ref is unavailable — fall through.
-        }
-      }
-    }
+    // When `.fetchBase()` is set, fetch the base branch ourselves so no manual
+    // `git fetch` step is needed; fall back to the working-tree diff otherwise.
+    const fetched = await fetchBaseDiff(this.#diff, run, this.#env);
+    if (fetched !== undefined) return fetched;
     try {
       return await run(this.#diff.argv_());
     } catch {

--- a/packages/ai/src/reviewer.ts
+++ b/packages/ai/src/reviewer.ts
@@ -22,6 +22,7 @@ import { AiReviewError } from "./errors.ts";
 import {
   DEFAULT_EXCLUDES,
   DiffSettings,
+  fetchBaseDiff,
   filterDiff,
   truncate,
 } from "./diff.ts";
@@ -44,7 +45,7 @@ import {
   toMarkdown,
   writeStepSummary,
 } from "./report.ts";
-import { detectReviewHost, readEnv } from "./hosts.ts";
+import { detectReviewHost, type EnvReader, readEnv } from "./hosts.ts";
 import type { RetryInfo, RetryOptions } from "./retry.ts";
 import type { Budget } from "./budget.ts";
 import type { AiCache } from "./cache.ts";
@@ -77,6 +78,7 @@ export class Reviewer implements Validation {
   #quiet = false;
   #fetch?: typeof fetch;
   #exec?: (argv: string[]) => Promise<string>;
+  #env: EnvReader = readEnv;
   #budget?: Budget;
   #cache?: AiCache;
   #suppress?: Suppressions;
@@ -255,6 +257,16 @@ export class Reviewer implements Validation {
   }
 
   /**
+   * Environment reader used to auto-detect the base branch for
+   * {@link "./diff.ts".DiffSettings.fetchBase} (reads `GITHUB_BASE_REF`). A test
+   * seam; defaults to the process environment.
+   */
+  env(reader: EnvReader): this {
+    this.#env = reader;
+    return this;
+  }
+
+  /**
    * Attach a shared {@link Budget} that caps spend by an exact **token** count
    * (a USD cap is opt-in, computed from prices you supply to the budget). Pass
    * the same budget to several reviewers and a fixer to bound the whole build:
@@ -291,6 +303,11 @@ export class Reviewer implements Validation {
     const text = this.#diff.text_();
     if (text !== undefined) return text;
     const run = this.#exec ?? ((argv: string[]) => new Command(argv).text());
+    // Honour `.fetchBase()` (fetch the base branch, diff against FETCH_HEAD) so
+    // CI PR review needs no manual `git fetch`; fall through to the configured
+    // source when no fetch was requested or it couldn't be done.
+    const fetched = await fetchBaseDiff(this.#diff, run, this.#env);
+    if (fetched !== undefined) return fetched;
     return await run(this.#diff.argv_());
   }
 

--- a/packages/ai/tests/ai_test.ts
+++ b/packages/ai/tests/ai_test.ts
@@ -162,6 +162,91 @@ Deno.test("security review passes below the threshold and calls Claude", async (
   assertEquals(body.output_config.format.schema.type, "object");
 });
 
+Deno.test("reviewer fetchBase fetches the base branch and diffs against it", async () => {
+  const { fetch, calls } = recordFetch(
+    claude({ score: 0, severity: "none", summary: "", findings: [] }),
+  );
+  const git: string[][] = [];
+  await securityReviewer((r) =>
+    r.provider("claude").apiKey("k").quiet()
+      .diff((d) => d.fetchBase())
+      .env((n) => n === "GITHUB_BASE_REF" ? "master" : undefined)
+      .exec((argv) => {
+        git.push(argv);
+        return Promise.resolve(
+          argv[1] === "diff" ? "diff --git a/z b/z\n+base context" : "",
+        );
+      })
+      .fetch(fetch)
+  ).validate({ target: "t" });
+  // The reviewer honours fetchBase itself (previously a silent no-op): it fetches
+  // the auto-detected base branch and diffs against FETCH_HEAD.
+  assertEquals(git[0], [
+    "git",
+    "fetch",
+    "--no-tags",
+    "--depth=1",
+    "origin",
+    "master",
+  ]);
+  assertEquals(git[1], ["git", "diff", "FETCH_HEAD"]);
+  // The fetched base diff is what reaches the model prompt.
+  const content = JSON.parse(calls[0].body).messages[0].content;
+  assertEquals(content.includes("base context"), true);
+});
+
+Deno.test("reviewer fetchBase falls back to the plain diff when the fetch fails", async () => {
+  const { fetch, calls } = recordFetch(
+    claude({ score: 0, severity: "none", summary: "", findings: [] }),
+  );
+  const git: string[][] = [];
+  await securityReviewer((r) =>
+    r.provider("claude").apiKey("k").quiet()
+      .diff((d) => d.fetchBase("develop", "upstream"))
+      .env(() => undefined)
+      .exec((argv) => {
+        git.push(argv);
+        if (argv[1] === "fetch") return Promise.reject(new Error("offline"));
+        return Promise.resolve("diff --git a/w b/w\n+working tree");
+      })
+      .fetch(fetch)
+  ).validate({ target: "t" });
+  assertEquals(git[0], [
+    "git",
+    "fetch",
+    "--no-tags",
+    "--depth=1",
+    "upstream",
+    "develop",
+  ]);
+  // The fetch threw, so it falls back to the configured (working-tree) diff.
+  assertEquals(git.some((g) => g.length === 2 && g[1] === "diff"), true);
+  const content = JSON.parse(calls[0].body).messages[0].content;
+  assertEquals(content.includes("working tree"), true);
+});
+
+Deno.test("reviewer fetchBase rejects an option-like base ref (never fetches)", async () => {
+  const { fetch } = recordFetch(
+    claude({ score: 0, severity: "none", summary: "", findings: [] }),
+  );
+  const git: string[][] = [];
+  await securityReviewer((r) =>
+    r.provider("claude").apiKey("k").quiet()
+      // A hostile GITHUB_BASE_REF must never reach `git fetch` as a flag.
+      .diff((d) => d.fetchBase())
+      .env((n) => n === "GITHUB_BASE_REF" ? "--upload-pack=evil" : undefined)
+      .exec((argv) => {
+        git.push(argv);
+        return Promise.resolve("diff --git a/w b/w\n+plain");
+      })
+      .fetch(fetch)
+  ).validate({ target: "t" });
+  // safeGitArg rejects the option-like ref: no `git fetch` runs, and it falls
+  // straight through to the configured diff.
+  assertEquals(git.some((g) => g[1] === "fetch"), false);
+  assertEquals(git[0], ["git", "diff"]);
+});
+
 Deno.test("the build breaks when the risk score exceeds the threshold", async () => {
   const { fetch } = recordFetch(
     claude({ score: 9, severity: "high", summary: "RCE risk", findings: [] }),


### PR DESCRIPTION
## What

The reviewer previously **ignored `.fetchBase()`** — a silent no-op — even though CI PR review is its primary use case (the fixer honoured it, the reviewer didn't). It now fetches the base branch itself (shallow, tag-less `git fetch`, auto-detecting the branch from `GITHUB_BASE_REF` when unset) and diffs against `FETCH_HEAD`, so a CI job needs no manual `git fetch` step.

## How

- **Shared helper** — the fixer's inline `fetchBase` logic is extracted into `fetchBaseDiff(diff, run, env)` in `diff.ts` (with `safeGitArg` moved there), so the reviewer and fixer resolve `fetchBase` **identically**. `fetchBaseDiff` is internal (not re-exported from `mod.ts`).
- **Fixer unchanged** — its `#resolveDiff` now calls the shared helper; the return value, the fall-through to the working-tree diff, and its return-`""`-on-failure behaviour are preserved exactly.
- **Reviewer** — its `#resolveDiff` honours `fetchBase` via the same helper, then falls through to the existing `git diff` (which still throws on a git failure — unchanged). A new public `.env(reader)` seam (default: process env) makes base-branch detection testable, mirroring the fixer.

## Tests

Three new reviewer cases in `ai_test.ts`:
- honours `fetchBase`: fetches the auto-detected base and diffs `FETCH_HEAD`, and the fetched diff reaches the prompt;
- falls back to the configured diff when the fetch fails;
- **rejects an option-like `GITHUB_BASE_REF`** (e.g. `--upload-pack=evil`) so it never reaches `git fetch` as a flag — the security guard, previously tested only on the fixer.

The fixer's existing `fetchBase` tests still pass, confirming the extraction is behaviour-preserving.

## Versioning

`feat` (minor): adds the working reviewer `fetchBase` capability and a new public `.env()` method (backward-compatible).

## Gate

`deno task ci` green (coverage 98.3% lines / 95.4% branches); `apiDocsCheck` + `docLint` pass (regenerated — the only public-API delta is the documented `.env()` method). Adversarial review: 2 dimensions (fixer behaviour-preservation, reviewer honour + `git`-arg-injection safety), **0 live defects**; it surfaced one coverage-gap (the reviewer-side injection test — added in this PR) and one pre-existing/out-of-scope consistency note.