### PR TITLE
fix(core): required array parameters stay required

### DIFF
--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -287,7 +287,7 @@ without hand-writing a target per item.
 
 ```ts
 class CD extends Build {
-  repos = parameter("services to deploy").array().required();
+  repos = parameter("services to deploy").required().array();
 
   deployBatch = target().forEach(
     () => this.repos.value, // items: a thunk, read when the target runs

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -59,16 +59,19 @@ declaration:
 | `.array()`           | a comma-separated / repeatable list           | `T[]`                 |
 
 `.number()` and `.boolean()` come first (they change the kind); `.options()`
-applies to strings; `.array()` comes **last** and composes with the kind and
-choices before it. A required parameter with no value (and no default) fails the
-build before any target runs, with a message naming the flag and env var —
-unless it can be supplied interactively (below).
+applies to strings; `.required()`/`.default()` set optionality; and `.array()`
+comes **last** and composes with everything before it — so a required list is
+`.required().array()` (in that order). A required parameter with no value (and
+no default) fails the build before any target runs, with a message naming the
+flag and env var — unless it can be supplied interactively (below).
 
 ## Lists
 
 `.array()` turns a string parameter into a list. On the command line, a comma
 separates values **or** the flag is repeated (the two are equivalent); blank
-entries are dropped, and an unsupplied list defaults to `[]`.
+entries are dropped. An unsupplied **optional** list defaults to `[]`; make it
+`.required().array()` to reject a missing value instead (the required flag
+carries through `.array()`).
 
 ```ts
 tags = parameter("Image tags").array();
@@ -90,6 +93,9 @@ workers = parameter("Worker ids").number().array();
 
 // each element must be one of the choices; "api,nope" is rejected.
 services = parameter("Services").options("api", "web", "worker").array();
