### PR TITLE
feat(security): scope the pull-request secret scan and keep a readable report

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,7 +8,10 @@ on:
     - cron: "42 5 * * 3"
 
 # The scanners run as a Zuke build gate (./zuke security) and fail the job on
-# findings; results are in the job log. Code-level SARIF for the Security tab
+# findings. gitleaks runs redacted, so its log line is only a count; the target
+# also writes a redacted JSON report, uploaded below, which names the file, line,
+# rule and fingerprint of each finding. Without it a failure is undiagnosable
+# without reproducing the scan locally. Code-level SARIF for the Security tab
 # comes from CodeQL's default setup and the Scorecard workflow.
 permissions:
   contents: read
@@ -25,7 +28,11 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # Full history so gitleaks scans past commits, not just the tip.
+          # Full history so gitleaks scans past commits, not just the tip. This
+          # also fetches every branch, which is why the target scopes the scan to
+          # the pull request's own commits — otherwise a secret-shaped string on
+          # an unrelated branch fails the scan on every open pull request. A push
+          # to master and the weekly run still walk the whole history.
           fetch-depth: 0
           persist-credentials: false
 
@@ -43,3 +50,15 @@ jobs:
       # typed `security` target (zizmor, actionlint, gitleaks).
       - name: Run security scanners with Zuke
         run: ./zuke security
+
+      # Uploaded even when the scan failed — that is the case where it is needed.
+      # The report is redacted, so it carries locations and rule ids rather than
+      # secret values.
+      - name: Upload the gitleaks report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gitleaks-report
+          path: gitleaks-report.json
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ plans/
 
 # OMC session state
 .omc/
+
+# Redacted gitleaks findings from `./zuke security` (uploaded as a CI artifact)
+/gitleaks-report.json

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9612,6 +9612,19 @@ class GitleaksDetectSettings extends ToolSettings
     Treat the source as a plain directory, not a git repo (`--no-git`).
   verbose(): this
     Verbose output (`--verbose`).
+  logOpts(opts: string): this
+    Restrict which commits are scanned, passed straight through to `git log`
+    (`--log-opts`).
+
+    Without this, `gitleaks detect` walks the whole history reachable from the
+    refs present in the checkout — so on a pull request, where CI typically
+    fetches every branch, a secret-shaped string on an unrelated branch fails
+    the scan and the failure appears on whichever pull request is looked at.
+    Passing a range such as `origin/main..HEAD` scopes the scan to the commits
+    under review.
+
+    Has no effect alongside {@linkcode noGit}, which makes gitleaks treat the
+    source as a plain directory and ignore history entirely.
   override protected buildArgs(): string[]
     Assemble the `gitleaks detect` argv.
 

--- a/packages/security/README.md
+++ b/packages/security/README.md
@@ -99,6 +99,19 @@ class GitleaksDetectSettings extends ToolSettings
     Treat the source as a plain directory, not a git repo (`--no-git`).
   verbose(): this
     Verbose output (`--verbose`).
+  logOpts(opts: string): this
+    Restrict which commits are scanned, passed straight through to `git log`
+    (`--log-opts`).
+
+    Without this, `gitleaks detect` walks the whole history reachable from the
+    refs present in the checkout — so on a pull request, where CI typically
+    fetches every branch, a secret-shaped string on an unrelated branch fails
+    the scan and the failure appears on whichever pull request is looked at.
+    Passing a range such as `origin/main..HEAD` scopes the scan to the commits
+    under review.
+
+    Has no effect alongside {@linkcode noGit}, which makes gitleaks treat the
+    source as a plain directory and ignore history entirely.
   override protected buildArgs(): string[]
     Assemble the `gitleaks detect` argv.
 

