### PR TITLE
feat(core): give a run a lease, so slow and dead stop looking alike

### DIFF
--- a/docs/locks.md
+++ b/docs/locks.md
@@ -110,5 +110,10 @@ holder is gone and the run can be taken over.
   not fire while the event loop is blocked in synchronous work. A run that blocks for longer than the TTL can therefore have
   its lease lapse and be taken over; losing the claim then stops it, so the
   outcome is a stopped run rather than two writers.
+- **Whoever takes the claim gives it back.** A resume releases the lease it took
+  on every path out, including one where the run fails — a claim held by nobody
+  would make a run that has demonstrably stopped look like one still being
+  worked on. A run that took its own lease releases it when it settles; if that
+  process breaks first, the claim lapses at its TTL instead.
 - **A crashed holder's claim lapses at the TTL.** Nothing polls for it: expiry is
   evaluated by the store the next time somebody tries to acquire.

--- a/docs/locks.md
+++ b/docs/locks.md
@@ -76,3 +76,39 @@ Acquisition is atomic. Two runs racing for the same free key → **exactly one**
 acquires; the other gets the conflict. An expired lock is taken over atomically.
 The filesystem backend is single-host (an `O_EXCL` marker serialises
 acquisition); the HTTP backend uses the same optimistic model across hosts.
+
+## The run's own lease
+
+Separately from any lock a target declares, a run with a
+[state store](./state.md) holds a **lease** on itself for as long as it is
+running: `zuke-run-<run-id>`, taken before the record is written `running` and
+released when the run settles. It is renewed by a background heartbeat at half
+its 60-second TTL.
+
+Its whole job is to make "slow" and "dead" different things. A run record cannot
+tell them apart on its own — a process mid-step and a process that was
+`SIGKILL`ed both leave a record that says `running` and stops changing. The lease
+answers it: a live holder keeps renewing, so a claim that has lapsed means the
+holder is gone and the run can be taken over.
+
+- **Ordering matters.** The lease is taken *before* the record says `running`,
+  and on a resume before the record leaves `suspended` — so a `running` record
+  always has a live holder. Acquiring afterwards would leave a window in which a
+  perfectly healthy run looked abandoned.
+- **A resume refuses a run whose holder has not let go.** Two processes working
+  one run is worse than a delayed resume, so the claim is checked before the
+  compare-and-swap and a resumer that cannot take it stops.
+- **Losing it stops the run.** If a renewal is refused — the claim is
+  demonstrably somebody else's now — the run aborts rather than carrying on
+  beside whoever took it over.
+- **A refused renewal is loss; a failed one is not.** A store answers "no" when
+  the claim has changed hands, but it *throws* for a filesystem mutex it could
+  not take in time, or an HTTP 503, or a DNS blip. None of those say who holds
+  the lease, so they are retried on the next tick rather than aborting a healthy
+  build over a bad second.
+- **The heartbeat never keeps a process alive** — and, like any timer, it does
+  not fire while the event loop is blocked in synchronous work. A run that blocks for longer than the TTL can therefore have
+  its lease lapse and be taken over; losing the claim then stops it, so the
+  outcome is a stopped run rather than two writers.
+- **A crashed holder's claim lapses at the TTL.** Nothing polls for it: expiry is
+  evaluated by the store the next time somebody tries to acquire.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -52,6 +52,21 @@ function absolutePath(first: string, ...rest: string[]): AbsolutePath
   @param rest
       Additional segments to append.
 
+async function acquireLease(store: StateStore, prefix: string, runId: string, actor: string, now: () => string, ttlMs: number, runUrl?: string): Promise<HeldLease | null>
+  Take a lease named `prefix` over `runId`, or `null` if a live holder has it.
+
+  While held, the lease renews on a background heartbeat until
+  {@link HeldLease.release}. That timer never keeps the process alive.
+
+  Only an explicit refusal counts as loss. A store reports `false` from a
+  renewal when the claim is demonstrably somebody else's; it throws for a
+  filesystem mutex it could not take in time, or an HTTP 503, or a DNS blip —
+  none of which say anything about who holds the lease. Treating those as loss
+  would abort a healthy build because the state service had a bad second, so
+  they are swallowed and the next tick tries again. A store that stays
+  unreachable lets the claim lapse at its TTL, which is the documented backstop
+  and the honest outcome.
+
 function affectedTargets(order: readonly TargetBuilder[], changed: readonly string[]): Set<TargetBuilder>
   Compute the set of targets in `order` affected by the given `changed` files.
 
@@ -645,6 +660,22 @@ const HARDEN_RUNNER_ACTION: "step-security/harden-runner"
 
 const REDACTED: "[redacted]"
   The placeholder a {@link Redactor} substitutes for each secret value.
+
+const RUN_LEASE_PREFIX: "zuke-run"
+  The lease name a run's own claim is taken under.
+
+  Named once because two places have to agree on it exactly: the process
+  claiming a run, and any sweep deciding whether that run still has an owner.
+
+const RUN_LEASE_TTL_MS: 60000
+  How long a lease lives before a crashed holder's claim lapses.
+
+  The holder renews at half this interval, so a live process keeps its claim
+  indefinitely while a dead one becomes reclaimable within the TTL. Sixty
+  seconds trades promptness for tolerance: long enough that an ordinary pause —
+  a slow step, a busy host, a paused container — does not look like death, short
+  enough that a genuinely dead run is picked up on the next sweep rather than
+  hours later.
 
 const ToolTasks: ToolTasksApi
   Provision external CLIs from a build. `ToolTasks.install((s) => …)` fetches a
@@ -2796,6 +2827,19 @@ interface GlobOptions
   cwd?: string
     Directory to resolve the pattern against (default: `Deno.cwd()`).
 
+interface HeldLease
+  A held lease. Release it when the work it covers is over.
+
+  readonly lost: AbortSignal
+    Aborts if the lease is lost — the store reports the claim is no longer this
+    holder's, which means something else has taken the work over.
+
+    A signal rather than a callback because a holder is not always ready to
+    receive one at the moment it acquires: a resume takes the lease before the
+    run it will drive exists. A signal can be read late and still be true.
+  release(): Promise<void>
+    Stop the heartbeat and release the claim (best-effort).
+
 interface HttpBuildRegistryOptions
   Configuration for an {@link HttpBuildRegistry}.
 
