### PR TITLE
docs(skills): document the githubWorkflow receiving contract and rescope rule 3

### DIFF
--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -112,6 +112,39 @@ class Release extends Build {
 - **Auth** uses `GH_TOKEN` / `GITHUB_TOKEN`; the GitHub API is an injectable
   transport, so it is testable without a real GitHub.
 
+#### The dispatched workflow's contract
+
+The gate is only half the wiring. Three requirements on the **target** workflow
+are load-bearing — each is a deterministic dispatch `422` or a gate that hangs
+until timeout:
+
+```yaml
+# .github/workflows/e2e.yml — in the repo being dispatched
+on:
+  workflow_dispatch:
+    inputs:
+      zuke_marker: { required: false } # rename → .markerInput("name") on the gate
+      # any `required: true` input here must be supplied via .inputs(...) below
+run-name: ${{ inputs.zuke_marker }} # the ENTIRE run-name; equality, not substring
+```
+
+- **Marker input name.** The correlation marker is dispatched as an input named
+  `zuke_marker` by default. GitHub `422`s a dispatch carrying an input the
+  workflow does not declare, so a workflow that names its marker input anything
+  else rejects the dispatch outright — declare `zuke_marker`, or point the gate
+  at your name with `.markerInput("<name>")`.
+- **Required inputs.** Every `required: true` input on the target workflow must be
+  supplied from the gate with `.inputs({ … })` / `.input(name, value)`, or the
+  dispatch `422`s. The settings lambda is evaluated when the build is defined and
+  has **no access to run state** (`ctx.state`) — it can read params but not a
+  value an earlier target recorded in run state, so an input whose value is
+  produced at run time needs a custom `WaitTrigger`.
+- **Strict run-name equality.** Marker correlation matches
+  `display_title === marker` — **exact equality, not substring**. A decorated
+  run-name like `run-name: E2E [${{ inputs.zuke_marker }}]` dispatches fine and
+  then never correlates, so the gate just times out. Echo the marker as the
+  workflow's _entire_ `run-name:`, or switch to `.correlate("created-window")`.
+
 ## What suspend does
 
 When the scheduler reaches a wait whose trigger is **not** satisfied:

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -41,11 +41,15 @@ await run(CI);
    initialise top-to-bottom; a forward reference is `undefined` and is reported
    as an error (TypeScript also flags it, `TS2729`). Order fields so
    dependencies come first.
-3. **Never guess the API and never shell out by hand.** Every external tool is a
-   namespaced `*Tasks` object configured with a **settings lambda** that mirrors
-   the real CLI's flags — `DenoTasks`, `NpmTasks`, `DockerTasks`, `GitTasks`,
-   and 30+ more. Reach for `jsr:@zuke/cmd` (`CmdTasks.exec`) or the `$` shell
-   from `jsr:@zuke/core/shell` only when no typed wrapper exists.
+3. **Inside a target body, never guess the API or shell out by hand.** Whatever
+   runs in an `.executes(...)` body drives an external tool through its
+   namespaced `*Tasks` object, configured with a **settings lambda** that mirrors
+   the real CLI's flags — `DenoTasks`, `NpmTasks`, `DockerTasks`, `GitTasks`, and
+   30+ more — never a raw `Deno.Command` or shell string. Reach for
+   `jsr:@zuke/cmd` (`CmdTasks.exec`) or the `$` shell from `jsr:@zuke/core/shell`
+   only when no typed wrapper exists. (If a build delegates its side effects to
+   your own tested modules behind injected clients, the wrapper rule still
+   governs whatever those modules run in the target body.)
 4. **A body is required.** Set `.executes(...)`; it may be sync or async.
 
 ## Find the exact signature first
@@ -182,8 +186,12 @@ Before calling any task or settings method, confirm the real shape:
   per-job result with `readWorkflowResult(ctx.stateOf("<gate>"))`. Correlates by
   a `run-name:` marker by default, or `.correlate("created-window")` for a
   workflow you can't modify; fails fast (`.discoveryTimeout(...)`) if the run
-  never correlates. Triggers are extensible — write your own against the exported
-  `WaitTrigger`/`WaitContext`.
+  never correlates. The **dispatched** workflow has a contract: declare the
+  marker input (`zuke_marker`, or rename via `.markerInput(...)`), echo it as its
+  _entire_ `run-name:` (equality, not substring), and receive any of its
+  `required: true` inputs via `.inputs(...)` — see the cheatsheet's
+  receiving-workflow contract. Triggers are extensible — write your own against
+  the exported `WaitTrigger`/`WaitContext`.
 - **OpenTelemetry export (`@zuke/otel`):** register `otel((s) => s.endpoint(…))`
   as a plugin (`run(MyBuild, { plugins: [otel(…)] })`) to ship run/target spans
   and `zuke.run.started` / `zuke.run.suspended` / `zuke.runs` counters as

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -264,8 +264,11 @@ class Deploy extends Build {
   correlates via a marker echoed into the run's `run-name:`; for a workflow you
   can't modify use `.correlate("created-window")` (best-effort). Either way it
   **fails fast** (`.discoveryTimeout(...)`, default 1m) if the run never
-  correlates, instead of eating the whole `.timeout()`. Write your own trigger
-  against the exported `WaitTrigger` / `WaitContext` interface.
+  correlates, instead of eating the whole `.timeout()`. The **dispatched**
+  workflow has its own contract (marker input, run-name, required inputs) — see
+  [The dispatched workflow's contract](#the-dispatched-workflows-contract-githubworkflow)
+  below. Write your own trigger against the exported `WaitTrigger` /
+  `WaitContext` interface.
 - Needs a state store (a build with `.waitsFor()` enables `.zuke/runs` by
   default). A resume is a fresh process, so **only `ctx.state`/`ctx.signals`
   cross the boundary**. See `docs/orchestration.md`.
@@ -274,6 +277,37 @@ class Deploy extends Build {
   `zuke resume --check [<id>]` for predicate waits/timeouts). Resumption is
   **exactly-once** (concurrent resumers get `AlreadyResumedError`) and re-runs
   only the not-yet-succeeded targets; `--force-graph` overrides a changed graph.
+
+### The dispatched workflow's contract (`githubWorkflow`)
+
+The gate is only half the wiring — the **target** workflow has a contract, and
+each of these three is a deterministic dispatch `422` or a gate that hangs until
+timeout:
+
+```yaml
+# .github/workflows/e2e.yml — in the repo being dispatched
+on:
+  workflow_dispatch:
+    inputs:
+      zuke_marker: { required: false } # rename → .markerInput("name") on the gate
+      # any `required: true` input here must be supplied via .inputs(...) below
+run-name: ${{ inputs.zuke_marker }} # the ENTIRE run-name; equality, not substring
+```
+
+- **Marker input name.** The marker is dispatched as an input named `zuke_marker`
+  by default; a dispatch carrying an input the workflow does not declare is
+  `422`ed, so a workflow that names it anything else rejects the dispatch. Declare
+  `zuke_marker`, or point the gate at your name with `.markerInput("<name>")`.
+- **Required inputs.** Every `required: true` input on the target workflow must be
+  passed from the gate with `.inputs({ … })` / `.input(name, value)`, or the
+  dispatch `422`s. The settings lambda is captured when the build is defined and
+  has **no run state** — it can read params but not a value an earlier target
+  recorded in `ctx.state`; for a run-time value, write a custom `WaitTrigger`.
+- **Strict run-name equality.** Marker mode matches `display_title === marker`
+  **exactly, not by substring**. A decorated run-name
+  (`run-name: E2E [${{ inputs.zuke_marker }}]`) dispatches fine but never
+  correlates — the gate just times out. Echo the marker as the workflow's
+  _entire_ `run-name:`, or use `.correlate("created-window")`.
 
 ## Cancellation & compensation — `.onCancel()`
 


### PR DESCRIPTION
Addresses items **3** and **4** of the upstream skill feedback in `plans/16-zuke-skill-upstream-feedback.md`. Docs-only — no code, no public-API change.

## Feedback #3 — `githubWorkflow`'s dispatched-workflow contract was undocumented

The skill showed the gate side but never the **target** workflow's contract, and each requirement is a deterministic dispatch `422` or a gate that hangs until timeout. A pilot hit all three at once (marker input named `marker` not `zuke_marker`, a required `namespace` input the gate never passed, and a decorated `run-name` that never correlated).

Added a paired snippet — the gate config **and** the minimal receiving workflow YAML — in the cheatsheet, mirrored in `docs/orchestration.md`, and pointed to from `SKILL.md`. It covers:

- **Marker input name** — dispatched as `zuke_marker` by default; rename with `.markerInput("<name>")`.
- **Required inputs** — every `required: true` input must be passed via `.inputs(...)` / `.input(...)`, and the no-run-state limit of the settings lambda (it reads params, not a value an earlier target recorded in `ctx.state`; a run-time value needs a custom `WaitTrigger`).
- **Strict run-name equality** — marker mode matches `display_title === marker` exactly, not by substring; a decorated run-name dispatches but never correlates. Echo the marker as the *entire* run-name, or use `.correlate("created-window")`.

## Feedback #4 — non-negotiable rule 3 was over-scoped

Rescoped rule 3 from an absolute API mandate to what runs in a target body, so a build that keeps `zuke.ts` a thin wiring layer and pushes side effects behind injected, tested clients is no longer read as forbidden — while the anti-guessing intent for target-body tool calls is preserved.

## Verification

Every claim checked against the real source, not the feedback's external JSR versions:

- `packages/gh/src/workflow.ts` — `markerInput_ = "zuke_marker"` default; `.markerInput` / `.inputs` / `.input` setters; `findRun` matches `display_title === marker` (exact equality); `.correlate("created-window")` fallback.
- `packages/core/src/target.ts:104` — the wait settings lambda "runs when the target is reached, so the trigger may read `this.<param>.value`", which is why "can read params" is stated as true and "run state" as the limit.

`deno task fmt:check` and `deno task spell` are green. No `.ts` snippets added (the contract block is YAML), so no typecheck surface changes.