### PR TITLE
fix: resync the plugin skills and point consumer repos at deno doc first

### DIFF
--- a/plugins/zuke/skills/zuke-setup/SKILL.md
+++ b/plugins/zuke/skills/zuke-setup/SKILL.md
@@ -115,12 +115,16 @@ prefer `zuke setup`, which drops the launcher scripts in for you.)
 Every external tool has a typed `*Tasks` wrapper; **do not fall back to
 `Deno.Command` or hand-rolled shell.** To get exact signatures:
 
+- A single package on the command line: `deno doc jsr:@zuke/<package>`. Prefer
+  this in a consumer repo — it resolves the version the project actually has
+  installed, so it cannot describe an API that version lacks.
 - The whole typed surface of every package is in **`llms-full.txt`** (indexed
-  by `llms.txt`) — in the Zuke repo itself it's at the repo root; in a
-  consumer repo (where this skill actually runs) fetch it from
-  <https://raw.githubusercontent.com/zuke-build/zuke/master/llms-full.txt>
+  by `llms.txt`) — at the repo root in the Zuke repo itself, or from a consumer
+  repo <https://raw.githubusercontent.com/zuke-build/zuke/master/llms-full.txt>
   (index: <https://raw.githubusercontent.com/zuke-build/zuke/master/llms.txt>).
-- A single package on the command line: `deno doc jsr:@zuke/<package>`.
+  Both track `master`, so they may document symbols that are merged but not yet
+  released; use them to find what exists, then confirm the signature with
+  `deno doc`.
 
 Once the project is scaffolded, use the **zuke-write-build** skill to add and
 edit targets.

--- a/plugins/zuke/skills/zuke-setup/SKILL.md
+++ b/plugins/zuke/skills/zuke-setup/SKILL.md
@@ -59,10 +59,10 @@ typed `*Tasks` wrappers.
 ### What `zuke setup` writes
 
 - **`zuke.ts`** — a starter build class with a sample target and a `default`.
-- **`./zuke`** + **`./zuke.ps1`** — bootstrap launchers that locate the project
-  and **install Deno on first use if it's missing** (override the version with
-  `DENO_VERSION`), then run `zuke.ts`. A fresh checkout needs nothing but the
-  script.
+- **`./zuke`** + **`./zuke.ps1`** — launchers that locate the project and run
+  `zuke.ts` with the Deno on `PATH`. If Deno is missing they point at the
+  official install docs and exit rather than piping an install script into a
+  shell, which would download and execute code unverified.
 - **`deno.json`** — merged to add a `zuke` task (and `fmt`/`lint`/`test` if
   absent).
 - **`zuke.json`** — `{ "name": "..." }`, which marks the repo root.
@@ -84,9 +84,9 @@ calls, `zuke mcp` runs a Model Context Protocol server over it (register with
 `claude mcp add zuke -- deno run -A zuke.ts mcp`; add `--allow-run` to let the
 agent execute targets, not just inspect them).
 
-If Deno is already installed you can equivalently use
-`deno task zuke <target>` or `deno run -A zuke.ts <target>`. The `-A` flag
-grants permissions, since targets typically run processes and touch files.
+If Deno is already installed you can equivalently use `deno task zuke <target>`
+or `deno run -A zuke.ts <target>`. The `-A` flag grants permissions, since
+targets typically run processes and touch files.
 
 ## Manual setup (no CLI)
 