@@ -3204,6 +3248,12 @@ interface ResumeState
     Its current store version, for the writer to continue from.
   done: ReadonlySet<string>
     Names of targets recorded `succeeded` — seeded as done, never re-run.
+  lease?: HeldLease
+    The lease the resumer took before moving the record out of `suspended`.
+
+    Held by the resumer rather than acquired here, because the record must never
+    read `running` in the store without its lease already held — that pairing is
+    what tells a sweep the difference between a live run and an abandoned one.
 
 interface ResumeWhenOptions
   Options for {@link resumeWhen}.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -106,6 +106,21 @@ function absolutePath(first: string, ...rest: string[]): AbsolutePath
   @param rest
       Additional segments to append.
 
+async function acquireLease(store: StateStore, prefix: string, runId: string, actor: string, now: () => string, ttlMs: number, runUrl?: string): Promise<HeldLease | null>
+  Take a lease named `prefix` over `runId`, or `null` if a live holder has it.
+
+  While held, the lease renews on a background heartbeat until
+  {@link HeldLease.release}. That timer never keeps the process alive.
+
+  Only an explicit refusal counts as loss. A store reports `false` from a
+  renewal when the claim is demonstrably somebody else's; it throws for a
+  filesystem mutex it could not take in time, or an HTTP 503, or a DNS blip —
+  none of which say anything about who holds the lease. Treating those as loss
+  would abort a healthy build because the state service had a bad second, so
+  they are swallowed and the next tick tries again. A store that stays
+  unreachable lets the claim lapse at its TTL, which is the documented backstop
+  and the honest outcome.
+
 function affectedTargets(order: readonly TargetBuilder[], changed: readonly string[]): Set<TargetBuilder>
   Compute the set of targets in `order` affected by the given `changed` files.
 
@@ -699,6 +714,22 @@ const HARDEN_RUNNER_ACTION: "step-security/harden-runner"
 
 const REDACTED: "[redacted]"
   The placeholder a {@link Redactor} substitutes for each secret value.
+
+const RUN_LEASE_PREFIX: "zuke-run"
+  The lease name a run's own claim is taken under.
+
+  Named once because two places have to agree on it exactly: the process
+  claiming a run, and any sweep deciding whether that run still has an owner.
+
+const RUN_LEASE_TTL_MS: 60000
+  How long a lease lives before a crashed holder's claim lapses.
+
+  The holder renews at half this interval, so a live process keeps its claim
+  indefinitely while a dead one becomes reclaimable within the TTL. Sixty
+  seconds trades promptness for tolerance: long enough that an ordinary pause —
+  a slow step, a busy host, a paused container — does not look like death, short
+  enough that a genuinely dead run is picked up on the next sweep rather than
+  hours later.
 
 const ToolTasks: ToolTasksApi
   Provision external CLIs from a build. `ToolTasks.install((s) => …)` fetches a
@@ -2850,6 +2881,19 @@ interface GlobOptions
   cwd?: string
     Directory to resolve the pattern against (default: `Deno.cwd()`).
 
+interface HeldLease
+  A held lease. Release it when the work it covers is over.
+
+  readonly lost: AbortSignal
+    Aborts if the lease is lost — the store reports the claim is no longer this
+    holder's, which means something else has taken the work over.
+
+    A signal rather than a callback because a holder is not always ready to
+    receive one at the moment it acquires: a resume takes the lease before the
+    run it will drive exists. A signal can be read late and still be true.
+  release(): Promise<void>
+    Stop the heartbeat and release the claim (best-effort).
+
 interface HttpBuildRegistryOptions
   Configuration for an {@link HttpBuildRegistry}.
 
@@ -3258,6 +3302,12 @@ interface ResumeState
     Its current store version, for the writer to continue from.
   done: ReadonlySet<string>
     Names of targets recorded `succeeded` — seeded as done, never re-run.
+  lease?: HeldLease
+    The lease the resumer took before moving the record out of `suspended`.
+
+    Held by the resumer rather than acquired here, because the record must never
+    read `running` in the store without its lease already held — that pairing is
+    what tells a sweep the difference between a live run and an abandoned one.
 
 interface ResumeWhenOptions
   Options for {@link resumeWhen}.

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -142,6 +142,12 @@ export {
   type LockHolder,
   lockKey,
 } from "./src/state/lock.ts";
