### PR TITLE
feat(core): expose per-target outcomes on the target context

### DIFF
--- a/docs/run-context.md
+++ b/docs/run-context.md
@@ -25,6 +25,8 @@ class Deploy extends Build {
 | `signal`     | `AbortSignal`       | Aborted when the run is cancelled (see below).                       |
 | `state`      | `TargetStateHandle` | Durable per-target metadata — see [Durable run state](./state.md).   |
 | `stateOf`    | `(t) => …`          | The state handle of **another** target — read a dependency's published metadata (e.g. a wait's result). |
+| `outcomeOf`  | `(t) => …`          | What another target in this run **did** — `succeeded`, `failed`, `skipped`, … or `undefined` if it has none yet. |
+| `outcomes`   | `() => ReadonlyMap` | Every outcome settled so far, keyed by target name. |
 | `signals`    | `ReadonlyMap`       | Payloads of external signals received so far (see [waits](./orchestration.md)). |
 | `dryRun`     | `boolean`           | `true` when the run is a dry run (bodies don't execute in a dry run). |
 
@@ -32,6 +34,41 @@ class Deploy extends Build {
 target, the run record ([Durable run state](./state.md)), a resumed run's
 spans ([Observability](./observability.md)), and a
 [resumption](./orchestration.md) of a suspended run.
+
+## Reading what the rest of the run did
+
+`ctx.outcomeOf(name)` reports another target's status in this run, and
+`ctx.outcomes()` returns all of them. The status is the **run record's**
+vocabulary — `succeeded`, `failed`, `skipped`, `waiting`, `running` — so a
+target whose body ran and one served from the incremental cache both read
+`succeeded`, which is the distinction the record keeps.
+
+<!-- check -->
+
+```ts
+import { Build, target } from "jsr:@zuke/core";
+
+class Ci extends Build {
+  unit = target().executes(() => {});
+  docs = target().onlyWhen(() => false).executes(() => {});
+  report = target().dependsOn(this.unit, this.docs).executes((ctx) => {
+    const skipped = [...ctx.outcomes()]
+      .filter(([, outcome]) => outcome.status === "skipped")
+      .map(([name]) => name);
+    console.log(`skipped: ${skipped.join(", ")}`);
+    console.log(`unit: ${ctx.outcomeOf("unit")?.status}`);
+  });
+}
+```
+
+- **A target that has not settled has no outcome** — `undefined` rather than a
+  placeholder. That includes the target doing the asking, and any sibling still
+  running concurrently. Depend on what you intend to read.
+- **Outcomes survive a resume.** After a suspend, the process that resumes never
+  re-runs what already succeeded, and still reports it — those come from the
+  durable [run record](./state.md).
+- **A store is not required.** A run with no state store answers the same way
+  for everything settled in that process.
 
 ## Cancellation
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3374,6 +3374,42 @@ interface TargetContext
     `.waitsFor(githubWorkflow(...))` gate recorded to its state). `stateOf(this target)` is equivalent to {@link state}. It reads the run's current
     record, so it sees writes a dependency made earlier in the run — including
     across a suspend/resume, since the record is durable.
+  outcomeOf(target: string): TargetOutcomeView | undefined
+    What another target in this run did, or `undefined` if it has no outcome
+    yet — it has not run, or is running now.
+
+    The seam for a target that must decide on the run's results rather than
+    merely follow them: an aggregate gate reporting one verdict for a fan of
+    checks, some of which are allowed to fail. `.dependsOn(...)` alone cannot
+    express that, because a failed dependency never lets its dependents run;
+    pair this with `.always()` and `.proceedAfterFailure()` on the checks.
+
+    It reads what this run has settled so far, whichever process settled it:
+    outcomes from a previous process come back after a resume, because they
+    are in the durable record. A sibling running concurrently has no
+    outcome yet — depend on what you intend to read.
+  outcomes(): ReadonlyMap<string, TargetOutcomeView>
+    Every outcome this run has settled so far, keyed by dotted target name — a
+    snapshot, not a live view. Targets that have not settled are absent rather
+    than present with a placeholder status.
+
+interface TargetOutcomeView
+  What another target in this run did, as {@link TargetContext.outcomeOf}
+  reports it.
+
+  The status is the record's vocabulary, not the summary's: a target whose
+  body ran and one served from the cache both read `"succeeded"`, because that
+  is the distinction the durable record keeps. A body branching on this wants
+  "did it work", which both answer the same way.
+
+  readonly status: TargetRunStatus
+    The target's status: `succeeded`, `failed`, `skipped`, `waiting`, …
+  readonly error?: string
+    The failure's message, when it failed. Redacted like every stored string.
+  readonly startedAt?: string
+    When it started, ISO-8601, if it did.
+  readonly endedAt?: string
+    When it settled, ISO-8601, if it has.
 
 interface TargetReport
   One row of the end-of-build summary.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -3428,6 +3428,42 @@ interface TargetContext
     `.waitsFor(githubWorkflow(...))` gate recorded to its state). `stateOf(this target)` is equivalent to {@link state}. It reads the run's current
     record, so it sees writes a dependency made earlier in the run — including
     across a suspend/resume, since the record is durable.
