### PR TITLE
refactor(core): split execute() orchestration into per-concern modules

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2265,8 +2265,8 @@ interface ExecuteOptions
     outside GitHub Actions) when omitted; off by default with a custom reporter.
   renderer?: Renderer
     Renderer for the per-target banners and the end-of-build summary. Defaults
-    to Zuke's built-in {@link defaultRenderer}; `@zuke/console` exports an
-    alternative a build can inject to restyle its output.
+    to Zuke's built-in {@link "./renderer.ts".defaultRenderer}; `@zuke/console`
+    exports an alternative a build can inject to restyle its output.
   signal?: AbortSignal
     Cancel the run when this signal aborts (wired to Ctrl-C/SIGTERM by the CLI,
     or fired by another process running `zuke cancel`). Every target body's

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2319,8 +2319,8 @@ interface ExecuteOptions
     outside GitHub Actions) when omitted; off by default with a custom reporter.
   renderer?: Renderer
     Renderer for the per-target banners and the end-of-build summary. Defaults
-    to Zuke's built-in {@link defaultRenderer}; `@zuke/console` exports an
-    alternative a build can inject to restyle its output.
+    to Zuke's built-in {@link "./renderer.ts".defaultRenderer}; `@zuke/console`
+    exports an alternative a build can inject to restyle its output.
   signal?: AbortSignal
     Cancel the run when this signal aborts (wired to Ctrl-C/SIGTERM by the CLI,
     or fired by another process running `zuke cancel`). Every target body's

--- a/packages/core/src/execute_cancel.ts
+++ b/packages/core/src/execute_cancel.ts
@@ -1,0 +1,98 @@
+/**
+ * Settling a cancelled run's durable state: the cancel-lock handshake that
+ * decides whether *this* process owns the compensation walk, the walk itself,
+ * and the audit trail it leaves behind.
+ *
+ * The walk is {@link "./cancel.ts".runCompensations}, shared with the
+ * out-of-process `zuke cancel`; what lives here is the in-process half —
+ * everything {@link "./executor.ts".execute} does once its plan has settled and
+ * the run turns out to have been cancelled.
+ *
+ * @module
+ */
+
+import type { TargetBuilder } from "./target.ts";
+import type { Reporter } from "./reporter.ts";
+import type { Redactor } from "./redact.ts";
+import type { Lifecycle } from "./lifecycle.ts";
+import type { RunStateWriter } from "./state/writer.ts";
+import type { SignalRecord } from "./state/types.ts";
+import { cancelEvent, compensationEvents, runCompensations } from "./cancel.ts";
+
+/**
+ * Settle a cancelled run's durable state: hold the per-run cancel lock, walk
+ * the succeeded targets' compensations in reverse, record them in the audit
+ * trail, and mark the run cancelled — unless another process owns the walk.
+ */
+export async function settleCancelledRun(opts: {
+  writer: RunStateWriter;
+  life: Lifecycle;
+  order: TargetBuilder[];
+  runId: string;
+  actor: string;
+  signals: ReadonlyMap<string, SignalRecord>;
+  reporter: Reporter;
+  redactor: Redactor;
+  nowIso: () => string;
+  isExternallyCancelled: () => boolean;
+}): Promise<void> {
+  const { writer, life, order, runId, actor, reporter } = opts;
+  // Hold the per-run cancel lock while we compensate, so a concurrent
+  // `zuke cancel` can't settle the run (declaring "no compensations") over
+  // our live cleanup. We only reach here with `externallyCancelled` false
+  // (the true case stopped above), so always attempt the acquire; a `null`
+  // result means another process already holds the lock and owns the walk —
+  // we stop and drain (F7).
+  const cancelLock = await writer.acquireCancelLock(actor);
+  if (cancelLock === null) {
+    await writer.drain();
+    reporter.info(
+      `Run ${runId} cancelled by another process — stopping.`,
+    );
+  } else {
+    try {
+      // We initiated it (Ctrl-C / options.signal): mark cancelling (which
+      // also drains every pending per-target write, so the snapshot is
+      // current).
+      await writer.markRunCancelling();
+      // markRunCancelling drains the write chain, so if another process's
+      // `zuke cancel` won the race in the meantime, the conflict has already
+      // fired onExternalCancel. Re-check before walking, so we never run the
+      // compensations twice (that canceller owns them now).
+      if (opts.isExternallyCancelled()) {
+        await writer.drain();
+        reporter.info(
+          `Run ${runId} cancelled by another process — stopping.`,
+        );
+      } else {
+        // Announce the intermediate `cancelling` transition (the record was
+        // just moved there) before compensations run, so a plugin sees the
+        // full running → cancelling → cancelled sequence.
+        await life.runStateChange(writer.snapshot());
+        // Run the succeeded targets' compensations in reverse order, record
+        // the cancellation in the audit trail (as `zuke cancel` does), then
+        // settle.
+        const comp = await runCompensations(order, writer.snapshot(), {
+          runId,
+          signals: opts.signals,
+          reporter,
+          redactor: opts.redactor,
+        });
+        const at = opts.nowIso();
+        for (const event of compensationEvents(comp.attempts, actor, at)) {
+          await writer.appendEvent(event);
+        }
+        await writer.appendEvent(cancelEvent(actor, comp, at));
+        await writer.markRunCancelled();
+        reporter.info(
+          `Run ${runId} cancelled — ${comp.compensated.length} ` +
+            `compensation(s) ran${
+              comp.failures.length > 0 ? `, ${comp.failures.length} failed` : ""
+            }.`,
+        );
+      }
+    } finally {
+      await cancelLock?.release();
+    }
+  }
+}

