### PR TITLE
feat(gh): post a check run without duplicating it

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9065,6 +9065,9 @@ async function mintAppToken(configure?: Configure<GhAppTokenSettings>): Promise<
 async function openPullRequest(configure?: (settings: GhPullRequestSettings) => GhPullRequestSettings): Promise<GhPullRequestResult>
   Perform the configured pull request.
 
+async function postCheckRun(configure?: (settings: GhCheckRunSettings) => GhCheckRunSettings): Promise<GhCheckRunResult>
+  Perform the configured check run.
+
 function readWorkflowResult(state: TargetStateHandle): WorkflowResult | undefined
   Read the {@link WorkflowResult} a completed {@link githubWorkflow} wait wrote
   to a target's state, or `undefined` if the wait has not completed (or this is
@@ -9148,6 +9151,72 @@ class GhAppTokenSettings
     The path that resolves this app's installation id.
   tokenRequest_(): Record<string, unknown>
     The `access_tokens` request body — only the fields that were narrowed.
+
+class GhCheckRunSettings
+  Settings for posting a completed check run.
+
+  `owner/repo` and the token fall back to the Actions environment, so a job
+  that already has them names only what it is reporting.
+
+  name_?: string
+    The check run's name — half of its identity. Set by {@link name}.
+  headSha_?: string
+    The commit it reports on. Set by {@link headSha}.
+  conclusion_?: GhCheckConclusion
+    The conclusion to report. Set by {@link conclusion}.
+  title_?: string
+    The output panel's title. Set by {@link title}.
+  summary_?: string
+    The output panel's markdown body. Set by {@link summary}.
+  externalId_?: string
+    The caller's own correlation id. Set by {@link externalId}.
+  detailsUrl_?: string
+    Where the check run's "Details" link points. Set by {@link detailsUrl}.
+  repo_?: string
+    `owner/repo`. Set by {@link repo}.
+  token_?: string
+    The token. Set by {@link token}.
+  baseUrl_: string
+    The API root. Set by {@link baseUrl}.
+  fetch_: typeof fetch
+    The `fetch` implementation. Set by {@link fetch}.
+  name(value: string): this
+    The check run's name — what appears in the PR's checks list, and what a
+    branch protection rule names as a required status context.
+  headSha(sha: string): this
+    The full SHA of the commit being reported on.
+
+    Pin this at the start of the work, not when the result is posted. A caller
+    that resolves the head of a pull request at post time reports on whatever
+    has been pushed since — which, for a required context, is a green check on
+    a commit nothing ever tested.
+  conclusion(value: GhCheckConclusion): this
+    The conclusion to report.
+  title(text: string): this
+    The output panel's title. Defaults to the check run's name.
+  summary(markdown: string): this
+    The output panel's body, as markdown.
+  externalId(id: string): this
+    A correlation id of the caller's own, stored on the check run.
+
+    Also what this operation matches on when deciding whether a check run is
+    "the same one": with an external id set, two callers writing the same name
+    on the same commit for different reasons stay distinct, and a re-drive of
+    one of them updates its own check run rather than the other's.
+  detailsUrl(url: string): this
+    Where the check run's "Details" link points.
+  repo(slug: string): this
+    `owner/repo`. Defaults to `GITHUB_REPOSITORY`.
+  token(value: string): this
+    The token to authenticate with. Defaults to `GITHUB_TOKEN`.
+  baseUrl(url: string): this
+    The API root, for GitHub Enterprise.
+  fetch(fn: typeof fetch): this
+    Override the `fetch` implementation (a test seam).
+  repoSlug_(): string
+    The effective `owner/repo`, from the setting or the environment.
+  authToken_(): string
+    The effective token, from the setting or the environment.
 
 class GhCommitSettings
   Settings for committing files through the API.
@@ -9421,6 +9490,33 @@ interface GhAppTokenResult
   installationId: number
     The installation the token was minted for.
 
+interface GhCheckRunApi
+  The check-run operation {@link GhTasks} exposes.
+
+  checkRun(configure?: (settings: GhCheckRunSettings) => GhCheckRunSettings): Promise<GhCheckRunResult>
+    Post a completed check run for `.headSha(...)` named `.name(...)`, updating
+    the one already on that commit if there is one.
+
+    The lookup and the write are two calls, so this is an upsert by
+    convergence, not an atomic one: two callers racing on a commit that has no
+    check run yet can both find nothing and both create one. What it removes is
+    the serial duplicate — the retry, the re-drive, the supervisor finishing
+    a dead process's work — which is the case that actually happens.
+
+interface GhCheckRunResult
+  The check run a {@link GhCheckRunApi.checkRun} call left on the commit.
+
+  id: number
+    Its numeric id.
+  url: string
+    Its web URL.
+  created: boolean
+    Whether this call created it, as opposed to updating one already there.
+
+    Worth reporting rather than hiding: a caller that expected to create and
+    updated instead has learned that something else posted first, which is the
+    difference between a first attempt and a re-drive.
+
 interface GhCommitApi
   The commit and tag operations {@link GhTasks} exposes.
 
@@ -9495,7 +9591,7 @@ interface GhSarifUploadResult
   url: string
     The URL that reports whether GitHub finished processing the report.
 
-interface GhTasksApi extends GhAppTokenApi, GhSarifApi, GhCommitApi, GhPullRequestApi
+interface GhTasksApi extends GhAppTokenApi, GhSarifApi, GhCommitApi, GhPullRequestApi, GhCheckRunApi
   The shape of {@link GhTasks}: the `gh` CLI plus the GitHub operations that
   have no CLI subcommand (see {@link GhAppTokenApi}, {@link GhSarifApi}) and
   would otherwise force a build back to a marketplace action.
@@ -9536,6 +9632,12 @@ type CorrelateMode = "marker" | "created-window"
   - `"created-window"` — claim the `workflow_dispatch` run on the dispatch ref
     created just after dispatch; best-effort, for workflows that can't echo
     the marker (fails loudly if two candidates are in the window).
+
+type GhCheckConclusion = "success" | "failure" | "neutral" | "cancelled" | "skipped" | "timed_out" | "action_required"
+  A check run's conclusion, as GitHub spells them.
+
+  `"stale"` is deliberately absent: GitHub sets it itself and rejects it from a
+  caller.
 
 type GhPermissionLevel = "read" | "write" | "admin"
   A permission level an installation token can be narrowed to.

--- a/packages/gh/README.md
+++ b/packages/gh/README.md
@@ -68,6 +68,50 @@ await run(Release);
 - **Auth** uses `GH_TOKEN` / `GITHUB_TOKEN`; the GitHub API is an injectable
   transport, so builds are testable without hitting GitHub.
 
+## Post a check run without duplicating it
+
+`GhTasks.checkRun` posts a **completed** check run for a commit, updating the
+one already there instead of creating a second. The GitHub API is create-only,
+so a caller that retries — a re-run step, a supervisor finishing work a dead
+process started — otherwise leaves several check runs of one name on a commit,
+and the newest silently wins. That matters when the name is a **required status
+context**.
+
+```ts
+import { GhTasks } from "jsr:@zuke/gh";
+
+// A token scoped to this one job: `checks: write` and nothing else.
+const { token } = await GhTasks.appToken((s) =>
+  s.appId(appId).privateKey(key).repositories("acme/app").permission(
+    "checks",
+    "write",
+  )
+);
+
+await GhTasks.checkRun((s) =>
+  s.repo("acme/app")
+    .name("CI / Required checks")
+    .headSha(headSha) // pinned when the work started, not resolved now
+    .conclusion(passed ? "success" : "failure")
+    .summary("11 of 12 checks passed")
+    .externalId(`${runId}/gate`)
+    .token(token)
+);
+```
+
+- **Upsert by convergence, not atomically.** The lookup and the write are two
+  calls, so two callers racing on a commit with no check run yet can both create
+  one. What it removes is the _serial_ duplicate — the retry, the re-drive —
+  which is the case that actually happens.
+- **`externalId` is identity, when set.** Only a check run carrying that id is a
+  candidate, so two callers reporting under one context stay distinct. Without
+  one, the name alone decides, and the newest match wins.
+- **Completed only.** A conclusion is required: a pending check run whose poster
+  dies never settles, and for a required context that is a pull request that can
+  never merge.
+- **Pin the head SHA.** Resolving it at post time reports on whatever has been
+  pushed since — a green required check on a commit nothing tested.
+
 <!-- ZUKE:API:START -->
 
 ## API
