### PR TITLE
feat: add missing typed builders, DenoSettings.frozen, and --frozen scaffolding

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5539,6 +5539,10 @@ class DockerComposeUpSettings extends DockerComposeSettings
     Remove containers for services no longer defined (`--remove-orphans`).
   wait(): this
     Wait until services are running/healthy (`--wait`).
+  abortOnContainerExit(): this
+    Stop all containers if any container stops (`--abort-on-container-exit`).
+  exitCodeFrom(service: string): this
+    Exit with this service's container's exit code (`--exit-code-from`).
   scale(service: string, instances: number): this
     Scale a service to N instances (`--scale service=N`); repeatable.
   services(...names: string[]): this
@@ -6509,6 +6513,12 @@ class VitestSettings extends ToolSettings
     Update snapshots (`-u`/`--update`).
   forceRun(): this
     Force one-shot mode even under watch (`--run`).
+  pool(name: VitestPool): this
+    Choose the worker pool implementation (`--pool`).
+  maxWorkers(count: number): this
+    Cap the number of parallel workers (`--maxWorkers`).
+  minWorkers(count: number): this
+    Set the minimum number of parallel workers (`--minWorkers`).
   bail(count: number): this
     Stop after N failed tests (`--bail`).
   retry(count: number): this
@@ -6537,6 +6547,9 @@ interface VitestTasksApi
 
   run(configure?: Configure<VitestSettings>): Promise<CommandOutput>
     Run tests with `vitest` (one-shot `run` unless {@link VitestSettings.watch}).
+
+type VitestPool = "threads" | "forks" | "vmThreads" | "vmForks"
+  The Vitest worker pool implementation (`--pool`).
 
 ========================================================================
 # @zuke/playwright
@@ -6603,10 +6616,14 @@ class PlaywrightTestSettings extends PlaywrightSettings
     Only run tests matching the pattern (`--grep`).
   headed(): this
     Run in headed browsers (`--headed`).
+  ui(): this
+    Open the interactive UI mode (`--ui`).
   workers(count: number): this
     Set the number of parallel workers (`--workers=`).
   reporter(name: string): this
     Choose the reporter (`--reporter=`).
+  updateSnapshots(): this
+    Update snapshots instead of failing on a mismatch (`--update-snapshots`).
   config(path: string): this
     Use a specific config file (`--config=`).
   paths(...filters: string[]): this
@@ -7485,6 +7502,12 @@ class TscBuildSettings extends TscBaseSettings
 
   projects(...values: PathLike[]): this
     Project config files or directories to build (positional); repeatable.
+  noEmit(): this
+    Type-check without emitting output (`--noEmit`). `tsc --build` accepts the
+    same compiler-option overrides as a plain compile, applied on top of each
+    project's build; this is not inherited from {@link TscBaseSettings} —
+    {@link TscSettings.noEmit} is a separate, unrelated field on the other
+    subclass.
   clean(): this
     Delete the outputs of all projects (`--clean`).
   force(): this

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3930,6 +3930,10 @@ class DenoCacheSettings extends DenoSettings
 
   reload(): this
     Reload remote modules instead of using the cache (`--reload`).
+  frozen(): this
+    Error out if the lockfile is out of date (`--frozen`). See
+    {@link DenoPermissionSettings.frozen} for why the name mirrors the real
+    Deno flag rather than `PnpmSettings.frozenLockfile()`'s naming.
   paths(...paths: PathLike[]): this
     The entry points to cache (at least one is required).
   override protected buildArgs(): string[]
@@ -3940,6 +3944,10 @@ class DenoCheckSettings extends DenoSettings
 
   paths(...paths: PathLike[]): this
     The files to type-check (at least one is required).
+  frozen(): this
+    Error out if the lockfile is out of date (`--frozen`). See
+    {@link DenoPermissionSettings.frozen} for why the name mirrors the real
+    Deno flag rather than `PnpmSettings.frozenLockfile()`'s naming.
   override protected buildArgs(): string[]
     Assemble the `deno check` argv.
 
@@ -3981,6 +3989,10 @@ class DenoDocSettings extends DenoSettings
     The source files (entry points) to document.
   json(): this
     Output the documentation as JSON (`--json`).
+  frozen(): this
+    Error out if the lockfile is out of date (`--frozen`). See
+    {@link DenoPermissionSettings.frozen} for why the name mirrors the real
+    Deno flag rather than `PnpmSettings.frozenLockfile()`'s naming.
   html(): this
     Generate static HTML documentation (`--html`).
   name(title: string): this
@@ -4041,8 +4053,20 @@ abstract class DenoPermissionSettings extends DenoSettings
     Grant all permissions (`--allow-all`).
   allow(permission: DenoPermission, ...values: string[]): this
     Grant one permission, optionally scoped to values (`--allow-read=a,b`).
+  frozen(): this
+    Error out if the lockfile is out of date instead of silently updating it
+    (`--frozen`). Use it whenever the module graph must match the committed
+    `deno.lock` exactly — running an `npm:` tool in CI, say, so its transitive
+    tree stays pinned to the audited integrity hashes rather than being
+    resolved afresh. Named `frozen` — not `frozenLockfile` — to mirror the real
+    Deno CLI flag exactly. This is a deliberate divergence from
+    `PnpmSettings.frozenLockfile()` in `@zuke/pnpm`, which follows pnpm's own
+    flag name instead: guideline 7 (mirror the real CLI) takes priority over
+    cross-package naming symmetry.
   protected get permissionArgs(): string[]
     The accumulated permission flags, in declaration order.
+  protected get frozenArgs(): string[]
+    The `--frozen` flag, if set; read by subclasses assembling their argv.
 
 class DenoPublishSettings extends DenoSettings
   Settings for `deno publish`.
@@ -4073,11 +4097,6 @@ class DenoRunSettings extends DenoPermissionSettings
     Use an explicit config file (`--config`).
   reload(): this
     Reload the module cache (`--reload`).
-  frozen(): this
-    Fail if the lockfile is out of date (`--frozen`) instead of updating it. Use
-    it whenever the module graph must match the committed `deno.lock` exactly —
-    running an `npm:` tool in CI, say, so its transitive tree stays pinned to
-    the audited integrity hashes rather than being resolved afresh.
   override protected buildArgs(): string[]
     Assemble the `deno run` argv.
 
@@ -4094,6 +4113,10 @@ class DenoTaskSettings extends DenoSettings
     The task name from deno.json (required).
   taskArgs(...args: Array<string | number>): this
     Arguments forwarded to the task.
+  frozen(): this
+    Error out if the lockfile is out of date (`--frozen`). See
+    {@link DenoPermissionSettings.frozen} for why the name mirrors the real
+    Deno flag rather than `PnpmSettings.frozenLockfile()`'s naming.
   override protected buildArgs(): string[]
     Assemble the `deno task` argv.
 
@@ -5110,7 +5133,10 @@ class DockerLoginSettings extends DockerSettings
   username(value: string): this
     The username (`-u`).
   password(value: string): this
-    The password (`-p`); prefer {@link passwordStdin} in CI.
+    The password (`-p`). This lands directly in the process argv, where it
+    can leak through `ps`/process listings, shell history, or CI job logs —
+    {@link passwordStdin} is the safe choice in CI (and generally), since it
+    pipes the secret through STDIN instead of putting it on the command line.
   passwordStdin(): this
     Read the password from STDIN (`--password-stdin`).
   registry(server: string): this

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -66,6 +66,10 @@ const DENO_INSTALL_DOCS =
  * lockfile fails outright ("The lockfile is out of date") instead of writing
  * one. So the first run resolves and records the graph, and every run after
  * that verifies it and fails loudly if it changed.