+  outcomeOf(target: string): TargetOutcomeView | undefined
+    What another target in this run did, or `undefined` if it has no outcome
+    yet — it has not run, or is running now.
+
+    The seam for a target that must decide on the run's results rather than
+    merely follow them: an aggregate gate reporting one verdict for a fan of
+    checks, some of which are allowed to fail. `.dependsOn(...)` alone cannot
+    express that, because a failed dependency never lets its dependents run;
+    pair this with `.always()` and `.proceedAfterFailure()` on the checks.
+
+    It reads what this run has settled so far, whichever process settled it:
+    outcomes from a previous process come back after a resume, because they
+    are in the durable record. A sibling running concurrently has no
+    outcome yet — depend on what you intend to read.
+  outcomes(): ReadonlyMap<string, TargetOutcomeView>
+    Every outcome this run has settled so far, keyed by dotted target name — a
+    snapshot, not a live view. Targets that have not settled are absent rather
+    than present with a placeholder status.
+
+interface TargetOutcomeView
+  What another target in this run did, as {@link TargetContext.outcomeOf}
+  reports it.
+
+  The status is the record's vocabulary, not the summary's: a target whose
+  body ran and one served from the cache both read `"succeeded"`, because that
+  is the distinction the durable record keeps. A body branching on this wants
+  "did it work", which both answer the same way.
+
+  readonly status: TargetRunStatus
+    The target's status: `succeeded`, `failed`, `skipped`, `waiting`, …
+  readonly error?: string
+    The failure's message, when it failed. Redacted like every stored string.
+  readonly startedAt?: string
+    When it started, ISO-8601, if it did.
+  readonly endedAt?: string
+    When it settled, ISO-8601, if it has.
 
 interface TargetReport
   One row of the end-of-build summary.

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -60,6 +60,7 @@ export {
   TargetBuilder,
   type TargetContext,
   type TargetFn,
+  type TargetOutcomeView,
   type TargetStateHandle,
   type Validation,
   type ValidationContext,

--- a/packages/core/src/cancel.ts
+++ b/packages/core/src/cancel.ts
@@ -43,6 +43,7 @@ import {
   type TargetContext,
   type TargetStateHandle,
 } from "./target.ts";
+import { outcomesFromRecord } from "./run_support.ts";
 import { absolutePath } from "./path.ts";
 import { findConfigDir, pathExists } from "./config.ts";
 import { defaultStateHost, type StateStore } from "./state/store.ts";
@@ -265,6 +266,10 @@ export async function runCompensations(
     });
   }
 
