### PR TITLE
fix(git): fix checkout flag order and support restoring paths

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8226,7 +8226,13 @@ class GitCheckoutSettings extends GitSettings
   Settings for `git checkout`.
 
   ref(target: string): this
-    The branch, commit, or path to check out (required).
+    The branch or commit to check out — or, with {@link paths}, the source to
+    restore those paths from. Required unless {@link paths} is given.
+  paths(...paths: string[]): this
+    Restore one or more paths (`git checkout [<ref>] -- <paths>`). The `--`
+    separates paths from any ref so a path is never misread as a branch name;
+    repeatable. With no {@link ref}, restores the paths from the index
+    (discarding working-tree changes).
   create(): this
     Create a new branch (`-b`).
   force(): this

--- a/packages/git/README.md
+++ b/packages/git/README.md
@@ -101,7 +101,13 @@ class GitCheckoutSettings extends GitSettings
   Settings for `git checkout`.
 
   ref(target: string): this
-    The branch, commit, or path to check out (required).
+    The branch or commit to check out — or, with {@link paths}, the source to
+    restore those paths from. Required unless {@link paths} is given.
+  paths(...paths: string[]): this
+    Restore one or more paths (`git checkout [<ref>] -- <paths>`). The `--`
+    separates paths from any ref so a path is never misread as a branch name;
+    repeatable. With no {@link ref}, restores the paths from the index
+    (discarding working-tree changes).
   create(): this
     Create a new branch (`-b`).
   force(): this

--- a/packages/git/src/git.ts
+++ b/packages/git/src/git.ts
@@ -266,12 +266,27 @@ export class GitStatusSettings extends GitSettings {
 /** Settings for `git checkout`. */
 export class GitCheckoutSettings extends GitSettings {
   #ref?: string;
+  #paths: string[] = [];
   #create = false;
   #force = false;
 
-  /** The branch, commit, or path to check out (required). */
+  /**
+   * The branch or commit to check out — or, with {@link paths}, the source to
+   * restore those paths from. Required unless {@link paths} is given.
+   */
   ref(target: string): this {
     this.#ref = target;
+    return this;
+  }
+
+  /**
+   * Restore one or more paths (`git checkout [<ref>] -- <paths>`). The `--`
+   * separates paths from any ref so a path is never misread as a branch name;
+   * repeatable. With no {@link ref}, restores the paths from the index
+   * (discarding working-tree changes).
+   */
+  paths(...paths: string[]): this {
+    this.#paths.push(...paths);
     return this;
   }
 
@@ -289,13 +304,23 @@ export class GitCheckoutSettings extends GitSettings {
 
   /** Assemble the `git checkout` argv. */
   protected override subcommandArgs(): string[] {
-    if (this.#ref === undefined) {
-      throw new Error("GitTasks.checkout: .ref() is required.");
+    if (this.#ref === undefined && this.#paths.length === 0) {
+      throw new Error("GitTasks.checkout: .ref() or .paths(...) is required.");
+    }
+    if (this.#create && this.#paths.length > 0) {
+      throw new Error(
+        "GitTasks.checkout: .create() cannot be combined with .paths(...) — " +
+          "`git checkout -b` creates a branch, it does not restore files.",
+      );
     }
     const argv = ["checkout"];
-    if (this.#create) argv.push("-b");
+    // `--force` must precede `-b`: `git checkout -b --force <ref>` makes git read
+    // `--force` as the new branch name (`cannot be created`), so force comes first.
     if (this.#force) argv.push("--force");
-    argv.push(this.#ref);
+    if (this.#create) argv.push("-b");
+    if (this.#ref !== undefined) argv.push(this.#ref);
+    // `-- <paths>` last so git never treats a path as a ref (mirrors `add`).
+    if (this.#paths.length > 0) argv.push("--", ...this.#paths);
     return argv;
   }
 }

--- a/packages/git/tests/git_test.ts
+++ b/packages/git/tests/git_test.ts
@@ -96,11 +96,37 @@ Deno.test("add and commit render their options", () => {
 });
 
 Deno.test("checkout requires a ref and supports -b/-f", () => {
+  // `--force` precedes `-b`: `git checkout -b --force feature` makes git read
+  // `--force` as the branch name and fails; `--force -b feature` is valid.
   assertEquals(
     new GitCheckoutSettings().create().force().ref("feature").argv(),
-    ["git", "checkout", "-b", "--force", "feature"],
+    ["git", "checkout", "--force", "-b", "feature"],
   );
   assertThrows(() => new GitCheckoutSettings().argv(), Error, ".ref()");
+});
+
+Deno.test("checkout restores paths with a `--` separator", () => {
+  // Restore paths from the index (discard working-tree changes): no ref.
+  assertEquals(
+    new GitCheckoutSettings().paths("src/a.ts", "src/b.ts").argv(),
+    ["git", "checkout", "--", "src/a.ts", "src/b.ts"],
+  );
+  // Restore a path from a ref — `--` keeps the path from being read as a branch.
+  assertEquals(
+    new GitCheckoutSettings().ref("origin/main").paths("src/a.ts").argv(),
+    ["git", "checkout", "origin/main", "--", "src/a.ts"],
+  );
+  // .paths() alone satisfies the requirement (no ref needed).
+  assertEquals(
+    new GitCheckoutSettings().paths("x").argv(),
+    ["git", "checkout", "--", "x"],
+  );
+  // -b creates a branch and cannot restore files.
+  assertThrows(
+    () => new GitCheckoutSettings().create().paths("x").argv(),
+    Error,
+    ".create() cannot be combined with .paths(",
+  );
 });
 
 Deno.test("branch and tag render their options", () => {


### PR DESCRIPTION
Completes **PR 3** of `plans/REMEDIATION_PLAN_V2.md` — the git `checkout` residual (item 3.4), split from the kubectl guards (#251) for clean per-package release attribution.

## Fixes

- **Path restore (3.4).** `git checkout` couldn't express `git checkout [<ref>] -- <paths>`: `ref()` pushed the ref bare with no `--`, so a path could be misread as a branch and multiple paths weren't possible. Added a `.paths(...)` setter that emits the paths after a `--` separator (mirroring how `add` already does). A `ref` is now optional when paths are given (`checkout -- <paths>` restores from the index), and `.create()` combined with `.paths(...)` is rejected — `git checkout -b` creates a branch, it doesn't restore files.

- **Flag order (pre-existing, found during verification).** `.create().force()` emitted `git checkout -b --force <ref>`, which **real git rejects** (`fatal: a branch '--force' cannot be created`) because `-b` reads `--force` as the new branch name. `--force` now precedes `-b` (`git checkout --force -b <ref>`). The old test blessed the broken order; it's corrected.

## Verification

- `deno task ci` green (check, tests, coverage ≥95%); `./zuke apiDocsCheck` green; API docs regenerated for the new `.paths()` method.
- **Verified against real git** (not guessed): confirmed `git checkout -b --force feature` fails and `git checkout --force -b feature` succeeds; confirmed `git checkout -b <br> -- file` is rejected (so the `create + paths` guard blocks a genuinely invalid form). A verification agent found no false positive/negative introduced by the `.paths()` change and surfaced the pre-existing flag-order bug, which is fixed here.
- Unit tests cover `checkout -- <paths>`, `checkout <ref> -- <paths>`, paths-only (no ref), the `create + paths` rejection, and the corrected `--force -b` order.

With this, PR 3 is complete. Next in the plan: V2 PR 6 (test backfill), PR C (orderWith × fan-out diagnostic), PR D (githubWorkflow docs).