### PR TITLE
fix(core): close a leaf-symlink zip-slip in tar extraction and cache ancestor lstats

### DIFF
--- a/packages/core/src/compression.ts
+++ b/packages/core/src/compression.ts
@@ -424,15 +424,24 @@ function stripComponents(name: string, n: number): string {
  * ancestor directory and rejects if one is a symlink — catching every alias
  * because it resolves the true inode, and touching nothing outside `destDir`
  * (it never `mkdir`s or writes through the symlink it finds).
+ *
+ * `realDirs` caches the ancestors already confirmed to be real directories so
+ * a deep tree isn't re-`lstat`ed once per file (thousands of redundant calls on
+ * a real runtime tarball). It is a cache of a *live* invariant, so the caller
+ * must evict a path from it the moment that path stops being a plain directory
+ * — i.e. when a symlink or file is created there — or a later entry could skip
+ * the check on a path that has since become a symlink.
  */
 async function assertNoSymlinkAncestor(
   root: string,
   name: string,
+  realDirs: Set<string>,
 ): Promise<void> {
   const parts = name.replace(/\/+$/, "").split("/").slice(0, -1);
   let current = root;
   for (const part of parts) {
     current = `${current}/${part}`;
+    if (realDirs.has(current)) continue;
     let info: Deno.FileInfo;
     try {
       info = await Deno.lstat(current);
@@ -446,17 +455,20 @@ async function assertNoSymlinkAncestor(
           `would redirect it out of the destination.`,
       );
     }
+    if (info.isDirectory) realDirs.add(current);
   }
 }
 
 /**
  * Write each archive `entry` under `destDir`, creating parent directories as
  * needed. Every entry name is validated first ({@link assertSafeEntryName}), a
- * symlink's target is validated ({@link assertSafeLinkTarget}), and no entry is
- * written through an ancestor symlink ({@link assertNoSymlinkAncestor}), so a
- * malicious archive cannot plant, point, or chain its way to a file outside
- * `destDir` (a "zip slip"). With {@link ExtractOptions.strip}, leading path
- * components are dropped and any entry left with an empty path is skipped.
+ * symlink's target is validated ({@link assertSafeLinkTarget}), no entry is
+ * written through an ancestor symlink ({@link assertNoSymlinkAncestor}), and a
+ * pre-existing symlink at an entry's own path is removed before the write — so a
+ * malicious archive can neither plant, point, nor chain its way (nor follow a
+ * symlink left in a reused `destDir`) to a file outside `destDir` (a "zip
+ * slip"). With {@link ExtractOptions.strip}, leading path components are dropped
+ * and any entry left with an empty path is skipped.
  */
 async function writeEntries(
   entries: TarEntry[],
@@ -467,10 +479,11 @@ async function writeEntries(
   for (const entry of entries) assertSafeEntryName(entry.name);
   const root = String(destDir);
   await Deno.mkdir(root, { recursive: true });
+  const realDirs = new Set<string>([root]);
   for (const entry of entries) {
     const name = stripComponents(entry.name, strip);
     if (name === "") continue; // fully stripped (e.g. the top-level directory)
-    await assertNoSymlinkAncestor(root, name);
+    await assertNoSymlinkAncestor(root, name, realDirs);
     const path = `${root}/${name}`;
     if (name.endsWith("/")) {
       // A directory entry (typeflag '5', or old tar's trailing-slash "file"):
@@ -481,19 +494,25 @@ async function writeEntries(
       const dirPath = path.replace(/\/+$/, "");
       await Deno.remove(dirPath).catch(() => {});
       await Deno.mkdir(dirPath, { recursive: true });
+      realDirs.add(dirPath);
       continue;
     }
     const slash = path.lastIndexOf("/");
     if (slash !== -1) {
       await Deno.mkdir(path.slice(0, slash), { recursive: true });
+      realDirs.add(path.slice(0, slash));
     }
+    // Remove any node already at the leaf before writing. This is not only
+    // "last one wins" for a duplicate entry: it unlinks a symlink sitting at the
+    // path — one this archive planted, or one left in a reused `destDir` — so
+    // the write lands at the leaf itself and cannot follow the link outside
+    // `destDir`. `Deno.remove` on a symlink drops the link, not its target.
+    await Deno.remove(path).catch(() => {});
+    // The path is about to become a file or symlink, so it is no longer a plain
+    // directory the ancestor check may trust (an empty dir can be replaced here).
+    realDirs.delete(path);
     if (entry.linkname !== undefined) {
       assertSafeLinkTarget(name, entry.linkname);
-      // `Deno.symlink` throws if the path already exists, whereas a file write
-      // silently overwrites; remove any prior entry first so a duplicate name in
-      // a malformed archive is "last one wins" (like a file) rather than a raw
-      // AlreadyExists crash.
-      await Deno.remove(path).catch(() => {});
       // Windows requires an explicit link `type`; POSIX ignores it. Runtime bins
       // (Node's bin/npm → npm-cli.js) are file symlinks.
       // caveat: assume "file"; a directory symlink in a tar unpacked on Windows

--- a/packages/core/tests/compression_test.ts
+++ b/packages/core/tests/compression_test.ts
@@ -408,6 +408,59 @@ Deno.test("extractTarGzip contains a symlink chain hidden behind case variation"
   ], "pwned.txt");
 });
 
+Deno.test("extractTarGzip does not follow a leaf symlink when a later file entry has the same name", async () => {
+  if (Deno.build.os === "windows") return; // symlink creation is privileged there
+  const dir = await Deno.makeTempDir();
+  try {
+    // A symlink planted AT the leaf (target lexically in-bounds via one hop),
+    // then a file of the same name: without unlinking the leaf first, writeFile
+    // follows the symlink and lands OUTSIDE destDir.
+    const archive = `${dir}/evil.tar.gz`;
+    await Deno.writeFile(
+      archive,
+      await gzip(tar([
+        { name: "d/up", data: new Uint8Array(0), linkname: ".." },
+        { name: "d/pwn", data: new Uint8Array(0), linkname: "up/../pwned" },
+        { name: "d/pwn", data: enc("PWNED") },
+      ])),
+    );
+    await extractTarGzip(archive, `${dir}/out`);
+    // Nothing landed outside the destination, and the file wrote at its own path.
+    assertEquals(
+      await Deno.stat(`${dir}/pwned`).then(() => true).catch(() => false),
+      false,
+    );
+    const leaf = await Deno.lstat(`${dir}/out/d/pwn`);
+    assertEquals(leaf.isFile, true); // a real file now, not the symlink
+    assertEquals(await Deno.readTextFile(`${dir}/out/d/pwn`), "PWNED");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("extractTarGzip does not follow a symlink left in a reused destination", async () => {
+  if (Deno.build.os === "windows") return; // symlink creation is privileged there
+  const dir = await Deno.makeTempDir();
+  try {
+    // A reused destDir already holding a symlink that points outside it; a plain
+    // file entry of that name must overwrite the link in place, not through it.
+    const out = `${dir}/out`;
+    await Deno.mkdir(out, { recursive: true });
+    await Deno.writeTextFile(`${dir}/secret.txt`, "ORIGINAL");
+    await Deno.symlink(`${dir}/secret.txt`, `${out}/ext`, { type: "file" });
+    const archive = `${dir}/a.tar.gz`;
+    await Deno.writeFile(
+      archive,
+      await gzip(tar([{ name: "ext", data: enc("SAFE") }])),
+    );
+    await extractTarGzip(archive, out);
+    assertEquals(await Deno.readTextFile(`${dir}/secret.txt`), "ORIGINAL"); // untouched
+    assertEquals(await Deno.readTextFile(`${out}/ext`), "SAFE"); // wrote in place
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
 Deno.test("extractTarGzip lets a directory entry replace an existing file at that path", async () => {
   if (Deno.build.os === "windows") return; // symlink-adjacent edge; keep POSIX
   const dir = await Deno.makeTempDir();


### PR DESCRIPTION
# Summary

Follow-up to #262 (already merged). A post-merge adversarial review pass found the symlink-escape guard added in #262 still had a hole, plus a performance regression it introduced. This PR closes both. Opened as a new PR because #262 was already merged.

## Changes

### Leaf-symlink zip-slip (security)

`assertNoSymlinkAncestor` only checked an entry's **ancestor directories**, and the file-write branch of `writeEntries` called `Deno.writeFile(path, data)` directly. So two shapes still escaped `destDir`, both reproduced writing a file outside the destination:

- A symlink planted **at a leaf path** whose target is lexically in-bounds via one hop (`d/up -> ..`, then `d/pwn -> up/../pwned`), followed by a **file entry of the same name** (`d/pwn`) — `writeFile` followed the leaf symlink out of `destDir`.
- A symlink left in a **reused `destDir`** that a plain file entry then wrote through.

Fix: every leaf is now `Deno.remove`'d before the write (removing a symlink unlinks the link, not its target), so the write always lands at the leaf itself. This generalizes the pre-remove the symlink branch already did.

### Ancestor-`lstat` caching (performance)

`assertNoSymlinkAncestor` re-`lstat`'d shared ancestor prefixes once per file — ~46,700 `lstat` calls on the real Node tarball (~48% of extract time). It now caches directories confirmed real, **evicting a path the instant a symlink or file is created there** so the check can never be skipped on a path that has since become a symlink (the empty-dir → symlink replacement that would otherwise re-open the escape). Redundant `lstat`s on the Node tarball drop to zero.

## Breaking changes

None. Behaviour changes only for malformed/malicious archives (now contained) and reused destinations holding a stale symlink.

## Testing

- New regression tests: leaf-symlink + same-name file, and a symlink left in a reused `destDir` — both proven to write in place, not through the link.
- `deno task ci` green (fmt, lint, spell, check, coverage gate 95%+).
- Re-ran the review's five proof-of-concept exploits (dot-segment, case, mixed-case chain, leaf-symlink, reused-dir) — all contained, nothing written outside `destDir`.
- Real `node-v22.17.1-linux-x64` tarball still extracts to a tree identical to system `tar` (4810 paths), now with **0** redundant `lstat` calls.