### PR TITLE
test(core): backfill throwing-cacheKey and unhandled-rejection guards

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -87,6 +87,7 @@
     "llms",
     "llmstxt",
     "lockfiles",
+    "macrotask",
     "mailto",
     "mastodon",
     "matkoch",

--- a/packages/core/tests/executor_test.ts
+++ b/packages/core/tests/executor_test.ts
@@ -2346,6 +2346,71 @@ Deno.test("a throwing predicate settles the parallel scheduler without hanging",
   assertEquals(result.executed.includes("good"), true);
 });
 
+Deno.test("a throwing cacheKey thunk fails the target, not the process (sequential)", async () => {
+  const dir = await Deno.makeTempDir();
+  const original = Deno.cwd();
+  try {
+    // Run from a temp dir so the default `.zuke` cache store never touches the
+    // repo (the real cache is exercised: a cacheKey target is cacheable).
+    await Deno.writeTextFile(`${dir}/zuke.json`, "{}\n");
+    Deno.chdir(dir);
+    const { lines, reporter } = recorder();
+    class B extends Build {
+      boom = target()
+        // A cache-key contributor is evaluated by cache.upToDate, outside
+        // runTarget's own try/catch (like onlyWhen). A throw here must finalize
+        // the run as failed — never reject out of execute() (stranding the
+        // record `running`) nor crash on an unhandled rejection.
+        .cacheKey(() => {
+          throw new Error("key boom");
+        })
+        .executes(() => {});
+    }
+    const b = new B();
+    discoverTargets(b);
+    const result = await execute(b, b.boom, { reporter, github: false });
+    assertEquals(result.ok, false);
+    assertEquals(lines.some((l) => l.includes("key boom")), true);
+  } finally {
+    Deno.chdir(original);
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("a throwing cacheKey settles the parallel scheduler without hanging", async () => {
+  const dir = await Deno.makeTempDir();
+  const original = Deno.cwd();
+  try {
+    await Deno.writeTextFile(`${dir}/zuke.json`, "{}\n");
+    Deno.chdir(dir);
+    const { reporter } = recorder();
+    class B extends Build {
+      good = target().executes(() => {});
+      bad = target()
+        .cacheKey(() => {
+          throw new Error("key boom");
+        })
+        .executes(() => {});
+      all = target().dependsOn(this.good, this.bad).executes(() => {});
+    }
+    const b = new B();
+    discoverTargets(b);
+    // The parallel scheduler's `.then(...).catch(...)` must route the rejecting
+    // cacheKey into the failure path so the slot frees and the run settles,
+    // instead of leaving `bad` stuck in the running set and hanging.
+    const result = await execute(b, b.all, {
+      reporter,
+      parallel: true,
+      github: false,
+    });
+    assertEquals(result.ok, false);
+    assertEquals(result.executed.includes("good"), true);
+  } finally {
+    Deno.chdir(original);
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
 Deno.test("a rejected lock renewal never crashes the build", async () => {
   const dir = await Deno.makeTempDir();
   try {

--- a/tests/integration/_harness.ts
+++ b/tests/integration/_harness.ts
@@ -38,10 +38,33 @@ export async function runCli(
   const origErr = console.error;
   console.log = (...a: unknown[]) => void out.push(a.join(" "));
   console.error = (...a: unknown[]) => void err.push(a.join(" "));
+  // Guard the async-safety fixes: a promise rejection that escapes the run
+  // (e.g. a scheduler path that dropped its `.catch`) must fail the test
+  // explicitly, not merely rely on the Deno runner's default handling — which
+  // this pins even if that default changes. We take ownership of the event
+  // (preventDefault) so the check below is authoritative; a rejection firing
+  // after this call (listener already removed) still falls back to the runner.
+  const rejections: unknown[] = [];
+  const onRejection = (event: PromiseRejectionEvent) => {
+    event.preventDefault();
+    rejections.push(event.reason);
+  };
+  addEventListener("unhandledrejection", onRejection);
   try {
     const code = await main(BuildClass, args, options);
+    // A macrotask boundary so any queued unhandledrejection event has dispatched
+    // before we inspect — it fires at a microtask checkpoint, which setTimeout(0)
+    // is guaranteed to follow.
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    if (rejections.length > 0) {
+      const reasons = rejections
+        .map((r) => (r instanceof Error ? r.message : String(r)))
+        .join("; ");
+      throw new Error(`unhandled promise rejection during runCli: ${reasons}`);
+    }
     return { code, out: out.join("\n"), err: err.join("\n") };
   } finally {
+    removeEventListener("unhandledrejection", onRejection);
     console.log = origLog;
     console.error = origErr;
   }

--- a/tests/integration/harness_test.ts
+++ b/tests/integration/harness_test.ts
@@ -7,8 +7,12 @@
  * @module
  */
 
-import { assertEquals } from "../../packages/core/tests/_assert.ts";
-import { withStateDir } from "./_harness.ts";
+import {
+  assertEquals,
+  assertRejects,
+} from "../../packages/core/tests/_assert.ts";
+import { Build, target } from "../../packages/core/mod.ts";
+import { runCli, withStateDir } from "./_harness.ts";
 
 Deno.test("withStateDir surfaces the body error even when cleanup fails", async () => {
   const marker = new Error("body failure");
@@ -38,4 +42,16 @@ Deno.test("withStateDir resolves when cleanup fails after a successful body", as
   });
   // The env var is still restored on the success-with-failed-cleanup path.
   assertEquals(Deno.env.get("ZUKE_STATE_DIR"), prev);
+});
+
+Deno.test("runCli surfaces an unhandled rejection during the run as a failure", async () => {
+  class Leaky extends Build {
+    // A body that fires a detached promise it never awaits — a genuine
+    // unhandled rejection escaping the run. The harness guard must surface it
+    // as a thrown error rather than let it slip past on the runner's defaults.
+    leak = target().executes(() => {
+      void Promise.reject(new Error("detached boom"));
+    });
+  }
+  await assertRejects(() => runCli(Leaky, ["leak"]), Error, "detached boom");
 });


### PR DESCRIPTION
Remediation V2 **PR 6** (`plans/REMEDIATION_PLAN_V2.md`) — pin two paths that are fixed but were unguarded. Test-only; no source change (so no release bump).

## 6.1 — throwing `cacheKey` regression tests

A cache-key contributor is evaluated inside `cache.upToDate` → `fingerprint` (`packages/core/src/cache.ts:219`), which runs **outside** `runTarget`'s own try/catch (`scheduler.ts:287`) — the same class as the `onlyWhen` predicate. #219 routed such rejections into the failure path (sequential catch at `scheduler.ts:496`, parallel `.catch` at `scheduler.ts:632`), but only the `onlyWhen` sibling was pinned by a test.

Added two tests next to the `onlyWhen` throwing tests in `executor_test.ts`:
- **sequential** — a `.cacheKey(() => { throw })` finalizes the run `failed` (not a reject out of `execute()`, not a process crash).
- **parallel** — the scheduler settles instead of hanging with the target stuck in the running set; the independent target still runs.

Both `chdir` to a temp dir with a `zuke.json` so the real `.zuke` cache store stays out of the repo (the established hermetic pattern from the existing default-store cache test).

**These genuinely pin the fix:** revert the sequential `try/catch` and `await execute(...)` rejects → the test throws; revert the parallel `.catch` and the run hangs → the test times out.

## 6.2 — unhandled-rejection guard in the integration harness

`runCli` now installs a per-call `unhandledrejection` listener that `preventDefault`s, records the reason, and (after a macrotask flush past `await main()`) throws if any rejection escaped — so the async-safety fixes stay pinned **even if the Deno runner's default handling changes**. The listener is scoped to the call (removed in `finally`), so a rejection firing after the call falls back to the runner — the guard is strictly additive, never masking. A self-test in `harness_test.ts` drives a body that fires a detached rejecting promise and asserts the harness surfaces it.

## Skipped (optional in the plan)
- **6.3** per-package coverage floor — subsumed by the existing per-file floor (#221).
- **6.4** Set/Map `assertEquals` diagnostics — cosmetic only.

## Verification
- `deno test -A --frozen`: **2005 passed, 0 failed** — the new harness guard breaks nothing (no pre-existing unhandled rejection fires during any `runCli`).
- `deno task ci` green — coverage gate **98.3% lines / 95.5% branches**.
- `./zuke apiDocsCheck` green (no API change).
- Adversarial review of the guard's timing/attribution in progress; any confirmed finding will be folded in before merge.