### PR TITLE
feat: generate the website's package grid from the package list

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,8 @@ jobs:
       - name: Publish new versions to JSR with Zuke
         run: ./zuke publishJsr
 
-  # Push refreshed docs (llms.txt/llms-full.txt) and api.json to the website by
+  # Push refreshed docs (llms.txt/llms-full.txt), api.json, and the landing
+  # page's generated package grid (src/data/tools.ts) to the website by
   # opening a PR on the separate `zuke-build.github.io` repo — and merging it, so
   # a release needs no manual step there. The default GITHUB_TOKEN cannot push
   # cross-repo, so we mint a short-lived installation token from the "Zuke Build"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -375,14 +375,18 @@ plugins/zuke/             # Claude Code plugin wrapping the skills
   version is bumped. The repo squash-merges, so the squash body comes from the
   PR description/commits: put illustrative code in the PR discussion, and keep
   commit bodies to prose. See [`RELEASING.md`](RELEASING.md).
-- **A new package must be added everywhere.** Membership is declared in six
+- **A new package must be added everywhere.** Membership is declared in seven
   places that must stay in lock-step: the `deno.json` workspace,
   `.release-please-config.json`, `.release-please-manifest.json`, the `PACKAGES`
   array in `zuke.ts` (the JSR publish loop), the package table in `README.md`,
-  and the list in `tests/release_config_test.ts`. `tests/release_config_test.ts`
-  enforces that all six agree — run it after adding a package. Omitting
-  `zuke.ts` means the package is released but never published; omitting the
-  `README.md` table means it is invisible to anyone browsing the repo.
+  the list in `tests/release_config_test.ts`, and the landing-page catalogue in
+  `build/website_tools.ts` (`TOOL_GROUPS` for a CLI wrapper, `CORE_PACKAGES` for
+  an engine or plugin package). `tests/release_config_test.ts` and
+  `tests/build_tools_test.ts` enforce that all seven agree — run them after
+  adding a package. Omitting `zuke.ts` means the package is released but never
+  published; omitting the `README.md` table means it is invisible to anyone
+  browsing the repo; omitting `build/website_tools.ts` fails the gate, because
+  the website's package grid is generated from it by `syncWebsite`.
 - **Update docs with code.** If behaviour changes, update `README.md`, JSDoc,
   and the spec/acceptance criteria in the same PR.
 - **Always read the reviewer comments on every PR.** This repo runs AI reviewers