+
+// required list: missing --repos fails the build (not a silent []).
+repos = parameter("Repos to deploy").required().array();
 ```
 
 ## Secrets

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1220,12 +1220,18 @@ class Parameter<K extends ParamValue = ParamValue, T extends K | K[] | undefined
   array(this: Parameter<E, E | undefined>): Parameter<E, E[]>
     Accept a comma-separated list (or a repeated flag), exposing `value` as an
     array. `--tags a,b` and `--tags a --tags b` both yield `["a", "b"]`; blank
-    entries are dropped, and an unsupplied list defaults to `[]`.
+    entries are dropped, and an unsupplied optional list defaults to `[]`
+    (a required one is reported missing — see below).
 
     Each element is parsed by this parameter's own element parser, so it
     composes: `.options("a", "b").array()` validates every element against
     the choices, and `.number().array()` yields a `number[]`, rejecting a
     non-numeric entry. (Apply `.options()`/`.number()` before `.array()`.)
+
+    `.array()` composes last, after `.required()` too: a
+    `.required().array()` list stays required, so an unsupplied value is
+    reported as missing rather than silently resolving to the empty-list
+    default. An optional (non-required) list defaults to `[]`.
   resolve_(raw: string | undefined): void
     Resolve from a raw input (or `undefined` when none was supplied).
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1274,12 +1274,18 @@ class Parameter<K extends ParamValue = ParamValue, T extends K | K[] | undefined
   array(this: Parameter<E, E | undefined>): Parameter<E, E[]>
     Accept a comma-separated list (or a repeated flag), exposing `value` as an
     array. `--tags a,b` and `--tags a --tags b` both yield `["a", "b"]`; blank
-    entries are dropped, and an unsupplied list defaults to `[]`.
+    entries are dropped, and an unsupplied optional list defaults to `[]`
+    (a required one is reported missing — see below).
 
     Each element is parsed by this parameter's own element parser, so it
     composes: `.options("a", "b").array()` validates every element against
     the choices, and `.number().array()` yields a `number[]`, rejecting a
     non-numeric entry. (Apply `.options()`/`.number()` before `.array()`.)
+
+    `.array()` composes last, after `.required()` too: a
+    `.required().array()` list stays required, so an unsupplied value is
+    reported as missing rather than silently resolving to the empty-list
+    default. An optional (non-required) list defaults to `[]`.
   resolve_(raw: string | undefined): void
     Resolve from a raw input (or `undefined` when none was supplied).
 

--- a/packages/core/src/params.ts
+++ b/packages/core/src/params.ts
@@ -400,12 +400,18 @@ export class Parameter<
   /**
    * Accept a comma-separated list (or a repeated flag), exposing `value` as an
    * array. `--tags a,b` and `--tags a --tags b` both yield `["a", "b"]`; blank
-   * entries are dropped, and an unsupplied list defaults to `[]`.
+   * entries are dropped, and an unsupplied *optional* list defaults to `[]`
+   * (a required one is reported missing — see below).
    *
    * Each element is parsed by this parameter's own element parser, so it
    * composes: `.options("a", "b").array()` validates **every** element against
    * the choices, and `.number().array()` yields a `number[]`, rejecting a
    * non-numeric entry. (Apply `.options()`/`.number()` before `.array()`.)
+   *
+   * `.array()` composes **last**, after `.required()` too: a
+   * `.required().array()` list stays required, so an unsupplied value is
+   * reported as missing rather than silently resolving to the empty-list
+   * default. An optional (non-required) list defaults to `[]`.
    */
   array<E extends string | number>(
     this: Parameter<E, E | undefined>,
@@ -416,7 +422,9 @@ export class Parameter<
     return new Parameter<E, E[]>({
       description: this.description_,
       kind: this.kind_,
-      required: false,
+      // Carry the required flag through: `.required().array()` stays required
+      // (no fallback), so a missing value errors instead of resolving to `[]`.
+      required: this.required_,
       options: this.options_,
       envName: this.envName_,
       parse: (raw) =>
@@ -429,7 +437,7 @@ export class Parameter<
             return value;
           },
         ),
-      fallback: { has: true, value: [] },
+      fallback: this.required_ ? { has: false } : { has: true, value: [] },
       secret: this.secret_,
       array: true,
       source: this.source_,

--- a/packages/core/tests/params_test.ts
+++ b/packages/core/tests/params_test.ts
@@ -157,6 +157,53 @@ Deno.test("array parameters resolve through the CLI map (repeated flag joined)",
   if (p instanceof Parameter) assertEquals(p.value, ["x", "y"]);
 });
 
+Deno.test("required().array() is a required list, not an []-default one", () => {
+  // Regression: `.array()` used to hardcode required:false, so a
+  // `.required().array()` list silently resolved to [] when unsupplied instead
+  // of being reported missing. It must carry the required flag through.
+  const p = parameter("repos").required().array();
+  assertEquals([p.required_, p.hasFallback_, p.array_], [true, false, true]);
+  p.resolve_(undefined);
+  assertThrows(() => p.value, ParameterError); // unsupplied stays unresolved
+  p.resolve_("a, b ,c");
+  assertEquals(p.value, ["a", "b", "c"]); // supplied, parses per element
+});
+
+Deno.test("required().array() composes with a kind and options", () => {
+  // The canonical order is kind/options → .required() → .array() (last).
+  const nums = parameter("workers").number().required().array();
+  assertEquals([nums.required_, nums.hasFallback_], [true, false]);
+  nums.resolve_("1, 2 ,3");
+  assertEquals(nums.value, [1, 2, 3]);
+  assertThrows(() => nums.resolve_("x"), ParameterError, "expected a number");
+
+  const opts = parameter("svc").options("api", "web").required().array();
+  assertEquals([opts.required_, opts.hasFallback_], [true, false]);
+  opts.resolve_("api,web");
+  assertEquals(opts.value, ["api", "web"]);
+  assertThrows(() => opts.resolve_("db"), ParameterError, "expected one of");
+});
+
+Deno.test("resolveParameters reports a missing required array parameter", async () => {
+  class B extends Build {
+    repos = parameter("repos").required().array();
+  }
+  const params = discoverParameters(new B());
+  const missing = await resolveParameters(params, {}, () => undefined);
+  assertEquals(missing.length, 1);
+  assertStringIncludes(missing[0], "--repos is required");
+  // Supplied via the CLI map, it resolves cleanly.
+  const supplied = discoverParameters(new B());
+  const ok = await resolveParameters(
+    supplied,
+    { repos: "a,b" },
+    () => undefined,
+  );
+  assertEquals(ok, []);
+  const p = supplied.get("repos");
+  if (p instanceof Parameter) assertEquals(p.value, ["a", "b"]);
+});
+
 Deno.test("resolveParameters prompts for a missing required value", async () => {
   class B extends Build {
     token = parameter("API token").required();

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -133,10 +133,12 @@ Before calling any task or settings method, confirm the real shape:
   record; `continueOnItemFailure()` isolates a failed item. An `.onCancel(...)`
   on a fan-out stage runs per item on cancel (item-scoped `ctx.state`, reverse
   order). See `docs/orchestration.md`.
-- **Typed inputs:** `parameter("...")` (with `.secret()` / `.required()`), read
-  as `this.x.value`, gated with `.requires(this.x)`. `.array()` composes:
+- **Typed inputs:** `parameter("...")` (with `.number()` / `.boolean()` /
+  `.options(...)` / `.secret()` / `.required()`), read as `this.x.value`, gated
+  with `.requires(this.x)`. `.array()` composes and comes **last**:
   `.options(...).array()` validates each element, `.number().array()` →
-  `number[]`.
+  `number[]`, and a required list is `.required().array()` (required before
+  array — `.array().required()` does not typecheck).
 - **Secrets from a manager:** `parameter(...).secret().from(source)` sources a
   value at run time (e.g. `execSecret(...)` shelling out to a secret CLI) and
   **redacts** it from all of Zuke's output. See the cheatsheet.

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -307,7 +307,7 @@ concurrency:
 import { Build, parameter, target } from "jsr:@zuke/core";
 
 class CD extends Build {
-  repos = parameter("services").array().required();
+  repos = parameter("services").required().array();
 
   deployBatch = target().forEach(
     () => this.repos.value, // items: thunk, read when the target runs
@@ -355,9 +355,17 @@ class MyBuild extends Build {
 
 Secrets are masked in CI output. Read a resolved value with `this.x.value`.
 
-Lists: `.array()` (comma-separated or repeated flag → `[]`-default array) comes
-last and composes — `.options("a", "b").array()` validates each element, and
-`.number().array()` yields a `number[]`.
+Kinds & modifiers: `.number()` → `number`, `.boolean()` → `boolean` (a flag,
+defaults to `false`), `.options("a", "b")` restricts a string, `.secret()`
+masks + redacts, `.default(v)`/`.required()` set optionality, `.env(NAME)`
+overrides the env var.
+
+Lists: `.array()` (comma-separated or repeated flag) comes **last** and
+composes — `.options("a", "b").array()` validates each element, and
+`.number().array()` yields a `number[]`. Order is kind/options →
+`.required()` → `.array()`: put `.required()` **before** `.array()`
+(`.required().array()`), not after — `.array().required()` fails to typecheck,
+and a non-required list defaults to `[]`.
 
 ### Secrets from a manager — `.from(source)`
 

--- a/tests/integration/params_test.ts
+++ b/tests/integration/params_test.ts
@@ -23,6 +23,23 @@ Deno.test("a missing required parameter fails the build with a clear error", asy
   assertStringIncludes(err, "--environment is required");
 });
 
+Deno.test("a required array parameter is enforced through the CLI", async () => {
+  const seen: string[][] = [];
+  class Deploy extends Build {
+    repos = parameter("repos to deploy").required().array();
+    deploy = target().executes(() => void seen.push(this.repos.value));
+  }
+  // Unsupplied: the build fails before running, not a silent empty list.
+  const missing = await runCli(Deploy, ["deploy"]);
+  assertEquals(missing.code, 1);
+  assertStringIncludes(missing.err, "--repos is required");
+  assertEquals(seen, []);
+  // Supplied: the target sees the parsed list.
+  const ok = await runCli(Deploy, ["deploy", "--repos", "a,b,c"]);
+  assertEquals(ok.code, 0);
+  assertEquals(seen, [["a", "b", "c"]]);
+});
+
 Deno.test("options() rejects an invalid value and accepts a valid one", async () => {
   class Deploy extends Build {
     environment = parameter("Target environment").options("dev", "prod")


### PR DESCRIPTION
## What & why

A pilot agent was fooled by our docs. The fan-out examples in `docs/orchestration.md` and the `zuke-write-build` skill showed `parameter(...).array().required()`, which **fails to typecheck** (TS2684). The agent's workaround — `.required().array()` — *did* typecheck, but it was **silently broken at runtime**: `Parameter.array()` hardcoded `required: false` with an empty-list fallback, discarding requiredness. So a "required" list resolved to `[]` when unsupplied instead of failing the build.

This fixes the root cause, not just the docs.

## Changes

- **`packages/core/src/params.ts`** — `array()` now carries the required flag through: `required: this.required_` with `fallback: this.required_ ? { has: false } : { has: true, value: [] }`. A `.required().array()` list with no value is reported missing; an optional list still defaults to `[]`. The canonical order is kind/options → `.required()` → `.array()` (last).
- **Docs/skill** — corrected the broken fan-out examples in `docs/orchestration.md` and `references/cheatsheet.md`; documented the ordering rule in `docs/parameters.md`, `SKILL.md`, and the cheatsheet; added the `.boolean()` parameter kind to the cheatsheet (was undocumented — upstream feedback item 5).
- **Tests** — unit (`required().array()` stays required and errors when unsupplied; composes with `.number()`/`.options()`; `resolveParameters` reports the missing required list) and integration (a required array enforced end-to-end through the CLI).
- **Generated docs** — `llms-full.txt` and `packages/core/README.md` regenerated via `./zuke apiDocs`.

## Verification

- `deno task ci` green (check, tests, coverage **98.3% lines / 95.5% branches**).
- `./zuke apiDocsCheck` green (no doc drift).
- **Adversarial review** run across correctness, types, integration, and docs dimensions with per-finding verification against the real code: correctness/types/integration came back clean; one confirmed doc nit (a stale unconditional "defaults to `[]`" line in the `array()` JSDoc) was fixed and the derived docs regenerated. Confirmed the MCP run-tool schema correctly marks a required array as `required`.

## Note

Both orders don't typecheck: `.array().required()` still errors by design — supporting it cleanly would need an `as` cast, which the repo bans in `src`. The docs and skill now state the required order explicitly.