+export {
+  acquireLease,
+  type HeldLease,
+  RUN_LEASE_PREFIX,
+  RUN_LEASE_TTL_MS,
+} from "./src/state/run_lease.ts";
 export { parseDuration } from "./src/duration.ts";
 export {
   type EffectState,

--- a/packages/core/src/execute_state.ts
+++ b/packages/core/src/execute_state.ts
@@ -23,6 +23,11 @@ import { defaultStateHost, type StateStore } from "./state/store.ts";
 import { resolveStateStore } from "./state/resolve.ts";
 import { buildRunRecord, ciRunUrl, resolveActor } from "./state/record.ts";
 import { RunStateWriter } from "./state/writer.ts";
+import {
+  acquireLease,
+  type HeldLease,
+  RUN_LEASE_PREFIX,
+} from "./state/run_lease.ts";
 import type { RunRecord, SignalRecord, WaitState } from "./state/types.ts";
 import type { ResumeState } from "./executor.ts";
 
@@ -62,12 +67,18 @@ function priorStatusesOf(
   return statuses;
 }
 
-/** Durable-state plumbing for one run: the writer and the RunEnv. */
+/** Durable-state plumbing for one run: the writer, the RunEnv, and the lease. */
 export interface RunState {
   /** The writer recording transitions, or `undefined` without a store. */
   writer?: RunStateWriter;
   /** The environment handed to the scheduler. */
   env: RunEnv;
+  /**
+   * The run's lease, when one was taken here — a fresh run's. A resumed run
+   * arrives holding the lease its resumer took before the record was moved to
+   * `running`, and that one stays the resumer's to release.
+   */
+  lease?: HeldLease;
 }
 
 /**
@@ -157,6 +168,38 @@ export async function openRunState(opts: {
   const actor = resolveActor(opts.actor, readEnv);
   const runUrl = ciRunUrl(readEnv);
   const warn = (message: string) => opts.reporter.info(message);
+  // Take the run's lease *before* the writer, because opening the writer
+  // persists the record as `running` — and "a `running` record whose lease is
+  // free" is exactly what a reaping sweep reads as an owner that died. Acquiring
+  // afterwards would leave a window where a healthy run looks abandoned.
+  //
+  // A resumed run already holds one: its resumer took the lease before moving
+  // the record out of `suspended`, for the same reason.
+  let lease: HeldLease | undefined;
+  if (stateStore !== undefined && resume === undefined) {
+    const held = await acquireLease(
+      stateStore,
+      RUN_LEASE_PREFIX,
+      opts.runId,
+      actor,
+      nowIso,
+      undefined,
+      runUrl,
+    );
+    if (held === null) {
+      // A fresh run's id is newly minted, so a live holder means the id was
+      // reused — worth refusing rather than running two processes under one
+      // record.
+      return {
+        ok: false,
+        error: new Error(
+          `Run "${opts.runId}" is already held by another process. A fresh ` +
+            `run's id is newly minted, so this means the id was reused.`,
+        ),
+      };
+    }
+    lease = held;
+  }
   const writer = stateStore === undefined ? undefined : resume !== undefined
     // A resume continues the existing record (already transitioned to running).
     ? RunStateWriter.adopt(
@@ -198,5 +241,8 @@ export async function openRunState(opts: {
     done: resume?.done,
     priorWaits: resume ? priorWaitsOf(resume.record) : undefined,
   };
-  return { ok: true, state: { writer, env } };
+  return {
+    ok: true,
+    state: { writer, env, ...(lease === undefined ? {} : { lease }) },
+  };
 }

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -386,10 +386,16 @@ export async function execute(
   const { writer, env } = opened.state;
   const actor = env.actor;
   // The run's lease: this process's claim that it is the one working on this
-  // run. A fresh run's was taken in openRunState; a resumed run arrives holding
-  // the one its resumer took. Losing it means another process has taken the run
-  // over, so this one stops rather than carrying on in parallel with it.
-  const lease = opened.state.lease ?? options.resume?.lease;
+  // run. Losing it means another process has taken the run over, so this one
+  // stops rather than carrying on in parallel with it — whoever holds the claim
+  // owns the outcome.
+  //
+  // Watched either way, released only if this call took it. A resumed run
+  // arrives holding its resumer's lease, and that resumer outlives this call, so
+  // it is the one that can guarantee the release — including when this call
+  // throws before it could reach one.
+  const ownLease = opened.state.lease;
+  const lease = ownLease ?? options.resume?.lease;
   if (lease !== undefined) {
     if (lease.lost.aborted) runController.abort();
     else lease.lost.addEventListener("abort", onCancel, { once: true });
@@ -505,10 +511,10 @@ export async function execute(
     else await writer?.markRunFinished(result.ok);
     // Released once the record is terminal (or suspended), so the moment this
     // run stops being ours to work on is the moment the claim goes. Any earlier
-    // throw leaves the lease to lapse at its TTL, which is correct: the record
-    // is still `running` and the process really is broken, so a sweep should
-    // find it — just a minute later.
-    await lease?.release();
+    // throw leaves this call's own lease to lapse at its TTL, which is correct:
+    // the record is still `running` and the process really is broken, so a sweep
+    // should find it — just a minute later.
+    await ownLease?.release();
   }
 
   // Announce the run's terminal durable state (succeeded/failed/suspended/

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -34,6 +34,7 @@ import {
   resolveRunParameters,
 } from "./execute_plan.ts";
 import { openRunState } from "./execute_state.ts";
+import type { HeldLease } from "./state/run_lease.ts";
 import { settleCancelledRun } from "./execute_cancel.ts";
 import { makeLifecycle } from "./lifecycle.ts";
 import type { RunOutcome } from "./run_support.ts";
@@ -207,6 +208,14 @@ export interface ResumeState {
   version: string;
   /** Names of targets recorded `succeeded` — seeded as done, never re-run. */
   done: ReadonlySet<string>;
+  /**
+   * The lease the resumer took before moving the record out of `suspended`.
+   *
+   * Held by the resumer rather than acquired here, because the record must never
+   * read `running` in the store without its lease already held — that pairing is
+   * what tells a sweep the difference between a live run and an abandoned one.
+   */
+  lease?: HeldLease;
 }
 
 /**
@@ -376,6 +385,15 @@ export async function execute(
   }
   const { writer, env } = opened.state;
   const actor = env.actor;
+  // The run's lease: this process's claim that it is the one working on this
+  // run. A fresh run's was taken in openRunState; a resumed run arrives holding
+  // the one its resumer took. Losing it means another process has taken the run
+  // over, so this one stops rather than carrying on in parallel with it.
+  const lease = opened.state.lease ?? options.resume?.lease;
+  if (lease !== undefined) {
+    if (lease.lost.aborted) runController.abort();
+    else lease.lost.addEventListener("abort", onCancel, { once: true });
+  }
 
   // Announce the run's initial durable state (`running`) to plugins — a no-op
   // without a store. Terminal transitions are announced once the plan settles.
@@ -485,6 +503,12 @@ export async function execute(
     // so every per-target transition has landed by the time the run returns.
     if (run.suspended) await writer?.markRunSuspended();
     else await writer?.markRunFinished(result.ok);
+    // Released once the record is terminal (or suspended), so the moment this
+    // run stops being ours to work on is the moment the claim goes. Any earlier
+    // throw leaves the lease to lapse at its TTL, which is correct: the record
+    // is still `running` and the process really is broken, so a sweep should
+    // find it — just a minute later.
+    await lease?.release();
   }
 
   // Announce the run's terminal durable state (succeeded/failed/suspended/

--- a/packages/core/src/resume.ts
+++ b/packages/core/src/resume.ts
@@ -224,16 +224,24 @@ export async function resumeRun(
       .map(([name]) => name),
   );
 
-  return await execute(build, root, {
-    stateStore: store,
-    params: { ...record.params, ...(options.params ?? {}) },
-    readEnv,
-    actor: resumerActor,
-    silent: options.silent,
-    reporter: options.reporter,
-    plugins: options.plugins,
-    resume: { record, version, done, lease },
-  });
+  // This scope took the lease, so this scope gives it back — on every path out,
+  // including one where `execute` throws before it could settle the run. The
+  // alternative is a claim held by nobody until its TTL lapses, which would make
+  // a run that has demonstrably stopped look like one still being worked on.
+  try {
+    return await execute(build, root, {
+      stateStore: store,
+      params: { ...record.params, ...(options.params ?? {}) },
+      readEnv,
+      actor: resumerActor,
+      silent: options.silent,
+      reporter: options.reporter,
+      plugins: options.plugins,
+      resume: { record, version, done, lease },
+    });
+  } finally {
+    await lease.release();
+  }
 }
 
 /** Resolve the store for a resume — like a normal run, but always defaulting on. */

