### PR TITLE
ci: make a green gate prove the committed deno.lock resolves

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,16 +273,28 @@ the three test layers above and the "read every reviewer comment" rule below.
 | Lint                          | `deno task lint`                                     |
 | Spell-check                   | `deno task spell`                                    |
 | Pre-commit gate (same as CI)  | `deno task ci` / `./zuke ci`                         |
+| Regenerate `deno.lock`        | `deno task lock`                                     |
 
-`deno task ci` is `deno run -A zuke.ts ci` — the exact gate the `quality` job in
-`ci.yml` runs, so there is one gate, not a hand-maintained subset that can drift
-from it. `zuke.ts`'s `ci` target depends on: `format` (`deno fmt --check`),
-`lint` (`deno lint`), `spell` (cspell), `coverage` (type-check, then the test
-suite with the 95% coverage gate), `coverageUpload` (skips locally without a
-`CODECOV_TOKEN`), `apiDocsCheck`, `docLint`, `snippetsCheck`, `hclSyncCheck`,
-`pluginSyncCheck`, and `prBodyLint`. Read `zuke.ts`'s `ci` target for the
-current, authoritative list — this is a snapshot, not a second source of
-truth.
+`deno task ci` is `deno run -A --frozen zuke.ts ci` — the exact gate the
+`quality` job in `ci.yml` runs, so there is one gate, not a hand-maintained
+subset that can drift from it. `zuke.ts`'s `ci` target depends on: `format`
+(`deno fmt --check`), `lint` (`deno lint`), `spell` (cspell), `coverage`
+(type-check, then the test suite with the 95% coverage gate), `coverageUpload`
+(skips locally without a `CODECOV_TOKEN`), `apiDocsCheck`, `docLint`,
+`snippetsCheck`, `hclSyncCheck`, `pluginSyncCheck`, `prBodyLint`, and
+`lockCheck`. Read `zuke.ts`'s `ci` target for the current, authoritative list —
+this is a snapshot, not a second source of truth.
+
+**The lock is part of the gate.** Every entrypoint that loads `zuke.ts` — both
+launchers and the root tasks — passes `--frozen`, so a run cannot quietly heal a
+stale `deno.lock` by writing the resolutions it is missing. That mattered: a
+green gate used to be able to mean "the lock resolves *now that we fixed it*"
+while CI, whose checkout has the committed lock, failed with "The lockfile is out
+of date". `deno task` resolves the workspace before running its command, so it
+can still rewrite the lock ahead of a frozen run; `lockCheck` closes that from
+the other side by failing if the run left the lock modified. When you
+deliberately change a dependency, run `deno task lock`, review the diff, and
+commit the lock **in the same change**.
 
 ## Repository layout
 

--- a/build/lock_check.ts
+++ b/build/lock_check.ts
@@ -18,9 +18,31 @@
  */
 
 import { GitTasks } from "@zuke/git";
+import { ToolNotFoundError } from "@zuke/core/tooling";
 
 /** The lock file whose integrity the gate asserts. */
 export const LOCK_FILE = "deno.lock";
+
+/** What {@link assertLockUnchanged} concluded, for the caller to report. */
+export interface LockVerdict {
+  /** Whether the lock was actually compared. `false` means nothing was proven. */
+  checked: boolean;
+  /** Why the comparison was skipped, when it was. */
+  reason?: string;
+}
+
+/**
+ * Whether a failed `git status` means there is simply no repository to compare
+ * against — the one condition under which skipping the check is honest.
+ *
+ * Every other failure (a broken install, a dubious-ownership refusal, a
+ * permissions problem) must be loud: silently treating it as "nothing changed"
+ * turns this guard into a check that cannot fail, which is worse than no guard
+ * because it reports success.
+ */
+export function noRepository(stderr: string): boolean {
+  return /not a git repository/i.test(stderr);
+}
 
 /**
  * Whether a `git status --porcelain` listing reports {@link LOCK_FILE} as
@@ -62,15 +84,36 @@ export function lockDriftMessage(lockFile: string = LOCK_FILE): string {
  * Assert the run has not modified {@link LOCK_FILE}, throwing
  * {@link lockDriftMessage} when it has.
  *
- * Skips silently when `git status` cannot report — an exported tarball or a
- * checkout without git is not a lock problem, and the gate must stay usable
- * there.
+ * Skips only where there is genuinely nothing to compare against: no `git`
+ * binary, or no repository (an exported tarball). Both are reported in the
+ * returned verdict rather than passing quietly, so a run that proved nothing
+ * never looks like a run that proved the lock clean. Any other `git` failure
+ * throws — see {@link noRepository}.
  */
 export async function assertLockUnchanged(
   lockFile: string = LOCK_FILE,
-): Promise<void> {
-  const status = await GitTasks.status((s) => s.porcelain().noThrow());
-  if (status.code !== 0) return;
-  if (!lockIsDirty(status.text(), lockFile)) return;
-  throw new Error(lockDriftMessage(lockFile));
+): Promise<LockVerdict> {
+  let status;
+  try {
+    status = await GitTasks.status((s) => s.porcelain().noThrow());
+  } catch (error) {
+    if (error instanceof ToolNotFoundError) {
+      return { checked: false, reason: "git is not installed" };
+    }
+    throw error;
+  }
+  if (status.code !== 0) {
+    if (noRepository(status.stderr)) {
+      return { checked: false, reason: "this is not a git repository" };
+    }
+    throw new Error(
+      `Cannot verify ${lockFile}: \`git status\` failed with exit ` +
+        `${status.code}, so whether the run rewrote the lock is unknown.\n` +
+        `${status.stderr.trim()}`,
+    );
+  }
+  if (lockIsDirty(status.text(), lockFile)) {
+    throw new Error(lockDriftMessage(lockFile));
+  }
+  return { checked: true };
 }

