### PR TITLE
fix(ai): close AI-review security regressions and hardening tail

### DIFF
--- a/docs/ai-review.md
+++ b/docs/ai-review.md
@@ -158,6 +158,11 @@ outage isn't a silent skip either.
   suppressed finding is still listed (under "Suppressed (not gating)") so the
   dismissal is auditable — it mutes the gate, it never silently buries a finding.
 
+  > **Migration:** the finding-fingerprint format was widened (32→64-bit), so
+  > IDs recorded before that change no longer match. If previously dismissed
+  > findings resurface, re-record them: copy the new ID shown in the report back
+  > into your suppress file (default `.zuke/ai-suppress.json`).
+
 ## GitHub Actions summary
 
 Under Actions, a review appends a Markdown section (score, severity, and a

--- a/docs/ai-review.md
+++ b/docs/ai-review.md
@@ -9,9 +9,10 @@ blob of prose.
 
 ## How it plugs in
 
-A reviewer is a [`Validation`](./authoring.md#validations--validatebefore--validateafter):
-an object with a `validate(ctx)` method. You build one fluently, then attach it
-to a target with `.validateBefore(...)` (gate before the body) or
+A reviewer is a
+[`Validation`](./authoring.md#validations--validatebefore--validateafter): an
+object with a `validate(ctx)` method. You build one fluently, then attach it to
+a target with `.validateBefore(...)` (gate before the body) or
 `.validateAfter(...)` (check after a successful body). The target decides _when_
 it runs; the reviewer decides _what_ it checks.
 
@@ -39,13 +40,13 @@ await run(Pipeline);
 
 All share the same fluent `Reviewer` and return a `Validation`:
 
-| Factory | Reviews for | Extra |
-| --- | --- | --- |
-| `securityReviewer` | security vulnerabilities | — |
-| `secretsReviewer` | leaked secrets/credentials | — |
-| `correctnessReviewer` | bugs and likely regressions | — |
-| `licenseReviewer` | license / dependency-compliance risk | — |
-| `genericReviewer` | code quality and maintainability | — |
+| Factory               | Reviews for                          | Extra |
+| --------------------- | ------------------------------------ | ----- |
+| `securityReviewer`    | security vulnerabilities             | —     |
+| `secretsReviewer`     | leaked secrets/credentials           | —     |
+| `correctnessReviewer` | bugs and likely regressions          | —     |
+| `licenseReviewer`     | license / dependency-compliance risk | —     |
+| `genericReviewer`     | code quality and maintainability     | —     |
 
 ## Providers and credentials
 
@@ -64,10 +65,12 @@ structured-output mode:
 - **OpenAI** → `response_format: { type: "json_schema", strict: true }`.
 - **Gemini** → `generationConfig.responseSchema`.
 
-The assessment is `{ score: 0–10, severity, summary, findings: [{ title,
-severity, file?, line?, detail? }] }`. The strict dialect (OpenAI/Claude) makes
-the optional fields nullable; the Gemini dialect drops `additionalProperties`
-and uses `nullable`. Both map to the same parsed result.
+The assessment is
+`{ score: 0–10, severity, summary, findings: [{ title,
+severity, file?, line?, detail? }] }`.
+The strict dialect (OpenAI/Claude) makes the optional fields nullable; the
+Gemini dialect drops `additionalProperties` and uses `nullable`. Both map to the
+same parsed result.
 
 ## Choosing the gate
 
@@ -121,12 +124,12 @@ start line echoing its settings, and a notice on every retry:
 // On by default; override only when you want different behaviour.
 securityReviewer((r) =>
   r.provider("gemini").apiKey(this.key)
-    .retry({ attempts: 5 })          // more aggressive — five tries total
+    .retry({ attempts: 5 }) // more aggressive — five tries total
 );
 
 genericReviewer((r) =>
   r.provider("openai").apiKey(this.key)
-    .retry({ attempts: 1 })          // disable retries
+    .retry({ attempts: 1 }) // disable retries
 );
 ```
 
@@ -154,14 +157,17 @@ outage isn't a silent skip either.
   is spent, the review is skipped (not failed) with a note. See
   [Cost controls and learning](./self-healing.md#cost-controls-and-learning).
 - `.suppress(suppressions(...))` hides findings you've dismissed as false
-  positives, matched by the stable ID shown next to each finding in the report. A
-  suppressed finding is still listed (under "Suppressed (not gating)") so the
-  dismissal is auditable — it mutes the gate, it never silently buries a finding.
+  positives, matched by the stable ID shown next to each finding in the report.
+  A suppressed finding is still listed (under "Suppressed (not gating)") so the
+  dismissal is auditable — it mutes the gate, it never silently buries a
+  finding.
 
-  > **Migration:** the finding-fingerprint format was widened (32→64-bit), so
-  > IDs recorded before that change no longer match. If previously dismissed
-  > findings resurface, re-record them: copy the new ID shown in the report back
-  > into your suppress file (default `.zuke/ai-suppress.json`).
+  > **One-time migration:** the finding-fingerprint format was widened
+  > (32→64-bit), so IDs recorded before that change no longer match. A
+  > previously dismissed finding therefore reappears in the report and re-trips
+  > the gate — it fails safe (a stale suppression is ignored, never silently
+  > applied to hide a finding). Re-record it once: copy the new ID shown next to
+  > it into your suppress file (default `.zuke/ai-suppress.json`).
 
 ## GitHub Actions summary
 
@@ -175,19 +181,19 @@ on a failure). `.quiet()` suppresses both the console output and the summary.
 `.comment()` additionally posts the assessment onto the pull/merge request,
 under a **"🤖 Zuke AI review"** header linking back to the project. Rather than
 adding a new comment every run, it **upserts a single comment per reviewer**:
-the body carries a hidden marker (`<!-- zuke-ai-review:<name> -->`), so a
-re-run finds its previous comment and edits it in place. Different reviewers
-(e.g. a security and a secrets review) keep separate comments because the
-marker includes the reviewer name.
+the body carries a hidden marker (`<!-- zuke-ai-review:<name> -->`), so a re-run
+finds its previous comment and edits it in place. Different reviewers (e.g. a
+security and a secrets review) keep separate comments because the marker
+includes the reviewer name.
 
 Which API gets called is decided at runtime by [`detectCiHost()`](authoring.md):
 
-| Host | API used | Default token env | Workflow scope to grant |
-| --- | --- | --- | --- |
-| **GitHub Actions** | issue/PR comments | `GITHUB_TOKEN` | `pull-requests: write` |
-| **GitLab CI** | merge-request notes | `GITLAB_TOKEN` | personal/group token with `api` scope (the job token can't post notes) |
-| **Azure Pipelines** | PR comment threads | `SYSTEM_ACCESSTOKEN` | `System.AccessToken` mapped into env |
-| **Bitbucket Pipelines** | PR comments | `BITBUCKET_TOKEN` | app password or workspace access token |
+| Host                    | API used            | Default token env    | Workflow scope to grant                                                |
+| ----------------------- | ------------------- | -------------------- | ---------------------------------------------------------------------- |
+| **GitHub Actions**      | issue/PR comments   | `GITHUB_TOKEN`       | `pull-requests: write`                                                 |
+| **GitLab CI**           | merge-request notes | `GITLAB_TOKEN`       | personal/group token with `api` scope (the job token can't post notes) |
+| **Azure Pipelines**     | PR comment threads  | `SYSTEM_ACCESSTOKEN` | `System.AccessToken` mapped into env                                   |
+| **Bitbucket Pipelines** | PR comments         | `BITBUCKET_TOKEN`    | app password or workspace access token                                 |
 
 Override the token explicitly with `.commentToken(param | string)` (or, for
 backwards compatibility, the GitHub-only alias `.githubToken(...)`). Outside a
@@ -202,8 +208,8 @@ workflow permissions automatically when any reviewer has `.comment()` set.
 
 If the provider's response reports token counts, the review prints them as a
 footer — `tokens: 1234 in · 567 out · 1801 total` on the console, and a
-`**Tokens:** …` line in the summary and PR comment. The counts are read from each
-provider's own shape (Claude `usage.input_tokens` / `output_tokens`, OpenAI
+`**Tokens:** …` line in the summary and PR comment. The counts are read from
+each provider's own shape (Claude `usage.input_tokens` / `output_tokens`, OpenAI
 `usage.*_tokens`, Gemini `usageMetadata.*TokenCount`); the total is taken
 verbatim when present, or derived from input + output (Claude) otherwise. Only
 the counts a provider actually returns are shown, so this is purely
@@ -213,10 +219,10 @@ informational — it never affects the gate.
 
 Maintaining `.github/workflows/ai-review.yml` by hand is a chore — it has to
 stay in sync with every reviewer's secret env var, with `pull-requests: write`
-when any reviewer uses `.comment()`, with the right harden-runner +
-checkout pins, with the fork-gating `if`. `aiReviewWorkflow({...})` does it for
-you: declare it on the build and Zuke writes a [`CiFile`](authoring.md#cicd)
-that the standard `cicd` sync keeps current.
+when any reviewer uses `.comment()`, with the right harden-runner + checkout
+pins, with the fork-gating `if`. `aiReviewWorkflow({...})` does it for you:
+declare it on the build and Zuke writes a [`CiFile`](authoring.md#cicd) that the
+standard `cicd` sync keeps current.
 
 ```ts
 import { aiReviewWorkflow, securityReviewer } from "jsr:@zuke/ai";
@@ -247,12 +253,12 @@ from the workflow env (the generator can't infer a secret name).
 generate the equivalent for those providers — matching the cross-platform PR
 commenting above. Output shape per host:
 
-| `host` | Default path | What's generated |
-| --- | --- | --- |
-| `"github"` | `.github/workflows/ai-review.yml` | Full workflow — fork-gated, harden-runner + pinned checkout, base-branch fetch, `pull-requests: write` if any reviewer comments. |
-| `"gitlab"` | `.gitlab/ai-review.gitlab-ci.yml` | Merge-request-only job snippet on `denoland/deno:latest`. **Include from your `.gitlab-ci.yml`** (`include: { local: '.gitlab/ai-review.gitlab-ci.yml' }`). GitLab project-level CI variables flow into the job automatically — no `variables:` block emitted. |
-| `"azure"` | `pipelines/ai-review.azure-pipelines.yml` | PR-only job snippet. Each reviewer's secret is wired into the script step's `env:` block as `$(NAME)` (Azure doesn't expose pipeline secrets as env vars by default); `SYSTEM_ACCESSTOKEN` is added when any reviewer uses `.comment()`. **Use as a template** from your main pipeline. |
-| `"bitbucket"` | `bitbucket-pipelines.yml` | Pull-request-only step on `denoland/deno:latest`, written to the repo-root pipelines file Bitbucket expects (it has no `include` mechanism). Repository variables flow into the step automatically — no env block emitted; map your secrets as **secured** repository variables. |
+| `host`        | Default path                              | What's generated                                                                                                                                                                                                                                                                        |
+| ------------- | ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"github"`    | `.github/workflows/ai-review.yml`         | Full workflow — fork-gated, harden-runner + pinned checkout, base-branch fetch, `pull-requests: write` if any reviewer comments.                                                                                                                                                        |
+| `"gitlab"`    | `.gitlab/ai-review.gitlab-ci.yml`         | Merge-request-only job snippet on `denoland/deno:latest`. **Include from your `.gitlab-ci.yml`** (`include: { local: '.gitlab/ai-review.gitlab-ci.yml' }`). GitLab project-level CI variables flow into the job automatically — no `variables:` block emitted.                          |
+| `"azure"`     | `pipelines/ai-review.azure-pipelines.yml` | PR-only job snippet. Each reviewer's secret is wired into the script step's `env:` block as `$(NAME)` (Azure doesn't expose pipeline secrets as env vars by default); `SYSTEM_ACCESSTOKEN` is added when any reviewer uses `.comment()`. **Use as a template** from your main pipeline. |
+| `"bitbucket"` | `bitbucket-pipelines.yml`                 | Pull-request-only step on `denoland/deno:latest`, written to the repo-root pipelines file Bitbucket expects (it has no `include` mechanism). Repository variables flow into the step automatically — no env block emitted; map your secrets as **secured** repository variables.        |
 
 ```ts
 // Declare one per host you care about — they share the same reviewers.
@@ -314,8 +320,8 @@ reviewer name, the two land as **separate comments** ("security review" and
 
 `.skipIfKeyMissing()` replaces an `.onlyWhen(() => this.openaiKey.isSet_())`
 gate on the target: rather than the target vanishing silently when a key is
-absent, the reviewer runs, sees no key, and prints a "skipped — no API key"
-line (and a matching job-summary note). The
+absent, the reviewer runs, sees no key, and prints a "skipped — no API key" line
+(and a matching job-summary note). The
 [`ai-review.yml`](../.github/workflows/ai-review.yml) workflow runs
 `./zuke review` on pull requests (non-fork only, so the secrets are never
 exposed to untrusted code), passing `OPENAI_API_KEY`, `GEMINI_API_KEY`, the

--- a/packages/ai/src/agent_fixer.ts
+++ b/packages/ai/src/agent_fixer.ts
@@ -40,6 +40,7 @@ import {
 } from "./context.ts";
 import { agentPrompt } from "./prompts/agent.ts";
 import { commitChanged, type GitRunner, porcelainPaths } from "./commit.ts";
+import { fenceMarkdown } from "./markdown.ts";
 import { writeStepSummary } from "./report.ts";
 import { postComment } from "./comment.ts";
 import { type EnvReader, readEnv } from "./hosts.ts";
@@ -107,9 +108,7 @@ function agentMarkdown(
     parts.push(
       "<details><summary>Agent output</summary>",
       "",
-      "```",
-      capped,
-      "```",
+      fenceMarkdown(capped),
       "</details>",
       "",
     );
@@ -257,15 +256,35 @@ export class AgentFixer implements Remediation {
   }
 
   /**
-   * Post the agent's working-tree changes (`git diff HEAD`) as committable
-   * inline suggestions on the PR. Returns the number posted; a no-op off GitHub,
-   * without a PR context, or when the agent produced no committable hunks.
+   * Post the agent's changes as committable inline suggestions on the PR. Scoped
+   * to only the paths the agent newly changed — dirty now but not in `before`
+   * (the pre-agent snapshot) — so a working tree already dirtied by the developer
+   * or earlier build steps is never leaked into the public PR as "agent" output.
+   * Returns the number posted; a no-op off GitHub, without a PR context, when the
+   * status can't be read (fail closed), or when the agent produced no committable
+   * hunks.
    */
-  async #postSuggestions(target: string): Promise<number> {
+  async #postSuggestions(target: string, before: string[]): Promise<number> {
     if (detectCiHost(this.#env) !== "github") return 0;
+    let changed: string[];
+    try {
+      const after = porcelainPaths(
+        await this.#git()(["git", "status", "--porcelain"]),
+      );
+      const beforeSet = new Set(before);
+      changed = after.filter((p) => !beforeSet.has(p));
+    } catch {
+      return 0; // fail closed: can't scope the diff → propose nothing
+    }
+    if (changed.length === 0) return 0;
     let diff: string;
     try {
-      diff = await this.#git()(["git", "diff", "HEAD"]);
+      // Scope the diff to the agent's own paths (never a bare `git diff HEAD`,
+      // which would post the whole dirty tree). `--literal-pathspecs` keeps a
+      // path with a `:` sigil from being read as pathspec magic.
+      diff = await this.#git()(
+        ["git", "--literal-pathspecs", "diff", "HEAD", "--", ...changed],
+      );
     } catch {
       return 0;
     }
@@ -330,11 +349,12 @@ export class AgentFixer implements Remediation {
       criteria: this.#criteria === "" ? undefined : this.#criteria,
     });
 
-    // When committing the fix, snapshot what is already dirty so only the
-    // agent's own changes are staged — never the developer's unrelated edits.
+    // Before committing OR suggesting, snapshot what is already dirty so only the
+    // agent's own changes are staged / proposed — never the developer's unrelated
+    // edits (which, in suggest mode, would otherwise leak into the public PR).
     let dirtyBefore: string[] = [];
     let snapshotOk = true;
-    if (this.#commitFixes) {
+    if (this.#commitFixes || this.#suggest) {
       try {
         dirtyBefore = porcelainPaths(
           await this.#git()(["git", "status", "--porcelain"]),
@@ -342,7 +362,8 @@ export class AgentFixer implements Remediation {
       } catch {
         // Fail CLOSED: without the snapshot we can't tell the agent's changes
         // from the developer's, and `dirtyBefore = []` would sweep everything
-        // in (the exact `git add -A` leak this fix removes). Skip the commit.
+        // in (the exact `git add -A` leak this fix removes). Skip the commit /
+        // suggestions rather than expose unrelated changes.
         snapshotOk = false;
       }
     }
@@ -370,10 +391,16 @@ export class AgentFixer implements Remediation {
     // when not auto-fixing; `.commitFixes()` (auto-fix) takes precedence and
     // reports an overview of what it committed instead.
     if (this.#suggest && !this.#commitFixes) {
-      const posted = await this.#postSuggestions(context.target);
-      const action = posted > 0
-        ? `ran the agent and proposed ${posted} inline suggestion(s) — apply them to fix`
-        : "ran the agent (no committable suggestions produced)";
+      let action: string;
+      if (!snapshotOk) {
+        action =
+          "ran the agent (skipped suggestions: could not snapshot the working tree)";
+      } else {
+        const posted = await this.#postSuggestions(context.target, dirtyBefore);
+        action = posted > 0
+          ? `ran the agent and proposed ${posted} inline suggestion(s) — apply them to fix`
+          : "ran the agent (no committable suggestions produced)";
+      }
       await this.#report(context.target, action, agentOutput);
       return { retry: false };
     }

--- a/packages/ai/src/apply.ts
+++ b/packages/ai/src/apply.ts
@@ -58,6 +58,13 @@ function matchesAny(patterns: string[], path: string, ci: boolean): boolean {
  * can't bypass the guards), then `.`/`..` segments are fully resolved: an
  * absolute path, a Windows drive, or any `..` that escapes the repo root is
  * rejected outright rather than written.
+ *
+ * A path whose first segment begins with `:` is rejected too: git reserves a
+ * leading `:` for pathspec *magic* (`:(glob)`, `:/`, `:(exclude)`, …), which
+ * `git add -- <path>` does **not** disable, so a magic path would later stage
+ * the whole tree rather than the one file (see {@link "./commit.ts".commitAndPush}).
+ * No trackable repo-relative path starts with `:`, so this can only be an attempt
+ * to smuggle a pathspec through the fixer's write/commit seam.
  */
 function normalizePath(path: string): string {
   const unified = path.replaceAll("\\", "/");
@@ -83,6 +90,9 @@ function normalizePath(path: string): string {
   }
   if (segments.length === 0) {
     throw new AiReviewError(`refusing to write outside the repo: ${path}`);
+  }
+  if (segments[0].startsWith(":")) {
+    throw new AiReviewError(`refusing a git pathspec-magic path: ${path}`);
   }
   return segments.join("/");
 }

--- a/packages/ai/src/commit.ts
+++ b/packages/ai/src/commit.ts
@@ -29,7 +29,16 @@ export interface CommitOptions {
  */
 export async function commitAndPush(options: CommitOptions): Promise<void> {
   if (options.paths.length === 0) return;
-  await options.run(["git", "add", "--", ...options.paths]);
+  // `--literal-pathspecs` disables pathspec magic (`:(glob)`, `:/`, …) so a path
+  // that slipped a guard can only ever stage that literal file, never sweep the
+  // tree. Defence in depth with normalizePath's leading-`:` rejection.
+  await options.run([
+    "git",
+    "--literal-pathspecs",
+    "add",
+    "--",
+    ...options.paths,
+  ]);
   await options.run(["git", "commit", "-m", options.message]);
   if (options.push !== false) {
     await options.run(["git", "push"]);

--- a/packages/ai/src/fix_report.ts
+++ b/packages/ai/src/fix_report.ts
@@ -9,6 +9,7 @@
 
 import type { Confidence, FixLocation } from "./fix.ts";
 import type { Usage } from "./types.ts";
+import { codeSpan, fenceMarkdown } from "./markdown.ts";
 import { formatUsage } from "./report.ts";
 
 /** A fixer's outcome, summarised for the report. */
@@ -29,9 +30,16 @@ export interface FixReport {
   usage?: Usage;
 }
 
-/** Escape `|` so a value is safe inside a Markdown table cell. */
+/**
+ * Neutralize a value for a plain inline Markdown context (a table cell or a
+ * blockquote): escape the `|` cell separator and collapse newlines, so
+ * model-controlled text can't inject block-level Markdown (a heading, a fake
+ * "approved" banner) by starting a fresh line. For an **inline code span** use
+ * {@link "./markdown.ts".codeSpan} (backticks need neutralizing too); for a
+ * fenced code body use {@link "./markdown.ts".fenceMarkdown}.
+ */
 function cell(value: string): string {
-  return value.replaceAll("|", "\\|");
+  return value.replaceAll(/[\r\n]+/g, " ").replaceAll("|", "\\|");
 }
 
 /** The `file:line` (or `file:line-endLine`) label for a location. */
@@ -57,7 +65,10 @@ function locationDiff(loc: FixLocation): string {
     ...signLines("-", loc.code),
     ...(suggestion === "" ? [] : signLines("+", suggestion)),
   ];
-  return ["```diff", ...body, "```"].join("\n");
+  // fenceMarkdown, not a bare ```diff fence: the model controls `code`,
+  // `suggestion`, and `file` (in the hunk header), so a plain fence could be
+  // closed early to inject Markdown into the PR comment / job summary.
+  return fenceMarkdown(body.join("\n"), "diff");
 }
 
 /** The console lines describing a fix. */
@@ -98,10 +109,12 @@ export function fixMarkdown(
     "",
   ];
   for (const loc of report.locations) {
-    parts.push(`#### \`${cell(locationLabel(loc))}\``, locationDiff(loc), "");
+    // codeSpan (not cell): loc.file is model-controlled and goes in an inline
+    // code span, where a backtick would close the span and inject Markdown.
+    parts.push(`#### ${codeSpan(locationLabel(loc))}`, locationDiff(loc), "");
   }
   if (report.files.length > 0) {
-    const list = report.files.map((f) => `\`${cell(f)}\``).join(", ");
+    const list = report.files.map((f) => codeSpan(f)).join(", ");
     parts.push(`**Files:** ${list}`, "");
   }
   return parts.join("\n");

--- a/packages/ai/src/hosts/azure.ts
+++ b/packages/ai/src/hosts/azure.ts
@@ -70,6 +70,10 @@ async function findThread(
   marker: string,
   doFetch: typeof fetch,
 ): Promise<{ threadId: number; commentId: number } | undefined> {
+  // No pagination loop (unlike the GitHub/GitLab/Bitbucket hosts): the Azure
+  // DevOps PR *threads* list endpoint returns every thread for the PR in one
+  // response — it exposes no `$top`/`$skip` and no continuation-token header — so
+  // a single fetch is complete and the marker can't hide on a later page.
   const url = `${threadsUrl(context)}?api-version=7.1`;
   const response = await doFetch(url, {
     headers: jsonHeaders({ "authorization": `Bearer ${context.token}` }),

--- a/packages/ai/src/markdown.ts
+++ b/packages/ai/src/markdown.ts
@@ -1,0 +1,54 @@
+/**
+ * Neutralizing model- and agent-controlled text before it is embedded in the
+ * Markdown of a PR comment or CI job summary — the Markdown analogue of the
+ * prompt-side {@link "./prompts/fence.ts".fenceUntrusted}.
+ *
+ * @module
+ */
+
+/**
+ * Wrap untrusted `content` in a Markdown fenced code block it cannot break out
+ * of. A CommonMark fence is closed only by a line bearing **at least** as many
+ * backticks as the opening fence, so the fence is built one backtick longer than
+ * the longest backtick run anywhere in the content (a minimum of three). An
+ * attacker embedding ``` — or a longer run — can then only produce a run shorter
+ * than the fence, which stays inert data inside the block instead of closing it
+ * and injecting arbitrary Markdown (fake "approved" banners, headings, links).
+ *
+ * @param content The untrusted text to embed.
+ * @param lang An optional info string (e.g. `"diff"`) for the opening fence.
+ */
+export function fenceMarkdown(content: string, lang = ""): string {
+  const fence = "`".repeat(Math.max(3, longestBacktickRun(content) + 1));
+  // The info string shares the opening fence's line, so a newline or backtick in
+  // it would break out; keep only a plain token (callers pass literals today).
+  const info = lang.replace(/[`\r\n]+/g, "");
+  return `${fence}${info}\n${content}\n${fence}`;
+}
+
+/**
+ * Wrap untrusted `value` in an **inline** Markdown code span it cannot break out
+ * of — the inline counterpart of {@link fenceMarkdown}, for a value embedded in a
+ * heading or table (e.g. a model-supplied file path). The span uses one more
+ * backtick than the longest run inside `value`, pads a leading/trailing backtick
+ * per CommonMark, and drops newlines (an inline span is single-line), so an
+ * embedded backtick can't close the span early and inject inline Markdown (a
+ * phishing link, a bold "approved" banner) into the surrounding text.
+ */
+export function codeSpan(value: string): string {
+  const clean = value.replace(/[\r\n]+/g, " ");
+  const ticks = "`".repeat(longestBacktickRun(clean) + 1);
+  // A code span whose content starts or ends with a backtick needs a padding
+  // space (CommonMark strips one space from each side), else the delimiters merge.
+  const pad = clean.startsWith("`") || clean.endsWith("`") ? " " : "";
+  return `${ticks}${pad}${clean}${pad}${ticks}`;
+}
+
+/** The length of the longest run of consecutive backticks in `text` (0 if none). */
+function longestBacktickRun(text: string): number {
+  let longest = 0;
+  for (const run of text.match(/`+/g) ?? []) {
+    if (run.length > longest) longest = run.length;
+  }
+  return longest;
+}

--- a/packages/ai/src/reviewer.ts
+++ b/packages/ai/src/reviewer.ts
@@ -298,17 +298,29 @@ export class Reviewer implements Validation {
     return this;
   }
 
-  /** Resolve the diff text from the configured source. */
-  async #resolveDiff(): Promise<string> {
+  /**
+   * Resolve the diff text from the configured source, reporting whether a
+   * requested `.fetchBase()` failed. `fetchFailed` is true only when a fetch was
+   * asked for but could not produce a base diff (offline, not a PR, unsafe ref):
+   * the caller must not let an empty working-tree fallback pass the gate silently.
+   */
+  async #resolveDiff(): Promise<{ diff: string; fetchFailed: boolean }> {
     const text = this.#diff.text_();
-    if (text !== undefined) return text;
+    if (text !== undefined) return { diff: text, fetchFailed: false };
     const run = this.#exec ?? ((argv: string[]) => new Command(argv).text());
     // Honour `.fetchBase()` (fetch the base branch, diff against FETCH_HEAD) so
     // CI PR review needs no manual `git fetch`; fall through to the configured
     // source when no fetch was requested or it couldn't be done.
+    const wantsFetch = this.#diff.fetch_() !== undefined;
     const fetched = await fetchBaseDiff(this.#diff, run, this.#env);
-    if (fetched !== undefined) return fetched;
-    return await run(this.#diff.argv_());
+    if (fetched !== undefined) return { diff: fetched, fetchFailed: false };
+    if (wantsFetch && !this.#quiet) {
+      console.warn(
+        `[${this.name}] fetchBase could not compute the base diff — ` +
+          `falling back to the working-tree diff`,
+      );
+    }
+    return { diff: await run(this.#diff.argv_()), fetchFailed: wantsFetch };
   }
 
   /**
@@ -386,7 +398,7 @@ export class Reviewer implements Validation {
   async #publish(markdown: string): Promise<void> {
     writeStepSummary(markdown);
     if (!this.#comment) return;
-    const host = detectReviewHost();
+    const host = detectReviewHost(this.#env);
     if (host === undefined) {
       console.warn(
         `[${this.name}] no PR-comment host detected — skipping comment`,
@@ -395,8 +407,8 @@ export class Reviewer implements Validation {
     }
     const token = this.#commentToken !== undefined
       ? resolveKey(this.#commentToken)
-      : readEnv(host.defaultTokenEnv) ?? "";
-    const upsert = host.prepare(token, readEnv);
+      : this.#env(host.defaultTokenEnv) ?? "";
+    const upsert = host.prepare(token, this.#env);
     if (upsert === undefined) {
       console.warn(
         `[${this.name}] no ${host.label} PR context — skipping comment`,
@@ -440,12 +452,28 @@ export class Reviewer implements Validation {
       }));
     }
 
+    const resolved = await this.#resolveDiff();
     let diff = filterDiff(
-      await this.#resolveDiff(),
+      resolved.diff,
       this.#include,
       [...DEFAULT_EXCLUDES, ...this.#exclude],
     ).trim();
     if (diff === "") {
+      // A requested fetchBase that failed leaves an empty working-tree fallback
+      // on a clean CI checkout. Passing that as an empty assessment would let the
+      // gate go green without reviewing anything — a silent security bypass. Fail
+      // (or, under `onError: "warn"`, skip visibly), never pass silently.
+      if (resolved.fetchFailed) {
+        const reason =
+          "could not compute the base diff (git fetch for the base branch failed)";
+        if (this.#onError === "warn") {
+          await this.#reportSkip(context.target, reason);
+          return;
+        }
+        throw new AiReviewError(
+          `${this.name} of "${context.target}" ${reason}; refusing to pass on an empty fallback diff`,
+        );
+      }
       await this.#report(emptyAssessment(), context.target);
       return;
     }

--- a/packages/ai/tests/agent_fixer_test.ts
+++ b/packages/ai/tests/agent_fixer_test.ts
@@ -87,7 +87,7 @@ Deno.test("commitFixes stages all changes, commits, and pushes", async () => {
   assertEquals(git, [
     ["git", "status", "--porcelain"], // pre-agent snapshot
     ["git", "status", "--porcelain"], // post-agent, inside commitChanged
-    ["git", "add", "--", "src/app.ts"], // only the agent's file, never `-A`
+    ["git", "--literal-pathspecs", "add", "--", "src/app.ts"], // only the agent's file, never `-A`
     ["git", "commit", "-m", 'Apply Zuke agent fix for "test"'],
     ["git", "push"],
   ]);
@@ -154,7 +154,7 @@ Deno.test("noPush commits without pushing, with a custom message", async () => {
   assertEquals(git, [
     ["git", "status", "--porcelain"], // pre-agent snapshot
     ["git", "status", "--porcelain"], // post-agent, inside commitChanged
-    ["git", "add", "--", "src/app.ts"],
+    ["git", "--literal-pathspecs", "add", "--", "src/app.ts"],
     ["git", "commit", "-m", "fix: heal"],
   ]); // no push
 });
@@ -229,6 +229,7 @@ Deno.test("suggest mode posts the agent's diff as inline suggestions, no commit,
       }),
     );
   }) as typeof fetch;
+  let statusCalls = 0;
   const fixer = agentFixer(() => Promise.resolve())
     .allowCI().suggest().conventions("").readFile(() =>
       Promise.resolve(undefined)
@@ -236,19 +237,59 @@ Deno.test("suggest mode posts the agent's diff as inline suggestions, no commit,
     .env((n) => prEnv[n])
     .exec((argv) => {
       git.push(argv);
-      return Promise.resolve(argv[1] === "diff" ? diff : "");
+      if (argv.includes("status")) {
+        // Pre-agent snapshot: clean. Post-agent: the agent changed zuke.ts.
+        statusCalls++;
+        return Promise.resolve(statusCalls === 1 ? "" : " M zuke.ts");
+      }
+      return Promise.resolve(argv.includes("diff") ? diff : "");
     })
     .fetch(impl).quiet();
   const result = await fixer.remediate(CTX);
   assertEquals(result.retry, false); // proposal mode — build stays failed
-  // It read the agent's diff and never committed.
-  assertEquals(git.some((a) => a[1] === "diff"), true);
-  assertEquals(git.some((a) => a[1] === "commit"), false);
+  // It read the agent's diff (scoped to its own path) and never committed.
+  assertEquals(git.some((a) => a.includes("diff")), true);
+  assertEquals(git.some((a) => a.includes("commit")), false);
   // A review comment with a suggestion block was posted.
   const posted = calls.some((c) =>
     c.url.endsWith("/pulls/7/comments") && c.body.includes("```suggestion")
   );
   assertEquals(posted, true);
+});
+
+Deno.test("suggest mode scopes the diff to the agent's paths, not pre-existing dirt", async () => {
+  const prEnv: Record<string, string> = {
+    GITHUB_ACTIONS: "true",
+    GITHUB_REPOSITORY: "o/r",
+    GITHUB_REF: "refs/pull/7/merge",
+    GITHUB_TOKEN: "tok",
+  };
+  const git: string[][] = [];
+  let statusCalls = 0;
+  const fixer = agentFixer(() => Promise.resolve())
+    .allowCI().suggest().conventions("").readFile(() =>
+      Promise.resolve(undefined)
+    )
+    .env((n) => prEnv[n])
+    .exec((argv) => {
+      git.push(argv);
+      if (argv.includes("status")) {
+        statusCalls++;
+        // Before the agent: the developer already had secrets.env dirty.
+        // After: the agent additionally changed zuke.ts.
+        return Promise.resolve(
+          statusCalls === 1 ? " M secrets.env" : " M secrets.env\n M zuke.ts",
+        );
+      }
+      return Promise.resolve(argv.includes("diff") ? "diff --git a/z b/z" : "");
+    })
+    .noComment().quiet();
+  await fixer.remediate(CTX);
+  // The diff is scoped to only the agent's new path — the developer's dirty
+  // secrets.env is never diffed (and so never leaked into the PR).
+  const diffCall = git.find((a) => a.includes("diff"));
+  assertEquals(diffCall?.includes("zuke.ts"), true);
+  assertEquals(diffCall?.includes("secrets.env"), false);
 });
 
 Deno.test("suggest mode off GitHub reports no committable suggestions", async () => {
@@ -270,16 +311,22 @@ Deno.test("suggest mode tolerates a git diff failure", async () => {
     GITHUB_REF: "refs/pull/7/merge",
     GITHUB_TOKEN: "tok",
   };
+  let statusCalls = 0;
   const fixer = agentFixer(() => Promise.resolve())
     .allowCI().suggest().conventions("").readFile(() =>
       Promise.resolve(undefined)
     )
     .env((n) => prEnv[n])
-    .exec((argv) =>
-      argv[1] === "diff"
+    .exec((argv) => {
+      if (argv.includes("status")) {
+        statusCalls++;
+        return Promise.resolve(statusCalls === 1 ? "" : " M zuke.ts");
+      }
+      // The scoped diff for the agent's changed path fails; suggest tolerates it.
+      return argv.includes("diff")
         ? Promise.reject(new Error("no HEAD"))
-        : Promise.resolve("")
-    )
+        : Promise.resolve("");
+    })
     .noComment().quiet();
   const result = await fixer.remediate(CTX);
   assertEquals(result.retry, false);
@@ -330,7 +377,7 @@ Deno.test("commitChanged stages only the agent's new changes, not pre-existing d
   });
   assertEquals(calls, [
     ["git", "status", "--porcelain"],
-    ["git", "add", "--", "new.ts"], // never `git add -A`, never `already.ts`
+    ["git", "--literal-pathspecs", "add", "--", "new.ts"], // never `git add -A`, never `already.ts`
     ["git", "commit", "-m", "m"],
   ]);
 });
@@ -382,7 +429,9 @@ Deno.test("commitFixes fails closed when the pre-snapshot cannot be taken", asyn
   // Never staged/committed/pushed: without the snapshot we can't isolate the
   // agent's changes, so the developer's dirty file is left untouched.
   assertEquals(
-    git.some((c) => c[1] === "add" || c[1] === "commit" || c[1] === "push"),
+    git.some((c) =>
+      c.includes("add") || c.includes("commit") || c.includes("push")
+    ),
     false,
   );
 });

--- a/packages/ai/tests/ai_test.ts
+++ b/packages/ai/tests/ai_test.ts
@@ -247,6 +247,88 @@ Deno.test("reviewer fetchBase rejects an option-like base ref (never fetches)", 
   assertEquals(git[0], ["git", "diff"]);
 });
 
+Deno.test("fetchBase failure with an empty fallback fails the gate, never a silent pass", async () => {
+  const { fetch, calls } = recordFetch(
+    claude({ score: 0, severity: "none", summary: "", findings: [] }),
+  );
+  // The fetch fails and the working-tree diff is empty (a clean CI checkout).
+  // Passing that as an empty assessment would green the gate without reviewing.
+  await assertRejects(
+    () =>
+      securityReviewer((r) =>
+        r.provider("claude").apiKey("k").quiet()
+          .diff((d) => d.fetchBase("main"))
+          .env(() => undefined)
+          .exec((argv) =>
+            argv[1] === "fetch"
+              ? Promise.reject(new Error("offline"))
+              : Promise.resolve("")
+          )
+          .fetch(fetch)
+      ).validate({ target: "t" }),
+    AiReviewError,
+    "could not compute the base diff",
+  );
+  assertEquals(calls.length, 0); // the model is never called
+});
+
+Deno.test("fetchBase failure with an empty fallback skips visibly under onError:warn", async () => {
+  const { fetch, calls } = recordFetch(
+    claude({ score: 0, severity: "none", summary: "", findings: [] }),
+  );
+  // onError:"warn" turns the hard fail into a visible skip — still not a call.
+  await securityReviewer((r) =>
+    r.provider("claude").apiKey("k").quiet().onError("warn")
+      .diff((d) => d.fetchBase("main"))
+      .env(() => undefined)
+      .exec((argv) =>
+        argv[1] === "fetch"
+          ? Promise.reject(new Error("offline"))
+          : Promise.resolve("")
+      )
+      .fetch(fetch)
+  ).validate({ target: "t" });
+  assertEquals(calls.length, 0);
+});
+
+Deno.test("fetchBase failure still reviews a non-empty working-tree fallback", async () => {
+  const { fetch, calls } = recordFetch(
+    claude({ score: 0, severity: "none", summary: "", findings: [] }),
+  );
+  // A non-empty fallback is a legitimate review (e.g. local dev): keep it, don't
+  // fail — only an *empty* fallback after a fetch failure is the silent-pass hole.
+  await securityReviewer((r) =>
+    r.provider("claude").apiKey("k").quiet()
+      .diff((d) => d.fetchBase("main"))
+      .env(() => undefined)
+      .exec((argv) =>
+        argv[1] === "fetch"
+          ? Promise.reject(new Error("offline"))
+          : Promise.resolve("diff --git a/w b/w\n+working tree")
+      )
+      .fetch(fetch)
+  ).validate({ target: "t" });
+  assertEquals(calls.length, 1); // the fallback diff was reviewed
+});
+
+Deno.test("a successful fetchBase with a genuinely empty diff passes, not fails", async () => {
+  const { fetch, calls } = recordFetch(
+    claude({ score: 0, severity: "none", summary: "", findings: [] }),
+  );
+  // Both the fetch and the base diff succeed but the diff is empty (a PR with no
+  // reviewable changes). That is a real "no changes" — it must pass as an empty
+  // assessment, NOT be mistaken for the fetch-failure hole. Locks the contract
+  // that fetchBaseDiff returns "" (not undefined) on an empty-but-successful diff.
+  await securityReviewer((r) =>
+    r.provider("claude").apiKey("k").quiet()
+      .diff((d) => d.fetchBase("main"))
+      .env(() => undefined)
+      .exec(() => Promise.resolve("")) // fetch ok, diff empty
+      .fetch(fetch)
+  ).validate({ target: "t" });
+  assertEquals(calls.length, 0); // no findings, no throw — a clean empty pass
+});
+
 Deno.test("the build breaks when the risk score exceeds the threshold", async () => {
   const { fetch } = recordFetch(
     claude({ score: 9, severity: "high", summary: "RCE risk", findings: [] }),

--- a/packages/ai/tests/fixer_test.ts
+++ b/packages/ai/tests/fixer_test.ts
@@ -154,7 +154,7 @@ Deno.test("commitFixes stages, commits, and pushes the applied files", async () 
   const result = await fixer.remediate(CTX);
   assertEquals(result.retry, true);
   assertEquals(s.git, [
-    ["git", "add", "--", "src/app.ts"],
+    ["git", "--literal-pathspecs", "add", "--", "src/app.ts"],
     ["git", "commit", "-m", 'Apply Zuke AI fix for "test"'],
     ["git", "push"],
   ]);
@@ -171,7 +171,7 @@ Deno.test("noPush commits without pushing", async () => {
   ).fetch(fetch).quiet();
   await fixer.remediate(CTX);
   assertEquals(s.git, [
-    ["git", "add", "--", "src/app.ts"],
+    ["git", "--literal-pathspecs", "add", "--", "src/app.ts"],
     ["git", "commit", "-m", "fix: heal build"],
   ]);
 });
@@ -321,6 +321,11 @@ Deno.test("checkEdits enforces the allowlist, exclusions, traversal, and the cap
       "\\\\server\\share\\x",
       "", // empty
       "./.", // resolves to nothing
+      // git pathspec magic: a leading `:` would sweep the tree at `git add`.
+      ":(glob)**",
+      ":/",
+      ":(exclude)*.ts",
+      "./:(glob)secrets.env",
     ]
   ) {
     let rejected = false;
@@ -858,6 +863,32 @@ Deno.test("fixMarkdown renders each location as a file:line diff block", () => {
   assertEquals(md.includes("-const X = 1;"), true);
 });
 
+Deno.test("fixMarkdown neutralizes Markdown injection in model-controlled fields", () => {
+  const md = fixMarkdown("AI fix", "lint", {
+    diagnosis: "ok\n## ✅ Approved by security",
+    rootCause: "x",
+    confidence: "high",
+    locations: [{
+      // A backtick in the model-controlled path must not break the inline code
+      // span in the #### header and inject a link/banner.
+      file: "a`.ts",
+      line: 1,
+      code: "x\n```\n## Injected heading",
+    }],
+    files: ["a`.ts"],
+    action: "diagnosed",
+  });
+  // A newline in the diagnosis is collapsed — it can't start a top-level heading.
+  assertEquals(md.includes("\n## ✅ Approved"), false);
+  // The code's embedded ``` can't close the diff fence (the fence outgrows it),
+  // so the injected heading stays inert data inside the block.
+  assertEquals(md.includes("\n## Injected heading"), false);
+  // The backtick path is wrapped in a longer (double-backtick) code span, not a
+  // single-backtick one it could close early.
+  assertEquals(md.includes("#### ``a`.ts:1``"), true);
+  assertEquals(md.includes("**Files:** ``a`.ts``"), true);
+});
+
 Deno.test("a single-line location with a replacement renders + and - lines", () => {
   const md = fixMarkdown("AI fix", "lint", {
     diagnosis: "Use const.",
@@ -931,6 +962,28 @@ Deno.test("conventions default reader reads from disk", async () => {
   // deno.json exists at the repo root (the test cwd); a missing file is undefined.
   assertEquals(typeof await readTextOrUndefined("deno.json"), "string");
   assertEquals(await readTextOrUndefined("does-not-exist.zzz"), undefined);
+});
+
+Deno.test("commitAndPush stages with --literal-pathspecs (no pathspec magic)", async () => {
+  const git: string[][] = [];
+  await commitAndPush({
+    paths: ["src/app.ts"],
+    message: "m",
+    push: false,
+    run: (argv) => {
+      git.push(argv);
+      return Promise.resolve("");
+    },
+  });
+  // Defence in depth: even if a `:`-prefixed path slipped the write guard, this
+  // disables git's pathspec magic so `add` can only ever stage the literal file.
+  assertEquals(git[0], [
+    "git",
+    "--literal-pathspecs",
+    "add",
+    "--",
+    "src/app.ts",
+  ]);
 });
 
 Deno.test("commitAndPush is a no-op when there are nothing to commit", async () => {

--- a/packages/ai/tests/markdown_test.ts
+++ b/packages/ai/tests/markdown_test.ts
@@ -1,0 +1,57 @@
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../core/tests/_assert.ts";
+import { codeSpan, fenceMarkdown } from "../src/markdown.ts";
+
+Deno.test("fenceMarkdown wraps plain content in a three-backtick fence", () => {
+  assertEquals(fenceMarkdown("hello"), "```\nhello\n```");
+  assertEquals(fenceMarkdown("x", "diff"), "```diff\nx\n```");
+});
+
+Deno.test("fenceMarkdown outgrows any backtick run so content cannot break out", () => {
+  // A payload embedding a closing fence must not terminate the block: the fence
+  // is one backtick longer than the longest run inside.
+  assertEquals(fenceMarkdown("```"), "````\n```\n````");
+  assertEquals(fenceMarkdown("a\n````\nb"), "`````\na\n````\nb\n`````");
+});
+
+Deno.test("fenceMarkdown drops backticks/newlines from the info string", () => {
+  // The info string shares the opening fence line; a newline or backtick there
+  // would break out. Callers pass literals today, but keep the helper robust.
+  assertEquals(fenceMarkdown("x", "di`ff\n## h"), "```diff## h\nx\n```");
+});
+
+Deno.test("codeSpan wraps a plain value in a single-backtick span", () => {
+  assertEquals(codeSpan("zuke.ts:42-45"), "`zuke.ts:42-45`");
+  assertEquals(codeSpan("a.ts:7"), "`a.ts:7`");
+});
+
+Deno.test("codeSpan neutralizes a backtick breakout in an inline label", () => {
+  // A model-supplied file path with a backtick must not close the span early and
+  // inject inline Markdown (a link/banner) into the surrounding heading.
+  const label = "x` ✅ **APPROVED** [merge](http://evil) `y:1";
+  const span = codeSpan(label);
+  // The delimiter outgrows the longest internal run, so the payload stays inside.
+  assertEquals(span, "``x` ✅ **APPROVED** [merge](http://evil) `y:1``");
+  // Newlines are dropped (an inline span is single-line).
+  assertEquals(codeSpan("a\nb").includes("\n"), false);
+  // A leading/trailing backtick is padded so the delimiters don't merge.
+  assertEquals(codeSpan("`x`"), "`` `x` ``");
+});
+
+Deno.test("fenceMarkdown neutralizes a Markdown-injection payload", () => {
+  const payload = "ok\n```\n## ✅ Approved by security\n[click](http://evil)";
+  const fenced = fenceMarkdown(payload, "diff");
+  // The opening fence uses 4 backticks (longer than the payload's 3), so the
+  // embedded ``` stays literal data and the injected heading never becomes
+  // top-level Markdown.
+  assertStringIncludes(fenced, "````diff\n");
+  assertEquals(fenced.startsWith("````diff\n"), true);
+  assertEquals(fenced.endsWith("\n````"), true);
+  // The longest backtick run in the whole rendered block is the fence itself:
+  // nothing inside can match or exceed it, so it cannot be closed early.
+  const runs = [...fenced.matchAll(/`+/g)].map((m) => m[0].length);
+  assertEquals(Math.max(...runs), 4);
+  assertEquals(runs.filter((n) => n === 4).length, 2); // only the two fences
+});


### PR DESCRIPTION
Implements **PR 1** of `plans/REMEDIATION_PLAN_V2.md` — the `@zuke/ai` security regressions and hardening tail. All fixes are model-reachable defenses on the fixer/reviewer paths.

## Fixes

- **🟠 Git pathspec-magic bypass (N1).** `normalizePath` (`apply.ts`) now rejects any edit path whose first segment begins with `:` (git reserves it for pathspec magic like `:(glob)`, `:/`), and `commitAndPush` stages with `git --literal-pathspecs add` — two independent defenses so a crafted path can no longer make the commit step re-stage the whole tree (the leak #222 closed).
- **🟡 Markdown fence/inline breakout (N3).** New `markdown.ts` with `fenceMarkdown` (a fence one backtick longer than any run inside the content) and `codeSpan` (the inline equivalent, with CommonMark padding). Applied to the agent-output block and the fix-report diff/headers; `cell()` now also collapses newlines. Model/agent output can no longer break out to inject Markdown (fake "approved" banners, phishing links) into PR comments or the job summary.
- **🟡 Suggest-mode diff scope (N2).** Suggest mode now snapshots the working tree **before** the agent runs and scopes `#postSuggestions` to only the agent's newly-changed paths, failing closed if the snapshot can't be taken — a tree dirtied by the developer or earlier steps is never posted as "agent" suggestions.
- **🟡 `fetchBase` fail-open (N4).** `#resolveDiff` distinguishes a failed base-diff fetch from a genuine no-change diff. An empty working-tree fallback after a fetch failure now **fails the gate** (or skips visibly under `onError: "warn"`) instead of silently passing an empty assessment. A genuinely empty successful diff still passes.
- **⚪ Env seam (N7).** `Reviewer.#publish` routes through the injected `this.#env` instead of the global reader.
- **🟡 Azure pagination (finding 6 residual).** Documented why the Azure DevOps PR-threads endpoint needs no pagination loop (it returns the full set — no `$top`/`$skip`/continuation), making the asymmetry with the other hosts intentional-on-the-record.
- **🟡 Suppression fingerprint change (N5).** Migration note in `docs/ai-review.md`: the 32→64-bit fingerprint change invalidated recorded suppressions; re-record them.

## Verification

- `deno task ci` green (check, tests, coverage ≥95%); `./zuke apiDocsCheck` green.
- **Adversarial review** (four attack dimensions — pathspec, markdown injection, suggest/fetchBase, regressions — each finding reproduced against the real code before verdict):
  - Found and **fixed** a real gap the pathspec/fence work missed: `cell()` didn't neutralize backticks, so a model-controlled `loc.file` in the `####`/`**Files:**` inline code spans could still inject inline Markdown. Fixed with `codeSpan` (variable-length delimiters) + tests.
  - Three other findings were **verified and refuted** against the code (a hypothetical `lang` info-string with no attacker-reachable caller; a rename/copy "leak" that produces a pure-insertion diff which `diffToSuggestions` skips, so nothing is posted; a "missing test" that was correct behavior). I still added the `lang` neutralization and the empty-successful-diff regression test as cheap contract-locking.

## Deferred

- **⚪ Symlink traversal in `applyEdits` (N6, pre-existing).** A robust `realpath` guard needs a subprocess/e2e test (its own cwd) to exercise real symlinks hermetically; disproportionate here. Filed for a follow-up — it's pre-existing and requires an attacker-planted in-tree symlink, unlike the regressions above.

Every fix ships unit + integration tests in this PR.