### PR TITLE
feat(docs): type-check the marked ts snippets in docs and skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 # Generated Zuke artifacts (e.g. `zuke graph` output)
 /.zuke/
 
+# Doc-snippet type-check scratch dirs (build/snippets.ts; cleaned up per run)
+/.snippets-*/
+
 # Editor / OS noise
 .DS_Store
 *.swp

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,11 +54,13 @@ The mental model:
   import { DenoTasks } from "jsr:@zuke/deno";
 
   class CI extends Build {
-    lint = target().executes(() => DenoTasks.lint());
+    lint = target().executes(async () => {
+      await DenoTasks.lint();
+    });
     test = target().dependsOn(this.lint)
-      .executes(() =>
-        DenoTasks.test((s) => s.allowAll().coverage("cov_profile"))
-      );
+      .executes(async () => {
+        await DenoTasks.test((s) => s.allowAll().coverage("cov_profile"));
+      });
   }
 
   await run(CI);

--- a/build/snippets.ts
+++ b/build/snippets.ts
@@ -111,10 +111,20 @@ const denoCheck: SnippetChecker = async (path) => {
   return { ok: out.code === 0, detail: `${out.stderr}${out.stdout}`.trim() };
 };
 
-/** Replace the snippet's temp path (bare and `file://` forms) with `snippet.ts`. */
-function reduceTempPath(detail: string, path: string): string {
-  const url = `file://${path.startsWith("/") ? path : `/${path}`}`;
-  return detail.replaceAll(url, "snippet.ts").replaceAll(path, "snippet.ts");
+/**
+ * Reduce the snippet's temp path to `snippet.ts` in checker output, in every
+ * form it can appear: the raw path, the forward-slash path, and the `file://`
+ * URL. `deno check` always emits forward-slash `file://` URLs even on Windows
+ * (where the path itself uses backslashes), so both separator conventions are
+ * normalised before matching.
+ */
+export function reduceTempPath(detail: string, path: string): string {
+  const forward = path.replaceAll("\\", "/");
+  const url = `file://${forward.startsWith("/") ? forward : `/${forward}`}`;
+  return detail
+    .replaceAll(url, "snippet.ts")
+    .replaceAll(forward, "snippet.ts")
+    .replaceAll(path, "snippet.ts");
 }
 
 /**

--- a/build/snippets.ts
+++ b/build/snippets.ts
@@ -1,0 +1,171 @@
+/**
+ * Type-check the ```ts snippets in the docs and skills that are explicitly
+ * marked for checking, so an example an agent pastes can't silently drift from
+ * the real API. Zuke's whole pitch is "never guess the API" — a marked example
+ * is held to the same bar via `deno check`.
+ *
+ * **Opt-in.** Only a fenced ```ts block whose opening fence is immediately
+ * preceded by a `<!-- check -->` line is checked. The rest of the corpus is
+ * intentionally-elided prose — class-body fragments, `/* … *\/` placeholders,
+ * deliberately-unimported symbols — that cannot compile standalone, so checking
+ * every block would be nothing but false positives.
+ *
+ * **Hermetic resolution.** A snippet's `jsr:@zuke/…` specifiers are rewritten to
+ * the bare workspace name (`@zuke/…`) and each snippet is checked in a temp
+ * directory *inside* the repo, so Deno resolves the imports to the local
+ * packages — never the network, never a published version that could drift from
+ * this working tree.
+ *
+ * @module
+ */
+
+import { FileTasks } from "@zuke/core";
+import { DenoTasks } from "@zuke/deno";
+
+/** The marker line that opts the following ```ts fence into type-checking. */
+export const CHECK_MARKER = "<!-- check -->";
+
+/** A ```ts snippet marked for type-checking, located in its source markdown. */
+export interface CheckedSnippet {
+  /** The markdown file the snippet lives in (repo-relative). */
+  file: string;
+  /** The 1-based line of the snippet's opening fence. */
+  line: number;
+  /** The snippet body, with `jsr:@zuke/…` rewritten to the workspace name. */
+  code: string;
+}
+
+/** A marked snippet that failed `deno check`, with the checker's output. */
+export interface SnippetFailure {
+  /** The markdown file the failing snippet lives in (repo-relative). */
+  file: string;
+  /** The 1-based line of the failing snippet's opening fence. */
+  line: number;
+  /** The `deno check` output, with the temp path reduced to `snippet.ts`. */
+  detail: string;
+}
+
+/** Matches an opening ```ts / ```typescript fence (nothing after the language). */
+const TS_FENCE = /^```(?:ts|typescript)$/;
+
+/**
+ * Extract every `<!-- check -->`-marked ```ts block from `markdown`. A block is
+ * checked only when the marker sits on the line immediately above its opening
+ * fence (blank lines aside); every other fenced block is left as prose.
+ *
+ * This is a line scanner, not a full Markdown parser: it does not track being
+ * *inside* another fenced block, so a literal `<!-- check -->` + ```ts written
+ * as content within an outer fence would be picked up. That only arises when
+ * documenting the marker itself, which the docs do in prose — not nested fences.
+ */
+export function extractCheckedSnippets(
+  markdown: string,
+  file: string,
+): CheckedSnippet[] {
+  const lines = markdown.split("\n");
+  const snippets: CheckedSnippet[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim() !== CHECK_MARKER) continue;
+    // The opening fence is the next non-blank line — tolerating the blank line
+    // `deno fmt` keeps between an HTML comment and a following code block. Only
+    // blank lines may sit between the marker and its fence; anything else means
+    // the marker is not attached to a ```ts block and is ignored.
+    let fence = i + 1;
+    while (fence < lines.length && lines[fence].trim() === "") fence++;
+    if (fence >= lines.length || !TS_FENCE.test(lines[fence].trim())) continue;
+    const body: string[] = [];
+    let j = fence + 1;
+    while (j < lines.length && lines[j].trim() !== "```") {
+      body.push(lines[j]);
+      j++;
+    }
+    snippets.push({
+      file,
+      line: fence + 1, // 1-based line of the opening fence
+      code: body.join("\n").replaceAll("jsr:@zuke/", "@zuke/"),
+    });
+    i = j; // resume past the closing fence
+  }
+  return snippets;
+}
+
+/** Read and extract the marked snippets from every file, in file then document order. */
+export async function collectCheckedSnippets(
+  files: string[],
+): Promise<CheckedSnippet[]> {
+  const all: CheckedSnippet[] = [];
+  for (const file of files) {
+    all.push(...extractCheckedSnippets(await FileTasks.readText(file), file));
+  }
+  return all;
+}
+
+/** The type-check seam: check the module at `path`, returning ok + any output. */
+export type SnippetChecker = (
+  path: string,
+) => Promise<{ ok: boolean; detail: string }>;
+
+/** The default checker: `deno check` against the local workspace. */
+const denoCheck: SnippetChecker = async (path) => {
+  const out = await DenoTasks.check((s) => s.paths(path).quiet().noThrow());
+  return { ok: out.code === 0, detail: `${out.stderr}${out.stdout}`.trim() };
+};
+
+/** Replace the snippet's temp path (bare and `file://` forms) with `snippet.ts`. */
+function reduceTempPath(detail: string, path: string): string {
+  const url = `file://${path.startsWith("/") ? path : `/${path}`}`;
+  return detail.replaceAll(url, "snippet.ts").replaceAll(path, "snippet.ts");
+}
+
+/**
+ * Type-check every marked snippet in `files`, returning one {@link
+ * SnippetFailure} per snippet that fails. Each snippet is written to a temp file
+ * *inside the repo* (so `@zuke/…` resolves to the workspace) and checked; the
+ * temp directory is removed afterwards, even on error. The `check` seam is
+ * injectable so the orchestration is unit-testable without spawning `deno`.
+ */
+export async function checkSnippets(
+  files: string[],
+  check: SnippetChecker = denoCheck,
+): Promise<SnippetFailure[]> {
+  const snippets = await collectCheckedSnippets(files);
+  if (snippets.length === 0) return [];
+  const dir = await Deno.makeTempDir({ dir: Deno.cwd(), prefix: ".snippets-" });
+  const failures: SnippetFailure[] = [];
+  try {
+    for (let i = 0; i < snippets.length; i++) {
+      const snippet = snippets[i];
+      const path = `${dir}/snippet_${i}.ts`;
+      await FileTasks.writeText(path, `${snippet.code}\n`);
+      const { ok, detail } = await check(path);
+      if (!ok) {
+        failures.push({
+          file: snippet.file,
+          line: snippet.line,
+          detail: reduceTempPath(detail, path),
+        });
+      }
+    }
+  } finally {
+    await FileTasks.remove(dir, { recursive: true });
+  }
+  return failures;
+}
+
+/**
+ * Render the {@link SnippetFailure}s as one friendly, actionable error message —
+ * each failing snippet named by its source location, above the checker output.
+ */
+export function formatSnippetFailures(failures: SnippetFailure[]): string {
+  const blocks = failures.map((f) => {
+    const detail = f.detail
+      .split("\n")
+      .map((line) => `    ${line}`)
+      .join("\n");
+    return `  ${f.file}:${f.line}\n${detail}`;
+  });
+  return `${failures.length} marked doc snippet(s) failed to type-check:\n` +
+    `${blocks.join("\n\n")}\n\n` +
+    "Fix the snippet, or remove its `<!-- check -->` marker if it is " +
+    "intentionally partial.";
+}

