### PR TITLE
fix(cli): raise the core floor to the version that has splitShellArgs

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1560,7 +1560,7 @@
       },
       "packages/cli": {
         "dependencies": [
-          "jsr:@zuke/core@^1.31.0"
+          "jsr:@zuke/core@^1.32.0"
         ]
       },
       "packages/cmd": {

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -7,7 +7,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1.31.0"
+    "@zuke/core": "jsr:@zuke/core@^1.32.0"
   },
   "publish": {
     "exclude": [


### PR DESCRIPTION
**A published release is currently broken for a subset of consumers. This fixes it.**

`@zuke/cli@0.8.0` imports `splitShellArgs` from `@zuke/core/shell`, which only exists from core **1.32.0**, while `packages/cli/deno.json` still declared `jsr:@zuke/core@^1.31.0`. Most installs resolve the newest matching core and work by luck. A consumer whose committed lockfile pins core 1.31.1, or anyone resolving with lockfile enforcement, gets a cli that imports a symbol its core does not export — and `zuke import` fails at runtime.

**Why it shipped that way, and why it could not have been fixed earlier.** The workspace refuses to resolve a member against a constraint the local core does not satisfy, so raising the floor before core 1.32.0 existed broke every test run. The implementer hit exactly that and documented it, and the PR that introduced the import said so in its description. Core 1.32.0 is now published, so the constraint resolves and the gate is green.

**Scope.** One line. I audited every other package's floor against its actual core usage: only the cli uses core API added since `^1.25.0`, so no sibling needs the same change and none was touched.

Verified: `deno task ci` green, 15 of 15 targets — which is itself the evidence the constraint now resolves.

**Worth noting as a structural gap, not fixed here.** Nothing mechanically prevents this. A package's declared floor is hand-maintained, and CI type-checks against the workspace-local core rather than the floor the manifest claims, so a package can import newer API and stay green right up until a consumer resolves the older version. Catching it automatically would mean type-checking each package against its declared floor, which needs network resolution and so cannot live in the hermetic suite as it stands.
