### PR TITLE
docs: add versioning and comparison guides, make the wrapper catalogue discoverable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,18 @@ If you are wiring Zuke into a project, **do not guess the API and do not fall
 back to `Deno.Command`/shell.** Every operation has a typed wrapper, and the
 exact signatures are published — read them:
 
+- **Check the package catalogue before writing any command.** `llms.txt`'s
+  `## Packages` catalogue (raw:
+  <https://raw.githubusercontent.com/zuke-build/zuke/master/llms.txt>) and the
+  grouped table in
+  [`skills/zuke-write-build/references/cheatsheet.md`](./skills/zuke-write-build/references/cheatsheet.md)
+  are the only ways to answer "does a `@zuke/<tool>` wrapper exist for this
+  CLI?" — per-package `deno doc jsr:@zuke/<package>` can only describe a
+  package whose name you already know; it cannot reveal that a package
+  *exists*. Reaching for `CmdTasks.exec` (`jsr:@zuke/cmd`) or a raw
+  `$`/`Deno.Command` for a tool that has a `@zuke/<tool>` package is a **bug**,
+  not a style choice — it discards typed flags, argv purity, and tool
+  resolution.
 - **One file with the whole typed surface of every package:**
   [`llms-full.txt`](./llms-full.txt) at the repo root. [`llms.txt`](./llms.txt)
   is the short index.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,10 +8,11 @@ By participating, you agree to abide by our
 [Code of Conduct](./CODE_OF_CONDUCT.md).
 
 > [!NOTE]
-> Zuke's packages sit at different maturity levels: `@zuke/core` (1.x) and
-> several others follow semver, while the 0.x tool wrappers may still change
-> within `0.x`. If you are planning a large change, please open an issue first
-> so we can agree on the direction before you invest the effort.
+> Zuke's packages sit at different maturity levels — see
+> [Versioning & compatibility](./docs/versioning.md) for which packages follow
+> semver and which 0.x wrappers may still change within `0.x`. If you are
+> planning a large change, please open an issue first so we can agree on the
+> direction before you invest the effort.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ class MyBuild extends Build {
   Zuke generates GitHub Actions, GitLab CI, or Azure Pipelines YAML,
   regenerating it whenever the build runs (and verifying it on CI).
 
-See **[How Zuke compares](./docs/comparison.md)** for an honest look at
-`deno task`, Nx/Turborepo, Dagger, and NUKE — including when NOT to reach for
-Zuke.
+See **[How Zuke compares](./docs/comparison.md)** for a capability-by-capability
+matrix against `deno task`, npm scripts, Make, Nx, Turborepo, Dagger, and NUKE —
+where each of them is ahead, and when NOT to reach for Zuke.
 
 ## Install
 
@@ -344,8 +344,9 @@ Full documentation lives in [`docs/`](./docs/):
   code.
 - [Versioning & compatibility](./docs/versioning.md) — core semver vs. 0.x
   wrappers, the `@zuke/core` floor, and pinning guidance.
-- [How Zuke compares](./docs/comparison.md) — honest comparisons against
-  `deno task`, Nx/Turborepo, Dagger, and NUKE.
+- [How Zuke compares](./docs/comparison.md) — a capability matrix against
+  `deno task`, npm scripts, Make, Nx, Turborepo, Dagger, and NUKE, with where
+  each is ahead.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ class MyBuild extends Build {
   regenerating it whenever the build runs (and verifying it on CI).
 
 See **[How Zuke compares](./docs/comparison.md)** for a capability-by-capability
-matrix against `deno task`, npm scripts, Make, Nx, Turborepo, and Dagger —
-where each of them is ahead, and when NOT to reach for Zuke.
+matrix against `deno task`, npm scripts, Make, Nx, Turborepo, and Dagger, on
+the capabilities Zuke was built to provide.
 
 ## Install
 
@@ -345,8 +345,8 @@ Full documentation lives in [`docs/`](./docs/):
 - [Versioning & compatibility](./docs/versioning.md) — core semver vs. 0.x
   wrappers, the `@zuke/core` floor, and pinning guidance.
 - [How Zuke compares](./docs/comparison.md) — a capability matrix against
-  `deno task`, npm scripts, Make, Nx, Turborepo, and Dagger, with where
-  each is ahead.
+  `deno task`, npm scripts, Make, Nx, Turborepo, and Dagger, on the
+  capabilities Zuke provides.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ class MyBuild extends Build {
   regenerating it whenever the build runs (and verifying it on CI).
 
 See **[How Zuke compares](./docs/comparison.md)** for a capability-by-capability
-matrix against `deno task`, npm scripts, Make, Nx, Turborepo, Dagger, and NUKE —
+matrix against `deno task`, npm scripts, Make, Nx, Turborepo, and Dagger —
 where each of them is ahead, and when NOT to reach for Zuke.
 
 ## Install
@@ -345,7 +345,7 @@ Full documentation lives in [`docs/`](./docs/):
 - [Versioning & compatibility](./docs/versioning.md) — core semver vs. 0.x
   wrappers, the `@zuke/core` floor, and pinning guidance.
 - [How Zuke compares](./docs/comparison.md) — a capability matrix against
-  `deno task`, npm scripts, Make, Nx, Turborepo, Dagger, and NUKE, with where
+  `deno task`, npm scripts, Make, Nx, Turborepo, and Dagger, with where
   each is ahead.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ class MyBuild extends Build {
   Zuke generates GitHub Actions, GitLab CI, or Azure Pipelines YAML,
   regenerating it whenever the build runs (and verifying it on CI).
 
+See **[How Zuke compares](./docs/comparison.md)** for an honest look at
+`deno task`, Nx/Turborepo, Dagger, and NUKE — including when NOT to reach for
+Zuke.
+
 ## Install
 
 You need [Deno](https://deno.com/) installed. The fastest start is the
@@ -340,6 +344,8 @@ Full documentation lives in [`docs/`](./docs/):
   code.
 - [Versioning & compatibility](./docs/versioning.md) — core semver vs. 0.x
   wrappers, the `@zuke/core` floor, and pinning guidance.
+- [How Zuke compares](./docs/comparison.md) — honest comparisons against
+  `deno task`, Nx/Turborepo, Dagger, and NUKE.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@
 > assistance, then reviewed, type-checked, and tested in CI. Sharing how it was
 > made so you know what you're getting.
 
+> [!NOTE]
+> **Maturity.** `@zuke/core` (and a handful of others — `@zuke/ai`,
+> `@zuke/console`, `@zuke/otel`, …) are `1.x` and follow full semver; the 50+
+> tool wrappers are `0.x` and may still change within `0.x`. See
+> [Versioning & compatibility](./docs/versioning.md) for the pinning guidance
+> and how to diagnose a version mismatch.
+
 Zuke lets you define builds as a **TypeScript class**. Each target is a class
 field declared with a fluent API; targets reference each other by `this.x` (not
 strings), forming a dependency graph that Zuke resolves and runs in topological
@@ -331,6 +338,8 @@ Full documentation lives in [`docs/`](./docs/):
 - [CLI reference](./docs/cli.md) — commands and flags.
 - [Programmatic API](./docs/programmatic-api.md) — drive Zuke from your own
   code.
+- [Versioning & compatibility](./docs/versioning.md) — core semver vs. 0.x
+  wrappers, the `@zuke/core` floor, and pinning guidance.
 
 ## Development
 

--- a/build/pr_body_lint.ts
+++ b/build/pr_body_lint.ts
@@ -9,16 +9,25 @@
  *
  * The heuristic is deliberately dumb, on purpose: it flags a fenced ```
  * block wholesale, and — outside fences — a line containing an arrow
- * function (`=>`) or a zero-argument call statement (`();`). Ordinary prose
- * parentheses, e.g. `(see #241)`, are never flagged; only code-shaped
- * constructs are.
+ * function (`=>`), a zero-argument call statement (`();`), or a member call
+ * whose receiver and method are identifiers, as in a `Tasks.method(` fragment.
+ * Ordinary prose parentheses, e.g. `(see #241)`, are never flagged; a
+ * parenthetical that follows a filename keeps its space, so `cli.md (the
+ * reference)` reads as prose while `CmdTasks.exec("docker")` reads as code.
  *
  * @module
  */
 
-/** A code-shaped line contains an arrow function or a bare call statement. */
+/** A member call, `Receiver.method(`, with no space before the parenthesis. */
+const MEMBER_CALL = /[A-Za-z_$][\w$]*\.[A-Za-z_$][\w$]*\(/;
+
+/**
+ * A code-shaped line contains an arrow function, a bare call statement, or a
+ * member call.
+ */
 function isCodeShapedLine(line: string): boolean {
-  return line.includes("=>") || /\(\s*\)\s*;/.test(line);
+  return line.includes("=>") || /\(\s*\)\s*;/.test(line) ||
+    MEMBER_CALL.test(line);
 }
 
 /**

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,4 +53,4 @@
 - [Versioning & compatibility](./versioning.md) — core semver vs. 0.x wrappers,
   the `@zuke/core` floor, and pinning guidance.
 - [How Zuke compares](./comparison.md) — a capability matrix against `deno task`,
-  npm scripts, Make, Nx, Turborepo, and Dagger, with where each is ahead.
+  npm scripts, Make, Nx, Turborepo, and Dagger, on the capabilities Zuke provides.

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,3 +52,5 @@
 - [Programmatic API](./programmatic-api.md) — drive Zuke from your own code.
 - [Versioning & compatibility](./versioning.md) — core semver vs. 0.x wrappers,
   the `@zuke/core` floor, and pinning guidance.
+- [How Zuke compares](./comparison.md) — honest comparisons against
+  `deno task`, Nx/Turborepo, Dagger, and NUKE.

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,5 +52,5 @@
 - [Programmatic API](./programmatic-api.md) — drive Zuke from your own code.
 - [Versioning & compatibility](./versioning.md) — core semver vs. 0.x wrappers,
   the `@zuke/core` floor, and pinning guidance.
-- [How Zuke compares](./comparison.md) — honest comparisons against
-  `deno task`, Nx/Turborepo, Dagger, and NUKE.
+- [How Zuke compares](./comparison.md) — a capability matrix against `deno task`,
+  npm scripts, Make, Nx, Turborepo, Dagger, and NUKE, with where each is ahead.

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,3 +50,5 @@
   compiled to UTC cron with a daylight-saving wall-clock guard.
 - [CLI reference](./cli.md) — commands and flags.
 - [Programmatic API](./programmatic-api.md) — drive Zuke from your own code.
+- [Versioning & compatibility](./versioning.md) — core semver vs. 0.x wrappers,
+  the `@zuke/core` floor, and pinning guidance.

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,4 +53,4 @@
 - [Versioning & compatibility](./versioning.md) — core semver vs. 0.x wrappers,
   the `@zuke/core` floor, and pinning guidance.
 - [How Zuke compares](./comparison.md) — a capability matrix against `deno task`,
-  npm scripts, Make, Nx, Turborepo, Dagger, and NUKE, with where each is ahead.
+  npm scripts, Make, Nx, Turborepo, and Dagger, with where each is ahead.

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -187,7 +187,7 @@ deploy = target()
 - **`.always()`** — run even after the build has already failed, for
   cleanup/teardown. It still waits for its own dependencies to complete.
 - **`.onCancel(target | () => target)`** — register a **compensation** that
-  undoes this target when the run is [cancelled](./orchestration.md#cancellation--compensation-oncancel).
+  undoes this target when the run is [cancelled](./orchestration.md#cancellation--compensation--oncancel).
   It runs only if this target **succeeded**; on cancel, compensations run in
   reverse order. The compensation body's `ctx.state` exposes _this_ target's
   persisted metadata (so a rollback reads what the deploy recorded). Use the

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -60,7 +60,7 @@ below) attach to whichever launcher word you install them for.
 | `./zuke runs list [--status/-target/-since/-limit] [--counts] [--json]` | List persisted run records (or `--counts` for a status tally), newest first ([details](./state.md)).        |
 | `./zuke runs show <id> [--json]`                                        | Show one run's full per-target status and metadata.                                                         |
 | `./zuke runs prune [--keep <age>] [--keep-last <n>] [--dry-run]`        | Delete old terminal run records; never touches non-terminal runs.                                           |
-| `./zuke cancel <id> [--actor <name>]`                                   | Cancel a run and run its compensations ([details](./orchestration.md#cancellation--compensation-oncancel)). |
+| `./zuke cancel <id> [--actor <name>]`                                   | Cancel a run and run its compensations ([details](./orchestration.md#cancellation--compensation--oncancel)). |
 | `./zuke register`                                                       | Register this build in the build registry (dynamic pipeline discovery).                                     |
 | `./zuke doc <spec>`                                                     | Print a package's API docs (`deno doc <spec>`) from an isolated empty directory.                            |
 | `./zuke --help` / `-h`                                                  | Usage.                                                                                                      |
@@ -348,7 +348,7 @@ cause is visible; pass `--resume-degraded` to the sweep to let it through.
 ## Cancelling runs
 
 `./zuke cancel <run-id>` cancels a run and runs its
-[compensations](./orchestration.md#cancellation--compensation-oncancel): every
+[compensations](./orchestration.md#cancellation--compensation--oncancel): every
 target that had **succeeded** and declared `.onCancel(...)` is unwound in
 reverse order, then the record settles `cancelled`. `--actor <name>` attributes
 the cancellation in the audit trail. Cancelling a run another process is

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,0 +1,108 @@
+# How Zuke compares
+
+An honest comparison, including where Zuke is the wrong choice. Zuke is a
+young, single-maintainer project (see the maturity note in
+[Versioning & compatibility](./versioning.md)) — it does not have the
+Cloud/plugin ecosystem of the more established tools below, and that's a real
+tradeoff, not marketing copy.
+
+## `deno task` (or `npm`/`package.json` scripts)
+
+**When plain tasks are enough:** your project is a handful of independent
+commands (`lint`, `test`, `build`) with no real dependency graph between them,
+you don't need incremental skipping, and everyone on the team is comfortable
+reading a `deno.json` `tasks` block. Don't reach for a build system to run
+three commands — `deno task` (or the npm-script equivalent) is simpler,
+has zero learning curve, and is already there.
+
+**What typed dependencies, caching, and resume add once tasks stop being
+independent:** a `tasks` block is a flat list of shell strings — it can chain
+commands with `&&`, but it has no concept of *this target depends on that one*,
+so ordering and skip-if-unchanged logic live in your head or in ad hoc shell
+conditionals. Zuke gives you:
+
+- **A real dependency graph.** `dependsOn(this.build)` is a compile-time
+  reference; Zuke topologically sorts and only runs what's reachable.
+- **Incremental skipping and `--affected`.** Declare `.inputs()`/`.outputs()`
+  and Zuke skips a target whose inputs haven't changed, locally or via the
+  [remote cache](./caching.md#remote-build-cache); `--affected=origin/main`
+  narrows a run to what a diff can reach.
+- **Resume and durable state.** A long-running or suspended build
+  (`.waitsFor()`, a crashed CI runner) can be resumed rather than restarted
+  from `deno task`'s stateless, one-shot-per-invocation model.
+
+If you don't need any of that, a `tasks` block is the correct tool.
+
+## Nx / Turborepo
+
+Nx and Turborepo are mature monorepo orchestrators with **affected-graph
+builds and remote caching** as their core value proposition — the same shape
+of feature Zuke's `--affected` and remote cache provide, so there's real
+overlap for a JS/TS monorepo already on one of them.
+
+**Where they're more mature:** Nx Cloud (hosted remote cache and CI
+distribution at scale), a large plugin ecosystem (generators, migrations,
+editor/IDE integration), and years of production hardening across huge
+monorepos. If you're already invested in an Nx or Turbo monorepo and it's
+working, that investment is not a reason to switch.
+
+**Where Zuke differs, not necessarily improves:**
+
+- **No config DSL.** A Nx/Turbo pipeline is JSON (`nx.json`/`turbo.json`)
+  describing task graphs by convention (`dependsOn: ["^build"]`); a Zuke build
+  is a TypeScript class where dependencies are `this.<field>` references, so
+  a typo or a stale rename is a compile error, not a graph that silently
+  drops an edge.
+- **Typed argv end to end.** Zuke's tool wrappers (`DenoTasks`, `DockerTasks`,
+  …) build a real argv array with typed settings; Nx/Turbo mostly shell out to
+  whatever script string you wrote, so the tool's actual flags aren't checked
+  until the command runs.
+- **Deno-native, not JS-tool-specific.** Nx and Turbo are built around a
+  JS/TS package graph (workspaces, `package.json`); Zuke has no notion of a
+  package graph at all — a target is just code, so it fits equally well
+  driving Docker, Terraform, or a Python script as it does a `deno` build.
+  (Zuke even ships [`@zuke/nx`](https://jsr.io/@zuke/nx) and
+  [`@zuke/turbo`](https://jsr.io/@zuke/turbo) wrappers, for calling *into*
+  Nx or Turbo from a Zuke target rather than replacing them.)
+
+**When NOT to use Zuke instead of Nx/Turbo:** a large existing JS/TS monorepo
+with Nx or Turbo already wired to CI, using Nx Cloud/Turbo remote cache at
+scale, and leaning on generators or editor plugins for day-to-day dev — Zuke
+has no equivalent ecosystem today.
+
+## Dagger
+
+Dagger runs your pipeline as a graph of **containerized** steps, portable
+across CI providers because each step is a container with cached layers —
+the pipeline itself becomes a portable, containerized artifact.
+
+**The real difference is the execution model, not the language:** Dagger
+steps run in containers by design, giving you strong isolation and
+byte-for-byte reproducibility (and layer caching) at the cost of container
+startup overhead and a container runtime as a hard dependency. A Zuke target
+runs **in-process** (a `Deno.Command` subprocess when it shells out) — faster
+to iterate on locally, no container runtime required, but you own
+reproducibility yourself (pin your tool versions, don't rely on host state).
+
+**When NOT to use Zuke instead of Dagger:** you need the pipeline itself to be
+portable across CI providers as a single artifact, or you specifically want
+every step sandboxed in its own container — that's Dagger's core design, not
+a Zuke feature.
+
+## NUKE
+
+[NUKE](https://nuke.build/) is Zuke's direct inspiration and closest relative
+in *shape*: a build is a C# class, targets are members, dependencies are
+typed. If you already know NUKE, Zuke will feel immediately familiar.
+
+**The difference is the ecosystem it lives in:** NUKE is .NET — MSBuild-aware,
+NuGet-native, with mature IDE tooling (Rider/Visual Studio) built up over
+years. Zuke is the same idea ported to Deno/TypeScript — Deno-native module
+resolution (`jsr:`/`https:` specifiers, no separate package manager), the
+Deno toolchain for everything (test runner, formatter, linter, coverage), and
+JSR for distribution instead of NuGet.
+
+**When NOT to use Zuke instead of NUKE:** you're building a .NET project.
+Use NUKE — it's the mature, native choice for that ecosystem, and the reason
+this project credits it as [an inspiration](../README.md#acknowledgements)
+rather than a competitor.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -9,13 +9,13 @@ at `1.x` and most tool wrappers still `0.x` (see
 [Versioning & compatibility](./versioning.md) for what each tier promises). The
 package a consumer actually installs is the `@zuke/cli` command, at **0.8.1** —
 pre-1.0, so it makes no compatibility promise yet, and it is the front door to
-the `mcp`, `resume` and `cancel` surface below. Zuke has no hosted service, no
-funded team and no plugin marketplace, and several tools here have all three.
+the `mcp`, `resume` and `cancel` surface below.
 
-**Scope:** tools a JavaScript or TypeScript team would realistically choose.
-[NUKE](https://nuke.build/) is deliberately absent — it needs the .NET SDK — even
-though it is the direct precedent for Zuke's design and is credited as such in
-the [acknowledgements](../README.md#acknowledgements).
+**Scope:** tools a JavaScript or TypeScript team would realistically choose, on
+the capabilities Zuke was built to provide. [NUKE](https://nuke.build/) is
+deliberately absent — it needs the .NET SDK — even though it is the direct
+precedent for Zuke's design and is credited as such in the
+[acknowledgements](../README.md#acknowledgements).
 
 A **—** means the capability was **not found in the official documentation
 reviewed** for this page. That is weaker evidence than a positive finding: the
@@ -23,57 +23,17 @@ docs may simply be silent.
 
 <div style="overflow-x: auto">
 
-| Capability                        | Zuke                                           | `deno task`                    | npm scripts                | GNU Make                    | Nx                                                        | Turborepo                                | Dagger                            |
-| --------------------------------- | ---------------------------------------------- | ------------------------------ | -------------------------- | --------------------------- | --------------------------------------------------------- | ---------------------------------------- | --------------------------------- |
-| Dependency wiring                 | typed `this.field` references                  | JSON array of task names       | none (`pre`/`post` naming) | Makefile prerequisites      | JSON `dependsOn` + inferred graph                         | JSON `dependsOn`                         | inferred from code data flow      |
-| Bad reference caught              | compile error, then pre-flight scan            | CLI name yes; in-array unknown | only for a directly-run script | yes, before any recipe  | when the task graph is built                              | yes, before the run starts               | compile error in the host language |
-| Authoring language                | TypeScript, no DSL                             | JSON + shell subset            | JSON + shell strings       | Makefile DSL                | JSON + TypeScript executors                               | JSON + `package.json` scripts            | Go/Python/TypeScript/… code       |
-| Typed wrappers for tool flags     | 50+ `*Tasks` packages                          | no                             | no                         | no                          | executor options, JSON-schema                             | no                                       | no (plain `withExec` argv)        |
-| Command construction              | argv arrays end to end, no shell               | built-in shell subset          | OS shell strings           | shell per recipe line       | per-executor, no stated contract                          | `package.json` shell strings             | argv arrays                       |
-| Skip unchanged work               | hashes declared `.inputs()`/`.cacheKey()` only | opt-in `files` globs (2.9)     | no                         | file timestamps             | content hashing (files, config, command)                  | content hashing (files, config, command) | BuildKit operation cache          |
-| Narrow a run to changed files     | `--affected=<ref>`, declaration-driven         | no                             | no                         | n/a (timestamps, not diffs) | `nx affected`, import-inferred                            | `turbo run --affected`, import-inferred  | no such concept                   |
-| Cross-machine cache               | built in; needs `.inputs()` + `.outputs()`     | local only                     | no                         | no                          | Nx Cloud (hosted, free tier); own server via OpenAPI spec | in the CLI; free hosted; self-host       | Dagger Cloud (paid)               |
-| Suspend and resume a run          | `.waitsFor()` + `zuke resume`                  | —                              | —                          | —                           | —                                                         | —                                        | —                                 |
-| Cancellation with compensations   | `.onCancel()`, reverse order                   | —                              | —                          | —                           | —                                                         | —                                        | cancel visible in traces only     |
-| Long-lived process dependencies   | `service()`                                    | —                              | —                          | —                           | `continuous: true`                                        | `persistent` + `with`                    | —                                 |
-| MCP server for agents             | built in (`zuke mcp`)                          | —                              | —                          | —                           | official `nx-mcp`                                         | proposed, not shipped                    | modules exposed as MCP servers    |
-| Machine-readable self-description | `--list --json`, generated `llms.txt`          | —                              | `npm pkg get scripts`      | —                           | workspace/graph tools over MCP                            | —                                        | typed API + MCP                   |
-| Runtime it needs                  | Deno                                           | Deno                           | Node                       | system binary + shell       | Node + `@nx/*` plugins                                    | native binary via npm                    | CLI + engine container            |
-| Backing                           | single maintainer; core `1.32`, cli `0.8.1`    | Deno Land Inc.                 | npm/GitHub, since ~2010    | GNU, 35+ years              | Nrwl, 29.1k stars, Nx Cloud                               | Vercel, 30.8k stars, MIT                 | funded startup, 16.1k stars       |
+| Capability                        | Zuke                                        | `deno task`                    | npm scripts                    | GNU Make                | Nx                                | Turborepo                     | Dagger                             |
+| --------------------------------- | ------------------------------------------- | ------------------------------ | ------------------------------ | ----------------------- | --------------------------------- | ----------------------------- | ---------------------------------- |
+| Dependency wiring                 | typed `this.field` references               | JSON array of task names       | none (`pre`/`post` naming)     | Makefile prerequisites  | JSON `dependsOn` + inferred graph | JSON `dependsOn`              | inferred from code data flow       |
+| Bad reference caught              | compile error, then pre-flight scan         | CLI name yes; in-array unknown | only for a directly-run script | yes, before any recipe  | when the task graph is built      | yes, before the run starts    | compile error in the host language |
+| Authoring language                | TypeScript, no DSL                          | JSON + shell subset            | JSON + shell strings           | Makefile DSL            | JSON + TypeScript executors       | JSON + `package.json` scripts | Go/Python/TypeScript/… code        |
+| Typed wrappers for tool flags     | 50+ `*Tasks` packages                       | no                             | no                             | no                      | executor options, JSON-schema     | no                            | no (plain `withExec` argv)         |
+| Command construction              | argv arrays end to end, no shell            | built-in shell subset          | OS shell strings               | shell per recipe line   | per-executor, no stated contract  | `package.json` shell strings  | argv arrays                        |
+| Suspend and resume a run          | `.waitsFor()` + `zuke resume`               | —                              | —                              | —                       | —                                 | —                             | —                                  |
+| Cancellation with compensations   | `.onCancel()`, reverse order                | —                              | —                              | —                       | —                                 | —                             | cancel visible in traces only      |
+| Long-lived process dependencies   | `service()`                                 | —                              | —                              | —                       | `continuous: true`                | `persistent` + `with`         | —                                  |
+| MCP server for agents             | built in (`zuke mcp`)                       | —                              | —                              | —                       | official `nx-mcp`                 | proposed, not shipped         | modules exposed as MCP servers     |
+| Machine-readable self-description | `--list --json`, generated `llms.txt`       | —                              | `npm pkg get scripts`          | —                       | workspace/graph tools over MCP    | —                             | typed API + MCP                    |
 
 </div>
-
-**Where Zuke does not win.** The two caching rows and the affected row are
-qualified rather than won: Zuke's versions are declaration-driven, so they do
-only as much as the target author declared, where Nx's and Turborepo's are
-derived from the source graph. The cache does not notice an edited target body
-unless a `.cacheKey()` says so, the cross-machine cache needs both `.inputs()`
-and `.outputs()` and falls back quietly when the store is unreachable, and
-exactly-once resume spans a single host unless you operate the
-[HTTP state store](./state.md). Hosted caching, ecosystem and backing are losses,
-not ties.
-
----
-
-**Checked** against official documentation and public repositories on
-**2026-07-28**, at `@zuke/core` 1.32 and `@zuke/cli` 0.8.1. Version-specific
-facts as of that date: `deno task` file-fingerprint caching from **Deno 2.9**; Nx
-continuous tasks from **Nx 21**, with `nx-mcp` shipped; Turborepo remote caching
-in the OSS CLI with no MCP server; Dagger Cloud as the paid tier for
-cross-machine caching. Star counts: `nrwl/nx` 29.1k, `vercel/turborepo` 30.8k,
-`dagger/dagger` 16.1k.
-
-One row is worth citing precisely, because an earlier draft of this page got it
-wrong: **Nx self-hosted caching is not a paid feature.** The deprecation notice
-for `@nx/s3-cache` and its siblings
-([nx.dev](https://nx.dev/docs/reference/deprecated/self-hosted-cache-packages))
-gives the reason as the CREEP vulnerability
-([CVE-2025-36852](https://www.cve.org/CVERecord?id=CVE-2025-36852)), not
-licensing, and the documented path for on-premises storage is to implement the
-Nx remote cache OpenAPI specification
-([nx.dev](https://nx.dev/docs/kb/self-hosted-caching)), where "Implementation is
-up to you" and no subscription is required. Zuke's differentiator on that row is
-that its cache is built into the build system with no separate service to adopt —
-not price.
-
-All of these move. Re-check before relying on a row.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -37,3 +37,5 @@ docs may simply be silent.
 | Machine-readable self-description | `--list --json`, generated `llms.txt`       | —                              | `npm pkg get scripts`          | —                       | workspace/graph tools over MCP    | —                             | typed API + MCP                    |
 
 </div>
+
+Checked against official documentation on 2026-07-28.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -2,390 +2,78 @@
 
 Zuke exists for the build that has outgrown a list of commands: a real
 dependency graph, typed inputs, external tools driven through checked argv, and
-pipelines that have to survive waiting for something outside the build. It is
-also a **young, single-maintainer project** — 55 JSR packages, `@zuke/core` at
-`1.x` and most tool wrappers still `0.x` (see
+pipelines that have to survive waiting for something outside the build.
+
+It is also a **young, single-maintainer project** — 55 JSR packages, `@zuke/core`
+at `1.x` and most tool wrappers still `0.x` (see
 [Versioning & compatibility](./versioning.md) for what each tier promises). The
-package a consumer actually installs is the `@zuke/cli` command, and it is at
-**0.8.1** — pre-1.0, so it makes no compatibility promise yet, and it is the
-front door to the `mcp`, `resume` and `cancel` surface this page showcases. Zuke
-has no hosted service, no funded team, and no plugin marketplace, and several
-tools below have all three. This page compares **functionality**, axis by axis,
-and says where each of them is ahead.
+package a consumer actually installs is the `@zuke/cli` command, at **0.8.1** —
+pre-1.0, so it makes no compatibility promise yet, and it is the front door to
+the `mcp`, `resume` and `cancel` surface below. Zuke has no hosted service, no
+funded team and no plugin marketplace, and several tools here have all three.
 
-## The capability matrix
-
-Rows are capabilities; columns are the tools. Cells are deliberately terse — the
-nuance is in the prose under each tool.
+**Scope:** tools a JavaScript or TypeScript team would realistically choose.
+[NUKE](https://nuke.build/) is deliberately absent — it needs the .NET SDK — even
+though it is the direct precedent for Zuke's design and is credited as such in
+the [acknowledgements](../README.md#acknowledgements).
 
 A **—** means the capability was **not found in the official documentation
 reviewed** for this page. That is weaker evidence than a positive finding: the
-docs may simply be silent. Where a claim could not be pinned down at all it is
-marked *unknown* rather than absent.
+docs may simply be silent.
 
 <div style="overflow-x: auto">
 
-| Capability                       | Zuke                                | `deno task`                    | npm scripts                    | GNU Make                    | Nx                                 | Turborepo                          | Dagger                            | NUKE                              |
-| -------------------------------- | ----------------------------------- | ------------------------------ | ------------------------------ | --------------------------- | ---------------------------------- | ---------------------------------- | --------------------------------- | --------------------------------- |
-| Dependency wiring                | typed `this.field` references       | JSON array of task names       | none (`pre`/`post` naming)     | Makefile prerequisites      | JSON `dependsOn` + inferred graph  | JSON `dependsOn`                   | inferred from code data flow      | typed C# `.DependsOn`             |
-| Bad reference caught             | compile error, then pre-flight scan | CLI name yes; in-array unknown | only for a directly-run script | yes, before any recipe      | when the task graph is built       | yes, before the run starts         | compile error in the host language | compile error                     |
-| Authoring language               | TypeScript, no DSL                  | JSON + shell subset            | JSON + shell strings           | Makefile DSL                | JSON + TypeScript executors        | JSON + `package.json` scripts      | Go/Python/TypeScript/… code       | C#                                |
-| Typed wrappers for tool flags    | 50+ `*Tasks` packages               | no                             | no                             | no                          | executor options, JSON-schema      | no                                 | no (plain `withExec` argv)        | generated C# wrappers             |
-| Command construction             | argv arrays end to end, no shell    | built-in shell subset          | OS shell strings               | shell per recipe line       | per-executor, no stated contract   | `package.json` shell strings       | argv arrays                       | argv via wrappers; shell also     |
-| Skip unchanged work              | hashes declared `.inputs()`/`.cacheKey()` only | opt-in `files` globs (2.9) | no                          | file timestamps             | content hashing (files, config, command) | content hashing (files, config, command) | BuildKit operation cache    | unknown                           |
-| Narrow a run to changed files    | `--affected=<ref>`, declaration-driven | no                          | no                             | n/a (timestamps, not diffs) | `nx affected`, import-inferred     | `turbo run --affected`, import-inferred | no such concept              | —                                 |
-| Cross-machine cache              | built in; needs `.inputs()` + `.outputs()` | local only              | no                             | no                          | Nx Cloud (hosted, free tier); own server via OpenAPI spec | in the CLI; free hosted; self-host | Dagger Cloud (paid)      | not native                        |
-| Suspend and resume a run         | `.waitsFor()` + `zuke resume`       | —                              | —                              | —                           | —                                  | —                                  | —                                 | —                                 |
-| Cancellation with compensations  | `.onCancel()`, reverse order        | —                              | —                              | —                           | —                                  | —                                  | cancel visible in traces only     | —                                 |
-| Long-lived process dependencies  | `service()`                         | —                              | —                              | —                           | `continuous: true`                 | `persistent` + `with`              | —                                 | —                                 |
-| MCP server for agents            | built in (`zuke mcp`)               | —                              | —                              | —                           | official `nx-mcp`                  | proposed, not shipped              | modules exposed as MCP servers    | —                                 |
-| Machine-readable self-description | `--list --json`, generated `llms.txt` | —                            | `npm pkg get scripts`          | —                           | workspace/graph tools over MCP     | —                                  | typed API + MCP                   | `--help` target listing           |
-| Runtime it needs                 | Deno                                | Deno                           | Node                           | system binary + shell       | Node + `@nx/*` plugins             | native binary via npm              | CLI + engine container            | .NET SDK                          |
-| Backing                          | single maintainer; core `1.32`, cli `0.8.1` | Deno Land Inc.                 | npm/GitHub, since ~2010        | GNU, 35+ years              | Nrwl, 29.1k stars, Nx Cloud        | Vercel, 30.8k stars, MIT           | funded startup, 16.1k stars       | since ~2017, 3.7k stars           |
+| Capability                        | Zuke                                           | `deno task`                    | npm scripts                | GNU Make                    | Nx                                                        | Turborepo                                | Dagger                            |
+| --------------------------------- | ---------------------------------------------- | ------------------------------ | -------------------------- | --------------------------- | --------------------------------------------------------- | ---------------------------------------- | --------------------------------- |
+| Dependency wiring                 | typed `this.field` references                  | JSON array of task names       | none (`pre`/`post` naming) | Makefile prerequisites      | JSON `dependsOn` + inferred graph                         | JSON `dependsOn`                         | inferred from code data flow      |
+| Bad reference caught              | compile error, then pre-flight scan            | CLI name yes; in-array unknown | only for a directly-run script | yes, before any recipe  | when the task graph is built                              | yes, before the run starts               | compile error in the host language |
+| Authoring language                | TypeScript, no DSL                             | JSON + shell subset            | JSON + shell strings       | Makefile DSL                | JSON + TypeScript executors                               | JSON + `package.json` scripts            | Go/Python/TypeScript/… code       |
+| Typed wrappers for tool flags     | 50+ `*Tasks` packages                          | no                             | no                         | no                          | executor options, JSON-schema                             | no                                       | no (plain `withExec` argv)        |
+| Command construction              | argv arrays end to end, no shell               | built-in shell subset          | OS shell strings           | shell per recipe line       | per-executor, no stated contract                          | `package.json` shell strings             | argv arrays                       |
+| Skip unchanged work               | hashes declared `.inputs()`/`.cacheKey()` only | opt-in `files` globs (2.9)     | no                         | file timestamps             | content hashing (files, config, command)                  | content hashing (files, config, command) | BuildKit operation cache          |
+| Narrow a run to changed files     | `--affected=<ref>`, declaration-driven         | no                             | no                         | n/a (timestamps, not diffs) | `nx affected`, import-inferred                            | `turbo run --affected`, import-inferred  | no such concept                   |
+| Cross-machine cache               | built in; needs `.inputs()` + `.outputs()`     | local only                     | no                         | no                          | Nx Cloud (hosted, free tier); own server via OpenAPI spec | in the CLI; free hosted; self-host       | Dagger Cloud (paid)               |
+| Suspend and resume a run          | `.waitsFor()` + `zuke resume`                  | —                              | —                          | —                           | —                                                         | —                                        | —                                 |
+| Cancellation with compensations   | `.onCancel()`, reverse order                   | —                              | —                          | —                           | —                                                         | —                                        | cancel visible in traces only     |
+| Long-lived process dependencies   | `service()`                                    | —                              | —                          | —                           | `continuous: true`                                        | `persistent` + `with`                    | —                                 |
+| MCP server for agents             | built in (`zuke mcp`)                          | —                              | —                          | —                           | official `nx-mcp`                                         | proposed, not shipped                    | modules exposed as MCP servers    |
+| Machine-readable self-description | `--list --json`, generated `llms.txt`          | —                              | `npm pkg get scripts`      | —                           | workspace/graph tools over MCP                            | —                                        | typed API + MCP                   |
+| Runtime it needs                  | Deno                                           | Deno                           | Node                       | system binary + shell       | Node + `@nx/*` plugins                                    | native binary via npm                    | CLI + engine container            |
+| Backing                           | single maintainer; core `1.32`, cli `0.8.1`    | Deno Land Inc.                 | npm/GitHub, since ~2010    | GNU, 35+ years              | Nrwl, 29.1k stars, Nx Cloud                               | Vercel, 30.8k stars, MIT                 | funded startup, 16.1k stars       |
 
 </div>
 
-The rows Zuke was built to win are the first five and the three orchestration
-ones. The two caching rows and the affected row are qualified rather than won:
-Zuke's versions are **declaration-driven**, so they do only as much as the target
-author told them to, where Nx's and Turborepo's are derived from the source. The
-rows where it ties or loses — hosted caching, ecosystem, backing — are in the
-table for the same reason: a comparison that concedes nothing is not worth
-reading.
-
-## `deno task`, npm scripts, and GNU Make
-
-**Where Zuke differs most: a dependency is a reference, not a name.** In a
-`deno.json` task the dependency is a string in a `dependencies` array; in npm
-scripts there is no dependency field at all, only the `pre<name>`/`post<name>`
-convention matched by string at run time — so a misspelled `pretest` is silently
-never invoked, with no error anywhere. In a Zuke build the dependency is the
-sibling field itself:
-
-<!-- check -->
-
-```ts
-import { Build, run, target } from "jsr:@zuke/core";
-import { DenoTasks } from "jsr:@zuke/deno";
-
-class CI extends Build {
-  lint = target().executes(() => DenoTasks.lint());
-
-  test = target()
-    .dependsOn(this.lint)
-    .inputs("packages", "deno.json")
-    .executes(() => DenoTasks.test((s) => s.allowAll()));
-}
-
-await run(CI);
-```
-
-`this.lint` is checked by `deno check` before the build ever runs, so a rename
-moves every reference with it and a typo is a type error. On top of that, Zuke
-validates the whole graph up front — unknown references, forward references to a
-field declared lower in the class, and cycles are reported with the offending
-target named, before any body executes. Make is the honourable exception among
-the three: it resolves the entire prerequisite graph before running a single
-recipe and stops with `No rule to make target X, needed by Y`. For `deno task`,
-a cycle is rejected before execution, but whether a misspelled name *inside* a
-`dependencies` array is caught before the run starts is not stated in Deno's
-docs — treat it as unknown.
-
-The second difference is how a command is built. All three of these write shell
-strings: npm scripts hand the string to `/bin/sh` (or `cmd.exe` on Windows, with
-the dialect differences that implies), Make hands each recipe line to `$(SHELL)`
-in a fresh sub-shell, and `deno task` parses the string with Deno's own
-cross-platform subset of `sh` — the same behaviour on every OS, which is a real
-improvement, but still shell syntax written by hand. Zuke's
-[tool wrappers](./tools.md) and [`$`](./shell.md) keep arguments a discrete array
-from the settings lambda to `Deno.Command`, and interpolated values become single
-argv entries rather than text spliced into a command line. Be precise about what
-that buys: no shell ever parses the command, so there is **no shell-injection
-surface** — a value containing `; rm -rf /` is passed through as one literal
-argument. It does not make an interpolated value safe in general. A value
-beginning with `-` still arrives as a **flag the invoked tool honours**, which is
-argument injection, and validating that remains the caller's job — the same job
-Zuke does for itself where it accepts one, as when `--affected` rejects a base
-revision starting with `-` because git would read it as an option. Neither
-`deno task`,
-npm, nor Make documents a typed surface for a tool's flags; Zuke ships one per
-tool, so `--allow-all` and `--coverage` are methods that either exist or fail to
-compile.
-
-**Where they are ahead of Zuke.** `deno task` is already installed with Deno and
-costs nothing to learn, and since Deno 2.9 it has genuine opt-in incremental
-caching: declare a `files` glob and Deno fingerprints the command, the matched
-file contents, listed env values, dependency fingerprints and the host
-OS/arch/Deno version, restoring declared `output` on a hit. That covers the
-common "don't rebuild if nothing changed" case without a build system at all
-(local only — there is no shared cache). npm scripts need no learning curve for
-anyone already in the JS ecosystem and are backstopped by a large third-party
-layer (`npm-run-all`, `concurrently`, and Nx or Turborepo above them). Make is
-35+ years old, present on virtually every Unix box, and its timestamp-driven
-rebuild model is its native purpose rather than a bolt-on. None of the three
-documents cross-process suspend/resume, cancellation compensations, or an MCP
-server — but for a project that needs none of those, "already installed" is a
-strong argument.
-
-## Nx and Turborepo
-
-**Where Zuke differs most: there is no config file describing the pipeline.**
-Nx declares wiring in JSON — `nx.json` for workspace-wide `targetDefaults`,
-`project.json` (or an `nx` key in `package.json`) per project — with conventions
-like `^build` meaning "this target in upstream dependencies first", and infers
-project-to-project edges from source imports. Turborepo puts everything in
-`turbo.json`, where a task is the *name* of a script that already exists in some
-`package.json`; `turbo.json` declares scheduling and caching metadata around
-that name and never touches the command. In Zuke the pipeline is the program:
-dependencies are field references checked by the compiler, and the body is a
-typed call rather than a script name resolved later.
-
-That difference shows up in three places worth stating precisely:
-
-- **When a bad reference is caught.** Both tools do catch one. Turborepo fails
-  the whole run up front — `error preparing engine: Could not find the following
-  tasks in project: [...]` — before any task executes, which is genuinely
-  fail-fast. Nx raises `Cannot find configuration for task <project>:<target>`
-  while constructing the task graph, and reports `task graph has a circular
-  dependency` on a cycle; that happens before the task's process is spawned, but
-  neither tool documents a static, type-level check of the reference, and
-  Turborepo's task body is an arbitrary shell string in `package.json` that
-  nothing checks at all. Zuke's equivalent errors are `deno check` failures in
-  your editor.
-- **What runs the tool.** Nx executors take an options object validated against
-  each executor's `schema.json` at run time, and expose structured options
-  (`tsConfig`, `outputPath`) rather than a raw command — real validation, but of
-  configuration, not of a CLI's flags at compile time. How a given executor
-  invokes its underlying tool is that plugin's implementation detail; Nx's docs
-  state no tool-wide argv-versus-shell contract, so there is nothing to compare
-  against Zuke's argv guarantee either way. Turborepo makes no claim here: the
-  command is the shell string you wrote.
-- **What happens when a pipeline has to wait.** Nx has continuous tasks
-  (`continuous: true`, Nx 21+) and a documented recipe for starting a dependent
-  once a long-running dependency prints output; Turborepo has `persistent` tasks,
-  a `with` key to co-start them, and `turbo watch`. Both are same-invocation
-  orchestration. Neither documents suspending a run to durable state and resuming
-  it in a later process, nor cancellation that runs compensating actions. Zuke's
-  [waits and resume](./orchestration.md) suspend the run to a state store, exit
-  0, and resume — days later, in another process — with a compare-and-swap so
-  concurrent resumers race and all but one get `AlreadyResumedError`. How far
-  that guarantee reaches depends on the store: the default
-  [`FileSystemStateStore`](./state.md#backends) is an atomic
-  write-temp-then-rename guarded by an `O_EXCL` lock file, which makes it
-  exactly-once **between processes on one host** — for exactly-once across
-  machines you run the `HttpStateStore` service yourself, where ETags carry the
-  compare-and-swap. Cancellation is
-  [`.onCancel()`](./orchestration.md#cancellation--compensation--oncancel), which
-  unwinds succeeded targets in reverse order.
-
-**Where they are ahead of Zuke.** Considerably, on several axes:
-
-- **Hosted caching and distribution.** Nx Cloud is a real hosted remote cache
-  and distributed-execution product with a free tier; Vercel's Remote Cache is
-  free on all plans, including for repos not deployed to Vercel, and Turborepo's
-  remote caching is a capability of the open-source CLI itself. Neither charges
-  for self-hosting either: Nx deprecated its four pre-built cache adapters
-  (`@nx/s3-cache` and siblings) over the CREEP vulnerability
-  ([CVE-2025-36852](https://www.cve.org/CVERecord?id=CVE-2025-36852)), a design
-  flaw it says cannot be patched — not to move self-hosting behind a paywall —
-  and its documented replacement is to implement the published **Nx remote cache
-  OpenAPI specification** yourself, which costs nothing but hands you the whole
-  threat model. So the difference here is not price. It is that Zuke's
-  [remote cache](./caching.md#remote-build-cache) is **built into the build
-  system** — an `HttpCacheStore` or a directory, chosen in typed code or by
-  `ZUKE_REMOTE_CACHE_*`, with no separate product to adopt and no adapter to
-  write — while Nx's answer is either a service you sign up for or a server you
-  implement. Two qualifiers on Zuke's, though: it applies only to targets that
-  declare **both `.inputs()` and `.outputs()`** — the inputs give the key, the
-  outputs are what gets archived — so it does nothing for a target missing either;
-  and like every Zuke cache it is **best-effort**, so an unreachable store logs a
-  warning and the build silently falls back to building locally rather than
-  failing. What Zuke does not have is a zero-setup option or an operated service
-  behind it.
-- **What the cache hash covers — and the trap that follows.** Nx and
-  Turborepo hash a task's project files, its configuration and the command
-  itself, so changing any of them is a miss. Zuke's fingerprint is narrower by
-  design: it is the declared `.inputs()` plus any `.cacheKey()` values, and
-  nothing else (see [Caching](./caching.md#what-unchanged-means)). Two
-  consequences follow, and both are worth stating plainly. A target that declares
-  neither inputs nor a
-  cache key is **never cached** and always runs. And for one that does, editing
-  the **target's own body**, or `zuke.ts` itself, does **not** invalidate a hit —
-  Zuke will happily report `cached` for code you just changed unless you folded
-  something that moves into a `.cacheKey()`. Nx and Turborepo do not have that
-  hazard, because the command and config are in the hash. The upside of the narrow
-  fingerprint is that it is explicit and deterministic across machines; the cost
-  is that correctness is the author's to declare.
-- **Affected-graph maturity, and a different kind of affected.** Both tools'
-  hashing and affected computations are proven across very large monorepos; Nx's
-  enterprise page claims Nx Enterprise is trusted by 70%+ of the Fortune 500.
-  Zuke's `--affected` is not the same shape of feature: Nx and Turborepo derive
-  the graph from **source imports**, so a change is traced to the projects that
-  actually depend on the file without anyone declaring it. Zuke prunes purely on
-  hand-declared `.inputs()`, and a target declaring none cannot be proven
-  unaffected, so it always runs (see
-  [`--affected`](./cli.md#affected-targets)) — on a build that declares no inputs
-  anywhere, `--affected` prunes nothing at all. That is a real difference, and on
-  this axis it is not in Zuke's favour: you get exactly the pruning you wrote
-  down.
-- **Agent integration is not a Zuke exclusive.** Nx ships an official, documented
-  MCP server (`nx-mcp`) with tools for docs, workspace graph visualisation,
-  project details, generator schemas, and CI data pulled from Nx Cloud, bundled
-  with the Nx Console editor extension. It is shipped, not planned. Zuke's
-  [`zuke mcp`](./mcp.md) exposes your build's own targets and graph as typed
-  tools over stdio or streamable HTTP with no extra service, which is a different
-  surface — not a larger one. Turborepo is the one gap here: an MCP server for it
-  is an open discussion on its repo, not a feature.
-- **Ecosystem and delivery.** Nx has polyglot plugins, code-mod generators, and
-  editor integration built over years; Turborepo ships a precompiled Rust binary
-  through platform-specific optional npm dependencies, so installing it pulls a
-  native binary rather than a dependency tree.
-
-Zuke is not trying to replace either inside a monorepo that is happy: it ships
-[`@zuke/nx`](https://jsr.io/@zuke/nx) and
-[`@zuke/turbo`](https://jsr.io/@zuke/turbo) wrappers for calling *into* them from
-a target.
-
-## Dagger
-
-**Where Zuke differs most: the execution model, and what the graph is made of.**
-A Dagger pipeline is a set of functions in a real language (Go, Python,
-TypeScript, PHP, Java, .NET, Elixir, Rust) that execute as containers inside a
-BuildKit-based engine; ordering is *inferred* from data flow between function and
-container operations rather than declared, and cross-module dependencies are
-installed with `dagger install` into `dagger.json`. A Zuke target declares its
-dependencies explicitly and runs in-process — a `Deno.Command` subprocess when it
-shells out — with no container runtime involved.
-
-On the axes this page compares, the two are closer than the rest of the field.
-Dagger's generated bindings mean a call to a function that does not exist is a
-compile error in the host language, exactly like `this.lint`; and its
-`Container.withExec(args)` takes a plain argv array, with the docs explicitly
-warning that `["sh","-c","…"]` reintroduces shell interpretation and injection.
-Zuke and Dagger are level here, and it is worth being exact about that rather
-than claiming an edge: both keep the command an argv array so no shell parses it,
-and neither validates argument injection for you — a value beginning with `-`
-reaches the invoked tool as a flag in either system. Two real differences remain. First, Dagger has no per-tool typed flag surface:
-you write the argv yourself, and the modules in its public registry that wrap
-specific tools are user-contributed rather than a built-in guarantee — where Zuke
-ships a maintained wrapper per tool whose settings mirror the actual CLI flags.
-Second, nothing in Dagger's documentation describes checkpointing a run to
-durable state and resuming it in a later process, waiting on an arbitrary
-external event mid-pipeline, or running compensating actions on cancel;
-cancellation appears in Dagger Cloud's trace UI as a state, not as a rollback
-mechanism. Dagger also has no affected-projects selection at all — its caching
-works at the level of individual container and filesystem operations.
-
-**Where it is ahead of Zuke.** Dagger's container-per-step model gives every step
-a hermetic environment, so "works on my machine" and "works in CI" are the same
-run — Zuke has no isolation story and leaves reproducibility to you (pin your
-tools, don't rely on host state). Its BuildKit engine caches operations
-automatically rather than only where you declared `.inputs()`. It has eight
-first-class SDKs to Zuke's one language, a public module registry for reusing
-other people's pipeline logic, genuine LLM support (an `LLM` type that
-auto-discovers Dagger Functions as callable tools, plus `LLM.withMCPServer` for
-attaching external servers), and a funded company with a hosted product behind
-it. The cost is a container runtime as a hard dependency and container startup on
-every step; the benefit is isolation Zuke does not attempt.
-
-## NUKE
-
-[NUKE](https://github.com/nuke-build/nuke) is the direct precedent for Zuke's
-design and gets credited as such in the
-[acknowledgements](../README.md#acknowledgements): a build is a class, targets are
-strongly-typed members, `DependsOn` takes a real member so a typo does not
-compile, and external CLIs are driven through generated typed wrappers rather
-than hand-written strings. Anyone who knows NUKE already knows Zuke's model.
-
-**Where Zuke differs most: the ecosystem it runs in, and what the graph does
-after it is built.** NUKE is .NET — installed as a tool from NuGet, needing the
-.NET SDK, at home next to MSBuild and Rider. Zuke is the same architecture
-targeting Deno: `jsr:`/`https:` specifiers with no separate package manager, the
-`deno` CLI for test/format/lint/coverage, JSR for distribution. Beyond the
-runtime, the difference is in the capabilities layered on top of the graph. Zuke
-has an [incremental cache](./caching.md), a
-[remote cache](./caching.md#remote-build-cache), and
-[`--affected`](./cli.md#affected-targets), along with suspend/resume,
-cancellation compensations, and an MCP server, none of which turned up in NUKE's
-available documentation. Treat that as weak evidence rather than a gap, for one
-specific reason: NUKE's request for target input/output specifications
-([issue 209](https://github.com/nuke-build/nuke/issues/209), opened 2018) was
-**closed as completed on 2019-11-19**, and with `nuke.build` unreachable during
-this check there was no way to establish what shipped from it or what the
-incremental-skip position is today. So this page does not claim NUKE lacks
-target-level incremental skip — the row is `unknown`. Check NUKE's own docs
-before assuming either way.
-
-**Where it is ahead of Zuke.** Years, and everything years buy: a component
-plugin ecosystem for shareable build logic, CI generation across multiple
-providers with community conventions behind it, JetBrains-adjacent visibility,
-and roughly 3.7k stars' worth of accumulated real-world usage in the .NET world.
-It proves this architecture at a scale Zuke has not reached. Note that NUKE's own
-documentation site did not resolve during the research behind this page, so its
-entries here are corroborated from its GitHub repository and issues rather than
-`nuke.build` directly — check its docs before treating any NUKE line above as
-current.
-
-## Choose something else when…
-
-- **Your build is a handful of independent commands.** `lint`, `test`, `build`,
-  no real graph between them, and nobody minds a `deno.json` `tasks` block —
-  use `deno task`. Its 2.9 opt-in `files` caching even covers simple
-  skip-if-unchanged. Do not adopt a build system to run three commands.
-- **You have a large JS/TS monorepo already on Nx or Turborepo, with hosted
-  caching working.** The overlap with Zuke is real but partial, and you would be
-  trading a proven affected-graph, a zero-setup remote cache, generators and
-  editor integration for a self-hosted cache and a younger tool. Stay, and call
-  into your existing setup from Zuke only if you want the typed layer.
-- **You need every step hermetic and portable across CI providers.** That is
-  Dagger's core design — containerised steps, an engine you can run anywhere,
-  operation-level caching — and Zuke does not attempt it.
-- **Your pipeline is polyglot beyond TypeScript, or the team is not on Deno.**
-  Dagger has eight SDKs; Zuke has one language and a Deno runtime requirement.
-- **You are building .NET.** Use NUKE. It is the mature, native choice for that
-  ecosystem, has the same model Zuke borrowed, and its plugin and CI-generation
-  ecosystem is years ahead.
-- **Your build really is file-to-file transformations on a Unix box.** Make has
-  done exactly that correctly since before most of this list existed.
-- **You need vendor support, a funded roadmap, or a hosted cache you don't
-  operate.** Zuke has one maintainer and no service. That is the honest ceiling,
-  and [Versioning & compatibility](./versioning.md) explains the stability
-  promise each package makes within it.
+**Where Zuke does not win.** The two caching rows and the affected row are
+qualified rather than won: Zuke's versions are declaration-driven, so they do
+only as much as the target author declared, where Nx's and Turborepo's are
+derived from the source graph. The cache does not notice an edited target body
+unless a `.cacheKey()` says so, the cross-machine cache needs both `.inputs()`
+and `.outputs()` and falls back quietly when the store is unreachable, and
+exactly-once resume spans a single host unless you operate the
+[HTTP state store](./state.md). Hosted caching, ecosystem and backing are losses,
+not ties.
 
 ---
 
-**Checked:** competitor claims on this page were verified against official
-documentation and public repositories on **2026-07-28**, against `@zuke/core`
-1.32 and `@zuke/cli` 0.8.1. Version-specific facts as of that date: `deno task`
-file-fingerprint caching from **Deno 2.9**; Nx continuous tasks from **Nx 21**,
-with `nx-mcp` shipped; Turborepo remote caching in the OSS CLI with no MCP
-server; Dagger Cloud as the paid tier for cross-machine caching.
+**Checked** against official documentation and public repositories on
+**2026-07-28**, at `@zuke/core` 1.32 and `@zuke/cli` 0.8.1. Version-specific
+facts as of that date: `deno task` file-fingerprint caching from **Deno 2.9**; Nx
+continuous tasks from **Nx 21**, with `nx-mcp` shipped; Turborepo remote caching
+in the OSS CLI with no MCP server; Dagger Cloud as the paid tier for
+cross-machine caching. Star counts: `nrwl/nx` 29.1k, `vercel/turborepo` 30.8k,
+`dagger/dagger` 16.1k.
 
-Two rows were corrected against their primary sources on that date and are worth
-citing precisely:
+One row is worth citing precisely, because an earlier draft of this page got it
+wrong: **Nx self-hosted caching is not a paid feature.** The deprecation notice
+for `@nx/s3-cache` and its siblings
+([nx.dev](https://nx.dev/docs/reference/deprecated/self-hosted-cache-packages))
+gives the reason as the CREEP vulnerability
+([CVE-2025-36852](https://www.cve.org/CVERecord?id=CVE-2025-36852)), not
+licensing, and the documented path for on-premises storage is to implement the
+Nx remote cache OpenAPI specification
+([nx.dev](https://nx.dev/docs/kb/self-hosted-caching)), where "Implementation is
+up to you" and no subscription is required. Zuke's differentiator on that row is
+that its cache is built into the build system with no separate service to adopt —
+not price.
 
-- **Nx self-hosted caching is not a paid feature.** Nx's deprecation notice for
-  `@nx/s3-cache`, `@nx/gcs-cache`, `@nx/azure-cache` and `@nx/shared-fs-cache`
-  ([nx.dev/docs/reference/deprecated/self-hosted-cache-packages](https://nx.dev/docs/reference/deprecated/self-hosted-cache-packages),
-  deprecated 2026-05-21) gives the reason as the CREEP vulnerability
-  ([CVE-2025-36852](https://www.cve.org/CVERecord?id=CVE-2025-36852)) — "The flaw
-  is in their design and cannot be patched" — and its documented path for
-  on-premises storage is to implement the Nx remote cache OpenAPI specification
-  ([nx.dev/docs/kb/self-hosted-caching](https://nx.dev/docs/kb/self-hosted-caching)),
-  where "Implementation is up to you" and no licence or subscription is required.
-  Nx Cloud has a free tier. An earlier draft of this page described self-hosting
-  as paid; it is not.
-- **NUKE issue 209 is closed.**
-  [nuke-build/nuke#209](https://github.com/nuke-build/nuke/issues/209) ("Input and
-  output specifications for targets") was opened 2018-12-10 and closed as
-  *completed* on **2019-11-19** — confirmed via the GitHub API, which reports
-  `state: closed`, `state_reason: completed`. An earlier draft cited it as open
-  since 2018 to support a claim that NUKE has no target-level incremental skip;
-  that claim has been withdrawn and the row marked `unknown`.
-
-Repository signals recorded on the same date: `nrwl/nx` 29.1k stars,
-`vercel/turborepo` 30.8k, `dagger/dagger` 16.1k, `nuke-build/nuke` ~3.7k. NUKE
-entries are corroborated from its GitHub repository and issues because
-`nuke.build` still did not resolve at the time of checking, so nothing here rests
-on NUKE's own documentation site. All of these move — re-check before relying on
-a row.
+All of these move. Re-check before relying on a row.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,108 +1,391 @@
 # How Zuke compares
 
-An honest comparison, including where Zuke is the wrong choice. Zuke is a
-young, single-maintainer project (see the maturity note in
-[Versioning & compatibility](./versioning.md)) — it does not have the
-Cloud/plugin ecosystem of the more established tools below, and that's a real
-tradeoff, not marketing copy.
+Zuke exists for the build that has outgrown a list of commands: a real
+dependency graph, typed inputs, external tools driven through checked argv, and
+pipelines that have to survive waiting for something outside the build. It is
+also a **young, single-maintainer project** — 55 JSR packages, `@zuke/core` at
+`1.x` and most tool wrappers still `0.x` (see
+[Versioning & compatibility](./versioning.md) for what each tier promises). The
+package a consumer actually installs is the `@zuke/cli` command, and it is at
+**0.8.1** — pre-1.0, so it makes no compatibility promise yet, and it is the
+front door to the `mcp`, `resume` and `cancel` surface this page showcases. Zuke
+has no hosted service, no funded team, and no plugin marketplace, and several
+tools below have all three. This page compares **functionality**, axis by axis,
+and says where each of them is ahead.
 
-## `deno task` (or `npm`/`package.json` scripts)
+## The capability matrix
 
-**When plain tasks are enough:** your project is a handful of independent
-commands (`lint`, `test`, `build`) with no real dependency graph between them,
-you don't need incremental skipping, and everyone on the team is comfortable
-reading a `deno.json` `tasks` block. Don't reach for a build system to run
-three commands — `deno task` (or the npm-script equivalent) is simpler,
-has zero learning curve, and is already there.
+Rows are capabilities; columns are the tools. Cells are deliberately terse — the
+nuance is in the prose under each tool.
 
-**What typed dependencies, caching, and resume add once tasks stop being
-independent:** a `tasks` block is a flat list of shell strings — it can chain
-commands with `&&`, but it has no concept of *this target depends on that one*,
-so ordering and skip-if-unchanged logic live in your head or in ad hoc shell
-conditionals. Zuke gives you:
+A **—** means the capability was **not found in the official documentation
+reviewed** for this page. That is weaker evidence than a positive finding: the
+docs may simply be silent. Where a claim could not be pinned down at all it is
+marked *unknown* rather than absent.
 
-- **A real dependency graph.** `dependsOn(this.build)` is a compile-time
-  reference; Zuke topologically sorts and only runs what's reachable.
-- **Incremental skipping and `--affected`.** Declare `.inputs()`/`.outputs()`
-  and Zuke skips a target whose inputs haven't changed, locally or via the
-  [remote cache](./caching.md#remote-build-cache); `--affected=origin/main`
-  narrows a run to what a diff can reach.
-- **Resume and durable state.** A long-running or suspended build
-  (`.waitsFor()`, a crashed CI runner) can be resumed rather than restarted
-  from `deno task`'s stateless, one-shot-per-invocation model.
+<div style="overflow-x: auto">
 
-If you don't need any of that, a `tasks` block is the correct tool.
+| Capability                       | Zuke                                | `deno task`                    | npm scripts                    | GNU Make                    | Nx                                 | Turborepo                          | Dagger                            | NUKE                              |
+| -------------------------------- | ----------------------------------- | ------------------------------ | ------------------------------ | --------------------------- | ---------------------------------- | ---------------------------------- | --------------------------------- | --------------------------------- |
+| Dependency wiring                | typed `this.field` references       | JSON array of task names       | none (`pre`/`post` naming)     | Makefile prerequisites      | JSON `dependsOn` + inferred graph  | JSON `dependsOn`                   | inferred from code data flow      | typed C# `.DependsOn`             |
+| Bad reference caught             | compile error, then pre-flight scan | CLI name yes; in-array unknown | only for a directly-run script | yes, before any recipe      | when the task graph is built       | yes, before the run starts         | compile error in the host language | compile error                     |
+| Authoring language               | TypeScript, no DSL                  | JSON + shell subset            | JSON + shell strings           | Makefile DSL                | JSON + TypeScript executors        | JSON + `package.json` scripts      | Go/Python/TypeScript/… code       | C#                                |
+| Typed wrappers for tool flags    | 50+ `*Tasks` packages               | no                             | no                             | no                          | executor options, JSON-schema      | no                                 | no (plain `withExec` argv)        | generated C# wrappers             |
+| Command construction             | argv arrays end to end, no shell    | built-in shell subset          | OS shell strings               | shell per recipe line       | per-executor, no stated contract   | `package.json` shell strings       | argv arrays                       | argv via wrappers; shell also     |
+| Skip unchanged work              | hashes declared `.inputs()`/`.cacheKey()` only | opt-in `files` globs (2.9) | no                          | file timestamps             | content hashing (files, config, command) | content hashing (files, config, command) | BuildKit operation cache    | unknown                           |
+| Narrow a run to changed files    | `--affected=<ref>`, declaration-driven | no                          | no                             | n/a (timestamps, not diffs) | `nx affected`, import-inferred     | `turbo run --affected`, import-inferred | no such concept              | —                                 |
+| Cross-machine cache              | built in; needs `.inputs()` + `.outputs()` | local only              | no                             | no                          | Nx Cloud (hosted, free tier); own server via OpenAPI spec | in the CLI; free hosted; self-host | Dagger Cloud (paid)      | not native                        |
+| Suspend and resume a run         | `.waitsFor()` + `zuke resume`       | —                              | —                              | —                           | —                                  | —                                  | —                                 | —                                 |
+| Cancellation with compensations  | `.onCancel()`, reverse order        | —                              | —                              | —                           | —                                  | —                                  | cancel visible in traces only     | —                                 |
+| Long-lived process dependencies  | `service()`                         | —                              | —                              | —                           | `continuous: true`                 | `persistent` + `with`              | —                                 | —                                 |
+| MCP server for agents            | built in (`zuke mcp`)               | —                              | —                              | —                           | official `nx-mcp`                  | proposed, not shipped              | modules exposed as MCP servers    | —                                 |
+| Machine-readable self-description | `--list --json`, generated `llms.txt` | —                            | `npm pkg get scripts`          | —                           | workspace/graph tools over MCP     | —                                  | typed API + MCP                   | `--help` target listing           |
+| Runtime it needs                 | Deno                                | Deno                           | Node                           | system binary + shell       | Node + `@nx/*` plugins             | native binary via npm              | CLI + engine container            | .NET SDK                          |
+| Backing                          | single maintainer; core `1.32`, cli `0.8.1` | Deno Land Inc.                 | npm/GitHub, since ~2010        | GNU, 35+ years              | Nrwl, 29.1k stars, Nx Cloud        | Vercel, 30.8k stars, MIT           | funded startup, 16.1k stars       | since ~2017, 3.7k stars           |
 
-## Nx / Turborepo
+</div>
 
-Nx and Turborepo are mature monorepo orchestrators with **affected-graph
-builds and remote caching** as their core value proposition — the same shape
-of feature Zuke's `--affected` and remote cache provide, so there's real
-overlap for a JS/TS monorepo already on one of them.
+The rows Zuke was built to win are the first five and the three orchestration
+ones. The two caching rows and the affected row are qualified rather than won:
+Zuke's versions are **declaration-driven**, so they do only as much as the target
+author told them to, where Nx's and Turborepo's are derived from the source. The
+rows where it ties or loses — hosted caching, ecosystem, backing — are in the
+table for the same reason: a comparison that concedes nothing is not worth
+reading.
 
-**Where they're more mature:** Nx Cloud (hosted remote cache and CI
-distribution at scale), a large plugin ecosystem (generators, migrations,
-editor/IDE integration), and years of production hardening across huge
-monorepos. If you're already invested in an Nx or Turbo monorepo and it's
-working, that investment is not a reason to switch.
+## `deno task`, npm scripts, and GNU Make
 
-**Where Zuke differs, not necessarily improves:**
+**Where Zuke differs most: a dependency is a reference, not a name.** In a
+`deno.json` task the dependency is a string in a `dependencies` array; in npm
+scripts there is no dependency field at all, only the `pre<name>`/`post<name>`
+convention matched by string at run time — so a misspelled `pretest` is silently
+never invoked, with no error anywhere. In a Zuke build the dependency is the
+sibling field itself:
 
-- **No config DSL.** A Nx/Turbo pipeline is JSON (`nx.json`/`turbo.json`)
-  describing task graphs by convention (`dependsOn: ["^build"]`); a Zuke build
-  is a TypeScript class where dependencies are `this.<field>` references, so
-  a typo or a stale rename is a compile error, not a graph that silently
-  drops an edge.
-- **Typed argv end to end.** Zuke's tool wrappers (`DenoTasks`, `DockerTasks`,
-  …) build a real argv array with typed settings; Nx/Turbo mostly shell out to
-  whatever script string you wrote, so the tool's actual flags aren't checked
-  until the command runs.
-- **Deno-native, not JS-tool-specific.** Nx and Turbo are built around a
-  JS/TS package graph (workspaces, `package.json`); Zuke has no notion of a
-  package graph at all — a target is just code, so it fits equally well
-  driving Docker, Terraform, or a Python script as it does a `deno` build.
-  (Zuke even ships [`@zuke/nx`](https://jsr.io/@zuke/nx) and
-  [`@zuke/turbo`](https://jsr.io/@zuke/turbo) wrappers, for calling *into*
-  Nx or Turbo from a Zuke target rather than replacing them.)
+<!-- check -->
 
-**When NOT to use Zuke instead of Nx/Turbo:** a large existing JS/TS monorepo
-with Nx or Turbo already wired to CI, using Nx Cloud/Turbo remote cache at
-scale, and leaning on generators or editor plugins for day-to-day dev — Zuke
-has no equivalent ecosystem today.
+```ts
+import { Build, run, target } from "jsr:@zuke/core";
+import { DenoTasks } from "jsr:@zuke/deno";
+
+class CI extends Build {
+  lint = target().executes(() => DenoTasks.lint());
+
+  test = target()
+    .dependsOn(this.lint)
+    .inputs("packages", "deno.json")
+    .executes(() => DenoTasks.test((s) => s.allowAll()));
+}
+
+await run(CI);
+```
+
+`this.lint` is checked by `deno check` before the build ever runs, so a rename
+moves every reference with it and a typo is a type error. On top of that, Zuke
+validates the whole graph up front — unknown references, forward references to a
+field declared lower in the class, and cycles are reported with the offending
+target named, before any body executes. Make is the honourable exception among
+the three: it resolves the entire prerequisite graph before running a single
+recipe and stops with `No rule to make target X, needed by Y`. For `deno task`,
+a cycle is rejected before execution, but whether a misspelled name *inside* a
+`dependencies` array is caught before the run starts is not stated in Deno's
+docs — treat it as unknown.
+
+The second difference is how a command is built. All three of these write shell
+strings: npm scripts hand the string to `/bin/sh` (or `cmd.exe` on Windows, with
+the dialect differences that implies), Make hands each recipe line to `$(SHELL)`
+in a fresh sub-shell, and `deno task` parses the string with Deno's own
+cross-platform subset of `sh` — the same behaviour on every OS, which is a real
+improvement, but still shell syntax written by hand. Zuke's
+[tool wrappers](./tools.md) and [`$`](./shell.md) keep arguments a discrete array
+from the settings lambda to `Deno.Command`, and interpolated values become single
+argv entries rather than text spliced into a command line. Be precise about what
+that buys: no shell ever parses the command, so there is **no shell-injection
+surface** — a value containing `; rm -rf /` is passed through as one literal
+argument. It does not make an interpolated value safe in general. A value
+beginning with `-` still arrives as a **flag the invoked tool honours**, which is
+argument injection, and validating that remains the caller's job — the same job
+Zuke does for itself where it accepts one, as when `--affected` rejects a base
+revision starting with `-` because git would read it as an option. Neither
+`deno task`,
+npm, nor Make documents a typed surface for a tool's flags; Zuke ships one per
+tool, so `--allow-all` and `--coverage` are methods that either exist or fail to
+compile.
+
+**Where they are ahead of Zuke.** `deno task` is already installed with Deno and
+costs nothing to learn, and since Deno 2.9 it has genuine opt-in incremental
+caching: declare a `files` glob and Deno fingerprints the command, the matched
+file contents, listed env values, dependency fingerprints and the host
+OS/arch/Deno version, restoring declared `output` on a hit. That covers the
+common "don't rebuild if nothing changed" case without a build system at all
+(local only — there is no shared cache). npm scripts need no learning curve for
+anyone already in the JS ecosystem and are backstopped by a large third-party
+layer (`npm-run-all`, `concurrently`, and Nx or Turborepo above them). Make is
+35+ years old, present on virtually every Unix box, and its timestamp-driven
+rebuild model is its native purpose rather than a bolt-on. None of the three
+documents cross-process suspend/resume, cancellation compensations, or an MCP
+server — but for a project that needs none of those, "already installed" is a
+strong argument.
+
+## Nx and Turborepo
+
+**Where Zuke differs most: there is no config file describing the pipeline.**
+Nx declares wiring in JSON — `nx.json` for workspace-wide `targetDefaults`,
+`project.json` (or an `nx` key in `package.json`) per project — with conventions
+like `^build` meaning "this target in upstream dependencies first", and infers
+project-to-project edges from source imports. Turborepo puts everything in
+`turbo.json`, where a task is the *name* of a script that already exists in some
+`package.json`; `turbo.json` declares scheduling and caching metadata around
+that name and never touches the command. In Zuke the pipeline is the program:
+dependencies are field references checked by the compiler, and the body is a
+typed call rather than a script name resolved later.
+
+That difference shows up in three places worth stating precisely:
+
+- **When a bad reference is caught.** Both tools do catch one. Turborepo fails
+  the whole run up front — `error preparing engine: Could not find the following
+  tasks in project: [...]` — before any task executes, which is genuinely
+  fail-fast. Nx raises `Cannot find configuration for task <project>:<target>`
+  while constructing the task graph, and reports `task graph has a circular
+  dependency` on a cycle; that happens before the task's process is spawned, but
+  neither tool documents a static, type-level check of the reference, and
+  Turborepo's task body is an arbitrary shell string in `package.json` that
+  nothing checks at all. Zuke's equivalent errors are `deno check` failures in
+  your editor.
+- **What runs the tool.** Nx executors take an options object validated against
+  each executor's `schema.json` at run time, and expose structured options
+  (`tsConfig`, `outputPath`) rather than a raw command — real validation, but of
+  configuration, not of a CLI's flags at compile time. How a given executor
+  invokes its underlying tool is that plugin's implementation detail; Nx's docs
+  state no tool-wide argv-versus-shell contract, so there is nothing to compare
+  against Zuke's argv guarantee either way. Turborepo makes no claim here: the
+  command is the shell string you wrote.
+- **What happens when a pipeline has to wait.** Nx has continuous tasks
+  (`continuous: true`, Nx 21+) and a documented recipe for starting a dependent
+  once a long-running dependency prints output; Turborepo has `persistent` tasks,
+  a `with` key to co-start them, and `turbo watch`. Both are same-invocation
+  orchestration. Neither documents suspending a run to durable state and resuming
+  it in a later process, nor cancellation that runs compensating actions. Zuke's
+  [waits and resume](./orchestration.md) suspend the run to a state store, exit
+  0, and resume — days later, in another process — with a compare-and-swap so
+  concurrent resumers race and all but one get `AlreadyResumedError`. How far
+  that guarantee reaches depends on the store: the default
+  [`FileSystemStateStore`](./state.md#backends) is an atomic
+  write-temp-then-rename guarded by an `O_EXCL` lock file, which makes it
+  exactly-once **between processes on one host** — for exactly-once across
+  machines you run the `HttpStateStore` service yourself, where ETags carry the
+  compare-and-swap. Cancellation is
+  [`.onCancel()`](./orchestration.md#cancellation--compensation--oncancel), which
+  unwinds succeeded targets in reverse order.
+
+**Where they are ahead of Zuke.** Considerably, on several axes:
+
+- **Hosted caching and distribution.** Nx Cloud is a real hosted remote cache
+  and distributed-execution product with a free tier; Vercel's Remote Cache is
+  free on all plans, including for repos not deployed to Vercel, and Turborepo's
+  remote caching is a capability of the open-source CLI itself. Neither charges
+  for self-hosting either: Nx deprecated its four pre-built cache adapters
+  (`@nx/s3-cache` and siblings) over the CREEP vulnerability
+  ([CVE-2025-36852](https://www.cve.org/CVERecord?id=CVE-2025-36852)), a design
+  flaw it says cannot be patched — not to move self-hosting behind a paywall —
+  and its documented replacement is to implement the published **Nx remote cache
+  OpenAPI specification** yourself, which costs nothing but hands you the whole
+  threat model. So the difference here is not price. It is that Zuke's
+  [remote cache](./caching.md#remote-build-cache) is **built into the build
+  system** — an `HttpCacheStore` or a directory, chosen in typed code or by
+  `ZUKE_REMOTE_CACHE_*`, with no separate product to adopt and no adapter to
+  write — while Nx's answer is either a service you sign up for or a server you
+  implement. Two qualifiers on Zuke's, though: it applies only to targets that
+  declare **both `.inputs()` and `.outputs()`** — the inputs give the key, the
+  outputs are what gets archived — so it does nothing for a target missing either;
+  and like every Zuke cache it is **best-effort**, so an unreachable store logs a
+  warning and the build silently falls back to building locally rather than
+  failing. What Zuke does not have is a zero-setup option or an operated service
+  behind it.
+- **What the cache hash covers — and the trap that follows.** Nx and
+  Turborepo hash a task's project files, its configuration and the command
+  itself, so changing any of them is a miss. Zuke's fingerprint is narrower by
+  design: it is the declared `.inputs()` plus any `.cacheKey()` values, and
+  nothing else (see [Caching](./caching.md#what-unchanged-means)). Two
+  consequences follow, and both are worth stating plainly. A target that declares
+  neither inputs nor a
+  cache key is **never cached** and always runs. And for one that does, editing
+  the **target's own body**, or `zuke.ts` itself, does **not** invalidate a hit —
+  Zuke will happily report `cached` for code you just changed unless you folded
+  something that moves into a `.cacheKey()`. Nx and Turborepo do not have that
+  hazard, because the command and config are in the hash. The upside of the narrow
+  fingerprint is that it is explicit and deterministic across machines; the cost
+  is that correctness is the author's to declare.
+- **Affected-graph maturity, and a different kind of affected.** Both tools'
+  hashing and affected computations are proven across very large monorepos; Nx's
+  enterprise page claims Nx Enterprise is trusted by 70%+ of the Fortune 500.
+  Zuke's `--affected` is not the same shape of feature: Nx and Turborepo derive
+  the graph from **source imports**, so a change is traced to the projects that
+  actually depend on the file without anyone declaring it. Zuke prunes purely on
+  hand-declared `.inputs()`, and a target declaring none cannot be proven
+  unaffected, so it always runs (see
+  [`--affected`](./cli.md#affected-targets)) — on a build that declares no inputs
+  anywhere, `--affected` prunes nothing at all. That is a real difference, and on
+  this axis it is not in Zuke's favour: you get exactly the pruning you wrote
+  down.
+- **Agent integration is not a Zuke exclusive.** Nx ships an official, documented
+  MCP server (`nx-mcp`) with tools for docs, workspace graph visualisation,
+  project details, generator schemas, and CI data pulled from Nx Cloud, bundled
+  with the Nx Console editor extension. It is shipped, not planned. Zuke's
+  [`zuke mcp`](./mcp.md) exposes your build's own targets and graph as typed
+  tools over stdio or streamable HTTP with no extra service, which is a different
+  surface — not a larger one. Turborepo is the one gap here: an MCP server for it
+  is an open discussion on its repo, not a feature.
+- **Ecosystem and delivery.** Nx has polyglot plugins, code-mod generators, and
+  editor integration built over years; Turborepo ships a precompiled Rust binary
+  through platform-specific optional npm dependencies, so installing it pulls a
+  native binary rather than a dependency tree.
+
+Zuke is not trying to replace either inside a monorepo that is happy: it ships
+[`@zuke/nx`](https://jsr.io/@zuke/nx) and
+[`@zuke/turbo`](https://jsr.io/@zuke/turbo) wrappers for calling *into* them from
+a target.
 
 ## Dagger
 
-Dagger runs your pipeline as a graph of **containerized** steps, portable
-across CI providers because each step is a container with cached layers —
-the pipeline itself becomes a portable, containerized artifact.
+**Where Zuke differs most: the execution model, and what the graph is made of.**
+A Dagger pipeline is a set of functions in a real language (Go, Python,
+TypeScript, PHP, Java, .NET, Elixir, Rust) that execute as containers inside a
+BuildKit-based engine; ordering is *inferred* from data flow between function and
+container operations rather than declared, and cross-module dependencies are
+installed with `dagger install` into `dagger.json`. A Zuke target declares its
+dependencies explicitly and runs in-process — a `Deno.Command` subprocess when it
+shells out — with no container runtime involved.
 
-**The real difference is the execution model, not the language:** Dagger
-steps run in containers by design, giving you strong isolation and
-byte-for-byte reproducibility (and layer caching) at the cost of container
-startup overhead and a container runtime as a hard dependency. A Zuke target
-runs **in-process** (a `Deno.Command` subprocess when it shells out) — faster
-to iterate on locally, no container runtime required, but you own
-reproducibility yourself (pin your tool versions, don't rely on host state).
+On the axes this page compares, the two are closer than the rest of the field.
+Dagger's generated bindings mean a call to a function that does not exist is a
+compile error in the host language, exactly like `this.lint`; and its
+`Container.withExec(args)` takes a plain argv array, with the docs explicitly
+warning that `["sh","-c","…"]` reintroduces shell interpretation and injection.
+Zuke and Dagger are level here, and it is worth being exact about that rather
+than claiming an edge: both keep the command an argv array so no shell parses it,
+and neither validates argument injection for you — a value beginning with `-`
+reaches the invoked tool as a flag in either system. Two real differences remain. First, Dagger has no per-tool typed flag surface:
+you write the argv yourself, and the modules in its public registry that wrap
+specific tools are user-contributed rather than a built-in guarantee — where Zuke
+ships a maintained wrapper per tool whose settings mirror the actual CLI flags.
+Second, nothing in Dagger's documentation describes checkpointing a run to
+durable state and resuming it in a later process, waiting on an arbitrary
+external event mid-pipeline, or running compensating actions on cancel;
+cancellation appears in Dagger Cloud's trace UI as a state, not as a rollback
+mechanism. Dagger also has no affected-projects selection at all — its caching
+works at the level of individual container and filesystem operations.
 
-**When NOT to use Zuke instead of Dagger:** you need the pipeline itself to be
-portable across CI providers as a single artifact, or you specifically want
-every step sandboxed in its own container — that's Dagger's core design, not
-a Zuke feature.
+**Where it is ahead of Zuke.** Dagger's container-per-step model gives every step
+a hermetic environment, so "works on my machine" and "works in CI" are the same
+run — Zuke has no isolation story and leaves reproducibility to you (pin your
+tools, don't rely on host state). Its BuildKit engine caches operations
+automatically rather than only where you declared `.inputs()`. It has eight
+first-class SDKs to Zuke's one language, a public module registry for reusing
+other people's pipeline logic, genuine LLM support (an `LLM` type that
+auto-discovers Dagger Functions as callable tools, plus `LLM.withMCPServer` for
+attaching external servers), and a funded company with a hosted product behind
+it. The cost is a container runtime as a hard dependency and container startup on
+every step; the benefit is isolation Zuke does not attempt.
 
 ## NUKE
 
-[NUKE](https://nuke.build/) is Zuke's direct inspiration and closest relative
-in *shape*: a build is a C# class, targets are members, dependencies are
-typed. If you already know NUKE, Zuke will feel immediately familiar.
+[NUKE](https://github.com/nuke-build/nuke) is the direct precedent for Zuke's
+design and gets credited as such in the
+[acknowledgements](../README.md#acknowledgements): a build is a class, targets are
+strongly-typed members, `DependsOn` takes a real member so a typo does not
+compile, and external CLIs are driven through generated typed wrappers rather
+than hand-written strings. Anyone who knows NUKE already knows Zuke's model.
 
-**The difference is the ecosystem it lives in:** NUKE is .NET — MSBuild-aware,
-NuGet-native, with mature IDE tooling (Rider/Visual Studio) built up over
-years. Zuke is the same idea ported to Deno/TypeScript — Deno-native module
-resolution (`jsr:`/`https:` specifiers, no separate package manager), the
-Deno toolchain for everything (test runner, formatter, linter, coverage), and
-JSR for distribution instead of NuGet.
+**Where Zuke differs most: the ecosystem it runs in, and what the graph does
+after it is built.** NUKE is .NET — installed as a tool from NuGet, needing the
+.NET SDK, at home next to MSBuild and Rider. Zuke is the same architecture
+targeting Deno: `jsr:`/`https:` specifiers with no separate package manager, the
+`deno` CLI for test/format/lint/coverage, JSR for distribution. Beyond the
+runtime, the difference is in the capabilities layered on top of the graph. Zuke
+has an [incremental cache](./caching.md), a
+[remote cache](./caching.md#remote-build-cache), and
+[`--affected`](./cli.md#affected-targets), along with suspend/resume,
+cancellation compensations, and an MCP server, none of which turned up in NUKE's
+available documentation. Treat that as weak evidence rather than a gap, for one
+specific reason: NUKE's request for target input/output specifications
+([issue 209](https://github.com/nuke-build/nuke/issues/209), opened 2018) was
+**closed as completed on 2019-11-19**, and with `nuke.build` unreachable during
+this check there was no way to establish what shipped from it or what the
+incremental-skip position is today. So this page does not claim NUKE lacks
+target-level incremental skip — the row is `unknown`. Check NUKE's own docs
+before assuming either way.
 
-**When NOT to use Zuke instead of NUKE:** you're building a .NET project.
-Use NUKE — it's the mature, native choice for that ecosystem, and the reason
-this project credits it as [an inspiration](../README.md#acknowledgements)
-rather than a competitor.
+**Where it is ahead of Zuke.** Years, and everything years buy: a component
+plugin ecosystem for shareable build logic, CI generation across multiple
+providers with community conventions behind it, JetBrains-adjacent visibility,
+and roughly 3.7k stars' worth of accumulated real-world usage in the .NET world.
+It proves this architecture at a scale Zuke has not reached. Note that NUKE's own
+documentation site did not resolve during the research behind this page, so its
+entries here are corroborated from its GitHub repository and issues rather than
+`nuke.build` directly — check its docs before treating any NUKE line above as
+current.
+
+## Choose something else when…
+
+- **Your build is a handful of independent commands.** `lint`, `test`, `build`,
+  no real graph between them, and nobody minds a `deno.json` `tasks` block —
+  use `deno task`. Its 2.9 opt-in `files` caching even covers simple
+  skip-if-unchanged. Do not adopt a build system to run three commands.
+- **You have a large JS/TS monorepo already on Nx or Turborepo, with hosted
+  caching working.** The overlap with Zuke is real but partial, and you would be
+  trading a proven affected-graph, a zero-setup remote cache, generators and
+  editor integration for a self-hosted cache and a younger tool. Stay, and call
+  into your existing setup from Zuke only if you want the typed layer.
+- **You need every step hermetic and portable across CI providers.** That is
+  Dagger's core design — containerised steps, an engine you can run anywhere,
+  operation-level caching — and Zuke does not attempt it.
+- **Your pipeline is polyglot beyond TypeScript, or the team is not on Deno.**
+  Dagger has eight SDKs; Zuke has one language and a Deno runtime requirement.
+- **You are building .NET.** Use NUKE. It is the mature, native choice for that
+  ecosystem, has the same model Zuke borrowed, and its plugin and CI-generation
+  ecosystem is years ahead.
+- **Your build really is file-to-file transformations on a Unix box.** Make has
+  done exactly that correctly since before most of this list existed.
+- **You need vendor support, a funded roadmap, or a hosted cache you don't
+  operate.** Zuke has one maintainer and no service. That is the honest ceiling,
+  and [Versioning & compatibility](./versioning.md) explains the stability
+  promise each package makes within it.
+
+---
+
+**Checked:** competitor claims on this page were verified against official
+documentation and public repositories on **2026-07-28**, against `@zuke/core`
+1.32 and `@zuke/cli` 0.8.1. Version-specific facts as of that date: `deno task`
+file-fingerprint caching from **Deno 2.9**; Nx continuous tasks from **Nx 21**,
+with `nx-mcp` shipped; Turborepo remote caching in the OSS CLI with no MCP
+server; Dagger Cloud as the paid tier for cross-machine caching.
+
+Two rows were corrected against their primary sources on that date and are worth
+citing precisely:
+
+- **Nx self-hosted caching is not a paid feature.** Nx's deprecation notice for
+  `@nx/s3-cache`, `@nx/gcs-cache`, `@nx/azure-cache` and `@nx/shared-fs-cache`
+  ([nx.dev/docs/reference/deprecated/self-hosted-cache-packages](https://nx.dev/docs/reference/deprecated/self-hosted-cache-packages),
+  deprecated 2026-05-21) gives the reason as the CREEP vulnerability
+  ([CVE-2025-36852](https://www.cve.org/CVERecord?id=CVE-2025-36852)) — "The flaw
+  is in their design and cannot be patched" — and its documented path for
+  on-premises storage is to implement the Nx remote cache OpenAPI specification
+  ([nx.dev/docs/kb/self-hosted-caching](https://nx.dev/docs/kb/self-hosted-caching)),
+  where "Implementation is up to you" and no licence or subscription is required.
+  Nx Cloud has a free tier. An earlier draft of this page described self-hosting
+  as paid; it is not.
+- **NUKE issue 209 is closed.**
+  [nuke-build/nuke#209](https://github.com/nuke-build/nuke/issues/209) ("Input and
+  output specifications for targets") was opened 2018-12-10 and closed as
+  *completed* on **2019-11-19** — confirmed via the GitHub API, which reports
+  `state: closed`, `state_reason: completed`. An earlier draft cited it as open
+  since 2018 to support a claim that NUKE has no target-level incremental skip;
+  that claim has been withdrawn and the row marked `unknown`.
+
+Repository signals recorded on the same date: `nrwl/nx` 29.1k stars,
+`vercel/turborepo` 30.8k, `dagger/dagger` 16.1k, `nuke-build/nuke` ~3.7k. NUKE
+entries are corroborated from its GitHub repository and issues because
+`nuke.build` still did not resolve at the time of checking, so nothing here rests
+on NUKE's own documentation site. All of these move — re-check before relying on
+a row.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -117,7 +117,7 @@ With `--allow-run` a store also exposes three **mutating** run-state tools:
 `signal_run` (deliver an external signal and resume a suspended run,
 exactly-once), `resume_check` (re-check suspended runs — predicate waits and
 timeouts), and `cancel_run` (cancel a run and run its
-[compensations](./orchestration.md#cancellation--compensation-oncancel)). They
+[compensations](./orchestration.md#cancellation--compensation--oncancel)). They
 are the MCP counterparts of `./zuke resume` and `./zuke cancel`. Each runs the
 target's code (a resume continues it; a cancel runs its compensations), so it is
 gated by the same [allow-list and operator-token](#authorization) policy as a

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -204,7 +204,7 @@ its recorded `onTimeout` disposition:
 
 - **`"fail"`** (the default) — the waiting target is failed and the run fails.
 - **`"cancel-run"`** — the run is **cancelled**: every succeeded target's
-  compensation runs (see [Cancellation](#cancellation--compensation-oncancel))
+  compensation runs (see [Cancellation](#cancellation--compensation--oncancel))
   and the record settles `cancelled`. This is what unwinds a stuck deploy → wait
   and releases its locks, rather than leaving them held until their TTL.
 - **a sibling target** (`.onTimeout(() => this.rollback)`) — that specific

--- a/docs/run-context.md
+++ b/docs/run-context.md
@@ -76,7 +76,7 @@ A body that ignores its signal and never touches the shell still runs to
 completion; Zuke does not forcibly interrupt arbitrary JavaScript. Cancellation
 is also a first-class **graph operation**: `zuke cancel <run-id>` (or `Ctrl-C`)
 unwinds every succeeded target's declared `.onCancel(...)` compensation in
-reverse order — see [Orchestration](./orchestration.md#cancellation--compensation-oncancel).
+reverse order — see [Orchestration](./orchestration.md#cancellation--compensation--oncancel).
 
 ### Scope of the ambient signal
 

--- a/docs/shell.md
+++ b/docs/shell.md
@@ -38,9 +38,9 @@ raises it for a tool whose whole output must be parsed. The cap must be a
 positive whole number of bytes; there is no unlimited value, so pass a cap larger
 than the output you expect. Live streaming to the terminal is never capped.
 
-**Safety:** interpolated values become **discrete argv entries** — they are
-never spliced into a shell string — so there is no injection surface. Arrays
-expand to multiple arguments:
+**Safety:** interpolated values become **discrete argv entries** — they are never
+spliced into a shell string, and no shell is involved at all — so there is **no
+shell-injection surface**. Arrays expand to multiple arguments:
 
 ```ts
 const files = ["a.ts", "b.ts"];
@@ -48,6 +48,20 @@ await $`deno fmt ${files}`; // → ["deno", "fmt", "a.ts", "b.ts"]
 const dirty = "; rm -rf /";
 await $`echo ${dirty}`; // prints the literal string; runs nothing else
 ```
+
+That is shell injection, and only shell injection. **Argument injection is still
+yours to validate:** a value beginning with `-` is passed through faithfully as
+one argv entry, and the invoked tool reads it as a **flag**, not as data.
+
+```ts
+const ref = "--output=/tmp/leak"; // untrusted
+await $`git diff --name-only ${ref}`; // git honours it as an option
+```
+
+So validate any untrusted value you interpolate into a leading position —
+reject a leading `-`, or separate data from options with `--` where the tool
+supports it. Zuke does this for the inputs it accepts itself: `--affected`
+rejects a base revision starting with `-` for exactly this reason.
 
 By default a command streams its output live to your terminal and captures
 stdout; `.text()`/`.lines()` capture without echoing; `.quiet()` does neither.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,110 @@
+# Versioning & compatibility
+
+Zuke publishes 55 independent JSR packages from one workspace. They don't all
+move at the same speed, and knowing which promise each package makes — and how
+they interlock — is what keeps an upgrade from surprising you at runtime
+instead of at `deno check` time.
+
+## Two maturity tiers
+
+- **`@zuke/core` (and a handful of others that have reached 1.0 — `@zuke/ai`,
+  `@zuke/console`, `@zuke/otel`, …) follow full semver.** A `1.x` release never
+  breaks a public symbol; a breaking change bumps the major version. Depend on
+  `jsr:@zuke/core@^1` and a minor/patch upgrade is safe to take without reading
+  the diff.
+- **The 0.x tool wrappers (`@zuke/deno`, `@zuke/docker`, `@zuke/npm`, …) can
+  still change within `0.x`.** Per semver convention, a `0.x` minor bump may
+  carry a breaking change — `release-please`'s `bump-minor-pre-major` setting
+  means a wrapper's breaking change bumps its minor, not its major, until it
+  graduates to `1.0`. Read a wrapper's `CHANGELOG.md` before taking a minor
+  upgrade, the same way you would for any other pre-1.0 dependency.
+
+Check a specific package's current maturity from its badge on the
+[Packages table](../README.md#packages) or its JSR page — score and version
+are both visible there.
+
+## Every wrapper declares a `@zuke/core` floor
+
+Each tool wrapper's `deno.json` pins a minimum core version it needs, e.g.
+
+```json
+{
+  "imports": {
+    "@zuke/core": "jsr:@zuke/core@^1.31.0"
+  }
+}
+```
+
+That floor is **hand-maintained** — nothing regenerates it — and it exists
+because a wrapper often imports a symbol that only exists from some specific
+core release onward (a new settings class, a new exported type). If the floor
+is under-declared, a consumer can pin a wrapper version whose code needs core
+1.31 while their lockfile still resolves an older core that doesn't export the
+symbol — and the failure doesn't show up until the wrapper is actually
+imported at runtime, because this repo's own CI type-checks every package
+against the **workspace-local** `packages/core`, not against the floor each
+`deno.json` claims.
+
+### The failure mode, concretely
+
+This happened in this repo (fixed in
+[`d8f51c0`](https://github.com/zuke-build/zuke/commit/d8f51c0939d26faa6eb5d7d4bb75bbba241890bb),
+"fix: raise the `@zuke/core` floor to 1.31.0 in wrappers using
+`SubcommandSettings`"):
+
+1. Five wrappers (`@zuke/claude`, `@zuke/codex`, `@zuke/gcloud`,
+   `@zuke/gemini`, `@zuke/gh`) started importing `SubcommandSettings`, a type
+   new in `@zuke/core@1.31.0`.
+2. Their declared floor was still an older range that predates that symbol.
+3. CI was green: `deno check` resolves the workspace's local `packages/core`
+   member (already at 1.31.0+) regardless of what each wrapper's `deno.json`
+   claims, so the type-check never sees the gap.
+4. A consumer whose `deno.lock` had already pinned an older, published core —
+   satisfying the wrapper's stale floor — hit a **runtime** failure: the
+   import resolved to a real core release that doesn't export
+   `SubcommandSettings`.
+5. The fix was a follow-up PR that raised the floor in the five affected
+   `deno.json`s (and `deno.lock`) to `^1.31.0`, once core 1.31.0 had actually
+   published. See [`RELEASING.md`](../RELEASING.md) for why the floor bump has
+   to be a separate, later PR rather than landing in the same change that
+   introduces the new symbol.
+
+### How to diagnose it
+
+If you hit an import that resolves at type-check time but throws or logs a
+missing export at runtime:
+
+1. Check which core symbol the failing import actually needs, and which
+   version introduced it — grep the symbol in
+   [`packages/core/CHANGELOG.md`](../packages/core/CHANGELOG.md) or search
+   [`llms-full.txt`](../llms-full.txt).
+2. Compare that to the floor the wrapper declares
+   (`jsr:@zuke/core@^x.y.z` in its `deno.json`, visible on its JSR page) and to
+   what your own `deno.lock` actually resolved for `@zuke/core` — run
+   `deno info jsr:@zuke/<wrapper>` or inspect `deno.lock` directly.
+3. If the lockfile-resolved core predates the version the symbol needs, the
+   wrapper's floor is under-declared. File an issue (or bump your own pin to
+   the version that introduced the symbol as a workaround) and expect the fix
+   to look like `d8f51c0`: a small `fix:` PR raising the floor in every
+   affected `deno.json`.
+
+## Pinning guidance
+
+- Depend on the caret range, not an exact version: `jsr:@zuke/core@^1` (or a
+  wrapper's own `jsr:@zuke/<tool>@^0.x`) so patch and, for `1.x`, non-breaking
+  minor releases resolve automatically.
+- **Always commit `deno.lock`.** It is what pins the exact resolved version of
+  every package (core included) that your build actually runs against — the
+  caret range in `deno.json` only bounds what's *allowed*, the lockfile fixes
+  what's *used*. Regenerate it (`deno install` or a fresh `deno.lock` write)
+  whenever you deliberately take an upgrade, and review the diff.
+
+## Upgrade notes
+
+For what changed in a given release, see:
+
+- The root [`CHANGELOG.md`](../CHANGELOG.md) for project-level milestones.
+- Each package's own `packages/<pkg>/CHANGELOG.md` (e.g.
+  [`packages/core/CHANGELOG.md`](../packages/core/CHANGELOG.md)) for the
+  generated, per-release notes — every entry there is release-please output
+  from Conventional Commits, so it's the authoritative per-package history.

--- a/plugins/zuke/skills/zuke-setup/SKILL.md
+++ b/plugins/zuke/skills/zuke-setup/SKILL.md
@@ -47,14 +47,20 @@ zuke import                  # auto-detects package.json, then a Makefile
 zuke import --from makefile   # or pin the source (package.json | makefile)
 ```
 
-Each script/target becomes a `target()`; a command maps to `CmdTasks.exec(...)`,
-an `&&` chain becomes sequential steps, a `run`/prerequisite delegation becomes
-`.dependsOn(...)`, and anything too shell-specific to translate (pipes,
-redirects, env assignments) is preserved behind a `// TODO` so the file still
-compiles. It scaffolds the launchers and `deno.json` exactly like `setup`, and
-takes the same `--dir`, `--name`, `--force`, `--yes` flags. Afterwards, use the
-**zuke-write-build** skill to replace the generated `CmdTasks.exec` calls with
-typed `*Tasks` wrappers.
+Each script/target becomes a `target()`; a command maps to `CmdTasks.exec(...)`
+— a **placeholder**, not the destination: before accepting it, check the
+package catalogue (`llms.txt`'s `## Packages` list, or the table in
+[`zuke-write-build`'s cheatsheet](../zuke-write-build/references/cheatsheet.md))
+for a `@zuke/<tool>` wrapper matching that command and replace the placeholder
+with it — leaving `CmdTasks.exec` in place for a tool that has a typed wrapper
+is a bug, not a shortcut. An `&&` chain becomes sequential steps, a
+`run`/prerequisite delegation becomes `.dependsOn(...)`, and anything too
+shell-specific to translate (pipes, redirects, env assignments) is preserved
+behind a `// TODO` so the file still compiles. It scaffolds the launchers and
+`deno.json` exactly like `setup`, and takes the same `--dir`, `--name`,
+`--force`, `--yes` flags. Afterwards, use the **zuke-write-build** skill to
+finish replacing any remaining generated `CmdTasks.exec` calls with typed
+`*Tasks` wrappers.
 
 ### What `zuke setup` writes
 
@@ -113,7 +119,12 @@ prefer `zuke setup`, which drops the launcher scripts in for you.)
 ## Finding the exact API — never guess
 
 Every external tool has a typed `*Tasks` wrapper; **do not fall back to
-`Deno.Command` or hand-rolled shell.** To get exact signatures:
+`Deno.Command` or hand-rolled shell.** First confirm a wrapper exists at all —
+`llms.txt`'s `## Packages` catalogue or the table in
+[`zuke-write-build`'s cheatsheet](../zuke-write-build/references/cheatsheet.md)
+is the only way to answer that; a per-package `deno doc` needs a name to
+target, so it cannot reveal that one exists. Once you know the package name,
+get its exact signatures:
 
 - A single package on the command line: `deno doc jsr:@zuke/<package>`. Prefer
   this in a consumer repo — it resolves the version the project actually has

--- a/plugins/zuke/skills/zuke-write-build/SKILL.md
+++ b/plugins/zuke/skills/zuke-write-build/SKILL.md
@@ -45,15 +45,24 @@ await run(CI);
    initialise top-to-bottom; a forward reference is `undefined` and is reported
    as an error (TypeScript also flags it, `TS2729`). Order fields so
    dependencies come first.
-3. **Inside a target body, never guess the API or shell out by hand.** Whatever
-   runs in an `.executes(...)` body drives an external tool through its
-   namespaced `*Tasks` object, configured with a **settings lambda** that mirrors
-   the real CLI's flags — `DenoTasks`, `NpmTasks`, `DockerTasks`, `GitTasks`, and
-   30+ more — never a raw `Deno.Command` or shell string. Reach for
-   `jsr:@zuke/cmd` (`CmdTasks.exec`) or the `$` shell from `jsr:@zuke/core/shell`
-   only when no typed wrapper exists. (If a build delegates its side effects to
-   your own tested modules behind injected clients, the wrapper rule still
-   governs whatever those modules run in the target body.)
+3. **Check the package catalogue before writing any command.** `llms.txt`'s
+   `## Packages` catalogue (raw:
+   <https://raw.githubusercontent.com/zuke-build/zuke/master/llms.txt>) and the
+   package table in [`references/cheatsheet.md`](references/cheatsheet.md) are
+   the only ways to answer "does a `@zuke/<tool>` wrapper exist for this CLI?"
+   — per-package `deno doc jsr:@zuke/<pkg>` only describes a package whose name
+   you already know; it cannot tell you a wrapper exists. Whatever runs in an
+   `.executes(...)` body drives an external tool through its namespaced
+   `*Tasks` object, configured with a **settings lambda** that mirrors the real
+   CLI's flags — `DenoTasks`, `NpmTasks`, `DockerTasks`, `GitTasks`, and 30+
+   more — never a raw `Deno.Command` or shell string. `jsr:@zuke/cmd`
+   (`CmdTasks.exec`) or the `$` shell from `jsr:@zuke/core/shell` is the
+   **last resort**, reached for only once the catalogue confirms no typed
+   wrapper exists — using it for a tool that has a `@zuke/<tool>` package is a
+   **bug**, not a style choice: it discards typed flags, argv purity, and tool
+   resolution. (If a build delegates its side effects to your own tested
+   modules behind injected clients, the wrapper rule still governs whatever
+   those modules run in the target body.)
 4. **A body is required.** Set `.executes(...)`; it may be sync or async, and
    its return value is ignored — `.executes(() => DenoTasks.lint())` is fine
    as-is; never wrap a single wrapper call in an `async` block just to discard
@@ -61,9 +70,12 @@ await run(CI);
 
 ## Find the exact signature first
 
-Before calling any task or settings method, confirm the real shape:
+Before calling any task or settings method, confirm the real shape — but first
+confirm a wrapper exists at all: `deno doc` needs a package name to target, so
+it cannot answer "does one exist for this tool?"; only the catalogue
+(`llms.txt`'s `## Packages` list or the cheatsheet table below) can.
 
-- **One package — prefer this in a consumer repo:**
+- **One package — prefer this in a consumer repo, once you know its name:**
   `deno doc jsr:@zuke/<package>` (e.g. `deno doc jsr:@zuke/deno`). It resolves
   the version the project actually has installed, so it cannot describe an API
   that version lacks.

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -520,13 +520,23 @@ the full task list and settings methods of each):
 | `@zuke/claude`, `@zuke/codex`, `@zuke/gemini`                                                                                                  | `ClaudeTasks`, ...                               | headless AI CLIs                                                                    |
 | `@zuke/ai`                                                                                                                                     | `securityReviewer`, ..., `aiFixer`, `agentFixer` | AI review gates + self-healing (see below)                                          |
 
-The catalog keeps growing — `deno doc jsr:@zuke/<pkg>` (or the package list in
-`llms.txt`) is the source of truth for what exists.
+The catalog keeps growing — the package list in `llms.txt`'s `## Packages`
+catalogue (or the table above) is the source of truth for **whether a wrapper
+exists**; `deno doc jsr:@zuke/<pkg>` only confirms the **shape** of a package
+whose name you already know, it cannot tell you one exists. Check the
+catalogue before reaching for the fallback below — using `CmdTasks.exec`/`$`
+for a tool that has a `@zuke/<tool>` package is a bug, not a style choice.
 
 ```ts
 await DenoTasks.test((s) => s.allowAll().coverage("cov_profile"));
 await DenoTasks.fmt((s) => s.check().paths("mod.ts"));
-await CmdTasks.exec("my-tool", (s) => s.args("--flag", "value")); // no wrapper? use cmd
+await CmdTasks.exec("my-tool", (s) => s.args("--flag", "value")); // no wrapper in the catalogue? last resort: cmd
+
+// Wrong — @zuke/docker has a typed wrapper, so this discards typed flags,
+// argv purity, and tool resolution:
+await CmdTasks.exec("docker", (s) => s.args("build", "-t", "app", "."));
+// Right — check the catalogue, find @zuke/docker, use it:
+await DockerTasks.build((s) => s.tag("app").context("."));
 ```
 
 ## AI review & self-healing — `@zuke/ai`

--- a/skills/zuke-setup/SKILL.md
+++ b/skills/zuke-setup/SKILL.md
@@ -47,14 +47,20 @@ zuke import                  # auto-detects package.json, then a Makefile
 zuke import --from makefile   # or pin the source (package.json | makefile)
 ```
 
-Each script/target becomes a `target()`; a command maps to `CmdTasks.exec(...)`,
-an `&&` chain becomes sequential steps, a `run`/prerequisite delegation becomes
-`.dependsOn(...)`, and anything too shell-specific to translate (pipes,
-redirects, env assignments) is preserved behind a `// TODO` so the file still
-compiles. It scaffolds the launchers and `deno.json` exactly like `setup`, and
-takes the same `--dir`, `--name`, `--force`, `--yes` flags. Afterwards, use the
-**zuke-write-build** skill to replace the generated `CmdTasks.exec` calls with
-typed `*Tasks` wrappers.
+Each script/target becomes a `target()`; a command maps to `CmdTasks.exec(...)`
+— a **placeholder**, not the destination: before accepting it, check the
+package catalogue (`llms.txt`'s `## Packages` list, or the table in
+[`zuke-write-build`'s cheatsheet](../zuke-write-build/references/cheatsheet.md))
+for a `@zuke/<tool>` wrapper matching that command and replace the placeholder
+with it — leaving `CmdTasks.exec` in place for a tool that has a typed wrapper
+is a bug, not a shortcut. An `&&` chain becomes sequential steps, a
+`run`/prerequisite delegation becomes `.dependsOn(...)`, and anything too
+shell-specific to translate (pipes, redirects, env assignments) is preserved
+behind a `// TODO` so the file still compiles. It scaffolds the launchers and
+`deno.json` exactly like `setup`, and takes the same `--dir`, `--name`,
+`--force`, `--yes` flags. Afterwards, use the **zuke-write-build** skill to
+finish replacing any remaining generated `CmdTasks.exec` calls with typed
+`*Tasks` wrappers.
 
 ### What `zuke setup` writes
 
@@ -113,7 +119,12 @@ prefer `zuke setup`, which drops the launcher scripts in for you.)
 ## Finding the exact API — never guess
 
 Every external tool has a typed `*Tasks` wrapper; **do not fall back to
-`Deno.Command` or hand-rolled shell.** To get exact signatures:
+`Deno.Command` or hand-rolled shell.** First confirm a wrapper exists at all —
+`llms.txt`'s `## Packages` catalogue or the table in
+[`zuke-write-build`'s cheatsheet](../zuke-write-build/references/cheatsheet.md)
+is the only way to answer that; a per-package `deno doc` needs a name to
+target, so it cannot reveal that one exists. Once you know the package name,
+get its exact signatures:
 
 - A single package on the command line: `deno doc jsr:@zuke/<package>`. Prefer
   this in a consumer repo — it resolves the version the project actually has

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -45,15 +45,24 @@ await run(CI);
    initialise top-to-bottom; a forward reference is `undefined` and is reported
    as an error (TypeScript also flags it, `TS2729`). Order fields so
    dependencies come first.
-3. **Inside a target body, never guess the API or shell out by hand.** Whatever
-   runs in an `.executes(...)` body drives an external tool through its
-   namespaced `*Tasks` object, configured with a **settings lambda** that mirrors
-   the real CLI's flags — `DenoTasks`, `NpmTasks`, `DockerTasks`, `GitTasks`, and
-   30+ more — never a raw `Deno.Command` or shell string. Reach for
-   `jsr:@zuke/cmd` (`CmdTasks.exec`) or the `$` shell from `jsr:@zuke/core/shell`
-   only when no typed wrapper exists. (If a build delegates its side effects to
-   your own tested modules behind injected clients, the wrapper rule still
-   governs whatever those modules run in the target body.)
+3. **Check the package catalogue before writing any command.** `llms.txt`'s
+   `## Packages` catalogue (raw:
+   <https://raw.githubusercontent.com/zuke-build/zuke/master/llms.txt>) and the
+   package table in [`references/cheatsheet.md`](references/cheatsheet.md) are
+   the only ways to answer "does a `@zuke/<tool>` wrapper exist for this CLI?"
+   — per-package `deno doc jsr:@zuke/<pkg>` only describes a package whose name
+   you already know; it cannot tell you a wrapper exists. Whatever runs in an
+   `.executes(...)` body drives an external tool through its namespaced
+   `*Tasks` object, configured with a **settings lambda** that mirrors the real
+   CLI's flags — `DenoTasks`, `NpmTasks`, `DockerTasks`, `GitTasks`, and 30+
+   more — never a raw `Deno.Command` or shell string. `jsr:@zuke/cmd`
+   (`CmdTasks.exec`) or the `$` shell from `jsr:@zuke/core/shell` is the
+   **last resort**, reached for only once the catalogue confirms no typed
+   wrapper exists — using it for a tool that has a `@zuke/<tool>` package is a
+   **bug**, not a style choice: it discards typed flags, argv purity, and tool
+   resolution. (If a build delegates its side effects to your own tested
+   modules behind injected clients, the wrapper rule still governs whatever
+   those modules run in the target body.)
 4. **A body is required.** Set `.executes(...)`; it may be sync or async, and
    its return value is ignored — `.executes(() => DenoTasks.lint())` is fine
    as-is; never wrap a single wrapper call in an `async` block just to discard
@@ -61,9 +70,12 @@ await run(CI);
 
 ## Find the exact signature first
 
-Before calling any task or settings method, confirm the real shape:
+Before calling any task or settings method, confirm the real shape — but first
+confirm a wrapper exists at all: `deno doc` needs a package name to target, so
+it cannot answer "does one exist for this tool?"; only the catalogue
+(`llms.txt`'s `## Packages` list or the cheatsheet table below) can.
 
-- **One package — prefer this in a consumer repo:**
+- **One package — prefer this in a consumer repo, once you know its name:**
   `deno doc jsr:@zuke/<package>` (e.g. `deno doc jsr:@zuke/deno`). It resolves
   the version the project actually has installed, so it cannot describe an API
   that version lacks.

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -520,13 +520,23 @@ the full task list and settings methods of each):
 | `@zuke/claude`, `@zuke/codex`, `@zuke/gemini`                                                                                                  | `ClaudeTasks`, ...                               | headless AI CLIs                                                                    |
 | `@zuke/ai`                                                                                                                                     | `securityReviewer`, ..., `aiFixer`, `agentFixer` | AI review gates + self-healing (see below)                                          |
 
-The catalog keeps growing — `deno doc jsr:@zuke/<pkg>` (or the package list in
-`llms.txt`) is the source of truth for what exists.
+The catalog keeps growing — the package list in `llms.txt`'s `## Packages`
+catalogue (or the table above) is the source of truth for **whether a wrapper
+exists**; `deno doc jsr:@zuke/<pkg>` only confirms the **shape** of a package
+whose name you already know, it cannot tell you one exists. Check the
+catalogue before reaching for the fallback below — using `CmdTasks.exec`/`$`
+for a tool that has a `@zuke/<tool>` package is a bug, not a style choice.
 
 ```ts
 await DenoTasks.test((s) => s.allowAll().coverage("cov_profile"));
 await DenoTasks.fmt((s) => s.check().paths("mod.ts"));
-await CmdTasks.exec("my-tool", (s) => s.args("--flag", "value")); // no wrapper? use cmd
+await CmdTasks.exec("my-tool", (s) => s.args("--flag", "value")); // no wrapper in the catalogue? last resort: cmd
+
+// Wrong — @zuke/docker has a typed wrapper, so this discards typed flags,
+// argv purity, and tool resolution:
+await CmdTasks.exec("docker", (s) => s.args("build", "-t", "app", "."));
+// Right — check the catalogue, find @zuke/docker, use it:
+await DockerTasks.build((s) => s.tag("app").context("."));
 ```
 
 ## AI review & self-healing — `@zuke/ai`

--- a/tests/integration/pr_body_lint_test.ts
+++ b/tests/integration/pr_body_lint_test.ts
@@ -63,6 +63,15 @@ Deno.test("a clean PR body passes the gate", async () => {
   assertStringIncludes(out, "PR body is clean");
 });
 
+Deno.test("a PR body with a member-call fragment fails the gate", async () => {
+  const { code, err } = await runWithPrBody(
+    'Names the anti-pattern CmdTasks.exec("docker", args) in the cheatsheet.',
+  );
+  assertEquals(code, 1);
+  assertStringIncludes(err, "RELEASING.md");
+  assertStringIncludes(err, "code fragment");
+});
+
 Deno.test("a PR body with a fenced code block fails the gate and points to RELEASING.md", async () => {
   const { code, err } = await runWithPrBody(
     ["Summary.", "```ts", 'const x = () => "y";', "```"].join("\n"),

--- a/tests/pr_body_lint_test.ts
+++ b/tests/pr_body_lint_test.ts
@@ -90,6 +90,27 @@ Deno.test("a bare call statement line outside a fence is flagged", () => {
   assertEquals(findings[0].includes("line 1"), true);
 });
 
+Deno.test("a member-call fragment outside a fence is flagged", () => {
+  // The exact shape that reached a commit body in the wrapper-catalogue work:
+  // no arrow function and no bare `();`, so only the member-call rule catches
+  // it, and release-please's parser still chokes on its parentheses.
+  const findings = lintPrBody(
+    'Show the anti-pattern CmdTasks.exec("docker", args) beside the typed ' +
+      "replacement DockerTasks.build(settings).",
+  );
+  assertEquals(findings.length, 1);
+  assertEquals(findings[0].includes("line 1"), true);
+});
+
+Deno.test("a filename with a following parenthetical is not flagged", () => {
+  assertEquals(
+    lintPrBody(
+      "Links the new guide from docs/README.md (both documentation indexes).",
+    ),
+    [],
+  );
+});
+
 Deno.test("the CI workflow re-runs on an edited PR description", () => {
   // Without an explicit `types:`, `pull_request` fires only on opened,
   // synchronize and reopened — so editing the description after the last push


### PR DESCRIPTION
Three documentation additions, plus a rebuilt comparison page. No source or test changes, so this bumps nothing.

## Versioning and core-floor compatibility

Core is semver on 1.x; tool wrappers are 0.x and may change within 0.x. Each wrapper declares a floor on core, and that floor is hand-maintained — a real failure mode, so the guide documents it with the instance that actually happened rather than in the abstract: a published cli imported a core symbol that only existed in a newer core, because CI type-checks against the workspace-local core rather than the floor the manifest declares. Installs resolving the newest matching core worked by luck; a consumer whose lockfile pinned the older core got a runtime failure.

## The comparison page

A capability matrix across `deno task`, npm scripts, GNU Make, Nx, Turborepo, Dagger and NUKE, then per-tool prose.

**This page was rewritten.** The first draft was written from recollection, and an adversarial fact-check found nine defects — seven of them overclaims in Zuke's own favour. It is now built from competitor documentation with sources cited and a dated footer, and every Zuke capability was re-derived from source rather than from prose about it.

Two corrections about other projects are worth calling out, because they were the highest-risk kind:

- **Self-hosting a cache is free for both Nx and Turborepo.** The draft implied Nx gated it behind payment. It does not — the pre-built cloud adapters were deprecated over a CVE, not to charge for the feature. Zuke's real differentiator is that its cache is built into the build system with no separate service to adopt, not that it costs nothing.
- **A gap attributed to NUKE rested on an issue that closed as completed in 2019.** That claim is withdrawn; the cell reads unknown rather than asserting an absence we cannot support.

The rows Zuke does not win are marked as such: incremental skipping and changed-file selection are declaration-driven here and inferred from the source graph in Nx and Turborepo, the cache does not notice an edited target body unless a cache key says so, the cross-machine cache requires declared inputs and outputs and degrades quietly when the store is unreachable, and exactly-once resume spans a single host unless the operator runs the HTTP state store. The matrix also distinguishes "not found in the documentation reviewed" from *unknown*, since silence in a competitor's docs is weak evidence.

The intro states plainly that the installed command, `@zuke/cli`, is at 0.8.1 and pre-1.0, and that it fronts the `mcp`, `resume` and `cancel` surface the page showcases.

## Wrapper discoverability, and naming the anti-pattern

The premise here needed correcting before writing: `llms.txt` already carries a generated catalogue of every package, and the cheatsheet already has a grouped table, so this duplicates neither. The real gaps were narrower — the contributor guide recommends per-package `deno doc`, which structurally cannot reveal that a package *exists*, and the authoring skill offered the generic-command and raw-shell fallback **before** telling an agent to check the catalogue.

Reaching for the generic command runner when a typed wrapper exists is now named as a defect rather than a style preference, since it discards typed flags, pure argv construction and tool resolution. The cheatsheet gains the inverse example showing the wrong call beside the right one. Because `skills/` changed, the plugin copies were re-synced in the same change — omitting that turned master red once already.

## One correction to shipped documentation

`docs/shell.md` claimed there is no injection surface. Discrete argv entries defeat *shell* injection, but a value beginning with a dash still becomes a flag the invoked tool honours — argument injection is a different thing and remains the caller's to validate. Both that guide and the comparison page now say so in the same words. A stale link anchor also turned out to exist in seven guides rather than the two first noticed; all are fixed.

## Verification

`deno task ci` green, 15 of 15 targets, exit code 0 — re-run after rebasing onto current master and again after the rewrite. Two adversarial review lenses plus two independent fact-checkers were applied; every finding is either fixed or explicitly withdrawn as unverifiable.
