### PR TITLE
feat(core): add splitShellArgs, cap captured output, escalate kills, redact echoes

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -50,6 +50,19 @@ the packages publish themselves.
 > built from the PR description/commits, so keep illustrative code in the PR
 > _discussion_, not in the commit body. Describe the change in prose instead.
 
+> [!IMPORTANT]
+> **A package that starts using a brand-new `@zuke/core` symbol needs a
+> follow-up floor bump.** The workspace only resolves the local `packages/core`
+> member while its version still satisfies the dependent's `jsr:@zuke/core@^x.y.z`
+> pin, so the PR that introduces the usage **cannot** raise that pin — doing so
+> makes Deno ignore the workspace member and try to download a version that is
+> not published yet, and the whole build fails to resolve. Land the usage against
+> the existing floor, then once the core release publishes, raise the floor in a
+> small follow-up `fix:` PR (see `fix: raise the @zuke/core floor to 1.31.0 in
+> wrappers using SubcommandSettings`). Until that lands, a consumer whose lockfile
+> already resolves the older core can hit a missing-export error, so treat the
+> follow-up as part of the change, not optional cleanup.
+
 ## Manual trigger
 
 `release.yml` also has a `workflow_dispatch` trigger, so you can run

--- a/deno.lock
+++ b/deno.lock
@@ -1558,6 +1558,11 @@
           "jsr:@zuke/core@^1.31.0"
         ]
       },
