### PR TITLE
feat: version the Marketplace action from the build, and let it check out a ref

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -81,17 +81,25 @@ runs:
     # mistake rather than the mistake.
     #
     # Hence: the refusal ignores `target`, and names the events rather than the
-    # steps. `pull_request` and `push` are absent from the list deliberately — a
-    # fork pull request receives no secrets and a read-only token, and pushing
-    # requires write access already. `workflow_dispatch`, `schedule` and
-    # `release` are absent too: their ref is chosen by someone who can already
-    # push.
+    # steps. It is an allowlist, not a denylist, because a denylist of the
+    # events that are dangerous today is wrong the moment GitHub adds one —
+    # and the failure is silent, since the guard simply does not fire. Listing
+    # the events where the ref can only come from someone who can already push
+    # means anything unrecognised is refused instead.
+    #
+    # Why each of these is safe: `pull_request` gives a fork no secrets and a
+    # read-only token; `push` and `merge_group` require write access;
+    # `workflow_dispatch`, `schedule` and `release` are triggered by someone
+    # who could push the same code directly. Everything else — `issue_comment`
+    # and the `/build` slash-command pattern, `workflow_run`,
+    # `pull_request_target`, the discussion and review events — lets a
+    # contributor's text choose what gets checked out while the job holds this
+    # repository's secrets.
     - name: Refuse an untrusted checkout on a secret-bearing event
       if: >-