--- a/packages/core/src/execute_output.ts
+++ b/packages/core/src/execute_output.ts
@@ -1,0 +1,158 @@
+/**
+ * The reporting surface of one run: the sink a run writes through, the redactor
+ * that masks resolved secrets in everything it prints, the resolved
+ * colour/width/Actions style, and the renderer that draws banners and summaries.
+ *
+ * Composed once per run by {@link composeOutput} so {@link
+ * "./executor.ts".execute} reads as orchestration rather than wiring. Visual
+ * rendering itself lives in `./report.ts` / `./renderer.ts`; this module only
+ * decides which sink and style a run gets.
+ *
+ * @module
+ */
+
+import {
+  consoleReporter,
+  redactingReporter,
+  type Reporter,
+  safeReporter,
+  silentReporter,
+} from "./reporter.ts";
+import { Redactor } from "./redact.ts";
+import { detectWidth, type Style, type TargetReport } from "./report.ts";
+import { defaultRenderer, type Renderer } from "./renderer.ts";
+
+/** Whether the build is running inside a GitHub Actions runner. */
+function inGitHubActions(): boolean {
+  try {
+    return Deno.env.get("GITHUB_ACTIONS") === "true";
+  } catch {
+    return false;
+  }
+}
+
+/** Whether terminal colour should be used (TTY, and `NO_COLOR` unset). */
+function autoColor(): boolean {
+  try {
+    if (Deno.env.get("NO_COLOR")) return false;
+  } catch {
+    return false;
+  }
+  return Deno.stdout.isTerminal();
+}
+
+/** Resolve the output style from the caller's overrides and the environment. */
+export function resolveStyle(
+  github: boolean,
+  color: boolean | undefined,
+  hasCustomReporter: boolean,
+): Style {
+  const resolved = color ?? (github || hasCustomReporter ? false : autoColor());
+  return { github, color: resolved, width: detectWidth() };
+}
+
+/** The reporting surface a run writes through, composed once per run. */
+export interface RunOutput {
+  /** The caller's (or default) sink, unwrapped — only the mask directives use it. */
+  baseReporter: Reporter;
+  /** The redaction- and failure-wrapped reporter every run message goes through. */
+  reporter: Reporter;
+  /** Masks each resolved `secret` parameter in everything the run prints. */
+  redactor: Redactor;
+  /** Whether output reaches the real console (not silenced, not redirected). */
+  writesToConsole: boolean;
+  /** The resolved colour/width/Actions output style. */
+  style: Style;
+  /** The banner/summary renderer. */
+  renderer: Renderer;
+}
+
+/** Compose the run's reporting surface: sink, redactor, style, renderer. */
+export function composeOutput(opts: {
+  reporter?: Reporter;
+  silent?: boolean;
+  github?: boolean;
+  color?: boolean;
+  renderer?: Renderer;
+}): RunOutput {
+  const baseReporter = opts.reporter ??
+    (opts.silent ? silentReporter : consoleReporter);
+  // Every line Zuke prints passes through the redactor, which masks the
+  // resolved value of each `secret` parameter. The redactor is populated during
+  // parameter resolution below; since nothing meaningful is reported before
+  // then, wrapping the reporter up-front is safe.
+  const redactor = new Redactor();
+  // …and every write is best-effort (see safeReporter): a throwing sink (a buggy
+  // custom reporter, or EPIPE on a piped stdout) must never escape `failTarget`
+  // and reject out of a scheduler, which would strand the run record `running`.
+  const reporter = safeReporter(redactingReporter(baseReporter, redactor));
+  // The GitHub job summary is a real-world output side effect (it appends to a
+  // shared file named by GITHUB_STEP_SUMMARY). Only write it when output goes to
+  // the default console — i.e. neither silenced nor redirected to a custom
+  // reporter. This keeps embedded/test runs (a build's own test suite calls
+  // `execute` with `silent`/a custom reporter) from polluting the workflow
+  // summary, while a normal CLI run still writes it.
+  const writesToConsole = opts.reporter === undefined && !opts.silent;
+  const github = opts.github ?? inGitHubActions();
+  const style = resolveStyle(github, opts.color, opts.reporter !== undefined);
+  const renderer = opts.renderer ?? defaultRenderer;
+  return {
+    baseReporter,
+    reporter,
+    redactor,
+    writesToConsole,
+    style,
+    renderer,
+  };
+}
+
+/**
+ * Emit `::add-mask::` for each secret so the Actions runner masks it too.
+ *
+ * Under GitHub Actions, also emit `::add-mask::` with the real value so the
+ * runner masks it in its own logs. This goes through the base reporter, which
+ * is not wrapped in the redactor — a masked directive would hide nothing. Gate
+ * it on `writesToConsole` too: when a custom reporter is supplied it *is* the
+ * base reporter, so an embedded `execute()` must never be handed the raw
+ * secret — only the real runner stdout should receive the directive.
+ */
+export function emitActionsMasks(
+  values: Iterable<string>,
+  baseReporter: Reporter,
+): void {
+  const maskReporter = safeReporter(baseReporter);
+  for (const value of values) {
+    // Straight to the base reporter (not redacted, so the directive works),
+    // but best-effort: an EPIPE here must not abort the run either.
+    maskReporter.info(`::add-mask::${value}`);
+  }
+}
+
+/** Append the Markdown job-summary table to `GITHUB_STEP_SUMMARY`, if set. */
+export function writeJobSummary(
+  renderer: Renderer,
+  reports: TargetReport[],
+  totalMs: number,
+  ok: boolean,
+): void {
+  let path: string | undefined;
+  try {
+    path = Deno.env.get("GITHUB_STEP_SUMMARY");
+  } catch {
+    return;
+  }
+  if (path === undefined || path === "") return;
+  try {
+    // Append, not overwrite: validations like the AI reviewers/fixer write their
+    // own sections to this same file during the run, and overwriting here would
+    // wipe them. GitHub provisions a fresh summary file per step, so a single
+    // run's appends never accumulate across steps.
+    Deno.writeTextFileSync(
+      path,
+      renderer.jobSummaryMarkdown(reports, totalMs, ok),
+      { append: true },
+    );
+  } catch {
+    // Best-effort: an unwritable summary file must never fail the build.
+  }
+}

