### PR TITLE
feat(core): record an effect's intent before it runs, and re-drive it

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -19,6 +19,7 @@
     "PULLREQUEST",
     "PULLREQUESTID",
     "Patrik",
+    "redriven",
     "Scorecard",
     "Svensson",
     "TEAMPROJECT",

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -10,6 +10,7 @@ body, which is required before the target can run.
 | `.description(text)`        | `(s: string) => this`                                 | Summary shown in `--list`.                                                                         |
 | `.dependsOn(...targets)`    | `(...t: Target[]) => this`                            | Hard prerequisites; run first, transitively.                                                       |
 | `.executes(fn)`             | `(fn: (ctx) => unknown \| Promise<unknown>) => this`  | The body. May be async; its return is ignored, so `() => DenoTasks.lint()` needs no async wrapper. |
+| `.effect(name, fn)`         | `(name: string, fn: (ctx) => unknown \| Promise<unknown>) => this` | A crash-durable side effect: its intent is recorded before it runs, and it is re-driven after an unclean exit. |
 | `.before(...targets)`       | `(...t: Target[]) => this`                            | Soft ordering: run before these _if both are planned_.                                             |
 | `.after(...targets)`        | `(...t: Target[]) => this`                            | Soft ordering: run after these _if both are planned_.                                              |
 | `.triggers(...targets)`     | `(...t: Target[]) => this`                            | Pull these into the plan and run them _after_ this.                                                |

