### PR TITLE
fix(core): let an always target wait for its dependencies to settle

### DIFF
--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -19,7 +19,7 @@ body, which is required before the target can run.
 | `.onlyWhen(condition)`      | `(c: () => boolean \| Promise<boolean>) => this`      | Run only when the condition holds, else skip.                                                      |
 | `.requires(...params)`      | `(...p: Parameter[]) => this`                         | Fail the target unless these parameters are set.                                                   |
 | `.proceedAfterFailure()`    | `() => this`                                          | Keep the build going if this target fails.                                                         |
-| `.always()`                 | `() => this`                                          | Run for cleanup even after the build has failed.                                                   |
+| `.always()`                 | `() => this`                                          | Run even after the build has failed; waits for dependencies to settle, not succeed.                |
 | `.unlisted()`               | `() => this`                                          | Hide the target from `--list`/`--help`.                                                            |
 | `.readOnly()`               | `() => this`                                          | Advertise the target as query-only over [MCP](./mcp.md) (`readOnlyHint`).                          |
 | `.cacheKey(fn)`             | `(fn: () => string \| Promise<string>) => this`       | Extra (non-file) input to the cache fingerprint.                                                   |
@@ -185,7 +185,13 @@ deploy = target()
   the build instead of aborting. The build still reports failure, and this
   target's own dependents are skipped.
 - **`.always()`** — run even after the build has already failed, for
