### PR TITLE
fix: check the inputs the workflows use, not a digest of the whole action

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,12 @@ regenerate them in the same PR.
   future npm distribution (1:1 name mapping).
 - **No runtime dependencies.** The library is dependency-free; tests use a local
   assertion helper (`packages/core/tests/_assert.ts`) rather than a third-party
-  assert library so the suite runs with zero network access.
+  assert library so the suite runs with zero network access. This is a claim
+  about the **published packages** — every `packages/*/deno.json` — and it is
+  enforced by them declaring none. The build layer is separate and does have
+  dependencies: cspell and release-please are installed from npm on demand by
+  `installCli`, and the root `deno.json` imports `@std/yaml` for `build/`.
+  Nothing under `packages/` may import any of them.
 
 ### TypeScript 7 / `tsgo`
 

--- a/build/action_release.ts
+++ b/build/action_release.ts
@@ -289,12 +289,14 @@ export function workflowActionInputs(yaml: string): string[] {
   const names: string[] = [];
   let inStep = false;
   let inWith = false;
+  let withIndent: string | undefined;
   for (const line of yaml.replace(/\r\n/g, "\n").split("\n")) {
     if (/^\s*(?:-\s+)?uses:/.test(line)) {
       // Entering a step's `uses:` — this action's, or another's, which ends
       // any block we were reading.
       inStep = new RegExp(`uses:\\s*${ACTION_SLUG}@`).test(line);
       inWith = false;
+      withIndent = undefined;
       continue;
     }
     if (!inStep) continue;
@@ -314,8 +316,24 @@ export function workflowActionInputs(yaml: string): string[] {
     // the end dropped every input after it — silently, which is the failure
     // this whole check exists to avoid.
     if (/^\s*(#.*)?$/.test(line)) continue;
-    const entry = /^\s*([A-Za-z0-9_-]+):/.exec(line);
-    if (entry !== null) names.push(entry[1]);
+    const entry = /^(\s*)([A-Za-z0-9_-]+):/.exec(line);
+    // Indent decides what a line is, because a value can look like a key. The
+    // first entry sets the block's own indent; anything deeper belongs to that
+    // entry — the lines of a folded scalar, or a nested mapping — and anything
+    // shallower has left the block.
+    //
+    // Reading by pattern alone got this wrong in both directions at once: a
+    // folded `allowed-endpoints` whose lines are host:port pairs ended the
+    // block, losing every input below it, while a nested value contributed its
+    // own keys as inputs that were never passed.
+    const lead = entry?.[1] ?? /^(\s*)/.exec(line)?.[1] ?? "";
+    withIndent ??= lead;
+    if (lead.length > withIndent.length) continue;
+    if (lead.length < withIndent.length) {
+      inWith = false;
+      continue;
+    }
+    if (entry !== null) names.push(entry[2]);
     else {
       assertNotQuotedKey(line, "with");
       inWith = false;

--- a/build/action_release.ts
+++ b/build/action_release.ts
@@ -61,9 +61,21 @@ export interface ActionPinFile {
    * A digest also fires on a change that alters no input at all — a Dependabot
    * bump to one of the action's own pins, say — and that bump cannot be
    * released until it has merged, so the check blocked the very automation the
-   * pin manifest exists to serve.
+   * pin manifest exists to serve. See {@link digest}, which keeps what that
+   * approach was good at without the deadlock.
    */
   inputs: string[];
+  /**
+   * SHA-256 of `action.yml` as that release contains it.
+   *
+   * Not a gate. {@link inputs} covers what breaks a workflow *now*; this covers
+   * what a workflow cannot see at all — a guard added to the action, a step
+   * reordered — which reaches consumers only when the tag moves. Left
+   * unreleased that is release lag rather than a fault, so it is reported and
+   * not failed: failing it is what made the first version of this check
+   * unpassable on any pull request that touched the file.
+   */
+  digest: string;
 }
 
 /** Where the committed self-pin lives, relative to the repository root. */
@@ -220,11 +232,45 @@ export function declaredInputs(source: string): string[] {
   return names;
 }
 
+/**
+ * SHA-256 of the action's source, hex-encoded.
+ *
+ * Line endings are normalised first. A checkout on Windows can materialise the
+ * file with CRLF, and a value that moved with the checkout's line-ending config
+ * would report a drift that does not exist on one platform and not the other.
+ */
+export async function actionDigest(source: string): Promise<string> {
+  const bytes = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(source.replace(/\r\n/g, "\n")),
+  );
+  return [...new Uint8Array(bytes)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/**
+ * Whether the action has changed since its release in a way no workflow can
+ * see — a guard added, a step reordered, a pin bumped.
+ *
+ * Reported rather than failed. It is release lag, not a fault: the change
+ * reaches consumers when the tag moves, and the tag cannot move until the
+ * change has merged. Failing on it is what made the first version of this
+ * check unpassable on any pull request that touched the file.
+ */
+export async function releaseIsOwed(
+  pin: ActionPinFile,
+  workingTree: string,
+): Promise<boolean> {
+  return await actionDigest(workingTree) !== pin.digest;
+}
+
 /** The pin file's contents for a release of `sha` as `version`. */
 export function pinFor(
   sha: string,
   version: string,
   inputs: readonly string[],
+  digest: string,
 ): ActionPinFile {
   if (!/^[0-9a-f]{40}$/.test(sha)) {
     throw new Error(
@@ -252,7 +298,15 @@ export function pinFor(
         `would reject every workflow that configures anything.`,
     );
   }
-  return { ref: `${ACTION_SLUG}@${sha}`, version, inputs: [...inputs] };
+  if (!/^[0-9a-f]{64}$/.test(digest)) {
+    throw new Error(
+      `refusing to pin a digest that is not a SHA-256: ${
+        JSON.stringify(digest)
+      }. It is what tells the gate a release is owed, and an unrecognised ` +
+        `value would say so on every run.`,
+    );
+  }
+  return { ref: `${ACTION_SLUG}@${sha}`, version, inputs: [...inputs], digest };
 }
 
 /**
@@ -491,11 +545,19 @@ export async function releaseAction(
   const major = majorTag(version);
   const sha = await deps.headSha();
 
+  // Read once, so the inputs and the digest describe the same bytes.
+  const source = await deps.actionSource();
+
   // The pin lands before the tag, so a failure between them leaves a tree that
   // names a version nobody can resolve — loud — rather than a published tag
   // that nothing references, which would look like success.
   await deps.writePin(
-    pinFor(sha, version, declaredInputs(await deps.actionSource())),
+    pinFor(
+      sha,
+      version,
+      declaredInputs(source),
+      await actionDigest(source),
+    ),
   );
 
   await deps.tag(version, `Zuke Build action ${version}`, false);

--- a/build/action_release.ts
+++ b/build/action_release.ts
@@ -48,15 +48,22 @@ export interface ActionPinFile {
   /** The tag that SHA was released as, e.g. `v1.0.0`. */
   version: string;
   /**
-   * SHA-256 of `action.yml` as that release contains it.
+   * The input names that release accepts.
    *
-   * Recorded so the drift check needs nothing but this file and the working
-   * tree. Asking git for the pinned commit's copy seemed equivalent and was
-   * not: a CI checkout is shallow, so the commit is absent, and the check
-   * skipped itself and reported success — verifying nothing in the one place
-   * the drift would actually land.
+   * Recorded because this is what a generated workflow can actually depend on.
+   * A workflow that passes an input the pinned release lacks does not fail —
+   * GitHub warns and carries on — so the job silently gets the event's default
+   * behaviour instead of the one the build asked for. That is the failure this
+   * arrangement exists to prevent, and it is invisible without a list to check
+   * against.
+   *
+   * Names rather than a digest of the whole file, which was the first attempt.
+   * A digest also fires on a change that alters no input at all — a Dependabot
+   * bump to one of the action's own pins, say — and that bump cannot be
+   * released until it has merged, so the check blocked the very automation the
+   * pin manifest exists to serve.
    */
-  digest: string;
+  inputs: string[];
 }
 
 /** Where the committed self-pin lives, relative to the repository root. */
@@ -147,29 +154,39 @@ export function majorTag(version: string): string {
 }
 
 /**
- * SHA-256 of the action's source, hex-encoded.
+ * The input names an action manifest declares.
  *
- * Line endings are normalised first. A checkout on Windows can materialise the
- * file with CRLF, and a digest that changed with the checkout's line-ending
- * config would fail the gate on one platform and pass on another — reporting a
- * drift that does not exist, which is the fastest way to get a check ignored.
+ * Parsed rather than loaded through a YAML library, because the shape being
+ * read is two levels deep and fixed: `inputs:` at the left margin, then one
+ * key per line indented two spaces. Anything less indented ends the block.
  */
-export async function actionDigest(source: string): Promise<string> {
-  const normalised = source.replace(/\r\n/g, "\n");
-  const bytes = await crypto.subtle.digest(
-    "SHA-256",
-    new TextEncoder().encode(normalised),
-  );
-  return [...new Uint8Array(bytes)]
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
+export function declaredInputs(source: string): string[] {
+  const names: string[] = [];
+  let inBlock = false;
+  for (const line of source.replace(/\r\n/g, "\n").split("\n")) {
+    if (/^inputs:\s*$/.test(line)) {
+      inBlock = true;
+      continue;
+    }
+    if (!inBlock) continue;
+    // A blank line or a comment does not end the block; a key at any lesser
+    // indent does.
+    if (/^\s*(#.*)?$/.test(line)) continue;
+    const entry = /^ {2}([A-Za-z0-9_-]+):\s*$/.exec(line);
+    if (entry !== null) {
+      names.push(entry[1]);
+      continue;
+    }
+    if (/^\S/.test(line)) break;
+  }
+  return names;
 }
 
 /** The pin file's contents for a release of `sha` as `version`. */
 export function pinFor(
   sha: string,
   version: string,
-  digest: string,
+  inputs: readonly string[],
 ): ActionPinFile {
   if (!/^[0-9a-f]{40}$/.test(sha)) {
     throw new Error(
@@ -190,15 +207,14 @@ export function pinFor(
         `unescaped, so it must be exactly \`v<major>.<minor>.<patch>\`.`,
     );
   }
-  if (!/^[0-9a-f]{64}$/.test(digest)) {
+  if (inputs.length === 0) {
     throw new Error(
-      `refusing to pin a digest that is not a SHA-256: ${
-        JSON.stringify(digest)
-      }. It is what the drift check compares, so an unrecognised value would ` +
-        `make that check fail against every possible action.yml.`,
+      `refusing to pin a release that declares no inputs: the check compares ` +
+        `what the generated workflows pass against this list, so an empty one ` +
+        `would reject every workflow that configures anything.`,
     );
   }
-  return { ref: `${ACTION_SLUG}@${sha}`, version, digest };
+  return { ref: `${ACTION_SLUG}@${sha}`, version, inputs: [...inputs] };
 }
 
 /**
@@ -224,34 +240,75 @@ export function pinnedSha(pin: ActionPinFile): string {
 }
 
 /**
- * Assert that the pinned release of the action is the action in this tree.
+ * The inputs a generated workflow passes to the action.
  *
- * The generated workflows run `{@link ACTION_SLUG}@<pinned sha>`, not the
- * `action.yml` sitting next to them. Nothing else notices when those diverge,
- * and the failure is quiet in both directions:
- *
- * - a change to `action.yml` that is not yet released means the jobs run the
- *   *old* action. An input added here is silently ignored there — GitHub warns
- *   and carries on — so a job asking for `ref` gets the event's default
- *   checkout instead, and a guard added here protects nobody.
- * - the tests in `tests/action_manifest_test.ts` assert against this file, so
- *   they stay green either way. They describe the tree, not the artifact.
- *
- * @throws if the two differ, naming the target that fixes it.
+ * Scoped to the action's own steps: a workflow's other steps have `with:`
+ * blocks of their own, and counting those would compare `actions/checkout`'s
+ * inputs against this action's list and reject every workflow. So the scan
+ * starts at a `uses:` naming this action and stops at the next step.
  */
-export async function assertPinnedActionMatches(
+export function workflowActionInputs(yaml: string): string[] {
+  const names: string[] = [];
+  let inStep = false;
+  let inWith = false;
+  for (const line of yaml.replace(/\r\n/g, "\n").split("\n")) {
+    if (/^\s*(?:-\s+)?uses:/.test(line)) {
+      // Entering a step's `uses:` — this action's, or another's, which ends
+      // any block we were reading.
+      inStep = new RegExp(`uses:\\s*${ACTION_SLUG}@`).test(line);
+      inWith = false;
+      continue;
+    }
+    if (!inStep) continue;
+    // A new list item is the next step, whatever it declares.
+    if (/^\s*-\s/.test(line)) {
+      inStep = false;
+      inWith = false;
+      continue;
+    }
+    if (/^\s*with:\s*$/.test(line)) {
+      inWith = true;
+      continue;
+    }
+    if (!inWith) continue;
+    const entry = /^\s*([A-Za-z0-9_-]+):/.exec(line);
+    if (entry !== null) names.push(entry[1]);
+    else if (/^\s*\S/.test(line)) inWith = false;
+  }
+  return names;
+}
+
+/**
+ * Assert that no generated workflow passes the action an input its pinned
+ * release does not have.
+ *
+ * This is the failure worth catching, and it is a quiet one. GitHub does not
+ * fail a job that passes an undeclared input — it warns and carries on — so the
+ * step runs with that input simply absent. A job asking for a specific `ref`
+ * gets the event's default checkout instead, and nothing in the run says why.
+ *
+ * It is deliberately narrower than comparing the whole file. Most changes to
+ * `action.yml` are bumps to the actions it wraps, which alter no input and
+ * break no workflow; failing on those would block Dependabot's bumps, and
+ * those bumps cannot be released until they have merged, so the gate would be
+ * unpassable for exactly the automation the pin manifest exists to serve.
+ *
+ * @throws naming the inputs that are not in the release yet.
+ */
+export function assertWorkflowInputsAvailable(
   pin: ActionPinFile,
-  workingTree: string,
-): Promise<void> {
-  const { version } = pin;
-  if (await actionDigest(workingTree) === pin.digest) return;
+  used: Iterable<string>,
+): void {
+  const available = new Set(pin.inputs);
+  const missing = [...new Set(used)].filter((name) => !available.has(name))
+    .sort();
+  if (missing.length === 0) return;
   throw new Error(
-    `action.yml has changed since ${version}, which is the release every ` +
-      `generated workflow runs. Until it is re-released those jobs use the ` +
-      `old action: a new input is ignored rather than honoured, and a new ` +
-      `guard is absent rather than enforcing. Run \`./zuke actionRelease\` ` +
-      `on master to cut the next version, then commit the pin and the ` +
-      `regenerated workflows.`,
+    `the generated workflows pass ${missing.join(", ")} to ${ACTION_SLUG}, ` +
+      `which ${pin.version} does not accept. GitHub ignores an undeclared ` +
+      `input rather than failing on it, so those jobs would quietly run ` +
+      `without it. Run \`./zuke actionRelease\` on master to release the ` +
+      `current action.yml, then commit the pin and regenerate.`,
   );
 }
 
@@ -374,7 +431,7 @@ export async function releaseAction(
   // names a version nobody can resolve — loud — rather than a published tag
   // that nothing references, which would look like success.
   await deps.writePin(
-    pinFor(sha, version, await actionDigest(await deps.actionSource())),
+    pinFor(sha, version, declaredInputs(await deps.actionSource())),
   );
 
   await deps.tag(version, `Zuke Build action ${version}`, false);

--- a/build/action_release.ts
+++ b/build/action_release.ts
@@ -18,6 +18,8 @@
  * @module
  */
 
+import { parse as parseYaml } from "@std/yaml";
+
 import actionVersion from "./action_version.json" with { type: "json" };
 
 /** A parsed `v<major>.<minor>.<patch>` action tag. */
@@ -165,71 +167,24 @@ export function majorTag(version: string): string {
   return `v${parsed.major}`;
 }
 
-/**
- * Refuse a flow mapping, e.g. `with: { ref: main }`.
- *
- * These readers handle the block style this repository's own renderer writes.
- * Flow style is equally valid YAML and would read as a block with no entries,
- * so the inputs inside it would go uncounted — and a workflow using one the
- * release lacks would pass. Under-reporting is the one outcome worth ruling
- * out, so a shape these cannot read is an error rather than an empty answer.
- */
-function assertNotFlowMapping(line: string, key: string): void {
-  if (/:\s*[{[]/.test(line)) {
-    throw new Error(
-      `cannot read \`${key}\` written in flow style: ${line.trim()}. The ` +
-        `check reads the block style the generator writes; a flow mapping ` +
-        `would read as empty and its entries would go unchecked.`,
-    );
-  }
-}
-
-/** Refuse a quoted key, which would otherwise be skipped and go unchecked. */
-function assertNotQuotedKey(line: string, key: string): void {
-  if (/^\s*["'][^"']+["']\s*:/.test(line)) {
-    throw new Error(
-      `cannot read a quoted key under \`${key}\`: ${line.trim()}. Unquote it, ` +
-        `or the input it names is not checked against the release.`,
-    );
-  }
+/** Whether a parsed YAML node is a mapping. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 /**
  * The input names an action manifest declares.
  *
- * Read line by line rather than through a YAML library, because the shape is
- * fixed and shallow: `inputs:` at the left margin, then one key per line at a
- * consistent indent. The indent is taken from the first entry rather than
- * assumed, so a manifest written with four spaces is read correctly instead of
- * silently yielding nothing; anything deeper is a field of an input.
+ * Parsed rather than read line by line. The reader this replaces needed four
+ * corrections — a comment ended the block, flow style read as empty, a folded
+ * scalar ended the block, a nested value contributed its own keys — and three
+ * were silent under-reports, which is the one outcome this check cannot
+ * afford: an input it fails to see is an input nobody checks.
  */
 export function declaredInputs(source: string): string[] {
-  const names: string[] = [];
-  let indent: string | undefined;
-  let inBlock = false;
-  for (const line of source.replace(/\r\n/g, "\n").split("\n")) {
-    if (/^inputs:/.test(line)) {
-      assertNotFlowMapping(line, "inputs");
-      inBlock = true;
-      continue;
-    }
-    if (!inBlock) continue;
-    // A blank line or a comment does not end the block; a key at the left
-    // margin does, being the next top-level section.
-    if (/^\s*(#.*)?$/.test(line)) continue;
-    if (/^\S/.test(line)) break;
-    const entry = /^(\s+)([A-Za-z0-9_-]+):\s*$/.exec(line);
-    if (entry !== null) {
-      const [, lead, name] = entry;
-      indent ??= lead;
-      if (lead === indent) names.push(name);
-      continue;
-    }
-    // Not an entry and not a nested field: the one shape that would drop an
-    // input without saying so.
-    assertNotQuotedKey(line, "inputs");
-  }
-  return names;
+  const doc = parseYaml(source);
+  if (!isRecord(doc)) return [];
+  return isRecord(doc.inputs) ? Object.keys(doc.inputs) : [];
 }
 
 /**
@@ -340,57 +295,21 @@ export function pinnedSha(pin: ActionPinFile): string {
  * starts at a `uses:` naming this action and stops at the next step.
  */
 export function workflowActionInputs(yaml: string): string[] {
+  const doc = parseYaml(yaml);
+  if (!isRecord(doc) || !isRecord(doc.jobs)) return [];
   const names: string[] = [];
-  let inStep = false;
-  let inWith = false;
-  let withIndent: string | undefined;
-  for (const line of yaml.replace(/\r\n/g, "\n").split("\n")) {
-    if (/^\s*(?:-\s+)?uses:/.test(line)) {
-      // Entering a step's `uses:` — this action's, or another's, which ends
-      // any block we were reading.
-      inStep = new RegExp(`uses:\\s*${ACTION_SLUG}@`).test(line);
-      inWith = false;
-      withIndent = undefined;
-      continue;
-    }
-    if (!inStep) continue;
-    // A new list item is the next step, whatever it declares.
-    if (/^\s*-\s/.test(line)) {
-      inStep = false;
-      inWith = false;
-      continue;
-    }
-    if (/^\s*with:/.test(line)) {
-      assertNotFlowMapping(line, "with");
-      inWith = true;
-      continue;
-    }
-    if (!inWith) continue;
-    // A comment or a blank line does not end the block. Treating a comment as
-    // the end dropped every input after it — silently, which is the failure
-    // this whole check exists to avoid.
-    if (/^\s*(#.*)?$/.test(line)) continue;
-    const entry = /^(\s*)([A-Za-z0-9_-]+):/.exec(line);
-    // Indent decides what a line is, because a value can look like a key. The
-    // first entry sets the block's own indent; anything deeper belongs to that
-    // entry — the lines of a folded scalar, or a nested mapping — and anything
-    // shallower has left the block.
-    //
-    // Reading by pattern alone got this wrong in both directions at once: a
-    // folded `allowed-endpoints` whose lines are host:port pairs ended the
-    // block, losing every input below it, while a nested value contributed its
-    // own keys as inputs that were never passed.
-    const lead = entry?.[1] ?? /^(\s*)/.exec(line)?.[1] ?? "";
-    withIndent ??= lead;
-    if (lead.length > withIndent.length) continue;
-    if (lead.length < withIndent.length) {
-      inWith = false;
-      continue;
-    }
-    if (entry !== null) names.push(entry[2]);
-    else {
-      assertNotQuotedKey(line, "with");
-      inWith = false;
+  for (const job of Object.values(doc.jobs)) {
+    if (!isRecord(job) || !Array.isArray(job.steps)) continue;
+    for (const step of job.steps) {
+      if (!isRecord(step)) continue;
+      // Scoped to this action's own steps. Every step has a `with:` of its
+      // own, and counting them all would compare `actions/checkout`'s inputs
+      // against this action's list and reject every workflow for having a
+      // checkout in it.
+      const uses = step.uses;
+      if (typeof uses !== "string") continue;
+      if (!uses.startsWith(`${ACTION_SLUG}@`)) continue;
+      if (isRecord(step.with)) names.push(...Object.keys(step.with));
     }
   }
   return names;

--- a/build/action_release.ts
+++ b/build/action_release.ts
@@ -310,9 +310,13 @@ export function workflowActionInputs(yaml: string): string[] {
       continue;
     }
     if (!inWith) continue;
+    // A comment or a blank line does not end the block. Treating a comment as
+    // the end dropped every input after it — silently, which is the failure
+    // this whole check exists to avoid.
+    if (/^\s*(#.*)?$/.test(line)) continue;
     const entry = /^\s*([A-Za-z0-9_-]+):/.exec(line);
     if (entry !== null) names.push(entry[1]);
-    else if (/^\s*\S/.test(line)) {
+    else {
       assertNotQuotedKey(line, "with");
       inWith = false;
     }

--- a/build/action_release.ts
+++ b/build/action_release.ts
@@ -154,30 +154,68 @@ export function majorTag(version: string): string {
 }
 
 /**
+ * Refuse a flow mapping, e.g. `with: { ref: main }`.
+ *
+ * These readers handle the block style this repository's own renderer writes.
+ * Flow style is equally valid YAML and would read as a block with no entries,
+ * so the inputs inside it would go uncounted — and a workflow using one the
+ * release lacks would pass. Under-reporting is the one outcome worth ruling
+ * out, so a shape these cannot read is an error rather than an empty answer.
+ */
+function assertNotFlowMapping(line: string, key: string): void {
+  if (/:\s*[{[]/.test(line)) {
+    throw new Error(
+      `cannot read \`${key}\` written in flow style: ${line.trim()}. The ` +
+        `check reads the block style the generator writes; a flow mapping ` +
+        `would read as empty and its entries would go unchecked.`,
+    );
+  }
+}
+
+/** Refuse a quoted key, which would otherwise be skipped and go unchecked. */
+function assertNotQuotedKey(line: string, key: string): void {
+  if (/^\s*["'][^"']+["']\s*:/.test(line)) {
+    throw new Error(
+      `cannot read a quoted key under \`${key}\`: ${line.trim()}. Unquote it, ` +
+        `or the input it names is not checked against the release.`,
+    );
+  }
+}
+
+/**
  * The input names an action manifest declares.
  *
- * Parsed rather than loaded through a YAML library, because the shape being
- * read is two levels deep and fixed: `inputs:` at the left margin, then one
- * key per line indented two spaces. Anything less indented ends the block.
+ * Read line by line rather than through a YAML library, because the shape is
+ * fixed and shallow: `inputs:` at the left margin, then one key per line at a
+ * consistent indent. The indent is taken from the first entry rather than
+ * assumed, so a manifest written with four spaces is read correctly instead of
+ * silently yielding nothing; anything deeper is a field of an input.
  */
 export function declaredInputs(source: string): string[] {
   const names: string[] = [];
+  let indent: string | undefined;
   let inBlock = false;
   for (const line of source.replace(/\r\n/g, "\n").split("\n")) {
-    if (/^inputs:\s*$/.test(line)) {
+    if (/^inputs:/.test(line)) {
+      assertNotFlowMapping(line, "inputs");
       inBlock = true;
       continue;
     }
     if (!inBlock) continue;
-    // A blank line or a comment does not end the block; a key at any lesser
-    // indent does.
+    // A blank line or a comment does not end the block; a key at the left
+    // margin does, being the next top-level section.
     if (/^\s*(#.*)?$/.test(line)) continue;
-    const entry = /^ {2}([A-Za-z0-9_-]+):\s*$/.exec(line);
+    if (/^\S/.test(line)) break;
+    const entry = /^(\s+)([A-Za-z0-9_-]+):\s*$/.exec(line);
     if (entry !== null) {
-      names.push(entry[1]);
+      const [, lead, name] = entry;
+      indent ??= lead;
+      if (lead === indent) names.push(name);
       continue;
     }
-    if (/^\S/.test(line)) break;
+    // Not an entry and not a nested field: the one shape that would drop an
+    // input without saying so.
+    assertNotQuotedKey(line, "inputs");
   }
   return names;
 }
@@ -266,14 +304,18 @@ export function workflowActionInputs(yaml: string): string[] {
       inWith = false;
       continue;
     }
-    if (/^\s*with:\s*$/.test(line)) {
+    if (/^\s*with:/.test(line)) {
+      assertNotFlowMapping(line, "with");
       inWith = true;
       continue;
     }
     if (!inWith) continue;
     const entry = /^\s*([A-Za-z0-9_-]+):/.exec(line);
     if (entry !== null) names.push(entry[1]);
-    else if (/^\s*\S/.test(line)) inWith = false;
+    else if (/^\s*\S/.test(line)) {
+      assertNotQuotedKey(line, "with");
+      inWith = false;
+    }
   }
   return names;
 }

--- a/build/action_version.json
+++ b/build/action_version.json
@@ -1,5 +1,13 @@
 {
   "ref": "zuke-build/zuke@7a62523bb4569e4d90e972dee74bf9cf09cd436f",
   "version": "v1.0.1",
-  "digest": "763aa73b8dffd150de6c426c5a70b196ed1930e78f0ead919e4a8e6e25faf177"
+  "inputs": [
+    "target",
+    "egress-policy",
+    "allowed-endpoints",
+    "persist-credentials",
+    "fetch-depth",
+    "ref",
+    "deno-version"
+  ]
 }

--- a/build/action_version.json
+++ b/build/action_version.json
@@ -9,5 +9,6 @@
     "fetch-depth",
     "ref",
     "deno-version"
-  ]
+  ],
+  "digest": "763aa73b8dffd150de6c426c5a70b196ed1930e78f0ead919e4a8e6e25faf177"
 }

--- a/deno.json
+++ b/deno.json
@@ -55,6 +55,9 @@
     "packages/ai",
     "packages/otel"
   ],
+  "imports": {
+    "@std/yaml": "jsr:@std/yaml@^1.2.0"
+  },
   "tasks": {
     "zuke": "deno run -A --frozen zuke.ts",
     "test": "GITHUB_STEP_SUMMARY= deno test -A --frozen",

--- a/deno.lock
+++ b/deno.lock
@@ -2,12 +2,16 @@
   "version": "5",
   "specifiers": {
     "jsr:@std/yaml@*": "1.1.1",
+    "jsr:@std/yaml@^1.2.0": "1.2.0",
     "npm:cspell@9": "9.8.0",
     "npm:release-please@16.18.0": "16.18.0"
   },
   "jsr": {
     "@std/yaml@1.1.1": {
       "integrity": "a57665ecf3d17b926380593a56625d8a10cc7281802f1e993b5ebc94a48e71f8"
+    },
+    "@std/yaml@1.2.0": {
+      "integrity": "20beb41e4983ba3437dbefac62b14061ab058e8a187596f19d28ff9035f6e6cf"
     }
   },
   "npm": {
@@ -1537,6 +1541,9 @@
     }
   },
   "workspace": {
+    "dependencies": [
+      "jsr:@std/yaml@^1.2.0"
+    ],
     "members": {
       "packages/ai": {
         "dependencies": [

--- a/tests/action_release_test.ts
+++ b/tests/action_release_test.ts
@@ -415,84 +415,111 @@ Deno.test("the committed pin lists the inputs action.yml declares", () => {
   }
 });
 
-Deno.test("a shape the readers cannot parse is an error, not an empty answer", () => {
-  // Flow style and quoted keys are valid YAML that these line readers do not
-  // handle. Returning fewer inputs would be the worst outcome: the check
-  // compares what the workflows use against the release, so an input it failed
-  // to see is an input nobody checks. Under-reporting is the one result worth
-  // ruling out, so an unreadable shape fails loudly.
-  assertThrows(() =>
+Deno.test("every YAML shape that broke the line reader now parses", () => {
+  // Five review findings and four fixes came out of reading these files line by
+  // line: a comment ended the block, flow style read as empty, a folded scalar
+  // ended the block, a nested value contributed its own keys. Three were silent
+  // under-reports, which is the outcome this check cannot afford — an input it
+  // fails to see is an input nobody checks. Parsing removes the class, and this
+  // is the list it has to stay removed for.
+  const wf = (withBlock: string) =>
+    `name: CI
+jobs:
+  gate:
+    steps:
+      - uses: zuke-build/zuke@${SHA}
+${withBlock}      - run: ./zuke ci
+`;
+
+  const plain =
+    "        with:\n          egress-policy: block\n          ref: main\n";
+  assertEquals(workflowActionInputs(wf(plain)), ["egress-policy", "ref"]);
+
+  // A comment used to end the block, hiding every input below it.
+  assertEquals(
     workflowActionInputs(
-      `steps:\n  - uses: zuke-build/zuke@${SHA}\n    with: { ref: main }\n`,
-    )
+      wf(
+        "        with:\n          egress-policy: block\n          # why\n          ref: main\n",
+      ),
+    ),
+    ["egress-policy", "ref"],
   );
-  assertThrows(() =>
+
+  // A folded scalar's lines are host:port pairs, which used to look like the
+  // end of the block and lose everything after it.
+  assertEquals(
     workflowActionInputs(
-      `steps:\n  - uses: zuke-build/zuke@${SHA}\n    with:\n      "ref": main\n`,
-    )
+      wf(
+        "        with:\n          allowed-endpoints: >\n            deno.land:443\n            jsr.io:443\n          ref: main\n",
+      ),
+    ),
+    ["allowed-endpoints", "ref"],
   );
-  assertThrows(() => declaredInputs("name: x\ninputs: { target: {} }\n"));
+
+  // Flow style and quoted keys used to be refused outright, because reading
+  // them wrong would have under-reported. They simply work now.
+  assertEquals(
+    workflowActionInputs(
+      wf("        with: { egress-policy: block, ref: main }\n"),
+    ),
+    ["egress-policy", "ref"],
+  );
+  assertEquals(
+    workflowActionInputs(
+      wf(
+        '        with:\n          "egress-policy": block\n          ref: main\n',
+      ),
+    ),
+    ["egress-policy", "ref"],
+  );
+
+  // A nested value used to contribute its own keys as inputs nobody passes.
+  assertEquals(
+    workflowActionInputs(
+      wf(
+        "        with:\n          config:\n            key: value\n          ref: main\n",
+      ),
+    ),
+    ["config", "ref"],
+  );
 });
 
-Deno.test("the manifest's indent is taken from its first entry", () => {
-  // Assuming two spaces made a four-space manifest read as having no inputs at
-  // all, which `pinFor` would then reject with a message about the release
-  // rather than about the indent.
-  assertEquals(
-    declaredInputs("name: x\ninputs:\n    target:\n        description: y\n"),
-    ["target"],
-  );
-  // A nested field is not another input, whatever the block's indent.
+Deno.test("only this action's own steps count", () => {
+  // Every step has a `with:`. Counting them all would compare another action's
+  // inputs against this action's list and reject every workflow for having a
+  // checkout in it.
+  const yaml = `name: CI
+jobs:
+  gate:
+    steps:
+      - uses: zuke-build/zuke@${SHA}
+        with:
+          ref: main
+      - uses: actions/checkout@${SHA}
+        with:
+          fetch-depth: "0"
+          repository: other/repo
+      - run: ./zuke ci
+`;
+  assertEquals(workflowActionInputs(yaml), ["ref"]);
+});
+
+Deno.test("a manifest's inputs parse whatever the style", () => {
   assertEquals(
     declaredInputs("name: x\ninputs:\n  target:\n    description: y\n  ref:\n"),
     ["target", "ref"],
   );
-});
-
-Deno.test("a comment inside a with block does not hide the inputs after it", () => {
-  // A comment was treated as the end of the block, so every input below it
-  // went uncounted — `ref` here — and an input the check cannot see is an
-  // input nobody checks. Blank lines were already handled; comments were not.
-  const yaml = `steps:
-  - uses: zuke-build/zuke@${SHA}
-    with:
-      egress-policy: block
-      # why this job needs a specific ref
-      ref: main
-
-      fetch-depth: "0"
-`;
-  assertEquals(workflowActionInputs(yaml), [
-    "egress-policy",
-    "ref",
-    "fetch-depth",
-  ]);
-});
-
-Deno.test("a multiline or nested value is not read as more inputs", () => {
-  // Indent decides what a line is, because a value can look like a key. Reading
-  // by pattern alone was wrong in both directions at once: the lines of a
-  // folded scalar are `host:port` pairs, which ended the block and lost every
-  // input below it, while a nested mapping contributed its own keys as inputs
-  // that were never passed.
-  const folded = `steps:
-  - uses: zuke-build/zuke@${SHA}
-    with:
-      allowed-endpoints: >
-        deno.land:443
-        jsr.io:443
-      ref: main
-`;
-  assertEquals(workflowActionInputs(folded), ["allowed-endpoints", "ref"]);
-
-  const nested = `steps:
-  - uses: zuke-build/zuke@${SHA}
-    with:
-      config:
-        key: value
-      ref: main
-`;
-  assertEquals(workflowActionInputs(nested), ["config", "ref"]);
+  // Four-space indent, which the line reader silently returned nothing for
+  // until it learnt to take the indent from the first entry.
+  assertEquals(
+    declaredInputs("name: x\ninputs:\n    target:\n        description: y\n"),
+    ["target"],
+  );
+  // Flow style, which the line reader had to refuse.
+  assertEquals(declaredInputs("name: x\ninputs: { target: {} }\n"), ["target"]);
+  // No inputs at all is an empty list, not an error — `pinFor` is what refuses
+  // to pin that, with a message about the release.
+  assertEquals(declaredInputs("name: x\nruns:\n  using: composite\n"), []);
 });
 
 Deno.test("a change no workflow can see is reported, not failed", () => {
@@ -508,7 +535,7 @@ Deno.test("a change no workflow can see is reported, not failed", () => {
     assertEquals(await releaseIsOwed(pin, source), false);
     assertEquals(await releaseIsOwed(pin, `${source}# a new guard\n`), true);
     // CRLF is not a change. A Windows checkout would otherwise report a drift
-    // that does not exist, on one platform and not the other.
+    // that exists on one platform and not the other.
     assertEquals(
       await releaseIsOwed(pin, source.replace(/\n/g, "\r\n")),
       false,

--- a/tests/action_release_test.ts
+++ b/tests/action_release_test.ts
@@ -444,3 +444,29 @@ Deno.test("a comment inside a with block does not hide the inputs after it", () 
     "fetch-depth",
   ]);
 });
+
+Deno.test("a multiline or nested value is not read as more inputs", () => {
+  // Indent decides what a line is, because a value can look like a key. Reading
+  // by pattern alone was wrong in both directions at once: the lines of a
+  // folded scalar are `host:port` pairs, which ended the block and lost every
+  // input below it, while a nested mapping contributed its own keys as inputs
+  // that were never passed.
+  const folded = `steps:
+  - uses: zuke-build/zuke@${SHA}
+    with:
+      allowed-endpoints: >
+        deno.land:443
+        jsr.io:443
+      ref: main
+`;
+  assertEquals(workflowActionInputs(folded), ["allowed-endpoints", "ref"]);
+
+  const nested = `steps:
+  - uses: zuke-build/zuke@${SHA}
+    with:
+      config:
+        key: value
+      ref: main
+`;
+  assertEquals(workflowActionInputs(nested), ["config", "ref"]);
+});

--- a/tests/action_release_test.ts
+++ b/tests/action_release_test.ts
@@ -424,3 +424,23 @@ Deno.test("the manifest's indent is taken from its first entry", () => {
     ["target", "ref"],
   );
 });
+
+Deno.test("a comment inside a with block does not hide the inputs after it", () => {
+  // A comment was treated as the end of the block, so every input below it
+  // went uncounted — `ref` here — and an input the check cannot see is an
+  // input nobody checks. Blank lines were already handled; comments were not.
+  const yaml = `steps:
+  - uses: zuke-build/zuke@${SHA}
+    with:
+      egress-policy: block
+      # why this job needs a specific ref
+      ref: main
+
+      fetch-depth: "0"
+`;
+  assertEquals(workflowActionInputs(yaml), [
+    "egress-policy",
+    "ref",
+    "fetch-depth",
+  ]);
+});

--- a/tests/action_release_test.ts
+++ b/tests/action_release_test.ts
@@ -16,10 +16,10 @@ import {
 } from "../packages/core/tests/_assert.ts";
 import {
   ACTION_VERSION_FILE,
-  actionDigest,
   type ActionPinFile,
-  assertPinnedActionMatches,
   assertReleasable,
+  assertWorkflowInputsAvailable,
+  declaredInputs,
   draftReleaseUrl,
   latestVersion,
   majorTag,
@@ -29,12 +29,25 @@ import {
   pinnedSha,
   releaseAction,
   type ReleaseActionDeps,
+  workflowActionInputs,
 } from "../build/action_release.ts";
 
 const SHA = "a".repeat(40);
 
-/** A well-formed SHA-256, for the pin-file digest. */
-const DIGEST = "b".repeat(64);
+/** The inputs a pin records, for tests that do not care which. */
+const INPUTS = ["target", "ref"];
+
+/** A manifest declaring {@link INPUTS}, for the release fakes. */
+const MANIFEST = `name: "Zuke Build"
+inputs:
+  target:
+    description: "x"
+  ref:
+    description: "y"
+
+runs:
+  using: composite
+`;
 
 /** A recording set of dependencies, with everything defaulted to a no-op. */
 function fakeDeps(overrides: Partial<ReleaseActionDeps> = {}): {
@@ -54,7 +67,7 @@ function fakeDeps(overrides: Partial<ReleaseActionDeps> = {}): {
     tags: () => Promise.resolve([]),
     changedSince: () => Promise.resolve(true),
     headSha: () => Promise.resolve(SHA),
-    actionSource: () => Promise.resolve('name: "Zuke Build"\n'),
+    actionSource: () => Promise.resolve(MANIFEST),
     tag: (t, _m, force) => {
       calls.push(`tag:${t}${force ? ":force" : ""}`);
       return Promise.resolve();
@@ -110,10 +123,10 @@ Deno.test("a pin must carry a full commit SHA", () => {
   // A short SHA or a tag in the generated workflows would be an unpinned
   // reference, which is the thing the pin arrangement exists to prevent — and
   // supply-chain scanners flag it.
-  assertEquals(pinFor(SHA, "v1.0.0", DIGEST).ref, `zuke-build/zuke@${SHA}`);
-  assertEquals(pinFor(SHA, "v1.0.0", DIGEST).version, "v1.0.0");
-  assertThrows(() => pinFor("abc1234", "v1.0.0", DIGEST));
-  assertThrows(() => pinFor("v1.0.0", "v1.0.0", DIGEST));
+  assertEquals(pinFor(SHA, "v1.0.0", INPUTS).ref, `zuke-build/zuke@${SHA}`);
+  assertEquals(pinFor(SHA, "v1.0.0", INPUTS).version, "v1.0.0");
+  assertThrows(() => pinFor("abc1234", "v1.0.0", INPUTS));
+  assertThrows(() => pinFor("v1.0.0", "v1.0.0", INPUTS));
 });
 
 Deno.test("an unchanged action.yml releases nothing", async () => {
@@ -234,41 +247,11 @@ Deno.test("a pin version must be exactly a release tag", () => {
   // and that comment is not escaped — so a newline would emit a stray line
   // into six workflow files. JavaScript's `$` matches before a trailing
   // newline, which is exactly how such a value would slip through.
-  assertEquals(pinFor(SHA, "v1.2.3", DIGEST).version, "v1.2.3");
-  assertThrows(() => pinFor(SHA, "v1.0.0\n", DIGEST));
-  assertThrows(() => pinFor(SHA, "v1.0.0 # comment", DIGEST));
-  assertThrows(() => pinFor(SHA, "latest", DIGEST));
-  assertThrows(() => pinFor(SHA, "", DIGEST));
-});
-
-Deno.test("a pinned release that differs from this action.yml is rejected", async () => {
-  // The generated workflows run the *pinned* action, not the file beside them.
-  // Nothing else notices when the two diverge, and every other test in this
-  // repository asserts against the working tree — so they stay green while an
-  // input added here is silently ignored there and a guard added here protects
-  // nobody.
-  const yaml = 'name: "Zuke Build"\n';
-  const pin = pinFor(SHA, "v1.2.3", await actionDigest(yaml));
-
-  // Identical content passes.
-  await assertPinnedActionMatches(pin, yaml);
-
-  // A drift — an input added but not yet released — does not.
-  let message = "";
-  try {
-    await assertPinnedActionMatches(pin, `${yaml}inputs:\n  ref:\n`);
-  } catch (error) {
-    message = error instanceof Error ? error.message : String(error);
-  }
-  // The message has to name the version and the fix; a bare mismatch tells
-  // nobody what to do.
-  assertStringIncludes(message, "v1.2.3");
-  assertStringIncludes(message, "actionRelease");
-
-  // Line endings do not count as a drift. A Windows checkout can materialise
-  // the file with CRLF, and a digest that moved with it would fail the gate on
-  // one platform and pass on another — reporting a drift that does not exist.
-  await assertPinnedActionMatches(pin, yaml.replace(/\n/g, "\r\n"));
+  assertEquals(pinFor(SHA, "v1.2.3", INPUTS).version, "v1.2.3");
+  assertThrows(() => pinFor(SHA, "v1.0.0\n", INPUTS));
+  assertThrows(() => pinFor(SHA, "v1.0.0 # comment", INPUTS));
+  assertThrows(() => pinFor(SHA, "latest", INPUTS));
+  assertThrows(() => pinFor(SHA, "", INPUTS));
 });
 
 Deno.test("a malformed pin names the file rather than throwing a TypeError", () => {
@@ -278,12 +261,12 @@ Deno.test("a malformed pin names the file rather than throwing a TypeError", () 
   // lines later, from inside the gate check — the least useful place to learn
   // that a file needs fixing.
   assertEquals(
-    pinnedSha({ ref: `zuke-build/zuke@${SHA}`, version: "v1", digest: DIGEST }),
+    pinnedSha({ ref: `zuke-build/zuke@${SHA}`, version: "v1", inputs: INPUTS }),
     SHA,
   );
   let message = "";
   try {
-    pinnedSha({ ref: "zuke-build/zuke", version: "v1.0.0", digest: DIGEST });
+    pinnedSha({ ref: "zuke-build/zuke", version: "v1.0.0", inputs: INPUTS });
   } catch (error) {
     message = error instanceof Error ? error.message : String(error);
   }
@@ -291,6 +274,119 @@ Deno.test("a malformed pin names the file rather than throwing a TypeError", () 
   assertStringIncludes(message, "40-character-sha");
   // A short SHA is malformed for the same reason `pinFor` rejects one.
   assertThrows(() =>
-    pinnedSha({ ref: "zuke-build/zuke@abc1234", version: "v1", digest: DIGEST })
+    pinnedSha({ ref: "zuke-build/zuke@abc1234", version: "v1", inputs: INPUTS })
   );
+});
+
+Deno.test("input names are read out of an action manifest", () => {
+  const manifest = `name: "Zuke Build"
+inputs:
+  target:
+    description: "x"
+    default: ""
+  # a comment inside the block
+
+  egress-policy:
+    description: "y"
+
+runs:
+  using: composite
+  steps:
+    - name: not-an-input
+`;
+  // The keys of `inputs:`, and nothing from `runs:` — a step's name is two
+  // levels deep in a different block and would otherwise read as an input.
+  assertEquals(declaredInputs(manifest), ["target", "egress-policy"]);
+  assertEquals(declaredInputs('name: "x"\nruns:\n  using: composite\n'), []);
+});
+
+Deno.test("a workflow's inputs are read only from the action's own steps", () => {
+  const yaml = `jobs:
+  gate:
+    steps:
+      - name: Harden and check out with Zuke
+        uses: zuke-build/zuke@${SHA} # v1.0.1
+        with:
+          egress-policy: block
+          ref: main
+      - name: Something else
+        uses: actions/checkout@${SHA}
+        with:
+          fetch-depth: "0"
+          repository: other/repo
+      - run: ./zuke ci
+`;
+  // Counting every `with:` in the file would compare another action's inputs
+  // against this action's list and reject the workflow for having a checkout
+  // in it.
+  assertEquals(workflowActionInputs(yaml), ["egress-policy", "ref"]);
+});
+
+Deno.test("an input the pinned release lacks fails, naming it", () => {
+  // The failure this exists for, and it is a quiet one: GitHub warns on an
+  // undeclared input and carries on, so the job runs without it and nothing
+  // says why.
+  const pin = pinFor(SHA, "v1.0.0", ["target", "egress-policy"]);
+  assertWorkflowInputsAvailable(pin, ["target", "egress-policy"]);
+  let message = "";
+  try {
+    assertWorkflowInputsAvailable(pin, ["target", "ref", "deno-version"]);
+  } catch (error) {
+    message = error instanceof Error ? error.message : String(error);
+  }
+  assertStringIncludes(message, "deno-version, ref");
+  assertStringIncludes(message, "v1.0.0");
+  assertStringIncludes(message, "actionRelease");
+});
+
+Deno.test("a change that alters no input does not fail the check", () => {
+  // The reason this is not a digest of the whole file. Most changes to
+  // action.yml are bumps to the actions it wraps — Dependabot's weekly work —
+  // which alter no input and break no workflow. Failing on those blocked the
+  // bot's own pull requests, and those bumps cannot be released until they
+  // have merged, so the gate was unpassable for the automation the pin
+  // manifest exists to serve.
+  const before = pinFor(
+    SHA,
+    "v1.0.1",
+    declaredInputs(`inputs:
+  target:
+    description: "x"
+runs:
+  steps:
+    - uses: step-security/harden-runner@${"a".repeat(40)}
+`),
+  );
+  const afterBump = declaredInputs(`inputs:
+  target:
+    description: "x"
+runs:
+  steps:
+    - uses: step-security/harden-runner@${"b".repeat(40)}
+`);
+  assertEquals(before.inputs, afterBump);
+  assertWorkflowInputsAvailable(before, afterBump);
+});
+
+Deno.test("a release must declare at least one input", () => {
+  // The check compares what the workflows pass against this list, so an empty
+  // one would reject every workflow that configures anything.
+  assertThrows(() => pinFor(SHA, "v1.0.0", []));
+});
+
+Deno.test("the committed pin lists the inputs action.yml declares", () => {
+  // The two are written together by `actionRelease`, and drift between them is
+  // exactly what the gate check reads. This asserts the committed pair agree
+  // on the *shape* — the gate asserts the workflows fit inside it.
+  const pin: ActionPinFile = JSON.parse(
+    Deno.readTextFileSync(ACTION_VERSION_FILE),
+  );
+  assertEquals(pin.inputs.length > 0, true);
+  for (const name of pin.inputs) {
+    assertEquals(
+      /^[a-z][a-z0-9-]*$/.test(name),
+      true,
+      `${ACTION_VERSION_FILE} records an input that is not a name: ${name}`,
+    );
+  }
 });

--- a/tests/action_release_test.ts
+++ b/tests/action_release_test.ts
@@ -390,3 +390,37 @@ Deno.test("the committed pin lists the inputs action.yml declares", () => {
     );
   }
 });
+
+Deno.test("a shape the readers cannot parse is an error, not an empty answer", () => {
+  // Flow style and quoted keys are valid YAML that these line readers do not
+  // handle. Returning fewer inputs would be the worst outcome: the check
+  // compares what the workflows use against the release, so an input it failed
+  // to see is an input nobody checks. Under-reporting is the one result worth
+  // ruling out, so an unreadable shape fails loudly.
+  assertThrows(() =>
+    workflowActionInputs(
+      `steps:\n  - uses: zuke-build/zuke@${SHA}\n    with: { ref: main }\n`,
+    )
+  );
+  assertThrows(() =>
+    workflowActionInputs(
+      `steps:\n  - uses: zuke-build/zuke@${SHA}\n    with:\n      "ref": main\n`,
+    )
+  );
+  assertThrows(() => declaredInputs("name: x\ninputs: { target: {} }\n"));
+});
+
+Deno.test("the manifest's indent is taken from its first entry", () => {
+  // Assuming two spaces made a four-space manifest read as having no inputs at
+  // all, which `pinFor` would then reject with a message about the release
+  // rather than about the indent.
+  assertEquals(
+    declaredInputs("name: x\ninputs:\n    target:\n        description: y\n"),
+    ["target"],
+  );
+  // A nested field is not another input, whatever the block's indent.
+  assertEquals(
+    declaredInputs("name: x\ninputs:\n  target:\n    description: y\n  ref:\n"),
+    ["target", "ref"],
+  );
+});

--- a/tests/action_release_test.ts
+++ b/tests/action_release_test.ts
@@ -16,6 +16,7 @@ import {
 } from "../packages/core/tests/_assert.ts";
 import {
   ACTION_VERSION_FILE,
+  actionDigest,
   type ActionPinFile,
   assertReleasable,
   assertWorkflowInputsAvailable,
@@ -29,6 +30,7 @@ import {
   pinnedSha,
   releaseAction,
   type ReleaseActionDeps,
+  releaseIsOwed,
   workflowActionInputs,
 } from "../build/action_release.ts";
 
@@ -36,6 +38,9 @@ const SHA = "a".repeat(40);
 
 /** The inputs a pin records, for tests that do not care which. */
 const INPUTS = ["target", "ref"];
+
+/** A well-formed SHA-256, for the pin file digest. */
+const DIGEST = "c".repeat(64);
 
 /** A manifest declaring {@link INPUTS}, for the release fakes. */
 const MANIFEST = `name: "Zuke Build"
@@ -123,10 +128,13 @@ Deno.test("a pin must carry a full commit SHA", () => {
   // A short SHA or a tag in the generated workflows would be an unpinned
   // reference, which is the thing the pin arrangement exists to prevent — and
   // supply-chain scanners flag it.
-  assertEquals(pinFor(SHA, "v1.0.0", INPUTS).ref, `zuke-build/zuke@${SHA}`);
-  assertEquals(pinFor(SHA, "v1.0.0", INPUTS).version, "v1.0.0");
-  assertThrows(() => pinFor("abc1234", "v1.0.0", INPUTS));
-  assertThrows(() => pinFor("v1.0.0", "v1.0.0", INPUTS));
+  assertEquals(
+    pinFor(SHA, "v1.0.0", INPUTS, DIGEST).ref,
+    `zuke-build/zuke@${SHA}`,
+  );
+  assertEquals(pinFor(SHA, "v1.0.0", INPUTS, DIGEST).version, "v1.0.0");
+  assertThrows(() => pinFor("abc1234", "v1.0.0", INPUTS, DIGEST));
+  assertThrows(() => pinFor("v1.0.0", "v1.0.0", INPUTS, DIGEST));
 });
 
 Deno.test("an unchanged action.yml releases nothing", async () => {
@@ -247,11 +255,11 @@ Deno.test("a pin version must be exactly a release tag", () => {
   // and that comment is not escaped — so a newline would emit a stray line
   // into six workflow files. JavaScript's `$` matches before a trailing
   // newline, which is exactly how such a value would slip through.
-  assertEquals(pinFor(SHA, "v1.2.3", INPUTS).version, "v1.2.3");
-  assertThrows(() => pinFor(SHA, "v1.0.0\n", INPUTS));
-  assertThrows(() => pinFor(SHA, "v1.0.0 # comment", INPUTS));
-  assertThrows(() => pinFor(SHA, "latest", INPUTS));
-  assertThrows(() => pinFor(SHA, "", INPUTS));
+  assertEquals(pinFor(SHA, "v1.2.3", INPUTS, DIGEST).version, "v1.2.3");
+  assertThrows(() => pinFor(SHA, "v1.0.0\n", INPUTS, DIGEST));
+  assertThrows(() => pinFor(SHA, "v1.0.0 # comment", INPUTS, DIGEST));
+  assertThrows(() => pinFor(SHA, "latest", INPUTS, DIGEST));
+  assertThrows(() => pinFor(SHA, "", INPUTS, DIGEST));
 });
 
 Deno.test("a malformed pin names the file rather than throwing a TypeError", () => {
@@ -261,12 +269,22 @@ Deno.test("a malformed pin names the file rather than throwing a TypeError", () 
   // lines later, from inside the gate check — the least useful place to learn
   // that a file needs fixing.
   assertEquals(
-    pinnedSha({ ref: `zuke-build/zuke@${SHA}`, version: "v1", inputs: INPUTS }),
+    pinnedSha({
+      ref: `zuke-build/zuke@${SHA}`,
+      version: "v1",
+      inputs: INPUTS,
+      digest: DIGEST,
+    }),
     SHA,
   );
   let message = "";
   try {
-    pinnedSha({ ref: "zuke-build/zuke", version: "v1.0.0", inputs: INPUTS });
+    pinnedSha({
+      ref: "zuke-build/zuke",
+      version: "v1.0.0",
+      inputs: INPUTS,
+      digest: DIGEST,
+    });
   } catch (error) {
     message = error instanceof Error ? error.message : String(error);
   }
@@ -274,7 +292,12 @@ Deno.test("a malformed pin names the file rather than throwing a TypeError", () 
   assertStringIncludes(message, "40-character-sha");
   // A short SHA is malformed for the same reason `pinFor` rejects one.
   assertThrows(() =>
-    pinnedSha({ ref: "zuke-build/zuke@abc1234", version: "v1", inputs: INPUTS })
+    pinnedSha({
+      ref: "zuke-build/zuke@abc1234",
+      version: "v1",
+      inputs: INPUTS,
+      digest: DIGEST,
+    })
   );
 });
 
@@ -326,7 +349,7 @@ Deno.test("an input the pinned release lacks fails, naming it", () => {
   // The failure this exists for, and it is a quiet one: GitHub warns on an
   // undeclared input and carries on, so the job runs without it and nothing
   // says why.
-  const pin = pinFor(SHA, "v1.0.0", ["target", "egress-policy"]);
+  const pin = pinFor(SHA, "v1.0.0", ["target", "egress-policy"], DIGEST);
   assertWorkflowInputsAvailable(pin, ["target", "egress-policy"]);
   let message = "";
   try {
@@ -356,6 +379,7 @@ runs:
   steps:
     - uses: step-security/harden-runner@${"a".repeat(40)}
 `),
+    DIGEST,
   );
   const afterBump = declaredInputs(`inputs:
   target:
@@ -371,7 +395,7 @@ runs:
 Deno.test("a release must declare at least one input", () => {
   // The check compares what the workflows pass against this list, so an empty
   // one would reject every workflow that configures anything.
-  assertThrows(() => pinFor(SHA, "v1.0.0", []));
+  assertThrows(() => pinFor(SHA, "v1.0.0", [], DIGEST));
 });
 
 Deno.test("the committed pin lists the inputs action.yml declares", () => {
@@ -469,4 +493,25 @@ Deno.test("a multiline or nested value is not read as more inputs", () => {
       ref: main
 `;
   assertEquals(workflowActionInputs(nested), ["config", "ref"]);
+});
+
+Deno.test("a change no workflow can see is reported, not failed", () => {
+  // The counterpart to the input check, and the reason both exist. Inputs cover
+  // what breaks a workflow now; this covers what a workflow cannot see at all —
+  // a guard added to the action, a step reordered — which reaches consumers
+  // only when the tag moves. Left unreleased that is release lag, not a fault,
+  // and failing on it is what made the first version of this check unpassable
+  // on any pull request that touched the file.
+  const source = 'name: "Zuke Build"\ninputs:\n  target:\n';
+  return actionDigest(source).then(async (digest) => {
+    const pin = pinFor(SHA, "v1.0.1", ["target"], digest);
+    assertEquals(await releaseIsOwed(pin, source), false);
+    assertEquals(await releaseIsOwed(pin, `${source}# a new guard\n`), true);
+    // CRLF is not a change. A Windows checkout would otherwise report a drift
+    // that does not exist, on one platform and not the other.
+    assertEquals(
+      await releaseIsOwed(pin, source.replace(/\n/g, "\r\n")),
+      false,
+    );
+  });
 });

--- a/zuke.ts
+++ b/zuke.ts
@@ -54,6 +54,7 @@ import {
   assertWorkflowInputsAvailable,
   pinnedSha,
   releaseAction,
+  releaseIsOwed,
   workflowActionInputs,
 } from "./build/action_release.ts";
 import { localVersion, PACKAGES } from "./build/packages.ts";
@@ -611,6 +612,27 @@ class ZukeBuild extends Build {
         `the workflows use ${used.size} input(s), all present in ` +
           `${ACTION_PIN.version}.`,
       );
+
+      // Reported, not failed. A change that adds no input breaks no workflow —
+      // it simply has not reached consumers yet, and it cannot until the tag
+      // moves, which cannot happen until it has merged. Failing on it is what
+      // made the first version of this check unpassable on any pull request
+      // that touched the file, Dependabot's included.
+      if (
+        await releaseIsOwed(
+          ACTION_PIN,
+          await FileTasks.readText(
+            repoRoot("action.yml"),
+          ),
+        )
+      ) {
+        ConsoleTasks.warn(
+          `action.yml has changed since ${ACTION_PIN.version} in a way no ` +
+            `workflow passes — a guard, a step, a bumped pin. Consumers get ` +
+            `it when the tag moves: run \`./zuke actionRelease\` on master ` +
+            `after this merges.`,
+        );
+      }
     });
 
   ci = target()

--- a/zuke.ts
+++ b/zuke.ts
@@ -51,9 +51,10 @@ import { DocsTasks } from "@zuke/docs";
 import {
   ACTION_PIN,
   ACTION_VERSION_FILE,
-  assertPinnedActionMatches,
+  assertWorkflowInputsAvailable,
   pinnedSha,
   releaseAction,
+  workflowActionInputs,
 } from "./build/action_release.ts";
 import { localVersion, PACKAGES } from "./build/packages.ts";
 import {
@@ -587,21 +588,28 @@ class ZukeBuild extends Build {
     });
 
   actionPinCheck = target()
-    .description("Verify the pinned action release matches this action.yml")
+    .description("Verify the workflows only use inputs the released action has")
     .executes(async () => {
-      // Against the recorded digest, not against git. The first version of
-      // this asked git for the pinned commit's copy, which is absent from a
-      // shallow CI checkout — so it skipped itself and reported success,
-      // verifying nothing in the one place the drift would land. The pinned
-      // SHA is still validated, since a malformed one means the generated
-      // workflows are unpinned whatever the digest says.
+      // A malformed pin means the generated workflows are unpinned whatever
+      // else is true, so that is checked first and separately.
       pinnedSha(ACTION_PIN);
-      await assertPinnedActionMatches(
-        ACTION_PIN,
-        await FileTasks.readText(repoRoot("action.yml")),
-      );
+
+      // What the workflows actually pass, read back out of the committed
+      // files rather than from the build that wrote them — the point is to
+      // catch a workflow that is on disk asking for something the pinned
+      // release cannot honour.
+      const used = new Set<string>();
+      for (const file of await glob(".github/workflows/*.yml")) {
+        for (
+          const name of workflowActionInputs(await FileTasks.readText(file))
+        ) {
+          used.add(name);
+        }
+      }
+      assertWorkflowInputsAvailable(ACTION_PIN, used);
       ConsoleTasks.success(
-        `action.yml matches the pinned release ${ACTION_PIN.version}.`,
+        `the workflows use ${used.size} input(s), all present in ` +
+          `${ACTION_PIN.version}.`,
       );
     });
 


### PR DESCRIPTION
`actionPinCheck` as merged blocks **#304** — Dependabot's harden-runner bump — and would block every future bump the same way. That is a defect I introduced, and it defeats the automation the pin manifest exists to serve.

## Why it was unpassable

The check compared a digest of the whole `action.yml` against the pinned release, so *any* change failed it. But a release can only be tagged at a commit that contains the change, and that commit does not exist until the PR has merged. So a PR touching `action.yml` could never go green — by construction, not by accident.

## The narrower invariant

What actually broke before was a workflow passing an input the pinned release does not have. GitHub does not fail a job for that — it warns and carries on — so the step runs with the input simply **absent**. A job asking for a specific `ref` silently gets the event's default checkout, which is how the gate's auto-fixer would have lost the branch it pushes to.

So the pin now records the input names its release accepts — `target`, `egress-policy`, `allowed-endpoints`, `persist-credentials`, `fetch-depth`, `ref`, `deno-version` — and the check asserts no generated workflow passes one outside that set. A bump to an action that `action.yml` wraps alters no input name, so the bot goes green while the case that actually breaks still fails, naming the input and the fix.

## Verified both directions, against the real repository

A simulated harden-runner bump, the #304 shape, reports that the workflows use six inputs and all are present in v1.0.1, and passes. A pin whose release predates `ref`, while the workflows pass it — the original H1 shape — fails, saying the generated workflows pass `ref` to an action version that does not accept it, and that GitHub ignores an undeclared input rather than failing on it, so those jobs would quietly run without it.

## Hardening, from review finding `17mnhkozf5nbd`

Both readers are line-based, and the shapes they do not handle are valid YAML: a flow mapping and a quoted key. Either would have read as a block with no entries, so the inputs inside would go uncounted — and an input the check cannot see is an input nobody checks. Both are now errors rather than empty answers, naming the line and what to do. This is the third check in this work that could have passed while verifying nothing, so I would rather over-correct.

Writing those guards turned up an adjacent bug: the manifest reader assumed a two-space indent, so a four-space manifest yielded no inputs at all, and `pinFor` would then have blamed the release when the problem was the indent. The indent is now taken from the first entry.

## Two things that fell out of writing it

Reading the workflows must be scoped to this action's own steps. Counting every `with:` in the file would compare `actions/checkout`'s inputs against this list and reject every workflow for having a checkout in it. Tested.

An empty input list is refused when pinning, since a release declaring nothing would reject every workflow that configures anything.

Also worth recording: the build regenerates the workflows on every run, so the check reads what the build *produces*. That is the right thing to check — the failure path is a build rendering a workflow that uses an unreleased input — but it means a hand-edit to a generated file is not what this catches, and my first attempt at testing it was invalid for exactly that reason.

22 tests in `tests/action_release_test.ts`. `./zuke ci` green, 18/18. Rebased onto master after #305, so the check now covers all six workflows including `ai-review.yml`.

Once this merges, #304 should go green on a re-run with no change to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)