--- a/packages/core/src/resume.ts
+++ b/packages/core/src/resume.ts
@@ -22,6 +22,7 @@ import { cancelRun } from "./cancel.ts";
 import { execute, type Reporter } from "./executor.ts";
 import type { Plugin } from "./plugin.ts";
 import { planGraph } from "./graph.ts";
+import { acquireLease, RUN_LEASE_PREFIX } from "./state/run_lease.ts";
 import type { JsonValue, TargetBuilder } from "./target.ts";
 import { absolutePath } from "./path.ts";
 import { findConfigDir, pathExists } from "./config.ts";
@@ -171,16 +172,47 @@ export async function resumeRun(
     throw degradedRecordError(options.runId);
   }
 
-  // Transition suspended → running (exactly one resumer wins).
-  const { record, version } = await transitionToRunning(
+  // Take the run's lease before moving it out of `suspended`, so the record is
+  // never `running` in the store without a live holder — the pairing a reaping
+  // sweep reads to tell an abandoned run from a working one. A resumer that
+  // cannot get the lease is not the owner: another process is already driving
+  // this run, which is the same answer `AlreadyResumedError` gives, from the
+  // other side of the same race.
+  const lease = await acquireLease(
     store,
+    RUN_LEASE_PREFIX,
     options.runId,
-    initial,
     resumerActor,
     now,
-    options.signal,
-    options.data ?? {},
   );
+  if (lease === null) {
+    throw new AlreadyResumedError(
+      options.runId,
+      initial.record.actor,
+      initial.record.updatedAt,
+    );
+  }
+
+  // Transition suspended → running (exactly one resumer wins).
+  let record: RunRecord;
+  let version: string;
+  try {
+    ({ record, version } = await transitionToRunning(
+      store,
+      options.runId,
+      initial,
+      resumerActor,
+      now,
+      options.signal,
+      options.data ?? {},
+    ));
+  } catch (error) {
+    // Losing the compare-and-swap means this process never owned the run, so it
+    // must not keep a claim on it — otherwise the winner's own lease attempt, or
+    // a later sweep, would see a holder that is doing nothing.
+    await lease.release();
+    throw error;
+  }
 
   // Targets recorded `succeeded` do not re-run; everything else does. On a
   // degraded record (only reachable with the override) that is exactly the risk
@@ -200,7 +232,7 @@ export async function resumeRun(
     silent: options.silent,
     reporter: options.reporter,
     plugins: options.plugins,
-    resume: { record, version, done },
+    resume: { record, version, done, lease },
   });
 }
 

--- a/packages/core/src/state/cancel_lock.ts
+++ b/packages/core/src/state/cancel_lock.ts
@@ -10,7 +10,7 @@
  * @module
  */
 
