### PR TITLE
fix(core): flag dead ordering edges and document the fan-out ordering limit

### DIFF
--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -697,6 +697,17 @@ override async orderWith(t: Map<string, Target>): Promise<OrderingEdge[]> {
 }
 ```
 
+The `targets` map holds only **class-field targets**. A
+[`.forEach()`](./orchestration.md#fan-out-over-a-list--foreach) fan-out's
+per-item sub-targets are materialised only while a run executes, so
+they are never in `targets` and **per-item ordering across a fan-out cannot be
+expressed** with `orderWith`/`extraEdges` (`t.get("parent[item].stage")` is
+`undefined`). Order whole fan-out **waves** instead — one `.forEach()` per wave,
+the waves chained with `.dependsOn` — so ordering lives between class-field
+targets. An edge whose endpoint is not a target in the build (a fan-out item
+name, a typo, or an ad-hoc `target()`) is logged as ignored when the run plans,
+rather than silently doing nothing.
+
 A field literally named `default` is the **default target**, run when no target
 is named on the command line.
 

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -332,3 +332,10 @@ Runtime lists pair naturally with [array parameters](./parameters.md#lists):
 `.options("api", "web").array()` validates each element, and `.number().array()`
 yields a `number[]` — so the batch's inputs are typed and checked before it
 runs.
+
+Because the sub-targets exist only at run time, they can't be referenced by the
+soft-ordering seams: `orderWith`/`extraEdges` (see
+[Authoring → `Build`](./authoring.md#build)) see only
+class-field targets, so **per-item ordering across a fan-out is not
+expressible**. When items must run in a dependency order, split them into ordered
+**waves** — one `.forEach()` per wave — and chain the waves with `.dependsOn`.

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -426,9 +426,10 @@ export async function execute(
   // can be a correctness requirement, a failure fails the build cleanly rather
   // than silently running in the base order or crashing with an unhandled
   // rejection. (No run record exists yet, so nothing is stranded.)
+  const discovered = discoverTargets(build);
   let extraEdges: OrderingEdge[];
   try {
-    extraEdges = await resolveOrderingEdges(build, discoverTargets(build));
+    extraEdges = await resolveOrderingEdges(build, discovered);
   } catch (error) {
     reporter.error(
       `Failed to resolve ordering edges: ${
@@ -438,6 +439,35 @@ export async function execute(
     return { ok: false, executed: [], error };
   }
   const { order, predecessors } = planGraph(root, extraEdges);
+  // Flag ordering edges that can never apply: an endpoint that is neither in this
+  // run's execution set nor a declared build target is dead weight (silently
+  // dropped otherwise). A declared target simply not in this run — a conditional
+  // target — is legitimately ignored, so it is not flagged. This catches feeding
+  // ad-hoc or fan-out per-item names into orderWith/extraEdges: per-item fan-out
+  // ordering is not expressible (order whole fan-out waves with .dependsOn).
+  if (extraEdges.length > 0) {
+    const inRun = new Set(order);
+    const declared = new Set(discovered.values());
+    const dangling = new Set<string>();
+    for (const edge of extraEdges) {
+      for (const endpoint of edge) {
+        // `endpoint &&` tolerates a malformed edge (a consumer bypassing the
+        // OrderingEdge type to pass a nullish endpoint) instead of crashing on
+        // `.name_`, matching planEdges' silent tolerance of such edges.
+        if (endpoint && !inRun.has(endpoint) && !declared.has(endpoint)) {
+          dangling.add(endpoint.name_ ?? "<unnamed>");
+        }
+      }
+    }
+    for (const name of dangling) {
+      reporter.info(
+        `ordering: an edge references "${name}", which is not a target in this ` +
+          `build — the edge is ignored. orderWith/extraEdges see only ` +
+          `class-field targets, not fan-out sub-targets (order whole fan-out ` +
+          `waves with .dependsOn instead).`,
+      );
+    }
+  }
   // Evaluate up-front conditions for `whenSkipped("skip-dependencies")` targets
   // and skip them plus any dependencies that nothing else needs.
   for (const name of await conditionSkips(root, order)) skip.add(name);

--- a/packages/core/tests/executor_test.ts
+++ b/packages/core/tests/executor_test.ts
@@ -4,14 +4,14 @@ import {
   assertStringIncludes,
   messageOf,
 } from "./_assert.ts";
-import { GraphError } from "../src/graph.ts";
+import { GraphError, type OrderingEdge } from "../src/graph.ts";
 import {
   Build,
   type BuildResult,
   discoverTargets,
   type TargetStatus,
 } from "../src/build.ts";
-import { group, target } from "../src/target.ts";
+import { group, target, type TargetBuilder } from "../src/target.ts";
 import type { BuildCache } from "../src/cache.ts";
 import type { RemoteCacheStore } from "../src/remote_cache.ts";
 import { parameter } from "../src/params.ts";
@@ -2572,4 +2572,28 @@ Deno.test("a failed run leaves no waiting target stranded in the record", async 
   } finally {
     await Deno.remove(dir, { recursive: true });
   }
+});
+
+Deno.test("execute flags an ordering edge to a target not in the build", async () => {
+  const { lines, reporter } = recorder();
+  class Mono extends Build {
+    a = target().executes(() => {});
+    other = target().executes(() => {}); // declared, but not reached by `all`
+    all = target().dependsOn(this.a).executes(() => {});
+    override orderWith(t: Map<string, TargetBuilder>): OrderingEdge[] {
+      const a = t.get("a"), other = t.get("other");
+      // `ghost` is not a class field → never in the run nor the declared set, so
+      // its edge is dead (mirrors a fan-out per-item name). `other` is declared
+      // but not in this run → legitimately ignored, must NOT be flagged.
+      const ghost = target();
+      return a && other ? [[a, ghost], [a, other]] : [];
+    }
+  }
+  const b = new Mono();
+  discoverTargets(b);
+  const result = await execute(b, b.all, { reporter, github: false });
+  assertEquals(result.ok, true); // the dead edge is ignored; the run succeeds
+  const out = lines.join("\n");
+  assertStringIncludes(out, "not a target in this build"); // ghost flagged
+  assertEquals(out.includes('"other"'), false); // conditional target not flagged
 });

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -43,6 +43,14 @@ external dependency graph in. `override orderWith(targets)` is the same, but
 with `extraEdges`. Cycle-checked; edges outside the run's set are ignored; both
 are honoured by a run and `zuke cancel`, but not by static `graph`/`--list`.
 