--- a/packages/core/src/execute_output.ts
+++ b/packages/core/src/execute_output.ts
@@ -78,9 +78,9 @@ export function composeOutput(opts: {
   const baseReporter = opts.reporter ??
     (opts.silent ? silentReporter : consoleReporter);
   // Every line Zuke prints passes through the redactor, which masks the
-  // resolved value of each `secret` parameter. The redactor is populated during
-  // parameter resolution below; since nothing meaningful is reported before
-  // then, wrapping the reporter up-front is safe.
+  // resolved value of each `secret` parameter. The redactor is populated later,
+  // during parameter resolution (see `./execute_plan.ts`); since nothing
+  // meaningful is reported before then, wrapping the reporter up-front is safe.
   const redactor = new Redactor();
   // …and every write is best-effort (see safeReporter): a throwing sink (a buggy
   // custom reporter, or EPIPE on a piped stdout) must never escape `failTarget`

--- a/packages/core/src/execute_plan.ts
+++ b/packages/core/src/execute_plan.ts
@@ -1,0 +1,180 @@
+/**
+ * Planning a run before any body executes: resolving the build's declared
+ * parameters, evaluating the up-front conditions that prune targets, narrowing
+ * the plan to the targets a change can reach, and flagging ordering edges that
+ * can never apply.
+ *
+ * Sequencing itself belongs to `./graph.ts`; this module holds the decisions
+ * {@link "./executor.ts".execute} makes around that plan.
+ *
+ * @module
+ */
+
+import type { Build } from "./build.ts";
+import type { TargetBuilder } from "./target.ts";
+import type { OrderingEdge } from "./graph.ts";
+import type { Reporter } from "./reporter.ts";
+import type { Redactor } from "./redact.ts";
+import {
+  type AnyParameter,
+  discoverParameters,
+  resolveParameters,
+} from "./params.ts";
+import {
+  type AffectedOptions,
+  affectedTargets,
+  gitChangedFiles,
+} from "./affected.ts";
+import { isCI } from "./host.ts";
+
+/** Prompt for a missing required parameter, only at an interactive (non-CI) TTY. */
+export function defaultPrompt(
+  flag: string,
+  description: string | undefined,
+): string | undefined {
+  let interactive = false;
+  try {
+    interactive = Deno.stdin.isTerminal();
+  } catch {
+    interactive = false;
+  }
+  if (!interactive || isCI()) return undefined;
+  const label = description ? `--${flag} (${description})` : `--${flag}`;
+  return prompt(`${label}:`) ?? undefined;
+}
+
+/**
+ * Resolve every declared parameter (CLI value → environment → default) and
+ * register each secret's resolved value with the redactor.
+ */
+export async function resolveRunParameters(
+  build: Build,
+  values: Record<string, string>,
+  readEnv: (name: string) => string | undefined,
+  prompt: (flag: string, description: string | undefined) => string | undefined,
+  redactor: Redactor,
+): Promise<{ params: Map<string, AnyParameter>; errors: string[] }> {
+  // Resolve declared parameters (CLI value → environment → default) before any
+  // target runs, so a target body can read `this.param.value`. A missing
+  // required parameter or an invalid value fails the build before it starts.
+  const params = discoverParameters(build);
+  const errors = await resolveParameters(
+    params,
+    values,
+    readEnv,
+    prompt,
+    redactor,
+  );
+  // Register each secret's final parsed value too — its raw form was already
+  // added during resolution, but a source that trims or a parser that
+  // normalises could yield a slightly different printed string.
+  for (const p of params.values()) {
+    if (!p.secret_) continue;
+    const value = p.stringValue_();
+    if (value !== undefined && value !== "") redactor.add(value);
+  }
+  return { params, errors };
+}
+
+/**
+ * Report ordering edges that can never apply: an endpoint that is neither in
+ * this run's execution set nor a declared build target.
+ */
+export function reportDanglingEdges(
+  extraEdges: readonly OrderingEdge[],
+  order: readonly TargetBuilder[],
+  declared: Iterable<TargetBuilder>,
+  reporter: Reporter,
+): void {
+  // Flag ordering edges that can never apply: an endpoint that is neither in this
+  // run's execution set nor a declared build target is dead weight (silently
+  // dropped otherwise). A declared target simply not in this run — a conditional
+  // target — is legitimately ignored, so it is not flagged. This catches feeding
+  // ad-hoc or fan-out per-item names into orderWith/extraEdges: per-item fan-out
+  // ordering is not expressible (order whole fan-out waves with .dependsOn).
+  if (extraEdges.length > 0) {
+    const inRun = new Set(order);
+    const declaredSet = new Set(declared);
+    const dangling = new Set<string>();
+    for (const edge of extraEdges) {
+      for (const endpoint of edge) {
+        // `endpoint &&` tolerates a malformed edge (a consumer bypassing the
+        // OrderingEdge type to pass a nullish endpoint) instead of crashing on
+        // `.name_`, matching planEdges' silent tolerance of such edges.
+        if (endpoint && !inRun.has(endpoint) && !declaredSet.has(endpoint)) {
+          dangling.add(endpoint.name_ ?? "<unnamed>");
+        }
+      }
+    }
+    for (const name of dangling) {
+      reporter.info(
+        `ordering: an edge references "${name}", which is not a target in this ` +
+          `build — the edge is ignored. orderWith/extraEdges see only ` +
+          `class-field targets, not fan-out sub-targets (order whole fan-out ` +
+          `waves with .dependsOn instead).`,
+      );
+    }
+  }
+}
+
+/**
+ * Evaluate up-front conditions for `whenSkipped("skip-dependencies")` targets;
+ * return the names to skip — those targets plus any dependencies that no other
+ * target in the plan needs.
+ */
+export async function conditionSkips(
+  root: TargetBuilder,
+  order: TargetBuilder[],
+): Promise<Set<string>> {
+  const pruned = new Set<TargetBuilder>();
+  for (const t of order) {
+    if (!t.skipDependencies_ || t.onlyWhen_.length === 0) continue;
+    let run = true;
+    for (const condition of t.onlyWhen_) {
+      if (!(await condition())) {
+        run = false;
+        break;
+      }
+    }
+    if (!run) pruned.add(t);
+  }
+  if (pruned.size === 0) return new Set();
+
+  // Everything still reachable from the root without pulling dependencies in
+  // *through* a pruned target.
+  const kept = new Set<TargetBuilder>();
+  const walk = (node: TargetBuilder) => {
+    if (node === undefined || kept.has(node)) return;
+    kept.add(node);
+    if (pruned.has(node)) return;
+    for (const dep of node.dependsOn_) walk(dep);
+    for (const trigger of node.triggers_) walk(trigger);
+  };
+  walk(root);
+
+  const names = new Set<string>();
+  for (const t of pruned) names.add(t.name_ ?? "");
+  for (const t of order) if (!kept.has(t)) names.add(t.name_ ?? "");
+  return names;
+}
+
+/**
+ * Narrow the plan to the targets a change can reach, adding every unaffected
+ * planned target's name to `skip` (CLI `--affected`).
+ */
+export async function applyAffectedSkips(
+  options: AffectedOptions,
+  order: readonly TargetBuilder[],
+  skip: Set<string>,
+  reporter: Reporter,
+): Promise<void> {
+  const base = options.base ?? "HEAD";
+  const changedFiles = options.changedFiles ?? gitChangedFiles;
+  const affected = affectedTargets(order, await changedFiles(base));
+  for (const t of order) {
+    if (!affected.has(t)) skip.add(t.name_ ?? "<unnamed>");
+  }
+  if (affected.size === 0) {
+    reporter.info(`No targets affected by changes since ${base}.`);
+  }
+}

--- a/packages/core/src/execute_state.ts
+++ b/packages/core/src/execute_state.ts
@@ -1,0 +1,157 @@
+/**
+ * Durable-state plumbing for one run: resolving the {@link StateStore}, opening
+ * (or adopting) the {@link RunStateWriter} that records the run and its
+ * per-target transitions, and assembling the {@link RunEnv} the schedulers are
+ * handed.
+ *
+ * Keeping this out of {@link "./executor.ts".execute} leaves the executor with
+ * the orchestration and this module with the "where does progress get
+ * persisted" question.
+ *
+ * @module
+ */
+
+import type { Build } from "./build.ts";
+import type { TargetBuilder } from "./target.ts";
+import type { Reporter } from "./reporter.ts";
+import type { Redactor } from "./redact.ts";
+import type { AnyParameter } from "./params.ts";
+import type { RunEnv } from "./run_support.ts";
+import { absolutePath } from "./path.ts";
+import { findConfigDir, pathExists } from "./config.ts";
+import { defaultStateHost, type StateStore } from "./state/store.ts";
+import { resolveStateStore } from "./state/resolve.ts";
+import { buildRunRecord, ciRunUrl, resolveActor } from "./state/record.ts";
+import { RunStateWriter } from "./state/writer.ts";
+import type { RunRecord, SignalRecord, WaitState } from "./state/types.ts";
+import type { ResumeState } from "./executor.ts";
+
+/**
+ * The still-waiting targets of a resumed run, mapped to the {@link WaitState}
+ * they last recorded — the source of the original timeout deadline that a
+ * re-suspend must preserve (see {@link RunEnv.priorWaits}).
+ */
+function priorWaitsOf(record: RunRecord): ReadonlyMap<string, WaitState> {
+  const waits = new Map<string, WaitState>();
+  for (const [name, state] of Object.entries(record.targets)) {
+    if (state.waitingFor !== undefined) waits.set(name, state.waitingFor);
+  }
+  return waits;
+}
+
+/** Durable-state plumbing for one run: the store, its writer, and the RunEnv. */
+export interface RunState {
+  /** The resolved store, or `undefined` when state is off. */
+  store?: StateStore;
+  /** The writer recording transitions, or `undefined` without a store. */
+  writer?: RunStateWriter;
+  /** The environment handed to the scheduler. */
+  env: RunEnv;
+}
+
+/**
+ * Resolve the durable state store, open (or adopt) the run's writer, and
+ * assemble the {@link RunEnv}. Returns the error instead of throwing when a
+ * target needs state that is disabled.
+ */
+export async function openRunState(opts: {
+  build: Build;
+  root: TargetBuilder;
+  order: TargetBuilder[];
+  params: Iterable<AnyParameter>;
+  runId: string;
+  dryRun: boolean;
+  signal: AbortSignal;
+  redactor: Redactor;
+  reporter: Reporter;
+  readEnv: (name: string) => string | undefined;
+  nowIso: () => string;
+  onExternalCancel: () => void;
+  stateStore?: StateStore | false;
+  state?: boolean;
+  actor?: string;
+  resume?: ResumeState;
+  artifactDir: string;
+}): Promise<{ ok: true; state: RunState } | { ok: false; error: Error }> {
+  const { dryRun, order, readEnv, nowIso, redactor, resume } = opts;
+  // Resolve the durable state store (if any) and open a writer that records the
+  // run and its per-target transitions. Never for a dry run — no body executes,
+  // so there is no run to persist. State writes are best-effort: a store hiccup
+  // is reported, never fatal (see RunStateWriter).
+  // A build that uses a durable feature (a cross-run lock; later, waits and
+  // compensations) turns the filesystem store on by default, so state "just
+  // works" without --state. Plain builds still opt in explicitly.
+  const usesDurableFeature = order.some((t) =>
+    t.lock_ !== undefined || t.waitsFor_ !== undefined ||
+    t.onCancel_ !== undefined
+  );
+  const stateStore = dryRun ? undefined : resolveStateStore(
+    opts.stateStore,
+    opts.build.stateStore(),
+    {
+      readEnv,
+      host: defaultStateHost,
+      defaultDir: absolutePath(
+        findConfigDir(Deno.cwd(), pathExists) ?? Deno.cwd(),
+      )(opts.artifactDir, "runs").path,
+      enableDefault: (opts.state ?? false) || usesDurableFeature,
+    },
+  );
+  // A wait needs somewhere to persist the suspension; without a store it could
+  // never be resumed. Fail fast with guidance instead of suspending into the
+  // void. (enableDefault turns the FS store on for waits, so this only triggers
+  // when state was explicitly disabled.)
+  if (
+    !dryRun && stateStore === undefined &&
+    order.some((t) => t.waitsFor_ !== undefined)
+  ) {
+    const error = new Error(
+      "A target uses .waitsFor(...), which needs a state store to persist the " +
+        "suspended run — but state is disabled. Enable it (drop stateStore: " +
+        "false, pass --state, or set ZUKE_STATE_DIR / ZUKE_STATE_URL).",
+    );
+    return { ok: false, error };
+  }
+  const actor = resolveActor(opts.actor, readEnv);
+  const runUrl = ciRunUrl(readEnv);
+  const warn = (message: string) => opts.reporter.info(message);
+  const writer = stateStore === undefined ? undefined : resume !== undefined
+    // A resume continues the existing record (already transitioned to running).
+    ? RunStateWriter.adopt(
+      stateStore,
+      resume.record,
+      resume.version,
+      nowIso,
+      redactor,
+      warn,
+      opts.onExternalCancel,
+    )
+    : await RunStateWriter.open(
+      stateStore,
+      buildRunRecord({
+        runId: opts.runId,
+        build: opts.build.constructor.name,
+        rootTarget: opts.root.name_ ?? "<unnamed>",
+        actor,
+        now: nowIso(),
+        order,
+        params: opts.params,
+      }),
+      nowIso,
+      redactor,
+      warn,
+      opts.onExternalCancel,
+    );
+  const env: RunEnv = {
+    runId: opts.runId,
+    signal: opts.signal,
+    writer,
+    store: stateStore,
+    actor,
+    runUrl,
+    signals: writer ? writer.signals() : new Map<string, SignalRecord>(),
+    done: resume?.done,
+    priorWaits: resume ? priorWaitsOf(resume.record) : undefined,
+  };
+  return { ok: true, state: { store: stateStore, writer, env } };
+}

--- a/packages/core/src/execute_state.ts
+++ b/packages/core/src/execute_state.ts
@@ -39,10 +39,8 @@ function priorWaitsOf(record: RunRecord): ReadonlyMap<string, WaitState> {
   return waits;
 }
 
-/** Durable-state plumbing for one run: the store, its writer, and the RunEnv. */
+/** Durable-state plumbing for one run: the writer and the RunEnv. */
 export interface RunState {
-  /** The resolved store, or `undefined` when state is off. */
-  store?: StateStore;
   /** The writer recording transitions, or `undefined` without a store. */
   writer?: RunStateWriter;
   /** The environment handed to the scheduler. */
@@ -58,7 +56,12 @@ export async function openRunState(opts: {
   build: Build;
   root: TargetBuilder;
   order: TargetBuilder[];
-  params: Iterable<AnyParameter>;
+  /**
+   * The run's resolved parameters, copied into the record. An array rather than
+   * an `Iterable` on purpose: a `MapIterator` is one-shot, so a second read
+   * inside this function would silently see an empty list.
+   */
+  params: readonly AnyParameter[];
   runId: string;
   dryRun: boolean;
   signal: AbortSignal;
@@ -153,5 +156,5 @@ export async function openRunState(opts: {
     done: resume?.done,
     priorWaits: resume ? priorWaitsOf(resume.record) : undefined,
   };
-  return { ok: true, state: { store: stateStore, writer, env } };
+  return { ok: true, state: { writer, env } };
 }

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -22,6 +22,13 @@ import {
   emitActionsMasks,
   writeJobSummary,
 } from "./execute_output.ts";
+import {
+  applyAffectedSkips,
+  conditionSkips,
+  defaultPrompt,
+  reportDanglingEdges,
+  resolveRunParameters,
+} from "./execute_plan.ts";
 import { makeLifecycle } from "./lifecycle.ts";
 import type { RunEnv, RunOutcome } from "./run_support.ts";
 import {
@@ -33,11 +40,7 @@ import {
 } from "./scheduler.ts";
 import { discoverTargets, resolveOrderingEdges } from "./build.ts";
 import { type OrderingEdge, planGraph } from "./graph.ts";
-import {
-  discoverParameters,
-  ParameterError,
-  resolveParameters,
-} from "./params.ts";
+import { ParameterError } from "./params.ts";
 import {
   type BuildCache,
   CACHE_FILE,
@@ -46,13 +49,8 @@ import {
   openCache,
 } from "./cache.ts";
 import { findConfigDir, pathExists } from "./config.ts";
-import {
-  type AffectedOptions,
-  affectedTargets,
-  gitChangedFiles,
-} from "./affected.ts";
+import type { AffectedOptions } from "./affected.ts";
 import { type RemoteCacheStore, resolveRemoteStore } from "./remote_cache.ts";
-import { isCI } from "./host.ts";
 import { ServiceRegistry } from "./service.ts";
 import { absolutePath } from "./path.ts";
 import type { TargetBuilder } from "./target.ts";
@@ -222,63 +220,6 @@ function priorWaitsOf(record: RunRecord): ReadonlyMap<string, WaitState> {
   return waits;
 }
 
-/** Prompt for a missing required parameter, only at an interactive (non-CI) TTY. */
-function defaultPrompt(
-  flag: string,
-  description: string | undefined,
-): string | undefined {
-  let interactive = false;
-  try {
-    interactive = Deno.stdin.isTerminal();
-  } catch {
-    interactive = false;
-  }
-  if (!interactive || isCI()) return undefined;
-  const label = description ? `--${flag} (${description})` : `--${flag}`;
-  return prompt(`${label}:`) ?? undefined;
-}
-
-/**
- * Evaluate up-front conditions for `whenSkipped("skip-dependencies")` targets;
- * return the names to skip — those targets plus any dependencies that no other
- * target in the plan needs.
- */
-async function conditionSkips(
-  root: TargetBuilder,
-  order: TargetBuilder[],
-): Promise<Set<string>> {
-  const pruned = new Set<TargetBuilder>();
-  for (const t of order) {
-    if (!t.skipDependencies_ || t.onlyWhen_.length === 0) continue;
-    let run = true;
-    for (const condition of t.onlyWhen_) {
-      if (!(await condition())) {
-        run = false;
-        break;
-      }
-    }
-    if (!run) pruned.add(t);
-  }
-  if (pruned.size === 0) return new Set();
-
-  // Everything still reachable from the root without pulling dependencies in
-  // *through* a pruned target.
-  const kept = new Set<TargetBuilder>();
-  const walk = (node: TargetBuilder) => {
-    if (node === undefined || kept.has(node)) return;
-    kept.add(node);
-    if (pruned.has(node)) return;
-    for (const dep of node.dependsOn_) walk(dep);
-    for (const trigger of node.triggers_) walk(trigger);
-  };
-  walk(root);
-
-  const names = new Set<string>();
-  for (const t of pruned) names.add(t.name_ ?? "");
-  for (const t of order) if (!kept.has(t)) names.add(t.name_ ?? "");
-  return names;
-}
-
 /**
  * Execute the requested target and its transitive dependencies.
  *
@@ -303,26 +244,14 @@ export async function execute(
   } = composeOutput(options);
   const skip = new Set(options.skip ?? []);
 
-  // Resolve declared parameters (CLI value → environment → default) before any
-  // target runs, so a target body can read `this.param.value`. A missing
-  // required parameter or an invalid value fails the build before it starts.
-  const params = discoverParameters(build);
   const readEnv = options.readEnv ?? defaultReadEnv;
-  const paramErrors = await resolveParameters(
-    params,
+  const { params, errors: paramErrors } = await resolveRunParameters(
+    build,
     options.params ?? {},
     readEnv,
     options.prompt ?? defaultPrompt,
     redactor,
   );
-  // Register each secret's final parsed value too — its raw form was already
-  // added during resolution, but a source that trims or a parser that
-  // normalises could yield a slightly different printed string.
-  for (const p of params.values()) {
-    if (!p.secret_) continue;
-    const value = p.stringValue_();
-    if (value !== undefined && value !== "") redactor.add(value);
-  }
   if (style.github && writesToConsole) {
     const secrets: string[] = [];
     for (const p of params.values()) {
@@ -361,35 +290,7 @@ export async function execute(
     return { ok: false, executed: [], error };
   }
   const { order, predecessors } = planGraph(root, extraEdges);
-  // Flag ordering edges that can never apply: an endpoint that is neither in this
-  // run's execution set nor a declared build target is dead weight (silently
-  // dropped otherwise). A declared target simply not in this run — a conditional
-  // target — is legitimately ignored, so it is not flagged. This catches feeding
-  // ad-hoc or fan-out per-item names into orderWith/extraEdges: per-item fan-out
-  // ordering is not expressible (order whole fan-out waves with .dependsOn).
-  if (extraEdges.length > 0) {
-    const inRun = new Set(order);
-    const declared = new Set(discovered.values());
-    const dangling = new Set<string>();
-    for (const edge of extraEdges) {
-      for (const endpoint of edge) {
-        // `endpoint &&` tolerates a malformed edge (a consumer bypassing the
-        // OrderingEdge type to pass a nullish endpoint) instead of crashing on
-        // `.name_`, matching planEdges' silent tolerance of such edges.
-        if (endpoint && !inRun.has(endpoint) && !declared.has(endpoint)) {
-          dangling.add(endpoint.name_ ?? "<unnamed>");
-        }
-      }
-    }
-    for (const name of dangling) {
-      reporter.info(
-        `ordering: an edge references "${name}", which is not a target in this ` +
-          `build — the edge is ignored. orderWith/extraEdges see only ` +
-          `class-field targets, not fan-out sub-targets (order whole fan-out ` +
-          `waves with .dependsOn instead).`,
-      );
-    }
-  }
+  reportDanglingEdges(extraEdges, order, discovered.values(), reporter);
   // Evaluate up-front conditions for `whenSkipped("skip-dependencies")` targets
   // and skip them plus any dependencies that nothing else needs.
   for (const name of await conditionSkips(root, order)) skip.add(name);
@@ -398,15 +299,7 @@ export async function execute(
   // targets still unblock their dependents (their prior outputs are assumed
   // current), so an affected target downstream of an unaffected one still runs.
   if (options.affected !== undefined) {
-    const base = options.affected.base ?? "HEAD";
-    const changedFiles = options.affected.changedFiles ?? gitChangedFiles;
-    const affected = affectedTargets(order, await changedFiles(base));
-    for (const t of order) {
-      if (!affected.has(t)) skip.add(t.name_ ?? "<unnamed>");
-    }
-    if (affected.size === 0) {
-      reporter.info(`No targets affected by changes since ${base}.`);
-    }
+    await applyAffectedSkips(options.affected, order, skip, reporter);
   }
 
   const limit = resolveConcurrency(options.parallel);

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -29,8 +29,9 @@ import {
   reportDanglingEdges,
   resolveRunParameters,
 } from "./execute_plan.ts";
+import { openRunState } from "./execute_state.ts";
 import { makeLifecycle } from "./lifecycle.ts";
-import type { RunEnv, RunOutcome } from "./run_support.ts";
+import type { RunOutcome } from "./run_support.ts";
 import {
   cpuCount,
   resolveConcurrency,
@@ -54,13 +55,10 @@ import { type RemoteCacheStore, resolveRemoteStore } from "./remote_cache.ts";
 import { ServiceRegistry } from "./service.ts";
 import { absolutePath } from "./path.ts";
 import type { TargetBuilder } from "./target.ts";
-import type { RunRecord, SignalRecord, WaitState } from "./state/types.ts";
+import type { RunRecord } from "./state/types.ts";
 import { withAmbientSignal } from "./ambient_signal.ts";
 import { withAmbientRedactor } from "./ambient_redactor.ts";
-import { defaultStateHost, type StateStore } from "./state/store.ts";
-import { resolveStateStore } from "./state/resolve.ts";
-import { buildRunRecord, ciRunUrl, resolveActor } from "./state/record.ts";
-import { RunStateWriter } from "./state/writer.ts";
+import type { StateStore } from "./state/store.ts";
 import { cancelEvent, compensationEvents, runCompensations } from "./cancel.ts";
 import type { Plugin, RunInfo } from "./plugin.ts";
 import type { Renderer } from "./renderer.ts";
@@ -208,19 +206,6 @@ export interface ResumeState {
 }
 
 /**
- * The still-waiting targets of a resumed run, mapped to the {@link WaitState}
- * they last recorded — the source of the original timeout deadline that a
- * re-suspend must preserve (see {@link RunEnv.priorWaits}).
- */
-function priorWaitsOf(record: RunRecord): ReadonlyMap<string, WaitState> {
-  const waits = new Map<string, WaitState>();
-  for (const [name, state] of Object.entries(record.targets)) {
-    if (state.waitingFor !== undefined) waits.set(name, state.waitingFor);
-  }
-  return waits;
-}
-
-/**
  * Execute the requested target and its transitive dependencies.
  *
  * Runs the build's `onStart`/`onFinish` lifecycle hooks around the plan. By
@@ -359,91 +344,32 @@ export async function execute(
     runController.abort();
   };
 
-  // Resolve the durable state store (if any) and open a writer that records the
-  // run and its per-target transitions. Never for a dry run — no body executes,
-  // so there is no run to persist. State writes are best-effort: a store hiccup
-  // is reported, never fatal (see RunStateWriter).
-  // A build that uses a durable feature (a cross-run lock; later, waits and
-  // compensations) turns the filesystem store on by default, so state "just
-  // works" without --state. Plain builds still opt in explicitly.
-  const usesDurableFeature = order.some((t) =>
-    t.lock_ !== undefined || t.waitsFor_ !== undefined ||
-    t.onCancel_ !== undefined
-  );
-  const stateStore = dryRun ? undefined : resolveStateStore(
-    options.stateStore,
-    build.stateStore(),
-    {
-      readEnv,
-      host: defaultStateHost,
-      defaultDir: absolutePath(
-        findConfigDir(Deno.cwd(), pathExists) ?? Deno.cwd(),
-      )(ARTIFACT_DIR, "runs").path,
-      enableDefault: (options.state ?? false) || usesDurableFeature,
-    },
-  );
-  // A wait needs somewhere to persist the suspension; without a store it could
-  // never be resumed. Fail fast with guidance instead of suspending into the
-  // void. (enableDefault turns the FS store on for waits, so this only triggers
-  // when state was explicitly disabled.)
-  if (
-    !dryRun && stateStore === undefined &&
-    order.some((t) => t.waitsFor_ !== undefined)
-  ) {
-    const error = new Error(
-      "A target uses .waitsFor(...), which needs a state store to persist the " +
-        "suspended run — but state is disabled. Enable it (drop stateStore: " +
-        "false, pass --state, or set ZUKE_STATE_DIR / ZUKE_STATE_URL).",
-    );
-    reporter.error(error.message);
-    return { ok: false, executed: [], error };
-  }
-  const actor = resolveActor(options.actor, readEnv);
-  const runUrl = ciRunUrl(readEnv);
   const nowIso = () => new Date().toISOString();
-  const warn = (message: string) => reporter.info(message);
-  const writer = stateStore === undefined
-    ? undefined
-    : options.resume !== undefined
-    // A resume continues the existing record (already transitioned to running).
-    ? RunStateWriter.adopt(
-      stateStore,
-      options.resume.record,
-      options.resume.version,
-      nowIso,
-      redactor,
-      warn,
-      onExternalCancel,
-    )
-    : await RunStateWriter.open(
-      stateStore,
-      buildRunRecord({
-        runId,
-        build: build.constructor.name,
-        rootTarget: root.name_ ?? "<unnamed>",
-        actor,
-        now: nowIso(),
-        order,
-        params: params.values(),
-      }),
-      nowIso,
-      redactor,
-      warn,
-      onExternalCancel,
-    );
-  const env: RunEnv = {
+  const opened = await openRunState({
+    build,
+    root,
+    order,
+    params: params.values(),
     runId,
+    dryRun,
     signal: runController.signal,
-    writer,
-    store: stateStore,
-    actor,
-    runUrl,
-    signals: writer ? writer.signals() : new Map<string, SignalRecord>(),
-    done: options.resume?.done,
-    priorWaits: options.resume
-      ? priorWaitsOf(options.resume.record)
-      : undefined,
-  };
+    redactor,
+    reporter,
+    readEnv,
+    nowIso,
+    onExternalCancel,
+    stateStore: options.stateStore,
+    state: options.state,
+    actor: options.actor,
+    resume: options.resume,
+    artifactDir: ARTIFACT_DIR,
+  });
+  if (!opened.ok) {
+    reporter.error(opened.error.message);
+    return { ok: false, executed: [], error: opened.error };
+  }
+  const { writer, env } = opened.state;
+  const actor = env.actor;
 
   // Announce the run's initial durable state (`running`) to plugins — a no-op
   // without a store. Terminal transitions are announced once the plan settles.

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -30,6 +30,7 @@ import {
   resolveRunParameters,
 } from "./execute_plan.ts";
 import { openRunState } from "./execute_state.ts";
+import { settleCancelledRun } from "./execute_cancel.ts";
 import { makeLifecycle } from "./lifecycle.ts";
 import type { RunOutcome } from "./run_support.ts";
 import {
@@ -59,7 +60,6 @@ import type { RunRecord } from "./state/types.ts";
 import { withAmbientSignal } from "./ambient_signal.ts";
 import { withAmbientRedactor } from "./ambient_redactor.ts";
 import type { StateStore } from "./state/store.ts";
-import { cancelEvent, compensationEvents, runCompensations } from "./cancel.ts";
 import type { Plugin, RunInfo } from "./plugin.ts";
 import type { Renderer } from "./renderer.ts";
 
@@ -237,6 +237,8 @@ export async function execute(
     options.prompt ?? defaultPrompt,
     redactor,
   );
+  // Gated on `writesToConsole` so an embedded `execute()` is never handed a raw
+  // secret — see emitActionsMasks for why the directive bypasses the redactor.
   if (style.github && writesToConsole) {
     const secrets: string[] = [];
     for (const p of params.values()) {
@@ -456,66 +458,18 @@ export async function execute(
         `Run ${runId} cancelled by another process — stopping.`,
       );
     } else if (writer !== undefined) {
-      // Hold the per-run cancel lock while we compensate, so a concurrent
-      // `zuke cancel` can't settle the run (declaring "no compensations") over
-      // our live cleanup. We only reach here with `externallyCancelled` false
-      // (the true case stopped above), so always attempt the acquire; a `null`
-      // result means another process already holds the lock and owns the walk —
-      // we stop and drain (F7).
-      const cancelLock = await writer.acquireCancelLock(actor);
-      if (cancelLock === null) {
-        await writer.drain();
-        reporter.info(
-          `Run ${runId} cancelled by another process — stopping.`,
-        );
-      } else {
-        try {
-          // We initiated it (Ctrl-C / options.signal): mark cancelling (which
-          // also drains every pending per-target write, so the snapshot is
-          // current).
-          await writer.markRunCancelling();
-          // markRunCancelling drains the write chain, so if another process's
-          // `zuke cancel` won the race in the meantime, the conflict has already
-          // fired onExternalCancel. Re-check before walking, so we never run the
-          // compensations twice (that canceller owns them now).
-          if (externallyCancelled) {
-            await writer.drain();
-            reporter.info(
-              `Run ${runId} cancelled by another process — stopping.`,
-            );
-          } else {
-            // Announce the intermediate `cancelling` transition (the record was
-            // just moved there) before compensations run, so a plugin sees the
-            // full running → cancelling → cancelled sequence.
-            await life.runStateChange(writer.snapshot());
-            // Run the succeeded targets' compensations in reverse order, record
-            // the cancellation in the audit trail (as `zuke cancel` does), then
-            // settle.
-            const comp = await runCompensations(order, writer.snapshot(), {
-              runId,
-              signals: env.signals,
-              reporter,
-              redactor,
-            });
-            const at = nowIso();
-            for (const event of compensationEvents(comp.attempts, actor, at)) {
-              await writer.appendEvent(event);
-            }
-            await writer.appendEvent(cancelEvent(actor, comp, at));
-            await writer.markRunCancelled();
-            reporter.info(
-              `Run ${runId} cancelled — ${comp.compensated.length} ` +
-                `compensation(s) ran${
-                  comp.failures.length > 0
-                    ? `, ${comp.failures.length} failed`
-                    : ""
-                }.`,
-            );
-          }
-        } finally {
-          await cancelLock?.release();
-        }
-      }
+      await settleCancelledRun({
+        writer,
+        life,
+        order,
+        runId,
+        actor,
+        signals: env.signals,
+        reporter,
+        redactor,
+        nowIso,
+        isExternallyCancelled: () => externallyCancelled,
+      });
     }
   } else {
     result = run.aborted

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -5,8 +5,12 @@
  * Visual rendering — colour, the ruled per-target headers, the end-of-build
  * summary table, the GitHub Actions `::group::` commands, and the Markdown
  * job-summary file — lives in `./report.ts`. The executor only decides what to
- * run and feeds the renderer; this module owns orchestration, parameter
- * resolution, caching, lifecycle hooks, and the sequential/parallel scheduler.
+ * run and feeds the renderer; this module owns orchestration — caching,
+ * lifecycle hooks, and the sequential/parallel scheduler — and delegates each
+ * other concern to a sibling: the reporting surface and job summary to
+ * `./execute_output.ts`, parameter resolution and the skip sets to
+ * `./execute_plan.ts`, the durable run record and its writer to
+ * `./execute_state.ts`, and the cancellation handshake to `./execute_cancel.ts`.
  *
  * Sequencing and de-duplication are handled by {@link plan} — the returned
  * order already contains each target exactly once, so diamond dependencies run
@@ -149,8 +153,8 @@ export interface ExecuteOptions {
   color?: boolean;
   /**
    * Renderer for the per-target banners and the end-of-build summary. Defaults
-   * to Zuke's built-in {@link defaultRenderer}; `@zuke/console` exports an
-   * alternative a build can inject to restyle its output.
+   * to Zuke's built-in {@link "./renderer.ts".defaultRenderer}; `@zuke/console`
+   * exports an alternative a build can inject to restyle its output.
    */
   renderer?: Renderer;
   /**
@@ -351,7 +355,7 @@ export async function execute(
     build,
     root,
     order,
-    params: params.values(),
+    params: [...params.values()],
     runId,
     dryRun,
     signal: runController.signal,

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -15,14 +15,13 @@
 
 import type { Build, BuildResult } from "./build.ts";
 import { defaultReadEnv } from "./internal.ts";
-import {
-  consoleReporter,
-  redactingReporter,
-  type Reporter,
-  safeReporter,
-  silentReporter,
-} from "./reporter.ts";
+import type { Reporter } from "./reporter.ts";
 export type { Reporter } from "./reporter.ts";
+import {
+  composeOutput,
+  emitActionsMasks,
+  writeJobSummary,
+} from "./execute_output.ts";
 import { makeLifecycle } from "./lifecycle.ts";
 import type { RunEnv, RunOutcome } from "./run_support.ts";
 import {
@@ -55,7 +54,6 @@ import {
 import { type RemoteCacheStore, resolveRemoteStore } from "./remote_cache.ts";
 import { isCI } from "./host.ts";
 import { ServiceRegistry } from "./service.ts";
-import { Redactor } from "./redact.ts";
 import { absolutePath } from "./path.ts";
 import type { TargetBuilder } from "./target.ts";
 import type { RunRecord, SignalRecord, WaitState } from "./state/types.ts";
@@ -67,8 +65,7 @@ import { buildRunRecord, ciRunUrl, resolveActor } from "./state/record.ts";
 import { RunStateWriter } from "./state/writer.ts";
 import { cancelEvent, compensationEvents, runCompensations } from "./cancel.ts";
 import type { Plugin, RunInfo } from "./plugin.ts";
-import { detectWidth, type Style, type TargetReport } from "./report.ts";
-import { defaultRenderer, type Renderer } from "./renderer.ts";
+import type { Renderer } from "./renderer.ts";
 
 /** The artifact directory (under the repo root) for the cache store. */
 const ARTIFACT_DIR = ".zuke";
@@ -225,15 +222,6 @@ function priorWaitsOf(record: RunRecord): ReadonlyMap<string, WaitState> {
   return waits;
 }
 
-/** Whether the build is running inside a GitHub Actions runner. */
-function inGitHubActions(): boolean {
-  try {
-    return Deno.env.get("GITHUB_ACTIONS") === "true";
-  } catch {
-    return false;
-  }
-}
-
 /** Prompt for a missing required parameter, only at an interactive (non-CI) TTY. */
 function defaultPrompt(
   flag: string,
@@ -291,51 +279,6 @@ async function conditionSkips(
   return names;
 }
 
-/** Whether terminal colour should be used (TTY, and `NO_COLOR` unset). */
-function autoColor(): boolean {
-  try {
-    if (Deno.env.get("NO_COLOR")) return false;
-  } catch {
-    return false;
-  }
-  return Deno.stdout.isTerminal();
-}
-
-/** Resolve the output style from the options and the detected environment. */
-function resolveStyle(options: ExecuteOptions, github: boolean): Style {
-  const color = options.color ??
-    (github || options.reporter !== undefined ? false : autoColor());
-  return { github, color, width: detectWidth() };
-}
-
-/** Append the Markdown job-summary table to `GITHUB_STEP_SUMMARY`, if set. */
-function writeJobSummary(
-  renderer: Renderer,
-  reports: TargetReport[],
-  totalMs: number,
-  ok: boolean,
-): void {
-  let path: string | undefined;
-  try {
-    path = Deno.env.get("GITHUB_STEP_SUMMARY");
-  } catch {
-    return;
-  }
-  if (path === undefined || path === "") return;
-  try {
-    // Append, not overwrite: validations like the AI reviewers/fixer write their
-    // own sections to this same file during the run, and overwriting here would
-    // wipe them. GitHub provisions a fresh summary file per step, so a single
-    // run's appends never accumulate across steps.
-    Deno.writeTextFileSync(
-      path,
-      renderer.jobSummaryMarkdown(reports, totalMs, ok),
-      { append: true },
-    );
-  } catch {
-    // Best-effort: an unwritable summary file must never fail the build.
-  }
-}
 /**
  * Execute the requested target and its transitive dependencies.
  *
@@ -350,27 +293,14 @@ export async function execute(
   root: TargetBuilder,
   options: ExecuteOptions = {},
 ): Promise<BuildResult> {
-  const baseReporter = options.reporter ??
-    (options.silent ? silentReporter : consoleReporter);
-  // Every line Zuke prints passes through the redactor, which masks the
-  // resolved value of each `secret` parameter. The redactor is populated during
-  // parameter resolution below; since nothing meaningful is reported before
-  // then, wrapping the reporter up-front is safe.
-  const redactor = new Redactor();
-  // …and every write is best-effort (see safeReporter): a throwing sink (a buggy
-  // custom reporter, or EPIPE on a piped stdout) must never escape `failTarget`
-  // and reject out of a scheduler, which would strand the run record `running`.
-  const reporter = safeReporter(redactingReporter(baseReporter, redactor));
-  // The GitHub job summary is a real-world output side effect (it appends to a
-  // shared file named by GITHUB_STEP_SUMMARY). Only write it when output goes to
-  // the default console — i.e. neither silenced nor redirected to a custom
-  // reporter. This keeps embedded/test runs (a build's own test suite calls
-  // `execute` with `silent`/a custom reporter) from polluting the workflow
-  // summary, while a normal CLI run still writes it.
-  const writesToConsole = options.reporter === undefined && !options.silent;
-  const github = options.github ?? inGitHubActions();
-  const style = resolveStyle(options, github);
-  const renderer = options.renderer ?? defaultRenderer;
+  const {
+    baseReporter,
+    reporter,
+    redactor,
+    writesToConsole,
+    style,
+    renderer,
+  } = composeOutput(options);
   const skip = new Set(options.skip ?? []);
 
   // Resolve declared parameters (CLI value → environment → default) before any
@@ -393,22 +323,13 @@ export async function execute(
     const value = p.stringValue_();
     if (value !== undefined && value !== "") redactor.add(value);
   }
-  // Under GitHub Actions, also emit `::add-mask::` with the real value so the
-  // runner masks it in its own logs. This goes through the base reporter, which
-  // is not wrapped in the redactor — a masked directive would hide nothing. Gate
-  // it on `writesToConsole` too: when a custom reporter is supplied it *is* the
-  // base reporter, so an embedded `execute()` must never be handed the raw
-  // secret — only the real runner stdout should receive the directive.
   if (style.github && writesToConsole) {
-    const maskReporter = safeReporter(baseReporter);
+    const secrets: string[] = [];
     for (const p of params.values()) {
       const value = p.secret_ ? p.stringValue_() : undefined;
-      if (value !== undefined && value !== "") {
-        // Straight to the base reporter (not redacted, so the directive works),
-        // but best-effort: an EPIPE here must not abort the run either.
-        maskReporter.info(`::add-mask::${value}`);
-      }
+      if (value !== undefined && value !== "") secrets.push(value);
     }
+    emitActionsMasks(secrets, baseReporter);
   }
   if (paramErrors.length > 0) {
     reporter.error("Invalid or missing parameters:");


### PR DESCRIPTION
The executor entry point had grown to roughly 470 lines and mixed five unrelated concerns. It is now orchestration only, delegating each concern to a sibling module.

Four new internal modules under packages/core/src: execute_output.ts owns the reporting surface — the sink, the redactor wrapping, the resolved colour and width style, the Actions mask directives, and the job summary. execute_plan.ts owns parameter resolution, the ordering-edge diagnostics, the condition and affected skip sets. execute_state.ts owns the durable state store, the run record, its writer, and the environment handed to the scheduler. execute_cancel.ts owns the cancellation handshake.

Behaviour is unchanged and so is the public surface. The core module still re-exports exactly the same four symbols from the executor, and none of the new modules is exported from it. Two independent proofs: the api-docs drift gate passes, and a doc-json comparison against master differs only in source locations, with no symbol added, removed, renamed or re-typed.

The comments in this function encode real defects fixed earlier in this effort, so preserving them was a requirement rather than a courtesy. Of 233 original comment lines, 232 survive verbatim across the five files; the single change is one doc line the task itself re-specified for a changed signature. Specifically preserved and independently re-verified: the raw-secret mask directive still goes to the unwrapped base reporter and stays gated so an embedded run is never handed a secret; the best-effort reporter wrapping order is intact; and the cancel-lock handshake still re-reads the external-cancellation flag after the write queue drains, passed as a thunk rather than snapshotted so both reads see the live value.

No new tests. This is behaviour-preserving and the existing suites are the regression net — nine of them drive the executor end to end and stayed green throughout, with the coverage gate passing on the first full run, so the split exposed no previously incidental coverage.

Verification: the full gate passes at exit zero, 15 of 15 targets, coverage at 98.0 percent lines and 95.7 percent branches. Doc lint over all six core entrypoints in one invocation is clean. A task review found no Critical and no Important findings; its five Minor findings are all fixed in the final commit.

A refactor title never bumps a version, which is intended here since nothing user-visible changes.

Generated with Claude Code