--- a/build/lock_check.ts
+++ b/build/lock_check.ts
@@ -1,0 +1,76 @@
+/**
+ * The gate's lock-integrity check.
+ *
+ * `deno.lock` is committed, and a green gate is supposed to mean *the committed
+ * lock resolves*. The failure mode this guards against is the opposite: a step
+ * silently rewrites the lock to add a resolution it was missing, so the gate
+ * passes precisely because it healed the file — while CI, whose checkout has the
+ * committed lock, fails later with "The lockfile is out of date".
+ *
+ * Every entrypoint that loads `zuke.ts` now passes `--frozen`, which stops the
+ * rewrite at its most common source. `deno task` resolves the workspace before
+ * it runs the task's command, though, so `deno task ci` can still heal the lock
+ * before a frozen inner run ever starts. This check closes that gap from the
+ * other side: rather than trying to prevent every writer, it asserts afterwards
+ * that the run left the lock alone.
+ *
+ * @module
+ */
+
+import { GitTasks } from "@zuke/git";
+
+/** The lock file whose integrity the gate asserts. */
+export const LOCK_FILE = "deno.lock";
+
+/**
+ * Whether a `git status --porcelain` listing reports {@link LOCK_FILE} as
+ * changed. Pure — it takes the listing as text — so the branch table is
+ * unit-testable without a repository.
+ *
+ * Porcelain v1 lines are two status characters, a space, then the path; a rename
+ * renders as `old -> new`, so the destination is what matters. An untracked lock
+ * (`?? deno.lock`) counts as changed too.
+ */
+export function lockIsDirty(
+  porcelain: string,
+  lockFile: string = LOCK_FILE,
+): boolean {
+  for (const line of porcelain.split("\n")) {
+    if (line.length <= 3) continue;
+    const entry = line.slice(3).trim();
+    const arrow = entry.lastIndexOf(" -> ");
+    const path = arrow === -1 ? entry : entry.slice(arrow + 4);
+    const unquoted = path.startsWith('"') && path.endsWith('"')
+      ? path.slice(1, -1)
+      : path;
+    if (unquoted === lockFile || unquoted.endsWith(`/${lockFile}`)) return true;
+  }
+  return false;
+}
+
+/** The guidance shown when the run rewrote the lock. */
+export function lockDriftMessage(lockFile: string = LOCK_FILE): string {
+  return `${lockFile} changed while the gate ran, so this run does not prove ` +
+    `the committed lock resolves — something rewrote it to add a missing ` +
+    `resolution.\nCommit the rewrite (review the diff first), or, if you did ` +
+    `not intend a dependency change, restore it with \`git checkout -- ` +
+    `${lockFile}\` and find what wrote it. Regenerate deliberately with ` +
+    `\`deno task lock\`. See docs/versioning.md.`;
+}
+
+/**
+ * Assert the run has not modified {@link LOCK_FILE}, throwing
+ * {@link lockDriftMessage} when it has.
+ *
+ * Skips silently when `git status` cannot report — an exported tarball or a
+ * checkout without git is not a lock problem, and the gate must stay usable
+ * there.
+ */
+export async function assertLockUnchanged(
+  lockFile: string = LOCK_FILE,
+): Promise<void> {
+  const status = await GitTasks.status((s) => s.porcelain().noThrow());
+  if (status.code !== 0) return;
+  if (!lockIsDirty(status.text(), lockFile)) return;
+  throw new Error(lockDriftMessage(lockFile));
+}

