### PR TITLE
fix(core): run compensations for unproven targets and share one filesystem mutex

### DIFF
--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -188,8 +188,10 @@ deploy = target()
   cleanup/teardown. It still waits for its own dependencies to complete.
 - **`.onCancel(target | () => target)`** — register a **compensation** that
   undoes this target when the run is [cancelled](./orchestration.md#cancellation--compensation--oncancel).
-  It runs only if this target **succeeded**; on cancel, compensations run in
-  reverse order. The compensation body's `ctx.state` exposes _this_ target's
+  It runs only if this target **succeeded** — or, on a
+  [degraded record](./state.md#degraded-records), if its success cannot be ruled
+  out; on cancel, compensations run in reverse order. The compensation body's
+  `ctx.state` exposes _this_ target's
   persisted metadata (so a rollback reads what the deploy recorded). Use the
   thunk form to reference a compensation declared below. Needs a state store.
 - **`.unlisted()`** — hide a helper target from `--list`/`--help`; it can still

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -350,7 +350,11 @@ cause is visible; pass `--resume-degraded` to the sweep to let it through.
 `./zuke cancel <run-id>` cancels a run and runs its
 [compensations](./orchestration.md#cancellation--compensation--oncancel): every
 target that had **succeeded** and declared `.onCancel(...)` is unwound in
-reverse order, then the record settles `cancelled`. `--actor <name>` attributes
+reverse order, then the record settles `cancelled`. On a
+[degraded record](./state.md#degraded-records) it also unwinds every target whose
+success the record cannot rule out — anything not recorded `failed` or `skipped`
+— and says so per compensation, because a lost write can hide a deploy that
+really happened. `--actor <name>` attributes
 the cancellation in the audit trail. Cancelling a run another process is
 executing stops it (a live run aborts on its next state write); cancelling an
 already-finished run is a friendly no-op. `Ctrl-C` (or `SIGTERM`) cancels the

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -256,6 +256,14 @@ What a cancellation does:
   skipped, or failed has nothing to undo. Compensations run in **reverse order**
   of the targets that succeeded, so later work is unwound before the work it was
   built on.
+- **…unless the record is [degraded](./state.md#degraded-records).** A record
+  that lost a state write cannot be read as an account of what ran: a target that
+  really did deploy may still be recorded `pending` or `running`. Cancel then
+  compensates every target whose success it cannot rule out (anything not
+  recorded `failed` or `skipped`) and names that reason in its output — a
+  rollback that runs for work which never happened is a no-op for an idempotent
+  compensation, while skipping one for work that did happen leaves the side
+  effect behind.
 - **Each compensation reads its target's persisted state.** The compensation
   body gets a normal `ctx` whose `ctx.state` exposes **the original target's**
   metadata — the `deploy` above rolls back from exactly the `slot` it recorded.

--- a/docs/state.md
+++ b/docs/state.md
@@ -215,7 +215,7 @@ incomplete, not that the target had succeeded. Under-cleanup is the more
 dangerous direction: a compensation that runs for work which never happened is a
 no-op for an idempotent rollback (a delete of what was never created), while one
 that is skipped leaves the side effect in place. See
-[Cancellation](./orchestration.md#cancellation--compensation-oncancel).
+[Cancellation](./orchestration.md#cancellation--compensation--oncancel).
 
 If _no_ later write ever lands — a store that stays down for the rest of the run
 — the flag never reaches the store. That run also never records its transition

--- a/docs/state.md
+++ b/docs/state.md
@@ -206,6 +206,17 @@ and a non-zero result is the only channel a cron watches. The run stays
 `suspended` either way, so it remains resumable. See
 [the CLI reference](./cli.md#resuming-suspended-runs).
 
+A **cancellation** faces the same missing transition from the other side. It
+normally compensates the targets recorded `succeeded`; on a degraded record that
+test would skip a deploy that really happened, leaving it un-rolled-back. So
+cancel widens the walk to every target whose success it cannot rule out —
+anything not recorded `failed` or `skipped` — and its output says the record was
+incomplete, not that the target had succeeded. Under-cleanup is the more
+dangerous direction: a compensation that runs for work which never happened is a
+no-op for an idempotent rollback (a delete of what was never created), while one
+that is skipped leaves the side effect in place. See
+[Cancellation](./orchestration.md#cancellation--compensation-oncancel).
+
 If _no_ later write ever lands — a store that stays down for the rest of the run
 — the flag never reaches the store. That run also never records its transition
 to `suspended`, so there is nothing for a resume to continue: it reports the run

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2891,7 +2891,10 @@ interface RunRecord
     succeeded can still be recorded `running` or `pending`, so a resume would
     re-run it — which is why a resume refuses a degraded record unless
     `--resume-degraded` overrides it (see
-    {@link "../resume.ts".ResumeOptions.resumeDegraded}).
+    {@link "../resume.ts".ResumeOptions.resumeDegraded}) — and why a
+    cancellation compensates every target whose success the record cannot rule
+    out, rather than only those recorded `succeeded` (see
+    {@link "../cancel.ts".runCompensations}).
 
     It is set by the writer when it loses a write and persisted by the next
     write that lands — the failing one, by definition, could not carry it. A

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2945,7 +2945,10 @@ interface RunRecord
     succeeded can still be recorded `running` or `pending`, so a resume would
     re-run it — which is why a resume refuses a degraded record unless
     `--resume-degraded` overrides it (see
-    {@link "../resume.ts".ResumeOptions.resumeDegraded}).
+    {@link "../resume.ts".ResumeOptions.resumeDegraded}) — and why a
+    cancellation compensates every target whose success the record cannot rule
+    out, rather than only those recorded `succeeded` (see
+    {@link "../cancel.ts".runCompensations}).
 
     It is set by the writer when it loses a write and persisted by the next
     write that lands — the failing one, by definition, could not carry it. A

--- a/packages/core/src/cancel.ts
+++ b/packages/core/src/cancel.ts
@@ -516,6 +516,18 @@ function isItemCompensable(
  * happened is a no-op for an idempotent compensation, while skipping one for
  * work that did happen leaves a real side effect behind. `failed` and `skipped`
  * are settlements that were recorded, so they are never unproven.
+ *
+ * `running` is the state a lost settlement usually leaves behind (the target's
+ * `markTargetRunning` write landed and the write recording how it ended did
+ * not), so it carries the same overlap window {@link isItemCompensable}
+ * documents one level down: an out-of-process `zuke cancel` compensates from a
+ * record, and if that target's body is in fact still live in the owning process
+ * — which aborts only on its next state write or lock heartbeat — the cleanup
+ * can run alongside the body's tail. Bodies that checkpoint via
+ * `ctx.state.set(...)` or hold a `.lock()` close the window; the full fix is
+ * prompt abort-propagation in the executor, the same cancellation-hardening
+ * follow-up. The executor's own in-process walk has no such window: it runs
+ * after every body has settled.
  */
 function isUnproven(status: TargetRunStatus | undefined): boolean {
   return status === undefined || status === "pending" ||
@@ -678,7 +690,16 @@ export async function cancelRun(
         failures: [],
       };
     }
-    const record = transitioned.record;
+    // The CAS wrote — and returned — the record as it looked *before* the
+    // transition. The owning process may have landed a write since: when its own
+    // compare-and-swap loses to ours it re-applies the mutation onto our
+    // cancelling record (see `./state/writer.ts`), so a target that had just
+    // finished can settle `succeeded`, or the record can be marked `degraded`,
+    // after our snapshot was taken. Re-read, so the walk decides on the newest
+    // account of what ran rather than one that predates the transition. A run
+    // that has vanished from the store leaves our own snapshot as the last word.
+    const reread = await store.getRun(runId);
+    const record = reread?.record ?? transitioned.record;
 
     // Resolve compensation targets by reference, and make `this.<param>.value`
     // available to their bodies (from the record's non-secret params; secrets

--- a/packages/core/src/cancel.ts
+++ b/packages/core/src/cancel.ts
@@ -18,6 +18,11 @@
  * `{ slot: "sit-7" }` can be rolled back from exactly that slot. Compensation
  * failures are recorded but never stop the walk (cleanup is maximal).
  *
+ * On a record marked {@link "./state/types.ts".RunRecord.degraded} — one that
+ * lost a state write for good — a target's recorded status is no longer proof of
+ * what happened, so the walk also compensates every target whose success cannot
+ * be ruled out, and says in its output why (see {@link isUnproven}).
+ *
  * The same {@link runCompensations} walk is reused by the executor for an
  * in-process cancellation (Ctrl-C / an aborted `options.signal`).
  *
@@ -49,6 +54,7 @@ import type {
   RunRecord,
   RunStatus,
   SignalRecord,
+  TargetRunStatus,
 } from "./state/types.ts";
 
 /** How many times a conflicting cancel CAS is re-read and retried. */
@@ -90,6 +96,13 @@ interface CompensationStep {
   forTarget: string;
   /** The original target's persisted metadata, exposed to the body via `ctx.state`. */
   meta: Record<string, JsonValue>;
+  /**
+   * How `forTarget` is recorded when the step was selected **only** because the
+   * record is {@link "./state/types.ts".RunRecord.degraded} — its settlement was
+   * never proven. Absent for a step whose target is recorded `succeeded` (or an
+   * in-flight fan-out item), which is compensated on any record.
+   */
+  unproven?: string;
 }
 
 /** A compensation that threw during the cancel walk (recorded, non-fatal). */
@@ -160,10 +173,11 @@ function seededStateHandle(seed: Record<string, JsonValue>): TargetStateHandle {
 /**
  * Run the compensations for a cancelled run: every succeeded target that
  * declared `.onCancel(...)`, in reverse topological order (later successes
- * unwound first). Each compensation body gets a normal {@link TargetContext}
- * whose `state` exposes the original target's persisted metadata. A compensation
- * that throws is recorded and the walk continues. Shared by {@link cancelRun}
- * and the executor's in-process cancellation.
+ * unwound first) — plus, on a `degraded` record, every target whose settlement
+ * was never proven ({@link isUnproven}). Each compensation body gets a normal
+ * {@link TargetContext} whose `state` exposes the original target's persisted
+ * metadata. A compensation that throws is recorded and the walk continues.
+ * Shared by {@link cancelRun} and the executor's in-process cancellation.
  */
 export async function runCompensations(
   order: TargetBuilder[],
@@ -176,6 +190,17 @@ export async function runCompensations(
   const failures: CompensationFailure[] = [];
   const attempts: CompensationAttempt[] = [];
   const steps: CompensationStep[] = [...(deps.extra ?? [])];
+  // A record that lost a state write for good cannot be read as a settled
+  // account of what ran, so the walk widens: anything whose success cannot be
+  // ruled out is compensated. Say so once, up front.
+  const degraded = record.degraded === true;
+  if (degraded) {
+    deps.reporter.info(
+      `cancel: this run's record is incomplete — a state write was ` +
+        `permanently lost, so every target whose success cannot be ruled out ` +
+        `is compensated.`,
+    );
+  }
   // Reverse topological order: undo the work that ran last before the work it
   // was built on.
   for (const t of [...order].reverse()) {
@@ -197,7 +222,9 @@ export async function runCompensations(
         ),
       );
     }
-    if (record.targets[name]?.status !== "succeeded") continue;
+    const status = record.targets[name]?.status;
+    const possiblySucceeded = degraded && isUnproven(status);
+    if (status !== "succeeded" && !possiblySucceeded) continue;
     if (t.onCancel_ === undefined) continue;
     // The thunk is user code: a throw here must be recorded, not allowed to
     // escape and wedge the run mid-cancel (cleanup stays maximal).
@@ -234,6 +261,7 @@ export async function runCompensations(
       compensation,
       forTarget: name,
       meta: record.targets[name]?.meta ?? {},
+      ...(possiblySucceeded ? { unproven: describeUnproven(status) } : {}),
     });
   }
 
@@ -261,7 +289,12 @@ export async function runCompensations(
       dryRun: false,
     };
     try {
-      deps.reporter.info(`↩ compensating ${step.forTarget} → ${compName}`);
+      deps.reporter.info(
+        `↩ compensating ${step.forTarget} → ${compName}` +
+          (step.unproven === undefined ? "" : ` — the run record is ` +
+            `incomplete and "${step.forTarget}" is ${step.unproven}, so its ` +
+            `success could not be ruled out`),
+      );
       // Honour the compensation's own `.timeout()` so a hung cleanup can't wedge
       // the walk (and leave the record non-terminal); no default, like a body.
       await runWithTimeout(() => body(ctx), step.compensation.timeout_);
@@ -331,7 +364,7 @@ function collectForEachSteps(
   const prefix = `${parent.name_ ?? ""}[`;
   for (const [rowName, row] of Object.entries(record.targets)) {
     if (!rowName.startsWith(prefix) || materialised.has(rowName)) continue;
-    if (!isItemCompensable(row.status)) continue;
+    if (!isItemCompensable(row.status, record.degraded === true)) continue;
     reporter.error(
       `cancel: fan-out item "${rowName}" has no matching re-materialised item ` +
         `— its compensation is skipped (is the item list deterministic?).`,
@@ -405,7 +438,9 @@ function collectForEachInto(
           out,
         );
       }
-      if (!isItemCompensable(record.targets[subName]?.status)) continue;
+      const status = record.targets[subName]?.status;
+      const degraded = record.degraded === true;
+      if (!isItemCompensable(status, degraded)) continue;
       if (sub.onCancel_ === undefined) continue;
       let compensation: TargetBuilder | undefined;
       try {
@@ -437,6 +472,11 @@ function collectForEachInto(
         compensation,
         forTarget: subName,
         meta: record.targets[subName]?.meta ?? {},
+        // `succeeded`/`running` items are compensated on any record; anything
+        // else here got in only because the record is degraded.
+        ...(status === "succeeded" || status === "running"
+          ? {}
+          : { unproven: describeUnproven(status) }),
       });
     }
   }
@@ -445,7 +485,9 @@ function collectForEachInto(
 /**
  * A fan-out item is worth compensating if it succeeded, or was still running
  * when the cancel landed — an item mid-flight may have partial side effects
- * (a started deploy) its `.onCancel(...)` needs to unwind.
+ * (a started deploy) its `.onCancel(...)` needs to unwind. On a degraded record
+ * an item whose settlement was never proven counts too (see
+ * {@link isUnproven}).
  *
  * An out-of-process `zuke cancel` compensates a `running` item from a
  * record snapshot, so if that item's body is still live in the owning process
@@ -455,8 +497,34 @@ function collectForEachInto(
  * full fix is prompt abort-propagation in the executor (background run-status
  * poll) — a cancellation-hardening follow-up, out of this milestone's scope.
  */
-function isItemCompensable(status: string | undefined): boolean {
-  return status === "succeeded" || status === "running";
+function isItemCompensable(
+  status: TargetRunStatus | undefined,
+  degraded: boolean,
+): boolean {
+  return status === "succeeded" || status === "running" ||
+    (degraded && isUnproven(status));
+}
+
+/**
+ * Whether `status` leaves a target's **settlement unproven**: no write recording
+ * how it ended ever landed, so a target that really did succeed reads exactly
+ * like one that never ran (`pending`, `running`, `waiting`, or no row at all).
+ *
+ * Only consulted on a {@link "./state/types.ts".RunRecord.degraded} record — one
+ * that lost a state write for good. There, an unproven target is treated as
+ * *possibly succeeded* and compensated: running a cleanup for work that never
+ * happened is a no-op for an idempotent compensation, while skipping one for
+ * work that did happen leaves a real side effect behind. `failed` and `skipped`
+ * are settlements that were recorded, so they are never unproven.
+ */
+function isUnproven(status: TargetRunStatus | undefined): boolean {
+  return status === undefined || status === "pending" ||
+    status === "running" || status === "waiting";
+}
+
+/** How an unproven target reads in the record, for the reporter's explanation. */
+function describeUnproven(status: TargetRunStatus | undefined): string {
+  return status === undefined ? "not recorded" : `recorded ${status}`;
 }
 
 /**

--- a/packages/core/src/registry/fs_registry.ts
+++ b/packages/core/src/registry/fs_registry.ts
@@ -4,9 +4,11 @@
  *
  * It is single-host by design (fine for dev, per the requirement); production
  * uses {@link "./http_registry.ts".HttpBuildRegistry}. Compare-and-swap is
- * enforced with an `O_EXCL` lock marker plus an atomic temp-file rename — the
- * same trick as {@link "../state/fs_store.ts".FileSystemStateStore} — so two
- * registrations racing at the same version cannot both win. The version is a
+ * enforced with the shared {@link "../state/mutex.ts".withFileMutex} marker plus
+ * an atomic temp-file rename — the same primitive
+ * {@link "../state/fs_store.ts".FileSystemStateStore} holds — so two
+ * registrations racing at the same version cannot both win, and a marker left by
+ * a killed writer expires instead of wedging the directory. The version is a
  * content hash, mirroring the ETag the HTTP backend uses.
  *
  * @module
@@ -22,7 +24,8 @@ import {
   toBuildSummary,
 } from "./descriptor.ts";
 import type { BuildRegistry, PutBuildResult } from "./registry.ts";
-import { delay, sha256Hex } from "../internal.ts";
+import { withFileMutex } from "../state/mutex.ts";
+import { sha256Hex } from "../internal.ts";
 
 /**
  * Reject a build id that could escape the builds directory. Ids are build class
@@ -34,10 +37,6 @@ function assertSafeId(id: string): void {
     throw new Error(`registry: unsafe build id "${id}"`);
   }
 }
-
-/** How long to wait for a contended lock before giving up. */
-const LOCK_ATTEMPTS = 100;
-const LOCK_DELAY_MS = 10;
 
 /**
  * A {@link BuildRegistry} that writes one `<id>.json` file per build under a
@@ -142,22 +141,21 @@ export class FileSystemBuildRegistry implements BuildRegistry {
     return sortNewestFirst(summaries);
   }
 
-  /** Take the build's lock (spinning briefly on contention), run `fn`, release. */
-  async #withLock<T>(id: string, fn: () => Promise<T>): Promise<T> {
-    const marker = this.#lock(id);
-    for (let attempt = 0; attempt < LOCK_ATTEMPTS; attempt++) {
-      if (await this.#host.createExclusive(marker)) {
-        try {
-          return await fn();
-        } finally {
-          await this.#host.remove(marker);
-        }
-      }
-      await delay(LOCK_DELAY_MS);
-    }
-    throw new Error(
-      `registry: could not acquire the mutex for build "${id}" — ` +
-        `a stale ${marker} may need removing.`,
+  /**
+   * Take the build's lock (spinning briefly on contention), run `fn`, release —
+   * through the same {@link withFileMutex} primitive the state store uses, so a
+   * marker left behind by a killed `zuke register` is reclaimed once it expires
+   * instead of wedging every later writer.
+   */
+  #withLock<T>(id: string, fn: () => Promise<T>): Promise<T> {
+    return withFileMutex(
+      {
+        host: this.#host,
+        marker: this.#lock(id),
+        scope: "registry",
+        subject: `build "${id}"`,
+      },
+      fn,
     );
   }
 }

--- a/packages/core/src/state/fs_store.ts
+++ b/packages/core/src/state/fs_store.ts
@@ -4,10 +4,11 @@
  *
  * It is single-host by design (fine for dev, per the requirement); production
  * uses {@link "./http_store.ts".HttpStateStore}. Compare-and-swap is enforced
- * with an `O_EXCL` lock marker plus an atomic temp-file rename: a writer takes
- * the lock, re-reads the current version, and only publishes if it still
- * matches — so two writers racing at the same version cannot both win. The
- * version is a content hash, mirroring the ETag the HTTP backend uses.
+ * with the shared {@link "./mutex.ts".withFileMutex} marker plus an atomic
+ * temp-file rename: a writer takes the mutex, re-reads the current version, and
+ * only publishes if it still matches — so two writers racing at the same version
+ * cannot both win. The version is a content hash, mirroring the ETag the HTTP
+ * backend uses.
  *
  * @module
  */
@@ -33,7 +34,8 @@ import {
   parseLockRecord,
   stringifyLockRecord,
 } from "./lock.ts";
-import { delay, sha256Hex } from "../internal.ts";
+import { withFileMutex } from "./mutex.ts";
+import { sha256Hex } from "../internal.ts";
 
 /**
  * Reject a run id that could escape the runs directory. Ids are UUIDs in
@@ -44,19 +46,6 @@ function assertSafeId(id: string): void {
     throw new Error(`state: unsafe run id "${id}"`);
   }
 }
-
-/** How long to wait for a contended lock before giving up. */
-const LOCK_ATTEMPTS = 100;
-const LOCK_DELAY_MS = 10;
-
-/**
- * How old a mutex marker may get before a waiter treats it as abandoned and
- * takes it over — the same 30s backstop a cross-run lock's TTL gives a crashed
- * holder ({@link "./cancel_lock.ts".CANCEL_LOCK_TTL_MS}). Two orders of
- * magnitude above the ~1s spin budget above, so a live holder is never stolen
- * from, yet a killed one cannot wedge every later writer for good.
- */
-const MUTEX_TTL_MS = 30_000;
 
 /**
  * A {@link StateStore} that writes one `<id>.json` file per run under a
@@ -246,87 +235,20 @@ export class FileSystemStateStore implements StateStore {
   }
 
   /**
-   * Hold the exclusive `marker` file (spinning briefly on contention) for the
-   * duration of `fn`, then release it. `subject` names what is being guarded,
-   * for the error raised if the marker cannot be taken. A marker whose holder
-   * was killed is reclaimed once it passes {@link MUTEX_TTL_MS} — or, when it
-   * carries no stamp to age, once the spin has run long enough to rule out a
-   * holder still writing one — so a single crashed writer cannot wedge the
-   * directory for every later one.
+   * Hold the exclusive `marker` file for the duration of `fn` through the shared
+   * {@link withFileMutex} primitive (which also reclaims a marker a killed holder
+   * left behind). `subject` names what is being guarded, for the error raised if
+   * the marker cannot be taken.
    */
-  async #withMutex<T>(
+  #withMutex<T>(
     marker: string,
     subject: string,
     fn: () => Promise<T>,
   ): Promise<T> {
-    for (let attempt = 0; attempt < LOCK_ATTEMPTS; attempt++) {
-      if (await this.#host.createExclusive(marker)) {
-        try {
-          // Stamp the marker with the acquire time so a later waiter can tell a
-          // live holder from one that died holding it. Inside the `try`, so a
-          // rejected write releases the marker instead of leaving an unstamped
-          // one behind — which would read as a live holder for good.
-          await this.#host.writeText(marker, String(this.#host.now()));
-          return await fn();
-        } finally {
-          await this.#host.remove(marker);
-        }
-      }
-      // Half the spin budget is far longer than the microseconds between a
-      // holder's create and its stamp, so past that point an unstamped marker is
-      // a leftover — including one from a zuke that never stamped at all — and
-      // may be reclaimed. Earlier than that, treat it as a holder mid-stamp.
-      const unstampedIsStale = attempt >= LOCK_ATTEMPTS / 2;
-      if (
-        await this.#markerExpired(marker, unstampedIsStale) &&
-        await this.#steal(marker)
-      ) {
-        continue; // reclaimed: retry the exclusive create straight away
-      }
-      await delay(LOCK_DELAY_MS);
-    }
-    throw new Error(
-      `state: could not acquire the mutex for ${subject} — ` +
-        `a stale ${marker} may need removing.`,
+    return withFileMutex(
+      { host: this.#host, marker, scope: "state", subject },
+      fn,
     );
-  }
-
-  /**
-   * Reclaim the abandoned `marker`, reporting whether this caller was the one
-   * that removed it.
-   *
-   * The marker is moved aside with an atomic rename before being deleted. A bare
-   * `remove` is not a compare-and-swap: two waiters that both read the same stale
-   * stamp would both delete a marker, the second deleting the one the first had
-   * just taken, and both would then be inside the critical section. Only one
-   * rename can find the marker, so at most one waiter reclaims it; the loser gets
-   * `false` and goes back to spinning, where it re-reads the new holder's stamp.
-   */
-  async #steal(marker: string): Promise<boolean> {
-    const stolen = `${marker}.steal-${crypto.randomUUID()}`;
-    try {
-      await this.#host.rename(marker, stolen);
-    } catch {
-      return false; // another waiter reclaimed it first, or the holder released
-    }
-    await this.#host.remove(stolen);
-    return true;
-  }
-
-  /**
-   * Whether `marker` was acquired longer ago than {@link MUTEX_TTL_MS} — its
-   * holder is gone and left it behind. A marker with no readable numeric stamp
-   * has no age to compare, so `unstampedIsStale` decides it: the caller passes
-   * `false` while a holder could still be writing its stamp, and `true` once it
-   * has spun long enough that no live holder could still be in that window.
-   */
-  async #markerExpired(
-    marker: string,
-    unstampedIsStale: boolean,
-  ): Promise<boolean> {
-    const stamp = await this.#host.readText(marker);
-    if (stamp === null || !/^\d+$/.test(stamp)) return unstampedIsStale;
-    return this.#host.now() - Number(stamp) > MUTEX_TTL_MS;
   }
 }
 

--- a/packages/core/src/state/mutex.ts
+++ b/packages/core/src/state/mutex.ts
@@ -1,0 +1,127 @@
+/**
+ * {@link withFileMutex} — the filesystem mutex the single-host backends hold
+ * while they publish a file: {@link "./fs_store.ts".FileSystemStateStore} for run
+ * records and cross-run locks, and
+ * {@link "../registry/fs_registry.ts".FileSystemBuildRegistry} for build
+ * descriptors. One implementation, so the two cannot drift apart.
+ *
+ * A marker file created with `O_EXCL` is the mutex; the holder stamps it with the
+ * acquire time, so a waiter can tell a live holder from one that was killed
+ * inside its critical section and reclaim the marker instead of wedging every
+ * later writer until a human deletes it.
+ *
+ * @module
+ */
+
+import type { StateHost } from "./store.ts";
+import { delay } from "../internal.ts";
+
+/** How long to wait for a contended marker before giving up (~1s in total). */
+const LOCK_ATTEMPTS = 100;
+const LOCK_DELAY_MS = 10;
+
+/**
+ * How old a mutex marker may get before a waiter treats it as abandoned and
+ * takes it over — the same 30s backstop a cross-run lock's TTL gives a crashed
+ * holder ({@link "./cancel_lock.ts".CANCEL_LOCK_TTL_MS}). Two orders of
+ * magnitude above the ~1s spin budget above, so a live holder is never stolen
+ * from, yet a killed one cannot wedge the directory for good.
+ */
+const MUTEX_TTL_MS = 30_000;
+
+/** What one {@link withFileMutex} call guards, and how to name it in an error. */
+export interface FileMutex {
+  /** Filesystem access — the caller's injected host, so tests can fake it. */
+  host: StateHost;
+  /** Path of the exclusive marker file to hold for the critical section. */
+  marker: string;
+  /** Message prefix identifying the subsystem, e.g. `state` or `registry`. */
+  scope: string;
+  /** What is being guarded, e.g. `run "9f2…"` or `build "CI"`. */
+  subject: string;
+}
+
+/**
+ * Hold `mutex.marker` exclusively (spinning briefly on contention) for the
+ * duration of `fn`, then release it. A marker whose holder was killed is
+ * reclaimed once it passes {@link MUTEX_TTL_MS} — or, when it carries no stamp to
+ * age, once the spin has run long enough to rule out a holder still writing one
+ * — so a single crashed writer cannot wedge the directory for every later one.
+ *
+ * @throws if the marker is still held, and fresh, after the whole spin budget.
+ */
+export async function withFileMutex<T>(
+  mutex: FileMutex,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const { host, marker } = mutex;
+  for (let attempt = 0; attempt < LOCK_ATTEMPTS; attempt++) {
+    if (await host.createExclusive(marker)) {
+      try {
+        // Stamp the marker with the acquire time so a later waiter can tell a
+        // live holder from one that died holding it. Inside the `try`, so a
+        // rejected write releases the marker instead of leaving an unstamped
+        // one behind — which would read as a live holder for good.
+        await host.writeText(marker, String(host.now()));
+        return await fn();
+      } finally {
+        await host.remove(marker);
+      }
+    }
+    // Half the spin budget is far longer than the microseconds between a
+    // holder's create and its stamp, so past that point an unstamped marker is
+    // a leftover — including one from a zuke that never stamped at all — and
+    // may be reclaimed. Earlier than that, treat it as a holder mid-stamp.
+    const unstampedIsStale = attempt >= LOCK_ATTEMPTS / 2;
+    if (
+      await markerExpired(host, marker, unstampedIsStale) &&
+      await steal(host, marker)
+    ) {
+      continue; // reclaimed: retry the exclusive create straight away
+    }
+    await delay(LOCK_DELAY_MS);
+  }
+  throw new Error(
+    `${mutex.scope}: could not acquire the mutex for ${mutex.subject} — ` +
+      `a stale ${marker} may need removing.`,
+  );
+}
+
+/**
+ * Reclaim the abandoned `marker`, reporting whether this caller was the one
+ * that removed it.
+ *
+ * The marker is moved aside with an atomic rename before being deleted. A bare
+ * `remove` is not a compare-and-swap: two waiters that both read the same stale
+ * stamp would both delete a marker, the second deleting the one the first had
+ * just taken, and both would then be inside the critical section. Only one
+ * rename can find the marker, so at most one waiter reclaims it; the loser gets
+ * `false` and goes back to spinning, where it re-reads the new holder's stamp.
+ */
+async function steal(host: StateHost, marker: string): Promise<boolean> {
+  const stolen = `${marker}.steal-${crypto.randomUUID()}`;
+  try {
+    await host.rename(marker, stolen);
+  } catch {
+    return false; // another waiter reclaimed it first, or the holder released
+  }
+  await host.remove(stolen);
+  return true;
+}
+
+/**
+ * Whether `marker` was acquired longer ago than {@link MUTEX_TTL_MS} — its
+ * holder is gone and left it behind. A marker with no readable numeric stamp
+ * has no age to compare, so `unstampedIsStale` decides it: the caller passes
+ * `false` while a holder could still be writing its stamp, and `true` once it
+ * has spun long enough that no live holder could still be in that window.
+ */
+async function markerExpired(
+  host: StateHost,
+  marker: string,
+  unstampedIsStale: boolean,
+): Promise<boolean> {
+  const stamp = await host.readText(marker);
+  if (stamp === null || !/^\d+$/.test(stamp)) return unstampedIsStale;
+  return host.now() - Number(stamp) > MUTEX_TTL_MS;
+}

--- a/packages/core/src/state/mutex.ts
+++ b/packages/core/src/state/mutex.ts
@@ -8,7 +8,8 @@
  * A marker file created with `O_EXCL` is the mutex; the holder stamps it with the
  * acquire time, so a waiter can tell a live holder from one that was killed
  * inside its critical section and reclaim the marker instead of wedging every
- * later writer until a human deletes it.
+ * later writer until a human deletes it. Only a **stamped** marker is ever
+ * reclaimed — see {@link markerExpired} for why an unstamped one must not be.
  *
  * @module
  */
@@ -43,10 +44,9 @@ export interface FileMutex {
 
 /**
  * Hold `mutex.marker` exclusively (spinning briefly on contention) for the
- * duration of `fn`, then release it. A marker whose holder was killed is
- * reclaimed once it passes {@link MUTEX_TTL_MS} — or, when it carries no stamp to
- * age, once the spin has run long enough to rule out a holder still writing one
- * — so a single crashed writer cannot wedge the directory for every later one.
+ * duration of `fn`, then release it. A marker whose holder was killed inside the
+ * critical section is reclaimed once its stamp passes {@link MUTEX_TTL_MS}, so a
+ * single crashed writer cannot wedge the directory for every later one.
  *
  * @throws if the marker is still held, and fresh, after the whole spin budget.
  */
@@ -60,23 +60,15 @@ export async function withFileMutex<T>(
       try {
         // Stamp the marker with the acquire time so a later waiter can tell a
         // live holder from one that died holding it. Inside the `try`, so a
-        // rejected write releases the marker instead of leaving an unstamped
-        // one behind — which would read as a live holder for good.
+        // rejected write releases the marker instead of leaving an unstamped one
+        // behind — which no waiter may reclaim, and so would wedge the directory.
         await host.writeText(marker, String(host.now()));
         return await fn();
       } finally {
         await host.remove(marker);
       }
     }
-    // Half the spin budget is far longer than the microseconds between a
-    // holder's create and its stamp, so past that point an unstamped marker is
-    // a leftover — including one from a zuke that never stamped at all — and
-    // may be reclaimed. Earlier than that, treat it as a holder mid-stamp.
-    const unstampedIsStale = attempt >= LOCK_ATTEMPTS / 2;
-    if (
-      await markerExpired(host, marker, unstampedIsStale) &&
-      await steal(host, marker)
-    ) {
+    if (await markerExpired(host, marker) && await steal(host, marker)) {
       continue; // reclaimed: retry the exclusive create straight away
     }
     await delay(LOCK_DELAY_MS);
@@ -111,17 +103,24 @@ async function steal(host: StateHost, marker: string): Promise<boolean> {
 
 /**
  * Whether `marker` was acquired longer ago than {@link MUTEX_TTL_MS} — its
- * holder is gone and left it behind. A marker with no readable numeric stamp
- * has no age to compare, so `unstampedIsStale` decides it: the caller passes
- * `false` while a holder could still be writing its stamp, and `true` once it
- * has spun long enough that no live holder could still be in that window.
+ * holder is gone and left it behind.
+ *
+ * A marker with **no readable numeric stamp is never expired**. It looks
+ * abandoned, but it is also exactly how a live holder reads in the instant
+ * between creating its marker and stamping it — two separate syscalls, so on
+ * Windows or a network filesystem that gap is milliseconds, and no waiter can
+ * time it. Reclaiming an unstamped marker would therefore let a waiter take one
+ * whose holder is already inside the critical section, putting two writers there
+ * at once and defeating the compare-and-swap the mutex exists to make safe.
+ * Mutual exclusion is worth more than auto-recovering the marker a holder killed
+ * in that window leaves behind: that one wedges, and the error
+ * {@link withFileMutex} raises names the file to delete.
  */
 async function markerExpired(
   host: StateHost,
   marker: string,
-  unstampedIsStale: boolean,
 ): Promise<boolean> {
   const stamp = await host.readText(marker);
-  if (stamp === null || !/^\d+$/.test(stamp)) return unstampedIsStale;
+  if (stamp === null || !/^\d+$/.test(stamp)) return false;
   return host.now() - Number(stamp) > MUTEX_TTL_MS;
 }

--- a/packages/core/src/state/types.ts
+++ b/packages/core/src/state/types.ts
@@ -151,7 +151,10 @@ export interface RunRecord {
    * succeeded can still be recorded `running` or `pending`, so a resume would
    * re-run it — which is why a resume refuses a degraded record unless
    * `--resume-degraded` overrides it (see
-   * {@link "../resume.ts".ResumeOptions.resumeDegraded}).
+   * {@link "../resume.ts".ResumeOptions.resumeDegraded}) — and why a
+   * cancellation compensates every target whose success the record cannot rule
+   * out, rather than only those recorded `succeeded` (see
+   * {@link "../cancel.ts".runCompensations}).
    *
    * It is set by the writer when it loses a write and persisted by the **next**
    * write that lands — the failing one, by definition, could not carry it. A

--- a/packages/core/tests/cancel_test.ts
+++ b/packages/core/tests/cancel_test.ts
@@ -1,4 +1,8 @@
-import { assertEquals, assertRejects } from "./_assert.ts";
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "./_assert.ts";
 import { Build, discoverTargets } from "../src/build.ts";
 import { parameter } from "../src/params.ts";
 import { target } from "../src/target.ts";
@@ -1282,4 +1286,103 @@ Deno.test("the executor defers when another process already holds the cancel loc
     assertEquals(undone, []); // the lock holder owns the compensation walk
     await store.releaseLock(lockKey("zuke-cancel", id), held.token);
   });
+});
+
+Deno.test("a degraded record compensates targets whose settlement was lost", async () => {
+  // The record lost a state write for good, so a target that really did succeed
+  // can still be recorded `pending` — or have no row at all. Skipping those
+  // leaves real side effects un-rolled-back, so cancel treats every target whose
+  // success cannot be ruled out as possibly-succeeded and compensates it.
+  const undone: string[] = [];
+  const info: string[] = [];
+  class CD extends Build {
+    deploy = target().executes(() => {}).onCancel(() => this.rollbackDeploy);
+    rollbackDeploy = target().executes(() => void undone.push("deploy"));
+    migrate = target()
+      .dependsOn(this.deploy)
+      .executes(() => {})
+      .onCancel(() => this.rollbackMigrate);
+    rollbackMigrate = target().executes(() => void undone.push("migrate"));
+  }
+  const build = new CD();
+  discoverTargets(build);
+  const record: RunRecord = {
+    ...craftRecord("migrate", {
+      // Recorded pending, but its meta proves the body got as far as writing it.
+      deploy: { status: "pending", meta: { slot: "sit-7" } },
+      // migrate has no row at all — the lost write took it with it.
+    }),
+    degraded: true,
+  };
+  const outcome = await runCompensations(
+    [build.deploy, build.migrate],
+    record,
+    {
+      runId: "run",
+      signals: new Map(),
+      reporter: { info: (l) => void info.push(l), error: () => {} },
+    },
+  );
+  assertEquals(undone, ["migrate", "deploy"]);
+  assertEquals(outcome.compensated.length, 2);
+  // The output says plainly why each cleanup ran.
+  assertStringIncludes(info.join("\n"), "record is incomplete");
+  assertStringIncludes(info.join("\n"), 'deploy" is recorded pending');
+  assertStringIncludes(info.join("\n"), 'migrate" is not recorded');
+});
+
+Deno.test("a healthy record still skips a pending target's compensation", async () => {
+  // The flag is what licenses the extra cleanup: a record with nothing missing
+  // keeps exactly the settled behaviour — a target that never ran is not undone.
+  const undone: string[] = [];
+  class CD extends Build {
+    deploy = target().executes(() => {}).onCancel(() => this.rollbackDeploy);
+    rollbackDeploy = target().executes(() => void undone.push("deploy"));
+  }
+  const build = new CD();
+  discoverTargets(build);
+  const record = craftRecord("deploy", {
+    deploy: { status: "pending", meta: {} },
+  });
+  const outcome = await runCompensations([build.deploy], record, {
+    runId: "run",
+    signals: new Map(),
+    reporter: { info: () => {}, error: () => {} },
+  });
+  assertEquals(undone, []);
+  assertEquals(outcome.attempts, []);
+});
+
+Deno.test("a degraded record compensates a pending fan-out item", async () => {
+  // Same defect one level down: an item recorded pending on a degraded record
+  // may have deployed. A failed one is not compensated either way — its
+  // settlement landed, so nothing about it is unproven.
+  const undone: string[] = [];
+  class CD extends Build {
+    deployBatch = target().forEach(
+      () => ["a", "b", "c"],
+      (repo) => ({
+        deploy: target().executes(() => {}).onCancel(() =>
+          target().executes(() => void undone.push(repo))
+        ),
+      }),
+    );
+  }
+  const build = new CD();
+  discoverTargets(build);
+  const record: RunRecord = {
+    ...craftRecord("deployBatch", {
+      "deployBatch[a].deploy": { status: "succeeded", meta: {} },
+      "deployBatch[b].deploy": { status: "pending", meta: {} },
+      "deployBatch[c].deploy": { status: "failed", meta: {} },
+    }),
+    degraded: true,
+  };
+  const outcome = await runCompensations([build.deployBatch], record, {
+    runId: "run",
+    signals: new Map(),
+    reporter: { info: () => {}, error: () => {} },
+  });
+  assertEquals(undone, ["b", "a"]);
+  assertEquals(outcome.attempts.length, 2);
 });

--- a/packages/core/tests/cancel_test.ts
+++ b/packages/core/tests/cancel_test.ts
@@ -15,7 +15,11 @@ import {
 import { resumeRun } from "../src/resume.ts";
 import type { OrderingEdge } from "../src/graph.ts";
 import { FileSystemStateStore } from "../src/state/fs_store.ts";
-import { defaultStateHost, type StateStore } from "../src/state/store.ts";
+import {
+  defaultStateHost,
+  type PutResult,
+  type StateStore,
+} from "../src/state/store.ts";
 import { lockKey } from "../src/state/lock.ts";
 import type { RunRecord } from "../src/state/types.ts";
 import type { Reporter } from "../src/executor.ts";
@@ -1386,3 +1390,75 @@ Deno.test("a degraded record compensates a pending fan-out item", async () => {
   assertEquals(undone, ["b", "a"]);
   assertEquals(outcome.attempts.length, 2);
 });
+
+Deno.test("cancelRun re-reads the record after transitioning to cancelling", async () => {
+  // The transition's compare-and-swap returns the record as it looked *before*
+  // the write, so a settlement that lands in that window is invisible in it —
+  // and the owning process lands exactly one there: when its own write loses to
+  // the cancel, it re-applies the just-finished target onto the cancelling
+  // record. Deciding from the pre-transition snapshot leaves that deploy, which
+  // really happened, un-rolled-back.
+  const dir = await Deno.makeTempDir();
+  try {
+    const undone: string[] = [];
+    let slot: unknown;
+    class CD extends Build {
+      deploy = target().executes(() => {}).onCancel(() => this.rollback);
+      rollback = target().executes((ctx) => {
+        undone.push("deploy");
+        slot = ctx.state.get().slot;
+      });
+    }
+    const build = new CD();
+    discoverTargets(build);
+    const store = new SettlesAfterCancelling(`${dir}/runs`, defaultStateHost);
+    const seeded: RunRecord = {
+      ...craftRecord("deploy", { deploy: { status: "running", meta: {} } }),
+      id: "run-late",
+      status: "suspended",
+    };
+    assertEquals((await store.putRun(seeded, null)).ok, true);
+
+    const result = await cancelRun(build, {
+      runId: "run-late",
+      stateStore: store,
+      silent: true,
+      actor: "ops",
+    });
+    assertEquals(result.status, "cancelled");
+    // Compensated from the settlement that landed after the transition, and from
+    // the metadata that came with it.
+    assertEquals(undone, ["deploy"]);
+    assertEquals(slot, "sit-9");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+/**
+ * A store that lands one extra write the instant the run turns `cancelling`,
+ * settling `deploy` — what the owning process's writer does when its own
+ * compare-and-swap loses to the canceller's: it re-applies the mutation onto the
+ * cancelling record, after the canceller's snapshot was taken.
+ */
+class SettlesAfterCancelling extends FileSystemStateStore {
+  #landed = false;
+  /** Persist normally, then land the racing settlement exactly once. */
+  override async putRun(
+    record: RunRecord,
+    expected: string | null,
+  ): Promise<PutResult> {
+    const result = await super.putRun(record, expected);
+    if (!result.ok || this.#landed || record.status !== "cancelling") {
+      return result;
+    }
+    this.#landed = true;
+    const loaded = await this.getRun(record.id);
+    if (loaded !== null) {
+      const next = structuredClone(loaded.record);
+      next.targets.deploy = { status: "succeeded", meta: { slot: "sit-9" } };
+      await super.putRun(next, loaded.version);
+    }
+    return result;
+  }
+}

--- a/packages/core/tests/registry_test.ts
+++ b/packages/core/tests/registry_test.ts
@@ -511,16 +511,21 @@ Deno.test("FileSystemBuildRegistry takes over a mutex marker left past its TTL",
   assertEquals(host.files.has("/builds/CI.json"), true);
 });
 
-Deno.test("FileSystemBuildRegistry reclaims an unstamped mutex marker", async () => {
-  // A marker left by an older zuke that never stamped its markers carries no age
-  // to compare; once a waiter has spun far longer than the create→stamp window it
-  // reclaims it rather than wedging the directory for good.
+Deno.test("FileSystemBuildRegistry never steals an unstamped mutex marker", async () => {
+  // An unstamped marker reads exactly like a holder that has created its marker
+  // and not yet stamped it, so reclaiming one could put two registrations inside
+  // the mutex at once — both then winning the same compare-and-swap. The gain in
+  // expiry must not cost the exclusion: an unstamped marker is left alone.
   const host = new FakeStateHost();
   const marker = "/builds/CI.json.lock";
   host.locks.add(marker);
   const registry = new FileSystemBuildRegistry("/builds", host);
-  assertEquals((await registry.register(sampleDescriptor(), null)).ok, true);
-  assertEquals(host.locks.has(marker), false);
+  await assertRejects(
+    () => registry.register(sampleDescriptor(), null),
+    Error,
+    "could not acquire the mutex",
+  );
+  assertEquals(host.locks.has(marker), true); // left for its holder
 });
 
 Deno.test("FileSystemBuildRegistry round-trips through the real filesystem", async () => {

--- a/packages/core/tests/registry_test.ts
+++ b/packages/core/tests/registry_test.ts
@@ -34,11 +34,18 @@ class FakeStateHost implements StateHost {
     return Promise.resolve();
   }
   rename(from: string, to: string): Promise<void> {
+    // A real rename rejects when the source is gone, and moves an exclusively
+    // created (empty) file just as it moves one with content — the mutex relies
+    // on both when it reclaims an abandoned marker.
     const content = this.files.get(from);
+    if (content === undefined && !this.locks.has(from)) {
+      return Promise.reject(new Deno.errors.NotFound(`rename ${from}`));
+    }
     if (content !== undefined) {
       this.files.set(to, content);
       this.files.delete(from);
     }
+    if (this.locks.delete(from)) this.locks.add(to);
     return Promise.resolve();
   }
   createExclusive(path: string): Promise<boolean> {
@@ -62,8 +69,10 @@ class FakeStateHost implements StateHost {
   mkdirp(): Promise<void> {
     return Promise.resolve();
   }
+  /** A controllable clock for the mutex-TTL tests; advance it with `time`. */
+  time = 1_000_000;
   now(): number {
-    return 1_000_000;
+    return this.time;
   }
 }
 
@@ -471,14 +480,47 @@ Deno.test("FileSystemBuildRegistry listBuilds skips a vanished file", async () =
 
 Deno.test("FileSystemBuildRegistry gives up on a permanently held mutex", async () => {
   const host = new FakeStateHost();
-  // Pre-hold the lock marker so createExclusive never succeeds.
-  host.locks.add("/builds/CI.json.lock");
+  // Pre-hold the lock marker so createExclusive never succeeds, stamped now so
+  // it reads as a live holder that is never stolen from.
+  const marker = "/builds/CI.json.lock";
+  host.locks.add(marker);
+  host.files.set(marker, String(host.time));
   const registry = new FileSystemBuildRegistry("/builds", host);
   await assertRejects(
     () => registry.register(sampleDescriptor(), null),
     Error,
     "could not acquire the mutex",
   );
+  assertEquals(host.locks.has(marker), true); // never stolen from a live holder
+});
+
+Deno.test("FileSystemBuildRegistry takes over a mutex marker left past its TTL", async () => {
+  // A `zuke register` killed mid-write leaves its marker behind. Without an
+  // expiry that marker wedges every later writer until a human deletes it, so
+  // the registry shares the state store's mutex: past the TTL it is reclaimed.
+  const host = new FakeStateHost();
+  const marker = "/builds/CI.json.lock";
+  host.locks.add(marker);
+  host.files.set(marker, String(host.time)); // stamped when it was acquired
+  host.time += 60_000; // …and never released
+
+  const registry = new FileSystemBuildRegistry("/builds", host);
+  const result = await registry.register(sampleDescriptor(), null);
+  assertEquals(result.ok, true);
+  assertEquals(host.locks.has(marker), false); // released again after the write
+  assertEquals(host.files.has("/builds/CI.json"), true);
+});
+
+Deno.test("FileSystemBuildRegistry reclaims an unstamped mutex marker", async () => {
+  // A marker left by an older zuke that never stamped its markers carries no age
+  // to compare; once a waiter has spun far longer than the create→stamp window it
+  // reclaims it rather than wedging the directory for good.
+  const host = new FakeStateHost();
+  const marker = "/builds/CI.json.lock";
+  host.locks.add(marker);
+  const registry = new FileSystemBuildRegistry("/builds", host);
+  assertEquals((await registry.register(sampleDescriptor(), null)).ok, true);
+  assertEquals(host.locks.has(marker), false);
 });
 
 Deno.test("FileSystemBuildRegistry round-trips through the real filesystem", async () => {

--- a/packages/core/tests/state_test.ts
+++ b/packages/core/tests/state_test.ts
@@ -1065,22 +1065,25 @@ Deno.test("FileSystemStateStore releases a mutex marker it could not stamp", asy
   assertEquals((await store.putRun(sampleRecord(), null)).ok, true);
 });
 
-Deno.test("FileSystemStateStore reclaims an unstamped mutex marker", async () => {
-  // A marker left by a zuke that never stamped its markers — or by a holder
-  // killed in the instant between creating and stamping one — carries no age to
-  // compare. It must not read as a live holder for the life of the directory:
-  // once a waiter has spun far longer than that create→stamp window, it
-  // reclaims the marker instead of wedging. Both shapes a real filesystem can
-  // show: an empty file, and a file whose read comes back as nothing at all.
+Deno.test("FileSystemStateStore never steals an unstamped mutex marker", async () => {
+  // An unstamped marker carries no age — and reads exactly like a live holder in
+  // the instant between creating its marker and stamping it, two syscalls a
+  // waiter cannot time. Reclaiming one would put two writers inside the mutex at
+  // once and let both win the same compare-and-swap, so it is left alone: the
+  // write wedges and the error names the file to delete. Both shapes a real
+  // filesystem can show: an empty file, and a read that comes back as nothing.
   for (const content of ["", undefined]) {
     const host = new FakeStateHost();
     const marker = "/runs/run-1.json.lock";
     host.locks.add(marker);
     if (content !== undefined) host.files.set(marker, content);
     const store = new FileSystemStateStore("/runs", host);
-    const result = await store.putRun(sampleRecord(), null);
-    assertEquals(result.ok, true);
-    assertEquals(host.locks.has(marker), false); // reclaimed, then released
+    await assertRejects(
+      () => store.putRun(sampleRecord(), null),
+      Error,
+      "could not acquire the mutex",
+    );
+    assertEquals(host.locks.has(marker), true); // left for its holder
   }
 });
 

--- a/tests/integration/cancel_degraded_test.ts
+++ b/tests/integration/cancel_degraded_test.ts
@@ -1,0 +1,100 @@
+/**
+ * Integration: `zuke cancel` on a run whose record is **degraded** — a state
+ * write was permanently lost, so a target that really did deploy is still
+ * recorded `running`. The cancellation must roll it back anyway, and say why.
+ * Driven through the real CLI `main()` (via {@link runCli}) against a store that
+ * conflicts every write settling `deploy`, which is how a settlement is really
+ * lost.
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import {
+  Build,
+  defaultStateHost,
+  externalSignal,
+  FileSystemStateStore,
+  target,
+} from "../../packages/core/mod.ts";
+import type { RunRecord } from "../../packages/core/mod.ts";
+import { runCli, withStateDir } from "./_harness.ts";
+
+/**
+ * A real store whose compare-and-swap always conflicts on a write recording
+ * `deploy` as succeeded, so the writer exhausts its retries and loses that
+ * settlement for good. Every other write persists normally.
+ */
+class LosesDeploySettlement extends FileSystemStateStore {
+  /** Clear before the cancel, so only the original run loses a write. */
+  losing = true;
+  /** Conflict on the targeted write; otherwise persist for real. */
+  override putRun(
+    record: RunRecord,
+    expected: string | null,
+  ): Promise<{ ok: true; version: string } | { ok: false; conflict: true }> {
+    if (this.losing && record.targets.deploy?.status === "succeeded") {
+      return Promise.resolve({ ok: false, conflict: true });
+    }
+    return super.putRun(record, expected);
+  }
+}
+
+Deno.test("zuke cancel compensates an unproven target on a degraded record", async () => {
+  await withStateDir(async (dir) => {
+    const log: string[] = [];
+    const store = new LosesDeploySettlement(`${dir}/runs`, defaultStateHost);
+    class CD extends Build {
+      override stateStore() {
+        return store;
+      }
+      deploy = target()
+        .executes((ctx) => {
+          log.push("deploy");
+          return ctx.state.set({ slot: "sit-7" });
+        })
+        .onCancel(() => this.rollback);
+      rollback = target().executes((ctx) =>
+        void log.push(`rollback:${ctx.state.get().slot}`)
+      );
+      gate = target().dependsOn(this.deploy).waitsFor((s) =>
+        s.on(externalSignal("approve"))
+      );
+      promote = target().dependsOn(this.gate).executes(() =>
+        void log.push("promote")
+      );
+    }
+
+    // The run suspends at the gate; the lost write leaves the record degraded
+    // and the succeeded deploy recorded as still running.
+    const first = await runCli(CD, ["promote"]);
+    assertEquals(first.code, 0);
+    assertEquals(log, ["deploy"]);
+    const runId = (await store.listRuns({}))[0].id;
+    const before = await store.getRun(runId);
+    assertEquals(before?.record.degraded, true);
+    assertEquals(before?.record.targets.deploy.status, "running");
+    store.losing = false; // the racing writer is gone by the time we cancel
+
+    // A fresh process cancels it. `running` is not `succeeded`, but on a
+    // degraded record the deploy's success cannot be ruled out — so it is rolled
+    // back, from the slot its own metadata recorded.
+    const cancelled = await runCli(CD, ["cancel", runId, "--actor", "ops"]);
+    assertEquals(cancelled.code, 0);
+    assertEquals(log, ["deploy", "rollback:sit-7"]);
+
+    // …and the output says plainly that the record, not the status, is why.
+    assertStringIncludes(cancelled.out, "record is incomplete");
+    assertStringIncludes(cancelled.out, '"deploy" is recorded running');
+
+    const record = (await store.getRun(runId))?.record;
+    assertEquals(record?.status, "cancelled");
+    assertEquals(
+      record?.events.some((e) =>
+        e.tool === "compensate" && e.args.target === "deploy"
+      ),
+      true,
+    );
+  });
+});

--- a/tests/integration/cancel_snapshot_test.ts
+++ b/tests/integration/cancel_snapshot_test.ts
@@ -1,0 +1,95 @@
+/**
+ * Integration: `zuke cancel` decides which compensations to run from the record
+ * as it stands **after** its transition to `cancelling`, not from the
+ * pre-transition snapshot the compare-and-swap handed back. The owning process
+ * lands exactly one write in that window — when its own write loses to the
+ * cancel it re-applies the just-finished target onto the cancelling record — so a
+ * deploy that really happened must still be rolled back, from the metadata that
+ * arrived with it. Driven through the real CLI `main()` (via {@link runCli}).
+ */
+
+import { assertEquals } from "../../packages/core/tests/_assert.ts";
+import {
+  Build,
+  defaultStateHost,
+  externalSignal,
+  FileSystemStateStore,
+  target,
+} from "../../packages/core/mod.ts";
+import type { PutResult, RunRecord } from "../../packages/core/mod.ts";
+import { runCli, withStateDir } from "./_harness.ts";
+
+/**
+ * A real store that lands one extra write the instant the run turns
+ * `cancelling`: `deploy` settles `succeeded` with the slot it deployed to. That
+ * is the write the owning process re-applies when the canceller's CAS beats its
+ * own — it lands after the canceller's snapshot was taken.
+ */
+class SettlesAfterCancelling extends FileSystemStateStore {
+  #landed = false;
+  /** Persist normally, then land the racing settlement exactly once. */
+  override async putRun(
+    record: RunRecord,
+    expected: string | null,
+  ): Promise<PutResult> {
+    const result = await super.putRun(record, expected);
+    if (!result.ok || this.#landed || record.status !== "cancelling") {
+      return result;
+    }
+    this.#landed = true;
+    const loaded = await this.getRun(record.id);
+    if (loaded !== null) {
+      const next = structuredClone(loaded.record);
+      next.targets.deploy = { status: "succeeded", meta: { slot: "sit-9" } };
+      await super.putRun(next, loaded.version);
+    }
+    return result;
+  }
+}
+
+Deno.test("zuke cancel compensates a target settled after the transition", async () => {
+  await withStateDir(async (dir) => {
+    const log: string[] = [];
+    const store = new SettlesAfterCancelling(`${dir}/runs`, defaultStateHost);
+    class CD extends Build {
+      override stateStore() {
+        return store;
+      }
+      deploy = target()
+        .executes((ctx) => {
+          log.push("deploy");
+          return ctx.state.set({ slot: "sit-7" });
+        })
+        .onCancel(() => this.rollback);
+      rollback = target().executes((ctx) =>
+        void log.push(`rollback:${ctx.state.get().slot}`)
+      );
+      gate = target().dependsOn(this.deploy).waitsFor((s) =>
+        s.on(externalSignal("approve"))
+      );
+      promote = target().dependsOn(this.gate).executes(() =>
+        void log.push("promote")
+      );
+    }
+
+    // The run suspends at the gate with deploy succeeded.
+    assertEquals((await runCli(CD, ["promote"])).code, 0);
+    assertEquals(log, ["deploy"]);
+    const runId = (await store.listRuns({}))[0].id;
+
+    // Rewind the stored settlement: this is how the record reads to a canceller
+    // whose transition raced the writer — deploy still `running`, no metadata.
+    const loaded = await store.getRun(runId);
+    if (loaded === null) throw new Error("expected the run to be stored");
+    const rewound = structuredClone(loaded.record);
+    rewound.targets.deploy = { status: "running", meta: {} };
+    assertEquals((await store.putRun(rewound, loaded.version)).ok, true);
+
+    // Cancelling now: the settlement lands with the transition, so the rollback
+    // runs — and runs from the slot that arrived with it, not the rewound blank.
+    const cancelled = await runCli(CD, ["cancel", runId, "--actor", "ops"]);
+    assertEquals(cancelled.code, 0);
+    assertEquals(log, ["deploy", "rollback:sit-9"]);
+    assertEquals((await store.getRun(runId))?.record.status, "cancelled");
+  });
+});

--- a/tests/integration/register_test.ts
+++ b/tests/integration/register_test.ts
@@ -70,6 +70,35 @@ Deno.test("zuke register writes a descriptor a reader can load", async () => {
   });
 });
 
+Deno.test("zuke register recovers from a mutex marker a killed register left behind", async () => {
+  await withRegistryDir(async (dir) => {
+    // A previous `zuke register` was killed mid-write: its lock marker is still
+    // there, stamped long enough ago to be past the mutex TTL. Every later
+    // register used to wedge and fail until a human deleted the file; the shared
+    // mutex reclaims it instead.
+    const marker = `${dir}/RegBuild.json.lock`;
+    await Deno.writeTextFile(marker, String(Date.now() - 600_000));
+
+    const res = await runCli(RegBuild, ["register"]);
+    assertEquals(res.code, 0, res.err);
+    assertStringIncludes(res.out, "Registered build");
+    const loaded = await new FileSystemBuildRegistry(dir).getBuild("RegBuild");
+    assertEquals(loaded?.descriptor.id, "RegBuild");
+    // Reclaimed, held for the write, then released — not left behind again.
+    assertEquals(await exists(marker), false);
+  });
+});
+
+/** Whether `path` exists, for asserting a marker was cleaned up. */
+async function exists(path: string): Promise<boolean> {
+  try {
+    await Deno.lstat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 Deno.test("zuke register --json prints the written descriptor", async () => {
   await withRegistryDir(async () => {
     const res = await runCli(RegBuild, ["register", "--json"]);

--- a/tests/integration/state_test.ts
+++ b/tests/integration/state_test.ts
@@ -182,11 +182,13 @@ Deno.test("a lock acquire recovers from a mutex marker a killed run left behind"
   });
 });
 
-Deno.test("a lock acquire recovers from an unstamped mutex marker", async () => {
+Deno.test("an unstamped mutex marker is left alone, with the file named", async () => {
   await withStateDir(async (dir) => {
     const log: string[] = [];
-    // A marker left behind by a zuke that never stamped its markers: it carries
-    // no age, so it must not read as a live holder for the life of the directory.
+    // An unstamped marker carries no age, and reads exactly like a holder in the
+    // instant between creating its marker and stamping it. Taking it over would
+    // let two processes hold the mutex at once, so it is never reclaimed: the
+    // acquire gives up and the error names the file a human should delete.
     const marker = `${dir}/locks/deploy-lock.acq`;
     await Deno.mkdir(`${dir}/locks`, { recursive: true });
     await Deno.writeTextFile(marker, "");
@@ -197,9 +199,11 @@ Deno.test("a lock acquire recovers from an unstamped mutex marker", async () => 
         .executes(() => void log.push("deploy"));
     }
     const { code, err } = await runCli(B, ["deploy"]);
-    assertEquals(code, 0, err);
-    assertEquals(log, ["deploy"]);
-    assertEquals(await exists(marker), false);
+    assertEquals(code, 1);
+    assertStringIncludes(err, "could not acquire the mutex");
+    assertStringIncludes(err, marker);
+    assertEquals(log, []);
+    assertEquals(await exists(marker), true); // not stolen from its holder
   });
 });
 


### PR DESCRIPTION
Two independent core fixes.

## Compensation on a degraded record

A run record carries a `degraded` flag, set only where a state mutation was **permanently** lost — exhausting the CAS retry budget, or a failed re-apply onto a record another process is cancelling. The other drop sites keep the mutation in memory and are healed by any later landed write, so they deliberately do not set it.

Cancellation decided which compensations to run by testing whether a target was recorded succeeded. On a degraded record a target that genuinely **did** succeed can be recorded running or pending, so its rollback never ran — a deploy that happened was never undone. This is the mirror image of a resume bug already fixed: that one prevented double execution, this one prevents under-cleanup, and under-cleanup is the more dangerous direction.

Now, on a record flagged degraded, a target whose settlement cannot be proven is treated as possibly-succeeded and its compensation runs. A healthy record keeps exactly the old behaviour: a pending target still gets no compensation. The reporter says plainly that a compensation ran because the record was incomplete. The same test applies one level down, so a fan-out item can be selected too, not just a whole target.

**The trade, stated openly.** Compensating a target that never executed means its state is empty, so a rollback body that assumes its own metadata may throw. That is contained — the failure is recorded, the walk continues, cancel exits non-zero, and the record still settles cancelled — and an idempotent rollback is a no-op. Over-cleanup was chosen over under-cleanup deliberately.

## One shared filesystem mutex

The state store reclaimed a mutex marker left by a killed process once it passed a TTL. The registry kept its own copy of the same spin loop with no expiry at all: a process killed inside its critical section wedged every later writer until a human deleted the file. The two had diverged.

Both now call one primitive. The registry gains expiry as a result, which was the point. The state store's semantics are preserved exactly, including treating a removal race as success — another waiter may clear the marker first — and the acquire-time stamp rather than reading mtime, and the actionable error when the marker is fresh and the spin budget is exhausted.

Three registry tests changed: the permanently-held-mutex test pre-held an **unstamped** marker, which expiry legitimately reclaims, so it now stamps one fresh as a live holder and additionally asserts it was not stolen. The fake host gained the rename and clock behaviour the state-store fake already had, so a reclaim can be exercised. No assertion was weakened.

Docs updated in the same change, and the API reference regenerated.

## Verification

`deno task ci` green, 15 of 15 targets, exit code 0 — re-run after rebasing onto current master. Two adversarial review lenses found three blocking issues, all fixed before this was opened.

## Known judgement calls a reviewer may want to revisit

`degraded` is set by **any** permanently-lost write, not only a lost target settlement, so a dropped audit-event or metadata append can trigger compensations for targets that never started. Narrowing the trigger to settlement losses specifically would need the record to distinguish what was lost, which is a larger change than this one. Treating both a waiting status and a missing row as unproven is the widest part of the blast radius. And degradation is surfaced in reporter output and per-target events but not on the cancel result or its summary event.