--- a/packages/security/src/security.ts
+++ b/packages/security/src/security.ts
@@ -169,6 +169,7 @@ export class GitleaksDetectSettings extends ToolSettings {
   #redact = false;
   #noGit = false;
   #verbose = false;
+  #logOpts?: string;
 
   /** The binary this settings object drives (`gitleaks`). */
   protected override defaultTool(): string {
@@ -217,6 +218,25 @@ export class GitleaksDetectSettings extends ToolSettings {
     return this;
   }
 
+  /**
+   * Restrict which commits are scanned, passed straight through to `git log`
+   * (`--log-opts`).
+   *
+   * Without this, `gitleaks detect` walks the whole history reachable from the
+   * refs present in the checkout — so on a pull request, where CI typically
+   * fetches every branch, a secret-shaped string on an unrelated branch fails
+   * the scan and the failure appears on whichever pull request is looked at.
+   * Passing a range such as `origin/main..HEAD` scopes the scan to the commits
+   * under review.
+   *
+   * Has no effect alongside {@linkcode noGit}, which makes gitleaks treat the
+   * source as a plain directory and ignore history entirely.
+   */
+  logOpts(opts: string): this {
+    this.#logOpts = opts;
+    return this;
+  }
+
   /** Assemble the `gitleaks detect` argv. */
   protected override buildArgs(): string[] {
     const argv = ["detect"];
@@ -231,6 +251,7 @@ export class GitleaksDetectSettings extends ToolSettings {
     if (this.#redact) argv.push("--redact");
     if (this.#noGit) argv.push("--no-git");
     if (this.#verbose) argv.push("--verbose");
+    if (this.#logOpts !== undefined) argv.push("--log-opts", this.#logOpts);
     return argv;
   }
 }

--- a/packages/security/tests/security_test.ts
+++ b/packages/security/tests/security_test.ts
@@ -73,6 +73,29 @@ Deno.test("gitleaks: full and minimal argv", () => {
   assertEquals(new GitleaksDetectSettings().argv(), ["gitleaks", "detect"]);
 });
 
+Deno.test("gitleaks: logOpts scopes the commits scanned", () => {
+  // Without a range, `detect` walks the history reachable from every ref in the
+  // checkout, so a secret on an unrelated branch fails the scan.
+  assertEquals(
+    new GitleaksDetectSettings()
+      .source(".").redact().logOpts("origin/master..HEAD").argv(),
+    [
+      "gitleaks",
+      "detect",
+      "--source",
+      ".",
+      "--redact",
+      "--log-opts",
+      "origin/master..HEAD",
+    ],
+  );
+  // Absent by default: a full-history scan stays the default behaviour.
+  assertEquals(
+    new GitleaksDetectSettings().source(".").argv().includes("--log-opts"),
+    false,
+  );
+});
+
 Deno.test("osv-scanner: full and minimal argv", () => {
   assertEquals(
     new OsvScannerSettings()

--- a/zuke.ts
+++ b/zuke.ts
@@ -67,6 +67,13 @@ import {
   syncPluginSkills,
 } from "./build/plugin_sync.ts";
 
+/**
+ * Where the `security` target writes gitleaks' findings. The security workflow
+ * uploads this path as an artifact, so the two must agree; it is git-ignored
+ * because a local `./zuke security` writes it too.
+ */
+const GITLEAKS_REPORT = "gitleaks-report.json";
+
 class ZukeBuild extends Build {
   clean = target()
     .description("Remove build artifacts")
@@ -530,9 +537,27 @@ class ZukeBuild extends Build {
         SecurityTasks.zizmor((s) => s.paths(".github/workflows").noThrow()),
       );
       await gate("actionlint", SecurityTasks.actionlint((s) => s.noThrow()));
+      // `gitleaks detect` walks the history reachable from every ref in the
+      // checkout, and the security workflow fetches all of them — so without a
+      // range, one secret-shaped string on any branch fails the scan on every
+      // open pull request, blaming whichever one is looked at. On a pull request
+      // (`GITHUB_BASE_REF` is set only there) the scan is scoped to the commits
+      // under review; a push to the default branch and the weekly schedule still
+      // walk the whole history, so nothing stops being covered.
+      const prBase = Deno.env.get("GITHUB_BASE_REF");
+      // The report stays redacted — it carries the file, line, rule and
+      // fingerprint of each finding but not the secret itself, which is what
+      // makes a failure diagnosable from the uploaded artifact instead of only
+      // from a bare count in the log.
       await gate(
         "gitleaks",
-        SecurityTasks.gitleaks((s) => s.source(".").redact().noThrow()),
+        SecurityTasks.gitleaks((s) => {
+          const settings = s.source(".").redact()
+            .reportFormat("json").reportPath(GITLEAKS_REPORT).noThrow();
+          return prBase === undefined || prBase === ""
+            ? settings
+            : settings.logOpts(`origin/${prBase}..HEAD`);
+        }),
       );
       // osv-scanner is omitted here: it has no extractor for Deno's lockfile.
       // The @zuke/security wrapper still ships it for projects with npm/cargo/


### PR DESCRIPTION
Fixes both halves of the secret-scan problem this effort ran into. Neither is hypothetical — both cost real time last week.

## A pull request was judged on every branch, not its own

The secret scan walks the history reachable from every ref in the checkout, and the workflow fetches all branches so past commits stay covered. The consequence: one secret-shaped string on one branch failed the scan on **every open pull request simultaneously**, and the failure appeared on whichever one you happened to open. That is exactly what happened — a fake credential in a test fixture on one branch turned eight unrelated pull requests red, and the branch that introduced it looked no guiltier than the seven that did not.

`GitleaksDetectSettings` gains a `logOpts` setter for the tool's own git-log option, and the `security` target uses it to scope the scan to the commits under review whenever the base-ref environment variable is set — which is only on a pull request. A push to the default branch and the weekly scheduled run still walk the whole history, so **nothing stops being covered**; a pull request is simply judged on its own commits.

Measured on this repository: a scoped range scans 3 commits where the unscoped scan walks 302.

## A failure was a bare count

The scan runs redacted, which is right, but wrote no report — so a finding surfaced as a count of one, with no file, no line and no rule. The only way to identify it was to install the tool locally and reproduce the scan by hand, which is how the fixture above was eventually found, after a detour through re-running seven other jobs.

The target now writes a JSON report and the workflow uploads it even when the scan fails, since that is the case which needs it.

**The report stays redacted, and that is what makes uploading it safe.** Verified rather than assumed: a redacted report on a synthetic leak keeps the rule id, the file, the start line and the fingerprint, while the secret and match fields both read as the literal string REDACTED. Sample output is in a comment below, since a fenced block in this description would trip the body linter. So anyone with repository read access can diagnose a failure without the artifact publishing the thing it found.

## Verification

The git-log option was confirmed against the tool's own help output on 8.30.1 before being added, rather than assumed — the repo's guideline is that a wrapper mirrors the real CLI. Also confirmed that treating the source as a plain directory nullifies it, which is noted in the setter's documentation.

The full settings chain the target now builds was executed end to end through the wrapper: correct argv, scoped commit count, report written. The local gate is green at 15 of 15 targets with exit code 0. The report path is git-ignored, since a local run of the target writes it too, and the path constant is shared so the build and the workflow cannot drift.

This is a feature on the security package, so it minor-bumps that package.