-import { lockKey } from "./lock.ts";
+import { acquireLease } from "./run_lease.ts";
 import type { StateStore } from "./store.ts";
 
 /**
@@ -33,6 +33,13 @@ export interface CancelLock {
  * background, unref'd heartbeat until {@link CancelLock.release}. `ttlMs`
  * defaults to {@link CANCEL_LOCK_TTL_MS}; a shorter value is for tests that need
  * the heartbeat to fire quickly.
+ *
+ * A thin naming of {@link "./run_lease.ts".acquireLease}: a cancel lock is one
+ * lease over a run, and the mechanics — the TTL, the half-TTL heartbeat, the
+ * best-effort release — belong to leases in general rather than to cancellation.
+ * The narrower return type is deliberate: a compensation walk has no use for the
+ * lease's loss signal, since the recovery path a lapsed cancel lock enables is
+ * driven by the *next* canceller, not by this one noticing.
  */
 export async function acquireCancelLock(
   store: StateStore,
@@ -41,29 +48,13 @@ export async function acquireCancelLock(
   now: () => string,
   ttlMs: number = CANCEL_LOCK_TTL_MS,
 ): Promise<CancelLock | null> {
-  const key = lockKey("zuke-cancel", runId);
-  const result = await store.acquireLock(
-    key,
-    { actor, runId, since: now() },
+  const lease = await acquireLease(
+    store,
+    "zuke-cancel",
+    runId,
+    actor,
+    now,
     ttlMs,
   );
-  if (!result.ok) return null;
-  const token = result.token;
-  // Renew at half the TTL so a long compensation walk keeps its lock. The timer
-  // is unref'd so it never keeps the process alive, and renewal is best-effort:
-  // a dropped renew just lets the lock lapse at its TTL (the documented
-  // backstop) rather than crashing on an unhandled rejection from a background
-  // timer.
-  const heartbeat = setInterval(() => {
-    store.renewLock(key, token, ttlMs).catch(() => {});
-  }, Math.max(1000, Math.floor(ttlMs / 2)));
-  Deno.unrefTimer(heartbeat);
-  return {
-    release: async () => {
-      clearInterval(heartbeat);
-      // Best-effort release for the same reason: a failed release must not turn
-      // a completed cancellation into a failure. The TTL reclaims the lock.
-      await store.releaseLock(key, token).catch(() => {});
-    },
-  };
+  return lease === null ? null : { release: () => lease.release() };
 }

--- a/packages/core/src/state/run_lease.ts
+++ b/packages/core/src/state/run_lease.ts
@@ -1,0 +1,123 @@
+/**
+ * Leases over a run: a TTL'd claim, renewed by a heartbeat, that says a live
+ * process is working on it.
+ *
+ * The point is to make "slow" and "dead" different things. A run record on its
+ * own cannot tell them apart — a process that is mid-step and one that was
+ * SIGKILLed both leave a record that says `running` and stops changing. A lease
+ * settles it: a live holder keeps renewing, so a claim that has lapsed means the
+ * holder is gone and its work can be taken over. Nothing here polls or sweeps;
+ * expiry is evaluated by the store when somebody next tries to acquire.
+ *
+ * Generalised from the cancellation lock, which is one instance of the same
+ * shape (see `./cancel_lock.ts`).
+ *
+ * @module
+ */
+
+import { lockKey } from "./lock.ts";
+import type { StateStore } from "./store.ts";
+
+/**
+ * How long a lease lives before a crashed holder's claim lapses.
+ *
+ * The holder renews at half this interval, so a live process keeps its claim
+ * indefinitely while a dead one becomes reclaimable within the TTL. Sixty
+ * seconds trades promptness for tolerance: long enough that an ordinary pause —
+ * a slow step, a busy host, a paused container — does not look like death, short
+ * enough that a genuinely dead run is picked up on the next sweep rather than
+ * hours later.
+ */
+export const RUN_LEASE_TTL_MS = 60_000;
+
+/**
+ * The lease name a run's own claim is taken under.
+ *
+ * Named once because two places have to agree on it exactly: the process
+ * claiming a run, and any sweep deciding whether that run still has an owner.
+ */
+export const RUN_LEASE_PREFIX = "zuke-run";
+
+/** A held lease. Release it when the work it covers is over. */
+export interface HeldLease {
+  /**
+   * Aborts if the lease is lost — the store reports the claim is no longer this
+   * holder's, which means something else has taken the work over.
+   *
+   * A signal rather than a callback because a holder is not always ready to
+   * receive one at the moment it acquires: a resume takes the lease before the
+   * run it will drive exists. A signal can be read late and still be true.
+   */
+  readonly lost: AbortSignal;
+  /** Stop the heartbeat and release the claim (best-effort). */
+  release(): Promise<void>;
+}
+
+/**
+ * Take a lease named `prefix` over `runId`, or `null` if a live holder has it.
+ *
+ * While held, the lease renews on a background heartbeat until
+ * {@link HeldLease.release}. That timer never keeps the process alive.
+ *
+ * **Only an explicit refusal counts as loss.** A store reports `false` from a
+ * renewal when the claim is demonstrably somebody else's; it *throws* for a
+ * filesystem mutex it could not take in time, or an HTTP 503, or a DNS blip —
+ * none of which say anything about who holds the lease. Treating those as loss
+ * would abort a healthy build because the state service had a bad second, so
+ * they are swallowed and the next tick tries again. A store that stays
+ * unreachable lets the claim lapse at its TTL, which is the documented backstop
+ * and the honest outcome.
+ */
+export async function acquireLease(
+  store: StateStore,
+  prefix: string,
+  runId: string,
+  actor: string,
+  now: () => string,
+  ttlMs: number = RUN_LEASE_TTL_MS,
+  runUrl?: string,
+): Promise<HeldLease | null> {
+  const key = lockKey(prefix, runId);
+  const result = await store.acquireLock(
+    key,
+    { actor, runId, since: now(), ...(runUrl === undefined ? {} : { runUrl }) },
+    ttlMs,
+  );
+  if (!result.ok) return null;
+  const token = result.token;
+  const controller = new AbortController();
+  const heartbeat = setInterval(() => {
+    void renew();
+  }, Math.max(1000, Math.floor(ttlMs / 2)));
+  // Never keep the process alive for a heartbeat; the work decides when the run
+  // ends, not the bookkeeping.
+  Deno.unrefTimer(heartbeat);
+
+  /** One renewal: report loss, ignore anything that is merely a bad moment. */
+  async function renew(): Promise<void> {
+    let held: boolean;
+    try {
+      held = await store.renewLock(key, token, ttlMs);
+    } catch {
+      return; // transient — says nothing about who holds the lease
+    }
+    if (held) return;
+    clearInterval(heartbeat);
+    controller.abort(
+      new Error(
+        `the lease on run "${runId}" was lost — another process has taken it ` +
+          `over, so this one must stop rather than keep working on it`,
+      ),
+    );
+  }
+
+  return {
+    lost: controller.signal,
+    release: async () => {
+      clearInterval(heartbeat);
+      // Best-effort, like the heartbeat: a failed release must not turn
+      // completed work into a failure. The TTL reclaims the lease.
+      await store.releaseLock(key, token).catch(() => {});
+    },
+  };
+}

--- a/packages/core/tests/run_lease_test.ts
+++ b/packages/core/tests/run_lease_test.ts
@@ -1,0 +1,179 @@
+/**
+ * Unit tests for the run lease — the claim that makes "slow" and "dead"
+ * different things, and the rule about what counts as losing it.
+ *
+ * @module
+ */
+
+import { assertEquals } from "./_assert.ts";
+import {
+  acquireLease,
+  RUN_LEASE_PREFIX,
+  RUN_LEASE_TTL_MS,
+} from "../src/state/run_lease.ts";
+import { acquireCancelLock } from "../src/state/cancel_lock.ts";
+import type { StateStore } from "../src/state/store.ts";
+
+const NOW = () => "2026-08-10T10:00:00.000Z";
+
+/** A store that records lock traffic and answers renewals as a test dictates. */
+class LockStore implements StateStore {
+  /** Keys currently held, mapped to their token. */
+  held = new Map<string, string>();
+  /** Every key an acquire was attempted for, in order. */
+  acquired: string[] = [];
+  /** Keys released, in order. */
+  released: string[] = [];
+  /** Renewal calls, in order. */
+  renewals: string[] = [];
+  /** Refuse the next acquire, as though a live holder had it. */
+  refuseAcquire = false;
+  /** What renewals answer: held, lost, or a thrown transient. */
+  renewal: "held" | "lost" | "throws" = "held";
+  #tokens = 0;
+
+  listRuns(): Promise<never[]> {
+    return Promise.resolve([]);
+  }
+  getRun(): Promise<null> {
+    return Promise.resolve(null);
+  }
+  putRun(): Promise<{ ok: true; version: string }> {
+    return Promise.resolve({ ok: true, version: "1" });
+  }
+  deleteRun(): Promise<void> {
+    return Promise.resolve();
+  }
+  acquireLock(
+    key: string,
+  ): Promise<
+    { ok: true; token: string } | {
+      ok: false;
+      holder: { actor: string; runId: string; since: string };
+    }
+  > {
+    this.acquired.push(key);
+    if (this.refuseAcquire) {
+      return Promise.resolve({
+        ok: false,
+        holder: { actor: "someone", runId: "r", since: NOW() },
+      });
+    }
+    const token = `t${++this.#tokens}`;
+    this.held.set(key, token);
+    return Promise.resolve({ ok: true, token });
+  }
+  renewLock(key: string): Promise<boolean> {
+    this.renewals.push(key);
+    if (this.renewal === "throws") {
+      return Promise.reject(new Error("state service had a bad second"));
+    }
+    return Promise.resolve(this.renewal === "held");
+  }
+  releaseLock(key: string): Promise<void> {
+    this.released.push(key);
+    this.held.delete(key);
+    return Promise.resolve();
+  }
+}
+
+/** Give the unref'd heartbeat time to tick at least `ticks` times. */
+function afterTicks(ttlMs: number, ticks: number): Promise<void> {
+  return new Promise((resolve) =>
+    setTimeout(resolve, Math.max(1000, Math.floor(ttlMs / 2)) * ticks + 60)
+  );
+}
+
+Deno.test("the default TTL leaves room for an ordinary pause", () => {
+  // Not a magic number worth changing casually: it is the window in which a
+  // slow step must not be mistaken for a dead process.
+  assertEquals(RUN_LEASE_TTL_MS, 60_000);
+  assertEquals(RUN_LEASE_PREFIX, "zuke-run");
+});
+
+Deno.test("a lease is taken under its prefixed key and released", async () => {
+  const store = new LockStore();
+  const lease = await acquireLease(store, "zuke-run", "run-1", "me", NOW);
+  if (lease === null) throw new Error("expected the lease");
+  assertEquals(store.acquired, ["zuke-run-run-1"]);
+  assertEquals(lease.lost.aborted, false);
+  await lease.release();
+  assertEquals(store.released, ["zuke-run-run-1"]);
+});
+
+Deno.test("a live holder means no lease", async () => {
+  const store = new LockStore();
+  store.refuseAcquire = true;
+  assertEquals(await acquireLease(store, "zuke-run", "run-1", "me", NOW), null);
+});
+
+Deno.test("an explicit refusal from a renewal is loss", async () => {
+  // The store says the claim is demonstrably somebody else's, so the holder has
+  // to stop rather than keep working alongside whoever took it.
+  const store = new LockStore();
+  const ttl = 2_000;
+  const lease = await acquireLease(
+    store,
+    "zuke-run",
+    "run-1",
+    "me",
+    NOW,
+    ttl,
+  );
+  if (lease === null) throw new Error("expected the lease");
+  store.renewal = "lost";
+  await afterTicks(ttl, 1);
+  assertEquals(lease.lost.aborted, true);
+  assertEquals(lease.lost.reason instanceof Error, true);
+  // The heartbeat stops once the claim is gone; there is nothing left to renew.
+  const seen = store.renewals.length;
+  await afterTicks(ttl, 1);
+  assertEquals(store.renewals.length, seen);
+  await lease.release();
+});
+
+Deno.test("a renewal that throws is not loss", async () => {
+  // A filesystem mutex it could not take in time, an HTTP 503, a DNS blip: none
+  // of these say who holds the lease, and aborting a healthy build because the
+  // state service had a bad second would be the wrong trade entirely.
+  const store = new LockStore();
+  const ttl = 2_000;
+  const lease = await acquireLease(store, "zuke-run", "run-1", "me", NOW, ttl);
+  if (lease === null) throw new Error("expected the lease");
+  store.renewal = "throws";
+  await afterTicks(ttl, 2);
+  assertEquals(lease.lost.aborted, false);
+  // And it keeps trying, so a blip that passes is simply survived.
+  assertEquals(store.renewals.length >= 2, true);
+  store.renewal = "held";
+  await afterTicks(ttl, 1);
+  assertEquals(lease.lost.aborted, false);
+  await lease.release();
+});
+
+Deno.test("a released lease stops renewing", async () => {
+  const store = new LockStore();
+  const ttl = 2_000;
+  const lease = await acquireLease(store, "zuke-run", "run-1", "me", NOW, ttl);
+  if (lease === null) throw new Error("expected the lease");
+  await lease.release();
+  await afterTicks(ttl, 1);
+  assertEquals(store.renewals.length, 0);
+});
+
+Deno.test("the cancel lock is the same lease under its own name", async () => {
+  // It delegates, so the mechanics live in one place — but its key must not
+  // change, or a canceller and the run's own claim would contend for one lock.
+  const store = new LockStore();
+  const lock = await acquireCancelLock(store, "run-1", "me", NOW);
+  if (lock === null) throw new Error("expected the lock");
+  assertEquals(store.acquired, ["zuke-cancel-run-1"]);
+  await lock.release();
+  assertEquals(store.released, ["zuke-cancel-run-1"]);
+});
+
+Deno.test("a cancel lock is refused when a live canceller holds it", async () => {
+  const store = new LockStore();
+  store.refuseAcquire = true;
+  assertEquals(await acquireCancelLock(store, "run-1", "me", NOW), null);
+});

--- a/tests/e2e/effect_redrive_e2e.ts
+++ b/tests/e2e/effect_redrive_e2e.ts
@@ -48,6 +48,16 @@ function spawn(
   }).spawn();
 }
 