+  // One snapshot for the whole walk: the record is not being written while the
+  // compensations run, and a per-step rebuild would say the same thing.
+  const outcomes = outcomesFromRecord(record.targets);
+
   for (const step of steps) {
     const compName = step.compensation.name_ ??
       `${step.forTarget}.onCancel`;
@@ -285,6 +290,11 @@ export async function runCompensations(
       // is available; other targets read as empty here.
       stateOf: (t) =>
         t === compName ? seededStateHandle(step.meta) : seededStateHandle({}),
+      // Outcomes, unlike state, come from the record the walk is reading — so a
+      // compensation can ask what actually happened to the run it is undoing,
+      // including in a process that never executed any of it.
+      outcomeOf: (t) => outcomes.get(t),
+      outcomes: () => outcomes,
       signals: deps.signals,
       dryRun: false,
     };

--- a/packages/core/src/execute_state.ts
+++ b/packages/core/src/execute_state.ts
@@ -23,7 +23,12 @@ import { defaultStateHost, type StateStore } from "./state/store.ts";
 import { resolveStateStore } from "./state/resolve.ts";
 import { buildRunRecord, ciRunUrl, resolveActor } from "./state/record.ts";
 import { RunStateWriter } from "./state/writer.ts";
-import type { RunRecord, SignalRecord, WaitState } from "./state/types.ts";
+import type {
+  RunRecord,
+  SignalRecord,
+  TargetRunStatus,
+  WaitState,
+} from "./state/types.ts";
 import type { ResumeState } from "./executor.ts";
 
 /**
@@ -37,6 +42,26 @@ function priorWaitsOf(record: RunRecord): ReadonlyMap<string, WaitState> {
     if (state.waitingFor !== undefined) waits.set(name, state.waitingFor);
   }
   return waits;
+}
+
+/**
+ * The outcomes a resumed run inherits — what an earlier process settled, as
+ * `ctx.outcomeOf(...)` should report it (see {@link RunEnv.statuses}).
+ *
+ * A fresh run starts empty. `pending` rows are left out: a target that has not
+ * run has no outcome, and reporting one would make a body branch on a target
+ * that is about to run in this very process.
+ */
+function priorStatusesOf(record: RunRecord | undefined): Map<
+  string,
+  TargetRunStatus
+> {
+  const statuses = new Map<string, TargetRunStatus>();
+  if (record === undefined) return statuses;
+  for (const [name, state] of Object.entries(record.targets)) {
+    if (state.status !== "pending") statuses.set(name, state.status);
+  }
+  return statuses;
 }
 
 /** Durable-state plumbing for one run: the writer and the RunEnv. */
@@ -153,6 +178,9 @@ export async function openRunState(opts: {
     actor,
     runUrl,
     signals: writer ? writer.signals() : new Map<string, SignalRecord>(),
+    // Seeded from the record so a resumed run's targets keep the outcomes an
+    // earlier process settled, rather than reading as though they never ran.
+    statuses: priorStatusesOf(resume?.record),
     done: resume?.done,
     priorWaits: resume ? priorWaitsOf(resume.record) : undefined,
   };

--- a/packages/core/src/execute_state.ts
+++ b/packages/core/src/execute_state.ts
@@ -16,19 +16,14 @@ import type { TargetBuilder } from "./target.ts";
 import type { Reporter } from "./reporter.ts";
 import type { Redactor } from "./redact.ts";
 import type { AnyParameter } from "./params.ts";
-import type { RunEnv } from "./run_support.ts";
+import type { RunEnv, TargetSettlement } from "./run_support.ts";
 import { absolutePath } from "./path.ts";
 import { findConfigDir, pathExists } from "./config.ts";
 import { defaultStateHost, type StateStore } from "./state/store.ts";
 import { resolveStateStore } from "./state/resolve.ts";
 import { buildRunRecord, ciRunUrl, resolveActor } from "./state/record.ts";
 import { RunStateWriter } from "./state/writer.ts";
-import type {
-  RunRecord,
-  SignalRecord,
-  TargetRunStatus,
-  WaitState,
-} from "./state/types.ts";
+import type { RunRecord, SignalRecord, WaitState } from "./state/types.ts";
 import type { ResumeState } from "./executor.ts";
 
 /**
@@ -52,14 +47,17 @@ function priorWaitsOf(record: RunRecord): ReadonlyMap<string, WaitState> {
  * run has no outcome, and reporting one would make a body branch on a target
  * that is about to run in this very process.
  */
-function priorStatusesOf(record: RunRecord | undefined): Map<
-  string,
-  TargetRunStatus
-> {
-  const statuses = new Map<string, TargetRunStatus>();
+function priorStatusesOf(
+  record: RunRecord | undefined,
+): Map<string, TargetSettlement> {
+  const statuses = new Map<string, TargetSettlement>();
   if (record === undefined) return statuses;
   for (const [name, state] of Object.entries(record.targets)) {
-    if (state.status !== "pending") statuses.set(name, state.status);
+    if (state.status === "pending") continue;
+    statuses.set(name, {
+      status: state.status,
+      ...(state.error === undefined ? {} : { error: state.error }),
+    });
   }
   return statuses;
 }

--- a/packages/core/src/run_support.ts
+++ b/packages/core/src/run_support.ts
@@ -8,10 +8,16 @@
  */
 
 import type { TargetStatus } from "./build.ts";
+import type { TargetOutcomeView } from "./target.ts";
 import type { TargetReport } from "./report.ts";
 import type { RunStateWriter } from "./state/writer.ts";
 import type { StateStore } from "./state/store.ts";
-import type { SignalRecord, WaitState } from "./state/types.ts";
+import type {
+  SignalRecord,
+  TargetRunState,
+  TargetRunStatus,
+  WaitState,
+} from "./state/types.ts";
 
 /** What running one target produced, fed back to the scheduler and summary. */
 export interface TargetOutcome {
@@ -63,6 +69,19 @@ export interface RunEnv {
   runUrl?: string;
   /** External signals received so far, exposed to bodies via `ctx.signals`. */
   signals: ReadonlyMap<string, SignalRecord>;
+  /**
+   * Statuses settled in **this** process, in the record's vocabulary — what
+   * `ctx.outcomeOf(...)` reads first.
+   *
+   * The durable record is not enough on its own. Every `markTargetSettled` is
+   * fire-and-forget through the writer's serialized chain, so a target that has
+   * just failed can still read `running` in the record for as long as that
+   * write is queued. A gate aggregating outcomes would then see a green run.
+   * This map is written synchronously as each target settles, so it cannot lag
+   * behind the thing it describes; the record backfills what a *previous*
+   * process settled.
+   */
+  statuses: Map<string, TargetRunStatus>;
   /** On a resume, target names already succeeded — seeded done, never re-run. */
   done?: ReadonlySet<string>;
   /**
@@ -72,6 +91,44 @@ export interface RunEnv {
    * `resume --check` and mean the timeout never fires).
    */
   priorWaits?: ReadonlyMap<string, WaitState>;
+}
+
+/**
+ * Build the caller-facing outcome view from a status and the record row it came
+ * with, if there is one.
+ *
+ * `status` wins over `row.status` deliberately: the row is the durable copy and
+ * can be a write behind, while the status passed here is whatever the caller
+ * established is current.
+ */
+export function outcomeView(
+  status: TargetRunStatus,
+  row: TargetRunState | undefined,
+): TargetOutcomeView {
+  if (row === undefined) return { status };
+  return {
+    status,
+    ...(row.error === undefined ? {} : { error: row.error }),
+    ...(row.startedAt === undefined ? {} : { startedAt: row.startedAt }),
+    ...(row.endedAt === undefined ? {} : { endedAt: row.endedAt }),
+  };
+}
+
+/**
+ * Every settled outcome a run record holds, keyed by target name.
+ *
+ * `pending` rows are omitted: a target that has not run has no outcome, and an
+ * entry saying otherwise would invite a body to branch on it.
+ */
+export function outcomesFromRecord(
+  targets: Readonly<Record<string, TargetRunState>>,
+): Map<string, TargetOutcomeView> {
+  const all = new Map<string, TargetOutcomeView>();
+  for (const [name, row] of Object.entries(targets)) {
+    if (row.status === "pending") continue;
+    all.set(name, outcomeView(row.status, row));
+  }
+  return all;
 }
 
 /** A failure's message, or `undefined` when there was none — for the state record. */

--- a/packages/core/src/run_support.ts
+++ b/packages/core/src/run_support.ts
@@ -70,7 +70,7 @@ export interface RunEnv {
   /** External signals received so far, exposed to bodies via `ctx.signals`. */
   signals: ReadonlyMap<string, SignalRecord>;
   /**
-   * Statuses settled in **this** process, in the record's vocabulary — what
+   * What settled in **this** process, in the record's vocabulary — what
    * `ctx.outcomeOf(...)` reads first.
    *
    * The durable record is not enough on its own. Every `markTargetSettled` is
@@ -80,8 +80,12 @@ export interface RunEnv {
    * This map is written synchronously as each target settles, so it cannot lag
    * behind the thing it describes; the record backfills what a *previous*
    * process settled.
+   *
+   * It carries the failure message as well as the status, so a run with no
+   * state store — where there is no record to fall back to — still reports
+   * *why* a target failed and not merely that it did.
    */
-  statuses: Map<string, TargetRunStatus>;
+  statuses: Map<string, TargetSettlement>;
   /** On a resume, target names already succeeded — seeded done, never re-run. */
   done?: ReadonlySet<string>;
   /**
@@ -93,24 +97,32 @@ export interface RunEnv {
   priorWaits?: ReadonlyMap<string, WaitState>;
 }
 
+/** What a target settled to in this process: its status and, if it failed, why. */
+export interface TargetSettlement {
+  /** The status, in the run record's vocabulary. */
+  status: TargetRunStatus;
+  /** The failure's message, when it failed. */
+  error?: string;
+}
+
 /**
- * Build the caller-facing outcome view from a status and the record row it came
- * with, if there is one.
+ * Build the caller-facing outcome view from a settlement and the record row it
+ * came with, if there is one.
  *
  * `status` wins over `row.status` deliberately: the row is the durable copy and
  * can be a write behind, while the status passed here is whatever the caller
  * established is current.
  */
 export function outcomeView(
-  status: TargetRunStatus,
+  settled: TargetSettlement,
   row: TargetRunState | undefined,
 ): TargetOutcomeView {
-  if (row === undefined) return { status };
+  const error = settled.error ?? row?.error;
   return {
-    status,
-    ...(row.error === undefined ? {} : { error: row.error }),
-    ...(row.startedAt === undefined ? {} : { startedAt: row.startedAt }),
-    ...(row.endedAt === undefined ? {} : { endedAt: row.endedAt }),
+    status: settled.status,
+    ...(error === undefined ? {} : { error }),
+    ...(row?.startedAt === undefined ? {} : { startedAt: row.startedAt }),
+    ...(row?.endedAt === undefined ? {} : { endedAt: row.endedAt }),
   };
 }
 
@@ -126,7 +138,7 @@ export function outcomesFromRecord(
   const all = new Map<string, TargetOutcomeView>();
   for (const [name, row] of Object.entries(targets)) {
     if (row.status === "pending") continue;
-    all.set(name, outcomeView(row.status, row));
+    all.set(name, outcomeView({ status: row.status }, row));
   }
   return all;
 }

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -213,7 +213,7 @@ function outcomeOf(
   const row = env.writer?.snapshot().targets[target];
   if (live === undefined) {
     if (row === undefined || row.status === "pending") return undefined;
-    return outcomeView(row.status, row);
+    return outcomeView({ status: row.status }, row);
   }
   return outcomeView(live, row);
 }
@@ -224,10 +224,10 @@ function allOutcomes(env: RunEnv): ReadonlyMap<string, TargetOutcomeView> {
   const rows = env.writer?.snapshot().targets ?? {};
   for (const [name, row] of Object.entries(rows)) {
     if (row.status === "pending") continue; // no outcome yet, so not an entry
-    all.set(name, outcomeView(row.status, row));
+    all.set(name, outcomeView({ status: row.status }, row));
   }
-  for (const [name, status] of env.statuses) {
-    all.set(name, outcomeView(status, rows[name]));
+  for (const [name, settled] of env.statuses) {
+    all.set(name, outcomeView(settled, rows[name]));
   }
   return all;
 }
@@ -350,7 +350,7 @@ async function runTarget(
       passTarget(reporter, renderer, style, name, 0);
       return { status: "passed", ms: 0 };
     }
-    env.statuses.set(name, "waiting");
+    env.statuses.set(name, { status: "waiting" });
     void env.writer?.markTargetWaiting(name, wait.waitState);
     for (const line of targetWaitFooter(style, name, wait.descriptor)) {
       reporter.info(line);
@@ -543,7 +543,7 @@ function settleTarget(
   status: TargetStatus,
   error?: string,
 ): void {
-  env.statuses.set(name, recordStatusOf(status));
+  env.statuses.set(name, { status: recordStatusOf(status), error });
   void env.writer?.markTargetSettled(name, status, error);
 }
 

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -17,6 +17,7 @@ import { acquireTargetLock, type HeldLock } from "./lock.ts";
 import { resolveWait, type WaitResolution } from "./wait_resolution.ts";
 import {
   errorMessage,
+  outcomeView,
   type RunEnv,
   type RunOutcome,
   type TargetOutcome,
@@ -32,10 +33,13 @@ import {
   type Remediation,
   type TargetBuilder,
   type TargetContext,
+  type TargetOutcomeView,
 } from "./target.ts";
 import type { BuildCache } from "./cache.ts";
 import { ServiceBuilder, type ServiceRegistry } from "./service.ts";
 import { inMemoryStateHandle } from "./state/writer.ts";
+import { recordStatusOf } from "./state/record.ts";
+import type { TargetStatus } from "./build.ts";
 
 /**
  * Open a target's section — a collapsible group under GitHub Actions, or a
@@ -189,6 +193,46 @@ async function runBodyWithRecovery(
 }
 
 /**
+ * What one target in this run did, for `ctx.outcomeOf(...)`.
+ *
+ * This process's own map answers first, and the durable record only fills in
+ * what that map has never seen. The order matters and is not an optimisation:
+ * the map is written the instant a target settles, while the record's write is
+ * queued behind every other pending write — so between a failure and its write
+ * landing, the record still says `running`. Reading the record first would let
+ * an aggregating gate call a failed run green, which is the exact outcome the
+ * durable-effects work exists to prevent. The record's turn comes for targets
+ * this process never ran: after a resume, everything an earlier process
+ * settled.
+ */
+function outcomeOf(
+  env: RunEnv,
+  target: string,
+): TargetOutcomeView | undefined {
+  const live = env.statuses.get(target);
+  const row = env.writer?.snapshot().targets[target];
+  if (live === undefined) {
+    if (row === undefined || row.status === "pending") return undefined;
+    return outcomeView(row.status, row);
+  }
+  return outcomeView(live, row);
+}
+
+/** Every settled outcome in this run, this process's map over the record's. */
+function allOutcomes(env: RunEnv): ReadonlyMap<string, TargetOutcomeView> {
+  const all = new Map<string, TargetOutcomeView>();
+  const rows = env.writer?.snapshot().targets ?? {};
+  for (const [name, row] of Object.entries(rows)) {
+    if (row.status === "pending") continue; // no outcome yet, so not an entry
+    all.set(name, outcomeView(row.status, row));
+  }
+  for (const [name, status] of env.statuses) {
+    all.set(name, outcomeView(status, rows[name]));
+  }
+  return all;
+}
+
+/**
  * Run one target: honour its `onlyWhen` conditions and the incremental cache,
  * then (if it must run) open its section, run its body, and report pass/fail.
  * A condition that fails yields `skipped`; an up-to-date target yields `cached`
@@ -234,6 +278,8 @@ async function runTarget(
         signal: env.signal,
         state: echoState,
         stateOf: (t2) => t2 === name ? echoState : inMemoryStateHandle(),
+        outcomeOf: (t2) => outcomeOf(env, t2),
+        outcomes: () => allOutcomes(env),
         signals: env.signals,
         dryRun: true,
       };
@@ -304,6 +350,7 @@ async function runTarget(
       passTarget(reporter, renderer, style, name, 0);
       return { status: "passed", ms: 0 };
     }
+    env.statuses.set(name, "waiting");
     void env.writer?.markTargetWaiting(name, wait.waitState);
     for (const line of targetWaitFooter(style, name, wait.descriptor)) {
       reporter.info(line);
@@ -339,6 +386,8 @@ async function runTarget(
       t === name
         ? ownState
         : (env.writer ? env.writer.stateHandle(t) : inMemoryStateHandle()),
+    outcomeOf: (t) => outcomeOf(env, t),
+    outcomes: () => allOutcomes(env),
     signals: env.signals,
     dryRun,
   };
@@ -477,6 +526,27 @@ export function cpuCount(): number {
   return cpus > 0 ? cpus : 4;
 }
 
+/**
+ * Record a target's terminal status — synchronously for this process, and
+ * durably through the writer.
+ *
+ * Both halves, always, and in that order. The durable write is fire-and-forget
+ * through the writer's serialized chain, so between a target failing and its
+ * write landing the record still says `running`; a gate reading outcomes in
+ * that window would aggregate a failure as though it had not happened yet. The
+ * in-memory map closes that window, and the record is what carries the same
+ * facts across a process boundary.
+ */
+function settleTarget(
+  env: RunEnv,
+  name: string,
+  status: TargetStatus,
+  error?: string,
+): void {
+  env.statuses.set(name, recordStatusOf(status));
+  void env.writer?.markTargetSettled(name, status, error);
+}
+
 /** Sequentially run the plan, aborting (and skipping the rest) on first failure. */
 export async function runSequential(
   ctx: RunContext,
@@ -494,7 +564,7 @@ export async function runSequential(
     const name = t.name_ ?? "<unnamed>";
     if (skip.has(name) || aborted) {
       reports.push({ name, status: "skipped", ms: 0 });
-      void env.writer?.markTargetSettled(name, "skipped");
+      settleTarget(env, name, "skipped");
       continue;
     }
     let outcome: TargetOutcome;
@@ -509,11 +579,7 @@ export async function runSequential(
       failTarget(reporter, renderer, style, name, 0, error);
       outcome = { status: "failed", ms: 0, error };
     }
-    void env.writer?.markTargetSettled(
-      name,
-      outcome.status,
-      errorMessage(outcome.error),
-    );
+    settleTarget(env, name, outcome.status, errorMessage(outcome.error));
     if (outcome.status === "passed" || outcome.status === "failed") opened++;
     reports.push({ name, status: outcome.status, ms: outcome.ms });
     // A fan-out target's sub-targets appear as their own rows beneath it.
@@ -564,7 +630,7 @@ export async function runScheduled(
       outcomes.set(t, { status: "skipped", ms: 0 });
       done.add(t);
       started.add(t);
-      void env.writer?.markTargetSettled(name, "skipped");
+      settleTarget(env, name, "skipped");
     } else if (env.done?.has(name)) {
       // Succeeded in the prior (suspended) run: unblock dependents, don't re-run,
       // and leave its recorded `succeeded` untouched.
@@ -601,7 +667,8 @@ export async function runScheduled(
               // A waiting gate already recorded its `waitingFor` via
               // markTargetWaiting; settling it here would clobber that.
               if (outcome.status !== "waiting") {
-                void env.writer?.markTargetSettled(
+                settleTarget(
+                  env,
                   t.name_ ?? "<unnamed>",
                   outcome.status,
                   errorMessage(outcome.error),
@@ -654,11 +721,7 @@ export async function runScheduled(
             failure ??= error;
             if (!t.proceedAfterFailure_) halted = true;
             failTarget(reporter, renderer, style, targetName, 0, error);
-            void env.writer?.markTargetSettled(
-              targetName,
-              "failed",
-              errorMessage(error),
-            );
+            settleTarget(env, targetName, "failed", errorMessage(error));
             pump();
           });
       }
@@ -673,10 +736,7 @@ export async function runScheduled(
             // them `skipped` — otherwise they linger `pending` inside a terminal
             // `failed` record that no resume sweep reaches (F8).
             if (!anyWaiting || anyFailed) {
-              void env.writer?.markTargetSettled(
-                t.name_ ?? "<unnamed>",
-                "skipped",
-              );
+              settleTarget(env, t.name_ ?? "<unnamed>", "skipped");
             }
           }
         }
@@ -695,7 +755,7 @@ export async function runScheduled(
     for (const [t, outcome] of outcomes) {
       if (outcome.status === "waiting") {
         outcomes.set(t, { status: "skipped", ms: outcome.ms });
-        void env.writer?.markTargetSettled(t.name_ ?? "<unnamed>", "skipped");
+        settleTarget(env, t.name_ ?? "<unnamed>", "skipped");
       }
     }
   }

--- a/packages/core/src/target.ts
+++ b/packages/core/src/target.ts
@@ -32,7 +32,7 @@ import type { AnyParameter } from "./params.ts";
 import type { Configure } from "./tooling.ts";
 import { type LockHolder, lockKey } from "./state/lock.ts";
 import type { WaitTrigger } from "./wait.ts";
-import type { SignalRecord } from "./state/types.ts";
+import type { SignalRecord, TargetRunStatus } from "./state/types.ts";
 
 /**
  * Fluent configuration for {@link TargetBuilder.lock}, in the settings-lambda
@@ -239,6 +239,26 @@ export interface TargetStateHandle {
 }
 
 /**
+ * What another target in this run did, as {@link TargetContext.outcomeOf}
+ * reports it.
+ *
+ * The status is the **record's** vocabulary, not the summary's: a target whose
+ * body ran and one served from the cache both read `"succeeded"`, because that
+ * is the distinction the durable record keeps. A body branching on this wants
+ * "did it work", which both answer the same way.
+ */
+export interface TargetOutcomeView {
+  /** The target's status: `succeeded`, `failed`, `skipped`, `waiting`, … */
+  readonly status: TargetRunStatus;
+  /** The failure's message, when it failed. Redacted like every stored string. */
+  readonly error?: string;
+  /** When it started, ISO-8601, if it did. */
+  readonly startedAt?: string;
+  /** When it settled, ISO-8601, if it has. */
+  readonly endedAt?: string;
+}
+
+/**
  * The context passed to every target body. Optional to receive — an existing
  * zero-argument `.executes(() => …)` stays valid, since a zero-argument
  * function is assignable to this one-parameter type — but a body that wants the
@@ -273,6 +293,28 @@ export interface TargetContext {
    * across a suspend/resume, since the record is durable.
    */
   stateOf(target: string): TargetStateHandle;
+  /**
+   * What another target in this run did, or `undefined` if it has no outcome
+   * yet — it has not run, or is running now.
+   *
+   * The seam for a target that must **decide** on the run's results rather than
+   * merely follow them: an aggregate gate reporting one verdict for a fan of
+   * checks, some of which are allowed to fail. `.dependsOn(...)` alone cannot
+   * express that, because a failed dependency never lets its dependents run;
+   * pair this with `.always()` and `.proceedAfterFailure()` on the checks.
+   *
+   * It reads what this run has settled so far, whichever process settled it:
+   * outcomes from a previous process come back after a resume, because they
+   * are in the durable record. A sibling running **concurrently** has no
+   * outcome yet — depend on what you intend to read.
+   */
+  outcomeOf(target: string): TargetOutcomeView | undefined;
+  /**
+   * Every outcome this run has settled so far, keyed by dotted target name — a
+   * snapshot, not a live view. Targets that have not settled are absent rather
+   * than present with a placeholder status.
+   */
+  outcomes(): ReadonlyMap<string, TargetOutcomeView>;
   /**
    * Payloads of the external signals received so far, keyed by name (see
    * `.waitsFor(...)` and {@link "./wait.ts".externalSignal}). Empty until a

--- a/packages/core/tests/outcome_view_test.ts
+++ b/packages/core/tests/outcome_view_test.ts
@@ -15,7 +15,9 @@ function row(over: Partial<TargetRunState> = {}): TargetRunState {
 }
 
 Deno.test("a status with no record row is the whole view", () => {
-  assertEquals(outcomeView("succeeded", undefined), { status: "succeeded" });
+  assertEquals(outcomeView({ status: "succeeded" }, undefined), {
+    status: "succeeded",
+  });
 });
 
 Deno.test("the row contributes its detail but never its status", () => {
@@ -23,7 +25,7 @@ Deno.test("the row contributes its detail but never its status", () => {
   // so carrying `row.status` over would reintroduce exactly the staleness the
   // caller resolved before calling.
   const view = outcomeView(
-    "failed",
+    { status: "failed" },
     row({
       status: "running",
       error: "boom",
@@ -39,10 +41,28 @@ Deno.test("the row contributes its detail but never its status", () => {
   });
 });
 
+Deno.test("the settlement carries the failure message when there is no record", () => {
+  // No record row exists to read `error` from, so a run with no state store
+  // would otherwise report *that* a target failed but never *why*.
+  assertEquals(outcomeView({ status: "failed", error: "boom" }, undefined), {
+    status: "failed",
+    error: "boom",
+  });
+});
+
+Deno.test("the settlement's message wins over the record's", () => {
+  // Same reason its status does: the row can be a write behind.
+  const view = outcomeView(
+    { status: "failed", error: "this attempt" },
+    row({ status: "failed", error: "a previous attempt" }),
+  );
+  assertEquals(view.error, "this attempt");
+});
+
 Deno.test("absent detail is absent, not undefined-valued", () => {
   // `{ status }` and `{ status, error: undefined }` compare differently, and
   // the second would make `"error" in outcome` true for a target that succeeded.
-  const view = outcomeView("succeeded", row());
+  const view = outcomeView({ status: "succeeded" }, row());
   assertEquals(view, { status: "succeeded" });
   assertEquals("error" in view, false);
   assertEquals("startedAt" in view, false);

--- a/packages/core/tests/outcome_view_test.ts
+++ b/packages/core/tests/outcome_view_test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit tests for the outcome views behind `ctx.outcomeOf(...)` — how a status
+ * and a run-record row become the shape a target body reads.
+ *
+ * @module
+ */
+
+import { assertEquals } from "./_assert.ts";
+import { outcomesFromRecord, outcomeView } from "../src/run_support.ts";
+import type { TargetRunState } from "../src/state/types.ts";
+
+/** A record row, with only the fields a case cares about set. */
+function row(over: Partial<TargetRunState> = {}): TargetRunState {
+  return { status: "succeeded", meta: {}, ...over };
+}
+
+Deno.test("a status with no record row is the whole view", () => {
+  assertEquals(outcomeView("succeeded", undefined), { status: "succeeded" });
+});
+
+Deno.test("the row contributes its detail but never its status", () => {
+  // The row is the durable copy and can be a write behind the status passed in,
+  // so carrying `row.status` over would reintroduce exactly the staleness the
+  // caller resolved before calling.
+  const view = outcomeView(
+    "failed",
+    row({
+      status: "running",
+      error: "boom",
+      startedAt: "2026-08-10T00:00:00.000Z",
+      endedAt: "2026-08-10T00:00:01.000Z",
+    }),
+  );
+  assertEquals(view, {
+    status: "failed",
+    error: "boom",
+    startedAt: "2026-08-10T00:00:00.000Z",
+    endedAt: "2026-08-10T00:00:01.000Z",
+  });
+});
+
+Deno.test("absent detail is absent, not undefined-valued", () => {
+  // `{ status }` and `{ status, error: undefined }` compare differently, and
+  // the second would make `"error" in outcome` true for a target that succeeded.
+  const view = outcomeView("succeeded", row());
+  assertEquals(view, { status: "succeeded" });
+  assertEquals("error" in view, false);
+  assertEquals("startedAt" in view, false);
+});
+
+Deno.test("a record becomes one entry per settled target", () => {
+  const all = outcomesFromRecord({
+    unit: row({ status: "succeeded", endedAt: "t1" }),
+    lint: row({ status: "failed", error: "nope" }),
+    docs: row({ status: "skipped" }),
+    gate: row({ status: "running" }),
+    later: row({ status: "pending" }),
+  });
+  // `pending` is left out: a target that has not run has no outcome, and an
+  // entry saying otherwise invites a body to branch on it.
+  assertEquals([...all.keys()].sort(), ["docs", "gate", "lint", "unit"]);
+  assertEquals(all.get("lint")?.error, "nope");
+  assertEquals(all.get("unit")?.endedAt, "t1");
+});
+
+Deno.test("an empty record has no outcomes", () => {
+  assertEquals(outcomesFromRecord({}).size, 0);
+});

--- a/tests/integration/outcomes_test.ts
+++ b/tests/integration/outcomes_test.ts
@@ -1,0 +1,142 @@
+/**
+ * Integration tests for `ctx.outcomeOf(...)` / `ctx.outcomes()` — a target
+ * reading what the rest of the run did.
+ *
+ * Driven through the real CLI entry point, because what is under test is what
+ * the scheduler has established by the time a body runs, which no unit of the
+ * scheduler can answer on its own.
+ *
+ * @module
+ */
+
+import { assertEquals } from "../../packages/core/tests/_assert.ts";
+import {
+  Build,
+  defaultStateHost,
+  externalSignal,
+  FileSystemStateStore,
+  target,
+  type TargetOutcomeView,
+} from "../../packages/core/mod.ts";
+import { runCli, withStateDir } from "./_harness.ts";
+
+/** The id of the (single) run the CLI persisted under `dir`. */
+async function onlyRunId(dir: string): Promise<string> {
+  const store = new FileSystemStateStore(dir, defaultStateHost);
+  const runs = await store.listRuns({});
+  assertEquals(runs.length, 1);
+  return runs[0].id;
+}
+
+Deno.test("a target reads its dependencies' outcomes, including a skipped one", async () => {
+  const seen = new Map<string, TargetOutcomeView | undefined>();
+
+  class Ci extends Build {
+    unit = target().executes(() => {});
+    optional = target().onlyWhen(() => false).executes(() => {});
+    gate = target()
+      .dependsOn(this.unit, this.optional)
+      .executes((ctx) => {
+        for (const name of ["unit", "optional", "gate", "nonexistent"]) {
+          seen.set(name, ctx.outcomeOf(name));
+        }
+      });
+  }
+
+  const { code } = await runCli(Ci, ["gate"]);
+  assertEquals(code, 0);
+  assertEquals(seen.get("unit")?.status, "succeeded");
+  assertEquals(seen.get("optional")?.status, "skipped");
+  // A target has no outcome while it is the one running, and a name that is not
+  // in the run has none either — neither is invented.
+  assertEquals(seen.get("gate"), undefined);
+  assertEquals(seen.get("nonexistent"), undefined);
+});
+
+Deno.test("a dependency's outcome is current, not one state write behind", async () => {
+  // The reason outcomes do not come from the run record: every
+  // `markTargetSettled` is fire-and-forget through the writer's serialized
+  // chain, so a record read taken right after a target settles still says
+  // `running`. A body reading that would branch on a target that has in fact
+  // finished — and for an aggregating gate, "not failed yet" reads as green.
+  let status: string | undefined;
+
+  class Ci extends Build {
+    unit = target().executes(() => {});
+    gate = target().dependsOn(this.unit).executes((ctx) => {
+      status = ctx.outcomeOf("unit")?.status;
+    });
+  }
+
+  await withStateDir(async () => {
+    const { code } = await runCli(Ci, ["gate", "--state"]);
+    assertEquals(code, 0);
+    assertEquals(status, "succeeded");
+  });
+});
+
+Deno.test("outcomes carry across a resume, for targets this process never ran", async () => {
+  // `first` succeeded in the process that suspended. The process that resumes
+  // never executes it, and must still report what it did — which only the
+  // durable record knows.
+  let afterResume: TargetOutcomeView | undefined;
+
+  class Cd extends Build {
+    first = target().executes(() => {});
+    hold = target().dependsOn(this.first).waitsFor((s) =>
+      s.on(externalSignal("go"))
+    );
+    last = target().dependsOn(this.hold).executes((ctx) => {
+      afterResume = ctx.outcomeOf("first");
+    });
+  }
+
+  await withStateDir(async (dir) => {
+    const started = await runCli(Cd, ["last"]);
+    assertEquals(started.code, 0); // a suspend is exit 0, not a failure
+    assertEquals(afterResume, undefined); // `last` has not run yet
+    const id = await onlyRunId(dir);
+
+    const resumed = await runCli(Cd, ["resume", id, "--signal", "go"]);
+    assertEquals(resumed.code, 0);
+    assertEquals(afterResume?.status, "succeeded");
+    // The timestamps come from the record, so they survive the process too.
+    assertEquals(typeof afterResume?.endedAt, "string");
+  });
+});
+
+Deno.test("outcomes work without a state store", async () => {
+  // Nothing about reading the run's own results requires durability, so a plain
+  // run answers the same as a state-backed one.
+  const seen: string[] = [];
+
+  class Plain extends Build {
+    one = target().executes(() => {});
+    two = target().dependsOn(this.one).executes((ctx) => {
+      const outcome = ctx.outcomeOf("one");
+      seen.push(outcome === undefined ? "missing" : outcome.status);
+    });
+  }
+
+  const { code } = await runCli(Plain, ["two"]);
+  assertEquals(code, 0);
+  assertEquals(seen, ["succeeded"]);
+});
+
+Deno.test("outcomes() lists what has settled and nothing that has not", async () => {
+  let listed: string[] = [];
+
+  class Ci extends Build {
+    a = target().executes(() => {});
+    b = target().dependsOn(this.a).executes(() => {});
+    gate = target().dependsOn(this.b).executes((ctx) => {
+      listed = [...ctx.outcomes()].map(([name, o]) => `${name}=${o.status}`)
+        .sort();
+    });
+    after = target().dependsOn(this.gate).executes(() => {});
+  }
+
+  await runCli(Ci, ["after"]);
+  // `gate` is running and `after` has not started: neither has an outcome.
+  assertEquals(listed, ["a=succeeded", "b=succeeded"]);
+});


### PR DESCRIPTION
## Why

A target could read another target's published metadata, but nothing told it what the other target actually **did**. An aggregate target that reports one verdict for a fan of checks had no way to compute that verdict from inside the run.

This is the first piece of the durable merge-gate work: a gate that posts a single required status context has to know which checks passed, which failed, and which were skipped.

## What changed

Two members on the target context:

- `outcomeOf(name)` — what another target in this run did, or `undefined` if it has no outcome yet.
- `outcomes()` — every outcome settled so far, keyed by target name.

The status is the run record's vocabulary, so a target whose body ran and one served from the incremental cache both read `succeeded` — the distinction the record keeps, and the one a body branching on "did it work" wants.

## The part worth reviewing

**Outcomes are deliberately not read from the run record.**

Every settlement goes through the writer as `void env.writer?.markTargetSettled(...)`, and the mutator only runs once the serialized chain drains through a store round trip. So a record read taken right after a target settles still says `running`. An aggregate reading that would see a finished failure as not-yet-failed — for a gate posting a required context, "not failed yet" reads as green.

So outcomes come from a status map on the run environment, written synchronously at every settle site, in the record's vocabulary. The record backfills only what the map has never seen, which is what an earlier process settled before a resume.

There is a regression test for exactly this, and it is mutation-checked: reordering the lookup to consult the record first makes it fail, reporting `running` for a dependency that had already succeeded.

Compensations get the same seam, built from the record the walk is already reading, so a cleanup can ask what happened to the run it is undoing even in a process that never executed any of it.

## Tests

- Unit, 5 cases: the view built from a status and a record row, the row contributing detail but never its status, absent detail staying absent rather than undefined-valued, and a record becoming one entry per settled target with pending rows omitted.
- Integration, 5 cases: reading a passed and a skipped dependency, the staleness guard above, outcomes surviving a resume for a target this process never ran, parity without a state store, and outcomes listing only what has settled.

Full gate green locally, 18 of 18 targets.

## Known limitation, addressed separately

A target whose dependency **failed** never becomes ready, so it cannot report on that failure. `.always()` exempts a target from the build-wide halt, not from waiting on its own dependencies. That makes the aggregate gate above unable to post a red verdict, and is fixed in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)