+      "packages/cli": {
+        "dependencies": [
+          "jsr:@zuke/core@^1.31.0"
+        ]
+      },
       "packages/cmd": {
         "dependencies": [
           "jsr:@zuke/core@^1.25.0"

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -40,6 +40,12 @@ value wherever it prints:
 - Every line the executor writes through its reporter — banners, per-target
   status, the build summary, and **error messages** (including a target that
   throws with the secret in its message, or a parse error on a malformed value).
+- The rendered **command line** of any `$` command: the echo under `--dry-run`, a
+  `CommandError`/`CommandTimeoutError` message, and a spawned service's recorded
+  line. A secret passed to a command as an argv token is masked there even if the
+  build prints the line itself, because the masking happens where the line is
+  built rather than at the reporter. The argv handed to the operating system is
+  unchanged — the command still works.
 - Under GitHub Actions, Zuke additionally emits `::add-mask::<value>` so the
   runner masks the value in its own log stream.
 

--- a/docs/shell.md
+++ b/docs/shell.md
@@ -32,7 +32,11 @@ stdout).
 cannot grow the buffer until the run dies. Past the cap the **newest** bytes are
 kept, `truncated` is `true`, and `.text()` prefixes
 `[output truncated to last 8 MiB]`. Raise or lower it per command with
-`.maxCapturedBytes(bytes)`; live streaming to the terminal is never capped.
+`.maxCapturedBytes(bytes)` — the same setting exists on every tool wrapper's
+settings lambda, so `SomeTasks.run((s) => s.maxCapturedBytes(64 * 1024 * 1024))`
+raises it for a tool whose whole output must be parsed. The cap must be a
+positive whole number of bytes; there is no unlimited value, so pass a cap larger
+than the output you expect. Live streaming to the terminal is never capped.
 
 **Safety:** interpolated values become **discrete argv entries** — they are
 never spliced into a shell string — so there is no injection surface. Arrays

--- a/docs/shell.md
+++ b/docs/shell.md
@@ -24,8 +24,15 @@ await $`build`.env({ NODE_ENV: "prod" }).cwd("./app").quiet();
 | `.cwd(path)`   | Set the working directory.                                                                                     |
 | `.quiet()`     | Suppress live stdout/stderr streaming.                                                                         |
 
-Awaiting a command resolves to a `CommandOutput` (`{ code, stdout, stderr }`,
-plus a `.text()` helper for trimmed stdout).
+Awaiting a command resolves to a `CommandOutput`
+(`{ code, stdout, stderr, truncated }`, plus a `.text()` helper for trimmed
+stdout).
+
+**Bounded capture:** each captured stream keeps at most 8 MiB, so a runaway child
+cannot grow the buffer until the run dies. Past the cap the **newest** bytes are
+kept, `truncated` is `true`, and `.text()` prefixes
+`[output truncated to last 8 MiB]`. Raise or lower it per command with
+`.maxCapturedBytes(bytes)`; live streaming to the terminal is never capped.
 
 **Safety:** interpolated values become **discrete argv entries** — they are
 never spliced into a shell string — so there is no injection surface. Arrays

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3486,7 +3486,7 @@ class SpawnedProcess
     The operating-system process id (`-1` for a dry-run stub).
   get status(): Promise<Deno.CommandStatus>
     Resolves when the process exits (immediate success for a dry-run stub).
-  async stop(signal: Deno.Signal, graceMs: number): Promise<void>
+  stop(signal: Deno.Signal, graceMs: number): Promise<void>
     Terminate the process and wait for it to exit. Sends `signal` (default
     `SIGTERM`); if the process has not exited within `graceMs` (default 5s), it
     escalates to `SIGKILL` so a process that ignores `SIGTERM` cannot hang

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3427,7 +3427,11 @@ class Command implements PromiseLike<CommandOutput>
     run signal for this command. Composes with {@link killAfter}: either the
     timeout or the abort kills the process, whichever fires first.
   get commandLine(): string
-    The command line, for diagnostics.
+    The command line, for diagnostics — argv joined by spaces, with the resolved
+    value of every `secret` parameter of the enclosing run masked. This is the
+    only rendered form of the command (the echo under `--dry-run`, a
+    {@link CommandError} message), so a secret passed as an argv token cannot
+    leak through one. The argv given to the operating system is unchanged.
   then(onfulfilled?: ((value: CommandOutput) => TResult1 | PromiseLike<TResult1>) | null, onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null): PromiseLike<TResult1 | TResult2>
     Await support: run the command and resolve to a {@link CommandOutput}.
   async text(): Promise<string>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3350,6 +3350,44 @@ function $(strings: TemplateStringsArray, ...values: Interpolatable[]): Command
   @example
       `await $\`deno test -A``
 
+function splitShellArgs(input: string): string[]
+  Split `input` into argv the way a POSIX shell would, honouring the quoting
+  rules only:
+
+  - Unquoted runs of whitespace separate arguments; leading, trailing, and
+    repeated whitespace produce no empty arguments.
+  - Single quotes are fully literal — no escape sequences at all, so `'a\b'`
+    yields `a\b`.
+  - Inside double quotes a backslash escapes only `"`, `\`, ```, `$`, and a
+    newline; before anything else it stays literal, so `"\d+"` yields `\d+`
+    rather than silently losing the backslash.
+  - Outside quotes a backslash escapes the following character, so `a\ b` is one
+    argument.
+  - A backslash-newline pair is a line continuation and is removed, both
+    unquoted and inside double quotes; a backslash at the very end of the input
+    is a dangling continuation and is dropped.
+  - Adjacent segments concatenate (`a"b c"d` → `ab cd`) and a quoted empty
+    string is a real, empty argument (`''` → `[""]`).
+
+  Non-goals, deliberately not implemented — the input is turned into argv,
+  never interpreted: no variable expansion (`"$HOME"` stays `$HOME`), no
+  globbing, no tilde expansion, no command substitution, and no operator
+  handling of any kind (`|`, `&&`, `;`, `>` are ordinary characters). A caller
+  that needs those must split on them itself, or run a real shell.
+
+  `\r` is treated as a separator alongside space, tab, and newline so a command
+  line read from a CRLF file cannot smuggle an invisible carriage return into an
+  argument.
+
+  @param input
+      The command string to split.
+
+  @return
+      The argv entries, in order; an empty array for blank input.
+
+  @throws {ShellArgsError}
+      If a single or double quote is never closed.
+
 function tokenize(strings: ReadonlyArray<string>, values: ReadonlyArray<Interpolatable>): string[]
   Tokenise a tagged-template invocation into an argv array.
 
@@ -3421,6 +3459,16 @@ class CommandTimeoutError extends Error
 
   constructor(readonly command: string, readonly timeoutMs: number)
     Build the error from the command line and the elapsed-time budget.
+  override name: string
+    The error name.
+
+class ShellArgsError extends Error
+  Raised when {@link splitShellArgs} reaches the end of the input with a quote
+  still open. Names the offending quote character and the offset at which it was
+  opened so the bad spot in a long command line is findable.
+
+  constructor(readonly quote: string, readonly offset: number)
+    Build the error from the unclosed quote character and its offset.
   override name: string
     The error name.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3414,6 +3414,13 @@ class Command implements PromiseLike<CommandOutput>
   killAfter(ms: number): this
     Kill the process if it runs longer than `ms` milliseconds, raising a
     {@link CommandTimeoutError}. Fires even under {@link noThrow}.
+  maxCapturedBytes(bytes: number): this
+    Cap how much of each captured stream is kept in memory, in bytes
+    (default 8 MiB). Capture keeps the newest bytes: once the cap is reached the
+    oldest are dropped, {@link CommandOutput.truncated} is set, and
+    {@link CommandOutput.text} prefixes a notice. Raise it for a command whose
+    whole output you must parse; lower it to bound a chatty one. Live streaming
+    to the terminal is never capped — every byte still reaches it.
   signal(signal: AbortSignal): this
     Terminate the process (via `SIGTERM`) when `signal` aborts — for example
     when the enclosing run is cancelled. Overrides the executor's ambient
@@ -3424,7 +3431,8 @@ class Command implements PromiseLike<CommandOutput>
   then(onfulfilled?: ((value: CommandOutput) => TResult1 | PromiseLike<TResult1>) | null, onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null): PromiseLike<TResult1 | TResult2>
     Await support: run the command and resolve to a {@link CommandOutput}.
   async text(): Promise<string>
-    Run and resolve to trimmed stdout. Throws on non-zero unless `noThrow`.
+    Run and resolve to trimmed stdout — prefixed with a truncation notice if the
+    capture cap was hit. Throws on non-zero unless `noThrow`.
   async lines(): Promise<string[]>
     Run and resolve to stdout split into lines (trailing blank dropped).
   async code(): Promise<number>
@@ -3447,10 +3455,11 @@ class CommandError extends Error
 class CommandOutput
   The resolved result of a command, available when awaiting a {@link Command}.
 
-  constructor(readonly code: number, readonly stdout: string, readonly stderr: string)
+  constructor(readonly code: number, readonly stdout: string, readonly stderr: string, readonly truncated: boolean, readonly maxCapturedBytes: number)
     Build the output from the process exit code and captured streams.
   text(): string
-    Trimmed stdout.
+    Trimmed stdout, prefixed with a one-line notice when {@link truncated} — so
+    a caller reading the output cannot mistake a tail for the whole of it.
 
 class CommandTimeoutError extends Error
   Raised when a command is killed for exceeding its {@link Command.killAfter}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3421,6 +3421,10 @@ class Command implements PromiseLike<CommandOutput>
     {@link CommandOutput.text} prefixes a notice. Raise it for a command whose
     whole output you must parse; lower it to bound a chatty one. Live streaming
     to the terminal is never capped — every byte still reaches it.
+
+    @throws {RangeError}
+        If `bytes` is not a positive whole number.
+
   signal(signal: AbortSignal): this
     Terminate the process (via `SIGTERM`) when `signal` aborts — for example
     when the enclosing run is cancelled. Overrides the executor's ambient
@@ -3665,6 +3669,17 @@ abstract class ToolSettings
   killAfter(ms: number): this
     Kill the tool if it runs longer than `ms` milliseconds, raising a
     `CommandTimeoutError`. Fires even under {@link noThrow}.
+  maxCapturedBytes(bytes: number): this
+    Cap how much of each captured stream the run keeps in memory, in bytes
+    (default 8 MiB). Once the cap is reached the oldest bytes are dropped,
+    `CommandOutput.truncated` is set, and `CommandOutput.text` prefixes a
+    notice. Raise it for a tool whose whole output must be parsed — a coverage
+    report, a `--json` dump — and lower it to bound a chatty one. Live
+    streaming to the terminal is never capped.
+
+    @throws {RangeError}
+        If `bytes` is not a positive whole number.
+
   toolPath(path: PathLike): this
     Override the binary to run (e.g. an absolute path to the tool).
   fromNodeModules(): this

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -6,6 +6,9 @@
   "exports": {
     ".": "./mod.ts"
   },
+  "imports": {
+    "@zuke/core": "jsr:@zuke/core@^1.31.0"
+  },
   "publish": {
     "exclude": [
       "tests/"

--- a/packages/cli/src/import.ts
+++ b/packages/cli/src/import.ts
@@ -17,6 +17,7 @@
  * @module
  */
 
+import { splitShellArgs } from "@zuke/core/shell";
 import {
   isRecord,
   joinPath,
@@ -71,6 +72,7 @@ function delegatedScript(
   scripts: Set<string>,
 ): string | undefined {
   const tokens = tokenize(segment.trim());
+  if (tokens === undefined) return undefined;
   if (tokens.length === 0 || !RUNNERS.includes(tokens[0])) return undefined;
   const rest = tokens[1] === "run" ? tokens.slice(2) : tokens.slice(1);
   // A pure delegation is exactly the runner and one known script name.
@@ -159,7 +161,10 @@ export function translateCommand(command: string): BodyItem[] {
   for (const raw of splitChain(command)) {
     const segment = raw.trim();
     if (segment === "") continue;
-    if (needsShell(segment)) {
+    // A shell-specific segment, or one whose quoting does not balance, is
+    // preserved verbatim instead of being mistranslated.
+    const tokens = needsShell(segment) ? undefined : tokenize(segment);
+    if (tokens === undefined) {
       // Collapse whitespace so an embedded newline cannot break the raw command
       // out of its single-line `//` comment in the generated source.
       const oneLine = segment.replace(/\s+/g, " ").trim();
@@ -169,7 +174,6 @@ export function translateCommand(command: string): BodyItem[] {
       });
       continue;
     }
-    const tokens = tokenize(segment);
     const bin = tokens[0];
     if (bin === undefined) continue;
     const args = tokens.slice(1);
@@ -212,35 +216,18 @@ function splitChain(command: string): string[] {
   return parts;
 }
 
-/** Split a command segment into argv, honouring single/double quotes. */
-function tokenize(segment: string): string[] {
-  const tokens: string[] = [];
-  let current = "";
-  let quote: string | undefined;
-  let has = false;
-  for (const ch of segment) {
-    if (quote !== undefined) {
-      if (ch === quote) quote = undefined;
-      else {
-        current += ch;
-        has = true;
-      }
-    } else if (ch === '"' || ch === "'") {
-      quote = ch;
-      has = true;
-    } else if (ch === " " || ch === "\t") {
-      if (has) {
-        tokens.push(current);
-        current = "";
-        has = false;
-      }
-    } else {
-      current += ch;
-      has = true;
-    }
+/**
+ * Split a command segment into argv with POSIX quoting rules, or `undefined`
+ * when the segment's quoting is unbalanced. An unterminated quote is not
+ * translatable, so the caller falls back to preserving the raw text — the
+ * scaffold must never silently drop half a command.
+ */
+function tokenize(segment: string): string[] | undefined {
+  try {
+    return splitShellArgs(segment);
+  } catch {
+    return undefined; // Only ShellArgsError can escape splitShellArgs.
   }
-  if (has) tokens.push(current);
-  return tokens;
 }
 
 /** A double-quoted TypeScript string literal for `value`. */

--- a/packages/cli/src/import.ts
+++ b/packages/cli/src/import.ts
@@ -147,8 +147,35 @@ interface BodyItem {
 function needsShell(segment: string): boolean {
   if (/[|<>;`$]/.test(segment)) return true; // pipe, redirect, subst, env expand
   if (/(^|\s)&(\s|$)/.test(segment)) return true; // background job
+  if (hasUnquotedBackslash(segment)) return true; // escape or Windows separator?
   const first = segment.trim().split(/\s+/)[0] ?? "";
   return /^[A-Za-z_][A-Za-z0-9_]*=/.test(first); // leading VAR=value assignment
+}
+
+/**
+ * Whether `segment` contains a backslash outside quotes, which is ambiguous and
+ * therefore not translatable: a POSIX shell reads it as an escape (`a\ b` is one
+ * argument), while a `package.json` script written on Windows — where npm runs
+ * scripts through `cmd.exe` — uses it as a path separator (`node scripts\b.js`).
+ * Picking either reading silently changes the command, so the segment is
+ * preserved verbatim for a human to resolve. A backslash inside quotes is
+ * unambiguous and stays translatable.
+ */
+function hasUnquotedBackslash(segment: string): boolean {
+  let quote: string | undefined;
+  for (let i = 0; i < segment.length; i++) {
+    const ch = segment[i];
+    if (quote !== undefined) {
+      // Inside double quotes a backslash escapes the next character, so skip it
+      // and keep tracking the quote state accurately.
+      if (quote === '"' && ch === "\\") i++;
+      else if (ch === quote) quote = undefined;
+      continue;
+    }
+    if (ch === '"' || ch === "'") quote = ch;
+    else if (ch === "\\") return true;
+  }
+  return false;
 }
 
 /**

--- a/packages/cli/tests/import_test.ts
+++ b/packages/cli/tests/import_test.ts
@@ -132,6 +132,33 @@ Deno.test("translateCommand keeps quoted arguments together", () => {
   );
 });
 
+Deno.test("translateCommand keeps a backslash inside a double-quoted argument", () => {
+  // The old hand-rolled splitter had no backslash handling, so `"\d+"` imported
+  // as `d+` — a test-selection pattern that silently matches other tests.
+  const items = translateCommand(String.raw`vitest run -t "\d+"`);
+  assertEquals(
+    items[0].code,
+    String.raw`CmdTasks.exec("vitest", (s) => s.args("run", "-t", "\\d+"))`,
+  );
+});
+
+Deno.test("translateCommand preserves a segment whose quoting is unbalanced", () => {
+  const items = translateCommand('echo "oops');
+  assertEquals(items.length, 1);
+  assertEquals(items[0].runnable, false);
+  assertStringIncludes(items[0].code, `echo "oops`);
+});
+
+Deno.test("parsePackageJson keeps an unbalanced delegation as a command", () => {
+  // `delegatedScript` cannot tokenise it, so it is not mistaken for a `npm run`
+  // delegation and stays a (TODO-preserved) command.
+  const tasks = parsePackageJson(
+    JSON.stringify({ scripts: { lint: "eslint .", all: `npm run 'lint` } }),
+  );
+  assertEquals(tasks[1].deps, []);
+  assertEquals(tasks[1].command, `npm run 'lint`);
+});
+
 // --- toIdentifier ---
 
 Deno.test("toIdentifier produces valid camelCase field names", () => {

--- a/packages/cli/tests/import_test.ts
+++ b/packages/cli/tests/import_test.ts
@@ -142,6 +142,29 @@ Deno.test("translateCommand keeps a backslash inside a double-quoted argument", 
   );
 });
 
+Deno.test("translateCommand preserves a segment with an unquoted backslash", () => {
+  // A Windows-authored script (npm runs scripts through cmd.exe there) uses the
+  // backslash as a path separator, while POSIX argv splitting reads it as an
+  // escape and drops it, gluing the two path segments together into a silently
+  // broken path. Ambiguous, so the segment is preserved for a human instead.
+  const items = translateCommand(String.raw`node scripts\build.js`);
+  assertEquals(items.length, 1);
+  assertEquals(items[0].runnable, false);
+  assertStringIncludes(items[0].code, String.raw`node scripts\build.js`);
+});
+
+Deno.test("translateCommand still translates a backslash that is quoted", () => {
+  // Quoting removes the ambiguity, so these must NOT be pushed into a TODO —
+  // and the unquoted check must not be fooled by an escaped closing quote.
+  const items = translateCommand(String.raw`grep "a\"b" '\d+'`);
+  assertEquals(items.length, 1);
+  assertEquals(items[0].runnable, true);
+  assertEquals(
+    items[0].code,
+    String.raw`CmdTasks.exec("grep", (s) => s.args("a\"b", "\\d+"))`,
+  );
+});
+
 Deno.test("translateCommand preserves a segment whose quoting is unbalanced", () => {
   const items = translateCommand('echo "oops');
   assertEquals(items.length, 1);
@@ -247,6 +270,22 @@ Deno.test("runImport auto-detects package.json and scaffolds", async () => {
   assertEquals(result.taskCount, 1);
   assertStringIncludes(host.files.get("zuke.ts") ?? "", "build = target()");
   assertEquals(host.files.has("zuke"), true); // launcher scaffolded too
+});
+
+Deno.test("runImport keeps a Windows-style script path intact in the scaffold", async () => {
+  const host = new FakeHost({
+    "package.json": JSON.stringify({
+      scripts: { build: String.raw`node scripts\build.js` },
+    }),
+  });
+  const result = await runImport({ dir: ".", force: true, name: "B" }, host);
+  assertEquals(result.taskCount, 1);
+  const zuke = host.files.get("zuke.ts") ?? "";
+  // The path separator survives into the generated file, flagged for a human,
+  // instead of being silently swallowed by POSIX escape handling.
+  assertStringIncludes(zuke, String.raw`node scripts\build.js`);
+  assertStringIncludes(zuke, "// TODO"); // flagged, not silently mistranslated
+  assertEquals(zuke.includes("CmdTasks.exec"), false);
 });
 
 Deno.test("runImport falls back to a Makefile", async () => {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -3481,7 +3481,11 @@ class Command implements PromiseLike<CommandOutput>
     run signal for this command. Composes with {@link killAfter}: either the
     timeout or the abort kills the process, whichever fires first.
   get commandLine(): string
-    The command line, for diagnostics.
+    The command line, for diagnostics — argv joined by spaces, with the resolved
+    value of every `secret` parameter of the enclosing run masked. This is the
+    only rendered form of the command (the echo under `--dry-run`, a
+    {@link CommandError} message), so a secret passed as an argv token cannot
+    leak through one. The argv given to the operating system is unchanged.
   then(onfulfilled?: ((value: CommandOutput) => TResult1 | PromiseLike<TResult1>) | null, onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null): PromiseLike<TResult1 | TResult2>
     Await support: run the command and resolve to a {@link CommandOutput}.
   async text(): Promise<string>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -3475,6 +3475,10 @@ class Command implements PromiseLike<CommandOutput>
     {@link CommandOutput.text} prefixes a notice. Raise it for a command whose
     whole output you must parse; lower it to bound a chatty one. Live streaming
     to the terminal is never capped — every byte still reaches it.
+
+    @throws {RangeError}
+        If `bytes` is not a positive whole number.
+
   signal(signal: AbortSignal): this
     Terminate the process (via `SIGTERM`) when `signal` aborts — for example
     when the enclosing run is cancelled. Overrides the executor's ambient
@@ -3719,6 +3723,17 @@ abstract class ToolSettings
   killAfter(ms: number): this
     Kill the tool if it runs longer than `ms` milliseconds, raising a
     `CommandTimeoutError`. Fires even under {@link noThrow}.
+  maxCapturedBytes(bytes: number): this
+    Cap how much of each captured stream the run keeps in memory, in bytes
+    (default 8 MiB). Once the cap is reached the oldest bytes are dropped,
+    `CommandOutput.truncated` is set, and `CommandOutput.text` prefixes a
+    notice. Raise it for a tool whose whole output must be parsed — a coverage
+    report, a `--json` dump — and lower it to bound a chatty one. Live
+    streaming to the terminal is never capped.
+
+    @throws {RangeError}
+        If `bytes` is not a positive whole number.
+
   toolPath(path: PathLike): this
     Override the binary to run (e.g. an absolute path to the tool).
   fromNodeModules(): this

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -3540,7 +3540,7 @@ class SpawnedProcess
     The operating-system process id (`-1` for a dry-run stub).
   get status(): Promise<Deno.CommandStatus>
     Resolves when the process exits (immediate success for a dry-run stub).
-  async stop(signal: Deno.Signal, graceMs: number): Promise<void>
+  stop(signal: Deno.Signal, graceMs: number): Promise<void>
     Terminate the process and wait for it to exit. Sends `signal` (default
     `SIGTERM`); if the process has not exited within `graceMs` (default 5s), it
     escalates to `SIGKILL` so a process that ignores `SIGTERM` cannot hang

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -3404,6 +3404,44 @@ function $(strings: TemplateStringsArray, ...values: Interpolatable[]): Command
   @example
       `await $\`deno test -A``
 
+function splitShellArgs(input: string): string[]
+  Split `input` into argv the way a POSIX shell would, honouring the quoting
+  rules only:
+
+  - Unquoted runs of whitespace separate arguments; leading, trailing, and
+    repeated whitespace produce no empty arguments.
+  - Single quotes are fully literal — no escape sequences at all, so `'a\b'`
+    yields `a\b`.
+  - Inside double quotes a backslash escapes only `"`, `\`, ```, `$`, and a
+    newline; before anything else it stays literal, so `"\d+"` yields `\d+`
+    rather than silently losing the backslash.
+  - Outside quotes a backslash escapes the following character, so `a\ b` is one
+    argument.
+  - A backslash-newline pair is a line continuation and is removed, both
+    unquoted and inside double quotes; a backslash at the very end of the input
+    is a dangling continuation and is dropped.
+  - Adjacent segments concatenate (`a"b c"d` → `ab cd`) and a quoted empty
+    string is a real, empty argument (`''` → `[""]`).
+
+  Non-goals, deliberately not implemented — the input is turned into argv,
+  never interpreted: no variable expansion (`"$HOME"` stays `$HOME`), no
+  globbing, no tilde expansion, no command substitution, and no operator
+  handling of any kind (`|`, `&&`, `;`, `>` are ordinary characters). A caller
+  that needs those must split on them itself, or run a real shell.
+
+  `\r` is treated as a separator alongside space, tab, and newline so a command
+  line read from a CRLF file cannot smuggle an invisible carriage return into an
+  argument.
+
+  @param input
+      The command string to split.
+
+  @return
+      The argv entries, in order; an empty array for blank input.
+
+  @throws {ShellArgsError}
+      If a single or double quote is never closed.
+
 function tokenize(strings: ReadonlyArray<string>, values: ReadonlyArray<Interpolatable>): string[]
   Tokenise a tagged-template invocation into an argv array.
 
@@ -3475,6 +3513,16 @@ class CommandTimeoutError extends Error
 
   constructor(readonly command: string, readonly timeoutMs: number)
     Build the error from the command line and the elapsed-time budget.
+  override name: string
+    The error name.
+
+class ShellArgsError extends Error
+  Raised when {@link splitShellArgs} reaches the end of the input with a quote
+  still open. Names the offending quote character and the offset at which it was
+  opened so the bad spot in a long command line is findable.
+
+  constructor(readonly quote: string, readonly offset: number)
+    Build the error from the unclosed quote character and its offset.
   override name: string
     The error name.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -3468,6 +3468,13 @@ class Command implements PromiseLike<CommandOutput>
   killAfter(ms: number): this
     Kill the process if it runs longer than `ms` milliseconds, raising a
     {@link CommandTimeoutError}. Fires even under {@link noThrow}.
+  maxCapturedBytes(bytes: number): this
+    Cap how much of each captured stream is kept in memory, in bytes
+    (default 8 MiB). Capture keeps the newest bytes: once the cap is reached the
+    oldest are dropped, {@link CommandOutput.truncated} is set, and
+    {@link CommandOutput.text} prefixes a notice. Raise it for a command whose
+    whole output you must parse; lower it to bound a chatty one. Live streaming
+    to the terminal is never capped — every byte still reaches it.
   signal(signal: AbortSignal): this
     Terminate the process (via `SIGTERM`) when `signal` aborts — for example
     when the enclosing run is cancelled. Overrides the executor's ambient
@@ -3478,7 +3485,8 @@ class Command implements PromiseLike<CommandOutput>
   then(onfulfilled?: ((value: CommandOutput) => TResult1 | PromiseLike<TResult1>) | null, onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null): PromiseLike<TResult1 | TResult2>
     Await support: run the command and resolve to a {@link CommandOutput}.
   async text(): Promise<string>
-    Run and resolve to trimmed stdout. Throws on non-zero unless `noThrow`.
+    Run and resolve to trimmed stdout — prefixed with a truncation notice if the
+    capture cap was hit. Throws on non-zero unless `noThrow`.
   async lines(): Promise<string[]>
     Run and resolve to stdout split into lines (trailing blank dropped).
   async code(): Promise<number>
@@ -3501,10 +3509,11 @@ class CommandError extends Error
 class CommandOutput
   The resolved result of a command, available when awaiting a {@link Command}.
 
-  constructor(readonly code: number, readonly stdout: string, readonly stderr: string)
+  constructor(readonly code: number, readonly stdout: string, readonly stderr: string, readonly truncated: boolean, readonly maxCapturedBytes: number)
     Build the output from the process exit code and captured streams.
   text(): string
-    Trimmed stdout.
+    Trimmed stdout, prefixed with a one-line notice when {@link truncated} — so
+    a caller reading the output cannot mistake a tail for the whole of it.
 
 class CommandTimeoutError extends Error
   Raised when a command is killed for exceeding its {@link Command.killAfter}

--- a/packages/core/src/ambient_redactor.ts
+++ b/packages/core/src/ambient_redactor.ts
@@ -1,0 +1,51 @@
+/**
+ * The ambient {@link Redactor} for command lines.
+ *
+ * The executor seeds a redactor with every `secret` parameter's resolved value
+ * and runs the plan inside {@link withAmbientRedactor} (see `./executor.ts`).
+ * {@link "./shell.ts".Command.commandLine} then masks those values, so the
+ * diagnostic form of a command — the dry-run echo, a `CommandError` message, a
+ * {@link "./shell.ts".SpawnedProcess}'s recorded line — can never carry a secret
+ * that a target passed as an argv token. The argv handed to the operating system
+ * is untouched: masking happens only where the line is rendered for a human.
+ *
+ * This is belt-and-braces with the redacting {@link "./reporter.ts".Reporter}:
+ * that one masks everything Zuke prints, while this one keeps the secret out of
+ * the string in the first place — including a line a target body prints itself,
+ * which never passes through the reporter at all.
+ *
+ * Like the ambient signal, it lives in an `AsyncLocalStorage`, so it is scoped to
+ * the run's async subtree: concurrent runs do not see each other's, and nothing
+ * is left behind when a run ends. Internal (not a published entrypoint).
+ *
+ * @module
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { Redactor } from "./redact.ts";
+
+/** Per-async-context store holding the current run's redactor. */
+const storage = new AsyncLocalStorage<Redactor>();
+
+/** The redactor in effect, read when a command line is rendered. */
+export function ambientRedactor(): Redactor | undefined {
+  return storage.getStore();
+}
+
+/**
+ * Run `fn` with `redactor` installed as the ambient redactor for its entire
+ * async subtree, returning `fn`'s result. Confined to this call — not visible to
+ * concurrent runs, and needs no manual teardown.
+ */
+export function withAmbientRedactor<T>(
+  redactor: Redactor,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return storage.run(redactor, fn);
+}
+
+/** Mask every registered secret in `line`, or return it unchanged if none. */
+export function redactLine(line: string): string {
+  const redactor = ambientRedactor();
+  return redactor === undefined ? line : redactor.redact(line);
+}

--- a/packages/core/src/capture.ts
+++ b/packages/core/src/capture.ts
@@ -1,0 +1,107 @@
+/**
+ * Bounded capture of a child process's output.
+ *
+ * A command's stdout and stderr are captured into memory so
+ * {@link "./shell.ts".CommandOutput} can hand them back, which means an
+ * unbounded stream — a runaway test reporter, a container build log — would
+ * otherwise grow a buffer until the run dies. Capture keeps a bounded **tail**
+ * instead: the newest bytes up to the cap, which is the end anyone reads for the
+ * failure. Live streaming to the terminal is unaffected; every byte still goes
+ * to the sink as it arrives. Internal (not a published entrypoint).
+ *
+ * @module
+ */
+
+/** The default capture cap per stream, in bytes (8 MiB). */
+export const DEFAULT_MAX_CAPTURED_BYTES = 8 * 1024 * 1024;
+
+/** The result of a bounded capture: the decoded text and whether bytes were lost. */
+export interface Captured {
+  /** The captured text — the tail of the stream when {@link Captured.truncated}. */
+  readonly text: string;
+  /** Whether the cap was reached and leading bytes were discarded. */
+  readonly truncated: boolean;
+}
+
+/**
+ * Render a byte count the way the truncation notice should read: `8 MiB`,
+ * `4 KiB`, or a plain byte count when it is not a whole multiple.
+ */
+export function formatByteCap(bytes: number): string {
+  const KiB = 1024;
+  const MiB = KiB * KiB;
+  if (bytes >= MiB && bytes % MiB === 0) return `${bytes / MiB} MiB`;
+  if (bytes >= KiB && bytes % KiB === 0) return `${bytes / KiB} KiB`;
+  return `${bytes} bytes`;
+}
+
+/**
+ * The one-line notice prepended to truncated text, so a caller reading the
+ * captured output sees that the beginning is missing rather than silently
+ * parsing a fragment.
+ */
+export function truncationNotice(maxBytes: number): string {
+  return `[output truncated to last ${formatByteCap(maxBytes)}]`;
+}
+
+/**
+ * Drain `stream`, writing every chunk to `sink` when one is given, and capture
+ * at most `maxBytes` of it — dropping from the FRONT so the newest output
+ * survives.
+ *
+ * The cut is made at a byte boundary, so a multi-byte character straddling it
+ * decodes to a replacement character; that is the cost of bounding the buffer
+ * without decoding incrementally.
+ *
+ * @param stream The child's stdout or stderr.
+ * @param sink Where to tee each chunk live, or `null` to capture silently.
+ * @param maxBytes The capture cap for this stream, in bytes.
+ * @returns The captured tail and whether anything was dropped.
+ */
+export async function captureStream(
+  stream: ReadableStream<Uint8Array>,
+  sink: { writeSync(p: Uint8Array): number } | null,
+  maxBytes: number,
+): Promise<Captured> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  let truncated = false;
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      if (sink) sink.writeSync(value);
+      chunks.push(value);
+      total += value.length;
+      // Trim from the front until the retained bytes fit the cap: whole chunks
+      // first, then a partial slice of the oldest survivor.
+      while (total > maxBytes) {
+        const oldest = chunks[0];
+        if (total - oldest.length >= maxBytes) {
+          chunks.shift();
+          total -= oldest.length;
+        } else {
+          const drop = total - maxBytes;
+          chunks[0] = oldest.subarray(drop);
+          total -= drop;
+        }
+        truncated = true;
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return { text: decodeChunks(chunks, total), truncated };
+}
+
+/** Concatenate `total` bytes of `chunks` into one buffer and decode as UTF-8. */
+function decodeChunks(chunks: Uint8Array[], total: number): string {
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    merged.set(c, offset);
+    offset += c.length;
+  }
+  return new TextDecoder().decode(merged);
+}

--- a/packages/core/src/capture.ts
+++ b/packages/core/src/capture.ts
@@ -45,6 +45,29 @@ export function truncationNotice(maxBytes: number): string {
 }
 
 /**
+ * Reject a capture cap {@link captureStream} cannot honour — anything that is
+ * not a positive whole number of bytes — at the setter, before a process is
+ * spawned, rather than letting the trim loop fail mid-stream with an opaque
+ * internal error.
+ *
+ * There is deliberately no "unlimited" sentinel: a caller that must keep every
+ * byte passes a cap larger than the output it expects (`Number.MAX_SAFE_INTEGER`
+ * for "however much there is"), so the ceiling is always visible in the code.
+ *
+ * @param bytes The requested cap.
+ * @throws {RangeError} If `bytes` is not a positive integer.
+ */
+export function checkMaxCapturedBytes(bytes: number): void {
+  if (Number.isInteger(bytes) && bytes > 0) return;
+  throw new RangeError(
+    `maxCapturedBytes must be a positive whole number of bytes, got ${bytes}. ` +
+      `Pass the number of bytes to keep per stream, e.g. 8 * 1024 * 1024. ` +
+      `There is no unlimited value: to keep everything, pass a cap larger ` +
+      `than the output you expect, such as Number.MAX_SAFE_INTEGER.`,
+  );
+}
+
+/**
  * Drain `stream`, writing every chunk to `sink` when one is given, and capture
  * at most `maxBytes` of it — dropping from the FRONT so the newest output
  * survives.

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -60,6 +60,7 @@ import { absolutePath } from "./path.ts";
 import type { TargetBuilder } from "./target.ts";
 import type { RunRecord, SignalRecord, WaitState } from "./state/types.ts";
 import { withAmbientSignal } from "./ambient_signal.ts";
+import { withAmbientRedactor } from "./ambient_redactor.ts";
 import { defaultStateHost, type StateStore } from "./state/store.ts";
 import { resolveStateStore } from "./state/resolve.ts";
 import { buildRunRecord, ciRunUrl, resolveActor } from "./state/record.ts";
@@ -677,7 +678,13 @@ export async function execute(
     // the plan throws — nothing to restore. Both schedulers convert every
     // target-path reject into a failed outcome (never rejecting themselves), so
     // the run always settles here rather than stranding the record `running`.
-    run = await withAmbientSignal(runController.signal, runPlan);
+    // The same scope installs the redactor the shell renders command lines
+    // through, so a secret passed to `$` as an argv token is masked in the echo
+    // and in any error message that quotes the command.
+    run = await withAmbientSignal(
+      runController.signal,
+      () => withAmbientRedactor(redactor, runPlan),
+    );
   } finally {
     if (options.signal !== undefined) {
       options.signal.removeEventListener("abort", onCancel);

--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -19,6 +19,7 @@
 import type { AbsolutePath, PathLike } from "./path.ts";
 import { ambientSignal } from "./ambient_signal.ts";
 import { ambientEcho } from "./ambient_echo.ts";
+import { terminateProcess, TERMINATION_GRACE_MS } from "./terminate.ts";
 
 /**
  * Split an already-written command string into argv with POSIX quoting rules —
@@ -26,15 +27,6 @@ import { ambientEcho } from "./ambient_echo.ts";
  * recipe) rather than being constructed with `$`.
  */
 export { ShellArgsError, splitShellArgs } from "./split_args.ts";
-
-/** Combine an optional timeout signal and an optional cancellation signal. */
-function combineSignals(
-  a: AbortSignal | undefined,
-  b: AbortSignal | undefined,
-): AbortSignal | undefined {
-  if (a !== undefined && b !== undefined) return AbortSignal.any([a, b]);
-  return a ?? b;
-}
 
 /** A value that may be interpolated into a `$` template. */
 export type Interpolatable =
@@ -138,34 +130,13 @@ export class SpawnedProcess {
    * teardown. A process that has already exited is treated as stopped. A
    * dry-run stub (no child) is a no-op.
    */
-  async stop(
+  stop(
     signal: Deno.Signal = "SIGTERM",
-    graceMs = 5000,
+    graceMs: number = TERMINATION_GRACE_MS,
   ): Promise<void> {
     const child = this.#child;
-    if (child === undefined) return; // dry-run stub: nothing to stop.
-    try {
-      child.kill(signal);
-    } catch {
-      return; // Already exited: nothing to signal.
-    }
-    // Race the process's exit against a grace timer; escalate to SIGKILL if the
-    // timer wins. The timer is always cleared so it never leaks.
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    const graceExpired = new Promise<boolean>((resolve) => {
-      timer = setTimeout(() => resolve(true), graceMs);
-    });
-    const exited = child.status.then(() => false);
-    const shouldKill = await Promise.race([exited, graceExpired]);
-    if (timer !== undefined) clearTimeout(timer);
-    if (shouldKill) {
-      try {
-        child.kill("SIGKILL");
-      } catch {
-        // Raced to exit between the timeout and the kill.
-      }
-    }
-    await child.status;
+    if (child === undefined) return Promise.resolve(); // stub: nothing to stop.
+    return terminateProcess(child, signal, graceMs);
   }
 }
 
@@ -301,23 +272,11 @@ export class Command implements PromiseLike<CommandOutput> {
     const [cmd, ...args] = this.#argv;
     if (!cmd) throw new Error("Cannot run an empty command.");
 
-    // A timeout aborts the child via an AbortSignal; `timedOut` distinguishes
-    // that kill from an ordinary non-zero exit so we can raise a dedicated error.
     const ms = this.#timeoutMs;
-    const controller = ms === undefined ? undefined : new AbortController();
+    // `timedOut` distinguishes a timeout kill from an ordinary non-zero exit so
+    // we can raise a dedicated error.
     let timedOut = false;
-    const timer = ms === undefined ? undefined : setTimeout(() => {
-      timedOut = true;
-      controller?.abort();
-    }, ms);
-
-    // The timeout's own signal is folded together with the cancellation signal
-    // (an explicit `.signal()`, else the executor's ambient run signal), so an
-    // aborted run terminates the child even when a timeout is also armed.
-    const signal = combineSignals(
-      controller?.signal,
-      this.#signal ?? ambientSignal(),
-    );
+    let timer: ReturnType<typeof setTimeout> | undefined;
 
     try {
       const child = new Deno.Command(cmd, {
@@ -326,8 +285,21 @@ export class Command implements PromiseLike<CommandOutput> {
         env: this.#env,
         stdout: "piped",
         stderr: "piped",
-        signal,
+        // Cancellation (an explicit `.signal()`, else the executor's ambient run
+        // signal) terminates the child too, independently of the timeout below.
+        signal: this.#signal ?? ambientSignal(),
       }).spawn();
+
+      // A timeout terminates the child itself rather than aborting the spawn
+      // signal, because that only ever delivers SIGTERM: a child that ignores it
+      // would keep the streams open and hang the run forever. The escalating
+      // sequence guarantees the process dies and this promise settles.
+      if (ms !== undefined) {
+        timer = setTimeout(() => {
+          timedOut = true;
+          void terminateProcess(child);
+        }, ms);
+      }
 
       // When capturing programmatically, don't echo stdout to the terminal.
       const streamStdout = !this.#quiet && !this.#capturing;

--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -20,6 +20,11 @@ import type { AbsolutePath, PathLike } from "./path.ts";
 import { ambientSignal } from "./ambient_signal.ts";
 import { ambientEcho } from "./ambient_echo.ts";
 import { terminateProcess, TERMINATION_GRACE_MS } from "./terminate.ts";
+import {
+  captureStream,
+  DEFAULT_MAX_CAPTURED_BYTES,
+  truncationNotice,
+} from "./capture.ts";
 
 /**
  * Split an already-written command string into argv with POSIX quoting rules —
@@ -84,11 +89,24 @@ export class CommandOutput {
     readonly stdout: string,
     /** Captured standard error. */
     readonly stderr: string,
+    /**
+     * Whether either captured stream hit the capture cap, in which case it holds
+     * only its tail — the newest bytes — and its beginning is gone. See
+     * {@link Command.maxCapturedBytes}.
+     */
+    readonly truncated: boolean = false,
+    /** The per-stream capture cap that applied, in bytes. */
+    readonly maxCapturedBytes: number = DEFAULT_MAX_CAPTURED_BYTES,
   ) {}
 
-  /** Trimmed stdout. */
+  /**
+   * Trimmed stdout, prefixed with a one-line notice when {@link truncated} — so
+   * a caller reading the output cannot mistake a tail for the whole of it.
+   */
   text(): string {
-    return this.stdout.trim();
+    const text = this.stdout.trim();
+    if (!this.truncated) return text;
+    return `${truncationNotice(this.maxCapturedBytes)}\n${text}`;
   }
 }
 
@@ -144,39 +162,7 @@ interface RunResult {
   code: number;
   stdout: string;
   stderr: string;
-}
-
-/** Concatenate byte chunks into one buffer and decode as UTF-8. */
-function decodeChunks(chunks: Uint8Array[]): string {
-  let total = 0;
-  for (const c of chunks) total += c.length;
-  const merged = new Uint8Array(total);
-  let offset = 0;
-  for (const c of chunks) {
-    merged.set(c, offset);
-    offset += c.length;
-  }
-  return new TextDecoder().decode(merged);
-}
-
-/** Drain a stream, optionally tee-ing each chunk to a live sink, and capture. */
-async function collect(
-  stream: ReadableStream<Uint8Array>,
-  sink: { writeSync(p: Uint8Array): number } | null,
-): Promise<string> {
-  const reader = stream.getReader();
-  const chunks: Uint8Array[] = [];
-  try {
-    while (true) {
-      const { value, done } = await reader.read();
-      if (done) break;
-      chunks.push(value);
-      if (sink) sink.writeSync(value);
-    }
-  } finally {
-    reader.releaseLock();
-  }
-  return decodeChunks(chunks);
+  truncated: boolean;
 }
 
 /**
@@ -193,6 +179,7 @@ export class Command implements PromiseLike<CommandOutput> {
   #capturing = false;
   #timeoutMs?: number;
   #signal?: AbortSignal;
+  #maxCapturedBytes = DEFAULT_MAX_CAPTURED_BYTES;
   #result?: Promise<RunResult>;
 
   /** Build a command from a discrete argv array (binary first). */
@@ -234,6 +221,19 @@ export class Command implements PromiseLike<CommandOutput> {
   }
 
   /**
+   * Cap how much of **each** captured stream is kept in memory, in bytes
+   * (default 8 MiB). Capture keeps the newest bytes: once the cap is reached the
+   * oldest are dropped, {@link CommandOutput.truncated} is set, and
+   * {@link CommandOutput.text} prefixes a notice. Raise it for a command whose
+   * whole output you must parse; lower it to bound a chatty one. Live streaming
+   * to the terminal is never capped — every byte still reaches it.
+   */
+  maxCapturedBytes(bytes: number): this {
+    this.#maxCapturedBytes = bytes;
+    return this;
+  }
+
+  /**
    * Terminate the process (via `SIGTERM`) when `signal` aborts — for example
    * when the enclosing run is cancelled. Overrides the executor's ambient
    * run signal for this command. Composes with {@link killAfter}: either the
@@ -263,7 +263,12 @@ export class Command implements PromiseLike<CommandOutput> {
     const echo = ambientEcho();
     if (echo !== undefined) {
       echo(this.commandLine);
-      return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+      return Promise.resolve({
+        code: 0,
+        stdout: "",
+        stderr: "",
+        truncated: false,
+      });
     }
     return this.#spawn();
   }
@@ -305,15 +310,23 @@ export class Command implements PromiseLike<CommandOutput> {
       const streamStdout = !this.#quiet && !this.#capturing;
       const streamStderr = !this.#quiet;
 
+      // Capture is bounded (per stream) so a runaway child cannot grow the buffer
+      // until the run dies; the tee to the terminal above stays unbounded.
+      const cap = this.#maxCapturedBytes;
       const [stdout, stderr] = await Promise.all([
-        collect(child.stdout, streamStdout ? Deno.stdout : null),
-        collect(child.stderr, streamStderr ? Deno.stderr : null),
+        captureStream(child.stdout, streamStdout ? Deno.stdout : null, cap),
+        captureStream(child.stderr, streamStderr ? Deno.stderr : null, cap),
       ]);
       const status = await child.status;
       if (timedOut && ms !== undefined) {
         throw new CommandTimeoutError(this.commandLine, ms);
       }
-      return { code: status.code, stdout, stderr };
+      return {
+        code: status.code,
+        stdout: stdout.text,
+        stderr: stderr.text,
+        truncated: stdout.truncated || stderr.truncated,
+      };
     } finally {
       if (timer !== undefined) clearTimeout(timer);
     }
@@ -340,15 +353,22 @@ export class Command implements PromiseLike<CommandOutput> {
   async #output(): Promise<CommandOutput> {
     const r = await this.#run();
     this.#maybeThrow(r);
-    return new CommandOutput(r.code, r.stdout, r.stderr);
+    return new CommandOutput(
+      r.code,
+      r.stdout,
+      r.stderr,
+      r.truncated,
+      this.#maxCapturedBytes,
+    );
   }
 
-  /** Run and resolve to trimmed stdout. Throws on non-zero unless `noThrow`. */
+  /**
+   * Run and resolve to trimmed stdout — prefixed with a truncation notice if the
+   * capture cap was hit. Throws on non-zero unless `noThrow`.
+   */
   async text(): Promise<string> {
     this.#capturing = true;
-    const r = await this.#run();
-    this.#maybeThrow(r);
-    return r.stdout.trim();
+    return (await this.#output()).text();
   }
 
   /** Run and resolve to stdout split into lines (trailing blank dropped). */

--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -19,6 +19,7 @@
 import type { AbsolutePath, PathLike } from "./path.ts";
 import { ambientSignal } from "./ambient_signal.ts";
 import { ambientEcho } from "./ambient_echo.ts";
+import { redactLine } from "./ambient_redactor.ts";
 import { terminateProcess, TERMINATION_GRACE_MS } from "./terminate.ts";
 import {
   captureStream,
@@ -244,9 +245,15 @@ export class Command implements PromiseLike<CommandOutput> {
     return this;
   }
 
-  /** The command line, for diagnostics. */
+  /**
+   * The command line, for diagnostics — argv joined by spaces, with the resolved
+   * value of every `secret` parameter of the enclosing run masked. This is the
+   * only rendered form of the command (the echo under `--dry-run`, a
+   * {@link CommandError} message), so a secret passed as an argv token cannot
+   * leak through one. The argv given to the operating system is unchanged.
+   */
   get commandLine(): string {
-    return this.#argv.join(" ");
+    return redactLine(this.#argv.join(" "));
   }
 
   #run(): Promise<RunResult> {

--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -20,6 +20,13 @@ import type { AbsolutePath, PathLike } from "./path.ts";
 import { ambientSignal } from "./ambient_signal.ts";
 import { ambientEcho } from "./ambient_echo.ts";
 
+/**
+ * Split an already-written command string into argv with POSIX quoting rules —
+ * for input that arrives as one line (a `package.json` script, a Makefile
+ * recipe) rather than being constructed with `$`.
+ */
+export { ShellArgsError, splitShellArgs } from "./split_args.ts";
+
 /** Combine an optional timeout signal and an optional cancellation signal. */
 function combineSignals(
   a: AbortSignal | undefined,

--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -23,6 +23,7 @@ import { redactLine } from "./ambient_redactor.ts";
 import { terminateProcess, TERMINATION_GRACE_MS } from "./terminate.ts";
 import {
   captureStream,
+  checkMaxCapturedBytes,
   DEFAULT_MAX_CAPTURED_BYTES,
   truncationNotice,
 } from "./capture.ts";
@@ -228,8 +229,11 @@ export class Command implements PromiseLike<CommandOutput> {
    * {@link CommandOutput.text} prefixes a notice. Raise it for a command whose
    * whole output you must parse; lower it to bound a chatty one. Live streaming
    * to the terminal is never capped — every byte still reaches it.
+   *
+   * @throws {RangeError} If `bytes` is not a positive whole number.
    */
   maxCapturedBytes(bytes: number): this {
+    checkMaxCapturedBytes(bytes);
     this.#maxCapturedBytes = bytes;
     return this;
   }

--- a/packages/core/src/split_args.ts
+++ b/packages/core/src/split_args.ts
@@ -1,0 +1,162 @@
+/**
+ * Split a command **string** into an argv array using POSIX quoting rules.
+ *
+ * This is the escape hatch for input that arrives as one already-written command
+ * line — a `package.json` script, a Makefile recipe, a config field — which must
+ * become discrete argv entries before it can be handed to
+ * {@link "./shell.ts".Command}. Command *construction* inside a build should use
+ * the `$` template instead, which never has to parse anything.
+ *
+ * @module
+ */
+
+/**
+ * Raised when {@link splitShellArgs} reaches the end of the input with a quote
+ * still open. Names the offending quote character and the offset at which it was
+ * opened so the bad spot in a long command line is findable.
+ */
+export class ShellArgsError extends Error {
+  /** The error name. */
+  override name = "ShellArgsError";
+  /** Build the error from the unclosed quote character and its offset. */
+  constructor(
+    /** The quote character that was never closed — `'` or `"`. */
+    readonly quote: string,
+    /** The zero-based index in the input at which that quote was opened. */
+    readonly offset: number,
+  ) {
+    super(
+      `Unterminated ${quote} quote in command string at offset ${offset}. ` +
+        `Close the quote, or escape it with a backslash if the character was ` +
+        `meant literally.`,
+    );
+  }
+}
+
+/** Characters that separate arguments outside quotes. */
+const SEPARATORS = " \t\n\r";
+
+/**
+ * Split `input` into argv the way a POSIX shell would, honouring the **quoting
+ * rules only**:
+ *
+ * - Unquoted runs of whitespace separate arguments; leading, trailing, and
+ *   repeated whitespace produce no empty arguments.
+ * - Single quotes are fully literal — no escape sequences at all, so `'a\b'`
+ *   yields `a\b`.
+ * - Inside double quotes a backslash escapes only `"`, `\`, `` ` ``, `$`, and a
+ *   newline; before anything else it stays literal, so `"\d+"` yields `\d+`
+ *   rather than silently losing the backslash.
+ * - Outside quotes a backslash escapes the following character, so `a\ b` is one
+ *   argument.
+ * - A backslash-newline pair is a line continuation and is removed, both
+ *   unquoted and inside double quotes; a backslash at the very end of the input
+ *   is a dangling continuation and is dropped.
+ * - Adjacent segments concatenate (`a"b c"d` → `ab cd`) and a quoted empty
+ *   string is a real, empty argument (`''` → `[""]`).
+ *
+ * **Non-goals**, deliberately not implemented — the input is turned into argv,
+ * never interpreted: no variable expansion (`"$HOME"` stays `$HOME`), no
+ * globbing, no tilde expansion, no command substitution, and no operator
+ * handling of any kind (`|`, `&&`, `;`, `>` are ordinary characters). A caller
+ * that needs those must split on them itself, or run a real shell.
+ *
+ * `\r` is treated as a separator alongside space, tab, and newline so a command
+ * line read from a CRLF file cannot smuggle an invisible carriage return into an
+ * argument.
+ *
+ * @param input The command string to split.
+ * @returns The argv entries, in order; an empty array for blank input.
+ * @throws {ShellArgsError} If a single or double quote is never closed.
+ */
+export function splitShellArgs(input: string): string[] {
+  const args: string[] = [];
+  let current = "";
+  let started = false;
+
+  const flush = () => {
+    if (started) {
+      args.push(current);
+      current = "";
+      started = false;
+    }
+  };
+
+  let i = 0;
+  while (i < input.length) {
+    const ch = input[i];
+
+    if (ch === "'") {
+      // Fully literal: everything up to the next quote, escapes included.
+      const end = input.indexOf("'", i + 1);
+      if (end === -1) throw new ShellArgsError("'", i);
+      current += input.slice(i + 1, end);
+      started = true;
+      i = end + 1;
+      continue;
+    }
+
+    if (ch === '"') {
+      const opened = i;
+      let closed = false;
+      started = true;
+      i++;
+      while (i < input.length) {
+        const c = input[i];
+        if (c === '"') {
+          closed = true;
+          i++;
+          break;
+        }
+        if (c === "\\") {
+          const next = input[i + 1];
+          if (next === "\n") {
+            i += 2; // Line continuation: both characters vanish.
+            continue;
+          }
+          if (next === '"' || next === "\\" || next === "$" || next === "`") {
+            current += next;
+            i += 2;
+            continue;
+          }
+          // Any other character: the backslash is an ordinary character, so a
+          // pattern like "\d+" keeps its backslash.
+          current += "\\";
+          i++;
+          continue;
+        }
+        current += c;
+        i++;
+      }
+      if (!closed) throw new ShellArgsError('"', opened);
+      continue;
+    }
+
+    if (ch === "\\") {
+      const next = input[i + 1];
+      if (next === undefined || next === "\n") {
+        // Dangling or line continuation: nothing is contributed, and this does
+        // not start a word.
+        i = next === undefined ? i + 1 : i + 2;
+        continue;
+      }
+      current += next;
+      started = true;
+      i += 2;
+      continue;
+    }
+
+    if (SEPARATORS.includes(ch)) {
+      flush();
+      i++;
+      continue;
+    }
+
+    current += ch;
+    started = true;
+    i++;
+  }
+
+  flush();
+  return args;
+}

--- a/packages/core/src/terminate.ts
+++ b/packages/core/src/terminate.ts
@@ -1,0 +1,66 @@
+/**
+ * The one way Zuke ends a child process: signal politely, wait out a grace
+ * window, then `SIGKILL`.
+ *
+ * Both places that terminate a process — stopping a service
+ * ({@link "./shell.ts".SpawnedProcess.stop}) and reaping a command that blew its
+ * {@link "./shell.ts".Command.killAfter} budget — share this sequence, so a child
+ * that ignores `SIGTERM` can never hang a teardown or a timeout. Internal (not a
+ * published entrypoint).
+ *
+ * @module
+ */
+
+/** How long a process is given to exit on its own before `SIGKILL`, in ms. */
+export const TERMINATION_GRACE_MS = 5000;
+
+/** The part of `Deno.ChildProcess` the termination sequence needs. */
+export interface Terminable {
+  /** Deliver a signal to the process. Throws if it has already exited. */
+  kill(signal?: Deno.Signal): void;
+  /** Resolves when the process exits. */
+  readonly status: Promise<Deno.CommandStatus>;
+}
+
+/**
+ * Terminate `child` and resolve once it has actually exited.
+ *
+ * Sends `signal`, then races the process's exit against `graceMs`; if the grace
+ * window wins, escalates to `SIGKILL`. A process that has already exited (a
+ * throwing `kill`) is treated as stopped, and a process that exits in the
+ * instant between the grace timer and the escalation is fine too — neither is an
+ * error. The grace timer is always cleared, so nothing is left pending.
+ *
+ * Windows has no `SIGTERM` semantics: `kill` terminates the process outright
+ * there, so the escalation simply never fires — no platform branch needed.
+ *
+ * @param child The process to end.
+ * @param signal The signal to send first — `SIGTERM` unless a caller needs another.
+ * @param graceMs How long to wait for a clean exit before `SIGKILL`.
+ */
+export async function terminateProcess(
+  child: Terminable,
+  signal: Deno.Signal = "SIGTERM",
+  graceMs: number = TERMINATION_GRACE_MS,
+): Promise<void> {
+  try {
+    child.kill(signal);
+  } catch {
+    return; // Already exited: nothing to signal.
+  }
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const graceExpired = new Promise<boolean>((resolve) => {
+    timer = setTimeout(() => resolve(true), graceMs);
+  });
+  const exited = child.status.then(() => false);
+  const shouldKill = await Promise.race([exited, graceExpired]);
+  if (timer !== undefined) clearTimeout(timer);
+  if (shouldKill) {
+    try {
+      child.kill("SIGKILL");
+    } catch {
+      // Raced to exit between the timeout and the kill.
+    }
+  }
+  await child.status;
+}

--- a/packages/core/src/tooling.ts
+++ b/packages/core/src/tooling.ts
@@ -20,6 +20,7 @@
  */
 
 import { Command, type CommandOutput } from "./shell.ts";
+import { checkMaxCapturedBytes } from "./capture.ts";
 import { type AbsolutePath, absolutePath, type PathLike } from "./path.ts";
 
 export type { PathLike };
@@ -205,6 +206,7 @@ export abstract class ToolSettings {
   #throwOnError = true;
   #quiet = false;
   #timeoutMs?: number;
+  #maxCapturedBytes?: number;
   #toolPath?: string;
   #resolution?: ToolResolution;
   #extraArgs: string[] = [];
@@ -266,6 +268,22 @@ export abstract class ToolSettings {
    */
   killAfter(ms: number): this {
     this.#timeoutMs = ms;
+    return this;
+  }
+
+  /**
+   * Cap how much of **each** captured stream the run keeps in memory, in bytes
+   * (default 8 MiB). Once the cap is reached the oldest bytes are dropped,
+   * `CommandOutput.truncated` is set, and `CommandOutput.text` prefixes a
+   * notice. Raise it for a tool whose whole output must be parsed — a coverage
+   * report, a `--json` dump — and lower it to bound a chatty one. Live
+   * streaming to the terminal is never capped.
+   *
+   * @throws {RangeError} If `bytes` is not a positive whole number.
+   */
+  maxCapturedBytes(bytes: number): this {
+    checkMaxCapturedBytes(bytes);
+    this.#maxCapturedBytes = bytes;
     return this;
   }
 
@@ -352,6 +370,9 @@ export abstract class ToolSettings {
     if (!this.#throwOnError) command.noThrow();
     if (this.#quiet) command.quiet();
     if (this.#timeoutMs !== undefined) command.killAfter(this.#timeoutMs);
+    if (this.#maxCapturedBytes !== undefined) {
+      command.maxCapturedBytes(this.#maxCapturedBytes);
+    }
     return command;
   }
 

--- a/packages/core/tests/capture_test.ts
+++ b/packages/core/tests/capture_test.ts
@@ -1,0 +1,77 @@
+import { assertEquals } from "./_assert.ts";
+import {
+  captureStream,
+  DEFAULT_MAX_CAPTURED_BYTES,
+  formatByteCap,
+  truncationNotice,
+} from "../src/capture.ts";
+
+const encoder = new TextEncoder();
+
+/** A stream that yields each string as its own chunk — the chunk seam matters. */
+function streamOf(...parts: string[]): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const p of parts) controller.enqueue(encoder.encode(p));
+      controller.close();
+    },
+  });
+}
+
+/** A sink that records every byte written, standing in for `Deno.stdout`. */
+function recordingSink() {
+  const written: string[] = [];
+  const decoder = new TextDecoder();
+  return {
+    written,
+    writeSync(p: Uint8Array): number {
+      written.push(decoder.decode(p));
+      return p.length;
+    },
+  };
+}
+
+Deno.test("captureStream keeps everything under the cap", async () => {
+  const got = await captureStream(streamOf("abc", "def"), null, 1024);
+  assertEquals(got, { text: "abcdef", truncated: false });
+});
+
+Deno.test("captureStream slices the oldest chunk when it straddles the cap", async () => {
+  const got = await captureStream(streamOf("1111", "2222"), null, 6);
+  assertEquals(got.text, "112222");
+  assertEquals(got.truncated, true);
+});
+
+Deno.test("captureStream drops whole chunks that fall out of the window", async () => {
+  const got = await captureStream(streamOf("1111", "2222", "3333"), null, 4);
+  assertEquals(got.text, "3333");
+  assertEquals(got.truncated, true);
+});
+
+Deno.test("captureStream still streams every byte to the sink", async () => {
+  const sink = recordingSink();
+  const got = await captureStream(streamOf("1111", "2222"), sink, 4);
+  // Capture kept only the tail…
+  assertEquals(got.text, "2222");
+  // …but the live sink saw the whole thing.
+  assertEquals(sink.written.join(""), "11112222");
+});
+
+Deno.test("captureStream handles an empty stream", async () => {
+  const got = await captureStream(streamOf(), null, 8);
+  assertEquals(got, { text: "", truncated: false });
+});
+
+Deno.test("formatByteCap renders whole MiB, whole KiB, then bytes", () => {
+  assertEquals(formatByteCap(DEFAULT_MAX_CAPTURED_BYTES), "8 MiB");
+  assertEquals(formatByteCap(4096), "4 KiB");
+  assertEquals(formatByteCap(1500), "1500 bytes");
+  assertEquals(formatByteCap(10), "10 bytes");
+});
+
+Deno.test("truncationNotice names the cap that applied", () => {
+  assertEquals(
+    truncationNotice(4096),
+    "[output truncated to last 4 KiB]",
+  );
+});

--- a/packages/core/tests/shell_test.ts
+++ b/packages/core/tests/shell_test.ts
@@ -158,6 +158,43 @@ Deno.test("$ .killAfter() fires even under .noThrow()", async () => {
   );
 });
 
+Deno.test("$ caps captured output and keeps the tail", async () => {
+  // 40 lines of 1 KiB, numbered, into a 4 KiB cap: only the last few survive.
+  const emit =
+    `for (let i = 0; i < 40; i++) console.log(String(i).padStart(4, "0") + "x".repeat(1019));`;
+  const out = await $`${DENO} eval ${emit}`
+    .quiet()
+    .maxCapturedBytes(4096)
+    .then();
+  assertEquals(out.truncated, true);
+  // The bytes kept are the LAST ones written…
+  assertEquals(out.stdout.trimEnd().endsWith("x".repeat(1019)), true);
+  assertEquals(out.stdout.includes("0039"), true);
+  // …not the first, and the buffer really is bounded (a memory proxy).
+  assertEquals(out.stdout.includes("0000"), false);
+  assertEquals(out.stdout.length <= 4096, true, `kept ${out.stdout.length}`);
+  // The notice makes the loss visible instead of silently truncating.
+  assertEquals(out.text().startsWith("[output truncated to last 4 KiB]"), true);
+});
+
+Deno.test("$ leaves output under the cap untouched and not truncated", async () => {
+  const out = await $`${DENO} eval ${"console.log('small')"}`
+    .maxCapturedBytes(4096)
+    .then();
+  assertEquals(out.truncated, false);
+  assertEquals(out.text(), "small");
+});
+
+Deno.test("$ caps stderr independently of stdout", async () => {
+  const emit =
+    `console.log("out"); for (let i = 0; i < 8; i++) console.error("e".repeat(1024));`;
+  const out = await $`${DENO} eval ${emit}`.quiet().maxCapturedBytes(2048)
+    .then();
+  assertEquals(out.truncated, true);
+  assertEquals(out.stdout.includes("out"), true); // stdout was never over cap
+  assertEquals(out.stderr.length <= 2048, true);
+});
+
 Deno.test("$ .signal() terminates a running command when it aborts", async () => {
   const controller = new AbortController();
   const running = $`${DENO} eval ${SLEEP}`

--- a/packages/core/tests/shell_test.ts
+++ b/packages/core/tests/shell_test.ts
@@ -1,4 +1,8 @@
-import { assertEquals, assertRejects } from "./_assert.ts";
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "./_assert.ts";
 import {
   $,
   CommandError,
@@ -7,6 +11,8 @@ import {
 } from "../src/shell.ts";
 import { withAmbientSignal } from "../src/ambient_signal.ts";
 import { withAmbientEcho } from "../src/ambient_echo.ts";
+import { withAmbientRedactor } from "../src/ambient_redactor.ts";
+import { REDACTED, Redactor } from "../src/redact.ts";
 
 /** A command that sleeps far longer than any test would wait. */
 const SLEEP = "await new Promise((r) => setTimeout(r, 30000))";
@@ -247,6 +253,53 @@ Deno.test("$ .killAfter() and .signal() combine — either can end it", async ()
   setTimeout(() => controller.abort(), 50);
   const result = await running;
   assertEquals(result.code !== 0, true);
+});
+
+Deno.test("commandLine masks an ambient secret but the OS still gets it raw", async () => {
+  const redactor = new Redactor();
+  redactor.add("hunter2");
+  await withAmbientRedactor(redactor, async () => {
+    const cmd = $`${DENO} eval ${"console.log(Deno.args[0])"} -- ${"hunter2"}`;
+    // The rendered line is masked…
+    assertStringIncludes(cmd.commandLine, REDACTED);
+    assertEquals(cmd.commandLine.includes("hunter2"), false);
+    // …while the argv handed to the process is untouched: the child echoes the
+    // real value back.
+    assertEquals(await cmd.text(), "hunter2");
+  });
+});
+
+Deno.test("a failed command's error message masks an ambient secret", async () => {
+  const redactor = new Redactor();
+  redactor.add("hunter2");
+  await withAmbientRedactor(redactor, async () => {
+    const err = await assertRejects(
+      () => $`${DENO} eval ${"Deno.exit(9)"} -- ${"hunter2"}`.quiet().then(),
+      CommandError,
+    );
+    assertEquals(err.message.includes("hunter2"), false);
+    assertStringIncludes(err.message, REDACTED);
+  });
+});
+
+Deno.test("a dry-run echo of a secret argv token is masked", async () => {
+  const redactor = new Redactor();
+  redactor.add("hunter2");
+  const echoed: string[] = [];
+  await withAmbientRedactor(
+    redactor,
+    () =>
+      withAmbientEcho(
+        (line) => echoed.push(line),
+        async () => await $`login --password ${"hunter2"}`,
+      ),
+  );
+  assertEquals(echoed, [`login --password ${REDACTED}`]);
+});
+
+Deno.test("without an ambient redactor the command line is verbatim", () => {
+  const cmd = $`login --password ${"hunter2"}`;
+  assertEquals(cmd.commandLine, "login --password hunter2");
 });
 
 Deno.test("under an ambient echo sink, a command is echoed, not spawned", async () => {

--- a/packages/core/tests/shell_test.ts
+++ b/packages/core/tests/shell_test.ts
@@ -2,6 +2,8 @@ import {
   assertEquals,
   assertRejects,
   assertStringIncludes,
+  assertThrows,
+  messageOf,
 } from "./_assert.ts";
 import {
   $,
@@ -189,6 +191,20 @@ Deno.test("$ leaves output under the cap untouched and not truncated", async () 
     .then();
   assertEquals(out.truncated, false);
   assertEquals(out.text(), "small");
+});
+
+Deno.test("$ .maxCapturedBytes() rejects a cap capture cannot honour", () => {
+  // `-1` is the conventional "no limit" idiom and used to spin the trim loop
+  // into an internal TypeError mid-stream; a fractional cap hit a RangeError
+  // deep in a subarray. Both must fail at the setter, naming the setting.
+  for (const bad of [-1, 0, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+    const err = assertThrows(
+      () => $`${DENO} eval ${"1"}`.maxCapturedBytes(bad),
+      RangeError,
+    );
+    assertStringIncludes(messageOf(err), "maxCapturedBytes");
+    assertStringIncludes(messageOf(err), String(bad));
+  }
 });
 
 Deno.test("$ caps stderr independently of stdout", async () => {

--- a/packages/core/tests/split_args_test.ts
+++ b/packages/core/tests/split_args_test.ts
@@ -1,0 +1,83 @@
+import { assertEquals, assertStringIncludes, assertThrows } from "./_assert.ts";
+import { ShellArgsError, splitShellArgs } from "../src/split_args.ts";
+
+// The vector table below mirrors `bash -c 'printf "%s\n" <input>'` for the
+// quoting subset. Each row is one behaviour; the comment gives the *shell*
+// source, the TS literal escapes it.
+
+Deno.test("splitShellArgs: plain whitespace splitting", () => {
+  assertEquals(splitShellArgs("a b c"), ["a", "b", "c"]); // 1
+  assertEquals(splitShellArgs("  a   b  "), ["a", "b"]); // 2
+  assertEquals(splitShellArgs(""), []); // 3
+  assertEquals(splitShellArgs("   "), []); // 4
+});
+
+Deno.test("splitShellArgs: quoted words and adjacency", () => {
+  assertEquals(splitShellArgs("'a b'"), ["a b"]); // 5
+  assertEquals(splitShellArgs('"a b"'), ["a b"]); // 6
+  assertEquals(splitShellArgs('a"b c"d'), ["ab cd"]); // 7
+});
+
+Deno.test("splitShellArgs: single quotes are fully literal", () => {
+  // shell: 'a\b'
+  assertEquals(splitShellArgs("'a\\b'"), ["a\\b"]); // 8
+});
+
+Deno.test("splitShellArgs: double-quoted backslash escapes a subset only", () => {
+  // shell: "\d+" — the backslash is kept, so a regex survives the round trip.
+  assertEquals(splitShellArgs('"\\d+"'), ["\\d+"]); // 9
+  // shell: "a\"b"
+  assertEquals(splitShellArgs('"a\\"b"'), ['a"b']); // 10
+  // shell: "a\\b"
+  assertEquals(splitShellArgs('"a\\\\b"'), ["a\\b"]); // 11
+});
+
+Deno.test("splitShellArgs: unquoted backslash escapes the next character", () => {
+  assertEquals(splitShellArgs("a\\ b"), ["a b"]); // 12 — shell: a\ b
+  assertEquals(splitShellArgs("a\\\\b"), ["a\\b"]); // 13 — shell: a\\b
+});
+
+Deno.test("splitShellArgs: empty quotes yield an empty argument", () => {
+  assertEquals(splitShellArgs("''"), [""]); // 14
+  assertEquals(splitShellArgs('""'), [""]); // 15
+  assertEquals(splitShellArgs('a"" b'), ["a", "b"]); // 16
+});
+
+Deno.test("splitShellArgs: tabs and newlines separate; backslash-newline continues", () => {
+  assertEquals(splitShellArgs("a\tb\nc"), ["a", "b", "c"]); // 17
+  assertEquals(splitShellArgs('"a\\\nb"'), ["ab"]); // 18 — inside double quotes
+  assertEquals(splitShellArgs("a\\\nb"), ["ab"]); // 19 — unquoted
+});
+
+Deno.test("splitShellArgs: flags, and no variable expansion", () => {
+  assertEquals(splitShellArgs('--filter "x y" -x'), [ // 20
+    "--filter",
+    "x y",
+    "-x",
+  ]);
+  assertEquals(splitShellArgs('"$HOME"'), ["$HOME"]); // 21 — documented non-goal
+  assertEquals(splitShellArgs('"\\$HOME"'), ["$HOME"]); // 22 — shell: "\$HOME"
+});
+
+Deno.test("splitShellArgs: an unterminated quote is an error", () => {
+  const dq = assertThrows(() => splitShellArgs('"abc'), ShellArgsError); // 23
+  assertStringIncludes(dq.message, 'Unterminated " quote');
+  assertStringIncludes(dq.message, "offset 0");
+  const sq = assertThrows(() => splitShellArgs("'abc"), ShellArgsError); // 24
+  assertStringIncludes(sq.message, "Unterminated ' quote");
+  assertStringIncludes(sq.message, "offset 0");
+});
+
+Deno.test("splitShellArgs: error reports the offset of the opening quote", () => {
+  const e = assertThrows(() => splitShellArgs("echo 'abc"), ShellArgsError);
+  assertStringIncludes(e.message, "offset 5");
+  assertEquals(e.name, "ShellArgsError");
+});
+
+Deno.test("splitShellArgs: a trailing backslash is a dangling continuation", () => {
+  // bash drops a backslash at end of input (a line continuation with no next
+  // line) and it does not start a word: `printf "<%s>" a \` prints `<a>`.
+  assertEquals(splitShellArgs("a\\"), ["a"]);
+  assertEquals(splitShellArgs("a \\"), ["a"]);
+  assertEquals(splitShellArgs("\\"), []);
+});

--- a/packages/core/tests/terminate_test.ts
+++ b/packages/core/tests/terminate_test.ts
@@ -1,0 +1,70 @@
+import { assertEquals } from "./_assert.ts";
+import { terminateProcess } from "../src/terminate.ts";
+
+/**
+ * A stand-in for `Deno.ChildProcess` that records the signals it receives and
+ * exits only when told to — the seam the escalation logic is tested through.
+ */
+function fakeChild(
+  options: { exitsOn?: Deno.Signal; killThrows?: boolean } = {},
+) {
+  const signals: Deno.Signal[] = [];
+  // The Promise executor runs synchronously, so `exit` is assigned before use;
+  // the no-op initialiser keeps the field definitely assigned without a `!`.
+  let exit: () => void = () => {};
+  const status = new Promise<Deno.CommandStatus>((resolve) => {
+    exit = () => resolve({ success: false, code: 137, signal: "SIGKILL" });
+  });
+  return {
+    signals,
+    status,
+    kill(signal: Deno.Signal = "SIGTERM") {
+      if (options.killThrows) throw new TypeError("process already exited");
+      signals.push(signal);
+      if (signal === "SIGKILL" || signal === options.exitsOn) exit();
+    },
+  };
+}
+
+Deno.test("terminateProcess stops at SIGTERM when the process exits in grace", async () => {
+  const child = fakeChild({ exitsOn: "SIGTERM" });
+  await terminateProcess(child, "SIGTERM", 30_000);
+  assertEquals(child.signals, ["SIGTERM"]);
+});
+
+Deno.test("terminateProcess escalates to SIGKILL when the grace window expires", async () => {
+  const child = fakeChild(); // ignores SIGTERM entirely
+  await terminateProcess(child, "SIGTERM", 5);
+  assertEquals(child.signals, ["SIGTERM", "SIGKILL"]);
+});
+
+Deno.test("terminateProcess sends the requested signal", async () => {
+  const child = fakeChild({ exitsOn: "SIGINT" });
+  await terminateProcess(child, "SIGINT", 30_000);
+  assertEquals(child.signals, ["SIGINT"]);
+});
+
+Deno.test("terminateProcess treats an already-exited process as stopped", async () => {
+  const child = fakeChild({ killThrows: true });
+  await terminateProcess(child, "SIGTERM", 5);
+  // Nothing was delivered, and it did not wait out the grace window or throw.
+  assertEquals(child.signals, []);
+});
+
+Deno.test("terminateProcess tolerates a process that exits as SIGKILL is sent", async () => {
+  const child = fakeChild();
+  let killed = 0;
+  const racing = {
+    status: child.status,
+    kill(signal: Deno.Signal = "SIGTERM") {
+      killed++;
+      // The first signal lands; by the time the escalation fires the process is
+      // gone, so the second kill throws — which must not surface.
+      if (killed > 1) throw new TypeError("process already exited");
+      child.signals.push(signal);
+      setTimeout(() => child.kill("SIGKILL"), 20);
+    },
+  };
+  await terminateProcess(racing, "SIGTERM", 5);
+  assertEquals(killed, 2);
+});

--- a/packages/core/tests/tooling_test.ts
+++ b/packages/core/tests/tooling_test.ts
@@ -93,6 +93,41 @@ Deno.test("killAfter() kills a slow tool run", async () => {
   );
 });
 
+Deno.test("maxCapturedBytes() caps a tool run's captured output at the tail", async () => {
+  // Every wrapper funnels through ToolSettings, so the cap has to be settable
+  // there too — otherwise a wrapper whose whole output is parsed is stuck with
+  // the 8 MiB default and silently receives only the tail.
+  const emit =
+    `for (let i = 0; i < 40; i++) console.log(String(i).padStart(4, "0") + "x".repeat(1019));`;
+  const out = await new EvalSettings()
+    .script(emit)
+    .quiet()
+    .maxCapturedBytes(4096)
+    .run();
+  assertEquals(out.truncated, true);
+  assertEquals(out.maxCapturedBytes, 4096);
+  assertEquals(out.stdout.length <= 4096, true, `kept ${out.stdout.length}`);
+  assertEquals(out.stdout.includes("0039"), true); // the tail survived…
+  assertEquals(out.stdout.includes("0000"), false); // …not the head.
+});
+
+Deno.test("maxCapturedBytes() leaves output under the cap whole", async () => {
+  const out = await new EvalSettings()
+    .quiet()
+    .maxCapturedBytes(64 * 1024 * 1024) // raised well above the default
+    .run();
+  assertEquals(out.truncated, false);
+  assertEquals(out.stdout.includes("tool-ok"), true);
+});
+
+Deno.test("maxCapturedBytes() rejects a cap capture cannot honour", () => {
+  const err = assertThrows(
+    () => new EvalSettings().maxCapturedBytes(-1),
+    RangeError,
+  );
+  assertEquals(messageOf(err).includes("maxCapturedBytes"), true);
+});
+
 Deno.test("noThrow() suppresses the non-zero throw", async () => {
   const out = await new EvalSettings()
     .script("Deno.exit(3)")

--- a/tests/e2e/fixtures/kill_after_build.ts
+++ b/tests/e2e/fixtures/kill_after_build.ts
@@ -1,0 +1,35 @@
+/**
+ * A real, runnable Zuke build used by the e2e `killAfter` suite. Run as a
+ * subprocess (`deno run -A kill_after_build.ts timeout`), its one target starts a
+ * child that **ignores `SIGTERM`** and then sleeps far longer than the test would
+ * wait, under a short `killAfter`. A polite terminate alone can never reap that
+ * child, so the build only finishes if the timeout escalates to `SIGKILL`.
+ *
+ * @module
+ */
+
+import { Build, run, target } from "../../../packages/core/mod.ts";
+import { $ } from "../../../packages/core/src/shell.ts";
+
+/**
+ * The child program: swallow `SIGTERM`, announce itself, then sleep. Windows has
+ * no `SIGTERM` listener support, so registering it is best-effort — there the
+ * first signal terminates the child and the escalation simply never fires.
+ */
+const CHILD = [
+  `try { Deno.addSignalListener("SIGTERM", () => {}); } catch { /* windows */ }`,
+  `console.log("CHILD_UP");`,
+  `await new Promise((r) => setTimeout(r, 60000));`,
+].join("\n");
+
+/** A build whose single target must be reaped by the timeout, not by the child. */
+class KillAfter extends Build {
+  /** Runs the `SIGTERM`-proof child; fails with a `CommandTimeoutError`. */
+  timeout = target()
+    .description("run a SIGTERM-proof child under a short killAfter")
+    .executes(async () => {
+      await $`${Deno.execPath()} eval ${CHILD}`.quiet().killAfter(200);
+    });
+}
+
+await run(KillAfter);

--- a/tests/e2e/kill_after_e2e.ts
+++ b/tests/e2e/kill_after_e2e.ts
@@ -1,0 +1,45 @@
+/**
+ * End-to-end: a `killAfter` timeout must reap a child that ignores `SIGTERM`.
+ * The {@link file://./fixtures/kill_after_build.ts} fixture runs, in a real
+ * process, a real child that swallows `SIGTERM` and sleeps for a minute. Only a
+ * `SIGTERM` → grace → `SIGKILL` escalation ends that, so the build has to fail
+ * with a timeout in seconds rather than hang for the child's full sleep. Signal
+ * delivery to a live OS process is exactly what an in-process test cannot prove.
+ * Excluded from the fast unit gate; run by the `integration` target on the OS
+ * matrix.
+ */
+
+import { assertEquals } from "../../packages/core/tests/_assert.ts";
+
+const FIXTURE = new URL("./fixtures/kill_after_build.ts", import.meta.url);
+
+/** The child sleeps 60s; anything under this bound proves it was killed. */
+const MAX_MS = 30_000;
+
+Deno.test("a killAfter timeout escalates to SIGKILL and does not hang", async () => {
+  const started = performance.now();
+  const { code, stdout, stderr } = await new Deno.Command(Deno.execPath(), {
+    args: ["run", "-A", FIXTURE.href, "timeout"],
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  const elapsed = performance.now() - started;
+  const decoder = new TextDecoder();
+  const output = decoder.decode(stdout) + decoder.decode(stderr);
+
+  // The child really started (so the timeout raced a live process)…
+  assertEquals(
+    output.includes("CHILD_UP"),
+    true,
+    `child never started:\n${output}`,
+  );
+  // …the build failed with the timeout, not with something else…
+  assertEquals(code, 1, `expected a failing build, got ${code}:\n${output}`);
+  assertEquals(
+    output.includes("timed out after 200ms"),
+    true,
+    `expected a CommandTimeoutError:\n${output}`,
+  );
+  // …and it did not wait out the child's own sleep.
+  assertEquals(elapsed < MAX_MS, true, `took ${Math.round(elapsed)}ms`);
+});

--- a/tests/integration/dry_run_redaction_test.ts
+++ b/tests/integration/dry_run_redaction_test.ts
@@ -1,0 +1,57 @@
+/**
+ * Integration: a secret used as an argv token must not surface in a command
+ * echo. Under `--dry-run` a `.dryRunnable()` target's body runs with `$` in echo
+ * mode, so the resolved command line is printed — the one place a secret
+ * parameter reaches Zuke's own output verbatim. Driven through the real CLI.
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import { Build, parameter, REDACTED, target } from "../../packages/core/mod.ts";
+import { $ } from "../../packages/core/src/shell.ts";
+import { runCli } from "./_harness.ts";
+
+const SECRET = "fake-not-a-real-token";
+
+class Deploy extends Build {
+  token = parameter("Registry token").secret().required();
+  push = target()
+    .description("log in with the token")
+    .dryRunnable()
+    .executes(async () => {
+      await $`docker login --username ci --password ${this.token.value}`;
+    });
+}
+
+Deno.test("a dry-run command echo masks a secret argv token", async () => {
+  const { code, out } = await runCli(Deploy, [
+    "push",
+    "--dry-run",
+    "--token",
+    SECRET,
+  ]);
+  assertEquals(code, 0);
+  // The echo is there…
+  assertStringIncludes(out, "docker login --username ci --password");
+  // …with the secret masked, and the raw value nowhere in the output.
+  assertStringIncludes(out, REDACTED);
+  assertEquals(out.includes(SECRET), false, `secret leaked:\n${out}`);
+});
+
+Deno.test("a failing command's error message masks a secret argv token", async () => {
+  // The command line also reaches output through CommandError, reported when the
+  // target fails — the same argv, a different sink.
+  class Fail extends Build {
+    token = parameter("Registry token").secret().required();
+    run = target().executes(async () => {
+      await $`${Deno.execPath()} eval ${`Deno.exit(4)`} ${this.token.value}`
+        .quiet();
+    });
+  }
+  const { code, err } = await runCli(Fail, ["run", "--token", SECRET]);
+  assertEquals(code, 1);
+  assertStringIncludes(err, REDACTED);
+  assertEquals(err.includes(SECRET), false, `secret leaked:\n${err}`);
+});

--- a/tests/integration/dry_run_redaction_test.ts
+++ b/tests/integration/dry_run_redaction_test.ts
@@ -13,7 +13,27 @@ import { Build, parameter, REDACTED, target } from "../../packages/core/mod.ts";
 import { $ } from "../../packages/core/src/shell.ts";
 import { runCli } from "./_harness.ts";
 
+// Deliberately unremarkable: the value has to be searchable in the captured
+// output, but must not look like a real credential. A vendor-shaped, high-entropy
+// fixture trips this repo's own gitleaks gate, and because that scan walks git
+// history it then fails every open pull request, not just the one that added it.
 const SECRET = "fake-not-a-real-token";
+
+/**
+ * Strip the `::add-mask::` directives from captured output.
+ *
+ * Under GitHub Actions the executor deliberately emits `::add-mask::` followed by
+ * the *raw* secret through the un-redacted base reporter, so the runner censors
+ * the value in its own logs — a redacted directive would mask nothing. That line
+ * is the one sanctioned place the raw value appears, so it is removed here before
+ * asserting the secret shows up nowhere else. Everything else stays in scope.
+ */
+function withoutMaskDirectives(output: string): string {
+  return output
+    .split("\n")
+    .filter((line) => !line.trimStart().startsWith("::add-mask::"))
+    .join("\n");
+}
 
 class Deploy extends Build {
   token = parameter("Registry token").secret().required();
@@ -37,7 +57,11 @@ Deno.test("a dry-run command echo masks a secret argv token", async () => {
   assertStringIncludes(out, "docker login --username ci --password");
   // …with the secret masked, and the raw value nowhere in the output.
   assertStringIncludes(out, REDACTED);
-  assertEquals(out.includes(SECRET), false, `secret leaked:\n${out}`);
+  assertEquals(
+    withoutMaskDirectives(out).includes(SECRET),
+    false,
+    `secret leaked:\n${out}`,
+  );
 });
 
 Deno.test("a failing command's error message masks a secret argv token", async () => {
@@ -53,5 +77,9 @@ Deno.test("a failing command's error message masks a secret argv token", async (
   const { code, err } = await runCli(Fail, ["run", "--token", SECRET]);
   assertEquals(code, 1);
   assertStringIncludes(err, REDACTED);
-  assertEquals(err.includes(SECRET), false, `secret leaked:\n${err}`);
+  assertEquals(
+    withoutMaskDirectives(err).includes(SECRET),
+    false,
+    `secret leaked:\n${err}`,
+  );
 });

--- a/tests/integration/kill_after_test.ts
+++ b/tests/integration/kill_after_test.ts
@@ -1,0 +1,30 @@
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import { Build, target } from "../../packages/core/mod.ts";
+import { $ } from "../../packages/core/src/shell.ts";
+import { runCli } from "./_harness.ts";
+
+// A cooperative child (it does not trap SIGTERM) so the terminate sequence ends
+// at the first signal and the test stays fast; the grace → SIGKILL escalation
+// against a SIGTERM-proof child is covered by tests/e2e/kill_after_e2e.ts.
+class SlowBuild extends Build {
+  slow = target()
+    .description("run a child that outlives its killAfter budget")
+    .executes(async () => {
+      await $`${Deno.execPath()} eval ${"await new Promise((r) => setTimeout(r, 30000))"}`
+        .quiet()
+        .killAfter(150);
+    });
+}
+
+Deno.test("a killAfter timeout fails the build through the CLI", async () => {
+  const started = performance.now();
+  const { code, err } = await runCli(SlowBuild, ["slow"]);
+  const elapsed = performance.now() - started;
+  assertEquals(code, 1);
+  assertStringIncludes(err, "timed out after 150ms");
+  // The child would have slept 30s: the timeout really reaped it.
+  assertEquals(elapsed < 15_000, true, `took ${Math.round(elapsed)}ms`);
+});

--- a/tests/integration/shell_output_test.ts
+++ b/tests/integration/shell_output_test.ts
@@ -4,6 +4,7 @@ import {
 } from "../../packages/core/tests/_assert.ts";
 import { Build, target } from "../../packages/core/mod.ts";
 import { $ } from "../../packages/core/src/shell.ts";
+import { ToolSettings } from "../../packages/core/src/tooling.ts";
 import { runCli } from "./_harness.ts";
 
 // A child that writes far more than the cap: the target must still succeed, and
@@ -37,4 +38,45 @@ Deno.test("a build capturing oversized output succeeds and reports truncation", 
   assertStringIncludes(out, "bytes=4096");
   // …and it is the tail: the last line the child wrote is line 63.
   assertStringIncludes(out, "last=0063");
+});
+
+/** A tool wrapper, the surface every `*Tasks` package funnels through. */
+class EmitSettings extends ToolSettings {
+  protected override defaultTool(): string {
+    return Deno.execPath();
+  }
+  protected override buildArgs(): string[] {
+    return ["eval", EMIT];
+  }
+}
+
+class WrapperBuild extends Build {
+  capped = target()
+    .description("cap a tool wrapper's captured output")
+    .executes(async () => {
+      const out = await new EmitSettings().quiet().maxCapturedBytes(4096).run();
+      console.log(
+        `truncated=${out.truncated} cap=${out.maxCapturedBytes} ` +
+          `bytes=${out.stdout.length}`,
+      );
+    });
+
+  badCap = target()
+    .description("ask a tool wrapper for a cap capture cannot honour")
+    .executes(async () => {
+      await new EmitSettings().quiet().maxCapturedBytes(-1).run();
+    });
+}
+
+Deno.test("a tool wrapper can cap its captured output through the settings lambda", async () => {
+  const { code, out } = await runCli(WrapperBuild, ["capped"]);
+  assertEquals(code, 0);
+  assertStringIncludes(out, "truncated=true cap=4096 bytes=4096");
+});
+
+Deno.test("an impossible wrapper cap fails the target with a friendly error", async () => {
+  const { code, err } = await runCli(WrapperBuild, ["badCap"]);
+  assertEquals(code, 1);
+  assertStringIncludes(err, "maxCapturedBytes");
+  assertStringIncludes(err, "positive whole number");
 });

--- a/tests/integration/shell_output_test.ts
+++ b/tests/integration/shell_output_test.ts
@@ -1,0 +1,40 @@
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import { Build, target } from "../../packages/core/mod.ts";
+import { $ } from "../../packages/core/src/shell.ts";
+import { runCli } from "./_harness.ts";
+
+// A child that writes far more than the cap: the target must still succeed, and
+// what it reports must be the END of the output, flagged as truncated.
+const EMIT =
+  `for (let i = 0; i < 64; i++) console.log(String(i).padStart(4, "0") + "y".repeat(1019));`;
+
+class ChattyBuild extends Build {
+  chatty = target()
+    .description("capture a child that outruns the capture cap")
+    .executes(async () => {
+      const out = await $`${Deno.execPath()} eval ${EMIT}`
+        .quiet()
+        .maxCapturedBytes(4096)
+        .then();
+      const lines = out.stdout.trimEnd().split("\n");
+      console.log(
+        `code=${out.code} truncated=${out.truncated} ` +
+          `bytes=${out.stdout.length} last=${
+            lines[lines.length - 1].slice(0, 4)
+          }`,
+      );
+    });
+}
+
+Deno.test("a build capturing oversized output succeeds and reports truncation", async () => {
+  const { code, out } = await runCli(ChattyBuild, ["chatty"]);
+  assertEquals(code, 0);
+  assertStringIncludes(out, "code=0 truncated=true");
+  // The retained slice is bounded…
+  assertStringIncludes(out, "bytes=4096");
+  // …and it is the tail: the last line the child wrote is line 63.
+  assertStringIncludes(out, "last=0063");
+});

--- a/tests/integration/split_args_test.ts
+++ b/tests/integration/split_args_test.ts
@@ -1,0 +1,31 @@
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import { Build, target } from "../../packages/core/mod.ts";
+import { Command, splitShellArgs } from "../../packages/core/src/shell.ts";
+import { runCli } from "./_harness.ts";
+
+// A build that takes an already-written command line — the shape `zuke import`
+// deals with — splits it into argv, and hands it to a real process. Proves the
+// quoting survives the whole way: splitter → Command → the OS.
+class SplitBuild extends Build {
+  run = target()
+    .description("split a command string and run it")
+    .executes(async () => {
+      const args = splitShellArgs(
+        String.raw`eval "console.log(Deno.args.join('|'))" -- -t "\d+" 'a b'`,
+      );
+      const out = await new Command([Deno.execPath(), ...args]).quiet().text();
+      console.log(`argc=${args.length} received=${out}`);
+    });
+}
+
+Deno.test("splitShellArgs feeds a real process discrete argv through the CLI", async () => {
+  const { code, out } = await runCli(SplitBuild, ["run"]);
+  assertEquals(code, 0);
+  // 6 argv entries: eval, the code, --, -t, the regex, and the spaced argument.
+  assertStringIncludes(out, "argc=6");
+  // The backslash is intact and `a b` arrived as ONE argument, not two.
+  assertStringIncludes(out, String.raw`received=-t|\d+|a b`);
+});


### PR DESCRIPTION
Four shell-layer fixes.

**splitShellArgs** is new public API on the shell entrypoint. It splits a command string into argv using POSIX quoting rules for the quoting subset only — no expansion, globbing, command substitution or operator handling, all stated in its docs. It replaces a hand-rolled splitter in the CLI's import command that tracked quote state but had no backslash handling at all, so a package.json script containing a double-quoted regex lost its backslashes and imported as a different command. The three rules that matter: single quotes are fully literal, a backslash inside double quotes escapes only the characters a shell treats specially there and stays literal before anything else, and a backslash-newline pair is a line continuation. Twenty-four vectors cover it, including the throwing cases.

**killAfter** aborted a child by signal and only threw once the child exited, so a child ignoring the termination signal made the timeout unbounded. It now escalates to a hard kill after a grace window, reusing the sequence the spawned-process stop path already implemented in the same file rather than writing a second one.

**Captured output** was accumulated in full for every command, always, even when nobody read it — so a verbose container build could exhaust the build process. Output is now capped with a tail ring buffer, keeping the end rather than the beginning, and the truncation is surfaced on the command output.

**Registered secrets** are now masked where the command line is rendered, so a dry run cannot echo a password a wrapper places in argv. The argv handed to the operating system is untouched, and argv construction stays pure.

**Merge order matters here.** The cli package now imports splitShellArgs, but its dependency constraint remains at core 1.31.0 because the workspace refuses to resolve a member against a constraint the local core does not satisfy. splitShellArgs only exists from the 1.32.0 this PR cuts, and release-please rewrites versions but never import constraints. Core must publish 1.32.0 before that floor is raised — otherwise a published cli can resolve an older core and fail at runtime. This is the same failure mode as the earlier floor-raising fix.

**Verification.** Gate green; seven blocking review findings fixed. One review note worth recording: the dry-run echo already routed through the redacting reporter, so the originally-specified test could not fail. The real gap was masking at the point the line is rendered, which also covers a target that prints the command line itself.
