### PR TITLE
docs(cmd): stop demonstrating the wrapper anti-pattern in the example

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4888,10 +4888,15 @@ interface YarnTasksApi
 `@zuke/cmd` — generic command execution for Zuke builds: the fallback for
 tools that have no dedicated wrapper package.
 
+Check the package catalogue in `llms.txt` before reaching for it. A tool with
+a `@zuke/<tool>` wrapper should be driven through that wrapper — running it
+here instead gives up typed flags and the wrapper's tool resolution, so the
+example below deliberately uses a tool Zuke does not wrap.
+
 ```ts
 import { CmdTasks } from "jsr:@zuke/cmd";
 
-await CmdTasks.exec("git", (s) => s.args("rev-parse", "HEAD"));
+await CmdTasks.exec("shellcheck", (s) => s.args("--severity", "warning"));
 ```
 @module
 

--- a/packages/cmd/README.md
+++ b/packages/cmd/README.md
@@ -26,10 +26,15 @@ Every path argument accepts either a string or an `AbsolutePath` from
 `@zuke/cmd` — generic command execution for Zuke builds: the fallback for
 tools that have no dedicated wrapper package.
 
+Check the package catalogue in `llms.txt` before reaching for it. A tool with
+a `@zuke/<tool>` wrapper should be driven through that wrapper — running it
+here instead gives up typed flags and the wrapper's tool resolution, so the
+example below deliberately uses a tool Zuke does not wrap.
+
 ```ts
 import { CmdTasks } from "jsr:@zuke/cmd";
 
-await CmdTasks.exec("git", (s) => s.args("rev-parse", "HEAD"));
+await CmdTasks.exec("shellcheck", (s) => s.args("--severity", "warning"));
 ```
 @module
 

--- a/packages/cmd/mod.ts
+++ b/packages/cmd/mod.ts
@@ -2,10 +2,15 @@
  * `@zuke/cmd` — generic command execution for Zuke builds: the fallback for
  * tools that have no dedicated wrapper package.
  *
+ * Check the package catalogue in `llms.txt` before reaching for it. A tool with
+ * a `@zuke/<tool>` wrapper should be driven through that wrapper — running it
+ * here instead gives up typed flags and the wrapper's tool resolution, so the
+ * example below deliberately uses a tool Zuke does not wrap.
+ *
  * ```ts
  * import { CmdTasks } from "jsr:@zuke/cmd";
  *
- * await CmdTasks.exec("git", (s) => s.args("rev-parse", "HEAD"));
+ * await CmdTasks.exec("shellcheck", (s) => s.args("--severity", "warning"));
  * ```
  *
  * @module


### PR DESCRIPTION
The module doc for `@zuke/cmd` opened its example by running `git rev-parse HEAD` through `CmdTasks.exec` — but `@zuke/git` exists. Per `AGENTS.md`, reaching for `CmdTasks` when a `@zuke/<tool>` wrapper exists is "a **bug**, not a style choice": it discards typed flags, argv purity, and the wrapper's tool resolution. So the fallback package's headline example was demonstrating exactly what the project forbids, in the one place a reader goes to learn what the fallback is for.

The example now drives `shellcheck`, which Zuke genuinely does not wrap, and the doc says out loud that the package catalogue is worth checking before reaching for the fallback. `llms-full.txt` and the package README are regenerated by the `apiDocs` target.

Secondary purpose, stated plainly: this is the first change since #290 that gives the release's website sync a real diff to push, so it doubles as the end-to-end exercise of the new auto-merge path — open the sync PR, let the website's own build check gate it, and have auto-merge land it. That path has not yet run in production; the previous release short-circuited on "already in sync".

The title is `docs(cmd):` deliberately, so release-please bumps nothing and this exercises the sync without cutting a release.

`deno task ci` green, 16 of 16 targets.