--- a/docs/run-context.md
+++ b/docs/run-context.md
@@ -70,6 +70,57 @@ class Ci extends Build {
 - **A store is not required.** A run with no state store answers the same way
   for everything settled in that process.
 
+## Crash-durable effects — `.effect()`
+
+A target body that dies halfway leaves no trace of what it was doing. For work
+where that matters — posting a required status check, publishing a release,
+telling another system something finished — declare it as an **effect**. The
+intent to run it is written to the [run record](./state.md) and confirmed
+*before* the body runs, so a process killed anywhere inside it leaves evidence
+that the effect was owed, and a resume (or `zuke resume --check`) drives it
+again.
+
+<!-- check -->
+
+```ts
+import { Build, target } from "jsr:@zuke/core";
+
+class Ci extends Build {
+  checks = target().proceedAfterFailure().executes(() => {});
+  gate = target().dependsOn(this.checks).always()
+    .effect("post-gate", async (ctx) => {
+      const failed = [...ctx.outcomes()].some(([, o]) => o.status === "failed");
+      await postVerdict(failed ? "failure" : "success", ctx.redriven);
+    });
+}
+
+declare function postVerdict(
+  conclusion: string,
+  redriven: boolean,
+): Promise<void>;
+```
+
+- **At-least-once, not exactly-once.** A process that dies *after* the side
+  effect but before recording it will repeat the effect. Write bodies that
+  tolerate it — because repeating is harmless, or because the far side converges
+  (an upsert rather than an append). `ctx.redriven` is `true` when a previous
+  attempt already committed its intent.
+- **A completed effect is skipped, not repeated.** Once recorded `done`,
+  re-driving the target is free.
+- **Pin what the effect acts on.** Read it from `ctx.state` /
+  `ctx.stateOf(...)`, which is replayed from the record and cannot be overridden
+  from outside. A parameter is nearly as good: the record seeds a resume, so one
+  nobody re-supplies keeps its original value — but a resume that passes it
+  explicitly wins, which is how a secret gets re-supplied. For a value that must
+  not drift, use state.
+- **A store is required**, and enabled automatically. With state explicitly
+  disabled the run is refused rather than performing an effect nothing recorded
+  as owed.
+- **Effects run after the body**, in declaration order, and are repeatable. A
+  target may declare effects and no body.
+- **An intent that cannot be recorded fails the target**, with the body never
+  having run. No durable intent, no side effect.
+
 ## Cancellation
 
 A run can be cancelled by passing an `AbortSignal` to `execute`

--- a/docs/run-context.md
+++ b/docs/run-context.md
@@ -77,8 +77,7 @@ where that matters — posting a required status check, publishing a release,
 telling another system something finished — declare it as an **effect**. The
 intent to run it is written to the [run record](./state.md) and confirmed
 *before* the body runs, so a process killed anywhere inside it leaves evidence
-that the effect was owed, and a resume (or `zuke resume --check`) drives it
-again.
+that the effect was owed, and a resume drives it again.
 
 <!-- check -->
 
@@ -107,6 +106,13 @@ declare function postVerdict(
   attempt already committed its intent.
 - **A completed effect is skipped, not repeated.** Once recorded `done`,
   re-driving the target is free.
+- **What re-drives it, precisely.** A resume acts on a run recorded
+  `suspended`, so an effect owed by a run that suspended at a wait is driven
+  again by the ordinary `zuke resume` / `zuke resume --check`. A process that was
+  *killed* leaves its run `running`, and a run in that state is not resumable
+  until something moves it back to `suspended` — so an effect owed by a killed
+  process waits for a reaping sweep or an operator. The intent itself is durable
+  either way; what differs is what comes along to act on it.
 - **Pin what the effect acts on.** Read it from `ctx.state` /
   `ctx.stateOf(...)`, which is replayed from the record and cannot be overridden
   from outside. A parameter is nearly as good: the record seeds a resume, so one

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1327,6 +1327,14 @@ class ServiceBuilder extends TargetBuilder
   ordering methods (`dependsOn`, `before`, `after`, `description`) from
   {@link TargetBuilder}; a service has no `.executes` body.
 
+  override effect(name: string, fn: EffectFn): this
+    Refuse a crash-durable effect on a service.
+
+    A service target's whole job is launching a process; it runs no body, so
+    there is no point at which its effects would be driven and they would be
+    dropped without a word. Inherited from {@link TargetBuilder} only because
+    this is a subclass of it, so the refusal is stated here rather than left to
+    be discovered.
   start(fn: () => ServiceHandle | Promise<ServiceHandle>): this
     How to start the process. Return a {@link ServiceHandle} (e.g.
     `$\`…`.spawn()`) so the service can be stopped on teardown; provide a
@@ -1484,10 +1492,15 @@ class TargetBuilder
     it has been written to the run record, so a process killed anywhere inside
     it leaves evidence that it was owed.
 
-    That evidence is what a resume — or the `zuke resume --check` sweep — uses
-    to drive it again. The guarantee is at-least-once, not exactly-once: a
-    process that dies after the side effect but before recording it will repeat
-    the effect. Write bodies that tolerate that, either because repeating is
+    That evidence is what a resume uses to drive it again. Note the precondition
+    as it stands today: a resume only picks up a run recorded `suspended`, and a
+    process killed outright leaves its run `running`, so an effect owed by a
+    killed process is re-driven once something moves that run back to
+    `suspended` — a reaping sweep, or an operator. An effect owed by a run that
+    suspended for any other reason is re-driven by the ordinary resume.
+
+    The guarantee is at-least-once, not exactly-once: a process that dies
+    after the side effect but before recording it will repeat the effect. Write bodies that tolerate that, either because repeating is
     harmless or because the far side converges (an upsert rather than an
     append).
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1397,6 +1397,8 @@ class TargetBuilder
     Soft ordering: this runs after the listed targets if both are planned.
   fn_?: TargetFn
     The target body.
+  readonly effects_: DeclaredEffect[]
+    Crash-durable effects, in declaration order (set by {@link effect}).
   name_?: string
     Property name, assigned during discovery. Undefined until then.
   group_?: Group
@@ -1477,6 +1479,41 @@ class TargetBuilder
       .onlyWhen(() => this.environment.value === "production")
       .executes(...);
     ```
+  effect(name: string, fn: EffectFn): this
+    Declare a crash-durable effect: `fn` runs only after the intent to run
+    it has been written to the run record, so a process killed anywhere inside
+    it leaves evidence that it was owed.
+
+    That evidence is what a resume — or the `zuke resume --check` sweep — uses
+    to drive it again. The guarantee is at-least-once, not exactly-once: a
+    process that dies after the side effect but before recording it will repeat
+    the effect. Write bodies that tolerate that, either because repeating is
+    harmless or because the far side converges (an upsert rather than an
+    append).
+
+    ```ts
+    gate = target().dependsOn(this.checks).always()
+      .effect("post-gate", async (ctx) => {
+        await postCheckRun(ctx.outcomeOf("checks")?.status === "succeeded");
+      });
+    ```
+
+    Pin the inputs. A re-drive happens later, sometimes much later, so a
+    body that looks up "the current value" of anything acts on a world that has
+    moved on. Read what the effect acts on from durable state instead —
+    `ctx.state` or `ctx.stateOf(...)`, written by an earlier target — which is
+    replayed from the record and cannot be overridden from outside.
+
+    A parameter is nearly as good and not quite: the record seeds a resume, so
+    a parameter nobody re-supplies keeps the value the run started with, but a
+    resume that passes one explicitly overrides it (the only way to re-supply a
+    secret, since secrets are kept out of the record). For a value that must not
+    drift across a re-drive, prefer state.
+
+    Effects run after the body, in declaration order, and are repeatable. A
+    target may declare effects and no body at all. Requires a state store, which
+    is enabled automatically — an intent that cannot be recorded is a target
+    that fails before its effect runs, by design.
   executes(fn: TargetFn): this
     Set the target body. May be async.
   before(...targets: TargetBuilder[]): this
@@ -2514,11 +2551,52 @@ interface CreateDirectoryOptions
   recursive?: boolean
     Create parent directories as needed (default `true`).
 
+interface DeclaredEffect
+  One effect declared on a target: its name and its body.
+
+  name: string
+    The effect's name, unique within the target and stable across runs.
+  fn: EffectFn
+    The body run once the intent is durably recorded.
+
 interface DescribeCliOptions
   Options for {@link describeCli}.
 
   omitSecrets?: boolean
     Drop `.secret()` parameters from the surface (used for registry descriptors).
+
+interface EffectContext extends TargetContext
+  The context an effect body receives: the target's own context, plus which
+  effect this is and whether it has been driven before.
+
+  readonly effect: string
+    The effect's declared name.
+  readonly redriven: boolean
+    True when a previous attempt at this effect already committed its intent —
+    so its side effect may have happened, wholly or partly, and this run is
+    repeating it.
+
+    Effects are at-least-once. A body that can tell the difference should say
+    so in what it writes, rather than assume it is the first to get here.
+
+interface EffectState
+  The durable intent-and-completion row for one of a target's effects.
+
+  There is no idempotency key here. An effect is identified by where it sits —
+  the run, the target, and its declared name — which the record already spells
+  out structurally, so a key would be a second spelling of the same fact and a
+  place for a secret to end up.
+
+  status: EffectStatus
+    How far the effect got.
+  intentAt: string
+    ISO-8601 time the intent was committed — always before the body ran.
+  settledAt?: string
+    ISO-8601 time it settled, if it has.
+  error?: string
+    The failure message when `status` is `failed`.
+  attempts: number
+    How many times the body has been driven. Above one means it was re-driven.
 
 interface ExecuteOptions
   Options for {@link execute}.
@@ -3450,6 +3528,9 @@ interface TargetRunState
     The failure message when `status` is `failed`.
   waitingFor?: WaitState
     The pending wait when `status` is `waiting` (set by `.waitsFor(...)`).
+  effects?: Record<string, EffectState>
+    The declared effects of this target, keyed by effect name — present only
+    once at least one has been armed.
 
 interface TargetStateHandle
   A target's durable, per-target metadata, surfaced on {@link TargetContext} as
@@ -3621,6 +3702,16 @@ type DownloadFn = (url: string, dest: PathLike) => Promise<void>
 type DownloadFormat = "raw" | ArchiveFormat
   How a downloaded artifact is treated: `"raw"` is the binary itself, an
   {@link ArchiveFormat} is unpacked and one path taken from inside.
+
+type EffectFn = (ctx: EffectContext) => unknown | Promise<unknown>
+  The body of a declared effect (see {@link TargetBuilder.effect}).
+
+type EffectStatus = "pending" | "done" | "failed"
+  Where one declared effect has got to (see `.effect(...)`).
+
+  `pending` is the load-bearing one: it means the intent was committed and the
+  body may or may not have run. A process that dies mid-effect leaves exactly
+  that, which is what tells a later resume to drive it again.
 
 type ForEachFactory<Item> = (item: Item, index: number) => Record<string, TargetBuilder>
   Builds one item's ordered pipeline of sub-targets for {@link TargetBuilder.forEach}.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1451,6 +1451,8 @@ class TargetBuilder
     Soft ordering: this runs after the listed targets if both are planned.
   fn_?: TargetFn
     The target body.
+  readonly effects_: DeclaredEffect[]
+    Crash-durable effects, in declaration order (set by {@link effect}).
   name_?: string
     Property name, assigned during discovery. Undefined until then.
   group_?: Group
@@ -1531,6 +1533,41 @@ class TargetBuilder
       .onlyWhen(() => this.environment.value === "production")
       .executes(...);
     ```
+  effect(name: string, fn: EffectFn): this
+    Declare a crash-durable effect: `fn` runs only after the intent to run
+    it has been written to the run record, so a process killed anywhere inside
+    it leaves evidence that it was owed.
+
+    That evidence is what a resume — or the `zuke resume --check` sweep — uses
+    to drive it again. The guarantee is at-least-once, not exactly-once: a
+    process that dies after the side effect but before recording it will repeat
+    the effect. Write bodies that tolerate that, either because repeating is
+    harmless or because the far side converges (an upsert rather than an
+    append).
+
+    ```ts
+    gate = target().dependsOn(this.checks).always()
+      .effect("post-gate", async (ctx) => {
+        await postCheckRun(ctx.outcomeOf("checks")?.status === "succeeded");
+      });
+    ```
+
+    Pin the inputs. A re-drive happens later, sometimes much later, so a
+    body that looks up "the current value" of anything acts on a world that has
+    moved on. Read what the effect acts on from durable state instead —
+    `ctx.state` or `ctx.stateOf(...)`, written by an earlier target — which is
+    replayed from the record and cannot be overridden from outside.
+
+    A parameter is nearly as good and not quite: the record seeds a resume, so
+    a parameter nobody re-supplies keeps the value the run started with, but a
+    resume that passes one explicitly overrides it (the only way to re-supply a
+    secret, since secrets are kept out of the record). For a value that must not
+    drift across a re-drive, prefer state.
+
+    Effects run after the body, in declaration order, and are repeatable. A
+    target may declare effects and no body at all. Requires a state store, which
+    is enabled automatically — an intent that cannot be recorded is a target
+    that fails before its effect runs, by design.
   executes(fn: TargetFn): this
     Set the target body. May be async.
   before(...targets: TargetBuilder[]): this
@@ -2568,11 +2605,52 @@ interface CreateDirectoryOptions
   recursive?: boolean
     Create parent directories as needed (default `true`).
 
+interface DeclaredEffect
+  One effect declared on a target: its name and its body.
+
+  name: string
+    The effect's name, unique within the target and stable across runs.
+  fn: EffectFn
+    The body run once the intent is durably recorded.
+
 interface DescribeCliOptions
   Options for {@link describeCli}.
 
   omitSecrets?: boolean
     Drop `.secret()` parameters from the surface (used for registry descriptors).
+
+interface EffectContext extends TargetContext
+  The context an effect body receives: the target's own context, plus which
+  effect this is and whether it has been driven before.
+
+  readonly effect: string
+    The effect's declared name.
+  readonly redriven: boolean
+    True when a previous attempt at this effect already committed its intent —
+    so its side effect may have happened, wholly or partly, and this run is
+    repeating it.
+
+    Effects are at-least-once. A body that can tell the difference should say
+    so in what it writes, rather than assume it is the first to get here.
+
+interface EffectState
+  The durable intent-and-completion row for one of a target's effects.
+
+  There is no idempotency key here. An effect is identified by where it sits —
+  the run, the target, and its declared name — which the record already spells
+  out structurally, so a key would be a second spelling of the same fact and a
+  place for a secret to end up.
+
+  status: EffectStatus
+    How far the effect got.
+  intentAt: string
+    ISO-8601 time the intent was committed — always before the body ran.
+  settledAt?: string
+    ISO-8601 time it settled, if it has.
+  error?: string
+    The failure message when `status` is `failed`.
+  attempts: number
+    How many times the body has been driven. Above one means it was re-driven.
 
 interface ExecuteOptions
   Options for {@link execute}.
@@ -3504,6 +3582,9 @@ interface TargetRunState
     The failure message when `status` is `failed`.
   waitingFor?: WaitState
     The pending wait when `status` is `waiting` (set by `.waitsFor(...)`).
+  effects?: Record<string, EffectState>
+    The declared effects of this target, keyed by effect name — present only
+    once at least one has been armed.
 
 interface TargetStateHandle
   A target's durable, per-target metadata, surfaced on {@link TargetContext} as
@@ -3675,6 +3756,16 @@ type DownloadFn = (url: string, dest: PathLike) => Promise<void>
 type DownloadFormat = "raw" | ArchiveFormat
   How a downloaded artifact is treated: `"raw"` is the binary itself, an
   {@link ArchiveFormat} is unpacked and one path taken from inside.
+
+type EffectFn = (ctx: EffectContext) => unknown | Promise<unknown>
+  The body of a declared effect (see {@link TargetBuilder.effect}).
+
+type EffectStatus = "pending" | "done" | "failed"
+  Where one declared effect has got to (see `.effect(...)`).
+
+  `pending` is the load-bearing one: it means the intent was committed and the
+  body may or may not have run. A process that dies mid-effect leaves exactly
+  that, which is what tells a later resume to drive it again.
 
 type ForEachFactory<Item> = (item: Item, index: number) => Record<string, TargetBuilder>
   Builds one item's ordered pipeline of sub-targets for {@link TargetBuilder.forEach}.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1381,6 +1381,14 @@ class ServiceBuilder extends TargetBuilder
   ordering methods (`dependsOn`, `before`, `after`, `description`) from
   {@link TargetBuilder}; a service has no `.executes` body.
 
+  override effect(name: string, fn: EffectFn): this
+    Refuse a crash-durable effect on a service.
+
+    A service target's whole job is launching a process; it runs no body, so
+    there is no point at which its effects would be driven and they would be
+    dropped without a word. Inherited from {@link TargetBuilder} only because
+    this is a subclass of it, so the refusal is stated here rather than left to
+    be discovered.
   start(fn: () => ServiceHandle | Promise<ServiceHandle>): this
     How to start the process. Return a {@link ServiceHandle} (e.g.
     `$\`…`.spawn()`) so the service can be stopped on teardown; provide a
@@ -1538,10 +1546,15 @@ class TargetBuilder
     it has been written to the run record, so a process killed anywhere inside
     it leaves evidence that it was owed.
 
-    That evidence is what a resume — or the `zuke resume --check` sweep — uses
-    to drive it again. The guarantee is at-least-once, not exactly-once: a
-    process that dies after the side effect but before recording it will repeat
-    the effect. Write bodies that tolerate that, either because repeating is
+    That evidence is what a resume uses to drive it again. Note the precondition
+    as it stands today: a resume only picks up a run recorded `suspended`, and a
+    process killed outright leaves its run `running`, so an effect owed by a
+    killed process is re-driven once something moves that run back to
+    `suspended` — a reaping sweep, or an operator. An effect owed by a run that
+    suspended for any other reason is re-driven by the ordinary resume.
+
+    The guarantee is at-least-once, not exactly-once: a process that dies
+    after the side effect but before recording it will repeat the effect. Write bodies that tolerate that, either because repeating is
     harmless or because the far side converges (an upsert rather than an
     append).
 

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -42,6 +42,9 @@ export {
 } from "./src/host.ts";
 export {
   type Condition,
+  type DeclaredEffect,
+  type EffectContext,
+  type EffectFn,
   type ForEachFactory,
   type ForEachItem,
   ForEachSettings,
@@ -141,6 +144,8 @@ export {
 } from "./src/state/lock.ts";
 export { parseDuration } from "./src/duration.ts";
 export {
+  type EffectState,
+  type EffectStatus,
   type RunEvent,
   type RunEventOutcome,
   type RunGraphNode,

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -137,6 +137,11 @@ export async function fingerprint(
 
 /** Whether a target participates in caching (declares inputs or cache keys). */
 export function isCacheable(target: TargetBuilder): boolean {
+  // An effect must run, so a target that declares one is never cache-skipped:
+  // a cache hit returns before the effects are driven, which would drop the
+  // effect entirely — not defer it, drop it, with nothing recorded as owed and
+  // the run reporting success. Correctness over the saved seconds.
+  if (target.effects_.length > 0) return false;
   return target.inputs_.length > 0 || target.cacheKeys_.length > 0;
 }
 

--- a/packages/core/src/execute_state.ts
+++ b/packages/core/src/execute_state.ts
@@ -109,7 +109,7 @@ export async function openRunState(opts: {
   // works" without --state. Plain builds still opt in explicitly.
   const usesDurableFeature = order.some((t) =>
     t.lock_ !== undefined || t.waitsFor_ !== undefined ||
-    t.onCancel_ !== undefined
+    t.onCancel_ !== undefined || t.effects_.length > 0
   );
   const stateStore = dryRun ? undefined : resolveStateStore(
     opts.stateStore,
@@ -135,6 +135,22 @@ export async function openRunState(opts: {
       "A target uses .waitsFor(...), which needs a state store to persist the " +
         "suspended run — but state is disabled. Enable it (drop stateStore: " +
         "false, pass --state, or set ZUKE_STATE_DIR / ZUKE_STATE_URL).",
+    );
+    return { ok: false, error };
+  }
+  // An effect's intent has to be recorded before its body runs, so with nowhere
+  // to record it there is nothing to re-drive from — which is the entire
+  // guarantee. Refuse the run rather than perform side effects that no later
+  // process can discover were owed.
+  if (
+    !dryRun && stateStore === undefined &&
+    order.some((t) => t.effects_.length > 0)
+  ) {
+    const error = new Error(
+      "A target uses .effect(...), which needs a state store to record the " +
+        "effect's intent before it runs — but state is disabled. Enable it " +
+        "(drop stateStore: false, pass --state, or set ZUKE_STATE_DIR / " +
+        "ZUKE_STATE_URL).",
     );
     return { ok: false, error };
   }

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -10,7 +10,7 @@
  * @module
  */
 
-import { delay, runWithTimeout } from "./internal.ts";
+import { delay, messageOf, runWithTimeout } from "./internal.ts";
 import { bufferReporter, type Reporter } from "./reporter.ts";
 import type { Lifecycle } from "./lifecycle.ts";
 import { acquireTargetLock, type HeldLock } from "./lock.ts";
@@ -27,6 +27,7 @@ import { type Style, type TargetReport, targetWaitFooter } from "./report.ts";
 import type { Renderer } from "./renderer.ts";
 import {
   cloneTarget,
+  type EffectContext,
   type ForEachItem,
   ForEachSettings,
   type ForEachSpec,
@@ -189,6 +190,65 @@ async function runBodyWithRecovery(
       }
     }
     throw lastError;
+  }
+}
+
+/**
+ * Drive a target's declared effects, each behind a durable intent.
+ *
+ * The order is the whole feature: the intent is written and confirmed *before*
+ * the body runs, so a process killed anywhere inside the body leaves a
+ * `pending` row saying the effect was owed. A resume, or the sweep, drives it
+ * again from there.
+ *
+ * An effect already recorded `done` is skipped rather than repeated — the no-op
+ * that makes re-driving a completed effect free. A failure is recorded and then
+ * re-thrown, so the target fails and the run reports it; the row stays `failed`
+ * and a later attempt re-arms it.
+ *
+ * A write that cannot land throws out of here **without** the body having run,
+ * which is the fail-closed half: no durable intent, no side effect.
+ */
+async function driveEffects(
+  t: TargetBuilder,
+  name: string,
+  ctx: TargetContext,
+  env: RunEnv,
+): Promise<void> {
+  if (t.effects_.length === 0) return;
+  const writer = env.writer;
+  if (writer === undefined) {
+    // Unreachable in practice: a build that declares effects turns the state
+    // store on, and one with state explicitly disabled is refused before the
+    // run starts (see openRunState). Guarded anyway rather than silently
+    // running an effect with nothing recording it.
+    throw new Error(
+      `Target "${name}" declares an effect, which needs a state store to ` +
+        `record its intent — but this run has none.`,
+    );
+  }
+  for (const declared of t.effects_) {
+    const gate = await writer.beginEffect(name, declared.name);
+    if (gate === "skip") continue;
+    const attempts = writer.snapshot().targets[name]?.effects?.[declared.name]
+      ?.attempts ?? 1;
+    const effectCtx: EffectContext = {
+      ...ctx,
+      effect: declared.name,
+      redriven: attempts > 1,
+    };
+    try {
+      await declared.fn(effectCtx);
+    } catch (error) {
+      await writer.markEffectSettled(
+        name,
+        declared.name,
+        false,
+        messageOf(error),
+      );
+      throw error;
+    }
+    await writer.markEffectSettled(name, declared.name, true);
   }
 }
 
@@ -363,7 +423,7 @@ async function runTarget(
   void env.writer?.markTargetRunning(name);
   const start = performance.now();
 
-  if (!t.fn_) {
+  if (!t.fn_ && t.effects_.length === 0) {
     const error = new Error(
       `Target "${name}" has no body — call .executes(...) before running.`,
     );
@@ -406,6 +466,7 @@ async function runTarget(
   try {
     for (const v of t.validateBefore_) await v.validate({ target: name });
     await runBodyWithRecovery(t, name, globalRecovery, targetCtx);
+    await driveEffects(t, name, targetCtx, env);
     for (const v of t.validateAfter_) await v.validate({ target: name });
     const ms = performance.now() - start;
     if (cache !== undefined) await cache.record(t);

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -194,6 +194,40 @@ async function runBodyWithRecovery(
 }
 
 /**
+ * Build the {@link TargetContext} a target's body and effects receive.
+ *
+ * Shared rather than inlined because two paths need it: the ordinary body, and a
+ * `.waitsFor(...)` gate whose trigger is already satisfied — that gate returns
+ * early, and its effects are owed at exactly that moment.
+ */
+function targetContextFor(
+  name: string,
+  env: RunEnv,
+  dryRun: boolean,
+): TargetContext {
+  // One own-state handle, reused for `stateOf(this target)` so the documented
+  // `stateOf(self) === state` invariant holds even store-less (a fresh
+  // inMemoryStateHandle per call would drop writes).
+  const ownState = env.writer
+    ? env.writer.stateHandle(name)
+    : inMemoryStateHandle();
+  return {
+    runId: env.runId,
+    target: name,
+    signal: env.signal,
+    state: ownState,
+    stateOf: (t) =>
+      t === name
+        ? ownState
+        : (env.writer ? env.writer.stateHandle(t) : inMemoryStateHandle()),
+    outcomeOf: (t) => outcomeOf(env, t),
+    outcomes: () => allOutcomes(env),
+    signals: env.signals,
+    dryRun,
+  };
+}
+
+/**
  * Drive a target's declared effects, each behind a durable intent.
  *
  * The order is the whole feature: the intent is written and confirmed *before*
@@ -208,12 +242,22 @@ async function runBodyWithRecovery(
  *
  * A write that cannot land throws out of here **without** the body having run,
  * which is the fail-closed half: no durable intent, no side effect.
+ *
+ * Not driven at all when the target does not run: an `onlyWhen` condition that
+ * fails skips the target, and a skipped target's effects are not owed. Every
+ * *other* path that reaches a target's real execution drives them — including a
+ * `.waitsFor(...)` gate whose trigger is already satisfied, and a target that
+ * would otherwise have been served from the cache (declaring an effect takes a
+ * target out of the cache for exactly that reason). A service and a fan-out run no
+ * body of their own, so they refuse `.effect()` outright rather than silently
+ * dropping it.
  */
 async function driveEffects(
   t: TargetBuilder,
   name: string,
   ctx: TargetContext,
   env: RunEnv,
+  reporter: Reporter,
 ): Promise<void> {
   if (t.effects_.length === 0) return;
   const writer = env.writer;
@@ -240,12 +284,24 @@ async function driveEffects(
     try {
       await declared.fn(effectCtx);
     } catch (error) {
-      await writer.markEffectSettled(
-        name,
-        declared.name,
-        false,
-        messageOf(error),
-      );
+      // Recording the failure must not replace it. If this write is itself
+      // refused — the run cancelled elsewhere, or too many conflicting writes —
+      // the caller would otherwise see a message about bookkeeping instead of
+      // the API error that actually happened, which is the one thing anyone
+      // reading the incident needs.
+      try {
+        await writer.markEffectSettled(
+          name,
+          declared.name,
+          false,
+          messageOf(error),
+        );
+      } catch (settleError) {
+        reporter.info(
+          `effect "${declared.name}" on "${name}" failed, and recording that ` +
+            `failed too: ${messageOf(settleError)}`,
+        );
+      }
       throw error;
     }
     await writer.markEffectSettled(name, declared.name, true);
@@ -407,6 +463,22 @@ async function runTarget(
       return { status: "failed", ms: 0, error };
     }
     if (wait.satisfied) {
+      // The gate has opened, so this is the target's real run and its effects
+      // are owed now. Returning here without driving them would drop them
+      // silently — the run reports success and nothing records the effect was
+      // ever due.
+      try {
+        await driveEffects(
+          t,
+          name,
+          targetContextFor(name, env, dryRun),
+          env,
+          reporter,
+        );
+      } catch (error) {
+        failTarget(reporter, renderer, style, name, 0, error);
+        return { status: "failed", ms: 0, error };
+      }
       passTarget(reporter, renderer, style, name, 0);
       return { status: "passed", ms: 0 };
     }
@@ -431,26 +503,7 @@ async function runTarget(
     return { status: "failed", ms: 0, error };
   }
 
-  // One own-state handle, reused for `stateOf(this target)` so the documented
-  // `stateOf(self) === state` invariant holds even store-less (a fresh
-  // inMemoryStateHandle per call would drop writes).
-  const ownState = env.writer
-    ? env.writer.stateHandle(name)
-    : inMemoryStateHandle();
-  const targetCtx: TargetContext = {
-    runId: env.runId,
-    target: name,
-    signal: env.signal,
-    state: ownState,
-    stateOf: (t) =>
-      t === name
-        ? ownState
-        : (env.writer ? env.writer.stateHandle(t) : inMemoryStateHandle()),
-    outcomeOf: (t) => outcomeOf(env, t),
-    outcomes: () => allOutcomes(env),
-    signals: env.signals,
-    dryRun,
-  };
+  const targetCtx = targetContextFor(name, env, dryRun);
 
   // Acquire the target's cross-run lock (if any) before the body. A conflict —
   // or a lock declared with no store — fails the target with the guidance.
@@ -466,7 +519,7 @@ async function runTarget(
   try {
     for (const v of t.validateBefore_) await v.validate({ target: name });
     await runBodyWithRecovery(t, name, globalRecovery, targetCtx);
-    await driveEffects(t, name, targetCtx, env);
+    await driveEffects(t, name, targetCtx, env, reporter);
     for (const v of t.validateAfter_) await v.validate({ target: name });
     const ms = performance.now() - start;
     if (cache !== undefined) await cache.record(t);

--- a/packages/core/src/service.ts
+++ b/packages/core/src/service.ts
@@ -29,7 +29,7 @@
  * @module
  */
 
-import { TargetBuilder } from "./target.ts";
+import { type EffectFn, TargetBuilder } from "./target.ts";
 import { delay, messageOf } from "./internal.ts";
 
 /** The default time a service is given to become ready before it fails. */
@@ -100,6 +100,25 @@ export class ServiceBuilder extends TargetBuilder {
   #stop?: (handle: ServiceHandle) => void | Promise<void>;
   #readyTimeoutMs = DEFAULT_READY_TIMEOUT_MS;
   #pollIntervalMs = DEFAULT_POLL_INTERVAL_MS;
+
+  /**
+   * Refuse a crash-durable effect on a service.
+   *
+   * A service target's whole job is launching a process; it runs no body, so
+   * there is no point at which its effects would be driven and they would be
+   * dropped without a word. Inherited from {@link TargetBuilder} only because
+   * this is a subclass of it, so the refusal is stated here rather than left to
+   * be discovered.
+   */
+  override effect(name: string, fn: EffectFn): this {
+    void fn;
+    throw new Error(
+      `Service "${this.name_ ?? "<unnamed>"}" declares .effect(` +
+        `${JSON.stringify(name)}): a service launches a process and runs no ` +
+        `body, so its effect would never be driven. Put the effect on a ` +
+        `separate target that depends on this service.`,
+    );
+  }
 
   /**
    * How to start the process. Return a {@link ServiceHandle} (e.g.

--- a/packages/core/src/state/types.ts
+++ b/packages/core/src/state/types.ts
@@ -89,6 +89,36 @@ export interface WaitState {
   onTimeout: WaitDisposition;
 }
 
+/**
+ * Where one declared effect has got to (see `.effect(...)`).
+ *
+ * `pending` is the load-bearing one: it means the intent was committed and the
+ * body may or may not have run. A process that dies mid-effect leaves exactly
+ * that, which is what tells a later resume to drive it again.
+ */
+export type EffectStatus = "pending" | "done" | "failed";
+
+/**
+ * The durable intent-and-completion row for one of a target's effects.
+ *
+ * There is no idempotency key here. An effect is identified by where it sits —
+ * the run, the target, and its declared name — which the record already spells
+ * out structurally, so a key would be a second spelling of the same fact and a
+ * place for a secret to end up.
+ */
+export interface EffectState {
+  /** How far the effect got. */
+  status: EffectStatus;
+  /** ISO-8601 time the intent was committed — always *before* the body ran. */
+  intentAt: string;
+  /** ISO-8601 time it settled, if it has. */
+  settledAt?: string;
+  /** The failure message when `status` is `failed`. */
+  error?: string;
+  /** How many times the body has been driven. Above one means it was re-driven. */
+  attempts: number;
+}
+
 /** The recorded progress of a single target. */
 export interface TargetRunState {
   /** The target's current status within the run. */
@@ -103,6 +133,11 @@ export interface TargetRunState {
   error?: string;
   /** The pending wait when `status` is `waiting` (set by `.waitsFor(...)`). */
   waitingFor?: WaitState;
+  /**
+   * The declared effects of this target, keyed by effect name — present only
+   * once at least one has been armed.
+   */
+  effects?: Record<string, EffectState>;
 }
 
 /** One entry of a run's graph-shape snapshot. */
@@ -321,7 +356,50 @@ function parseTargetState(value: unknown): TargetRunState {
   if (object.waitingFor !== undefined) {
     state.waitingFor = parseWaitState(object.waitingFor);
   }
+  if (object.effects !== undefined) {
+    state.effects = parseEffects(object.effects);
+  }
   return state;
+}
+
+/** Validate a target's effect rows, keyed by effect name. */
+function parseEffects(value: unknown): Record<string, EffectState> {
+  const object = asObject(value);
+  if (object === null) throw new Error("state: effects is not an object");
+  const effects: Record<string, EffectState> = {};
+  for (const [name, entry] of Object.entries(object)) {
+    effects[name] = parseEffectState(entry);
+  }
+  return effects;
+}
+
+/** Validate and narrow one {@link EffectState}. */
+function parseEffectState(value: unknown): EffectState {
+  const object = asObject(value);
+  if (object === null) throw new Error("state: effect state is not an object");
+  const attempts = object.attempts;
+  if (typeof attempts !== "number" || !Number.isFinite(attempts)) {
+    throw new Error("state: effect attempts is not a number");
+  }
+  const state: EffectState = {
+    status: effectStatus(str(object, "status")),
+    intentAt: str(object, "intentAt"),
+    attempts,
+  };
+  // Optional fields only when present, so a round-trip preserves the key set.
+  const settledAt = optionalStr(object, "settledAt");
+  if (settledAt !== undefined) state.settledAt = settledAt;
+  const error = optionalStr(object, "error");
+  if (error !== undefined) state.error = error;
+  return state;
+}
+
+/** Validate an effect status. */
+function effectStatus(value: string): EffectStatus {
+  if (value === "pending" || value === "done" || value === "failed") {
+    return value;
+  }
+  throw new Error(`state: unknown effect status "${value}"`);
 }
 
 /** Validate a timed-out-wait disposition. */

--- a/packages/core/src/state/types.ts
+++ b/packages/core/src/state/types.ts
@@ -378,8 +378,14 @@ function parseEffectState(value: unknown): EffectState {
   const object = asObject(value);
   if (object === null) throw new Error("state: effect state is not an object");
   const attempts = object.attempts;
-  if (typeof attempts !== "number" || !Number.isFinite(attempts)) {
-    throw new Error("state: effect attempts is not a number");
+  // At least one, and whole. An armed effect has been attempted once by
+  // definition, and a record claiming zero would make a genuine re-drive report
+  // itself as a first attempt — records can come from another writer, so the
+  // shape is checked rather than trusted.
+  if (
+    typeof attempts !== "number" || !Number.isInteger(attempts) || attempts < 1
+  ) {
+    throw new Error("state: effect attempts is not a positive integer");
   }
   const state: EffectState = {
     status: effectStatus(str(object, "status")),

--- a/packages/core/src/state/writer.ts
+++ b/packages/core/src/state/writer.ts
@@ -25,6 +25,7 @@ import type { StateStore } from "./store.ts";
 import type {
   RunEvent,
   RunRecord,
+  RunStatus,
   SignalRecord,
   TargetRunState,
   WaitState,
@@ -35,6 +36,33 @@ import { messageOf } from "../internal.ts";
 
 /** How many times a conflicting write is re-read and retried before giving up. */
 const MAX_RETRIES = 5;
+
+/**
+ * An effect write was refused because the run is no longer `running` — another
+ * process settled it while this one was still working.
+ *
+ * Its own type because the caller has to tell it apart from a store being
+ * unreachable: this one means "stop, someone else owns the outcome now", and
+ * retrying it would be the bug.
+ */
+export class RunNotActiveError extends Error {
+  /** The error name. */
+  override name = "RunNotActiveError";
+  /** The run that is no longer running. */
+  readonly runId: string;
+  /** The status it is in now. */
+  readonly status: RunStatus;
+  /** Build the error from the run and the status that refused the write. */
+  constructor(runId: string, status: RunStatus) {
+    super(
+      `run "${runId}" is ${status}, not running — refusing to record an ` +
+        `effect on it. Another process has settled this run, and its outcome ` +
+        `is that process's to report.`,
+    );
+    this.runId = runId;
+    this.status = status;
+  }
+}
 
 /** Ensure a target's entry exists in the record, seeding it `pending`. */
 function ensureTarget(record: RunRecord, name: string): TargetRunState {
@@ -296,10 +324,153 @@ export class RunStateWriter {
     };
   }
 
