### PR TITLE
fix: raise the @zuke/core floor to 1.31.0 in wrappers using SubcommandSettings

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -580,7 +580,7 @@
       },
       "packages/claude": {
         "dependencies": [
-          "jsr:@zuke/core@^1.25.0"
+          "jsr:@zuke/core@^1.31.0"
         ]
       },
       "packages/cmd": {
@@ -595,7 +595,7 @@
       },
       "packages/codex": {
         "dependencies": [
-          "jsr:@zuke/core@^1.25.0"
+          "jsr:@zuke/core@^1.31.0"
         ]
       },
       "packages/console": {
@@ -650,17 +650,17 @@
       },
       "packages/gcloud": {
         "dependencies": [
-          "jsr:@zuke/core@^1.25.0"
+          "jsr:@zuke/core@^1.31.0"
         ]
       },
       "packages/gemini": {
         "dependencies": [
-          "jsr:@zuke/core@^1.25.0"
+          "jsr:@zuke/core@^1.31.0"
         ]
       },
       "packages/gh": {
         "dependencies": [
-          "jsr:@zuke/core@^1.25.0"
+          "jsr:@zuke/core@^1.31.0"
         ]
       },
       "packages/git": {

--- a/packages/claude/deno.json
+++ b/packages/claude/deno.json
@@ -7,7 +7,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1.25.0"
+    "@zuke/core": "jsr:@zuke/core@^1.31.0"
   },
   "publish": {
     "exclude": [

--- a/packages/codex/deno.json
+++ b/packages/codex/deno.json
@@ -7,7 +7,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1.25.0"
+    "@zuke/core": "jsr:@zuke/core@^1.31.0"
   },
   "publish": {
     "exclude": [

--- a/packages/gcloud/deno.json
+++ b/packages/gcloud/deno.json
@@ -7,7 +7,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1.25.0"
+    "@zuke/core": "jsr:@zuke/core@^1.31.0"
   },
   "publish": {
     "exclude": [

--- a/packages/gemini/deno.json
+++ b/packages/gemini/deno.json
@@ -7,7 +7,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1.25.0"
+    "@zuke/core": "jsr:@zuke/core@^1.31.0"
   },
   "publish": {
     "exclude": [

--- a/packages/gh/deno.json
+++ b/packages/gh/deno.json
@@ -7,7 +7,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1.25.0"
+    "@zuke/core": "jsr:@zuke/core@^1.31.0"
   },
   "publish": {
     "exclude": [


### PR DESCRIPTION
Follow-up to #258 (the deferred version-floor item).

`claude`, `codex`, `gcloud`, `gemini`, `gh` now import `SubcommandSettings`, new in `@zuke/core@1.31.0`, but their `deno.json` still declared `@zuke/core@^1.25.0` — which doesn't cover that symbol. #258 couldn't raise it: the Deno workspace only resolves the local `@zuke/core` member when its version satisfies the pin, and core was still 1.30.4 then. Now that **core 1.31.0 has shipped**, `^1.31.0` resolves locally, so this raises the five wrappers' floor to match the symbol they use — closing the under-declared dependency the adversarial pass on #258 flagged.

Only these five change (the other 45 wrappers don't use `SubcommandSettings`, so their `^1.25.0` stays accurate).

## Verification
- `deno task check` resolves (previously impossible with `^1.31.0` until core 1.31.0 existed).
- `deno task ci` green (fmt, lint, spell, check, cov).
- `fix:` title so the corrected floor republishes to consumers.