### PR TITLE
docs: add a Marketplace badge for the action

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   <a href="https://github.com/zuke-build/zuke/actions/workflows/release.yml"><img alt="Release" src="https://github.com/zuke-build/zuke/actions/workflows/release.yml/badge.svg" /></a>
   <a href="https://codecov.io/gh/zuke-build/zuke"><img alt="Coverage" src="https://codecov.io/gh/zuke-build/zuke/branch/master/graph/badge.svg" /></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/zuke-build/zuke"><img alt="OpenSSF Scorecard" src="https://api.scorecard.dev/projects/github.com/zuke-build/zuke/badge" /></a>
+  <a href="https://github.com/marketplace/actions/zuke-build"><img alt="GitHub Marketplace" src="https://img.shields.io/github/v/release/zuke-build/zuke?filter=v%2A.%2A.%2A&amp;label=Marketplace&amp;logo=github&amp;color=2ea44f" /></a>
   <a href="https://jsr.io/@zuke/core"><img alt="JSR" src="https://jsr.io/badges/@zuke/core" /></a>
   <a href="https://jsr.io/@zuke/core"><img alt="JSR score" src="https://jsr.io/badges/@zuke/core/score" /></a>
   <a href="./LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-yellow.svg" /></a>


### PR DESCRIPTION
Adds a badge linking to the [Zuke Build](https://github.com/marketplace/actions/zuke-build) listing, showing the published version.

Placed with the supply-chain badges rather than the distribution ones, since what it reports is which release consumers of `@v1` are actually getting.

## The filter is the substance

This repository's tag namespace is overwhelmingly component releases, so an **unfiltered** release badge reports whichever package published most recently. Verified against the live endpoint — it renders `ai-v1.8.1`, which says nothing about the action and reads as though it did.

Three globs, all checked against the real endpoint before choosing:

| filter | today | later |
| --- | --- | --- |
| *(none)* | `ai-v1.8.1` | always wrong — tracks whichever package released last |
| `v1.*` | `v1.0.2` | freezes at the last v1 when the action goes to v2 |
| `v*` | `v1.0.2` | also matches the moving `v1` pointer tag |
| `v*.*.*` | `v1.0.2` | correct across majors, excludes the pointer tag |

`v*.*.*` it is.

Live rather than a hardcoded version, so it cannot go stale — which is the failure this repository spent the day removing everywhere else.

`./zuke ci` green, 18/18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)