### PR TITLE
fix(gh): send app-token permissions under the API's own spelling

### DIFF
--- a/build/website_sync.ts
+++ b/build/website_sync.ts
@@ -142,7 +142,7 @@ export async function mintWebsiteToken(
       .owner(owner)
       .repositories(name)
       .permission("contents", "write")
-      .permission("pull-requests", "write")
+      .permission("pull_requests", "write")
   );
   return token;
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8905,6 +8905,13 @@ class GhAppTokenSettings
     Request one permission, e.g. `.permission("contents", "write")`. Repeatable.
     Narrowing to what the target needs beats inheriting the app's full set;
     requesting more than the installation grants is an error from GitHub.
+
+    The API names multi-word permissions with underscores (`pull_requests`), so
+    a hyphen is normalised to one. That spelling is the trap here:
+    `create-github-app-token` takes its inputs as `permission-pull-requests`,
+    and passing that form straight through is rejected as a permission the
+    installation does not grant — which reads as a misconfigured app rather
+    than a misspelled key.
   baseUrl(url: string): this
     Use a different REST base (GitHub Enterprise Server).
   fetch(fn: typeof fetch): this

--- a/packages/gh/README.md
+++ b/packages/gh/README.md
@@ -151,6 +151,13 @@ class GhAppTokenSettings
     Request one permission, e.g. `.permission("contents", "write")`. Repeatable.
     Narrowing to what the target needs beats inheriting the app's full set;
     requesting more than the installation grants is an error from GitHub.
+
+    The API names multi-word permissions with underscores (`pull_requests`), so
+    a hyphen is normalised to one. That spelling is the trap here:
+    `create-github-app-token` takes its inputs as `permission-pull-requests`,
+    and passing that form straight through is rejected as a permission the
+    installation does not grant — which reads as a misconfigured app rather
+    than a misspelled key.
   baseUrl(url: string): this
     Use a different REST base (GitHub Enterprise Server).
   fetch(fn: typeof fetch): this

