### PR TITLE
fix(core): reject wait gates inside a fan-out (forEach)

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1603,6 +1603,12 @@ class TargetBuilder
     and each is a first-class target with its own status in the summary and the
     run record. The fan-out target fails if any item's pipeline fails.
 
+    A fan-out cannot contain a wait gate: neither the fan-out target itself
+    nor any stage may use {@link waitsFor} — a materialised sub-target has no
+    resume path, so the gate would be silently swallowed. Combining them fails
+    the target with guidance. Gate a fan-out by putting the wait on a separate
+    target that the fan-out `.dependsOn(...)`.
+
     ```ts
     deployBatch = target()
       .forEach(

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1657,6 +1657,12 @@ class TargetBuilder
     and each is a first-class target with its own status in the summary and the
     run record. The fan-out target fails if any item's pipeline fails.
 
+    A fan-out cannot contain a wait gate: neither the fan-out target itself
+    nor any stage may use {@link waitsFor} — a materialised sub-target has no
+    resume path, so the gate would be silently swallowed. Combining them fails
+    the target with guidance. Gate a fan-out by putting the wait on a separate
+    target that the fan-out `.dependsOn(...)`.
+
     ```ts
     deployBatch = target()
       .forEach(

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -440,6 +440,12 @@ async function runForEachTarget(
     () => true, // items and stages overlap; predecessors enforce per-item order
   );
   const ms = performance.now() - start;
+  // Only `aborted` (a failed sub-target) is possible here — never `suspended`. A
+  // fan-out sub-target can't carry a `.waitsFor()` gate (rejected at materialise
+  // above), so no stage can end "waiting"; `run.suspended` is therefore always
+  // false. Were a suspend to slip through it would be swallowed (the parent would
+  // report "passed" while the row stayed durably "waiting"), which the materialise
+  // guard exists to prevent.
   if (run.aborted) {
     const failed = run.reports.filter((r) => r.status === "failed").length;
     const error = run.failure ??

--- a/packages/core/src/target.ts
+++ b/packages/core/src/target.ts
@@ -824,6 +824,12 @@ export class TargetBuilder {
    * and each is a first-class target with its own status in the summary and the
    * run record. The fan-out target fails if any item's pipeline fails.
    *
+   * A fan-out cannot contain a **wait gate**: neither the fan-out target itself
+   * nor any stage may use {@link waitsFor} — a materialised sub-target has no
+   * resume path, so the gate would be silently swallowed. Combining them fails
+   * the target with guidance. Gate a fan-out by putting the wait on a separate
+   * target that the fan-out `.dependsOn(...)`.
+   *
    * ```ts
    * deployBatch = target()
    *   .forEach(
@@ -846,6 +852,21 @@ export class TargetBuilder {
       // ForEachItems (string keys, TargetBuilder stages), so no `Item` escapes
       // into the non-generic stored spec.
       materialize: () => {
+        // A wait gate has no coherent place inside a fan-out: a fan-out
+        // sub-target is materialised per run and never listed by the resume
+        // sweep, so a "waiting" gate — on the parent or on any stage — would be
+        // silently swallowed (the run finishes "succeeded" while a durable row
+        // is stranded "waiting" forever). Reject both loudly; put the wait on a
+        // separate target the fan-out `.dependsOn(...)` instead.
+        const self = this.name_ ?? "<unnamed>";
+        if (this.waitsFor_ !== undefined) {
+          throw new Error(
+            `Target "${self}" combines .forEach() with .waitsFor(): a wait gate ` +
+              `on a fan-out target has no resume path and would be silently ` +
+              `skipped. Put the wait on a separate target that this fan-out ` +
+              `.dependsOn(...).`,
+          );
+        }
         const seen = new Map<string, number>();
         return items().map((item, index) => {
           const base = itemKey(item, index);
@@ -853,7 +874,19 @@ export class TargetBuilder {
           seen.set(base, count + 1);
           // Disambiguate duplicate keys so sub-target names stay unique.
           const key = count === 0 ? base : `${base}#${index}`;
-          return { key, stages: factory(item, index) };
+          const stages = factory(item, index);
+          for (const [stage, sub] of Object.entries(stages)) {
+            if (sub.waitsFor_ !== undefined) {
+              throw new Error(
+                `Fan-out target "${self}" stage "${stage}" uses .waitsFor(): a ` +
+                  `wait gate inside a fan-out has no resume path (the resume ` +
+                  `sweep can't reach a materialised sub-target), so it would be ` +
+                  `silently swallowed. Put the wait on a separate target that ` +
+                  `the fan-out .dependsOn(...).`,
+              );
+            }
+          }
+          return { key, stages };
         });
       },
       configure,

