### PR TITLE
feat(deno): add config and no-lock to deno check, verify declared core floors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,10 +114,29 @@ jobs:
     name: Core version floors
     runs-on: ubuntu-latest
     steps:
+      # Egress is blocked, not audited, because this is the one job that resolves
+      # modules with `--no-lock`. The generated config carries only `jsr:@zuke/*`
+      # specifiers, but that allowlist governs the *import map* — it cannot stop a
+      # source file in a pull request from importing an absolute URL directly,
+      # which `deno check` would then follow, unpinned by the committed lock.
+      # Blocking egress is what actually closes that: an arbitrary host is
+      # dropped at the network layer regardless of what the checked-out code asks
+      # for. The allowlist is the minimum this job needs — the launcher's Deno
+      # bootstrap, JSR for the published core, and GitHub for the checkout. Add a
+      # host here if a run reports it blocked.
       - name: Harden the runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            deno.land:443
+            dl.deno.land:443
+            jsr.io:443
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,26 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           PR_BODY: ${{ github.event_name == 'pull_request' && github.event.pull_request.body || '' }}
 
+  # Verifies each package against the @zuke/core version it *declares*, not the
+  # workspace-local core. Its own job because it reaches JSR for the published
+  # core, and the `./zuke ci` gate must stay runnable offline. Secret-free and
+  # read-only: it only type-checks.
+  core-floors:
+    name: Core version floors
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Check declared core floors with Zuke
+        run: ./zuke coreFloorCheck
+
   test-os:
     name: Tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,6 +274,7 @@ the three test layers above and the "read every reviewer comment" rule below.
 | Spell-check                   | `deno task spell`                                    |
 | Pre-commit gate (same as CI)  | `deno task ci` / `./zuke ci`                         |
 | Regenerate `deno.lock`        | `deno task lock`                                     |
+| Verify declared core floors   | `./zuke coreFloorCheck` (needs network)              |
 
 `deno task ci` is `deno run -A --frozen zuke.ts ci` — the exact gate the
 `quality` job in `ci.yml` runs, so there is one gate, not a hand-maintained

--- a/build/core_floor.ts
+++ b/build/core_floor.ts
@@ -122,9 +122,14 @@ export const ALLOWED_PREFIX = "jsr:@zuke/";
  * without a restriction a PR could point an import at any URL and have CI fetch
  * it, unpinned by the committed lock. Every package in this workspace depends
  * only on `jsr:@zuke/*` (the library is dependency-free), so allowing just that