+/** Narrow parsed JSON to an object, so the lock record can be edited without a cast. */
+function recordOf(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`expected a JSON object, got ${JSON.stringify(value)}`);
+  }
+  const out: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value)) out[key] = val;
+  return out;
+}
+
 /** The marker file's lines, or an empty list if it does not exist yet. */
 async function markerLines(marker: string): Promise<string[]> {
   try {
@@ -114,10 +124,18 @@ Deno.test("a SIGKILL mid-effect leaves a durable intent another process re-drive
     assertEquals((await tooEarly.status).code, 1);
     assertEquals(await markerLines(marker), ["announce redriven=false"]);
 
-    // Now let the lease lapse. Removing the lock is what expiry looks like to
-    // the store — the next acquirer finds nothing holding the run — and it is the
-    // second thing the reaper will establish before it moves a run.
-    await Deno.remove(`${dir}/locks/zuke-run-${id}.json`);
+    // Now let the lease lapse. Only the clock is moved: the lock record stays
+    // exactly as the killed process left it, with its holder and token intact,
+    // and only its expiry is backdated. So the resume goes through the store's
+    // real expired-lease takeover — the branch that runs in production when a
+    // dead holder's claim runs out — rather than the different path a missing
+    // lock would take. Waiting out a 60-second TTL is the only alternative, and
+    // it would test the same branch a minute later.
+    const lockPath = `${dir}/locks/zuke-run-${id}.json`;
+    const lock = recordOf(JSON.parse(await Deno.readTextFile(lockPath)));
+    assertEquals(typeof lock.token, "string"); // still the dead holder's
+    lock.expiresAt = Date.now() - 1;
+    await Deno.writeTextFile(lockPath, JSON.stringify(lock));
 
     // Process 2: a real, separate `resume`. It drives the owed effect again.
     const resumer = spawn(["resume", id], dir, marker, false);

--- a/tests/e2e/effect_redrive_e2e.ts
+++ b/tests/e2e/effect_redrive_e2e.ts
@@ -8,10 +8,11 @@
  * suite is excluded from the fast unit gate and runs on its own OS matrix (see
  * the `integration` target / integration.yml).
  *
- * One seam is stood in for: moving an abandoned `running` run back to
- * `suspended` is the reaper's job, and the reaper does not exist yet. Here the
- * parent does that single transition by hand, and says so — everything either
- * side of it is real processes and real state.
+ * The reaper is stood in for, because it does not exist yet. It has two
+ * observations to make — the owner's lease has lapsed, and the run is stuck
+ * `running` — and the parent makes both by hand here. Everything either side of
+ * that is real processes and real state, including the fact that a resume
+ * *refuses* the run while the dead owner's lease is still live.
  *
  * @module
  */
@@ -101,12 +102,22 @@ Deno.test("a SIGKILL mid-effect leaves a durable intent another process re-drive
     const intentAt = owed?.intentAt;
     assertEquals(typeof intentAt, "string");
 
-    // The reaper's one transition, by hand until it exists: an abandoned
-    // `running` run becomes resumable.
+    // The killed process never released its lease, and a lease outlives its
+    // holder by design — so until it lapses, a resume must refuse this run
+    // rather than start a second process against it. That refusal is the whole
+    // point of holding a lease, so it is asserted rather than worked around.
     const record = structuredClone(killed.record);
     record.status = "suspended";
-    const moved = await store.putRun(record, killed.version);
-    assertEquals(moved.ok, true);
+    assertEquals((await store.putRun(record, killed.version)).ok, true);
+
+    const tooEarly = spawn(["resume", id], dir, marker, false);
+    assertEquals((await tooEarly.status).code, 1);
+    assertEquals(await markerLines(marker), ["announce redriven=false"]);
+
+    // Now let the lease lapse. Removing the lock is what expiry looks like to
+    // the store — the next acquirer finds nothing holding the run — and it is the
+    // second thing the reaper will establish before it moves a run.
+    await Deno.remove(`${dir}/locks/zuke-run-${id}.json`);
 
     // Process 2: a real, separate `resume`. It drives the owed effect again.
     const resumer = spawn(["resume", id], dir, marker, false);

--- a/tests/integration/run_lease_test.ts
+++ b/tests/integration/run_lease_test.ts
@@ -1,0 +1,81 @@
+/**
+ * Integration tests for the run lease — a process's claim that it is the one
+ * working on a run, driven through the real CLI.
+ *
+ * The pairing these protect: a record that says `running` always has a live
+ * holder. That is what lets a sweep tell an abandoned run from a working one,
+ * and it is why a resume refuses a run whose previous holder has not let go.
+ *
+ * @module
+ */
+
+import { assertEquals } from "../../packages/core/tests/_assert.ts";
+import {
+  Build,
+  defaultStateHost,
+  externalSignal,
+  FileSystemStateStore,
+  target,
+} from "../../packages/core/mod.ts";
+import { runCli, withStateDir } from "./_harness.ts";
+
+/** The id of the (single) run the CLI persisted under `dir`. */
+async function onlyRunId(dir: string): Promise<string> {
+  const store = new FileSystemStateStore(dir, defaultStateHost);
+  const runs = await store.listRuns({});
+  assertEquals(runs.length, 1);
+  return runs[0].id;
+}
+
+Deno.test("a run holds a lease while it runs, and releases it when it settles", async () => {
+  // The pairing a reaping sweep depends on: a record that says `running` always
+  // has a live holder, and the claim goes the moment the run stops being this
+  // process's to work on.
+  let heldDuringRun = false;
+
+  class Ci extends Build {
+    work = target().effect("announce", async (ctx) => {
+      const dir = Deno.env.get("ZUKE_STATE_DIR") ?? "";
+      heldDuringRun = await Deno.stat(`${dir}/locks/zuke-run-${ctx.runId}.json`)
+        .then(() => true, () => false);
+    });
+  }
+
+  await withStateDir(async (dir) => {
+    const { code } = await runCli(Ci, ["work"]);
+    assertEquals(code, 0);
+    assertEquals(heldDuringRun, true);
+    const id = await onlyRunId(dir);
+    // Released: the lock is gone rather than left to lapse at its TTL.
+    const stillHeld = await Deno.stat(`${dir}/locks/zuke-run-${id}.json`)
+      .then(() => true, () => false);
+    assertEquals(stillHeld, false);
+  });
+});
+
+Deno.test("a resume refuses a run whose previous holder is still live", async () => {
+  // A lease outlives the process that took it, so a run whose owner has not let
+  // go is not available — the refusal is what stops two processes working the
+  // same run when one of them merely looks dead.
+  class Cd extends Build {
+    hold = target().waitsFor((s) => s.on(externalSignal("go")));
+    done = target().dependsOn(this.hold).executes(() => {});
+  }
+
+  await withStateDir(async (dir) => {
+    assertEquals((await runCli(Cd, ["done"])).code, 0); // suspended
+    const id = await onlyRunId(dir);
+
+    // Stand in for a killed holder: a lease over this run, held by nobody.
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    const taken = await store.acquireLock(
+      `zuke-run-${id}`,
+      { actor: "a-dead-process", runId: id, since: "2026-08-10T10:00:00.000Z" },
+      60_000,
+    );
+    assertEquals(taken.ok, true);
+
+    const refused = await runCli(Cd, ["resume", id, "--signal", "go"]);
+    assertEquals(refused.code, 1);
+  });
+});

--- a/tests/integration/run_lease_test.ts
+++ b/tests/integration/run_lease_test.ts
@@ -79,3 +79,32 @@ Deno.test("a resume refuses a run whose previous holder is still live", async ()
     assertEquals(refused.code, 1);
   });
 });
+
+Deno.test("a resume gives the lease back even when the run fails", async () => {
+  // The acquirer releases, on every path out. A claim left held by nobody would
+  // make a run that has demonstrably stopped look like one still being worked
+  // on, which is the one thing the lease exists to distinguish.
+  class Cd extends Build {
+    hold = target().waitsFor((s) => s.on(externalSignal("go")));
+    boom = target().dependsOn(this.hold).executes(() => {
+      throw new Error("the deploy failed");
+    });
+  }
+
+  await withStateDir(async (dir) => {
+    assertEquals((await runCli(Cd, ["boom"])).code, 0); // suspended
+    const id = await onlyRunId(dir);
+
+    const resumed = await runCli(Cd, ["resume", id, "--signal", "go"]);
+    assertEquals(resumed.code, 1); // the run failed
+
+    // Released rather than left to lapse, so the next acquirer sees it free.
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    const free = await store.acquireLock(
+      `zuke-run-${id}`,
+      { actor: "next", runId: id, since: "2026-08-10T10:00:00.000Z" },
+      1_000,
+    );
+    assertEquals(free.ok, true);
+  });
+});


### PR DESCRIPTION
## Why

A run record cannot tell a working process from a dead one. A process mid-step and a process that was `SIGKILL`ed both leave a record that says `running` and then stops changing. Anything that wants to take over abandoned work has to guess, and guessing either way is wrong: too eager and two processes drive one run, too cautious and nothing ever recovers it.

This is R2 of the durable merge-gate work, and it is the precondition for the reaper — which cannot exist until "abandoned" is a thing zuke can observe rather than infer.

## What it does

A run with a state store holds a lease on itself, `zuke-run-<run-id>`, renewed by a heartbeat at half its 60-second TTL and released when the run settles. A lapsed claim means the holder is gone. Nothing polls for expiry; the store evaluates it when somebody next tries to acquire.

The cancellation lock becomes a thin naming of the same thing, signature and key unchanged — its mechanics were never about cancellation.

## The three decisions worth reviewing

**The lease is taken before the record says `running`** — and on a resume, before the record leaves `suspended`. So a `running` record always has a live holder. Acquiring afterwards would leave a window in which a perfectly healthy run looked abandoned, which is precisely the question the lease exists to answer. That is why acquisition lives in `openRunState` ahead of the writer (opening the writer persists `running`) and in `resumeRun` ahead of the compare-and-swap, threaded through `ResumeState`.

**Loss is an `AbortSignal`, not a callback.** A resumer takes the lease before the run it will drive exists, so there is nothing to hand a callback to yet — and a callback would drop the already-lost-before-you-subscribed case. A signal can be read late and still be true.

**A refused renewal is loss; a failed one is not.** Both stores return `false` only when the claim has demonstrably changed hands; they *throw* for a filesystem mutex they could not take in time, an HTTP 503, or a DNS blip. None of those say anything about who holds the lease, so they are retried on the next tick. Treating them as loss would abort a healthy build because the state service had a bad second.

A resume also now refuses a run whose previous holder has not let go. Two processes working one run is worse than a resume that waits, and it is the same answer the existing exactly-one-resumer race already gives, from the other side.

## A caveat, documented rather than hidden

The heartbeat is a timer, so it does not fire while the event loop is blocked in synchronous work. A run that blocks for longer than the TTL can have its lease lapse and be taken over. Losing the claim then stops it, so the outcome is a stopped run rather than two writers — but it is a real limitation and `docs/locks.md` says so.

## Tests

- **Unit, 8:** the key and TTL, acquire and release, refusal when a live holder has it, an explicit refusal counting as loss and stopping the heartbeat, a throwing renewal *not* counting as loss and surviving a blip that passes, release stopping renewal, and the cancel lock delegating without changing its key.
- **Integration, 2:** a run holding its lease while a target runs and having released it once settled, and a resume refusing a run whose holder is still live.
- **E2E:** the existing effect re-drive test now proves both halves of this. A resume **refuses** the killed process's run while its lease is still live, and succeeds once the lease lapses — which also makes explicit what the reaper will have to establish: a lapsed lease *and* a run to move.

Full gate green locally, 18 of 18 targets, plus the e2e suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)