--- a/packages/core/tests/foreach_test.ts
+++ b/packages/core/tests/foreach_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertStringIncludes } from "./_assert.ts";
+import { assertEquals, assertStringIncludes, assertThrows } from "./_assert.ts";
 import { Build, discoverTargets } from "../src/build.ts";
 import { target } from "../src/target.ts";
 import { execute, type Reporter } from "../src/executor.ts";
@@ -83,6 +83,20 @@ Deno.test("forEach rejects a .waitsFor() on a stage (no resume path)", async () 
   assertStringIncludes(message, "deployBatch");
   assertStringIncludes(message, ".waitsFor()");
   assertStringIncludes(message, ".dependsOn(");
+});
+
+Deno.test("the fan-out wait-gate rejection names an undiscovered target as <unnamed>", () => {
+  // materialize() can run before discovery assigns a name; the error still reads
+  // cleanly (covers the `name_ ?? "<unnamed>"` fallback).
+  const t = target()
+    .waitsFor((s) => s.on(externalSignal("go")))
+    .forEach(() => ["a"], () => ({ deploy: target().executes(() => {}) }));
+  const spec = t.forEach_;
+  assertEquals(spec !== undefined, true);
+  if (spec !== undefined) {
+    const error = assertThrows(() => spec.materialize());
+    assertStringIncludes(errorMessage(error), '"<unnamed>"');
+  }
 });
 
 Deno.test("forEach rejects a .waitsFor() on the fan-out target itself", async () => {

--- a/packages/core/tests/foreach_test.ts
+++ b/packages/core/tests/foreach_test.ts
@@ -10,6 +10,12 @@ import {
 } from "../src/params.ts";
 import { FileSystemStateStore } from "../src/state/fs_store.ts";
 import { defaultStateHost } from "../src/state/store.ts";
+import { externalSignal } from "../src/wait.ts";
+
+/** The message of a failed `execute` result. */
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
 
 /** A reporter that records every printed line, for asserting output. */
 function recorder(): { lines: string[]; reporter: Reporter } {
@@ -55,6 +61,46 @@ Deno.test("forEach runs each item's stages in order, items in parallel", async (
   assertEquals(log.indexOf("checks:a") < log.indexOf("deploy:a"), true);
   assertEquals(log.indexOf("checks:b") < log.indexOf("deploy:b"), true);
   assertEquals(log.length, 4);
+});
+
+Deno.test("forEach rejects a .waitsFor() on a stage (no resume path)", async () => {
+  // A wait gate on a materialised sub-target would be silently swallowed (the
+  // run finishes "succeeded" while the row is stranded "waiting"); reject it.
+  class Batch extends Build {
+    deployBatch = target().forEach(
+      () => ["a"],
+      () => ({
+        gate: target().waitsFor((s) => s.on(externalSignal("go"))),
+        deploy: target().executes(() => {}),
+      }),
+    );
+  }
+  const b = new Batch();
+  discoverTargets(b);
+  const result = await execute(b, b.deployBatch, { silent: true });
+  assertEquals(result.ok, false);
+  const message = errorMessage(result.error);
+  assertStringIncludes(message, "deployBatch");
+  assertStringIncludes(message, ".waitsFor()");
+  assertStringIncludes(message, ".dependsOn(");
+});
+
+Deno.test("forEach rejects a .waitsFor() on the fan-out target itself", async () => {
+  // A wait on the fan-out parent is dispatched before the gate is checked, so it
+  // is silently skipped; reject the combination.
+  class Batch extends Build {
+    deployBatch = target()
+      .waitsFor((s) => s.on(externalSignal("go")))
+      .forEach(() => ["a"], () => ({ deploy: target().executes(() => {}) }));
+  }
+  const b = new Batch();
+  discoverTargets(b);
+  const result = await execute(b, b.deployBatch, { silent: true });
+  assertEquals(result.ok, false);
+  assertStringIncludes(
+    errorMessage(result.error),
+    "combines .forEach() with .waitsFor()",
+  );
 });
 
 Deno.test("forEach isolates a failed item with continueOnItemFailure", async () => {

--- a/tests/integration/waiting_test.ts
+++ b/tests/integration/waiting_test.ts
@@ -38,6 +38,36 @@ async function runStatus(dir: string, id: string): Promise<string> {
   return got === null ? "" : got.record.status;
 }
 
+Deno.test("a .waitsFor() gate inside a forEach fails loudly, never stranding the run", async () => {
+  await withStateDir(async (dir) => {
+    class CD extends Build {
+      deployBatch = target().forEach(
+        () => ["repo-a", "repo-b"],
+        () => ({
+          deploy: target().executes(() => {}),
+          // A wait gate on a fan-out sub-target has no resume path. Before the
+          // fix this returned exit 0 ("succeeded") while durably recording a
+          // stranded "waiting" row the resume sweep could never reach.
+          gate: target().waitsFor((s) => s.on(externalSignal("approved"))),
+        }),
+      );
+    }
+    const res = await runCli(CD, ["deployBatch"]);
+    // Fails loudly with guidance — not a silent exit-0 success.
+    assertEquals(res.code, 1);
+    const output = res.err + "\n" + res.out;
+    assertStringIncludes(output, ".waitsFor()");
+    assertStringIncludes(output, ".dependsOn(");
+    // No run is left resumable/stranded: any recorded run is terminal (failed).
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    for (const summary of await store.listRuns({})) {
+      const got = await store.getRun(summary.id);
+      const status = got === null ? "" : got.record.status;
+      assertEquals(["suspended", "succeeded"].includes(status), false);
+    }
+  });
+});
+
 Deno.test("a signal gate suspends, then resume delivers the signal and continues", async () => {
   await withStateDir(async (dir) => {
     const log: string[] = [];


### PR DESCRIPTION
Implements **PR 2** of `plans/REMEDIATION_PLAN_V2.md` — the 🟠 forEach `.waitsFor` swallow (a durable-state correctness hole in a flagship feature).

## The bug

A `.waitsFor()` gate on a `forEach` sub-target was **silently swallowed**: `runForEachTarget` (`scheduler.ts`) checked only `run.aborted` from its nested scheduler and discarded `run.suspended`. So the fan-out parent returned `passed`, the run finished `succeeded`, but the gated sub-target row was durably recorded `waiting` with its later stages `pending`. The resume sweep lists only `suspended` runs, so those rows were **stranded forever** and the gated stages never ran — the same class as the fixed F8, one level down.

While fixing it I found the same swallow one level up: a `.waitsFor()` on the fan-out **parent** is also silently ignored, because the `forEach_` dispatch in `runTarget` runs *before* the `waitsFor_` check.

## The fix

A fan-out sub-target is materialised per run and has no resume path, so a wait gate inside a fan-out cannot work coherently (the plan's preferred "reject" option). Both cases are now **rejected at materialise time** — the `forEach` materialize closure in `target.ts` throws a friendly `Error` (caught by `runForEachTarget`'s existing try/catch, which fails the target cleanly) when:
- the fan-out target itself has `.waitsFor()`, or
- any factory-produced stage has `.waitsFor()`.

The error names the target and stage and points to the working alternative: **put the wait on a separate target the fan-out `.dependsOn(...)`** (the pattern the existing cancel tests already use). Rejection fires at every level, including a nested fan-out. A clarifying comment at the `scheduler.ts` check documents why `run.suspended` is now impossible there, and the `forEach` JSDoc documents the restriction.

## Verification

- `deno task ci` green (check, tests, coverage ≥95%); `./zuke apiDocsCheck` green.
- Tests: unit (`foreach_test.ts` — stage-level, parent-level, and the unnamed-target error path) and integration (`waiting_test.ts` — the fan-out wait gate fails loudly with exit 1 and leaves no run in a `suspended`/`succeeded` stranded state).
- **Adversarial review** (3 attack dimensions — bypass, false-rejection/regression, rules/coverage — each finding reproduced against real code): **0 confirmed findings**. Two nits were verified and refuted — the deliberately-unguarded `run.suspended` (unreachable by construction since `.waitsFor()` is synchronous and every stage is re-checked at materialize; a guard would be dead code failing the coverage gate) and the `<unnamed>` fallback branch (unreachable, gate-safe, and the mandated `??` idiom since `!` is banned). I confirmed all realistic vectors — nested fan-out, service stage, `resumeWhen`, parent `forEach`+`waitsFor` in either order, `group`/`partOf` — fail loudly with no stranded row.

## Not in scope

Supporting a *gate-then-fan-out* (option 2 — a per-item wait with real resume/re-materialisation) is a larger feature; use the `.dependsOn(a gate target)` pattern instead. Noted for a possible future enhancement.