@@ -127,6 +171,9 @@ async function mintAppToken(configure?: Configure<GhAppTokenSettings>): Promise<
 
 async function openPullRequest(configure?: (settings: GhPullRequestSettings) => GhPullRequestSettings): Promise<GhPullRequestResult>
   Perform the configured pull request.
+
+async function postCheckRun(configure?: (settings: GhCheckRunSettings) => GhCheckRunSettings): Promise<GhCheckRunResult>
+  Perform the configured check run.
 
 function readWorkflowResult(state: TargetStateHandle): WorkflowResult | undefined
   Read the {@link WorkflowResult} a completed {@link githubWorkflow} wait wrote
@@ -211,6 +258,72 @@ class GhAppTokenSettings
     The path that resolves this app's installation id.
   tokenRequest_(): Record<string, unknown>
     The `access_tokens` request body — only the fields that were narrowed.
+
+class GhCheckRunSettings
+  Settings for posting a completed check run.
+
+  `owner/repo` and the token fall back to the Actions environment, so a job
+  that already has them names only what it is reporting.
+
+  name_?: string
+    The check run's name — half of its identity. Set by {@link name}.
+  headSha_?: string
+    The commit it reports on. Set by {@link headSha}.
+  conclusion_?: GhCheckConclusion
+    The conclusion to report. Set by {@link conclusion}.
+  title_?: string
+    The output panel's title. Set by {@link title}.
+  summary_?: string
+    The output panel's markdown body. Set by {@link summary}.
+  externalId_?: string
+    The caller's own correlation id. Set by {@link externalId}.
+  detailsUrl_?: string
+    Where the check run's "Details" link points. Set by {@link detailsUrl}.
+  repo_?: string
+    `owner/repo`. Set by {@link repo}.
+  token_?: string
+    The token. Set by {@link token}.
+  baseUrl_: string
+    The API root. Set by {@link baseUrl}.
+  fetch_: typeof fetch
+    The `fetch` implementation. Set by {@link fetch}.
+  name(value: string): this
+    The check run's name — what appears in the PR's checks list, and what a
+    branch protection rule names as a required status context.
+  headSha(sha: string): this
+    The full SHA of the commit being reported on.
+
+    Pin this at the start of the work, not when the result is posted. A caller
+    that resolves the head of a pull request at post time reports on whatever
+    has been pushed since — which, for a required context, is a green check on
+    a commit nothing ever tested.
+  conclusion(value: GhCheckConclusion): this
+    The conclusion to report.
+  title(text: string): this
+    The output panel's title. Defaults to the check run's name.
+  summary(markdown: string): this
+    The output panel's body, as markdown.
+  externalId(id: string): this
+    A correlation id of the caller's own, stored on the check run.
+
+    Also what this operation matches on when deciding whether a check run is
+    "the same one": with an external id set, two callers writing the same name
+    on the same commit for different reasons stay distinct, and a re-drive of
+    one of them updates its own check run rather than the other's.
+  detailsUrl(url: string): this
+    Where the check run's "Details" link points.
+  repo(slug: string): this
+    `owner/repo`. Defaults to `GITHUB_REPOSITORY`.
+  token(value: string): this
+    The token to authenticate with. Defaults to `GITHUB_TOKEN`.
+  baseUrl(url: string): this
+    The API root, for GitHub Enterprise.
+  fetch(fn: typeof fetch): this
+    Override the `fetch` implementation (a test seam).
+  repoSlug_(): string
+    The effective `owner/repo`, from the setting or the environment.
+  authToken_(): string
+    The effective token, from the setting or the environment.
 
 class GhCommitSettings
   Settings for committing files through the API.
@@ -484,6 +597,33 @@ interface GhAppTokenResult
   installationId: number
     The installation the token was minted for.
 
+interface GhCheckRunApi
+  The check-run operation {@link GhTasks} exposes.
+
+  checkRun(configure?: (settings: GhCheckRunSettings) => GhCheckRunSettings): Promise<GhCheckRunResult>
+    Post a completed check run for `.headSha(...)` named `.name(...)`, updating
+    the one already on that commit if there is one.
+
+    The lookup and the write are two calls, so this is an upsert by
+    convergence, not an atomic one: two callers racing on a commit that has no
+    check run yet can both find nothing and both create one. What it removes is
+    the serial duplicate — the retry, the re-drive, the supervisor finishing
+    a dead process's work — which is the case that actually happens.
+
+interface GhCheckRunResult
+  The check run a {@link GhCheckRunApi.checkRun} call left on the commit.
+
+  id: number
+    Its numeric id.
+  url: string
+    Its web URL.
+  created: boolean
+    Whether this call created it, as opposed to updating one already there.
+
+    Worth reporting rather than hiding: a caller that expected to create and
+    updated instead has learned that something else posted first, which is the
+    difference between a first attempt and a re-drive.
+
 interface GhCommitApi
   The commit and tag operations {@link GhTasks} exposes.
 
@@ -558,7 +698,7 @@ interface GhSarifUploadResult
   url: string
     The URL that reports whether GitHub finished processing the report.
 
-interface GhTasksApi extends GhAppTokenApi, GhSarifApi, GhCommitApi, GhPullRequestApi
+interface GhTasksApi extends GhAppTokenApi, GhSarifApi, GhCommitApi, GhPullRequestApi, GhCheckRunApi
   The shape of {@link GhTasks}: the `gh` CLI plus the GitHub operations that
   have no CLI subcommand (see {@link GhAppTokenApi}, {@link GhSarifApi}) and
   would otherwise force a build back to a marketplace action.
@@ -599,6 +739,12 @@ type CorrelateMode = "marker" | "created-window"
   - `"created-window"` — claim the `workflow_dispatch` run on the dispatch ref
     created just after dispatch; best-effort, for workflows that can't echo
     the marker (fails loudly if two candidates are in the window).
+
+type GhCheckConclusion = "success" | "failure" | "neutral" | "cancelled" | "skipped" | "timed_out" | "action_required"
+  A check run's conclusion, as GitHub spells them.
+
+  `"stale"` is deliberately absent: GitHub sets it itself and rejects it from a
+  caller.
 
 type GhPermissionLevel = "read" | "write" | "admin"
   A permission level an installation token can be narrowed to.