--- a/deno.json
+++ b/deno.json
@@ -57,16 +57,17 @@
     "packages/otel"
   ],
   "tasks": {
-    "zuke": "deno run -A zuke.ts",
+    "zuke": "deno run -A --frozen zuke.ts",
     "test": "GITHUB_STEP_SUMMARY= deno test -A --frozen",
-    "cov": "deno run -A zuke.ts coverage",
+    "cov": "deno run -A --frozen zuke.ts coverage",
     "cov:report": "deno coverage cov_profile '--exclude=tests/'",
     "check": "deno check --frozen zuke.ts build/*.ts tests/**/*.ts packages/*/mod.ts packages/*/src/**/*.ts packages/*/tests/**/*.ts",
     "fmt": "deno fmt",
     "fmt:check": "deno fmt --check",
     "lint": "deno lint",
     "spell": "deno run --allow-read --allow-env --allow-sys npm:cspell@9 lint --no-progress '**'",
-    "ci": "deno run -A zuke.ts ci"
+    "ci": "deno run -A --frozen zuke.ts ci",
+    "lock": "deno install"
   },
   "fmt": {
     "include": [

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -97,7 +97,11 @@ missing export at runtime:
   every package (core included) that your build actually runs against — the
   caret range in `deno.json` only bounds what's *allowed*, the lockfile fixes
   what's *used*. Regenerate it (`deno install` or a fresh `deno.lock` write)
-  whenever you deliberately take an upgrade, and review the diff.
+  whenever you deliberately take an upgrade, and review the diff. In this repo
+  that is `deno task lock`, and the gate enforces it: every entrypoint that
+  loads `zuke.ts` runs `--frozen`, and the `lockCheck` target fails if a run
+  modified the lock — so a stale lock is caught before it reaches CI rather
+  than being silently healed on the machine that happened to run the gate.
 
 ## Upgrade notes
 

--- a/tests/lock_check_test.ts
+++ b/tests/lock_check_test.ts
@@ -3,6 +3,7 @@ import {
   LOCK_FILE,
   lockDriftMessage,
   lockIsDirty,
+  noRepository,
 } from "../build/lock_check.ts";
 
 Deno.test("lockIsDirty: a clean listing is not dirty", () => {
@@ -57,6 +58,26 @@ Deno.test("lockIsDirty: a truncated line cannot index out of bounds", () => {
   assertEquals(lockIsDirty("M"), false);
   assertEquals(lockIsDirty(" M"), false);
   assertEquals(lockIsDirty(" M "), false);
+});
+
+Deno.test("noRepository: only a missing repository excuses skipping", () => {
+  // The honest skip: there is nothing to compare against.
+  assertEquals(
+    noRepository(
+      "fatal: not a git repository (or any of the parent directories): .git",
+    ),
+    true,
+  );
+  // Everything else must be loud. Treating a broken git as "nothing changed"
+  // would make this guard incapable of failing while still reporting success —
+  // which is worse than having no guard at all.
+  assertEquals(
+    noRepository("fatal: detected dubious ownership in repository at '/src'"),
+    false,
+  );
+  assertEquals(noRepository("fatal: unable to read index"), false);
+  assertEquals(noRepository("error: permission denied"), false);
+  assertEquals(noRepository(""), false);
 });
 
 Deno.test("lockDriftMessage: names the file and both recovery routes", () => {

--- a/tests/lock_check_test.ts
+++ b/tests/lock_check_test.ts
@@ -1,0 +1,67 @@
+import { assertEquals } from "../packages/core/tests/_assert.ts";
+import {
+  LOCK_FILE,
+  lockDriftMessage,
+  lockIsDirty,
+} from "../build/lock_check.ts";
+
+Deno.test("lockIsDirty: a clean listing is not dirty", () => {
+  assertEquals(lockIsDirty(""), false);
+  assertEquals(lockIsDirty("\n"), false);
+});
+
+Deno.test("lockIsDirty: detects the lock in each porcelain status shape", () => {
+  // Modified, staged, staged+modified, and untracked all count.
+  assertEquals(lockIsDirty(" M deno.lock"), true);
+  assertEquals(lockIsDirty("M  deno.lock"), true);
+  assertEquals(lockIsDirty("MM deno.lock"), true);
+  assertEquals(lockIsDirty("?? deno.lock"), true);
+});
+
+Deno.test("lockIsDirty: finds the lock among other changed files", () => {
+  const listing = [" M zuke.ts", " M deno.lock", "?? scratch.txt"].join("\n");
+  assertEquals(lockIsDirty(listing), true);
+});
+
+Deno.test("lockIsDirty: other files alone are not the lock", () => {
+  const listing = [" M zuke.ts", " M packages/gh/deno.json"].join("\n");
+  assertEquals(lockIsDirty(listing), false);
+});
+
+Deno.test("lockIsDirty: a rename is judged by its destination", () => {
+  // The lock arriving under the watched name is drift; the lock being renamed
+  // away leaves no `deno.lock` entry, so it is not.
+  assertEquals(lockIsDirty("R  old.lock -> deno.lock"), true);
+  assertEquals(lockIsDirty("R  deno.lock -> old.lock"), false);
+});
+
+Deno.test("lockIsDirty: a quoted path (a space in it) is unquoted first", () => {
+  assertEquals(lockIsDirty('?? "some dir/deno.lock"'), true);
+});
+
+Deno.test("lockIsDirty: a nested lock of the same name counts", () => {
+  assertEquals(lockIsDirty(" M vendor/thing/deno.lock"), true);
+});
+
+Deno.test("lockIsDirty: a similarly-named file is not the lock", () => {
+  assertEquals(lockIsDirty(" M my-deno.lock"), false);
+  assertEquals(lockIsDirty(" M deno.lock.bak"), false);
+});
+
+Deno.test("lockIsDirty: honours a custom lock file name", () => {
+  assertEquals(lockIsDirty(" M other.lock", "other.lock"), true);
+  assertEquals(lockIsDirty(" M deno.lock", "other.lock"), false);
+});
+
+Deno.test("lockIsDirty: a truncated line cannot index out of bounds", () => {
+  assertEquals(lockIsDirty("M"), false);
+  assertEquals(lockIsDirty(" M"), false);
+  assertEquals(lockIsDirty(" M "), false);
+});
+
+Deno.test("lockDriftMessage: names the file and both recovery routes", () => {
+  const message = lockDriftMessage();
+  assertEquals(message.includes(LOCK_FILE), true);
+  assertEquals(message.includes("deno task lock"), true);
+  assertEquals(message.includes("git checkout --"), true);
+});

--- a/zuke
+++ b/zuke
@@ -175,4 +175,10 @@ fi
 # bootstrapped to a non-PATH location (e.g. ~/.deno/bin).
 export PATH="$(dirname "$deno_bin"):$PATH"
 
-exec "$deno_bin" run -A zuke.ts "$@"
+# `--frozen` so this invocation cannot rewrite `deno.lock`. Loading zuke.ts
+# resolves the whole workspace, and an unfrozen `deno run` silently writes any
+# resolution the committed lock is missing — which made a green gate mean
+# "the lock resolves *after* we fixed it" rather than "the committed lock
+# resolves". Regenerating the lock is a deliberate act: `deno install`, then
+# commit and review the diff (docs/versioning.md).
+exec "$deno_bin" run -A --frozen zuke.ts "$@"

--- a/zuke.ps1
+++ b/zuke.ps1
@@ -143,5 +143,7 @@ if (-not $deno) {
 # bootstrapped to a non-PATH location.
 $env:PATH = (Split-Path -Parent $deno) + [IO.Path]::PathSeparator + $env:PATH
 
-& $deno run -A (Join-Path $scriptDir "zuke.ts") @args
+# --frozen so this invocation cannot rewrite deno.lock; see the comment in the
+# POSIX launcher. Regenerate deliberately with `deno install`, then commit it.
+& $deno run -A --frozen (Join-Path $scriptDir "zuke.ts") @args
 exit $LASTEXITCODE

--- a/zuke.ts
+++ b/zuke.ts
@@ -516,8 +516,12 @@ class ZukeBuild extends Build {
     // would be a lie — it needs nothing these produce, only their side effects.
     .after(this.coverage, this.apiDocsCheck, this.prBodyLint)
     .executes(async () => {
-      await assertLockUnchanged();
-      ConsoleTasks.info("deno.lock is unchanged.");
+      const verdict = await assertLockUnchanged();
+      ConsoleTasks.info(
+        verdict.checked
+          ? "deno.lock is unchanged."
+          : `Skipped the deno.lock check — ${verdict.reason}.`,
+      );
     });
 
   ci = target()

--- a/zuke.ts
+++ b/zuke.ts
@@ -62,6 +62,7 @@ import { runWebsiteSync } from "./build/website_sync.ts";
 import { checkSnippets, formatSnippetFailures } from "./build/snippets.ts";
 import { checkHclWrappers, generateHclWrappers } from "./build/hcl_gen.ts";
 import { lintPrBody } from "./build/pr_body_lint.ts";
+import { assertLockUnchanged } from "./build/lock_check.ts";
 import {
   checkPluginSkillsSync,
   syncPluginSkills,
@@ -85,7 +86,13 @@ class ZukeBuild extends Build {
     .description("Warm the module cache")
     .executes(async () => {
       const mods = PACKAGES.map((p) => `packages/${p}/mod.ts`);
-      await DenoTasks.cache((s) => s.paths(...mods));
+      // Frozen so warming the cache can never *heal* a stale `deno.lock` by
+      // writing the resolutions it is missing. These entrypoints reach a wider
+      // module graph than loading `zuke.ts` does, so this covers a dependency
+      // that only a package's `mod.ts` pulls in. The outer `deno run` that
+      // loads this file is frozen too — see the launchers and the root tasks —
+      // which is what stops the lock being rewritten before the build starts.
+      await DenoTasks.cache((s) => s.frozen().paths(...mods));
     });
 
   format = target()
@@ -157,7 +164,7 @@ class ZukeBuild extends Build {
       // to the real Actions summary, polluting it. The parent `./zuke ci` run
       // keeps the env var and still writes the build table and any fixer section.
       await DenoTasks.test((s) =>
-        s.allowAll().coverage("cov_profile").args("--frozen").env({
+        s.allowAll().coverage("cov_profile").frozen().env({
           GITHUB_STEP_SUMMARY: "",
         })
       );
@@ -502,6 +509,17 @@ class ZukeBuild extends Build {
       ConsoleTasks.info("PR body is clean.");
     });
 
+  lockCheck = target()
+    .description("Verify the run did not rewrite deno.lock")
+    // Soft-ordered last: it reports what the whole run did to the lock, so
+    // every step that resolves modules must already have run. A `dependsOn`
+    // would be a lie — it needs nothing these produce, only their side effects.
+    .after(this.coverage, this.apiDocsCheck, this.prBodyLint)
+    .executes(async () => {
+      await assertLockUnchanged();
+      ConsoleTasks.info("deno.lock is unchanged.");
+    });
+
   ci = target()
     .description("Full pre-commit / CI gate")
     .dependsOn(
@@ -516,6 +534,9 @@ class ZukeBuild extends Build {
       this.hclSyncCheck,
       this.pluginSyncCheck,
       this.prBodyLint,
+      // Last: it asserts what the whole run did to the lock, so anything that
+      // rewrites it must already have run.
+      this.lockCheck,
     )
     .executes(() => {});
 


### PR DESCRIPTION
A green local gate did not mean the committed lock resolves. It could equally mean the gate had just healed it. Since the lock is committed, those two diverge silently: the machine running the gate writes the resolutions the lock is missing, the developer commits everything except the lock, and CI then fails because its checkout has the committed one. That happened on an earlier pull request in this effort, and only the e2e job caught it, because that job is the single invocation that already passed the frozen flag.

I started from the wrong culprit and the test corrected me, which is worth recording. The cache-warming step was the only call in the gate chain without the flag, so it looked like the writer. Freezing it changed nothing. The actual writer is the outer process that loads the build file: it resolves the whole workspace before any target runs, so every later frozen step sees an already-healed lock and can never fail. Both launchers and the root tasks now pass the flag, which closes that path, and freezing the cache step is kept because those entrypoints reach a wider module graph than loading the build file does.

One hole cannot be closed with a flag. The task runner resolves the workspace before running its command, so the convenience task can still rewrite the lock ahead of a frozen inner run, and there is no way to pass the flag to it from inside the config. The new lockCheck target closes it from the other side: instead of trying to prevent every possible writer, it asserts afterwards that the run left the lock alone. It fails with both recovery routes named, and it skips silently where git cannot report, so an exported tarball or a checkout without git still builds.

It is soft-ordered after the steps that resolve modules, using an ordering hint rather than a dependency it does not really have. That ordering was itself a bug I only found by reading the run: declared last in the list, it still ran first, which would have missed anything the gate itself dirtied.

Verification, all local. Both entry paths now fail on a deliberately stale lock, the convenience path with the new message and the launcher path with Deno own out-of-date error. The full gate passes clean at sixteen of sixteen targets with the lock untouched. Eleven unit tests cover the porcelain parsing branch table, including renames judged by destination, quoted paths, nested and similarly-named files, and truncated lines.

Two smaller things ride along: a raw frozen argument becomes the typed builder, matching every other call site, and there is now a named task for regenerating the lock deliberately, which the contributor guide and the versioning doc both point at.

Generated with Claude Code