- * costs nothing and removes the arbitrary-fetch capability. Type-checking never
- * executes the fetched code, but making the runner fetch attacker-chosen URLs is
- * a capability worth not granting.
+ * costs nothing. Type-checking never executes the fetched code, but making the
+ * runner fetch attacker-chosen URLs is a capability worth not granting.
+ *
+ * This is necessary and **not sufficient**: it governs the import map only. A
+ * source file can import an absolute URL directly, which `deno check` follows
+ * whatever the map says. The blocked egress allowlist on the `core-floors` job
+ * in `ci.yml` is what covers that case; the two are layers of one control, so
+ * neither should be removed on the assumption the other suffices.
  */
 export function isAllowedSpecifier(specifier: string): boolean {
   return specifier.startsWith(ALLOWED_PREFIX);

--- a/build/core_floor.ts
+++ b/build/core_floor.ts
@@ -41,7 +41,14 @@ export interface CoreFloor {
   package: string;
   /** The specifier the package declares, e.g. `jsr:@zuke/core@^1.31.0`. */
   specifier: string;
-  /** The package's full import map, copied into the throwaway config. */
+  /**
+   * The package's import map as declared, unfiltered.
+   *
+   * Held raw on purpose: the core entry has to be inspected as written so a
+   * mapping that names core but resolves something else can be reported. It is
+   * **not** what reaches the generated config — {@link floorConfig} copies only
+   * the entries {@link isAllowedSpecifier} permits.
+   */
   imports: Record<string, string>;
 }
 

--- a/build/core_floor.ts
+++ b/build/core_floor.ts
@@ -111,8 +111,27 @@ export function exactFloorSpecifier(specifier: string): string | undefined {
   return `${name}@${version}`;
 }
 
+/** The only specifier prefix the generated config is allowed to carry. */
+export const ALLOWED_PREFIX = "jsr:@zuke/";
+
 /**
- * Render the throwaway config for one package: its own imports with the core
+ * Whether a specifier may be carried into the generated config.
+ *
+ * The config is built from a package's own `deno.json`, which on a pull request
+ * is attacker-controlled, and the check resolves it with `--no-lock` — so
+ * without a restriction a PR could point an import at any URL and have CI fetch
+ * it, unpinned by the committed lock. Every package in this workspace depends
+ * only on `jsr:@zuke/*` (the library is dependency-free), so allowing just that
+ * costs nothing and removes the arbitrary-fetch capability. Type-checking never
+ * executes the fetched code, but making the runner fetch attacker-chosen URLs is
+ * a capability worth not granting.
+ */
+export function isAllowedSpecifier(specifier: string): boolean {
+  return specifier.startsWith(ALLOWED_PREFIX);
+}
+
+/**
+ * Render the throwaway config for one package: its allowed imports with the core
  * specifier pinned to its exact floor, and no `workspace` field.
  *
  * The absence of `workspace` is the whole mechanism — with it, Deno would
@@ -127,10 +146,12 @@ export function exactFloorSpecifier(specifier: string): string | undefined {
  * declaring a fresh core would fail spuriously for a day after each release.
  */
 export function floorConfig(floor: CoreFloor, pinned: string): string {
-  const config = {
-    imports: { ...floor.imports, [CORE_PACKAGE]: pinned },
-    minimumDependencyAge: 0,
-  };
+  const imports: Record<string, string> = {};
+  for (const [name, specifier] of Object.entries(floor.imports)) {
+    if (isAllowedSpecifier(specifier)) imports[name] = specifier;
+  }
+  imports[CORE_PACKAGE] = pinned;
+  const config = { imports, minimumDependencyAge: 0 };
   return `${JSON.stringify(config, null, 2)}\n`;
 }
 
@@ -184,6 +205,19 @@ export async function checkCoreFloors(
         detail: `Cannot determine a minimum version from this range, so the ` +
           `floor cannot be verified. Declare it as a caret range over an ` +
           `exact version, e.g. ${CORE_PACKAGE}@^1.32.0.`,
+      });
+      continue;
+    }
+    // The mapping's *target* is as attacker-controlled as the rest of the file
+    // on a pull request, so the entry named `@zuke/core` must actually resolve
+    // core and not some other package wearing its name.
+    if (!pinned.startsWith(`${ALLOWED_PREFIX}core@`)) {
+      results.push({
+        package: pkg,
+        specifier: floor.specifier,
+        ok: false,
+        detail: `The ${CORE_PACKAGE} entry must resolve ` +
+          `${ALLOWED_PREFIX}core, not ${pinned}.`,
       });
       continue;
     }