--- a/packages/gh/src/app_token.ts
+++ b/packages/gh/src/app_token.ts
@@ -208,9 +208,16 @@ export class GhAppTokenSettings {
    * Request one permission, e.g. `.permission("contents", "write")`. Repeatable.
    * Narrowing to what the target needs beats inheriting the app's full set;
    * requesting more than the installation grants is an error from GitHub.
+   *
+   * The API names multi-word permissions with underscores (`pull_requests`), so
+   * a hyphen is normalised to one. That spelling is the trap here:
+   * `create-github-app-token` takes its inputs as `permission-pull-requests`,
+   * and passing that form straight through is rejected as a permission the
+   * installation does not grant — which reads as a misconfigured app rather
+   * than a misspelled key.
    */
   permission(name: string, level: GhPermissionLevel): this {
-    this.permissions_[name] = level;
+    this.permissions_[name.replace(/-/g, "_")] = level;
     return this;
   }
 

--- a/packages/gh/tests/app_token_test.ts
+++ b/packages/gh/tests/app_token_test.ts
@@ -139,8 +139,39 @@ Deno.test("appToken signs a JWT, resolves the installation, and mints a token", 
   // The mint narrows to exactly the requested repositories and permissions.
   assertEquals(JSON.parse(seen[1].body ?? "{}"), {
     repositories: ["zuke-build.github.io"],
-    permissions: { "contents": "write", "pull-requests": "write" },
+    permissions: { contents: "write", pull_requests: "write" },
   });
+});
+
+Deno.test("a hyphenated permission is sent under the API's own spelling", async () => {
+  // The trap: `create-github-app-token` takes `permission-pull-requests`, and
+  // passing that spelling to the API is refused as a permission the
+  // installation does not grant — a 422 that reads as a misconfigured app
+  // rather than a misspelled key. Asserting the *shape* of every key is what
+  // catches this class of mistake, since a fake transport accepts anything.
+  const { pkcs8 } = await testKeys();
+  const seen: Seen[] = [];
+  await GhTasks.appToken((s) =>
+    s
+      .appId("1")
+      .privateKey(pkcs8)
+      .owner("acme")
+      .permission("pull-requests", "write")
+      .permission("secret-scanning-alerts", "read")
+      .fetch(fakeGithub(seen))
+  );
+  const body: unknown = JSON.parse(seen[1].body ?? "{}");
+  if (
+    typeof body !== "object" || body === null || !("permissions" in body) ||
+    typeof body.permissions !== "object" || body.permissions === null
+  ) {
+    throw new Error("expected a permissions object");
+  }
+  const keys = Object.keys(body.permissions).sort();
+  assertEquals(keys, ["pull_requests", "secret_scanning_alerts"]);
+  // Every key the API accepts is lower-case with underscores; a hyphen in any
+  // of them is the bug this guards.
+  for (const key of keys) assertEquals(/^[a-z_]+$/.test(key), true, key);
 });
 
 Deno.test("appToken reads the PKCS#1 PEM GitHub actually issues", async () => {

--- a/zuke.ts
+++ b/zuke.ts
@@ -195,7 +195,16 @@ class ZukeBuild extends Build {
       // instead of silently running nowhere until someone remembers to add it
       // here.
       const paths = await glob("tests/e2e/*_e2e.ts");
-      await DenoTasks.test((s) => s.allowAll().paths(...paths));
+      // Blank GITHUB_STEP_SUMMARY for the suite, as the `test` target does.
+      // These fixtures are whole builds run as real subprocesses, so each one
+      // appends its own result table to the Actions summary — including the
+      // ones that are *meant* to fail or suspend (a target reaped by a timeout,
+      // a `waitsFor` gate that never opens). The job then displays a red,
+      // half-finished build table while passing, which reads as a broken suite
+      // and buries the one table that describes the actual run.
+      await DenoTasks.test((s) =>
+        s.allowAll().paths(...paths).env({ GITHUB_STEP_SUMMARY: "" })
+      );
     });
 
   // The dedicated workflow for the `integration` target, generated from this


### PR DESCRIPTION
Two fixes found by watching what the merged prep change actually did in CI. Unrelated to each other, both one-liners with the reasoning in the tests.

## The release failed at the website sync

Minting the installation token returned `422 Unprocessable Entity` — "The permissions requested are not granted to this installation". The app grants them fine; the key was misspelled.

GitHub's REST API names multi-word permissions with underscores, `pull_requests`. The `create-github-app-token` action takes its inputs hyphenated, `permission-pull-requests`. Moving the mint into code carried the step's spelling into the API call, which asked for a permission that does not exist — and the error blames the installation rather than the key, so it reads as a misconfigured app.

The call site now uses the API's spelling, and the setter normalises a hyphen to an underscore so either form works. That normalisation is worth having: the hyphenated form is the one anyone arriving from the action will reach for.

**The old test encoded the bug rather than catching it.** It asserted the request body contained the hyphenated key, which a fake transport accepts as readily as a real one — so it passed while the call was wrong. The replacement asserts the *shape* of every permission key, which is what catches this class of mistake without a live app:

    for (const key of keys) assertEquals(/^[a-z_]+$/.test(key), true, key);

The version bump and the JSR publish in that release both succeeded; only the sync job failed, so the effect was the website docs not being refreshed. Once this lands, that job can be re-run.

## The E2E job summaries looked like failing builds

Each E2E job showed several build tables, one of them red, while the job passed — including a `0/1 targets` table with a failed `timeout` target, and tables with `Waiting` and `Skipped` rows.

Those are the fixtures' own build tables. Every e2e fixture is a whole build ending in `run(...)`, spawned as a real subprocess, so it inherits `GITHUB_STEP_SUMMARY` and appends its own result table to the job summary. Several of them are *meant* to fail or suspend — a target reaped by a timeout, a `waitsFor` gate that never opens — so the summary showed exactly the alarming thing they exist to prove.

Reproduced before fixing, which matched the reported output line for line, including the duration:

    ## ❌ Zuke build — 0/1 targets in 5.2s
    | timeout | ✘ Failed | 5.2s |

The `test` target already blanked that variable for its subprocess, with a comment explaining why; the `integration` target did not. It now does. Verified under a simulated Actions environment: the summary carries exactly one table, the run's own, and no fixture tables. This is a pre-existing bug rather than fallout from the previous change — it just became visible once the summary was worth reading.