+  /**
+   * Commit the intent to run `effect` on `target`, before its body does
+   * anything.
+   *
+   * Returns `"skip"` when the effect is already recorded `done` — the no-op that
+   * makes a re-drive after a completed effect harmless — and `"run"` once the
+   * intent is armed `pending`. A previous `failed` attempt is re-armed and
+   * `attempts` goes up.
+   *
+   * Unlike every other method here this is **strict**: it resolves only once the
+   * write has landed, and throws otherwise. A caller that cannot record its
+   * intent must not perform the effect, because nothing would then know to
+   * re-drive it — the whole point is that the record leads the side effect
+   * rather than trailing it.
+   *
+   * @throws {RunNotActiveError} if the run is no longer `running` — see
+   * {@link "#applyStrict"} for why that check is what stops a stale process
+   * writing over a settled run.
+   */
+  beginEffect(target: string, effect: string): Promise<"run" | "skip"> {
+    const at = this.#now();
+    let gate: "run" | "skip" = "run";
+    return this.#updateStrict((record) => {
+      const state = ensureTarget(record, target);
+      const effects = state.effects ?? {};
+      state.effects = effects;
+      const existing = effects[effect];
+      if (existing?.status === "done") {
+        gate = "skip";
+        return;
+      }
+      gate = "run";
+      effects[effect] = {
+        status: "pending",
+        intentAt: existing?.intentAt ?? at,
+        attempts: (existing?.attempts ?? 0) + 1,
+      };
+    }).then(() => gate);
+  }
+
+  /**
+   * Record that `effect` on `target` finished, or failed.
+   *
+   * Strict for the same reason as {@link beginEffect}, from the other side: a
+   * lost `done` leaves the effect `pending`, and a later resume drives it again.
+   * That is survivable — the contract is at-least-once — but it should be
+   * reported rather than silently absorbed.
+   */
+  markEffectSettled(
+    target: string,
+    effect: string,
+    ok: boolean,
+    error?: string,
+  ): Promise<void> {
+    const at = this.#now();
+    const message = error === undefined
+      ? undefined
+      : this.#redactor.redact(error);
+    return this.#updateStrict((record) => {
+      const state = ensureTarget(record, target);
+      const effects = state.effects ?? {};
+      state.effects = effects;
+      const existing = effects[effect];
+      effects[effect] = {
+        status: ok ? "done" : "failed",
+        intentAt: existing?.intentAt ?? at,
+        attempts: existing?.attempts ?? 1,
+        settledAt: at,
+        ...(message === undefined ? {} : { error: message }),
+      };
+    });
+  }
+
   /** Serialise `mutator` after all pending writes, then persist (best-effort). */
   #update(mutator: (record: RunRecord) => void): Promise<void> {
     this.#chain = this.#chain.then(() => this.#applyAndPersist(mutator));
     return this.#chain;
