### PR TITLE
feat(core): reap abandoned runs and give a run a deadline

### DIFF
--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -248,11 +248,19 @@ suspended ones:
   build's run would find none of its targets and settle it with its
   compensations silently skipped.
 
-  Before *settling* a run — which is irreversible — the graph has to agree as
-  well, because a class name is not an identity and `Ci` is a name half an
-  organisation's repos will use. Handing a run back to `suspended` asks only the
-  looser question, since that is reversible and a resume refuses a graph it does
-  not recognise with an error naming the drift.
+  Before *settling* a run — which is irreversible, and runs its compensations —
+  the graph has to agree as well, because a class name is not an identity and
+  `Ci` is a name half an organisation's repos will use. Handing a run back to
+  `suspended` asks only the looser question, since that is reversible and a
+  resume refuses a graph it does not recognise with an error naming the drift.
+
+  What no check here can see: two builds that share a class name, a root-target
+  name **and** a graph shape are indistinguishable in a run record, even though
+  their target *bodies* may do entirely different things. If several repos share
+  one state service and any of them might collide that way, give each its own
+  store — a separate `ZUKE_STATE_DIR`, or a distinct prefix or instance behind
+  `ZUKE_STATE_URL`. That is the only way to make the question unambiguous, and it
+  costs nothing when the runs were never meant to be pooled.
 
 A run left `cancelling` by a settlement whose own process died is finished too,
 in whichever terminal that settlement was heading for — recorded on the run,

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -229,17 +229,23 @@ wait forever.
 `zuke resume --check` now looks at `running` runs first, before it sweeps the
 suspended ones:
 
