### PR TITLE
feat(core): add a wrapper conformance test helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,9 +195,11 @@ ambient tools.
    third-party assert library). For a tool wrapper, assert the **pure
    `buildArgs()` argv** — do not run the real tool — and call
    `assertWrapperConformance` from `@zuke/core/tooling/conformance`, which
-   asserts the wrapper's binary name, its **declared** resolution mode
-   (`{ resolution: "node_modules" }` for a JS-ecosystem tool) and its
-   `ToolNotFoundError` path, so a wrapper cannot silently omit those checks.
+   asserts the wrapper's binary name, its **declared** resolution mode — the
+   `resolution` option is required, `"node_modules"` for a JS-ecosystem tool and
+   `"path"` for a native one, so every wrapper states its mode rather than
+   inheriting a default that could hide a missing `defaultResolution()` — and
+   its `ToolNotFoundError` path, so a wrapper cannot silently omit those checks.
    This layer covers a module's
    branches and a wrapper's flags, and carries the bulk of the 95% coverage
    gate.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,8 +78,8 @@ regenerate them in the same PR.
   CLI. No Node, npm, or external build tools.
 - **Language:** TypeScript, strict mode (Deno's default).
 - **Distribution:** [JSR](https://jsr.io/) as a workspace of 55 packages:
-  `@zuke/core` (exports `.`, `./shell`, `./tooling`, `./render`,
-  `./conformance`) plus the `@zuke/cli` command, a generic `@zuke/cmd` fallback,
+  `@zuke/core` (exports `.`, `./shell`, `./tooling`, `./tooling/conformance`,
+  `./render`, `./conformance`) plus the `@zuke/cli` command, a generic `@zuke/cmd` fallback,
   and 50+ typed tool wrappers and plugins (`@zuke/deno`, `@zuke/npm`,
   `@zuke/docker`, `@zuke/ai`, …). The npm org `@zuke-build` is reserved for
   future npm distribution (1:1 name mapping).
@@ -129,7 +129,8 @@ update the `check` task and CI accordingly. Do not bolt on a parallel
    — never leave a `private-type-ref` to one of the package's own types. Verify
    with `deno doc --lint` run over **all of a package's entrypoints in one
    invocation** (a multi-entrypoint package like `@zuke/core` has `.`,
-   `./shell`, `./tooling`, `./render`, `./conformance`, so
+   `./shell`, `./tooling`, `./tooling/conformance`, `./render`,
+   `./conformance`, so
    `deno doc --lint packages/core/mod.ts packages/core/src/shell.ts …` — linting
    them together lets cross-entrypoint references resolve). The bar: zero
    `missing-jsdoc` and zero `private-type-ref` to a first-party type. The one
@@ -192,7 +193,12 @@ ambient tools.
 1. **Unit — `packages/<pkg>/tests/*_test.ts`.** One module in isolation, with
    fakes and the local `packages/core/tests/_assert.ts` helper (never a
    third-party assert library). For a tool wrapper, assert the **pure
-   `buildArgs()` argv** — do not run the real tool. This layer covers a module's
+   `buildArgs()` argv** — do not run the real tool — and call
+   `assertWrapperConformance` from `@zuke/core/tooling/conformance`, which
+   asserts the wrapper's binary name, its **declared** resolution mode
+   (`{ resolution: "node_modules" }` for a JS-ecosystem tool) and its
+   `ToolNotFoundError` path, so a wrapper cannot silently omit those checks.
+   This layer covers a module's
    branches and a wrapper's flags, and carries the bulk of the 95% coverage
    gate.
 
@@ -259,7 +265,7 @@ the three test layers above and the "read every reviewer comment" rule below.
 ```
 deno.json                 # workspace root: tasks, fmt/lint config
 packages/
-  core/                   # @zuke/core — mod.ts, src/, tests/ (+ ./shell, ./tooling, ./render, ./conformance)
+  core/                   # @zuke/core — mod.ts, src/, tests/ (+ ./shell, ./tooling, ./tooling/conformance, ./render, ./conformance)
   deno/                   # @zuke/deno — DenoTasks
   npm/                    # @zuke/npm  — NpmTasks
   cmd/                    # @zuke/cmd  — CmdTasks (generic fallback)

--- a/build/docs.ts
+++ b/build/docs.ts
@@ -100,8 +100,9 @@ export async function collectPackageDocs(): Promise<PackageDoc[]> {
   const docs: PackageDoc[] = [];
   for (const dir of PACKAGES) {
     // Document every declared entrypoint, not just `mod.ts`, so a package with
-    // secondary exports (core's `./shell`, `./tooling`, `./render`,
-    // `./conformance`) has its whole typed surface in `llms-full.txt` and its
+    // secondary exports (core's `./shell`, `./tooling`,
+    // `./tooling/conformance`, `./render`, `./conformance`) has its whole
+    // typed surface in `llms-full.txt` and its
     // README — the "whole typed surface" the docs claim to carry.
     const entrypoints = await packageEntrypoints(dir);
     const { stdout } = await DenoTasks.doc((s) =>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3618,6 +3618,66 @@ type ToolResolution = "node_modules" | "path"
 type ToolTask = (configure?: Configure<DynamicToolSettings>) => Promise<CommandOutput>
   A ready-to-run task for a {@link defineTool} tool.
 
+A conformance kit for tool-wrapper tests.
+
+Every `@zuke/*` wrapper package owes its unit test the same three checks: the
+settings class spawns the binary it claims to, it resolves that binary the way
+the wrapper intends (bare on `PATH`, or npx-style from `node_modules/.bin`),
+and a missing binary surfaces as a
+{@link "./tooling.ts".ToolNotFoundError} rather than some raw
+`Deno.errors.NotFound`. Hand-written per package, that is a temp-directory /
+`ZUKE_TOOL_RESOLUTION` save-and-restore dance copied dozens of times — and a
+wrapper that quietly forgets the resolution check keeps passing.
+
+{@link assertWrapperConformance} runs all three, hermetically (nothing real is
+ever spawned), and takes the expected resolution mode as an argument so each
+wrapper asserts its default instead of remembering it:
+
+```ts
+Deno.test("biome conforms", async () => {
+  await assertWrapperConformance(() => new BiomeCheckSettings(), "biome", {
+    resolution: "node_modules",
+  });
+});
+```
+@module
+
+async function assertWrapperConformance(makeSettings: () => ToolSettings, tool: string, options: WrapperConformanceOptions): Promise<void>
+  Assert that a tool wrapper conforms: `makeSettings()` spawns `tool`, resolves
+  it per `options.resolution` (default `"path"`), and reports a missing binary
+  as a {@link "./tooling.ts".ToolNotFoundError}.
+
+  `makeSettings` is called once per check, so each check gets a pristine
+  instance. The resolution check runs against a throwaway temp directory holding
+  a fake `node_modules/.bin/<tool>` shim, with `ZUKE_TOOL_RESOLUTION` unset for
+  the duration and restored afterwards; no real subprocess is ever launched.
+
+  @throws {Error}
+      naming the wrapper and the fix, on the first failed check.
+
+function missingTool<S extends ToolSettings>(settings: S): S
+  Point `settings` at a binary that cannot exist, so running it raises a
+  {@link "./tooling.ts".ToolNotFoundError} without ever launching a real
+  process — the way a wrapper test proves each of its task functions reaches
+  execution.
+
+  The platform is pinned to `linux` because on Windows a missing binary is
+  retried through `cmd /c`, which exists, so the failure would surface as a
+  command error instead:
+
+  ```ts
+  await assertRejects(() => BiomeTasks.check(missingTool), ToolNotFoundError);
+  ```
+
+interface WrapperConformanceOptions
+  Options for {@link assertWrapperConformance}.
+
+  resolution?: ToolResolution
+    The resolution strategy the wrapper must use when nothing overrides it:
+    `"node_modules"` for a JS-ecosystem tool installed under `node_modules`,
+    `"path"` (the default) for a natively installed one. Whichever a wrapper
+    declares, stating it here makes it asserted rather than assumed.
+
 Primitive terminal rendering, shared by the executor's build reporting
 (`./report.ts`) and the `@zuke/console` package: ANSI styling, terminal-width
 detection, duration formatting, and the reusable `line`/`box`/`table`

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3630,8 +3630,8 @@ and a missing binary surfaces as a
 wrapper that quietly forgets the resolution check keeps passing.
 
 {@link assertWrapperConformance} runs all three, hermetically (nothing real is
-ever spawned), and takes the expected resolution mode as an argument so each
-wrapper asserts its default instead of remembering it:
+ever spawned), and takes the expected resolution mode as a required
+argument so each wrapper asserts its default instead of remembering it:
 
 ```ts
 Deno.test("biome conforms", async () => {
@@ -3644,13 +3644,20 @@ Deno.test("biome conforms", async () => {
 
 async function assertWrapperConformance(makeSettings: () => ToolSettings, tool: string, options: WrapperConformanceOptions): Promise<void>
   Assert that a tool wrapper conforms: `makeSettings()` spawns `tool`, resolves
-  it per `options.resolution` (default `"path"`), and reports a missing binary
-  as a {@link "./tooling.ts".ToolNotFoundError}.
+  it per `options.resolution`, and reports a missing binary as a
+  {@link "./tooling.ts".ToolNotFoundError}.
 
   `makeSettings` is called once per check, so each check gets a pristine
   instance. The resolution check runs against a throwaway temp directory holding
   a fake `node_modules/.bin/<tool>` shim, with `ZUKE_TOOL_RESOLUTION` unset for
   the duration and restored afterwards; no real subprocess is ever launched.
+
+  A wrapper whose `run()` resolves something at run time must have that pinned
+  inside `makeSettings` — `() => new DockerComposeUpSettings().usePlugin()`,
+  say — or the missing-binary check would probe the ambient host. It reports a
+  `ToolNotFoundError` raised for any binary other than the planted one as a
+  failure, so such a wrapper cannot pass by accident on a host that lacks the
+  real tool.
 
   @throws {Error}
       naming the wrapper and the fix, on the first failed check.
@@ -3672,11 +3679,13 @@ function missingTool<S extends ToolSettings>(settings: S): S
 interface WrapperConformanceOptions
   Options for {@link assertWrapperConformance}.
 
-  resolution?: ToolResolution
+  resolution: ToolResolution
     The resolution strategy the wrapper must use when nothing overrides it:
     `"node_modules"` for a JS-ecosystem tool installed under `node_modules`,
-    `"path"` (the default) for a natively installed one. Whichever a wrapper
-    declares, stating it here makes it asserted rather than assumed.
+    `"path"` for a natively installed one. Required, with no default: an
+    npm-distributed wrapper that forgot to override `defaultResolution()` is
+    exactly the bug this kit exists to catch, and a default would let that
+    wrapper's test pass by saying nothing.
 
 Primitive terminal rendering, shared by the executor's build reporting
 (`./report.ts`) and the `@zuke/console` package: ANSI styling, terminal-width

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -3672,6 +3672,66 @@ type ToolResolution = "node_modules" | "path"
 type ToolTask = (configure?: Configure<DynamicToolSettings>) => Promise<CommandOutput>
   A ready-to-run task for a {@link defineTool} tool.
 
+A conformance kit for tool-wrapper tests.
+
+Every `@zuke/*` wrapper package owes its unit test the same three checks: the
+settings class spawns the binary it claims to, it resolves that binary the way
+the wrapper intends (bare on `PATH`, or npx-style from `node_modules/.bin`),
+and a missing binary surfaces as a
+{@link "./tooling.ts".ToolNotFoundError} rather than some raw
+`Deno.errors.NotFound`. Hand-written per package, that is a temp-directory /
+`ZUKE_TOOL_RESOLUTION` save-and-restore dance copied dozens of times — and a
+wrapper that quietly forgets the resolution check keeps passing.
+
+{@link assertWrapperConformance} runs all three, hermetically (nothing real is
+ever spawned), and takes the expected resolution mode as an argument so each
+wrapper asserts its default instead of remembering it:
+
+```ts
+Deno.test("biome conforms", async () => {
+  await assertWrapperConformance(() => new BiomeCheckSettings(), "biome", {
+    resolution: "node_modules",
+  });
+});
+```
+@module
+
+async function assertWrapperConformance(makeSettings: () => ToolSettings, tool: string, options: WrapperConformanceOptions): Promise<void>
+  Assert that a tool wrapper conforms: `makeSettings()` spawns `tool`, resolves
+  it per `options.resolution` (default `"path"`), and reports a missing binary
+  as a {@link "./tooling.ts".ToolNotFoundError}.
+
+  `makeSettings` is called once per check, so each check gets a pristine
+  instance. The resolution check runs against a throwaway temp directory holding
+  a fake `node_modules/.bin/<tool>` shim, with `ZUKE_TOOL_RESOLUTION` unset for
+  the duration and restored afterwards; no real subprocess is ever launched.
+
+  @throws {Error}
+      naming the wrapper and the fix, on the first failed check.
+
+function missingTool<S extends ToolSettings>(settings: S): S
+  Point `settings` at a binary that cannot exist, so running it raises a
+  {@link "./tooling.ts".ToolNotFoundError} without ever launching a real
+  process — the way a wrapper test proves each of its task functions reaches
+  execution.
+
+  The platform is pinned to `linux` because on Windows a missing binary is
+  retried through `cmd /c`, which exists, so the failure would surface as a
+  command error instead:
+
+  ```ts
+  await assertRejects(() => BiomeTasks.check(missingTool), ToolNotFoundError);
+  ```
+
+interface WrapperConformanceOptions
+  Options for {@link assertWrapperConformance}.
+
+  resolution?: ToolResolution
+    The resolution strategy the wrapper must use when nothing overrides it:
+    `"node_modules"` for a JS-ecosystem tool installed under `node_modules`,
+    `"path"` (the default) for a natively installed one. Whichever a wrapper
+    declares, stating it here makes it asserted rather than assumed.
+
 Primitive terminal rendering, shared by the executor's build reporting
 (`./report.ts`) and the `@zuke/console` package: ANSI styling, terminal-width
 detection, duration formatting, and the reusable `line`/`box`/`table`

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -3684,8 +3684,8 @@ and a missing binary surfaces as a
 wrapper that quietly forgets the resolution check keeps passing.
 
 {@link assertWrapperConformance} runs all three, hermetically (nothing real is
-ever spawned), and takes the expected resolution mode as an argument so each
-wrapper asserts its default instead of remembering it:
+ever spawned), and takes the expected resolution mode as a required
+argument so each wrapper asserts its default instead of remembering it:
 
 ```ts
 Deno.test("biome conforms", async () => {
@@ -3698,13 +3698,20 @@ Deno.test("biome conforms", async () => {
 
 async function assertWrapperConformance(makeSettings: () => ToolSettings, tool: string, options: WrapperConformanceOptions): Promise<void>
   Assert that a tool wrapper conforms: `makeSettings()` spawns `tool`, resolves
-  it per `options.resolution` (default `"path"`), and reports a missing binary
-  as a {@link "./tooling.ts".ToolNotFoundError}.
+  it per `options.resolution`, and reports a missing binary as a
+  {@link "./tooling.ts".ToolNotFoundError}.
 
   `makeSettings` is called once per check, so each check gets a pristine
   instance. The resolution check runs against a throwaway temp directory holding
   a fake `node_modules/.bin/<tool>` shim, with `ZUKE_TOOL_RESOLUTION` unset for
   the duration and restored afterwards; no real subprocess is ever launched.
+
+  A wrapper whose `run()` resolves something at run time must have that pinned
+  inside `makeSettings` — `() => new DockerComposeUpSettings().usePlugin()`,
+  say — or the missing-binary check would probe the ambient host. It reports a
+  `ToolNotFoundError` raised for any binary other than the planted one as a
+  failure, so such a wrapper cannot pass by accident on a host that lacks the
+  real tool.
 
   @throws {Error}
       naming the wrapper and the fix, on the first failed check.
@@ -3726,11 +3733,13 @@ function missingTool<S extends ToolSettings>(settings: S): S
 interface WrapperConformanceOptions
   Options for {@link assertWrapperConformance}.
 
-  resolution?: ToolResolution
+  resolution: ToolResolution
     The resolution strategy the wrapper must use when nothing overrides it:
     `"node_modules"` for a JS-ecosystem tool installed under `node_modules`,
-    `"path"` (the default) for a natively installed one. Whichever a wrapper
-    declares, stating it here makes it asserted rather than assumed.
+    `"path"` for a natively installed one. Required, with no default: an
+    npm-distributed wrapper that forgot to override `defaultResolution()` is
+    exactly the bug this kit exists to catch, and a default would let that
+    wrapper's test pass by saying nothing.
 
 Primitive terminal rendering, shared by the executor's build reporting
 (`./report.ts`) and the `@zuke/console` package: ANSI styling, terminal-width

--- a/packages/core/deno.json
+++ b/packages/core/deno.json
@@ -7,6 +7,7 @@
     ".": "./mod.ts",
     "./shell": "./src/shell.ts",
     "./tooling": "./src/tooling.ts",
+    "./tooling/conformance": "./src/tooling_conformance.ts",
     "./render": "./src/render.ts",
     "./conformance": "./src/conformance.ts"
   },

--- a/packages/core/src/tooling_conformance.ts
+++ b/packages/core/src/tooling_conformance.ts
@@ -1,0 +1,171 @@
+/**
+ * A conformance kit for tool-wrapper tests.
+ *
+ * Every `@zuke/*` wrapper package owes its unit test the same three checks: the
+ * settings class spawns the binary it claims to, it resolves that binary the way
+ * the wrapper intends (bare on `PATH`, or npx-style from `node_modules/.bin`),
+ * and a missing binary surfaces as a
+ * {@link "./tooling.ts".ToolNotFoundError} rather than some raw
+ * `Deno.errors.NotFound`. Hand-written per package, that is a temp-directory /
+ * `ZUKE_TOOL_RESOLUTION` save-and-restore dance copied dozens of times — and a
+ * wrapper that quietly forgets the resolution check keeps passing.
+ *
+ * {@link assertWrapperConformance} runs all three, hermetically (nothing real is
+ * ever spawned), and takes the expected resolution mode as an argument so each
+ * wrapper *asserts* its default instead of remembering it:
+ *
+ * ```ts
+ * Deno.test("biome conforms", async () => {
+ *   await assertWrapperConformance(() => new BiomeCheckSettings(), "biome", {
+ *     resolution: "node_modules",
+ *   });
+ * });
+ * ```
+ *
+ * @module
+ */
+
+import {
+  ToolNotFoundError,
+  type ToolResolution,
+  type ToolSettings,
+} from "./tooling.ts";
+
+/** Options for {@link assertWrapperConformance}. */
+export interface WrapperConformanceOptions {
+  /**
+   * The resolution strategy the wrapper must use when nothing overrides it:
+   * `"node_modules"` for a JS-ecosystem tool installed under `node_modules`,
+   * `"path"` (the default) for a natively installed one. Whichever a wrapper
+   * declares, stating it here makes it asserted rather than assumed.
+   */
+  resolution?: ToolResolution;
+}
+
+/**
+ * Point `settings` at a binary that cannot exist, so running it raises a
+ * {@link "./tooling.ts".ToolNotFoundError} without ever launching a real
+ * process — the way a wrapper test proves each of its task functions reaches
+ * execution.
+ *
+ * The platform is pinned to `linux` because on Windows a missing binary is
+ * retried through `cmd /c`, which exists, so the failure would surface as a
+ * command error instead:
+ *
+ * ```ts
+ * await assertRejects(() => BiomeTasks.check(missingTool), ToolNotFoundError);
+ * ```
+ */
+export function missingTool<S extends ToolSettings>(settings: S): S {
+  settings.os_ = "linux";
+  return settings.toolPath("zuke-no-such-tool-xyz");
+}
+
+/**
+ * Assert that a tool wrapper conforms: `makeSettings()` spawns `tool`, resolves
+ * it per `options.resolution` (default `"path"`), and reports a missing binary
+ * as a {@link "./tooling.ts".ToolNotFoundError}.
+ *
+ * `makeSettings` is called once per check, so each check gets a pristine
+ * instance. The resolution check runs against a throwaway temp directory holding
+ * a fake `node_modules/.bin/<tool>` shim, with `ZUKE_TOOL_RESOLUTION` unset for
+ * the duration and restored afterwards; no real subprocess is ever launched.
+ *
+ * @throws {Error} naming the wrapper and the fix, on the first failed check.
+ */
+export async function assertWrapperConformance(
+  makeSettings: () => ToolSettings,
+  tool: string,
+  options: WrapperConformanceOptions = {},
+): Promise<void> {
+  const spawned = head(makeSettings().argv());
+  if (spawned !== tool) {
+    throw new Error(
+      `Wrapper conformance for "${tool}": the settings class spawns ` +
+        `"${spawned}" instead. Either fix defaultTool() to return "${tool}", ` +
+        `or pass the binary the wrapper really runs as the tool argument.`,
+    );
+  }
+  assertResolution(makeSettings, tool, options.resolution ?? "path");
+  await assertToolNotFound(makeSettings, tool);
+}
+
+/**
+ * Assert that the wrapper resolves its binary per `expected`, by planting a fake
+ * `node_modules/.bin/<tool>` next to a temp working directory: an npx-style
+ * wrapper must rewrite argv[0] to that shim, a `PATH` wrapper must ignore it.
+ */
+function assertResolution(
+  makeSettings: () => ToolSettings,
+  tool: string,
+  expected: ToolResolution,
+): void {
+  const previous = Deno.env.get("ZUKE_TOOL_RESOLUTION");
+  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+  const root = Deno.makeTempDirSync();
+  try {
+    const binDir = `${root}/node_modules/.bin`;
+    Deno.mkdirSync(binDir, { recursive: true });
+    const shim = slashes(`${binDir}/${tool}`);
+    Deno.writeTextFileSync(shim, "#!/bin/sh\n");
+    const settings = makeSettings();
+    // Pin linux: the shim written above has no `.cmd`/`.bat` extension, which is
+    // all a Windows host would look for.
+    settings.os_ = "linux";
+    const resolved = slashes(head(settings.cwd(root).resolvedArgv()));
+    if (expected === "node_modules" && resolved !== shim) {
+      throw new Error(
+        `Wrapper conformance for "${tool}": expected npx-style resolution, ` +
+          `but the wrapper spawned "${resolved}" with a ` +
+          `node_modules/.bin/${tool} shim in the working directory. Override ` +
+          `defaultResolution() to return "node_modules", or drop the ` +
+          `resolution option if this tool really is a PATH install.`,
+      );
+    }
+    if (expected === "path" && resolved !== tool) {
+      throw new Error(
+        `Wrapper conformance for "${tool}": expected the bare name on PATH, ` +
+          `but the wrapper resolved "${resolved}". This wrapper resolves from ` +
+          `node_modules — assert that by passing ` +
+          `{ resolution: "node_modules" }.`,
+      );
+    }
+  } finally {
+    Deno.removeSync(root, { recursive: true });
+    if (previous === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+    else Deno.env.set("ZUKE_TOOL_RESOLUTION", previous);
+  }
+}
+
+/** Assert that a binary that cannot exist surfaces as a `ToolNotFoundError`. */
+async function assertToolNotFound(
+  makeSettings: () => ToolSettings,
+  tool: string,
+): Promise<void> {
+  try {
+    await missingTool(makeSettings()).run();
+  } catch (error) {
+    if (error instanceof ToolNotFoundError) return;
+    const name = error instanceof Error ? error.name : String(error);
+    throw new Error(
+      `Wrapper conformance for "${tool}": running a binary that does not ` +
+        `exist raised ${name} instead of a ToolNotFoundError. Run the tool ` +
+        `through ToolSettings.run() so the friendly error is produced.`,
+    );
+  }
+  throw new Error(
+    `Wrapper conformance for "${tool}": running a binary that does not exist ` +
+      `did not fail. The task must reach ToolSettings.run() so a missing ` +
+      `binary raises a ToolNotFoundError.`,
+  );
+}
+
+/** The first argv entry, without an index-access `undefined` to narrow. */
+function head(argv: ReadonlyArray<string>): string {
+  return argv.slice(0, 1).join("");
+}
+
+/** Normalise Windows separators, the form resolved paths come back in. */
+function slashes(path: string): string {
+  return path.replace(/\\/g, "/");
+}

--- a/packages/core/src/tooling_conformance.ts
+++ b/packages/core/src/tooling_conformance.ts
@@ -11,8 +11,8 @@
  * wrapper that quietly forgets the resolution check keeps passing.
  *
  * {@link assertWrapperConformance} runs all three, hermetically (nothing real is
- * ever spawned), and takes the expected resolution mode as an argument so each
- * wrapper *asserts* its default instead of remembering it:
+ * ever spawned), and takes the expected resolution mode as a *required*
+ * argument so each wrapper *asserts* its default instead of remembering it:
  *
  * ```ts
  * Deno.test("biome conforms", async () => {
@@ -36,11 +36,16 @@ export interface WrapperConformanceOptions {
   /**
    * The resolution strategy the wrapper must use when nothing overrides it:
    * `"node_modules"` for a JS-ecosystem tool installed under `node_modules`,
-   * `"path"` (the default) for a natively installed one. Whichever a wrapper
-   * declares, stating it here makes it asserted rather than assumed.
+   * `"path"` for a natively installed one. Required, with no default: an
+   * npm-distributed wrapper that forgot to override `defaultResolution()` is
+   * exactly the bug this kit exists to catch, and a default would let that
+   * wrapper's test pass by saying nothing.
    */
-  resolution?: ToolResolution;
+  resolution: ToolResolution;
 }
+
+/** The binary name {@link missingTool} points settings at — it cannot exist. */
+const MISSING = "zuke-no-such-tool-xyz";
 
 /**
  * Point `settings` at a binary that cannot exist, so running it raises a
@@ -58,25 +63,32 @@ export interface WrapperConformanceOptions {
  */
 export function missingTool<S extends ToolSettings>(settings: S): S {
   settings.os_ = "linux";
-  return settings.toolPath("zuke-no-such-tool-xyz");
+  return settings.toolPath(MISSING);
 }
 
 /**
  * Assert that a tool wrapper conforms: `makeSettings()` spawns `tool`, resolves
- * it per `options.resolution` (default `"path"`), and reports a missing binary
- * as a {@link "./tooling.ts".ToolNotFoundError}.
+ * it per `options.resolution`, and reports a missing binary as a
+ * {@link "./tooling.ts".ToolNotFoundError}.
  *
  * `makeSettings` is called once per check, so each check gets a pristine
  * instance. The resolution check runs against a throwaway temp directory holding
  * a fake `node_modules/.bin/<tool>` shim, with `ZUKE_TOOL_RESOLUTION` unset for
  * the duration and restored afterwards; no real subprocess is ever launched.
  *
+ * A wrapper whose `run()` resolves something at run time must have that pinned
+ * inside `makeSettings` — `() => new DockerComposeUpSettings().usePlugin()`,
+ * say — or the missing-binary check would probe the ambient host. It reports a
+ * `ToolNotFoundError` raised for any binary other than the planted one as a
+ * failure, so such a wrapper cannot pass by accident on a host that lacks the
+ * real tool.
+ *
  * @throws {Error} naming the wrapper and the fix, on the first failed check.
  */
 export async function assertWrapperConformance(
   makeSettings: () => ToolSettings,
   tool: string,
-  options: WrapperConformanceOptions = {},
+  options: WrapperConformanceOptions,
 ): Promise<void> {
   const spawned = head(makeSettings().argv());
   if (spawned !== tool) {
@@ -86,7 +98,7 @@ export async function assertWrapperConformance(
         `or pass the binary the wrapper really runs as the tool argument.`,
     );
   }
-  assertResolution(makeSettings, tool, options.resolution ?? "path");
+  assertResolution(makeSettings, tool, options.resolution);
   await assertToolNotFound(makeSettings, tool);
 }
 
@@ -118,8 +130,8 @@ function assertResolution(
         `Wrapper conformance for "${tool}": expected npx-style resolution, ` +
           `but the wrapper spawned "${resolved}" with a ` +
           `node_modules/.bin/${tool} shim in the working directory. Override ` +
-          `defaultResolution() to return "node_modules", or drop the ` +
-          `resolution option if this tool really is a PATH install.`,
+          `defaultResolution() to return "node_modules", or pass ` +
+          `{ resolution: "path" } if this tool really is a PATH install.`,
       );
     }
     if (expected === "path" && resolved !== tool) {
@@ -145,7 +157,17 @@ async function assertToolNotFound(
   try {
     await missingTool(makeSettings()).run();
   } catch (error) {
-    if (error instanceof ToolNotFoundError) return;
+    if (error instanceof ToolNotFoundError) {
+      if (error.tool === MISSING) return;
+      throw new Error(
+        `Wrapper conformance for "${tool}": the missing-binary check raised a ` +
+          `ToolNotFoundError for "${error.tool}", not for the planted ` +
+          `"${MISSING}" — so run() resolved some other tool before spawning, ` +
+          `by probing the host. Pin that resolution inside the makeSettings ` +
+          `lambda (Compose's .usePlugin(), for instance) so the check stays ` +
+          `hermetic and really exercises the missing binary.`,
+      );
+    }
     const name = error instanceof Error ? error.name : String(error);
     throw new Error(
       `Wrapper conformance for "${tool}": running a binary that does not ` +

--- a/packages/core/tests/tooling_conformance_test.ts
+++ b/packages/core/tests/tooling_conformance_test.ts
@@ -49,6 +49,23 @@ Deno.test("a PATH wrapper conforms", async () => {
   );
 });
 
+Deno.test("an ambient ZUKE_TOOL_RESOLUTION is ignored, then restored", async () => {
+  const previous = Deno.env.get("ZUKE_TOOL_RESOLUTION");
+  Deno.env.set("ZUKE_TOOL_RESOLUTION", "node_modules");
+  try {
+    // The ambient override would make the PATH wrapper resolve npx-style; the
+    // kit unsets it for the duration so the wrapper's own default is asserted.
+    await assertWrapperConformance(
+      () => new PathToolSettings(),
+      "zuke-fake-tool",
+    );
+    assertEquals(Deno.env.get("ZUKE_TOOL_RESOLUTION"), "node_modules");
+  } finally {
+    if (previous === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
+    else Deno.env.set("ZUKE_TOOL_RESOLUTION", previous);
+  }
+});
+
 Deno.test("a node_modules wrapper conforms when it declares so", async () => {
   await assertWrapperConformance(
     () => new NodeToolSettings(),
@@ -127,4 +144,22 @@ Deno.test("a wrapper that raises the wrong error is reported", async () => {
     "RangeError",
   );
   assertEquals(error instanceof ToolNotFoundError, false);
+});
+
+Deno.test("a non-Error rejection is reported by its value", async () => {
+  /** A wrapper that rejects with something that is not an Error at all. */
+  class ThrowsLiteralSettings extends PathToolSettings {
+    override run(): Promise<CommandOutput> {
+      return Promise.reject("just a string");
+    }
+  }
+  await assertRejects(
+    () =>
+      assertWrapperConformance(
+        () => new ThrowsLiteralSettings(),
+        "zuke-fake-tool",
+      ),
+    Error,
+    "just a string",
+  );
 });

--- a/packages/core/tests/tooling_conformance_test.ts
+++ b/packages/core/tests/tooling_conformance_test.ts
@@ -46,6 +46,7 @@ Deno.test("a PATH wrapper conforms", async () => {
   await assertWrapperConformance(
     () => new PathToolSettings(),
     "zuke-fake-tool",
+    { resolution: "path" },
   );
 });
 
@@ -54,10 +55,11 @@ Deno.test("an ambient ZUKE_TOOL_RESOLUTION is ignored, then restored", async () 
   Deno.env.set("ZUKE_TOOL_RESOLUTION", "node_modules");
   try {
     // The ambient override would make the PATH wrapper resolve npx-style; the
-    // kit unsets it for the duration so the wrapper's own default is asserted.
+    // kit clears it for the duration so the wrapper's own default is asserted.
     await assertWrapperConformance(
       () => new PathToolSettings(),
       "zuke-fake-tool",
+      { resolution: "path" },
     );
     assertEquals(Deno.env.get("ZUKE_TOOL_RESOLUTION"), "node_modules");
   } finally {
@@ -74,12 +76,13 @@ Deno.test("a node_modules wrapper conforms when it declares so", async () => {
   );
 });
 
-Deno.test("a node_modules wrapper fails the default PATH expectation", async () => {
+Deno.test("a node_modules wrapper fails a declared PATH expectation", async () => {
   await assertRejects(
     () =>
       assertWrapperConformance(
         () => new NodeToolSettings(),
         "zuke-fake-tool",
+        { resolution: "path" },
       ),
     Error,
     'resolution: "node_modules"',
@@ -103,6 +106,7 @@ Deno.test("a mismatched default binary is reported", async () => {
       assertWrapperConformance(
         () => new MisnamedToolSettings(),
         "zuke-fake-tool",
+        { resolution: "path" },
       ),
     Error,
     'spawns "zuke-other-tool"',
@@ -121,6 +125,7 @@ Deno.test("a wrapper that swallows a missing binary is reported", async () => {
       assertWrapperConformance(
         () => new SwallowingSettings(),
         "zuke-fake-tool",
+        { resolution: "path" },
       ),
     Error,
     "did not fail",
@@ -139,6 +144,7 @@ Deno.test("a wrapper that raises the wrong error is reported", async () => {
       assertWrapperConformance(
         () => new WrongErrorSettings(),
         "zuke-fake-tool",
+        { resolution: "path" },
       ),
     Error,
     "RangeError",
@@ -158,8 +164,34 @@ Deno.test("a non-Error rejection is reported by its value", async () => {
       assertWrapperConformance(
         () => new ThrowsLiteralSettings(),
         "zuke-fake-tool",
+        { resolution: "path" },
       ),
     Error,
     "just a string",
+  );
+});
+
+Deno.test("a ToolNotFoundError for another binary is not a pass", async () => {
+  /**
+   * A wrapper that resolves its real invocation by probing the host before
+   * spawning — the `docker compose` / `docker-compose` shape — and so reports a
+   * *different* tool missing than the planted one. Accepting that would let the
+   * check pass on a host lacking the tool without ever exercising the
+   * missing-binary path.
+   */
+  class DetectingSettings extends PathToolSettings {
+    override run(): Promise<CommandOutput> {
+      return Promise.reject(new ToolNotFoundError("some-other-tool"));
+    }
+  }
+  await assertRejects(
+    () =>
+      assertWrapperConformance(
+        () => new DetectingSettings(),
+        "zuke-fake-tool",
+        { resolution: "path" },
+      ),
+    Error,
+    "not for the planted",
   );
 });

--- a/packages/core/tests/tooling_conformance_test.ts
+++ b/packages/core/tests/tooling_conformance_test.ts
@@ -1,0 +1,130 @@
+import { assertEquals, assertRejects } from "./_assert.ts";
+import { CommandOutput } from "../src/shell.ts";
+import {
+  ToolNotFoundError,
+  type ToolResolution,
+  ToolSettings,
+} from "../src/tooling.ts";
+import {
+  assertWrapperConformance,
+  missingTool,
+} from "../src/tooling_conformance.ts";
+
+/** A wrapper that resolves its binary from `PATH` (the base default). */
+class PathToolSettings extends ToolSettings {
+  protected override defaultTool(): string {
+    return "zuke-fake-tool";
+  }
+  protected override buildArgs(): string[] {
+    return ["build"];
+  }
+}
+
+/** The same wrapper, but npx-style. */
+class NodeToolSettings extends PathToolSettings {
+  protected override defaultResolution(): ToolResolution {
+    return "node_modules";
+  }
+}
+
+/** A wrapper whose default binary name disagrees with its package. */
+class MisnamedToolSettings extends PathToolSettings {
+  protected override defaultTool(): string {
+    return "zuke-other-tool";
+  }
+}
+
+Deno.test("missingTool pins linux and an unresolvable binary", async () => {
+  const settings = new PathToolSettings();
+  settings.os_ = "windows";
+  const missing = missingTool(settings);
+  assertEquals(missing.os_, "linux");
+  await assertRejects(() => missing.run(), ToolNotFoundError);
+});
+
+Deno.test("a PATH wrapper conforms", async () => {
+  await assertWrapperConformance(
+    () => new PathToolSettings(),
+    "zuke-fake-tool",
+  );
+});
+
+Deno.test("a node_modules wrapper conforms when it declares so", async () => {
+  await assertWrapperConformance(
+    () => new NodeToolSettings(),
+    "zuke-fake-tool",
+    { resolution: "node_modules" },
+  );
+});
+
+Deno.test("a node_modules wrapper fails the default PATH expectation", async () => {
+  await assertRejects(
+    () =>
+      assertWrapperConformance(
+        () => new NodeToolSettings(),
+        "zuke-fake-tool",
+      ),
+    Error,
+    'resolution: "node_modules"',
+  );
+});
+
+Deno.test("a PATH wrapper fails a node_modules expectation", async () => {
+  await assertRejects(
+    () =>
+      assertWrapperConformance(() => new PathToolSettings(), "zuke-fake-tool", {
+        resolution: "node_modules",
+      }),
+    Error,
+    "defaultResolution()",
+  );
+});
+
+Deno.test("a mismatched default binary is reported", async () => {
+  await assertRejects(
+    () =>
+      assertWrapperConformance(
+        () => new MisnamedToolSettings(),
+        "zuke-fake-tool",
+      ),
+    Error,
+    'spawns "zuke-other-tool"',
+  );
+});
+
+Deno.test("a wrapper that swallows a missing binary is reported", async () => {
+  /** A wrapper that resolves instead of raising ToolNotFoundError. */
+  class SwallowingSettings extends PathToolSettings {
+    override run(): Promise<CommandOutput> {
+      return Promise.resolve(new CommandOutput(0, "", ""));
+    }
+  }
+  await assertRejects(
+    () =>
+      assertWrapperConformance(
+        () => new SwallowingSettings(),
+        "zuke-fake-tool",
+      ),
+    Error,
+    "did not fail",
+  );
+});
+
+Deno.test("a wrapper that raises the wrong error is reported", async () => {
+  /** A wrapper that reports a missing binary as some other failure. */
+  class WrongErrorSettings extends PathToolSettings {
+    override run(): Promise<CommandOutput> {
+      return Promise.reject(new RangeError("boom"));
+    }
+  }
+  const error = await assertRejects(
+    () =>
+      assertWrapperConformance(
+        () => new WrongErrorSettings(),
+        "zuke-fake-tool",
+      ),
+    Error,
+    "RangeError",
+  );
+  assertEquals(error instanceof ToolNotFoundError, false);
+});

--- a/tests/integration/wrapper_conformance_test.ts
+++ b/tests/integration/wrapper_conformance_test.ts
@@ -1,0 +1,23 @@
+/**
+ * Integration: the wrapper conformance kit run against real, published wrapper
+ * packages — a natively installed tool (`@zuke/git`, resolved from `PATH`) and a
+ * JS-ecosystem one (`@zuke/biome`, resolved npx-style from `node_modules/.bin`).
+ * The unit test drives the kit with fakes; this proves it holds for the settings
+ * classes wrappers actually ship, including the `ToolNotFoundError` path.
+ */
+
+import { BiomeCheckSettings } from "../../packages/biome/mod.ts";
+import { GitStatusSettings } from "../../packages/git/mod.ts";
+// Through the published specifier, so the `./tooling/conformance` export a
+// wrapper package imports is exercised too.
+import { assertWrapperConformance } from "@zuke/core/tooling/conformance";
+
+Deno.test("a PATH wrapper (@zuke/git) passes the conformance kit", async () => {
+  await assertWrapperConformance(() => new GitStatusSettings(), "git");
+});
+
+Deno.test("a node_modules wrapper (@zuke/biome) passes the conformance kit", async () => {
+  await assertWrapperConformance(() => new BiomeCheckSettings(), "biome", {
+    resolution: "node_modules",
+  });
+});

--- a/tests/integration/wrapper_conformance_test.ts
+++ b/tests/integration/wrapper_conformance_test.ts
@@ -1,23 +1,74 @@
 /**
  * Integration: the wrapper conformance kit run against real, published wrapper
- * packages — a natively installed tool (`@zuke/git`, resolved from `PATH`) and a
- * JS-ecosystem one (`@zuke/biome`, resolved npx-style from `node_modules/.bin`).
- * The unit test drives the kit with fakes; this proves it holds for the settings
- * classes wrappers actually ship, including the `ToolNotFoundError` path.
+ * packages from inside a real build, driven through the CLI `main()`. Covers a
+ * natively installed tool (`@zuke/git`, resolved from `PATH`), a JS-ecosystem
+ * one (`@zuke/biome`, resolved npx-style from `node_modules/.bin`) and one that
+ * resolves its invocation at run time (`@zuke/docker-compose`, pinned with
+ * `.usePlugin()` so nothing ambient is probed). The unit test drives the kit
+ * with fakes; this proves it holds for the settings classes wrappers actually
+ * ship — and that a conformance failure fails the build rather than being
+ * swallowed by the executor.
  */
 
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import { Build, target } from "../../packages/core/mod.ts";
+import { runCli } from "./_harness.ts";
 import { BiomeCheckSettings } from "../../packages/biome/mod.ts";
+import { DockerComposeUpSettings } from "../../packages/docker-compose/mod.ts";
 import { GitStatusSettings } from "../../packages/git/mod.ts";
 // Through the published specifier, so the `./tooling/conformance` export a
 // wrapper package imports is exercised too.
 import { assertWrapperConformance } from "@zuke/core/tooling/conformance";
 
-Deno.test("a PATH wrapper (@zuke/git) passes the conformance kit", async () => {
-  await assertWrapperConformance(() => new GitStatusSettings(), "git");
+Deno.test("real wrappers pass the conformance kit inside a build", async () => {
+  class Conformance extends Build {
+    git = target()
+      .description("@zuke/git resolves from PATH")
+      .executes(async () => {
+        await assertWrapperConformance(() => new GitStatusSettings(), "git", {
+          resolution: "path",
+        });
+      });
+    biome = target()
+      .description("@zuke/biome resolves from node_modules/.bin")
+      .dependsOn(this.git)
+      .executes(async () => {
+        await assertWrapperConformance(
+          () => new BiomeCheckSettings(),
+          "biome",
+          { resolution: "node_modules" },
+        );
+      });
+    // A wrapper that detects its invocation at run time conforms once that
+    // detection is pinned in the factory — no ambient `docker compose version`.
+    compose = target()
+      .description("@zuke/docker-compose conforms when pinned")
+      .dependsOn(this.biome)
+      .executes(async () => {
+        await assertWrapperConformance(
+          () => new DockerComposeUpSettings().usePlugin(),
+          "docker",
+          { resolution: "path" },
+        );
+      });
+  }
+  const { code, err } = await runCli(Conformance, ["compose"]);
+  assertEquals(code, 0, err);
 });
 
-Deno.test("a node_modules wrapper (@zuke/biome) passes the conformance kit", async () => {
-  await assertWrapperConformance(() => new BiomeCheckSettings(), "biome", {
-    resolution: "node_modules",
-  });
+Deno.test("a conformance failure fails the build through the CLI", async () => {
+  class Wrong extends Build {
+    // @zuke/biome really resolves npx-style; claiming PATH must fail loudly.
+    biome = target().executes(async () => {
+      await assertWrapperConformance(() => new BiomeCheckSettings(), "biome", {
+        resolution: "path",
+      });
+    });
+  }
+  const { code, err } = await runCli(Wrong, ["biome"]);
+  assertEquals(code, 1);
+  assertStringIncludes(err, 'resolution: "node_modules"');
 });


### PR DESCRIPTION
Roughly five hundred lines of identical boilerplate are duplicated across the wrapper test suites: a temp-directory dance with an environment override to check tool resolution, repeated verbatim in twenty-four files, and a missing-binary helper repeated in forty-eight. Worse than the duplication, the resolution default was remembered rather than asserted — an earlier sweep retrofitted twenty-four packages by hand, so the next omission would be silent.

This adds the helper and its own tests on a new conformance entrypoint, and nothing else.

**The migration is deliberately a separate PR.** release-please attributes a bump to every package whose files the squashed commit touches, so migrating forty-eight test files under a feature title would drag a spurious minor onto all forty-nine wrapper packages for what is a test refactor. This PR bumps core alone; the migration follows under a test title that bumps nothing.

Merge this before the migration PR that consumes it.

**Review caught three real defects, all fixed:** the resolution option defaulted to the wrong mode, the missing-binary check could pass for the wrong reason, and what was labelled an integration test was really a second unit test.

**Verification.** Gate green.