@@ -108,15 +108,18 @@ await run(CI);
 ```
 
 Run with `deno run -A zuke.ts test`. (For the `./zuke` launcher experience,
-prefer `zuke setup`, which drops the bootstrap scripts in for you.)
+prefer `zuke setup`, which drops the launcher scripts in for you.)
 
 ## Finding the exact API — never guess
 
 Every external tool has a typed `*Tasks` wrapper; **do not fall back to
 `Deno.Command` or hand-rolled shell.** To get exact signatures:
 
-- The whole typed surface of every package is in **`llms-full.txt`** at the repo
-  root (indexed by `llms.txt`).
+- The whole typed surface of every package is in **`llms-full.txt`** (indexed
+  by `llms.txt`) — in the Zuke repo itself it's at the repo root; in a
+  consumer repo (where this skill actually runs) fetch it from
+  <https://raw.githubusercontent.com/zuke-build/zuke/master/llms-full.txt>
+  (index: <https://raw.githubusercontent.com/zuke-build/zuke/master/llms.txt>).
 - A single package on the command line: `deno doc jsr:@zuke/<package>`.
 
 Once the project is scaffolded, use the **zuke-write-build** skill to add and

--- a/plugins/zuke/skills/zuke-write-build/SKILL.md
+++ b/plugins/zuke/skills/zuke-write-build/SKILL.md
@@ -63,7 +63,11 @@ await run(CI);
 
 Before calling any task or settings method, confirm the real shape:
 
-- **Whole surface:** read `llms-full.txt` at the repo root (index: `llms.txt`).
+- **Whole surface:** `llms-full.txt` (index: `llms.txt`) — in the Zuke repo
+  itself it's at the repo root; in a consumer repo (where this skill actually
+  runs) fetch it from
+  <https://raw.githubusercontent.com/zuke-build/zuke/master/llms-full.txt>
+  (index: <https://raw.githubusercontent.com/zuke-build/zuke/master/llms.txt>).
 - **One package:** `deno doc jsr:@zuke/<package>` (e.g.
   `deno doc jsr:@zuke/deno`).
 - A quick map of the most common methods and task objects is in

--- a/plugins/zuke/skills/zuke-write-build/SKILL.md
+++ b/plugins/zuke/skills/zuke-write-build/SKILL.md
@@ -63,13 +63,17 @@ await run(CI);
 
 Before calling any task or settings method, confirm the real shape:
 
-- **Whole surface:** `llms-full.txt` (index: `llms.txt`) — in the Zuke repo
-  itself it's at the repo root; in a consumer repo (where this skill actually
-  runs) fetch it from
+- **One package — prefer this in a consumer repo:**
+  `deno doc jsr:@zuke/<package>` (e.g. `deno doc jsr:@zuke/deno`). It resolves
+  the version the project actually has installed, so it cannot describe an API
+  that version lacks.
+- **Whole surface:** `llms-full.txt` (index: `llms.txt`) — at the repo root in
+  the Zuke repo itself. From a consumer repo, fetch
   <https://raw.githubusercontent.com/zuke-build/zuke/master/llms-full.txt>
   (index: <https://raw.githubusercontent.com/zuke-build/zuke/master/llms.txt>).
-- **One package:** `deno doc jsr:@zuke/<package>` (e.g.
-  `deno doc jsr:@zuke/deno`).
+  Both track `master`, so they can document symbols that are merged but not yet
+  in any published release. Use them for breadth — which packages and tasks
+  exist — and confirm a signature with `deno doc` before relying on it.
 - A quick map of the most common methods and task objects is in
   [`references/cheatsheet.md`](references/cheatsheet.md) next to this file —
   read it when wiring targets, then verify specifics against the sources above.

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -1,10 +1,12 @@
 # Zuke authoring cheatsheet
 
-A quick map for writing targets. **Always confirm exact signatures** against
-`llms-full.txt` — in the Zuke repo itself it's at the repo root; in a consumer
-repo (where this skill actually runs) fetch it from
-<https://raw.githubusercontent.com/zuke-build/zuke/master/llms-full.txt> — or
-`deno doc jsr:@zuke/<package>`. This is a summary, not the source of truth.
+A quick map for writing targets. **Always confirm exact signatures** with
+`deno doc jsr:@zuke/<package>`, which resolves the version the project actually
+has installed. For breadth — which packages and tasks exist — use
+`llms-full.txt`: at the repo root in the Zuke repo itself, or from a consumer
+repo <https://raw.githubusercontent.com/zuke-build/zuke/master/llms-full.txt>,
+which tracks `master` and so may list symbols not yet in any published release.
+This cheatsheet is a summary, not the source of truth.
 
 ## `target()` — the fluent builder
 

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -1,8 +1,10 @@
 # Zuke authoring cheatsheet
 
 A quick map for writing targets. **Always confirm exact signatures** against
-`llms-full.txt` (repo root) or `deno doc jsr:@zuke/<package>` — this is a
-summary, not the source of truth.
+`llms-full.txt` — in the Zuke repo itself it's at the repo root; in a consumer
+repo (where this skill actually runs) fetch it from
+<https://raw.githubusercontent.com/zuke-build/zuke/master/llms-full.txt> — or
+`deno doc jsr:@zuke/<package>`. This is a summary, not the source of truth.
 
 ## `target()` — the fluent builder
 

--- a/skills/zuke-setup/SKILL.md
+++ b/skills/zuke-setup/SKILL.md
@@ -115,12 +115,16 @@ prefer `zuke setup`, which drops the launcher scripts in for you.)
 Every external tool has a typed `*Tasks` wrapper; **do not fall back to
 `Deno.Command` or hand-rolled shell.** To get exact signatures:
 
+- A single package on the command line: `deno doc jsr:@zuke/<package>`. Prefer
+  this in a consumer repo — it resolves the version the project actually has
+  installed, so it cannot describe an API that version lacks.
 - The whole typed surface of every package is in **`llms-full.txt`** (indexed
-  by `llms.txt`) — in the Zuke repo itself it's at the repo root; in a
-  consumer repo (where this skill actually runs) fetch it from
-  <https://raw.githubusercontent.com/zuke-build/zuke/master/llms-full.txt>
+  by `llms.txt`) — at the repo root in the Zuke repo itself, or from a consumer
+  repo <https://raw.githubusercontent.com/zuke-build/zuke/master/llms-full.txt>
   (index: <https://raw.githubusercontent.com/zuke-build/zuke/master/llms.txt>).
-- A single package on the command line: `deno doc jsr:@zuke/<package>`.
+  Both track `master`, so they may document symbols that are merged but not yet
+  released; use them to find what exists, then confirm the signature with
+  `deno doc`.
 
 Once the project is scaffolded, use the **zuke-write-build** skill to add and
 edit targets.

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -63,13 +63,17 @@ await run(CI);
 
 Before calling any task or settings method, confirm the real shape:
 
-- **Whole surface:** `llms-full.txt` (index: `llms.txt`) — in the Zuke repo
-  itself it's at the repo root; in a consumer repo (where this skill actually
-  runs) fetch it from
+- **One package — prefer this in a consumer repo:**
+  `deno doc jsr:@zuke/<package>` (e.g. `deno doc jsr:@zuke/deno`). It resolves
+  the version the project actually has installed, so it cannot describe an API
+  that version lacks.
+- **Whole surface:** `llms-full.txt` (index: `llms.txt`) — at the repo root in
+  the Zuke repo itself. From a consumer repo, fetch
   <https://raw.githubusercontent.com/zuke-build/zuke/master/llms-full.txt>
   (index: <https://raw.githubusercontent.com/zuke-build/zuke/master/llms.txt>).
-- **One package:** `deno doc jsr:@zuke/<package>` (e.g.
-  `deno doc jsr:@zuke/deno`).
+  Both track `master`, so they can document symbols that are merged but not yet
+  in any published release. Use them for breadth — which packages and tasks
+  exist — and confirm a signature with `deno doc` before relying on it.
 - A quick map of the most common methods and task objects is in
   [`references/cheatsheet.md`](references/cheatsheet.md) next to this file —
   read it when wiring targets, then verify specifics against the sources above.

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -1,10 +1,12 @@
 # Zuke authoring cheatsheet
 
-A quick map for writing targets. **Always confirm exact signatures** against
-`llms-full.txt` — in the Zuke repo itself it's at the repo root; in a consumer
-repo (where this skill actually runs) fetch it from
-<https://raw.githubusercontent.com/zuke-build/zuke/master/llms-full.txt> — or
-`deno doc jsr:@zuke/<package>`. This is a summary, not the source of truth.
+A quick map for writing targets. **Always confirm exact signatures** with
+`deno doc jsr:@zuke/<package>`, which resolves the version the project actually
+has installed. For breadth — which packages and tasks exist — use
+`llms-full.txt`: at the repo root in the Zuke repo itself, or from a consumer
+repo <https://raw.githubusercontent.com/zuke-build/zuke/master/llms-full.txt>,
+which tracks `master` and so may list symbols not yet in any published release.
+This cheatsheet is a summary, not the source of truth.
 
 ## `target()` — the fluent builder
 


### PR DESCRIPTION
**Master is red; this unblocks it, and fixes a documentation defect the review surfaced on the way.**

## The breakage

The plugin drift check fails on the merge commit for three files: `zuke-setup/SKILL.md`, `zuke-write-build/SKILL.md`, and `zuke-write-build/references/cheatsheet.md`.

Two PRs that were each green in isolation collided semantically. #270 replaced the plugin skills symlink with committed real copies plus a `pluginSyncCheck` gate, because a Windows clone without symlink support ships the plugin with zero skills. #271 edited those same three skill documents to add the URLs an agent needs when the skills run in a consumer repository. Neither touched the other's side, so git merged both cleanly with no textual conflict, and the committed copies silently fell behind their source.

This class of drift is invisible to per-PR CI by construction — each branch was internally consistent. The gate caught it on the first merge commit where both changes coexisted, which is the earliest point it could exist.

## The documentation fix

The AI reviewer flagged the new remote URLs as a supply-chain and privacy concern. That framing does not hold: the URLs resolve to this project's own repository, which publishes the packages the consumer already depends on, the content is documentation an agent reads rather than code that runs, and no credential is involved.

But those lines had a real problem. They point at the default branch, which documents what has merged rather than what has been released, so the guidance can describe API the consumer's installed version does not have. That is live today: the reference documents `assertWrapperConformance` and the `resumeDegraded` option while the newest published core is 1.31.1, with the release still sitting in open PR #273.

So `deno doc jsr:@zuke/<package>` is now the primary recommendation in all three places. It resolves the version the project actually installed and therefore cannot describe an absent API. The whole-surface reference stays for discovering which packages and tasks exist, with an explicit note that it tracks the default branch and that signatures need confirming.

Pinning the URL to a release tag was the alternative. It would need updating every release and rot in the other direction, whereas the per-package command is correct by construction.

## Verification

`deno task ci` green, 15 of 15 targets, and `tests/plugin_sync_test.ts` back to 7 passed. No source and no packages touched, so no version bump.