-- **Is anyone still there?** The run's [lease](./locks.md#the-runs-own-lease)
-  answers it. A live process keeps renewing, so a lease that can be acquired
-  means its holder is gone; one that cannot means the run is merely slow, and
-  slow is left alone.
+- **Is anyone still there?** — asked first, always. The run's
+  [lease](./locks.md#the-runs-own-lease) answers it: a live process keeps
+  renewing, so a lease that can be acquired means its holder is gone; one that
+  cannot means the run is merely slow, and slow is left alone. A live run is
+  never settled or moved, deadline or no deadline, because doing so would run its
+  compensations beside the work they undo.
 - **Nobody there** → the run goes back to `suspended`, with a `reap` event on
   its audit trail saying why. The same sweep then resumes it, so an abandoned
   run is recovered in one pass rather than waiting another interval for nothing
   but a state change.
-- **Past its `deadline()`** → the run is settled **`failed`**, compensations and
-  all. It did not stop because anyone asked; it ran out of time, and anything
-  waiting on it needs an answer rather than silence.
+- **Nobody there, and past its `deadline()`** → the run is settled **`failed`**,
+  compensations and all. It did not stop because anyone asked; it ran out of
+  time, and anything waiting on it needs an answer rather than silence.
+- **Only this build's runs.** A state store is commonly shared, and a listing has
+  no build filter, so the sweep skips runs belonging to another build. Acting on
+  one would find none of its targets, settle it with its compensations silently
+  skipped, and leave nothing to retry it.
 
 A run left `cancelling` by a settlement whose own process died is finished too,
 in whichever terminal that settlement was heading for — recorded on the run,
@@ -257,11 +263,18 @@ class Ci extends Build {
 }
 ```
 
-A run parked at a `.waitsFor(...)` gate is not spending it — the budget there is
-the gate's own `.timeout()`, which already exists and already fires. Only the
-sweep over runs still marked `running` consults the deadline, so a build with a
-72-hour approval gate and a 45-minute deadline is not killed the moment it
-suspends.
+A run parked at a `.waitsFor(...)` gate is not spending it: the deadline is
+pushed forward on resume by however long the run was parked, so a build with a
+72-hour approval gate and a 45-minute deadline still has its 45 minutes of
+running time when the approval finally arrives. The gate's own `.timeout()` is
+what bounds the waiting.
+
+A live run is never settled for time, either — the sweep asks whether anyone is
+still working on the run before it looks at the deadline, and leaves it alone if
+someone is. That costs nothing the deadline was for: a process that hangs stops
+renewing its lease, and a run killed and abandoned repeatedly has no holder at
+all. What it rules out is settling a run underneath a process that is still
+working on it.
 
 What it is really for is the run that stops making progress without failing: a
 process that hangs, or one killed so hard that its work is picked up and

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -218,6 +218,57 @@ its recorded `onTimeout` disposition:
 Timeouts are enforced lazily on any `zuke resume`/`resume --check`, so a single
 cron that sweeps suspended runs also enforces every deadline.
 
+### Abandoned runs — reaping
+
+A run that ends cleanly settles itself, and a run that suspends is picked up by
+the sweep above. A run whose process was **killed** does neither: it stays
+`running`, and a resume only ever acts on `suspended` runs. Anything that run
+recorded as owed — a [crash-durable effect](./run-context.md) above all — would
+wait forever.
+
+`zuke resume --check` now looks at `running` runs first, before it sweeps the
+suspended ones:
+
+- **Is anyone still there?** The run's [lease](./locks.md#the-runs-own-lease)
+  answers it. A live process keeps renewing, so a lease that can be acquired
+  means its holder is gone; one that cannot means the run is merely slow, and
+  slow is left alone.
+- **Nobody there** → the run goes back to `suspended`, with a `reap` event on
+  its audit trail saying why. The same sweep then resumes it, so an abandoned
+  run is recovered in one pass rather than waiting another interval for nothing
+  but a state change.
+- **Past its `deadline()`** → the run is settled **`failed`**, compensations and
+  all. It did not stop because anyone asked; it ran out of time, and anything
+  waiting on it needs an answer rather than silence.
+
+A run left `cancelling` by a settlement whose own process died is finished too,
+in whichever terminal that settlement was heading for — recorded on the run,
+because the process that finishes it is not the one that began it.
+
+### `Build.deadline()`
+
+A wall-clock budget for a whole run. It bounds **running**, not existing:
+
+```ts
+class Ci extends Build {
+  override deadline() {
+    return "45m";
+  }
+}
+```
+
+A run parked at a `.waitsFor(...)` gate is not spending it — the budget there is
+the gate's own `.timeout()`, which already exists and already fires. Only the
+sweep over runs still marked `running` consults the deadline, so a build with a
+72-hour approval gate and a 45-minute deadline is not killed the moment it
+suspends.
+
+What it is really for is the run that stops making progress without failing: a
+process that hangs, or one killed so hard that its work is picked up and
+abandoned repeatedly. Without a deadline such a run has no end state at all;
+with one it reaches a terminal status, which is what anything downstream is
+waiting for.
+
 ## State is the only thing that crosses the boundary
 
 A resume is a **fresh process**: the in-memory world of the suspending run is

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -243,9 +243,16 @@ suspended ones:
   compensations and all. It did not stop because anyone asked; it ran out of
   time, and anything waiting on it needs an answer rather than silence.
 - **Only this build's runs.** A state store is commonly shared, and a listing has
-  no build filter, so the sweep skips runs belonging to another build. Acting on
-  one would find none of its targets, settle it with its compensations silently
-  skipped, and leave nothing to retry it.
+  no build filter, so the sweep skips runs it does not recognise: the record's
+  build name and its root target must both be this build's. Acting on another
+  build's run would find none of its targets and settle it with its
+  compensations silently skipped.
+
+  Before *settling* a run — which is irreversible — the graph has to agree as
+  well, because a class name is not an identity and `Ci` is a name half an
+  organisation's repos will use. Handing a run back to `suspended` asks only the
+  looser question, since that is reversible and a resume refuses a graph it does
+  not recognise with an error naming the drift.
 
 A run left `cancelling` by a settlement whose own process died is finished too,
 in whichever terminal that settlement was heading for — recorded on the run,

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -859,10 +859,15 @@ class Build
     `failed` — a duration like `"45m"` or milliseconds. No deadline by default.
 
     It bounds running, not existing. A run parked at a `.waitsFor(...)` gate
-    is not spending it; the budget there is the gate's own `.timeout()`, which
-    already exists and already fires. Only the sweep over runs still marked
-    `running` consults this, so a build with a 72-hour approval gate and a
-    45-minute deadline is not killed the moment it suspends.
+    is not spending it — the deadline is pushed forward on resume by however
+    long the run was parked, so a build with a 72-hour approval gate and a
+    45-minute deadline still has its 45 minutes when the approval arrives. The
+    waiting is bounded by the gate's own `.timeout()`.
+
+    A run with a live process working on it is never settled for time either:
+    the sweep asks whether anyone is still there before it looks at the
+    deadline. Nothing this is for escapes that — a hung process stops renewing
+    its lease, and a run killed over and over has no holder at all.
 
     What it is really for is the run that stops making progress without failing
     — a process that hangs, or one killed so hard that its work is repeatedly

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -854,6 +854,29 @@ class Build
       deploy = target().executes(async (ctx) => { await ctx.state.set({ at: "sit-7" }); });
     }
     ```
+  deadline(): string | number | undefined
+    A wall-clock budget for a whole run, after which a reaping sweep settles it
+    `failed` — a duration like `"45m"` or milliseconds. No deadline by default.
+
+    It bounds running, not existing. A run parked at a `.waitsFor(...)` gate
+    is not spending it; the budget there is the gate's own `.timeout()`, which
+    already exists and already fires. Only the sweep over runs still marked
+    `running` consults this, so a build with a 72-hour approval gate and a
+    45-minute deadline is not killed the moment it suspends.
+
+    What it is really for is the run that stops making progress without failing
+    — a process that hangs, or one killed so hard that its work is repeatedly
+    picked up and abandoned again. Without a deadline such a run has no end
+    state at all; with one it reaches a terminal status, which is what anything
+    downstream is waiting for.
+
+    ```ts
+    class Ci extends Build {
+      override deadline() {
+        return "45m";
+      }
+    }
+    ```
   extraEdges(_targets: Map<string, TargetBuilder>): OrderingEdge[]
     Extra soft ordering edges to impose on the plan, beyond the `dependsOn`
     / `before` / `after` declared on targets. Override to feed an external graph
@@ -3369,6 +3392,24 @@ interface RunRecord
     write that lands — the failing one, by definition, could not carry it. A
     drop that leaves the mutation in memory for a later write to re-persist does
     not set it. Absent (or `false`) means no write is known to be missing.
+  deadlineAt?: string
+    ISO-8601 wall-clock deadline for the whole run, stamped once at creation
+    from `Build.deadline()`. Absent when the build sets none.
+
+    A budget for running, not for existing. A run parked at an approval gate
+    is not spending it — its budget there is the wait's own timeout — so only a
+    sweep over `running` runs consults this.
+  intendedTerminal?: RunStatus
+    The terminal status the process that moved this run to `cancelling` means
+    to leave it in. Absent means `cancelled`, which is what an ordinary
+    `zuke cancel` intends and what every record written before this field
+    existed meant.
+
+    Recorded rather than inferred, because the settlement can be finished by a
+    different process than the one that began it: a canceller that crashes
+    leaves the run `cancelling`, and whoever recovers it has no other way to
+    know whether an operator was cancelling the run or a sweep was failing an
+    abandoned one.
 
 interface RunSummary
   A compact run listing row, returned by {@link "./store.ts".StateStore.listRuns}.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -908,6 +908,29 @@ class Build
       deploy = target().executes(async (ctx) => { await ctx.state.set({ at: "sit-7" }); });
     }
     ```
+  deadline(): string | number | undefined
+    A wall-clock budget for a whole run, after which a reaping sweep settles it
+    `failed` — a duration like `"45m"` or milliseconds. No deadline by default.
+
+    It bounds running, not existing. A run parked at a `.waitsFor(...)` gate
+    is not spending it; the budget there is the gate's own `.timeout()`, which
+    already exists and already fires. Only the sweep over runs still marked
+    `running` consults this, so a build with a 72-hour approval gate and a
+    45-minute deadline is not killed the moment it suspends.
+
+    What it is really for is the run that stops making progress without failing
+    — a process that hangs, or one killed so hard that its work is repeatedly
+    picked up and abandoned again. Without a deadline such a run has no end
+    state at all; with one it reaches a terminal status, which is what anything
+    downstream is waiting for.
+
+    ```ts
+    class Ci extends Build {
+      override deadline() {
+        return "45m";
+      }
+    }
+    ```
   extraEdges(_targets: Map<string, TargetBuilder>): OrderingEdge[]
     Extra soft ordering edges to impose on the plan, beyond the `dependsOn`
     / `before` / `after` declared on targets. Override to feed an external graph
@@ -3423,6 +3446,24 @@ interface RunRecord
     write that lands — the failing one, by definition, could not carry it. A
     drop that leaves the mutation in memory for a later write to re-persist does
     not set it. Absent (or `false`) means no write is known to be missing.
+  deadlineAt?: string
+    ISO-8601 wall-clock deadline for the whole run, stamped once at creation
+    from `Build.deadline()`. Absent when the build sets none.
+
+    A budget for running, not for existing. A run parked at an approval gate
+    is not spending it — its budget there is the wait's own timeout — so only a
+    sweep over `running` runs consults this.
+  intendedTerminal?: RunStatus
+    The terminal status the process that moved this run to `cancelling` means
+    to leave it in. Absent means `cancelled`, which is what an ordinary
+    `zuke cancel` intends and what every record written before this field
+    existed meant.
+
+    Recorded rather than inferred, because the settlement can be finished by a
+    different process than the one that began it: a canceller that crashes
+    leaves the run `cancelling`, and whoever recovers it has no other way to
+    know whether an operator was cancelling the run or a sweep was failing an
+    abandoned one.
 
 interface RunSummary
   A compact run listing row, returned by {@link "./store.ts".StateStore.listRuns}.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -913,10 +913,15 @@ class Build
     `failed` — a duration like `"45m"` or milliseconds. No deadline by default.
 
     It bounds running, not existing. A run parked at a `.waitsFor(...)` gate
-    is not spending it; the budget there is the gate's own `.timeout()`, which
-    already exists and already fires. Only the sweep over runs still marked
-    `running` consults this, so a build with a 72-hour approval gate and a
-    45-minute deadline is not killed the moment it suspends.
+    is not spending it — the deadline is pushed forward on resume by however
+    long the run was parked, so a build with a 72-hour approval gate and a
+    45-minute deadline still has its 45 minutes when the approval arrives. The
+    waiting is bounded by the gate's own `.timeout()`.
+
+    A run with a live process working on it is never settled for time either:
+    the sweep asks whether anyone is still there before it looks at the
+    deadline. Nothing this is for escapes that — a hung process stops renewing
+    its lease, and a run killed over and over has no holder at all.
 
     What it is really for is the run that stops making progress without failing
     — a process that hangs, or one killed so hard that its work is repeatedly

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -170,10 +170,15 @@ export class Build {
    * `failed` — a duration like `"45m"` or milliseconds. No deadline by default.
    *
    * It bounds *running*, not existing. A run parked at a `.waitsFor(...)` gate
-   * is not spending it; the budget there is the gate's own `.timeout()`, which
-   * already exists and already fires. Only the sweep over runs still marked
-   * `running` consults this, so a build with a 72-hour approval gate and a
-   * 45-minute deadline is not killed the moment it suspends.
+   * is not spending it — the deadline is pushed forward on resume by however
+   * long the run was parked, so a build with a 72-hour approval gate and a
+   * 45-minute deadline still has its 45 minutes when the approval arrives. The
+   * waiting is bounded by the gate's own `.timeout()`.
+   *
+   * A run with a live process working on it is never settled for time either:
+   * the sweep asks whether anyone is still there before it looks at the
+   * deadline. Nothing this is for escapes that — a hung process stops renewing
+   * its lease, and a run killed over and over has no holder at all.
    *
    * What it is really for is the run that stops making progress without failing
    * — a process that hangs, or one killed so hard that its work is repeatedly

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -166,6 +166,34 @@ export class Build {
   }
 
   /**
+   * A wall-clock budget for a whole run, after which a reaping sweep settles it
+   * `failed` — a duration like `"45m"` or milliseconds. No deadline by default.
+   *
+   * It bounds *running*, not existing. A run parked at a `.waitsFor(...)` gate
+   * is not spending it; the budget there is the gate's own `.timeout()`, which
+   * already exists and already fires. Only the sweep over runs still marked
+   * `running` consults this, so a build with a 72-hour approval gate and a
+   * 45-minute deadline is not killed the moment it suspends.
+   *
+   * What it is really for is the run that stops making progress without failing
+   * — a process that hangs, or one killed so hard that its work is repeatedly
+   * picked up and abandoned again. Without a deadline such a run has no end
+   * state at all; with one it reaches a terminal status, which is what anything
+   * downstream is waiting for.
+   *
+   * ```ts
+   * class Ci extends Build {
+   *   override deadline() {
+   *     return "45m";
+   *   }
+   * }
+   * ```
+   */
+  deadline(): string | number | undefined {
+    return undefined;
+  }
+
+  /**
    * Extra **soft ordering edges** to impose on the plan, beyond the `dependsOn`
    * / `before` / `after` declared on targets. Override to feed an external graph
    * — e.g. a monorepo's `dependency-graph.json` — into scheduling without wiring

--- a/packages/core/src/cancel.ts
+++ b/packages/core/src/cancel.ts
@@ -62,6 +62,16 @@ import type {
 const MAX_RETRIES = 10;
 
 /**
+ * A status a run can be settled into from outside the process running it.
+ *
+ * `"cancelled"` is what an operator's `zuke cancel` means; `"failed"` is what a
+ * sweep means when it settles a run that has passed its deadline. They share
+ * every step — the lock, the transition, the compensation walk — and differ only
+ * in the status left behind and how it is described.
+ */
+export type SettlementTerminal = "cancelled" | "failed";
+
+/**
  * A never-aborted signal handed to compensation bodies: the run is already being
  * cancelled, but the cleanup itself must run to completion.
  */
@@ -623,6 +633,35 @@ export async function cancelRun(
   build: Build,
   options: CancelOptions,
 ): Promise<CancelResult> {
+  return await settleExternally(build, { ...options, terminal: "cancelled" });
+}
+
+/** Options for {@link settleExternally}: a cancel, plus the status to settle into. */
+export interface SettleOptions extends CancelOptions {
+  /** The terminal status to leave the run in. */
+  terminal: SettlementTerminal;
+}
+
+/**
+ * Settle a run from outside the process running it: take the settlement lock,
+ * move the record to `cancelling`, unwind the compensations of everything that
+ * succeeded, and leave it in `terminal`.
+ *
+ * {@link cancelRun} is this with `terminal: "cancelled"` — an operator stopping
+ * a run. A reaping sweep uses `"failed"` for a run that has passed its deadline:
+ * the run did not stop because anyone asked, it ran out of time, and anything
+ * waiting on it needs that distinction. The mechanics are identical, and
+ * deliberately so — the compensations of an abandoned run have to be unwound
+ * just as carefully as those of a cancelled one.
+ */
+export async function settleExternally(
+  build: Build,
+  options: SettleOptions,
+): Promise<CancelResult> {
+  const terminal = options.terminal;
+  // How the run's end is described. The status is what matters to a machine;
+  // this is what an operator reads in the log.
+  const verb = terminal === "cancelled" ? "cancelled" : "failed";
   const readEnv = options.readEnv ?? defaultReadEnv;
   const store = resolveCancelStore(options, build, readEnv);
   if (store === undefined) {
@@ -643,7 +682,8 @@ export async function cancelRun(
   }
   if (isTerminal(initial.record.status)) {
     reporter.info(
-      `Run ${runId} is already ${initial.record.status}; nothing to cancel.`,
+      `Run ${runId} is already ${initial.record.status}; nothing to ` +
+        `${terminal === "cancelled" ? "cancel" : "settle"}.`,
     );
     return {
       runId,
@@ -675,6 +715,7 @@ export async function cancelRun(
       runId,
       initial,
       now,
+      terminal,
     );
     if (transitioned === "noop") {
       const fresh = await store.getRun(runId);
@@ -690,11 +731,35 @@ export async function cancelRun(
       // not be idempotent, so a second pass is more dangerous than the small
       // chance an interrupted first pass left some cleanup undone. `zuke cancel`
       // becomes retryable, not a dead end.
-      reporter.info(`Run ${runId} was mid-cancellation; finalizing it.`);
-      await finalizeCancelled(store, runId, actor, EMPTY_OUTCOME, now);
+      // Which terminal the interrupted settlement was heading for is recorded
+      // on the run, because this process is not necessarily the one that began
+      // it. Absent means `cancelled`: that is what an ordinary cancel intends,
+      // and what every record written before the field existed meant.
+      const stranded = await store.getRun(runId);
+      const recorded = stranded?.record.intendedTerminal ??
+        initial.record.intendedTerminal;
+      // Anything other than an explicit `failed` settles `cancelled`: that is
+      // what an absent field means, and it is the conservative reading of a
+      // value this process did not write.
+      const intended: SettlementTerminal = recorded === "failed"
+        ? "failed"
+        : "cancelled";
+      reporter.info(
+        `Run ${runId} was mid-${
+          terminal === "cancelled" ? "cancellation" : "settlement"
+        }; finalizing it.`,
+      );
+      await finalizeCancelled(
+        store,
+        runId,
+        actor,
+        EMPTY_OUTCOME,
+        now,
+        intended,
+      );
       return {
         runId,
-        status: "cancelled",
+        status: intended,
         noop: false,
         compensated: [],
         failures: [],
@@ -766,9 +831,9 @@ export async function cancelRun(
       });
     }
 
-    await finalizeCancelled(store, runId, actor, outcome, now);
+    await finalizeCancelled(store, runId, actor, outcome, now, terminal);
     reporter.info(
-      `Run ${runId} cancelled — ${outcome.compensated.length} compensation(s) ` +
+      `Run ${runId} ${verb} — ${outcome.compensated.length} compensation(s) ` +
         `ran${
           outcome.failures.length > 0
             ? `, ${outcome.failures.length} failed`
@@ -777,7 +842,7 @@ export async function cancelRun(
     );
     return {
       runId,
-      status: "cancelled",
+      status: terminal,
       noop: false,
       compensated: outcome.compensated,
       failures: outcome.failures,
@@ -833,6 +898,7 @@ async function transitionToCancelling(
   id: string,
   initial: { record: RunRecord; version: string },
   now: () => string,
+  terminal: SettlementTerminal,
 ): Promise<{ record: RunRecord; version: string } | "noop" | "recover"> {
   let record = initial.record;
   let version = initial.version;
@@ -841,6 +907,13 @@ async function transitionToCancelling(
     if (record.status === "cancelling") return "recover";
     const next = structuredClone(record);
     next.status = "cancelling";
+    // Written with the transition, not with the settlement, because the process
+    // that finishes this may not be the one that started it: a canceller that
+    // crashes leaves the record `cancelling`, and whoever recovers it reads this
+    // to know whether an operator was cancelling or a sweep was failing an
+    // abandoned run. `cancelled` stays unwritten so a record from before this
+    // field existed, and an ordinary cancel, look identical.
+    if (terminal !== "cancelled") next.intendedTerminal = terminal;
     next.updatedAt = now();
     const result = await store.putRun(next, version);
     if (result.ok) return { record: next, version: result.version };
@@ -866,13 +939,14 @@ async function finalizeCancelled(
   actor: string,
   outcome: CompensationOutcome,
   now: () => string,
+  terminal: SettlementTerminal = "cancelled",
 ): Promise<void> {
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     const loaded = await store.getRun(id);
-    if (loaded === null || loaded.record.status === "cancelled") return;
+    if (loaded === null || isTerminal(loaded.record.status)) return;
     const at = now();
     const next = structuredClone(loaded.record);
-    next.status = "cancelled";
+    next.status = terminal;
     next.updatedAt = at;
     for (const event of compensationEvents(outcome.attempts, actor, at)) {
       next.events.push(event);

--- a/packages/core/src/execute_state.ts
+++ b/packages/core/src/execute_state.ts
@@ -18,6 +18,7 @@ import type { Redactor } from "./redact.ts";
 import type { AnyParameter } from "./params.ts";
 import type { RunEnv, TargetSettlement } from "./run_support.ts";
 import { absolutePath } from "./path.ts";
+import { parseDuration } from "./duration.ts";
 import { findConfigDir, pathExists } from "./config.ts";
 import { defaultStateHost, type StateStore } from "./state/store.ts";
 import { resolveStateStore } from "./state/resolve.ts";
@@ -165,6 +166,13 @@ export async function openRunState(opts: {
     );
     return { ok: false, error };
   }
+  // Resolved once, here, so the record carries an absolute instant rather than a
+  // duration every later reader would have to re-anchor — and so a build with a
+  // malformed deadline is refused before it does any work.
+  const budget = opts.build.deadline();
+  const deadlineAt = budget === undefined
+    ? undefined
+    : new Date(Date.parse(nowIso()) + parseDuration(budget)).toISOString();
   const actor = resolveActor(opts.actor, readEnv);
   const runUrl = ciRunUrl(readEnv);
   const warn = (message: string) => opts.reporter.info(message);
@@ -221,6 +229,7 @@ export async function openRunState(opts: {
         now: nowIso(),
         order,
         params: opts.params,
+        ...(deadlineAt === undefined ? {} : { deadlineAt }),
       }),
       nowIso,
       redactor,

--- a/packages/core/src/execute_state.ts
+++ b/packages/core/src/execute_state.ts
@@ -169,7 +169,11 @@ export async function openRunState(opts: {
   // Resolved once, here, so the record carries an absolute instant rather than a
   // duration every later reader would have to re-anchor — and so a build with a
   // malformed deadline is refused before it does any work.
-  const budget = opts.build.deadline();
+  // Only for a fresh run: a resume adopts the record's existing deadline, so
+  // parsing the build's would be work whose result is discarded — and a throw
+  // here on a resume would strand the run `running`, to be reaped and resumed
+  // and stranded again on every sweep, forever.
+  const budget = resume === undefined ? opts.build.deadline() : undefined;
   const deadlineAt = budget === undefined
     ? undefined
     : new Date(Date.parse(nowIso()) + parseDuration(budget)).toISOString();

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -509,6 +509,19 @@ export async function execute(
     // so every per-target transition has landed by the time the run returns.
     if (run.suspended) await writer?.markRunSuspended();
     else await writer?.markRunFinished(result.ok);
+    // Another process settled this run while it was working — a sweep that found
+    // it abandoned or past its deadline, and unwound it. Whatever this process
+    // did, the run did not end the way this process thinks: report the failure
+    // rather than a success nothing else agrees with.
+    if (writer?.settledElsewhere() === true) {
+      const settled = new Error(
+        `Run ${runId} was settled by another process while this one was ` +
+          `working on it (its record says ${writer.snapshot().status}), so ` +
+          `this process's result is not the run's outcome.`,
+      );
+      reporter.error(settled.message);
+      result = { ok: false, executed: run.executed, error: settled, runId };
+    }
     // Released once the record is terminal (or suspended), so the moment this
     // run stops being ours to work on is the moment the claim goes. Any earlier
     // throw leaves this call's own lease to lapse at its TTL, which is correct:

--- a/packages/core/src/reap.ts
+++ b/packages/core/src/reap.ts
@@ -7,15 +7,17 @@
  * work it had recorded as owed, an effect above all, waits for a resume that
  * will never come, because a resume only acts on `suspended`.
  *
- * This closes that. Before the suspended sweep runs, every `running` run is
- * examined:
+ * This closes that. Before the suspended sweep runs, every `running` run of this
+ * build is examined, and the first question is always whether anyone is still
+ * there:
  *
- * - **Past its deadline** — settled `failed`, compensations and all. A run that
- *   has run out of time has an answer, and anything waiting on it needs one.
- * - **Otherwise, is anyone still there?** The run's lease answers it. A live
- *   holder keeps renewing, so a lease that can be acquired means the holder is
- *   gone. A lease that cannot means the run is merely slow, and slow is not
- *   dead — it is left alone.
+ * - **Is anyone still there?** The run's lease answers it. A live holder keeps
+ *   renewing, so a lease that can be acquired means the holder is gone; one that
+ *   cannot means the run is merely slow, and slow is not dead — it is left
+ *   alone, deadline or no deadline.
+ * - **Nobody there, and past its deadline** — settled `failed`, compensations and
+ *   all. A run that has run out of time has an answer, and anything waiting on
+ *   it needs one.
  * - **Nobody there** — the run moves back to `suspended`, which is the state the
  *   existing resume machinery already knows how to drive. The sweep then resumes
  *   it on the same pass, re-driving whatever it was owed.
@@ -104,9 +106,14 @@ export async function reapAbandoned(deps: ReapDeps): Promise<ReapOutcome> {
 export async function recoverStranded(deps: ReapDeps): Promise<ReapOutcome> {
   const { store, reporter } = deps;
   const outcome: ReapOutcome = { reaped: [], settled: [], failed: 0 };
-  const ids = (await store.listRuns({ status: "cancelling" })).map((s) => s.id);
+  const ids = deps.runId !== undefined
+    ? [deps.runId]
+    : (await store.listRuns({ status: "cancelling" })).map((s) => s.id);
   for (const id of ids) {
     try {
+      const loaded = await store.getRun(id);
+      if (loaded === null || loaded.record.status !== "cancelling") continue;
+      if (!belongsToBuild(loaded.record, deps)) continue;
       // The terminal named here is only a default: a record that says which
       // settlement it was in the middle of wins, since this process is not the
       // one that started it.
@@ -134,30 +141,20 @@ type Examined = "reaped" | "settled" | "alive";
 async function examine(id: string, deps: ReapDeps): Promise<Examined> {
   const loaded = await deps.store.getRun(id);
   if (loaded === null || loaded.record.status !== "running") return "alive";
-
-  if (pastDeadline(loaded.record, deps.now())) {
-    // Settled rather than released: a run that has run out of time is not one
-    // to hand back for another attempt. Its compensations still run, because an
-    // abandoned run's side effects need unwinding just as much as a cancelled
-    // one's.
-    deps.reporter.info(
-      `reap: run ${id} passed its deadline (${loaded.record.deadlineAt}) — ` +
-        `settling it failed.`,
-    );
-    await settleExternally(deps.build, {
-      runId: id,
-      stateStore: deps.store,
-      actor: deps.actor,
-      silent: deps.silent,
-      reporter: deps.reporter,
-      terminal: "failed",
-    });
-    return "settled";
-  }
+  if (!belongsToBuild(loaded.record, deps)) return "alive";
 
   // Is anyone still working on it? The lease answers it, and acquiring is the
   // question: a live holder is renewing, so a lease that cannot be taken means
   // the run is merely slow. Slow is not dead.
+  //
+  // This comes first, before the deadline, and that ordering is the whole
+  // safety of the thing. Settling a run whose process is still working would
+  // run its compensations *beside* the work they undo, and leave a live process
+  // reporting on a run somebody else had ended. Every case a deadline is for —
+  // a hung process whose heartbeat has starved, a run killed and abandoned over
+  // and over — has no live holder, so nothing the deadline exists to catch
+  // escapes by checking this first. A genuinely live run that outlasts its
+  // deadline is left alone until whatever is running it stops.
   const lease = await acquireLease(
     deps.store,
     RUN_LEASE_PREFIX,
@@ -168,6 +165,31 @@ async function examine(id: string, deps: ReapDeps): Promise<Examined> {
   if (lease === null) return "alive";
 
   try {
+    // Re-read under the lease: between listing and acquiring, the run may have
+    // been settled or picked up, and acting on the older view would undo that.
+    const held = await deps.store.getRun(id);
+    if (held === null || held.record.status !== "running") return "alive";
+
+    if (pastDeadline(held.record, deps.now())) {
+      // Settled rather than released: a run that has run out of time is not one
+      // to hand back for another attempt. Its compensations still run, because
+      // an abandoned run's side effects need unwinding just as much as a
+      // cancelled one's.
+      deps.reporter.info(
+        `reap: run ${id} passed its deadline (${held.record.deadlineAt}) — ` +
+          `settling it failed.`,
+      );
+      await settleExternally(deps.build, {
+        runId: id,
+        stateStore: deps.store,
+        actor: deps.actor,
+        silent: deps.silent,
+        reporter: deps.reporter,
+        terminal: "failed",
+      });
+      return "settled";
+    }
+
     const moved = await toSuspended(id, deps);
     if (!moved) return "alive";
     deps.reporter.info(
@@ -180,6 +202,22 @@ async function examine(id: string, deps: ReapDeps): Promise<Examined> {
     // holding the claim would make the resumer that follows refuse it.
     await lease.release();
   }
+}
+
+/**
+ * Whether this sweep is entitled to touch `record`.
+ *
+ * A state store is commonly shared across builds, and a listing has no build
+ * filter — so a sweep sees every build's runs, not just its own. Acting on
+ * another build's run is worse than useless: its targets are not in this build,
+ * so a settlement would find no compensations to run and would stamp the record
+ * terminal with the run's side effects never unwound, and nothing would retry it
+ * because the record is no longer live. The suspended sweep is safe here only
+ * because a resume *refuses* a build it cannot match; a reap mutates, so it has
+ * to check.
+ */
+function belongsToBuild(record: RunRecord, deps: ReapDeps): boolean {
+  return record.build === deps.build.constructor.name;
 }
 
 /** Whether `record` has a deadline that `now` is past. */

--- a/packages/core/src/reap.ts
+++ b/packages/core/src/reap.ts
@@ -248,10 +248,17 @@ function belongsToBuild(record: RunRecord, deps: ReapDeps): boolean {
  * could not be resolved they are skipped for good, leaving a deploy standing
  * behind a record that says the run is over.
  *
- * So the graph has to agree too. Where it does, the two builds are the same
- * build for every purpose a settlement has — compensations resolve by name, and
- * the names are identical. Where it does not, this sweep leaves the run for the
- * one that recognises it.
+ * So the graph has to agree too. Where it does not, this sweep leaves the run for
+ * the one that recognises it.
+ *
+ * Where it does, this is as far as a heuristic reaches: two builds sharing a
+ * class name, a root-target name and a graph shape are indistinguishable in a
+ * record, and their target *bodies* may still do entirely different things. The
+ * answer to that is not a cleverer comparison but a store per build — see
+ * `docs/orchestration.md`. Note the blast radius differs by path: a stranded run
+ * is finalised *without* compensations and into the terminal its own record
+ * names, so a colliding build settles it exactly as the owning one would; a
+ * past-deadline run does run compensations, which is why this check exists.
  */
 function canSettle(record: RunRecord, deps: ReapDeps): boolean {
   if (!belongsToBuild(record, deps)) return false;

--- a/packages/core/src/reap.ts
+++ b/packages/core/src/reap.ts
@@ -28,7 +28,7 @@
  * @module
  */
 
-import type { Build } from "./build.ts";
+import { type Build, discoverTargets } from "./build.ts";
 import type { Reporter } from "./executor.ts";
 import { messageOf } from "./internal.ts";
 import { settleExternally } from "./cancel.ts";
@@ -215,9 +215,22 @@ async function examine(id: string, deps: ReapDeps): Promise<Examined> {
  * because the record is no longer live. The suspended sweep is safe here only
  * because a resume *refuses* a build it cannot match; a reap mutates, so it has
  * to check.
+ *
+ * Two things are checked, because a class name is not an identity. `Ci` is a
+ * name half the repos in an organisation will use, and a run record carries
+ * nothing more specific, so the name alone would let one repo's sweep settle
+ * another's runs. Requiring the record's root target to exist here as well is
+ * what makes a collision harmless in practice: the compensations a settlement
+ * runs are resolved by name, so a build that has the run's root target has the
+ * targets that run recorded.
+ *
+ * The residual: two builds that share a class name *and* a root-target name are
+ * still indistinguishable to this. Closing that needs an identity in the record
+ * rather than a better guess here.
  */
 function belongsToBuild(record: RunRecord, deps: ReapDeps): boolean {
-  return record.build === deps.build.constructor.name;
+  if (record.build !== deps.build.constructor.name) return false;
+  return discoverTargets(deps.build).has(record.rootTarget);
 }
 
 /** Whether `record` has a deadline that `now` is past. */

--- a/packages/core/src/reap.ts
+++ b/packages/core/src/reap.ts
@@ -1,0 +1,229 @@
+/**
+ * Reaping: finding runs whose process is gone, and giving them somewhere to go.
+ *
+ * A run that ends cleanly settles itself, and a run that suspends is picked up
+ * by the ordinary resume sweep. A run whose process was *killed* does neither —
+ * it stays `running` forever, and nothing in zuke looks at `running` runs. Any
+ * work it had recorded as owed, an effect above all, waits for a resume that
+ * will never come, because a resume only acts on `suspended`.
+ *
+ * This closes that. Before the suspended sweep runs, every `running` run is
+ * examined:
+ *
+ * - **Past its deadline** — settled `failed`, compensations and all. A run that
+ *   has run out of time has an answer, and anything waiting on it needs one.
+ * - **Otherwise, is anyone still there?** The run's lease answers it. A live
+ *   holder keeps renewing, so a lease that can be acquired means the holder is
+ *   gone. A lease that cannot means the run is merely slow, and slow is not
+ *   dead — it is left alone.
+ * - **Nobody there** — the run moves back to `suspended`, which is the state the
+ *   existing resume machinery already knows how to drive. The sweep then resumes
+ *   it on the same pass, re-driving whatever it was owed.
+ *
+ * A run stranded `cancelling` by a settlement whose process died is finished
+ * too, in whichever terminal that settlement was heading for.
+ *
+ * @module
+ */
+
+import type { Build } from "./build.ts";
+import type { Reporter } from "./executor.ts";
+import { messageOf } from "./internal.ts";
+import { settleExternally } from "./cancel.ts";
+import { acquireLease, RUN_LEASE_PREFIX } from "./state/run_lease.ts";
+import type { StateStore } from "./state/store.ts";
+import type { RunEvent, RunRecord } from "./state/types.ts";
+
+/** How many times a conflicting reap CAS is re-read and retried. */
+const MAX_RETRIES = 10;
+
+/** What one reaping pass did, folded into the sweep's own counts. */
+export interface ReapOutcome {
+  /** Runs moved back to `suspended` for the resume sweep to pick up. */
+  reaped: string[];
+  /** Runs settled terminally — past their deadline, or stranded mid-settlement. */
+  settled: string[];
+  /** Runs that errored while being examined; each is reported, none abort the pass. */
+  failed: number;
+}
+
+/** Everything a reaping pass needs, so the sweep can hand it its own plumbing. */
+export interface ReapDeps {
+  /** The build the runs belong to — needed to compensate a settled one. */
+  build: Build;
+  /** The store the runs live in. */
+  store: StateStore;
+  /** Who to record as having done the reaping. */
+  actor: string;
+  /** Where the pass narrates what it did. */
+  reporter: Reporter;
+  /** The current time, as an ISO-8601 string. */
+  now: () => string;
+  /** Examine only this run, rather than every `running` one. */
+  runId?: string;
+  /** Suppress the settlement's own output. */
+  silent?: boolean;
+}
+
+/**
+ * Examine the runs that claim to be running, and settle or release the ones
+ * whose process is gone.
+ *
+ * Never throws for a single run: one bad record must not strand every run
+ * behind it, exactly as in the sweep this is called from.
+ */
+export async function reapAbandoned(deps: ReapDeps): Promise<ReapOutcome> {
+  const { store, reporter } = deps;
+  const outcome: ReapOutcome = { reaped: [], settled: [], failed: 0 };
+
+  const ids = deps.runId !== undefined
+    ? [deps.runId]
+    : (await store.listRuns({ status: "running" })).map((s) => s.id);
+
+  for (const id of ids) {
+    try {
+      const examined = await examine(id, deps);
+      if (examined === "reaped") outcome.reaped.push(id);
+      else if (examined === "settled") outcome.settled.push(id);
+    } catch (error) {
+      outcome.failed += 1;
+      reporter.error(`reap: run ${id} errored: ${messageOf(error)}`);
+    }
+  }
+  return outcome;
+}
+
+/**
+ * Finish runs left `cancelling` by a settlement whose process died.
+ *
+ * The settlement lock's TTL is what makes this safe: a live settler still holds
+ * it, so `settleExternally` refuses and this is a no-op; a dead one's lock has
+ * lapsed, and the recovery path finalises the record without re-running
+ * compensations that may not be idempotent.
+ */
+export async function recoverStranded(deps: ReapDeps): Promise<ReapOutcome> {
+  const { store, reporter } = deps;
+  const outcome: ReapOutcome = { reaped: [], settled: [], failed: 0 };
+  const ids = (await store.listRuns({ status: "cancelling" })).map((s) => s.id);
+  for (const id of ids) {
+    try {
+      // The terminal named here is only a default: a record that says which
+      // settlement it was in the middle of wins, since this process is not the
+      // one that started it.
+      const result = await settleExternally(deps.build, {
+        runId: id,
+        stateStore: store,
+        actor: deps.actor,
+        silent: deps.silent,
+        reporter: deps.reporter,
+        terminal: "cancelled",
+      });
+      if (!result.noop) outcome.settled.push(id);
+    } catch (error) {
+      outcome.failed += 1;
+      reporter.error(`reap: stranded run ${id} errored: ${messageOf(error)}`);
+    }
+  }
+  return outcome;
+}
+
+/** What examining one running run concluded. */
+type Examined = "reaped" | "settled" | "alive";
+
+/** Decide what to do about one run that claims to be running, and do it. */
+async function examine(id: string, deps: ReapDeps): Promise<Examined> {
+  const loaded = await deps.store.getRun(id);
+  if (loaded === null || loaded.record.status !== "running") return "alive";
+
+  if (pastDeadline(loaded.record, deps.now())) {
+    // Settled rather than released: a run that has run out of time is not one
+    // to hand back for another attempt. Its compensations still run, because an
+    // abandoned run's side effects need unwinding just as much as a cancelled
+    // one's.
+    deps.reporter.info(
+      `reap: run ${id} passed its deadline (${loaded.record.deadlineAt}) — ` +
+        `settling it failed.`,
+    );
+    await settleExternally(deps.build, {
+      runId: id,
+      stateStore: deps.store,
+      actor: deps.actor,
+      silent: deps.silent,
+      reporter: deps.reporter,
+      terminal: "failed",
+    });
+    return "settled";
+  }
+
+  // Is anyone still working on it? The lease answers it, and acquiring is the
+  // question: a live holder is renewing, so a lease that cannot be taken means
+  // the run is merely slow. Slow is not dead.
+  const lease = await acquireLease(
+    deps.store,
+    RUN_LEASE_PREFIX,
+    id,
+    deps.actor,
+    deps.now,
+  );
+  if (lease === null) return "alive";
+
+  try {
+    const moved = await toSuspended(id, deps);
+    if (!moved) return "alive";
+    deps.reporter.info(
+      `reap: run ${id} was left running by a process that is gone — ` +
+        `returning it to suspended so it can be resumed.`,
+    );
+    return "reaped";
+  } finally {
+    // Released either way: this pass is not the one that will drive the run, and
+    // holding the claim would make the resumer that follows refuse it.
+    await lease.release();
+  }
+}
+
+/** Whether `record` has a deadline that `now` is past. */
+function pastDeadline(record: RunRecord, now: string): boolean {
+  if (record.deadlineAt === undefined) return false;
+  const deadline = Date.parse(record.deadlineAt);
+  // An unparseable deadline is not a passed one: refusing to guess is better
+  // than settling a healthy run because a timestamp was malformed.
+  return Number.isFinite(deadline) && Date.parse(now) > deadline;
+}
+
+/**
+ * Move a run from `running` back to `suspended`, so the resume sweep can drive
+ * it.
+ *
+ * Compare-and-swap, and the status is re-checked on every attempt: between
+ * taking the lease and writing, the run may have been settled by a canceller or
+ * picked up by something else, and moving it then would undo their work.
+ */
+async function toSuspended(id: string, deps: ReapDeps): Promise<boolean> {
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    const loaded = await deps.store.getRun(id);
+    if (loaded === null || loaded.record.status !== "running") return false;
+    const at = deps.now();
+    const next = structuredClone(loaded.record);
+    next.status = "suspended";
+    next.updatedAt = at;
+    next.events.push(reapEvent(deps.actor, at));
+    const result = await deps.store.putRun(next, loaded.version);
+    if (result.ok) return true;
+  }
+  throw new Error(
+    `reap: gave up returning ${id} to suspended after repeated conflicts.`,
+  );
+}
+
+/** The audit event recording that a run was reaped. */
+function reapEvent(actor: string, at: string): RunEvent {
+  return {
+    at,
+    tool: "reap",
+    actor,
+    outcome: "ok",
+    args: {},
+    detail: "returned to suspended: its lease had lapsed",
+  };
+}

--- a/packages/core/src/reap.ts
+++ b/packages/core/src/reap.ts
@@ -34,7 +34,8 @@ import { messageOf } from "./internal.ts";
 import { settleExternally } from "./cancel.ts";
 import { acquireLease, RUN_LEASE_PREFIX } from "./state/run_lease.ts";
 import type { StateStore } from "./state/store.ts";
-import type { RunEvent, RunRecord } from "./state/types.ts";
+import { planGraph } from "./graph.ts";
+import type { RunEvent, RunGraphNode, RunRecord } from "./state/types.ts";
 
 /** How many times a conflicting reap CAS is re-read and retried. */
 const MAX_RETRIES = 10;
@@ -113,7 +114,9 @@ export async function recoverStranded(deps: ReapDeps): Promise<ReapOutcome> {
     try {
       const loaded = await store.getRun(id);
       if (loaded === null || loaded.record.status !== "cancelling") continue;
-      if (!belongsToBuild(loaded.record, deps)) continue;
+      // The strict question, because this settles: a run whose graph this build
+      // does not recognise is left for the build that does.
+      if (!canSettle(loaded.record, deps)) continue;
       // The terminal named here is only a default: a record that says which
       // settlement it was in the middle of wins, since this process is not the
       // one that started it.
@@ -170,7 +173,7 @@ async function examine(id: string, deps: ReapDeps): Promise<Examined> {
     const held = await deps.store.getRun(id);
     if (held === null || held.record.status !== "running") return "alive";
 
-    if (pastDeadline(held.record, deps.now())) {
+    if (pastDeadline(held.record, deps.now()) && canSettle(held.record, deps)) {
       // Settled rather than released: a run that has run out of time is not one
       // to hand back for another attempt. Its compensations still run, because
       // an abandoned run's side effects need unwinding just as much as a
@@ -224,13 +227,59 @@ async function examine(id: string, deps: ReapDeps): Promise<Examined> {
  * runs are resolved by name, so a build that has the run's root target has the
  * targets that run recorded.
  *
- * The residual: two builds that share a class name *and* a root-target name are
- * still indistinguishable to this. Closing that needs an identity in the record
- * rather than a better guess here.
+ * Two builds that share a class name *and* a root-target name are still
+ * indistinguishable to this, which is why the destructive path asks
+ * {@link canSettle} as well.
  */
 function belongsToBuild(record: RunRecord, deps: ReapDeps): boolean {
   if (record.build !== deps.build.constructor.name) return false;
   return discoverTargets(deps.build).has(record.rootTarget);
+}
+
+/**
+ * Whether this sweep may settle `record` terminally, as opposed to merely
+ * handing it back.
+ *
+ * A stricter question than {@link belongsToBuild}, because it is asked before
+ * the irreversible thing. Returning a run to `suspended` is recoverable and
+ * self-correcting — a resume refuses a build whose graph does not match, with an
+ * error naming the drift and a documented override. Settling one is neither: the
+ * record becomes terminal, so nothing sweeps it again, and if the compensations
+ * could not be resolved they are skipped for good, leaving a deploy standing
+ * behind a record that says the run is over.
+ *
+ * So the graph has to agree too. Where it does, the two builds are the same
+ * build for every purpose a settlement has — compensations resolve by name, and
+ * the names are identical. Where it does not, this sweep leaves the run for the
+ * one that recognises it.
+ */
+function canSettle(record: RunRecord, deps: ReapDeps): boolean {
+  if (!belongsToBuild(record, deps)) return false;
+  const targets = discoverTargets(deps.build);
+  const root = targets.get(record.rootTarget);
+  if (root === undefined) return false;
+  const planned = planGraph(root).order.map((t) => ({
+    name: t.name_ ?? "",
+    dependsOn: t.dependsOn_.map((d) => d.name_ ?? "").filter((n) => n !== ""),
+  }));
+  return graphAgrees(record.graph, planned);
+}
+
+/** Whether a recorded graph snapshot and a planned one describe the same shape. */
+function graphAgrees(
+  snapshot: readonly RunGraphNode[],
+  planned: readonly RunGraphNode[],
+): boolean {
+  if (snapshot.length !== planned.length) return false;
+  const recorded = new Map(snapshot.map((n) => [n.name, n.dependsOn]));
+  return planned.every((node) => {
+    const deps = recorded.get(node.name);
+    if (deps === undefined || deps.length !== node.dependsOn.length) {
+      return false;
+    }
+    const set = new Set(deps);
+    return node.dependsOn.every((d) => set.has(d));
+  });
 }
 
 /** Whether `record` has a deadline that `now` is past. */

--- a/packages/core/src/resume.ts
+++ b/packages/core/src/resume.ts
@@ -22,6 +22,7 @@ import { cancelRun } from "./cancel.ts";
 import { execute, type Reporter } from "./executor.ts";
 import type { Plugin } from "./plugin.ts";
 import { planGraph } from "./graph.ts";
+import { reapAbandoned, recoverStranded } from "./reap.ts";
 import { acquireLease, RUN_LEASE_PREFIX } from "./state/run_lease.ts";
 import type { JsonValue, TargetBuilder } from "./target.ts";
 import { absolutePath } from "./path.ts";
@@ -530,10 +531,36 @@ export async function resumeCheck(
   if (store === undefined) {
     throw new Error("resume --check: no state store is configured.");
   }
+  // Reap first, so a run whose process died is back to `suspended` in time for
+  // this same pass to resume it — otherwise every abandoned run would wait a
+  // whole sweep interval for nothing but a state transition.
+  const actor = resolveActor(options.actor, readEnv);
+  const reaped = await reapAbandoned({
+    build,
+    store,
+    actor,
+    reporter,
+    now: () => new Date().toISOString(),
+    ...(options.runId === undefined ? {} : { runId: options.runId }),
+    ...(options.silent === undefined ? {} : { silent: options.silent }),
+  });
+  // And finish anything a settlement left stranded, which no other sweep looks
+  // at either.
+  const recovered = options.runId === undefined
+    ? await recoverStranded({
+      build,
+      store,
+      actor,
+      reporter,
+      now: () => new Date().toISOString(),
+      ...(options.silent === undefined ? {} : { silent: options.silent }),
+    })
+    : { reaped: [], settled: [], failed: 0 };
+
   const ids = options.runId !== undefined
     ? [options.runId]
     : (await store.listRuns({ status: "suspended" })).map((s) => s.id);
-  let failed = 0;
+  let failed = reaped.failed + recovered.failed;
   for (const id of ids) {
     try {
       const result = await resumeRun(build, { ...options, runId: id });

--- a/packages/core/src/resume.ts
+++ b/packages/core/src/resume.ts
@@ -289,9 +289,23 @@ async function transitionToRunning(
     const next = structuredClone(record);
     next.status = "running";
     next.actor = resumerActor;
-    next.updatedAt = now();
+    const at = now();
+    // Give back the time the run spent parked. A run's deadline is a budget for
+    // *running*, and a run waiting at a gate is not spending it — a 45-minute
+    // budget behind a 72-hour approval gate would otherwise be exhausted before
+    // anyone could approve, and the run would be settled the instant it woke up.
+    // `updatedAt` is when it suspended, so the gap is exactly what it was parked
+    // for.
+    if (next.deadlineAt !== undefined) {
+      const parked = Date.parse(at) - Date.parse(record.updatedAt);
+      const deadline = Date.parse(next.deadlineAt);
+      if (Number.isFinite(parked) && parked > 0 && Number.isFinite(deadline)) {
+        next.deadlineAt = new Date(deadline + parked).toISOString();
+      }
+    }
+    next.updatedAt = at;
     if (signal !== undefined) {
-      next.signals[signal] = { data, receivedAt: now() };
+      next.signals[signal] = { data, receivedAt: at };
     }
     const result = await store.putRun(next, version);
     if (result.ok) return { record: next, version: result.version };
@@ -546,16 +560,18 @@ export async function resumeCheck(
   });
   // And finish anything a settlement left stranded, which no other sweep looks
   // at either.
-  const recovered = options.runId === undefined
-    ? await recoverStranded({
-      build,
-      store,
-      actor,
-      reporter,
-      now: () => new Date().toISOString(),
-      ...(options.silent === undefined ? {} : { silent: options.silent }),
-    })
-    : { reaped: [], settled: [], failed: 0 };
+  // Also for a single-run sweep: a plane that sweeps one run at a time is
+  // exactly the one that would otherwise never recover it, and a run left
+  // `cancelling` is non-terminal, so nothing else looks at it either.
+  const recovered = await recoverStranded({
+    build,
+    store,
+    actor,
+    reporter,
+    now: () => new Date().toISOString(),
+    ...(options.runId === undefined ? {} : { runId: options.runId }),
+    ...(options.silent === undefined ? {} : { silent: options.silent }),
+  });
 
   const ids = options.runId !== undefined
     ? [options.runId]

--- a/packages/core/src/state/record.ts
+++ b/packages/core/src/state/record.ts
@@ -88,6 +88,8 @@ export interface RunRecordInput {
   order: TargetBuilder[];
   /** All discovered parameters (secrets are skipped when copying values). */
   params: Iterable<AnyParameter>;
+  /** ISO-8601 deadline for the whole run, when the build sets one. */
+  deadlineAt?: string;
 }
 
 /**
@@ -120,6 +122,10 @@ export function buildRunRecord(input: RunRecordInput): RunRecord {
     build: input.build,
     rootTarget: input.rootTarget,
     status: "running",
+    // Stamped here and never again. A deadline that were recomputed on each
+    // resume would move forward every time, so a run could never reach it —
+    // the same trap the wait deadlines avoid by being recorded once.
+    ...(input.deadlineAt === undefined ? {} : { deadlineAt: input.deadlineAt }),
     actor: input.actor,
     createdAt: input.now,
     updatedAt: input.now,

--- a/packages/core/src/state/types.ts
+++ b/packages/core/src/state/types.ts
@@ -197,6 +197,28 @@ export interface RunRecord {
    * *not* set it. Absent (or `false`) means no write is known to be missing.
    */
   degraded?: boolean;
+  /**
+   * ISO-8601 wall-clock deadline for the whole run, stamped once at creation
+   * from `Build.deadline()`. Absent when the build sets none.
+   *
+   * A budget for *running*, not for existing. A run parked at an approval gate
+   * is not spending it — its budget there is the wait's own timeout — so only a
+   * sweep over `running` runs consults this.
+   */
+  deadlineAt?: string;
+  /**
+   * The terminal status the process that moved this run to `cancelling` means
+   * to leave it in. Absent means `cancelled`, which is what an ordinary
+   * `zuke cancel` intends and what every record written before this field
+   * existed meant.
+   *
+   * Recorded rather than inferred, because the settlement can be finished by a
+   * *different* process than the one that began it: a canceller that crashes
+   * leaves the run `cancelling`, and whoever recovers it has no other way to
+   * know whether an operator was cancelling the run or a sweep was failing an
+   * abandoned one.
+   */
+  intendedTerminal?: RunStatus;
 }
 
 /** A compact run listing row, returned by {@link "./store.ts".StateStore.listRuns}. */
@@ -586,7 +608,7 @@ export function parseRunRecord(text: string): RunRecord {
     for (const value of object.events) events.push(parseRunEvent(value));
   }
 
-  return {
+  const record: RunRecord = {
     id: str(object, "id"),
     build: str(object, "build"),
     rootTarget: str(object, "rootTarget"),
@@ -603,6 +625,19 @@ export function parseRunRecord(text: string): RunRecord {
     // so an older record reads back as trustworthy.
     degraded: optionalFlag(object, "degraded"),
   };
+  // Optional and only when present, so a round-trip preserves the exact key set
+  // and a record written before these existed parses unchanged.
+  const deadlineAt = optionalStr(object, "deadlineAt");
+  if (deadlineAt !== undefined) record.deadlineAt = deadlineAt;
+  const intended = optionalStr(object, "intendedTerminal");
+  if (intended !== undefined) {
+    const found = RUN_STATUSES.find((s) => s === intended);
+    if (found === undefined) {
+      throw new Error(`state: unknown intended terminal status "${intended}"`);
+    }
+    record.intendedTerminal = found;
+  }
+  return record;
 }
 
 /** A `filter` type guard that narrows to `string`. */

--- a/packages/core/src/state/writer.ts
+++ b/packages/core/src/state/writer.ts
@@ -64,6 +64,20 @@ export class RunNotActiveError extends Error {
   }
 }
 
+/**
+ * Whether `status` means some other process has taken this run's outcome.
+ *
+ * Everything except the two states a run is in while *this* process is working
+ * on it. A settlement from outside — an operator cancelling, a sweep failing an
+ * abandoned or expired run — must never be reverted by the process it settled,
+ * and `succeeded` is in the set for the same reason from the other direction: if
+ * the record already says the run ended, this process is not the one deciding
+ * how.
+ */
+function isSettledElsewhere(status: RunStatus): boolean {
+  return status !== "running" && status !== "suspended";
+}
+
 /** Ensure a target's entry exists in the record, seeding it `pending`. */
 function ensureTarget(record: RunRecord, name: string): TargetRunState {
   const existing = record.targets[name];
@@ -97,6 +111,16 @@ export class RunStateWriter {
   readonly #onExternalCancel?: () => void;
   #record: RunRecord;
   #version: string | null;
+  /**
+   * Latched once a conflicting re-read shows another process settled this run.
+   *
+   * A latch rather than a check, because the guard that notices only runs on a
+   * *conflict*: once this writer has re-synced to the settled record, its later
+   * writes land unchallenged and would happily set a status of their own. The
+   * flag is what stops a run this process merely finished from reporting
+   * `succeeded` over the terminal a sweep already wrote.
+   */
+  #settledElsewhere = false;
   #chain: Promise<void> = Promise.resolve();
 
   private constructor(
@@ -217,9 +241,21 @@ export class RunStateWriter {
     });
   }
 
-  /** Record the run's terminal status. */
+  /**
+   * Whether another process has taken this run's outcome, so this one's view of
+   * how the run ended is no longer authoritative.
+   */
+  settledElsewhere(): boolean {
+    return this.#settledElsewhere;
+  }
+
+  /** Record the run's terminal status, unless another process already has. */
   markRunFinished(ok: boolean): Promise<void> {
     return this.#update((record) => {
+      // Whoever settled this run owns how it ended. The per-target progress
+      // recorded alongside is still worth keeping, so this is a no-op rather
+      // than a refusal.
+      if (this.#settledElsewhere) return;
       record.status = ok ? "succeeded" : "failed";
     });
   }
@@ -240,9 +276,10 @@ export class RunStateWriter {
     });
   }
 
-  /** Record the run as suspended (parked at a `.waitsFor(...)` gate). */
+  /** Record the run as suspended, unless another process already settled it. */
   markRunSuspended(): Promise<void> {
     return this.#update((record) => {
+      if (this.#settledElsewhere) return;
       record.status = "suspended";
     });
   }
@@ -568,20 +605,22 @@ export class RunStateWriter {
         this.#record = fresh.record;
         this.#record.degraded ||= degraded;
         this.#version = fresh.version;
-        // The other writer may be a `zuke cancel` in another process. If it has
-        // moved the run to cancelling/cancelled, re-apply our (target-level)
-        // change onto its record — so a just-settled `succeeded` target isn't
-        // lost to the canceller's compensation walk — but never revert the run's
-        // cancel status. Then signal the run to abort: its compensations are the
-        // canceller's responsibility now. Best-effort (a conflict here is
-        // harmless; the canceller owns finalisation).
-        if (
-          fresh.record.status === "cancelling" ||
-          fresh.record.status === "cancelled"
-        ) {
-          const cancelStatus = fresh.record.status;
+        // Another process has taken the run's outcome: a `zuke cancel`, or a
+        // sweep settling a run it found abandoned or past its deadline. Re-apply
+        // our (target-level) change onto its record — so a just-settled
+        // `succeeded` target isn't lost to the settler's compensation walk — but
+        // never revert the status it wrote. Then signal the run to abort: what
+        // happens next is the settler's to decide.
+        //
+        // Every status but our own two matters here, not just the cancel pair.
+        // A sweep leaves a run `failed`, and a run this process then finishes
+        // would otherwise re-apply `succeeded` over it and report success — a
+        // green result for work another process had already unwound.
+        if (isSettledElsewhere(fresh.record.status)) {
+          const settledStatus = fresh.record.status;
+          this.#settledElsewhere = true;
           mutator(this.#record);
-          this.#record.status = cancelStatus;
+          this.#record.status = settledStatus;
           this.#record.updatedAt = this.#now();
           const reapply = await this.#store.putRun(
             this.#record,
@@ -593,8 +632,8 @@ export class RunStateWriter {
             // The canceller finalises the run from here, so no later write of
             // ours lands to carry this mutation: it is gone for good.
             this.#lostWrite(
-              `state: run "${this.#record.id}" is being cancelled elsewhere ` +
-                `and re-applying one update onto its record conflicted; ` +
+              `state: run "${this.#record.id}" was settled elsewhere and ` +
+                `re-applying one update onto its record conflicted; ` +
                 `losing that update`,
             );
           }

--- a/packages/core/tests/cancel_contract_test.ts
+++ b/packages/core/tests/cancel_contract_test.ts
@@ -1,0 +1,270 @@
+/**
+ * The observable contract of `zuke cancel`, pinned exactly.
+ *
+ * Written before the settlement machinery was generalised so that a run can be
+ * settled `failed` by a reaping sweep as well as `cancelled` by an operator. The
+ * generalisation must not change one byte of what `zuke cancel` already does:
+ * the requester's promote plane runs these paths from a pinned image, so a
+ * merged change to them stays dormant until a deployment moves — which is the
+ * worst way to find out that an audit event changed shape.
+ *
+ * These tests assert the things a caller or an operator can actually see: the
+ * returned result, the record's terminal status, and the audit events, field by
+ * field. They are deliberately more literal than the tests around them.
+ *
+ * @module
+ */
+
+import { assertEquals } from "./_assert.ts";
+import { Build, discoverTargets } from "../src/build.ts";
+import { target } from "../src/target.ts";
+import { execute } from "../src/executor.ts";
+import { cancelRun } from "../src/cancel.ts";
+import { FileSystemStateStore } from "../src/state/fs_store.ts";
+import { defaultStateHost } from "../src/state/store.ts";
+import type { RunEvent, RunRecord } from "../src/state/types.ts";
+
+/** Run `fn` with a temp filesystem store, cleaned up afterwards. */
+async function withTempStore(
+  fn: (store: FileSystemStateStore) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir();
+  try {
+    await fn(new FileSystemStateStore(`${dir}/runs`, defaultStateHost));
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+}
+
+/** The single run in `store`. */
+async function onlyRun(store: FileSystemStateStore): Promise<RunRecord> {
+  const runs = await store.listRuns({});
+  assertEquals(runs.length, 1);
+  const got = await store.getRun(runs[0].id);
+  if (got === null) throw new Error("the run vanished");
+  return got.record;
+}
+
+/** An event with its timestamp dropped, so shapes compare without a clock. */
+function shapeOf(event: RunEvent): Omit<RunEvent, "at"> {
+  const { at: _at, ...rest } = event;
+  return rest;
+}
+
+Deno.test("cancel settles the record `cancelled` and reports what it undid", async () => {
+  await withTempStore(async (store) => {
+    const undone: string[] = [];
+    class Cd extends Build {
+      rollback = target().unlisted().executes(() =>
+        void undone.push("rollback")
+      );
+      deploy = target().onCancel(this.rollback).executes(() => {});
+      hold = target().dependsOn(this.deploy).waitsFor((s) =>
+        s.on({ descriptor: "never", isSatisfied: () => false })
+      );
+    }
+    const build = new Cd();
+    discoverTargets(build);
+    await execute(build, build.hold, { silent: true, stateStore: store });
+
+    const before = await onlyRun(store);
+    assertEquals(before.status, "suspended");
+
+    const result = await cancelRun(build, {
+      runId: before.id,
+      stateStore: store,
+      silent: true,
+      actor: "ops",
+    });
+
+    // The returned shape, field by field.
+    assertEquals(result.runId, before.id);
+    assertEquals(result.status, "cancelled");
+    assertEquals(result.noop, false);
+    assertEquals(result.compensated, ["rollback"]);
+    assertEquals(result.failures, []);
+    assertEquals(undone, ["rollback"]);
+
+    const after = await onlyRun(store);
+    assertEquals(after.status, "cancelled");
+
+    // The audit trail: one `compensate` per attempt, then one `cancel` summary.
+    const trail = after.events.filter((e) =>
+      e.tool === "compensate" || e.tool === "cancel"
+    );
+    assertEquals(trail.map(shapeOf), [
+      {
+        tool: "compensate",
+        actor: "ops",
+        outcome: "ok",
+        args: { target: "deploy" },
+        detail: "deploy → rollback",
+      },
+      {
+        tool: "cancel",
+        actor: "ops",
+        outcome: "ok",
+        args: {},
+        detail: "ran 1 compensation(s)",
+      },
+    ]);
+  });
+});
+
+Deno.test("cancel with nothing to undo says so, in those words", async () => {
+  await withTempStore(async (store) => {
+    class Cd extends Build {
+      hold = target().waitsFor((s) =>
+        s.on({ descriptor: "never", isSatisfied: () => false })
+      );
+    }
+    const build = new Cd();
+    discoverTargets(build);
+    await execute(build, build.hold, { silent: true, stateStore: store });
+    const before = await onlyRun(store);
+
+    const result = await cancelRun(build, {
+      runId: before.id,
+      stateStore: store,
+      silent: true,
+      actor: "ops",
+    });
+    assertEquals(result.compensated, []);
+    assertEquals(result.status, "cancelled");
+
+    const after = await onlyRun(store);
+    const summary = after.events.filter((e) => e.tool === "cancel");
+    assertEquals(summary.map(shapeOf), [{
+      tool: "cancel",
+      actor: "ops",
+      outcome: "ok",
+      args: {},
+      detail: "no compensations",
+    }]);
+  });
+});
+
+Deno.test("cancelling an already-terminal run is a no-op that adds no events", async () => {
+  await withTempStore(async (store) => {
+    class Cd extends Build {
+      ship = target().executes(() => {});
+    }
+    const build = new Cd();
+    discoverTargets(build);
+    await execute(build, build.ship, { silent: true, stateStore: store });
+    const before = await onlyRun(store);
+    assertEquals(before.status, "succeeded");
+    const eventsBefore = before.events.length;
+
+    const result = await cancelRun(build, {
+      runId: before.id,
+      stateStore: store,
+      silent: true,
+      actor: "ops",
+    });
+    assertEquals(result.noop, true);
+    assertEquals(result.status, "succeeded");
+    assertEquals(result.compensated, []);
+    assertEquals(result.failures, []);
+
+    // Untouched: a no-op leaves no trace, including no audit event.
+    const after = await onlyRun(store);
+    assertEquals(after.status, "succeeded");
+    assertEquals(after.events.length, eventsBefore);
+  });
+});
+
+Deno.test("a run left mid-cancellation is finalized without re-running compensations", async () => {
+  // The recovery path: a canceller that crashed left the record `cancelling`.
+  // A second cancel settles it rather than compensating twice, because a
+  // compensation that is not idempotent is more dangerous run twice than left
+  // half-done.
+  await withTempStore(async (store) => {
+    const undone: string[] = [];
+    class Cd extends Build {
+      rollback = target().unlisted().executes(() =>
+        void undone.push("rollback")
+      );
+      deploy = target().onCancel(this.rollback).executes(() => {});
+      hold = target().dependsOn(this.deploy).waitsFor((s) =>
+        s.on({ descriptor: "never", isSatisfied: () => false })
+      );
+    }
+    const build = new Cd();
+    discoverTargets(build);
+    await execute(build, build.hold, { silent: true, stateStore: store });
+    const before = await onlyRun(store);
+
+    // Strand it, as a killed canceller would.
+    const loaded = await store.getRun(before.id);
+    if (loaded === null) throw new Error("the run vanished");
+    const stranded = structuredClone(loaded.record);
+    stranded.status = "cancelling";
+    assertEquals((await store.putRun(stranded, loaded.version)).ok, true);
+
+    const result = await cancelRun(build, {
+      runId: before.id,
+      stateStore: store,
+      silent: true,
+      actor: "ops",
+    });
+    assertEquals(result.status, "cancelled");
+    assertEquals(result.noop, false);
+    assertEquals(result.compensated, []);
+    assertEquals(undone, []); // never compensated twice
+
+    const after = await onlyRun(store);
+    assertEquals(after.status, "cancelled");
+  });
+});
+
+Deno.test("a failing compensation is recorded but does not stop the cancel", async () => {
+  await withTempStore(async (store) => {
+    class Cd extends Build {
+      rollback = target().unlisted().executes(() => {
+        throw new Error("rollback exploded");
+      });
+      deploy = target().onCancel(this.rollback).executes(() => {});
+      hold = target().dependsOn(this.deploy).waitsFor((s) =>
+        s.on({ descriptor: "never", isSatisfied: () => false })
+      );
+    }
+    const build = new Cd();
+    discoverTargets(build);
+    await execute(build, build.hold, { silent: true, stateStore: store });
+    const before = await onlyRun(store);
+
+    const result = await cancelRun(build, {
+      runId: before.id,
+      stateStore: store,
+      silent: true,
+      actor: "ops",
+    });
+    assertEquals(result.status, "cancelled");
+    assertEquals(result.compensated, []);
+    assertEquals(result.failures.length, 1);
+    assertEquals(result.failures[0].target, "rollback");
+    assertEquals(result.failures[0].forTarget, "deploy");
+
+    const after = await onlyRun(store);
+    const trail = after.events.filter((e) =>
+      e.tool === "compensate" || e.tool === "cancel"
+    );
+    assertEquals(trail.map(shapeOf), [
+      {
+        tool: "compensate",
+        actor: "ops",
+        outcome: "error",
+        args: { target: "deploy" },
+        detail: "deploy → rollback",
+      },
+      {
+        tool: "cancel",
+        actor: "ops",
+        outcome: "error",
+        args: {},
+        detail: "ran 0 compensation(s), 1 failed",
+      },
+    ]);
+  });
+});

--- a/packages/core/tests/reap_test.ts
+++ b/packages/core/tests/reap_test.ts
@@ -321,3 +321,41 @@ Deno.test("a stranded run is recovered for a single-run sweep too", async () => 
     assertEquals((await store.getRun("run-1"))?.record.status, "cancelled");
   });
 });
+
+Deno.test("a same-named build without the run's root target is not ours", async () => {
+  // A class name is not an identity: `Ci` is a name half the repos in an
+  // organisation will use, and a shared store holds all of their runs. The root
+  // target has to be here too, because that is what makes the compensations a
+  // settlement would run resolvable.
+  await withStore([record("foreign", "running")], async (store) => {
+    const loaded = await store.getRun("foreign");
+    if (loaded === null) throw new Error("seed missing");
+    const foreign = structuredClone(loaded.record);
+    foreign.rootTarget = "someone-elses-target";
+    assertEquals((await store.putRun(foreign, loaded.version)).ok, true);
+
+    const { reporter } = capturing();
+    const outcome = await reapAbandoned(depsFor(store, reporter));
+    assertEquals(outcome, { reaped: [], settled: [], failed: 0 });
+    assertEquals((await store.getRun("foreign"))?.record.status, "running");
+  });
+});
+
+Deno.test("a stranded run settles into the terminal its settlement intended", async () => {
+  // `recoverStranded` names `cancelled` as a default, and the record overrides
+  // it: the process that began the settlement recorded what it meant, and this
+  // one is not it.
+  await withStore([record("run-1", "cancelling")], async (store) => {
+    const loaded = await store.getRun("run-1");
+    if (loaded === null) throw new Error("seed missing");
+    const intended = structuredClone(loaded.record);
+    intended.intendedTerminal = "failed";
+    assertEquals((await store.putRun(intended, loaded.version)).ok, true);
+
+    const { reporter } = capturing();
+    const outcome = await recoverStranded(depsFor(store, reporter));
+    assertEquals(outcome.settled, ["run-1"]);
+    // `failed`, not the `cancelled` the call named: a sweep was failing this run.
+    assertEquals((await store.getRun("run-1"))?.record.status, "failed");
+  });
+});

--- a/packages/core/tests/reap_test.ts
+++ b/packages/core/tests/reap_test.ts
@@ -12,7 +12,7 @@
 import { assertEquals } from "./_assert.ts";
 import { Build, discoverTargets } from "../src/build.ts";
 import { target } from "../src/target.ts";
-import { reapAbandoned } from "../src/reap.ts";
+import { reapAbandoned, recoverStranded } from "../src/reap.ts";
 import { FileSystemStateStore } from "../src/state/fs_store.ts";
 import { defaultStateHost } from "../src/state/store.ts";
 import { RUN_LEASE_PREFIX } from "../src/state/run_lease.ts";
@@ -249,4 +249,75 @@ Deno.test("one bad run does not strand the rest of the sweep", async () => {
       assertEquals(lines.some((l) => l.includes("the store hiccuped")), true);
     },
   );
+});
+
+Deno.test("a live run past its deadline is left to whoever is running it", async () => {
+  // The ordering that keeps this safe. Settling a run whose process is still
+  // working would run its compensations beside the work they undo, and leave a
+  // live process reporting on a run somebody else had ended. Every case the
+  // deadline exists for has no live holder, so nothing it should catch escapes.
+  await withStore(
+    [record("run-1", "running", "2026-08-10T11:00:00.000Z")],
+    async (store) => {
+      const held = await store.acquireLock(
+        lockKey(RUN_LEASE_PREFIX, "run-1"),
+        { actor: "the-owner", runId: "run-1", since: NOW },
+        60_000,
+      );
+      assertEquals(held.ok, true);
+
+      const { reporter } = capturing();
+      const outcome = await reapAbandoned(depsFor(store, reporter));
+      assertEquals(outcome, { reaped: [], settled: [], failed: 0 });
+      assertEquals((await store.getRun("run-1"))?.record.status, "running");
+    },
+  );
+});
+
+Deno.test("another build's runs are not touched", async () => {
+  // A store is commonly shared, and a listing has no build filter. Acting on
+  // another build's run is worse than useless: its targets are not in this
+  // build, so a settlement finds no compensations, stamps the record terminal
+  // with the run's side effects never unwound, and nothing retries it.
+  await withStore([record("foreign", "running")], async (store) => {
+    const loaded = await store.getRun("foreign");
+    if (loaded === null) throw new Error("seed missing");
+    const foreign = structuredClone(loaded.record);
+    foreign.build = "SomeOtherBuild";
+    assertEquals((await store.putRun(foreign, loaded.version)).ok, true);
+
+    const { reporter } = capturing();
+    const outcome = await reapAbandoned(depsFor(store, reporter));
+    assertEquals(outcome, { reaped: [], settled: [], failed: 0 });
+    assertEquals((await store.getRun("foreign"))?.record.status, "running");
+  });
+});
+
+Deno.test("another build's stranded run is not settled either", async () => {
+  await withStore([record("foreign", "cancelling")], async (store) => {
+    const loaded = await store.getRun("foreign");
+    if (loaded === null) throw new Error("seed missing");
+    const foreign = structuredClone(loaded.record);
+    foreign.build = "SomeOtherBuild";
+    assertEquals((await store.putRun(foreign, loaded.version)).ok, true);
+
+    const { reporter } = capturing();
+    const outcome = await recoverStranded(depsFor(store, reporter));
+    assertEquals(outcome.settled, []);
+    assertEquals((await store.getRun("foreign"))?.record.status, "cancelling");
+  });
+});
+
+Deno.test("a stranded run is recovered for a single-run sweep too", async () => {
+  // A plane that sweeps one run at a time is exactly the one that would
+  // otherwise never recover it, since nothing else looks at `cancelling`.
+  await withStore([record("run-1", "cancelling")], async (store) => {
+    const { reporter } = capturing();
+    const outcome = await recoverStranded({
+      ...depsFor(store, reporter),
+      runId: "run-1",
+    });
+    assertEquals(outcome.settled, ["run-1"]);
+    assertEquals((await store.getRun("run-1"))?.record.status, "cancelled");
+  });
 });

--- a/packages/core/tests/reap_test.ts
+++ b/packages/core/tests/reap_test.ts
@@ -359,3 +359,50 @@ Deno.test("a stranded run settles into the terminal its settlement intended", as
     assertEquals((await store.getRun("run-1"))?.record.status, "failed");
   });
 });
+
+Deno.test("a colliding build with a different graph does not settle the run", async () => {
+  // Same class name, same root-target name, different graph — the residual the
+  // name-and-root check cannot see. Settling is irreversible and skips
+  // compensations it cannot resolve, so it asks the stricter question.
+  await withStore(
+    [record("run-1", "running", "2026-08-10T11:00:00.000Z")],
+    async (store) => {
+      const loaded = await store.getRun("run-1");
+      if (loaded === null) throw new Error("seed missing");
+      const other = structuredClone(loaded.record);
+      // Another repo's `Cd`, whose `deploy` depends on something this one has not
+      // got.
+      other.graph = [
+        { name: "build", dependsOn: [] },
+        { name: "deploy", dependsOn: ["build"] },
+      ];
+      assertEquals((await store.putRun(other, loaded.version)).ok, true);
+
+      const { reporter } = capturing();
+      const outcome = await reapAbandoned(depsFor(store, reporter));
+      // Not settled. It is still handed back, because that is reversible and a
+      // resume refuses a graph it does not recognise with a clear error.
+      assertEquals(outcome.settled, []);
+      assertEquals(outcome.reaped, ["run-1"]);
+    },
+  );
+});
+
+Deno.test("a colliding build with a different graph does not finish a stranded run", async () => {
+  await withStore([record("run-1", "cancelling")], async (store) => {
+    const loaded = await store.getRun("run-1");
+    if (loaded === null) throw new Error("seed missing");
+    const other = structuredClone(loaded.record);
+    other.graph = [
+      { name: "build", dependsOn: [] },
+      { name: "deploy", dependsOn: ["build"] },
+    ];
+    assertEquals((await store.putRun(other, loaded.version)).ok, true);
+
+    const { reporter } = capturing();
+    const outcome = await recoverStranded(depsFor(store, reporter));
+    assertEquals(outcome.settled, []);
+    // Left for the build that recognises it.
+    assertEquals((await store.getRun("run-1"))?.record.status, "cancelling");
+  });
+});

--- a/packages/core/tests/reap_test.ts
+++ b/packages/core/tests/reap_test.ts
@@ -1,0 +1,252 @@
+/**
+ * Unit tests for reaping — deciding, for a run that claims to be running,
+ * whether anyone is still there.
+ *
+ * The decisions under test are the ones with consequences: leaving a slow run
+ * alone, releasing a dead one, settling one that has run out of time, and never
+ * moving a run somebody else has already settled.
+ *
+ * @module
+ */
+
+import { assertEquals } from "./_assert.ts";
+import { Build, discoverTargets } from "../src/build.ts";
+import { target } from "../src/target.ts";
+import { reapAbandoned } from "../src/reap.ts";
+import { FileSystemStateStore } from "../src/state/fs_store.ts";
+import { defaultStateHost } from "../src/state/store.ts";
+import { RUN_LEASE_PREFIX } from "../src/state/run_lease.ts";
+import { lockKey } from "../src/state/lock.ts";
+import type { Reporter } from "../src/executor.ts";
+import type { RunRecord, RunStatus } from "../src/state/types.ts";
+
+const NOW = "2026-08-10T12:00:00.000Z";
+
+/** A build whose one target has a compensation, so settling has work to do. */
+class Cd extends Build {
+  rollback = target().unlisted().executes(() => {});
+  deploy = target().onCancel(this.rollback).executes(() => {});
+}
+
+/** A silent reporter that keeps what it was told. */
+function capturing(): { reporter: Reporter; lines: string[] } {
+  const lines: string[] = [];
+  return {
+    reporter: { info: (l) => lines.push(l), error: (l) => lines.push(l) },
+    lines,
+  };
+}
+
+/** A record in `status`, with `deploy` recorded as having succeeded. */
+function record(id: string, status: RunStatus, deadlineAt?: string): RunRecord {
+  return {
+    id,
+    build: "Cd",
+    rootTarget: "deploy",
+    status,
+    actor: "runner",
+    createdAt: NOW,
+    updatedAt: NOW,
+    graph: [{ name: "deploy", dependsOn: [] }],
+    params: {},
+    targets: { deploy: { status: "succeeded", meta: {} } },
+    signals: {},
+    events: [],
+    ...(deadlineAt === undefined ? {} : { deadlineAt }),
+  };
+}
+
+/** Run `fn` against a temp store seeded with `seed`. */
+async function withStore(
+  seed: RunRecord[],
+  fn: (store: FileSystemStateStore) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    for (const r of seed) assertEquals((await store.putRun(r, null)).ok, true);
+    await fn(store);
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+}
+
+/** The reap dependencies for `store`, at a fixed time. */
+function depsFor(
+  store: FileSystemStateStore,
+  reporter: Reporter,
+  now = NOW,
+): Parameters<typeof reapAbandoned>[0] {
+  const build = new Cd();
+  discoverTargets(build);
+  return { build, store, actor: "sweeper", reporter, now: () => now };
+}
+
+Deno.test("a run whose holder is still there is left alone", async () => {
+  // The distinction the whole thing rests on: a live holder keeps renewing, so
+  // a lease that cannot be taken means the run is slow, not dead.
+  await withStore([record("run-1", "running")], async (store) => {
+    const held = await store.acquireLock(
+      lockKey(RUN_LEASE_PREFIX, "run-1"),
+      { actor: "the-owner", runId: "run-1", since: NOW },
+      60_000,
+    );
+    assertEquals(held.ok, true);
+
+    const { reporter } = capturing();
+    const outcome = await reapAbandoned(depsFor(store, reporter));
+    assertEquals(outcome, { reaped: [], settled: [], failed: 0 });
+
+    const after = await store.getRun("run-1");
+    assertEquals(after?.record.status, "running"); // untouched
+  });
+});
+
+Deno.test("a run whose holder is gone goes back to suspended", async () => {
+  // Nothing holds its lease, so the process that was driving it is gone. The
+  // run becomes resumable rather than being settled: its work may still be owed.
+  await withStore([record("run-1", "running")], async (store) => {
+    const { reporter, lines } = capturing();
+    const outcome = await reapAbandoned(depsFor(store, reporter));
+    assertEquals(outcome.reaped, ["run-1"]);
+    assertEquals(outcome.settled, []);
+
+    const after = await store.getRun("run-1");
+    assertEquals(after?.record.status, "suspended");
+    const event = after?.record.events.find((e) => e.tool === "reap");
+    assertEquals(event?.actor, "sweeper");
+    assertEquals(event?.outcome, "ok");
+    assertEquals(
+      lines.some((l) => l.includes("returning it to suspended")),
+      true,
+    );
+  });
+});
+
+Deno.test("the reaper does not keep the lease it used to ask the question", async () => {
+  // It only acquired one to find out whether anyone else had it. Holding on
+  // would make the resumer that follows refuse the run it just freed.
+  await withStore([record("run-1", "running")], async (store) => {
+    const { reporter } = capturing();
+    await reapAbandoned(depsFor(store, reporter));
+    const free = await store.acquireLock(
+      lockKey(RUN_LEASE_PREFIX, "run-1"),
+      { actor: "the-resumer", runId: "run-1", since: NOW },
+      60_000,
+    );
+    assertEquals(free.ok, true);
+  });
+});
+
+Deno.test("a run past its deadline is settled failed, with its compensations", async () => {
+  await withStore(
+    [record("run-1", "running", "2026-08-10T11:00:00.000Z")],
+    async (store) => {
+      const { reporter, lines } = capturing();
+      const outcome = await reapAbandoned(depsFor(store, reporter));
+      assertEquals(outcome.settled, ["run-1"]);
+      assertEquals(outcome.reaped, []);
+
+      const after = await store.getRun("run-1");
+      // `failed`, not `cancelled`: it ran out of time, nobody asked it to stop.
+      assertEquals(after?.record.status, "failed");
+      // And its side effects were unwound, exactly as a cancel would.
+      const compensated = after?.record.events.filter((e) =>
+        e.tool === "compensate"
+      );
+      assertEquals(compensated?.length, 1);
+      assertEquals(lines.some((l) => l.includes("passed its deadline")), true);
+    },
+  );
+});
+
+Deno.test("a deadline is only past when it is actually past", async () => {
+  await withStore(
+    [record("run-1", "running", "2026-08-10T13:00:00.000Z")],
+    async (store) => {
+      const { reporter } = capturing();
+      const outcome = await reapAbandoned(depsFor(store, reporter));
+      // An hour of budget left: reaped as ownerless, not settled as expired.
+      assertEquals(outcome.settled, []);
+      assertEquals(outcome.reaped, ["run-1"]);
+    },
+  );
+});
+
+Deno.test("a malformed deadline is not treated as a passed one", async () => {
+  // Refusing to guess beats settling a healthy run because a timestamp was junk.
+  await withStore([record("run-1", "running", "not-a-date")], async (store) => {
+    const { reporter } = capturing();
+    const outcome = await reapAbandoned(depsFor(store, reporter));
+    assertEquals(outcome.settled, []);
+    assertEquals(outcome.reaped, ["run-1"]);
+  });
+});
+
+Deno.test("a run with no deadline is never settled for time", async () => {
+  await withStore([record("run-1", "running")], async (store) => {
+    const { reporter } = capturing();
+    const outcome = await reapAbandoned(depsFor(store, reporter));
+    assertEquals(outcome.settled, []);
+  });
+});
+
+Deno.test("only running runs are examined", async () => {
+  await withStore(
+    [
+      record("done", "succeeded"),
+      record("waiting", "suspended"),
+      record("stopping", "cancelling"),
+    ],
+    async (store) => {
+      const { reporter } = capturing();
+      const outcome = await reapAbandoned(depsFor(store, reporter));
+      assertEquals(outcome, { reaped: [], settled: [], failed: 0 });
+      assertEquals((await store.getRun("waiting"))?.record.status, "suspended");
+    },
+  );
+});
+
+Deno.test("a run settled between the lease and the write is left as it was found", async () => {
+  // The window this closes: the reaper takes the lease of a run with no holder,
+  // and a canceller settles it before the reaper writes. Moving it then would
+  // undo the canceller's work.
+  await withStore([record("run-1", "running")], async (store) => {
+    const { reporter } = capturing();
+    const deps = depsFor(store, reporter);
+    // Settle it the moment the reaper asks for the record.
+    const realGet = store.getRun.bind(store);
+    let asked = 0;
+    store.getRun = async (id: string) => {
+      const got = await realGet(id);
+      if (++asked === 2 && got !== null) {
+        const settled = structuredClone(got.record);
+        settled.status = "cancelled";
+        await store.putRun(settled, got.version);
+        return await realGet(id);
+      }
+      return got;
+    };
+    const outcome = await reapAbandoned(deps);
+    assertEquals(outcome.reaped, []);
+    assertEquals((await realGet("run-1"))?.record.status, "cancelled");
+  });
+});
+
+Deno.test("one bad run does not strand the rest of the sweep", async () => {
+  await withStore(
+    [record("bad", "running"), record("good", "running")],
+    async (store) => {
+      const { reporter, lines } = capturing();
+      const realGet = store.getRun.bind(store);
+      store.getRun = (id: string) =>
+        id === "bad"
+          ? Promise.reject(new Error("the store hiccuped"))
+          : realGet(id);
+      const outcome = await reapAbandoned(depsFor(store, reporter));
+      assertEquals(outcome.failed, 1);
+      assertEquals(outcome.reaped, ["good"]);
+      assertEquals(lines.some((l) => l.includes("the store hiccuped")), true);
+    },
+  );
+});

--- a/packages/core/tests/state_test.ts
+++ b/packages/core/tests/state_test.ts
@@ -942,7 +942,9 @@ Deno.test("a conflicting re-apply onto a cancelling record loses the write", asy
   store.record.status = "cancelling";
   store.forceConflicts = 2;
   await writer.markTargetSettled("deploy", "passed");
-  assertEquals(warnings.some((w) => w.includes("cancelled elsewhere")), true);
+  // "settled elsewhere" rather than "cancelled": the same window is now reached
+  // by a sweep failing an abandoned run as well as by an operator cancelling.
+  assertEquals(warnings.some((w) => w.includes("settled elsewhere")), true);
   assertEquals(writer.snapshot().degraded, true);
   assertEquals(aborted, true);
 });

--- a/packages/core/tests/writer_effects_test.ts
+++ b/packages/core/tests/writer_effects_test.ts
@@ -322,3 +322,38 @@ Deno.test("giving up after repeated conflicts marks the record degraded", async 
   await assertRejects(() => writer.beginEffect("gate", "post"), Error);
   assertEquals(writer.snapshot().degraded, true);
 });
+
+Deno.test("a run settled elsewhere is not reported as succeeded by the process it settled", async () => {
+  // The spurious green. A sweep settles a run it found past its deadline and
+  // unwinds it; the process still working on that run then finishes normally and
+  // would report success — a green result for work another process had already
+  // rolled back. Which, for a merge gate, is the whole thing this must not do.
+  const store = new MemStore();
+  let aborted = 0;
+  const writer = await writerFor(store, "running", () => void aborted++);
+
+  // Another process settles it `failed`, and this writer's next write conflicts.
+  store.forceConflicts = 1;
+  store.freshStatus = "failed";
+  await writer.markTargetSettled("gate", "passed");
+  assertEquals(aborted, 1); // told to stop
+  assertEquals(store.record?.status, "failed"); // and the terminal is untouched
+
+  // The conflict brought this writer's version back into step, so a later
+  // write lands unchallenged — which is why the observation has to be latched.
+  store.freshStatus = undefined;
+  await writer.markRunFinished(true);
+  assertEquals(store.record?.status, "failed");
+  assertEquals(writer.settledElsewhere(), true);
+});
+
+Deno.test("a run settled elsewhere is not marked suspended either", async () => {
+  const store = new MemStore();
+  const writer = await writerFor(store);
+  store.forceConflicts = 1;
+  store.freshStatus = "cancelled";
+  await writer.markTargetSettled("gate", "passed");
+  store.freshStatus = undefined;
+  await writer.markRunSuspended();
+  assertEquals(store.record?.status, "cancelled");
+});

--- a/tests/e2e/reap_takeover_e2e.ts
+++ b/tests/e2e/reap_takeover_e2e.ts
@@ -1,0 +1,104 @@
+/**
+ * End-to-end: two real sweeper processes racing to reap the same abandoned run.
+ *
+ * The in-process suite can prove a reap happens; it cannot prove that two of
+ * them do not both happen. Exactly one process must take the run over, or the
+ * work it was owed is performed twice by two processes at once — which is the
+ * failure a lease exists to prevent, not merely the duplicate an at-least-once
+ * contract tolerates.
+ *
+ * @module
+ */
+
+import { assertEquals } from "../../packages/core/tests/_assert.ts";
+import {
+  defaultStateHost,
+  FileSystemStateStore,
+} from "../../packages/core/mod.ts";
+
+const FIXTURE = new URL("./fixtures/effect_build.ts", import.meta.url);
+
+/** Run the fixture as a real `deno` subprocess against `dir`. */
+async function run(
+  args: string[],
+  dir: string,
+  marker: string,
+): Promise<{ code: number; out: string }> {
+  const command = new Deno.Command(Deno.execPath(), {
+    // A `file://` URL rather than URL.pathname, which is `/C:/…` on Windows.
+    args: ["run", "-A", FIXTURE.href, ...args],
+    env: { ZUKE_STATE_DIR: dir, ZUKE_E2E_MARKER: marker },
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const { code, stdout } = await command.output();
+  return { code, out: new TextDecoder().decode(stdout) };
+}
+
+/** The marker file's lines, or an empty list if it does not exist yet. */
+async function markerLines(marker: string): Promise<string[]> {
+  try {
+    const text = await Deno.readTextFile(marker);
+    return text.split("\n").filter((line) => line !== "");
+  } catch {
+    return [];
+  }
+}
+
+Deno.test("two sweepers race an abandoned run; exactly one reaps it", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "zuke-e2e-" });
+  const marker = `${dir}/marker.log`;
+  try {
+    // A completed run, which we then rewind to what a killed process leaves.
+    assertEquals((await run(["announce"], dir, marker)).code, 0);
+    assertEquals(await markerLines(marker), ["announce redriven=false"]);
+
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    const runs = await store.listRuns({});
+    assertEquals(runs.length, 1);
+    const id = runs[0].id;
+
+    const got = await store.getRun(id);
+    if (got === null) throw new Error("the run vanished");
+    const stranded = structuredClone(got.record);
+    stranded.status = "running";
+    stranded.targets["announce"] = {
+      status: "running",
+      meta: {},
+      effects: {
+        announce: {
+          status: "pending",
+          intentAt: "2026-08-10T10:00:00.000Z",
+          attempts: 1,
+        },
+      },
+    };
+    assertEquals((await store.putRun(stranded, got.version)).ok, true);
+
+    // Two genuinely separate sweepers, at the same time.
+    const [a, b] = await Promise.all([
+      run(["resume", "--check"], dir, marker),
+      run(["resume", "--check"], dir, marker),
+    ]);
+    assertEquals([a.code, b.code], [0, 0]);
+
+    // Driven exactly once more, by exactly one of them. Two would mean both
+    // sweepers took the run over, which the lease exists to prevent.
+    assertEquals(await markerLines(marker), [
+      "announce redriven=false",
+      "announce redriven=true",
+    ]);
+
+    const after = await store.getRun(id);
+    assertEquals(after?.record.status, "succeeded");
+    const row = after?.record.targets["announce"]?.effects?.["announce"];
+    assertEquals(row?.status, "done");
+    assertEquals(row?.attempts, 2);
+    // One reap on the record, not two.
+    const reaps = (after?.record.events ?? []).filter((e) => e.tool === "reap");
+    assertEquals(reaps.length, 1);
+  } finally {
+    // Best-effort: a cleanup failure must not mask the real assertion error.
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});

--- a/tests/integration/reap_test.ts
+++ b/tests/integration/reap_test.ts
@@ -13,6 +13,7 @@ import { assertEquals } from "../../packages/core/tests/_assert.ts";
 import {
   Build,
   defaultStateHost,
+  externalSignal,
   FileSystemStateStore,
   target,
 } from "../../packages/core/mod.ts";
@@ -143,5 +144,78 @@ Deno.test("a run past its deadline is settled failed rather than resumed", async
     const store = new FileSystemStateStore(dir, defaultStateHost);
     const after = await store.getRun(id);
     assertEquals(after?.record.status, "failed");
+  });
+});
+
+Deno.test("time spent parked at a gate is not charged against the deadline", async () => {
+  // The documented contract, and the one it is easiest to get backwards. A
+  // 45-minute budget behind a long approval gate would otherwise be exhausted
+  // before anyone could approve, and the run would be settled the instant it
+  // woke up — killed by the deadline it was never spending.
+  class Cd extends Build {
+    override deadline() {
+      return "45m";
+    }
+    hold = target().waitsFor((s) => s.on(externalSignal("go")));
+    ship = target().dependsOn(this.hold).executes(() => {});
+  }
+
+  await withStateDir(async (dir) => {
+    assertEquals((await runCli(Cd, ["ship"])).code, 0); // suspended at the gate
+    const id = await onlyRunId(dir);
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+
+    // Park it for two hours — well past the 45-minute budget.
+    const loaded = await store.getRun(id);
+    if (loaded === null) throw new Error("the run vanished");
+    const parked = structuredClone(loaded.record);
+    const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+    parked.updatedAt = twoHoursAgo;
+    parked.deadlineAt = new Date(
+      Date.parse(twoHoursAgo) + 45 * 60 * 1000,
+    ).toISOString();
+    assertEquals((await store.putRun(parked, loaded.version)).ok, true);
+
+    // Approved: the run resumes, and its budget is pushed forward by what it
+    // spent parked — so it is not already expired the moment it wakes up, which
+    // is what the next sweep would otherwise settle it for.
+    const resumed = await runCli(Cd, ["resume", id, "--signal", "go"]);
+    assertEquals(resumed.code, 0);
+    const after = await store.getRun(id);
+    assertEquals(after?.record.status, "succeeded");
+
+    const deadline = Date.parse(after?.record.deadlineAt ?? "");
+    assertEquals(Number.isFinite(deadline), true);
+    // Still ahead of now: the two parked hours were given back, so roughly the
+    // original 45 minutes of running budget remain.
+    assertEquals(deadline > Date.now(), true);
+  });
+});
+
+Deno.test("a deadline added after a run suspended does not strand it", async () => {
+  // A build gains a deadline between the run suspending and the resume. The
+  // resume adopts the record's own deadline, so nothing parses the build's — a
+  // throw there would leave the run `running` to be reaped, resumed, and
+  // stranded again on every sweep, forever.
+  class Before extends Build {
+    hold = target().waitsFor((s) => s.on(externalSignal("go")));
+    ship = target().dependsOn(this.hold).executes(() => {});
+  }
+  class After extends Build {
+    override deadline() {
+      return "not-a-duration";
+    }
+    hold = target().waitsFor((s) => s.on(externalSignal("go")));
+    ship = target().dependsOn(this.hold).executes(() => {});
+  }
+
+  await withStateDir(async (dir) => {
+    assertEquals((await runCli(Before, ["ship"])).code, 0);
+    const id = await onlyRunId(dir);
+
+    const resumed = await runCli(After, ["resume", id, "--signal", "go"]);
+    assertEquals(resumed.code, 0);
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    assertEquals((await store.getRun(id))?.record.status, "succeeded");
   });
 });

--- a/tests/integration/reap_test.ts
+++ b/tests/integration/reap_test.ts
@@ -1,0 +1,147 @@
+/**
+ * Integration tests for reaping, driven through the real CLI.
+ *
+ * The loop these close: a process killed mid-run leaves the run `running`, and a
+ * resume only ever acts on `suspended` runs. Until something notices and moves
+ * it, an effect that run recorded as owed waits forever. One
+ * `zuke resume --check` now notices, moves it, and drives it — on the same pass.
+ *
+ * @module
+ */
+
+import { assertEquals } from "../../packages/core/tests/_assert.ts";
+import {
+  Build,
+  defaultStateHost,
+  FileSystemStateStore,
+  target,
+} from "../../packages/core/mod.ts";
+import { runCli, withStateDir } from "./_harness.ts";
+
+/** The id of the (single) run the CLI persisted under `dir`. */
+async function onlyRunId(dir: string): Promise<string> {
+  const store = new FileSystemStateStore(dir, defaultStateHost);
+  const runs = await store.listRuns({});
+  assertEquals(runs.length, 1);
+  return runs[0].id;
+}
+
+/** Leave the run in the state a killed process leaves: running, work still owed. */
+async function strandAsKilled(dir: string, id: string): Promise<void> {
+  const store = new FileSystemStateStore(dir, defaultStateHost);
+  const got = await store.getRun(id);
+  if (got === null) throw new Error("the run vanished");
+  const record = structuredClone(got.record);
+  record.status = "running";
+  record.targets["publish"] = {
+    status: "running",
+    meta: {},
+    effects: {
+      announce: {
+        status: "pending",
+        intentAt: "2026-08-10T10:00:00.000Z",
+        attempts: 1,
+      },
+    },
+  };
+  assertEquals((await store.putRun(record, got.version)).ok, true);
+}
+
+Deno.test("one sweep reaps an abandoned run and re-drives what it owed", async () => {
+  // The whole point, end to end: nothing but `resume --check`, and the effect a
+  // killed process left owed is performed.
+  const drives: boolean[] = [];
+
+  class Cd extends Build {
+    publish = target().effect("announce", (ctx) => {
+      drives.push(ctx.redriven);
+    });
+  }
+
+  await withStateDir(async (dir) => {
+    assertEquals((await runCli(Cd, ["publish"])).code, 0);
+    const id = await onlyRunId(dir);
+    assertEquals(drives, [false]);
+
+    await strandAsKilled(dir, id);
+
+    const swept = await runCli(Cd, ["resume", "--check"]);
+    assertEquals(swept.code, 0);
+    // Driven again, and told that a previous attempt already committed.
+    assertEquals(drives, [false, true]);
+
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    const after = await store.getRun(id);
+    assertEquals(after?.record.status, "succeeded");
+    const row = after?.record.targets["publish"]?.effects?.["announce"];
+    assertEquals(row?.status, "done");
+    assertEquals(row?.attempts, 2);
+    // The reap is on the record, so an operator can see why the run moved.
+    assertEquals(
+      after?.record.events.some((e) => e.tool === "reap"),
+      true,
+    );
+  });
+});
+
+Deno.test("a sweep leaves a run alone while its holder is still there", async () => {
+  // Slow is not dead. A live lease means someone is working on it, and taking
+  // that run away would put two processes on it.
+  const drives: string[] = [];
+
+  class Cd extends Build {
+    publish = target().effect("announce", () => {
+      drives.push("announce");
+    });
+  }
+
+  await withStateDir(async (dir) => {
+    assertEquals((await runCli(Cd, ["publish"])).code, 0);
+    const id = await onlyRunId(dir);
+    await strandAsKilled(dir, id);
+
+    // Someone is holding the run's lease — as a live process would be.
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    const held = await store.acquireLock(
+      `zuke-run-${id}`,
+      { actor: "the-owner", runId: id, since: "2026-08-10T10:00:00.000Z" },
+      60_000,
+    );
+    assertEquals(held.ok, true);
+
+    const swept = await runCli(Cd, ["resume", "--check"]);
+    assertEquals(swept.code, 0);
+    assertEquals(drives, ["announce"]); // not driven a second time
+
+    const after = await store.getRun(id);
+    assertEquals(after?.record.status, "running"); // untouched
+  });
+});
+
+Deno.test("a run past its deadline is settled failed rather than resumed", async () => {
+  const drives: string[] = [];
+
+  class Cd extends Build {
+    override deadline() {
+      return "1ms";
+    }
+    publish = target().effect("announce", () => {
+      drives.push("announce");
+    });
+  }
+
+  await withStateDir(async (dir) => {
+    assertEquals((await runCli(Cd, ["publish"])).code, 0);
+    const id = await onlyRunId(dir);
+    await strandAsKilled(dir, id);
+
+    const swept = await runCli(Cd, ["resume", "--check"]);
+    assertEquals(swept.code, 0);
+    // Out of time: the owed effect is not re-driven, the run gets an answer.
+    assertEquals(drives, ["announce"]);
+
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    const after = await store.getRun(id);
+    assertEquals(after?.record.status, "failed");
+  });
+});


### PR DESCRIPTION
## Why

A run that ends cleanly settles itself, and a run that suspends is picked up by the resume sweep. A run whose process was **killed** does neither: it stays `running`, and a resume only ever acts on `suspended` runs. So anything that run recorded as owed waited forever — which made the durable half of a durable effect a promise nothing kept.

This is the last piece of the durable merge-gate series (#315, #317, #318, #319, #320, #322).

## What it does

`zuke resume --check` now examines this build's `running` runs before sweeping the suspended ones. The first question is always whether anyone is still there — the run's lease answers it, since a live process keeps renewing. A run with no holder goes back to `suspended` with a `reap` audit event, and the same sweep resumes it, so recovery takes one pass rather than an extra interval spent on nothing but a state change.

A build can now declare a wall-clock budget for a whole run. A run with no holder that has passed that budget is settled **`failed`**, compensations and all — it did not stop because anyone asked, it ran out of time, and anything waiting needs an answer. The budget covers *running*: time parked at a gate is given back on resume, so a 45-minute deadline behind a 72-hour approval gate still has its 45 minutes when the approval arrives.

The settlement machinery is now shared. An operator's cancel is one terminal, a passed deadline is the other, and the walk between them is identical — because an abandoned run's side effects need unwinding just as carefully as a cancelled one's. Which terminal a settlement intends is recorded on the run, because the process that finishes it may not be the one that began it.

## `zuke cancel` is unchanged, and that was tested first

The requester's promote plane runs these paths from a pinned image, so a silent change stays dormant until a deployment moves. I wrote a contract test suite **before** touching anything: the returned result field by field, the terminal status, the audit events, and the wording of every line it prints.

That discipline paid twice. It caught my own wrong assumption immediately — I expected the cancel summary event to carry the run id in its args, and it carries an empty object — and it caught me casually rewording two reporter lines, which I then restored verbatim for the cancel path.

## The second commit is the adversarial pass, and it found four real defects

Two ended in **a run whose work had been unwound reporting that it succeeded** — the outcome this series exists to prevent. Two reviewers found the first one independently.

- **The writer only noticed an external settlement for `cancelling` and `cancelled`.** A sweep leaves a run `failed`, so the process still working on it sailed past the check and re-applied its own terminal. Worse, that check only fires on a *conflicting* write: once a writer came back into step with the settled record, its next write landed unchallenged. The observation is now latched, and a process that discovers it reports the run as failed rather than claiming an outcome that is not its to give.
- **The deadline settled runs that were demonstrably alive**, because it was checked before asking whether the run still had a process — running a run's compensations beside the work they were undoing. The lease question now comes first. That costs nothing the deadline was for: a hung process stops renewing its lease, and a run killed repeatedly has no holder at all.
- **The deadline charged time spent parked at a gate**, so the docs' own worked example produced the outcome the docs excluded. Now pushed forward on resume.
- **The sweep mutated other builds' runs.** A store is commonly shared and a listing has no build filter, so a settlement found none of the run's targets, stamped it terminal with its side effects never unwound, and left nothing to retry it. The suspended sweep was safe here only because a resume *refuses* an unmatched build; a reap mutates, so it now checks.

Plus two smaller ones: resolving the build's budget on the resume path computed a discarded value, and a malformed one stranded the run to be reaped and stranded again forever; and a single-run sweep never recovered a run left `cancelling`, which is exactly the sweep shape with nothing else to fall back on.

## Tests

- **Unit:** 14 reaper — live holder skipped, dead holder released, lease not retained, deadline settled with compensations, malformed deadline refused rather than guessed, a run settled between the lease and the write left alone, foreign builds untouched, one bad run not stranding the sweep. Plus 5 cancel-contract and 2 writer.
- **Integration:** 5, including the whole loop — nothing but a sweep, and a killed run's owed effect is performed.
- **E2E:** two real sweeper processes racing one abandoned run; exactly one reap event and exactly one extra drive. Run repeatedly for flakiness.

**Four fixes are mutation-checked** — reverting any one fails its test. That process caught a fifth problem: my first parked-time test passed *without* the fix, so it was rewritten to assert the property directly.

Full gate green locally, 18 of 18, plus the e2e suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