+  }
+
+  /**
+   * Serialise `mutator` like {@link "#update"}, but hand its failure to the
+   * caller.
+   *
+   * The chain deliberately does not inherit the rejection. `#chain` is shared by
+   * every write on this writer, so assigning it a rejected promise would make
+   * each later best-effort write reject too — one failed effect intent would
+   * take the run's whole bookkeeping down with it. The caller gets the real
+   * promise; the chain gets a settled copy that only preserves ordering.
+   */
+  #updateStrict(mutator: (record: RunRecord) => void): Promise<void> {
+    const result = this.#chain.then(() => this.#applyStrict(mutator));
+    this.#chain = result.then(() => {}, () => {});
+    return result;
+  }
+
+  /**
+   * Apply `mutator` and CAS-write, refusing to write to a run that is not
+   * `running` and throwing rather than dropping the write.
+   *
+   * The status check is the important half, and it is checked again after every
+   * re-read. A process can be alive and holding a stale view of a run another
+   * process has already settled — a sweeper that reaped it past its deadline,
+   * say. The best-effort path handles that by re-applying its mutation onto the
+   * settling record and carrying on, which is right for bookkeeping and wrong
+   * for an effect: it would arm the intent and let the body post a result over
+   * the one the settler already published. For a merge gate that is a green
+   * check on top of a red one, so an effect write to a non-`running` run is
+   * refused outright.
+   *
+   * The executor is still told, via `onExternalCancel`, so it stops rather than
+   * carrying on to the next target.
+   */
+  async #applyStrict(mutator: (record: RunRecord) => void): Promise<void> {
+    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+      if (this.#record.status !== "running") {
+        throw new RunNotActiveError(this.#record.id, this.#record.status);
+      }
+      mutator(this.#record);
+      this.#record.updatedAt = this.#now();
+      const result = await this.#store.putRun(this.#record, this.#version);
+      if (result.ok) {
+        this.#version = result.version;
+        return;
+      }
+      // Another writer moved the record on. Re-read a fresh base and re-apply on
+      // the next pass — the mutation just applied is discarded with the stale
+      // base, exactly as in the best-effort path.
+      const fresh = await this.#store.getRun(this.#record.id);
+      if (fresh === null) {
+        throw new Error(
+          `state: run "${this.#record.id}" vanished from the store while ` +
+            `recording an effect; refusing to run it without a durable intent`,
+        );
+      }
+      const degraded = this.#record.degraded;
+      this.#record = fresh.record;
+      this.#record.degraded ||= degraded;
+      this.#version = fresh.version;
+      if (fresh.record.status !== "running") {
+        this.#onExternalCancel?.();
+        throw new RunNotActiveError(fresh.record.id, fresh.record.status);
+      }
+    }
+    throw new Error(
+      `state: gave up recording an effect on run "${this.#record.id}" after ` +
+        `${MAX_RETRIES} conflicting writes`,
+    );
   }
 
   /**

--- a/packages/core/src/state/writer.ts
+++ b/packages/core/src/state/writer.ts
@@ -387,6 +387,11 @@ export class RunStateWriter {
       const effects = state.effects ?? {};
       state.effects = effects;
       const existing = effects[effect];
+      // Never write over a completed effect. Once two processes can share a
+      // running run, a re-applied `failed` from the slower one would bury a
+      // `done` the faster one already recorded — leaving the record claiming an
+      // effect failed when it had in fact succeeded.
+      if (existing?.status === "done") return;
       effects[effect] = {
         status: ok ? "done" : "failed",
         intentAt: existing?.intentAt ?? at,
@@ -441,9 +446,21 @@ export class RunStateWriter {
       if (this.#record.status !== "running") {
         throw new RunNotActiveError(this.#record.id, this.#record.status);
       }
+      // The mutation is applied to the live record, so a throw would otherwise
+      // leave it there for the next write that lands to persist — recording an
+      // intent for an effect that provably never ran, and making the body's
+      // first execution report itself as a re-drive. Keep a copy of the rows
+      // this touches so a refusal really does leave nothing behind.
+      const before = structuredClone(this.#record.targets);
       mutator(this.#record);
       this.#record.updatedAt = this.#now();
-      const result = await this.#store.putRun(this.#record, this.#version);
+      let result;
+      try {
+        result = await this.#store.putRun(this.#record, this.#version);
+      } catch (error) {
+        this.#record.targets = before;
+        throw error;
+      }
       if (result.ok) {
         this.#version = result.version;
         return;
@@ -451,8 +468,14 @@ export class RunStateWriter {
       // Another writer moved the record on. Re-read a fresh base and re-apply on
       // the next pass — the mutation just applied is discarded with the stale
       // base, exactly as in the best-effort path.
-      const fresh = await this.#store.getRun(this.#record.id);
+      const fresh = await this.#store.getRun(this.#record.id).catch(
+        (error: unknown) => {
+          this.#record.targets = before;
+          throw error;
+        },
+      );
       if (fresh === null) {
+        this.#record.targets = before;
         throw new Error(
           `state: run "${this.#record.id}" vanished from the store while ` +
             `recording an effect; refusing to run it without a durable intent`,
@@ -467,6 +490,15 @@ export class RunStateWriter {
         throw new RunNotActiveError(fresh.record.id, fresh.record.status);
       }
     }
+    // The last attempt's mutation went with the stale base it was applied to,
+    // and no later write carries it — the same permanent loss the best-effort
+    // path marks, so mark it the same way. It matters here because a resume
+    // that cannot trust the record is exactly what `--resume-degraded` makes
+    // an operator opt into before a non-idempotent step is repeated.
+    this.#lostWrite(
+      `state: gave up recording an effect on run "${this.#record.id}" after ` +
+        `${MAX_RETRIES} conflicting writes`,
+    );
     throw new Error(
       `state: gave up recording an effect on run "${this.#record.id}" after ` +
         `${MAX_RETRIES} conflicting writes`,

--- a/packages/core/src/target.ts
+++ b/packages/core/src/target.ts
@@ -336,6 +336,35 @@ export interface TargetContext {
  */
 export type TargetFn = (ctx: TargetContext) => unknown | Promise<unknown>;
 
