### PR TITLE
fix(core): clone forEach builders and expire stale fs-store mutexes

### DIFF
--- a/packages/core/src/cancel.ts
+++ b/packages/core/src/cancel.ts
@@ -30,12 +30,13 @@ import type { Reporter } from "./executor.ts";
 import { type OrderingEdge, planGraph } from "./graph.ts";
 import { discoverParameters, resolveParameters } from "./params.ts";
 import { Redactor } from "./redact.ts";
-import type {
-  ForEachSpec,
-  JsonValue,
-  TargetBuilder,
-  TargetContext,
-  TargetStateHandle,
+import {
+  cloneTarget,
+  type ForEachSpec,
+  type JsonValue,
+  type TargetBuilder,
+  type TargetContext,
+  type TargetStateHandle,
 } from "./target.ts";
 import { absolutePath } from "./path.ts";
 import { findConfigDir, pathExists } from "./config.ts";
@@ -380,11 +381,15 @@ function collectForEachInto(
     return;
   }
   for (const { key, stages } of items) {
-    for (const [stage, sub] of Object.entries(stages)) {
+    for (const [stage, declared] of Object.entries(stages)) {
       const subName = `${parentName}[${key}].${stage}`;
-      // Name the sub as the executor does, so a nested fan-out reconstructs its
+      // Name a clone, as the executor does, so a nested fan-out reconstructs its
       // grandchildren under the same `parent[key].stage[innerKey].innerStage`
-      // names.
+      // names — without renaming the factory's own builder. The factory may hand
+      // back a builder the build also declares as a target, and renaming it in
+      // place would make the rest of this walk look that target's compensation
+      // decision up under the sub-target's name.
+      const sub = cloneTarget(declared);
       sub.name_ = subName;
       materialised.add(subName);
       // A stage that is itself a fan-out: recurse so nested items' onCancel runs.

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -25,6 +25,7 @@ import { withAmbientEcho } from "./ambient_echo.ts";
 import { type Style, type TargetReport, targetWaitFooter } from "./report.ts";
 import type { Renderer } from "./renderer.ts";
 import {
+  cloneTarget,
   type ForEachItem,
   ForEachSettings,
   type ForEachSpec,
@@ -409,7 +410,11 @@ async function runForEachTarget(
     items = spec.materialize();
     for (const { key, stages } of items) {
       let prev: TargetBuilder | undefined;
-      for (const [stage, sub] of Object.entries(stages)) {
+      for (const [stage, declared] of Object.entries(stages)) {
+        // Work on a clone: the factory may hand back the same builder for every
+        // item (or on every run of a long-lived process), and renaming/chaining
+        // it in place would corrupt that object and pile up duplicate edges.
+        const sub = cloneTarget(declared);
         sub.name_ = `${name}[${key}].${stage}`;
         // Isolating item failures means a failed stage stays lenient: its
         // siblings keep running, only this item's later stages are blocked.

--- a/packages/core/src/state/fs_store.ts
+++ b/packages/core/src/state/fs_store.ts
@@ -50,6 +50,15 @@ const LOCK_ATTEMPTS = 100;
 const LOCK_DELAY_MS = 10;
 
 /**
+ * How old a mutex marker may get before a waiter treats it as abandoned and
+ * takes it over — the same 30s backstop a cross-run lock's TTL gives a crashed
+ * holder ({@link "./cancel_lock.ts".CANCEL_LOCK_TTL_MS}). Two orders of
+ * magnitude above the ~1s spin budget above, so a live holder is never stolen
+ * from, yet a killed one cannot wedge every later writer for good.
+ */
+const MUTEX_TTL_MS = 30_000;
+
+/**
  * A {@link StateStore} that writes one `<id>.json` file per run under a
  * directory.
  *
@@ -239,7 +248,9 @@ export class FileSystemStateStore implements StateStore {
   /**
    * Hold the exclusive `marker` file (spinning briefly on contention) for the
    * duration of `fn`, then release it. `subject` names what is being guarded,
-   * for the error raised if the marker cannot be taken.
+   * for the error raised if the marker cannot be taken. A marker whose holder
+   * was killed is reclaimed once it passes {@link MUTEX_TTL_MS}, so a single
+   * crashed writer cannot wedge the directory for every later one.
    */
   async #withMutex<T>(
     marker: string,
@@ -248,11 +259,23 @@ export class FileSystemStateStore implements StateStore {
   ): Promise<T> {
     for (let attempt = 0; attempt < LOCK_ATTEMPTS; attempt++) {
       if (await this.#host.createExclusive(marker)) {
+        // Stamp the marker with the acquire time so a later waiter can tell a
+        // live holder from one that died holding it. Written after the exclusive
+        // create, so the stamp never weakens the create's mutual exclusion.
+        await this.#host.writeText(marker, String(this.#host.now()));
         try {
           return await fn();
         } finally {
           await this.#host.remove(marker);
         }
+      }
+      if (await this.#markerExpired(marker)) {
+        // Remove, then re-create exclusively on the next attempt: the same
+        // compare-and-swap the marker already relies on, so two waiters racing a
+        // takeover still end with exactly one holder. Losing that race is
+        // success, not an error — `remove` treats an already-gone marker as done.
+        await this.#host.remove(marker);
+        continue;
       }
       await delay(LOCK_DELAY_MS);
     }
@@ -260,6 +283,21 @@ export class FileSystemStateStore implements StateStore {
       `state: could not acquire the mutex for ${subject} — ` +
         `a stale ${marker} may need removing.`,
     );
+  }
+
+  /**
+   * Whether `marker` was acquired longer ago than {@link MUTEX_TTL_MS} — its
+   * holder is gone and left it behind. A marker with no readable stamp counts as
+   * live: a holder killed in the instant between creating and stamping one is
+   * indistinguishable from a holder still writing its stamp, so the spin ends in
+   * the error naming the file rather than a waiter stealing a marker that may
+   * still be in use.
+   */
+  async #markerExpired(marker: string): Promise<boolean> {
+    const stamp = await this.#host.readText(marker);
+    // Released while we were spinning, or never stamped: not ours to reclaim.
+    if (stamp === null || !/^\d+$/.test(stamp)) return false;
+    return this.#host.now() - Number(stamp) > MUTEX_TTL_MS;
   }
 }
 

--- a/packages/core/src/state/fs_store.ts
+++ b/packages/core/src/state/fs_store.ts
@@ -249,8 +249,10 @@ export class FileSystemStateStore implements StateStore {
    * Hold the exclusive `marker` file (spinning briefly on contention) for the
    * duration of `fn`, then release it. `subject` names what is being guarded,
    * for the error raised if the marker cannot be taken. A marker whose holder
-   * was killed is reclaimed once it passes {@link MUTEX_TTL_MS}, so a single
-   * crashed writer cannot wedge the directory for every later one.
+   * was killed is reclaimed once it passes {@link MUTEX_TTL_MS} — or, when it
+   * carries no stamp to age, once the spin has run long enough to rule out a
+   * holder still writing one — so a single crashed writer cannot wedge the
+   * directory for every later one.
    */
   async #withMutex<T>(
     marker: string,
@@ -259,23 +261,27 @@ export class FileSystemStateStore implements StateStore {
   ): Promise<T> {
     for (let attempt = 0; attempt < LOCK_ATTEMPTS; attempt++) {
       if (await this.#host.createExclusive(marker)) {
-        // Stamp the marker with the acquire time so a later waiter can tell a
-        // live holder from one that died holding it. Written after the exclusive
-        // create, so the stamp never weakens the create's mutual exclusion.
-        await this.#host.writeText(marker, String(this.#host.now()));
         try {
+          // Stamp the marker with the acquire time so a later waiter can tell a
+          // live holder from one that died holding it. Inside the `try`, so a
+          // rejected write releases the marker instead of leaving an unstamped
+          // one behind — which would read as a live holder for good.
+          await this.#host.writeText(marker, String(this.#host.now()));
           return await fn();
         } finally {
           await this.#host.remove(marker);
         }
       }
-      if (await this.#markerExpired(marker)) {
-        // Remove, then re-create exclusively on the next attempt: the same
-        // compare-and-swap the marker already relies on, so two waiters racing a
-        // takeover still end with exactly one holder. Losing that race is
-        // success, not an error — `remove` treats an already-gone marker as done.
-        await this.#host.remove(marker);
-        continue;
+      // Half the spin budget is far longer than the microseconds between a
+      // holder's create and its stamp, so past that point an unstamped marker is
+      // a leftover — including one from a zuke that never stamped at all — and
+      // may be reclaimed. Earlier than that, treat it as a holder mid-stamp.
+      const unstampedIsStale = attempt >= LOCK_ATTEMPTS / 2;
+      if (
+        await this.#markerExpired(marker, unstampedIsStale) &&
+        await this.#steal(marker)
+      ) {
+        continue; // reclaimed: retry the exclusive create straight away
       }
       await delay(LOCK_DELAY_MS);
     }
@@ -286,17 +292,40 @@ export class FileSystemStateStore implements StateStore {
   }
 
   /**
-   * Whether `marker` was acquired longer ago than {@link MUTEX_TTL_MS} — its
-   * holder is gone and left it behind. A marker with no readable stamp counts as
-   * live: a holder killed in the instant between creating and stamping one is
-   * indistinguishable from a holder still writing its stamp, so the spin ends in
-   * the error naming the file rather than a waiter stealing a marker that may
-   * still be in use.
+   * Reclaim the abandoned `marker`, reporting whether this caller was the one
+   * that removed it.
+   *
+   * The marker is moved aside with an atomic rename before being deleted. A bare
+   * `remove` is not a compare-and-swap: two waiters that both read the same stale
+   * stamp would both delete a marker, the second deleting the one the first had
+   * just taken, and both would then be inside the critical section. Only one
+   * rename can find the marker, so at most one waiter reclaims it; the loser gets
+   * `false` and goes back to spinning, where it re-reads the new holder's stamp.
    */
-  async #markerExpired(marker: string): Promise<boolean> {
+  async #steal(marker: string): Promise<boolean> {
+    const stolen = `${marker}.steal-${crypto.randomUUID()}`;
+    try {
+      await this.#host.rename(marker, stolen);
+    } catch {
+      return false; // another waiter reclaimed it first, or the holder released
+    }
+    await this.#host.remove(stolen);
+    return true;
+  }
+
+  /**
+   * Whether `marker` was acquired longer ago than {@link MUTEX_TTL_MS} — its
+   * holder is gone and left it behind. A marker with no readable numeric stamp
+   * has no age to compare, so `unstampedIsStale` decides it: the caller passes
+   * `false` while a holder could still be writing its stamp, and `true` once it
+   * has spun long enough that no live holder could still be in that window.
+   */
+  async #markerExpired(
+    marker: string,
+    unstampedIsStale: boolean,
+  ): Promise<boolean> {
     const stamp = await this.#host.readText(marker);
-    // Released while we were spinning, or never stamped: not ours to reclaim.
-    if (stamp === null || !/^\d+$/.test(stamp)) return false;
+    if (stamp === null || !/^\d+$/.test(stamp)) return unstampedIsStale;
     return this.#host.now() - Number(stamp) > MUTEX_TTL_MS;
   }
 }

--- a/packages/core/src/target.ts
+++ b/packages/core/src/target.ts
@@ -904,6 +904,29 @@ export class TargetBuilder {
 }
 
 /**
+ * Shallow-copy a {@link TargetBuilder} so the copy can be renamed and re-wired
+ * without touching the original. Array fields become fresh arrays; everything
+ * else (the body, the group, the settings lambdas) is shared — the copy is the
+ * same target, with its own identity.
+ *
+ * Used by the fan-out materialiser: a `.forEach(...)` factory may legitimately
+ * return the same builder for every item (a memoised or module-level pipeline),
+ * and naming/chaining it in place would corrupt that object and accumulate
+ * duplicate dependency edges across runs. Module-internal: never re-exported
+ * from `mod.ts`.
+ */
+export function cloneTarget(source: TargetBuilder): TargetBuilder {
+  const clone = Object.assign(new TargetBuilder(), source);
+  // `Object.assign` copies array *references*; give the clone its own copies so
+  // pushing a dependency onto it can never reach back into the original.
+  for (const key of Object.keys(clone)) {
+    const value: unknown = Reflect.get(clone, key);
+    if (Array.isArray(value)) Reflect.set(clone, key, [...value]);
+  }
+  return clone;
+}
+
+/**
  * A configured target. Alias of {@link TargetBuilder} — the same object both
  * builds and represents the target. Exposed as `Target` for use in signatures.
  */

--- a/packages/core/tests/cancel_test.ts
+++ b/packages/core/tests/cancel_test.ts
@@ -982,6 +982,40 @@ Deno.test("cancel runs a nested fan-out item's onCancel without false-warning", 
   );
 });
 
+Deno.test("a declared target reused as a fan-out stage keeps its own name at cancel", async () => {
+  const undone: string[] = [];
+  class CD extends Build {
+    // `seed` is both a target of its own and the factory's stage builder, which a
+    // build is free to do. Re-materialising the fan-out must not rename it: the
+    // walk reaches `seed` afterwards and looks its compensation decision up by
+    // name.
+    seed = target().executes(() => {}).onCancel(() =>
+      target().executes(() => void undone.push("seed"))
+    );
+    deployBatch = target().forEach(() => ["a"], () => ({ seed: this.seed }));
+  }
+  const build = new CD();
+  discoverTargets(build);
+  // `seed` itself succeeded; the fan-out's only item failed — which is why the
+  // run is being cancelled — so the item has nothing to undo.
+  const record = craftRecord("deployBatch", {
+    "seed": { status: "succeeded", meta: {} },
+    "deployBatch[a].seed": { status: "failed", meta: {} },
+  });
+  const outcome = await runCompensations(
+    [build.seed, build.deployBatch],
+    record,
+    {
+      runId: "run",
+      signals: new Map(),
+      reporter: capturingReporter().reporter,
+    },
+  );
+  assertEquals(build.seed.name_, "seed"); // the factory's builder is untouched
+  assertEquals(undone, ["seed"]); // …so its own compensation still runs
+  assertEquals(outcome.attempts.map((a) => a.forTarget), ["seed"]);
+});
+
 Deno.test("a fan-out parent's own onCancel runs after its item compensations", async () => {
   const seq: string[] = [];
   class CD extends Build {

--- a/packages/core/tests/foreach_test.ts
+++ b/packages/core/tests/foreach_test.ts
@@ -327,6 +327,72 @@ Deno.test("a throwing forEach items thunk settles the run record to failed", asy
   });
 });
 
+Deno.test("forEach clones the factory's builders instead of mutating them", async () => {
+  // A factory is free to hand back the same builder objects for every item (a
+  // memoised or module-level pipeline). Materialising must not rename or re-wire
+  // those objects: the fan-out works on clones, so the factory's builders are
+  // untouched and repeated runs add no duplicate dependency edges.
+  const log: string[] = [];
+  const checks = target().executes(() => void log.push("checks"));
+  const deploy = target().executes(() => void log.push("deploy"));
+  class Batch extends Build {
+    batch = target().forEach(
+      () => ["a", "b"],
+      () => ({ checks, deploy }),
+      (s) => s.concurrency(1),
+    );
+  }
+
+  // Twice, as a long-lived MCP server would run the same build again.
+  for (const run of [1, 2]) {
+    log.length = 0;
+    const b = new Batch();
+    discoverTargets(b);
+    const { lines, reporter } = recorder();
+    const result = await execute(b, b.batch, { reporter, github: false });
+    assertEquals(result.ok, true, `run ${run} failed`);
+
+    // Every item ran every stage, under its own name.
+    assertEquals(log, ["checks", "deploy", "checks", "deploy"]);
+    const out = lines.join("\n");
+    for (
+      const name of ["batch[a].checks", "batch[a].deploy", "batch[b].checks"]
+    ) {
+      assertStringIncludes(out, name);
+    }
+    assertStringIncludes(out, "batch[b].deploy");
+
+    // The factory's own objects are pristine after the run.
+    assertEquals(checks.name_, undefined);
+    assertEquals(deploy.name_, undefined);
+    assertEquals(deploy.dependsOn_.length, 0);
+    assertEquals(deploy.proceedAfterFailure_, false);
+  }
+});
+
+Deno.test("forEach clones carry the stage's own configuration", async () => {
+  // The clone must behave like the original: its body, retries and lenient flag
+  // all come across, so a reused stage still retries and isolates as declared.
+  let attempts = 0;
+  const flaky = target()
+    .retry(1)
+    .proceedAfterFailure()
+    .executes(() => {
+      attempts++;
+      if (attempts === 1) throw new Error("first attempt");
+    });
+  class Batch extends Build {
+    batch = target().forEach(() => ["only"], () => ({ flaky }));
+  }
+  const b = new Batch();
+  discoverTargets(b);
+  const result = await execute(b, b.batch, { silent: true });
+  assertEquals(result.ok, true);
+  assertEquals(attempts, 2); // retried, not failed outright
+  assertEquals(flaky.retries_, 1);
+  assertEquals(flaky.proceedAfterFailure_, true);
+});
+
 Deno.test("--list and graph annotate a fan-out target", () => {
   class Batch extends Build {
     plain = target().description("plain").executes(() => {});

--- a/packages/core/tests/state_test.ts
+++ b/packages/core/tests/state_test.ts
@@ -73,11 +73,18 @@ class FakeStateHost implements StateHost {
     return Promise.resolve();
   }
   rename(from: string, to: string): Promise<void> {
+    // A real rename rejects when the source is gone, and moves an exclusively
+    // created (empty) file just as it moves one with content — the store relies
+    // on both when it reclaims an abandoned mutex marker.
     const content = this.files.get(from);
+    if (content === undefined && !this.locks.has(from)) {
+      return Promise.reject(new Deno.errors.NotFound(`rename ${from}`));
+    }
     if (content !== undefined) {
       this.files.set(to, content);
       this.files.delete(from);
     }
+    if (this.locks.delete(from)) this.locks.add(to);
     return Promise.resolve();
   }
   createExclusive(path: string): Promise<boolean> {
@@ -898,13 +905,16 @@ Deno.test("defaultStateHost performs real filesystem effects", async () => {
 
 Deno.test("FileSystemStateStore errors when a lock is permanently held", async () => {
   const host = new FakeStateHost();
-  host.locks.add("/runs/run-1.json.lock"); // never released
+  const marker = "/runs/run-1.json.lock";
+  host.locks.add(marker);
+  host.files.set(marker, String(host.time)); // a live holder, never released
   const store = new FileSystemStateStore("/runs", host);
   await assertRejects(
     () => store.putRun(sampleRecord(), null),
     Error,
     "could not acquire",
   );
+  assertEquals(host.locks.has(marker), true); // never stolen from a live holder
 });
 
 Deno.test("FileSystemStateStore takes over a mutex marker left past its TTL", async () => {
@@ -923,23 +933,85 @@ Deno.test("FileSystemStateStore takes over a mutex marker left past its TTL", as
   assertEquals(host.files.get("/runs/run-1.json") === undefined, false);
 });
 
-Deno.test("FileSystemStateStore never steals a live mutex marker", async () => {
-  // A marker stamped just now belongs to a live holder; one with no readable
-  // stamp (a holder killed between creating and stamping it) is treated the same
-  // way. Both keep the existing behaviour: spin, then fail with guidance.
-  for (const stamp of [String(new FakeStateHost().time), ""]) {
+Deno.test("FileSystemStateStore releases a mutex marker it could not stamp", async () => {
+  // The stamp write lives inside the marker's `try`, so a filesystem that
+  // rejects it (a full disk, a scanner holding the freshly created file) still
+  // releases the marker. Leaving an unstamped one behind would wedge the next
+  // writer instead.
+  const marker = "/runs/run-1.json.lock";
+  class FlakyStampHost extends FakeStateHost {
+    failStamp = true;
+    override writeText(path: string, content: string): Promise<void> {
+      if (path === marker && this.failStamp) {
+        this.failStamp = false;
+        return Promise.reject(new Error("ENOSPC: no space left on device"));
+      }
+      return super.writeText(path, content);
+    }
+  }
+  const host = new FlakyStampHost();
+  const store = new FileSystemStateStore("/runs", host);
+  await assertRejects(
+    () => store.putRun(sampleRecord(), null),
+    Error,
+    "ENOSPC",
+  );
+  assertEquals(host.locks.has(marker), false); // released, not left behind
+  // …so the next write takes the mutex straight away rather than wedging.
+  assertEquals((await store.putRun(sampleRecord(), null)).ok, true);
+});
+
+Deno.test("FileSystemStateStore reclaims an unstamped mutex marker", async () => {
+  // A marker left by a zuke that never stamped its markers — or by a holder
+  // killed in the instant between creating and stamping one — carries no age to
+  // compare. It must not read as a live holder for the life of the directory:
+  // once a waiter has spun far longer than that create→stamp window, it
+  // reclaims the marker instead of wedging. Both shapes a real filesystem can
+  // show: an empty file, and a file whose read comes back as nothing at all.
+  for (const content of ["", undefined]) {
     const host = new FakeStateHost();
     const marker = "/runs/run-1.json.lock";
     host.locks.add(marker);
-    host.files.set(marker, stamp);
+    if (content !== undefined) host.files.set(marker, content);
     const store = new FileSystemStateStore("/runs", host);
-    await assertRejects(
-      () => store.putRun(sampleRecord(), null),
-      Error,
-      "could not acquire",
-    );
-    assertEquals(host.locks.has(marker), true); // the holder kept its marker
+    const result = await store.putRun(sampleRecord(), null);
+    assertEquals(result.ok, true);
+    assertEquals(host.locks.has(marker), false); // reclaimed, then released
   }
+});
+
+Deno.test("two writers never both reclaim the same stale mutex marker", async () => {
+  // Reclaiming with a bare `remove` is not a compare-and-swap: two writers that
+  // read the same stale stamp would both delete a marker — the second deleting
+  // the one the first had just taken — and both would run inside the mutex. The
+  // trace of every hold and release of the marker must stay strictly alternating.
+  const marker = "/runs/run-1.json.lock";
+  const trace: string[] = [];
+  class TracingHost extends FakeStateHost {
+    override async createExclusive(path: string): Promise<boolean> {
+      const created = await super.createExclusive(path);
+      if (created && path === marker) trace.push("hold");
+      return created;
+    }
+    override async remove(path: string): Promise<void> {
+      const held = this.locks.has(path);
+      await super.remove(path);
+      if (held && path === marker) trace.push("free");
+    }
+  }
+  const host = new TracingHost();
+  host.locks.add(marker);
+  host.files.set(marker, String(host.time - 60_000)); // abandoned 60s ago
+
+  const store = new FileSystemStateStore("/runs", host);
+  const results = await Promise.all([
+    store.putRun(sampleRecord(), null),
+    store.putRun(sampleRecord({ status: "succeeded" }), null),
+  ]);
+  assertEquals(trace, ["hold", "free", "hold", "free"]);
+  // One writer publishes; the other sees the version has moved on.
+  assertEquals(results.filter((r) => r.ok).length, 1);
+  assertEquals(host.locks.has(marker), false);
 });
 
 // ---------------------------------------------------------------- duration

--- a/packages/core/tests/state_test.ts
+++ b/packages/core/tests/state_test.ts
@@ -907,6 +907,41 @@ Deno.test("FileSystemStateStore errors when a lock is permanently held", async (
   );
 });
 
+Deno.test("FileSystemStateStore takes over a mutex marker left past its TTL", async () => {
+  // A holder killed mid-write leaves its marker behind. Once the marker is older
+  // than the mutex TTL, the next writer reclaims it instead of wedging forever.
+  const host = new FakeStateHost();
+  const marker = "/runs/run-1.json.lock";
+  host.locks.add(marker);
+  host.files.set(marker, String(host.time)); // stamped when it was acquired
+  host.time += 60_000; // …and never released
+
+  const store = new FileSystemStateStore("/runs", host);
+  const result = await store.putRun(sampleRecord(), null);
+  assertEquals(result.ok, true);
+  assertEquals(host.locks.has(marker), false); // released again after the write
+  assertEquals(host.files.get("/runs/run-1.json") === undefined, false);
+});
+
+Deno.test("FileSystemStateStore never steals a live mutex marker", async () => {
+  // A marker stamped just now belongs to a live holder; one with no readable
+  // stamp (a holder killed between creating and stamping it) is treated the same
+  // way. Both keep the existing behaviour: spin, then fail with guidance.
+  for (const stamp of [String(new FakeStateHost().time), ""]) {
+    const host = new FakeStateHost();
+    const marker = "/runs/run-1.json.lock";
+    host.locks.add(marker);
+    host.files.set(marker, stamp);
+    const store = new FileSystemStateStore("/runs", host);
+    await assertRejects(
+      () => store.putRun(sampleRecord(), null),
+      Error,
+      "could not acquire",
+    );
+    assertEquals(host.locks.has(marker), true); // the holder kept its marker
+  }
+});
+
 // ---------------------------------------------------------------- duration
 
 Deno.test("parseDuration parses units and passes numbers through", () => {

--- a/tests/integration/cancel_test.ts
+++ b/tests/integration/cancel_test.ts
@@ -137,6 +137,43 @@ Deno.test("zuke cancel runs each fan-out item's own onCancel compensation", asyn
   });
 });
 
+Deno.test("zuke cancel compensates a declared target reused as a fan-out stage", async () => {
+  await withStateDir(async (dir) => {
+    const undone: string[] = [];
+    class CD extends Build {
+      // A build may reuse a declared target as the fan-out's stage. Cancel
+      // re-materialises the fan-out, and doing that must not rename `seed` —
+      // the walk reaches it afterwards and finds its record row by name.
+      seed = target()
+        .executes(() => {})
+        .onCancel(() => target().executes(() => void undone.push("seed")));
+      deployBatch = target()
+        .dependsOn(this.seed)
+        .forEach(() => ["repo-a"], () => ({ seed: this.seed }));
+      gate = target()
+        .dependsOn(this.deployBatch)
+        .waitsFor((s) => s.on(externalSignal("approved")));
+    }
+
+    const first = await runCli(CD, ["gate"]);
+    assertEquals(first.code, 0, first.err);
+    const id = await onlyRunId(dir);
+    assertEquals((await loadRun(dir, id)).status, "suspended");
+
+    const cancelled = await runCli(CD, ["cancel", id]);
+    assertEquals(cancelled.code, 0, cancelled.err);
+    // Both the fan-out item and the declared target are undone, each recorded
+    // under its own name — not the item's name twice.
+    assertEquals(undone, ["seed", "seed"]);
+    const record = await loadRun(dir, id);
+    const compensated = record.events
+      .filter((e) => e.tool === "compensate")
+      .map((e) => e.args.target)
+      .sort();
+    assertEquals(compensated, ["deployBatch[repo-a].seed", "seed"]);
+  });
+});
+
 Deno.test("zuke cancel of a finished run is a no-op", async () => {
   await withStateDir(async (dir) => {
     const log: string[] = [];

--- a/tests/integration/foreach_test.ts
+++ b/tests/integration/foreach_test.ts
@@ -1,0 +1,55 @@
+/**
+ * Integration: a `.forEach(...)` fan-out whose factory returns builders it does
+ * not own — the pattern a shared pipeline helper produces — driven twice through
+ * the real CLI. The second run must behave exactly like the first: materialising
+ * works on clones, so the factory's builders are never renamed or re-wired and
+ * no duplicate dependency edges accumulate in a long-lived process.
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import { Build, target } from "../../packages/core/mod.ts";
+import { runCli } from "./_harness.ts";
+
+/** Every stage's execution, in order, for the run currently under way. */
+const log: string[] = [];
+
+// Module-level stages, shared by every item of every run — the factory hands
+// back these same two objects each time it is called.
+const checks = target()
+  .description("verify the item")
+  .executes(() => void log.push("checks"));
+const deploy = target().executes(() => void log.push("deploy"));
+
+class Batch extends Build {
+  deployBatch = target().forEach(
+    () => ["alpha", "beta"],
+    () => ({ checks, deploy }),
+    (s) => s.concurrency(1), // serialise so the log order is deterministic
+  );
+}
+
+Deno.test("a fan-out over shared stage builders is identical on every run", async () => {
+  const runs: string[][] = [];
+  for (const _ of [1, 2]) {
+    log.length = 0;
+    const { code, out } = await runCli(Batch, ["deployBatch"]);
+    assertEquals(code, 0);
+    for (const name of ["alpha", "beta"]) {
+      assertStringIncludes(out, `deployBatch[${name}].checks`);
+      assertStringIncludes(out, `deployBatch[${name}].deploy`);
+    }
+    runs.push([...log]);
+  }
+
+  assertEquals(runs[0], ["checks", "deploy", "checks", "deploy"]);
+  assertEquals(runs[1], runs[0]); // second run identical — no state carried over
+
+  // The build author's own objects came back untouched.
+  assertEquals(checks.name_, undefined);
+  assertEquals(deploy.name_, undefined);
+  assertEquals(deploy.dependsOn_.length, 0);
+  assertEquals(checks.description_, "verify the item");
+});

--- a/tests/integration/state_test.ts
+++ b/tests/integration/state_test.ts
@@ -182,6 +182,27 @@ Deno.test("a lock acquire recovers from a mutex marker a killed run left behind"
   });
 });
 
+Deno.test("a lock acquire recovers from an unstamped mutex marker", async () => {
+  await withStateDir(async (dir) => {
+    const log: string[] = [];
+    // A marker left behind by a zuke that never stamped its markers: it carries
+    // no age, so it must not read as a live holder for the life of the directory.
+    const marker = `${dir}/locks/deploy-lock.acq`;
+    await Deno.mkdir(`${dir}/locks`, { recursive: true });
+    await Deno.writeTextFile(marker, "");
+
+    class B extends Build {
+      deploy = target()
+        .lock((s) => s.key("deploy-lock").withTtl("1h"))
+        .executes(() => void log.push("deploy"));
+    }
+    const { code, err } = await runCli(B, ["deploy"]);
+    assertEquals(code, 0, err);
+    assertEquals(log, ["deploy"]);
+    assertEquals(await exists(marker), false);
+  });
+});
+
 /** Whether `path` exists, for asserting a marker was cleaned up. */
 async function exists(path: string): Promise<boolean> {
   try {

--- a/tests/integration/state_test.ts
+++ b/tests/integration/state_test.ts
@@ -159,6 +159,39 @@ Deno.test("listRuns can filter persisted runs by status", async () => {
   });
 });
 
+Deno.test("a lock acquire recovers from a mutex marker a killed run left behind", async () => {
+  await withStateDir(async (dir) => {
+    const log: string[] = [];
+    // A previous run was killed while acquiring: its `.acq` mutex marker is still
+    // there, stamped long enough ago to be past the mutex TTL. Every later run
+    // that touches this lock used to wedge and fail; now the marker is reclaimed.
+    const marker = `${dir}/locks/deploy-lock.acq`;
+    await Deno.mkdir(`${dir}/locks`, { recursive: true });
+    await Deno.writeTextFile(marker, String(Date.now() - 600_000));
+
+    class B extends Build {
+      deploy = target()
+        .lock((s) => s.key("deploy-lock").withTtl("1h"))
+        .executes(() => void log.push("deploy"));
+    }
+    const { code, err } = await runCli(B, ["deploy"]);
+    assertEquals(code, 0, err);
+    assertEquals(log, ["deploy"]);
+    // Reclaimed, held for the acquire, then released — not left behind again.
+    assertEquals(await exists(marker), false);
+  });
+});
+
+/** Whether `path` exists, for asserting a marker was cleaned up. */
+async function exists(path: string): Promise<boolean> {
+  try {
+    await Deno.lstat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 Deno.test("a target loses a held lock and fails with the conflict guidance", async () => {
   await withStateDir(async (dir) => {
     const log: string[] = [];


### PR DESCRIPTION
Two independent latent-corruption fixes in core.

**forEach fan-out mutated the builder its factory returned** — setting the name, pushing a dependency edge, and forcing proceed-after-failure onto the caller's object. A factory that returns a shared or memoised builder therefore had its build graph permanently corrupted, and the dependency push accumulated a duplicate edge on every materialise, so a long-lived process such as the MCP server degraded run over run. The scheduler now clones before mutating.

**The filesystem state store's mutex had no expiry.** A process killed inside its critical section wedged every later writer until a human deleted the marker file — even though the cross-run locks that mutex exists to protect already self-heal by TTL. A stale marker is now expired and the acquisition retried, with removal races treated as success since another waiter may clear it first.

One brief correction worth recording: the TTL default this was supposed to mirror does not exist. The line cited is the cross-run lock expiry check, and that TTL is caller-supplied. The cancel-lock TTL was mirrored into a documented local constant instead, rather than importing a cancellation-specific value into the store.

**Verification.** Gate green: 2054 tests pass, coverage 98.3 percent lines and 95.5 percent branches. Eight blocking review findings were fixed before this was opened.

**Two follow-ups this PR deliberately does not cover.** First, the identical mutex wedge exists in the registry's filesystem store, which keeps its own copy of the spin loop — so the two implementations have now diverged, one self-healing and one still wedging. The root-cause fix is a shared primitive both call, which is wider than this change. Second, the fan-out spec closes over the declaring builder, so the clone the scheduler now runs never hands its name back: a nested fan-out's validation errors lose the target name. That is a regression against this repo's bar that errors name the offending target, and it should be fixed before this pattern spreads.
