### PR TITLE
chore: repo hygiene — license metadata, lock, doc entrypoints, notes

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -73,6 +73,14 @@ What the project does to keep releases trustworthy:
   tree as a backstop. The merged release tree should already be clean; once a
   real release confirms this, drop the flag for the strongest
   "published == committed source" guarantee.
+- **`contents: write` + `persist-credentials` on the `quality` job.** The
+  `quality` job in `ci.yml` runs on `pull_request` with `contents: write` and
+  `actions/checkout`'s `persist-credentials: true`, because the AI lint fixer may
+  push a fix commit back to the PR branch. This is a deliberate trade-off, and it
+  is fork-safe: `pull_request` (not `pull_request_target`) runs with the base
+  repository's read-only `GITHUB_TOKEN` for a fork PR, so the elevated write and
+  persisted credential apply only to same-repository branches, never to code a
+  fork controls. Workflow egress is audited by `step-security/harden-runner`.
 
 ## Running the scanners yourself
 

--- a/deno.lock
+++ b/deno.lock
@@ -1,13 +1,7 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@std/yaml@1": "1.1.1",
     "npm:cspell@9": "9.8.0"
-  },
-  "jsr": {
-    "@std/yaml@1.1.1": {
-      "integrity": "a57665ecf3d17b926380593a56625d8a10cc7281802f1e993b5ebc94a48e71f8"
-    }
   },
   "npm": {
     "@cspell/cspell-bundled-dicts@9.8.0": {

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2960,16 +2960,6 @@ interface StateStore
   releaseLock(key: string, token: string): Promise<void>
     Release the lock `key` if still held under `token`; a no-op otherwise.
 
-interface Style
-  How a run renders its output.
-
-  github: boolean
-    Wrap target output in `::group::`/`::endgroup::` and emit `::error::`.
-  color: boolean
-    Emit ANSI colour codes (off when piped, under `NO_COLOR`, or in CI).
-  width: number
-    Width of horizontal rules and boxes, in characters.
-
 interface TarEntry
   A single entry within a tar archive — a regular file or a symbolic link.
 
@@ -3280,6 +3270,480 @@ type TargetStatus = "passed" | "failed" | "skipped" | "cached" | "waiting"
 
 type WaitDisposition = "fail" | "cancel-run" | { target: string; }
   What a timed-out wait does: fail, cancel the run, or run a compensation target.
+
+Ergonomic process execution built on `Deno.Command`, exposed as the `$`
+tagged template.
+
+```ts
+await $`deno test -A`;                            // throws on non-zero exit
+const out = await $`git rev-parse HEAD`.text();   // trimmed stdout
+const code = await $`flaky-cmd`.noThrow().code();  // exit code, no throw
+await $`build`.env({ NODE_ENV: "prod" }).cwd("./app");
+```
+
+Interpolated values become discrete argv entries — they are never spliced
+into a shell string — so there is no shell-injection surface. Arrays expand
+to multiple arguments.
+@module
+
+function $(strings: TemplateStringsArray, ...values: Interpolatable[]): Command
+  Run an external command, ergonomically.
+
+  @example
+      `await $\`deno test -A``
+
+function tokenize(strings: ReadonlyArray<string>, values: ReadonlyArray<Interpolatable>): string[]
+  Tokenise a tagged-template invocation into an argv array.
+
+  Literal whitespace separates arguments; interpolated values are appended as
+  atomic tokens (so `--flag=${x}` and `pre${x}` work), and arrays expand to one
+  argument per element. Interpolated values are never re-split on whitespace,
+  which is what keeps command construction injection-free.
+
+class Command implements PromiseLike<CommandOutput>
+  A lazily-executed command. Built by the `$` tagged template. The process does
+  not start until the command is awaited or a terminal method (`text`, `lines`,
+  `code`) is called; the result is memoised so repeated reads are cheap.
+
+  constructor(argv: string[])
+    Build a command from a discrete argv array (binary first).
+  env(record: Record<string, string>): this
+    Merge additional environment variables.
+  cwd(path: PathLike): this
+    Set the working directory for the process.
+  noThrow(): this
+    Do not throw on a non-zero exit; combine with {@link code}.
+  quiet(): this
+    Suppress live stdout/stderr streaming to the terminal.
+  killAfter(ms: number): this
+    Kill the process if it runs longer than `ms` milliseconds, raising a
+    {@link CommandTimeoutError}. Fires even under {@link noThrow}.
+  signal(signal: AbortSignal): this
+    Terminate the process (via `SIGTERM`) when `signal` aborts — for example
+    when the enclosing run is cancelled. Overrides the executor's ambient
+    run signal for this command. Composes with {@link killAfter}: either the
+    timeout or the abort kills the process, whichever fires first.
+  get commandLine(): string
+    The command line, for diagnostics.
+  then(onfulfilled?: ((value: CommandOutput) => TResult1 | PromiseLike<TResult1>) | null, onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null): PromiseLike<TResult1 | TResult2>
+    Await support: run the command and resolve to a {@link CommandOutput}.
+  async text(): Promise<string>
+    Run and resolve to trimmed stdout. Throws on non-zero unless `noThrow`.
+  async lines(): Promise<string[]>
+    Run and resolve to stdout split into lines (trailing blank dropped).
+  async code(): Promise<number>
+    Run and resolve to the numeric exit code. Never throws on non-zero.
+  spawn(): SpawnedProcess
+    Start the command as a long-lived process without waiting for it to
+    exit, returning a {@link SpawnedProcess} handle. Use this for a service —
+    a dev server, a database, `docker compose up` — that must keep running
+    while other targets execute; stop it with {@link SpawnedProcess.stop}.
+    stdout/stderr are inherited so the process's output is visible.
+
+class CommandError extends Error
+  Raised when a command exits non-zero and throwing was not suppressed.
+
+  constructor(readonly command: string, readonly code: number, readonly stderr: string)
+    Build the error from the failed command line, exit code, and stderr.
+  override name: string
+    The error name.
+
+class CommandOutput
+  The resolved result of a command, available when awaiting a {@link Command}.
+
+  constructor(readonly code: number, readonly stdout: string, readonly stderr: string)
+    Build the output from the process exit code and captured streams.
+  text(): string
+    Trimmed stdout.
+
+class CommandTimeoutError extends Error
+  Raised when a command is killed for exceeding its {@link Command.killAfter}
+  budget. Thrown regardless of {@link Command.noThrow}, since a timeout is a
+  distinct, exceptional outcome from a normal non-zero exit.
+
+  constructor(readonly command: string, readonly timeoutMs: number)
+    Build the error from the command line and the elapsed-time budget.
+  override name: string
+    The error name.
+
+class SpawnedProcess
+  A long-lived process started with {@link Command.spawn} — the handle a
+  {@link https://jsr.io/@zuke/core service} keeps alive. Unlike awaiting a
+  {@link Command}, spawning does not wait for the process to exit; call
+  {@link SpawnedProcess.stop} to terminate it (which is also the default
+  service teardown). Its stdout/stderr are inherited so the process's own
+  output is visible.
+
+  constructor(child: Deno.ChildProcess | undefined, readonly commandLine: string)
+    Wrap a spawned child process (or none, for a stub) and its command line.
+  get pid(): number
+    The operating-system process id (`-1` for a dry-run stub).
+  get status(): Promise<Deno.CommandStatus>
+    Resolves when the process exits (immediate success for a dry-run stub).
+  async stop(signal: Deno.Signal, graceMs: number): Promise<void>
+    Terminate the process and wait for it to exit. Sends `signal` (default
+    `SIGTERM`); if the process has not exited within `graceMs` (default 5s), it
+    escalates to `SIGKILL` so a process that ignores `SIGTERM` cannot hang
+    teardown. A process that has already exited is treated as stopped. A
+    dry-run stub (no child) is a no-op.
+
+type Interpolatable = string | number | AbsolutePath | Array<string | number | AbsolutePath>
+  A value that may be interpolated into a `$` template.
+
+Foundations for typed tool wrappers (settings-lambda task functions).
+
+A tool package (e.g. `@zuke/deno`, `@zuke/npm`) defines one settings class
+per subcommand by extending {@link ToolSettings}: `buildArgs()` assembles
+the subcommand argv purely (no I/O), while the base contributes the common
+fluent chainers (`env`, `cwd`, `noThrow`, `quiet`, `toolPath`, `args`) and
+the execution logic, which reuses {@link Command} so argv stays an array
+end-to-end — there is no shell string and no injection surface.
+
+```ts
+class MyToolSettings extends ToolSettings {
+  protected defaultTool() { return "mytool"; }
+  protected buildArgs() { return ["build", "--fast"]; }
+}
+await runSettings(new MyToolSettings(), (s) => s.cwd("app"));
+```
+@module
+
+function defineTool(tool: string, options: DefineToolOptions): ToolTask
+  Define a fluent task for a CLI that has no dedicated `@zuke` wrapper. Returns
+  a task that runs the tool, configured through a {@link DynamicToolSettings}
+  lambda — the same settings-lambda style as the built-in wrappers, with
+  `arg`/`flag`/`option` for argv and the shared `cwd`/`env`/`noThrow`/… chainers.
+
+  ```ts
+  import { defineTool } from "jsr:@zuke/core/tooling";
+
+  const terraform = defineTool("terraform");
+  await terraform((s) => s.arg("plan").option("out", "plan.tfplan"));
+  // → terraform plan --out plan.tfplan
+
+  const helmUpgrade = defineTool("helm", { subcommand: "upgrade" });
+  await helmUpgrade((s) => s.arg("api", "./chart").flag("install"));
+  // → helm upgrade api ./chart --install
+  ```
+
+function runSettings<S extends ToolSettings>(settings: S, configure?: Configure<S>): Promise<CommandOutput>
+  Construct-configure-run: the shared shape of every task function.
+
+  ```ts
+  export const MyTasks = {
+    build: (configure?: Configure<MyBuildSettings>) =>
+      runSettings(new MyBuildSettings(), configure),
+  };
+  ```
+
+function shimFallbackArgv(argv: ReadonlyArray<string>, os: typeof Deno.build.os): string[] | null
+  On Windows, wrap an argv in a `cmd /c` invocation so `.cmd`/`.bat` shims
+  (such as npm's) become spawnable; returns `null` on other platforms.
+
+function windowsCmdShim(argv: ReadonlyArray<string>, os: typeof Deno.build.os): string[]
+  On Windows, spawn a resolved `.cmd`/`.bat` shim (such as npm's `node_modules`
+  shims) through `cmd /c` — a batch shim is not a PE executable, so
+  `Deno.Command` cannot launch it directly. Returns `argv` unchanged on other
+  platforms or when the binary is not a batch shim.
+
+class DynamicToolSettings extends ToolSettings
+  Fluent settings for a {@link defineTool} tool: build the argv with
+  {@link DynamicToolSettings.arg}/{@link DynamicToolSettings.flag}/{@link
+  DynamicToolSettings.option} (in call order), plus all the shared chainers
+  (`cwd`, `env`, `noThrow`, `quiet`, `toolPath`, `args`).
+
+  constructor(tool: string, initial: string[])
+    Build settings for `tool`, seeded with any `initial` subcommand tokens.
+  override protected defaultTool(): string
+    The configured tool binary.
+  arg(...values: Array<string | number>): this
+    Append raw positional/argument tokens.
+  flag(name: string): this
+    Append a boolean flag, e.g. `flag("verbose")` → `--verbose` (or `-v`).
+  option(name: string, value: string | number): this
+    Append a flag and its value as two tokens, e.g. `--output dist`.
+  override protected buildArgs(): string[]
+    The argv assembled from the `arg`/`flag`/`option` calls, in order.
+
+class ToolNotFoundError extends Error
+  Raised when a tool's binary cannot be found on the system.
+
+  constructor(readonly tool: string, sawNodeModules: boolean)
+    Build the error naming the tool binary that could not be found.
+  override name: string
+    The error name.
+
+abstract class ToolSettings
+  Abstract fluent base for tool settings. Subclasses provide the binary
+  ({@link defaultTool}) and the pure subcommand argv ({@link buildArgs});
+  the base provides the shared chainers and {@link run}.
+
+  os_: typeof Deno.build.os
+    The platform identifier used by {@link run} to decide whether to retry a
+    missing binary through the `cmd /c` shim path (Windows only).
+
+    In production this is always `Deno.build.os`. It is exposed as a public
+    field — rather than read from `Deno.build.os` inline — so that tests can
+    pin a specific platform without spawning a subprocess or touching the
+    environment:
+
+    ```ts
+    const s = new MyToolSettings();
+    s.os_ = "windows"; // exercise the cmd /c retry branch on any host
+    ```
+
+    The trailing underscore signals an internal test seam: do not rely on this
+    field in production code.
+  abstract protected defaultTool(): string
+    The binary to spawn when {@link toolPath} is not set.
+  abstract protected buildArgs(): string[]
+    The subcommand argv. Must be pure — no I/O, no environment reads.
+  protected defaultResolution(): ToolResolution
+    The wrapper's default binary-resolution strategy. The base returns
+    `"path"` (bare name on `PATH`); a JS-ecosystem wrapper whose binary is
+    almost always installed under `node_modules` overrides this to
+    `"node_modules"`. A per-call {@link fromNodeModules}/{@link fromPath} and
+    the ambient `ZUKE_TOOL_RESOLUTION` both take precedence over this default.
+  env(record: Record<string, string>): this
+    Merge additional environment variables for the process.
+  cwd(path: PathLike): this
+    Set the working directory for the process.
+  noThrow(): this
+    Do not throw on a non-zero exit; inspect `code` on the output instead.
+  get throwsOnError(): boolean
+    Whether a failure should throw — the default, or `false` after
+    {@link noThrow}. A task that layers its own validation on top of the
+    subprocess (e.g. a coverage-threshold gate) reads this to decide whether a
+    gate failure throws or is merely reported.
+  quiet(): this
+    Suppress live stdout/stderr streaming to the terminal.
+  killAfter(ms: number): this
+    Kill the tool if it runs longer than `ms` milliseconds, raising a
+    `CommandTimeoutError`. Fires even under {@link noThrow}.
+  toolPath(path: PathLike): this
+    Override the binary to run (e.g. an absolute path to the tool).
+  fromNodeModules(): this
+    Resolve the binary npx-style: walk up from the working directory looking
+    for `node_modules/.bin/<tool>`, falling back to `PATH` on a miss. Overrides
+    both the wrapper default and the ambient `ZUKE_TOOL_RESOLUTION`. Has no
+    effect once {@link toolPath} is set (an explicit path always wins).
+  fromPath(): this
+    Resolve the binary from `PATH` only, ignoring any `node_modules/.bin`.
+  args(...extra: Array<string | number | AbsolutePath>): this
+    Escape hatch: append raw arguments after all typed options.
+  argv(): string[]
+    The full argv (binary first). Pure — useful for tests and diagnostics.
+  resolvedArgv(): string[]
+    The argv {@link run} will actually spawn — like {@link argv}, but with the
+    `node_modules/.bin` resolution applied (so it performs I/O). Useful for
+    tests and diagnostics: it reveals whether a wrapper resolved to a local
+    shim or fell back to the bare name on `PATH`.
+  async run(): Promise<CommandOutput>
+    Run the configured tool. If the binary is missing and the platform is
+    Windows, retry once through `cmd /c` (covers `.cmd`/`.bat` shims);
+    otherwise raise a {@link ToolNotFoundError} naming the tool.
+
+interface DefineToolOptions
+  Options for {@link defineTool}.
+
+  subcommand?: string | string[]
+    Leading subcommand token(s) prepended to every invocation.
+
+type Configure<S> = (settings: S) => S
+  A lambda that configures a settings instance and returns it.
+
+type ToolResolution = "node_modules" | "path"
+  How {@link ToolSettings.run} locates a wrapper's binary when no explicit
+  {@link ToolSettings.toolPath} is set:
+
+  - `"path"` — spawn the bare tool name and let the OS resolve it on `PATH`
+    (the default, matching a native/global install);
+  - `"node_modules"` — npx-style: walk up from the working directory looking
+    for `node_modules/.bin/<tool>`, falling back to `PATH` on a miss (so a
+    package hoisted to a monorepo root runs with no `.toolPath()`).
+
+type ToolTask = (configure?: Configure<DynamicToolSettings>) => Promise<CommandOutput>
+  A ready-to-run task for a {@link defineTool} tool.
+
+Primitive terminal rendering, shared by the executor's build reporting
+(`./report.ts`) and the `@zuke/console` package: ANSI styling, terminal-width
+detection, duration formatting, and the reusable `line`/`box`/`table`
+primitives that draw a build's output.
+
+Everything here is pure — no I/O, no process state — so argv-free output can
+be unit-tested and reused without duplicating escape codes. Cells may already
+carry ANSI codes; width is measured on the visible text ({@link visibleWidth})
+so painted content still aligns.
+@module
+
+function box(style: Style, content: string | readonly string[], options: BoxOptions): string[]
+  A bordered panel around `content` (a string, split on newlines, or an array
+  of lines). Content may carry ANSI codes; padding is measured on the visible
+  text so the border stays flush.
+
+function detectWidth(): number
+  Read the terminal width if available, clamped to a sane range.
+
+function formatDuration(ms: number): string
+  Format a duration in milliseconds as `1.2s`.
+
+function isStyleName(name: string): name is StyleName
+  Whether a string names one of the {@link SGR} styles.
+
+function line(style: Style, options: LineOptions): string
+  A horizontal rule spanning the style's width (dimmed by default).
+
+function pad(text: string, width: number, align: "left" | "right"): string
+  Pad `text` to `width` visible columns, aligning left (default) or right.
+
+function paint(color: boolean, codes: string, text: string): string
+  Wrap text in ANSI codes when colour is enabled, otherwise return it as-is.
+
+function sgrCodes(names: readonly StyleName[]): string
+  Concatenate the escape codes for `names` (an unknown name contributes none).
+
+function stripAnsi(text: string): string
+  Strip ANSI escape sequences, leaving the visible text.
+
+function stylize(color: boolean, names: readonly StyleName[], text: string): string
+  Paint `text` in the named styles when `color` is enabled.
+
+function table(style: Style, columns: readonly TableColumn[], rows: readonly (readonly string[])[], options: TableOptions): string[]
+  An aligned text table: a styled header row, an optional dividing rule, then
+  one line per row. Column widths fit the widest visible cell; cells may already
+  carry ANSI colour. Rows shorter than the columns are padded with empty cells.
+
+function visibleWidth(text: string): number
+  The printable width of `text`, ignoring any ANSI colour codes it carries.
+
+const SGR: { reset: string; bold: string; dim: string; italic: string; underline: string; black: string; red: string; green: string; yellow: string; blue: string; magenta: string; cyan: string; white: string; gray: string; }
+  ANSI select-graphic-rendition codes, keyed by style name.
+
+interface BoxOptions
+  Options for {@link box}.
+
+  title?: string
+    A title embedded in the top border.
+  padding?: number
+    Horizontal padding inside the border, in spaces. Defaults to `1`.
+  width?: number
+    Force an inner width; widened automatically to fit content and title.
+  border?: readonly StyleName[]
+    Styles for the border characters. Defaults to `["dim"]`.
+  titleStyle?: readonly StyleName[]
+    Styles for the title text. Defaults to `["bold"]`.
+
+interface LineOptions
+  Options for {@link line}.
+
+  char?: string
+    The character to repeat. Defaults to `═`.
+  width?: number
+    The rule width. Defaults to the style's width.
+  style?: readonly StyleName[]
+    Styles applied to the whole rule. Defaults to `["dim"]`.
+
+interface Style
+  How a run renders its output.
+
+  github: boolean
+    Wrap target output in `::group::`/`::endgroup::` and emit `::error::`.
+  color: boolean
+    Emit ANSI colour codes (off when piped, under `NO_COLOR`, or in CI).
+  width: number
+    Width of horizontal rules and boxes, in characters.
+
+interface TableColumn
+  One column of a {@link table}.
+
+  header: string
+    The column header.
+  align?: "left" | "right"
+    Cell alignment. Defaults to `left`.
+
+interface TableOptions
+  Options for {@link table}.
+
+  separator?: string
+    Column separator. Defaults to two spaces.
+  divider?: boolean
+    Draw a dividing rule under the header. Defaults to `true`.
+  headerStyle?: readonly StyleName[]
+    Styles for the header row. Defaults to `["bold"]`.
+  dividerStyle?: readonly StyleName[]
+    Styles for the divider rule. Defaults to `["dim"]`.
+
+type StyleName = keyof typeof SGR
+  A style name understood by {@link sgrCodes}, {@link paint}, and markup.
+
+A backend conformance kit for the state-api (`docs/state-api.md`).
+
+A hosted {@link "./state/store.ts".StateStore} / {@link
+"./registry/registry.ts".BuildRegistry} backend must implement the same
+compare-and-swap, listing, and TTL-lock semantics the filesystem backend
+does — the exactly-once resume, lock takeover, and one-writer-wins guarantees
+the core relies on ride on them. This module extracts those semantics into
+store-agnostic scenarios you can point at any implementation: Zuke's own test
+lane runs them against the filesystem store, and a backend author runs them
+against a live service:
+
+```sh
+deno run -A jsr:@zuke/core/conformance --url http://localhost:8080 [--token …]
+```
+
+Every scenario uses freshly-generated ids, so it is safe to run against a
+shared, persistent service; the lock-takeover scenario uses a short real TTL
+and a brief sleep, so it takes a beat of wall-clock time. A backend that
+passes is compatible with
+{@link "./state/http_store.ts".HttpStateStore} /
+{@link "./registry/http_registry.ts".HttpBuildRegistry}; one that violates
+CAS fails loudly.
+@module
+
+async function checkBuildRegistry(make: BuildRegistryFactory): Promise<ConformanceResult[]>
+  Run the build-registry conformance scenarios against the registry `make` builds.
+
+async function checkStateStore(make: StateStoreFactory, options: ConformanceOptions): Promise<ConformanceResult[]>
+  Run the state-store conformance scenarios against the store `make` builds.
+
+async function runConformanceCli(args: string[], deps: ConformanceCliDeps): Promise<number>
+  Run the conformance kit as a CLI: `--url <base>` (required) and `--token <bearer>` (optional) name the backend, then both suites run against it. Prints
+  a `PASS`/`FAIL` line per scenario and resolves to a process exit code — `0`
+  when every scenario passes, `1` when any fails or `--url` is missing.
+
+interface ConformanceCliDeps
+  Injectable dependencies for {@link runConformanceCli} (tests override them).
+
+  makeStateStore?: (url: string, token?: string) => StateStore
+    Build the {@link StateStore} for a url/token (default {@link HttpStateStore}).
+  makeBuildRegistry?: (url: string, token?: string) => BuildRegistry
+    Build the {@link BuildRegistry} for a url/token (default {@link HttpBuildRegistry}).
+  log?: (line: string) => void
+    Emit a line of output (default `console.log`).
+
+interface ConformanceOptions
+  Tuning options for the conformance scenarios.
+
+  lockTtlMs?: number
+    The lock TTL (ms) the takeover scenario acquires with; it then waits a bit
+    longer than this for the lock to expire. Raise it for a slow backend.
+    Default 200.
+
+interface ConformanceResult
+  The outcome of one conformance scenario.
+
+  readonly name: string
+    The scenario's name.
+  readonly ok: boolean
+    Whether the backend satisfied it.
+  readonly error?: string
+    The failure detail when `ok` is false.
+
+type BuildRegistryFactory = () => BuildRegistry | Promise<BuildRegistry>
+  A `() =>` factory the kit calls once to obtain the registry under test.
+
+type StateStoreFactory = () => StateStore | Promise<StateStore>
+  A `() =>` factory the kit calls once to obtain the store under test.
 
 ========================================================================
 # @zuke/deno

--- a/packages/ai/deno.json
+++ b/packages/ai/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/ai",
   "version": "1.6.0",
+  "license": "MIT",
   "description": "AI code review for Zuke builds — define a reviewer (Claude/OpenAI/Gemini) with a settings-lambda API and plug it into a target's validateBefore/validateAfter to gate the build on a security (or custom) assessment.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/biome/deno.json
+++ b/packages/biome/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/biome",
   "version": "0.1.3",
+  "license": "MIT",
   "description": "Typed Biome CLI task wrappers for Zuke builds — check, format, lint, and ci via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/bun/deno.json
+++ b/packages/bun/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/bun",
   "version": "0.1.2",
+  "license": "MIT",
   "description": "Typed bun CLI task wrappers for Zuke builds — install, add, remove, run, x, and test via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/claude/deno.json
+++ b/packages/claude/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/claude",
   "version": "1.0.2",
+  "license": "MIT",
   "description": "Typed Claude Code CLI task wrapper for Zuke builds — drive prompts non-interactively and manage MCP/config via an injection-free, settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/cli",
   "version": "0.7.0",
+  "license": "MIT",
   "description": "The zuke command-line tool — scaffold a Zuke project with `zuke setup`, including a starter build, launchers, and tasks.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/cmd/deno.json
+++ b/packages/cmd/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/cmd",
   "version": "0.3.2",
+  "license": "MIT",
   "description": "Generic command task wrapper for Zuke builds — run any CLI tool through a typed, injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/codecov/deno.json
+++ b/packages/codecov/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/codecov",
   "version": "1.0.2",
+  "license": "MIT",
   "description": "Typed Codecov CLI (codecovcli) task wrapper for Zuke builds — upload coverage reports to Codecov via a settings-lambda API, injection-free.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/codex/deno.json
+++ b/packages/codex/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/codex",
   "version": "1.0.2",
+  "license": "MIT",
   "description": "Typed OpenAI Codex CLI task wrapper for Zuke builds — run prompts non-interactively with codex exec and manage MCP via an injection-free, settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/console/deno.json
+++ b/packages/console/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/console",
   "version": "1.0.1",
+  "license": "MIT",
   "description": "Task-shaped console output for Zuke builds — a levelled logger, inline style markup with a semantic theme, and line/box/table primitives, so builds never reach for console.log.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -3014,16 +3014,6 @@ interface StateStore
   releaseLock(key: string, token: string): Promise<void>
     Release the lock `key` if still held under `token`; a no-op otherwise.
 
-interface Style
-  How a run renders its output.
-
-  github: boolean
-    Wrap target output in `::group::`/`::endgroup::` and emit `::error::`.
-  color: boolean
-    Emit ANSI colour codes (off when piped, under `NO_COLOR`, or in CI).
-  width: number
-    Width of horizontal rules and boxes, in characters.
-
 interface TarEntry
   A single entry within a tar archive — a regular file or a symbolic link.
 
@@ -3334,6 +3324,480 @@ type TargetStatus = "passed" | "failed" | "skipped" | "cached" | "waiting"
 
 type WaitDisposition = "fail" | "cancel-run" | { target: string; }
   What a timed-out wait does: fail, cancel the run, or run a compensation target.
+
+Ergonomic process execution built on `Deno.Command`, exposed as the `$`
+tagged template.
+
+```ts
+await $`deno test -A`;                            // throws on non-zero exit
+const out = await $`git rev-parse HEAD`.text();   // trimmed stdout
+const code = await $`flaky-cmd`.noThrow().code();  // exit code, no throw
+await $`build`.env({ NODE_ENV: "prod" }).cwd("./app");
+```
+
+Interpolated values become discrete argv entries — they are never spliced
+into a shell string — so there is no shell-injection surface. Arrays expand
+to multiple arguments.
+@module
+
+function $(strings: TemplateStringsArray, ...values: Interpolatable[]): Command
+  Run an external command, ergonomically.
+
+  @example
+      `await $\`deno test -A``
+
+function tokenize(strings: ReadonlyArray<string>, values: ReadonlyArray<Interpolatable>): string[]
+  Tokenise a tagged-template invocation into an argv array.
+
+  Literal whitespace separates arguments; interpolated values are appended as
+  atomic tokens (so `--flag=${x}` and `pre${x}` work), and arrays expand to one
+  argument per element. Interpolated values are never re-split on whitespace,
+  which is what keeps command construction injection-free.
+
+class Command implements PromiseLike<CommandOutput>
+  A lazily-executed command. Built by the `$` tagged template. The process does
+  not start until the command is awaited or a terminal method (`text`, `lines`,
+  `code`) is called; the result is memoised so repeated reads are cheap.
+
+  constructor(argv: string[])
+    Build a command from a discrete argv array (binary first).
+  env(record: Record<string, string>): this
+    Merge additional environment variables.
+  cwd(path: PathLike): this
+    Set the working directory for the process.
+  noThrow(): this
+    Do not throw on a non-zero exit; combine with {@link code}.
+  quiet(): this
+    Suppress live stdout/stderr streaming to the terminal.
+  killAfter(ms: number): this
+    Kill the process if it runs longer than `ms` milliseconds, raising a
+    {@link CommandTimeoutError}. Fires even under {@link noThrow}.
+  signal(signal: AbortSignal): this
+    Terminate the process (via `SIGTERM`) when `signal` aborts — for example
+    when the enclosing run is cancelled. Overrides the executor's ambient
+    run signal for this command. Composes with {@link killAfter}: either the
+    timeout or the abort kills the process, whichever fires first.
+  get commandLine(): string
+    The command line, for diagnostics.
+  then(onfulfilled?: ((value: CommandOutput) => TResult1 | PromiseLike<TResult1>) | null, onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null): PromiseLike<TResult1 | TResult2>
+    Await support: run the command and resolve to a {@link CommandOutput}.
+  async text(): Promise<string>
+    Run and resolve to trimmed stdout. Throws on non-zero unless `noThrow`.
+  async lines(): Promise<string[]>
+    Run and resolve to stdout split into lines (trailing blank dropped).
+  async code(): Promise<number>
+    Run and resolve to the numeric exit code. Never throws on non-zero.
+  spawn(): SpawnedProcess
+    Start the command as a long-lived process without waiting for it to
+    exit, returning a {@link SpawnedProcess} handle. Use this for a service —
+    a dev server, a database, `docker compose up` — that must keep running
+    while other targets execute; stop it with {@link SpawnedProcess.stop}.
+    stdout/stderr are inherited so the process's output is visible.
+
+class CommandError extends Error
+  Raised when a command exits non-zero and throwing was not suppressed.
+
+  constructor(readonly command: string, readonly code: number, readonly stderr: string)
+    Build the error from the failed command line, exit code, and stderr.
+  override name: string
+    The error name.
+
+class CommandOutput
+  The resolved result of a command, available when awaiting a {@link Command}.
+
+  constructor(readonly code: number, readonly stdout: string, readonly stderr: string)
+    Build the output from the process exit code and captured streams.
+  text(): string
+    Trimmed stdout.
+
+class CommandTimeoutError extends Error
+  Raised when a command is killed for exceeding its {@link Command.killAfter}
+  budget. Thrown regardless of {@link Command.noThrow}, since a timeout is a
+  distinct, exceptional outcome from a normal non-zero exit.
+
+  constructor(readonly command: string, readonly timeoutMs: number)
+    Build the error from the command line and the elapsed-time budget.
+  override name: string
+    The error name.
+
+class SpawnedProcess
+  A long-lived process started with {@link Command.spawn} — the handle a
+  {@link https://jsr.io/@zuke/core service} keeps alive. Unlike awaiting a
+  {@link Command}, spawning does not wait for the process to exit; call
+  {@link SpawnedProcess.stop} to terminate it (which is also the default
+  service teardown). Its stdout/stderr are inherited so the process's own
+  output is visible.
+
+  constructor(child: Deno.ChildProcess | undefined, readonly commandLine: string)
+    Wrap a spawned child process (or none, for a stub) and its command line.
+  get pid(): number
+    The operating-system process id (`-1` for a dry-run stub).
+  get status(): Promise<Deno.CommandStatus>
+    Resolves when the process exits (immediate success for a dry-run stub).
+  async stop(signal: Deno.Signal, graceMs: number): Promise<void>
+    Terminate the process and wait for it to exit. Sends `signal` (default
+    `SIGTERM`); if the process has not exited within `graceMs` (default 5s), it
+    escalates to `SIGKILL` so a process that ignores `SIGTERM` cannot hang
+    teardown. A process that has already exited is treated as stopped. A
+    dry-run stub (no child) is a no-op.
+
+type Interpolatable = string | number | AbsolutePath | Array<string | number | AbsolutePath>
+  A value that may be interpolated into a `$` template.
+
+Foundations for typed tool wrappers (settings-lambda task functions).
+
+A tool package (e.g. `@zuke/deno`, `@zuke/npm`) defines one settings class
+per subcommand by extending {@link ToolSettings}: `buildArgs()` assembles
+the subcommand argv purely (no I/O), while the base contributes the common
+fluent chainers (`env`, `cwd`, `noThrow`, `quiet`, `toolPath`, `args`) and
+the execution logic, which reuses {@link Command} so argv stays an array
+end-to-end — there is no shell string and no injection surface.
+
+```ts
+class MyToolSettings extends ToolSettings {
+  protected defaultTool() { return "mytool"; }
+  protected buildArgs() { return ["build", "--fast"]; }
+}
+await runSettings(new MyToolSettings(), (s) => s.cwd("app"));
+```
+@module
+
+function defineTool(tool: string, options: DefineToolOptions): ToolTask
+  Define a fluent task for a CLI that has no dedicated `@zuke` wrapper. Returns
+  a task that runs the tool, configured through a {@link DynamicToolSettings}
+  lambda — the same settings-lambda style as the built-in wrappers, with
+  `arg`/`flag`/`option` for argv and the shared `cwd`/`env`/`noThrow`/… chainers.
+
+  ```ts
+  import { defineTool } from "jsr:@zuke/core/tooling";
+
+  const terraform = defineTool("terraform");
+  await terraform((s) => s.arg("plan").option("out", "plan.tfplan"));
+  // → terraform plan --out plan.tfplan
+
+  const helmUpgrade = defineTool("helm", { subcommand: "upgrade" });
+  await helmUpgrade((s) => s.arg("api", "./chart").flag("install"));
+  // → helm upgrade api ./chart --install
+  ```
+
+function runSettings<S extends ToolSettings>(settings: S, configure?: Configure<S>): Promise<CommandOutput>
+  Construct-configure-run: the shared shape of every task function.
+
+  ```ts
+  export const MyTasks = {
+    build: (configure?: Configure<MyBuildSettings>) =>
+      runSettings(new MyBuildSettings(), configure),
+  };
+  ```
+
+function shimFallbackArgv(argv: ReadonlyArray<string>, os: typeof Deno.build.os): string[] | null
+  On Windows, wrap an argv in a `cmd /c` invocation so `.cmd`/`.bat` shims
+  (such as npm's) become spawnable; returns `null` on other platforms.
+
+function windowsCmdShim(argv: ReadonlyArray<string>, os: typeof Deno.build.os): string[]
+  On Windows, spawn a resolved `.cmd`/`.bat` shim (such as npm's `node_modules`
+  shims) through `cmd /c` — a batch shim is not a PE executable, so
+  `Deno.Command` cannot launch it directly. Returns `argv` unchanged on other
+  platforms or when the binary is not a batch shim.
+
+class DynamicToolSettings extends ToolSettings
+  Fluent settings for a {@link defineTool} tool: build the argv with
+  {@link DynamicToolSettings.arg}/{@link DynamicToolSettings.flag}/{@link
+  DynamicToolSettings.option} (in call order), plus all the shared chainers
+  (`cwd`, `env`, `noThrow`, `quiet`, `toolPath`, `args`).
+
+  constructor(tool: string, initial: string[])
+    Build settings for `tool`, seeded with any `initial` subcommand tokens.
+  override protected defaultTool(): string
+    The configured tool binary.
+  arg(...values: Array<string | number>): this
+    Append raw positional/argument tokens.
+  flag(name: string): this
+    Append a boolean flag, e.g. `flag("verbose")` → `--verbose` (or `-v`).
+  option(name: string, value: string | number): this
+    Append a flag and its value as two tokens, e.g. `--output dist`.
+  override protected buildArgs(): string[]
+    The argv assembled from the `arg`/`flag`/`option` calls, in order.
+
+class ToolNotFoundError extends Error
+  Raised when a tool's binary cannot be found on the system.
+
+  constructor(readonly tool: string, sawNodeModules: boolean)
+    Build the error naming the tool binary that could not be found.
+  override name: string
+    The error name.
+
+abstract class ToolSettings
+  Abstract fluent base for tool settings. Subclasses provide the binary
+  ({@link defaultTool}) and the pure subcommand argv ({@link buildArgs});
+  the base provides the shared chainers and {@link run}.
+
+  os_: typeof Deno.build.os
+    The platform identifier used by {@link run} to decide whether to retry a
+    missing binary through the `cmd /c` shim path (Windows only).
+
+    In production this is always `Deno.build.os`. It is exposed as a public
+    field — rather than read from `Deno.build.os` inline — so that tests can
+    pin a specific platform without spawning a subprocess or touching the
+    environment:
+
+    ```ts
+    const s = new MyToolSettings();
+    s.os_ = "windows"; // exercise the cmd /c retry branch on any host
+    ```
+
+    The trailing underscore signals an internal test seam: do not rely on this
+    field in production code.
+  abstract protected defaultTool(): string
+    The binary to spawn when {@link toolPath} is not set.
+  abstract protected buildArgs(): string[]
+    The subcommand argv. Must be pure — no I/O, no environment reads.
+  protected defaultResolution(): ToolResolution
+    The wrapper's default binary-resolution strategy. The base returns
+    `"path"` (bare name on `PATH`); a JS-ecosystem wrapper whose binary is
+    almost always installed under `node_modules` overrides this to
+    `"node_modules"`. A per-call {@link fromNodeModules}/{@link fromPath} and
+    the ambient `ZUKE_TOOL_RESOLUTION` both take precedence over this default.
+  env(record: Record<string, string>): this
+    Merge additional environment variables for the process.
+  cwd(path: PathLike): this
+    Set the working directory for the process.
+  noThrow(): this
+    Do not throw on a non-zero exit; inspect `code` on the output instead.
+  get throwsOnError(): boolean
+    Whether a failure should throw — the default, or `false` after
+    {@link noThrow}. A task that layers its own validation on top of the
+    subprocess (e.g. a coverage-threshold gate) reads this to decide whether a
+    gate failure throws or is merely reported.
+  quiet(): this
+    Suppress live stdout/stderr streaming to the terminal.
+  killAfter(ms: number): this
+    Kill the tool if it runs longer than `ms` milliseconds, raising a
+    `CommandTimeoutError`. Fires even under {@link noThrow}.
+  toolPath(path: PathLike): this
+    Override the binary to run (e.g. an absolute path to the tool).
+  fromNodeModules(): this
+    Resolve the binary npx-style: walk up from the working directory looking
+    for `node_modules/.bin/<tool>`, falling back to `PATH` on a miss. Overrides
+    both the wrapper default and the ambient `ZUKE_TOOL_RESOLUTION`. Has no
+    effect once {@link toolPath} is set (an explicit path always wins).
+  fromPath(): this
+    Resolve the binary from `PATH` only, ignoring any `node_modules/.bin`.
+  args(...extra: Array<string | number | AbsolutePath>): this
+    Escape hatch: append raw arguments after all typed options.
+  argv(): string[]
+    The full argv (binary first). Pure — useful for tests and diagnostics.
+  resolvedArgv(): string[]
+    The argv {@link run} will actually spawn — like {@link argv}, but with the
+    `node_modules/.bin` resolution applied (so it performs I/O). Useful for
+    tests and diagnostics: it reveals whether a wrapper resolved to a local
+    shim or fell back to the bare name on `PATH`.
+  async run(): Promise<CommandOutput>
+    Run the configured tool. If the binary is missing and the platform is
+    Windows, retry once through `cmd /c` (covers `.cmd`/`.bat` shims);
+    otherwise raise a {@link ToolNotFoundError} naming the tool.
+
+interface DefineToolOptions
+  Options for {@link defineTool}.
+
+  subcommand?: string | string[]
+    Leading subcommand token(s) prepended to every invocation.
+
+type Configure<S> = (settings: S) => S
+  A lambda that configures a settings instance and returns it.
+
+type ToolResolution = "node_modules" | "path"
+  How {@link ToolSettings.run} locates a wrapper's binary when no explicit
+  {@link ToolSettings.toolPath} is set:
+
+  - `"path"` — spawn the bare tool name and let the OS resolve it on `PATH`
+    (the default, matching a native/global install);
+  - `"node_modules"` — npx-style: walk up from the working directory looking
+    for `node_modules/.bin/<tool>`, falling back to `PATH` on a miss (so a
+    package hoisted to a monorepo root runs with no `.toolPath()`).
+
+type ToolTask = (configure?: Configure<DynamicToolSettings>) => Promise<CommandOutput>
+  A ready-to-run task for a {@link defineTool} tool.
+
+Primitive terminal rendering, shared by the executor's build reporting
+(`./report.ts`) and the `@zuke/console` package: ANSI styling, terminal-width
+detection, duration formatting, and the reusable `line`/`box`/`table`
+primitives that draw a build's output.
+
+Everything here is pure — no I/O, no process state — so argv-free output can
+be unit-tested and reused without duplicating escape codes. Cells may already
+carry ANSI codes; width is measured on the visible text ({@link visibleWidth})
+so painted content still aligns.
+@module
+
+function box(style: Style, content: string | readonly string[], options: BoxOptions): string[]
+  A bordered panel around `content` (a string, split on newlines, or an array
+  of lines). Content may carry ANSI codes; padding is measured on the visible
+  text so the border stays flush.
+
+function detectWidth(): number
+  Read the terminal width if available, clamped to a sane range.
+
+function formatDuration(ms: number): string
+  Format a duration in milliseconds as `1.2s`.
+
+function isStyleName(name: string): name is StyleName
+  Whether a string names one of the {@link SGR} styles.
+
+function line(style: Style, options: LineOptions): string
+  A horizontal rule spanning the style's width (dimmed by default).
+
+function pad(text: string, width: number, align: "left" | "right"): string
+  Pad `text` to `width` visible columns, aligning left (default) or right.
+
+function paint(color: boolean, codes: string, text: string): string
+  Wrap text in ANSI codes when colour is enabled, otherwise return it as-is.
+
+function sgrCodes(names: readonly StyleName[]): string
+  Concatenate the escape codes for `names` (an unknown name contributes none).
+
+function stripAnsi(text: string): string
+  Strip ANSI escape sequences, leaving the visible text.
+
+function stylize(color: boolean, names: readonly StyleName[], text: string): string
+  Paint `text` in the named styles when `color` is enabled.
+
+function table(style: Style, columns: readonly TableColumn[], rows: readonly (readonly string[])[], options: TableOptions): string[]
+  An aligned text table: a styled header row, an optional dividing rule, then
+  one line per row. Column widths fit the widest visible cell; cells may already
+  carry ANSI colour. Rows shorter than the columns are padded with empty cells.
+
+function visibleWidth(text: string): number
+  The printable width of `text`, ignoring any ANSI colour codes it carries.
+
+const SGR: { reset: string; bold: string; dim: string; italic: string; underline: string; black: string; red: string; green: string; yellow: string; blue: string; magenta: string; cyan: string; white: string; gray: string; }
+  ANSI select-graphic-rendition codes, keyed by style name.
+
+interface BoxOptions
+  Options for {@link box}.
+
+  title?: string
+    A title embedded in the top border.
+  padding?: number
+    Horizontal padding inside the border, in spaces. Defaults to `1`.
+  width?: number
+    Force an inner width; widened automatically to fit content and title.
+  border?: readonly StyleName[]
+    Styles for the border characters. Defaults to `["dim"]`.
+  titleStyle?: readonly StyleName[]
+    Styles for the title text. Defaults to `["bold"]`.
+
+interface LineOptions
+  Options for {@link line}.
+
+  char?: string
+    The character to repeat. Defaults to `═`.
+  width?: number
+    The rule width. Defaults to the style's width.
+  style?: readonly StyleName[]
+    Styles applied to the whole rule. Defaults to `["dim"]`.
+
+interface Style
+  How a run renders its output.
+
+  github: boolean
+    Wrap target output in `::group::`/`::endgroup::` and emit `::error::`.
+  color: boolean
+    Emit ANSI colour codes (off when piped, under `NO_COLOR`, or in CI).
+  width: number
+    Width of horizontal rules and boxes, in characters.
+
+interface TableColumn
+  One column of a {@link table}.
+
+  header: string
+    The column header.
+  align?: "left" | "right"
+    Cell alignment. Defaults to `left`.
+
+interface TableOptions
+  Options for {@link table}.
+
+  separator?: string
+    Column separator. Defaults to two spaces.
+  divider?: boolean
+    Draw a dividing rule under the header. Defaults to `true`.
+  headerStyle?: readonly StyleName[]
+    Styles for the header row. Defaults to `["bold"]`.
+  dividerStyle?: readonly StyleName[]
+    Styles for the divider rule. Defaults to `["dim"]`.
+
+type StyleName = keyof typeof SGR
+  A style name understood by {@link sgrCodes}, {@link paint}, and markup.
+
+A backend conformance kit for the state-api (`docs/state-api.md`).
+
+A hosted {@link "./state/store.ts".StateStore} / {@link
+"./registry/registry.ts".BuildRegistry} backend must implement the same
+compare-and-swap, listing, and TTL-lock semantics the filesystem backend
+does — the exactly-once resume, lock takeover, and one-writer-wins guarantees
+the core relies on ride on them. This module extracts those semantics into
+store-agnostic scenarios you can point at any implementation: Zuke's own test
+lane runs them against the filesystem store, and a backend author runs them
+against a live service:
+
+```sh
+deno run -A jsr:@zuke/core/conformance --url http://localhost:8080 [--token …]
+```
+
+Every scenario uses freshly-generated ids, so it is safe to run against a
+shared, persistent service; the lock-takeover scenario uses a short real TTL
+and a brief sleep, so it takes a beat of wall-clock time. A backend that
+passes is compatible with
+{@link "./state/http_store.ts".HttpStateStore} /
+{@link "./registry/http_registry.ts".HttpBuildRegistry}; one that violates
+CAS fails loudly.
+@module
+
+async function checkBuildRegistry(make: BuildRegistryFactory): Promise<ConformanceResult[]>
+  Run the build-registry conformance scenarios against the registry `make` builds.
+
+async function checkStateStore(make: StateStoreFactory, options: ConformanceOptions): Promise<ConformanceResult[]>
+  Run the state-store conformance scenarios against the store `make` builds.
+
+async function runConformanceCli(args: string[], deps: ConformanceCliDeps): Promise<number>
+  Run the conformance kit as a CLI: `--url <base>` (required) and `--token <bearer>` (optional) name the backend, then both suites run against it. Prints
+  a `PASS`/`FAIL` line per scenario and resolves to a process exit code — `0`
+  when every scenario passes, `1` when any fails or `--url` is missing.
+
+interface ConformanceCliDeps
+  Injectable dependencies for {@link runConformanceCli} (tests override them).
+
+  makeStateStore?: (url: string, token?: string) => StateStore
+    Build the {@link StateStore} for a url/token (default {@link HttpStateStore}).
+  makeBuildRegistry?: (url: string, token?: string) => BuildRegistry
+    Build the {@link BuildRegistry} for a url/token (default {@link HttpBuildRegistry}).
+  log?: (line: string) => void
+    Emit a line of output (default `console.log`).
+
+interface ConformanceOptions
+  Tuning options for the conformance scenarios.
+
+  lockTtlMs?: number
+    The lock TTL (ms) the takeover scenario acquires with; it then waits a bit
+    longer than this for the lock to expire. Raise it for a slow backend.
+    Default 200.
+
+interface ConformanceResult
+  The outcome of one conformance scenario.
+
+  readonly name: string
+    The scenario's name.
+  readonly ok: boolean
+    Whether the backend satisfied it.
+  readonly error?: string
+    The failure detail when `ok` is false.
+
+type BuildRegistryFactory = () => BuildRegistry | Promise<BuildRegistry>
+  A `() =>` factory the kit calls once to obtain the registry under test.
+
+type StateStoreFactory = () => StateStore | Promise<StateStore>
+  A `() =>` factory the kit calls once to obtain the store under test.
 ````
 
 </details>

--- a/packages/core/deno.json
+++ b/packages/core/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/core",
   "version": "1.30.2",
+  "license": "MIT",
   "description": "Core of Zuke: a code-first, strongly-typed build-automation library for Deno & TypeScript with a typed target graph and an injection-free shell.",
   "exports": {
     ".": "./mod.ts",

--- a/packages/core/tests/mcp_authz_test.ts
+++ b/packages/core/tests/mcp_authz_test.ts
@@ -21,6 +21,15 @@ Deno.test("targetMatcher: an empty list matches nothing", () => {
   assertEquals(match("deploy"), false);
 });
 
+// `timingSafeEqual` is the constant-time bearer-token comparison used by the
+// MCP HTTP transport. For two equal-length inputs the loop always visits every
+// character (it accumulates the XOR diff with no early `return`), so a partial
+// prefix match leaks no timing signal about how many characters were correct —
+// the property that stops a byte-at-a-time token guess. The one deliberate leak
+// is the initial `a.length !== b.length` short-circuit: it reveals only the
+// length, not the contents, which is an accepted trade-off (a token's length is
+// not the secret). These cases pin the value semantics; the constant-time
+// property is a structural guarantee of the implementation, not timed here.
 Deno.test("timingSafeEqual compares by value, length first", () => {
   assertEquals(timingSafeEqual("abc", "abc"), true);
   assertEquals(timingSafeEqual("abc", "abd"), false);

--- a/packages/cspell/deno.json
+++ b/packages/cspell/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/cspell",
   "version": "0.2.3",
+  "license": "MIT",
   "description": "Typed cspell task wrappers for Zuke builds — spell-check files and globs via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/cypress/deno.json
+++ b/packages/cypress/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/cypress",
   "version": "0.1.3",
+  "license": "MIT",
   "description": "Typed Cypress CLI task wrappers for Zuke builds — run, open, install, verify, and info via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/deno/deno.json
+++ b/packages/deno/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/deno",
   "version": "0.6.1",
+  "license": "MIT",
   "description": "Typed deno CLI task wrappers for Zuke builds — run, test, check, fmt, lint, doc, cache, coverage, and task via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/docker-compose/deno.json
+++ b/packages/docker-compose/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/docker-compose",
   "version": "0.3.2",
+  "license": "MIT",
   "description": "Typed Docker Compose task wrappers for Zuke builds — auto-detects `docker compose` (v2) vs `docker-compose` (v1); up, down, build, logs, ps, and more.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/docker/deno.json
+++ b/packages/docker/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/docker",
   "version": "0.3.2",
+  "license": "MIT",
   "description": "Typed docker CLI task wrappers for Zuke builds — build, run, exec, push, pull, tag, login, images, ps, and more via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/docs/deno.json
+++ b/packages/docs/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/docs",
   "version": "0.3.2",
+  "license": "MIT",
   "description": "Typed Zuke tasks that render already-generated API docs (e.g. `deno doc` output) into an llms.txt index, an llms-full.txt reference, and per-package README API blocks — plus a check task to gate them in CI. Pure: runs no subprocess and depends only on @zuke/core.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/docs/src/render.ts
+++ b/packages/docs/src/render.ts
@@ -26,15 +26,26 @@ export interface DocEntry {
 }
 
 /**
- * Normalise supplied doc text: drop machine-specific `Defined in file://…`
- * source locations (they leak an absolute path and add no API information),
- * strip trailing whitespace per line (so the embedded block stays
- * formatter-clean), and collapse the blank-line runs this leaves behind.
+ * Normalise supplied doc text: drop the machine-specific `file://…` source
+ * locations `deno doc` emits (they leak an absolute checkout path and add no
+ * API information), strip trailing whitespace per line (so the embedded block
+ * stays formatter-clean), and collapse the blank-line runs this leaves behind.
+ *
+ * Three shapes of location line are dropped: the single-file `Defined in
+ * file://…` line, and — in `deno doc`'s multi-file mode (a package with several
+ * entrypoints) — the bare `file://…` per-file section header and the
+ * `reference <Name>: file://…` re-export pointer. All embed an absolute path
+ * that differs per machine/CI runner, so leaving them in would both leak the
+ * path and make `apiDocsCheck` drift off the author's checkout.
  */
 export function cleanDoc(text: string): string {
   return text
     .split("\n")
-    .filter((line) => !/^\s*Defined in /.test(line))
+    .filter((line) =>
+      !/^\s*Defined in /.test(line) &&
+      !/^\s*file:\/\//.test(line) &&
+      !/^\s*reference \S+: file:\/\//.test(line)
+    )
     .map((line) => line.replace(/[ \t]+$/, ""))
     .join("\n")
     .replace(/\n{3,}/g, "\n\n")

--- a/packages/docs/tests/render_test.ts
+++ b/packages/docs/tests/render_test.ts
@@ -42,6 +42,28 @@ Deno.test("cleanDoc strips machine paths, trailing space, and blank runs", () =>
   assertStringIncludes(out, "function go(): void");
 });
 
+Deno.test("cleanDoc strips deno doc multi-file file:// headers and reference lines", () => {
+  // `deno doc a.ts b.ts` (a multi-entrypoint package) emits bare `file://`
+  // section headers and `reference X: file://` re-export pointers, both with an
+  // absolute checkout path. Neither is a `Defined in` line, so both must be
+  // dropped explicitly or they leak the path and drift apiDocsCheck per machine.
+  const raw = [
+    "file:///Users/someone/work/zuke/packages/core/mod.ts",
+    "`@zuke/core` — the core.",
+    "",
+    "reference Style: file:///Users/someone/work/zuke/packages/core/src/render.ts:41:1",
+    "file:///Users/someone/work/zuke/packages/core/src/shell.ts",
+    "class Command",
+  ].join("\n");
+  const out = cleanDoc(raw);
+  assertEquals(/file:\/\//.test(out), false);
+  assertEquals(/reference Style/.test(out), false);
+  assertStringIncludes(out, "`@zuke/core` — the core.");
+  assertStringIncludes(out, "class Command");
+  // The summary is the real description, not the leading path header.
+  assertEquals(summarize(out), "the core");
+});
+
 Deno.test("summarize takes the text after the em dash, without trailing dot", () => {
   assertEquals(summarize("`@acme/foo` — does a thing."), "does a thing");
 });

--- a/packages/dpdm/deno.json
+++ b/packages/dpdm/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/dpdm",
   "version": "0.1.3",
+  "license": "MIT",
   "description": "Typed dpdm CLI task wrapper for Zuke builds — analyze module dependency graphs and circular imports via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/dprint/deno.json
+++ b/packages/dprint/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/dprint",
   "version": "0.1.3",
+  "license": "MIT",
   "description": "Typed dprint task wrappers for Zuke builds — format and check code with config, excludes, and incremental support via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/eslint/deno.json
+++ b/packages/eslint/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/eslint",
   "version": "0.2.3",
+  "license": "MIT",
   "description": "Typed eslint task wrappers for Zuke builds — lint, fix, caching, and reporters via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/gcloud/deno.json
+++ b/packages/gcloud/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/gcloud",
   "version": "0.2.2",
+  "license": "MIT",
   "description": "Typed Google Cloud tooling for Zuke builds — the gcloud (Google Cloud SDK) CLI wrapper plus GCS and Secret Manager REST task groups sharing gcloud-based auth, all injection-free and testable without network.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/gemini/deno.json
+++ b/packages/gemini/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/gemini",
   "version": "1.0.2",
+  "license": "MIT",
   "description": "Typed Gemini CLI task wrapper for Zuke builds — run prompts non-interactively and manage MCP/extensions via an injection-free, settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/gh/deno.json
+++ b/packages/gh/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/gh",
   "version": "0.3.2",
+  "license": "MIT",
   "description": "Typed gh (GitHub CLI) task wrapper for Zuke builds — a flexible, injection-free command builder for pr/release/issue/api and more via a settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/git/deno.json
+++ b/packages/git/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/git",
   "version": "0.2.2",
+  "license": "MIT",
   "description": "Typed git task wrappers for Zuke builds — common commands (add, commit, push, tag, checkout, …) plus a generic escape hatch, via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/helm/deno.json
+++ b/packages/helm/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/helm",
   "version": "0.1.2",
+  "license": "MIT",
   "description": "Typed Helm CLI task wrappers for Zuke builds — install, upgrade, uninstall, template, lint, dependency update, repo add, and package via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/husky/deno.json
+++ b/packages/husky/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/husky",
   "version": "0.2.3",
+  "license": "MIT",
   "description": "Typed husky task wrappers for Zuke builds — initialise and install Git hooks with husky v9+ via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/jest/deno.json
+++ b/packages/jest/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/jest",
   "version": "0.2.3",
+  "license": "MIT",
   "description": "Typed jest task wrappers for Zuke builds — coverage, CI mode, workers, snapshots, and reporters via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/jsr/deno.json
+++ b/packages/jsr/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/jsr",
   "version": "0.2.2",
+  "license": "MIT",
   "description": "Typed JSR CLI task wrappers for Zuke builds — publish, add, and remove via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/knip/deno.json
+++ b/packages/knip/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/knip",
   "version": "0.1.3",
+  "license": "MIT",
   "description": "Typed Knip CLI task wrapper for Zuke builds — find unused files, dependencies, and exports via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/kubectl/deno.json
+++ b/packages/kubectl/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/kubectl",
   "version": "0.3.2",
+  "license": "MIT",
   "description": "Typed kubectl CLI task wrappers for Zuke builds — apply, create, delete, get, describe, logs, exec, rollout, scale, set image, patch, port-forward, wait, and top via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/kustomize/deno.json
+++ b/packages/kustomize/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/kustomize",
   "version": "0.1.2",
+  "license": "MIT",
   "description": "Typed Kustomize CLI task wrappers for Zuke builds — build and edit set image via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/nest/deno.json
+++ b/packages/nest/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/nest",
   "version": "0.2.3",
+  "license": "MIT",
   "description": "Typed NestJS CLI (nest) task wrappers for Zuke builds — scaffold, generate, build, and start NestJS projects via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/node/deno.json
+++ b/packages/node/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/node",
   "version": "0.2.2",
+  "license": "MIT",
   "description": "Typed Node.js task wrappers for Zuke builds — run scripts, evaluate code, and run the built-in test runner with the `node` runtime via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/npm/deno.json
+++ b/packages/npm/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/npm",
   "version": "0.3.2",
+  "license": "MIT",
   "description": "Typed npm CLI task wrappers for Zuke builds — install, ci, run, exec, publish, and version via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/npx/deno.json
+++ b/packages/npx/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/npx",
   "version": "0.2.2",
+  "license": "MIT",
   "description": "Typed npx package-runner task wrappers for Zuke builds — download and execute package binaries via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/nx/deno.json
+++ b/packages/nx/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/nx",
   "version": "0.1.3",
+  "license": "MIT",
   "description": "Typed Nx CLI task wrappers for Zuke builds — run, run-many, and affected via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/openapi-ts/deno.json
+++ b/packages/openapi-ts/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/openapi-ts",
   "version": "0.2.3",
+  "license": "MIT",
   "description": "Typed openapi-ts task wrappers for Zuke builds — generate type-safe API clients from OpenAPI specs with Hey API via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/orval/deno.json
+++ b/packages/orval/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/orval",
   "version": "0.2.3",
+  "license": "MIT",
   "description": "Typed orval task wrappers for Zuke builds — generate TypeScript API clients and mocks from an OpenAPI spec via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/otel/deno.json
+++ b/packages/otel/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/otel",
   "version": "1.0.1",
+  "license": "MIT",
   "description": "OpenTelemetry (OTLP/HTTP JSON) export plugin for Zuke builds — per-target spans linked across resume boundaries by run id, plus run counters, with no runtime dependencies.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/oxlint/deno.json
+++ b/packages/oxlint/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/oxlint",
   "version": "0.2.3",
+  "license": "MIT",
   "description": "Typed oxlint task wrappers for Zuke builds — fast Rust-based linting via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/playwright/deno.json
+++ b/packages/playwright/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/playwright",
   "version": "0.1.3",
+  "license": "MIT",
   "description": "Typed Playwright CLI task wrappers for Zuke builds — test, install (browsers), show-report, and codegen via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/pnpm/deno.json
+++ b/packages/pnpm/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/pnpm",
   "version": "0.1.2",
+  "license": "MIT",
   "description": "Typed pnpm CLI task wrappers for Zuke builds — install, add, remove, run, dlx, and publish via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/release-please/deno.json
+++ b/packages/release-please/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/release-please",
   "version": "1.0.2",
+  "license": "MIT",
   "description": "Typed release-please CLI task wrappers for Zuke builds — maintain release PRs and cut GitHub releases via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/security/deno.json
+++ b/packages/security/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/security",
   "version": "0.2.2",
+  "license": "MIT",
   "exports": {
     ".": "./mod.ts"
   },

--- a/packages/terraform/deno.json
+++ b/packages/terraform/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/terraform",
   "version": "0.1.2",
+  "license": "MIT",
   "description": "Typed Terraform CLI task wrappers for Zuke builds — init, validate, plan, apply, destroy, fmt, and output via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/tofu/deno.json
+++ b/packages/tofu/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/tofu",
   "version": "0.1.2",
+  "license": "MIT",
   "description": "Typed OpenTofu CLI task wrappers for Zuke builds — init, validate, plan, apply, destroy, fmt, and output via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/tsc-alias/deno.json
+++ b/packages/tsc-alias/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/tsc-alias",
   "version": "0.2.3",
+  "license": "MIT",
   "description": "Typed tsc-alias task wrappers for Zuke builds — rewrite TypeScript path aliases in compiled output via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/tsc/deno.json
+++ b/packages/tsc/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/tsc",
   "version": "0.2.3",
+  "license": "MIT",
   "description": "Typed tsc task wrappers for Zuke builds — type-check, compile, and run project-reference builds with the TypeScript compiler via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/tsdown/deno.json
+++ b/packages/tsdown/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/tsdown",
   "version": "0.2.3",
+  "license": "MIT",
   "description": "Typed tsdown CLI task wrapper for Zuke builds — bundle TypeScript/JavaScript with the Rolldown-powered tsdown bundler (formats, dts, minify, and more) via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/tsgo/deno.json
+++ b/packages/tsgo/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/tsgo",
   "version": "0.1.3",
+  "license": "MIT",
   "description": "Typed tsgo task wrappers for Zuke builds — type-check and compile with the native TypeScript compiler (TypeScript 7) via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/tsup/deno.json
+++ b/packages/tsup/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/tsup",
   "version": "0.1.3",
+  "license": "MIT",
   "description": "Typed tsup CLI task wrapper for Zuke builds — bundle TypeScript/JavaScript with formats, dts, minify, and more via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/tsx/deno.json
+++ b/packages/tsx/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/tsx",
   "version": "0.1.3",
+  "license": "MIT",
   "description": "Typed tsx task wrappers for Zuke builds — run TypeScript entry points directly, with watch mode, tsconfig, and preload support via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/turbo/deno.json
+++ b/packages/turbo/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/turbo",
   "version": "0.1.3",
+  "license": "MIT",
   "description": "Typed Turborepo CLI task wrappers for Zuke builds — run and prune via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/vite/deno.json
+++ b/packages/vite/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/vite",
   "version": "0.1.3",
+  "license": "MIT",
   "description": "Typed Vite CLI task wrappers for Zuke builds — dev, build, and preview via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/vitest/deno.json
+++ b/packages/vitest/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/vitest",
   "version": "0.2.3",
+  "license": "MIT",
   "description": "Typed vitest task wrappers for Zuke builds — one-shot run by default, plus coverage, reporters, and watch mode via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/packages/yarn/deno.json
+++ b/packages/yarn/deno.json
@@ -1,6 +1,7 @@
 {
   "name": "@zuke/yarn",
   "version": "0.1.2",
+  "license": "MIT",
   "description": "Typed yarn CLI task wrappers for Zuke builds — install, add, remove, run, and dlx via an injection-free settings-lambda API.",
   "exports": {
     ".": "./mod.ts"

--- a/tests/release_config_test.ts
+++ b/tests/release_config_test.ts
@@ -92,6 +92,20 @@ Deno.test("manifest versions match each package deno.json", async () => {
   }
 });
 
+Deno.test("every package declares the MIT license", async () => {
+  // Per-package license metadata so a published JSR artifact carries its own
+  // license rather than relying solely on root inference. Keep it in lock-step
+  // with the root LICENSE (MIT).
+  for (const path of PACKAGES) {
+    const pkg = await readJson(`${path}/deno.json`);
+    assertEquals(
+      pkg.license,
+      "MIT",
+      `${path}/deno.json must declare "license": "MIT"`,
+    );
+  }
+});
+
 Deno.test("the deno workspace lists exactly the configured packages", async () => {
   const root = await readJson("deno.json");
   const workspace = root.workspace;

--- a/zuke.ts
+++ b/zuke.ts
@@ -193,8 +193,13 @@ function docsOptions(): ApiDocsOptions {
 async function collectPackageDocs(): Promise<PackageDoc[]> {
   const docs: PackageDoc[] = [];
   for (const dir of PACKAGES) {
+    // Document every declared entrypoint, not just `mod.ts`, so a package with
+    // secondary exports (core's `./shell`, `./tooling`, `./render`,
+    // `./conformance`) has its whole typed surface in `llms-full.txt` and its
+    // README — the "whole typed surface" the docs claim to carry.
+    const entrypoints = await packageEntrypoints(dir);
     const { stdout } = await DenoTasks.doc((s) =>
-      s.paths(`packages/${dir}/mod.ts`).env({ NO_COLOR: "1" }).quiet()
+      s.paths(...entrypoints).env({ NO_COLOR: "1" }).quiet()
     );
     docs.push({ name: `@zuke/${dir}`, dir, doc: stdout });
   }


### PR DESCRIPTION
## What

Repo hygiene (remediation PR 10), no consumer-facing behaviour change.

- **Per-package license** — added `"license": "MIT"` to all 55 `packages/*/deno.json` (was 0/55) so a published JSR artifact carries its own license rather than relying solely on root inference. A new `release_config_test` case asserts every package declares it.
- **`deno.lock` cleanup** — removed the orphaned `jsr:@std/yaml@1` entry (nothing imports it; the CI-YAML generator hand-rolls its output). Surgical removal only — verified `deno check --frozen` and a `--frozen` cspell run still pass, and the diff touches nothing else.
- **`llms-full.txt` / README completeness** — `collectPackageDocs` now documents every declared entrypoint (via the existing `packageEntrypoints`), not just `mod.ts`, so core's `./shell`, `./tooling`, `./render`, `./conformance` appear in the generated docs — matching the "whole typed surface" claim.
- **`cleanDoc` path-strip** — `deno doc`'s multi-file mode (needed for the above) emits bare `file://<abs-path>` section headers and `reference X: file://…` lines. `cleanDoc` now strips them too, so no machine/checkout path leaks into the committed docs and `apiDocsCheck` stays location-independent (deterministic on any runner). Regression test added.
- **Docs** — a `SECURITY.md` "Known trade-offs" note on the `quality` job's fork-safe `contents: write` + `persist-credentials`, and an accurate constant-time note on `timingSafeEqual` (explicitly flagging the length short-circuit as the one accepted leak).

## Skipped

The plan's `.gitignore` local-vs-project split (`plans/`, `.omc/`, `docs/superpowers/` → a local exclude) is **not done**: those entries are load-bearing. The `cspell '**'` gate (and deno's file discovery) read `.gitignore`, not `.git/info/exclude`, so moving them out makes cspell lint local scratch files. Leaving them in `.gitignore` is the correct hygiene.

## Versioning

`chore` (no bump). The license metadata lands in each package's next release; the `cleanDoc` change is behaviour-identical for existing single-entrypoint doc consumers (the new filters only fire in multi-file mode, newly enabled here).

## Gate

`deno task ci` green (coverage 98.3% lines / 95.4% branches); `apiDocsCheck` + `docLint` pass and are now checkout-independent. Adversarial review: 2 dimensions (lock/license validity; doc-gen + note accuracy) — it **caught a confirmed critical**: the multi-entrypoint change initially leaked absolute paths into the committed docs and would have failed `apiDocsCheck` on CI. Fixed at the root (`cleanDoc`) with a regression test before this PR; re-verified no absolute path remains in any generated file.