+/**
+ * The context an effect body receives: the target's own context, plus which
+ * effect this is and whether it has been driven before.
+ */
+export interface EffectContext extends TargetContext {
+  /** The effect's declared name. */
+  readonly effect: string;
+  /**
+   * True when a previous attempt at this effect already committed its intent —
+   * so its side effect may have happened, wholly or partly, and this run is
+   * repeating it.
+   *
+   * Effects are at-least-once. A body that can tell the difference should say
+   * so in what it writes, rather than assume it is the first to get here.
+   */
+  readonly redriven: boolean;
+}
+
+/** The body of a declared effect (see {@link TargetBuilder.effect}). */
+export type EffectFn = (ctx: EffectContext) => unknown | Promise<unknown>;
+
+/** One effect declared on a target: its name and its body. */
+export interface DeclaredEffect {
+  /** The effect's name, unique within the target and stable across runs. */
+  name: string;
+  /** The body run once the intent is durably recorded. */
+  fn: EffectFn;
+}
+
 /** A predicate gating whether a target runs; may be synchronous or async. */
 export type Condition = () => boolean | Promise<boolean>;
 
@@ -432,6 +461,8 @@ export class TargetBuilder {
   readonly after_: TargetBuilder[] = [];
   /** The target body. */
   fn_?: TargetFn;
+  /** Crash-durable effects, in declaration order (set by {@link effect}). */
+  readonly effects_: DeclaredEffect[] = [];
   /** Property name, assigned during discovery. Undefined until then. */
   name_?: string;
   /** The parallel batch this target belongs to, if any (set by {@link partOf}). */
@@ -552,6 +583,47 @@ export class TargetBuilder {
    */
   onlyWhen(condition: Condition): this {
     this.onlyWhen_.push(condition);
+    return this;
+  }
+
+  /**
+   * Declare a **crash-durable effect**: `fn` runs only after the intent to run
+   * it has been written to the run record, so a process killed anywhere inside
+   * it leaves evidence that it was owed.
+   *
+   * That evidence is what a resume — or the `zuke resume --check` sweep — uses
+   * to drive it again. The guarantee is **at-least-once**, not exactly-once: a
+   * process that dies after the side effect but before recording it will repeat
+   * the effect. Write bodies that tolerate that, either because repeating is
+   * harmless or because the far side converges (an upsert rather than an
+   * append).
+   *
+   * ```ts
+   * gate = target().dependsOn(this.checks).always()
+   *   .effect("post-gate", async (ctx) => {
+   *     await postCheckRun(ctx.outcomeOf("checks")?.status === "succeeded");
+   *   });
+   * ```
+   *
+   * **Pin the inputs.** A re-drive happens later, sometimes much later, so a
+   * body that looks up "the current value" of anything acts on a world that has
+   * moved on. Read what the effect acts on from durable state instead —
+   * `ctx.state` or `ctx.stateOf(...)`, written by an earlier target — which is
+   * replayed from the record and cannot be overridden from outside.
+   *
+   * A parameter is *nearly* as good and not quite: the record seeds a resume, so
+   * a parameter nobody re-supplies keeps the value the run started with, but a
+   * resume that passes one explicitly overrides it (the only way to re-supply a
+   * secret, since secrets are kept out of the record). For a value that must not
+   * drift across a re-drive, prefer state.
+   *
+   * Effects run after the body, in declaration order, and are repeatable. A
+   * target may declare effects and no body at all. Requires a state store, which
+   * is enabled automatically — an intent that cannot be recorded is a target
+   * that fails before its effect runs, by design.
+   */
+  effect(name: string, fn: EffectFn): this {
+    this.effects_.push({ name, fn });
     return this;
   }
 

--- a/packages/core/src/target.ts
+++ b/packages/core/src/target.ts
@@ -591,10 +591,15 @@ export class TargetBuilder {
    * it has been written to the run record, so a process killed anywhere inside
    * it leaves evidence that it was owed.
    *
-   * That evidence is what a resume — or the `zuke resume --check` sweep — uses
-   * to drive it again. The guarantee is **at-least-once**, not exactly-once: a
-   * process that dies after the side effect but before recording it will repeat
-   * the effect. Write bodies that tolerate that, either because repeating is
+   * That evidence is what a resume uses to drive it again. Note the precondition
+   * as it stands today: a resume only picks up a run recorded `suspended`, and a
+   * process killed outright leaves its run `running`, so an effect owed by a
+   * killed process is re-driven once something moves that run back to
+   * `suspended` — a reaping sweep, or an operator. An effect owed by a run that
+   * suspended for any other reason is re-driven by the ordinary resume.
+   *
+   * The guarantee is **at-least-once**, not exactly-once: a process that dies
+   * after the side effect but before recording it will repeat the effect. Write bodies that tolerate that, either because repeating is
    * harmless or because the far side converges (an upsert rather than an
    * append).
    *
@@ -623,6 +628,17 @@ export class TargetBuilder {
    * that fails before its effect runs, by design.
    */
   effect(name: string, fn: EffectFn): this {
+    // A duplicate name is not a second effect, it is a lost one: both rows are
+    // the same row, so the first to settle `done` makes every later one skip.
+    // That loses a side effect with no error at all, so it is refused here.
+    if (this.effects_.some((declared) => declared.name === name)) {
+      throw new Error(
+        `Target already declares an effect named ${JSON.stringify(name)}. ` +
+          `An effect's name is its identity in the run record, so a second one ` +
+          `under the same name would be skipped once the first completed. Give ` +
+          `them distinct names.`,
+      );
+    }
     this.effects_.push({ name, fn });
     return this;
   }
@@ -1003,6 +1019,19 @@ export class TargetBuilder {
               `.dependsOn(...).`,
           );
         }
+        // An effect has the same problem for the same reason: a fan-out target
+        // delegates to its materialised sub-targets and never runs a body of its
+        // own, and those sub-targets are invisible to the machinery that would
+        // enable the state store and re-drive an owed effect. Rejected loudly
+        // rather than dropped.
+        if (this.effects_.length > 0) {
+          throw new Error(
+            `Target "${self}" combines .forEach() with .effect(): a fan-out ` +
+              `target runs no body of its own, so its effect would never be ` +
+              `driven. Put the effect on a separate target that this fan-out ` +
+              `.dependsOn(...).`,
+          );
+        }
         const seen = new Map<string, number>();
         return items().map((item, index) => {
           const base = itemKey(item, index);
@@ -1019,6 +1048,15 @@ export class TargetBuilder {
                   `sweep can't reach a materialised sub-target), so it would be ` +
                   `silently swallowed. Put the wait on a separate target that ` +
                   `the fan-out .dependsOn(...).`,
+              );
+            }
+            if (sub.effects_.length > 0) {
+              throw new Error(
+                `Fan-out target "${self}" stage "${stage}" uses .effect(): a ` +
+                  `materialised sub-target is invisible to the state store's ` +
+                  `own enablement and to the resume sweep, so its intent would ` +
+                  `be recorded nowhere and never re-driven. Put the effect on a ` +
+                  `separate target that the fan-out .dependsOn(...).`,
               );
             }
           }

--- a/packages/core/tests/outcome_view_test.ts
+++ b/packages/core/tests/outcome_view_test.ts
@@ -8,6 +8,7 @@
 import { assertEquals } from "./_assert.ts";
 import { outcomesFromRecord, outcomeView } from "../src/run_support.ts";
 import type { TargetRunState } from "../src/state/types.ts";
+import { parseRunRecord } from "../src/state/types.ts";
 
 /** A record row, with only the fields a case cares about set. */
 function row(over: Partial<TargetRunState> = {}): TargetRunState {
@@ -85,4 +86,41 @@ Deno.test("a record becomes one entry per settled target", () => {
 
 Deno.test("an empty record has no outcomes", () => {
   assertEquals(outcomesFromRecord({}).size, 0);
+});
+
+Deno.test("an effect record claiming zero attempts is refused", () => {
+  // An armed effect has been attempted once by definition, and a zero would make
+  // a genuine re-drive report itself as a first attempt. Records can come from
+  // another writer, so the shape is checked rather than trusted.
+  const bad = {
+    status: "succeeded",
+    meta: {},
+    effects: {
+      post: {
+        status: "pending",
+        intentAt: "2026-08-10T10:00:00.000Z",
+        attempts: 0,
+      },
+    },
+  };
+  let message = "";
+  try {
+    parseRunRecord(JSON.stringify({
+      id: "r",
+      build: "B",
+      rootTarget: "gate",
+      status: "running",
+      actor: "a",
+      createdAt: "2026-08-10T10:00:00.000Z",
+      updatedAt: "2026-08-10T10:00:00.000Z",
+      graph: [],
+      params: {},
+      targets: { gate: bad },
+      signals: {},
+      events: [],
+    }));
+  } catch (error) {
+    message = error instanceof Error ? error.message : String(error);
+  }
+  assertEquals(message.includes("positive integer"), true, message);
 });

--- a/packages/core/tests/writer_effects_test.ts
+++ b/packages/core/tests/writer_effects_test.ts
@@ -1,0 +1,281 @@
+/**
+ * Unit tests for the writer's effect methods — the durable intent that has to
+ * land *before* an effect's body runs, and the guard that stops a stale process
+ * writing one onto a run somebody else already settled.
+ *
+ * @module
+ */
+
+import { assertEquals, assertRejects } from "./_assert.ts";
+import { Build, discoverTargets } from "../src/build.ts";
+import { execute } from "../src/executor.ts";
+import { target } from "../src/target.ts";
+import { Redactor } from "../src/redact.ts";
+import { RunNotActiveError, RunStateWriter } from "../src/state/writer.ts";
+import type { StateStore } from "../src/state/store.ts";
+import type { EffectState, RunRecord, RunStatus } from "../src/state/types.ts";
+
+const NOW = "2026-08-10T10:00:00.000Z";
+
+/** A minimal run record with one target. */
+function sampleRecord(status: RunStatus = "running"): RunRecord {
+  return {
+    id: "run-1",
+    build: "Ci",
+    rootTarget: "gate",
+    status,
+    actor: "tester",
+    createdAt: NOW,
+    updatedAt: NOW,
+    graph: [{ name: "gate", dependsOn: [] }],
+    params: {},
+    targets: { gate: { status: "pending", meta: {} } },
+    signals: {},
+    events: [],
+  };
+}
+
+/** An in-memory store whose failure modes each test drives directly. */
+class MemStore implements StateStore {
+  record: RunRecord | null = null;
+  version = 0;
+  /** Reject the next put with a store error. */
+  failNextPut = false;
+  /** Answer this many puts with a conflict before accepting one. */
+  forceConflicts = 0;
+  /** Return null from getRun, as though the run were pruned mid-write. */
+  vanish = false;
+  /** What a conflicting re-read reports the run's status as. */
+  freshStatus?: RunStatus;
+
+  listRuns(): Promise<never[]> {
+    return Promise.resolve([]);
+  }
+  getRun(): Promise<{ record: RunRecord; version: string } | null> {
+    if (this.vanish || this.record === null) return Promise.resolve(null);
+    const record = structuredClone(this.record);
+    if (this.freshStatus !== undefined) record.status = this.freshStatus;
+    return Promise.resolve({ record, version: String(this.version) });
+  }
+  putRun(
+    record: RunRecord,
+    expected: string | null,
+  ): Promise<{ ok: true; version: string } | { ok: false; conflict: true }> {
+    if (this.failNextPut) {
+      this.failNextPut = false;
+      return Promise.reject(new Error("store down"));
+    }
+    if (this.forceConflicts > 0) {
+      this.forceConflicts -= 1;
+      return Promise.resolve({ ok: false, conflict: true });
+    }
+    const current = this.record === null ? null : String(this.version);
+    if (current !== expected) {
+      return Promise.resolve({ ok: false, conflict: true });
+    }
+    this.record = structuredClone(record);
+    this.version += 1;
+    return Promise.resolve({ ok: true, version: String(this.version) });
+  }
+  deleteRun(): Promise<void> {
+    this.record = null;
+    return Promise.resolve();
+  }
+  acquireLock(): Promise<never> {
+    throw new Error("MemStore: locks are unused here");
+  }
+  renewLock(): Promise<never> {
+    throw new Error("MemStore: locks are unused here");
+  }
+  releaseLock(): Promise<never> {
+    throw new Error("MemStore: locks are unused here");
+  }
+}
+
+/** A writer over `store`, seeded with a record in `status`. */
+async function writerFor(
+  store: MemStore,
+  status: RunStatus = "running",
+  onExternalCancel?: () => void,
+): Promise<RunStateWriter> {
+  const redactor = new Redactor();
+  redactor.add("swordfish");
+  return await RunStateWriter.open(
+    store,
+    sampleRecord(status),
+    () => NOW,
+    redactor,
+    undefined,
+    onExternalCancel,
+  );
+}
+
+/** The persisted effect row, or undefined. */
+function effectOf(store: MemStore, name = "post"): EffectState | undefined {
+  return store.record?.targets["gate"]?.effects?.[name];
+}
+
+Deno.test("beginEffect arms the intent and says to run", async () => {
+  const store = new MemStore();
+  const writer = await writerFor(store);
+  assertEquals(await writer.beginEffect("gate", "post"), "run");
+  // Persisted, not merely in memory: the point is that a later process can see
+  // the effect was owed.
+  assertEquals(effectOf(store)?.status, "pending");
+  assertEquals(effectOf(store)?.intentAt, NOW);
+  assertEquals(effectOf(store)?.attempts, 1);
+});
+
+Deno.test("an effect already done is skipped rather than repeated", async () => {
+  const store = new MemStore();
+  const writer = await writerFor(store);
+  await writer.beginEffect("gate", "post");
+  await writer.markEffectSettled("gate", "post", true);
+  assertEquals(await writer.beginEffect("gate", "post"), "skip");
+  // The row is untouched by the skip — still one attempt, still done.
+  assertEquals(effectOf(store)?.status, "done");
+  assertEquals(effectOf(store)?.attempts, 1);
+});
+
+Deno.test("a failed effect is re-armed, keeping its first intent time", async () => {
+  const store = new MemStore();
+  let clock = "2026-08-10T10:00:00.000Z";
+  const writer = await RunStateWriter.open(
+    store,
+    sampleRecord(),
+    () => clock,
+    new Redactor(),
+  );
+  await writer.beginEffect("gate", "post");
+  await writer.markEffectSettled("gate", "post", false, "boom");
+  assertEquals(effectOf(store)?.status, "failed");
+  assertEquals(effectOf(store)?.error, "boom");
+
+  clock = "2026-08-10T11:00:00.000Z";
+  assertEquals(await writer.beginEffect("gate", "post"), "run");
+  assertEquals(effectOf(store)?.status, "pending");
+  assertEquals(effectOf(store)?.attempts, 2);
+  // intentAt is when the effect was first owed, not when it was last tried —
+  // it dates the obligation, and a later attempt does not reset it.
+  assertEquals(effectOf(store)?.intentAt, "2026-08-10T10:00:00.000Z");
+});
+
+Deno.test("a settled effect records when, and a failure's message is redacted", async () => {
+  const store = new MemStore();
+  const writer = await writerFor(store);
+  await writer.beginEffect("gate", "post");
+  await writer.markEffectSettled("gate", "post", false, "token swordfish bad");
+  assertEquals(effectOf(store)?.settledAt, NOW);
+  assertEquals(effectOf(store)?.error?.includes("swordfish"), false);
+});
+
+Deno.test("an effect is refused on a run that is no longer running", async () => {
+  // The one that matters. A process can be alive holding a stale view of a run
+  // a sweeper already settled; arming an effect there would let it publish a
+  // result over the one the settler already published — for a merge gate, a
+  // green check over a red one.
+  const settled: RunStatus[] = [
+    "cancelling",
+    "cancelled",
+    "failed",
+    "succeeded",
+  ];
+  for (const status of settled) {
+    const store = new MemStore();
+    const writer = await writerFor(store, status);
+    const error = await assertRejects(
+      () => writer.beginEffect("gate", "post"),
+      RunNotActiveError,
+      "not running",
+    );
+    if (!(error instanceof RunNotActiveError)) throw new Error("wrong type");
+    assertEquals(error.status, status);
+    assertEquals(error.runId, "run-1");
+    // Nothing was armed, so nothing will run.
+    assertEquals(effectOf(store), undefined);
+  }
+});
+
+Deno.test("a conflicting re-read that has been settled elsewhere is refused too", async () => {
+  // The window the best-effort path handles by re-applying onto the settling
+  // record and carrying on. For an effect that is exactly wrong.
+  const store = new MemStore();
+  let cancelled = 0;
+  const guarded = await writerFor(store, "running", () => void cancelled++);
+  store.forceConflicts = 1;
+  store.freshStatus = "cancelling";
+  await assertRejects(
+    () => guarded.beginEffect("gate", "post"),
+    RunNotActiveError,
+  );
+  // The executor is told to stop, rather than only being refused.
+  assertEquals(cancelled, 1);
+});
+
+Deno.test("a vanished run refuses the effect rather than dropping the write", async () => {
+  // The best-effort path drops this one with a warning. Doing that here would
+  // run a side effect that nothing recorded as owed.
+  const store = new MemStore();
+  const writer = await writerFor(store);
+  store.forceConflicts = 1;
+  store.vanish = true;
+  await assertRejects(
+    () => writer.beginEffect("gate", "post"),
+    Error,
+    "vanished",
+  );
+});
+
+Deno.test("exhausting the retries refuses the effect", async () => {
+  const store = new MemStore();
+  const writer = await writerFor(store);
+  store.forceConflicts = 99; // every attempt conflicts
+  await assertRejects(
+    () => writer.beginEffect("gate", "post"),
+    Error,
+    "conflicting writes",
+  );
+});
+
+Deno.test("a store error refuses the effect", async () => {
+  const store = new MemStore();
+  const writer = await writerFor(store);
+  store.failNextPut = true;
+  await assertRejects(
+    () => writer.beginEffect("gate", "post"),
+    Error,
+    "store down",
+  );
+});
+
+Deno.test("a refused effect does not poison the writer's other writes", async () => {
+  // Every write shares one serialising chain. A rejected effect write that was
+  // left on it would make each later best-effort write reject too, so one
+  // failed intent would take the run's whole bookkeeping down with it.
+  const store = new MemStore();
+  const writer = await writerFor(store);
+  store.failNextPut = true;
+  await assertRejects(() => writer.beginEffect("gate", "post"), Error);
+
+  await writer.markTargetSettled("gate", "passed");
+  assertEquals(store.record?.targets["gate"]?.status, "succeeded");
+  assertEquals(await writer.beginEffect("gate", "post"), "run");
+  assertEquals(effectOf(store)?.status, "pending");
+});
+
+Deno.test("a run with state disabled refuses to start a build that declares an effect", async () => {
+  // With nowhere to record the intent there is nothing for a later process to
+  // re-drive from, which is the entire guarantee — so the run is refused rather
+  // than performing a side effect nothing knows was owed.
+  let ran = false;
+  class B extends Build {
+    gate = target().effect("post", () => {
+      ran = true;
+    });
+  }
+  const b = new B();
+  discoverTargets(b);
+  const result = await execute(b, b.gate, { silent: true, stateStore: false });
+  assertEquals(result.ok, false);
+  assertEquals(ran, false);
+});

--- a/packages/core/tests/writer_effects_test.ts
+++ b/packages/core/tests/writer_effects_test.ts
@@ -279,3 +279,46 @@ Deno.test("a run with state disabled refuses to start a build that declares an e
   assertEquals(result.ok, false);
   assertEquals(ran, false);
 });
+
+Deno.test("a refused intent leaves nothing behind for a later write to persist", async () => {
+  // The mutation is applied to the live record before the write is attempted, so
+  // a throw that left it there would have the next landing write persist an
+  // intent for an effect that provably never ran — and make the body's first
+  // execution report itself as a re-drive.
+  const store = new MemStore();
+  const writer = await writerFor(store);
+  store.failNextPut = true;
+  await assertRejects(() => writer.beginEffect("gate", "post"), Error);
+
+  // A later best-effort write lands; it must not carry a phantom intent.
+  await writer.markTargetSettled("gate", "failed", "boom");
+  assertEquals(effectOf(store), undefined);
+
+  // And the next real arming is attempt one, not two.
+  assertEquals(await writer.beginEffect("gate", "post"), "run");
+  assertEquals(effectOf(store)?.attempts, 1);
+});
+
+Deno.test("a settlement never writes over an effect another process completed", async () => {
+  // Once two live processes can share a running run, a re-applied `failed` from
+  // the slower one would bury a `done` the faster one recorded, leaving the
+  // record claiming an effect failed when it had in fact succeeded.
+  const store = new MemStore();
+  const writer = await writerFor(store);
+  await writer.beginEffect("gate", "post");
+  await writer.markEffectSettled("gate", "post", true);
+  await writer.markEffectSettled("gate", "post", false, "boom");
+  assertEquals(effectOf(store)?.status, "done");
+  assertEquals(effectOf(store)?.error, undefined);
+});
+
+Deno.test("giving up after repeated conflicts marks the record degraded", async () => {
+  // The last attempt's mutation goes with the stale base it was applied to and
+  // no later write carries it — a permanent loss, and the flag is what makes a
+  // resume demand `--resume-degraded` before repeating a non-idempotent step.
+  const store = new MemStore();
+  const writer = await writerFor(store);
+  store.forceConflicts = 99;
+  await assertRejects(() => writer.beginEffect("gate", "post"), Error);
+  assertEquals(writer.snapshot().degraded, true);
+});

--- a/tests/e2e/effect_redrive_e2e.ts
+++ b/tests/e2e/effect_redrive_e2e.ts
@@ -1,0 +1,133 @@
+/**
+ * End-to-end: the one thing the in-process suite cannot prove — that an effect's
+ * intent survives a real `SIGKILL`, and that a **different** OS process finds it
+ * and drives the effect again.
+ *
+ * The fixture ({@link file://./fixtures/effect_build.ts}) appends a line per
+ * drive to a marker file, so the count is observed rather than inferred. This
+ * suite is excluded from the fast unit gate and runs on its own OS matrix (see
+ * the `integration` target / integration.yml).
+ *
+ * One seam is stood in for: moving an abandoned `running` run back to
+ * `suspended` is the reaper's job, and the reaper does not exist yet. Here the
+ * parent does that single transition by hand, and says so — everything either
+ * side of it is real processes and real state.
+ *
+ * @module
+ */
+
+import { assertEquals } from "../../packages/core/tests/_assert.ts";
+import {
+  defaultStateHost,
+  FileSystemStateStore,
+} from "../../packages/core/mod.ts";
+
+const FIXTURE = new URL("./fixtures/effect_build.ts", import.meta.url);
+
+/** How long to wait for the child to reach its effect before giving up. */
+const REACH_TIMEOUT_MS = 30_000;
+
+/** Spawn the fixture as a real `deno` subprocess against `dir`. */
+function spawn(
+  args: string[],
+  dir: string,
+  marker: string,
+  hang: boolean,
+): Deno.ChildProcess {
+  return new Deno.Command(Deno.execPath(), {
+    // A `file://` URL rather than URL.pathname, which is `/C:/…` on Windows.
+    args: ["run", "-A", FIXTURE.href, ...args],
+    env: {
+      ZUKE_STATE_DIR: dir,
+      ZUKE_E2E_MARKER: marker,
+      ...(hang ? { ZUKE_E2E_HANG: "1" } : {}),
+    },
+    stdout: "piped",
+    stderr: "piped",
+  }).spawn();
+}
+
+/** The marker file's lines, or an empty list if it does not exist yet. */
+async function markerLines(marker: string): Promise<string[]> {
+  try {
+    const text = await Deno.readTextFile(marker);
+    return text.split("\n").filter((line) => line !== "");
+  } catch {
+    return [];
+  }
+}
+
+/** Wait until the marker file has `count` lines, or fail after the timeout. */
+async function waitForLines(marker: string, count: number): Promise<string[]> {
+  const deadline = Date.now() + REACH_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const lines = await markerLines(marker);
+    if (lines.length >= count) return lines;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(
+    `the effect did not reach ${count} line(s) within ${REACH_TIMEOUT_MS}ms`,
+  );
+}
+
+Deno.test("a SIGKILL mid-effect leaves a durable intent another process re-drives", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "zuke-e2e-" });
+  const marker = `${dir}/marker.log`;
+  try {
+    // Process 1: reaches the effect — which appends its line — and then parks.
+    const child = spawn(["announce"], dir, marker, true);
+    const first = await waitForLines(marker, 1);
+    assertEquals(first, ["announce redriven=false"]);
+
+    // Kill it where a pod eviction would: intent committed, effect performed,
+    // settlement never written.
+    child.kill("SIGKILL");
+    await child.status;
+
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    const runs = await store.listRuns({});
+    assertEquals(runs.length, 1);
+    const id = runs[0].id;
+
+    // What a killed process leaves, read by a different process entirely: the
+    // run never finished, and the effect is still recorded as owed.
+    const killed = await store.getRun(id);
+    if (killed === null) throw new Error("the run vanished");
+    assertEquals(killed.record.status, "running");
+    const owed = killed.record.targets["announce"]?.effects?.["announce"];
+    assertEquals(owed?.status, "pending");
+    assertEquals(owed?.attempts, 1);
+    assertEquals(owed?.settledAt, undefined);
+    const intentAt = owed?.intentAt;
+    assertEquals(typeof intentAt, "string");
+
+    // The reaper's one transition, by hand until it exists: an abandoned
+    // `running` run becomes resumable.
+    const record = structuredClone(killed.record);
+    record.status = "suspended";
+    const moved = await store.putRun(record, killed.version);
+    assertEquals(moved.ok, true);
+
+    // Process 2: a real, separate `resume`. It drives the owed effect again.
+    const resumer = spawn(["resume", id], dir, marker, false);
+    const status = await resumer.status;
+    assertEquals(status.code, 0);
+
+    const lines = await markerLines(marker);
+    assertEquals(lines, [
+      "announce redriven=false",
+      "announce redriven=true",
+    ]);
+
+    const settled = await store.getRun(id);
+    const row = settled?.record.targets["announce"]?.effects?.["announce"];
+    assertEquals(row?.status, "done");
+    assertEquals(row?.attempts, 2);
+    // The obligation keeps the time it was first owed, across the process
+    // boundary — a re-drive does not restart the clock on it.
+    assertEquals(row?.intentAt, intentAt);
+  } finally {
+    // Best-effort: a cleanup failure must not mask the real assertion error.
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});

--- a/tests/e2e/fixtures/effect_build.ts
+++ b/tests/e2e/fixtures/effect_build.ts
@@ -1,0 +1,38 @@
+/**
+ * A real, runnable Zuke build used by the effect re-drive e2e suite. Run as a
+ * subprocess (`deno run -A effect_build.ts announce`), its one target declares a
+ * crash-durable effect that appends a line to a marker file — so the spawning
+ * test can count how many times the effect body actually ran across separate OS
+ * processes.
+ *
+ * With `ZUKE_E2E_HANG=1` the effect blocks forever after appending, so the
+ * parent can `SIGKILL` it at a point where the intent is durable but the effect
+ * has not been recorded as settled. `run()` reads `ZUKE_STATE_DIR` from the
+ * environment for its durable state.
+ *
+ * @module
+ */
+
+import { Build, run, target } from "../../../packages/core/mod.ts";
+
+/** A build whose single target's work is a durable effect. */
+class Publish extends Build {
+  /** Appends one line per drive, then optionally blocks so it can be killed. */
+  announce = target().effect("announce", async (ctx) => {
+    const marker = Deno.env.get("ZUKE_E2E_MARKER");
+    if (marker === undefined) throw new Error("ZUKE_E2E_MARKER is required");
+    await Deno.writeTextFile(
+      marker,
+      `announce redriven=${ctx.redriven}\n`,
+      { append: true },
+    );
+    console.log("EFFECT-RAN");
+    if (Deno.env.get("ZUKE_E2E_HANG") === "1") {
+      // Park forever: the parent kills this process here, which is the whole
+      // point — the intent is already durable, the settlement never happens.
+      await new Promise(() => {});
+    }
+  });
+}
+
+await run(Publish);

--- a/tests/integration/effects_test.ts
+++ b/tests/integration/effects_test.ts
@@ -9,7 +9,10 @@
  * @module
  */
 
-import { assertEquals } from "../../packages/core/tests/_assert.ts";
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
 import {
   Build,
   defaultStateHost,
@@ -17,6 +20,8 @@ import {
   externalSignal,
   FileSystemStateStore,
   parameter,
+  resumeWhen,
+  service,
   target,
 } from "../../packages/core/mod.ts";
 import { runCli, withStateDir } from "./_harness.ts";
@@ -328,4 +333,104 @@ Deno.test("state written before an effect is stable across its re-drive", async 
     await runCli(Cd, ["resume", id, "--signal", "go"]);
     assertEquals(seen, ["aaaa1111", "aaaa1111"]);
   });
+});
+
+Deno.test("a cache hit never swallows an effect", async () => {
+  // A cache hit returns before the effects are driven, so a cacheable target
+  // that declares one would drop it outright on the second run — nothing run,
+  // nothing recorded as owed, and the run reporting success.
+  const calls: string[] = [];
+
+  class Ci extends Build {
+    publish = target().inputs("deno.json").executes(() => {}).effect(
+      "announce",
+      () => {
+        calls.push("announce");
+      },
+    );
+  }
+
+  await withStateDir(async (dir) => {
+    assertEquals((await runCli(Ci, ["publish"])).code, 0);
+    assertEquals((await runCli(Ci, ["publish"])).code, 0);
+    // Twice, because a target with an effect is never cache-skipped.
+    assertEquals(calls, ["announce", "announce"]);
+    void dir;
+  });
+});
+
+Deno.test("a wait gate that is already satisfied still drives its effects", async () => {
+  // The gate opened, so this is the target's real run and the effect is owed
+  // now. The satisfied path returns early and used to return past the effects.
+  const calls: string[] = [];
+
+  class Cd extends Build {
+    gate = target()
+      .waitsFor((s) => s.on(resumeWhen(() => true)))
+      .effect("announce", () => {
+        calls.push("announce");
+      });
+  }
+
+  await withStateDir(async (dir) => {
+    const { code } = await runCli(Cd, ["gate"]);
+    assertEquals(code, 0);
+    assertEquals(calls, ["announce"]);
+    const id = await onlyRunId(dir);
+    assertEquals(
+      (await effectRow(dir, id, "gate", "announce"))?.status,
+      "done",
+    );
+  });
+});
+
+Deno.test("two effects of the same name are refused rather than one being lost", () => {
+  // Same name means the same record row, so the first to settle makes the second
+  // skip — a copy-paste losing a side effect with no error at all.
+  let message = "";
+  try {
+    target().effect("post", () => {}).effect("post", () => {});
+  } catch (error) {
+    message = error instanceof Error ? error.message : String(error);
+  }
+  assertStringIncludes(message, "already declares an effect named");
+});
+
+Deno.test("an effect on a fan-out is refused, on the parent and on a stage", () => {
+  // A fan-out parent runs no body of its own, and its materialised sub-targets
+  // are invisible both to the state store's enablement and to any resume — so an
+  // effect there is recorded nowhere and never re-driven.
+  const onParent = target()
+    .forEach(() => ["a"], () => ({ work: target().executes(() => {}) }))
+    .effect("announce", () => {});
+  let parentMessage = "";
+  try {
+    onParent.forEach_?.materialize();
+  } catch (error) {
+    parentMessage = error instanceof Error ? error.message : String(error);
+  }
+  assertStringIncludes(parentMessage, ".forEach() with .effect()");
+
+  const onStage = target().forEach(() => ["a"], () => ({
+    work: target().executes(() => {}).effect("announce", () => {}),
+  }));
+  let stageMessage = "";
+  try {
+    onStage.forEach_?.materialize();
+  } catch (error) {
+    stageMessage = error instanceof Error ? error.message : String(error);
+  }
+  assertStringIncludes(stageMessage, 'stage "work" uses .effect()');
+});
+
+Deno.test("an effect on a service is refused", () => {
+  // A service launches a process and runs no body, so an effect declared on it
+  // would never be driven.
+  let message = "";
+  try {
+    service().start(() => ({ stop: () => {} })).effect("post", () => {});
+  } catch (error) {
+    message = error instanceof Error ? error.message : String(error);
+  }
+  assertStringIncludes(message, "runs no body");
 });

--- a/tests/integration/effects_test.ts
+++ b/tests/integration/effects_test.ts
@@ -1,0 +1,331 @@
+/**
+ * Integration tests for `.effect(...)` — a side effect whose intent is durable
+ * before it runs, driven through the real CLI.
+ *
+ * What these prove that a unit test cannot: the intent is visible in the store
+ * *from inside the effect body*, and a resume in a second process drives an
+ * unfinished effect again while leaving a finished one alone.
+ *
+ * @module
+ */
+
+import { assertEquals } from "../../packages/core/tests/_assert.ts";
+import {
+  Build,
+  defaultStateHost,
+  type EffectState,
+  externalSignal,
+  FileSystemStateStore,
+  parameter,
+  target,
+} from "../../packages/core/mod.ts";
+import { runCli, withStateDir } from "./_harness.ts";
+
+/** The id of the (single) run the CLI persisted under `dir`. */
+async function onlyRunId(dir: string): Promise<string> {
+  const store = new FileSystemStateStore(dir, defaultStateHost);
+  const runs = await store.listRuns({});
+  assertEquals(runs.length, 1);
+  return runs[0].id;
+}
+
+/** The persisted effect row for `target`/`effect` in run `id`. */
+async function effectRow(
+  dir: string,
+  id: string,
+  targetName: string,
+  effect: string,
+): Promise<EffectState | undefined> {
+  const store = new FileSystemStateStore(dir, defaultStateHost);
+  const got = await store.getRun(id);
+  return got?.record.targets[targetName]?.effects?.[effect];
+}
+
+Deno.test("the intent is already durable when the effect body runs", async () => {
+  // The ordering that makes the whole feature work: from inside the body, the
+  // store already says this effect is owed. A process killed on the next line
+  // leaves that behind.
+  let seenFromInside: EffectState | undefined;
+
+  class Ci extends Build {
+    gate = target().effect("post", async (ctx) => {
+      seenFromInside = await effectRow(dir, ctx.runId, "gate", "post");
+    });
+  }
+
+  let dir = "";
+  await withStateDir(async (stateDir) => {
+    dir = stateDir;
+    const { code } = await runCli(Ci, ["gate"]);
+    assertEquals(code, 0);
+    assertEquals(seenFromInside?.status, "pending");
+    assertEquals(seenFromInside?.attempts, 1);
+    // And by the end it is settled.
+    const id = await onlyRunId(dir);
+    assertEquals((await effectRow(dir, id, "gate", "post"))?.status, "done");
+  });
+});
+
+Deno.test("a state store is enabled automatically for an effect", async () => {
+  // Declaring an effect is enough; no --state flag, no ZUKE_STATE_DIR by hand.
+  let ran = false;
+
+  class Ci extends Build {
+    gate = target().effect("post", () => {
+      ran = true;
+    });
+  }
+
+  await withStateDir(async (dir) => {
+    await runCli(Ci, ["gate"]);
+    assertEquals(ran, true);
+    const id = await onlyRunId(dir);
+    assertEquals((await effectRow(dir, id, "gate", "post"))?.status, "done");
+  });
+});
+
+Deno.test("a failed effect is recorded, and the target fails with it", async () => {
+  class Ci extends Build {
+    gate = target().effect("post", () => {
+      throw new Error("the API refused");
+    });
+  }
+
+  await withStateDir(async (dir) => {
+    const { code } = await runCli(Ci, ["gate"]);
+    assertEquals(code, 1);
+    const id = await onlyRunId(dir);
+    const row = await effectRow(dir, id, "gate", "post");
+    assertEquals(row?.status, "failed");
+    assertEquals(row?.error, "the API refused");
+  });
+});
+
+Deno.test("an unfinished effect is driven again on resume; a finished one is not", async () => {
+  // The crash case, staged deterministically: the effect runs before a wait, so
+  // the first process settles it, and the resume must leave it alone. Then the
+  // same build with a body that would fail proves the skip is what spared it.
+  const calls: string[] = [];
+
+  class Cd extends Build {
+    publish = target().effect("announce", () => {
+      calls.push("announce");
+    });
+    hold = target().dependsOn(this.publish).waitsFor((s) =>
+      s.on(externalSignal("go"))
+    );
+    done = target().dependsOn(this.hold).executes(() => {});
+  }
+
+  await withStateDir(async (dir) => {
+    const first = await runCli(Cd, ["done"]);
+    assertEquals(first.code, 0); // suspended at the wait
+    assertEquals(calls, ["announce"]);
+    const id = await onlyRunId(dir);
+    assertEquals(
+      (await effectRow(dir, id, "publish", "announce"))?.status,
+      "done",
+    );
+
+    const resumed = await runCli(Cd, ["resume", id, "--signal", "go"]);
+    assertEquals(resumed.code, 0);
+    // Not driven a second time: the target succeeded, so the resume never
+    // re-runs it — and even if it did, the `done` row would skip the effect.
+    assertEquals(calls, ["announce"]);
+    assertEquals(
+      (await effectRow(dir, id, "publish", "announce"))?.attempts,
+      1,
+    );
+  });
+});
+
+Deno.test("an effect left pending by a dead process is re-driven, and told so", async () => {
+  // What a killed process leaves: a `pending` row with no settlement. Written
+  // directly, because the point is what a *later* process does with it.
+  const drives: boolean[] = [];
+
+  class Cd extends Build {
+    publish = target().effect("announce", (ctx) => {
+      drives.push(ctx.redriven);
+    });
+    hold = target().dependsOn(this.publish).waitsFor((s) =>
+      s.on(externalSignal("go"))
+    );
+    done = target().dependsOn(this.hold).executes(() => {});
+  }
+
+  await withStateDir(async (dir) => {
+    await runCli(Cd, ["done"]);
+    const id = await onlyRunId(dir);
+    assertEquals(drives, [false]); // first drive, not a re-drive
+
+    // Rewind the record to what a kill mid-effect leaves behind: the target
+    // never settled, and its effect is still owed.
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    const got = await store.getRun(id);
+    if (got === null) throw new Error("the run vanished");
+    const record = structuredClone(got.record);
+    record.targets["publish"] = {
+      status: "running",
+      meta: {},
+      effects: {
+        announce: {
+          status: "pending",
+          intentAt: "2026-08-10T10:00:00.000Z",
+          attempts: 1,
+        },
+      },
+    };
+    const put = await store.putRun(record, got.version);
+    assertEquals(put.ok, true);
+
+    const resumed = await runCli(Cd, ["resume", id, "--signal", "go"]);
+    assertEquals(resumed.code, 0);
+    // Driven again, and the body is told a previous attempt already committed.
+    assertEquals(drives, [false, true]);
+    const row = await effectRow(dir, id, "publish", "announce");
+    assertEquals(row?.status, "done");
+    assertEquals(row?.attempts, 2);
+    // The obligation keeps its original timestamp across the re-drive.
+    assertEquals(row?.intentAt, "2026-08-10T10:00:00.000Z");
+  });
+});
+
+Deno.test("a re-driven effect sees the parameter the run started with", async () => {
+  // The rule effects live or die by: inputs are pinned when the run starts. If
+  // a re-drive could see a newer value, a gate re-driven after a fresh push
+  // would report on a commit whose checks never ran.
+  const seen: Array<string | undefined> = [];
+
+  class Cd extends Build {
+    sha = parameter("The commit under test").required();
+    publish = target().requires(this.sha).effect("announce", () => {
+      seen.push(this.sha.value);
+    });
+    hold = target().dependsOn(this.publish).waitsFor((s) =>
+      s.on(externalSignal("go"))
+    );
+    done = target().dependsOn(this.hold).executes(() => {});
+  }
+
+  await withStateDir(async (dir) => {
+    const first = await runCli(Cd, ["done", "--sha", "aaaa1111"]);
+    assertEquals(first.code, 0);
+    assertEquals(seen, ["aaaa1111"]);
+    const id = await onlyRunId(dir);
+
+    // Put the effect back to owed, as a kill mid-effect would.
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    const got = await store.getRun(id);
+    if (got === null) throw new Error("the run vanished");
+    const record = structuredClone(got.record);
+    record.targets["publish"] = {
+      status: "running",
+      meta: {},
+      effects: {
+        announce: {
+          status: "pending",
+          intentAt: "2026-08-10T10:00:00.000Z",
+          attempts: 1,
+        },
+      },
+    };
+    assertEquals((await store.putRun(record, got.version)).ok, true);
+
+    // The resume does not re-supply the parameter — which is what a sweep or a
+    // cron does. The recorded value is what the re-drive acts on.
+    const resumed = await runCli(Cd, ["resume", id, "--signal", "go"]);
+    assertEquals(resumed.code, 0);
+    assertEquals(seen, ["aaaa1111", "aaaa1111"]);
+  });
+});
+
+Deno.test("a resume that re-supplies a parameter overrides the recorded value", async () => {
+  // The other half, and it is deliberate rather than a gap: the record seeds a
+  // resume so nothing has to be repeated, and an explicit value still wins —
+  // which is the only way to re-supply a secret, since secrets are kept out of
+  // the record.
+  //
+  // The consequence for effects is worth being plain about: a value that must
+  // not drift across a re-drive belongs in `ctx.state`, written by an earlier
+  // target, not in a parameter a resumer might pass differently.
+  const seen: Array<string | undefined> = [];
+
+  class Cd extends Build {
+    sha = parameter("The commit under test").required();
+    publish = target().requires(this.sha).effect("announce", () => {
+      seen.push(this.sha.value);
+    });
+    hold = target().dependsOn(this.publish).waitsFor((s) =>
+      s.on(externalSignal("go"))
+    );
+    done = target().dependsOn(this.hold).executes(() => {});
+  }
+
+  await withStateDir(async (dir) => {
+    await runCli(Cd, ["done", "--sha", "aaaa1111"]);
+    const id = await onlyRunId(dir);
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    const got = await store.getRun(id);
+    if (got === null) throw new Error("the run vanished");
+    const record = structuredClone(got.record);
+    record.targets["publish"] = {
+      status: "running",
+      meta: {},
+      effects: {
+        announce: {
+          status: "pending",
+          intentAt: "2026-08-10T10:00:00.000Z",
+          attempts: 1,
+        },
+      },
+    };
+    assertEquals((await store.putRun(record, got.version)).ok, true);
+
+    await runCli(Cd, ["resume", id, "--signal", "go", "--sha", "bbbb2222"]);
+    assertEquals(seen, ["aaaa1111", "bbbb2222"]);
+  });
+});
+
+Deno.test("state written before an effect is stable across its re-drive", async () => {
+  // The pinning that always holds, and so the one an effect should rely on:
+  // durable target state is replayed from the record and cannot be overridden
+  // from a command line.
+  const seen: string[] = [];
+
+  class Cd extends Build {
+    pin = target().executes((ctx) => ctx.state.set({ sha: "aaaa1111" }));
+    publish = target().dependsOn(this.pin).effect("announce", (ctx) => {
+      const sha = ctx.stateOf("pin").get()["sha"];
+      seen.push(typeof sha === "string" ? sha : "missing");
+    });
+    hold = target().dependsOn(this.publish).waitsFor((s) =>
+      s.on(externalSignal("go"))
+    );
+    done = target().dependsOn(this.hold).executes(() => {});
+  }
+
+  await withStateDir(async (dir) => {
+    await runCli(Cd, ["done"]);
+    const id = await onlyRunId(dir);
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    const got = await store.getRun(id);
+    if (got === null) throw new Error("the run vanished");
+    const record = structuredClone(got.record);
+    record.targets["publish"] = {
+      status: "running",
+      meta: {},
+      effects: {
+        announce: {
+          status: "pending",
+          intentAt: "2026-08-10T10:00:00.000Z",
+          attempts: 1,
+        },
+      },
+    };
+    assertEquals((await store.putRun(record, got.version)).ok, true);
+
+    await runCli(Cd, ["resume", id, "--signal", "go"]);
+    assertEquals(seen, ["aaaa1111", "aaaa1111"]);
+  });
+});


### PR DESCRIPTION
## Why

A target body that dies halfway leaves no trace of what it was doing. There was no way to express work where that matters — posting a required status check, publishing a release, telling another system something finished. A process killed mid-post left a run nothing would pick up, and nothing that could say the post was owed.

This is R1 of the durable merge-gate work.

## What it does

`.effect(name, fn)` on a target. The intent to run it is written to the run record and confirmed **before** the body runs, so a process killed anywhere inside the effect leaves a `pending` row, and a resume drives it again. An effect already recorded `done` is skipped rather than repeated. A store is required and enabled automatically; with state explicitly disabled the run is refused rather than performing an effect nothing recorded as owed.

**At-least-once, not exactly-once.** A process that dies after the side effect but before recording it repeats the effect. That is the honest cost of never losing one, and it is what the requester asked for.

Two details worth review attention:

The effect writes are **strict**, unlike every other write on the writer: each throws rather than dropping, because a caller that cannot record its intent must not perform the effect. They also **refuse to write to a run that is not `running`**, rechecked after every conflicting re-read — without that, a process still alive on a run another process already settled would arm its effect and publish a result over the settled one, which for a merge gate is a green check over a red.

A strict failure is kept **off the writer's shared chain**. Every write serialises through it, so leaving a rejection there would make each later best-effort write reject too, and one failed intent would take the run's whole bookkeeping down with it.

## Third commit: the adversarial pass, which found a critical defect

Effects were driven from one place in the target lifecycle, and four other paths reach a target's real execution and return before it. A cache hit, a satisfied wait gate, a service, and a fan-out each skipped the effects **and the run reported success with nothing recorded as owed** — so the effect had not been deferred, it had never existed. Silent, and green.

Fixed: a target declaring an effect is no longer cacheable; a satisfied gate drives its effects before returning; a service and a fan-out refuse the declaration outright, following the wait gate's existing precedent. A condition that skips the target still skips its effects, which is the one case where not running is correct.

Also from that pass: two effects under one name were silently one effect, now refused at declaration; a refused intent no longer leaves its mutation on the live record for a later write to persist; giving up after repeated conflicts now marks the record `degraded` like every other permanent loss; a settlement no longer overwrites an effect another process completed; and a failing settle write no longer replaces the effect's real error with a message about bookkeeping.

The docs claimed a killed process's effect is re-driven by a resume. A resume acts on a `suspended` run and a killed process leaves its run `running`, so that claim needed its precondition stated — the intent is durable either way, but something has to move the run back first. That something is the reaper, in a later PR.

## One correction to carry forward

A test written to prove that effect inputs are pinned across a re-drive **failed**, which is how this surfaced: `resumeRun` merges the recorded parameters with any freshly supplied ones, and fresh wins. That is deliberate — it is the only way to re-supply a secret, since secrets are kept out of the record — but it means a parameter is pinned only if nobody re-supplies it. The docs now say that, and three tests cover it, including one that demonstrates the override. A value that must not drift belongs in `ctx.state`.

## Tests

- **Unit, 14:** every silent path the best-effort writer forgives (vanished record, retries exhausted, store error), the run-status guard against all four settled statuses, the guard after a conflicting re-read, chain isolation, the no-phantom-intent and no-overwrite-`done` rules, the degraded marking, and a record claiming zero attempts being refused.
- **Integration, 13:** the intent read from the store *inside* the effect body, auto-enabled state, a failed effect recorded, re-drive versus skip, `redriven` reporting, all three parameter/state pinning cases, and one regression per confirmed finding.
- **E2E, 1:** a real subprocess `SIGKILL`ed inside its effect, the record read from the parent showing the effect still owed, and a genuinely separate `resume` driving it again — marker file showing exactly two drives, `intentAt` preserved across the process boundary. One seam is stood in for and labelled: moving an abandoned `running` run back to `suspended` is the reaper's job.

Full gate green locally, 18 of 18 targets, plus the e2e suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)