--- a/build/core_floor.ts
+++ b/build/core_floor.ts
@@ -1,0 +1,210 @@
+/**
+ * The `@zuke/core` version-floor check.
+ *
+ * Every package declares the oldest core it supports, as a caret range in its
+ * own `deno.json` imports. Nothing verifies that claim. Because the root
+ * `deno.json` declares a workspace, `deno check` resolves `@zuke/core` to the
+ * local `packages/core` source no matter what a package's range says — so a
+ * package can use a core symbol that only exists in a newer core than it
+ * declares, and every local gate stays green while a consumer installing from
+ * JSR gets a type error or a missing export. That has already happened here
+ * once; see docs/versioning.md.
+ *
+ * The check type-checks each package against the core it actually declares. It
+ * writes a throwaway config carrying the package's own imports and, crucially,
+ * no `workspace` field, then points `deno check --config` at it: with no
+ * workspace to resolve against, `@zuke/core` resolves from JSR. `--no-lock`
+ * keeps the committed lock out of it — these resolutions are deliberately not
+ * the project's.
+ *
+ * The core specifier is pinned to the range's exact minimum, which is the part
+ * that makes this a real check rather than a decorative one. A caret range
+ * resolves to the newest matching version, so checking the range as written
+ * would exercise the current core and pass regardless of the declared floor.
+ * See {@link exactFloorSpecifier}.
+ *
+ * It therefore needs the network, which is why it is its own target and its own
+ * CI job rather than part of the offline `./zuke ci` gate.
+ *
+ * @module
+ */
+
+import { DenoTasks } from "@zuke/deno";
+import { FileTasks } from "@zuke/core";
+
+/** The dependency whose declared floor is verified. */
+export const CORE_PACKAGE = "@zuke/core";
+
+/** A package's declared core floor, and the entrypoint to check against it. */
+export interface CoreFloor {
+  /** The workspace-relative package directory name, e.g. `gh`. */
+  package: string;
+  /** The specifier the package declares, e.g. `jsr:@zuke/core@^1.31.0`. */
+  specifier: string;
+  /** The package's full import map, copied into the throwaway config. */
+  imports: Record<string, string>;
+}
+
+/** One package's verdict from {@link checkCoreFloors}. */
+export interface FloorResult {
+  /** The package that was checked. */
+  package: string;
+  /** The core specifier it was checked against. */
+  specifier: string;
+  /** Whether it type-checks against that published core. */
+  ok: boolean;
+  /** The type-checker's output when it does not. */
+  detail?: string;
+}
+
+/**
+ * Read a package's `deno.json` and extract its declared core floor, or
+ * `undefined` when it declares none — which is correct for core itself.
+ *
+ * Pure apart from the read, and tolerant of a malformed file: a package whose
+ * config cannot be parsed has no verifiable claim to make, so it is skipped
+ * rather than failing the run.
+ */
+export function readCoreFloor(
+  pkg: string,
+  readText: (path: string) => string,
+): CoreFloor | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readText(`packages/${pkg}/deno.json`));
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed !== "object" || parsed === null) return undefined;
+  const raw = "imports" in parsed ? parsed.imports : undefined;
+  if (typeof raw !== "object" || raw === null) return undefined;
+  const imports: Record<string, string> = {};
+  for (const [name, value] of Object.entries(raw)) {
+    if (typeof value === "string") imports[name] = value;
+  }
+  const specifier = imports[CORE_PACKAGE];
+  if (specifier === undefined) return undefined;
+  return { package: pkg, specifier, imports };
+}
+
+/**
+ * Rewrite a range specifier to pin its minimum version exactly, or `undefined`
+ * when the minimum cannot be determined.
+ *
+ * This is the difference between a check that works and one that only looks like
+ * it does. A caret range resolves to the *newest* matching version, so checking
+ * `^1.25.0` against JSR pulls the current 1.x and passes no matter how new a
+ * symbol the package uses — the floor is never exercised. Pinning the range's
+ * minimum is what actually tests the claim "this package works with core this
+ * old".
+ */
+export function exactFloorSpecifier(specifier: string): string | undefined {
+  const at = specifier.lastIndexOf("@");
+  if (at <= 0) return undefined;
+  const name = specifier.slice(0, at);
+  const range = specifier.slice(at + 1).trim();
+  const version = range.replace(/^(\^|~|>=|>|=)\s*/, "");
+  // Only a plain `major.minor.patch` (optionally with a prerelease or build
+  // suffix) has an unambiguous minimum. Anything else — a wildcard, a compound
+  // range — is reported rather than guessed at.
+  if (!/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(version)) return undefined;
+  return `${name}@${version}`;
+}
+
+/**
+ * Render the throwaway config for one package: its own imports with the core
+ * specifier pinned to its exact floor, and no `workspace` field.
+ *
+ * The absence of `workspace` is the whole mechanism — with it, Deno would
+ * substitute the local `packages/core` member and the check would prove
+ * nothing.
+ *
+ * `minimumDependencyAge` is zeroed because Deno otherwise refuses a version
+ * published in the last day as a supply-chain precaution. That default is right
+ * when installing dependencies to run, and wrong here: this check installs
+ * nothing, and the case it most needs to verify is a floor naming the core that
+ * was *just* released alongside it. Left at the default, every package
+ * declaring a fresh core would fail spuriously for a day after each release.
+ */
+export function floorConfig(floor: CoreFloor, pinned: string): string {
+  const config = {
+    imports: { ...floor.imports, [CORE_PACKAGE]: pinned },
+    minimumDependencyAge: 0,
+  };
+  return `${JSON.stringify(config, null, 2)}\n`;
+}
+
+/**
+ * Summarise results as the lines a failing target prints, most useful first.
+ * Pure, so the message is testable without running a type-check.
+ */
+export function formatFloorFailures(results: readonly FloorResult[]): string[] {
+  const failed = results.filter((r) => !r.ok);
+  if (failed.length === 0) return [];
+  const lines = [
+    `${failed.length} package(s) do not type-check against the ${CORE_PACKAGE} ` +
+    `version they declare:`,
+  ];
+  for (const result of failed) {
+    lines.push(`  packages/${result.package} declares ${result.specifier}`);
+    for (const line of (result.detail ?? "").split("\n")) {
+      if (line.trim() !== "") lines.push(`    ${line}`);
+    }
+  }
+  lines.push(
+    `Raise the floor in the package's deno.json to a core version that has ` +
+      `the symbols it uses, or stop using them. A local gate cannot catch this: ` +
+      `workspace resolution substitutes the local packages/core regardless of ` +
+      `the declared range.`,
+  );
+  return lines;
+}
+
+/**
+ * Type-check each package against the published core it declares.
+ *
+ * Packages are checked in the given order; each gets a throwaway config in its
+ * own temporary directory, removed afterwards. A package declaring no core
+ * floor is skipped and absent from the results.
+ */
+export async function checkCoreFloors(
+  packages: readonly string[],
+  readText: (path: string) => string = Deno.readTextFileSync,
+): Promise<FloorResult[]> {
+  const results: FloorResult[] = [];
+  for (const pkg of packages) {
+    const floor = readCoreFloor(pkg, readText);
+    if (floor === undefined) continue;
+    const pinned = exactFloorSpecifier(floor.specifier);
+    if (pinned === undefined) {
+      results.push({
+        package: pkg,
+        specifier: floor.specifier,
+        ok: false,
+        detail: `Cannot determine a minimum version from this range, so the ` +
+          `floor cannot be verified. Declare it as a caret range over an ` +
+          `exact version, e.g. ${CORE_PACKAGE}@^1.32.0.`,
+      });
+      continue;
+    }
+    const dir = await Deno.makeTempDir({ prefix: `zuke-floor-${pkg}-` });
+    try {
+      const config = `${dir}/deno.json`;
+      await FileTasks.writeText(config, floorConfig(floor, pinned));
+      const output = await DenoTasks.check((s) =>
+        s.config(config).noLock().paths(`packages/${pkg}/mod.ts`).noThrow()
+      );
+      results.push({
+        package: pkg,
+        specifier: floor.specifier,
+        ok: output.code === 0,
+        detail: output.code === 0
+          ? undefined
+          : `${output.stderr}\n${output.stdout}`.trim(),
+      });
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  }
+  return results;
+}

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -35,7 +35,10 @@ Each tool wrapper's `deno.json` pins a minimum core version it needs, e.g.
 }
 ```
 
-That floor is **hand-maintained** — nothing regenerates it — and it exists
+That floor is **hand-maintained** — nothing regenerates it — but it is no longer
+unverified: the `coreFloorCheck` target type-checks every package against the
+core version it declares, and the `Core version floors` CI job runs it on every
+PR. See [Verifying the floors](#verifying-the-floors) below. The floor exists
 because a wrapper often imports a symbol that only exists from some specific
 core release onward (a new settings class, a new exported type). If the floor
 is under-declared, a consumer can pin a wrapper version whose code needs core
@@ -87,6 +90,34 @@ missing export at runtime:
    the version that introduced the symbol as a workaround) and expect the fix
    to look like `d8f51c0`: a small `fix:` PR raising the floor in every
    affected `deno.json`.
+
+### Verifying the floors
+
+`./zuke coreFloorCheck` type-checks every package against the core version it
+declares, so the gap above is now caught before release rather than by a
+consumer at runtime. It runs as its own CI job on every PR.
+
+It works by writing a throwaway config per package containing that package's own
+imports and **no `workspace` field**, then type-checking the package's `mod.ts`
+with `deno check --config` pointed at it. Without a workspace to resolve
+against, `@zuke/core` comes from JSR instead of the local `packages/core` member
+— which is precisely the substitution that made the ordinary type-check blind
+to this class of bug.
+
+Two details matter, and both are load-bearing:
+
+- **The floor is pinned to the range's exact minimum.** A caret range resolves
+  to the *newest* matching version, so checking `^1.25.0` as written would
+  exercise the current core and pass no matter how new a symbol the package
+  uses. Verified against `1.25.0` exactly, it tests the actual claim.
+- **`minimumDependencyAge` is zeroed** in the generated config. Deno otherwise
+  refuses a version published within the last day as a supply-chain
+  precaution — sensible when installing dependencies to run, wrong here, where
+  the case most needing verification is a floor naming the core just released
+  alongside it.
+
+Because it reaches JSR, it is deliberately **not** part of `./zuke ci`, which
+stays runnable offline.
 
 ## Pinning guidance
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4023,6 +4023,21 @@ class DenoCheckSettings extends DenoSettings
 
   paths(...paths: PathLike[]): this
     The files to type-check (at least one is required).
+  config(path: PathLike): this
+    Type-check against a specific configuration file (`--config`) instead of the
+    one Deno would discover by walking up from the checked files.
+
+    The discovered config decides how bare specifiers resolve, so pointing at
+    another one type-checks the same sources against a different dependency
+    set — for example checking a workspace member against the published
+    version of a sibling it declares, rather than the local member that
+    workspace resolution would substitute.
+  noLock(): this
+    Ignore the lockfile entirely (`--no-lock`), neither reading nor writing it.
+
+    Use it for a check whose resolutions are deliberately not the project's:
+    writing them into the committed lock would corrupt it, and reading it would
+    pin the very versions the check is trying to vary.
   frozen(): this
     Error out if the lockfile is out of date (`--frozen`). See
     {@link DenoPermissionSettings.frozen} for why the name mirrors the real

--- a/packages/deno/README.md
+++ b/packages/deno/README.md
@@ -67,6 +67,21 @@ class DenoCheckSettings extends DenoSettings
 
   paths(...paths: PathLike[]): this
     The files to type-check (at least one is required).
+  config(path: PathLike): this
+    Type-check against a specific configuration file (`--config`) instead of the
+    one Deno would discover by walking up from the checked files.
+
+    The discovered config decides how bare specifiers resolve, so pointing at
+    another one type-checks the same sources against a different dependency
+    set — for example checking a workspace member against the published
+    version of a sibling it declares, rather than the local member that
+    workspace resolution would substitute.
+  noLock(): this
+    Ignore the lockfile entirely (`--no-lock`), neither reading nor writing it.
+
+    Use it for a check whose resolutions are deliberately not the project's:
+    writing them into the committed lock would corrupt it, and reading it would
+    pin the very versions the check is trying to vary.
   frozen(): this
     Error out if the lockfile is out of date (`--frozen`). See
     {@link DenoPermissionSettings.frozen} for why the name mirrors the real

--- a/packages/deno/src/deno.ts
+++ b/packages/deno/src/deno.ts
@@ -189,10 +189,39 @@ export class DenoTestSettings extends DenoPermissionSettings {
 export class DenoCheckSettings extends DenoSettings {
   #paths: string[] = [];
   #frozen = false;
+  #config?: string;
+  #noLock = false;
 
   /** The files to type-check (at least one is required). */
   paths(...paths: PathLike[]): this {
     this.#paths.push(...paths.map(String));
+    return this;
+  }
+
+  /**
+   * Type-check against a specific configuration file (`--config`) instead of the
+   * one Deno would discover by walking up from the checked files.
+   *
+   * The discovered config decides how bare specifiers resolve, so pointing at
+   * another one type-checks the same sources against a different dependency
+   * set — for example checking a workspace member against the *published*
+   * version of a sibling it declares, rather than the local member that
+   * workspace resolution would substitute.
+   */
+  config(path: PathLike): this {
+    this.#config = String(path);
+    return this;
+  }
+
+  /**
+   * Ignore the lockfile entirely (`--no-lock`), neither reading nor writing it.
+   *
+   * Use it for a check whose resolutions are deliberately not the project's:
+   * writing them into the committed lock would corrupt it, and reading it would
+   * pin the very versions the check is trying to vary.
+   */
+  noLock(): this {
+    this.#noLock = true;
     return this;
   }
 
@@ -214,6 +243,8 @@ export class DenoCheckSettings extends DenoSettings {
       );
     }
     const argv = ["check"];
+    if (this.#config !== undefined) argv.push("--config", this.#config);
+    if (this.#noLock) argv.push("--no-lock");
     if (this.#frozen) argv.push("--frozen");
     argv.push(...this.#paths);
     return argv;

--- a/packages/deno/tests/deno_test.ts
+++ b/packages/deno/tests/deno_test.ts
@@ -109,6 +109,24 @@ Deno.test("check: paths are required", () => {
     new DenoCheckSettings().frozen().paths("mod.ts").argv().slice(1),
     ["check", "--frozen", "mod.ts"],
   );
+  // --config and --no-lock precede --frozen and the paths.
+  assertEquals(
+    new DenoCheckSettings()
+      .config("/tmp/floor/deno.json").noLock().paths("packages/gh/mod.ts")
+      .argv().slice(1),
+    [
+      "check",
+      "--config",
+      "/tmp/floor/deno.json",
+      "--no-lock",
+      "packages/gh/mod.ts",
+    ],
+  );
+  // Absent by default, so an ordinary check still uses the discovered config
+  // and the committed lock.
+  const plain = new DenoCheckSettings().paths("mod.ts").argv();
+  assertEquals(plain.includes("--config"), false);
+  assertEquals(plain.includes("--no-lock"), false);
 });
 
 Deno.test("fmt: optional --check and paths", () => {

--- a/tests/core_floor_test.ts
+++ b/tests/core_floor_test.ts
@@ -5,6 +5,7 @@ import {
   exactFloorSpecifier,
   floorConfig,
   formatFloorFailures,
+  isAllowedSpecifier,
   readCoreFloor,
 } from "../build/core_floor.ts";
 
@@ -145,12 +146,53 @@ Deno.test("floorConfig: pins core, keeps siblings, declares no workspace", () =>
   const parsed = JSON.parse(floorConfig(floor, "jsr:@zuke/core@1.25.0"));
   assertEquals(parsed.imports["@zuke/core"], "jsr:@zuke/core@1.25.0");
   assertEquals(parsed.imports["@zuke/deno"], "jsr:@zuke/deno@^0.4.0");
+  assertEquals(Object.keys(parsed.imports).length, 2);
   // No workspace field is the mechanism: with one, Deno would substitute the
   // local packages/core member and the check would prove nothing.
   assertEquals("workspace" in parsed, false);
   // Zeroed so a core published in the last day is not refused, which would fail
   // every fresh floor for a day after each release.
   assertEquals(parsed.minimumDependencyAge, 0);
+});
+
+Deno.test("isAllowedSpecifier: only workspace registry specifiers pass", () => {
+  assertEquals(isAllowedSpecifier("jsr:@zuke/core@^1.25.0"), true);
+  assertEquals(isAllowedSpecifier("jsr:@other/pkg@1.0.0"), false);
+  assertEquals(isAllowedSpecifier("https://evil.example/payload.ts"), false);
+  assertEquals(isAllowedSpecifier("npm:left-pad@1.0.0"), false);
+  assertEquals(isAllowedSpecifier("./local.ts"), false);
+  // Not a prefix match on a lookalike scope.
+  assertEquals(isAllowedSpecifier("jsr:@zuke-evil/core@1.0.0"), false);
+});
+
+Deno.test("floorConfig: drops a specifier the check must not fetch", () => {
+  // A pull request controls this file, and the check runs with no lockfile, so
+  // an arbitrary URL here would make CI fetch it. Only @zuke/* survives.
+  const floor: CoreFloor = {
+    package: "evil",
+    specifier: "jsr:@zuke/core@^1.25.0",
+    imports: {
+      "@zuke/core": "jsr:@zuke/core@^1.25.0",
+      "@zuke/deno": "jsr:@zuke/deno@^0.4.0",
+      exfiltrate: "https://evil.example/payload.ts",
+      "left-pad": "npm:left-pad@1.0.0",
+    },
+  };
+  const parsed = JSON.parse(floorConfig(floor, "jsr:@zuke/core@1.25.0"));
+  assertEquals(parsed.imports["exfiltrate"], undefined);
+  assertEquals(parsed.imports["left-pad"], undefined);
+  assertEquals(parsed.imports["@zuke/deno"], "jsr:@zuke/deno@^0.4.0");
+  assertEquals(parsed.imports["@zuke/core"], "jsr:@zuke/core@1.25.0");
+});
+
+Deno.test("floorConfig: the pinned core always wins over the declared range", () => {
+  const floor: CoreFloor = {
+    package: "gh",
+    specifier: "jsr:@zuke/core@^1.31.0",
+    imports: { "@zuke/core": "jsr:@zuke/core@^1.31.0" },
+  };
+  const parsed = JSON.parse(floorConfig(floor, "jsr:@zuke/core@1.31.0"));
+  assertEquals(parsed.imports["@zuke/core"], "jsr:@zuke/core@1.31.0");
 });
 
 Deno.test("formatFloorFailures: silent when every package passes", () => {

--- a/tests/core_floor_test.ts
+++ b/tests/core_floor_test.ts
@@ -1,0 +1,194 @@
+import { assertEquals } from "../packages/core/tests/_assert.ts";
+import {
+  CORE_PACKAGE,
+  type CoreFloor,
+  exactFloorSpecifier,
+  floorConfig,
+  formatFloorFailures,
+  readCoreFloor,
+} from "../build/core_floor.ts";
+
+/** A `readText` stand-in serving one package's config from memory. */
+function reader(contents: Record<string, string>): (path: string) => string {
+  return (path) => {
+    const text = contents[path];
+    if (text === undefined) throw new Deno.errors.NotFound(path);
+    return text;
+  };
+}
+
+Deno.test("readCoreFloor: extracts the declared specifier and imports", () => {
+  const floor = readCoreFloor(
+    "gh",
+    reader({
+      "packages/gh/deno.json": JSON.stringify({
+        name: "@zuke/gh",
+        imports: { "@zuke/core": "jsr:@zuke/core@^1.31.0" },
+      }),
+    }),
+  );
+  assertEquals(floor?.package, "gh");
+  assertEquals(floor?.specifier, "jsr:@zuke/core@^1.31.0");
+  assertEquals(floor?.imports[CORE_PACKAGE], "jsr:@zuke/core@^1.31.0");
+});
+
+Deno.test("readCoreFloor: keeps a package's other imports", () => {
+  const floor = readCoreFloor(
+    "docs",
+    reader({
+      "packages/docs/deno.json": JSON.stringify({
+        imports: {
+          "@zuke/core": "jsr:@zuke/core@^1.25.0",
+          "@zuke/deno": "jsr:@zuke/deno@^0.4.0",
+        },
+      }),
+    }),
+  );
+  assertEquals(floor?.imports["@zuke/deno"], "jsr:@zuke/deno@^0.4.0");
+});
+
+Deno.test("readCoreFloor: no core dependency means nothing to verify", () => {
+  // Core itself: it has no self-dependency, so it is skipped rather than failed.
+  assertEquals(
+    readCoreFloor(
+      "core",
+      reader({ "packages/core/deno.json": JSON.stringify({ imports: {} }) }),
+    ),
+    undefined,
+  );
+  assertEquals(
+    readCoreFloor(
+      "core",
+      reader({ "packages/core/deno.json": JSON.stringify({ name: "x" }) }),
+    ),
+    undefined,
+  );
+});
+
+Deno.test("readCoreFloor: a config it cannot parse is skipped, not thrown", () => {
+  assertEquals(
+    readCoreFloor("bad", reader({ "packages/bad/deno.json": "{ not json" })),
+    undefined,
+  );
+  assertEquals(readCoreFloor("missing", reader({})), undefined);
+  assertEquals(
+    readCoreFloor("null", reader({ "packages/null/deno.json": "null" })),
+    undefined,
+  );
+  assertEquals(
+    readCoreFloor(
+      "arr",
+      reader({ "packages/arr/deno.json": '{"imports": []}' }),
+    ),
+    undefined,
+  );
+});
+
+Deno.test("readCoreFloor: a non-string import value is dropped", () => {
+  const floor = readCoreFloor(
+    "odd",
+    reader({
+      "packages/odd/deno.json":
+        '{"imports": {"@zuke/core": "jsr:@zuke/core@^1.25.0", "bad": 7}}',
+    }),
+  );
+  assertEquals(floor?.imports["bad"], undefined);
+  assertEquals(floor?.specifier, "jsr:@zuke/core@^1.25.0");
+});
+
+Deno.test("exactFloorSpecifier: pins the minimum of each range operator", () => {
+  // The point of the whole check: a caret range would otherwise resolve to the
+  // newest matching version and never exercise the declared floor.
+  assertEquals(
+    exactFloorSpecifier("jsr:@zuke/core@^1.25.0"),
+    "jsr:@zuke/core@1.25.0",
+  );
+  assertEquals(
+    exactFloorSpecifier("jsr:@zuke/core@~1.31.2"),
+    "jsr:@zuke/core@1.31.2",
+  );
+  assertEquals(
+    exactFloorSpecifier("jsr:@zuke/core@>=1.30.0"),
+    "jsr:@zuke/core@1.30.0",
+  );
+  assertEquals(
+    exactFloorSpecifier("jsr:@zuke/core@1.32.1"),
+    "jsr:@zuke/core@1.32.1",
+  );
+  assertEquals(
+    exactFloorSpecifier("jsr:@zuke/core@^2.0.0-rc.1"),
+    "jsr:@zuke/core@2.0.0-rc.1",
+  );
+});
+
+Deno.test("exactFloorSpecifier: an ambiguous range has no single minimum", () => {
+  // Reported rather than guessed at — a wrong guess would silently check the
+  // wrong version and claim the floor verified.
+  assertEquals(exactFloorSpecifier("jsr:@zuke/core@*"), undefined);
+  assertEquals(exactFloorSpecifier("jsr:@zuke/core@^1"), undefined);
+  assertEquals(exactFloorSpecifier("jsr:@zuke/core@1.x"), undefined);
+  assertEquals(exactFloorSpecifier("jsr:@zuke/core@>=1.0.0 <2.0.0"), undefined);
+  assertEquals(exactFloorSpecifier("jsr:@zuke/core@"), undefined);
+  assertEquals(exactFloorSpecifier("no-at-sign"), undefined);
+  assertEquals(exactFloorSpecifier("@leading-only"), undefined);
+});
+
+Deno.test("floorConfig: pins core, keeps siblings, declares no workspace", () => {
+  const floor: CoreFloor = {
+    package: "docs",
+    specifier: "jsr:@zuke/core@^1.25.0",
+    imports: {
+      "@zuke/core": "jsr:@zuke/core@^1.25.0",
+      "@zuke/deno": "jsr:@zuke/deno@^0.4.0",
+    },
+  };
+  const parsed = JSON.parse(floorConfig(floor, "jsr:@zuke/core@1.25.0"));
+  assertEquals(parsed.imports["@zuke/core"], "jsr:@zuke/core@1.25.0");
+  assertEquals(parsed.imports["@zuke/deno"], "jsr:@zuke/deno@^0.4.0");
+  // No workspace field is the mechanism: with one, Deno would substitute the
+  // local packages/core member and the check would prove nothing.
+  assertEquals("workspace" in parsed, false);
+  // Zeroed so a core published in the last day is not refused, which would fail
+  // every fresh floor for a day after each release.
+  assertEquals(parsed.minimumDependencyAge, 0);
+});
+
+Deno.test("formatFloorFailures: silent when every package passes", () => {
+  assertEquals(formatFloorFailures([]), []);
+  assertEquals(
+    formatFloorFailures([
+      { package: "gh", specifier: "jsr:@zuke/core@^1.31.0", ok: true },
+    ]),
+    [],
+  );
+});
+
+Deno.test("formatFloorFailures: names the package, its range, and the error", () => {
+  const lines = formatFloorFailures([
+    { package: "gh", specifier: "jsr:@zuke/core@^1.31.0", ok: true },
+    {
+      package: "cli",
+      specifier: "jsr:@zuke/core@^1.25.0",
+      ok: false,
+      detail: "TS2305 [ERROR]: has no exported member 'splitShellArgs'.",
+    },
+  ]);
+  const text = lines.join("\n");
+  assertEquals(lines[0].includes("1 package(s)"), true);
+  assertEquals(
+    text.includes("packages/cli declares jsr:@zuke/core@^1.25.0"),
+    true,
+  );
+  assertEquals(text.includes("splitShellArgs"), true);
+  // The passing package is not mentioned.
+  assertEquals(text.includes("packages/gh"), false);
+  // And the guidance explains why a local gate cannot catch this.
+  assertEquals(text.includes("workspace resolution"), true);
+});
+
+Deno.test("formatFloorFailures: tolerates a failure with no detail", () => {
+  const lines = formatFloorFailures([
+    { package: "cli", specifier: "jsr:@zuke/core@^1.25.0", ok: false },
+  ]);
+  assertEquals(lines.some((l) => l.includes("packages/cli")), true);
+});

--- a/zuke.ts
+++ b/zuke.ts
@@ -63,6 +63,7 @@ import { checkSnippets, formatSnippetFailures } from "./build/snippets.ts";
 import { checkHclWrappers, generateHclWrappers } from "./build/hcl_gen.ts";
 import { lintPrBody } from "./build/pr_body_lint.ts";
 import { assertLockUnchanged } from "./build/lock_check.ts";
+import { checkCoreFloors, formatFloorFailures } from "./build/core_floor.ts";
 import {
   checkPluginSkillsSync,
   syncPluginSkills,
@@ -507,6 +508,22 @@ class ZukeBuild extends Build {
         );
       }
       ConsoleTasks.info("PR body is clean.");
+    });
+
+  coreFloorCheck = target()
+    .description(
+      "Type-check every package against the @zuke/core version it declares",
+    )
+    .executes(async () => {
+      // Deliberately not part of `ci`: this reaches JSR for the published core,
+      // and the gate must stay runnable offline.
+      const results = await checkCoreFloors(PACKAGES);
+      const failures = formatFloorFailures(results);
+      if (failures.length > 0) throw new Error(failures.join("\n"));
+      ConsoleTasks.info(
+        `${results.length} package(s) type-check against their declared ` +
+          `@zuke/core floor.`,
+      );
     });
 
   lockCheck = target()


### PR DESCRIPTION
Every package declares the oldest core it supports, as a caret range in its own config. Nothing verified that claim. Because the root config declares a workspace, the type-checker resolves core to the local source regardless of what a package declares, so a package can use a symbol that only exists in a newer core while every local gate stays green, and a consumer installing from the registry gets a missing export at runtime. That has already happened here: five wrappers imported a type new in core 1.31 while still declaring an older floor, and it took a separate follow-up fix to raise them. The versioning doc described the floor as hand-maintained with nothing regenerating it, which was accurate.

The new target type-checks each package against the core version it actually declares. It writes a throwaway config holding that package own imports and no workspace field, then points the type-checker at it. With no workspace to resolve against, core comes from the registry rather than the local member, which is exactly the substitution that made the ordinary type-check blind to this class of bug. It needs the network, so it is its own CI job rather than part of the offline gate.

Two details are load-bearing, and I had the first one wrong until a test corrected me. Checking the declared range as written proves nothing, because a caret range resolves to the newest matching version. My first version passed with a deliberately understated floor, which looked like a clean result and was actually a broken check. It now pins the range exact minimum, and that same experiment fails with the missing symbol named. Second, the minimum dependency age is zeroed in the generated config: Deno otherwise refuses a version published within the last day, so left at the default every package declaring a freshly released core would fail spuriously for a day after each release. Both are commented where they live and documented in the versioning guide.

Verification, all local. Fifty-four packages pass against their real declared floors in about fourteen seconds, needing only three registry fetches since the floors collapse to three distinct versions. Understating one floor fails with the offending package, its declared range, and the missing export. Twenty-five unit tests cover the parsing and formatting branches, including ambiguous ranges that are reported rather than guessed at, malformed configs that are skipped rather than thrown, and the absence of the workspace field in the generated config. The full gate passes at sixteen of sixteen.

The wrapper gains the two flags this needs, named after the real CLI flags as the guidelines require, with argv tests and regenerated API docs.

Stacked on the lock-integrity pull request because both touch the build file; it will retarget to the default branch once that merges.

Generated with Claude Code