### PR TITLE
chore: docs and CI hygiene sweep

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,6 +20,10 @@ jobs:
           - macos-latest
           - windows-latest
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,6 +268,11 @@ tests/
   integration/            # in-process: real builds via the CLI main() + _harness.ts
   e2e/                    # subprocess: *_e2e.ts + fixtures/ (run by the `integration` target)
 zuke.ts                   # Zuke's own build (runnable example)
+build/                    # reusable helpers behind zuke.ts's targets (docs, publish, snippets, …)
+zuke, zuke.ps1            # bootstrap launchers (install Deno, run the build); zuke.json names the build class
+docs/                     # long-form guides (linked from the README)
+skills/                   # agent skills: zuke-write-build, zuke-setup
+plugins/zuke/             # Claude Code plugin wrapping the skills
 .github/workflows/ci.yml           # PR checks (quality + test-os matrix)
 .github/workflows/integration.yml  # e2e suite on the OS matrix (generated)
 .github/workflows/ai-review.yml    # @zuke/ai PR review

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,9 +12,9 @@ request.
    Conventional Commits (`feat:`, `fix:`, `feat!:` / `BREAKING CHANGE:`).
    Versions are per-package. `bump-minor-pre-major` is enabled, so a package
    still in `0.x` (most tool wrappers) takes a **minor** bump on a breaking
-   change and stays in `0.x`. Packages that have reached 1.0 — `@zuke/core`
-   (1.30.0), plus `@zuke/ai`, `@zuke/console`, `@zuke/otel`, and others — follow
-   full semver: a breaking change bumps the **major** version.
+   change and stays in `0.x`. Packages that have reached 1.0 — `@zuke/core`,
+   plus `@zuke/ai`, `@zuke/console`, `@zuke/otel`, and others — follow full
+   semver: a breaking change bumps the **major** version.
 
 2. **Zuke runs the whole release.** `.github/workflows/release.yml` is itself
    driven by Zuke: on every push to `master` it runs a single command,

--- a/cspell.json
+++ b/cspell.json
@@ -169,7 +169,11 @@
     "zukebox",
     "zukeeper"
   ],