+> **Fan-out caveat:** `targets` holds only **class-field targets** — a
+> `.forEach()` fan-out's per-item sub-targets (`parent[item].stage`) don't exist
+> at plan time, so **per-item ordering across a fan-out is not expressible** with
+> `orderWith`/`extraEdges`. Order whole fan-out **waves** instead: split the work
+> into one `.forEach()` per wave and chain the waves with `.dependsOn`. An edge to
+> a target that isn't in the build (a fan-out item name, a typo, an ad-hoc
+> `target()`) is logged as ignored rather than silently dropped.
+
 ## `group()` — parallel batches
 
 ```ts

--- a/tests/integration/orderwith_test.ts
+++ b/tests/integration/orderwith_test.ts
@@ -77,6 +77,62 @@ Deno.test("orderWith and extraEdges merge into one edge set", async () => {
   assertEquals(log.indexOf("b") < log.indexOf("c"), true);
 });
 
+Deno.test("orderWith warns about a dead edge to a target not in the build", async () => {
+  class Mono extends Build {
+    a = target().executes(() => {});
+    all = target().dependsOn(this.a).executes(() => {});
+    override orderWith(t: Map<string, TargetBuilder>): OrderingEdge[] {
+      const a = t.get("a");
+      // An ad-hoc target that is not a class field — never in the run or the
+      // discovered set, so this edge can never apply. Mirrors the trap of
+      // feeding a fan-out per-item name (which is not a class field) into
+      // orderWith: the edge is dead, and used to be dropped silently.
+      const ghost = target();
+      return a ? [[a, ghost]] : [];
+    }
+  }
+  const res = await runCli(Mono, ["all"]);
+  assertEquals(res.code, 0); // the dead edge is ignored; the run still succeeds
+  assertStringIncludes(res.out + res.err, "not a target in this build");
+});
+
+Deno.test("orderWith stays silent for a declared target simply not in this run", async () => {
+  class Mono extends Build {
+    a = target().executes(() => {});
+    other = target().executes(() => {}); // a real target, but not reached by `all`
+    all = target().dependsOn(this.a).executes(() => {});
+    // `other` is a declared (conditional) target, legitimately ignored here — it
+    // must NOT be flagged like the dangling ad-hoc target above.
+    override extraEdges(t: Map<string, TargetBuilder>): OrderingEdge[] {
+      const a = t.get("a"), other = t.get("other");
+      return a && other ? [[a, other]] : [];
+    }
+  }
+  const res = await runCli(Mono, ["all"]);
+  assertEquals(res.code, 0);
+  assertEquals(
+    (res.out + res.err).includes("not a target in this build"),
+    false,
+  );
+});
+
+Deno.test("orderWith tolerates a malformed edge with a nullish endpoint (no crash)", async () => {
+  class Mono extends Build {
+    a = target().executes(() => {});
+    all = target().dependsOn(this.a).executes(() => {});
+    override orderWith(t: Map<string, TargetBuilder>): OrderingEdge[] {
+      const a = t.get("a");
+      if (!a) return [];
+      // A consumer bypassing the OrderingEdge type to feed a nullish endpoint:
+      // the run must tolerate it (like any out-of-set edge), never crash on it.
+      // @ts-expect-error deliberately pass a nullish endpoint to exercise the guard
+      return [[a, undefined]];
+    }
+  }
+  const res = await runCli(Mono, ["all"]);
+  assertEquals(res.code, 0); // tolerated, not a crash
+});
+
 Deno.test("a failing orderWith fails the run cleanly, not with an unhandled rejection", async () => {
   class B extends Build {
     a = target().executes(() => {});


### PR DESCRIPTION
Implements **PR C** of `plans/17-consolidated-plan.md` — the `orderWith` × fan-out trap (upstream skill feedback #2). The pilot fed a service dependency graph into per-repo fork ordering; because fan-out sub-targets don't exist at plan time, the edges were dead on arrival — no error, no warning, invisible to `deno check` and `--list`/`graph`.

## Fixes

- **Diagnostic (feedback #3).** `orderWith`/`extraEdges` see only class-field targets, and `planEdges` silently drops any edge whose endpoint isn't in the run's execution set. The executor now **logs an edge as ignored** when its endpoint is neither in the run nor a declared build target — a fan-out per-item name, a typo, or an ad-hoc `target()`. An edge to a *declared* target simply not in this run (a conditional target) stays silently ignored, as before, so the diagnostic is quiet for legitimate use.
- **Docs (the direct fix).** The cheatsheet, `docs/authoring.md`, and `docs/orchestration.md` now state that per-item ordering across a fan-out is **not expressible** with `orderWith`/`extraEdges`, and give the workaround: order whole fan-out **waves** — one `.forEach()` per wave — chained with `.dependsOn`.

## Verification

- `deno task ci` green (check, tests, coverage ≥95%); `./zuke apiDocsCheck` green.
- Unit (`executor_test.ts`) + integration (`orderwith_test.ts`) tests cover: a dead edge to a non-build target is flagged; a conditional (declared-but-not-in-run) target is **not** flagged (no noise); and a malformed nullish endpoint is tolerated without crashing.
- **Adversarial review:** confirmed no false positives across legitimate `orderWith`/`extraEdges` patterns (object identity is consistent via the single shared `discovered` map), and caught a **crash regression** — `endpoint.name_` threw on a type-bypassed nullish endpoint, which the old `planEdges` tolerated. Fixed with a guard and pinned by a `@ts-expect-error` regression test.

## Deferred (noted in feedback #2)
Re-resolving ordering after fan-out materialisation, or per-item edges in `.forEach` settings, is a larger feature left for later — the wave workaround covers the need today.