### PR TITLE
test: migrate wrappers to the conformance helper, cover git and the release tooling

### DIFF
--- a/build/api_reference.ts
+++ b/build/api_reference.ts
@@ -156,7 +156,7 @@ interface ApiReference {
  * `Promise`/`Array` would otherwise lose its `<T>`. Everything exotic falls
  * back to the pre-rendered `repr` (safe), then to `"unknown"`.
  */
-function renderType(t: DocTsType | undefined): string {
+export function renderType(t: DocTsType | undefined): string {
   if (t === undefined) return "unknown";
   const value = t.value;
   if (
@@ -180,7 +180,7 @@ function renderType(t: DocTsType | undefined): string {
 }
 
 /** Render one parameter as `name: Type` (with `...`/`?` as appropriate). */
-function renderParam(p: DocParam): string {
+export function renderParam(p: DocParam): string {
   if (p.kind === "rest") {
     return `...${p.arg?.name ?? "args"}: ${renderType(p.tsType)}`;
   }
@@ -193,14 +193,17 @@ function renderParam(p: DocParam): string {
 }
 
 /** `[async ]function name(params): Return` for one function declaration. */
-function functionSignature(name: string, def: DocDef | undefined): string {
+export function functionSignature(
+  name: string,
+  def: DocDef | undefined,
+): string {
   const params = (def?.params ?? []).map(renderParam).join(", ");
   const prefix = def?.isAsync === true ? "async " : "";
   return `${prefix}function ${name}(${params}): ${renderType(def?.returnType)}`;
 }
 
 /** Build the one-line signature for a symbol from its declaration(s). */
-function symbolSignature(
+export function symbolSignature(
   name: string,
   kind: string,
   decls: DocDeclaration[],
@@ -235,12 +238,12 @@ function symbolSignature(
 }
 
 /** A member is public unless explicitly `private`/`protected`. */
-function isPublicMember(accessibility: string | undefined): boolean {
+export function isPublicMember(accessibility: string | undefined): boolean {
   return accessibility === undefined || accessibility === "public";
 }
 
 /** Render a method member as `name(params): Return`. */
-function memberMethod(m: DocMethod): ApiMember {
+export function memberMethod(m: DocMethod): ApiMember {
   // Class methods nest under `functionDef`; interface methods are flat.
   const fn = m.functionDef ?? m;
   const params = (fn.params ?? []).map(renderParam).join(", ");
@@ -258,7 +261,7 @@ function memberMethod(m: DocMethod): ApiMember {
 }
 
 /** Render a property member as `name: Type`. */
-function memberProperty(p: DocProperty): ApiMember {
+export function memberProperty(p: DocProperty): ApiMember {
   const optional = p.optional === true;
   const name = p.name ?? "";
   return {
@@ -271,7 +274,7 @@ function memberProperty(p: DocProperty): ApiMember {
 }
 
 /** Public methods then properties of a class/interface def. */
-function symbolMembers(def: DocDef | undefined): ApiMember[] {
+export function symbolMembers(def: DocDef | undefined): ApiMember[] {
   const members: ApiMember[] = [];
   for (const m of def?.methods ?? []) {
     if (isPublicMember(m.accessibility)) members.push(memberMethod(m));
@@ -283,7 +286,7 @@ function symbolMembers(def: DocDef | undefined): ApiMember[] {
 }
 
 /** Reshape one documented symbol into its `api.json` entry. */
-function buildSymbol(sym: DocSymbol): ApiSymbol {
+export function buildSymbol(sym: DocSymbol): ApiSymbol {
   const decls = sym.declarations ?? [];
   const first = decls[0];
   const kind = first?.kind ?? "variable";
@@ -303,7 +306,7 @@ function buildSymbol(sym: DocSymbol): ApiSymbol {
 }
 
 /** The package summary: the first non-empty line of any module doc. */
-function moduleSummary(nodes: DocNode[]): string {
+export function moduleSummary(nodes: DocNode[]): string {
   for (const node of nodes) {
     const doc = node.module_doc?.doc;
     if (doc !== undefined && doc.trim() !== "") {
@@ -314,7 +317,7 @@ function moduleSummary(nodes: DocNode[]): string {
 }
 
 /** Reshape a package's whole `deno doc --json` output into `api.json` form. */
-function transformPackage(dir: string, root: DocRoot): ApiPackage {
+export function transformPackage(dir: string, root: DocRoot): ApiPackage {
   const nodes = Object.values(root.nodes ?? {});
   // Aggregate symbols across every entrypoint, first-seen wins (a re-export
   // can surface the same symbol from more than one entrypoint file).

--- a/build/docs.ts
+++ b/build/docs.ts
@@ -149,8 +149,11 @@ export async function crossPackageTypesOf(dir: string): Promise<string[]> {
           if (local !== undefined) names.add(local);
         }
       } else {
-        // A bare default import: `import Foo from "@zuke/…"`.
-        const def = clause.match(/^([A-Za-z_$][\w$]*)\s*$/);
+        // A bare default import: `import Foo from "@zuke/…"`. The capture
+        // group between `import` and `from` always carries the separating
+        // whitespace (`\bimport\b` doesn't consume it), so the match must
+        // tolerate leading space too, not just trailing.
+        const def = clause.match(/^\s*([A-Za-z_$][\w$]*)\s*$/);
         if (def !== null) names.add(def[1]);
       }
     }

--- a/build/publish.ts
+++ b/build/publish.ts
@@ -62,7 +62,7 @@ export async function installCli(
  * `deno` discovers the workspace `deno.lock`) with the caller's own arguments
  * appended. Every word is quoted, because the repository path is arbitrary.
  */
-function launcherScript(argv: string[], onWindows: boolean): string {
+export function launcherScript(argv: string[], onWindows: boolean): string {
   const root = String(repoRoot());
   if (onWindows) {
     const line = argv.map((word) => `"${word.replaceAll('"', '""')}"`).join(
@@ -108,4 +108,52 @@ export async function publishPackage(pkg: string): Promise<boolean> {
     if (error instanceof CommandTimeoutError) return false;
     throw error;
   }
+}
+
+/**
+ * The dependencies {@link publishOne} needs, injected so its skip/publish/
+ * re-check decision is unit-testable without a real `deno publish` or a
+ * network call to JSR.
+ */
+export interface PublishOneDeps {
+  /** Whether `pkg`@`version` is already on JSR. */
+  isPublished(pkg: string, version: string): Promise<boolean>;
+  /** Publish `pkg`; `false` means the upload timed out (see {@link publishPackage}). */
+  publishPackage(pkg: string): Promise<boolean>;
+  /** Report an in-progress/skip status line. */
+  info(message: string): void;
+  /** Report that a stalled publish is confirmed to have landed. */
+  success(message: string): void;
+}
+
+/**
+ * Publish one package's pending version to JSR: skip it if already published,
+ * otherwise publish it — and, if the publish itself times out, re-check JSR
+ * once before deciding whether the timeout was fatal. JSR's post-upload
+ * provenance finalization occasionally hangs *after* the upload completes, so
+ * a `false` from {@link PublishOneDeps.publishPackage} isn't necessarily a
+ * failed publish.
+ *
+ * @throws {Error} naming the package/version, if the publish times out and the
+ * re-check still doesn't find it on JSR.
+ */
+export async function publishOne(
+  pkg: string,
+  version: string,
+  deps: PublishOneDeps,
+): Promise<void> {
+  const name = `@zuke/${pkg}@${version}`;
+  if (await deps.isPublished(`@zuke/${pkg}`, version)) {
+    deps.info(`${name} is already on JSR.`);
+    return;
+  }
+  deps.info(`Publishing ${name} to JSR...`);
+  if (await deps.publishPackage(pkg)) return;
+  // Timed out: the upload usually lands before JSR's finalization hangs, so a
+  // re-check tells us whether it actually published.
+  if (await deps.isPublished(`@zuke/${pkg}`, version)) {
+    deps.success(`${name} uploaded (provenance stalled).`);
+    return;
+  }
+  throw new Error(`Publishing ${name} timed out before reaching JSR.`);
 }

--- a/build/website_sync.ts
+++ b/build/website_sync.ts
@@ -13,81 +13,164 @@ import { collectPackageDocs, docsOptions } from "./docs.ts";
 import { writeApiJson } from "./api_reference.ts";
 import { localVersion } from "./packages.ts";
 
+/** The website repo the sync targets, absent an override. */
+export const DEFAULT_WEBSITE_REPO = "zuke-build/zuke-build.github.io";
+
+/** Where the sync pushes and opens its PR: a cross-repo token plus a repo slug. */
+export interface SyncTarget {
+  /** The fine-grained PAT / GitHub App token authorizing the cross-repo push. */
+  token: string;
+  /** The `owner/repo` slug of the website repository. */
+  repo: string;
+}
+
 /**
- * Open a PR to the website with refreshed llms.txt + api.json. Takes the build
- * so it can render the live CLI block via {@link docsOptions}.
+ * The sync's target, derived from env — or `null` when the cross-repo token
+ * isn't set. `GITHUB_TOKEN` cannot push to another repo, so this needs a
+ * fine-grained PAT / GitHub App token (contents + pull-requests write on the
+ * website repo); it is absent locally and on fork PRs, where the sync skips
+ * cleanly rather than failing.
  */
-export async function runWebsiteSync(build: Build): Promise<void> {
-  // The push is cross-repo, which GITHUB_TOKEN cannot do — it needs a
-  // fine-grained PAT / GitHub App token (contents + pull-requests write on
-  // the website repo). Absent locally and on fork PRs: skip cleanly.
-  const token = Deno.env.get("WEBSITE_SYNC_TOKEN");
-  if (token === undefined || token === "") {
-    ConsoleTasks.warn(
-      "WEBSITE_SYNC_TOKEN not set — skipping the website sync.",
-    );
-    return;
-  }
-  const repo = Deno.env.get("WEBSITE_REPO") ??
-    "zuke-build/zuke-build.github.io";
+export function resolveSyncTarget(
+  env: { token?: string; repo?: string },
+): SyncTarget | null {
+  if (env.token === undefined || env.token === "") return null;
+  return { token: env.token, repo: env.repo ?? DEFAULT_WEBSITE_REPO };
+}
 
-  // Regenerate exactly what the website consumes: the llms.txt /
-  // llms-full.txt indexes (the `apiDocs` flow) and the structured
-  // dist/api.json (the `apiReference` flow).
-  await DocsTasks.apiDocs(await collectPackageDocs(), docsOptions(build));
-  await writeApiJson();
+/** The sync branch name and commit message for a given `core` version. */
+export function syncBranchInfo(
+  coreVersion: string,
+): { branch: string; message: string } {
+  return {
+    branch: `zuke-sync/${coreVersion}`,
+    message: `chore: sync docs + api reference for core@${coreVersion}`,
+  };
+}
 
-  // Shallow-clone the website (a public repo — the clone needs no credential)
-  // into a throwaway temp dir, deleted in `finally`.
-  const coreVersion = await localVersion("core");
-  const branch = `zuke-sync/${coreVersion}`;
-  const message = `chore: sync docs + api reference for core@${coreVersion}`;
-  const dir = await Deno.makeTempDir({ prefix: "zuke-sync-" });
-  // The push carries the token as a one-off HTTP Authorization header rather
-  // than embedding it in the remote URL — so it is never persisted in
-  // .git/config or echoed back by git. Mirrors how actions/checkout injects
-  // credentials.
-  const authHeader = `AUTHORIZATION: basic ${btoa(`x-access-token:${token}`)}`;
-  try {
+/** The outcome of opening (or finding an already-open) sync PR. */
+export interface OpenPrResult {
+  /** The `gh pr create` exit code: `0` on a freshly opened PR. */
+  code: number;
+  /** The command's trimmed text output (the PR URL on success). */
+  text: string;
+}
+
+/**
+ * The I/O `runWebsiteSync` performs, injected so its skip/idempotent/PR
+ * decisions are unit-testable without a real clone, push, or `gh` call —
+ * mirroring the seam style {@link "../packages/core/src/conformance.ts"} uses
+ * for its own CLI dependencies.
+ */
+export interface WebsiteSyncDeps {
+  /** Regenerate llms.txt / llms-full.txt (the `apiDocs` flow). */
+  regenerateDocs(build: Build): Promise<void>;
+  /** Regenerate `dist/api.json` (the `apiReference` flow). */
+  regenerateApiJson(): Promise<void>;
+  /** A fresh temp directory to clone the website into. */
+  makeTempDir(): Promise<string>;
+  /** Recursively remove `dir`. */
+  removeDir(dir: string): Promise<void>;
+  /** Shallow-clone `repo` into `dir`. */
+  cloneWebsite(repo: string, dir: string): Promise<void>;
+  /** Create the sync branch in `dir`, off the freshly-cloned default branch. */
+  createSyncBranch(dir: string, branch: string): Promise<void>;
+  /** Copy the regenerated artifacts into `dir`'s expected locations. */
+  copyArtifacts(dir: string): Promise<void>;
+  /** Stage every change in `dir`. */
+  stageAll(dir: string): Promise<void>;
+  /** Whether `dir` has any staged change (idempotency check). */
+  hasStagedChanges(dir: string): Promise<boolean>;
+  /** Commit the staged changes in `dir` with `message`, under a bot identity. */
+  commitStaged(dir: string, message: string): Promise<void>;
+  /** Force-push `branch` from `dir`, authenticated with `token`. */
+  pushBranch(dir: string, branch: string, token: string): Promise<void>;
+  /** Open the sync PR, or note the one a push to the same head already refreshed. */
+  openOrRefreshPr(
+    repo: string,
+    branch: string,
+    message: string,
+    dir: string,
+    token: string,
+  ): Promise<OpenPrResult>;
+  /** Report an in-progress/skip status line. */
+  info(message: string): void;
+  /** Report a freshly opened PR. */
+  success(message: string): void;
+  /** Report that the sync itself is being skipped. */
+  warn(message: string): void;
+}
+
+/** The PR body posted for every sync — idempotent, so its text never varies. */
+const PR_BODY = "Automated docs sync from the Zuke framework: refreshed " +
+  "`public/llms.txt`, `public/llms-full.txt`, and " +
+  "`src/data/api.json`. Idempotent — regenerated each release.";
+
+/** The bot identity commits are authored under (no human git identity in CI). */
+const BOT_NAME = "github-actions[bot]";
+/** The bot email paired with {@link BOT_NAME}. */
+const BOT_EMAIL = "41898282+github-actions[bot]@users.noreply.github.com";
+
+/**
+ * The real {@link WebsiteSyncDeps}: an actual clone, push, and `gh pr create`
+ * against GitHub. This is what `runWebsiteSync` uses in production; a test
+ * substitutes a fake instead.
+ */
+const REAL_DEPS: WebsiteSyncDeps = {
+  regenerateDocs: async (build) => {
+    await DocsTasks.apiDocs(await collectPackageDocs(), docsOptions(build));
+  },
+  regenerateApiJson: async () => {
+    await writeApiJson();
+  },
+  makeTempDir: () => Deno.makeTempDir({ prefix: "zuke-sync-" }),
+  removeDir: async (dir) => {
+    await FileTasks.remove(dir, { recursive: true });
+  },
+  cloneWebsite: async (repo, dir) => {
+    // A public repo — the clone needs no credential.
     await GitTasks.clone((s) =>
       s.repository(`https://github.com/${repo}.git`).directory(dir).depth(1)
     );
-
-    // Reset the sync branch off the freshly-cloned default branch.
+  },
+  createSyncBranch: async (dir, branch) => {
     await GitTasks.checkout((s) => s.dir(dir).ref(branch).create());
-
-    // Copy the artifacts into the website's expected locations.
+  },
+  copyArtifacts: async (dir) => {
     await FileTasks.createDirectory(`${dir}/public`);
     await FileTasks.createDirectory(`${dir}/src/data`);
     await FileTasks.copy("llms.txt", `${dir}/public/llms.txt`);
     await FileTasks.copy("llms-full.txt", `${dir}/public/llms-full.txt`);
     await FileTasks.copy("dist/api.json", `${dir}/src/data/api.json`);
-
-    // Idempotent: bail out before committing if nothing changed — no empty
-    // PR. `api.json`'s `generated` is `core@<version>` (no timestamp) and
-    // the llms files are deterministic, so re-runs diff to nothing.
+  },
+  stageAll: async (dir) => {
     await GitTasks.add((s) => s.dir(dir).all());
+  },
+  hasStagedChanges: async (dir) => {
     const { stdout } = await GitTasks.status((s) =>
       s.dir(dir).porcelain().quiet()
     );
-    if (stdout.trim() === "") {
-      ConsoleTasks.info("website already in sync — no PR needed.");
-      return;
-    }
-
+    return stdout.trim() !== "";
+  },
+  commitStaged: async (dir, message) => {
     // A non-interactive CI runner has no git identity, so set one.
     await GitTasks.commit((s) =>
       s
         .dir(dir)
-        .config("user.name", "github-actions[bot]")
-        .config(
-          "user.email",
-          "41898282+github-actions[bot]@users.noreply.github.com",
-        )
+        .config("user.name", BOT_NAME)
+        .config("user.email", BOT_EMAIL)
         .message(message)
     );
-    // Force-push so the branch is create-or-reset on every release. The token
-    // rides as a one-off `-c http.extraheader`, never in the remote URL.
+  },
+  pushBranch: async (dir, branch, token) => {
+    // The token rides as a one-off HTTP Authorization header rather than
+    // embedding it in the remote URL — so it is never persisted in
+    // .git/config or echoed back by git. Mirrors how actions/checkout
+    // injects credentials. Force-push so the branch is create-or-reset on
+    // every release.
+    const authHeader = `AUTHORIZATION: basic ${
+      btoa(`x-access-token:${token}`)
+    }`;
     await GitTasks.run((s) =>
       s.dir(dir).config("http.extraheader", authHeader).command(
         "push",
@@ -96,33 +179,84 @@ export async function runWebsiteSync(build: Build): Promise<void> {
         branch,
       )
     );
-
-    // Open the PR, or note the existing one — a push to the same head
-    // branch already refreshed it, and `gh` rejects a duplicate.
+  },
+  openOrRefreshPr: async (repo, branch, message, dir, token) => {
+    // `gh` rejects a duplicate PR — a push to the same head branch already
+    // refreshed the existing one, so a non-zero exit here just means that.
     const pr = await GhTasks.run((s) =>
       s
         .command("pr", "create")
         .repo(repo)
         .flag("head", branch)
         .flag("title", message)
-        .flag(
-          "body",
-          "Automated docs sync from the Zuke framework: refreshed " +
-            "`public/llms.txt`, `public/llms-full.txt`, and " +
-            "`src/data/api.json`. Idempotent — regenerated each release.",
-        )
+        .flag("body", PR_BODY)
         .cwd(dir)
         .env({ GH_TOKEN: token })
         .noThrow()
     );
+    return { code: pr.code, text: pr.text() };
+  },
+  info: (message) => ConsoleTasks.info(message),
+  success: (message) => ConsoleTasks.success(message),
+  warn: (message) => ConsoleTasks.warn(message),
+};
+
+/**
+ * Open a PR to the website with refreshed llms.txt + api.json. Takes the build
+ * so it can render the live CLI block via {@link docsOptions}. `deps` defaults
+ * to the real clone/push/`gh` implementation; a test overrides it.
+ */
+export async function runWebsiteSync(
+  build: Build,
+  deps: WebsiteSyncDeps = REAL_DEPS,
+): Promise<void> {
+  const target = resolveSyncTarget({
+    token: Deno.env.get("WEBSITE_SYNC_TOKEN"),
+    repo: Deno.env.get("WEBSITE_REPO"),
+  });
+  if (target === null) {
+    deps.warn("WEBSITE_SYNC_TOKEN not set — skipping the website sync.");
+    return;
+  }
+  const { token, repo } = target;
+
+  // Regenerate exactly what the website consumes: the llms.txt /
+  // llms-full.txt indexes (the `apiDocs` flow) and the structured
+  // dist/api.json (the `apiReference` flow).
+  await deps.regenerateDocs(build);
+  await deps.regenerateApiJson();
+
+  const coreVersion = await localVersion("core");
+  const { branch, message } = syncBranchInfo(coreVersion);
+  // Shallow-clone the website into a throwaway temp dir, deleted in `finally`.
+  const dir = await deps.makeTempDir();
+  try {
+    await deps.cloneWebsite(repo, dir);
+    await deps.createSyncBranch(dir, branch);
+    await deps.copyArtifacts(dir);
+    await deps.stageAll(dir);
+
+    // Idempotent: bail out before committing if nothing changed — no empty
+    // PR. `api.json`'s `generated` is `core@<version>` (no timestamp) and the
+    // llms files are deterministic, so re-runs diff to nothing.
+    if (!(await deps.hasStagedChanges(dir))) {
+      deps.info("website already in sync — no PR needed.");
+      return;
+    }
+
+    await deps.commitStaged(dir, message);
+    await deps.pushBranch(dir, branch, token);
+
+    // Open the PR, or note the existing one.
+    const pr = await deps.openOrRefreshPr(repo, branch, message, dir, token);
     if (pr.code === 0) {
-      ConsoleTasks.success(`Opened website sync PR: ${pr.text()}`);
+      deps.success(`Opened website sync PR: ${pr.text}`);
     } else {
-      ConsoleTasks.info(
+      deps.info(
         `Website sync PR for ${branch} already open — updated by the push.`,
       );
     }
   } finally {
-    await FileTasks.remove(dir, { recursive: true });
+    await deps.removeDir(dir);
   }
 }

--- a/build/website_sync.ts
+++ b/build/website_sync.ts
@@ -25,16 +25,36 @@ export interface SyncTarget {
 }
 
 /**
+ * A GitHub `owner/repo` slug: exactly two non-empty segments of the characters
+ * GitHub allows in an owner or repository name.
+ */
+const REPO_SLUG = /^[A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+/**
  * The sync's target, derived from env — or `null` when the cross-repo token
  * isn't set. `GITHUB_TOKEN` cannot push to another repo, so this needs a
  * fine-grained PAT / GitHub App token (contents + pull-requests write on the
  * website repo); it is absent locally and on fork PRs, where the sync skips
  * cleanly rather than failing.
+ *
+ * An overridden repo is checked against {@link REPO_SLUG} before it is returned.
+ * This is the one place a cross-repo write token leaves for another repository,
+ * so a slug that is not a plain `owner/repo` — anything carrying a URL, a host,
+ * a credential, or an extra path segment — is refused rather than handed to
+ * `git push` and `gh pr create`.
+ *
+ * @throws if `env.repo` is set but is not a valid `owner/repo` slug.
  */
 export function resolveSyncTarget(
   env: { token?: string; repo?: string },
 ): SyncTarget | null {
   if (env.token === undefined || env.token === "") return null;
+  if (env.repo !== undefined && !REPO_SLUG.test(env.repo)) {
+    throw new Error(
+      `website sync: WEBSITE_REPO must be an "owner/repo" slug, got ` +
+        `"${env.repo}". Unset it to target ${DEFAULT_WEBSITE_REPO}.`,
+    );
+  }
   return { token: env.token, repo: env.repo ?? DEFAULT_WEBSITE_REPO };
 }
 

--- a/packages/biome/tests/biome_test.ts
+++ b/packages/biome/tests/biome_test.ts
@@ -1,5 +1,9 @@
 import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import {
+  assertWrapperConformance,
+  missingTool,
+} from "@zuke/core/tooling/conformance";
 import {
   BiomeCheckSettings,
   BiomeCiSettings,
@@ -60,33 +64,15 @@ Deno.test("ci: bare", () => {
   assertEquals(new BiomeCiSettings().argv().slice(1), ["ci"]);
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zuke-no-such-biome-xyz");
-};
-
-Deno.test("biome: resolves its binary from node_modules by default", () => {
-  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
-  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-  const root = Deno.makeTempDirSync();
-  try {
-    const binDir = `${root}/node_modules/.bin`;
-    Deno.mkdirSync(binDir, { recursive: true });
-    const bin = `${binDir}/biome`;
-    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
-    const s = new BiomeCheckSettings();
-    s.os_ = "linux";
-    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
-  } finally {
-    Deno.removeSync(root, { recursive: true });
-    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
-  }
+Deno.test("biome: resolves its binary from node_modules by default", async () => {
+  await assertWrapperConformance(() => new BiomeCheckSettings(), "biome", {
+    resolution: "node_modules",
+  });
 });
 
 Deno.test("every BiomeTasks function reaches execution", async () => {
-  await assertRejects(() => BiomeTasks.check(missing), ToolNotFoundError);
-  await assertRejects(() => BiomeTasks.format(missing), ToolNotFoundError);
-  await assertRejects(() => BiomeTasks.lint(missing), ToolNotFoundError);
-  await assertRejects(() => BiomeTasks.ci(missing), ToolNotFoundError);
+  await assertRejects(() => BiomeTasks.check(missingTool), ToolNotFoundError);
+  await assertRejects(() => BiomeTasks.format(missingTool), ToolNotFoundError);
+  await assertRejects(() => BiomeTasks.lint(missingTool), ToolNotFoundError);
+  await assertRejects(() => BiomeTasks.ci(missingTool), ToolNotFoundError);
 });

--- a/packages/bun/tests/bun_test.ts
+++ b/packages/bun/tests/bun_test.ts
@@ -3,7 +3,8 @@ import {
   assertRejects,
   assertThrows,
 } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import { missingTool } from "@zuke/core/tooling/conformance";
 import {
   BunAddSettings,
   BunInstallSettings,
@@ -91,33 +92,23 @@ Deno.test("test: bare, --coverage, --bail, and paths", () => {
   );
 });
 
-/**
- * Point a settings object at a guaranteed-missing binary with the shim
- * fallback disabled, so each BunTasks function reaches execution WITHOUT
- * ever invoking a real bun (tests must stay hermetic).
- */
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zuke-no-such-bun-xyz");
-};
-
 Deno.test("every BunTasks function reaches execution", async () => {
-  await assertRejects(() => BunTasks.install(missing), ToolNotFoundError);
+  await assertRejects(() => BunTasks.install(missingTool), ToolNotFoundError);
   await assertRejects(
-    () => BunTasks.add((s) => missing(s).packages("x")),
+    () => BunTasks.add((s) => missingTool(s).packages("x")),
     ToolNotFoundError,
   );
   await assertRejects(
-    () => BunTasks.remove((s) => missing(s).packages("x")),
+    () => BunTasks.remove((s) => missingTool(s).packages("x")),
     ToolNotFoundError,
   );
   await assertRejects(
-    () => BunTasks.run((s) => missing(s).script("x")),
+    () => BunTasks.run((s) => missingTool(s).script("x")),
     ToolNotFoundError,
   );
   await assertRejects(
-    () => BunTasks.x((s) => missing(s).command("x")),
+    () => BunTasks.x((s) => missingTool(s).command("x")),
     ToolNotFoundError,
   );
-  await assertRejects(() => BunTasks.test(missing), ToolNotFoundError);
+  await assertRejects(() => BunTasks.test(missingTool), ToolNotFoundError);
 });

--- a/packages/claude/tests/claude_test.ts
+++ b/packages/claude/tests/claude_test.ts
@@ -3,7 +3,8 @@ import {
   assertRejects,
   assertThrows,
 } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import { missingTool } from "@zuke/core/tooling/conformance";
 import {
   ClaudeConfigSettings,
   ClaudeMcpSettings,
@@ -140,35 +141,30 @@ Deno.test("update: builds the update subcommand", () => {
   assertEquals(new ClaudeUpdateSettings().argv(), ["claude", "update"]);
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zz-no-such-claude-zz");
-};
-
 Deno.test("ClaudeTasks.run reaches execution", async () => {
   await assertRejects(
-    () => ClaudeTasks.run((s) => missing(s.prompt("hi"))),
+    () => ClaudeTasks.run((s) => missingTool(s.prompt("hi"))),
     ToolNotFoundError,
   );
 });
 
 Deno.test("ClaudeTasks.mcp reaches execution", async () => {
   await assertRejects(
-    () => ClaudeTasks.mcp((s) => missing(s.command("list"))),
+    () => ClaudeTasks.mcp((s) => missingTool(s.command("list"))),
     ToolNotFoundError,
   );
 });
 
 Deno.test("ClaudeTasks.config reaches execution", async () => {
   await assertRejects(
-    () => ClaudeTasks.config((s) => missing(s.command("list"))),
+    () => ClaudeTasks.config((s) => missingTool(s.command("list"))),
     ToolNotFoundError,
   );
 });
 
 Deno.test("ClaudeTasks.update reaches execution", async () => {
   await assertRejects(
-    () => ClaudeTasks.update((s) => missing(s)),
+    () => ClaudeTasks.update((s) => missingTool(s)),
     ToolNotFoundError,
   );
 });

--- a/packages/codecov/tests/codecov_test.ts
+++ b/packages/codecov/tests/codecov_test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import { missingTool } from "@zuke/core/tooling/conformance";
 import { CodecovTasks, CodecovUploadSettings } from "../src/codecov.ts";
 
 Deno.test("default tool is codecovcli, subcommand upload-process", () => {
@@ -78,16 +79,9 @@ Deno.test("codecov: pullRequest accepts a string too", () => {
   ]);
 });
 
-// Force a missing binary on a known OS so the run reaches execution and fails
-// with ToolNotFoundError rather than depending on an ambient `codecovcli`.
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zz-no-such-codecovcli-zz");
-};
-
 Deno.test("CodecovTasks.upload reaches execution", async () => {
   await assertRejects(
-    () => CodecovTasks.upload((s) => missing(s.files("cov.lcov"))),
+    () => CodecovTasks.upload((s) => missingTool(s.files("cov.lcov"))),
     ToolNotFoundError,
   );
 });

--- a/packages/codex/tests/codex_test.ts
+++ b/packages/codex/tests/codex_test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import { missingTool } from "@zuke/core/tooling/conformance";
 import {
   CodexExecSettings,
   CodexMcpSettings,
@@ -96,21 +97,16 @@ Deno.test("mcp: command then bare and valued flags", () => {
   ]);
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zz-no-such-codex-zz");
-};
-
 Deno.test("CodexTasks.exec reaches execution", async () => {
   await assertRejects(
-    () => CodexTasks.exec((s) => missing(s.prompt("hi"))),
+    () => CodexTasks.exec((s) => missingTool(s.prompt("hi"))),
     ToolNotFoundError,
   );
 });
 
 Deno.test("CodexTasks.mcp reaches execution", async () => {
   await assertRejects(
-    () => CodexTasks.mcp((s) => missing(s.command("list"))),
+    () => CodexTasks.mcp((s) => missingTool(s.command("list"))),
     ToolNotFoundError,
   );
 });

--- a/packages/cspell/tests/cspell_test.ts
+++ b/packages/cspell/tests/cspell_test.ts
@@ -1,5 +1,9 @@
 import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import {
+  assertWrapperConformance,
+  missingTool,
+} from "@zuke/core/tooling/conformance";
 import { CspellSettings, CspellTasks } from "../src/cspell.ts";
 
 Deno.test("the default invocation is cspell lint", () => {
@@ -47,30 +51,12 @@ Deno.test("cspell: minimal checks just the given glob", () => {
   ]);
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zz-no-such-cspell-zz");
-};
-
 Deno.test("CspellTasks.lint reaches execution", async () => {
-  await assertRejects(() => CspellTasks.lint(missing), ToolNotFoundError);
+  await assertRejects(() => CspellTasks.lint(missingTool), ToolNotFoundError);
 });
 
-Deno.test("cspell: resolves its binary from node_modules by default", () => {
-  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
-  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-  const root = Deno.makeTempDirSync();
-  try {
-    const binDir = `${root}/node_modules/.bin`;
-    Deno.mkdirSync(binDir, { recursive: true });
-    const bin = `${binDir}/cspell`;
-    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
-    const s = new CspellSettings();
-    s.os_ = "linux"; // pin so the planted bare shim matches on any host
-    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
-  } finally {
-    Deno.removeSync(root, { recursive: true });
-    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
-  }
+Deno.test("cspell: resolves its binary from node_modules by default", async () => {
+  await assertWrapperConformance(() => new CspellSettings(), "cspell", {
+    resolution: "node_modules",
+  });
 });

--- a/packages/cypress/tests/cypress_test.ts
+++ b/packages/cypress/tests/cypress_test.ts
@@ -1,5 +1,9 @@
 import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import {
+  assertWrapperConformance,
+  missingTool,
+} from "@zuke/core/tooling/conformance";
 import {
   CypressInfoSettings,
   CypressInstallSettings,
@@ -13,23 +17,10 @@ Deno.test("the default binary is cypress", () => {
   assertEquals(new CypressRunSettings().argv()[0], "cypress");
 });
 
-Deno.test("cypress: resolves its binary from node_modules by default", () => {
-  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
-  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-  const root = Deno.makeTempDirSync();
-  try {
-    const binDir = `${root}/node_modules/.bin`;
-    Deno.mkdirSync(binDir, { recursive: true });
-    const bin = `${binDir}/cypress`;
-    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
-    const s = new CypressRunSettings();
-    s.os_ = "linux"; // pin so the planted bare shim matches on any host
-    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
-  } finally {
-    Deno.removeSync(root, { recursive: true });
-    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
-  }
+Deno.test("cypress: resolves its binary from node_modules by default", async () => {
+  await assertWrapperConformance(() => new CypressRunSettings(), "cypress", {
+    resolution: "node_modules",
+  });
 });
 
 Deno.test("run: bare and all options (shared + run-specific)", () => {
@@ -93,15 +84,16 @@ Deno.test("verify and info are fixed argv", () => {
   assertEquals(new CypressInfoSettings().argv().slice(1), ["info"]);
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zuke-no-such-cypress-xyz");
-};
-
 Deno.test("every CypressTasks function reaches execution", async () => {
-  await assertRejects(() => CypressTasks.run(missing), ToolNotFoundError);
-  await assertRejects(() => CypressTasks.open(missing), ToolNotFoundError);
-  await assertRejects(() => CypressTasks.install(missing), ToolNotFoundError);
-  await assertRejects(() => CypressTasks.verify(missing), ToolNotFoundError);
-  await assertRejects(() => CypressTasks.info(missing), ToolNotFoundError);
+  await assertRejects(() => CypressTasks.run(missingTool), ToolNotFoundError);
+  await assertRejects(() => CypressTasks.open(missingTool), ToolNotFoundError);
+  await assertRejects(
+    () => CypressTasks.install(missingTool),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => CypressTasks.verify(missingTool),
+    ToolNotFoundError,
+  );
+  await assertRejects(() => CypressTasks.info(missingTool), ToolNotFoundError);
 });

--- a/packages/deno/tests/deno_test.ts
+++ b/packages/deno/tests/deno_test.ts
@@ -3,7 +3,8 @@ import {
   assertRejects,
   assertThrows,
 } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import { missingTool } from "@zuke/core/tooling/conformance";
 import {
   DenoCacheSettings,
   DenoCheckSettings,
@@ -364,32 +365,22 @@ Deno.test("publish: bare and all options", () => {
   );
 });
 
-/**
- * Point a settings object at a guaranteed-missing binary with the shim
- * fallback disabled, so the task function reaches execution without running
- * anything real. Keeps the remaining DenoTasks functions covered, hermetic.
- */
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zuke-no-such-tool-xyz");
-};
-
 Deno.test("every remaining DenoTasks function reaches execution", async () => {
-  await assertRejects(() => DenoTasks.test(missing), ToolNotFoundError);
-  await assertRejects(() => DenoTasks.fmt(missing), ToolNotFoundError);
-  await assertRejects(() => DenoTasks.lint(missing), ToolNotFoundError);
+  await assertRejects(() => DenoTasks.test(missingTool), ToolNotFoundError);
+  await assertRejects(() => DenoTasks.fmt(missingTool), ToolNotFoundError);
+  await assertRejects(() => DenoTasks.lint(missingTool), ToolNotFoundError);
   await assertRejects(
-    () => DenoTasks.cache((s) => missing(s).paths("x.ts")),
+    () => DenoTasks.cache((s) => missingTool(s).paths("x.ts")),
     ToolNotFoundError,
   );
-  await assertRejects(() => DenoTasks.coverage(missing), ToolNotFoundError);
+  await assertRejects(() => DenoTasks.coverage(missingTool), ToolNotFoundError);
   await assertRejects(
-    () => DenoTasks.install((s) => missing(s).module("npm:x")),
+    () => DenoTasks.install((s) => missingTool(s).module("npm:x")),
     ToolNotFoundError,
   );
-  await assertRejects(() => DenoTasks.publish(missing), ToolNotFoundError);
+  await assertRejects(() => DenoTasks.publish(missingTool), ToolNotFoundError);
   await assertRejects(
-    () => DenoTasks.task((s) => missing(s).name("x")),
+    () => DenoTasks.task((s) => missingTool(s).name("x")),
     ToolNotFoundError,
   );
 });

--- a/packages/docker-compose/tests/docker_compose_test.ts
+++ b/packages/docker-compose/tests/docker_compose_test.ts
@@ -3,7 +3,8 @@ import {
   assertRejects,
   assertThrows,
 } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import { missingTool } from "@zuke/core/tooling/conformance";
 import {
   defaultComposeProbe,
   DockerComposeBuildSettings,
@@ -409,18 +410,6 @@ Deno.test("defaultComposeProbe reports presence by exit code", async () => {
   assertEquals(await defaultComposeProbe(["zz-no-such-binary-zz"]), false);
 });
 
-const M = "zz-no-such-compose-binary-zz";
-
-/**
- * Point a settings object at a guaranteed-missing binary with the Windows shim
- * fallback disabled, so each task reaches execution and raises a
- * {@link ToolNotFoundError} on every platform — without invoking real Compose.
- */
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath(M);
-};
-
 Deno.test("every DockerComposeTasks function reaches execution", async () => {
   // Seed the cache so the detection path resolves without touching the host.
   resetComposeInvocationCache_();
@@ -428,20 +417,20 @@ Deno.test("every DockerComposeTasks function reaches execution", async () => {
     Promise.resolve(argv[0] === "docker-compose")
   );
   const calls: Array<() => Promise<unknown>> = [
-    () => DockerComposeTasks.up(missing),
-    () => DockerComposeTasks.down(missing),
-    () => DockerComposeTasks.build(missing),
-    () => DockerComposeTasks.pull(missing),
-    () => DockerComposeTasks.push(missing),
-    () => DockerComposeTasks.run((s) => missing(s).service("web")),
-    () => DockerComposeTasks.exec((s) => missing(s).service("web")),
-    () => DockerComposeTasks.logs(missing),
-    () => DockerComposeTasks.ps(missing),
-    () => DockerComposeTasks.config(missing),
-    () => DockerComposeTasks.start(missing),
-    () => DockerComposeTasks.stop(missing),
-    () => DockerComposeTasks.restart(missing),
-    () => DockerComposeTasks.rm(missing),
+    () => DockerComposeTasks.up(missingTool),
+    () => DockerComposeTasks.down(missingTool),
+    () => DockerComposeTasks.build(missingTool),
+    () => DockerComposeTasks.pull(missingTool),
+    () => DockerComposeTasks.push(missingTool),
+    () => DockerComposeTasks.run((s) => missingTool(s).service("web")),
+    () => DockerComposeTasks.exec((s) => missingTool(s).service("web")),
+    () => DockerComposeTasks.logs(missingTool),
+    () => DockerComposeTasks.ps(missingTool),
+    () => DockerComposeTasks.config(missingTool),
+    () => DockerComposeTasks.start(missingTool),
+    () => DockerComposeTasks.stop(missingTool),
+    () => DockerComposeTasks.restart(missingTool),
+    () => DockerComposeTasks.rm(missingTool),
   ];
   for (const call of calls) {
     await assertRejects(call, ToolNotFoundError);
@@ -453,11 +442,11 @@ Deno.test("a pinned invocation skips detection", async () => {
   // No cache seeded: usePlugin/useStandalone must not consult the resolver.
   resetComposeInvocationCache_();
   await assertRejects(
-    () => DockerComposeTasks.up((s) => missing(s).usePlugin()),
+    () => DockerComposeTasks.up((s) => missingTool(s).usePlugin()),
     ToolNotFoundError,
   );
   await assertRejects(
-    () => DockerComposeTasks.down((s) => missing(s).useStandalone()),
+    () => DockerComposeTasks.down((s) => missingTool(s).useStandalone()),
     ToolNotFoundError,
   );
 });

--- a/packages/docker/tests/docker_test.ts
+++ b/packages/docker/tests/docker_test.ts
@@ -3,7 +3,8 @@ import {
   assertRejects,
   assertThrows,
 } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import { missingTool } from "@zuke/core/tooling/conformance";
 import {
   DockerBuildSettings,
   DockerExecSettings,
@@ -300,35 +301,23 @@ Deno.test("subcommands with required arguments validate them", () => {
   );
 });
 
-const M = "zz-no-such-docker-binary-zz";
-
-/**
- * Point a settings object at a guaranteed-missing binary with the Windows shim
- * fallback disabled, so each DockerTasks function reaches execution and raises
- * a {@link ToolNotFoundError} on every platform — without invoking real docker.
- */
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath(M);
-};
-
 Deno.test("every DockerTasks function reaches execution", async () => {
   const calls: Array<() => Promise<unknown>> = [
-    () => DockerTasks.build(missing),
-    () => DockerTasks.run((s) => missing(s).image("x")),
-    () => DockerTasks.exec((s) => missing(s).container("c")),
-    () => DockerTasks.push((s) => missing(s).image("x")),
-    () => DockerTasks.pull((s) => missing(s).image("x")),
-    () => DockerTasks.tag((s) => missing(s).source("a").target("b")),
-    () => DockerTasks.login(missing),
-    () => DockerTasks.images(missing),
-    () => DockerTasks.ps(missing),
-    () => DockerTasks.stop((s) => missing(s).containers("c")),
-    () => DockerTasks.start((s) => missing(s).containers("c")),
-    () => DockerTasks.rm((s) => missing(s).containers("c")),
-    () => DockerTasks.rmi((s) => missing(s).images("x")),
-    () => DockerTasks.save((s) => missing(s).images("x")),
-    () => DockerTasks.load(missing),
+    () => DockerTasks.build(missingTool),
+    () => DockerTasks.run((s) => missingTool(s).image("x")),
+    () => DockerTasks.exec((s) => missingTool(s).container("c")),
+    () => DockerTasks.push((s) => missingTool(s).image("x")),
+    () => DockerTasks.pull((s) => missingTool(s).image("x")),
+    () => DockerTasks.tag((s) => missingTool(s).source("a").target("b")),
+    () => DockerTasks.login(missingTool),
+    () => DockerTasks.images(missingTool),
+    () => DockerTasks.ps(missingTool),
+    () => DockerTasks.stop((s) => missingTool(s).containers("c")),
+    () => DockerTasks.start((s) => missingTool(s).containers("c")),
+    () => DockerTasks.rm((s) => missingTool(s).containers("c")),
+    () => DockerTasks.rmi((s) => missingTool(s).images("x")),
+    () => DockerTasks.save((s) => missingTool(s).images("x")),
+    () => DockerTasks.load(missingTool),
   ];
   for (const call of calls) {
     await assertRejects(call, ToolNotFoundError);

--- a/packages/dpdm/tests/dpdm_test.ts
+++ b/packages/dpdm/tests/dpdm_test.ts
@@ -1,5 +1,9 @@
 import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import {
+  assertWrapperConformance,
+  missingTool,
+} from "@zuke/core/tooling/conformance";
 import { DpdmAnalyzeSettings, DpdmTasks } from "../src/dpdm.ts";
 
 Deno.test("the default binary is dpdm", () => {
@@ -73,30 +77,12 @@ Deno.test("analyze: all options render in order", () => {
   );
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zuke-no-such-dpdm-xyz");
-};
-
 Deno.test("DpdmTasks.analyze reaches execution", async () => {
-  await assertRejects(() => DpdmTasks.analyze(missing), ToolNotFoundError);
+  await assertRejects(() => DpdmTasks.analyze(missingTool), ToolNotFoundError);
 });
 
-Deno.test("dpdm: resolves its binary from node_modules by default", () => {
-  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
-  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-  const root = Deno.makeTempDirSync();
-  try {
-    const binDir = `${root}/node_modules/.bin`;
-    Deno.mkdirSync(binDir, { recursive: true });
-    const bin = `${binDir}/dpdm`;
-    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
-    const s = new DpdmAnalyzeSettings();
-    s.os_ = "linux";
-    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
-  } finally {
-    Deno.removeSync(root, { recursive: true });
-    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
-  }
+Deno.test("dpdm: resolves its binary from node_modules by default", async () => {
+  await assertWrapperConformance(() => new DpdmAnalyzeSettings(), "dpdm", {
+    resolution: "node_modules",
+  });
 });

--- a/packages/dprint/tests/dprint_test.ts
+++ b/packages/dprint/tests/dprint_test.ts
@@ -1,5 +1,9 @@
 import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import {
+  assertWrapperConformance,
+  missingTool,
+} from "@zuke/core/tooling/conformance";
 import {
   DprintCheckSettings,
   DprintFmtSettings,
@@ -35,31 +39,13 @@ Deno.test("dprint check: minimal checks everything", () => {
   assertEquals(new DprintCheckSettings().argv(), ["dprint", "check"]);
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zz-no-such-dprint-zz");
-};
-
-Deno.test("dprint: resolves its binary from node_modules by default", () => {
-  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
-  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-  const root = Deno.makeTempDirSync();
-  try {
-    const binDir = `${root}/node_modules/.bin`;
-    Deno.mkdirSync(binDir, { recursive: true });
-    const bin = `${binDir}/dprint`;
-    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
-    const s = new DprintFmtSettings();
-    s.os_ = "linux";
-    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
-  } finally {
-    Deno.removeSync(root, { recursive: true });
-    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
-  }
+Deno.test("dprint: resolves its binary from node_modules by default", async () => {
+  await assertWrapperConformance(() => new DprintFmtSettings(), "dprint", {
+    resolution: "node_modules",
+  });
 });
 
 Deno.test("DprintTasks.fmt and .check reach execution", async () => {
-  await assertRejects(() => DprintTasks.fmt(missing), ToolNotFoundError);
-  await assertRejects(() => DprintTasks.check(missing), ToolNotFoundError);
+  await assertRejects(() => DprintTasks.fmt(missingTool), ToolNotFoundError);
+  await assertRejects(() => DprintTasks.check(missingTool), ToolNotFoundError);
 });

--- a/packages/eslint/tests/eslint_test.ts
+++ b/packages/eslint/tests/eslint_test.ts
@@ -1,5 +1,9 @@
 import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import {
+  assertWrapperConformance,
+  missingTool,
+} from "@zuke/core/tooling/conformance";
 import { EslintSettings, EslintTasks } from "../src/eslint.ts";
 
 Deno.test("the default binary is eslint", () => {
@@ -54,30 +58,12 @@ Deno.test("eslint: minimal lints just the given path", () => {
   assertEquals(new EslintSettings().paths("src").argv(), ["eslint", "src"]);
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zz-no-such-eslint-zz");
-};
-
 Deno.test("EslintTasks.lint reaches execution", async () => {
-  await assertRejects(() => EslintTasks.lint(missing), ToolNotFoundError);
+  await assertRejects(() => EslintTasks.lint(missingTool), ToolNotFoundError);
 });
 
-Deno.test("eslint: resolves its binary from node_modules by default", () => {
-  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
-  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-  const root = Deno.makeTempDirSync();
-  try {
-    const binDir = `${root}/node_modules/.bin`;
-    Deno.mkdirSync(binDir, { recursive: true });
-    const bin = `${binDir}/eslint`;
-    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
-    const s = new EslintSettings();
-    s.os_ = "linux";
-    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
-  } finally {
-    Deno.removeSync(root, { recursive: true });
-    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
-  }
+Deno.test("eslint: resolves its binary from node_modules by default", async () => {
+  await assertWrapperConformance(() => new EslintSettings(), "eslint", {
+    resolution: "node_modules",
+  });
 });

--- a/packages/gcloud/tests/gcloud_test.ts
+++ b/packages/gcloud/tests/gcloud_test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import { missingTool } from "@zuke/core/tooling/conformance";
 import { GcloudSettings, GcloudTasks } from "../src/gcloud.ts";
 
 Deno.test("the default binary is gcloud", () => {
@@ -43,14 +44,9 @@ Deno.test("gcloud: minimal runs just the command", () => {
   ]);
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zz-no-such-gcloud-zz");
-};
-
 Deno.test("GcloudTasks.run reaches execution", async () => {
   await assertRejects(
-    () => GcloudTasks.run((s) => missing(s.command("version"))),
+    () => GcloudTasks.run((s) => missingTool(s.command("version"))),
     ToolNotFoundError,
   );
 });

--- a/packages/gemini/tests/gemini_test.ts
+++ b/packages/gemini/tests/gemini_test.ts
@@ -3,7 +3,8 @@ import {
   assertRejects,
   assertThrows,
 } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import { missingTool } from "@zuke/core/tooling/conformance";
 import {
   GeminiExtensionsSettings,
   GeminiMcpSettings,
@@ -116,28 +117,23 @@ Deno.test("extensions: numeric operands and bare/valued flags", () => {
   ]);
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zz-no-such-gemini-zz");
-};
-
 Deno.test("GeminiTasks.run reaches execution", async () => {
   await assertRejects(
-    () => GeminiTasks.run((s) => missing(s.prompt("hi"))),
+    () => GeminiTasks.run((s) => missingTool(s.prompt("hi"))),
     ToolNotFoundError,
   );
 });
 
 Deno.test("GeminiTasks.mcp reaches execution", async () => {
   await assertRejects(
-    () => GeminiTasks.mcp((s) => missing(s.command("list"))),
+    () => GeminiTasks.mcp((s) => missingTool(s.command("list"))),
     ToolNotFoundError,
   );
 });
 
 Deno.test("GeminiTasks.extensions reaches execution", async () => {
   await assertRejects(
-    () => GeminiTasks.extensions((s) => missing(s.command("list"))),
+    () => GeminiTasks.extensions((s) => missingTool(s.command("list"))),
     ToolNotFoundError,
   );
 });

--- a/packages/gh/tests/gh_test.ts
+++ b/packages/gh/tests/gh_test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import { missingTool } from "@zuke/core/tooling/conformance";
 import { GhSettings, GhTasks } from "../src/gh.ts";
 
 Deno.test("the default binary is gh", () => {
@@ -34,14 +35,9 @@ Deno.test("gh: minimal runs just the command", () => {
   ]);
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zz-no-such-gh-zz");
-};
-
 Deno.test("GhTasks.run reaches execution", async () => {
   await assertRejects(
-    () => GhTasks.run((s) => missing(s.command("auth", "status"))),
+    () => GhTasks.run((s) => missingTool(s.command("auth", "status"))),
     ToolNotFoundError,
   );
 });

--- a/packages/git/tests/git_test.ts
+++ b/packages/git/tests/git_test.ts
@@ -3,7 +3,8 @@ import {
   assertRejects,
   assertThrows,
 } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import { missingTool } from "@zuke/core/tooling/conformance";
 import {
   GitAddSettings,
   GitBranchSettings,
@@ -182,11 +183,6 @@ Deno.test("run executes an arbitrary command", () => {
   );
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zz-no-such-git-zz");
-};
-
 Deno.test("GitTasks.status reaches execution", async () => {
-  await assertRejects(() => GitTasks.status(missing), ToolNotFoundError);
+  await assertRejects(() => GitTasks.status(missingTool), ToolNotFoundError);
 });

--- a/packages/git/tests/git_test.ts
+++ b/packages/git/tests/git_test.ts
@@ -36,6 +36,13 @@ Deno.test("the default binary is git and global options precede the subcommand",
   ]);
 });
 
+Deno.test("status: --porcelain and --branch render alongside --short", () => {
+  assertEquals(
+    new GitStatusSettings().porcelain().branch().argv(),
+    ["git", "status", "--porcelain", "--branch"],
+  );
+});
+
 Deno.test("init and clone render their options", () => {
   assertEquals(
     new GitInitSettings().bare().initialBranch("main").argv(),
@@ -176,6 +183,13 @@ Deno.test("push, pull, and fetch render their options", () => {
   );
 });
 
+Deno.test("push: --delete renders the remote ref removal", () => {
+  assertEquals(
+    new GitPushSettings().deleteRef().remote("origin").ref("stale").argv(),
+    ["git", "push", "--delete", "origin", "stale"],
+  );
+});
+
 Deno.test("run executes an arbitrary command", () => {
   assertEquals(
     new GitRunSettings().command("rev-parse", "--short", "HEAD").argv(),
@@ -185,4 +199,60 @@ Deno.test("run executes an arbitrary command", () => {
 
 Deno.test("GitTasks.status reaches execution", async () => {
   await assertRejects(() => GitTasks.status(missingTool), ToolNotFoundError);
+});
+
+Deno.test("GitTasks.init reaches execution", async () => {
+  await assertRejects(() => GitTasks.init(missingTool), ToolNotFoundError);
+});
+
+Deno.test("GitTasks.clone reaches execution", async () => {
+  await assertRejects(
+    () => GitTasks.clone((s) => missingTool(s).repository("git@host:r.git")),
+    ToolNotFoundError,
+  );
+});
+
+Deno.test("GitTasks.add reaches execution", async () => {
+  await assertRejects(() => GitTasks.add(missingTool), ToolNotFoundError);
+});
+
+Deno.test("GitTasks.commit reaches execution", async () => {
+  await assertRejects(
+    () => GitTasks.commit((s) => missingTool(s).message("msg")),
+    ToolNotFoundError,
+  );
+});
+
+Deno.test("GitTasks.checkout reaches execution", async () => {
+  await assertRejects(
+    () => GitTasks.checkout((s) => missingTool(s).ref("main")),
+    ToolNotFoundError,
+  );
+});
+
+Deno.test("GitTasks.branch reaches execution", async () => {
+  await assertRejects(() => GitTasks.branch(missingTool), ToolNotFoundError);
+});
+
+Deno.test("GitTasks.tag reaches execution", async () => {
+  await assertRejects(() => GitTasks.tag(missingTool), ToolNotFoundError);
+});
+
+Deno.test("GitTasks.push reaches execution", async () => {
+  await assertRejects(() => GitTasks.push(missingTool), ToolNotFoundError);
+});
+
+Deno.test("GitTasks.pull reaches execution", async () => {
+  await assertRejects(() => GitTasks.pull(missingTool), ToolNotFoundError);
+});
+
+Deno.test("GitTasks.fetch reaches execution", async () => {
+  await assertRejects(() => GitTasks.fetch(missingTool), ToolNotFoundError);
+});
+
+Deno.test("GitTasks.run reaches execution", async () => {
+  await assertRejects(
+    () => GitTasks.run((s) => missingTool(s).command("rev-parse", "HEAD")),
+    ToolNotFoundError,
+  );
 });

--- a/packages/helm/tests/helm_test.ts
+++ b/packages/helm/tests/helm_test.ts
@@ -3,7 +3,8 @@ import {
   assertRejects,
   assertThrows,
 } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import { missingTool } from "@zuke/core/tooling/conformance";
 import {
   HelmDependencyUpdateSettings,
   HelmInstallSettings,
@@ -208,42 +209,37 @@ Deno.test("package: requires chart; destination, version, app-version", () => {
   );
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zuke-no-such-helm-xyz");
-};
-
 Deno.test("every HelmTasks function reaches execution", async () => {
   await assertRejects(
-    () => HelmTasks.install((s) => missing(s).release("a").chart("c")),
+    () => HelmTasks.install((s) => missingTool(s).release("a").chart("c")),
     ToolNotFoundError,
   );
   await assertRejects(
-    () => HelmTasks.upgrade((s) => missing(s).release("a").chart("c")),
+    () => HelmTasks.upgrade((s) => missingTool(s).release("a").chart("c")),
     ToolNotFoundError,
   );
   await assertRejects(
-    () => HelmTasks.uninstall((s) => missing(s).release("a")),
+    () => HelmTasks.uninstall((s) => missingTool(s).release("a")),
     ToolNotFoundError,
   );
   await assertRejects(
-    () => HelmTasks.template((s) => missing(s).release("a").chart("c")),
+    () => HelmTasks.template((s) => missingTool(s).release("a").chart("c")),
     ToolNotFoundError,
   );
   await assertRejects(
-    () => HelmTasks.lint((s) => missing(s).chart("c")),
+    () => HelmTasks.lint((s) => missingTool(s).chart("c")),
     ToolNotFoundError,
   );
   await assertRejects(
-    () => HelmTasks.dependencyUpdate((s) => missing(s).chart("c")),
+    () => HelmTasks.dependencyUpdate((s) => missingTool(s).chart("c")),
     ToolNotFoundError,
   );
   await assertRejects(
-    () => HelmTasks.repoAdd((s) => missing(s).name("n").url("u")),
+    () => HelmTasks.repoAdd((s) => missingTool(s).name("n").url("u")),
     ToolNotFoundError,
   );
   await assertRejects(
-    () => HelmTasks.package((s) => missing(s).chart("c")),
+    () => HelmTasks.package((s) => missingTool(s).chart("c")),
     ToolNotFoundError,
   );
 });

--- a/packages/husky/tests/husky_test.ts
+++ b/packages/husky/tests/husky_test.ts
@@ -1,5 +1,9 @@
 import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import {
+  assertWrapperConformance,
+  missingTool,
+} from "@zuke/core/tooling/conformance";
 import {
   HuskyInitSettings,
   HuskyInstallSettings,
@@ -25,34 +29,16 @@ Deno.test("install with dir renders the positional directory", () => {
   );
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zz-no-such-husky-zz");
-};
-
 Deno.test("HuskyTasks.init reaches execution", async () => {
-  await assertRejects(() => HuskyTasks.init(missing), ToolNotFoundError);
+  await assertRejects(() => HuskyTasks.init(missingTool), ToolNotFoundError);
 });
 
 Deno.test("HuskyTasks.install reaches execution", async () => {
-  await assertRejects(() => HuskyTasks.install(missing), ToolNotFoundError);
+  await assertRejects(() => HuskyTasks.install(missingTool), ToolNotFoundError);
 });
 
-Deno.test("husky: resolves its binary from node_modules by default", () => {
-  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
-  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-  const root = Deno.makeTempDirSync();
-  try {
-    const binDir = `${root}/node_modules/.bin`;
-    Deno.mkdirSync(binDir, { recursive: true });
-    const bin = `${binDir}/husky`;
-    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
-    const s = new HuskyInstallSettings();
-    s.os_ = "linux";
-    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
-  } finally {
-    Deno.removeSync(root, { recursive: true });
-    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
-  }
+Deno.test("husky: resolves its binary from node_modules by default", async () => {
+  await assertWrapperConformance(() => new HuskyInstallSettings(), "husky", {
+    resolution: "node_modules",
+  });
 });

--- a/packages/jest/tests/jest_test.ts
+++ b/packages/jest/tests/jest_test.ts
@@ -1,5 +1,9 @@
 import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import {
+  assertWrapperConformance,
+  missingTool,
+} from "@zuke/core/tooling/conformance";
 import { JestSettings, JestTasks } from "../src/jest.ts";
 
 Deno.test("the default binary is jest", () => {
@@ -65,30 +69,12 @@ Deno.test("jest: minimal invocation is bare", () => {
   assertEquals(new JestSettings().argv(), ["jest"]);
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zz-no-such-jest-zz");
-};
-
 Deno.test("JestTasks.run reaches execution", async () => {
-  await assertRejects(() => JestTasks.run(missing), ToolNotFoundError);
+  await assertRejects(() => JestTasks.run(missingTool), ToolNotFoundError);
 });
 
-Deno.test("jest: resolves its binary from node_modules by default", () => {
-  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
-  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-  const root = Deno.makeTempDirSync();
-  try {
-    const binDir = `${root}/node_modules/.bin`;
-    Deno.mkdirSync(binDir, { recursive: true });
-    const bin = `${binDir}/jest`;
-    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
-    const s = new JestSettings();
-    s.os_ = "linux"; // pin so the planted bare shim matches on any host
-    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
-  } finally {
-    Deno.removeSync(root, { recursive: true });
-    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
-  }
+Deno.test("jest: resolves its binary from node_modules by default", async () => {
+  await assertWrapperConformance(() => new JestSettings(), "jest", {
+    resolution: "node_modules",
+  });
 });

--- a/packages/jsr/tests/jsr_test.ts
+++ b/packages/jsr/tests/jsr_test.ts
@@ -3,7 +3,8 @@ import {
   assertRejects,
   assertThrows,
 } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import { missingTool } from "@zuke/core/tooling/conformance";
 import {
   JsrAddSettings,
   JsrPublishSettings,
@@ -67,19 +68,14 @@ Deno.test("remove: names required", () => {
   );
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zuke-no-such-jsr-xyz");
-};
-
 Deno.test("every JsrTasks function reaches execution", async () => {
-  await assertRejects(() => JsrTasks.publish(missing), ToolNotFoundError);
+  await assertRejects(() => JsrTasks.publish(missingTool), ToolNotFoundError);
   await assertRejects(
-    () => JsrTasks.add((s) => missing(s).packages("@std/assert")),
+    () => JsrTasks.add((s) => missingTool(s).packages("@std/assert")),
     ToolNotFoundError,
   );
   await assertRejects(
-    () => JsrTasks.remove((s) => missing(s).packages("@std/assert")),
+    () => JsrTasks.remove((s) => missingTool(s).packages("@std/assert")),
     ToolNotFoundError,
   );
 });

--- a/packages/knip/tests/knip_test.ts
+++ b/packages/knip/tests/knip_test.ts
@@ -1,5 +1,9 @@
 import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import {
+  assertWrapperConformance,
+  missingTool,
+} from "@zuke/core/tooling/conformance";
 import { KnipRunSettings, KnipTasks } from "../src/knip.ts";
 
 Deno.test("the default binary is knip", () => {
@@ -42,30 +46,12 @@ Deno.test("run: all options render", () => {
   );
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zuke-no-such-knip-xyz");
-};
-
 Deno.test("KnipTasks.run reaches execution", async () => {
-  await assertRejects(() => KnipTasks.run(missing), ToolNotFoundError);
+  await assertRejects(() => KnipTasks.run(missingTool), ToolNotFoundError);
 });
 
-Deno.test("knip: resolves its binary from node_modules by default", () => {
-  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
-  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-  const root = Deno.makeTempDirSync();
-  try {
-    const binDir = `${root}/node_modules/.bin`;
-    Deno.mkdirSync(binDir, { recursive: true });
-    const bin = `${binDir}/knip`;
-    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
-    const s = new KnipRunSettings();
-    s.os_ = "linux"; // pin so the planted bare shim matches on any host
-    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
-  } finally {
-    Deno.removeSync(root, { recursive: true });
-    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
-  }
+Deno.test("knip: resolves its binary from node_modules by default", async () => {
+  await assertWrapperConformance(() => new KnipRunSettings(), "knip", {
+    resolution: "node_modules",
+  });
 });

--- a/packages/kubectl/tests/kubectl_test.ts
+++ b/packages/kubectl/tests/kubectl_test.ts
@@ -4,7 +4,8 @@ import {
   assertStringIncludes,
   assertThrows,
 } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import { missingTool } from "@zuke/core/tooling/conformance";
 import { withAmbientEcho } from "../../core/src/ambient_echo.ts";
 import {
   KubectlAnnotateSettings,
@@ -897,94 +898,94 @@ Deno.test("top: requires pods or nodes; all options", () => {
   );
 });
 
-/**
- * Point a settings object at a guaranteed-missing binary with the shim
- * fallback disabled, so each KubectlTasks function reaches execution WITHOUT
- * ever invoking a real kubectl (tests must stay hermetic).
- */
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zuke-no-such-kubectl-xyz");
-};
-
 Deno.test("every KubectlTasks function reaches execution", async () => {
   await assertRejects(
-    () => KubectlTasks.apply((s) => missing(s).file("a.yaml")),
-    ToolNotFoundError,
-  );
-  await assertRejects(() => KubectlTasks.create(missing), ToolNotFoundError);
-  await assertRejects(
-    () => KubectlTasks.delete((s) => missing(s).resource("pod", "web")),
+    () => KubectlTasks.apply((s) => missingTool(s).file("a.yaml")),
     ToolNotFoundError,
   );
   await assertRejects(
-    () => KubectlTasks.get((s) => missing(s).resource("pods")),
+    () => KubectlTasks.create(missingTool),
     ToolNotFoundError,
   );
   await assertRejects(
-    () => KubectlTasks.describe((s) => missing(s).resource("pod/web")),
+    () => KubectlTasks.delete((s) => missingTool(s).resource("pod", "web")),
     ToolNotFoundError,
   );
   await assertRejects(
-    () => KubectlTasks.logs((s) => missing(s).resource("web-0")),
+    () => KubectlTasks.get((s) => missingTool(s).resource("pods")),
     ToolNotFoundError,
   );
   await assertRejects(
-    () => KubectlTasks.exec((s) => missing(s).resource("web-0").command("sh")),
+    () => KubectlTasks.describe((s) => missingTool(s).resource("pod/web")),
     ToolNotFoundError,
   );
   await assertRejects(
-    () =>
-      KubectlTasks.rollout((s) => missing(s).status().resource("deploy/api")),
+    () => KubectlTasks.logs((s) => missingTool(s).resource("web-0")),
     ToolNotFoundError,
   );
   await assertRejects(
     () =>
-      KubectlTasks.scale((s) => missing(s).replicas(2).resource("deploy/api")),
+      KubectlTasks.exec((s) => missingTool(s).resource("web-0").command("sh")),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () =>
+      KubectlTasks.rollout((s) =>
+        missingTool(s).status().resource("deploy/api")
+      ),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () =>
+      KubectlTasks.scale((s) =>
+        missingTool(s).replicas(2).resource("deploy/api")
+      ),
     ToolNotFoundError,
   );
   await assertRejects(
     () =>
       KubectlTasks.setImage((s) =>
-        missing(s).resource("deploy/api").image("api", "api:1")
+        missingTool(s).resource("deploy/api").image("api", "api:1")
       ),
     ToolNotFoundError,
   );
   await assertRejects(
     () =>
       KubectlTasks.annotate((s) =>
-        missing(s).resource("deploy", "api").annotation("team", "payments")
+        missingTool(s).resource("deploy", "api").annotation("team", "payments")
       ),
     ToolNotFoundError,
   );
   await assertRejects(
     () =>
       KubectlTasks.label((s) =>
-        missing(s).resource("deploy", "api").label("team", "payments")
+        missingTool(s).resource("deploy", "api").label("team", "payments")
       ),
     ToolNotFoundError,
   );
   await assertRejects(
     () =>
-      KubectlTasks.patch((s) => missing(s).resource("deploy/api").patch("{}")),
+      KubectlTasks.patch((s) =>
+        missingTool(s).resource("deploy/api").patch("{}")
+      ),
     ToolNotFoundError,
   );
   await assertRejects(
     () =>
       KubectlTasks.portForward((s) =>
-        missing(s).resource("svc/api").port("80")
+        missingTool(s).resource("svc/api").port("80")
       ),
     ToolNotFoundError,
   );
   await assertRejects(
     () =>
       KubectlTasks.wait((s) =>
-        missing(s).resource("pod/web").forCondition("delete")
+        missingTool(s).resource("pod/web").forCondition("delete")
       ),
     ToolNotFoundError,
   );
   await assertRejects(
-    () => KubectlTasks.top((s) => missing(s).nodes()),
+    () => KubectlTasks.top((s) => missingTool(s).nodes()),
     ToolNotFoundError,
   );
 });

--- a/packages/kustomize/tests/kustomize_test.ts
+++ b/packages/kustomize/tests/kustomize_test.ts
@@ -3,7 +3,8 @@ import {
   assertRejects,
   assertThrows,
 } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import { missingTool } from "@zuke/core/tooling/conformance";
 import {
   KustomizeBuildSettings,
   KustomizeEditSetImageSettings,
@@ -52,15 +53,14 @@ Deno.test("editSetImage: requires an image; renders name=ref pairs", () => {
   );
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zuke-no-such-kustomize-xyz");
-};
-
 Deno.test("every KustomizeTasks function reaches execution", async () => {
-  await assertRejects(() => KustomizeTasks.build(missing), ToolNotFoundError);
   await assertRejects(
-    () => KustomizeTasks.editSetImage((s) => missing(s).image("api", "api:1")),
+    () => KustomizeTasks.build(missingTool),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () =>
+      KustomizeTasks.editSetImage((s) => missingTool(s).image("api", "api:1")),
     ToolNotFoundError,
   );
 });

--- a/packages/nest/tests/nest_test.ts
+++ b/packages/nest/tests/nest_test.ts
@@ -3,7 +3,11 @@ import {
   assertRejects,
   assertThrows,
 } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import {
+  assertWrapperConformance,
+  missingTool,
+} from "@zuke/core/tooling/conformance";
 import {
   NestBuildSettings,
   NestGenerateSettings,
@@ -17,23 +21,10 @@ Deno.test("the default binary is nest and the subcommand follows", () => {
   assertEquals(new NestInfoSettings().argv(), ["nest", "info"]);
 });
 
-Deno.test("nest: resolves its binary from node_modules by default", () => {
-  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
-  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-  const root = Deno.makeTempDirSync();
-  try {
-    const binDir = `${root}/node_modules/.bin`;
-    Deno.mkdirSync(binDir, { recursive: true });
-    const bin = `${binDir}/nest`;
-    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
-    const s = new NestInfoSettings();
-    s.os_ = "linux";
-    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
-  } finally {
-    Deno.removeSync(root, { recursive: true });
-    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
-  }
+Deno.test("nest: resolves its binary from node_modules by default", async () => {
+  await assertWrapperConformance(() => new NestInfoSettings(), "nest", {
+    resolution: "node_modules",
+  });
 });
 
 Deno.test("new renders every option and requires a name", () => {
@@ -176,33 +167,28 @@ Deno.test("start renders every option with the app positional last", () => {
   );
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zz-no-such-nest-zz");
-};
-
 Deno.test("NestTasks.new reaches execution", async () => {
   await assertRejects(
-    () => NestTasks.new((s) => missing(s.name("my-app"))),
+    () => NestTasks.new((s) => missingTool(s.name("my-app"))),
     ToolNotFoundError,
   );
 });
 
 Deno.test("NestTasks.generate reaches execution", async () => {
   await assertRejects(
-    () => NestTasks.generate((s) => missing(s.schematic("module"))),
+    () => NestTasks.generate((s) => missingTool(s.schematic("module"))),
     ToolNotFoundError,
   );
 });
 
 Deno.test("NestTasks.build reaches execution", async () => {
-  await assertRejects(() => NestTasks.build(missing), ToolNotFoundError);
+  await assertRejects(() => NestTasks.build(missingTool), ToolNotFoundError);
 });
 
 Deno.test("NestTasks.start reaches execution", async () => {
-  await assertRejects(() => NestTasks.start(missing), ToolNotFoundError);
+  await assertRejects(() => NestTasks.start(missingTool), ToolNotFoundError);
 });
 
 Deno.test("NestTasks.info reaches execution", async () => {
-  await assertRejects(() => NestTasks.info(missing), ToolNotFoundError);
+  await assertRejects(() => NestTasks.info(missingTool), ToolNotFoundError);
 });

--- a/packages/node/tests/node_test.ts
+++ b/packages/node/tests/node_test.ts
@@ -3,7 +3,8 @@ import {
   assertRejects,
   assertThrows,
 } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import { missingTool } from "@zuke/core/tooling/conformance";
 import {
   NodeEvalSettings,
   NodeRunSettings,
@@ -126,28 +127,23 @@ Deno.test("test renders every option in order", () => {
   ]);
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zz-no-such-node-zz");
-};
-
 Deno.test("NodeTasks.run reaches execution", async () => {
   await assertRejects(
-    () => NodeTasks.run((s) => missing(s).script("main.js")),
+    () => NodeTasks.run((s) => missingTool(s).script("main.js")),
     ToolNotFoundError,
   );
 });
 
 Deno.test("NodeTasks.eval reaches execution", async () => {
   await assertRejects(
-    () => NodeTasks.eval((s) => missing(s).code("1")),
+    () => NodeTasks.eval((s) => missingTool(s).code("1")),
     ToolNotFoundError,
   );
 });
 
 Deno.test("NodeTasks.test reaches execution", async () => {
   await assertRejects(
-    () => NodeTasks.test((s) => missing(s)),
+    () => NodeTasks.test((s) => missingTool(s)),
     ToolNotFoundError,
   );
 });

--- a/packages/npm/tests/npm_test.ts
+++ b/packages/npm/tests/npm_test.ts
@@ -3,7 +3,8 @@ import {
   assertRejects,
   assertThrows,
 } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import { missingTool } from "@zuke/core/tooling/conformance";
 import {
   NpmCiSettings,
   NpmExecSettings,
@@ -141,30 +142,20 @@ Deno.test("version: bump required; message and --no-git-tag-version", () => {
   );
 });
 
-/**
- * Point a settings object at a guaranteed-missing binary with the shim
- * fallback disabled, so each NpmTasks function reaches execution WITHOUT
- * ever invoking a real npm (tests must stay hermetic).
- */
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zuke-no-such-npm-xyz");
-};
-
 Deno.test("every NpmTasks function reaches execution", async () => {
-  await assertRejects(() => NpmTasks.install(missing), ToolNotFoundError);
-  await assertRejects(() => NpmTasks.ci(missing), ToolNotFoundError);
+  await assertRejects(() => NpmTasks.install(missingTool), ToolNotFoundError);
+  await assertRejects(() => NpmTasks.ci(missingTool), ToolNotFoundError);
   await assertRejects(
-    () => NpmTasks.run((s) => missing(s).script("x")),
+    () => NpmTasks.run((s) => missingTool(s).script("x")),
     ToolNotFoundError,
   );
   await assertRejects(
-    () => NpmTasks.exec((s) => missing(s).command("x")),
+    () => NpmTasks.exec((s) => missingTool(s).command("x")),
     ToolNotFoundError,
   );
-  await assertRejects(() => NpmTasks.publish(missing), ToolNotFoundError);
+  await assertRejects(() => NpmTasks.publish(missingTool), ToolNotFoundError);
   await assertRejects(
-    () => NpmTasks.version((s) => missing(s).bump("patch")),
+    () => NpmTasks.version((s) => missingTool(s).bump("patch")),
     ToolNotFoundError,
   );
 });

--- a/packages/npx/tests/npx_test.ts
+++ b/packages/npx/tests/npx_test.ts
@@ -3,7 +3,8 @@ import {
   assertRejects,
   assertThrows,
 } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import { missingTool } from "@zuke/core/tooling/conformance";
 import { NpxSettings, NpxTasks } from "../src/npx.ts";
 
 Deno.test("the default binary is npx", () => {
@@ -58,19 +59,9 @@ Deno.test("npx: --call runs a string without a command", () => {
   );
 });
 
-/**
- * Point a settings object at a guaranteed-missing binary with the shim
- * fallback disabled, so the NpxTasks function reaches execution WITHOUT ever
- * invoking a real npx (tests must stay hermetic).
- */
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zuke-no-such-npx-xyz");
-};
-
 Deno.test("NpxTasks.npx reaches execution", async () => {
   await assertRejects(
-    () => NpxTasks.npx((s) => missing(s).command("x")),
+    () => NpxTasks.npx((s) => missingTool(s).command("x")),
     ToolNotFoundError,
   );
 });

--- a/packages/nx/tests/nx_test.ts
+++ b/packages/nx/tests/nx_test.ts
@@ -3,7 +3,11 @@ import {
   assertRejects,
   assertThrows,
 } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import {
+  assertWrapperConformance,
+  missingTool,
+} from "@zuke/core/tooling/conformance";
 import {
   NxAffectedSettings,
   NxRunManySettings,
@@ -15,26 +19,14 @@ Deno.test("the default binary is nx", () => {
   assertEquals(new NxRunSettings().target("web:build").argv()[0], "nx");
 });
 
-Deno.test("nx: resolves its binary from node_modules by default", () => {
-  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
-  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-  const root = Deno.makeTempDirSync();
-  try {
-    const binDir = `${root}/node_modules/.bin`;
-    Deno.mkdirSync(binDir, { recursive: true });
-    const bin = `${binDir}/nx`;
-    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
-    const s = new NxRunSettings();
-    s.os_ = "linux";
-    assertEquals(
-      s.cwd(root).target("web:build").resolvedArgv()[0],
-      bin.replace(/\\/g, "/"),
-    );
-  } finally {
-    Deno.removeSync(root, { recursive: true });
-    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
-  }
+Deno.test("nx: resolves its binary from node_modules by default", async () => {
+  await assertWrapperConformance(
+    () => new NxRunSettings().target("web:build"),
+    "nx",
+    {
+      resolution: "node_modules",
+    },
+  );
 });
 
 Deno.test("run: requires a target; configuration", () => {
@@ -110,22 +102,17 @@ Deno.test("affected: requires a target; base, head, configuration, parallel", ()
   );
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zuke-no-such-nx-xyz");
-};
-
 Deno.test("every NxTasks function reaches execution", async () => {
   await assertRejects(
-    () => NxTasks.run((s) => missing(s).target("web:build")),
+    () => NxTasks.run((s) => missingTool(s).target("web:build")),
     ToolNotFoundError,
   );
   await assertRejects(
-    () => NxTasks.runMany((s) => missing(s).target("build")),
+    () => NxTasks.runMany((s) => missingTool(s).target("build")),
     ToolNotFoundError,
   );
   await assertRejects(
-    () => NxTasks.affected((s) => missing(s).target("test")),
+    () => NxTasks.affected((s) => missingTool(s).target("test")),
     ToolNotFoundError,
   );
 });

--- a/packages/openapi-ts/tests/openapi_ts_test.ts
+++ b/packages/openapi-ts/tests/openapi_ts_test.ts
@@ -1,5 +1,9 @@
 import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import {
+  assertWrapperConformance,
+  missingTool,
+} from "@zuke/core/tooling/conformance";
 import {
   OpenapiTsGenerateSettings,
   OpenapiTsTasks,
@@ -41,33 +45,19 @@ Deno.test("generate: minimal input and output", () => {
   ]);
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zz-no-such-openapi-ts-zz");
-};
-
 Deno.test("OpenapiTsTasks.generate reaches execution", async () => {
   await assertRejects(
-    () => OpenapiTsTasks.generate(missing),
+    () => OpenapiTsTasks.generate(missingTool),
     ToolNotFoundError,
   );
 });
 
-Deno.test("openapi-ts: resolves its binary from node_modules by default", () => {
-  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
-  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-  const root = Deno.makeTempDirSync();
-  try {
-    const binDir = `${root}/node_modules/.bin`;
-    Deno.mkdirSync(binDir, { recursive: true });
-    const bin = `${binDir}/openapi-ts`;
-    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
-    const s = new OpenapiTsGenerateSettings();
-    s.os_ = "linux";
-    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
-  } finally {
-    Deno.removeSync(root, { recursive: true });
-    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
-  }
+Deno.test("openapi-ts: resolves its binary from node_modules by default", async () => {
+  await assertWrapperConformance(
+    () => new OpenapiTsGenerateSettings(),
+    "openapi-ts",
+    {
+      resolution: "node_modules",
+    },
+  );
 });

--- a/packages/orval/tests/orval_test.ts
+++ b/packages/orval/tests/orval_test.ts
@@ -1,5 +1,9 @@
 import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import {
+  assertWrapperConformance,
+  missingTool,
+} from "@zuke/core/tooling/conformance";
 import { OrvalGenerateSettings, OrvalTasks } from "../src/orval.ts";
 
 Deno.test("the default binary is orval", () => {
@@ -36,30 +40,15 @@ Deno.test("generate: minimal uses just the config", () => {
   ]);
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zz-no-such-orval-zz");
-};
-
 Deno.test("OrvalTasks.generate reaches execution", async () => {
-  await assertRejects(() => OrvalTasks.generate(missing), ToolNotFoundError);
+  await assertRejects(
+    () => OrvalTasks.generate(missingTool),
+    ToolNotFoundError,
+  );
 });
 
-Deno.test("orval: resolves its binary from node_modules by default", () => {
-  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
-  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-  const root = Deno.makeTempDirSync();
-  try {
-    const binDir = `${root}/node_modules/.bin`;
-    Deno.mkdirSync(binDir, { recursive: true });
-    const bin = `${binDir}/orval`;
-    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
-    const s = new OrvalGenerateSettings();
-    s.os_ = "linux"; // pin so the planted bare shim matches on any host
-    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
-  } finally {
-    Deno.removeSync(root, { recursive: true });
-    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
-  }
+Deno.test("orval: resolves its binary from node_modules by default", async () => {
+  await assertWrapperConformance(() => new OrvalGenerateSettings(), "orval", {
+    resolution: "node_modules",
+  });
 });

--- a/packages/oxlint/tests/oxlint_test.ts
+++ b/packages/oxlint/tests/oxlint_test.ts
@@ -1,5 +1,9 @@
 import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import {
+  assertWrapperConformance,
+  missingTool,
+} from "@zuke/core/tooling/conformance";
 import { OxlintSettings, OxlintTasks } from "../src/oxlint.ts";
 
 Deno.test("the default binary is oxlint", () => {
@@ -48,30 +52,12 @@ Deno.test("oxlint: minimal lints just the given path", () => {
   assertEquals(new OxlintSettings().paths("src").argv(), ["oxlint", "src"]);
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zz-no-such-oxlint-zz");
-};
-
 Deno.test("OxlintTasks.lint reaches execution", async () => {
-  await assertRejects(() => OxlintTasks.lint(missing), ToolNotFoundError);
+  await assertRejects(() => OxlintTasks.lint(missingTool), ToolNotFoundError);
 });
 
-Deno.test("oxlint: resolves its binary from node_modules by default", () => {
-  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
-  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-  const root = Deno.makeTempDirSync();
-  try {
-    const binDir = `${root}/node_modules/.bin`;
-    Deno.mkdirSync(binDir, { recursive: true });
-    const bin = `${binDir}/oxlint`;
-    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
-    const s = new OxlintSettings();
-    s.os_ = "linux"; // pin so the planted bare shim matches on any host
-    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
-  } finally {
-    Deno.removeSync(root, { recursive: true });
-    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
-  }
+Deno.test("oxlint: resolves its binary from node_modules by default", async () => {
+  await assertWrapperConformance(() => new OxlintSettings(), "oxlint", {
+    resolution: "node_modules",
+  });
 });

--- a/packages/playwright/tests/playwright_test.ts
+++ b/packages/playwright/tests/playwright_test.ts
@@ -1,5 +1,9 @@
 import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import {
+  assertWrapperConformance,
+  missingTool,
+} from "@zuke/core/tooling/conformance";
 import {
   PlaywrightCodegenSettings,
   PlaywrightInstallSettings,
@@ -79,47 +83,31 @@ Deno.test("codegen: bare, --target, --output, and a url", () => {
   );
 });
 
-/**
- * Point a settings object at a guaranteed-missing binary with the shim
- * fallback disabled, so each PlaywrightTasks function reaches execution WITHOUT
- * ever invoking a real playwright (tests must stay hermetic).
- */
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zuke-no-such-playwright-xyz");
-};
-
-Deno.test("playwright: resolves its binary from node_modules by default", () => {
-  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
-  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-  const root = Deno.makeTempDirSync();
-  try {
-    const binDir = `${root}/node_modules/.bin`;
-    Deno.mkdirSync(binDir, { recursive: true });
-    const bin = `${binDir}/playwright`;
-    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
-    const s = new PlaywrightTestSettings();
-    s.os_ = "linux"; // pin so the planted bare shim matches on any host
-    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
-  } finally {
-    Deno.removeSync(root, { recursive: true });
-    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
-  }
+Deno.test("playwright: resolves its binary from node_modules by default", async () => {
+  await assertWrapperConformance(
+    () => new PlaywrightTestSettings(),
+    "playwright",
+    {
+      resolution: "node_modules",
+    },
+  );
 });
 
 Deno.test("every PlaywrightTasks function reaches execution", async () => {
-  await assertRejects(() => PlaywrightTasks.test(missing), ToolNotFoundError);
   await assertRejects(
-    () => PlaywrightTasks.install(missing),
+    () => PlaywrightTasks.test(missingTool),
     ToolNotFoundError,
   );
   await assertRejects(
-    () => PlaywrightTasks.showReport(missing),
+    () => PlaywrightTasks.install(missingTool),
     ToolNotFoundError,
   );
   await assertRejects(
-    () => PlaywrightTasks.codegen(missing),
+    () => PlaywrightTasks.showReport(missingTool),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => PlaywrightTasks.codegen(missingTool),
     ToolNotFoundError,
   );
 });

--- a/packages/pnpm/tests/pnpm_test.ts
+++ b/packages/pnpm/tests/pnpm_test.ts
@@ -3,7 +3,8 @@ import {
   assertRejects,
   assertThrows,
 } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import { missingTool } from "@zuke/core/tooling/conformance";
 import {
   PnpmAddSettings,
   PnpmDlxSettings,
@@ -111,33 +112,23 @@ Deno.test("publish: tag, access, --no-git-checks, --dry-run", () => {
   );
 });
 
-/**
- * Point a settings object at a guaranteed-missing binary with the shim
- * fallback disabled, so each PnpmTasks function reaches execution WITHOUT
- * ever invoking a real pnpm (tests must stay hermetic).
- */
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zuke-no-such-pnpm-xyz");
-};
-
 Deno.test("every PnpmTasks function reaches execution", async () => {
-  await assertRejects(() => PnpmTasks.install(missing), ToolNotFoundError);
+  await assertRejects(() => PnpmTasks.install(missingTool), ToolNotFoundError);
   await assertRejects(
-    () => PnpmTasks.add((s) => missing(s).packages("x")),
+    () => PnpmTasks.add((s) => missingTool(s).packages("x")),
     ToolNotFoundError,
   );
   await assertRejects(
-    () => PnpmTasks.remove((s) => missing(s).packages("x")),
+    () => PnpmTasks.remove((s) => missingTool(s).packages("x")),
     ToolNotFoundError,
   );
   await assertRejects(
-    () => PnpmTasks.run((s) => missing(s).script("x")),
+    () => PnpmTasks.run((s) => missingTool(s).script("x")),
     ToolNotFoundError,
   );
   await assertRejects(
-    () => PnpmTasks.dlx((s) => missing(s).command("x")),
+    () => PnpmTasks.dlx((s) => missingTool(s).command("x")),
     ToolNotFoundError,
   );
-  await assertRejects(() => PnpmTasks.publish(missing), ToolNotFoundError);
+  await assertRejects(() => PnpmTasks.publish(missingTool), ToolNotFoundError);
 });

--- a/packages/release-please/tests/release_please_test.ts
+++ b/packages/release-please/tests/release_please_test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import { missingTool } from "@zuke/core/tooling/conformance";
 import {
   ReleasePleaseGithubReleaseSettings,
   ReleasePleaseReleasePrSettings,
@@ -54,18 +55,13 @@ Deno.test("github-release: subcommand token", () => {
   );
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zuke-no-such-release-please-xyz");
-};
-
 Deno.test("every ReleasePleaseTasks function reaches execution", async () => {
   await assertRejects(
-    () => ReleasePleaseTasks.releasePr(missing),
+    () => ReleasePleaseTasks.releasePr(missingTool),
     ToolNotFoundError,
   );
   await assertRejects(
-    () => ReleasePleaseTasks.githubRelease(missing),
+    () => ReleasePleaseTasks.githubRelease(missingTool),
     ToolNotFoundError,
   );
 });

--- a/packages/security/tests/security_test.ts
+++ b/packages/security/tests/security_test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import { missingTool } from "@zuke/core/tooling/conformance";
 import {
   ActionlintSettings,
   GitleaksDetectSettings,
@@ -165,27 +166,15 @@ Deno.test("trivy config: full and minimal argv", () => {
   assertEquals(new TrivyConfigSettings().argv(), ["trivy", "config", "."]);
 });
 
-const M = "zz-no-such-security-binary-zz";
-
-/**
- * Point a settings object at a guaranteed-missing binary with the Windows shim
- * fallback disabled, so each SecurityTasks function reaches execution and raises
- * a {@link ToolNotFoundError} on every platform — without invoking real tools.
- */
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath(M);
-};
-
 Deno.test("every SecurityTasks function reaches execution", async () => {
   const calls: Array<() => Promise<unknown>> = [
-    () => SecurityTasks.zizmor(missing),
-    () => SecurityTasks.actionlint(missing),
-    () => SecurityTasks.gitleaks(missing),
-    () => SecurityTasks.osvScanner(missing),
-    () => SecurityTasks.semgrep(missing),
-    () => SecurityTasks.trivyFs(missing),
-    () => SecurityTasks.trivyConfig(missing),
+    () => SecurityTasks.zizmor(missingTool),
+    () => SecurityTasks.actionlint(missingTool),
+    () => SecurityTasks.gitleaks(missingTool),
+    () => SecurityTasks.osvScanner(missingTool),
+    () => SecurityTasks.semgrep(missingTool),
+    () => SecurityTasks.trivyFs(missingTool),
+    () => SecurityTasks.trivyConfig(missingTool),
   ];
   for (const call of calls) {
     await assertRejects(call, ToolNotFoundError);

--- a/packages/terraform/tests/terraform_test.ts
+++ b/packages/terraform/tests/terraform_test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import { missingTool } from "@zuke/core/tooling/conformance";
 import {
   TerraformApplySettings,
   TerraformDestroySettings,
@@ -116,25 +117,30 @@ Deno.test("output: bare, -json, -raw, and a name", () => {
   );
 });
 
-/**
- * Point a settings object at a guaranteed-missing binary with the shim
- * fallback disabled, so each TerraformTasks function reaches execution WITHOUT
- * ever invoking a real terraform (tests must stay hermetic).
- */
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zuke-no-such-terraform-xyz");
-};
-
 Deno.test("every TerraformTasks function reaches execution", async () => {
-  await assertRejects(() => TerraformTasks.init(missing), ToolNotFoundError);
   await assertRejects(
-    () => TerraformTasks.validate(missing),
+    () => TerraformTasks.init(missingTool),
     ToolNotFoundError,
   );
-  await assertRejects(() => TerraformTasks.plan(missing), ToolNotFoundError);
-  await assertRejects(() => TerraformTasks.apply(missing), ToolNotFoundError);
-  await assertRejects(() => TerraformTasks.destroy(missing), ToolNotFoundError);
-  await assertRejects(() => TerraformTasks.fmt(missing), ToolNotFoundError);
-  await assertRejects(() => TerraformTasks.output(missing), ToolNotFoundError);
+  await assertRejects(
+    () => TerraformTasks.validate(missingTool),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => TerraformTasks.plan(missingTool),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => TerraformTasks.apply(missingTool),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => TerraformTasks.destroy(missingTool),
+    ToolNotFoundError,
+  );
+  await assertRejects(() => TerraformTasks.fmt(missingTool), ToolNotFoundError);
+  await assertRejects(
+    () => TerraformTasks.output(missingTool),
+    ToolNotFoundError,
+  );
 });

--- a/packages/tofu/tests/tofu_test.ts
+++ b/packages/tofu/tests/tofu_test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import { missingTool } from "@zuke/core/tooling/conformance";
 import {
   TofuApplySettings,
   TofuDestroySettings,
@@ -116,22 +117,12 @@ Deno.test("output: bare, -json, -raw, and a name", () => {
   );
 });
 
-/**
- * Point a settings object at a guaranteed-missing binary with the shim
- * fallback disabled, so each TofuTasks function reaches execution WITHOUT
- * ever invoking a real tofu (tests must stay hermetic).
- */
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zuke-no-such-tofu-xyz");
-};
-
 Deno.test("every TofuTasks function reaches execution", async () => {
-  await assertRejects(() => TofuTasks.init(missing), ToolNotFoundError);
-  await assertRejects(() => TofuTasks.validate(missing), ToolNotFoundError);
-  await assertRejects(() => TofuTasks.plan(missing), ToolNotFoundError);
-  await assertRejects(() => TofuTasks.apply(missing), ToolNotFoundError);
-  await assertRejects(() => TofuTasks.destroy(missing), ToolNotFoundError);
-  await assertRejects(() => TofuTasks.fmt(missing), ToolNotFoundError);
-  await assertRejects(() => TofuTasks.output(missing), ToolNotFoundError);
+  await assertRejects(() => TofuTasks.init(missingTool), ToolNotFoundError);
+  await assertRejects(() => TofuTasks.validate(missingTool), ToolNotFoundError);
+  await assertRejects(() => TofuTasks.plan(missingTool), ToolNotFoundError);
+  await assertRejects(() => TofuTasks.apply(missingTool), ToolNotFoundError);
+  await assertRejects(() => TofuTasks.destroy(missingTool), ToolNotFoundError);
+  await assertRejects(() => TofuTasks.fmt(missingTool), ToolNotFoundError);
+  await assertRejects(() => TofuTasks.output(missingTool), ToolNotFoundError);
 });

--- a/packages/tsc-alias/tests/tsc_alias_test.ts
+++ b/packages/tsc-alias/tests/tsc_alias_test.ts
@@ -1,5 +1,9 @@
 import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import {
+  assertWrapperConformance,
+  missingTool,
+} from "@zuke/core/tooling/conformance";
 import { TscAliasRunSettings, TscAliasTasks } from "../src/tsc_alias.ts";
 
 Deno.test("the default binary is tsc-alias", () => {
@@ -46,30 +50,12 @@ Deno.test("run: minimal targets the given project", () => {
   ]);
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zz-no-such-tsc-alias-zz");
-};
-
 Deno.test("TscAliasTasks.run reaches execution", async () => {
-  await assertRejects(() => TscAliasTasks.run(missing), ToolNotFoundError);
+  await assertRejects(() => TscAliasTasks.run(missingTool), ToolNotFoundError);
 });
 
-Deno.test("tsc-alias: resolves its binary from node_modules by default", () => {
-  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
-  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-  const root = Deno.makeTempDirSync();
-  try {
-    const binDir = `${root}/node_modules/.bin`;
-    Deno.mkdirSync(binDir, { recursive: true });
-    const bin = `${binDir}/tsc-alias`;
-    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
-    const s = new TscAliasRunSettings();
-    s.os_ = "linux";
-    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
-  } finally {
-    Deno.removeSync(root, { recursive: true });
-    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
-  }
+Deno.test("tsc-alias: resolves its binary from node_modules by default", async () => {
+  await assertWrapperConformance(() => new TscAliasRunSettings(), "tsc-alias", {
+    resolution: "node_modules",
+  });
 });

--- a/packages/tsc/tests/tsc_test.ts
+++ b/packages/tsc/tests/tsc_test.ts
@@ -1,5 +1,9 @@
 import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import {
+  assertWrapperConformance,
+  missingTool,
+} from "@zuke/core/tooling/conformance";
 import { TscBuildSettings, TscSettings, TscTasks } from "../src/tsc.ts";
 
 Deno.test("the default binary is tsc", () => {
@@ -61,34 +65,16 @@ Deno.test("build: every option renders, projects last", () => {
   ]);
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zz-no-such-tsc-zz");
-};
-
 Deno.test("TscTasks.tsc reaches execution", async () => {
-  await assertRejects(() => TscTasks.tsc(missing), ToolNotFoundError);
+  await assertRejects(() => TscTasks.tsc(missingTool), ToolNotFoundError);
 });
 
 Deno.test("TscTasks.build reaches execution", async () => {
-  await assertRejects(() => TscTasks.build(missing), ToolNotFoundError);
+  await assertRejects(() => TscTasks.build(missingTool), ToolNotFoundError);
 });
 
-Deno.test("tsc: resolves its binary from node_modules by default", () => {
-  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
-  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-  const root = Deno.makeTempDirSync();
-  try {
-    const binDir = `${root}/node_modules/.bin`;
-    Deno.mkdirSync(binDir, { recursive: true });
-    const bin = `${binDir}/tsc`;
-    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
-    const s = new TscSettings();
-    s.os_ = "linux"; // pin so the planted bare shim matches on any host
-    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
-  } finally {
-    Deno.removeSync(root, { recursive: true });
-    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
-  }
+Deno.test("tsc: resolves its binary from node_modules by default", async () => {
+  await assertWrapperConformance(() => new TscSettings(), "tsc", {
+    resolution: "node_modules",
+  });
 });

--- a/packages/tsdown/tests/tsdown_test.ts
+++ b/packages/tsdown/tests/tsdown_test.ts
@@ -1,5 +1,9 @@
 import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import {
+  assertWrapperConformance,
+  missingTool,
+} from "@zuke/core/tooling/conformance";
 import {
   TsdownBuildSettings,
   TsdownMigrateSettings,
@@ -75,34 +79,19 @@ Deno.test("migrate: every option renders", () => {
   );
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zz-no-such-tsdown-zz");
-};
-
 Deno.test("TsdownTasks.build reaches execution", async () => {
-  await assertRejects(() => TsdownTasks.build(missing), ToolNotFoundError);
+  await assertRejects(() => TsdownTasks.build(missingTool), ToolNotFoundError);
 });
 
 Deno.test("TsdownTasks.migrate reaches execution", async () => {
-  await assertRejects(() => TsdownTasks.migrate(missing), ToolNotFoundError);
+  await assertRejects(
+    () => TsdownTasks.migrate(missingTool),
+    ToolNotFoundError,
+  );
 });
 
-Deno.test("tsdown: resolves its binary from node_modules by default", () => {
-  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
-  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-  const root = Deno.makeTempDirSync();
-  try {
-    const binDir = `${root}/node_modules/.bin`;
-    Deno.mkdirSync(binDir, { recursive: true });
-    const bin = `${binDir}/tsdown`;
-    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
-    const s = new TsdownBuildSettings();
-    s.os_ = "linux"; // pin so the planted bare shim matches on any host
-    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
-  } finally {
-    Deno.removeSync(root, { recursive: true });
-    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
-  }
+Deno.test("tsdown: resolves its binary from node_modules by default", async () => {
+  await assertWrapperConformance(() => new TsdownBuildSettings(), "tsdown", {
+    resolution: "node_modules",
+  });
 });

--- a/packages/tsgo/tests/tsgo_test.ts
+++ b/packages/tsgo/tests/tsgo_test.ts
@@ -1,5 +1,9 @@
 import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import {
+  assertWrapperConformance,
+  missingTool,
+} from "@zuke/core/tooling/conformance";
 import { TsgoSettings, TsgoTasks } from "../src/tsgo.ts";
 
 Deno.test("the default binary is tsgo", () => {
@@ -41,30 +45,12 @@ Deno.test("tsgo: minimal checks the given file", () => {
   assertEquals(new TsgoSettings().paths("mod.ts").argv(), ["tsgo", "mod.ts"]);
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zz-no-such-tsgo-zz");
-};
-
 Deno.test("TsgoTasks.tsgo reaches execution", async () => {
-  await assertRejects(() => TsgoTasks.tsgo(missing), ToolNotFoundError);
+  await assertRejects(() => TsgoTasks.tsgo(missingTool), ToolNotFoundError);
 });
 
-Deno.test("tsgo: resolves its binary from node_modules by default", () => {
-  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
-  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-  const root = Deno.makeTempDirSync();
-  try {
-    const binDir = `${root}/node_modules/.bin`;
-    Deno.mkdirSync(binDir, { recursive: true });
-    const bin = `${binDir}/tsgo`;
-    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
-    const s = new TsgoSettings();
-    s.os_ = "linux"; // pin so the planted bare shim matches on any host
-    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
-  } finally {
-    Deno.removeSync(root, { recursive: true });
-    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
-  }
+Deno.test("tsgo: resolves its binary from node_modules by default", async () => {
+  await assertWrapperConformance(() => new TsgoSettings(), "tsgo", {
+    resolution: "node_modules",
+  });
 });

--- a/packages/tsup/tests/tsup_test.ts
+++ b/packages/tsup/tests/tsup_test.ts
@@ -1,5 +1,9 @@
 import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import {
+  assertWrapperConformance,
+  missingTool,
+} from "@zuke/core/tooling/conformance";
 import { TsupBuildSettings, TsupTasks } from "../src/tsup.ts";
 
 Deno.test("the default binary is tsup", () => {
@@ -48,30 +52,12 @@ Deno.test("build: entries first, then flags; formats joined", () => {
   );
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zuke-no-such-tsup-xyz");
-};
-
 Deno.test("TsupTasks.build reaches execution", async () => {
-  await assertRejects(() => TsupTasks.build(missing), ToolNotFoundError);
+  await assertRejects(() => TsupTasks.build(missingTool), ToolNotFoundError);
 });
 
-Deno.test("tsup: resolves its binary from node_modules by default", () => {
-  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
-  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-  const root = Deno.makeTempDirSync();
-  try {
-    const binDir = `${root}/node_modules/.bin`;
-    Deno.mkdirSync(binDir, { recursive: true });
-    const bin = `${binDir}/tsup`;
-    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
-    const s = new TsupBuildSettings();
-    s.os_ = "linux"; // pin so the planted bare shim matches on any host
-    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
-  } finally {
-    Deno.removeSync(root, { recursive: true });
-    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
-  }
+Deno.test("tsup: resolves its binary from node_modules by default", async () => {
+  await assertWrapperConformance(() => new TsupBuildSettings(), "tsup", {
+    resolution: "node_modules",
+  });
 });

--- a/packages/tsx/tests/tsx_test.ts
+++ b/packages/tsx/tests/tsx_test.ts
@@ -3,7 +3,11 @@ import {
   assertRejects,
   assertThrows,
 } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import {
+  assertWrapperConformance,
+  missingTool,
+} from "@zuke/core/tooling/conformance";
 import { TsxSettings, TsxTasks, TsxWatchSettings } from "../src/tsx.ts";
 
 Deno.test("the default binary is tsx", () => {
@@ -75,43 +79,26 @@ Deno.test("tsx: a missing script is reported", () => {
   );
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zz-no-such-tsx-zz");
-};
-
 Deno.test("TsxTasks.tsx reaches execution", async () => {
   await assertRejects(
-    () => TsxTasks.tsx((s) => missing(s.script("main.ts"))),
+    () => TsxTasks.tsx((s) => missingTool(s.script("main.ts"))),
     ToolNotFoundError,
   );
 });
 
 Deno.test("TsxTasks.watch reaches execution", async () => {
   await assertRejects(
-    () => TsxTasks.watch((s) => missing(s.script("main.ts"))),
+    () => TsxTasks.watch((s) => missingTool(s.script("main.ts"))),
     ToolNotFoundError,
   );
 });
 
-Deno.test("tsx: resolves its binary from node_modules by default", () => {
-  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
-  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-  const root = Deno.makeTempDirSync();
-  try {
-    const binDir = `${root}/node_modules/.bin`;
-    Deno.mkdirSync(binDir, { recursive: true });
-    const bin = `${binDir}/tsx`;
-    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
-    const s = new TsxSettings();
-    s.os_ = "linux";
-    assertEquals(
-      s.cwd(root).script("main.ts").resolvedArgv()[0],
-      bin.replace(/\\/g, "/"),
-    );
-  } finally {
-    Deno.removeSync(root, { recursive: true });
-    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
-  }
+Deno.test("tsx: resolves its binary from node_modules by default", async () => {
+  await assertWrapperConformance(
+    () => new TsxSettings().script("main.ts"),
+    "tsx",
+    {
+      resolution: "node_modules",
+    },
+  );
 });

--- a/packages/turbo/tests/turbo_test.ts
+++ b/packages/turbo/tests/turbo_test.ts
@@ -3,7 +3,11 @@ import {
   assertRejects,
   assertThrows,
 } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import {
+  assertWrapperConformance,
+  missingTool,
+} from "@zuke/core/tooling/conformance";
 import {
   TurboPruneSettings,
   TurboRunSettings,
@@ -14,26 +18,14 @@ Deno.test("the default binary is turbo", () => {
   assertEquals(new TurboRunSettings().tasks("build").argv()[0], "turbo");
 });
 
-Deno.test("turbo: resolves its binary from node_modules by default", () => {
-  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
-  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-  const root = Deno.makeTempDirSync();
-  try {
-    const binDir = `${root}/node_modules/.bin`;
-    Deno.mkdirSync(binDir, { recursive: true });
-    const bin = `${binDir}/turbo`;
-    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
-    const s = new TurboRunSettings();
-    s.os_ = "linux"; // pin so the planted bare shim matches on any host
-    assertEquals(
-      s.cwd(root).tasks("build").resolvedArgv()[0],
-      bin.replace(/\\/g, "/"),
-    );
-  } finally {
-    Deno.removeSync(root, { recursive: true });
-    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
-  }
+Deno.test("turbo: resolves its binary from node_modules by default", async () => {
+  await assertWrapperConformance(
+    () => new TurboRunSettings().tasks("build"),
+    "turbo",
+    {
+      resolution: "node_modules",
+    },
+  );
 });
 
 Deno.test("run: requires a task; tasks first, then flags", () => {
@@ -91,18 +83,13 @@ Deno.test("prune: requires a package; --docker and --out-dir", () => {
   );
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zuke-no-such-turbo-xyz");
-};
-
 Deno.test("every TurboTasks function reaches execution", async () => {
   await assertRejects(
-    () => TurboTasks.run((s) => missing(s).tasks("build")),
+    () => TurboTasks.run((s) => missingTool(s).tasks("build")),
     ToolNotFoundError,
   );
   await assertRejects(
-    () => TurboTasks.prune((s) => missing(s).package("web")),
+    () => TurboTasks.prune((s) => missingTool(s).package("web")),
     ToolNotFoundError,
   );
 });

--- a/packages/vite/tests/vite_test.ts
+++ b/packages/vite/tests/vite_test.ts
@@ -1,5 +1,9 @@
 import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import {
+  assertWrapperConformance,
+  missingTool,
+} from "@zuke/core/tooling/conformance";
 import {
   ViteBuildSettings,
   ViteDevSettings,
@@ -74,32 +78,14 @@ Deno.test("preview: bare and all options", () => {
   );
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zuke-no-such-vite-xyz");
-};
-
-Deno.test("vite: resolves its binary from node_modules by default", () => {
-  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
-  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-  const root = Deno.makeTempDirSync();
-  try {
-    const binDir = `${root}/node_modules/.bin`;
-    Deno.mkdirSync(binDir, { recursive: true });
-    const bin = `${binDir}/vite`;
-    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
-    const s = new ViteDevSettings();
-    s.os_ = "linux";
-    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
-  } finally {
-    Deno.removeSync(root, { recursive: true });
-    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
-  }
+Deno.test("vite: resolves its binary from node_modules by default", async () => {
+  await assertWrapperConformance(() => new ViteDevSettings(), "vite", {
+    resolution: "node_modules",
+  });
 });
 
 Deno.test("every ViteTasks function reaches execution", async () => {
-  await assertRejects(() => ViteTasks.dev(missing), ToolNotFoundError);
-  await assertRejects(() => ViteTasks.build(missing), ToolNotFoundError);
-  await assertRejects(() => ViteTasks.preview(missing), ToolNotFoundError);
+  await assertRejects(() => ViteTasks.dev(missingTool), ToolNotFoundError);
+  await assertRejects(() => ViteTasks.build(missingTool), ToolNotFoundError);
+  await assertRejects(() => ViteTasks.preview(missingTool), ToolNotFoundError);
 });

--- a/packages/vitest/tests/vitest_test.ts
+++ b/packages/vitest/tests/vitest_test.ts
@@ -1,5 +1,9 @@
 import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import {
+  assertWrapperConformance,
+  missingTool,
+} from "@zuke/core/tooling/conformance";
 import { VitestSettings, VitestTasks } from "../src/vitest.ts";
 
 Deno.test("the default invocation is a one-shot run", () => {
@@ -60,30 +64,12 @@ Deno.test("vitest: every option renders, filters last", () => {
   ]);
 });
 
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zz-no-such-vitest-zz");
-};
-
 Deno.test("VitestTasks.run reaches execution", async () => {
-  await assertRejects(() => VitestTasks.run(missing), ToolNotFoundError);
+  await assertRejects(() => VitestTasks.run(missingTool), ToolNotFoundError);
 });
 
-Deno.test("vitest: resolves its binary from node_modules by default", () => {
-  const prevRes = Deno.env.get("ZUKE_TOOL_RESOLUTION");
-  Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-  const root = Deno.makeTempDirSync();
-  try {
-    const binDir = `${root}/node_modules/.bin`;
-    Deno.mkdirSync(binDir, { recursive: true });
-    const bin = `${binDir}/vitest`;
-    Deno.writeTextFileSync(bin, "#!/bin/sh\n");
-    const s = new VitestSettings();
-    s.os_ = "linux";
-    assertEquals(s.cwd(root).resolvedArgv()[0], bin.replace(/\\/g, "/"));
-  } finally {
-    Deno.removeSync(root, { recursive: true });
-    if (prevRes === undefined) Deno.env.delete("ZUKE_TOOL_RESOLUTION");
-    else Deno.env.set("ZUKE_TOOL_RESOLUTION", prevRes);
-  }
+Deno.test("vitest: resolves its binary from node_modules by default", async () => {
+  await assertWrapperConformance(() => new VitestSettings(), "vitest", {
+    resolution: "node_modules",
+  });
 });

--- a/packages/yarn/tests/yarn_test.ts
+++ b/packages/yarn/tests/yarn_test.ts
@@ -3,7 +3,8 @@ import {
   assertRejects,
   assertThrows,
 } from "../../core/tests/_assert.ts";
-import { ToolNotFoundError, type ToolSettings } from "@zuke/core/tooling";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import { missingTool } from "@zuke/core/tooling/conformance";
 import {
   YarnAddSettings,
   YarnDlxSettings,
@@ -85,32 +86,22 @@ Deno.test("dlx: command required; --package and forwarded args", () => {
   );
 });
 
-/**
- * Point a settings object at a guaranteed-missing binary with the shim
- * fallback disabled, so each YarnTasks function reaches execution WITHOUT
- * ever invoking a real yarn (tests must stay hermetic).
- */
-const missing = <S extends ToolSettings>(s: S): S => {
-  s.os_ = "linux";
-  return s.toolPath("zuke-no-such-yarn-xyz");
-};
-
 Deno.test("every YarnTasks function reaches execution", async () => {
-  await assertRejects(() => YarnTasks.install(missing), ToolNotFoundError);
+  await assertRejects(() => YarnTasks.install(missingTool), ToolNotFoundError);
   await assertRejects(
-    () => YarnTasks.add((s) => missing(s).packages("x")),
+    () => YarnTasks.add((s) => missingTool(s).packages("x")),
     ToolNotFoundError,
   );
   await assertRejects(
-    () => YarnTasks.remove((s) => missing(s).packages("x")),
+    () => YarnTasks.remove((s) => missingTool(s).packages("x")),
     ToolNotFoundError,
   );
   await assertRejects(
-    () => YarnTasks.run((s) => missing(s).script("x")),
+    () => YarnTasks.run((s) => missingTool(s).script("x")),
     ToolNotFoundError,
   );
   await assertRejects(
-    () => YarnTasks.dlx((s) => missing(s).command("x")),
+    () => YarnTasks.dlx((s) => missingTool(s).command("x")),
     ToolNotFoundError,
   );
 });

--- a/tests/build_tools_test.ts
+++ b/tests/build_tools_test.ts
@@ -1,0 +1,751 @@
+/**
+ * Smoke tests for the release-tooling modules under `build/` — code that runs
+ * only in CI's release jobs and, before this file, wasn't imported by any
+ * test, so it carried zero coverage. Each test below exercises the pure logic
+ * of its module (JSON/shape parsing, decision branches, string rendering)
+ * without a network call, a real `deno publish`, or a real `deno doc`.
+ *
+ * @module
+ */
+
+import { Build } from "@zuke/core";
+import {
+  assertEquals,
+  assertRejects,
+  assertThrows,
+} from "../packages/core/tests/_assert.ts";
+import {
+  localVersion,
+  packageEntrypoints,
+  PACKAGES,
+  readVersion,
+} from "../build/packages.ts";
+import {
+  buildSymbol,
+  functionSignature,
+  isPublicMember,
+  memberMethod,
+  memberProperty,
+  moduleSummary,
+  renderParam,
+  renderType,
+  symbolMembers,
+  symbolSignature,
+  transformPackage,
+} from "../build/api_reference.ts";
+import { launcherScript, publishOne } from "../build/publish.ts";
+import {
+  DEFAULT_WEBSITE_REPO,
+  resolveSyncTarget,
+  runWebsiteSync,
+  syncBranchInfo,
+  type WebsiteSyncDeps,
+} from "../build/website_sync.ts";
+import {
+  cliReference,
+  crossPackageTypesOf,
+  docsOptions,
+} from "../build/docs.ts";
+
+// ---------------------------------------------------------------------------
+// build/packages.ts
+// ---------------------------------------------------------------------------
+
+Deno.test("PACKAGES lists core first and has no duplicates", () => {
+  assertEquals(PACKAGES.length > 0, true);
+  assertEquals(PACKAGES[0], "core");
+  assertEquals(new Set(PACKAGES).size, PACKAGES.length);
+});
+
+Deno.test("readVersion accepts a well-formed deno.json shape", () => {
+  assertEquals(readVersion({ version: "1.2.3" }), "1.2.3");
+});
+
+Deno.test("readVersion rejects a non-object", () => {
+  assertThrows(() => readVersion(null), Error, "must be a JSON object");
+  assertThrows(() => readVersion("nope"), Error, "must be a JSON object");
+});
+
+Deno.test("readVersion rejects a missing version field", () => {
+  assertThrows(() => readVersion({}), Error, 'missing a "version" field');
+});
+
+Deno.test("readVersion rejects a non-string version", () => {
+  assertThrows(
+    () => readVersion({ version: 1 }),
+    Error,
+    '"version" must be a string',
+  );
+});
+
+Deno.test("packageEntrypoints resolves core's exports map to real paths", async () => {
+  const entrypoints = await packageEntrypoints("core");
+  assertEquals(entrypoints.includes("packages/core/mod.ts"), true);
+  assertEquals(entrypoints.includes("packages/core/src/tooling.ts"), true);
+  assertEquals(
+    entrypoints.includes("packages/core/src/tooling_conformance.ts"),
+    true,
+  );
+});
+
+Deno.test("localVersion matches core's own deno.json", async () => {
+  const raw = JSON.parse(await Deno.readTextFile("packages/core/deno.json"));
+  assertEquals(await localVersion("core"), raw.version);
+});
+
+// ---------------------------------------------------------------------------
+// build/api_reference.ts
+// ---------------------------------------------------------------------------
+
+Deno.test("renderType: typeRef with and without generics", () => {
+  assertEquals(
+    renderType({
+      kind: "typeRef",
+      value: { typeName: "Promise", typeParams: [{ repr: "string" }] },
+    }),
+    "Promise<string>",
+  );
+  assertEquals(
+    renderType({ kind: "typeRef", value: { typeName: "Thing" } }),
+    "Thing",
+  );
+});
+
+Deno.test("renderType: array, union, intersection, fallback, undefined", () => {
+  assertEquals(
+    renderType({ kind: "array", value: { repr: "string" } }),
+    "string[]",
+  );
+  assertEquals(
+    renderType({ kind: "union", value: [{ repr: "A" }, { repr: "B" }] }),
+    "A | B",
+  );
+  assertEquals(
+    renderType({
+      kind: "intersection",
+      value: [{ repr: "A" }, { repr: "B" }],
+    }),
+    "A & B",
+  );
+  assertEquals(renderType({ repr: "Weird" }), "Weird");
+  assertEquals(renderType({}), "unknown");
+  assertEquals(renderType(undefined), "unknown");
+});
+
+Deno.test("renderParam: rest, assign, and identifier forms", () => {
+  assertEquals(
+    renderParam({
+      kind: "rest",
+      arg: { name: "parts" },
+      tsType: { kind: "array", value: { repr: "string" } },
+    }),
+    "...parts: string[]",
+  );
+  assertEquals(
+    renderParam({ kind: "rest", tsType: { repr: "unknown" } }),
+    "...args: unknown",
+  );
+  assertEquals(
+    renderParam({
+      kind: "assign",
+      left: { name: "scale", optional: true, tsType: { repr: "number" } },
+    }),
+    "scale?: number",
+  );
+  assertEquals(renderParam({ kind: "assign", left: {} }), "arg?: unknown");
+  assertEquals(
+    renderParam({ name: "x", optional: false, tsType: { repr: "number" } }),
+    "x: number",
+  );
+  assertEquals(
+    renderParam({ name: "y", optional: true, tsType: { repr: "string" } }),
+    "y?: string",
+  );
+  assertEquals(
+    renderParam({ left: { name: "z" }, tsType: { repr: "number" } }),
+    "z: number",
+  );
+});
+
+Deno.test("functionSignature: async, params, and a missing def", () => {
+  assertEquals(
+    functionSignature("run", {
+      isAsync: true,
+      params: [{ name: "a", tsType: { repr: "A" } }],
+      returnType: { repr: "void" },
+    }),
+    "async function run(a: A): void",
+  );
+  assertEquals(functionSignature("run", undefined), "function run(): unknown");
+});
+
+Deno.test("symbolSignature: every kind branch, including overloads", () => {
+  assertEquals(
+    symbolSignature("run", "function", [
+      { kind: "function", def: { params: [], returnType: { repr: "void" } } },
+      {
+        kind: "function",
+        def: {
+          params: [{ name: "x", tsType: { repr: "number" } }],
+          returnType: { repr: "void" },
+        },
+      },
+    ]),
+    "function run(): void\nfunction run(x: number): void",
+  );
+  assertEquals(symbolSignature("run", "function", []), "function run()");
+  assertEquals(
+    symbolSignature("count", "variable", [
+      { def: { tsType: { repr: "number" } } },
+    ]),
+    "const count: number",
+  );
+  assertEquals(
+    symbolSignature("Mode", "typeAlias", [
+      { def: { tsType: { repr: '"a" | "b"' } } },
+    ]),
+    'type Mode = "a" | "b"',
+  );
+  assertEquals(
+    symbolSignature("Widget", "class", [{ def: { extends: "Base" } }]),
+    "class Widget extends Base",
+  );
+  assertEquals(
+    symbolSignature("Widget", "class", [{ def: {} }]),
+    "class Widget",
+  );
+  assertEquals(symbolSignature("Shape", "interface", [{}]), "interface Shape");
+  assertEquals(symbolSignature("Color", "enum", [{}]), "enum Color");
+  assertEquals(symbolSignature("NS", "namespace", [{}]), "namespace NS");
+  assertEquals(symbolSignature("Mystery", "weird-kind", [{}]), "Mystery");
+});
+
+Deno.test("isPublicMember: undefined and public are public; private/protected are not", () => {
+  assertEquals(isPublicMember(undefined), true);
+  assertEquals(isPublicMember("public"), true);
+  assertEquals(isPublicMember("private"), false);
+  assertEquals(isPublicMember("protected"), false);
+});
+
+Deno.test("memberMethod: class-style (functionDef) and interface-style (flat)", () => {
+  assertEquals(
+    memberMethod({
+      name: "render",
+      functionDef: {
+        params: [{ name: "x", tsType: { repr: "number" } }],
+        returnType: { repr: "string" },
+      },
+      jsDoc: { doc: "Renders." },
+    }),
+    {
+      name: "render",
+      kind: "method",
+      optional: false,
+      signature: "render(x: number): string",
+      doc: "Renders.",
+    },
+  );
+  assertEquals(
+    memberMethod({
+      name: "area",
+      optional: true,
+      params: [],
+      returnType: { repr: "number" },
+    }),
+    {
+      name: "area",
+      kind: "method",
+      optional: true,
+      signature: "area?(): number",
+      doc: "",
+    },
+  );
+});
+
+Deno.test("memberProperty: optional and required", () => {
+  assertEquals(
+    memberProperty({
+      name: "count",
+      optional: true,
+      tsType: { repr: "number" },
+    }),
+    {
+      name: "count",
+      kind: "property",
+      optional: true,
+      signature: "count?: number",
+      doc: "",
+    },
+  );
+  assertEquals(
+    memberProperty({ name: "id", tsType: { repr: "string" } }),
+    {
+      name: "id",
+      kind: "property",
+      optional: false,
+      signature: "id: string",
+      doc: "",
+    },
+  );
+});
+
+Deno.test("symbolMembers: keeps only public members, methods before properties", () => {
+  const members = symbolMembers({
+    methods: [
+      { name: "render", params: [], returnType: { repr: "void" } },
+      {
+        name: "secret",
+        accessibility: "private",
+        params: [],
+        returnType: { repr: "void" },
+      },
+    ],
+    properties: [
+      { name: "count", tsType: { repr: "number" } },
+      {
+        name: "hidden",
+        accessibility: "protected",
+        tsType: { repr: "number" },
+      },
+    ],
+  });
+  assertEquals(members.map((m) => m.name), ["render", "count"]);
+  assertEquals(symbolMembers(undefined), []);
+});
+
+Deno.test("buildSymbol: flags deprecated via a jsDoc tag", () => {
+  const symbol = buildSymbol({
+    name: "Widget",
+    declarations: [
+      {
+        kind: "class",
+        jsDoc: { doc: "A widget.", tags: [{ kind: "deprecated" }] },
+        def: { extends: "Base", methods: [], properties: [] },
+      },
+    ],
+  });
+  assertEquals(symbol.name, "Widget");
+  assertEquals(symbol.kind, "class");
+  assertEquals(symbol.doc, "A widget.");
+  assertEquals(symbol.signature, "class Widget extends Base");
+  assertEquals(symbol.deprecated, true);
+  assertEquals(symbol.members, []);
+});
+
+Deno.test("buildSymbol: no declarations falls back to a bare variable", () => {
+  const symbol = buildSymbol({ name: "ghost", declarations: [] });
+  assertEquals(symbol.kind, "variable");
+  assertEquals(symbol.doc, "");
+  assertEquals(symbol.deprecated, false);
+  assertEquals(symbol.members, undefined);
+});
+
+Deno.test("moduleSummary: first non-empty line, skipping blank module docs", () => {
+  assertEquals(
+    moduleSummary([
+      { module_doc: { doc: "" } },
+      { module_doc: { doc: "\nSecond node doc.\nmore text" } },
+    ]),
+    "Second node doc.",
+  );
+  assertEquals(moduleSummary([{}]), "");
+  assertEquals(moduleSummary([]), "");
+});
+
+Deno.test("transformPackage: dedupes first-seen, sorts, drops zero-declaration symbols", () => {
+  const pkg = transformPackage("demo", {
+    nodes: {
+      "a.ts": {
+        module_doc: { doc: "" },
+        symbols: [
+          { name: "zebra", declarations: [{ kind: "enum" }] },
+          {
+            name: "alpha",
+            declarations: [
+              {
+                kind: "function",
+                def: { params: [], returnType: { repr: "void" } },
+              },
+            ],
+          },
+          { name: "ghost", declarations: [] },
+        ],
+      },
+      "b.ts": {
+        module_doc: { doc: "\nPackage summary line.\n" },
+        symbols: [
+          {
+            name: "alpha",
+            declarations: [
+              {
+                kind: "function",
+                def: { params: [], returnType: { repr: "number" } },
+              },
+            ],
+          },
+          {
+            name: "beta",
+            declarations: [{
+              kind: "variable",
+              def: { tsType: { repr: "string" } },
+            }],
+          },
+        ],
+      },
+    },
+  });
+  assertEquals(pkg.name, "@zuke/demo");
+  assertEquals(pkg.dir, "demo");
+  assertEquals(pkg.summary, "Package summary line.");
+  assertEquals(pkg.symbols.map((s) => s.name), ["alpha", "beta", "zebra"]);
+  // a.ts's declaration wins (returnType void), not b.ts's later duplicate.
+  const alpha = pkg.symbols.find((s) => s.name === "alpha");
+  assertEquals(alpha?.signature, "function alpha(): void");
+});
+
+// ---------------------------------------------------------------------------
+// build/publish.ts — the timeout re-check decision
+// ---------------------------------------------------------------------------
+
+/** A fake {@link import("../build/publish.ts").PublishOneDeps} recording every call. */
+function fakeDeps(opts: {
+  publishedAnswers: boolean[];
+  publishResult: boolean;
+}) {
+  const calls = { info: [] as string[], success: [] as string[] };
+  const answers = [...opts.publishedAnswers];
+  return {
+    deps: {
+      isPublished: (_pkg: string, _version: string) => {
+        const next = answers.shift();
+        return Promise.resolve(next ?? false);
+      },
+      publishPackage: (_pkg: string) => Promise.resolve(opts.publishResult),
+      info: (m: string) => calls.info.push(m),
+      success: (m: string) => calls.success.push(m),
+    },
+    calls,
+  };
+}
+
+Deno.test("publishOne: skips a package already on JSR", async () => {
+  const { deps, calls } = fakeDeps({
+    publishedAnswers: [true],
+    publishResult: true,
+  });
+  await publishOne("core", "1.0.0", deps);
+  assertEquals(calls.info, ["@zuke/core@1.0.0 is already on JSR."]);
+  assertEquals(calls.success, []);
+});
+
+Deno.test("publishOne: publishes cleanly when not yet on JSR", async () => {
+  const { deps, calls } = fakeDeps({
+    publishedAnswers: [false],
+    publishResult: true,
+  });
+  await publishOne("core", "1.0.0", deps);
+  assertEquals(calls.info, ["Publishing @zuke/core@1.0.0 to JSR..."]);
+  assertEquals(calls.success, []);
+});
+
+Deno.test("publishOne: a stalled publish that actually landed is a success", async () => {
+  const { deps, calls } = fakeDeps({
+    publishedAnswers: [false, true],
+    publishResult: false,
+  });
+  await publishOne("core", "1.0.0", deps);
+  assertEquals(calls.success, [
+    "@zuke/core@1.0.0 uploaded (provenance stalled).",
+  ]);
+});
+
+Deno.test("publishOne: a stalled publish that never landed throws", async () => {
+  const { deps } = fakeDeps({
+    publishedAnswers: [false, false],
+    publishResult: false,
+  });
+  await assertRejects(
+    () => publishOne("core", "1.0.0", deps),
+    Error,
+    "timed out before reaching JSR",
+  );
+});
+
+Deno.test("launcherScript: posix quotes every argv word and cds to the repo root", () => {
+  const script = launcherScript(["deno", "run", "-A", "it's.ts"], false);
+  assertEquals(script.startsWith("#!/bin/sh\n"), true);
+  assertEquals(script.includes("|| exit 1"), true);
+  // A literal single quote is escaped by closing, escaping, reopening.
+  assertEquals(script.includes("'it'\\''s.ts'"), true);
+  assertEquals(script.trimEnd().endsWith('"$@"'), true);
+});
+
+Deno.test("launcherScript: windows quotes every argv word and cds to the repo root", () => {
+  const script = launcherScript(["deno", "run", 'say "hi"'], true);
+  assertEquals(script.startsWith("@echo off\r\n"), true);
+  assertEquals(script.includes("|| exit /b 1"), true);
+  // A literal double quote is escaped by doubling.
+  assertEquals(script.includes('"say ""hi"""'), true);
+  assertEquals(script.trimEnd().endsWith("%*"), true);
+});
+
+// ---------------------------------------------------------------------------
+// build/website_sync.ts
+// ---------------------------------------------------------------------------
+
+Deno.test("resolveSyncTarget: null when the token is absent or empty", () => {
+  assertEquals(resolveSyncTarget({}), null);
+  assertEquals(resolveSyncTarget({ token: "" }), null);
+});
+
+Deno.test("resolveSyncTarget: the default repo, or an explicit override", () => {
+  assertEquals(resolveSyncTarget({ token: "abc" }), {
+    token: "abc",
+    repo: DEFAULT_WEBSITE_REPO,
+  });
+  assertEquals(resolveSyncTarget({ token: "abc", repo: "me/site" }), {
+    token: "abc",
+    repo: "me/site",
+  });
+});
+
+Deno.test("syncBranchInfo: names the branch and commit message from a version", () => {
+  assertEquals(syncBranchInfo("1.2.3"), {
+    branch: "zuke-sync/1.2.3",
+    message: "chore: sync docs + api reference for core@1.2.3",
+  });
+});
+
+/**
+ * A {@link WebsiteSyncDeps} that fails any call except `.warn` — used to prove
+ * the no-token guard returns before touching any real dependency.
+ */
+function unreachableDeps(warnings: string[]): WebsiteSyncDeps {
+  const boom = (name: string) => () => {
+    throw new Error(`unexpected call: ${name}`);
+  };
+  return {
+    regenerateDocs: boom("regenerateDocs"),
+    regenerateApiJson: boom("regenerateApiJson"),
+    makeTempDir: boom("makeTempDir"),
+    removeDir: boom("removeDir"),
+    cloneWebsite: boom("cloneWebsite"),
+    createSyncBranch: boom("createSyncBranch"),
+    copyArtifacts: boom("copyArtifacts"),
+    stageAll: boom("stageAll"),
+    hasStagedChanges: boom("hasStagedChanges"),
+    commitStaged: boom("commitStaged"),
+    pushBranch: boom("pushBranch"),
+    openOrRefreshPr: boom("openOrRefreshPr"),
+    info: boom("info"),
+    success: boom("success"),
+    warn: (m) => warnings.push(m),
+  };
+}
+
+/** What a {@link fakeSyncDeps} run recorded, for assertions without `unknown` indexing. */
+interface SyncCalls {
+  cloneWebsite: Array<{ repo: string; dir: string }>;
+  commitStaged: number;
+  pushBranch: number;
+  openOrRefreshPr: number;
+  removeDir: string[];
+  info: string[];
+  success: string[];
+  warn: string[];
+}
+
+/** A {@link WebsiteSyncDeps} that performs every step as a hermetic no-op. */
+function fakeSyncDeps(
+  overrides: Partial<WebsiteSyncDeps> = {},
+): { deps: WebsiteSyncDeps; calls: SyncCalls } {
+  const calls: SyncCalls = {
+    cloneWebsite: [],
+    commitStaged: 0,
+    pushBranch: 0,
+    openOrRefreshPr: 0,
+    removeDir: [],
+    info: [],
+    success: [],
+    warn: [],
+  };
+  const deps: WebsiteSyncDeps = {
+    regenerateDocs: () => Promise.resolve(),
+    regenerateApiJson: () => Promise.resolve(),
+    makeTempDir: () => Promise.resolve("/tmp/fake-sync-dir"),
+    removeDir: (dir) => {
+      calls.removeDir.push(dir);
+      return Promise.resolve();
+    },
+    cloneWebsite: (repo, dir) => {
+      calls.cloneWebsite.push({ repo, dir });
+      return Promise.resolve();
+    },
+    createSyncBranch: () => Promise.resolve(),
+    copyArtifacts: () => Promise.resolve(),
+    stageAll: () => Promise.resolve(),
+    hasStagedChanges: () => Promise.resolve(false),
+    commitStaged: () => {
+      calls.commitStaged++;
+      return Promise.resolve();
+    },
+    pushBranch: () => {
+      calls.pushBranch++;
+      return Promise.resolve();
+    },
+    openOrRefreshPr: () => {
+      calls.openOrRefreshPr++;
+      return Promise.resolve({ code: 0, text: "" });
+    },
+    info: (m) => calls.info.push(m),
+    success: (m) => calls.success.push(m),
+    warn: (m) => calls.warn.push(m),
+    ...overrides,
+  };
+  return { deps, calls };
+}
+
+/** Run `fn` with `WEBSITE_SYNC_TOKEN`/`WEBSITE_REPO` set, restoring both after. */
+async function withSyncEnv(
+  env: { token?: string; repo?: string },
+  fn: () => Promise<void>,
+): Promise<void> {
+  const prevToken = Deno.env.get("WEBSITE_SYNC_TOKEN");
+  const prevRepo = Deno.env.get("WEBSITE_REPO");
+  if (env.token === undefined) {
+    Deno.env.delete("WEBSITE_SYNC_TOKEN");
+  } else {
+    Deno.env.set("WEBSITE_SYNC_TOKEN", env.token);
+  }
+  if (env.repo === undefined) {
+    Deno.env.delete("WEBSITE_REPO");
+  } else {
+    Deno.env.set("WEBSITE_REPO", env.repo);
+  }
+  try {
+    await fn();
+  } finally {
+    if (prevToken === undefined) Deno.env.delete("WEBSITE_SYNC_TOKEN");
+    else Deno.env.set("WEBSITE_SYNC_TOKEN", prevToken);
+    if (prevRepo === undefined) Deno.env.delete("WEBSITE_REPO");
+    else Deno.env.set("WEBSITE_REPO", prevRepo);
+  }
+}
+
+Deno.test("runWebsiteSync: skips cleanly with no token, touching no deps", async () => {
+  await withSyncEnv({ token: undefined }, async () => {
+    // unreachableDeps throws if anything beyond the warn ran, proving the
+    // function returns right after the guard without touching a real
+    // dependency.
+    const warnings: string[] = [];
+    await runWebsiteSync(new Build(), unreachableDeps(warnings));
+    assertEquals(warnings, [
+      "WEBSITE_SYNC_TOKEN not set — skipping the website sync.",
+    ]);
+  });
+});
+
+Deno.test("runWebsiteSync: already in sync — no commit, push, or PR", async () => {
+  await withSyncEnv({ token: "tok" }, async () => {
+    const { deps, calls } = fakeSyncDeps({
+      hasStagedChanges: () => Promise.resolve(false),
+    });
+    await runWebsiteSync(new Build(), deps);
+    assertEquals(calls.info, ["website already in sync — no PR needed."]);
+    assertEquals(calls.commitStaged, 0);
+    assertEquals(calls.pushBranch, 0);
+    assertEquals(calls.openOrRefreshPr, 0);
+    assertEquals(calls.removeDir, ["/tmp/fake-sync-dir"]);
+  });
+});
+
+Deno.test("runWebsiteSync: a freshly opened PR reports success", async () => {
+  await withSyncEnv({ token: "tok", repo: "me/site" }, async () => {
+    const { deps, calls } = fakeSyncDeps({
+      hasStagedChanges: () => Promise.resolve(true),
+      openOrRefreshPr: () => Promise.resolve({ code: 0, text: "https://pr/1" }),
+    });
+    await runWebsiteSync(new Build(), deps);
+    assertEquals(calls.success, ["Opened website sync PR: https://pr/1"]);
+    assertEquals(calls.cloneWebsite, [{
+      repo: "me/site",
+      dir: "/tmp/fake-sync-dir",
+    }]);
+    // The idempotent path was not taken: staged changes were found.
+    assertEquals(calls.commitStaged, 1);
+    assertEquals(calls.pushBranch, 1);
+    // Cleanup always runs, success or not.
+    assertEquals(calls.removeDir, ["/tmp/fake-sync-dir"]);
+  });
+});
+
+Deno.test("runWebsiteSync: an already-open PR is reported, not treated as a failure", async () => {
+  await withSyncEnv({ token: "tok" }, async () => {
+    const { deps, calls } = fakeSyncDeps({
+      hasStagedChanges: () => Promise.resolve(true),
+      openOrRefreshPr: () => Promise.resolve({ code: 1, text: "" }),
+    });
+    await runWebsiteSync(new Build(), deps);
+    assertEquals(calls.success, []);
+    assertEquals(
+      calls.info.some((m) => m.includes("already open")),
+      true,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// build/docs.ts
+// ---------------------------------------------------------------------------
+
+Deno.test("cliReference: lists the build's reserved commands and flags", () => {
+  const text = cliReference(new Build());
+  assertEquals(text.includes("Reserved commands:"), true);
+  assertEquals(text.includes("Option flags:"), true);
+  assertEquals(text.includes("docs/cli.md"), true);
+});
+
+Deno.test("docsOptions: carries the project framing plus a live CLI block", () => {
+  const options = docsOptions(new Build());
+  assertEquals(options.regenerateCommand, "./zuke apiDocs");
+  if (options.project === undefined) {
+    throw new Error("docsOptions must set .project");
+  }
+  assertEquals(options.project.title, "Zuke");
+  assertEquals(options.project.cli, cliReference(new Build()));
+});
+
+Deno.test("crossPackageTypesOf: named, type, namespace, and default imports; tests/ excluded", async () => {
+  const original = Deno.cwd();
+  const dir = await Deno.makeTempDir();
+  try {
+    Deno.chdir(dir);
+    await Deno.mkdir("packages/demo/tests", { recursive: true });
+    await Deno.writeTextFile(
+      "packages/demo/mod.ts",
+      [
+        'import { type Configure, target } from "@zuke/core";',
+        'import { ToolSettings as Settings } from "@zuke/core/tooling";',
+        'import * as shell from "@zuke/core/shell";',
+        'import Something from "@zuke/thing";',
+        'import { unrelated } from "./local.ts";',
+        "",
+        "export const x: Configure<Settings> = (s) => s;",
+        "export { target, shell, Something, unrelated };",
+      ].join("\n"),
+    );
+    // A `@zuke/*` reference inside tests/ must not count — it isn't doc surface.
+    await Deno.writeTextFile(
+      "packages/demo/tests/demo_test.ts",
+      'import { NotCounted } from "@zuke/core";\nexport { NotCounted };\n',
+    );
+    const names = await crossPackageTypesOf("demo");
+    assertEquals(
+      new Set(names),
+      new Set(["Configure", "target", "Settings", "shell", "Something"]),
+    );
+  } finally {
+    Deno.chdir(original);
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/tests/build_tools_test.ts
+++ b/tests/build_tools_test.ts
@@ -509,6 +509,31 @@ Deno.test("resolveSyncTarget: the default repo, or an explicit override", () => 
   });
 });
 
+Deno.test("resolveSyncTarget: refuses an override that is not an owner/repo slug", () => {
+  // This is the one place a cross-repo write token leaves for another
+  // repository, so the slug is checked before it reaches `git push` and
+  // `gh pr create` rather than after.
+  for (
+    const repo of [
+      "https://evil.example/x/y", // a URL, not a slug
+      "user:token@github.com/o/r", // embedded credential
+      "owner/repo/extra", // an extra path segment
+      "owner", // no repo half
+      "/repo", // no owner half
+      "owner/", // empty repo half
+      "-owner/repo", // segment may not start with a dash
+      "owner/repo with space",
+      "", // set but empty: not the same as unset
+    ]
+  ) {
+    assertThrows(
+      () => resolveSyncTarget({ token: "abc", repo }),
+      Error,
+      "owner/repo",
+    );
+  }
+});
+
 Deno.test("syncBranchInfo: names the branch and commit message from a version", () => {
   assertEquals(syncBranchInfo("1.2.3"), {
     branch: "zuke-sync/1.2.3",

--- a/zuke.ts
+++ b/zuke.ts
@@ -48,6 +48,7 @@ import { localVersion, PACKAGES } from "./build/packages.ts";
 import {
   CODECOV_CLI_VERSION,
   installCli,
+  publishOne,
   publishPackage,
   TOOLS_ROOT,
 } from "./build/publish.ts";
@@ -684,23 +685,12 @@ class ZukeBuild extends Build {
           ConsoleTasks.info(`@zuke/${pkg} has no released version yet.`);
           continue;
         }
-        if (await isPublished(`@zuke/${pkg}`, version)) {
-          ConsoleTasks.info(`@zuke/${pkg}@${version} is already on JSR.`);
-          continue;
-        }
-        ConsoleTasks.info(`Publishing @zuke/${pkg}@${version} to JSR...`);
-        if (await publishPackage(pkg)) continue;
-        // Timed out: the upload usually lands before JSR's finalization hangs,
-        // so a re-check tells us whether it actually published.
-        if (await isPublished(`@zuke/${pkg}`, version)) {
-          ConsoleTasks.success(
-            `@zuke/${pkg}@${version} uploaded (provenance stalled).`,
-          );
-          continue;
-        }
-        throw new Error(
-          `Publishing @zuke/${pkg}@${version} timed out before reaching JSR.`,
-        );
+        await publishOne(pkg, version, {
+          isPublished,
+          publishPackage,
+          info: ConsoleTasks.info,
+          success: ConsoleTasks.success,
+        });
       }
     });
 


### PR DESCRIPTION
Three test changes. Deliberately titled as a test change so it bumps nothing — which is the entire reason it is separate from the PR that added the conformance helper.

## Migrate the wrapper suites onto the shared helper

Roughly five hundred lines of identical boilerplate were duplicated across the wrapper tests: a temp-directory dance with an environment override to check tool resolution, repeated verbatim in about two dozen files, and a missing-binary helper repeated in about four dozen. Worse than the duplication, the resolution default was *remembered* rather than asserted — an earlier sweep retrofitted two dozen packages by hand, so the next omission would have been silent.

Each wrapper now calls the shared helper and states its resolution mode explicitly, because that argument is required by design. Each wrapper's current declared behaviour was taken as the truth rather than guessed.

## Git wrapper parity

The git wrapper had thirteen settings classes but only one task function with a test that reached execution, against fifteen of fifteen in docker and seventeen of seventeen in kubectl. It was also where the last argv-semantics bug landed. The missing task functions now have reaches-execution tests, and the two chainers that had no argv coverage are covered.

## Put the release tooling under the coverage gate

Roughly fifteen hundred lines under `build/` were invisible to the coverage instrument because no test imported them — the least-tested code in a repo whose headline discipline is 95%, and the code that cuts and publishes releases. Each module is now imported from a test, with the pure logic covered: the published-version check's JSON parsing, the timeout re-check decision, and the packages-list shape.

## Verification

`deno task ci` green, 15 of 15 targets, exit code 0 — re-run after rebasing onto current master, and independently re-run a second time by the orchestrator rather than taken on report.