--- a/build/snippets.ts
+++ b/build/snippets.ts
@@ -107,7 +107,13 @@ export type SnippetChecker = (
 
 /** The default checker: `deno check` against the local workspace. */
 const denoCheck: SnippetChecker = async (path) => {
-  const out = await DenoTasks.check((s) => s.paths(path).quiet().noThrow());
+  // `--quiet` drops deno's `Check <relative-path>` progress line, which would
+  // otherwise leak the random temp-dir name into failure output as a relative
+  // path (a form {@link reduceTempPath} can't match); the `file://` error
+  // locations deno still prints are reduced there.
+  const out = await DenoTasks.check((s) =>
+    s.paths(path).args("--quiet").quiet().noThrow()
+  );
   return { ok: out.code === 0, detail: `${out.stderr}${out.stdout}`.trim() };
 };
 

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -11,6 +11,8 @@ precedence):
 3. a [secret source](./secrets.md) declared with `.from(...)`
 4. the declared default
 
+<!-- check -->
+
 ```ts
 import { Build, parameter, run, target } from "jsr:@zuke/core";
 
@@ -23,10 +25,15 @@ class Deploy extends Build {
 
   dryRun = parameter("Print actions without performing them").boolean();
 
+  // A required list: `.required()` comes before `.array()` — the reverse order
+  // does not type-check.
+  repos = parameter("Repos to deploy").required().array();
+
   deploy = target().executes(() => {
     if (this.dryRun.value) console.log("(dry run)");
     console.log(
-      `Deploying to ${this.environment.value} with ${this.workers.value} workers`,
+      `Deploying ${this.repos.value.join(", ")} to ${this.environment.value} ` +
+        `with ${this.workers.value} workers`,
     );
   });
 }

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -9,6 +9,8 @@ A build is a class that **extends `Build`**. Each **target is a class field**
 created with `target()` and made runnable with `await run(MyBuild)` at the
 bottom of `zuke.ts` (no `import.meta.main` guard — `run` no-ops on import).
 
+<!-- check -->
+
 ```ts
 import { Build, run, target } from "jsr:@zuke/core";
 import { DenoTasks } from "jsr:@zuke/deno";
