### PR TITLE
feat(ai): let core render the review workflow's prelude

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -14,12 +14,10 @@ jobs:
     if: "${{ github.event.pull_request.head.repo.fork == false }}"
     timeout-minutes: 15
     steps:
-      - name: Harden the runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920
+      - name: Harden and check out with Zuke
+        uses: zuke-build/zuke@7a62523bb4569e4d90e972dee74bf9cf09cd436f # v1.0.1
         with:
           egress-policy: audit
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-        with:
           persist-credentials: "false"
       - name: AI review with Zuke
         run: ./zuke review

--- a/deno.lock
+++ b/deno.lock
@@ -1540,7 +1540,7 @@
     "members": {
       "packages/ai": {
         "dependencies": [
-          "jsr:@zuke/core@^1.25.0"
+          "jsr:@zuke/core@^1.34.0"
         ]
       },
       "packages/biome": {

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -10678,19 +10678,14 @@ interface AiReviewWorkflowSpec
     `zuke review` then works locally, where no workflow step exists to run.
   hardenRunner?: string
     The pinned `step-security/harden-runner@<sha>` to harden the runner with.
-    Defaults to a pin baked in here.
 
-    Pass it when the build sources pins from somewhere that stays current — a
-    generated workflow whose SHA comes from a constant in a published package is
-    a trap: a bot bumps the committed file, the next run regenerates it from the
-    stale constant, and the bump is silently reverted.
-
-    A bare `owner/repo@<sha>`, without the `# vX.Y.Z` comment the other
-    generated workflows carry: attaching one needs a core newer than this
-    package's declared floor, and Dependabot bumps a comment-less pin anyway.
-    Adopt the richer form once the floor moves past that release.
+    Supplying this — or {@link checkout} — renders the two separate steps
+    instead of the prelude action, because naming an action means those
+    specific actions were asked for. Leave both unset for the default, which
+    is the one action that does both and carries its own pin.
   checkout?: string
     The pinned `actions/checkout@<sha>` to check the repository out with.
+    Like {@link hardenRunner}, supplying it renders the separate steps.
   path?: string
     Output path. Defaults to the host's conventional location.
   name?: string

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -603,19 +603,14 @@ interface AiReviewWorkflowSpec
     `zuke review` then works locally, where no workflow step exists to run.
   hardenRunner?: string
     The pinned `step-security/harden-runner@<sha>` to harden the runner with.
-    Defaults to a pin baked in here.
 
-    Pass it when the build sources pins from somewhere that stays current — a
-    generated workflow whose SHA comes from a constant in a published package is
-    a trap: a bot bumps the committed file, the next run regenerates it from the
-    stale constant, and the bump is silently reverted.
-
-    A bare `owner/repo@<sha>`, without the `# vX.Y.Z` comment the other
-    generated workflows carry: attaching one needs a core newer than this
-    package's declared floor, and Dependabot bumps a comment-less pin anyway.
-    Adopt the richer form once the floor moves past that release.
+    Supplying this — or {@link checkout} — renders the two separate steps
+    instead of the prelude action, because naming an action means those
+    specific actions were asked for. Leave both unset for the default, which
+    is the one action that does both and carries its own pin.
   checkout?: string
     The pinned `actions/checkout@<sha>` to check the repository out with.
+    Like {@link hardenRunner}, supplying it renders the separate steps.
   path?: string
     Output path. Defaults to the host's conventional location.
   name?: string

--- a/packages/ai/deno.json
+++ b/packages/ai/deno.json
@@ -7,7 +7,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1.25.0"
+    "@zuke/core": "jsr:@zuke/core@^1.34.0"
   },
   "publish": {
     "exclude": [

--- a/packages/ai/src/workflow.ts
+++ b/packages/ai/src/workflow.ts
@@ -36,13 +36,6 @@ import {
 } from "@zuke/core";
 import type { Reviewer } from "./reviewer.ts";
 
-/** SHA-pinned `step-security/harden-runner` (v2.20.0). */
-const HARDEN_RUNNER =
-  "step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920";
-
-/** SHA-pinned `actions/checkout` (v7.0.0). */
-const CHECKOUT = "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1";
-
 /** Default output paths per host — see {@link AiReviewWorkflowSpec}. */
 const DEFAULT_PATHS: Record<CiProvider, string> = {
   github: ".github/workflows/ai-review.yml",
@@ -104,20 +97,17 @@ export interface AiReviewWorkflowSpec {
   fetchBase?: boolean;
   /**
    * The pinned `step-security/harden-runner@<sha>` to harden the runner with.
-   * Defaults to a pin baked in here.
    *
-   * Pass it when the build sources pins from somewhere that stays current — a
-   * generated workflow whose SHA comes from a constant in a published package is
-   * a trap: a bot bumps the committed file, the next run regenerates it from the
-   * stale constant, and the bump is silently reverted.
-   *
-   * A bare `owner/repo@<sha>`, without the `# vX.Y.Z` comment the other
-   * generated workflows carry: attaching one needs a core newer than this
-   * package's declared floor, and Dependabot bumps a comment-less pin anyway.
-   * Adopt the richer form once the floor moves past that release.
+   * Supplying this — or {@link checkout} — renders the two separate steps
+   * instead of the prelude action, because naming an action means those
+   * specific actions were asked for. Leave both unset for the default, which
+   * is the one action that does both and carries its own pin.
    */
   hardenRunner?: string;
-  /** The pinned `actions/checkout@<sha>` to check the repository out with. */
+  /**
+   * The pinned `actions/checkout@<sha>` to check the repository out with.
+   * Like {@link hardenRunner}, supplying it renders the separate steps.
+   */
   checkout?: string;
   /** Output path. Defaults to the host's conventional location. */
   path?: string;
@@ -257,16 +247,20 @@ class AiReviewWorkflow extends CiFile {
       // no secrets, so the reviewers would skip there anyway.
       if: "${{ github.event.pull_request.head.repo.fork == false }}",
       timeoutMinutes: this.#spec.timeoutMinutes ?? DEFAULT_TIMEOUT_MINUTES,
+      // Declared rather than built here, so the prelude is whatever core
+      // renders for one — today a single `zuke-build/zuke` step that hardens
+      // and checks out. Naming either action opts back out to the two separate
+      // steps, which is what `hardenRunner` and `checkout` configure.
+      //
+      // This retires the trap this file used to carry. Its two SHAs were
+      // constants inside a published package, so a generated workflow's pins
+      // came from a release rather than from the file a bot edits: Dependabot
+      // bumped ai-review.yml, the next regeneration wrote the stale constant
+      // back, and the bump was silently reverted. That happened, and the
+      // constant had to be hand-updated to match.
+      harden: { egress: "audit", action: this.#spec.hardenRunner },
+      checkout: { persistCredentials: false, action: this.#spec.checkout },
       steps: [
-        {
-          name: "Harden the runner",
-          uses: this.#spec.hardenRunner ?? HARDEN_RUNNER,
-          with: { "egress-policy": "audit" },
-        },
-        {
-          uses: this.#spec.checkout ?? CHECKOUT,
-          with: { "persist-credentials": "false" },
-        },
         ...(fetchBase
           ? [{
             name: "Fetch the base branch",

--- a/packages/ai/tests/workflow_test.ts
+++ b/packages/ai/tests/workflow_test.ts
@@ -60,17 +60,15 @@ Deno.test("the generated YAML carries the right triggers, permissions, concurren
   assertStringIncludes(yaml, "timeout-minutes: 15");
 });
 
-Deno.test("the steps are: harden, checkout (no credentials), fetch base, run ./zuke <target>", () => {
+Deno.test("the steps are: the Zuke prelude, fetch base, run ./zuke <target>", () => {
   const yaml = dualBuild().wf.render();
-  assertStringIncludes(
-    yaml,
-    "uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920",
-  );
+  // One prelude step from core, rather than a harden and a checkout built here
+  // from this package's own pinned constants.
+  assertStringIncludes(yaml, "uses: zuke-build/zuke@");
+  assertEquals(yaml.includes("step-security/harden-runner"), false);
+  assertEquals(yaml.includes("actions/checkout"), false);
+  // The policy those two steps carried is still stated, as the action's inputs.
   assertStringIncludes(yaml, "egress-policy: audit");
-  assertStringIncludes(
-    yaml,
-    "uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
-  );
   // `false` is a string here so YAML doesn't read it as a boolean.
   assertStringIncludes(yaml, 'persist-credentials: "false"');
   // `=` in the command forces YAML to quote the run scalar.
@@ -373,9 +371,8 @@ Deno.test("fetchBase: false drops the fetch step and the FETCH_HEAD override", (
   // duplicate the fetch nor override the base the target set up.
   assertEquals(yaml.includes("git fetch"), false);
   assertEquals(yaml.includes("ZUKE_REVIEW_BASE"), false);
-  // Everything else is unchanged: hardening, checkout, and the review run.
-  assertStringIncludes(yaml, "harden-runner@");
-  assertStringIncludes(yaml, "actions/checkout@");
+  // Everything else is unchanged: the prelude and the review run.
+  assertStringIncludes(yaml, "uses: zuke-build/zuke@");
   assertStringIncludes(yaml, "run: ./zuke review");
 });
 
@@ -385,10 +382,10 @@ Deno.test("fetchBase defaults to true, since a PR checkout has no base", () => {
   assertStringIncludes(yaml, "ZUKE_REVIEW_BASE: FETCH_HEAD");
 });
 
-Deno.test("pinned action refs can be supplied instead of the baked-in ones", () => {
-  // A generated workflow whose SHA comes from a constant in a published package
-  // silently reverts a bot's bump on the next run. Overriding lets the build
-  // source pins from somewhere that stays current.
+Deno.test("naming either action renders the two separate steps", () => {
+  // The opt-out, for a repository that cannot consume a Marketplace action.
+  // Naming an action means those specific actions were asked for, so rendering
+  // one that runs neither would discard a pin the caller chose.
   class B extends Build {
     key = parameter("OpenAI key").secret().env("OPENAI_API_KEY");
     rev = securityReviewer((r) => r.provider("openai").apiKey(this.key));
@@ -402,12 +399,17 @@ Deno.test("pinned action refs can be supplied instead of the baked-in ones", () 
   const b = new B();
   discoverParameters(b);
   const yaml = b.wf.render();
+  assertEquals(yaml.includes("zuke-build/zuke"), false);
   assertStringIncludes(yaml, `harden-runner@${"a".repeat(40)}`);
   assertStringIncludes(yaml, `checkout@${"b".repeat(40)}`);
 });
 
-Deno.test("the baked-in pins are used when none are supplied", () => {
+Deno.test("the prelude carries a pin without this package holding one", () => {
+  // Why the two constants could be deleted: core's prelude ships its own pin,
+  // so nothing here can go stale against a release. That mattered — those
+  // constants made ai-review.yml the one generated workflow whose SHAs came
+  // from a published package, and a Dependabot bump to it was reverted by the
+  // next regeneration.
   const yaml = dualBuild().wf.render();
-  assertStringIncludes(yaml, "step-security/harden-runner@");
-  assertStringIncludes(yaml, "actions/checkout@");
+  assertEquals(/uses: zuke-build\/zuke@[0-9a-f]{40}/.test(yaml), true);
 });

--- a/zuke.ts
+++ b/zuke.ts
@@ -83,7 +83,6 @@ import {
   checkPluginSkillsSync,
   syncPluginSkills,
 } from "./build/plugin_sync.ts";
-import { actionPin } from "./build/action_pins.ts";
 import { actionlintTool, gitleaksTool, zizmorTool } from "./build/scanners.ts";
 import { githubWorkflows } from "./build/workflows.ts";
 
@@ -815,20 +814,17 @@ class ZukeBuild extends Build {
     // the base itself — so the same command works locally, where no workflow
     // step exists to do it.
     fetchBase: false,
-    // Pins from the committed workflows rather than @zuke/ai's own constants.
-    // Without this the file is the one generated workflow whose SHA comes from a
-    // published package: a Dependabot bump lands in ai-review.yml, the next run
-    // regenerates it from the stale constant, and the bump is reverted. That has
-    // already happened once here — the constant had to be hand-updated to match
-    // what Dependabot set.
+    // Nothing about the prelude: core renders it as the one action that hardens
+    // and checks out, and that action's pin resolves through the same `pins`
+    // hook as every other. Naming either action here would opt back out to the
+    // two separate steps.
     //
-    // Still the two separate steps, unlike every other workflow here, because
-    // @zuke/ai cannot declare the prelude until it can name the core that has
-    // it: its floor is `^1.25.0`, which has no `harden`/`checkout` on a job at
-    // all. Raising that floor needs the core released from this change, so the
-    // switch is the follow-up to it.
-    hardenRunner: actionPin("step-security/harden-runner").ref,
-    checkout: actionPin("actions/checkout").ref,
+    // This file used to name both SHAs to avoid @zuke/ai's own constants, which
+    // lived inside a published package — so ai-review.yml's pins came from a
+    // release rather than from the file Dependabot edits, and a bump landed in
+    // the workflow only for the next regeneration to write the stale constant
+    // back. Both constants are now deleted, and the pins live in `action.yml`
+    // where nothing overwrites them.
   });
 
   release = target()


### PR DESCRIPTION
The follow-up promised in #302, now that core 1.34.0 is on JSR.

## What changed

`ai-review.yml` was the last workflow still spelling out a harden and a checkout step, and `@zuke/ai` was the last place holding pinned SHAs for them. It now declares what it wants and lets core render the prelude — one `zuke-build/zuke` step, same as every other workflow here.

Its declared core floor is what kept it there. `^1.25.0` has no `harden` or `checkout` on a job at all, so there was no way to declare a prelude rather than build one. That is why #302 left this out: raising the floor needed the core that #302 itself released.

## The constants are gone, and that is the point

Both `HARDEN_RUNNER` and `CHECKOUT` are deleted. They lived inside a **published package**, which made `ai-review.yml` the one generated workflow whose pins came from a release rather than from the file Dependabot edits. The failure mode was real and had already happened here: a bump landed in the workflow, the next regeneration wrote the stale constant back, and the upgrade was silently reverted — someone had to hand-update the constant to match what the bot had set.

Nothing in this package names an action SHA now. `zuke.ts` also stops passing its own pins in, since there is nothing left to override.

## Backward compatibility

`hardenRunner` and `checkout` keep working and keep their meaning: supplying either renders the two separate steps. That is the same rule core applies — naming an action means those specific actions were asked for, so a caller who pinned them does not silently get one that runs neither.

## Verification

- `coreFloorCheck` passes against the real JSR release — this is the check that failed on #302 and forced the split, so it is the one that matters here.
- `deno.lock` moves with the floor in the same commit, since a dependency range is what changed. One line.
- 22 tests in `packages/ai/tests/workflow_test.ts`.
- `./zuke ci` green, 18/18.

The generated diff is the whole story:

- two steps, `step-security/harden-runner@…` and `actions/checkout@…`
- one step, `zuke-build/zuke@7a62523… # v1.0.1`, carrying `egress-policy: audit` and `persist-credentials: "false"` as inputs

Every workflow in this repository now opens with the action, and the only remaining `actions/checkout` is the deliberate `harden: false` fallback in the test matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)