### PR TITLE
fix(kubectl): reject invalid flag combinations in top, annotate, label

### DIFF
--- a/packages/kubectl/src/kubectl.ts
+++ b/packages/kubectl/src/kubectl.ts
@@ -749,6 +749,17 @@ export class KubectlSetImageSettings extends KubectlSettings {
   }
 }
 
+/**
+ * Whether the resource tokens name a specific resource: a `type/name` token, or
+ * a non-flag positional after the type (a bare NAME). An inline `-l`/`--all`
+ * token (which starts with `-`) is not a name.
+ */
+function hasResourceName(resources: readonly string[]): boolean {
+  if (resources.length === 0) return false;
+  return resources[0].includes("/") ||
+    (resources.length >= 2 && !resources[1].startsWith("-"));
+}
+
 /** Settings for `kubectl annotate`. */
 export class KubectlAnnotateSettings extends KubectlSettings {
   #resources: string[] = [];
@@ -806,6 +817,25 @@ export class KubectlAnnotateSettings extends KubectlSettings {
     if (this.#annotations.length === 0 && this.#removals.length === 0) {
       throw new Error(
         "KubectlTasks.annotate: at least one .annotation() or .remove() is required.",
+      );
+    }
+    const hasName = hasResourceName(this.#resources);
+    const hasSelector = this.#selector !== undefined;
+    if (!hasName && !this.#all && !hasSelector && this.#resources.length < 2) {
+      throw new Error(
+        "KubectlTasks.annotate: a resource name, .selector(), or .all() is " +
+          "required alongside the type — kubectl rejects a bare type like " +
+          "`annotate pods key=val`.",
+      );
+    }
+    // kubectl rejects a label selector combined with a name or with --all
+    // ("name cannot be provided when a selector is specified" / "cannot set
+    // --all and --selector"). A name + --all is accepted by kubectl (it ignores
+    // --all), so it is not rejected here.
+    if (hasSelector && (hasName || this.#all)) {
+      throw new Error(
+        "KubectlTasks.annotate: .selector() is mutually exclusive with a " +
+          "resource name and with .all() — kubectl rejects `-l` with either.",
       );
     }
     const argv = [
@@ -879,6 +909,25 @@ export class KubectlLabelSettings extends KubectlSettings {
     if (this.#labels.length === 0 && this.#removals.length === 0) {
       throw new Error(
         "KubectlTasks.label: at least one .label() or .remove() is required.",
+      );
+    }
+    const hasName = hasResourceName(this.#resources);
+    const hasSelector = this.#selector !== undefined;
+    if (!hasName && !this.#all && !hasSelector && this.#resources.length < 2) {
+      throw new Error(
+        "KubectlTasks.label: a resource name, .selector(), or .all() is " +
+          "required alongside the type — kubectl rejects a bare type like " +
+          "`label pods key=val`.",
+      );
+    }
+    // kubectl rejects a label selector combined with a name or with --all
+    // ("name cannot be provided when a selector is specified" / "cannot set
+    // --all and --selector"). A name + --all is accepted by kubectl (it ignores
+    // --all), so it is not rejected here.
+    if (hasSelector && (hasName || this.#all)) {
+      throw new Error(
+        "KubectlTasks.label: .selector() is mutually exclusive with a resource " +
+          "name and with .all() — kubectl rejects `-l` with either.",
       );
     }
     const argv = [
@@ -1090,6 +1139,15 @@ export class KubectlTopSettings extends KubectlSettings {
   protected override buildArgs(): string[] {
     if (this.#kind === undefined) {
       throw new Error("KubectlTasks.top: choose .pods() or .nodes().");
+    }
+    // kubectl `top` accepts a single NAME or a label selector, never both — for
+    // pods and nodes alike. Emitting `top pods NAME -l sel` is rejected by
+    // kubectl, so reject it here (same class as the `logs` name+selector fix).
+    if (this.#name !== undefined && this.#selector !== undefined) {
+      throw new Error(
+        "KubectlTasks.top: .name() and .selector() are mutually exclusive — " +
+          "pass a single name or a label selector, not both.",
+      );
     }
     // `--containers` and `-A`/`--all-namespaces` are `top pod`-only; kubectl
     // rejects them on `top node` ("unknown flag"). `-l`/selector stays valid.

--- a/packages/kubectl/tests/kubectl_test.ts
+++ b/packages/kubectl/tests/kubectl_test.ts
@@ -581,7 +581,8 @@ Deno.test("annotate: resource + annotations, remove, and flags", () => {
       .slice(1),
     ["annotate", "deploy", "api", "team-"],
   );
-  // Everything together, incl. --all and the label selector.
+  // Everything together with --all (kubectl rejects --all combined with -l, so
+  // the selector is covered separately, not here).
   assertEquals(
     new KubectlAnnotateSettings()
       .resource("pods")
@@ -589,7 +590,6 @@ Deno.test("annotate: resource + annotations, remove, and flags", () => {
       .remove("old")
       .overwrite()
       .all()
-      .selector("app=web")
       .argv()
       .slice(1),
     [
@@ -599,8 +599,6 @@ Deno.test("annotate: resource + annotations, remove, and flags", () => {
       "old-",
       "--overwrite",
       "--all",
-      "-l",
-      "app=web",
     ],
   );
 });
@@ -616,17 +614,18 @@ Deno.test("label: resource + labels, remove, and flags", () => {
       .slice(1),
     ["label", "pods", "team=payments", "-l", "app=web"],
   );
-  // Everything together, incl. remove(key), --overwrite, and --all.
+  // Everything together with --all (a name would conflict with --all, so the
+  // type alone is used here — name-targeted forms are covered separately).
   assertEquals(
     new KubectlLabelSettings()
-      .resource("deploy", "api")
+      .resource("deploy")
       .label("team", "payments")
       .remove("old")
       .overwrite()
       .all()
       .argv()
       .slice(1),
-    ["label", "deploy", "api", "team=payments", "old-", "--overwrite", "--all"],
+    ["label", "deploy", "team=payments", "old-", "--overwrite", "--all"],
   );
 });
 
@@ -691,6 +690,74 @@ Deno.test("annotate and label require a resource type and a payload", () => {
     Error,
     "at least one .label()",
   );
+});
+
+Deno.test("annotate and label reject a bare type with no name, selector, or --all", () => {
+  // kubectl rejects `annotate pods key=val` ("no name was specified").
+  assertThrows(
+    () =>
+      new KubectlAnnotateSettings().resource("pods").annotation("a", "b")
+        .argv(),
+    Error,
+    "a resource name, .selector(), or .all()",
+  );
+  assertThrows(
+    () => new KubectlLabelSettings().resource("pods").label("a", "b").argv(),
+    Error,
+    "a resource name, .selector(), or .all()",
+  );
+  // The valid targeting forms all pass: a name, a type/name token, --all, or -l
+  // (whether via the setter or inline as a raw resource token).
+  const ok = [
+    new KubectlAnnotateSettings().resource("pods", "web-0").annotation(
+      "a",
+      "b",
+    ),
+    new KubectlAnnotateSettings().resource("pods/web-0").annotation("a", "b"),
+    new KubectlAnnotateSettings().resource("pods").all().annotation("a", "b"),
+    new KubectlAnnotateSettings().resource("pods").selector("app=web")
+      .annotation("a", "b"),
+    new KubectlLabelSettings().resource("pods", "web-0").label("a", "b"),
+    new KubectlLabelSettings().resource("pods/web-0").label("a", "b"),
+    new KubectlLabelSettings().resource("pods").all().label("a", "b"),
+    new KubectlLabelSettings().resource("pods").selector("app=web").label(
+      "a",
+      "b",
+    ),
+    // name + --all is accepted by kubectl (it ignores --all), so it passes.
+    new KubectlAnnotateSettings().resource("pods", "web-0").all().annotation(
+      "a",
+      "b",
+    ),
+    new KubectlLabelSettings().resource("pods/web-0").all().label("a", "b"),
+  ];
+  for (const s of ok) s.argv(); // none throw
+});
+
+Deno.test("annotate and label reject a selector combined with a name or --all", () => {
+  // A label selector is mutually exclusive with a name and with --all (kubectl
+  // rejects both client-side). A name + --all is NOT rejected — kubectl accepts
+  // it (ignoring --all), so the wrapper mirrors that. Covers annotate and label
+  // and both name-detection paths (a second positional token and a type/name).
+  const rejected = [
+    // --all + selector: "cannot set --all and --selector at the same time".
+    new KubectlAnnotateSettings().resource("pods").all().selector("app=web")
+      .annotation("a", "b"),
+    new KubectlLabelSettings().resource("pods").all().selector("app=web").label(
+      "a",
+      "b",
+    ),
+    // name + selector: "name cannot be provided when a selector is specified".
+    new KubectlAnnotateSettings().resource("pods", "web-0").selector("app=web")
+      .annotation("a", "b"),
+    new KubectlLabelSettings().resource("pods/web-0").selector("app=web").label(
+      "a",
+      "b",
+    ),
+  ];
+  for (const s of rejected) {
+    assertThrows(() => s.argv(), Error, "mutually exclusive with a resource");
+  }
 });
 
 Deno.test("patch: requires resource and patch; --type ordering", () => {
@@ -790,12 +857,23 @@ Deno.test("top: requires pods or nodes; all options", () => {
     new KubectlTopSettings()
       .pods()
       .name("web-0")
-      .selector("app=api")
       .containers()
       .allNamespaces()
       .argv()
       .slice(1),
-    ["top", "pods", "web-0", "-l", "app=api", "--containers", "-A"],
+    ["top", "pods", "web-0", "--containers", "-A"],
+  );
+  // A selector (without a name) is valid on pods too.
+  assertEquals(
+    new KubectlTopSettings().pods().selector("app=api").argv().slice(1),
+    ["top", "pods", "-l", "app=api"],
+  );
+  // A name and a selector are mutually exclusive — kubectl rejects both together.
+  assertThrows(
+    () =>
+      new KubectlTopSettings().pods().name("web-0").selector("app=api").argv(),
+    Error,
+    "mutually exclusive",
   );
   assertEquals(
     new KubectlTopSettings().nodes().argv().slice(1),


### PR DESCRIPTION
Implements the kubectl portion of **PR 3** of `plans/REMEDIATION_PLAN_V2.md` — residual flag-interaction guards. (The git `checkout -- <path>` item 3.4 is a separate single-package PR.)

## Fixes

- **`top` name + selector (3.2).** `kubectl top` accepts a single name **or** a label selector, never both (pods and nodes alike); the wrapper emitted both when set. Now mutually exclusive with a clear error — the same class as the existing `logs` fix.
- **`annotate` / `label` targeting (3.3).** kubectl requires a target and rejects certain combinations client-side; the wrapper only required a resource *type*, so it emitted commands kubectl rejects:
  - a **bare type** (`annotate pods key=val` → "no name was specified");
  - a **selector + name** ("name cannot be provided when a selector is specified");
  - a **selector + --all** ("cannot set --all and --selector at the same time").

  The guard requires a target (a name, `--all`, or a selector) and rejects the two selector conflicts, sharing a `hasResourceName` helper between the two commands.

## Verified against real kubectl (not guessed)

Two plan premises turned out to be wrong, caught by verifying against the actual kubectl reference / a live `kubectl v1.36.1`:

- **`scale --current-replicas` is NOT deprecated** (plan item 3.1). It's a current, valid precondition flag, so removing it would have been a regression — **deliberately left untouched**.
- **`name + --all` is NOT rejected** by kubectl — it's accepted (with `--all` silently ignored). An adversarial review had me over-rejecting it; corrected so the wrapper mirrors kubectl. A regression test now asserts `name + --all` passes.

## Verification

- `deno task ci` green (check, tests, coverage ≥95%); `./zuke apiDocsCheck` green.
- Unit tests (the layer for tool-wrapper argv guards) cover each rejection and every valid targeting form (name, `type/name`, `--all`, selector, `name + --all`) for both commands, plus the `top` mutual-exclusion.
- **Adversarial review** (2 attack dimensions, verified against a live kubectl): caught two real defects the first pass missed — annotate/label didn't reject `--all + selector` or `name + selector`. Both are now fixed and tested. A follow-up verification pass then caught (and I corrected) an over-rejection of the kubectl-accepted `name + --all`.

## Not in scope
- git `checkout -- <path>` (item 3.4) — separate single-package PR next, for clean release attribution.