### PR TITLE
docs: split the CLI reference and fix stale milestones, pins, and indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ class MyBuild extends Build {
 - **Ergonomic shell.** The `$` tagged template runs processes with sane defaults
   (throw on failure, capture output) and is injection-safe.
 - **Small and explicit.** A tiny core: discover targets, build a graph, sort,
-  run. No magic, no plugins to learn (yet).
+  run. No magic, and no plugins to learn for a basic build — the
+  [plugin contract](./docs/extending.md) is there once you want one.
 - **Code-first CI.** Declare your pipeline in the build with
   `cicd({ provider: "github" })` — the provider is the only required field — and
   Zuke generates GitHub Actions, GitLab CI, or Azure Pipelines YAML,
@@ -290,6 +291,10 @@ Full documentation lives in [`docs/`](./docs/):
   code-first CI generation (`cicd()`), and gotchas.
 - [Run context & cancellation](./docs/run-context.md) — the `TargetContext` a
   body receives (`runId`, `signal`, `state`) and cancelling a run.
+- [Secrets](./docs/secrets.md) — source secret values from a manager with
+  `.from(...)`, with guaranteed redaction from every output.
+- [Service targets](./docs/services.md) — `service()` for long-lived processes
+  (a dev server, a database) kept running while dependents execute.
 - [Caching](./docs/caching.md) — the incremental build cache
   (`.inputs()`/`.outputs()`) and the AI response cache (`aiCache`).
 - [Durable run state](./docs/state.md) — persist a run's status and per-target
@@ -299,18 +304,30 @@ Full documentation lives in [`docs/`](./docs/):
   across runs and machines, with a TTL backstop and typed `LockConflictError`s.
 - [Orchestration: waits](./docs/orchestration.md) — `.waitsFor()` suspends a run
   until an external signal or predicate, saving its state to be resumed later.
+- [Build registry](./docs/registry.md) — `zuke register` catalogs a build for
+  dynamic, agentic discovery by an MCP server.
+- [Console output](./docs/console.md) — `@zuke/console`: the levelled logger,
+  markup, boxes/tables/rules, and the renderer behind Zuke's own build log.
 - [Shell wrapper (`$`)](./docs/shell.md) — ergonomic, injection-safe process
   execution.
 - [Paths (`absolutePath`)](./docs/paths.md) — the fluent path type.
 - [Tools](./docs/tools.md) — the typed tool-wrapper packages and their tasks.
+- [Installing tools](./docs/installing-tools.md) — fetch pinned,
+  checksum-verified CLIs with `installRelease()` and `toolchain()`.
+- [Extending Zuke](./docs/extending.md) — the plugin contract: lifecycle
+  plugins, tool wrappers, and reusable target bundles.
+- [Observability (OpenTelemetry)](./docs/observability.md) — `@zuke/otel`
+  exports run and target spans plus counters as OTLP/HTTP JSON.
+- [MCP server](./docs/mcp.md) — `./zuke mcp` exposes the build to AI agents as
+  typed tools over the Model Context Protocol.
 - [AI code review](./docs/ai-review.md) — gate the build on a structured LLM
   assessment of the diff (`@zuke/ai`).
 - [Self-healing builds](./docs/self-healing.md) — diagnose and fix failing
   targets with `recoverWith` and `aiFixer`, including Copilot-style suggestions.
-- [Extending Zuke](./docs/extending.md) — the plugin contract: lifecycle
-  plugins, tool wrappers, and reusable target bundles.
 - [Using Zuke in a Node/npm project](./docs/node-projects.md) — drive a Node
   build with Deno.
+- [Scheduled runs](./docs/schedules.md) — `triggers.schedule` (`{ cron, tz }`)
+  compiled to UTC cron with a daylight-saving wall-clock guard.
 - [CLI reference](./docs/cli.md) — commands and flags.
 - [Programmatic API](./docs/programmatic-api.md) — drive Zuke from your own
   code.

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,8 @@
   suspends a run until an external event, to be resumed later.
 - [State HTTP API](./state-api.md) — the REST contract for hosting a production
   state backend.
+- [Build registry](./registry.md) — `zuke register` catalogs a build for
+  dynamic, agentic discovery by an MCP server.
 - [Console output](./console.md) — `@zuke/console`: the levelled logger, markup,
   boxes/tables/rules, and the renderer behind Zuke's own build log.
 - [Shell wrapper (`$`)](./shell.md) — ergonomic, injection-safe process

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -126,9 +126,11 @@ The script is a static snapshot of the build it was generated from, so
 regenerate and re-source it when you add, rename, or remove targets — the same
 model as `deno completions`. A missing or unknown sub-action or shell prints a
 usage line and exits `1`. `completions` is a reserved command name: a target
-called `completions` can't be run by name. The completions attach to whichever
-word you sourced them for — `./zuke`, `zuke`, or `deno task zuke` all work, as
-long as the printed script's word matches how you invoke the build.
+called `completions` can't be run by name. The printed script registers the
+completion against the words `zuke` and `./zuke`, so both of those forms
+complete. `deno task zuke <target>` does not: a shell picks the completion from
+the first word of the line, which is `deno` there — invoke the launcher
+directly when you want completion.
 
 ### Installing
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,34 +1,70 @@
 # CLI reference
 
-| Command                                                               | Behaviour                                                                                                   |
-| --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| `zuke <target>`                                                       | Run the target and all its transitive dependencies, in order.                                               |
-| `zuke <target> --skip <dep>`                                          | Run the target but skip the named dependency (repeatable).                                                  |
-| `zuke <target> --parallel`                                            | Run independent targets concurrently (`--parallel=N` caps it).                                              |
-| `zuke <target> --no-cache`                                            | Ignore the incremental cache; re-run every target.                                                          |
-| `zuke <target> --affected[=<base>]`                                   | Run only targets affected by files changed since a git base.                                                |
-| `zuke <target> --dry-run`                                             | Print the plan without executing any target body.                                                           |
-| `zuke <target> --state`                                               | Persist [durable run state](./state.md) under `.zuke/runs`.                                                 |
-| `zuke <target> --actor <name>`                                        | Attribute the run to `<name>` in its state record.                                                          |
-| `zuke --list` / `-l`                                                  | List all targets with descriptions and dependencies.                                                        |
-| `zuke graph`                                                          | Print the dependency graph (`target → deps`).                                                               |
-| `zuke graph --output=html`                                            | Render an interactive HTML graph into `.zuke/` and open it.                                                 |
-| `zuke completions print <shell>`                                      | Print a shell-completion script (`bash`, `zsh`, or `fish`).                                                 |
-| `zuke completions install <shell>`                                    | Write the script and wire it into the shell's startup.                                                      |
-| `zuke generate-ci [--check]`                                          | Write the declared CI workflow files (`--check` verifies they are up to date instead of writing).           |
-| `zuke mcp [--allow-run[=<globs>]] [--http <host:port>]`               | Run an MCP server over the build for AI agents, on stdio or HTTP ([details](./mcp.md)).                     |
-| `zuke resume <id> [--signal <n>] [--data <json>]`                     | Resume a suspended run, optionally delivering a signal ([details](./orchestration.md)).                     |
-| `zuke resume --check [<id>]`                                          | Re-check suspended runs (predicate waits, timeouts).                                                        |
-| `zuke runs list [--status/-target/-since/-limit] [--counts] [--json]` | List persisted run records (or `--counts` for a status tally), newest first ([details](./state.md)).        |
-| `zuke runs show <id> [--json]`                                        | Show one run's full per-target status and metadata.                                                         |
-| `zuke runs prune [--keep <age>] [--keep-last <n>] [--dry-run]`        | Delete old terminal run records; never touches non-terminal runs.                                           |
-| `zuke cancel <id> [--actor <name>]`                                   | Cancel a run and run its compensations ([details](./orchestration.md#cancellation--compensation-oncancel)). |
-| `zuke register`                                                       | Register this build in the build registry (dynamic pipeline discovery).                                     |
-| `zuke doc <spec>`                                                     | Print a package's API docs (`deno doc <spec>`) from an isolated empty directory.                            |
-| `zuke --help` / `-h`                                                  | Usage.                                                                                                      |
-| `zuke` (no target)                                                    | Run the `default` target if defined, else print `--list`.                                                   |
+"zuke" names **two different programs**, and this reference is split to match:
 
-(Read `zuke` as `deno run -A zuke.ts` until the launcher binary ships.)
+- **The global `zuke` CLI** (`jsr:@zuke/cli`, installed once with
+  `deno install -A -g -n zuke jsr:@zuke/cli`) only scaffolds and inspects
+  projects — `setup`, `import`, `doc`, `--help`, `--version`. It never runs a
+  target.
+- **Your build's own CLI** — reached via the `./zuke` launcher (or
+  `deno run -A zuke.ts`) that `zuke setup`/`zuke import` drop into your repo —
+  is what runs targets and everything else: `graph`, `--list`, `generate-ci`,
+  `completions`, `mcp`, `resume`, `runs`, `cancel`, `register`, its own `doc`.
+
+If a command isn't in the first table, it belongs to the second one — run it
+with `./zuke <command>`, not the bare `zuke` you installed globally.
+
+## The global `zuke` CLI (`jsr:@zuke/cli`)
+
+| Command                    | Behaviour                                                                                              |
+| --------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `zuke setup [options]`      | Scaffold a starter `zuke.ts`, the `./zuke`/`zuke.ps1` launchers, `deno.json`, and `zuke.json` into a directory. See [Getting started](./getting-started.md#scaffold-a-project-with-zuke-setup). |
+| `zuke import [options]`     | Generate a `zuke.ts` with one target per `package.json` script or Makefile target, plus the same scaffolding as `setup`. See [Getting started](./getting-started.md#migrate-an-existing-project-with-zuke-import). |
+| `zuke doc <package>`        | Print a `@zuke/*` package's API (`zuke doc core`, `zuke doc @scope/pkg`, or a `jsr:`/`npm:`/`https:` spec as-is) via an isolated `deno doc`. |
+| `zuke --help` / `-h`        | Usage.                                                                                                    |
+| `zuke --version` / `-V`     | Print the installed `@zuke/cli` version.                                                                 |
+
+`setup` and `import` share the same flags: `--dir <path>`, `--name <Class>`,
+`--launcher-name <name>` (when a `zuke/` directory already occupies the
+launcher's name), `--force`/`-f`, `--yes`/`-y`; `import` additionally takes
+`--from <package.json|makefile>` to pin the source instead of auto-detecting
+it. Both finish by scaffolding the launchers and `deno.json`, so the very next
+command you run is your build's own CLI, `./zuke`.
+
+## Your build's CLI (`./zuke` / `deno run -A zuke.ts`)
+
+Everything below runs *your build* — the `zuke.ts` in your project, driven
+through the `./zuke` (or `.\zuke.ps1`) launcher or directly with
+`deno run -A zuke.ts`. Shell completions (see [`./zuke completions`](#zuke-completions)
+below) attach to whichever launcher word you install them for.
+
+| Command                                                                 | Behaviour                                                                                                   |
+| ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| `./zuke <target>`                                                       | Run the target and all its transitive dependencies, in order.                                               |
+| `./zuke <target> --skip <dep>`                                          | Run the target but skip the named dependency (repeatable).                                                  |
+| `./zuke <target> --parallel`                                            | Run independent targets concurrently (`--parallel=N` caps it).                                              |
+| `./zuke <target> --no-cache`                                            | Ignore the incremental cache; re-run every target.                                                          |
+| `./zuke <target> --affected[=<base>]`                                   | Run only targets affected by files changed since a git base.                                                |
+| `./zuke <target> --dry-run`                                             | Print the plan without executing any target body.                                                           |
+| `./zuke <target> --state`                                               | Persist [durable run state](./state.md) under `.zuke/runs`.                                                 |
+| `./zuke <target> --actor <name>`                                        | Attribute the run to `<name>` in its state record.                                                          |
+| `./zuke --list` / `-l`                                                  | List all targets with descriptions and dependencies.                                                        |
+| `./zuke graph`                                                          | Print the dependency graph (`target → deps`).                                                               |
+| `./zuke graph --output=html`                                            | Render an interactive HTML graph into `.zuke/` and open it.                                                 |
+| `./zuke completions print <shell>`                                      | Print a shell-completion script (`bash`, `zsh`, or `fish`).                                                 |
+| `./zuke completions install <shell>`                                    | Write the script and wire it into the shell's startup.                                                      |
+| `./zuke generate-ci [--check]`                                          | Write the declared CI workflow files (`--check` verifies they are up to date instead of writing).           |
+| `./zuke mcp [--allow-run[=<globs>]] [--http <host:port>]`               | Run an MCP server over the build for AI agents, on stdio or HTTP ([details](./mcp.md)).                     |
+| `./zuke resume <id> [--signal <n>] [--data <json>]`                     | Resume a suspended run, optionally delivering a signal ([details](./orchestration.md)).                     |
+| `./zuke resume --check [<id>]`                                          | Re-check suspended runs (predicate waits, timeouts).                                                        |
+| `./zuke runs list [--status/-target/-since/-limit] [--counts] [--json]` | List persisted run records (or `--counts` for a status tally), newest first ([details](./state.md)).        |
+| `./zuke runs show <id> [--json]`                                        | Show one run's full per-target status and metadata.                                                         |
+| `./zuke runs prune [--keep <age>] [--keep-last <n>] [--dry-run]`        | Delete old terminal run records; never touches non-terminal runs.                                           |
+| `./zuke cancel <id> [--actor <name>]`                                   | Cancel a run and run its compensations ([details](./orchestration.md#cancellation--compensation-oncancel)). |
+| `./zuke register`                                                       | Register this build in the build registry (dynamic pipeline discovery).                                     |
+| `./zuke doc <spec>`                                                     | Print a package's API docs (`deno doc <spec>`) from an isolated empty directory.                            |
+| `./zuke --help` / `-h`                                                  | Usage.                                                                                                      |
+| `./zuke` (no target)                                                    | Run the `default` target if defined, else print `--list`.                                                   |
 
 ## `zuke graph`
 
@@ -65,11 +101,11 @@ emit `::error::` annotations, and the summary is written to the job summary.
 
 ## `zuke completions`
 
-`zuke completions` takes an explicit sub-action — `print` or `install` — then a
-shell (`bash`, `zsh`, or `fish`). `print` writes the completion script to
-stdout; the script completes the build's target names, the reserved commands
-(`graph`, `generate-ci`, `completions`, `mcp`, `resume`, `runs`, `cancel`,
-`register`, `doc`), the built-in option flags, and any declared
+`./zuke completions` takes an explicit sub-action — `print` or `install` —
+then a shell (`bash`, `zsh`, or `fish`). `print` writes the completion script
+to stdout; the script completes the build's target names, the reserved
+commands (`graph`, `generate-ci`, `completions`, `mcp`, `resume`, `runs`,
+`cancel`, `register`, `doc`), the built-in option flags, and any declared
 [parameters](./parameters.md) as `--flag` candidates. Unlisted targets
 (`.unlisted()`) stay hidden, just as they are in `--list`.
 
@@ -77,26 +113,28 @@ Source the printed script for the current shell:
 
 ```sh
 # bash — current shell, or append to ~/.bashrc
-source <(zuke completions print bash)
+source <(./zuke completions print bash)
 
 # zsh — current shell, or write to a file named _zuke on your $fpath
-source <(zuke completions print zsh)
+source <(./zuke completions print zsh)
 
 # fish — current shell, or save to ~/.config/fish/completions/zuke.fish
-zuke completions print fish | source
+./zuke completions print fish | source
 ```
 
 The script is a static snapshot of the build it was generated from, so
 regenerate and re-source it when you add, rename, or remove targets — the same
 model as `deno completions`. A missing or unknown sub-action or shell prints a
 usage line and exits `1`. `completions` is a reserved command name: a target
-called `completions` can't be run by name.
+called `completions` can't be run by name. The completions attach to whichever
+word you sourced them for — `./zuke`, `zuke`, or `deno task zuke` all work, as
+long as the printed script's word matches how you invoke the build.
 
 ### Installing
 
-`zuke completions install <shell>` does the wiring for you: it writes the script
-to a file under your config directory and makes the shell load it on the next
-start — no manual `source` step.
+`./zuke completions install <shell>` does the wiring for you: it writes the
+script to a file under your config directory and makes the shell load it on
+the next start — no manual `source` step.
 
 - **bash** → writes `~/.config/zuke/completions/zuke.bash` and appends a
   `source` line to `~/.bashrc`.
@@ -122,24 +160,29 @@ resolves) and — only with `--allow-run` — one `run:<target>` tool per target
 requires a `ZUKE_OPERATOR_TOKEN` operator token, and `--confirm-destructive`
 makes a destructive run return its plan until called with `confirm:true`. Every
 mutating or denied call is written to an audit trail
-(`zuke runs show mcp-audit`). `--http <host:port>` serves the streamable-HTTP
+(`./zuke runs show mcp-audit`). `--http <host:port>` serves the streamable-HTTP
 transport instead of stdio (loopback by default; a non-loopback bind requires a
 `ZUKE_MCP_TOKEN` bearer token). `mcp` is a reserved command name. See the full
 guide: [MCP server](./mcp.md).
 
-## `zuke doc`
+## `zuke doc` (the build's own)
 
-`zuke doc <spec>` prints a package's API by running `deno doc <spec>` (e.g.
-`zuke doc jsr:@zuke/deno`) — but from a fresh empty directory instead of the
+`./zuke doc <spec>` prints a package's API by running `deno doc <spec>` (e.g.
+`./zuke doc jsr:@zuke/deno`) — but from a fresh empty directory instead of the
 current one. Run inside a Node repository, a bare `deno doc jsr:@zuke/...`
 resolves the repo's `node_modules/@types/*` and buries the API under dozens of
 `Failed resolving types …` warnings; the isolated empty working directory has
 nothing to resolve, so the output is just the API. Any relative file path
-(`zuke doc ./mod.ts` or `zuke doc mod.ts`) is resolved against the real working
-directory before the isolated `deno doc` runs; `jsr:`/`npm:`/`https:` specifiers
-and absolute paths are passed through unchanged. `doc` is a reserved command
-name. (This complements the generated [`llms-full.txt`](../llms-full.txt) and
-each package's README `## API` block.)
+(`./zuke doc ./mod.ts` or `./zuke doc mod.ts`) is resolved against the real
+working directory before the isolated `deno doc` runs; `jsr:`/`npm:`/`https:`
+specifiers and absolute paths are passed through unchanged. `doc` is a
+reserved command name. (This complements the generated
+[`llms-full.txt`](../llms-full.txt) and each package's README `## API` block.)
+
+This is a different command from the global `zuke doc` above: the global one
+takes a bare package name (`zuke doc core`) and resolves it to `jsr:@zuke/core`
+for you; the build's own `./zuke doc` needs the full spec (or a relative
+path), since it is just another reserved command on your build's CLI.
 
 ## Parallel execution
 
@@ -236,8 +279,8 @@ rest are skipped (their prior outputs are assumed current, so a skipped
 dependency still unblocks its dependents).
 
 ```sh
-zuke ci --affected                 # vs HEAD (uncommitted changes)
-zuke ci --affected=origin/main     # vs a base branch — the usual CI form
+./zuke ci --affected                 # vs HEAD (uncommitted changes)
+./zuke ci --affected=origin/main     # vs a base branch — the usual CI form
 ```
 
 A target is affected when a changed file falls inside one of its declared
@@ -273,7 +316,7 @@ store.
 ## Resuming suspended runs
 
 A run parked at a [`.waitsFor()`](./orchestration.md) gate is continued with
-`zuke resume`. `--signal <name>` delivers a named external signal (with an
+`./zuke resume`. `--signal <name>` delivers a named external signal (with an
 optional `--data <json>` payload); `--check [<run-id>]` re-checks predicate
 waits and enforces timeouts across suspended runs (the cron/webhook entry
 point). Resumption is **exactly-once** — concurrent resumers race a
@@ -284,7 +327,7 @@ build graph changed since the run was suspended. See
 
 ## Cancelling runs
 
-`zuke cancel <run-id>` cancels a run and runs its
+`./zuke cancel <run-id>` cancels a run and runs its
 [compensations](./orchestration.md#cancellation--compensation-oncancel): every
 target that had **succeeded** and declared `.onCancel(...)` is unwound in
 reverse order, then the record settles `cancelled`. `--actor <name>` attributes
@@ -296,30 +339,31 @@ exit.
 
 ## Inspecting runs
 
-`zuke runs` reads persisted [run records](./state.md) back from the store, so a
-run's full status survives the process that produced it.
+`./zuke runs` reads persisted [run records](./state.md) back from the store, so
+a run's full status survives the process that produced it.
 
-- `zuke runs list` prints one row per run — id, status, root target, actor, and
-  creation time — newest first. Narrow it with `--status <s>` (one of `running`,
-  `suspended`, `cancelling`, `succeeded`, `failed`, `cancelled`), `--target <t>`
-  (only runs whose graph contains that target), `--since <iso>` (only runs
-  created at or after an ISO-8601 timestamp), and `--limit <n>` (at most the
-  newest N). The filters compose. Add `--counts` to print aggregate counts (a
-  total and one line per status) instead of rows — with `--json` it emits
-  `{ total, byStatus }` (status keys sorted for stable output), honouring the
-  same filters.
-- `zuke runs show <run-id>` reconstructs one run in full: the header, resolved
-  (non-secret) parameters, each target's status with its duration, error, or
-  pending wait, and any external signals received.
-- `zuke runs prune` deletes old records. `--keep <age>` (e.g. `90d`) keeps runs
-  newer than that; `--keep-last <n>` always keeps the newest N; a run is deleted
-  only when it is **terminal** and matches neither. **Non-terminal** runs
-  (`suspended`, `running`, `cancelling`) are never pruned. At least one rule is
-  required, and `--dry-run` reports what would go without deleting. See
-  [retention](./state.md#retention) for who owns it on each backend.
+- `./zuke runs list` prints one row per run — id, status, root target, actor,
+  and creation time — newest first. Narrow it with `--status <s>` (one of
+  `running`, `suspended`, `cancelling`, `succeeded`, `failed`, `cancelled`),
+  `--target <t>` (only runs whose graph contains that target), `--since <iso>`
+  (only runs created at or after an ISO-8601 timestamp), and `--limit <n>` (at
+  most the newest N). The filters compose. Add `--counts` to print aggregate
+  counts (a total and one line per status) instead of rows — with `--json` it
+  emits `{ total, byStatus }` (status keys sorted for stable output),
+  honouring the same filters.
+- `./zuke runs show <run-id>` reconstructs one run in full: the header,
+  resolved (non-secret) parameters, each target's status with its duration,
+  error, or pending wait, and any external signals received.
+- `./zuke runs prune` deletes old records. `--keep <age>` (e.g. `90d`) keeps
+  runs newer than that; `--keep-last <n>` always keeps the newest N; a run is
+  deleted only when it is **terminal** and matches neither. **Non-terminal**
+  runs (`suspended`, `running`, `cancelling`) are never pruned. At least one
+  rule is required, and `--dry-run` reports what would go without deleting.
+  See [retention](./state.md#retention) for who owns it on each backend.
 
 Both accept `--json` — `list` emits the summary array, `show` emits the whole
 record — for tools and agents. The store is resolved exactly as a run resolves
 it (`ZUKE_STATE_URL` / `ZUKE_STATE_DIR`, the build's `stateStore()` override, or
 the default `.zuke/runs`); with no store configured, both report a friendly
-error. (MCP `list_runs` / `show_run` tools arrive in a later milestone.)
+error. The MCP server's `list_runs`/`show_run` tools (see [`./zuke mcp`](#zuke-mcp)
+above) read the same store.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -84,6 +84,13 @@ fresh checkout needs nothing but the script:
 If you already have Deno, `deno task zuke <target>` (via the `zuke` task in
 `deno.json`) does the same thing.
 
+`zuke setup`/`zuke import` scaffold this launcher for you, so once it's in
+place run every target with `./zuke <target>` — the bare `zuke` you installed
+globally only knows `setup`/`import`/`doc` (see the
+[CLI reference](./cli.md) for the full split). Shell completions
+(`./zuke completions install <shell>`) attach to whichever launcher word you
+source or install them for — `./zuke`, `zuke`, or `deno task zuke`.
+
 ## Quick start
 
 ```ts
@@ -118,7 +125,7 @@ class MyBuild extends Build {
       await DenoTasks.test((s) => s.allowAll());
     });
 
-  // Optional: runs when you invoke `zuke` with no target.
+  // Optional: runs when you invoke `./zuke` with no target.
   default = target().dependsOn(this.test).executes(() => {});
 }
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -88,8 +88,9 @@ If you already have Deno, `deno task zuke <target>` (via the `zuke` task in
 place run every target with `./zuke <target>` — the bare `zuke` you installed
 globally only knows `setup`/`import`/`doc` (see the
 [CLI reference](./cli.md) for the full split). Shell completions
-(`./zuke completions install <shell>`) attach to whichever launcher word you
-source or install them for — `./zuke`, `zuke`, or `deno task zuke`.
+(`./zuke completions install <shell>`) register the words `zuke` and `./zuke`,
+so those two forms complete targets; `deno task zuke <target>` does not,
+because the shell matches the completion on the first word of the line.
 
 ## Quick start
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,10 +1,12 @@
 # MCP server
 
-`zuke mcp` runs a [Model Context Protocol](https://modelcontextprotocol.io)
+`./zuke mcp` — a command on **your build's own CLI**, not the globally
+installed `jsr:@zuke/cli` (see the [CLI reference](./cli.md) for the
+difference) — runs a [Model Context Protocol](https://modelcontextprotocol.io)
 server over your build. MCP is the open standard that lets an AI client — Claude
 Desktop, Claude Code, an IDE, any agent — discover a server's **tools** (typed,
-schema-described functions) and call them. Pointing a client at `zuke mcp` lets
-an agent **operate the pipeline through typed calls** — list the targets,
+schema-described functions) and call them. Pointing a client at `./zuke mcp`
+lets an agent **operate the pipeline through typed calls** — list the targets,
 inspect the graph, run one with the right parameters — instead of guessing shell
 invocations.
 
@@ -18,14 +20,13 @@ newline-delimited JSON-RPC 2.0 on stdio, the standard MCP local transport.
 ## Running it
 
 ```sh
-zuke mcp              # read-only: inspect the build, never execute
-zuke mcp --allow-run  # also expose run:<target> tools that execute targets
+./zuke mcp              # read-only: inspect the build, never execute
+./zuke mcp --allow-run  # also expose run:<target> tools that execute targets
 ```
 
 The process reads JSON-RPC from stdin and writes responses to stdout; its one
 startup line goes to stderr so it never corrupts the protocol stream. It runs
-until stdin closes. (Read `zuke` as `deno run -A zuke.ts` until the launcher
-binary ships.)
+until stdin closes.
 
 ### Registering with a client
 
@@ -45,8 +46,8 @@ For a client that connects over the network rather than launching the process,
 `--http` serves MCP's **streamable-HTTP** transport instead of stdio:
 
 ```sh
-zuke mcp --http 7777                 # bind 127.0.0.1:7777 (local only)
-zuke mcp --http 0.0.0.0:7777         # bind all interfaces — needs a token
+./zuke mcp --http 7777                 # bind 127.0.0.1:7777 (local only)
+./zuke mcp --http 0.0.0.0:7777         # bind all interfaces — needs a token
 ```
 
 Each request is a `POST` whose body is one JSON-RPC message; the response is
@@ -117,7 +118,7 @@ With `--allow-run` a store also exposes three **mutating** run-state tools:
 exactly-once), `resume_check` (re-check suspended runs — predicate waits and
 timeouts), and `cancel_run` (cancel a run and run its
 [compensations](./orchestration.md#cancellation--compensation-oncancel)). They
-are the MCP counterparts of `zuke resume` and `zuke cancel`. Each runs the
+are the MCP counterparts of `./zuke resume` and `./zuke cancel`. Each runs the
 target's code (a resume continues it; a cancel runs its compensations), so it is
 gated by the same [allow-list and operator-token](#authorization) policy as a
 `run:` tool and appended to the [audit log](#audit-log).
@@ -154,7 +155,7 @@ token".
 ```sh
 # Expose everything to run, but gate promoteToProd behind an operator token
 # and make every destructive run confirm first:
-ZUKE_OPERATOR_TOKEN=… zuke mcp --http 7777 \
+ZUKE_OPERATOR_TOKEN=… ./zuke mcp --http 7777 \
   --allow-run --protect promoteToProd --confirm-destructive
 ```
 
@@ -167,7 +168,7 @@ and the call's arguments. Arguments are **redacted** — the operator token is
 dropped and every `.secret()` parameter's value is masked — before anything is
 persisted.
 
-The trail lives in a store-level record; read it with `zuke runs show mcp-audit`
+The trail lives in a store-level record; read it with `./zuke runs show mcp-audit`
 (or the `show_run` tool). The actor resolves by precedence: the **identity
 hook** (below) → `--actor` → `ZUKE_ACTOR` → the CI actor → the connecting
 client's `initialize` name → `"anonymous"`. The client name is an **untrusted
@@ -207,15 +208,15 @@ header stripping are the proxy's job, not Zuke's.
 
 ## Registry mode (dynamic discovery)
 
-By default `zuke mcp` serves the single build its process was launched with.
+By default `./zuke mcp` serves the single build its process was launched with.
 With `--registry` it instead serves the [build registry](./registry.md) — the
-catalog `zuke register` writes to — and **re-reads it on every `tools/list` and
-`tools/call`**. So a pipeline registered by another process appears as a tool in
-an already-running server with **no restart**:
+catalog `./zuke register` writes to — and **re-reads it on every `tools/list`
+and `tools/call`**. So a pipeline registered by another process appears as a
+tool in an already-running server with **no restart**:
 
 ```sh
 # Serve every registered pipeline, execution enabled:
-zuke mcp --registry --allow-run
+./zuke mcp --registry --allow-run
 ```
 
 - **Discovery.** `list_builds` returns the catalog; `describe_build` (with a
@@ -223,7 +224,7 @@ zuke mcp --registry --allow-run
   a `run:<buildId>:<target>` tool, re-read live.
 - **Execution is a spawn.** A registered build has no live instance in the
   server, so a run tool **spawns the build's registered launch location** (the
-  `deno run <module> <target>` `zuke register` recorded, or an explicit command)
+  `deno run <module> <target>` `./zuke register` recorded, or an explicit command)
   and returns its captured output. This is code execution, so it is off unless
   `--allow-run`, and it honours the same [authorization](#authorization) tiers —
   the allow-list and `--protect` globs match the **qualified**
@@ -240,7 +241,7 @@ zuke mcp --registry --allow-run
   call omits it. Because a descriptor does not record whether a target is
   read-only, every registry run tool is treated as destructive.
 - **Secrets never cross the boundary.** `.secret()` parameters are omitted from
-  the descriptor entirely (`zuke register` writes the secret-free surface), so a
+  the descriptor entirely (`./zuke register` writes the secret-free surface), so a
   secret can neither be requested nor forwarded — it is rejected as an unknown
   parameter if a client tries. The spawned build resolves a secret from its own
   environment / `.from()` source instead. In the [audit log](#audit-log) only a
@@ -270,7 +271,7 @@ The registry resolves like the run store: `ZUKE_REGISTRY_URL`/`_TOKEN` or
 
 **Trust model.** On the default stdio transport the server has no network
 endpoint: it speaks only over the stdin/stdout of a process the client launches,
-so its trust boundary is the local machine — anyone who can start `zuke mcp`
+so its trust boundary is the local machine — anyone who can start `./zuke mcp`
 already has a shell there and could run `deno run -A zuke.ts <target>` directly.
 The [HTTP transport](#http-transport) adds a network endpoint, so it moves that
 boundary: it binds loopback by default, requires a bearer token off loopback,

--- a/docs/node-projects.md
+++ b/docs/node-projects.md
@@ -20,7 +20,7 @@ my-app/
 ```json
 {
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^0",
+    "@zuke/core": "jsr:@zuke/core@^1",
     "@zuke/npm": "jsr:@zuke/npm@^0"
   }
 }
@@ -75,6 +75,13 @@ await run(AppBuild);
 Now `npm run build` runs the default pipeline, `npm run build -- test` runs one
 target, and `npm run build -- --list` / `-- graph` show what the build can do
 — no one has to learn Deno commands.
+
+> **`./zuke` launcher note.** The bootstrap launcher (`./zuke` /
+> `zuke.ps1`) hardcodes a repo-root `zuke.ts` — it does not know about a
+> `build/` subdirectory. With this layout, invoke the build directly with
+> `deno run -A build/zuke.ts` (or the `npm run build` script above), not
+> `./zuke`. If you'd rather use the `./zuke` launcher as-is, put `zuke.ts` at
+> the repo root instead of under `build/`.
 
 ## Other package managers
 

--- a/docs/run-context.md
+++ b/docs/run-context.md
@@ -29,8 +29,9 @@ class Deploy extends Build {
 | `dryRun`     | `boolean`           | `true` when the run is a dry run (bodies don't execute in a dry run). |
 
 `runId` is minted once per run (`crypto.randomUUID()`), so it correlates every
-target, the run record ([Durable run state](./state.md)), and — in later
-milestones — spans and resumptions.
+target, the run record ([Durable run state](./state.md)), a resumed run's
+spans ([Observability](./observability.md)), and a
+[resumption](./orchestration.md) of a suspended run.
 
 ## Cancellation
 
@@ -72,9 +73,10 @@ When the signal aborts:
   — the timeout or the cancellation — terminates the process.
 
 A body that ignores its signal and never touches the shell still runs to
-completion; Zuke does not forcibly interrupt arbitrary JavaScript. Turning
-cancellation into a first-class graph operation — compensations that run in
-reverse order, `zuke cancel <run-id>`, `Ctrl-C` — is a later milestone.
+completion; Zuke does not forcibly interrupt arbitrary JavaScript. Cancellation
+is also a first-class **graph operation**: `zuke cancel <run-id>` (or `Ctrl-C`)
+unwinds every succeeded target's declared `.onCancel(...)` compensation in
+reverse order — see [Orchestration](./orchestration.md#cancellation--compensation-oncancel).
 
 ### Scope of the ambient signal
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -80,9 +80,9 @@ Each run is stored as one JSON document:
 ```
 
 A target's `status` is one of `pending`, `running`, `succeeded`, `failed`,
-`skipped` (and `waiting`, from a later milestone). This is a **separate
-vocabulary** from the console's `passed`/`cached`: both of those map to
-`succeeded` in the record.
+`skipped`, and `waiting` (parked at a [`.waitsFor()`](./orchestration.md) gate).
+This is a **separate vocabulary** from the console's `passed`/`cached`: both of
+those map to `succeeded` in the record.
 
 The executor writes the record when it is created, on each target's start and
 finish, and when the run ends. So if the process is killed mid-run, the record
@@ -110,8 +110,8 @@ deploy = target().executes(async (ctx) => {
 `set` merges a JSON patch into the target's `meta` and awaits the write; `get`
 returns the current metadata. When no store is configured, the handle is an
 in-memory no-op — `set`/`get` are consistent within the run, but nothing is
-persisted. It is the carrier for anything that must survive across a
-suspend/resume boundary in later milestones.
+persisted. It is the carrier for anything that must survive a
+[suspend/resume](./orchestration.md) boundary.
 
 ### Secrets never touch state
 
@@ -169,8 +169,9 @@ Writes are **compare-and-swap**: each write carries the version the writer last
 read, and only lands if the stored version still matches. Two writers racing at
 the same version → exactly one wins; the loser gets a typed conflict and
 re-reads. Within a single process, Zuke serialises its own writes, so conflicts
-only arise across processes (which a later milestone — resuming a suspended run
-— relies on).
+only arise across processes — which is exactly what
+[resuming a suspended run](./orchestration.md) relies on: concurrent resumers
+race this same compare-and-swap, and all but one get `AlreadyResumedError`.
 
 State writes are **best-effort**: a store that is briefly unavailable is
 reported through the run's reporter but never crashes the build. The build's

--- a/packages/core/tests/completions_test.ts
+++ b/packages/core/tests/completions_test.ts
@@ -97,6 +97,42 @@ Deno.test("formatCompletions defaults to no parameters", () => {
   assertEquals(script.includes("--dry-mode"), false);
 });
 
+/**
+ * The command words a generated script binds completion to, deduped and
+ * sorted — the registration lines only, never a candidate's description (one
+ * reserved command's description mentions `deno doc`).
+ */
+function registeredWords(script: string): string[] {
+  const words = new Set<string>();
+  for (const m of script.matchAll(/^complete -F _zuke_complete (\S+)$/gm)) {
+    words.add(m[1]);
+  }
+  for (const m of script.matchAll(/^(?:#compdef| {2}compdef _zuke) (.+)$/gm)) {
+    for (const w of m[1].trim().split(/\s+/)) words.add(w);
+  }
+  for (const m of script.matchAll(/^complete -c (\S+)/gm)) words.add(m[1]);
+  return [...words].sort();
+}
+
+Deno.test("completion binds the launcher words only, never `deno`", () => {
+  // What the docs promise: `zuke <TAB>` and `./zuke <TAB>` complete, and
+  // `deno task zuke <TAB>` does not — a shell picks the completion from the
+  // line's first word, so binding `deno` would be the only way, and nothing
+  // does (it would hijack deno's own completion). See docs/cli.md's
+  // `zuke completions` section, which states exactly this.
+  const expected: Record<string, string[]> = {
+    bash: ["./zuke", "zuke"],
+    zsh: ["./zuke", "zuke"],
+    fish: ["zuke"], // fish matches on the basename, so `./zuke` is covered
+  };
+  for (const shell of COMPLETION_SHELLS) {
+    assertEquals(
+      registeredWords(formatCompletions(shell, targets, params)),
+      expected[shell],
+    );
+  }
+});
+
 Deno.test("every shared command and flag is completed (no drift)", () => {
   // Completion derives its command/flag set from cli_spec, so adding one there
   // surfaces it here automatically — nothing to keep in sync by hand.

--- a/skills/zuke-setup/SKILL.md
+++ b/skills/zuke-setup/SKILL.md
@@ -115,8 +115,11 @@ prefer `zuke setup`, which drops the bootstrap scripts in for you.)
 Every external tool has a typed `*Tasks` wrapper; **do not fall back to
 `Deno.Command` or hand-rolled shell.** To get exact signatures:
 
-- The whole typed surface of every package is in **`llms-full.txt`** at the repo
-  root (indexed by `llms.txt`).
+- The whole typed surface of every package is in **`llms-full.txt`** (indexed
+  by `llms.txt`) — in the Zuke repo itself it's at the repo root; in a
+  consumer repo (where this skill actually runs) fetch it from
+  <https://raw.githubusercontent.com/zuke-build/zuke/master/llms-full.txt>
+  (index: <https://raw.githubusercontent.com/zuke-build/zuke/master/llms.txt>).
 - A single package on the command line: `deno doc jsr:@zuke/<package>`.
 
 Once the project is scaffolded, use the **zuke-write-build** skill to add and

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -63,7 +63,11 @@ await run(CI);
 
 Before calling any task or settings method, confirm the real shape:
 
-- **Whole surface:** read `llms-full.txt` at the repo root (index: `llms.txt`).
+- **Whole surface:** `llms-full.txt` (index: `llms.txt`) — in the Zuke repo
+  itself it's at the repo root; in a consumer repo (where this skill actually
+  runs) fetch it from
+  <https://raw.githubusercontent.com/zuke-build/zuke/master/llms-full.txt>
+  (index: <https://raw.githubusercontent.com/zuke-build/zuke/master/llms.txt>).
 - **One package:** `deno doc jsr:@zuke/<package>` (e.g.
   `deno doc jsr:@zuke/deno`).
 - A quick map of the most common methods and task objects is in

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -1,8 +1,10 @@
 # Zuke authoring cheatsheet
 
 A quick map for writing targets. **Always confirm exact signatures** against
-`llms-full.txt` (repo root) or `deno doc jsr:@zuke/<package>` — this is a
-summary, not the source of truth.
+`llms-full.txt` — in the Zuke repo itself it's at the repo root; in a consumer
+repo (where this skill actually runs) fetch it from
+<https://raw.githubusercontent.com/zuke-build/zuke/master/llms-full.txt> — or
+`deno doc jsr:@zuke/<package>`. This is a summary, not the source of truth.
 
 ## `target()` — the fluent builder
 

--- a/tests/integration/cli_test.ts
+++ b/tests/integration/cli_test.ts
@@ -154,6 +154,15 @@ Deno.test("generate-ci writes a timezone-aware scheduled workflow", async () => 
   });
 });
 
+// The line each shell's script uses to bind the completion to the launcher —
+// the word a user must type for completion to fire, which is why the docs say
+// `zuke`/`./zuke` complete and `deno task zuke` does not.
+const BINDING: Record<string, string> = {
+  bash: "complete -F _zuke_complete ./zuke",
+  zsh: "compdef _zuke zuke ./zuke",
+  fish: "complete -c zuke -f",
+};
+
 for (const shell of ["bash", "zsh", "fish"]) {
   Deno.test(`completions print ${shell} emits a non-empty script naming the targets`, async () => {
     const { code, out } = await runCli(Demo, ["completions", "print", shell]);
@@ -161,6 +170,7 @@ for (const shell of ["bash", "zsh", "fish"]) {
     assertEquals(out.length > 0, true);
     assertStringIncludes(out, "zuke");
     assertStringIncludes(out, "build");
+    assertStringIncludes(out, BINDING[shell]);
   });
 }
 


### PR DESCRIPTION
Documentation correctness only; no source changes, so no releases are cut.

**The word zuke named two different programs, and the CLI reference documented the unreachable one.** The globally installed CLI accepts only setup, import, doc, help and version. Everything else in that reference's twenty-row command table — targets, graph, runs, mcp, cancel, register, completions — belongs to the build's own CLI. So the first thing a user typed after setup failed with an unknown-command error, and the two commands the README leads with appeared nowhere in the file titled CLI reference. The reference is now split into the two surfaces, with every command checked against the actual command registries rather than copied from the previous table, and the hand-waving parenthetical removed here and in the MCP guide. Cross-reference anchors were checked for breakage.

**Also fixed.** The only version-pinned example in the repo pinned a dead major and could not resolve. The Node guide's layout contradicted the launcher, which requires the build file at the repo root. Four passages still described shipped features as later milestones, one of them contradicting itself within a single file. The skills instructed agents to read a file that does not exist in a consumer project, and now carry raw URLs. And the two documentation indexes disagreed by eight guides, with one guide missing from both.

The README turned out not to need the change the plan predicted; the reasoning is recorded in the lane report.

**Verification.** Gate green, including the snippet type-check that covers marked documentation examples.