--- a/build/website_sync.ts
+++ b/build/website_sync.ts
@@ -227,8 +227,12 @@ const REAL_DEPS: WebsiteSyncDeps = {
   mergePr: async (repo, branch, dir, token) => {
     // Selected by head branch rather than PR number, so the same call merges a
     // PR this run opened and one an earlier run left open. Squash keeps the
-    // website history one commit per release; `--delete-branch` is explicit
-    // because the website repo does not delete merged branches on its own.
+    // website history one commit per release.
+    //
+    // No `--delete-branch`: `gh` implements that by deleting the branch itself
+    // once the merge returns, which never happens under `--auto` — it hands the
+    // merge to GitHub and exits. The website repo has `delete_branch_on_merge`
+    // instead, which is what actually reaps `zuke-sync/*`.
     //
     // `--auto` rather than a straight merge: the website repo's ruleset
     // requires its `Build the site` check, which builds the very artifacts this
@@ -242,7 +246,6 @@ const REAL_DEPS: WebsiteSyncDeps = {
         .repo(repo)
         .flag("auto")
         .flag("squash")
-        .flag("delete-branch")
         .cwd(dir)
         .env({ GH_TOKEN: token })
         .noThrow()

--- a/build/website_sync.ts
+++ b/build/website_sync.ts
@@ -12,7 +12,8 @@ import { GitTasks } from "@zuke/git";
 import { GhTasks } from "@zuke/gh";
 import { collectPackageDocs, docsOptions } from "./docs.ts";
 import { writeApiJson } from "./api_reference.ts";
-import { localVersion } from "./packages.ts";
+import { localVersion, PACKAGES } from "./packages.ts";
+import { renderToolsModule } from "./website_tools.ts";
 
 /** The website repo the sync targets, absent an override. */
 export const DEFAULT_WEBSITE_REPO = "zuke-build/zuke-build.github.io";
@@ -170,6 +171,13 @@ const REAL_DEPS: WebsiteSyncDeps = {
     await FileTasks.copy("llms.txt", `${dir}/public/llms.txt`);
     await FileTasks.copy("llms-full.txt", `${dir}/public/llms-full.txt`);
     await FileTasks.copy("dist/api.json", `${dir}/src/data/api.json`);
+    // The landing page's package grid. Generated from this repo's catalogue so
+    // dropping a package updates the site in the same release, rather than the
+    // website keeping its own list that quietly advertises a dead package.
+    await FileTasks.writeText(
+      `${dir}/src/data/tools.ts`,
+      renderToolsModule(PACKAGES),
+    );
   },
   stageAll: async (dir) => {
     await GitTasks.add((s) => s.dir(dir).all());

--- a/build/website_tools.ts
+++ b/build/website_tools.ts
@@ -1,0 +1,415 @@
+/**
+ * The landing page's package catalogue, and the generator that renders it into
+ * the website's `src/data/tools.ts`.
+ *
+ * The copy lives here, next to the packages it describes, so that adding or
+ * removing a `@zuke/*` package updates the website in the same change — the
+ * website used to keep its own hand-maintained list, which silently kept
+ * advertising a package after it was dropped. {@linkcode renderToolsModule}
+ * refuses to render a catalogue that disagrees with the real package list, so
+ * the drift fails the gate instead of reaching the page.
+ */
+
+/** One package as the landing page presents it. */
+export interface ToolEntry {
+  /** The tool's display name, as a reader would say it ("Docker Compose"). */
+  name: string;
+  /** The JSR package that wraps it, e.g. `@zuke/docker-compose`. */
+  pkg: string;
+  /** A few words on what the wrapper covers — a grid cell, not a sentence. */
+  desc: string;
+}
+
+/** A capability heading on the landing page, with the tools filed under it. */
+export interface ToolGroup {
+  /** The heading, e.g. "Containers & orchestration". */
+  category: string;
+  /** One line under the heading framing the category. */
+  blurb: string;
+  /** The tools in the group, in display order. */
+  tools: ToolEntry[];
+}
+
+/** A first-party engine or plugin package — everything that is not a CLI wrapper. */
+export interface CorePackage {
+  /** The JSR package name, e.g. `@zuke/core`. */
+  name: string;
+  /** What it is, in a phrase. */
+  desc: string;
+}
+
+/** The CLI wrappers, grouped by capability, in landing-page order. */
+export const TOOL_GROUPS: ToolGroup[] = [
+  {
+    category: "Runtimes & package managers",
+    blurb: "Install, run, and publish across every major JS toolchain.",
+    tools: [
+      {
+        name: "Deno",
+        pkg: "@zuke/deno",
+        desc: "run, test, check, fmt, lint, coverage",
+      },
+      {
+        name: "Node",
+        pkg: "@zuke/node",
+        desc: "run scripts, npx, version pinning",
+      },
+      {
+        name: "npm",
+        pkg: "@zuke/npm",
+        desc: "install, ci, run scripts, publish",
+      },
+      { name: "Bun", pkg: "@zuke/bun", desc: "install, add, run, x, bun test" },
+      {
+        name: "pnpm",
+        pkg: "@zuke/pnpm",
+        desc: "frozen installs, dlx, --filter",
+      },
+      {
+        name: "Yarn",
+        pkg: "@zuke/yarn",
+        desc: "Classic & Berry: install, add, dlx",
+      },
+      {
+        name: "npx",
+        pkg: "@zuke/npx",
+        desc: "download & run a package binary in one step",
+      },
+    ],
+  },
+  {
+    category: "Bundlers & monorepo",
+    blurb: "Bundle apps and orchestrate monorepos from a typed pipeline.",
+    tools: [
+      { name: "Vite", pkg: "@zuke/vite", desc: "dev, build, preview" },
+      { name: "tsup", pkg: "@zuke/tsup", desc: "zero-config bundling" },
+      {
+        name: "tsdown",
+        pkg: "@zuke/tsdown",
+        desc: "fast TS bundling on Rolldown",
+      },
+      { name: "Turbo", pkg: "@zuke/turbo", desc: "run, prune" },
+      { name: "Nx", pkg: "@zuke/nx", desc: "run, runMany, affected" },
+    ],
+  },
+  {
+    category: "TypeScript runners & compilers",
+    blurb:
+      "Execute, type-check, and compile TypeScript with or without a build step.",
+    tools: [
+      { name: "tsx", pkg: "@zuke/tsx", desc: "run TS on Node, watch" },
+      // Since TypeScript 7.0 this binary is the native Go compiler.
+      {
+        name: "tsc",
+        pkg: "@zuke/tsc",
+        desc: "the TypeScript compiler, now Go-native, --build",
+      },
+      {
+        name: "tsc-alias",
+        pkg: "@zuke/tsc-alias",
+        desc: "rewrite path aliases after tsc",
+      },
+    ],
+  },
+  {
+    category: "Frameworks & code generation",
+    blurb: "Scaffold app frameworks and generate typed clients from a schema.",
+    tools: [
+      {
+        name: "Nest",
+        pkg: "@zuke/nest",
+        desc: "NestJS: build, start, generate",
+      },
+      {
+        name: "openapi-ts",
+        pkg: "@zuke/openapi-ts",
+        desc: "OpenAPI → typed TS client",
+      },
+      {
+        name: "Orval",
+        pkg: "@zuke/orval",
+        desc: "generate API clients & mocks",
+      },
+      { name: "docs", pkg: "@zuke/docs", desc: "generate API documentation" },
+    ],
+  },
+  {
+    category: "AI coding, review & self-healing",
+    blurb:
+      "Fold the major AI coding CLIs into a build, gate it on a model-assessed review, or let a fixer heal failures.",
+    tools: [
+      {
+        name: "Claude Code",
+        pkg: "@zuke/claude",
+        desc: "headless run, model & tool limits, MCP",
+      },
+      {
+        name: "OpenAI Codex",
+        pkg: "@zuke/codex",
+        desc: "codex exec headless, MCP config",
+      },
+      {
+        name: "Gemini CLI",
+        pkg: "@zuke/gemini",
+        desc: "headless prompt, MCP & extensions",
+      },
+      {
+        name: "AI review",
+        pkg: "@zuke/ai",
+        desc: "code-review gate with a structured risk score",
+      },
+      {
+        name: "Self-healing",
+        pkg: "@zuke/ai",
+        desc:
+          "diagnose, suggest & auto-fix failed builds, then re-run to verify",
+      },
+    ],
+  },
+  {
+    category: "Lint, format & quality",
+    blurb:
+      "Keep the tree clean with linters, formatters, and dead-code checks.",
+    tools: [
+      { name: "oxlint", pkg: "@zuke/oxlint", desc: "ultra-fast Rust linter" },
+      { name: "ESLint", pkg: "@zuke/eslint", desc: "configs, --fix, caching" },
+      { name: "Biome", pkg: "@zuke/biome", desc: "check, format, lint, ci" },
+      { name: "dprint", pkg: "@zuke/dprint", desc: "fmt, check" },
+      { name: "cspell", pkg: "@zuke/cspell", desc: "spell-check your sources" },
+      { name: "Knip", pkg: "@zuke/knip", desc: "find unused files & exports" },
+      {
+        name: "dpdm",
+        pkg: "@zuke/dpdm",
+        desc: "detect circular deps & dependency trees",
+      },
+    ],
+  },
+  {
+    category: "Test, coverage & browsers",
+    blurb:
+      "Run unit and end-to-end suites, then upload coverage to your dashboard.",
+    tools: [
+      {
+        name: "Jest",
+        pkg: "@zuke/jest",
+        desc: "projects, coverage thresholds",
+      },
+      { name: "Vitest", pkg: "@zuke/vitest", desc: "watch, coverage, UI" },
+      {
+        name: "Playwright",
+        pkg: "@zuke/playwright",
+        desc: "test, codegen, reports",
+      },
+      { name: "Cypress", pkg: "@zuke/cypress", desc: "run, open, verify" },
+      {
+        name: "Codecov",
+        pkg: "@zuke/codecov",
+        desc: "upload coverage via codecovcli, flags, token from env",
+      },
+    ],
+  },
+  {
+    category: "Containers & orchestration",
+    blurb: "Build images and ship to clusters from a typed pipeline.",
+    tools: [
+      { name: "Docker", pkg: "@zuke/docker", desc: "build, tag, push, run" },
+      {
+        name: "Docker Compose",
+        pkg: "@zuke/docker-compose",
+        desc: "up, down, logs",
+      },
+      {
+        name: "kubectl",
+        pkg: "@zuke/kubectl",
+        desc: "apply, get, rollout, logs",
+      },
+      {
+        name: "Helm",
+        pkg: "@zuke/helm",
+        desc: "install, upgrade, template, lint",
+      },
+      {
+        name: "Kustomize",
+        pkg: "@zuke/kustomize",
+        desc: "build, editSetImage",
+      },
+    ],
+  },
+  {
+    category: "Cloud & infrastructure",
+    blurb: "Provision and deploy with infra-as-code, typed end to end.",
+    tools: [
+      { name: "gcloud", pkg: "@zuke/gcloud", desc: "deploy, run, IAM" },
+      {
+        name: "Terraform",
+        pkg: "@zuke/terraform",
+        desc: "init, plan, apply, destroy",
+      },
+      { name: "OpenTofu", pkg: "@zuke/tofu", desc: "open-source Terraform" },
+    ],
+  },
+  {
+    category: "Version control, registry & CI",
+    blurb: "Script Git, GitHub, and publishing straight from your build.",
+    tools: [
+      { name: "Git", pkg: "@zuke/git", desc: "commit, tag, push, gitInfo()" },
+      { name: "GitHub CLI", pkg: "@zuke/gh", desc: "releases, PRs, workflows" },
+      { name: "Husky", pkg: "@zuke/husky", desc: "install & manage git hooks" },
+      { name: "JSR", pkg: "@zuke/jsr", desc: "publish, add, remove" },
+      {
+        name: "release-please",
+        pkg: "@zuke/release-please",
+        desc: "release PRs & GitHub releases",
+      },
+    ],
+  },
+  {
+    category: "Supply-chain security",
+    blurb: "Scan workflows, secrets, and dependencies as part of the gate.",
+    tools: [
+      {
+        name: "Security",
+        pkg: "@zuke/security",
+        desc: "zizmor, gitleaks, trivy, semgrep, osv-scanner",
+      },
+    ],
+  },
+];
+
+/** The engine and plugin packages, shown apart from the wrapper grid. */
+export const CORE_PACKAGES: CorePackage[] = [
+  {
+    name: "@zuke/core",
+    desc: "the Build base class, target() graph, $ shell, and cicd()",
+  },
+  {
+    name: "@zuke/cli",
+    desc:
+      "the global zuke command: setup, run targets, --list, graph, generate-ci",
+  },
+  {
+    name: "@zuke/cmd",
+    desc: "the typed process layer the wrappers are built on",
+  },
+  {
+    name: "@zuke/console",
+    desc:
+      "markup, rules, boxes & tables — the levelled logger behind Zuke's output",
+  },
+  {
+    name: "@zuke/otel",
+    desc:
+      "OpenTelemetry export plugin — run & target spans over OTLP, joined across resume",
+  },
+];
+
+/** Every `@zuke/*` package the catalogue mentions, deduped. */
+export function curatedPackages(): Set<string> {
+  return new Set([
+    ...TOOL_GROUPS.flatMap((group) => group.tools.map((tool) => tool.pkg)),
+    ...CORE_PACKAGES.map((entry) => entry.name),
+  ]);
+}
+
+/**
+ * How the catalogue differs from the real package list: packages with no entry
+ * (they would be missing from the site) and entries naming a package that no
+ * longer exists (the site would advertise it after it was dropped).
+ */
+export function catalogueDrift(
+  packages: readonly string[],
+): { missing: string[]; unknown: string[] } {
+  const real = new Set(packages.map((pkg) => `@zuke/${pkg}`));
+  const curated = curatedPackages();
+  return {
+    missing: [...real].filter((pkg) => !curated.has(pkg)).sort(),
+    unknown: [...curated].filter((pkg) => !real.has(pkg)).sort(),
+  };
+}
+
+/**
+ * Render an object literal with bare keys, matching the style the file was
+ * hand-written in. Keeping the shape means a sync PR diffs only the entries
+ * that actually changed, instead of reformatting all of them once.
+ */
+function renderEntry(fields: Record<string, string>, indent: string): string {
+  const body = Object.entries(fields)
+    .map(([key, value]) => `${key}: ${JSON.stringify(value)}`)
+    .join(", ");
+  return `${indent}{ ${body} },`;
+}
+
+/**
+ * Render the website's `src/data/tools.ts`, the module its landing page imports
+ * for the package grid. Throws when the catalogue and `packages` disagree, so a
+ * package added or dropped in this repo cannot ship a stale page.
+ */
+export function renderToolsModule(packages: readonly string[]): string {
+  const { missing, unknown } = catalogueDrift(packages);
+  if (missing.length > 0 || unknown.length > 0) {
+    const parts = [
+      missing.length > 0
+        ? `no landing-page entry for ${missing.join(", ")} — add one to ` +
+          `TOOL_GROUPS or CORE_PACKAGES in build/website_tools.ts`
+        : "",
+      unknown.length > 0
+        ? `entries for packages that no longer exist: ${unknown.join(", ")}`
+        : "",
+    ].filter((part) => part !== "");
+    throw new Error(
+      `The website package catalogue is out of date — ${parts.join("; ")}.`,
+    );
+  }
+
+  const groups = TOOL_GROUPS.map((group) =>
+    [
+      "  {",
+      `    category: ${JSON.stringify(group.category)},`,
+      `    blurb: ${JSON.stringify(group.blurb)},`,
+      "    tools: [",
+      ...group.tools.map((tool) =>
+        renderEntry(
+          { name: tool.name, pkg: tool.pkg, desc: tool.desc },
+          "      ",
+        )
+      ),
+      "    ],",
+      "  },",
+    ].join("\n")
+  ).join("\n");
+
+  const core = CORE_PACKAGES
+    .map((entry) => renderEntry({ name: entry.name, desc: entry.desc }, "  "))
+    .join("\n");
+
+  return `// Generated by \`zuke syncWebsite\` from build/website_tools.ts in
+// zuke-build/zuke — do not edit by hand; the next release overwrites it.
+
+/**
+ * The Zuke tool-wrapper ecosystem — typed packages published to JSR under the
+ * \`@zuke/*\` scope. Each wraps a real CLI with a fluent, strongly-typed API so
+ * build steps are refactor-safe and editor-completable.
+ */
+export interface ToolGroup {
+  category: string;
+  blurb: string;
+  tools: { name: string; pkg: string; desc: string }[];
+}
+
+export const toolGroups: ToolGroup[] = [
+${groups}
+];
+
+/** The first-party engine and plugin packages — everything that isn't a CLI wrapper. */
+export const corePackages = [
+${core}
+];
+
+/** Total distinct @zuke package count, for display (some packages, e.g.
+ * @zuke/ai, appear under more than one capability, so dedupe by name). */
+export const packageCount = new Set([
+  ...toolGroups.flatMap((g) => g.tools.map((t) => t.pkg)),
+  ...corePackages.map((p) => p.name),
+]).size;
+`;
+}

--- a/tests/build_tools_test.ts
+++ b/tests/build_tools_test.ts
@@ -12,6 +12,7 @@ import { Build } from "@zuke/core";
 import {
   assertEquals,
   assertRejects,
+  assertStringIncludes,
   assertThrows,
 } from "../packages/core/tests/_assert.ts";
 import {
@@ -41,6 +42,11 @@ import {
   syncBranchInfo,
   type WebsiteSyncDeps,
 } from "../build/website_sync.ts";
+import {
+  catalogueDrift,
+  curatedPackages,
+  renderToolsModule,
+} from "../build/website_tools.ts";
 import {
   cliReference,
   crossPackageTypesOf,
@@ -765,6 +771,56 @@ Deno.test("runWebsiteSync: a failed merge fails the job and still cleans up", as
     // The `finally` still runs on the throw — no leaked temp clone.
     assertEquals(calls.removeDir, ["/tmp/fake-sync-dir"]);
   });
+});
+
+// ---------------------------------------------------------------------------
+// build/website_tools.ts
+// ---------------------------------------------------------------------------
+
+Deno.test("the landing-page catalogue covers exactly the published packages", () => {
+  // The guard that makes the website self-updating worth anything: add a
+  // package without landing-page copy, or drop one and leave its entry, and the
+  // gate fails here rather than the site quietly advertising the wrong set.
+  assertEquals(catalogueDrift(PACKAGES), { missing: [], unknown: [] });
+});
+
+Deno.test("catalogueDrift names a package with no entry and an entry with no package", () => {
+  const drift = catalogueDrift(["core", "brand-new-tool"]);
+  assertEquals(drift.missing, ["@zuke/brand-new-tool"]);
+  // Everything curated beyond `core` is now unknown — spot-check one.
+  assertEquals(drift.unknown.includes("@zuke/deno"), true);
+  assertEquals(drift.unknown.includes("@zuke/core"), false);
+});
+
+Deno.test("renderToolsModule refuses to render a stale catalogue", () => {
+  assertThrows(
+    () => renderToolsModule([...PACKAGES, "brand-new-tool"]),
+    Error,
+    "no landing-page entry for @zuke/brand-new-tool",
+  );
+  assertThrows(
+    () => renderToolsModule(PACKAGES.filter((pkg) => pkg !== "deno")),
+    Error,
+    "packages that no longer exist: @zuke/deno",
+  );
+});
+
+Deno.test("renderToolsModule emits the exports the landing page imports", () => {
+  const module = renderToolsModule(PACKAGES);
+  // index.astro imports these three by name; renaming one breaks the site.
+  assertStringIncludes(module, "export const toolGroups: ToolGroup[] = [");
+  assertStringIncludes(module, "export const corePackages = [");
+  assertStringIncludes(module, "export const packageCount = new Set([");
+  assertStringIncludes(module, "do not edit by hand");
+  // A dropped package must not survive anywhere in the generated copy.
+  assertEquals(module.includes("@zuke/tsgo"), false);
+  assertEquals(curatedPackages().has("@zuke/deno"), true);
+});
+
+Deno.test("renderToolsModule output is deterministic", () => {
+  // The sync diffs this file against the website's copy to decide whether a PR
+  // is needed, so unstable output would open an empty PR every release.
+  assertEquals(renderToolsModule(PACKAGES), renderToolsModule(PACKAGES));
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Dropping `@zuke/tsgo` updated the workspace, the release config, the publish loop, the README table and the release-config test — and the website kept advertising it anyway, because the landing page's package grid is a separate hand-maintained list in the website repo that nothing keeps honest. The API reference on that site was already correct, since `api.json` is generated and synced; only the grid drifted.

So the grid moves to where the packages are. `build/website_tools.ts` holds the catalogue — categories, display names and the short descs, ported from the website file unchanged — and `syncWebsite` renders it into the website's `src/data/tools.ts` alongside the artifacts it already copies. Adding or dropping a package now updates the landing page in the same release, with no website edit.

The generator refuses to render a catalogue that disagrees with the real package list: a package with no entry would be missing from the site, and an entry for a package that no longer exists is exactly today's bug. `tests/build_tools_test.ts` runs that check against `PACKAGES`, so the drift fails the gate here rather than reaching the page. `AGENTS.md`'s membership rule goes from six places to seven and names the new one.

Rendering keeps the file's hand-written shape — bare keys, one entry per line — so a sync PR diffs only the entries that changed instead of reformatting all of them once.

Verified against the real website checkout rather than in the abstract: generating over the current `src/data/tools.ts` produces a four-line diff, which is the generated-file header, the corrected `tsc` desc, and the removed `tsgo` entry, and nothing else — so the port is faithful. `./zuke build` in the website repo then passes `astro check` and the build, the rendered `dist/index.html` contains no `tsgo`, and the page count corrects itself from 55 to 54. The website checkout was left untouched; the next release writes the file for real.

`deno task ci` green, 16 of 16 targets, 43 tests in the build-tools suite.