+ *
+ * The unfrozen branch prints a notice to stderr. The same branch is taken if a
+ * `deno.lock` is later removed, which drops integrity verification, so it says
+ * so rather than running unverified in silence.
  */
 export function launcherBash(): string {
   return `#!/usr/bin/env bash
@@ -79,10 +83,13 @@ if ! command -v deno >/dev/null 2>&1; then
   exit 1
 fi
 # The first run has no lockfile to verify against, so let Deno write one; from
-# then on --frozen fails the build if the module graph changed.
+# then on --frozen fails the build if the module graph changed. Say so when
+# skipping, so a deleted lockfile downgrades verification visibly instead of
+# silently.
 if [ -f deno.lock ]; then
   deno run -A --frozen zuke.ts "$@"
 else
+  echo "zuke: no deno.lock here yet — running without lockfile verification so Deno can write one." >&2
   deno run -A zuke.ts "$@"
 fi
 `;
@@ -104,9 +111,15 @@ if (-not $found) {
   exit 1
 }
 # The first run has no lockfile to verify against, so let Deno write one; from
-# then on --frozen fails the build if the module graph changed.
+# then on --frozen fails the build if the module graph changed. Say so when
+# skipping, so a deleted lockfile downgrades verification visibly instead of
+# silently.
 $denoArgs = @("run", "-A")
-if (Test-Path (Join-Path $dir "deno.lock")) { $denoArgs += "--frozen" }
+if (Test-Path (Join-Path $dir "deno.lock")) {
+  $denoArgs += "--frozen"
+} else {
+  Write-Warning "zuke: no deno.lock here yet - running without lockfile verification so Deno can write one."
+}
 $denoArgs += (Join-Path $dir "zuke.ts")
 & $found.Source @denoArgs @args
 exit $LASTEXITCODE

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -15,7 +15,7 @@ export function isRecord(value: unknown): value is Record<string, unknown> {
 
 /** The starter `zuke.ts`, with the build class named `name`. */
 export function starterBuild(name: string): string {
-  return `import { Build, run, target } from "jsr:@zuke/core";
+  return `import { Build, run, target } from "jsr:@zuke/core@^1";
 
 /** Your project's build. Run a target with \`./zuke <target>\`. */
 class ${name} extends Build {
@@ -70,7 +70,7 @@ if ! command -v deno >/dev/null 2>&1; then
   echo "      ${DENO_INSTALL_DOCS}" >&2
   exit 1
 fi
-deno run -A zuke.ts "$@"
+deno run -A --frozen zuke.ts "$@"
 `;
 }
 
@@ -86,7 +86,7 @@ if (-not $found) {
   Write-Error "zuke: Deno not found on PATH. Install it, then re-run this launcher: ${DENO_INSTALL_DOCS}"
   exit 1
 }
-& $found.Source run -A (Join-Path $dir "zuke.ts") @args
+& $found.Source run -A --frozen (Join-Path $dir "zuke.ts") @args
 exit $LASTEXITCODE
 `;
 }
@@ -95,7 +95,7 @@ exit $LASTEXITCODE
 
 /** The task names `setup` writes into `deno.json`, with their commands. */
 const DEFAULT_TASKS: ReadonlyArray<readonly [string, string]> = [
-  ["zuke", "deno run -A zuke.ts"],
+  ["zuke", "deno run -A --frozen zuke.ts"],
   ["fmt", "deno fmt"],
   ["lint", "deno lint"],
   ["test", "deno test -A"],

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -58,7 +58,15 @@ const DENO_INSTALL_DOCS =
 
 /* cspell:disable */
 
-/** The bash launcher (`./zuke`). Runs `zuke.ts` with the Deno on `PATH`. */
+/**
+ * The bash launcher (`./zuke`). Runs `zuke.ts` with the Deno on `PATH`.
+ *
+ * `--frozen` is passed only when a `deno.lock` is already there: a freshly
+ * scaffolded project has none, and `deno run --frozen` against a missing
+ * lockfile fails outright ("The lockfile is out of date") instead of writing
+ * one. So the first run resolves and records the graph, and every run after
+ * that verifies it and fails loudly if it changed.
+ */
 export function launcherBash(): string {
   return `#!/usr/bin/env bash
 # Zuke launcher — runs zuke.ts with Deno.
@@ -70,11 +78,20 @@ if ! command -v deno >/dev/null 2>&1; then
   echo "      ${DENO_INSTALL_DOCS}" >&2
   exit 1
 fi
-deno run -A --frozen zuke.ts "$@"
+# The first run has no lockfile to verify against, so let Deno write one; from
+# then on --frozen fails the build if the module graph changed.
+if [ -f deno.lock ]; then
+  deno run -A --frozen zuke.ts "$@"
+else
+  deno run -A zuke.ts "$@"
+fi
 `;
 }
 
-/** The PowerShell launcher (`.\\zuke.ps1`). */
+/**
+ * The PowerShell launcher (`.\\zuke.ps1`). Mirrors {@link launcherBash},
+ * including its conditional `--frozen`.
+ */
 export function launcherPwsh(): string {
   return `#!/usr/bin/env pwsh
 # Zuke launcher — runs zuke.ts with Deno.
@@ -86,16 +103,30 @@ if (-not $found) {
   Write-Error "zuke: Deno not found on PATH. Install it, then re-run this launcher: ${DENO_INSTALL_DOCS}"
   exit 1
 }
-& $found.Source run -A --frozen (Join-Path $dir "zuke.ts") @args
+# The first run has no lockfile to verify against, so let Deno write one; from
+# then on --frozen fails the build if the module graph changed.
+$denoArgs = @("run", "-A")
+if (Test-Path (Join-Path $dir "deno.lock")) { $denoArgs += "--frozen" }
+$denoArgs += (Join-Path $dir "zuke.ts")
+& $found.Source @denoArgs @args
 exit $LASTEXITCODE
 `;
 }
 
 /* cspell:enable */
 
-/** The task names `setup` writes into `deno.json`, with their commands. */
+/**
+ * The task names `setup` writes into `deno.json`, with their commands.
+ *
+ * The `zuke` task deliberately omits `--frozen`, unlike the launchers: a task
+ * command runs in `deno task`'s own shell, which has no conditionals, so it
+ * cannot skip the flag on the first run when no `deno.lock` exists yet — and
+ * hard-coding it would make a fresh scaffold fail before it could ever write
+ * one. The launcher (`./zuke`, the advertised entry point) does the lockfile
+ * check and enforces `--frozen` from the second run onward.
+ */
 const DEFAULT_TASKS: ReadonlyArray<readonly [string, string]> = [
-  ["zuke", "deno run -A --frozen zuke.ts"],
+  ["zuke", "deno run -A zuke.ts"],
   ["fmt", "deno fmt"],
   ["lint", "deno lint"],
   ["test", "deno test -A"],

--- a/packages/cli/tests/setup_test.ts
+++ b/packages/cli/tests/setup_test.ts
@@ -34,20 +34,12 @@ Deno.test("starterConfig records the build name as JSON", () => {
   assertEquals(starterConfig("Acme").endsWith("\n"), true);
 });
 
-Deno.test("launchers carry a shebang and run zuke.ts with a frozen lockfile", () => {
+Deno.test("launchers carry a shebang and run zuke.ts", () => {
   const bash = launcherBash();
   assertEquals(bash.startsWith("#!/usr/bin/env bash"), true);
-  // Every deno invocation the launcher makes gets --frozen — otherwise the
-  // module graph resolves unlocked before a build's own --frozen check ever
-  // runs, and the check validates a lockfile that was already rewritten a
-  // moment earlier.
-  const bashRunCount = bash.split("run -A ").length - 1;
-  const bashFrozenCount = bash.split("run -A --frozen zuke.ts").length - 1;
-  assertEquals(bashFrozenCount, bashRunCount);
-  assertEquals(bashFrozenCount, 1);
+  assertEquals(bash.includes("run -A zuke.ts"), true);
   const pwsh = launcherPwsh();
   assertEquals(pwsh.startsWith("#!/usr/bin/env pwsh"), true);
-  assertEquals(pwsh.includes("run -A --frozen "), true);
   assertEquals(pwsh.includes("zuke.ts"), true);
 });
 
@@ -69,12 +61,35 @@ Deno.test("scaffolded launchers never pipe an unverified install script", () => 
   }
 });
 
+Deno.test("launchers pass --frozen only once a deno.lock exists", () => {
+  // A fresh scaffold has no lockfile, and `deno run --frozen` against a
+  // missing one fails outright rather than writing it — so an unconditional
+  // --frozen breaks the very first `./zuke` the CLI tells the user to run.
+  // Every --frozen must therefore sit behind a lockfile check, with a
+  // plain (lock-writing) invocation as the other branch.
+  const bash = launcherBash();
+  assertEquals(bash.includes("if [ -f deno.lock ]; then"), true);
+  assertEquals(bash.split("run -A --frozen zuke.ts").length - 1, 1);
+  assertEquals(bash.split(`run -A zuke.ts "$@"`).length - 1, 1);
+  // The frozen branch comes first, the bootstrap branch after the `else`.
+  assertEquals(
+    bash.indexOf("--frozen") < bash.indexOf("else\n  deno run -A zuke.ts"),
+    true,
+  );
+
+  const pwsh = launcherPwsh();
+  assertEquals(pwsh.includes(`Test-Path (Join-Path $dir "deno.lock")`), true);
+  assertEquals(pwsh.split(`$denoArgs += "--frozen"`).length - 1, 1);
+  // --frozen is only ever appended inside that check, never in the base argv.
+  assertEquals(pwsh.includes(`@("run", "-A")`), true);
+});
+
 Deno.test("mergeDenoJson seeds tasks from scratch", () => {
   const text = mergeDenoJson(null);
   const parsed: unknown = JSON.parse(text);
   assertEquals(isRecord(parsed) && isRecord(parsed.tasks), true);
   if (isRecord(parsed) && isRecord(parsed.tasks)) {
-    assertEquals(parsed.tasks.zuke, "deno run -A --frozen zuke.ts");
+    assertEquals(parsed.tasks.zuke, "deno run -A zuke.ts");
     assertEquals(parsed.tasks.test, "deno test -A");
   }
   assertEquals(text.endsWith("\n"), true);
@@ -87,7 +102,7 @@ Deno.test("mergeDenoJson preserves existing keys and tasks", () => {
   if (isRecord(parsed) && isRecord(parsed.tasks)) {
     assertEquals(parsed.name, "x");
     assertEquals(parsed.tasks.fmt, "custom");
-    assertEquals(parsed.tasks.zuke, "deno run -A --frozen zuke.ts");
+    assertEquals(parsed.tasks.zuke, "deno run -A zuke.ts");
   }
 });
 
@@ -95,7 +110,7 @@ Deno.test("mergeDenoJson ignores a non-object document", () => {
   const parsed: unknown = JSON.parse(mergeDenoJson("[]"));
   assertEquals(isRecord(parsed) && isRecord(parsed.tasks), true);
   if (isRecord(parsed) && isRecord(parsed.tasks)) {
-    assertEquals(parsed.tasks.zuke, "deno run -A --frozen zuke.ts");
+    assertEquals(parsed.tasks.zuke, "deno run -A zuke.ts");
   }
 });
 

--- a/packages/cli/tests/setup_test.ts
+++ b/packages/cli/tests/setup_test.ts
@@ -23,6 +23,7 @@ Deno.test("isRecord distinguishes plain objects", () => {
 Deno.test("starterBuild embeds the class name and entry point", () => {
   const out = starterBuild("Acme");
   assertEquals(out.includes("import { Build, run, target }"), true);
+  assertEquals(out.includes('jsr:@zuke/core@^1"'), true);
   assertEquals(out.includes("class Acme extends Build"), true);
   assertEquals(out.includes("await run(Acme)"), true);
 });
@@ -33,12 +34,20 @@ Deno.test("starterConfig records the build name as JSON", () => {
   assertEquals(starterConfig("Acme").endsWith("\n"), true);
 });
 
-Deno.test("launchers carry a shebang and run zuke.ts", () => {
+Deno.test("launchers carry a shebang and run zuke.ts with a frozen lockfile", () => {
   const bash = launcherBash();
   assertEquals(bash.startsWith("#!/usr/bin/env bash"), true);
-  assertEquals(bash.includes("deno run -A zuke.ts"), true);
+  // Every deno invocation the launcher makes gets --frozen — otherwise the
+  // module graph resolves unlocked before a build's own --frozen check ever
+  // runs, and the check validates a lockfile that was already rewritten a
+  // moment earlier.
+  const bashRunCount = bash.split("run -A ").length - 1;
+  const bashFrozenCount = bash.split("run -A --frozen zuke.ts").length - 1;
+  assertEquals(bashFrozenCount, bashRunCount);
+  assertEquals(bashFrozenCount, 1);
   const pwsh = launcherPwsh();
   assertEquals(pwsh.startsWith("#!/usr/bin/env pwsh"), true);
+  assertEquals(pwsh.includes("run -A --frozen "), true);
   assertEquals(pwsh.includes("zuke.ts"), true);
 });
 
@@ -65,7 +74,7 @@ Deno.test("mergeDenoJson seeds tasks from scratch", () => {
   const parsed: unknown = JSON.parse(text);
   assertEquals(isRecord(parsed) && isRecord(parsed.tasks), true);
   if (isRecord(parsed) && isRecord(parsed.tasks)) {
-    assertEquals(parsed.tasks.zuke, "deno run -A zuke.ts");
+    assertEquals(parsed.tasks.zuke, "deno run -A --frozen zuke.ts");
     assertEquals(parsed.tasks.test, "deno test -A");
   }
   assertEquals(text.endsWith("\n"), true);
@@ -78,7 +87,7 @@ Deno.test("mergeDenoJson preserves existing keys and tasks", () => {
   if (isRecord(parsed) && isRecord(parsed.tasks)) {
     assertEquals(parsed.name, "x");
     assertEquals(parsed.tasks.fmt, "custom");
-    assertEquals(parsed.tasks.zuke, "deno run -A zuke.ts");
+    assertEquals(parsed.tasks.zuke, "deno run -A --frozen zuke.ts");
   }
 });
 
@@ -86,7 +95,7 @@ Deno.test("mergeDenoJson ignores a non-object document", () => {
   const parsed: unknown = JSON.parse(mergeDenoJson("[]"));
   assertEquals(isRecord(parsed) && isRecord(parsed.tasks), true);
   if (isRecord(parsed) && isRecord(parsed.tasks)) {
-    assertEquals(parsed.tasks.zuke, "deno run -A zuke.ts");
+    assertEquals(parsed.tasks.zuke, "deno run -A --frozen zuke.ts");
   }
 });
 

--- a/packages/cli/tests/setup_test.ts
+++ b/packages/cli/tests/setup_test.ts
@@ -72,8 +72,9 @@ Deno.test("launchers pass --frozen only once a deno.lock exists", () => {
   assertEquals(bash.split("run -A --frozen zuke.ts").length - 1, 1);
   assertEquals(bash.split(`run -A zuke.ts "$@"`).length - 1, 1);
   // The frozen branch comes first, the bootstrap branch after the `else`.
+  assertEquals(bash.indexOf("--frozen") < bash.indexOf("else\n"), true);
   assertEquals(
-    bash.indexOf("--frozen") < bash.indexOf("else\n  deno run -A zuke.ts"),
+    bash.indexOf("else\n") < bash.indexOf(`run -A zuke.ts "$@"`),
     true,
   );
 
@@ -82,6 +83,28 @@ Deno.test("launchers pass --frozen only once a deno.lock exists", () => {
   assertEquals(pwsh.split(`$denoArgs += "--frozen"`).length - 1, 1);
   // --frozen is only ever appended inside that check, never in the base argv.
   assertEquals(pwsh.includes(`@("run", "-A")`), true);
+});
+
+Deno.test("the unfrozen branch says so, so a deleted lockfile is not silent", () => {
+  // Skipping --frozen is correct on a fresh scaffold, but the same branch is
+  // taken if someone removes deno.lock later — which drops integrity
+  // verification. Both launchers must announce that on stderr rather than
+  // quietly running unverified.
+  const bash = launcherBash();
+  assertEquals(bash.includes("without lockfile verification"), true);
+  // On stderr, and only in the branch that skips --frozen.
+  assertEquals(
+    bash.indexOf("without lockfile verification") > bash.indexOf("else\n"),
+    true,
+  );
+  assertEquals(
+    bash.slice(bash.indexOf("without lockfile verification")).includes(">&2"),
+    true,
+  );
+
+  const pwsh = launcherPwsh();
+  assertEquals(pwsh.includes("without lockfile verification"), true);
+  assertEquals(pwsh.includes("Write-Warning"), true);
 });
 
 Deno.test("mergeDenoJson seeds tasks from scratch", () => {

--- a/packages/deno/README.md
+++ b/packages/deno/README.md
@@ -53,6 +53,10 @@ class DenoCacheSettings extends DenoSettings
 
   reload(): this
     Reload remote modules instead of using the cache (`--reload`).
+  frozen(): this
+    Error out if the lockfile is out of date (`--frozen`). See
+    {@link DenoPermissionSettings.frozen} for why the name mirrors the real
+    Deno flag rather than `PnpmSettings.frozenLockfile()`'s naming.
   paths(...paths: PathLike[]): this
     The entry points to cache (at least one is required).
   override protected buildArgs(): string[]
@@ -63,6 +67,10 @@ class DenoCheckSettings extends DenoSettings
 
   paths(...paths: PathLike[]): this
     The files to type-check (at least one is required).
+  frozen(): this
+    Error out if the lockfile is out of date (`--frozen`). See
+    {@link DenoPermissionSettings.frozen} for why the name mirrors the real
+    Deno flag rather than `PnpmSettings.frozenLockfile()`'s naming.
   override protected buildArgs(): string[]
     Assemble the `deno check` argv.
 
@@ -104,6 +112,10 @@ class DenoDocSettings extends DenoSettings
     The source files (entry points) to document.
   json(): this
     Output the documentation as JSON (`--json`).
+  frozen(): this
+    Error out if the lockfile is out of date (`--frozen`). See
+    {@link DenoPermissionSettings.frozen} for why the name mirrors the real
+    Deno flag rather than `PnpmSettings.frozenLockfile()`'s naming.
   html(): this
     Generate static HTML documentation (`--html`).
   name(title: string): this
@@ -164,8 +176,20 @@ abstract class DenoPermissionSettings extends DenoSettings
     Grant all permissions (`--allow-all`).
   allow(permission: DenoPermission, ...values: string[]): this
     Grant one permission, optionally scoped to values (`--allow-read=a,b`).
+  frozen(): this
+    Error out if the lockfile is out of date instead of silently updating it
+    (`--frozen`). Use it whenever the module graph must match the committed
+    `deno.lock` exactly — running an `npm:` tool in CI, say, so its transitive
+    tree stays pinned to the audited integrity hashes rather than being
+    resolved afresh. Named `frozen` — not `frozenLockfile` — to mirror the real
+    Deno CLI flag exactly. This is a deliberate divergence from
+    `PnpmSettings.frozenLockfile()` in `@zuke/pnpm`, which follows pnpm's own
+    flag name instead: guideline 7 (mirror the real CLI) takes priority over
+    cross-package naming symmetry.
   protected get permissionArgs(): string[]
     The accumulated permission flags, in declaration order.
+  protected get frozenArgs(): string[]
+    The `--frozen` flag, if set; read by subclasses assembling their argv.
 
 class DenoPublishSettings extends DenoSettings
   Settings for `deno publish`.
@@ -196,11 +220,6 @@ class DenoRunSettings extends DenoPermissionSettings
     Use an explicit config file (`--config`).
   reload(): this
     Reload the module cache (`--reload`).
-  frozen(): this
-    Fail if the lockfile is out of date (`--frozen`) instead of updating it. Use
-    it whenever the module graph must match the committed `deno.lock` exactly —
-    running an `npm:` tool in CI, say, so its transitive tree stays pinned to
-    the audited integrity hashes rather than being resolved afresh.
   override protected buildArgs(): string[]
     Assemble the `deno run` argv.
 
@@ -217,6 +236,10 @@ class DenoTaskSettings extends DenoSettings
     The task name from deno.json (required).
   taskArgs(...args: Array<string | number>): this
     Arguments forwarded to the task.
+  frozen(): this
+    Error out if the lockfile is out of date (`--frozen`). See
+    {@link DenoPermissionSettings.frozen} for why the name mirrors the real
+    Deno flag rather than `PnpmSettings.frozenLockfile()`'s naming.
   override protected buildArgs(): string[]
     Assemble the `deno task` argv.
 

--- a/packages/deno/src/deno.ts
+++ b/packages/deno/src/deno.ts
@@ -44,6 +44,7 @@ export abstract class DenoSettings extends ToolSettings {
 /** Base for subcommands that accept `--allow-*` permission flags. */
 export abstract class DenoPermissionSettings extends DenoSettings {
   #permissions: string[] = [];
+  #frozen = false;
 
   /** Grant all permissions (`--allow-all`). */
   allowAll(): this {
@@ -61,9 +62,30 @@ export abstract class DenoPermissionSettings extends DenoSettings {
     return this;
   }
 
+  /**
+   * Error out if the lockfile is out of date instead of silently updating it
+   * (`--frozen`). Use it whenever the module graph must match the committed
+   * `deno.lock` exactly — running an `npm:` tool in CI, say, so its transitive
+   * tree stays pinned to the audited integrity hashes rather than being
+   * resolved afresh. Named `frozen` — not `frozenLockfile` — to mirror the real
+   * Deno CLI flag exactly. This is a deliberate divergence from
+   * `PnpmSettings.frozenLockfile()` in `@zuke/pnpm`, which follows pnpm's own
+   * flag name instead: guideline 7 (mirror the real CLI) takes priority over
+   * cross-package naming symmetry.
+   */
+  frozen(): this {
+    this.#frozen = true;
+    return this;
+  }
+
   /** The accumulated permission flags, in declaration order. */
   protected get permissionArgs(): string[] {
     return [...this.#permissions];
+  }
+
+  /** The `--frozen` flag, if set; read by subclasses assembling their argv. */
+  protected get frozenArgs(): string[] {
+    return this.#frozen ? ["--frozen"] : [];
   }
 }
 
@@ -73,7 +95,6 @@ export class DenoRunSettings extends DenoPermissionSettings {
   #scriptArgs: string[] = [];
   #config?: string;
   #reload = false;
-  #frozen = false;
 
   /** The script to run (required). */
   script(path: PathLike): this {
@@ -99,24 +120,12 @@ export class DenoRunSettings extends DenoPermissionSettings {
     return this;
   }
 
-  /**
-   * Fail if the lockfile is out of date (`--frozen`) instead of updating it. Use
-   * it whenever the module graph must match the committed `deno.lock` exactly —
-   * running an `npm:` tool in CI, say, so its transitive tree stays pinned to
-   * the audited integrity hashes rather than being resolved afresh.
-   */
-  frozen(): this {
-    this.#frozen = true;
-    return this;
-  }
-
   /** Assemble the `deno run` argv. */
   protected override buildArgs(): string[] {
     if (this.#script === undefined) {
       throw new Error("DenoTasks.run: .script() is required.");
     }
-    const argv = ["run", ...this.permissionArgs];
-    if (this.#frozen) argv.push("--frozen");
+    const argv = ["run", ...this.permissionArgs, ...this.frozenArgs];
     if (this.#config !== undefined) argv.push("--config", this.#config);
     if (this.#reload) argv.push("--reload");
     argv.push(this.#script, ...this.#scriptArgs);
@@ -164,7 +173,7 @@ export class DenoTestSettings extends DenoPermissionSettings {
 
   /** Assemble the `deno test` argv. */
   protected override buildArgs(): string[] {
-    const argv = ["test", ...this.permissionArgs];
+    const argv = ["test", ...this.permissionArgs, ...this.frozenArgs];
     if (this.#coverage !== undefined) {
       argv.push(`--coverage=${this.#coverage}`);
     }
@@ -179,10 +188,21 @@ export class DenoTestSettings extends DenoPermissionSettings {
 /** Settings for `deno check`. */
 export class DenoCheckSettings extends DenoSettings {
   #paths: string[] = [];
+  #frozen = false;
 
   /** The files to type-check (at least one is required). */
   paths(...paths: PathLike[]): this {
     this.#paths.push(...paths.map(String));
+    return this;
+  }
+
+  /**
+   * Error out if the lockfile is out of date (`--frozen`). See
+   * {@link DenoPermissionSettings.frozen} for why the name mirrors the real
+   * Deno flag rather than `PnpmSettings.frozenLockfile()`'s naming.
+   */
+  frozen(): this {
+    this.#frozen = true;
     return this;
   }
 
@@ -193,7 +213,10 @@ export class DenoCheckSettings extends DenoSettings {
         "DenoTasks.check: at least one path is required (use .paths()).",
       );
     }
-    return ["check", ...this.#paths];
+    const argv = ["check"];
+    if (this.#frozen) argv.push("--frozen");
+    argv.push(...this.#paths);
+    return argv;
   }
 }
 
@@ -266,6 +289,16 @@ export class DenoDocSettings extends DenoSettings {
     return this;
   }
 
+  /**
+   * Error out if the lockfile is out of date (`--frozen`). See
+   * {@link DenoPermissionSettings.frozen} for why the name mirrors the real
+   * Deno flag rather than `PnpmSettings.frozenLockfile()`'s naming.
+   */
+  frozen(): this {
+    this.#flags.push("--frozen");
+    return this;
+  }
+
   /** Generate static HTML documentation (`--html`). */
   html(): this {
     this.#flags.push("--html");
@@ -311,11 +344,22 @@ export class DenoDocSettings extends DenoSettings {
 /** Settings for `deno cache`. */
 export class DenoCacheSettings extends DenoSettings {
   #reload = false;
+  #frozen = false;
   #paths: string[] = [];
 
   /** Reload remote modules instead of using the cache (`--reload`). */
   reload(): this {
     this.#reload = true;
+    return this;
+  }
+
+  /**
+   * Error out if the lockfile is out of date (`--frozen`). See
+   * {@link DenoPermissionSettings.frozen} for why the name mirrors the real
+   * Deno flag rather than `PnpmSettings.frozenLockfile()`'s naming.
+   */
+  frozen(): this {
+    this.#frozen = true;
     return this;
   }
 
@@ -333,6 +377,7 @@ export class DenoCacheSettings extends DenoSettings {
       );
     }
     const argv = ["cache"];
+    if (this.#frozen) argv.push("--frozen");
     if (this.#reload) argv.push("--reload");
     argv.push(...this.#paths);
     return argv;
@@ -486,7 +531,7 @@ export class DenoInstallSettings extends DenoPermissionSettings {
 
   /** Assemble the `deno install` argv. */
   protected override buildArgs(): string[] {
-    const argv = ["install", ...this.permissionArgs];
+    const argv = ["install", ...this.permissionArgs, ...this.frozenArgs];
     if (this.#global) argv.push("--global");
     if (this.#force) argv.push("--force");
     if (this.#root !== undefined) argv.push("--root", this.#root);
@@ -559,6 +604,7 @@ export class DenoPublishSettings extends DenoSettings {
 export class DenoTaskSettings extends DenoSettings {
   #name?: string;
   #taskArgs: string[] = [];
+  #frozen = false;
 
   /** The task name from deno.json (required). */
   name(value: string): this {
@@ -572,12 +618,25 @@ export class DenoTaskSettings extends DenoSettings {
     return this;
   }
 
+  /**
+   * Error out if the lockfile is out of date (`--frozen`). See
+   * {@link DenoPermissionSettings.frozen} for why the name mirrors the real
+   * Deno flag rather than `PnpmSettings.frozenLockfile()`'s naming.
+   */
+  frozen(): this {
+    this.#frozen = true;
+    return this;
+  }
+
   /** Assemble the `deno task` argv. */
   protected override buildArgs(): string[] {
     if (this.#name === undefined) {
       throw new Error("DenoTasks.task: .name() is required.");
     }
-    return ["task", this.#name, ...this.#taskArgs];
+    const argv = ["task"];
+    if (this.#frozen) argv.push("--frozen");
+    argv.push(this.#name, ...this.#taskArgs);
+    return argv;
   }
 }
 

--- a/packages/deno/tests/deno_test.ts
+++ b/packages/deno/tests/deno_test.ts
@@ -22,6 +22,7 @@ import {
 Deno.test("run: script, permissions, config, reload, script args", () => {
   const argv = new DenoRunSettings()
     .allowAll()
+    .frozen()
     .config("deno.json")
     .reload()
     .script("main.ts")
@@ -31,6 +32,7 @@ Deno.test("run: script, permissions, config, reload, script args", () => {
   assertEquals(argv, [
     "run",
     "--allow-all",
+    "--frozen",
     "--config",
     "deno.json",
     "--reload",
@@ -66,6 +68,7 @@ Deno.test("run: .script() is required", () => {
 Deno.test("test: coverage, filter, parallel, fail-fast, paths", () => {
   const argv = new DenoTestSettings()
     .allowAll()
+    .frozen()
     .coverage("cov_profile")
     .filter("graph")
     .parallel()
@@ -76,6 +79,7 @@ Deno.test("test: coverage, filter, parallel, fail-fast, paths", () => {
   assertEquals(argv, [
     "test",
     "--allow-all",
+    "--frozen",
     "--coverage=cov_profile",
     "--filter",
     "graph",
@@ -100,6 +104,10 @@ Deno.test("check: paths are required", () => {
     "check",
     "mod.ts",
   ]);
+  assertEquals(
+    new DenoCheckSettings().frozen().paths("mod.ts").argv().slice(1),
+    ["check", "--frozen", "mod.ts"],
+  );
 });
 
 Deno.test("fmt: optional --check and paths", () => {
@@ -126,6 +134,7 @@ Deno.test("doc: flags precede the source paths", () => {
   assertEquals(
     new DenoDocSettings()
       .json()
+      .frozen()
       .private()
       .filter("MyClass.method")
       .paths("mod.ts", "src/extra.ts")
@@ -134,6 +143,7 @@ Deno.test("doc: flags precede the source paths", () => {
     [
       "doc",
       "--json",
+      "--frozen",
       "--private",
       "--filter",
       "MyClass.method",
@@ -175,6 +185,10 @@ Deno.test("cache: paths required, optional --reload", () => {
   assertEquals(
     new DenoCacheSettings().reload().paths("mod.ts").argv().slice(1),
     ["cache", "--reload", "mod.ts"],
+  );
+  assertEquals(
+    new DenoCacheSettings().frozen().paths("mod.ts").argv().slice(1),
+    ["cache", "--frozen", "mod.ts"],
   );
 });
 
@@ -236,6 +250,10 @@ Deno.test("task: name required, then task args", () => {
     new DenoTaskSettings().name("test").taskArgs("--quiet").argv().slice(1),
     ["task", "test", "--quiet"],
   );
+  assertEquals(
+    new DenoTaskSettings().frozen().name("test").argv().slice(1),
+    ["task", "--frozen", "test"],
+  );
 });
 
 Deno.test("the default binary is the running deno executable", () => {
@@ -276,6 +294,7 @@ Deno.test("install: global executable from an npm module, with perms", () => {
     .allow("read")
     .allow("env")
     .allow("sys")
+    .frozen()
     .module("npm:cspell@9")
     .moduleArgs("--version")
     .argv()
@@ -285,6 +304,7 @@ Deno.test("install: global executable from an npm module, with perms", () => {
     "--allow-read",
     "--allow-env",
     "--allow-sys",
+    "--frozen",
     "--global",
     "--force",
     "--root",

--- a/packages/docker-compose/README.md
+++ b/packages/docker-compose/README.md
@@ -286,6 +286,10 @@ class DockerComposeUpSettings extends DockerComposeSettings
     Remove containers for services no longer defined (`--remove-orphans`).
   wait(): this
     Wait until services are running/healthy (`--wait`).
+  abortOnContainerExit(): this
+    Stop all containers if any container stops (`--abort-on-container-exit`).
+  exitCodeFrom(service: string): this
+    Exit with this service's container's exit code (`--exit-code-from`).
   scale(service: string, instances: number): this
     Scale a service to N instances (`--scale service=N`); repeatable.
   services(...names: string[]): this

--- a/packages/docker-compose/src/docker_compose.ts
+++ b/packages/docker-compose/src/docker_compose.ts
@@ -194,6 +194,8 @@ export class DockerComposeUpSettings extends DockerComposeSettings {
   #forceRecreate = false;
   #removeOrphans = false;
   #wait = false;
+  #abortOnContainerExit = false;
+  #exitCodeFrom?: string;
   #scale: string[] = [];
   #services: string[] = [];
 
@@ -227,6 +229,18 @@ export class DockerComposeUpSettings extends DockerComposeSettings {
     return this;
   }
 
+  /** Stop all containers if any container stops (`--abort-on-container-exit`). */
+  abortOnContainerExit(): this {
+    this.#abortOnContainerExit = true;
+    return this;
+  }
+
+  /** Exit with this service's container's exit code (`--exit-code-from`). */
+  exitCodeFrom(service: string): this {
+    this.#exitCodeFrom = service;
+    return this;
+  }
+
   /** Scale a service to N instances (`--scale service=N`); repeatable. */
   scale(service: string, instances: number): this {
     this.#scale.push("--scale", `${service}=${instances}`);
@@ -247,6 +261,10 @@ export class DockerComposeUpSettings extends DockerComposeSettings {
     if (this.#forceRecreate) argv.push("--force-recreate");
     if (this.#removeOrphans) argv.push("--remove-orphans");
     if (this.#wait) argv.push("--wait");
+    if (this.#abortOnContainerExit) argv.push("--abort-on-container-exit");
+    if (this.#exitCodeFrom !== undefined) {
+      argv.push("--exit-code-from", this.#exitCodeFrom);
+    }
     argv.push(...this.#scale, ...this.#services);
     return argv;
   }

--- a/packages/docker-compose/tests/docker_compose_test.ts
+++ b/packages/docker-compose/tests/docker_compose_test.ts
@@ -72,6 +72,7 @@ Deno.test("global options precede the subcommand", () => {
 Deno.test("up: all flags, scale, and services", () => {
   const argv = new DockerComposeUpSettings()
     .detach().build().forceRecreate().removeOrphans().wait()
+    .abortOnContainerExit().exitCodeFrom("web")
     .scale("web", 3).services("web", "db").argv();
   assertEquals(argv, [
     "docker",
@@ -82,6 +83,9 @@ Deno.test("up: all flags, scale, and services", () => {
     "--force-recreate",
     "--remove-orphans",
     "--wait",
+    "--abort-on-container-exit",
+    "--exit-code-from",
+    "web",
     "--scale",
     "web=3",
     "web",

--- a/packages/docker/README.md
+++ b/packages/docker/README.md
@@ -113,7 +113,10 @@ class DockerLoginSettings extends DockerSettings
   username(value: string): this
     The username (`-u`).
   password(value: string): this
-    The password (`-p`); prefer {@link passwordStdin} in CI.
+    The password (`-p`). This lands directly in the process argv, where it
+    can leak through `ps`/process listings, shell history, or CI job logs —
+    {@link passwordStdin} is the safe choice in CI (and generally), since it
+    pipes the secret through STDIN instead of putting it on the command line.
   passwordStdin(): this
     Read the password from STDIN (`--password-stdin`).
   registry(server: string): this

--- a/packages/docker/src/docker.ts
+++ b/packages/docker/src/docker.ts
@@ -377,7 +377,12 @@ export class DockerLoginSettings extends DockerSettings {
     return this;
   }
 
-  /** The password (`-p`); prefer {@link passwordStdin} in CI. */
+  /**
+   * The password (`-p`). This lands directly in the process argv, where it
+   * can leak through `ps`/process listings, shell history, or CI job logs —
+   * {@link passwordStdin} is the safe choice in CI (and generally), since it
+   * pipes the secret through STDIN instead of putting it on the command line.
+   */
   password(value: string): this {
     this.#password = value;
     return this;

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -80,10 +80,14 @@ class PlaywrightTestSettings extends PlaywrightSettings
     Only run tests matching the pattern (`--grep`).
   headed(): this
     Run in headed browsers (`--headed`).
+  ui(): this
+    Open the interactive UI mode (`--ui`).
   workers(count: number): this
     Set the number of parallel workers (`--workers=`).
   reporter(name: string): this
     Choose the reporter (`--reporter=`).
+  updateSnapshots(): this
+    Update snapshots instead of failing on a mismatch (`--update-snapshots`).
   config(path: string): this
     Use a specific config file (`--config=`).
   paths(...filters: string[]): this

--- a/packages/playwright/src/playwright.ts
+++ b/packages/playwright/src/playwright.ts
@@ -41,8 +41,10 @@ export class PlaywrightTestSettings extends PlaywrightSettings {
   #projects: string[] = [];
   #grep?: string;
   #headed = false;
+  #ui = false;
   #workers?: number;
   #reporter?: string;
+  #updateSnapshots = false;
   #config?: string;
   #paths: string[] = [];
 
@@ -64,6 +66,12 @@ export class PlaywrightTestSettings extends PlaywrightSettings {
     return this;
   }
 
+  /** Open the interactive UI mode (`--ui`). */
+  ui(): this {
+    this.#ui = true;
+    return this;
+  }
+
   /** Set the number of parallel workers (`--workers=`). */
   workers(count: number): this {
     this.#workers = count;
@@ -73,6 +81,12 @@ export class PlaywrightTestSettings extends PlaywrightSettings {
   /** Choose the reporter (`--reporter=`). */
   reporter(name: string): this {
     this.#reporter = name;
+    return this;
+  }
+
+  /** Update snapshots instead of failing on a mismatch (`--update-snapshots`). */
+  updateSnapshots(): this {
+    this.#updateSnapshots = true;
     return this;
   }
 
@@ -94,8 +108,10 @@ export class PlaywrightTestSettings extends PlaywrightSettings {
     for (const p of this.#projects) argv.push(`--project=${p}`);
     if (this.#grep !== undefined) argv.push("--grep", this.#grep);
     if (this.#headed) argv.push("--headed");
+    if (this.#ui) argv.push("--ui");
     if (this.#workers !== undefined) argv.push(`--workers=${this.#workers}`);
     if (this.#reporter !== undefined) argv.push(`--reporter=${this.#reporter}`);
+    if (this.#updateSnapshots) argv.push("--update-snapshots");
     if (this.#config !== undefined) argv.push(`--config=${this.#config}`);
     argv.push(...this.#paths);
     return argv;

--- a/packages/playwright/tests/playwright_test.ts
+++ b/packages/playwright/tests/playwright_test.ts
@@ -19,8 +19,10 @@ Deno.test("test: bare, projects, grep, headed, workers, reporter, config, paths"
       .project("chromium", "firefox")
       .grep("@smoke")
       .headed()
+      .ui()
       .workers(4)
       .reporter("dot")
+      .updateSnapshots()
       .config("pw.config.ts")
       .paths("tests/e2e")
       .argv()
@@ -32,8 +34,10 @@ Deno.test("test: bare, projects, grep, headed, workers, reporter, config, paths"
       "--grep",
       "@smoke",
       "--headed",
+      "--ui",
       "--workers=4",
       "--reporter=dot",
+      "--update-snapshots",
       "--config=pw.config.ts",
       "tests/e2e",
     ],

--- a/packages/tsc/README.md
+++ b/packages/tsc/README.md
@@ -64,6 +64,12 @@ class TscBuildSettings extends TscBaseSettings
 
   projects(...values: PathLike[]): this
     Project config files or directories to build (positional); repeatable.
+  noEmit(): this
+    Type-check without emitting output (`--noEmit`). `tsc --build` accepts the
+    same compiler-option overrides as a plain compile, applied on top of each
+    project's build; this is not inherited from {@link TscBaseSettings} —
+    {@link TscSettings.noEmit} is a separate, unrelated field on the other
+    subclass.
   clean(): this
     Delete the outputs of all projects (`--clean`).
   force(): this

--- a/packages/tsc/src/tsc.ts
+++ b/packages/tsc/src/tsc.ts
@@ -176,6 +176,7 @@ export class TscSettings extends TscBaseSettings {
 /** Settings for a `tsc --build` project-references run. */
 export class TscBuildSettings extends TscBaseSettings {
   #projects: string[] = [];
+  #noEmit = false;
   #clean = false;
   #force = false;
   #dry = false;
@@ -186,6 +187,18 @@ export class TscBuildSettings extends TscBaseSettings {
   /** Project config files or directories to build (positional); repeatable. */
   projects(...values: PathLike[]): this {
     this.#projects.push(...values.map(String));
+    return this;
+  }
+
+  /**
+   * Type-check without emitting output (`--noEmit`). `tsc --build` accepts the
+   * same compiler-option overrides as a plain compile, applied on top of each
+   * project's build; this is not inherited from {@link TscBaseSettings} —
+   * {@link TscSettings.noEmit} is a separate, unrelated field on the other
+   * subclass.
+   */
+  noEmit(): this {
+    this.#noEmit = true;
     return this;
   }
 
@@ -228,6 +241,7 @@ export class TscBuildSettings extends TscBaseSettings {
   /** Assemble the `tsc --build` argv from the configured options. */
   protected override buildArgs(): string[] {
     const argv: string[] = ["--build"];
+    if (this.#noEmit) argv.push("--noEmit");
     if (this.#clean) argv.push("--clean");
     if (this.#force) argv.push("--force");
     if (this.#dry) argv.push("--dry");

--- a/packages/tsc/tests/tsc_test.ts
+++ b/packages/tsc/tests/tsc_test.ts
@@ -44,11 +44,12 @@ Deno.test("tsc: minimal checks the given file", () => {
 
 Deno.test("build: every option renders, projects last", () => {
   const argv = new TscBuildSettings()
-    .clean().force().dry().watch().verbose().incremental()
+    .noEmit().clean().force().dry().watch().verbose().incremental()
     .projects("packages/a", "packages/b").argv();
   assertEquals(argv, [
     "tsc",
     "--build",
+    "--noEmit",
     "--clean",
     "--force",
     "--dry",

--- a/packages/vitest/README.md
+++ b/packages/vitest/README.md
@@ -68,6 +68,12 @@ class VitestSettings extends ToolSettings
     Update snapshots (`-u`/`--update`).
   forceRun(): this
     Force one-shot mode even under watch (`--run`).
+  pool(name: VitestPool): this
+    Choose the worker pool implementation (`--pool`).
+  maxWorkers(count: number): this
+    Cap the number of parallel workers (`--maxWorkers`).
+  minWorkers(count: number): this
+    Set the minimum number of parallel workers (`--minWorkers`).
   bail(count: number): this
     Stop after N failed tests (`--bail`).
   retry(count: number): this
@@ -96,6 +102,9 @@ interface VitestTasksApi
 
   run(configure?: Configure<VitestSettings>): Promise<CommandOutput>
     Run tests with `vitest` (one-shot `run` unless {@link VitestSettings.watch}).
+
+type VitestPool = "threads" | "forks" | "vmThreads" | "vmForks"
+  The Vitest worker pool implementation (`--pool`).
 ````
 
 </details>

--- a/packages/vitest/src/vitest.ts
+++ b/packages/vitest/src/vitest.ts
@@ -28,6 +28,9 @@ import {
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
 
+/** The Vitest worker pool implementation (`--pool`). */
+export type VitestPool = "threads" | "forks" | "vmThreads" | "vmForks";
+
 /** Settings for a `vitest` run. */
 export class VitestSettings extends ToolSettings {
   #filters: string[] = [];
@@ -39,6 +42,9 @@ export class VitestSettings extends ToolSettings {
   #ui = false;
   #update = false;
   #run = false;
+  #pool?: VitestPool;
+  #maxWorkers?: number;
+  #minWorkers?: number;
   #bail?: number;
   #retry?: number;
   #shard?: string;
@@ -114,6 +120,24 @@ export class VitestSettings extends ToolSettings {
     return this;
   }
 
+  /** Choose the worker pool implementation (`--pool`). */
+  pool(name: VitestPool): this {
+    this.#pool = name;
+    return this;
+  }
+
+  /** Cap the number of parallel workers (`--maxWorkers`). */
+  maxWorkers(count: number): this {
+    this.#maxWorkers = count;
+    return this;
+  }
+
+  /** Set the minimum number of parallel workers (`--minWorkers`). */
+  minWorkers(count: number): this {
+    this.#minWorkers = count;
+    return this;
+  }
+
   /** Stop after N failed tests (`--bail`). */
   bail(count: number): this {
     this.#bail = count;
@@ -184,6 +208,13 @@ export class VitestSettings extends ToolSettings {
     if (this.#ui) argv.push("--ui");
     if (this.#update) argv.push("-u");
     if (this.#run) argv.push("--run");
+    if (this.#pool !== undefined) argv.push("--pool", this.#pool);
+    if (this.#maxWorkers !== undefined) {
+      argv.push("--maxWorkers", String(this.#maxWorkers));
+    }
+    if (this.#minWorkers !== undefined) {
+      argv.push("--minWorkers", String(this.#minWorkers));
+    }
     if (this.#bail !== undefined) argv.push("--bail", String(this.#bail));
     if (this.#retry !== undefined) argv.push("--retry", String(this.#retry));
     if (this.#shard !== undefined) argv.push("--shard", this.#shard);

--- a/packages/vitest/tests/vitest_test.ts
+++ b/packages/vitest/tests/vitest_test.ts
@@ -13,7 +13,8 @@ Deno.test("watch() switches to the watch subcommand", () => {
 Deno.test("vitest: every option renders, filters last", () => {
   const argv = new VitestSettings()
     .config("vitest.config.ts").root(".").dir("src").coverage().ui().update()
-    .forceRun().bail(1).retry(2).shard("1/4").reporter("dot", "junit")
+    .forceRun().pool("forks").maxWorkers(4).minWorkers(1).bail(1).retry(2)
+    .shard("1/4").reporter("dot", "junit")
     .outputFile("out.xml").testNamePattern("renders").environment("jsdom")
     .globals().passWithNoTests().silent().filters("math", "string").argv();
   assertEquals(argv, [
@@ -29,6 +30,12 @@ Deno.test("vitest: every option renders, filters last", () => {
     "--ui",
     "-u",
     "--run",
+    "--pool",
+    "forks",
+    "--maxWorkers",
+    "4",
+    "--minWorkers",
+    "1",
     "--bail",
     "1",
     "--retry",

--- a/tests/integration/setup_scaffold_test.ts
+++ b/tests/integration/setup_scaffold_test.ts
@@ -1,0 +1,90 @@
+/**
+ * Integration coverage for `zuke setup`: drive the real `@zuke/cli` `main()`
+ * against a real temporary directory (the production {@link defaultHost}, only
+ * its logging captured) and assert the files that land on disk are a scaffold
+ * whose advertised next step — `./zuke <target>` — can actually run.
+ *
+ * The regression this pins: a scaffold has no `deno.lock` yet, and
+ * `deno run --frozen` against a missing lockfile fails ("The lockfile is out of
+ * date") instead of writing one, so an unconditional `--frozen` in the launcher
+ * or the `deno.json` task breaks every project on its very first run.
+ *
+ * @module
+ */
+
+import { assertEquals } from "../../packages/core/tests/_assert.ts";
+import { main } from "../../packages/cli/mod.ts";
+import { defaultHost, type SetupHost } from "../../packages/cli/src/setup.ts";
+
+/** Scaffold into a fresh temp directory and return its files plus the log. */
+async function scaffold(): Promise<{
+  read: (name: string) => Promise<string>;
+  log: string;
+  code: number;
+}> {
+  const dir = await Deno.makeTempDir({ prefix: "zuke-setup-" });
+  const lines: string[] = [];
+  const host: SetupHost = {
+    ...defaultHost,
+    log: (message: string) => void lines.push(message),
+  };
+  try {
+    const code = await main(
+      ["setup", "--yes", "--name", "Foo", "--dir", dir],
+      host,
+    );
+    const files = new Map<string, string>();
+    for await (const entry of Deno.readDir(dir)) {
+      if (entry.isFile) {
+        files.set(entry.name, await Deno.readTextFile(`${dir}/${entry.name}`));
+      }
+    }
+    return {
+      read: (name: string) => {
+        const text = files.get(name);
+        if (text === undefined) throw new Error(`setup did not write ${name}`);
+        return Promise.resolve(text);
+      },
+      log: lines.join("\n"),
+      code,
+    };
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+Deno.test("zuke setup scaffolds a project whose first run has no lockfile to freeze", async () => {
+  const { read, log, code } = await scaffold();
+  assertEquals(code, 0);
+  assertEquals(log.includes("Next: ./zuke"), true);
+
+  // The bash launcher — the entry point setup tells the user to run — only
+  // asks for --frozen when there is a lockfile to verify.
+  const bash = await read("zuke");
+  assertEquals(bash.includes("if [ -f deno.lock ]; then"), true);
+  assertEquals(bash.split("run -A --frozen").length - 1, 1);
+  assertEquals(bash.split(`run -A zuke.ts "$@"`).length - 1, 1);
+
+  // The PowerShell launcher agrees.
+  const pwsh = await read("zuke.ps1");
+  assertEquals(pwsh.includes(`Test-Path (Join-Path $dir "deno.lock")`), true);
+  assertEquals(pwsh.split(`$denoArgs += "--frozen"`).length - 1, 1);
+  assertEquals(pwsh.includes(`@("run", "-A")`), true);
+
+  // `deno task`'s shell has no conditionals, so the task cannot bootstrap a
+  // lockfile — it must not demand one either.
+  const denoJson: unknown = JSON.parse(await read("deno.json"));
+  const tasks =
+    denoJson !== null && typeof denoJson === "object" && "tasks" in denoJson
+      ? denoJson.tasks
+      : undefined;
+  const zukeTask =
+    tasks !== null && typeof tasks === "object" && "zuke" in tasks
+      ? tasks.zuke
+      : undefined;
+  assertEquals(zukeTask, "deno run -A zuke.ts");
+
+  // The starter build stays pinned, so the lock the first run writes is
+  // meaningful for every run after it.
+  assertEquals((await read("zuke.ts")).includes('jsr:@zuke/core@^1"'), true);
+});


### PR DESCRIPTION
Adds typed builders that previously forced callers through the generic args escape hatch, and closes a supply-chain gap in what the scaffolder writes.

**New builders.** vitest gains pool, maxWorkers and minWorkers; compose gains abort-on-container-exit and exit-code-from; playwright gains ui and update-snapshots; and the tsc build settings gain noEmit. That last one was verified rather than assumed: the build settings class extends the tsc base class as a sibling rather than a subclass, so it genuinely lacked noEmit even though the non-build path has it. Every new name was checked against the base settings surface for collisions first.

**DenoSettings gains a frozen builder.** It is named after the real Deno flag rather than matching the pnpm wrapper's frozen-lockfile spelling, because mirroring the actual CLI wins over cross-package symmetry; the deliberate divergence is noted in its docs. It was added to more subcommands than the minimum asked for, after checking which ones really accept the flag.

**The scaffolder wrote a launcher with no lockfile enforcement**, so the first thing a generated build did was resolve its module graph unlocked — meaning any frozen check inside that build validated a lockfile already rewritten moments earlier. All four launcher sites now pass frozen, and the starter build's import is pinned to a major rather than floating.

Also strengthens the docker login password docs to state plainly that the password lands in argv and that the stdin variant is the right choice in CI.

**Verification.** Gate green. This is deliberately one PR: release-please attributes a bump to every package whose files the squashed commit touches, so a single feature title correctly minor-bumps each wrapper changed here.
