### PR TITLE
fix: name the Marketplace listing "Zuke Build"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: "Zuke"
+name: "Zuke Build"
 description: "Harden the runner, check out the repository, and run a Zuke target."
 branding:
   icon: terminal

--- a/tests/action_manifest_test.ts
+++ b/tests/action_manifest_test.ts
@@ -91,10 +91,14 @@ function brandingValue(key: string): string | undefined {
 Deno.test("the manifest names the action as the Marketplace listing does", () => {
   // The listing's unique identifier. Changing it is not a rename but a new
   // listing, so it is worth pinning to the value that was actually published.
+  // "Zuke" alone is rejected: the uniqueness check spans users and
+  // organizations as well as listings, and github.com/zuke is a real account.
+  // "Zuke Build" slugs to this repository's own org, which the rule exempts
+  // because that owner is the one publishing.
   assertEquals(
-    /^name: "Zuke"$/m.test(MANIFEST),
+    /^name: "Zuke Build"$/m.test(MANIFEST),
     true,
-    'action.yml does not declare `name: "Zuke"`',
+    'action.yml does not declare `name: "Zuke Build"`',
   );
 });
 


### PR DESCRIPTION
## What

`name: "Zuke"` → `name: "Zuke Build"` in `action.yml`, and the test that pins it.

## Why

The publish form rejected `Zuke`:

> Name must be unique. Cannot match an existing action, user or organization name.

The rule is wider than an existing listing. `github.com/zuke` is a real **User** account, so the name collides there — which is why a Marketplace search for `zuke` returned nothing while the form still refused it. The collision was never on the Marketplace.

`Zuke Build` slugs to `zuke-build`, this repository's own organization. GitHub's rule exempts a name matching a user or organization **when that owner is the one publishing the action**, so this should be accepted. Verified as unclaimed if it is not: `run-zuke`, `zuke-ci`, `zuke-action`, `zuke-build-action`. `Run Zuke` is the fallback.

## Follow-up after merge

The name only takes effect at the tag. `v1.0.0` and `v1` currently point at `cb0cb2b`, where the name is still `Zuke`, so both need re-pointing at this squash before the release is drafted. Safe to move — `gh release view v1.0.0` reports no release object for either tag yet.

`./zuke ci` green, 17/17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)