-        inputs.ref != '' && contains(fromJSON('[
-          "pull_request_target", "issue_comment", "issues", "workflow_run",
-          "discussion", "discussion_comment", "pull_request_review",
-          "pull_request_review_comment"
+        inputs.ref != '' && !contains(fromJSON('[
+          "pull_request", "push", "merge_group",
+          "workflow_dispatch", "schedule", "release"
         ]'), github.event_name)
       shell: bash
       # Through the environment, not the script text — the same rule the run

--- a/action.yml
+++ b/action.yml
@@ -15,9 +15,13 @@ branding:
 # It is also a usable composite action in its own right, published to the GitHub
 # Marketplace. A repository that builds with Zuke can make this its first step —
 # `uses: zuke-build/zuke@<sha>` needs no prior checkout, since a remote action is
-# fetched by the runner. This repository cannot use it that way for hardening:
-# `uses: ./` resolves inside the workspace, so it would require the checkout it
-# is meant to precede.
+# fetched by the runner. That is how this repository's own generated workflows
+# now start, so the action is exercised on every run here rather than only by
+# strangers. It is the remote form that makes that possible: `uses: ./` resolves
+# inside the workspace and would need the very checkout this is meant to
+# precede, which is why the workflows inlined these steps until it was
+# published. Their pin comes from `build/action_version.json`, since this file
+# cannot pin the action to itself.
 #
 # The action is versioned by a plain `v1` tag (and the `v1.x.y` it points at),
 # which is the tag consumers write. That namespace is the action's alone: the
@@ -46,6 +50,10 @@ inputs:
     description: "Commits to fetch. `0` is the full history, which a secret scan needs."
     required: false
     default: "1"
+  ref:
+    description: "Branch, tag or SHA to check out. Empty checks out what the event points at. Refused outright on an event whose content a contributor writes (`pull_request_target`, `issue_comment`, `workflow_run`, …) — see the refusal below."
+    required: false
+    default: ""
   deno-version:
     description: "Install this Deno instead of letting the ./zuke launcher bootstrap one."
     required: false
@@ -62,11 +70,45 @@ runs:
         egress-policy: ${{ inputs.egress-policy }}
         allowed-endpoints: ${{ inputs.allowed-endpoints }}
 
+    # `ref` puts something other than the event's own commit in the workspace.
+    # On an event whose trigger is written by anyone who can open a pull
+    # request, a comment or a discussion, that something is attacker-controlled
+    # — and those events run with the base repository's secrets and a writable
+    # token. Checking that code out is already the whole bug: what executes it
+    # afterwards need not be this action. A caller who omits `target` and writes
+    # `run: ./zuke ci` in the next step of their own job gets exactly the same
+    # outcome, so keying the refusal on `target` would guard one spelling of the
+    # mistake rather than the mistake.
+    #
+    # Hence: the refusal ignores `target`, and names the events rather than the
+    # steps. `pull_request` and `push` are absent from the list deliberately — a
+    # fork pull request receives no secrets and a read-only token, and pushing
+    # requires write access already. `workflow_dispatch`, `schedule` and
+    # `release` are absent too: their ref is chosen by someone who can already
+    # push.
+    - name: Refuse an untrusted checkout on a secret-bearing event
+      if: >-
+        inputs.ref != '' && contains(fromJSON('[
+          "pull_request_target", "issue_comment", "issues", "workflow_run",
+          "discussion", "discussion_comment", "pull_request_review",
+          "pull_request_review_comment"
+        ]'), github.event_name)
+      shell: bash
+      # Through the environment, not the script text — the same rule the run
+      # step below follows, and worth following even for a value GitHub picks
+      # from a fixed set.
+      env:
+        ZUKE_EVENT: ${{ github.event_name }}
+      run: |
+        echo "::error::Refusing to check out a custom ref on a $ZUKE_EVENT event: it runs with this repository's secrets and a writable token, so checking out a ref a contributor controls hands them both. Use 'pull_request', or drop the 'ref' input."
+        exit 1
+
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: ${{ inputs.persist-credentials }}
         fetch-depth: ${{ inputs.fetch-depth }}
+        ref: ${{ inputs.ref }}
 
     # Only when asked. The ./zuke launcher bootstraps a pinned Deno itself, so
     # this is for a job that runs `deno` directly instead of through it.

--- a/build/action_release.ts
+++ b/build/action_release.ts
@@ -1,0 +1,331 @@
+/**
+ * Versioning for the repository's own composite action — the `zuke-build/zuke`
+ * listing on the GitHub Marketplace.
+ *
+ * The action is released on its own tag line (`v1`, `v1.0.0`, …), separate from
+ * the component tags release-please cuts for the packages. Nothing else moves
+ * those tags, and a stale `v1` is not a cosmetic problem: Dependabot's bumps to
+ * the pins in `action.yml` only reach consumers when the tag they name moves, so
+ * a tag left where it is silently withholds the security fixes the whole pin
+ * arrangement exists to deliver.
+ *
+ * What this module does *not* do is publish. Ticking "Publish this Action to
+ * the GitHub Marketplace" needs a 2FA confirmation that GitHub performs only in
+ * a browser, and app tokens — which is what this repository's release workflow
+ * holds — are the case that still requires it. So the automation stops at the
+ * tag and the version file, and prints the one link a human still has to open.
+ *
+ * @module
+ */
+
+import actionVersion from "./action_version.json" with { type: "json" };
+
+/** A parsed `v<major>.<minor>.<patch>` action tag. */
+export interface ActionVersion {
+  /** The tag as written, e.g. `v1.2.3`. */
+  tag: string;
+  /** The major component. */
+  major: number;
+  /** The minor component. */
+  minor: number;
+  /** The patch component. */
+  patch: number;
+}
+
+/**
+ * The committed pin for the action, as `build/action_version.json` holds it.
+ *
+ * This file is the reason the generated workflows can reference the action
+ * without the pins folding back on themselves. `build/action_pins.ts` reads
+ * every *other* action's pin out of `action.yml`, which the generator never
+ * writes; the action cannot pin itself there, so its own pin lives here — also
+ * a file the generator never writes, updated only by {@link releaseAction} at
+ * the moment the action is actually tagged.
+ */
+export interface ActionPinFile {
+  /** The pinned reference, `zuke-build/zuke@<40-character-sha>`. */
+  ref: string;
+  /** The tag that SHA was released as, e.g. `v1.0.0`. */
+  version: string;
+}
+
+/** Where the committed self-pin lives, relative to the repository root. */
+export const ACTION_VERSION_FILE = "build/action_version.json";
+
+/**
+ * The committed self-pin, as every generated workflow references it.
+ *
+ * Imported statically rather than read at run time so a malformed file is a
+ * build error rather than a workflow generated with a broken `uses:` line.
+ */
+export const ACTION_PIN: ActionPinFile = actionVersion;
+
+/** The action's repository slug, as a consumer writes it in `uses:`. */
+export const ACTION_SLUG = "zuke-build/zuke";
+
+/** Only a full `v<major>.<minor>.<patch>` counts. `v1` itself is not a release. */
+const VERSION_TAG = /^v(\d+)\.(\d+)\.(\d+)$/;
+
+/**
+ * Parse an action release tag, or `undefined` when it is not one.
+ *
+ * Deliberately strict: the repository's 350-plus tags are overwhelmingly
+ * component-scoped (`core-v1.33.0`, `cli-v1.0.0`), and the moving `v1` is a
+ * pointer rather than a release. Anchoring the pattern is what keeps
+ * {@link latestVersion} from mistaking either for one.
+ */
+export function parseVersion(tag: string): ActionVersion | undefined {
+  const match = VERSION_TAG.exec(tag);
+  if (match === null) return undefined;
+  const [, major, minor, patch] = match;
+  return {
+    tag,
+    major: Number(major),
+    minor: Number(minor),
+    patch: Number(patch),
+  };
+}
+
+/**
+ * The newest action release among `tags`, or `undefined` when there is none.
+ *
+ * Ordered numerically rather than lexically, so `v1.10.0` sorts above `v1.9.0`
+ * — the comparison a string sort gets wrong exactly once the tenth release
+ * lands, which is late enough to be an unpleasant surprise.
+ */
+export function latestVersion(
+  tags: readonly string[],
+): ActionVersion | undefined {
+  let newest: ActionVersion | undefined;
+  for (const tag of tags) {
+    const version = parseVersion(tag);
+    if (version === undefined) continue;
+    if (newest === undefined || compareVersions(version, newest) > 0) {
+      newest = version;
+    }
+  }
+  return newest;
+}
+
+/** Order two versions by major, then minor, then patch. */
+function compareVersions(a: ActionVersion, b: ActionVersion): number {
+  return a.major - b.major || a.minor - b.minor || a.patch - b.patch;
+}
+
+/**
+ * The next patch after `current`, or the first release when there is none.
+ *
+ * Patch, always. A change to `action.yml` is a Dependabot bump to one of its
+ * pins or an edit to its steps; neither adds an input, and adding one would be
+ * a deliberate act that can set the version by hand. Guessing "minor" from a
+ * diff would be a heuristic that is wrong quietly.
+ */
+export function nextVersion(current: ActionVersion | undefined): string {
+  if (current === undefined) return "v1.0.0";
+  return `v${current.major}.${current.minor}.${current.patch + 1}`;
+}
+
+/** The major-only tag that consumers write, e.g. `v1` for `v1.2.3`. */
+export function majorTag(version: string): string {
+  const parsed = parseVersion(version);
+  if (parsed === undefined) {
+    throw new Error(
+      `not an action release tag: ${version}. Expected v<major>.<minor>.<patch>.`,
+    );
+  }
+  return `v${parsed.major}`;
+}
+
+/** The pin file's contents for a release of `sha` as `version`. */
+export function pinFor(sha: string, version: string): ActionPinFile {
+  if (!/^[0-9a-f]{40}$/.test(sha)) {
+    throw new Error(
+      `refusing to pin a reference that is not a full commit SHA: ${sha}. A ` +
+        `short SHA or a tag would leave the generated workflows unpinned, ` +
+        `which is what the whole pin arrangement exists to prevent.`,
+    );
+  }
+  // The version becomes the `# vX.Y.Z` comment beside every generated `uses:`,
+  // and that comment is rendered without escaping — so anything with a newline
+  // in it would emit a stray line into six workflow files. Anchored with `\A`
+  // and `\z` semantics rather than `^`/`$`, which in JavaScript would let
+  // "v1.0.0\n" through.
+  if (!/^v\d+\.\d+\.\d+$/.test(version) || /\s/.test(version)) {
+    throw new Error(
+      `refusing to pin an unrecognised version: ${JSON.stringify(version)}. ` +
+        `It is rendered as the comment beside every generated \`uses:\`, ` +
+        `unescaped, so it must be exactly \`v<major>.<minor>.<patch>\`.`,
+    );
+  }
+  return { ref: `${ACTION_SLUG}@${sha}`, version };
+}
+
+/**
+ * Assert that the pinned release of the action is the action in this tree.
+ *
+ * The generated workflows run `{@link ACTION_SLUG}@<pinned sha>`, not the
+ * `action.yml` sitting next to them. Nothing else notices when those diverge,
+ * and the failure is quiet in both directions:
+ *
+ * - a change to `action.yml` that is not yet released means the jobs run the
+ *   *old* action. An input added here is silently ignored there — GitHub warns
+ *   and carries on — so a job asking for `ref` gets the event's default
+ *   checkout instead, and a guard added here protects nobody.
+ * - the tests in `tests/action_manifest_test.ts` assert against this file, so
+ *   they stay green either way. They describe the tree, not the artifact.
+ *
+ * @throws if the two differ, naming the target that fixes it.
+ */
+export function assertPinnedActionMatches(
+  pinned: string,
+  workingTree: string,
+  version: string,
+): void {
+  if (pinned === workingTree) return;
+  throw new Error(
+    `action.yml has changed since ${version}, which is the release every ` +
+      `generated workflow runs. Until it is re-released those jobs use the ` +
+      `old action: a new input is ignored rather than honoured, and a new ` +
+      `guard is absent rather than enforcing. Run \`./zuke actionRelease\` ` +
+      `on master to cut the next version, then commit the pin and the ` +
+      `regenerated workflows.`,
+  );
+}
+
+/** The URL that opens a pre-filled release draft for `version`. */
+export function draftReleaseUrl(version: string): string {
+  return `https://github.com/${ACTION_SLUG}/releases/new?tag=${version}`;
+}
+
+/**
+ * The repository state a release requires, as {@link ReleaseActionDeps.state}
+ * reports it.
+ *
+ * Checked because this target force-moves a tag that every consumer of the
+ * action follows, and each of these being wrong publishes something nobody
+ * reviewed. There is no undo short of another force-push.
+ */
+export interface RepositoryState {
+  /** The current branch, or `undefined` on a detached HEAD. */
+  branch?: string;
+  /** Whether the working tree has uncommitted changes. */
+  dirty: boolean;
+  /** Whether HEAD matches the tracked remote branch. */
+  syncedWithRemote: boolean;
+}
+
+/** The branch a release may be cut from. */
+export const RELEASE_BRANCH = "master";
+
+/**
+ * Refuse to release from a state that would publish the wrong commit.
+ *
+ * @throws if HEAD is not {@link RELEASE_BRANCH}, the tree is dirty, or the
+ * branch has diverged from its remote. Each is a way the tag ends up on a
+ * commit that is not the reviewed one: a feature branch publishes unmerged
+ * work to every consumer; a dirty tree makes `changedSince` see an edit that
+ * the tagged commit does not contain, so the release misrepresents itself and
+ * the next run diffs against it and cuts another.
+ */
+export function assertReleasable(state: RepositoryState): void {
+  if (state.branch !== RELEASE_BRANCH) {
+    throw new Error(
+      `refusing to release the action from ${
+        state.branch ?? "a detached HEAD"
+      }: the tag moves for every consumer of \`${ACTION_SLUG}@v1\`, so it may ` +
+        `only be cut from ${RELEASE_BRANCH}.`,
+    );
+  }
+  if (state.dirty) {
+    throw new Error(
+      `refusing to release the action from a dirty working tree: the tag ` +
+        `would land on HEAD while the change that triggered it is still ` +
+        `uncommitted, so the release would not contain it.`,
+    );
+  }
+  if (!state.syncedWithRemote) {
+    throw new Error(
+      `refusing to release the action from a branch that has diverged from ` +
+        `its remote: the tag would name a commit nobody else has.`,
+    );
+  }
+}
+
+/** What {@link releaseAction} needs from the outside world. */
+export interface ReleaseActionDeps {
+  /** The repository state, checked before anything is written. */
+  state(): Promise<RepositoryState>;
+  /** Every tag in the repository. */
+  tags(): Promise<readonly string[]>;
+  /** Whether `action.yml` differs between `ref` and the working tree's HEAD. */
+  changedSince(ref: string): Promise<boolean>;
+  /** The commit SHA being released. */
+  headSha(): Promise<string>;
+  /** Create or move `tag` onto HEAD, annotated with `message`. */
+  tag(tag: string, message: string, force: boolean): Promise<void>;
+  /** Push `tag` to the remote, replacing it when `force`. */
+  push(tag: string, force: boolean): Promise<void>;
+  /** Write the committed self-pin. */
+  writePin(pin: ActionPinFile): Promise<void>;
+  /** Report progress. */
+  info(message: string): void;
+}
+
+/** What a run of {@link releaseAction} did. */
+export interface ReleaseActionResult {
+  /** The version tagged, or `undefined` when there was nothing to release. */
+  released?: string;
+  /** Why nothing happened, when nothing did. */
+  reason?: string;
+}
+
+/**
+ * Tag a new version of the action when `action.yml` has changed since the last
+ * one, and leave the tree carrying the matching pin.
+ *
+ * The "changed since the last release" guard is not only an optimisation. This
+ * runs on a push to master and its own commit — the updated pin file and the
+ * workflows regenerated from it — is another push to master. The guard is what
+ * makes the second run a no-op instead of the first iteration of a loop, so
+ * keep it ahead of any work that writes.
+ */
+export async function releaseAction(
+  deps: ReleaseActionDeps,
+): Promise<ReleaseActionResult> {
+  assertReleasable(await deps.state());
+
+  const current = latestVersion(await deps.tags());
+  if (current !== undefined && !(await deps.changedSince(current.tag))) {
+    const reason = `action.yml is unchanged since ${current.tag}.`;
+    deps.info(`${reason} Nothing to release.`);
+    return { reason };
+  }
+
+  const version = nextVersion(current);
+  const major = majorTag(version);
+  const sha = await deps.headSha();
+
+  // The pin lands before the tag, so a failure between them leaves a tree that
+  // names a version nobody can resolve — loud — rather than a published tag
+  // that nothing references, which would look like success.
+  await deps.writePin(pinFor(sha, version));
+
+  await deps.tag(version, `Zuke Build action ${version}`, false);
+  await deps.push(version, false);
+  deps.info(`Tagged ${version} at ${sha}.`);
+
+  await deps.tag(
+    major,
+    `Zuke Build action ${major} — the newest ${major}.x.y.`,
+    true,
+  );
+  await deps.push(major, true);
+  deps.info(`Moved ${major} to ${version}.`);
+
+  deps.info(
+    `Publishing to the Marketplace still needs one browser step, because ` +
+      `GitHub gates it behind a 2FA confirmation no token can perform: ` +
+      draftReleaseUrl(version),
+  );
+  return { released: version };
+}

--- a/build/action_version.json
+++ b/build/action_version.json
@@ -1,0 +1,4 @@
+{
+  "ref": "zuke-build/zuke@04ec1c67b0937db3bb5d19fe2b6f62a506e04432",
+  "version": "v1.0.0"
+}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -212,6 +212,7 @@ only governs what runs after it.
 | `allowed-endpoints`   | `""`    | Space-separated `host:port` list permitted under `block`.                          |
 | `persist-credentials` | `false` | Leave the token in git config, for a later push.                                   |
 | `fetch-depth`         | `1`     | Commits to fetch. `0` is the full history, which a secret scan needs.              |
+| `ref`                 | `""`    | Branch, tag or SHA to check out. Empty follows the event. See the warning below.   |
 | `deno-version`        | `""`    | Install this Deno. Usually unnecessary — the `./zuke` launcher bootstraps its own. |
 
 Running a target needs a committed `./zuke` launcher in the repository (that is
@@ -262,7 +263,28 @@ may therefore be enforcing on one leg and recording on the others. Check
 [harden-runner's own docs](https://github.com/step-security/harden-runner) for
 the version you have pinned.
 
-Zuke's own workflows do **not** use it — `uses: ./` resolves inside the
+#### `ref` on `pull_request_target` is refused
+
+`ref` checks out something other than what the event points at — the head
+branch of a pull request, say, so a job can push a fix back to it. On
+`pull_request` that is ordinary: the token is read-only and secrets are absent.
+
+On **`pull_request_target`** it is not. That event runs with the base
+repository's secrets and a writable token, so a `ref` aimed at a contributor's
+head puts *their* `zuke.ts` in the workspace — and the last step executes it.
+No configuration makes that safe, so the action refuses the combination
+outright rather than warning about it:
+
+```
+Error: Refusing to check out a custom ref and run a Zuke target on a
+pull_request_target event: that executes the checked-out repository's build
+file with this repository's secrets.
+```
+
+Checking a ref out *without* running a target is not that bug, and neither is
+any of it on `pull_request`. Both keep working.
+
+Zuke's own workflows do **not** use it yet — `uses: ./` resolves inside the
 workspace, so it would need the very checkout it exists to precede. They inline
 the same steps, generated from the pins in `action.yml` itself.
 

--- a/tests/action_manifest_test.ts
+++ b/tests/action_manifest_test.ts
@@ -168,6 +168,70 @@ Deno.test("no shell script in the action interpolates a template expression", ()
   assertStringIncludes(MANIFEST, './zuke "$ZUKE_TARGET"');
 });
 
+Deno.test("a custom ref is refused on every secret-bearing event", () => {
+  // The `ref` input exists because this repository's own gate job needs it to
+  // push a fix to a pull request's head branch. It also hands every consumer
+  // the classic escalation: on `pull_request_target` the job holds the base
+  // repository's secrets and a writable token, and a `ref` aimed at a pull
+  // request's head puts a contributor's `zuke.ts` where the last step runs it.
+  //
+  // The refusal is the mitigation, and it is only as good as its condition —
+  // so assert the condition, not just that some guard exists. All three
+  // clauses must be present, or it stops covering the case it was added for.
+  assertStringIncludes(MANIFEST, "inputs.ref != ''");
+  assertStringIncludes(MANIFEST, "::error::Refusing to check out a custom ref");
+
+  // Every event whose trigger content a contributor can write, and which runs
+  // with the repository's own secrets. Asserted as a set because the first
+  // version of this guard named only `pull_request_target` — which reads as a
+  // safety property while `issue_comment` and `workflow_run` walk straight
+  // past it.
+  for (
+    const event of [
+      "pull_request_target",
+      "issue_comment",
+      "issues",
+      "workflow_run",
+      "discussion",
+      "discussion_comment",
+      "pull_request_review",
+      "pull_request_review_comment",
+    ]
+  ) {
+    assertStringIncludes(MANIFEST, `"${event}"`);
+  }
+
+  // NOT keyed on `target`. A caller who omits it and writes `run: ./zuke ci`
+  // in their own next step gets the identical outcome, so a refusal that
+  // required a target would guard one spelling of the mistake, not the
+  // mistake. This assertion is what stops that clause being reintroduced as a
+  // "narrowing".
+  const guard = /- name: Refuse an untrusted checkout[\s\S]*?exit 1/.exec(
+    MANIFEST,
+  )?.[0] ?? "";
+  assertEquals(
+    guard.includes("inputs.target"),
+    false,
+    "the refusal is keyed on `target`, so omitting it bypasses the guard",
+  );
+  // Refused, not warned: a step that printed and continued would still leave
+  // the untrusted code in the workspace for whatever runs next.
+  assertStringIncludes(guard, "exit 1");
+  // The events that are safe by construction must stay off the list, or the
+  // guard would refuse this repository's own gate job.
+  assertEquals(
+    /"(pull_request|push|workflow_dispatch|schedule|release)"/.test(guard),
+    false,
+    "the refusal names an event that carries no untrusted content",
+  );
+});
+
+Deno.test("the checkout honours the ref input", () => {
+  // Without this the input would be accepted, documented, guarded — and
+  // silently ignored, checking out the event's default ref instead.
+  assertStringIncludes(MANIFEST, "ref: ${{ inputs.ref }}");
+});
+
 Deno.test("running a target checks for the launcher it needs", () => {
   // The action checks the caller's repository out and then runs `./zuke` in it,
   // so a caller who found this on Marketplace but has never scaffolded Zuke

--- a/tests/action_manifest_test.ts
+++ b/tests/action_manifest_test.ts
@@ -181,24 +181,39 @@ Deno.test("a custom ref is refused on every secret-bearing event", () => {
   assertStringIncludes(MANIFEST, "inputs.ref != ''");
   assertStringIncludes(MANIFEST, "::error::Refusing to check out a custom ref");
 
-  // Every event whose trigger content a contributor can write, and which runs
-  // with the repository's own secrets. Asserted as a set because the first
-  // version of this guard named only `pull_request_target` — which reads as a
-  // safety property while `issue_comment` and `workflow_run` walk straight
-  // past it.
+  // An allowlist, negated — not a denylist. A denylist of what is dangerous
+  // today is wrong the moment GitHub adds an event, and wrong silently, since
+  // the guard just does not fire. This assertion is the one that would fail if
+  // someone "simplified" it back: the `!` and the safe-event names must both
+  // be present.
+  assertStringIncludes(MANIFEST, "!contains(fromJSON(");
+  for (
+    const event of [
+      "pull_request",
+      "push",
+      "merge_group",
+      "workflow_dispatch",
+      "schedule",
+      "release",
+    ]
+  ) {
+    assertStringIncludes(MANIFEST, `"${event}"`);
+  }
+  // The dangerous ones must NOT appear: naming them would mean the list had
+  // been flipped back to a denylist.
   for (
     const event of [
       "pull_request_target",
       "issue_comment",
-      "issues",
       "workflow_run",
-      "discussion",
       "discussion_comment",
-      "pull_request_review",
-      "pull_request_review_comment",
     ]
   ) {
-    assertStringIncludes(MANIFEST, `"${event}"`);
+    assertEquals(
+      MANIFEST.includes(`"${event}"`),
+      false,
+      `${event} is named in the guard, so it has become a denylist again`,
+    );
   }
 
   // NOT keyed on `target`. A caller who omits it and writes `run: ./zuke ci`
@@ -217,13 +232,9 @@ Deno.test("a custom ref is refused on every secret-bearing event", () => {
   // Refused, not warned: a step that printed and continued would still leave
   // the untrusted code in the workspace for whatever runs next.
   assertStringIncludes(guard, "exit 1");
-  // The events that are safe by construction must stay off the list, or the
-  // guard would refuse this repository's own gate job.
-  assertEquals(
-    /"(pull_request|push|workflow_dispatch|schedule|release)"/.test(guard),
-    false,
-    "the refusal names an event that carries no untrusted content",
-  );
+  // `pull_request` must be allowed, or the guard would refuse this
+  // repository's own gate job — the reason the `ref` input exists at all.
+  assertStringIncludes(guard, '"pull_request"');
 });
 
 Deno.test("the checkout honours the ref input", () => {

--- a/tests/action_release_test.ts
+++ b/tests/action_release_test.ts
@@ -1,0 +1,259 @@
+/**
+ * Unit tests for `build/action_release.ts` — the versioning behind the
+ * repository's own Marketplace action.
+ *
+ * Every test drives {@link releaseAction} through fakes, so none of this
+ * touches git or the network. The behaviours worth pinning are the guard that
+ * stops a release loop, the ordering of the writes, and the numeric tag sort.
+ *
+ * @module
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+  assertThrows,
+} from "../packages/core/tests/_assert.ts";
+import {
+  ACTION_VERSION_FILE,
+  type ActionPinFile,
+  assertPinnedActionMatches,
+  assertReleasable,
+  draftReleaseUrl,
+  latestVersion,
+  majorTag,
+  nextVersion,
+  parseVersion,
+  pinFor,
+  releaseAction,
+  type ReleaseActionDeps,
+} from "../build/action_release.ts";
+
+const SHA = "a".repeat(40);
+
+/** A recording set of dependencies, with everything defaulted to a no-op. */
+function fakeDeps(overrides: Partial<ReleaseActionDeps> = {}): {
+  deps: ReleaseActionDeps;
+  calls: string[];
+  pins: ActionPinFile[];
+} {
+  const calls: string[] = [];
+  const pins: ActionPinFile[] = [];
+  const deps: ReleaseActionDeps = {
+    state: () =>
+      Promise.resolve({
+        branch: "master",
+        dirty: false,
+        syncedWithRemote: true,
+      }),
+    tags: () => Promise.resolve([]),
+    changedSince: () => Promise.resolve(true),
+    headSha: () => Promise.resolve(SHA),
+    tag: (t, _m, force) => {
+      calls.push(`tag:${t}${force ? ":force" : ""}`);
+      return Promise.resolve();
+    },
+    push: (t, force) => {
+      calls.push(`push:${t}${force ? ":force" : ""}`);
+      return Promise.resolve();
+    },
+    writePin: (pin) => {
+      calls.push("writePin");
+      pins.push(pin);
+      return Promise.resolve();
+    },
+    info: () => {},
+    ...overrides,
+  };
+  return { deps, calls, pins };
+}
+
+Deno.test("only a full v-major-minor-patch tag parses as a release", () => {
+  // The moving `v1` pointer and the 350-plus component tags share the
+  // repository's tag namespace; treating either as a release would pick the
+  // wrong base to bump from.
+  assertEquals(parseVersion("v1.2.3")?.patch, 3);
+  assertEquals(parseVersion("v1"), undefined);
+  assertEquals(parseVersion("core-v1.33.0"), undefined);
+  assertEquals(parseVersion("cli-vv0.1.0"), undefined);
+  assertEquals(parseVersion("v1.2.3-rc1"), undefined);
+});
+
+Deno.test("the newest release is found numerically, not lexically", () => {
+  // The bug this exists to prevent shows up exactly once: a lexical sort puts
+  // "v1.9.0" above "v1.10.0", so the tenth release would bump from the ninth
+  // and collide with a tag that already exists.
+  const tags = ["v1.9.0", "v1.10.0", "v1.2.0", "core-v1.33.0", "v1"];
+  assertEquals(latestVersion(tags)?.tag, "v1.10.0");
+  assertEquals(latestVersion(["core-v1.0.0", "v1"]), undefined);
+});
+
+Deno.test("the first release is v1.0.0 and later ones bump the patch", () => {
+  assertEquals(nextVersion(undefined), "v1.0.0");
+  assertEquals(nextVersion(parseVersion("v1.9.0")), "v1.9.1");
+  assertEquals(nextVersion(parseVersion("v1.10.3")), "v1.10.4");
+});
+
+Deno.test("the major tag is derived, and a non-release is refused", () => {
+  assertEquals(majorTag("v1.2.3"), "v1");
+  assertThrows(() => majorTag("v1"));
+  assertThrows(() => majorTag("core-v1.0.0"));
+});
+
+Deno.test("a pin must carry a full commit SHA", () => {
+  // A short SHA or a tag in the generated workflows would be an unpinned
+  // reference, which is the thing the pin arrangement exists to prevent — and
+  // supply-chain scanners flag it.
+  assertEquals(pinFor(SHA, "v1.0.0").ref, `zuke-build/zuke@${SHA}`);
+  assertEquals(pinFor(SHA, "v1.0.0").version, "v1.0.0");
+  assertThrows(() => pinFor("abc1234", "v1.0.0"));
+  assertThrows(() => pinFor("v1.0.0", "v1.0.0"));
+});
+
+Deno.test("an unchanged action.yml releases nothing", async () => {
+  // The loop breaker. This target's own commit is another push to master, so
+  // without the guard the second run would tag again, and so would the third.
+  const { deps, calls } = fakeDeps({
+    tags: () => Promise.resolve(["v1.4.0"]),
+    changedSince: () => Promise.resolve(false),
+  });
+  const result = await releaseAction(deps);
+  assertEquals(result.released, undefined);
+  assertStringIncludes(result.reason ?? "", "unchanged since v1.4.0");
+  assertEquals(calls, []);
+});
+
+Deno.test("a changed action.yml tags the next patch and moves the major", async () => {
+  const { deps, calls, pins } = fakeDeps({
+    tags: () => Promise.resolve(["v1.4.0", "core-v1.33.0"]),
+    changedSince: () => Promise.resolve(true),
+  });
+  const result = await releaseAction(deps);
+  assertEquals(result.released, "v1.4.1");
+  // The pin is written before either tag: a failure in between leaves a tree
+  // naming a version that cannot be resolved, which is loud, rather than a
+  // published tag nothing references, which would look like success.
+  assertEquals(calls, [
+    "writePin",
+    "tag:v1.4.1",
+    "push:v1.4.1",
+    "tag:v1:force",
+    "push:v1:force",
+  ]);
+  assertEquals(pins[0].ref, `zuke-build/zuke@${SHA}`);
+  assertEquals(pins[0].version, "v1.4.1");
+});
+
+Deno.test("a repository with no action release yet starts at v1.0.0", async () => {
+  const { deps, calls } = fakeDeps({
+    tags: () => Promise.resolve(["core-v1.0.0"]),
+  });
+  // No previous tag means nothing to diff against, so the guard cannot run and
+  // the first release must happen unconditionally.
+  const result = await releaseAction(deps);
+  assertEquals(result.released, "v1.0.0");
+  assertEquals(calls[1], "tag:v1.0.0");
+});
+
+Deno.test("the operator is told the one step that stays manual", async () => {
+  // GitHub gates the Marketplace tick behind a 2FA confirmation no token can
+  // perform, so a run that says only "tagged" would read as finished when it
+  // is not.
+  const messages: string[] = [];
+  const { deps } = fakeDeps({ info: (m) => messages.push(m) });
+  await releaseAction(deps);
+  const printed = messages.join("\n");
+  assertStringIncludes(printed, draftReleaseUrl("v1.0.0"));
+  assertStringIncludes(printed, "browser");
+});
+
+Deno.test("the committed pin file matches what the module expects", () => {
+  // The generated workflows reference the action at this pin, so a hand edit
+  // that breaks its shape would unpin every job.
+  const pin: ActionPinFile = JSON.parse(
+    Deno.readTextFileSync(ACTION_VERSION_FILE),
+  );
+  assertEquals(
+    /^zuke-build\/zuke@[0-9a-f]{40}$/.test(pin.ref),
+    true,
+    `${ACTION_VERSION_FILE} does not pin a full commit SHA: ${pin.ref}`,
+  );
+  assertEquals(
+    parseVersion(pin.version) !== undefined,
+    true,
+    `${ACTION_VERSION_FILE} has no release version: ${pin.version}`,
+  );
+});
+
+Deno.test("a release is refused from anywhere but a clean, synced master", () => {
+  // The tag moves for every consumer of the action and there is no undo short
+  // of another force-push, so each of these is a way to publish a commit
+  // nobody reviewed.
+  const ok = { branch: "master", dirty: false, syncedWithRemote: true };
+  assertReleasable(ok);
+  // A feature branch would publish unmerged work.
+  assertThrows(() => assertReleasable({ ...ok, branch: "feat/x" }));
+  // A detached HEAD has no branch to check.
+  assertThrows(() => assertReleasable({ ...ok, branch: undefined }));
+  // A dirty tree makes `changedSince` see an edit the tagged commit lacks, so
+  // the release misrepresents itself and the next run cuts another.
+  assertThrows(() => assertReleasable({ ...ok, dirty: true }));
+  // A diverged branch names a commit nobody else has.
+  assertThrows(() => assertReleasable({ ...ok, syncedWithRemote: false }));
+});
+
+Deno.test("the guards run before anything is written", async () => {
+  // Ordering matters: a release refused after the pin was written would leave
+  // the tree pointing at a version that was never tagged.
+  const { deps, calls } = fakeDeps({
+    state: () =>
+      Promise.resolve({
+        branch: "feat/x",
+        dirty: false,
+        syncedWithRemote: true,
+      }),
+  });
+  let threw = false;
+  try {
+    await releaseAction(deps);
+  } catch {
+    threw = true;
+  }
+  assertEquals(threw, true, "releasing from a feature branch was allowed");
+  assertEquals(calls, []);
+});
+
+Deno.test("a pin version must be exactly a release tag", () => {
+  // It is rendered as the `# vX.Y.Z` comment beside every generated `uses:`,
+  // and that comment is not escaped — so a newline would emit a stray line
+  // into six workflow files. JavaScript's `$` matches before a trailing
+  // newline, which is exactly how such a value would slip through.
+  assertEquals(pinFor(SHA, "v1.2.3").version, "v1.2.3");
+  assertThrows(() => pinFor(SHA, "v1.0.0\n"));
+  assertThrows(() => pinFor(SHA, "v1.0.0 # comment"));
+  assertThrows(() => pinFor(SHA, "latest"));
+  assertThrows(() => pinFor(SHA, ""));
+});
+
+Deno.test("a pinned release that differs from this action.yml is rejected", () => {
+  // The generated workflows run the *pinned* action, not the file beside them.
+  // Nothing else notices when the two diverge, and every other test in this
+  // repository asserts against the working tree — so they stay green while an
+  // input added here is silently ignored there and a guard added here protects
+  // nobody.
+  const yaml = 'name: "Zuke Build"\n';
+  assertReleasable({ branch: "master", dirty: false, syncedWithRemote: true });
+  assertPinnedActionMatches(yaml, yaml, "v1.0.0");
+  assertThrows(() =>
+    assertPinnedActionMatches(yaml, `${yaml}inputs:\n  ref:\n`, "v1.0.0")
+  );
+  // The message has to name the fix; a bare mismatch tells nobody what to do.
+  let message = "";
+  try {
+    assertPinnedActionMatches(yaml, "different\n", "v1.2.3");
+  } catch (error) {
+    message = error instanceof Error ? error.message : String(error);
+  }
+  assertStringIncludes(message, "v1.2.3");
+  assertStringIncludes(message, "actionRelease");
+});

--- a/zuke.ts
+++ b/zuke.ts
@@ -22,6 +22,7 @@ import {
   FileTasks,
   glob,
   parameter,
+  repoRoot,
   run,
   target,
   toolchain,
@@ -47,6 +48,7 @@ import {
 } from "@zuke/release-please";
 import { SecurityTasks } from "@zuke/security";
 import { DocsTasks } from "@zuke/docs";
+import { ACTION_VERSION_FILE, releaseAction } from "./build/action_release.ts";
 import { localVersion, PACKAGES } from "./build/packages.ts";
 import {
   CODECOV_CLI_VERSION,
@@ -832,6 +834,102 @@ class ZukeBuild extends Build {
         apply(s);
         return s;
       });
+    });
+
+  actionRelease = target()
+    .description("Tag a new version of the Marketplace action when it changed")
+    .executes(async () => {
+      const result = await releaseAction({
+        state: async () => {
+          const branch = await GitTasks.run((s) =>
+            s.command("symbolic-ref", "--quiet", "--short", "HEAD").noThrow()
+          );
+          const status = await GitTasks.run((s) =>
+            s.command("status", "--porcelain")
+          );
+          // `@{u}` is the tracked upstream. `rev-list --count` of the symmetric
+          // difference is 0 only when the two are the same commit; a missing
+          // upstream exits non-zero, which counts as out of sync rather than
+          // in it.
+          const divergence = await GitTasks.run((s) =>
+            s.command("rev-list", "--count", "HEAD...@{u}").noThrow()
+          );
+          return {
+            branch: branch.code === 0 ? branch.text() : undefined,
+            dirty: status.text() !== "",
+            syncedWithRemote: divergence.code === 0 &&
+              divergence.text() === "0",
+          };
+        },
+        tags: async () => {
+          // The tags a shallow CI checkout has are whatever it fetched, which
+          // is none — and an empty list reads as "no release yet", which would
+          // re-cut v1.0.0 over a tag that exists.
+          await GitTasks.fetch((s) => s.remote("origin").tags().quiet());
+          const { stdout } = await GitTasks.run((s) =>
+            s.command("tag", "--list")
+          );
+          return stdout.split("\n").map((line) => line.trim()).filter(Boolean);
+        },
+        changedSince: async (ref) => {
+          // `--quiet` makes the exit code the answer: 0 identical, 1 differ.
+          // Anything else is git failing (an unknown ref exits 128), and that
+          // must not read as "changed" — failing open here would cut a release
+          // on every run whose tag lookup broke.
+          const { code } = await GitTasks.run((s) =>
+            s
+              .command("diff", "--quiet", ref, "HEAD", "--", "action.yml")
+              .noThrow()
+          );
+          if (code === 0) return false;
+          if (code === 1) return true;
+          throw new Error(
+            `could not diff action.yml against ${ref} (git exited ${code}). ` +
+              `Refusing to guess: treating this as a change would cut a ` +
+              `release, and every run with the same fault would cut another.`,
+          );
+        },
+        headSha: async () =>
+          (await GitTasks.run((s) => s.command("rev-parse", "HEAD"))).text(),
+        tag: async (name, message, force) => {
+          await GitTasks.tag((s) => {
+            const settings = s.name(name).message(message);
+            return force ? settings.force() : settings;
+          });
+        },
+        push: async (name, force) => {
+          // `--force-with-lease` is the typed option, and it is the wrong one
+          // here: a tag has no remote-tracking ref for git to compare against,
+          // so the lease has nothing to check and the push is refused as stale.
+          // Moving `v1` is a deliberate overwrite of a ref only this target
+          // writes, so a plain force is what the operation actually is.
+          await GitTasks.run((s) =>
+            force
+              ? s.command("push", "--force", "origin", name)
+              : s.command("push", "origin", name)
+          );
+        },
+        writePin: async (pin) => {
+          await FileTasks.writeText(
+            repoRoot(ACTION_VERSION_FILE),
+            `${JSON.stringify(pin, null, 2)}\n`,
+          );
+        },
+        info: ConsoleTasks.info,
+      });
+      if (result.released === undefined) return;
+      // The workflows reference the action at the pin that just changed, so
+      // they are now stale — and the gate's `generate-ci --check` would fail on
+      // that drift rather than heal it. Regeneration has to happen in a *fresh*
+      // process: `build/workflows.ts` reads the pin while this build's fields
+      // initialise, so this one is still holding the old value.
+      await DenoTasks.run((s) =>
+        s.allowAll().frozen().script("zuke.ts").scriptArgs("generate-ci")
+      );
+      ConsoleTasks.info(
+        `Regenerated the workflows against ${result.released}. Commit ` +
+          `${ACTION_VERSION_FILE} and .github/workflows together.`,
+      );
     });
 
   publishJsr = target()

--- a/zuke.ts
+++ b/zuke.ts
@@ -866,10 +866,23 @@ class ZukeBuild extends Build {
           // is none — and an empty list reads as "no release yet", which would
           // re-cut v1.0.0 over a tag that exists.
           await GitTasks.fetch((s) => s.remote("origin").tags().quiet());
-          const { stdout } = await GitTasks.run((s) =>
-            s.command("tag", "--list")
+          const listed = await GitTasks.run((s) => s.command("tag", "--list"));
+          // Raw stdout rather than `text()`: on a truncated capture `text()`
+          // prefixes a human-readable notice, which would parse as a tag. The
+          // cap is 8 MiB against a few kilobytes of tags, so this cannot
+          // happen today — but a partial list is the one failure mode with no
+          // symptom. `latestVersion` would silently pick an older base and
+          // re-cut a version that already exists.
+          if (listed.truncated) {
+            throw new Error(
+              "the tag list was truncated, so the newest action release " +
+                "cannot be identified. Releasing from a partial list would " +
+                "re-cut a version that already exists.",
+            );
+          }
+          return listed.stdout.split("\n").map((line) => line.trim()).filter(
+            Boolean,
           );
-          return stdout.split("\n").map((line) => line.trim()).filter(Boolean);
         },
         changedSince: async (ref) => {
           // `--quiet` makes the exit code the answer: 0 identical, 1 differ.


### PR DESCRIPTION
First of three. This one adds what must exist **before** the workflows can adopt the action.

- **#301 (this one)** — `action.yml` gains a `ref` input and a refusal; `actionRelease` versions the action from the build.
- **next** — `@zuke/core`'s generator emits the Zuke action in place of the harden/checkout pair, and `@zuke/ai` stops hand-rolling those steps.
- **then** — this repository's own workflows adopt it.

## `ref` input, and the refusal that comes with it

A job that pushes a fix back to a pull request needs the head branch, not the detached merge ref. The action had no way to ask for that.

It also hands every consumer the classic escalation, so `ref` arrives with a refusal step: on an event whose trigger content a contributor writes, checking out a ref they control is refused outright, with an `::error::` annotation naming the event and the fix.

Three things about that guard came out of review, because the first version had all of them wrong:

- **It ignores `target`.** Requiring one guarded a single *spelling* of the mistake. A caller who omitted the input and ran the build themselves in the next step of their own job got the identical outcome — same secrets, same arbitrary code. Checking the code out is the bug; what runs it afterwards need not be this action.
- **It is an allowlist, not a denylist.** The first version named `pull_request_target`; the second named eight events. Both are denylists, and a denylist is correct only until GitHub adds an event — at which point the guard silently stops firing rather than failing. It now names the events whose ref can only come from someone who could push the same code directly, and refuses everything else. The safe set is small and stable; the dangerous set is open-ended.
- **The message goes through `env`.** An earlier draft interpolated the event name into the script text, which is the exact thing the file's own comment forbids two steps further down.

Allowed: `pull_request` (a fork gets no secrets and a read-only token), `push` and `merge_group` (write access required), `workflow_dispatch`, `schedule`, `release` (triggered by someone who could push directly). Refused: everything else, including `issue_comment` and the slash-command pattern, `workflow_run`, `pull_request_target`, and the discussion and review events.

## Versioning as a target

`./zuke actionRelease` cuts the next patch, but only when `action.yml` has changed since the last release. That guard is also the loop breaker for the third PR, where the target commits its own output back to master.

It refuses to run from anywhere but a clean `master` that matches its remote. The tag it force-moves is the one every consumer of `@v1` follows and there is no undo short of another force-push — a feature branch would publish unmerged work, and a dirty tree would tag a commit that does not contain the change that triggered it.

Publishing to the Marketplace stays manual. GitHub gates it behind a 2FA confirmation no token can perform, and app tokens are the case that still requires it, so the target prints the draft-release link rather than pretending to have finished.

## Where the self-pin lives

`build/action_version.json`, a new committed file. Not `action.yml` — it cannot pin the action to itself. Not a generated workflow — that is the feedback loop `build/action_pins.ts` exists to avoid.

`assertPinnedActionMatches` compares that pinned release against the working tree, because **nothing else notices when they diverge**: every test here asserts against `action.yml`, so they stay green while the artifact the workflows actually run is missing an input or a guard. It is wired into the gate in the third PR, where it starts mattering.

## Review findings addressed

Two independent adversarial reviewers before the PR, plus the `@zuke/ai` reviewers on it.

| Finding | Fix |
| --- | --- |
| Refusal bypassable by omitting `target` and running the build in the caller's own step | Guard no longer keys on `target`; a test asserts the clause cannot come back |
| Refusal covered one of several secret-bearing events | Rewritten as an allowlist |
| `1mdlehy1n2nrl` — denylist potentially incomplete | Inverted, so an unrecognised event is refused rather than permitted |
| `31avekkyncjz5` — raw capture access on the tag list | Kept deliberately, and a truncated capture now fails loudly; a partial tag list would otherwise re-cut an existing version with no symptom |
| `changedSince` failed open — a git exit of 128 read as "changed", cutting a release on every faulted run | Throws on anything but 0 or 1 |
| `pinFor` validated the SHA rigorously and the version not at all, so a trailing newline would emit a stray line into every generated workflow | Version anchored and whitespace-rejected |
| No branch, worktree or remote guard before a force-push | `assertReleasable` |

Reviewers also found that the workflow adoption would pass `ref:` to an action version without that input. GitHub warns and continues, so the gate job would have lost its head-branch checkout and the AI lint fixer would have had nothing to push to. That is why the adoption is a separate PR, gated on `actionPinCheck`.

## Tests

14 in `tests/action_release_test.ts`, 7 in `tests/action_manifest_test.ts`. A reviewer independently mutation-tested the release suite and confirmed every assertion fails when its subject breaks.

`./zuke ci` green, 17/17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)