--- a/packages/gh/README.md
+++ b/packages/gh/README.md
@@ -101,11 +101,18 @@ await GhTasks.checkRun((s) =>
 
 - **Upsert by convergence, not atomically.** The lookup and the write are two
   calls, so two callers racing on a commit with no check run yet can both create
-  one. What it removes is the _serial_ duplicate — the retry, the re-drive —
-  which is the case that actually happens.
+  one, and nothing here orders two conclusions written at the same moment. What
+  it removes is the _serial_ duplicate — the retry, the re-drive — which is the
+  case that actually happens. Callers that need one answer must agree on it
+  before they get here.
 - **`externalId` is identity, when set.** Only a check run carrying that id is a
-  candidate, so two callers reporting under one context stay distinct. Without
-  one, the name alone decides, and the newest match wins.
+  candidate, so two callers reporting under one context stay distinct — and the
+  match is symmetric, so a caller that sets no id never adopts one that did.
+  With no id on either side, the name alone decides and the newest wins.
+- **A check run owned by another app is replaced, not updated.** Only the app
+  that created a check run may update it, so a refusal means "not ours" and a
+  new one is posted instead. That is what keeps this working during a migration,
+  while the workflow being replaced still posts the same name.
 - **Completed only.** A conclusion is required: a pending check run whose poster
   dies never settles, and for a required context that is a pull request that can
   never merge.

--- a/packages/gh/mod.ts
+++ b/packages/gh/mod.ts
@@ -29,6 +29,13 @@ export {
   tagCommit,
 } from "./src/commit.ts";
 export {
+  type GhCheckConclusion,
+  type GhCheckRunApi,
+  type GhCheckRunResult,
+  GhCheckRunSettings,
+  postCheckRun,
+} from "./src/check_run.ts";
+export {
   type GhAppTokenApi,
   type GhAppTokenResult,
   GhAppTokenSettings,

--- a/packages/gh/src/api.ts
+++ b/packages/gh/src/api.ts
@@ -99,18 +99,30 @@ export function encodePath(value: string): string {
 /**
  * Reject a repository slug that is not exactly `owner/name`.
  *
- * Encoding already stops the slug escaping upwards — a `..` segment survives as
- * a literal name rather than resolving — so this is not the traversal guard.
- * What it stops is a slug with the wrong number of segments silently changing
- * which endpoint is called: `a/b/c` builds `/repos/a/b/c/git/trees`, sending a
- * token-bearing request somewhere the caller never named. The slug is a trust
- * boundary like the ref names beside it, and the ref names are checked.
+ * Two things, and the second used to be missing. A slug with the wrong number
+ * of segments silently changes which endpoint is called: `a/b/c` builds
+ * `/repos/a/b/c/git/trees`, sending a token-bearing request somewhere the
+ * caller never named.
+ *
+ * And the segments have to be checked, not just counted. `encodePath` does not
+ * save us here the way it does for `%2e%2e`: a *literal* `..` is left alone by
+ * `encodeURIComponent`, so `../x` passes a count-only check and the URL parser
+ * then resolves `/repos/../x/commits/…` to `/x/commits/…` — a different
+ * endpoint, with the token attached. GitHub's own names are alphanumerics,
+ * dot, dash and underscore, so requiring exactly that costs nothing and makes
+ * the guard mean what it says.
  */
 export function assertRepoSlug(slug: string): void {
   const parts = slug.split("/");
-  if (parts.length !== 2 || parts.some((part) => part === "")) {
+  const wellFormed = parts.length === 2 &&
+    parts.every((part) =>
+      /^[A-Za-z0-9._-]+$/.test(part) && part !== "." && part !== ".."
+    );
+  if (!wellFormed) {
     throw new Error(
-      `invalid repository ${JSON.stringify(slug)}: expected "owner/name".`,
+      `invalid repository ${JSON.stringify(slug)}: expected "owner/name" ` +
+        `(letters, digits, ".", "-", "_"), and neither segment may be "." ` +
+        `or "..".`,
     );
   }
 }

--- a/packages/gh/src/check_run.ts
+++ b/packages/gh/src/check_run.ts
@@ -1,0 +1,363 @@
+/**
+ * Post a completed check run, creating it or updating the one already there.
+ *
+ * The GitHub API for check runs is create-only: `POST /check-runs` makes a new
+ * one every time it is called, so a caller that retries — a step re-run, a
+ * re-driven Zuke effect, a supervisor finishing work a dead process started —
+ * ends up with several check runs of the same name on one commit. That is not
+ * cosmetic when the name is a **required status context**: the newest one wins,
+ * and which one is newest is decided by whichever caller happened to finish
+ * last.
+ *
+ * So this operation looks first. It is the piece that lets everything upstream
+ * of it be honestly at-least-once: retry as often as you like, and the commit
+ * still carries exactly one check run of that name, holding the conclusion of
+ * the most recent attempt.
+ *
+ * @module
+ */
+
+import {
+  caller,
+  DEFAULT_BASE_URL,
+  env,
+  type GhCall,
+  isRecord,
+  readNumber,
+  readString,
+} from "./api.ts";
+
+/**
+ * A check run's conclusion, as GitHub spells them.
+ *
+ * `"stale"` is deliberately absent: GitHub sets it itself and rejects it from a
+ * caller.
+ */
+export type GhCheckConclusion =
+  | "success"
+  | "failure"
+  | "neutral"
+  | "cancelled"
+  | "skipped"
+  | "timed_out"
+  | "action_required";
+
+/** The check run a {@link GhCheckRunApi.checkRun} call left on the commit. */
+export interface GhCheckRunResult {
+  /** Its numeric id. */
+  id: number;
+  /** Its web URL. */
+  url: string;
+  /**
+   * Whether this call created it, as opposed to updating one already there.
+   *
+   * Worth reporting rather than hiding: a caller that expected to create and
+   * updated instead has learned that something else posted first, which is the
+   * difference between a first attempt and a re-drive.
+   */
+  created: boolean;
+}
+
+/**
+ * Settings for posting a completed check run.
+ *
+ * `owner/repo` and the token fall back to the Actions environment, so a job
+ * that already has them names only what it is reporting.
+ */
+export class GhCheckRunSettings {
+  /** The check run's name — half of its identity. Set by {@link name}. */
+  name_?: string;
+  /** The commit it reports on. Set by {@link headSha}. */
+  headSha_?: string;
+  /** The conclusion to report. Set by {@link conclusion}. */
+  conclusion_?: GhCheckConclusion;
+  /** The output panel's title. Set by {@link title}. */
+  title_?: string;
+  /** The output panel's markdown body. Set by {@link summary}. */
+  summary_?: string;
+  /** The caller's own correlation id. Set by {@link externalId}. */
+  externalId_?: string;
+  /** Where the check run's "Details" link points. Set by {@link detailsUrl}. */
+  detailsUrl_?: string;
+  /** `owner/repo`. Set by {@link repo}. */
+  repo_?: string;
+  /** The token. Set by {@link token}. */
+  token_?: string;
+  /** The API root. Set by {@link baseUrl}. */
+  baseUrl_: string = DEFAULT_BASE_URL;
+  /** The `fetch` implementation. Set by {@link fetch}. */
+  fetch_: typeof fetch = fetch;
+
+  /**
+   * The check run's name — what appears in the PR's checks list, and what a
+   * branch protection rule names as a required status context.
+   */
+  name(value: string): this {
+    this.name_ = value;
+    return this;
+  }
+
+  /**
+   * The full SHA of the commit being reported on.
+   *
+   * Pin this at the start of the work, not when the result is posted. A caller
+   * that resolves the head of a pull request at post time reports on whatever
+   * has been pushed since — which, for a required context, is a green check on
+   * a commit nothing ever tested.
+   */
+  headSha(sha: string): this {
+    this.headSha_ = sha;
+    return this;
+  }
+
+  /** The conclusion to report. */
+  conclusion(value: GhCheckConclusion): this {
+    this.conclusion_ = value;
+    return this;
+  }
+
+  /** The output panel's title. Defaults to the check run's name. */
+  title(text: string): this {
+    this.title_ = text;
+    return this;
+  }
+
+  /** The output panel's body, as markdown. */
+  summary(markdown: string): this {
+    this.summary_ = markdown;
+    return this;
+  }
+
+  /**
+   * A correlation id of the caller's own, stored on the check run.
+   *
+   * Also what this operation matches on when deciding whether a check run is
+   * "the same one": with an external id set, two callers writing the same name
+   * on the same commit for different reasons stay distinct, and a re-drive of
+   * one of them updates its own check run rather than the other's.
+   */
+  externalId(id: string): this {
+    this.externalId_ = id;
+    return this;
+  }
+
+  /** Where the check run's "Details" link points. */
+  detailsUrl(url: string): this {
+    this.detailsUrl_ = url;
+    return this;
+  }
+
+  /** `owner/repo`. Defaults to `GITHUB_REPOSITORY`. */
+  repo(slug: string): this {
+    this.repo_ = slug;
+    return this;
+  }
+
+  /** The token to authenticate with. Defaults to `GITHUB_TOKEN`. */
+  token(value: string): this {
+    this.token_ = value;
+    return this;
+  }
+
+  /** The API root, for GitHub Enterprise. */
+  baseUrl(url: string): this {
+    this.baseUrl_ = url.replace(/\/+$/, "");
+    return this;
+  }
+
+  /** Override the `fetch` implementation (a test seam). */
+  fetch(fn: typeof fetch): this {
+    this.fetch_ = fn;
+    return this;
+  }
+
+  /** The effective `owner/repo`, from the setting or the environment. */
+  repoSlug_(): string {
+    const slug = this.repo_ ?? env("GITHUB_REPOSITORY");
+    if (slug === undefined) {
+      throw new Error(
+        "posting a check run requires .repo('owner/name') (or " +
+          "GITHUB_REPOSITORY).",
+      );
+    }
+    return slug;
+  }
+
+  /** The effective token, from the setting or the environment. */
+  authToken_(): string {
+    const token = this.token_ ?? env("GITHUB_TOKEN");
+    if (token === undefined) {
+      throw new Error(
+        "posting a check run requires .token(...) (or GITHUB_TOKEN). It needs " +
+          "the `checks: write` permission and nothing else.",
+      );
+    }
+    return token;
+  }
+}
+
+/** The check-run operation {@link GhTasks} exposes. */
+export interface GhCheckRunApi {
+  /**
+   * Post a completed check run for `.headSha(...)` named `.name(...)`, updating
+   * the one already on that commit if there is one.
+   *
+   * The lookup and the write are two calls, so this is an upsert by
+   * convergence, not an atomic one: two callers racing on a commit that has no
+   * check run yet can both find nothing and both create one. What it removes is
+   * the *serial* duplicate — the retry, the re-drive, the supervisor finishing
+   * a dead process's work — which is the case that actually happens.
+   */
+  checkRun(
+    configure?: (settings: GhCheckRunSettings) => GhCheckRunSettings,
+  ): Promise<GhCheckRunResult>;
+}
+
+/**
+ * Reject a head SHA that is not one.
+ *
+ * It is interpolated into the lookup path, so the same reasoning as the ref
+ * names in `api.ts` applies — but the more common failure this catches is a
+ * caller passing a branch name or an abbreviated SHA. GitHub rejects both when
+ * creating a check run, with a 422 that does not say which field was wrong.
+ */
+function assertHeadSha(sha: string): void {
+  if (!/^[0-9a-fA-F]{40}$|^[0-9a-fA-F]{64}$/.test(sha)) {
+    throw new Error(
+      `refusing to use ${JSON.stringify(sha)} as a head SHA: expected a full ` +
+        `40- or 64-character commit SHA. An abbreviated SHA or a branch name ` +
+        `is rejected when the check run is created.`,
+    );
+  }
+}
+
+/** Perform the configured check run. */
+export async function postCheckRun(
+  configure?: (settings: GhCheckRunSettings) => GhCheckRunSettings,
+): Promise<GhCheckRunResult> {
+  const settings = configure?.(new GhCheckRunSettings()) ??
+    new GhCheckRunSettings();
+  const name = settings.name_;
+  const headSha = settings.headSha_;
+  const conclusion = settings.conclusion_;
+  if (name === undefined) {
+    throw new Error("posting a check run requires .name(...).");
+  }
+  if (headSha === undefined) {
+    throw new Error("posting a check run requires .headSha(...).");
+  }
+  if (conclusion === undefined) {
+    // Only completed check runs, on purpose: a caller that posts a pending one
+    // and then dies leaves a check that never settles, which for a required
+    // context is a pull request that can never merge. There is no way to write
+    // that here by accident.
+    throw new Error(
+      "posting a check run requires .conclusion(...) — this posts a completed " +
+        "check run in one call.",
+    );
+  }
+  assertHeadSha(headSha);
+
+  const repo = settings.repoSlug_();
+  const call = caller(
+    settings.baseUrl_,
+    repo,
+    settings.authToken_(),
+    settings.fetch_,
+  );
+
+  const body: Record<string, unknown> = { name, conclusion };
+  if (settings.externalId_ !== undefined) {
+    body.external_id = settings.externalId_;
+  }
+  if (settings.detailsUrl_ !== undefined) {
+    body.details_url = settings.detailsUrl_;
+  }
+  if (settings.title_ !== undefined || settings.summary_ !== undefined) {
+    // GitHub rejects an output panel that has one of these without the other,
+    // so naming either fills in the other rather than 422-ing on the caller's
+    // behalf.
+    body.output = {
+      title: settings.title_ ?? name,
+      summary: settings.summary_ ?? "",
+    };
+  }
+
+  const existing = await findCheckRun(
+    call,
+    headSha,
+    name,
+    settings.externalId_,
+  );
+  if (existing !== undefined) {
+    const updated = await call("PATCH", `/check-runs/${existing}`, body);
+    return {
+      id: readNumber(updated, "id", "check run"),
+      url: readString(updated, ["html_url"], "check run"),
+      created: false,
+    };
+  }
+  // `head_sha` is create-only — an update cannot move a check run to another
+  // commit, so it is sent here and nowhere else.
+  const created = await call("POST", "/check-runs", {
+    ...body,
+    head_sha: headSha,
+  });
+  return {
+    id: readNumber(created, "id", "check run"),
+    url: readString(created, ["html_url"], "check run"),
+    created: true,
+  };
+}
+
+/**
+ * Find the check run this call would be updating, if the commit has one.
+ *
+ * Newest wins, by id. GitHub does not document an order for this listing, and
+ * "the one a previous attempt left" is by definition the most recently created
+ * of the candidates — picking any other would update a stale check run and
+ * leave the visible one saying whatever it said before.
+ *
+ * With an `externalId`, only a check run carrying that id is a candidate: the
+ * name alone is not identity when two different callers report under one
+ * required context. Without one, the name is all there is.
+ */
+async function findCheckRun(
+  call: GhCall,
+  headSha: string,
+  name: string,
+  externalId: string | undefined,
+): Promise<number | undefined> {
+  const query = new URLSearchParams({
+    check_name: name,
+    per_page: "100",
+  });
+  let page = 1;
+  let seen = 0;
+  let best: number | undefined;
+  // Paginated rather than trusting the first page: the filter makes more than
+  // one page pathological, but a missed candidate is a duplicate check run,
+  // which is the failure this whole function exists to prevent.
+  while (true) {
+    query.set("page", String(page));
+    const response = await call(
+      "GET",
+      `/commits/${headSha}/check-runs?${query}`,
+    );
+    if (!isRecord(response)) return best;
+    const runs = response.check_runs;
+    if (!Array.isArray(runs) || runs.length === 0) return best;
+    for (const run of runs) {
+      if (!isRecord(run)) continue;
+      if (run.name !== name) continue;
+      if (externalId !== undefined && run.external_id !== externalId) continue;
+      const id = run.id;
+      if (typeof id !== "number") continue;
+      if (best === undefined || id > best) best = id;
+    }
+    seen += runs.length;
+    const total = response.total_count;
+    if (typeof total !== "number" || seen >= total) return best;
+    page += 1;
+  }
+}

--- a/packages/gh/src/check_run.ts
+++ b/packages/gh/src/check_run.ts
@@ -9,10 +9,16 @@
  * and which one is newest is decided by whichever caller happened to finish
  * last.
  *
- * So this operation looks first. It is the piece that lets everything upstream
- * of it be honestly at-least-once: retry as often as you like, and the commit
- * still carries exactly one check run of that name, holding the conclusion of
- * the most recent attempt.
+ * So this operation looks first, and updates what it finds. That is what lets
+ * everything upstream of it be honestly at-least-once: a retry, a re-drive, or
+ * a supervisor finishing a dead process's work converges on one check run
+ * rather than adding another.
+ *
+ * It converges; it does not serialise. The lookup and the write are two calls,
+ * so two callers racing on a commit that has no check run yet can still each
+ * create one, and nothing here orders two conclusions written at the same
+ * moment. Callers that need one answer must agree on it before they get here —
+ * which is exactly what computing it from a run's durable outcomes does.
  *
  * @module
  */
@@ -21,6 +27,7 @@ import {
   caller,
   DEFAULT_BASE_URL,
   env,
+  GhApiError,
   type GhCall,
   isRecord,
   readNumber,
@@ -290,12 +297,26 @@ export async function postCheckRun(
     settings.externalId_,
   );
   if (existing !== undefined) {
-    const updated = await call("PATCH", `/check-runs/${existing}`, body);
-    return {
-      id: readNumber(updated, "id", "check run"),
-      url: readString(updated, ["html_url"], "check run"),
-      created: false,
+    // The output panel is rewritten on every update, even when this call named
+    // neither half of it. A partial update would leave the previous attempt's
+    // text under this attempt's conclusion — "12 of 12 checks passed" above a
+    // failure — which is worse than an empty panel.
+    const update = {
+      ...body,
+      output: {
+        title: settings.title_ ?? name,
+        summary: settings.summary_ ?? "",
+      },
     };
+    const updated = await update_(call, existing, update);
+    if (updated !== undefined) {
+      return {
+        id: readNumber(updated, "id", "check run"),
+        url: readString(updated, ["html_url"], "check run"),
+        created: false,
+      };
+    }
+    // The check run is not ours to update — fall through and post our own.
   }
   // `head_sha` is create-only — an update cannot move a check run to another
   // commit, so it is sent here and nowhere else.
@@ -308,6 +329,39 @@ export async function postCheckRun(
     url: readString(created, ["html_url"], "check run"),
     created: true,
   };
+}
+
+/**
+ * Update `id`, or report that it cannot be updated by this caller.
+ *
+ * A check run may only be updated by the GitHub App that created it; anyone
+ * else is refused. That is not an edge case here — the name this posts under is
+ * a required status context, and during a migration the same name is often
+ * still being produced by the workflow being replaced, owned by a different
+ * app. Left to propagate, the refusal would repeat identically on every
+ * re-drive and the context would never be posted at all, which for a required
+ * check means a pull request nobody can merge.
+ *
+ * So a refusal means "not ours", and posting our own is the answer. A token
+ * that genuinely lacks `checks: write` is not masked: the create that follows
+ * is refused too, and that error is the one the caller sees.
+ */
+async function update_(
+  call: GhCall,
+  id: number,
+  body: Record<string, unknown>,
+): Promise<unknown | undefined> {
+  try {
+    return await call("PATCH", `/check-runs/${id}`, body);
+  } catch (error) {
+    if (
+      error instanceof GhApiError &&
+      (error.status === 403 || error.status === 404)
+    ) {
+      return undefined;
+    }
+    throw error;
+  }
 }
 
 /**
@@ -330,6 +384,12 @@ async function findCheckRun(
 ): Promise<number | undefined> {
   const query = new URLSearchParams({
     check_name: name,
+    // `filter` defaults to `latest`, which returns at most **one** check run per
+    // name — so on a commit that already carries two, the one this call is
+    // looking for may not be in the response at all, and it would create a
+    // third. Everything below (matching on external id, taking the newest of
+    // several) only means anything with the full list.
+    filter: "all",
     per_page: "100",
   });
   let page = 1;
@@ -350,7 +410,10 @@ async function findCheckRun(
     for (const run of runs) {
       if (!isRecord(run)) continue;
       if (run.name !== name) continue;
-      if (externalId !== undefined && run.external_id !== externalId) continue;
+      // Symmetric on purpose. Matching only when *this* call sets an id would
+      // let an id-less caller adopt a check run that belongs to one that does,
+      // which is the isolation the setting is documented to provide.
+      if (String(run.external_id ?? "") !== (externalId ?? "")) continue;
       const id = run.id;
       if (typeof id !== "number") continue;
       if (best === undefined || id > best) best = id;

--- a/packages/gh/src/gh.ts
+++ b/packages/gh/src/gh.ts
@@ -35,6 +35,12 @@ import {
   mintAppToken,
 } from "./app_token.ts";
 import {
+  type GhCheckRunApi,
+  type GhCheckRunResult,
+  type GhCheckRunSettings,
+  postCheckRun,
+} from "./check_run.ts";
+import {
   commitFiles,
   type GhCommitApi,
   type GhCommitResult,
@@ -83,7 +89,12 @@ export class GhSettings extends SubcommandSettings {
  * would otherwise force a build back to a marketplace action.
  */
 export interface GhTasksApi
-  extends GhAppTokenApi, GhSarifApi, GhCommitApi, GhPullRequestApi {
+  extends
+    GhAppTokenApi,
+    GhSarifApi,
+    GhCommitApi,
+    GhPullRequestApi,
+    GhCheckRunApi {
   /** Run a `gh` command. */
   run(configure?: Configure<GhSettings>): Promise<CommandOutput>;
 }
@@ -110,6 +121,11 @@ export const GhTasks: GhTasksApi = {
     configure?: (s: GhPullRequestSettings) => GhPullRequestSettings,
   ): Promise<GhPullRequestResult | undefined> {
     return findPullRequest(configure);
+  },
+  checkRun(
+    configure?: (s: GhCheckRunSettings) => GhCheckRunSettings,
+  ): Promise<GhCheckRunResult> {
+    return postCheckRun(configure);
   },
   appToken(
     configure?: Configure<GhAppTokenSettings>,

--- a/packages/gh/tests/check_run_test.ts
+++ b/packages/gh/tests/check_run_test.ts
@@ -53,6 +53,7 @@ function fakeFetch(
 function listPath(name: string, page = 1): string {
   const query = new URLSearchParams({
     check_name: name,
+    filter: "all",
     per_page: "100",
     page: String(page),
   });
@@ -350,6 +351,133 @@ Deno.test("a branch name or an abbreviated SHA is refused before the call", asyn
   }
   // Nothing was sent: the guard runs before the transport is built.
   assertEquals(calls.length, 0);
+});
+
+Deno.test("the listing asks for every check run, not just the latest per name", async () => {
+  // GitHub's default is filter=latest, which returns at most one run per name.
+  // On a commit that already carries two, the one being looked for may not be
+  // in the response at all — and this would create a third.
+  const { fetch, calls } = fakeFetch({
+    ...noneYet("gate"),
+    "POST /check-runs": { status: 201, body: { id: 1, html_url: "u" } },
+  });
+  await postCheckRun((s) =>
+    s.repo("acme/app").token("t").name("gate").headSha(SHA)
+      .conclusion("success").fetch(fetch)
+  );
+  assertStringIncludes(calls[0].path, "filter=all");
+});
+
+Deno.test("a check run owned by another app is not updated but replaced", async () => {
+  // A check run may only be updated by the app that created it. During a
+  // migration the same name is often still produced by the workflow being
+  // replaced, owned by a different app — and a refusal that propagated would
+  // repeat on every re-drive, leaving a required context never posted at all.
+  const { fetch, calls } = fakeFetch({
+    [listPath("CI / Required checks")]: {
+      status: 200,
+      body: {
+        total_count: 1,
+        check_runs: [{ id: 99, name: "CI / Required checks" }],
+      },
+    },
+    "PATCH /check-runs/99": {
+      status: 403,
+      body: { message: "Resource not accessible by integration" },
+    },
+    "POST /check-runs": { status: 201, body: { id: 100, html_url: "u" } },
+  });
+  const result = await postCheckRun((s) =>
+    s.repo("acme/app").token("t").name("CI / Required checks").headSha(SHA)
+      .conclusion("failure").fetch(fetch)
+  );
+  assertEquals(result.created, true);
+  assertEquals(result.id, 100);
+  assertEquals(calls.map((c) => c.method), ["GET", "PATCH", "POST"]);
+});
+
+Deno.test("a refused create is not masked by the update fallback", async () => {
+  // The fallback must not turn a token that genuinely lacks checks:write into
+  // silence: the create is refused too, and that error is the one to report.
+  const { fetch } = fakeFetch({
+    [listPath("gate")]: {
+      status: 200,
+      body: { total_count: 1, check_runs: [{ id: 99, name: "gate" }] },
+    },
+    "PATCH /check-runs/99": { status: 403, body: { message: "nope" } },
+    "POST /check-runs": { status: 403, body: { message: "still nope" } },
+  });
+  const error = await assertRejects(
+    () =>
+      postCheckRun((s) =>
+        s.repo("acme/app").token("t").name("gate").headSha(SHA)
+          .conclusion("success").fetch(fetch)
+      ),
+    GhApiError,
+  );
+  assertStringIncludes(error.message, "still nope");
+});
+
+Deno.test("an update failure that is not a refusal propagates", async () => {
+  // A 500 says nothing about ownership. Creating a second check run because
+  // the server had a bad minute is the duplicate this function exists to avoid.
+  const { fetch, calls } = fakeFetch({
+    [listPath("gate")]: {
+      status: 200,
+      body: { total_count: 1, check_runs: [{ id: 99, name: "gate" }] },
+    },
+    "PATCH /check-runs/99": { status: 500, body: { message: "server error" } },
+  });
+  await assertRejects(
+    () =>
+      postCheckRun((s) =>
+        s.repo("acme/app").token("t").name("gate").headSha(SHA)
+          .conclusion("success").fetch(fetch)
+      ),
+    GhApiError,
+  );
+  assertEquals(calls.filter((c) => c.method === "POST").length, 0);
+});
+
+Deno.test("an update rewrites the output panel rather than leaving a stale one", async () => {
+  // A partial update would leave the previous attempt's text under this
+  // attempt's conclusion — "12 of 12 checks passed" above a failure.
+  const { fetch, calls } = fakeFetch({
+    [listPath("gate")]: {
+      status: 200,
+      body: { total_count: 1, check_runs: [{ id: 7, name: "gate" }] },
+    },
+    "PATCH /check-runs/7": { status: 200, body: { id: 7, html_url: "u" } },
+  });
+  await postCheckRun((s) =>
+    s.repo("acme/app").token("t").name("gate").headSha(SHA)
+      .conclusion("failure").fetch(fetch)
+  );
+  assertEquals(calls[calls.length - 1].body.output, {
+    title: "gate",
+    summary: "",
+  });
+});
+
+Deno.test("a caller with no external id does not adopt one that has it", async () => {
+  // The isolation has to hold from both sides, or the setting only protects
+  // the caller that remembered to set it.
+  const { fetch, calls } = fakeFetch({
+    [listPath("gate")]: {
+      status: 200,
+      body: {
+        total_count: 1,
+        check_runs: [{ id: 20, name: "gate", external_id: "someone-else" }],
+      },
+    },
+    "POST /check-runs": { status: 201, body: { id: 21, html_url: "u" } },
+  });
+  const result = await postCheckRun((s) =>
+    s.repo("acme/app").token("t").name("gate").headSha(SHA)
+      .conclusion("success").fetch(fetch)
+  );
+  assertEquals(result.created, true);
+  assertEquals(calls.filter((c) => c.method === "PATCH").length, 0);
 });
 
 Deno.test("the repo and token fall back to the Actions environment", async () => {

--- a/packages/gh/tests/check_run_test.ts
+++ b/packages/gh/tests/check_run_test.ts
@@ -1,0 +1,489 @@
+/**
+ * Unit tests for `src/check_run.ts` — posting a completed check run without
+ * leaving a second one behind on a retry.
+ *
+ * `fetch` is injected via the settings seam, so none of this touches the
+ * network.
+ *
+ * @module
+ */
+
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "../../core/tests/_assert.ts";
+import { postCheckRun } from "../src/check_run.ts";
+import { GhApiError } from "../src/api.ts";
+
+/** A full commit SHA — the only shape the API accepts. */
+const SHA = "a".repeat(40);
+
+/** One recorded request. */
+interface Call {
+  method: string;
+  path: string;
+  body: Record<string, unknown>;
+}
+
+/** A fake transport answering each path from a canned table. */
+function fakeFetch(
+  replies: Record<string, { status: number; body: unknown }>,
+): { fetch: typeof fetch; calls: Call[] } {
+  const calls: Call[] = [];
+  const impl: typeof fetch = (input, init) => {
+    const url = new URL(String(input));
+    const path = `${url.pathname.replace("/repos/acme/app", "")}${url.search}`;
+    const method = init?.method ?? "GET";
+    const raw = init?.body;
+    calls.push({
+      method,
+      path,
+      body: typeof raw === "string" ? JSON.parse(raw) : {},
+    });
+    const reply = replies[`${method} ${path}`] ?? { status: 200, body: {} };
+    return Promise.resolve(
+      new Response(JSON.stringify(reply.body), { status: reply.status }),
+    );
+  };
+  return { fetch: impl, calls };
+}
+
+/** The listing path for a name, on the canonical SHA. */
+function listPath(name: string, page = 1): string {
+  const query = new URLSearchParams({
+    check_name: name,
+    per_page: "100",
+    page: String(page),
+  });
+  return `GET /commits/${SHA}/check-runs?${query}`;
+}
+
+/** Run `fn` with the Actions environment variables set to `values`. */
+async function withEnv(
+  values: Record<string, string | undefined>,
+  fn: () => Promise<void>,
+): Promise<void> {
+  const saved = new Map<string, string | undefined>();
+  for (const [name, value] of Object.entries(values)) {
+    saved.set(name, Deno.env.get(name));
+    if (value === undefined) Deno.env.delete(name);
+    else Deno.env.set(name, value);
+  }
+  try {
+    await fn();
+  } finally {
+    for (const [name, value] of saved) {
+      if (value === undefined) Deno.env.delete(name);
+      else Deno.env.set(name, value);
+    }
+  }
+}
+
+/** An empty listing — the commit has no check run of that name yet. */
+function noneYet(
+  name: string,
+): Record<string, { status: number; body: unknown }> {
+  return {
+    [listPath(name)]: { status: 200, body: { total_count: 0, check_runs: [] } },
+  };
+}
+
+Deno.test("a commit with no check run of that name gets one created", async () => {
+  const { fetch, calls } = fakeFetch({
+    ...noneYet("CI / Required checks"),
+    "POST /check-runs": {
+      status: 201,
+      body: { id: 42, html_url: "https://github.com/acme/app/runs/42" },
+    },
+  });
+  const result = await postCheckRun((s) =>
+    s.repo("acme/app").token("t")
+      .name("CI / Required checks")
+      .headSha(SHA)
+      .conclusion("success")
+      .fetch(fetch)
+  );
+  assertEquals(result.created, true);
+  assertEquals(result.id, 42);
+  assertEquals(result.url, "https://github.com/acme/app/runs/42");
+  const post = calls[calls.length - 1];
+  assertEquals(post.method, "POST");
+  assertEquals(post.body.head_sha, SHA);
+  assertEquals(post.body.name, "CI / Required checks");
+  assertEquals(post.body.conclusion, "success");
+});
+
+Deno.test("an existing check run of that name is updated, not duplicated", async () => {
+  // The re-drive case: a second attempt at the same post must leave the commit
+  // with one check run, not two of which the newest silently wins.
+  const { fetch, calls } = fakeFetch({
+    [listPath("CI / Required checks")]: {
+      status: 200,
+      body: {
+        total_count: 1,
+        check_runs: [{ id: 7, name: "CI / Required checks" }],
+      },
+    },
+    "PATCH /check-runs/7": {
+      status: 200,
+      body: { id: 7, html_url: "https://github.com/acme/app/runs/7" },
+    },
+  });
+  const result = await postCheckRun((s) =>
+    s.repo("acme/app").token("t")
+      .name("CI / Required checks")
+      .headSha(SHA)
+      .conclusion("failure")
+      .fetch(fetch)
+  );
+  assertEquals(result.created, false);
+  assertEquals(result.id, 7);
+  const patch = calls[calls.length - 1];
+  assertEquals(patch.method, "PATCH");
+  assertEquals(patch.body.conclusion, "failure");
+  // head_sha is create-only: an update must not suggest a check run can move.
+  assertEquals("head_sha" in patch.body, false);
+  assertEquals(calls.filter((c) => c.method === "POST").length, 0);
+});
+
+Deno.test("the newest matching check run wins", async () => {
+  // GitHub documents no order for the listing, and the stale one is the one a
+  // previous attempt superseded — updating it would leave the visible check
+  // saying whatever it said before.
+  const { fetch, calls } = fakeFetch({
+    [listPath("gate")]: {
+      status: 200,
+      body: {
+        total_count: 3,
+        check_runs: [
+          { id: 5, name: "gate" },
+          { id: 11, name: "gate" },
+          { id: 9, name: "gate" },
+        ],
+      },
+    },
+    "PATCH /check-runs/11": { status: 200, body: { id: 11, html_url: "u" } },
+  });
+  const result = await postCheckRun((s) =>
+    s.repo("acme/app").token("t").name("gate").headSha(SHA)
+      .conclusion("success").fetch(fetch)
+  );
+  assertEquals(result.id, 11);
+  assertEquals(calls[calls.length - 1].path, "/check-runs/11");
+});
+
+Deno.test("with an external id, only a check run carrying it is updated", async () => {
+  // Two callers reporting under one required context stay distinct: a re-drive
+  // of one must not overwrite the other's conclusion.
+  const { fetch, calls } = fakeFetch({
+    [listPath("gate")]: {
+      status: 200,
+      body: {
+        total_count: 2,
+        check_runs: [
+          { id: 20, name: "gate", external_id: "run-b/gate" },
+          { id: 8, name: "gate", external_id: "run-a/gate" },
+        ],
+      },
+    },
+    "PATCH /check-runs/8": { status: 200, body: { id: 8, html_url: "u" } },
+  });
+  const result = await postCheckRun((s) =>
+    s.repo("acme/app").token("t").name("gate").headSha(SHA)
+      .externalId("run-a/gate").conclusion("success").fetch(fetch)
+  );
+  // The newer id 20 is a different caller's check run, so it is not touched.
+  assertEquals(result.id, 8);
+  assertEquals(calls[calls.length - 1].path, "/check-runs/8");
+  assertEquals(calls[calls.length - 1].body.external_id, "run-a/gate");
+});
+
+Deno.test("an external id that matches nothing creates rather than overwrites", async () => {
+  const { fetch, calls } = fakeFetch({
+    [listPath("gate")]: {
+      status: 200,
+      body: {
+        total_count: 1,
+        check_runs: [{ id: 20, name: "gate", external_id: "someone-else" }],
+      },
+    },
+    "POST /check-runs": { status: 201, body: { id: 21, html_url: "u" } },
+  });
+  const result = await postCheckRun((s) =>
+    s.repo("acme/app").token("t").name("gate").headSha(SHA)
+      .externalId("mine").conclusion("success").fetch(fetch)
+  );
+  assertEquals(result.created, true);
+  assertEquals(calls.filter((c) => c.method === "PATCH").length, 0);
+});
+
+Deno.test("the listing is paginated to the last candidate", async () => {
+  // A missed candidate is a duplicate check run — the one failure this whole
+  // lookup exists to prevent — so the first page is not taken on trust.
+  const page1 = Array.from({ length: 100 }, (_, i) => ({
+    id: i + 1,
+    name: "gate",
+  }));
+  const { fetch, calls } = fakeFetch({
+    [listPath("gate", 1)]: {
+      status: 200,
+      body: { total_count: 101, check_runs: page1 },
+    },
+    [listPath("gate", 2)]: {
+      status: 200,
+      body: { total_count: 101, check_runs: [{ id: 900, name: "gate" }] },
+    },
+    "PATCH /check-runs/900": { status: 200, body: { id: 900, html_url: "u" } },
+  });
+  const result = await postCheckRun((s) =>
+    s.repo("acme/app").token("t").name("gate").headSha(SHA)
+      .conclusion("success").fetch(fetch)
+  );
+  assertEquals(result.id, 900);
+  assertEquals(calls.filter((c) => c.method === "GET").length, 2);
+});
+
+Deno.test("a listing that stops short of its own total does not loop", async () => {
+  // A total_count that overstates the pages must not spin: an empty page ends
+  // the walk with whatever was found.
+  const { fetch, calls } = fakeFetch({
+    [listPath("gate", 1)]: {
+      status: 200,
+      body: { total_count: 999, check_runs: [{ id: 3, name: "gate" }] },
+    },
+    [listPath("gate", 2)]: {
+      status: 200,
+      body: { total_count: 999, check_runs: [] },
+    },
+    "PATCH /check-runs/3": { status: 200, body: { id: 3, html_url: "u" } },
+  });
+  const result = await postCheckRun((s) =>
+    s.repo("acme/app").token("t").name("gate").headSha(SHA)
+      .conclusion("success").fetch(fetch)
+  );
+  assertEquals(result.id, 3);
+  assertEquals(calls.filter((c) => c.method === "GET").length, 2);
+});
+
+Deno.test("naming either half of the output panel fills in the other", async () => {
+  // GitHub rejects an output panel with a title and no summary, or the reverse.
+  const { fetch, calls } = fakeFetch({
+    ...noneYet("gate"),
+    "POST /check-runs": { status: 201, body: { id: 1, html_url: "u" } },
+  });
+  await postCheckRun((s) =>
+    s.repo("acme/app").token("t").name("gate").headSha(SHA)
+      .conclusion("success").summary("11 of 12 checks passed").fetch(fetch)
+  );
+  assertEquals(calls[calls.length - 1].body.output, {
+    title: "gate",
+    summary: "11 of 12 checks passed",
+  });
+
+  const second = fakeFetch({
+    ...noneYet("gate"),
+    "POST /check-runs": { status: 201, body: { id: 2, html_url: "u" } },
+  });
+  await postCheckRun((s) =>
+    s.repo("acme/app").token("t").name("gate").headSha(SHA)
+      .conclusion("success").title("Required checks").fetch(second.fetch)
+  );
+  assertEquals(second.calls[second.calls.length - 1].body.output, {
+    title: "Required checks",
+    summary: "",
+  });
+});
+
+Deno.test("no output panel is sent when neither half is named", async () => {
+  const { fetch, calls } = fakeFetch({
+    ...noneYet("gate"),
+    "POST /check-runs": { status: 201, body: { id: 1, html_url: "u" } },
+  });
+  await postCheckRun((s) =>
+    s.repo("acme/app").token("t").name("gate").headSha(SHA)
+      .conclusion("success").detailsUrl("https://ci.example/run/1").fetch(fetch)
+  );
+  const post = calls[calls.length - 1];
+  assertEquals("output" in post.body, false);
+  assertEquals(post.body.details_url, "https://ci.example/run/1");
+});
+
+Deno.test("the required settings are named individually when missing", async () => {
+  const { fetch } = fakeFetch({});
+  await assertRejects(
+    () => postCheckRun((s) => s.repo("acme/app").token("t").fetch(fetch)),
+    Error,
+    ".name(...)",
+  );
+  await assertRejects(
+    () =>
+      postCheckRun((s) =>
+        s.repo("acme/app").token("t").name("gate").fetch(fetch)
+      ),
+    Error,
+    ".headSha(...)",
+  );
+  await assertRejects(
+    () =>
+      postCheckRun((s) =>
+        s.repo("acme/app").token("t").name("gate").headSha(SHA).fetch(fetch)
+      ),
+    Error,
+    ".conclusion(...)",
+  );
+});
+
+Deno.test("a branch name or an abbreviated SHA is refused before the call", async () => {
+  const { fetch, calls } = fakeFetch({});
+  for (const bad of ["master", "a1b2c3d", `${SHA}/../../x`]) {
+    const error = await assertRejects(
+      () =>
+        postCheckRun((s) =>
+          s.repo("acme/app").token("t").name("gate").headSha(bad)
+            .conclusion("success").fetch(fetch)
+        ),
+      Error,
+      "head SHA",
+    );
+    assertStringIncludes(error.message, "40- or 64-character");
+  }
+  // Nothing was sent: the guard runs before the transport is built.
+  assertEquals(calls.length, 0);
+});
+
+Deno.test("the repo and token fall back to the Actions environment", async () => {
+  const { fetch, calls } = fakeFetch({
+    ...noneYet("gate"),
+    "POST /check-runs": { status: 201, body: { id: 1, html_url: "u" } },
+  });
+  await withEnv(
+    { GITHUB_REPOSITORY: "acme/app", GITHUB_TOKEN: "ghs_env" },
+    async () => {
+      const result = await postCheckRun((s) =>
+        s.name("gate").headSha(SHA).conclusion("success").fetch(fetch)
+      );
+      assertEquals(result.created, true);
+    },
+  );
+  // The path was built from the environment's slug — fakeFetch strips it.
+  assertEquals(calls[0].path.startsWith("/commits/"), true);
+});
+
+Deno.test("a missing repo or token says which setting to reach for", async () => {
+  const { fetch } = fakeFetch({});
+  await withEnv({ GITHUB_REPOSITORY: undefined }, async () => {
+    const error = await assertRejects(
+      () =>
+        postCheckRun((s) =>
+          s.name("gate").headSha(SHA).conclusion("success").token("t")
+            .fetch(fetch)
+        ),
+      Error,
+      ".repo('owner/name')",
+    );
+    assertStringIncludes(error.message, "GITHUB_REPOSITORY");
+  });
+  await withEnv({ GITHUB_TOKEN: undefined }, async () => {
+    const error = await assertRejects(
+      () =>
+        postCheckRun((s) =>
+          s.repo("acme/app").name("gate").headSha(SHA).conclusion("success")
+            .fetch(fetch)
+        ),
+      Error,
+      ".token(...)",
+    );
+    // The message names the one permission the token needs, so nobody reaches
+    // for a broader one to make the error go away.
+    assertStringIncludes(error.message, "`checks: write`");
+  });
+});
+
+Deno.test("a GitHub Enterprise base URL is used, trailing slashes and all", async () => {
+  const calls: string[] = [];
+  const impl: typeof fetch = (input) => {
+    calls.push(String(input));
+    return Promise.resolve(
+      new Response(
+        JSON.stringify({
+          total_count: 0,
+          check_runs: [],
+          id: 1,
+          html_url: "u",
+        }),
+        { status: 200 },
+      ),
+    );
+  };
+  await postCheckRun((s) =>
+    s.repo("acme/app").token("t").name("gate").headSha(SHA)
+      .conclusion("success").baseUrl("https://ghe.example/api/v3//").fetch(impl)
+  );
+  assertEquals(
+    calls[0].startsWith("https://ghe.example/api/v3/repos/acme/app/"),
+    true,
+  );
+});
+
+Deno.test("a listing of junk is treated as no match, not as a candidate", async () => {
+  // Every field of the response is checked rather than trusted: a malformed
+  // entry that slipped through as a match would send the update to whatever id
+  // happened to parse.
+  const { fetch, calls } = fakeFetch({
+    [listPath("gate")]: {
+      status: 200,
+      body: {
+        total_count: 4,
+        check_runs: [
+          null,
+          "not a record",
+          { id: 3, name: "some other check" },
+          { id: "not a number", name: "gate" },
+        ],
+      },
+    },
+    "POST /check-runs": { status: 201, body: { id: 50, html_url: "u" } },
+  });
+  const result = await postCheckRun((s) =>
+    s.repo("acme/app").token("t").name("gate").headSha(SHA)
+      .conclusion("success").fetch(fetch)
+  );
+  assertEquals(result.created, true);
+  assertEquals(calls.filter((c) => c.method === "PATCH").length, 0);
+});
+
+Deno.test("a listing that is not an object at all creates rather than guessing", async () => {
+  const { fetch } = fakeFetch({
+    [listPath("gate")]: { status: 200, body: "gateway said hello" },
+    "POST /check-runs": { status: 201, body: { id: 60, html_url: "u" } },
+  });
+  const result = await postCheckRun((s) =>
+    s.repo("acme/app").token("t").name("gate").headSha(SHA)
+      .conclusion("success").fetch(fetch)
+  );
+  assertEquals(result.created, true);
+});
+
+Deno.test("a refused write surfaces as a GhApiError carrying the status", async () => {
+  const { fetch } = fakeFetch({
+    ...noneYet("gate"),
+    "POST /check-runs": {
+      status: 403,
+      body: { message: "Resource not accessible by integration" },
+    },
+  });
+  const error = await assertRejects(
+    () =>
+      postCheckRun((s) =>
+        s.repo("acme/app").token("s3cr3t-token").name("gate").headSha(SHA)
+          .conclusion("success").fetch(fetch)
+      ),
+    GhApiError,
+  );
+  if (!(error instanceof GhApiError)) throw new Error("expected a GhApiError");
+  assertEquals(error.status, 403);
+  assertStringIncludes(error.message, "not accessible by integration");
+  // The token lives in a request header and never in a message.
+  assertEquals(error.message.includes("s3cr3t-token"), false);
+});

--- a/packages/gh/tests/commit_test.ts
+++ b/packages/gh/tests/commit_test.ts
@@ -371,42 +371,55 @@ Deno.test("a slash inside a branch name stays a path separator", async () => {
   assertEquals(seen[0], "/repos/acme/app/git/ref/heads/chore/action-v1.0.3");
 });
 
-Deno.test("the repository slug is encoded too", async () => {
-  // It was interpolated into the same path with no validation at all — the
-  // same primitive, one field over.
-  const seen: string[] = [];
-  const capture = ((url: string | URL | Request) => {
-    seen.push(new URL(String(url)).pathname);
-    return Promise.resolve(
-      new Response(
-        JSON.stringify({ object: { sha: "a" }, tree: { sha: "t" }, sha: "c" }),
-        { status: 200 },
-      ),
-    );
-  }) as typeof fetch;
-
-  await commitFiles((s) =>
-    s.repo("acme/%2e%2e").token("t").branch("main").message("m")
-      .fetch(capture)
-  );
-  assertEquals(seen[0].startsWith("/repos/acme/%252e%252e/"), true);
-  // Every request stayed under the slug, encoded — none climbed out of it.
-  assertEquals(
-    seen.every((path) => path.startsWith("/repos/acme/%252e%252e/")),
-    true,
-  );
-});
-
-Deno.test("a repository slug that is not owner/name is refused", async () => {
-  // Encoding stops the slug climbing out of `/repos/`, so this is not the
-  // traversal guard. It stops a slug with the wrong number of segments
-  // quietly redirecting a token-bearing request: `a/b/c` would build
-  // `/repos/a/b/c/git/trees`, an endpoint the caller never named.
+Deno.test("a percent-escaped slug is refused rather than relied on to encode", async () => {
+  // This used to assert that `acme/%2e%2e` was encoded to `%252e%252e` and so
+  // could not climb out of `/repos/`. Encoding does hold, and still runs — but
+  // it was the *only* thing standing between a slug and a redirected
+  // token-bearing request, and it does not cover a literal `..`, which
+  // `encodeURIComponent` leaves alone. A GitHub repository name contains none
+  // of these characters, so the slug is now refused outright and the encoding
+  // is defence in depth rather than the defence.
   const reject = (() => {
     throw new Error("no request should have been made");
   }) as typeof fetch;
 
-  for (const slug of ["acme", "acme/app/extra", "/app", "acme/", "", "/"]) {
+  let message = "";
+  try {
+    await commitFiles((s) =>
+      s.repo("acme/%2e%2e").token("t").branch("main").message("m")
+        .fetch(reject)
+    );
+  } catch (error) {
+    message = error instanceof Error ? error.message : String(error);
+  }
+  assertEquals(message.includes('expected "owner/name"'), true, message);
+});
+
+Deno.test("a repository slug that is not owner/name is refused", async () => {
+  // Two failures, both of which quietly redirect a token-bearing request.
+  // A slug with the wrong number of segments names a different endpoint:
+  // `a/b/c` builds `/repos/a/b/c/git/trees`. And a `..` segment climbs out of
+  // `/repos/` entirely — encoding does not stop that one, because a literal
+  // `..` is left alone by `encodeURIComponent` and the URL parser then
+  // resolves it.
+  const reject = (() => {
+    throw new Error("no request should have been made");
+  }) as typeof fetch;
+
+  for (
+    const slug of [
+      "acme",
+      "acme/app/extra",
+      "/app",
+      "acme/",
+      "",
+      "/",
+      "../app",
+      "acme/..",
+      "./app",
+      "acme/ap p",
+    ]
+  ) {
     let message = "";
     try {
       await commitFiles((s) =>


### PR DESCRIPTION
## Why

GitHub's check-runs API is create-only, so a caller that retries leaves several check runs of one name on a commit and the newest silently wins. That is not cosmetic when the name is a **required status context**: which conclusion branch protection sees depends on which caller finished last.

This is the consumer half of the durable merge-gate work. It is what lets everything upstream be honestly at-least-once — retry as often as needed, and the commit still carries one check run of that name holding the most recent conclusion.

## What it does

`GhTasks.checkRun` lists the check runs on the commit for that name, updates the newest match, and creates one only when there is none.

- **An external id is identity, when set**, and matched from both sides — two callers reporting under one required context stay distinct, and a caller that sets no id never adopts one that did.
- **A conclusion is required.** A pending check run whose poster dies never settles, and for a required context that is a pull request that can never merge. There is no way to write one here by accident.
- **The head SHA is validated before the transport is built**, because a branch name or an abbreviated SHA is otherwise a late and unexplained rejection. The docs are explicit that it must be pinned when the work starts, not resolved at post time — resolving it late reports on whatever has been pushed since.
- **It converges, it does not serialise.** The lookup and the write are two calls. Both the module docs and the README say so plainly rather than implying an atomic upsert.

## The second commit is an adversarial pass

Per AGENTS.md, this shipped through a review that tried to break it. Two findings each ended in the exact failure the task exists to prevent, and both are confirmed against GitHub's published API reference:

- **The listing took the default filter**, which returns at most one check run per name. On a commit already carrying two, the one being looked for could be absent from the response entirely — so the call created a third, and a stale attempt's conclusion became the newest on a required context. Every other part of the lookup depended on seeing the full list, so external-id matching and newest-wins were both inert against the real API.
- **A check run may only be updated by the app that created it.** During a migration the same name is still produced by the workflow being replaced, owned by another app, so the update was refused — identically on every re-drive, leaving the required context never posted. A refusal now means "not ours" and one of ours is posted instead. A token that genuinely lacks the permission is not masked: the create is refused too, and that error is what surfaces.

Four smaller findings from the same pass: symmetric external-id matching, the output panel being rewritten on update rather than leaving stale text under a new conclusion, the module header no longer promising exactly-once, and the shared repository-slug guard actually checking its segments — encoding leaves a literal double dot alone, so a slug could climb out of the repository path with the token attached, which that guard's own comment claimed was impossible.

That last one changes shared behaviour: a slug is now required to look like a GitHub slug. One existing test asserted the old encoding-only defence and is rewritten to assert refusal instead, with the reasoning recorded in place.

## Tests

23 unit cases over an injected transport, no network. They cover create, update, newest-wins, both external-id directions, pagination, the filter, the ownership fallback and its non-masking, a non-refusal error propagating rather than creating a duplicate, malformed listings, validation messages, the environment fallbacks, GitHub Enterprise, and that the token never reaches an error message. 100% line coverage on the new file.

Full gate green locally, 18 of 18 targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)