@@ -16,14 +18,16 @@ import { DenoTasks } from "jsr:@zuke/deno";
 class CI extends Build {
   lint = target()
     .description("Lint sources")
-    .executes(() => DenoTasks.lint());
+    .executes(async () => {
+      await DenoTasks.lint();
+    });
 
   test = target()
     .description("Type-check and test")
     .dependsOn(this.lint)
-    .executes(() =>
-      DenoTasks.test((s) => s.allowAll().coverage("cov_profile"))
-    );
+    .executes(async () => {
+      await DenoTasks.test((s) => s.allowAll().coverage("cov_profile"));
+    });
 
   // A field named `default` runs when no target is named on the CLI.
   default = target().dependsOn(this.test).executes(() => {});

--- a/tests/snippets_test.ts
+++ b/tests/snippets_test.ts
@@ -211,6 +211,10 @@ Deno.test("check (real deno): the pilot's wrong order fails, the correct order p
     assertEquals(failures[0].line, 11); // the second (Bad) block's fence line
     assertStringIncludes(failures[0].detail, "snippet.ts"); // temp path reduced
     assertEquals(failures[0].detail.includes(dir), false);
+    // No random temp-dir name leaks — neither the scratch dir prefix nor the
+    // raw temp filename survive (the `Check <relative>` progress line is off).
+    assertEquals(failures[0].detail.includes(".snippets-"), false);
+    assertEquals(failures[0].detail.includes("snippet_"), false);
   } finally {
     await Deno.remove(dir, { recursive: true });
   }

--- a/tests/snippets_test.ts
+++ b/tests/snippets_test.ts
@@ -1,0 +1,200 @@
+/**
+ * Unit tests for the doc-snippet type-check gate (`build/snippets.ts`): the
+ * extractor is pure and fully exercised here; the checker's orchestration is
+ * driven through an injected fake, and one end-to-end case runs the real
+ * `deno check` against the local workspace to prove a genuinely broken example
+ * (the pilot's `.array().required()`) is caught and a correct one passes.
+ *
+ * @module
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../packages/core/tests/_assert.ts";
+import {
+  CHECK_MARKER,
+  checkSnippets,
+  collectCheckedSnippets,
+  extractCheckedSnippets,
+  formatSnippetFailures,
+  type SnippetChecker,
+} from "../build/snippets.ts";
+
+Deno.test("extract: a marked ts block is captured with jsr specifiers rewritten", () => {
+  const md = [
+    "# Title",
+    "",
+    CHECK_MARKER,
+    "```ts",
+    'import { Build } from "jsr:@zuke/core";',
+    "class B extends Build {}",
+    "```",
+    "",
+  ].join("\n");
+  const snippets = extractCheckedSnippets(md, "docs/x.md");
+  assertEquals(snippets.length, 1);
+  assertEquals(snippets[0].file, "docs/x.md");
+  assertEquals(snippets[0].line, 4); // 1-based line of the opening fence
+  assertStringIncludes(snippets[0].code, 'import { Build } from "@zuke/core";');
+  assertEquals(snippets[0].code.includes("jsr:@zuke/"), false);
+});
+
+Deno.test("extract: an unmarked ts block is left as prose", () => {
+  const md = ["```ts", "const broken: number = 'x';", "```"].join("\n");
+  assertEquals(extractCheckedSnippets(md, "docs/x.md").length, 0);
+});
+
+Deno.test("extract: a blank line between the marker and the fence is tolerated", () => {
+  const md = [CHECK_MARKER, "", "", "```ts", "const a = 1;", "```"].join("\n");
+  const snippets = extractCheckedSnippets(md, "docs/x.md");
+  assertEquals(snippets.length, 1);
+  assertEquals(snippets[0].line, 4);
+  assertEquals(snippets[0].code, "const a = 1;");
+});
+
+Deno.test("extract: the marker only attaches to a ts/typescript fence", () => {
+  const yaml = [CHECK_MARKER, "```yaml", "a: 1", "```"].join("\n");
+  assertEquals(extractCheckedSnippets(yaml, "docs/x.md").length, 0);
+  // A tsx fence is not a ts fence.
+  const tsx = [CHECK_MARKER, "```tsx", "const a = 1;", "```"].join("\n");
+  assertEquals(extractCheckedSnippets(tsx, "docs/x.md").length, 0);
+  // The marker followed by prose (not a fence) is ignored.
+  const prose = [CHECK_MARKER, "just text", "```ts", "const a = 1;", "```"]
+    .join("\n");
+  assertEquals(extractCheckedSnippets(prose, "docs/x.md").length, 0);
+  // A `typescript` fence is accepted.
+  const ts = [CHECK_MARKER, "```typescript", "const a = 1;", "```"].join("\n");
+  assertEquals(extractCheckedSnippets(ts, "docs/x.md").length, 1);
+});
+
+Deno.test("extract: multiple marked blocks keep document order and line numbers", () => {
+  const md = [
+    CHECK_MARKER,
+    "```ts",
+    "const a = 1;",
+    "```",
+    "prose",
+    CHECK_MARKER,
+    "```ts",
+    "const b = 2;",
+    "```",
+  ].join("\n");
+  const snippets = extractCheckedSnippets(md, "docs/x.md");
+  assertEquals(snippets.map((s) => s.line), [2, 7]);
+  assertEquals(snippets.map((s) => s.code), ["const a = 1;", "const b = 2;"]);
+});
+
+Deno.test("collect: reads and aggregates marked snippets across files in order", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const a = `${dir}/a.md`;
+    const b = `${dir}/b.md`;
+    await Deno.writeTextFile(
+      a,
+      [CHECK_MARKER, "```ts", "const a = 1;", "```"].join("\n"),
+    );
+    await Deno.writeTextFile(
+      b,
+      [CHECK_MARKER, "```ts", "const b = 2;", "```"].join("\n"),
+    );
+    const snippets = await collectCheckedSnippets([a, b]);
+    assertEquals(snippets.map((s) => s.file), [a, b]);
+    assertEquals(snippets.map((s) => s.code), ["const a = 1;", "const b = 2;"]);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("check: no marked snippets means no work and no failures", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const md = `${dir}/x.md`;
+    await Deno.writeTextFile(md, "```ts\nconst broken: number = 'x';\n```");
+    let called = false;
+    const spy: SnippetChecker = () => {
+      called = true;
+      return Promise.resolve({ ok: true, detail: "" });
+    };
+    assertEquals(await checkSnippets([md], spy), []);
+    assertEquals(called, false); // the checker is never invoked
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("check: a failing snippet is reported with its source location, temp path reduced", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const md = `${dir}/x.md`;
+    await Deno.writeTextFile(
+      md,
+      [CHECK_MARKER, "```ts", "const a = 1;", "```"].join("\n"),
+    );
+    // A fake checker that fails and echoes both the bare temp path and its
+    // file:// URL, so the reduction of both forms to `snippet.ts` is asserted.
+    const fake: SnippetChecker = (path) =>
+      Promise.resolve({
+        ok: false,
+        detail: `error ${path} and file://${path} end`,
+      });
+    const failures = await checkSnippets([md], fake);
+    assertEquals(failures.length, 1);
+    assertEquals(failures[0].file, md);
+    assertEquals(failures[0].line, 2);
+    assertEquals(failures[0].detail, "error snippet.ts and snippet.ts end");
+    // The scratch dir is cleaned up.
+    assertEquals(failures[0].detail.includes(dir), false);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("format: renders every failure by source location above its detail", () => {
+  const message = formatSnippetFailures([
+    { file: "docs/x.md", line: 12, detail: "TS2684 boom" },
+    { file: "skills/y.md", line: 3, detail: "TS2322 nope" },
+  ]);
+  assertStringIncludes(message, "2 marked doc snippet(s) failed");
+  assertStringIncludes(message, "docs/x.md:12");
+  assertStringIncludes(message, "    TS2684 boom");
+  assertStringIncludes(message, "skills/y.md:3");
+  assertStringIncludes(message, "<!-- check -->");
+});
+
+Deno.test("check (real deno): the pilot's wrong order fails, the correct order passes", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const md = `${dir}/params.md`;
+    await Deno.writeTextFile(
+      md,
+      [
+        CHECK_MARKER,
+        "```ts",
+        'import { Build, parameter, run } from "jsr:@zuke/core";',
+        "class Good extends Build {",
+        '  repos = parameter("r").required().array();',
+        "}",
+        "await run(Good);",
+        "```",
+        "",
+        CHECK_MARKER,
+        "```ts",
+        'import { Build, parameter, run } from "jsr:@zuke/core";',
+        "class Bad extends Build {",
+        '  repos = parameter("r").array().required();',
+        "}",
+        "await run(Bad);",
+        "```",
+      ].join("\n"),
+    );
+    const failures = await checkSnippets([md]); // real deno check
+    assertEquals(failures.length, 1); // only the wrong-order block fails
+    assertEquals(failures[0].file, md);
+    assertEquals(failures[0].line, 11); // the second (Bad) block's fence line
+    assertStringIncludes(failures[0].detail, "snippet.ts"); // temp path reduced
+    assertEquals(failures[0].detail.includes(dir), false);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/tests/snippets_test.ts
+++ b/tests/snippets_test.ts
@@ -18,6 +18,7 @@ import {
   collectCheckedSnippets,
   extractCheckedSnippets,
   formatSnippetFailures,
+  reduceTempPath,
   type SnippetChecker,
 } from "../build/snippets.ts";
 
@@ -131,23 +132,39 @@ Deno.test("check: a failing snippet is reported with its source location, temp p
       md,
       [CHECK_MARKER, "```ts", "const a = 1;", "```"].join("\n"),
     );
-    // A fake checker that fails and echoes both the bare temp path and its
-    // file:// URL, so the reduction of both forms to `snippet.ts` is asserted.
-    const fake: SnippetChecker = (path) =>
-      Promise.resolve({
-        ok: false,
-        detail: `error ${path} and file://${path} end`,
-      });
+    // A fake checker that fails and echoes the snippet's `file://` URL the way
+    // `deno check` does (forward slashes on every OS), so the reduction to
+    // `snippet.ts` is asserted through the full orchestration.
+    const fake: SnippetChecker = (path) => {
+      const forward = path.replaceAll("\\", "/");
+      const url = `file://${forward.startsWith("/") ? forward : `/${forward}`}`;
+      return Promise.resolve({ ok: false, detail: `error at ${url}:2:1` });
+    };
     const failures = await checkSnippets([md], fake);
     assertEquals(failures.length, 1);
     assertEquals(failures[0].file, md);
     assertEquals(failures[0].line, 2);
-    assertEquals(failures[0].detail, "error snippet.ts and snippet.ts end");
-    // The scratch dir is cleaned up.
-    assertEquals(failures[0].detail.includes(dir), false);
+    assertEquals(failures[0].detail, "error at snippet.ts:2:1");
   } finally {
     await Deno.remove(dir, { recursive: true });
   }
+});
+
+Deno.test("reduceTempPath normalises POSIX and Windows path forms to snippet.ts", () => {
+  // POSIX: the forward-slash path and its file:// URL both reduce.
+  assertEquals(
+    reduceTempPath("at file:///t/s_0.ts:1:1 then /t/s_0.ts", "/t/s_0.ts"),
+    "at snippet.ts:1:1 then snippet.ts",
+  );
+  // Windows: the temp path uses backslashes, but deno emits a forward-slash
+  // file:// URL — both forms must still reduce.
+  assertEquals(
+    reduceTempPath(
+      "at file:///C:/t/s_0.ts:1:1 then C:/t/s_0.ts",
+      "C:\\t\\s_0.ts",
+    ),
+    "at snippet.ts:1:1 then snippet.ts",
+  );
 });
 
 Deno.test("format: renders every failure by source location above its detail", () => {

--- a/zuke.ts
+++ b/zuke.ts
@@ -19,6 +19,7 @@ import {
   Build,
   cicd,
   FileTasks,
+  glob,
   parameter,
   run,
   target,
@@ -57,6 +58,7 @@ import {
 } from "./build/docs.ts";
 import { writeApiJson } from "./build/api_reference.ts";
 import { runWebsiteSync } from "./build/website_sync.ts";
+import { checkSnippets, formatSnippetFailures } from "./build/snippets.ts";
 
 class ZukeBuild extends Build {
   clean = target()
@@ -361,6 +363,24 @@ class ZukeBuild extends Build {
       ConsoleTasks.info("Documentation lint clean.");
     });
 
+  snippetsCheck = target()
+    .description("Type-check the marked ts snippets in docs and skills")
+    .executes(async () => {
+      // Opt-in: only `<!-- check -->`-marked ```ts blocks are checked (the rest
+      // of the corpus is intentionally-elided prose). Snippets resolve `@zuke/…`
+      // against the local workspace, so the gate holds every checkable example
+      // to the real API — never a published version that could drift.
+      const files = [
+        ...await glob("docs/*.md"),
+        ...await glob("skills/**/*.md"),
+      ];
+      const failures = await checkSnippets(files);
+      if (failures.length > 0) {
+        throw new Error(formatSnippetFailures(failures));
+      }
+      ConsoleTasks.info("Doc snippets type-check clean.");
+    });
+
   ci = target()
     .description("Full pre-commit / CI gate")
     .dependsOn(
@@ -371,6 +391,7 @@ class ZukeBuild extends Build {
       this.coverageUpload,
       this.apiDocsCheck,
       this.docLint,
+      this.snippetsCheck,
     )
     .executes(() => {});
 


### PR DESCRIPTION
Consolidated-plan **PR B** — a snippet type-check gate so a copy-and-paste example an agent follows can't silently drift from the real API (the same "never guess the API" bar the skill sets for authors). Addresses the "bigger win" in skill feedback #1.

## Opt-in, by necessity

The `ts` corpus in `docs/` + `skills/` is ~180 fenced blocks, but overwhelmingly **pedagogical fragments** — class-body field declarations, `/* … */` placeholders, deliberately-unimported symbols (`DenoTasks`), undefined identifiers. Most cannot `deno check` standalone, so "check every block with an opt-out" would be ~170 false positives. The gate is therefore **opt-in**: only a ```ts block whose opening fence is preceded by a `<!-- check -->` marker is checked; everything else stays prose. (Decision confirmed after inspecting the corpus.)

## How it works — `build/snippets.ts`

- `extractCheckedSnippets` — a line scanner that pulls each `<!-- check -->`-marked ```ts/```typescript block (blank lines between marker and fence tolerated, for `deno fmt`).
- `checkSnippets` — writes each snippet to a temp dir **inside the repo** and `deno check`s it, so Deno resolves `@zuke/…` to the **local workspace** — hermetic, no network, no published-version drift. The `jsr:@zuke/` prefix is rewritten to the bare workspace name; the temp path is reduced to `snippet.ts` in error output; the scratch dir is always cleaned up. The checker is an injectable seam for testing.
- A new `snippetsCheck` build target runs it and is wired into the `ci` target — so the existing `Build & verify with Zuke` job (which runs `./zuke ci`) covers it with **no workflow change**.

## Notable find

Writing the gate surfaced that **both canonical top examples were themselves broken**: `.executes(() => DenoTasks.lint())` returns `Promise<CommandOutput>`, which isn't assignable to the target-body signature `() => void | Promise<void>`. An agent pasting the skill's first example hit a TS error. Corrected the skill's top example and the parameters guide's first example to the `async () => { await … }` idiom the real `zuke.ts` uses, and fixed the matching example in `AGENTS.md`.

## Seeds

- `skills/zuke-write-build/SKILL.md` top build example (marked + fixed).
- `docs/parameters.md` first example (marked + fixed), extended with a `.required().array()` field so it also **pins the pilot's reported `.array().required()` bug** — the gate fails on the wrong order and passes on the right one.

## Verification

- `deno task ci` green — coverage **98.3% lines / 95.5% branches**; `build/snippets.ts` at **100% line / 100% func / 95.2% branch**.
- `deno run -A zuke.ts snippetsCheck` clean on the real corpus; verified end-to-end that it **fails** with a friendly, source-located error when a marked snippet is broken, and reverts to clean.
- `apiDocsCheck` + `docLint` green (no package source changed → no release bump).
- 10 new unit tests, incl. a real-`deno check` end-to-end case.
- Adversarial review of the extractor/checker in progress; any confirmed finding folded in before merge.