-  cleanup/teardown. It still waits for its own dependencies to complete.
+  cleanup/teardown or an aggregate that must report on the failure. It still
+  waits for its own dependencies, but for them to **settle** rather than
+  succeed: a dependency that failed releases it, the same as one that passed.
+  Read what happened with
+  [`ctx.outcomeOf(...)`](./run-context.md#reading-what-the-rest-of-the-run-did).
+  A dependency parked at a wait is the exception — it has not settled, so the
+  target waits for the resume.
 - **`.onCancel(target | () => target)`** — register a **compensation** that
   undoes this target when the run is [cancelled](./orchestration.md#cancellation--compensation--oncancel).
   It runs only if this target **succeeded** — or, on a

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1506,9 +1506,23 @@ class TargetBuilder
     runs its real body — so declare it on targets that inspect rather than
     mutate (a status check, a report).
   always(): this
-    Run this target even after the build has failed — for cleanup/teardown that
-    must happen regardless. It still waits for its own dependencies to complete;
-    the build's overall result is unchanged. Repeatable conditions/inputs apply.
+    Run this target even after the build has failed — for cleanup, teardown, or
+    an aggregate that has to report on the failure.
+
+    It still waits for its own dependencies, but waits for them to settle
+    rather than to succeed: a dependency that failed releases it, the same as
+    one that passed or was skipped. Anything else would make the modifier
+    unusable for the case it exists for, since a target that depends on the work
+    it is cleaning up would be held back by exactly the failure that should
+    trigger it. Use {@link TargetContext.outcomeOf} to see what actually
+    happened.
+
+    A dependency parked at a `.waitsFor(...)` gate is the exception: it has not
+    settled, so the target waits for the resume rather than reporting on a run
+    that is still in progress.
+
+    The build's overall result is unchanged — an `always` target that passes
+    does not rescue a failed build. Repeatable conditions/inputs apply.
   dryRunnable(): this
     Run this target's body under `--dry-run` instead of skipping it, with the
     `$` shell in echo mode: each command (awaited or `.spawn()`ed) prints its

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1560,9 +1560,23 @@ class TargetBuilder
     runs its real body — so declare it on targets that inspect rather than
     mutate (a status check, a report).
   always(): this
-    Run this target even after the build has failed — for cleanup/teardown that
-    must happen regardless. It still waits for its own dependencies to complete;
-    the build's overall result is unchanged. Repeatable conditions/inputs apply.
+    Run this target even after the build has failed — for cleanup, teardown, or
+    an aggregate that has to report on the failure.
+
+    It still waits for its own dependencies, but waits for them to settle
+    rather than to succeed: a dependency that failed releases it, the same as
+    one that passed or was skipped. Anything else would make the modifier
+    unusable for the case it exists for, since a target that depends on the work
+    it is cleaning up would be held back by exactly the failure that should
+    trigger it. Use {@link TargetContext.outcomeOf} to see what actually
+    happened.
+
+    A dependency parked at a `.waitsFor(...)` gate is the exception: it has not
+    settled, so the target waits for the resume rather than reporting on a run
+    that is still in progress.
+
+    The build's overall result is unchanged — an `always` target that passes
+    does not rescue a failed build. Repeatable conditions/inputs apply.
   dryRunnable(): this
     Run this target's body under `--dry-run` instead of skipping it, with the
     `$` shell in echo mode: each command (awaited or `.spawn()`ed) prints its

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -614,6 +614,13 @@ export async function runScheduled(
   const { life, reporter, renderer, style, env } = ctx;
   const outcomes = new Map<TargetBuilder, TargetOutcome>();
   const done = new Set<TargetBuilder>(); // passed/cached/skipped → unblocks dependents
+  // Reached a terminal status, whatever it was — `done` plus the failures. This
+  // is what an `always` target waits for: it runs *because* something failed, so
+  // gating it on `done` (which a failure never enters) is the one thing that
+  // guarantees it cannot. A parked wait is deliberately absent: it has not
+  // finished, it is going to be resumed, and a finalizer that fired before it
+  // resolved would report on a run that is still in progress.
+  const settled = new Set<TargetBuilder>();
   const started = new Set<TargetBuilder>();
   const runningSet = new Set<TargetBuilder>();
   let failure: unknown;
@@ -629,6 +636,7 @@ export async function runScheduled(
     if (skip.has(name)) {
       outcomes.set(t, { status: "skipped", ms: 0 });
       done.add(t);
+      settled.add(t);
       started.add(t);
       settleTarget(env, name, "skipped");
     } else if (env.done?.has(name)) {
@@ -636,12 +644,15 @@ export async function runScheduled(
       // and leave its recorded `succeeded` untouched.
       outcomes.set(t, { status: "cached", ms: 0 });
       done.add(t);
+      settled.add(t);
       started.add(t);
     }
   }
 
   const ready = (t: TargetBuilder): boolean =>
-    (predecessors.get(t) ?? []).every((p) => done.has(p));
+    (predecessors.get(t) ?? []).every((p) =>
+      t.always_ ? settled.has(p) : done.has(p)
+    );
   const overlaps = (t: TargetBuilder): boolean =>
     [...runningSet].every((r) => canOverlap(t, r));
 
@@ -685,6 +696,7 @@ export async function runScheduled(
               }
               outcomes.set(t, outcome);
               runningSet.delete(t);
+              if (outcome.status !== "waiting") settled.add(t);
               if (outcome.status === "failed") {
                 anyFailed = true;
                 failure ??= outcome.error;
@@ -717,6 +729,7 @@ export async function runScheduled(
             const targetName = t.name_ ?? "<unnamed>";
             outcomes.set(t, { status: "failed", ms: 0, error });
             runningSet.delete(t);
+            settled.add(t);
             anyFailed = true;
             failure ??= error;
             if (!t.proceedAfterFailure_) halted = true;

--- a/packages/core/src/target.ts
+++ b/packages/core/src/target.ts
@@ -630,9 +630,23 @@ export class TargetBuilder {
   }
 
   /**
-   * Run this target even after the build has failed — for cleanup/teardown that
-   * must happen regardless. It still waits for its own dependencies to complete;
-   * the build's overall result is unchanged. Repeatable conditions/inputs apply.
+   * Run this target even after the build has failed — for cleanup, teardown, or
+   * an aggregate that has to report on the failure.
+   *
+   * It still waits for its own dependencies, but waits for them to **settle**
+   * rather than to succeed: a dependency that failed releases it, the same as
+   * one that passed or was skipped. Anything else would make the modifier
+   * unusable for the case it exists for, since a target that depends on the work
+   * it is cleaning up would be held back by exactly the failure that should
+   * trigger it. Use {@link TargetContext.outcomeOf} to see what actually
+   * happened.
+   *
+   * A dependency parked at a `.waitsFor(...)` gate is the exception: it has not
+   * settled, so the target waits for the resume rather than reporting on a run
+   * that is still in progress.
+   *
+   * The build's overall result is unchanged — an `always` target that passes
+   * does not rescue a failed build. Repeatable conditions/inputs apply.
    */
   always(): this {
     this.always_ = true;

--- a/tests/integration/always_settled_test.ts
+++ b/tests/integration/always_settled_test.ts
@@ -1,0 +1,125 @@
+/**
+ * Integration tests for `.always()` readiness — a target that runs *because*
+ * something failed must not be held back by that failure.
+ *
+ * @module
+ */
+
+import { assertEquals } from "../../packages/core/tests/_assert.ts";
+import {
+  Build,
+  defaultStateHost,
+  externalSignal,
+  FileSystemStateStore,
+  target,
+} from "../../packages/core/mod.ts";
+import { runCli, withStateDir } from "./_harness.ts";
+
+Deno.test("an always target runs when a dependency failed, and can report on it", async () => {
+  // The aggregate-gate shape: one target that reports a single verdict for a
+  // fan of checks. It has to run in exactly the case a plain dependency edge
+  // would block it.
+  let verdict: string | undefined;
+  let failedNames: string[] = [];
+
+  class Ci extends Build {
+    lint = target().proceedAfterFailure().executes(() => {});
+    test = target().proceedAfterFailure().executes(() => {
+      throw new Error("2 tests failed");
+    });
+    gate = target()
+      .dependsOn(this.lint, this.test)
+      .always()
+      .executes((ctx) => {
+        failedNames = [...ctx.outcomes()]
+          .filter(([, o]) => o.status === "failed")
+          .map(([name]) => name);
+        verdict = failedNames.length === 0 ? "success" : "failure";
+      });
+  }
+
+  const { code } = await runCli(Ci, ["gate"]);
+  assertEquals(verdict, "failure");
+  assertEquals(failedNames, ["test"]);
+  // The gate passing does not rescue the build: it reports the failure, it does
+  // not absorb it.
+  assertEquals(code, 1);
+});
+
+Deno.test("the failure's message reaches the always target", async () => {
+  let message: string | undefined;
+
+  class Ci extends Build {
+    broken = target().proceedAfterFailure().executes(() => {
+      throw new Error("2 tests failed");
+    });
+    gate = target().dependsOn(this.broken).always().executes((ctx) => {
+      message = ctx.outcomeOf("broken")?.error;
+    });
+  }
+
+  await runCli(Ci, ["gate"]);
+  assertEquals(message, "2 tests failed");
+});
+
+Deno.test("a non-always target is still blocked by a failed dependency", async () => {
+  // The change is scoped to `.always()`. An ordinary dependent must not start
+  // running against a dependency that failed.
+  let ran = false;
+
+  class Ci extends Build {
+    broken = target().proceedAfterFailure().executes(() => {
+      throw new Error("nope");
+    });
+    dependent = target().dependsOn(this.broken).executes(() => {
+      ran = true;
+    });
+  }
+
+  const { code } = await runCli(Ci, ["dependent"]);
+  assertEquals(ran, false);
+  assertEquals(code, 1);
+});
+
+Deno.test("an always target waits for a parked wait rather than reporting early", async () => {
+  // A dependency at a `.waitsFor(...)` gate has not settled — it is going to be
+  // resumed. Releasing the always target here would have it report on a run
+  // that is still in progress, and the resume would then find it already done.
+  const ran: string[] = [];
+
+  class Cd extends Build {
+    hold = target().waitsFor((s) => s.on(externalSignal("go")));
+    gate = target().dependsOn(this.hold).always().executes(() => {
+      ran.push("gate");
+    });
+  }
+
+  await withStateDir(async (dir) => {
+    const first = await runCli(Cd, ["gate"]);
+    assertEquals(first.code, 0); // suspended
+    assertEquals(ran, []); // the gate did NOT fire early
+
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    const runs = await store.listRuns({});
+    assertEquals(runs.length, 1);
+
+    const resumed = await runCli(Cd, ["resume", runs[0].id, "--signal", "go"]);
+    assertEquals(resumed.code, 0);
+    assertEquals(ran, ["gate"]); // it fires once the wait resolves
+  });
+});
+
+Deno.test("an always target still runs when its dependencies all passed", async () => {
+  const ran: string[] = [];
+
+  class Ci extends Build {
+    unit = target().executes(() => void ran.push("unit"));
+    cleanup = target().dependsOn(this.unit).always().executes(() => {
+      ran.push("cleanup");
+    });
+  }
+
+  const { code } = await runCli(Ci, ["cleanup"]);
+  assertEquals(code, 0);
+  assertEquals(ran, ["unit", "cleanup"]);
+});


### PR DESCRIPTION
> Stacked on #317 — the base retargets to master once that merges. The diff to review is the last commit.

## Why

The always modifier exists for work that must happen when something went wrong: cleanup, teardown, or an aggregate that reports one verdict for a fan of checks. It was unusable for the failure case, which is the case it exists for.

Readiness required every dependency to be in the done set, and a failed target never enters it. So a target that depended on the work it was reporting on was held back by exactly the failure that should have triggered it, and the run settled it as skipped. With lint succeeding and test failing, the gate came out skipped and never ran at all.

Its own documentation already said it "still waits for its own dependencies to **complete**". A failed target has completed. The code read that as "succeeded", so this is the documentation and the behaviour disagreeing rather than a deliberate design.

This blocks the durable merge-gate work directly. A gate that posts a required status context could post green when everything passed and **nothing at all** when anything failed. For a required context a missing verdict is worse than a red one: the pull request is not red, it is stuck with no answer, and only an org owner editing branch protection can unstick it.

## What changed

An always target now waits for its dependencies to **settle** rather than to succeed. A failure releases it, the same as a pass or a skip, and it reads what actually happened through the target context's outcome accessors added in #317.

Scoped deliberately:

- An ordinary dependent is **still** blocked by a failed dependency. The new set is consulted only for always targets.
- An always target that passes still does not rescue a failed build.
- A dependency parked at a wait is **not** settled. It has not finished and is going to be resumed, so releasing the target there would have it report on a run still in progress, and the resume would then find it already done.

## Compatibility

This is an observable behaviour change to a public modifier: an always target with a dependency that fails now runs where it used to be skipped. That is the documented contract, and no existing test pinned the old behaviour. A cleanup body that assumed its dependency succeeded should check the dependency's outcome.

## Tests

Five integration cases: the aggregate-gate shape reporting a failure it depends on, the failure's message reaching it without a state store, an ordinary dependent still being blocked, a parked wait holding it back until the resume, and the all-passed path still working.

Full gate green locally, 18 of 18 targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)