### PR TITLE
fix: drop the delete-branch flag that --auto never honours

### DIFF
--- a/build/website_sync.ts
+++ b/build/website_sync.ts
@@ -227,8 +227,12 @@ const REAL_DEPS: WebsiteSyncDeps = {
   mergePr: async (repo, branch, dir, token) => {
     // Selected by head branch rather than PR number, so the same call merges a
     // PR this run opened and one an earlier run left open. Squash keeps the
-    // website history one commit per release; `--delete-branch` is explicit
-    // because the website repo does not delete merged branches on its own.
+    // website history one commit per release.
+    //
+    // No `--delete-branch`: `gh` implements that by deleting the branch itself
+    // once the merge returns, which never happens under `--auto` — it hands the
+    // merge to GitHub and exits. The website repo has `delete_branch_on_merge`
+    // instead, which is what actually reaps `zuke-sync/*`.
     //
     // `--auto` rather than a straight merge: the website repo's ruleset
     // requires its `Build the site` check, which builds the very artifacts this
@@ -242,7 +246,6 @@ const REAL_DEPS: WebsiteSyncDeps = {
         .repo(repo)
         .flag("auto")
         .flag("squash")
-        .flag("delete-branch")
         .cwd(dir)
         .env({ GH_TOKEN: token })
         .noThrow()


### PR DESCRIPTION
The first production run of the automated website sync merged its PR correctly but left the `zuke-sync/1.32.1` branch behind on the website repo.

Cause: `gh` implements `--delete-branch` by deleting the branch itself after the merge call returns. Under `--auto` it does not wait for a merge — it registers the request with GitHub and exits — so it is never around to delete anything. Left as-is, one branch would accumulate per core version.

Branch cleanup under auto-merge is GitHub's responsibility, driven by the repository's `delete_branch_on_merge` setting. That is now enabled on `zuke-build.github.io`, and this removes the flag rather than leaving it to document an intent it cannot deliver. The stale branch has been deleted.

Found by the deliberate dry run in #291 rather than by an unattended release.