### PR TITLE
fix(gh): persist the dispatch marker before dispatching the workflow

### DIFF
--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -88,10 +88,14 @@ class Release extends Build {
 }
 ```
 
-- **Dispatch-once, then poll.** On first reach it dispatches, records a
-  correlation marker in the gate's durable state, and suspends. Each
-  `resume --check` polls the run; a resume in a **different process** never
-  re-dispatches, because the marker persisted with the run.
+- **Dispatch-once, then poll.** On first reach it records a correlation marker
+  in the gate's durable state, dispatches, and suspends. Each `resume --check`
+  polls the run; a resume in a **different process** never re-dispatches,
+  because the marker persisted with the run. The marker is written **before**
+  the dispatch call, so a process killed mid-dispatch still re-polls rather than
+  starting a second workflow; the cost of that ordering is the mirror case — a
+  dispatch that never landed is reported when the discovery window elapses,
+  instead of immediately.
 - **Correlation.** `workflow_dispatch` returns no run id, so by default the
   trigger passes a marker input (default `zuke_marker`) and matches it against
   the run's display title — the dispatched workflow must echo it into `run-name`:

--- a/packages/gh/src/workflow.ts
+++ b/packages/gh/src/workflow.ts
@@ -39,7 +39,10 @@
  *
  * The marker (`zuke:<runId>:<target>`) and the resolved run id are persisted in
  * the awaiting target's durable state, so a resume in a **different process**
- * never re-dispatches — it polls the run it already started.
+ * never re-dispatches — it polls the run it already started. The marker is
+ * written **before** the dispatch call, so even a process killed mid-dispatch
+ * re-polls rather than dispatching twice; the cost is that a dispatch which
+ * never landed is reported at the discovery deadline instead of immediately.
  *
  * **Unmodified workflows.** A workflow that can't echo the marker (a long tail
  * of repos you don't own) correlates **best-effort** with
@@ -715,19 +718,27 @@ export function githubWorkflowWith(
       // 1. Dispatch once. In created-window mode, snapshot the runs that already
       //    exist **before** dispatching, so correlation never claims one that
       //    was already there (e.g. a nightly cron or a colleague's run on the
-      //    same branch). Then stamp the dispatch time and suspend.
+      //    same branch).
+      //
+      //    The marker is stamped **before** the dispatch, never after. A process
+      //    killed between the two writes the record either way; the question is
+      //    which way it errs. Persisting first means a re-evaluation polls for a
+      //    run that may not exist — it fails at the discovery deadline with the
+      //    usual guidance. Persisting after means a re-evaluation dispatches a
+      //    second time, which for a deploy workflow is a second deploy. A late
+      //    failure is recoverable; a duplicate side effect is not.
       if (!dispatched) {
         const baseline = mode === "created-window"
           ? await snapshotBaseline(api, repo, workflow)
           : undefined;
-        await api.dispatch(repo, workflow, settings.ref_, {
-          ...settings.inputs_,
-          [settings.markerInput_]: marker,
-        });
         await persist(ctx.state, {
           marker,
           dispatchedAt: now(),
           baselineIds: baseline,
+        });
+        await api.dispatch(repo, workflow, settings.ref_, {
+          ...settings.inputs_,
+          [settings.markerInput_]: marker,
         });
         return false;
       }

--- a/packages/gh/tests/workflow_test.ts
+++ b/packages/gh/tests/workflow_test.ts
@@ -101,6 +101,36 @@ class ScriptedApi implements GhWorkflowApi {
   }
 }
 
+/** A {@link ScriptedApi} that snapshots the durable state as it dispatches. */
+class StateObservingApi extends ScriptedApi {
+  /** The target meta as it stood when `dispatch` was called, if it was. */
+  stateAtDispatch: Record<string, JsonValue> | undefined;
+  readonly #state: TargetStateHandle;
+
+  constructor(state: TargetStateHandle) {
+    super();
+    this.#state = state;
+  }
+
+  override dispatch(
+    repo: string,
+    workflow: string,
+    ref: string,
+    inputs: Record<string, string>,
+  ): Promise<void> {
+    this.stateAtDispatch = { ...this.#state.get() };
+    return super.dispatch(repo, workflow, ref, inputs);
+  }
+}
+
+/** Narrow a {@link JsonValue} to a plain object, throwing if it is not one. */
+function recordOf(value: JsonValue | undefined): Record<string, JsonValue> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`expected a JSON object, got ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
 Deno.test("githubWorkflow requires a repo and a workflow", () => {
   assertThrows(() => githubWorkflow((g) => g), Error, "repo and a workflow");
   assertThrows(
@@ -134,6 +164,26 @@ Deno.test("first evaluation dispatches with a marker and suspends", async () => 
   assertEquals(api.dispatches[0].ref, "release");
   assertEquals(api.dispatches[0].inputs.env, "prod");
   assertEquals(api.dispatches[0].inputs.zuke_marker, "zuke:r1:e2e");
+});
+
+Deno.test("the marker is persisted before the workflow is dispatched", async () => {
+  // Intent before effect: a process killed between the two must re-poll for the
+  // run it may have started, never dispatch a second one.
+  const state = fakeState();
+  const api = new StateObservingApi(state);
+  const trigger = githubWorkflowWith(
+    (g) => g.repo("acme/app").workflow("e2e.yml"),
+    { api },
+  );
+  assertEquals(await trigger.isSatisfied(NO_SIGNALS, ctx(state)), false);
+  assertEquals(api.dispatches.length, 1);
+  // The record the dispatch call saw already carries the marker it dispatched.
+  const seen = api.stateAtDispatch;
+  if (seen === undefined) throw new Error("dispatch was never called");
+  const entry = recordOf(seen.githubWorkflow);
+  assertEquals(entry.dispatched, true);
+  assertEquals(entry.marker, "zuke:r1:e2e");
+  assertEquals(entry.marker, api.dispatches[0].inputs.zuke_marker);
 });
 
 Deno.test("polls until the run completes, then records the per-job result", async () => {
@@ -510,6 +560,37 @@ Deno.test("a persisted record without dispatchedAt (pre-M18) fails fast after ba
     WorkflowCorrelationError,
     "run-name",
   );
+});
+
+Deno.test("a marker persisted without a landed dispatch re-polls, never re-dispatches", async () => {
+  // The record a process killed between the marker write and the dispatch call
+  // leaves behind — the state the reaper now makes reachable. The trigger must
+  // poll for the run it may have started and fail at the discovery deadline,
+  // rather than dispatching a second workflow (for a deploy, a second deploy).
+  const api = new ScriptedApi();
+  api.appears = false; // the dispatch never landed, so no run exists
+  const c = clock(DISPATCH_AT);
+  const state = fakeState({
+    githubWorkflow: {
+      dispatched: true,
+      marker: "zuke:r1:e2e",
+      dispatchedAt: DISPATCH_AT,
+    },
+  });
+  const trigger = githubWorkflowWith(
+    (g) => g.repo("a/b").workflow("e2e.yml").discoveryTimeout("60s"),
+    { api, now: c.now },
+  );
+  const cv = ctx(state);
+  assertEquals(await trigger.isSatisfied(NO_SIGNALS, cv), false);
+  assertEquals(api.dispatches.length, 0);
+  c.advance(61_000);
+  await assertRejects(
+    () => Promise.resolve(trigger.isSatisfied(NO_SIGNALS, cv)),
+    WorkflowCorrelationError,
+    "run-name",
+  );
+  assertEquals(api.dispatches.length, 0);
 });
 
 Deno.test("created-window excludes a run that already existed before dispatch", async () => {


### PR DESCRIPTION
## Why

The `githubWorkflow` wait trigger dispatched the workflow first and persisted the correlation marker afterwards. A process killed between those two steps leaves a record saying nothing was dispatched, so the next evaluation dispatches a second workflow.

Today that window is nearly unreachable: an abandoned run stays `running` forever and is never resumed, so nothing re-evaluates the trigger. The run reaper being added to core for the durable-effects work turns that dead end into a live path — and for a deploy workflow, a second dispatch is a second deploy.

## What changed

The marker is written **before** the dispatch call. A process killed mid-dispatch now re-polls for the run it may have started instead of starting another one.

The trade is explicit and documented in the module JSDoc and in `docs/orchestration.md`: a dispatch that never landed is now reported when the discovery window elapses instead of immediately. A late failure is recoverable; a duplicate side effect is not.

The dispatch timestamp is now stamped just before the dispatch rather than just after — a difference of one HTTP round trip against a 30 second created-window skew, and it moves the correlation floor earlier, so no run that used to correlate stops correlating.

## Tests

- `the marker is persisted before the workflow is dispatched` — a fake API snapshots the durable state as it is called, and the test asserts the record already carries the marker being dispatched. Mutation-checked: reverting the source ordering fails this test.
- `a marker persisted without a landed dispatch re-polls, never re-dispatches` — replays the exact record a mid-dispatch kill leaves behind, and asserts the trigger polls and then fails at the discovery deadline having dispatched nothing.

Full gate green locally, 18 of 18 targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)