+  "flagWords": [
+    "ponytail"
+  ],
   "ignorePaths": [
+    "cspell.json",
     "cov_profile/",
     "cov.lcov",
     "/llms.txt",

--- a/packages/ai/src/apply.ts
+++ b/packages/ai/src/apply.ts
@@ -147,7 +147,7 @@ export async function applyEdits(
 ): Promise<string[]> {
   const paths = checkEdits(edits, guards);
   // Writes are sequential and not transactional: if a later write fails (e.g. a
-  // permission error), files written earlier stay written. ponytail: no rollback
+  // permission error), files written earlier stay written. caveat: no rollback
   // — the fixer's output is human-reviewed and the run is re-runnable, so atomic
   // multi-file application (temp + rename) isn't worth the complexity here.
   for (let i = 0; i < edits.length; i++) {

--- a/packages/ai/src/commit.ts
+++ b/packages/ai/src/commit.ts
@@ -52,7 +52,7 @@ export async function commitAndPush(options: CommitOptions): Promise<void> {
  * so an ordinary file whose name literally contains ` -> ` isn't mis-parsed.
  * Blank lines are ignored.
  *
- * ponytail: paths git would quote (non-ASCII under `core.quotePath`, or names
+ * caveat: paths git would quote (non-ASCII under `core.quotePath`, or names
  * with control chars) come back quoted and won't stage — fail-safe (the fix is
  * reported failed, nothing wrong is committed); upgrade to `--porcelain=v2 -z`
  * if exotic filenames need committing.

--- a/packages/ai/src/diff.ts
+++ b/packages/ai/src/diff.ts
@@ -29,7 +29,7 @@ function isFileSection(section: string): boolean {
 function sectionPath(section: string): string | undefined {
   const plus = section.match(/^\+\+\+ b\/(.*)$/m);
   if (plus) return plus[1].replace(/\t.*$/, "");
-  // ponytail: this greedy fallback only fires for a section with no `+++` line
+  // caveat: this greedy fallback only fires for a section with no `+++` line
   // (a pure rename/mode change, which carries no content), and mis-splits a path
   // that itself contains ` b/` — a genuinely ambiguous git header. Acceptable:
   // no reviewable body is at stake. Reach for `git diff -z` if it ever matters.

--- a/packages/ai/src/hosts/types.ts
+++ b/packages/ai/src/hosts/types.ts
@@ -55,7 +55,7 @@ export const HEADER = "🤖 **[Zuke](https://zuke.build) AI review**";
 /**
  * Cap on pages followed when scanning for an existing comment. A safety bound so
  * a misbehaving API can't loop forever; 100 pages × 100 per page = 10k comments,
- * far beyond any real PR. (ponytail: fixed cap; the marker is our own recent
+ * far beyond any real PR. (caveat: fixed cap; the marker is our own recent
  * comment, so it is found long before this on any real thread.)
  */
 export const MAX_COMMENT_PAGES = 100;

--- a/packages/core/src/ci_schedule.ts
+++ b/packages/core/src/ci_schedule.ts
@@ -10,7 +10,7 @@
  * zone matches the schedule. A fixed-offset zone (or plain UTC) needs a single
  * cron and no guard.
  *
- * ponytail: on the DST *fall-back* day the ambiguous hour occurs twice, and both
+ * caveat: on the DST *fall-back* day the ambiguous hour occurs twice, and both
  * offsets' UTC crons then satisfy the wall-clock guard — so a schedule inside
  * that one hour can fire twice that day. Suppressing it would need per-cron
  * offset context in the guard; a once-a-year double-run is a smaller cost, so

--- a/packages/core/src/compression.ts
+++ b/packages/core/src/compression.ts
@@ -236,7 +236,7 @@ function isZeroBlock(archive: Uint8Array, offset: number): boolean {
  * `@LongLink` pseudo-entries instead), so `readString` there yields `"ustar "`
  * (trailing space), not `"ustar"`, and the prefix is skipped.
  *
- * ponytail: GNU `@LongLink` (typeflag `'L'`) long names are not reconstructed —
+ * caveat: GNU `@LongLink` (typeflag `'L'`) long names are not reconstructed —
  * the release tarballs Zuke provisions use the ustar prefix split; add LongLink
  * handling if a consumed archive ever needs it.
  */
@@ -355,7 +355,7 @@ async function writeEntries(
       await Deno.remove(path).catch(() => {});
       // Windows requires an explicit link `type`; POSIX ignores it. Runtime bins
       // (Node's bin/npm → npm-cli.js) are file symlinks.
-      // ponytail: assume "file"; a directory symlink in a tar unpacked on Windows
+      // caveat: assume "file"; a directory symlink in a tar unpacked on Windows
       // would get the wrong type — rare (runtimes ship .zip on Windows).
       await Deno.symlink(entry.linkname, path, { type: "file" });
     } else {

--- a/packages/core/src/install.ts
+++ b/packages/core/src/install.ts
@@ -368,7 +368,7 @@ function treeMarkerPath(treeRoot: AbsolutePath): string {
  * satisfied the same checksum, and every declared bin is still present. Unlike a
  * single-binary install, a tree is not re-hashed file-by-file — the pinned
  * archive checksum is the integrity boundary, and a present-bins check catches a
- * half-deleted directory. (ponytail: no whole-tree re-hash; the download's
+ * half-deleted directory. (caveat: no whole-tree re-hash; the download's
  * checksum already gates integrity, re-verify by re-pinning a new checksum.)
  */
 async function cachedTree(

--- a/packages/core/src/mcp/audit.ts
+++ b/packages/core/src/mcp/audit.ts
@@ -4,7 +4,7 @@
  * "../state/store.ts".StateStore} method — it rides the same CAS-append path as
  * any run record, through {@link "../state/writer.ts".RunStateWriter.appendEvent}.
  *
- * ponytail: reuses one run record as the audit stream, so it shows up in
+ * caveat: reuses one run record as the audit stream, so it shows up in
  * `zuke runs list` (and `zuke runs show mcp-audit` prints the trail — handy) and
  * grows unbounded. Fine for the dev-grade filesystem backend. Upgrade path if it
  * grows large or a hosted operator wants it separate: a dedicated store-level

--- a/packages/gh/tests/workflow_test.ts
+++ b/packages/gh/tests/workflow_test.ts
@@ -496,11 +496,12 @@ Deno.test("a persisted record without dispatchedAt (pre-M18) fails fast after ba
   const cv = ctx(state);
   // First observation backfills and persists the anchor at the current time.
   assertEquals(await trigger.isSatisfied(NO_SIGNALS, cv), false);
-  assertEquals(
-    typeof (state.get().githubWorkflow as { dispatchedAt?: number })
-      .dispatchedAt,
-    "number",
-  );
+  const persisted = state.get().githubWorkflow;
+  const dispatchedAt = typeof persisted === "object" && persisted !== null &&
+      !Array.isArray(persisted)
+    ? persisted.dispatchedAt
+    : undefined;
+  assertEquals(typeof dispatchedAt, "number");
   // The anchor is now stable, so advancing past the window fails fast (it would
   // never elapse if each resume re-stamped the anchor).
   c.advance(61_000);

--- a/tests/e2e/mcp_e2e.ts
+++ b/tests/e2e/mcp_e2e.ts
@@ -21,7 +21,7 @@ import {
 
 const FIXTURE = new URL("./fixtures/gate_build.ts", import.meta.url);
 // An OS-assigned free port instead of a fixed constant, removing the port
-// collision-flake class. ponytail: a tiny bind→close→rebind race window
+// collision-flake class. caveat: a tiny bind→close→rebind race window
 // remains; the race-free fix is to bind `:0` in the server and report the
 // assigned port, which needs a core CLI change and is out of scope here.
 const PORT = freePort();

--- a/tests/e2e/registry_mcp_e2e.ts
+++ b/tests/e2e/registry_mcp_e2e.ts
@@ -17,7 +17,7 @@ import {
 
 const FIXTURE = new URL("./fixtures/discoverable_build.ts", import.meta.url);
 // An OS-assigned free port instead of a fixed constant, removing the port
-// collision-flake class. ponytail: a tiny bind→close→rebind race window
+// collision-flake class. caveat: a tiny bind→close→rebind race window
 // remains; the race-free fix is to bind `:0` in the server and report the
 // assigned port, which needs a core CLI change and is out of scope here.
 const PORT = freePort();

--- a/zuke.ts
+++ b/zuke.ts
@@ -195,6 +195,18 @@ class ZukeBuild extends Build {
         matrix: { os: ["ubuntu-latest", "macos-latest", "windows-latest"] },
         steps: [
           {
+            // Audit runner egress on the e2e matrix, matching every other
+            // workflow (only secret-bearing `ci.yml` blocks) and SECURITY.md's
+            // stated posture. This job carries no secrets and a read-only token,
+            // so `audit` — observe, don't block — is the right trade-off: it
+            // records outbound calls without risking a false-block of the
+            // cross-OS Deno bootstrap.
+            name: "Harden the runner",
+            uses:
+              "step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920",
+            with: { "egress-policy": "audit" },
+          },
+          {
             name: "Checkout",
             uses: "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
             with: { "persist-credentials": "false" },


### PR DESCRIPTION
Remediation V2 **PR 5** — the low-risk hygiene tail. Comment/config/docs only; no logic changes, so no release bump.

## Included (5 of 6 plan items)

- **5.1 — `ponytail:` → `caveat:`** across `@zuke/ai` + `@zuke/core` sources and the two e2e tests (11 sites, comment-only). Added `"flagWords": ["ponytail"]` to `cspell.json` so the token can't creep back; `cspell.json` lists itself under `ignorePaths` so the entry doesn't self-trip. Verified the guard fires on a planted token and stays clean otherwise.
- **5.2 — harden-runner on `integration.yml`.** Added `step-security/harden-runner` (SHA-pinned, `egress-policy: audit`) as the first step of the `integrationCi` pipeline in `zuke.ts`, regenerated the YAML, and confirmed `generate-ci --check` is green. `audit` matches every workflow except the secret-bearing `ci.yml` (which blocks) and the posture SECURITY.md describes.
- **5.4 — `as`-cast removed.** The `state.get().githubWorkflow as { … }` cast in `packages/gh/tests/workflow_test.ts` is now a control-flow type guard (no `as`, same assertion).
- **5.5 — AGENTS.md layout** completed with `build/`, `docs/`, `skills/`, `plugins/zuke/`, and the `zuke`/`zuke.ps1`/`zuke.json` launchers (each verified to exist).
- **5.6 — RELEASING.md** stale inline `(1.30.0)` version removed from the prose claim.

## Deferred (with reason): 5.3 — `.gitignore` dev-local entries

The plan proposed moving `docs/superpowers/`, `plans/`, `.omc/` out of the tracked `.gitignore` into `.git/info/exclude`. Attempting it **regresses the documented local `deno task ci` gate**: cspell (`useGitignore: true`) honors `.gitignore` but **not** `.git/info/exclude`, so it would then descend into those scratch dirs and fail spell-check (confirmed: `deno task spell` → 40 issues in `plans/`, including the now-forbidden `ponytail`). Adding them to `cspell.json` instead only relocates the same tooling-specific clutter the item set out to remove. CI is unaffected (a clean checkout has none of these dirs), so the net change is a pure local-dev regression for a 3-line declutter — not worth it. Entries stay put.

## Verification

- `deno task ci` fully green (fmt, lint, spell, check, cov 98.3%/95.5%).
- `deno run -A zuke.ts generate-ci --check` → exit 0 (YAML in sync).
- 5-dimension adversarial-verification workflow run over the sweep: harden-runner and the type-guard/docs checks clean; it independently surfaced the 5.3/cspell interaction above (which drove the deferral) and confirmed the src changes are comment-only (no spurious release). One minor note it raised — a `core-v1.30.0` in RELEASING.md line 30 — is a legitimate *tag-format example* (`<component>-v<version>`), not a drift-prone version claim, so left as-is.