### PR TITLE
feat(core): enforce operator token over whole run plan

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -394,6 +394,28 @@ plugins/zuke/             # Claude Code plugin wrapping the skills
   the website's package grid is generated from it by `syncWebsite`.
 - **Update docs with code.** If behaviour changes, update `README.md`, JSDoc,
   and the spec/acceptance criteria in the same PR.
+- **The agent skills are docs too — and they ship to a marketplace.** `skills/`
+  is the source of truth for `zuke-write-build` and `zuke-setup`, and
+  `plugins/zuke/` is the Claude Code plugin that publishes them. Any change to
+  the authoring surface or to a documented guarantee — a new `target()` method,
+  a new `Build` override, changed CLI or authorization semantics — must be
+  reflected in `skills/zuke-write-build/SKILL.md` and
+  `skills/zuke-write-build/references/cheatsheet.md` **in the same PR**. The
+  cheatsheet is one of the two canonical answers to "does a wrapper exist?", so
+  a new package belongs in its catalogue table as well. Then, in order:
+  1. Run `./zuke pluginSync` to regenerate `plugins/zuke/skills/`. Never hand-edit
+     the copies — `pluginSyncCheck` fails on drift, and it is the only part of
+     this that is automated.
+  2. **Bump the plugin version by hand, in both manifests**:
+     `plugins/zuke/.claude-plugin/plugin.json` and the entry in
+     `.claude-plugin/marketplace.json`. They must agree —
+     `tests/plugin_manifest_test.ts` enforces that much, but nothing can tell
+     you that you *forgot* to bump, because that needs the base branch to
+     compare against. Clients use the version to decide whether an installed
+     plugin is stale, so skills edited without a bump simply never reach agents
+     that already hold the old copy. release-please does **not** manage
+     `plugins/` — it is not a workspace package and has no `deno.json`.
+     Additive skill content is a minor bump; a correction is a patch.
 - **Always read the reviewer comments on every PR.** This repo runs AI reviewers
   (`@zuke/ai`) that post their assessments as PR comments (and human reviewers
   do too). Before considering a PR done — and again after each push — fetch and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,7 +294,8 @@ subset that can drift from it. `zuke.ts`'s `ci` target depends on: `format`
 (`deno fmt --check`), `lint` (`deno lint`), `spell` (cspell), `coverage`
 (type-check, then the test suite with the 95% coverage gate), `coverageUpload`
 (skips locally without a `CODECOV_TOKEN`), `apiDocsCheck`, `docLint`,
-`snippetsCheck`, `hclSyncCheck`, `pluginSyncCheck`, `prBodyLint`, and
+`snippetsCheck`, `hclSyncCheck`, `pluginSyncCheck`, `pluginVersionCheck`,
+`prBodyLint`, `actionPinCheck`, `security`, and
 `lockCheck`. Read `zuke.ts`'s `ci` target for the current, authoritative list —
 this is a snapshot, not a second source of truth.
 
@@ -403,19 +404,24 @@ plugins/zuke/             # Claude Code plugin wrapping the skills
   `skills/zuke-write-build/references/cheatsheet.md` **in the same PR**. The
   cheatsheet is one of the two canonical answers to "does a wrapper exist?", so
   a new package belongs in its catalogue table as well. Then, in order:
-  1. Run `./zuke pluginSync` to regenerate `plugins/zuke/skills/`. Never hand-edit
-     the copies — `pluginSyncCheck` fails on drift, and it is the only part of
-     this that is automated.
+  1. Run `./zuke pluginSync` to regenerate `plugins/zuke/skills/`. Never
+     hand-edit the copies — `pluginSyncCheck` fails on drift.
   2. **Bump the plugin version by hand, in both manifests**:
      `plugins/zuke/.claude-plugin/plugin.json` and the entry in
-     `.claude-plugin/marketplace.json`. They must agree —
-     `tests/plugin_manifest_test.ts` enforces that much, but nothing can tell
-     you that you *forgot* to bump, because that needs the base branch to
-     compare against. Clients use the version to decide whether an installed
-     plugin is stale, so skills edited without a bump simply never reach agents
-     that already hold the old copy. release-please does **not** manage
-     `plugins/` — it is not a workspace package and has no `deno.json`.
-     Additive skill content is a minor bump; a correction is a patch.
+     `.claude-plugin/marketplace.json`. Clients use the version to decide
+     whether an installed plugin is stale, so skills edited without a bump
+     simply never reach agents that already hold the old copy. release-please
+     does **not** manage `plugins/` — it is not a workspace package and has no
+     `deno.json`. Additive skill content is a minor bump; a correction is a
+     patch.
+
+  Two gate targets hold this up, so a miss fails the build rather than shipping
+  quietly: `pluginVersionCheck` fails when a published skill changed against the
+  base branch and the version did not move, and `tests/plugin_manifest_test.ts`
+  fails when the two manifests disagree. `pluginVersionCheck` is the one part of
+  the gate that needs history — it compares against `origin/<PR base>`, or
+  `ZUKE_PLUGIN_BASE_REF` when you set one — and it reports itself *skipped*,
+  never passed, in a clone that has no base to compare against.
 - **Always read the reviewer comments on every PR.** This repo runs AI reviewers
   (`@zuke/ai`) that post their assessments as PR comments (and human reviewers
   do too). Before considering a PR done — and again after each push — fetch and

--- a/build/plugin_version_check.ts
+++ b/build/plugin_version_check.ts
@@ -1,0 +1,229 @@
+/**
+ * The gate's plugin-version check.
+ *
+ * `plugins/zuke` is published to a Claude Code plugin marketplace, and clients
+ * use its declared version to decide whether an installed copy is stale. It is
+ * not a workspace package — it has no `deno.json` and release-please does not
+ * manage it — so the bump is manual, in two manifests, and nothing downstream
+ * complains when it is missed. The failure is silent in the worst way: the PR
+ * is green, the skills are correct in the repository, and every agent that
+ * already holds the old version simply never sees them.
+ *
+ * `pluginSyncCheck` guards the other half — that the committed copies under
+ * `plugins/zuke/skills/` match `skills/`. It cannot help here, because both
+ * sides move together and the version sits outside them.
+ *
+ * This check needs history, which is what makes it different from the rest of
+ * the gate: "the content changed but the version did not" is not a property of
+ * one snapshot. It compares against a base ref, so it does real work in CI (and
+ * in any clone that has the base) and honestly reports itself skipped when
+ * there is nothing to compare against — never silently passing, which would
+ * make it a check that cannot fail.
+ *
+ * @module
+ */
+
+import { GitTasks } from "@zuke/git";
+
+/** The skills tree that is the source of truth for the plugin. */
+export const SKILLS_DIR = "skills/";
+
+/** The committed copy the plugin ships. */
+export const PLUGIN_SKILLS_DIR = "plugins/zuke/skills/";
+
+/** The plugin's own manifest, whose version the marketplace reads. */
+export const PLUGIN_MANIFEST = "plugins/zuke/.claude-plugin/plugin.json";
+
+/** The marketplace manifest listing the plugin. */
+export const MARKETPLACE_MANIFEST = ".claude-plugin/marketplace.json";
+
+/** Whether a changed path is part of what the plugin publishes. */
+export function isSkillPath(path: string): boolean {
+  return path.startsWith(SKILLS_DIR) || path.startsWith(PLUGIN_SKILLS_DIR);
+}
+
+/** The subset of `paths` that would change what the marketplace serves. */
+export function skillPaths(paths: readonly string[]): string[] {
+  return paths.filter(isSkillPath);
+}
+
+/**
+ * Read `$.version` from a plugin manifest's text, or `undefined` when the text
+ * is absent or carries no string version. A malformed manifest is reported as
+ * missing rather than throwing: the caller decides whether that is fatal, and
+ * for the *base* side it legitimately is not (the file may be new).
+ */
+export function manifestVersion(text: string | null): string | undefined {
+  if (text === null) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (typeof parsed !== "object" || parsed === null) return undefined;
+    const version = (parsed as Record<string, unknown>).version;
+    return typeof version === "string" ? version : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** The git reads this check needs, injectable so the decision is testable. */
+export interface GitHistory {
+  /** Whether `ref` resolves in this clone. */
+  hasRef(ref: string): Promise<boolean>;
+  /** Paths differing between the merge base with `ref` and the working tree. */
+  changedSince(ref: string): Promise<string[]>;
+  /** A file's text at `ref`, or `null` when it did not exist there. */
+  fileAt(ref: string, path: string): Promise<string | null>;
+}
+
+/** What {@link checkPluginVersionBump} concluded, for the caller to report. */
+export interface BumpVerdict {
+  /** Whether the comparison actually ran. `false` means nothing was proven. */
+  checked: boolean;
+  /** Why the comparison was skipped, when it was. */
+  reason?: string;
+  /** The skill files that changed against the base. */
+  changed: string[];
+  /** The plugin version at the base ref, when it could be read. */
+  baseVersion?: string;
+  /** The plugin version in the working tree. */
+  headVersion?: string;
+  /** Whether the version moved. Meaningless unless `checked` and `changed`. */
+  bumped: boolean;
+}
+
+/**
+ * Decide whether the plugin version was bumped alongside the skills it ships.
+ *
+ * Returns a verdict rather than throwing so the caller owns the message; see
+ * {@link bumpFailure} for the failing case's text.
+ */
+export async function checkPluginVersionBump(
+  git: GitHistory,
+  base: string,
+  readHead: (path: string) => Promise<string | null>,
+): Promise<BumpVerdict> {
+  if (!(await git.hasRef(base))) {
+    return {
+      checked: false,
+      reason: `the base ref "${base}" is not present in this clone`,
+      changed: [],
+      bumped: false,
+    };
+  }
+  const changed = skillPaths(await git.changedSince(base));
+  const headVersion = manifestVersion(await readHead(PLUGIN_MANIFEST));
+  if (headVersion === undefined) {
+    // The working tree's manifest is the one thing that must always be
+    // readable. An unreadable one is a real problem, not a reason to skip.
+    return {
+      checked: true,
+      reason: `${PLUGIN_MANIFEST} has no readable string version`,
+      changed,
+      bumped: false,
+    };
+  }
+  if (changed.length === 0) {
+    return { checked: true, changed, headVersion, bumped: false };
+  }
+  const baseVersion = manifestVersion(await git.fileAt(base, PLUGIN_MANIFEST));
+  // No manifest at the base means the plugin is new on this branch; there is
+  // no previous version to differ from, so the bump requirement cannot apply.
+  const bumped = baseVersion === undefined || baseVersion !== headVersion;
+  return { checked: true, changed, baseVersion, headVersion, bumped };
+}
+
+/** The failure message for a verdict whose skills moved without a bump. */
+export function bumpFailure(verdict: BumpVerdict): string {
+  const listed = verdict.changed.slice(0, 5).map((p) => `  ${p}`).join("\n");
+  const more = verdict.changed.length > 5
+    ? `\n  …and ${verdict.changed.length - 5} more`
+    : "";
+  return [
+    `The published skills changed but the plugin version did not (still ` +
+    `${verdict.headVersion}).`,
+    "",
+    "Changed:",
+    `${listed}${more}`,
+    "",
+    "Clients use this version to decide whether an installed plugin is stale,",
+    "so skills shipped without a bump never reach agents holding the old copy.",
+    "",
+    `Bump the version in BOTH manifests (they must agree):`,
+    `  ${PLUGIN_MANIFEST}`,
+    `  ${MARKETPLACE_MANIFEST}`,
+    "Additive skill content is a minor bump; a correction is a patch.",
+  ].join("\n");
+}
+
+/** Whether a failed git invocation means the ref simply is not there. */
+function missingRef(stderr: string): boolean {
+  return /unknown revision|bad revision|not a valid object name|ambiguous argument/i
+    .test(stderr);
+}
+
+/** A {@link GitHistory} backed by the real `git` in the working directory. */
+export function defaultGitHistory(): GitHistory {
+  return {
+    async hasRef(ref) {
+      const out = await GitTasks.run((s) =>
+        s.command("rev-parse", "--verify", `${ref}^{commit}`).noThrow().quiet()
+      );
+      return out.code === 0;
+    },
+    async changedSince(ref) {
+      // Resolve the merge base first, then diff from it *without* the three-dot
+      // form. Both exclude commits that landed on the base branch after this
+      // one forked, which is the point — but `diff a...b` compares two commits
+      // and so ignores the working tree entirely. That would make the check
+      // pass locally for the person about to commit a skill edit with no bump,
+      // fail only once CI saw it committed: green here, red there, which is the
+      // exact failure mode the gate exists to prevent.
+      const base = await GitTasks.run((s) =>
+        s.command("merge-base", ref, "HEAD").noThrow().quiet()
+      );
+      if (base.code !== 0) {
+        throw new Error(
+          `git merge-base ${ref} HEAD failed: ${base.stderr.trim()}`,
+        );
+      }
+      const out = await GitTasks.run((s) =>
+        s.command("diff", "--name-only", base.stdout.trim()).noThrow().quiet()
+      );
+      if (out.code !== 0) {
+        throw new Error(`git diff against ${ref} failed: ${out.stderr.trim()}`);
+      }
+      return out.stdout.split("\n").map((l) => l.trim()).filter((l) =>
+        l !== ""
+      );
+    },
+    async fileAt(ref, path) {
+      const out = await GitTasks.run((s) =>
+        s.command("show", `${ref}:${path}`).noThrow().quiet()
+      );
+      if (out.code === 0) return out.stdout;
+      // A path absent at the base is an ordinary answer; anything else is not.
+      if (/does not exist|exists on disk, but not in/i.test(out.stderr)) {
+        return null;
+      }
+      if (missingRef(out.stderr)) return null;
+      throw new Error(
+        `git show ${ref}:${path} failed: ${out.stderr.trim()}`,
+      );
+    },
+  };
+}
+
+/**
+ * The base ref to compare against: GitHub's PR base when running on Actions,
+ * else `origin/master`. Returned as a remote-tracking ref, which is what a CI
+ * checkout has — `GITHUB_BASE_REF` is a bare branch name.
+ */
+export function resolveBaseRef(
+  readEnv: (name: string) => string | undefined = Deno.env.get,
+): string {
+  const explicit = readEnv("ZUKE_PLUGIN_BASE_REF");
+  if (explicit !== undefined && explicit !== "") return explicit;
+  const prBase = readEnv("GITHUB_BASE_REF");
+  if (prBase !== undefined && prBase !== "") return `origin/${prBase}`;
+  return "origin/master";
+}

--- a/build/plugin_version_check.ts
+++ b/build/plugin_version_check.ts
@@ -57,12 +57,17 @@ export function manifestVersion(text: string | null): string | undefined {
   if (text === null) return undefined;
   try {
     const parsed: unknown = JSON.parse(text);
-    if (typeof parsed !== "object" || parsed === null) return undefined;
-    const version = (parsed as Record<string, unknown>).version;
+    if (!isRecord(parsed)) return undefined;
+    const version = parsed.version;
     return typeof version === "string" ? version : undefined;
   } catch {
     return undefined;
   }
+}
+
+/** Whether a parsed JSON value is a plain object, narrowing it for field reads. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 /** The git reads this check needs, injectable so the decision is testable. */

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -101,7 +101,7 @@ agent can query runs it did not start:
 | Tool        | Returns                                                                             |
 | ----------- | ----------------------------------------------------------------------------------- |
 | `list_runs` | Persisted run summaries (optional `status`/`target`/`since` filters), newest first. |
-| `show_run`  | One run's full record — status, per-target progress, signals, and the audit trail.  |
+| `show_run`  | One run's full record — status, per-target progress, and signals. Refuses the audit trail. |
 
 With `--allow-run`, the server also exposes one **`run:<target>`** tool per
 target (subject to the [allow-list](#authorization)). Its input schema is built
@@ -138,12 +138,23 @@ token".
   list (`deploy,checks*`) are exposed as run tools; every other target is
   **invisible**, and a call to one is answered exactly like a call to a
   nonexistent tool (`Unknown tool: run:<name>`) — so a denial never reveals
-  which protected targets exist.
-- **Operator token — `--protect <globs>` + `ZUKE_OPERATOR_TOKEN`.** A matching
-  target's run tool gains a required `operatorToken` argument, checked (in
-  constant time) against `ZUKE_OPERATOR_TOKEN`. This is **fail-closed**: if no
-  token is configured, every protected target is denied, so a misconfigured
-  server can never silently expose one. A denial is a structured
+  which protected targets exist. The allow-list gates **invocation**: invoking a
+  target runs its dependencies, which is what depending on a target means, so
+  allow-listing `release` allows everything `release` does. Scope it to the
+  entry points you want an agent to have, not to individual steps. The read
+  tools narrow to match — with an allow-list they describe the allow-listed
+  targets and their dependency closure, and nothing else, so a target outside it
+  is genuinely unreachable rather than merely undisplayed.
+- **Operator token — `--protect <globs>` + `ZUKE_OPERATOR_TOKEN`.** A run that
+  would execute a matching target gains a required `operatorToken` argument,
+  checked (in constant time) against `ZUKE_OPERATOR_TOKEN`. Protection is a
+  property of the **operation**, so it is enforced across the whole plan: a
+  protected `deploy` reached as a dependency of an unprotected `release` still
+  demands the token, and `run:release` advertises the requirement in its schema.
+  This is **fail-closed**: if no token is configured, every protected target is
+  denied; and a call whose plan cannot be resolved (a run record whose root
+  target no longer exists) is denied rather than assumed harmless — so a
+  misconfigured server can never silently expose one. A denial is a structured
   `{"error": "unauthorized", …}` result, and the token is never written to the
   audit log or any output.
 - **Confirmation — `--confirm-destructive`.** A destructive run tool (any target
@@ -169,7 +180,10 @@ dropped and every `.secret()` parameter's value is masked — before anything is
 persisted.
 
 The trail lives in a store-level record; read it with `./zuke runs show mcp-audit`
-(or the `show_run` tool). The actor resolves by precedence: the **identity
+**on the host**. It is deliberately not readable over MCP — `show_run` refuses
+it and `list_runs` omits it — because the clients it audits must not be able to
+read who called what, or to confirm which of their calls were denied. The actor
+resolves by precedence: the **identity
 hook** (below) → `--actor` → `ZUKE_ACTOR` → the CI actor → the connecting
 client's `initialize` name → `"anonymous"`. The client name is an **untrusted
 label** for the trail only — it never influences authorization. On a shared HTTP

--- a/packages/core/src/mcp/http.ts
+++ b/packages/core/src/mcp/http.ts
@@ -65,6 +65,48 @@ export interface HttpTransportOptions {
 }
 
 /** A JSON `Response` with the given status and `application/json` content type. */
+/**
+ * The largest JSON-RPC request body this transport will buffer. A single MCP
+ * message is a tool call with a handful of scalar arguments, so a megabyte is
+ * already generous; the cap exists so an unauthenticated (or merely buggy)
+ * client cannot exhaust memory with one very large POST.
+ */
+const MAX_BODY_BYTES = 1024 * 1024;
+
+/**
+ * Read a request body as text, or return `null` once it exceeds `limit` bytes.
+ * Reads incrementally and abandons the stream at the cap, so an oversized body
+ * — including a chunked one that declares no `content-length` — is never
+ * buffered whole just to be rejected.
+ */
+async function readBounded(
+  request: Request,
+  limit: number,
+): Promise<string | null> {
+  const body = request.body;
+  if (body === null) return "";
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > limit) {
+      await reader.cancel();
+      return null;
+    }
+    chunks.push(value);
+  }
+  const joined = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    joined.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(joined);
+}
+
 function jsonResponse(body: unknown, status: number): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -195,9 +237,16 @@ export async function serveHttp(
         );
       }
     }
+    const body = await readBounded(request, MAX_BODY_BYTES);
+    if (body === null) {
+      return jsonResponse(
+        err(null, INVALID_REQUEST, "Request body too large"),
+        413,
+      );
+    }
     let message: unknown;
     try {
-      message = JSON.parse(await request.text());
+      message = JSON.parse(body);
     } catch {
       return jsonResponse(err(null, PARSE_ERROR, "Parse error"), 400);
     }

--- a/packages/core/src/mcp/jsonrpc.ts
+++ b/packages/core/src/mcp/jsonrpc.ts
@@ -129,6 +129,20 @@ export function resolveIdentity(
 const STDIO_CONTEXT: McpRequestContext = { headers: new Headers() };
 
 /**
+ * The JSON-RPC id of a parsed message, or `null` when it carries none — so an
+ * error response raised before dispatch can still be correlated by the client.
+ */
+function messageId(message: unknown): string | number | null {
+  if (
+    typeof message === "object" && message !== null && "id" in message &&
+    (typeof message.id === "string" || typeof message.id === "number")
+  ) {
+    return message.id;
+  }
+  return null;
+}
+
+/**
  * Read newline-delimited JSON-RPC messages from `input`, pass each parsed
  * message to `handle`, and write any non-null response back to `output`
  * (newline-framed). A line that is not valid JSON yields a parse-error response
@@ -157,7 +171,16 @@ export async function serveStdio(
       await send(err(null, PARSE_ERROR, "Parse error"));
       return;
     }
-    const response = await handle(message, STDIO_CONTEXT);
+    // Backstop, mirroring the one inside the server's tools/call: a dispatch
+    // that throws must not end the read loop, or one bad message silently
+    // kills the connection for every message after it.
+    let response: JsonRpcResponse | null;
+    try {
+      response = await handle(message, STDIO_CONTEXT);
+    } catch {
+      await send(err(messageId(message), INTERNAL_ERROR, "Internal error"));
+      return;
+    }
     if (response !== null) await send(response);
   };
 

--- a/packages/core/src/mcp/registry_server.ts
+++ b/packages/core/src/mcp/registry_server.ts
@@ -33,7 +33,7 @@ import { resolveActor } from "../state/record.ts";
 import type { RunEvent, RunEventOutcome } from "../state/types.ts";
 import type { StateStore } from "../state/store.ts";
 import type { RunStateWriter } from "../state/writer.ts";
-import type { CliParameterInfo } from "../describe.ts";
+import type { CliParameterInfo, CliTargetInfo } from "../describe.ts";
 import type { BuildLocation } from "../registry/descriptor.ts";
 import type { BuildRegistry } from "../registry/registry.ts";
 import { openAuditLog } from "./audit.ts";
@@ -295,6 +295,29 @@ function validateParamArgs(
 }
 
 /** Whether a JSON value is a plain object (a string-keyed record). */
+/**
+ * `root` plus every target it transitively depends on, read from a registered
+ * build's declared surface. A dependency the surface does not carry is skipped:
+ * the descriptor is the only graph available to the registry host, and the
+ * spawned child resolves the real one itself — so this is a conservative view
+ * of what a run will touch, never an authoritative plan.
+ */
+function closureOf(
+  targets: readonly CliTargetInfo[],
+  root: string,
+): string[] {
+  const byName = new Map(targets.map((t) => [t.name, t]));
+  const seen = new Set<string>();
+  const stack = [root];
+  while (stack.length > 0) {
+    const name = stack.pop();
+    if (name === undefined || seen.has(name)) continue;
+    seen.add(name);
+    for (const dep of byName.get(name)?.dependsOn ?? []) stack.push(dep);
+  }
+  return [...seen];
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -466,6 +489,7 @@ export class RegistryMcpServer {
               target.name,
               target.description,
               loaded.descriptor.surface.parameters,
+              loaded.descriptor.surface.targets,
             ),
           );
         }
@@ -474,12 +498,29 @@ export class RegistryMcpServer {
     return tools;
   }
 
+  /**
+   * Whether spawning `buildId:target` would run any protected target — the one
+   * named, or anything in its declared dependency closure. Spawning a target
+   * runs its dependencies in the child process, so protection has to be checked
+   * across the plan; gating only the named target leaves every protected target
+   * reachable through an unprotected dependent.
+   */
+  #planTouchesProtected(
+    buildId: string,
+    targets: readonly CliTargetInfo[],
+    root: string,
+  ): boolean {
+    return closureOf(targets, root)
+      .some((name) => this.#isProtected(`${buildId}:${name}`));
+  }
+
   /** Build the `run:<buildId>:<target>` tool definition. */
   #runTool(
     buildId: string,
     target: string,
     description: string,
     parameters: readonly CliParameterInfo[],
+    targets: readonly CliTargetInfo[],
   ): McpTool {
     const qualified = `${buildId}:${target}`;
     const properties: Record<string, Record<string, unknown>> = {};
@@ -494,11 +535,12 @@ export class RegistryMcpServer {
       type: "boolean",
       description: "Plan without executing any target body.",
     };
-    if (this.#isProtected(qualified)) {
+    if (this.#planTouchesProtected(buildId, targets, target)) {
       properties.operatorToken = {
         type: "string",
         description:
-          "Operator token (ZUKE_OPERATOR_TOKEN) required to run this protected target.",
+          "Operator token (ZUKE_OPERATOR_TOKEN) required: this target, or one " +
+          "it depends on, is protected.",
       };
       required.push("operatorToken");
     }
@@ -637,7 +679,13 @@ export class RegistryMcpServer {
       loaded.descriptor.surface.parameters.map((p) => p.name),
     );
 
-    if (this.#isProtected(qualified)) {
+    if (
+      this.#planTouchesProtected(
+        buildId,
+        loaded.descriptor.surface.targets,
+        target,
+      )
+    ) {
       const denial = this.#checkOperatorToken(args);
       if (denial !== null) {
         await this.#audit(runName, args, "denied", actor, denial, knownParams);

--- a/packages/core/src/mcp/runtools.ts
+++ b/packages/core/src/mcp/runtools.ts
@@ -22,6 +22,7 @@ import {
   toJsonValue,
 } from "../state/types.ts";
 import type { JsonValue } from "../target.ts";
+import { AUDIT_RUN_ID } from "./audit.ts";
 import type { McpTool } from "./server.ts";
 
 /** What a run-state tool needs to reach the durable surfaces. */
@@ -269,7 +270,10 @@ async function listRuns(
   if (since !== undefined) query.since = since;
   const limit = positiveIntArg(args, "limit");
   if (limit !== undefined) query.limit = limit;
-  return jsonResult(await deps.store.listRuns(query));
+  const runs = await deps.store.listRuns(query);
+  // The audit trail rides on a run record, so it would otherwise surface here
+  // as an ordinary run. Keep it out of the listing to match `show_run`.
+  return jsonResult(runs.filter((run) => run.id !== AUDIT_RUN_ID));
 }
 
 /** `show_run`: return one run's full record, or a structured not-found. */
@@ -280,6 +284,13 @@ async function showRun(
   const runId = stringArg(args, "runId");
   if (runId === undefined) {
     return jsonResult({ error: "missing_argument", argument: "runId" }, true);
+  }
+  // The audit trail records who called what through this very server. Handing
+  // it back through an MCP tool would let the principals it audits read every
+  // actor, argument, and denial reason in it — so it is operator-only, readable
+  // on the host with `zuke runs show mcp-audit`, never over the wire.
+  if (runId === AUDIT_RUN_ID) {
+    return jsonResult({ error: "not_readable", runId }, true);
   }
   const loaded = await deps.store.getRun(runId);
   if (loaded === null) return jsonResult({ error: "no_run", runId }, true);

--- a/packages/core/src/mcp/runtools.ts
+++ b/packages/core/src/mcp/runtools.ts
@@ -273,7 +273,21 @@ async function listRuns(
   const runs = await deps.store.listRuns(query);
   // The audit trail rides on a run record, so it would otherwise surface here
   // as an ordinary run. Keep it out of the listing to match `show_run`.
-  return jsonResult(runs.filter((run) => run.id !== AUDIT_RUN_ID));
+  return jsonResult(runs.filter((run) => !isAuditRun(run.id)));
+}
+
+/**
+ * Whether `runId` names the audit trail.
+ *
+ * Compared **case-insensitively**, which is the whole point: the filesystem
+ * store maps an id straight to `<id>.json`, and `assertSafeId` permits capitals.
+ * On a case-insensitive volume — macOS and Windows, two of the three supported
+ * platforms — `MCP-AUDIT` therefore opens the very same file as `mcp-audit`, so
+ * an exact-match guard would refuse the trail on Linux and serve it everywhere
+ * else. A guard that holds on one platform is not a guard.
+ */
+function isAuditRun(runId: string): boolean {
+  return runId.toLowerCase() === AUDIT_RUN_ID.toLowerCase();
 }
 
 /** `show_run`: return one run's full record, or a structured not-found. */
@@ -289,7 +303,7 @@ async function showRun(
   // it back through an MCP tool would let the principals it audits read every
   // actor, argument, and denial reason in it — so it is operator-only, readable
   // on the host with `zuke runs show mcp-audit`, never over the wire.
-  if (runId === AUDIT_RUN_ID) {
+  if (isAuditRun(runId)) {
     return jsonResult({ error: "not_readable", runId }, true);
   }
   const loaded = await deps.store.getRun(runId);

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -581,8 +581,10 @@ export class McpServer {
         build: this.build,
         actor,
         readEnv: this.#readEnv,
-        authorize: (targetName, callArgs) =>
-          this.#authorizeTarget(targetName, callArgs),
+        authorize: (targetName, callArgs) => {
+          const denial = this.#authorizeTarget(targetName, callArgs);
+          return denial === null ? null : clientDenial(denial);
+        },
       },
       name,
       args,
@@ -646,12 +648,18 @@ export class McpServer {
     // and so is a protected target with no server-side token configured.
     const denial = this.#authorizeTarget(targetName, args);
     if (denial !== null) {
+      // The precise reason goes to the audit trail, which is operator-only; the
+      // caller gets the collapsed one (see clientDenial).
       await this.#audit(runName, args, "denied", actor, denial);
       return ok(
         id,
         textResult(
           JSON.stringify(
-            { error: "unauthorized", tool: runName, reason: denial },
+            {
+              error: "unauthorized",
+              tool: runName,
+              reason: clientDenial(denial),
+            },
             null,
             2,
           ),
@@ -857,6 +865,21 @@ export class McpServer {
     }
     return out;
   }
+}
+
+/**
+ * The denial reason a *client* is told, collapsing `unresolved_plan` into
+ * `not_allowed`.
+ *
+ * Both mean the same thing to a caller — you may not cause this to run — and
+ * telling them apart on the wire separates a target that is merely outside the
+ * allow-list from one that is no longer in the build at all, which is precisely
+ * the kind of existence signal the opaque `Unknown tool` answer exists to
+ * withhold. The precise reason still reaches the audit trail, which is
+ * operator-only, so nothing is lost where it is actually useful for diagnosis.
+ */
+function clientDenial(reason: string): string {
+  return reason === "unresolved_plan" ? "not_allowed" : reason;
 }
 
 /**

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -96,12 +96,22 @@ export interface McpServerOptions {
    * Restrict the exposed `run:` tools to targets matching these globs (from
    * `--allow-run=a,b*`). `undefined` (a bare `--allow-run`) exposes every
    * target. A target not matched is not advertised and cannot be run — a call
-   * to it is indistinguishable from a call to a nonexistent tool.
+   * to it is indistinguishable from a call to a nonexistent tool, and the read
+   * tools narrow to the matched targets' dependency closure so it is not
+   * discoverable there either.
+   *
+   * This gates **invocation**, not execution: invoking a target runs its
+   * dependencies, so allow-listing a root allows everything that root does.
+   * Use {@link protectPatterns} to gate an individual operation wherever it is
+   * reached from.
    */
   allowRunPatterns?: readonly string[];
   /**
-   * Targets (globs, from `--protect a,b*`) whose `run:` tool additionally
-   * requires an operator token argument, checked against {@link operatorToken}.
+   * Targets (globs, from `--protect a,b*`) that require an operator token
+   * argument, checked against {@link operatorToken}. Enforced over a run's
+   * whole plan: a call that would execute a protected target — as the root
+   * **or** anywhere in its dependency closure — requires the token, and
+   * advertises it in that run tool's schema.
    */
   protectPatterns?: readonly string[];
   /**
@@ -205,8 +215,12 @@ export class McpServer {
   readonly #version: string;
   /** Matches a target name allowed to run (allow-list glob, or all). */
   readonly #allowMatch: (name: string) => boolean;
+  /** Whether an allow-list was configured at all (a bare `--allow-run` sets none). */
+  readonly #hasAllowList: boolean;
   /** Matches a target name that needs an operator token to run. */
   readonly #isProtected: (name: string) => boolean;
+  /** Memoised visible-target closure, computed on first describe/list. */
+  #visibleNames?: ReadonlySet<string>;
   readonly #operatorToken?: string;
   readonly #confirmDestructive: boolean;
   readonly #store?: StateStore;
@@ -226,6 +240,7 @@ export class McpServer {
     this.#params = discoverParameters(build);
     this.#allowRun = options.allowRun ?? false;
     this.#allowMatch = targetMatcher(options.allowRunPatterns);
+    this.#hasAllowList = options.allowRunPatterns !== undefined;
     this.#isProtected = targetMatcher(options.protectPatterns);
     // An empty protect list means "protect nothing"; targetMatcher(undefined)
     // matches everything, so map the absent/empty case to a never-match.
@@ -247,6 +262,70 @@ export class McpServer {
   /** Whether a `run:<name>` tool is exposed and runnable (allow-list gate). */
   #isRunnable(name: string): boolean {
     return this.#allowRun && this.#targets.has(name) && this.#allowMatch(name);
+  }
+
+  /**
+   * The names of every target invoking `name` would run — the root plus its
+   * whole dependency closure — or `null` when that cannot be determined (an
+   * unknown target, or a graph `planGraph` rejects). A `null` is never treated
+   * as "nothing runs": callers fail closed on it, because an unresolvable plan
+   * is an unknown blast radius.
+   */
+  #plannedNames(name: string): string[] | null {
+    const root = this.#targets.get(name);
+    if (root === undefined) return null;
+    let order: readonly TargetBuilder[];
+    try {
+      order = planGraph(root).order;
+    } catch {
+      return null;
+    }
+    return order
+      .map((t) => t.name_)
+      .filter((n): n is string => n !== undefined);
+  }
+
+  /**
+   * Whether a plan would run any protected target. Protection is a property of
+   * the **operation**, not of the entry point: a protected `deploy` reached as
+   * a dependency of an unprotected `release` must still require the operator
+   * token, or every protected target is one unprotected dependent away from
+   * being run without one.
+   */
+  #planTouchesProtected(planned: readonly string[]): boolean {
+    return planned.some((name) => this.#isProtected(name));
+  }
+
+  /**
+   * The targets a client may see through the read tools.
+   *
+   * Without an allow-list every target is visible — the documented "inspect
+   * only" tier. With one, visibility is the **closure** of the allow-listed
+   * targets: the roots a client may invoke, plus everything invoking them would
+   * run. A target outside that set is genuinely unreachable through this
+   * server, so hiding it is a real boundary rather than cosmetic; a dependency
+   * inside it stays visible, because a client that can already cause it to run
+   * gains nothing from being kept ignorant of it — and an agent asked to invoke
+   * a target should be able to see what that target actually does.
+   */
+  #visibleTargets(): Map<string, TargetBuilder> {
+    if (!this.#hasAllowList) return this.#targets;
+    if (this.#visibleNames === undefined) {
+      const names = new Set<string>();
+      for (const name of this.#targets.keys()) {
+        if (!this.#allowMatch(name)) continue;
+        names.add(name);
+        for (const planned of this.#plannedNames(name) ?? []) {
+          names.add(planned);
+        }
+      }
+      this.#visibleNames = names;
+    }
+    const visible = new Map<string, TargetBuilder>();
+    for (const [name, target] of this.#targets) {
+      if (this.#visibleNames.has(name)) visible.set(name, target);
+    }
+    return visible;
   }
 
   /** The tools advertised to the client, honouring {@link McpServerOptions.allowRun}. */
@@ -274,8 +353,9 @@ export class McpServer {
       },
     ];
     for (const [name, target] of this.#targets) {
-      // Only allow-listed targets are advertised; the rest are invisible, so a
-      // client cannot even discover which protected targets exist.
+      // Only allow-listed targets are advertised as run tools; the read tools
+      // narrow to the same allow-list's closure (see #visibleTargets), so a
+      // target outside it is not discoverable through any tool here.
       if (this.#isRunnable(name)) tools.push(this.#runTool(name, target));
     }
     // Store-backed run tools: read tools whenever a store resolves, mutating
@@ -299,12 +379,17 @@ export class McpServer {
       type: "boolean",
       description: "Plan without executing any target body.",
     };
-    // A protected target's call must carry the operator token.
-    if (this.#isProtected(name)) {
+    // A call that would run a protected target must carry the operator token.
+    // Checked over the whole plan, so a target that merely *depends* on a
+    // protected one advertises the requirement too — otherwise the schema would
+    // omit the very argument the call is then denied for.
+    const planned = this.#plannedNames(name);
+    if (planned === null || this.#planTouchesProtected(planned)) {
       properties.operatorToken = {
         type: "string",
         description:
-          "Operator token (ZUKE_OPERATOR_TOKEN) required to run this protected target.",
+          "Operator token (ZUKE_OPERATOR_TOKEN) required: this target, or one " +
+          "it depends on, is protected.",
       };
       required.push("operatorToken");
     }
@@ -373,7 +458,14 @@ export class McpServer {
       case "ping":
         return ok(id, {});
       case "tools/list":
-        return ok(id, { tools: this.tools() });
+        // Same backstop as tools/call: building the tool list now walks each
+        // target's plan, so an unforeseen throw must not tear down the
+        // transport for every later message on the connection.
+        try {
+          return ok(id, { tools: this.tools() });
+        } catch {
+          return err(id, INTERNAL_ERROR, "Internal error listing tools");
+        }
       case "tools/call":
         // Backstop: no tool call may crash the transport. Expected failures are
         // already structured tool results; this catches anything unforeseen and
@@ -504,7 +596,7 @@ export class McpServer {
 
   /** The three read tools' payloads, as pretty JSON / text. */
   #describe(): { targets: string; full: string; graph: string } {
-    const surface = describeBuildSurface(this.#targets, this.#params);
+    const surface = describeBuildSurface(this.#visibleTargets(), this.#params);
     const graph = surface.targets
       .map((t) =>
         t.dependsOn.length > 0
@@ -548,24 +640,24 @@ export class McpServer {
       return ok(id, textResult(`Unknown tool: ${runName}`, true));
     }
 
-    // Protected target: require a valid operator token. Fail-closed — a target
-    // protected with no server-side token configured is always denied.
-    if (this.#isProtected(targetName)) {
-      const denial = this.#checkOperatorToken(args);
-      if (denial !== null) {
-        await this.#audit(runName, args, "denied", actor, denial);
-        return ok(
-          id,
-          textResult(
-            JSON.stringify(
-              { error: "unauthorized", tool: runName, reason: denial },
-              null,
-              2,
-            ),
-            true,
+    // Protection is enforced over the whole plan, not just the root, so a
+    // protected target reached as a dependency still demands the operator
+    // token. Fail-closed twice over: a plan that cannot be resolved is denied,
+    // and so is a protected target with no server-side token configured.
+    const denial = this.#authorizeTarget(targetName, args);
+    if (denial !== null) {
+      await this.#audit(runName, args, "denied", actor, denial);
+      return ok(
+        id,
+        textResult(
+          JSON.stringify(
+            { error: "unauthorized", tool: runName, reason: denial },
+            null,
+            2,
           ),
-        );
-      }
+          true,
+        ),
+      );
     }
 
     const dryRun = args.dryRun === true;
@@ -661,13 +753,21 @@ export class McpServer {
 
   /**
    * Authorize causing target `name` to run — the shared gate for a `run:` tool
-   * and for a resume (`signal_run`/`resume_check`, which re-run the target's
-   * code). Returns a denial reason (allow-list miss or operator-token failure)
-   * or `null` when allowed.
+   * and for a resume or cancel (`signal_run`/`resume_check`/`cancel_run`, which
+   * re-run the target's code). Returns a denial reason or `null` when allowed.
+   *
+   * The two gates deliberately have different reach. The **allow-list** is an
+   * entry-point control: it decides which targets a client may invoke, and
+   * invoking one necessarily runs its dependencies — that is what a build
+   * target means, so a dependency is not separately allow-listed. The
+   * **operator token** is an operation control: it must hold wherever the
+   * protected target runs, so it is checked across the entire plan.
    */
   #authorizeTarget(name: string, args: Record<string, unknown>): string | null {
     if (!this.#allowMatch(name)) return "not_allowed";
-    if (this.#isProtected(name)) {
+    const planned = this.#plannedNames(name);
+    if (planned === null) return "unresolved_plan";
+    if (this.#planTouchesProtected(planned)) {
       const denial = this.#checkOperatorToken(args);
       if (denial !== null) return denial;
     }
@@ -739,10 +839,12 @@ export class McpServer {
   #auditArgs(args: Record<string, unknown>): Record<string, string> {
     const redactor = new Redactor();
     for (const [key, value] of Object.entries(args)) {
-      if (typeof value !== "string") continue;
-      if (key === "operatorToken" || this.#params.get(key)?.secret_) {
-        redactor.add(value);
-      }
+      if (value === undefined) continue;
+      if (key !== "operatorToken" && !this.#params.get(key)?.secret_) continue;
+      // Seed from the value's *audit* string form, not just from strings: a
+      // secret supplied as a JSON number (or nested in a structure) must still
+      // be masked when it is echoed into some other, non-secret argument.
+      redactor.add(auditText(value));
     }
     const out: Record<string, string> = {};
     for (const [key, value] of Object.entries(args)) {
@@ -751,13 +853,22 @@ export class McpServer {
         out[key] = "[redacted]";
         continue;
       }
-      const text = typeof value === "object" && value !== null
-        ? JSON.stringify(value)
-        : String(value);
-      out[key] = redactor.redact(text);
+      out[key] = redactor.redact(auditText(value));
     }
     return out;
   }
+}
+
+/**
+ * The string form an argument takes in the audit trail: a structure is
+ * serialised, everything else stringified. Used both to seed the redactor and
+ * to render the recorded value, so the two can never disagree about what text
+ * a value produces.
+ */
+function auditText(value: unknown): string {
+  return typeof value === "object" && value !== null
+    ? JSON.stringify(value)
+    : String(value);
 }
 
 /** Extract a JSON-RPC id from a message, defaulting to `null`. */

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -66,6 +66,9 @@ export const PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSIONS[0];
 /** The `run:` prefix that names a per-target execution tool. */
 const RUN_PREFIX = "run:";
 
+/** Control keys whose values are always safe to record (booleans, never secrets). */
+const AUDIT_SAFE_KEYS: ReadonlySet<string> = new Set(["dryRun", "confirm"]);
+
 /** The request context handed to {@link McpServer.handleMessage} on stdio (no headers). */
 const EMPTY_CONTEXT: McpRequestContext = { headers: new Headers() };
 
@@ -859,6 +862,16 @@ export class McpServer {
       if (key === "operatorToken") continue; // never persist the operator token
       if (this.#params.get(key)?.secret_) {
         out[key] = "[redacted]";
+        continue;
+      }
+      // A key the build does not declare keeps its name but loses its value.
+      // Redaction can only mask what it recognises, so a value supplied under a
+      // *misspelled* secret parameter's name would otherwise be written to the
+      // durable trail verbatim — it matches no declared secret, so nothing
+      // masks it. Eliding by default is the same posture the registry server
+      // already takes, and costs only the value of a key that was not asked for.
+      if (!this.#params.has(key) && !AUDIT_SAFE_KEYS.has(key)) {
+        out[key] = "<omitted>";
         continue;
       }
       out[key] = redactor.redact(auditText(value));

--- a/packages/core/tests/mcp_authz_closure_test.ts
+++ b/packages/core/tests/mcp_authz_closure_test.ts
@@ -397,6 +397,28 @@ Deno.test("an unresolvable plan is denied without saying so to the caller", asyn
   );
 });
 
+Deno.test("a value under an undeclared key is elided from the trail", async () => {
+  // Redaction can only mask what it recognises. A value supplied under a
+  // *misspelled* secret parameter's name matches no declared secret, so nothing
+  // would mask it and it would land in the durable trail verbatim. Undeclared
+  // keys therefore keep their name and lose their value — the same posture the
+  // registry server already takes.
+  await withServer(
+    { allowRun: true, actor: "agent" },
+    async (server, store) => {
+      await call(server, "run:lint", {
+        tokens: "please-do-not-store-me", // near-miss for the `token` secret
+        note: "kept", // declared, so its value is useful in the trail
+        dryRun: true, // a control flag, always safe
+      });
+      const last = (await auditEvents(store)).at(-1);
+      assertEquals(last?.args?.tokens, "<omitted>");
+      assertEquals(last?.args?.note, "kept");
+      assertEquals(last?.args?.dryRun, "true");
+    },
+  );
+});
+
 Deno.test("a secret supplied as a non-string is still masked where it is echoed", async () => {
   await withServer(
     { allowRun: true, actor: "agent" },

--- a/packages/core/tests/mcp_authz_closure_test.ts
+++ b/packages/core/tests/mcp_authz_closure_test.ts
@@ -1,0 +1,390 @@
+/**
+ * Authorization over a run's **whole plan**, not just its root target.
+ *
+ * A `run:` tool executes the root's entire dependency closure, so a gate that
+ * only inspects the root name is one unprotected dependent away from being
+ * bypassed: `--protect deploy` means nothing if an unprotected `release` that
+ * depends on `deploy` can be called without a token.
+ *
+ * The two gates deliberately keep different reach, and these tests pin both:
+ * the **operator token** is an operation control checked across the plan, while
+ * the **allow-list** stays an entry-point control (invoking a target inherently
+ * runs its dependencies — that is what a target means). Read-tool visibility
+ * follows the allow-list's closure so a hidden target is genuinely unreachable
+ * rather than merely undisplayed.
+ */
+
+import { assertEquals, assertStringIncludes } from "./_assert.ts";
+import { Build, parameter, target } from "../mod.ts";
+import { McpServer, type McpServerOptions } from "../src/mcp/server.ts";
+import { FileSystemStateStore } from "../src/state/fs_store.ts";
+import { defaultStateHost } from "../src/state/store.ts";
+import { AUDIT_RUN_ID } from "../src/mcp/audit.ts";
+import type { RunEvent, RunRecord } from "../src/state/types.ts";
+
+/**
+ * A build with a real dependency chain. `release` → `deploy` → `lint`, plus an
+ * `unrelated` target reachable from nothing, so a closure can be told apart
+ * from "every target in the build".
+ */
+class Chain extends Build {
+  token = parameter("Token").secret();
+  note = parameter("Note");
+  lint = target().description("Lint").executes(() => {});
+  deploy = target().description("Deploy").dependsOn(this.lint).executes(
+    () => {},
+  );
+  release = target().description("Release").dependsOn(this.deploy).executes(
+    () => {},
+  );
+  unrelated = target().description("Unrelated").executes(() => {});
+}
+
+/** A JSON-RPC request with id 1. */
+function req(method: string, params?: unknown): Record<string, unknown> {
+  return { jsonrpc: "2.0", id: 1, method, ...(params ? { params } : {}) };
+}
+
+/** The `{ text, isError }` of a `tools/call` result. */
+function callResult(result: unknown): { text: string; isError: boolean } {
+  if (typeof result !== "object" || result === null || !("content" in result)) {
+    throw new Error("not a tool result");
+  }
+  const content = (result as { content: Array<{ text: string }> }).content;
+  const isError = (result as { isError?: boolean }).isError ?? false;
+  return { text: content[0].text, isError };
+}
+
+/** Call a tool and return its result body. */
+async function call(
+  server: McpServer,
+  name: string,
+  args: Record<string, unknown> = {},
+): Promise<{ text: string; isError: boolean }> {
+  const res = await server.handleMessage(
+    req("tools/call", { name, arguments: args }),
+  );
+  return callResult(res?.result);
+}
+
+/** One advertised tool, as the client sees it. */
+interface ListedTool {
+  name: string;
+  inputSchema?: { properties?: Record<string, unknown>; required?: string[] };
+}
+
+/** The advertised tool list. */
+async function toolList(server: McpServer): Promise<ListedTool[]> {
+  const res = await server.handleMessage(req("tools/list"));
+  const result = res?.result;
+  if (typeof result !== "object" || result === null || !("tools" in result)) {
+    throw new Error("no tools");
+  }
+  return (result as { tools: ListedTool[] }).tools;
+}
+
+/** The target names `list_targets` reports. */
+async function visibleTargets(server: McpServer): Promise<string[]> {
+  const listed = await call(server, "list_targets");
+  const targets: Array<{ name: string }> = JSON.parse(listed.text);
+  return targets.map((t) => t.name).sort();
+}
+
+/** Run `fn` with a temp-dir store and a server over {@link Chain}. */
+async function withServer(
+  options: Omit<McpServerOptions, "stateStore">,
+  fn: (server: McpServer, store: FileSystemStateStore) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    const server = new McpServer(new Chain(), {
+      ...options,
+      stateStore: store,
+    });
+    await fn(server, store);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+/** Seed a suspended run rooted at `rootTarget`, returning its id. */
+async function seedSuspended(
+  store: FileSystemStateStore,
+  rootTarget: string,
+): Promise<string> {
+  const now = new Date().toISOString();
+  const record: RunRecord = {
+    id: `run-${rootTarget}`,
+    build: "Chain",
+    rootTarget,
+    status: "suspended",
+    actor: "someone",
+    createdAt: now,
+    updatedAt: now,
+    graph: [{ name: rootTarget, dependsOn: [] }],
+    params: {},
+    targets: { [rootTarget]: { status: "waiting", meta: {} } },
+    signals: {},
+    events: [],
+  };
+  const put = await store.putRun(record, null);
+  if (!put.ok) throw new Error("failed to seed suspended run");
+  return record.id;
+}
+
+/** Read the audit trail from the store. */
+async function auditEvents(store: FileSystemStateStore): Promise<RunEvent[]> {
+  const loaded = await store.getRun(AUDIT_RUN_ID);
+  return loaded === null ? [] : loaded.record.events;
+}
+
+// --- The bypass itself -----------------------------------------------------
+
+Deno.test("a protected target reached as a dependency still needs the token", async () => {
+  await withServer(
+    { allowRun: true, protectPatterns: ["deploy"], operatorToken: "swordfish" },
+    async (server, store) => {
+      // `release` is not itself protected, but running it runs `deploy`.
+      const denied = await call(server, "run:release", {});
+      assertEquals(denied.isError, true);
+      assertEquals(JSON.parse(denied.text).reason, "missing_operator_token");
+
+      // The denial is audited against the tool that was actually called.
+      const events = await auditEvents(store);
+      assertEquals(events.at(-1)?.tool, "run:release");
+      assertEquals(events.at(-1)?.outcome, "denied");
+
+      // A wrong token is refused just the same.
+      const wrong = await call(server, "run:release", {
+        operatorToken: "guess",
+      });
+      assertEquals(wrong.isError, true);
+      assertEquals(JSON.parse(wrong.text).reason, "invalid_operator_token");
+
+      // The right token lets the whole plan run.
+      const allowed = await call(server, "run:release", {
+        operatorToken: "swordfish",
+      });
+      assertEquals(allowed.isError, false);
+      assertStringIncludes(allowed.text, "release succeeded");
+    },
+  );
+});
+
+Deno.test("a dependent of a protected target advertises operatorToken as required", async () => {
+  await withServer(
+    { allowRun: true, protectPatterns: ["deploy"], operatorToken: "swordfish" },
+    async (server) => {
+      const tools = await toolList(server);
+      // The schema must state the requirement, or a client would be denied for
+      // omitting an argument it was never told about.
+      const release = tools.find((t) => t.name === "run:release");
+      assertEquals(
+        release?.inputSchema?.required?.includes("operatorToken"),
+        true,
+      );
+      // `lint` runs nothing protected, so it stays unencumbered.
+      const lint = tools.find((t) => t.name === "run:lint");
+      assertEquals(
+        lint?.inputSchema?.required?.includes("operatorToken"),
+        undefined,
+      );
+      assertEquals(
+        Object.hasOwn(lint?.inputSchema?.properties ?? {}, "operatorToken"),
+        false,
+      );
+    },
+  );
+});
+
+Deno.test("protection over the plan also gates signal_run and cancel_run", async () => {
+  await withServer(
+    { allowRun: true, protectPatterns: ["deploy"], operatorToken: "swordfish" },
+    async (server, store) => {
+      // A run rooted at `release` resumes into `deploy`, so it is protected too.
+      const id = await seedSuspended(store, "release");
+
+      const signal = await call(server, "signal_run", {
+        runId: id,
+        signal: "go",
+      });
+      assertEquals(signal.isError, true);
+      assertEquals(JSON.parse(signal.text).reason, "missing_operator_token");
+
+      const cancel = await call(server, "cancel_run", { runId: id });
+      assertEquals(cancel.isError, true);
+      assertEquals(JSON.parse(cancel.text).reason, "missing_operator_token");
+
+      // A sweep silently skips what it may not resume.
+      const sweep = await call(server, "resume_check");
+      assertEquals(JSON.parse(sweep.text).checked, 0);
+    },
+  );
+});
+
+Deno.test("a run whose root target no longer exists is denied, not authorized", async () => {
+  await withServer(
+    { allowRun: true, protectPatterns: ["deploy"], operatorToken: "swordfish" },
+    async (server, store) => {
+      // The build was refactored and the root target renamed away. Its plan
+      // cannot be resolved, so its blast radius is unknown — fail closed rather
+      // than let an unmatched name slip past a protect glob.
+      const id = await seedSuspended(store, "targetThatWasDeleted");
+      const signal = await call(server, "signal_run", {
+        runId: id,
+        signal: "go",
+      });
+      assertEquals(signal.isError, true);
+      assertEquals(JSON.parse(signal.text).reason, "unresolved_plan");
+    },
+  );
+});
+
+/** A build that reaches a protected target through `.triggers()`, not `dependsOn`. */
+class Triggering extends Build {
+  deploy = target().description("Deploy").executes(() => {});
+  notify = target().description("Notify").triggers(this.deploy).executes(
+    () => {},
+  );
+}
+
+Deno.test("a protected target reached through triggers also needs the token", async () => {
+  // `triggers` is the second way a target enters the execution set (executionSet
+  // walks dependsOn_ *and* triggers_), so a gate that only followed dependsOn
+  // would leave this route open.
+  const server = new McpServer(new Triggering(), {
+    allowRun: true,
+    protectPatterns: ["deploy"],
+    operatorToken: "swordfish",
+  });
+  const denied = await call(server, "run:notify", {});
+  assertEquals(denied.isError, true);
+  assertEquals(JSON.parse(denied.text).reason, "missing_operator_token");
+
+  const allowed = await call(server, "run:notify", {
+    operatorToken: "swordfish",
+  });
+  assertEquals(allowed.isError, false);
+});
+
+Deno.test("confirm-destructive does not leak a protected plan before the token", async () => {
+  // The confirmation gate answers with the resolved plan — the target names a
+  // run would touch. It must sit *behind* the operator-token check, or an
+  // unauthenticated caller could enumerate a protected pipeline just by
+  // omitting confirm:true.
+  await withServer(
+    {
+      allowRun: true,
+      confirmDestructive: true,
+      protectPatterns: ["deploy"],
+      operatorToken: "swordfish",
+    },
+    async (server) => {
+      const probe = await call(server, "run:release", {});
+      assertEquals(probe.isError, true);
+      assertEquals(JSON.parse(probe.text).reason, "missing_operator_token");
+      // No plan, and no target names, came back.
+      assertEquals(probe.text.includes("confirmation_required"), false);
+      assertEquals(probe.text.includes("deploy"), false);
+    },
+  );
+});
+
+// --- The allow-list stays an entry-point control ---------------------------
+
+Deno.test("the allow-list gates invocation, not the dependencies invoking pulls in", async () => {
+  await withServer(
+    { allowRun: true, allowRunPatterns: ["release"] },
+    async (server) => {
+      // `deploy` and `lint` are not allow-listed, but running `release` runs
+      // them — that is what depending on a target means. Allow-listing a root
+      // is allow-listing what it does.
+      const ran = await call(server, "run:release", {});
+      assertEquals(ran.isError, false);
+
+      // Invoking an excluded target directly is still refused, opaquely.
+      const direct = await call(server, "run:deploy", {});
+      assertEquals(direct.isError, true);
+      assertStringIncludes(direct.text, "Unknown tool: run:deploy");
+    },
+  );
+});
+
+// --- Read-tool visibility follows the allow-list closure --------------------
+
+Deno.test("an allow-list narrows the read tools to its closure", async () => {
+  await withServer(
+    { allowRun: true, allowRunPatterns: ["release"] },
+    async (server) => {
+      // Visible: the invokable root and everything invoking it would run.
+      // Hidden: `unrelated`, which this client can never cause to run.
+      assertEquals(await visibleTargets(server), ["deploy", "lint", "release"]);
+
+      const graph = await call(server, "graph");
+      assertStringIncludes(graph.text, "release -> deploy");
+      assertEquals(graph.text.includes("unrelated"), false);
+
+      const full = await call(server, "describe_build");
+      assertEquals(full.text.includes("unrelated"), false);
+    },
+  );
+});
+
+Deno.test("without an allow-list every target stays visible (the inspect tier)", async () => {
+  // A bare --allow-run, and the read-only server, both describe the whole build.
+  await withServer({ allowRun: true }, async (server) => {
+    assertEquals(await visibleTargets(server), [
+      "deploy",
+      "lint",
+      "release",
+      "unrelated",
+    ]);
+  });
+  await withServer({}, async (server) => {
+    assertEquals(await visibleTargets(server), [
+      "deploy",
+      "lint",
+      "release",
+      "unrelated",
+    ]);
+  });
+});
+
+// --- The audit trail is not readable through the tools it audits ------------
+
+Deno.test("the audit trail is not readable over MCP", async () => {
+  await withServer(
+    { allowRun: true, actor: "agent" },
+    async (server, store) => {
+      // Generate a trail entry so the record exists.
+      await call(server, "run:lint", {});
+      assertEquals((await auditEvents(store)).length > 0, true);
+
+      // show_run refuses it: the principals it audits must not be able to read
+      // who called what, nor to confirm their own denials were recorded.
+      const shown = await call(server, "show_run", { runId: AUDIT_RUN_ID });
+      assertEquals(shown.isError, true);
+      assertEquals(JSON.parse(shown.text).error, "not_readable");
+
+      // …and it is not listed as an ordinary run either.
+      const listed = await call(server, "list_runs");
+      assertEquals(listed.text.includes(AUDIT_RUN_ID), false);
+    },
+  );
+});
+
+Deno.test("a secret supplied as a non-string is still masked where it is echoed", async () => {
+  await withServer(
+    { allowRun: true, actor: "agent" },
+    async (server, store) => {
+      // The secret arrives as a JSON number and is echoed into a non-secret
+      // argument. Seeding the redactor only from string values would leave the
+      // echo in the durable trail.
+      await call(server, "run:lint", { token: 13579, note: "code 13579 sent" });
+      const last = (await auditEvents(store)).at(-1);
+      assertEquals(last?.args?.token, "[redacted]");
+      assertEquals(last?.args?.note, "code [redacted] sent");
+    },
+  );
+});

--- a/packages/core/tests/mcp_authz_closure_test.ts
+++ b/packages/core/tests/mcp_authz_closure_test.ts
@@ -223,24 +223,6 @@ Deno.test("protection over the plan also gates signal_run and cancel_run", async
   );
 });
 
-Deno.test("a run whose root target no longer exists is denied, not authorized", async () => {
-  await withServer(
-    { allowRun: true, protectPatterns: ["deploy"], operatorToken: "swordfish" },
-    async (server, store) => {
-      // The build was refactored and the root target renamed away. Its plan
-      // cannot be resolved, so its blast radius is unknown — fail closed rather
-      // than let an unmatched name slip past a protect glob.
-      const id = await seedSuspended(store, "targetThatWasDeleted");
-      const signal = await call(server, "signal_run", {
-        runId: id,
-        signal: "go",
-      });
-      assertEquals(signal.isError, true);
-      assertEquals(JSON.parse(signal.text).reason, "unresolved_plan");
-    },
-  );
-});
-
 /** A build that reaches a protected target through `.triggers()`, not `dependsOn`. */
 class Triggering extends Build {
   deploy = target().description("Deploy").executes(() => {});
@@ -370,6 +352,47 @@ Deno.test("the audit trail is not readable over MCP", async () => {
       // …and it is not listed as an ordinary run either.
       const listed = await call(server, "list_runs");
       assertEquals(listed.text.includes(AUDIT_RUN_ID), false);
+    },
+  );
+});
+
+Deno.test("the audit trail stays unreadable under a differently-cased id", async () => {
+  // The store maps a run id straight to `<id>.json` and permits capitals, so on
+  // a case-insensitive volume (macOS, Windows) `MCP-AUDIT` opens the very same
+  // file. An exact-match refusal would hold on Linux and serve the trail on the
+  // other two platforms — so the guard is case-insensitive, and this pins it on
+  // every platform rather than only where the filesystem would expose the gap.
+  await withServer({ allowRun: true, actor: "agent" }, async (server) => {
+    await call(server, "run:lint", {});
+    for (const id of ["MCP-AUDIT", "Mcp-Audit", "mcp-AUDIT"]) {
+      const shown = await call(server, "show_run", { runId: id });
+      assertEquals(shown.isError, true, `${id} was not refused`);
+      assertEquals(JSON.parse(shown.text).error, "not_readable");
+    }
+  });
+});
+
+Deno.test("an unresolvable plan is denied without saying so to the caller", async () => {
+  // The denial must not separate "not in the allow-list" from "no longer in the
+  // build" — that distinction is an existence signal the opaque answer exists
+  // to withhold. The caller sees the collapsed reason; the operator still gets
+  // the precise one from the audit trail.
+  await withServer(
+    {
+      allowRun: true,
+      protectPatterns: ["deploy"],
+      operatorToken: "swordfish",
+      actor: "agent",
+    },
+    async (server, store) => {
+      const id = await seedSuspended(store, "targetThatWasDeleted");
+      const signal = await call(server, "signal_run", {
+        runId: id,
+        signal: "go",
+      });
+      assertEquals(signal.isError, true);
+      assertEquals(JSON.parse(signal.text).reason, "not_allowed");
+      assertEquals(signal.text.includes("unresolved_plan"), false);
     },
   );
 });

--- a/packages/core/tests/mcp_http_test.ts
+++ b/packages/core/tests/mcp_http_test.ts
@@ -158,6 +158,36 @@ Deno.test("http transport answers unparseable JSON with a 400 parse error", asyn
   }
 });
 
+Deno.test("http transport refuses an oversized body with 413", async () => {
+  const server = new McpServer(new Demo());
+  const s = await startHttp((m) => server.handleMessage(m));
+  try {
+    // A single MCP message is a tool call with a few scalar arguments, so a
+    // body past the cap is either a bug or an attempt to exhaust memory. It is
+    // refused without being buffered whole.
+    const huge = `{"jsonrpc":"2.0","id":1,"method":"ping","params":"${
+      "x".repeat(1024 * 1024 + 64)
+    }"}`;
+    const res = await fetch(`http://127.0.0.1:${s.port}/`, {
+      method: "POST",
+      body: huge,
+    });
+    assertEquals(res.status, 413);
+    const body = await res.json();
+    assertEquals(body.error.code, -32600);
+
+    // A normal message on the same server is unaffected.
+    const fine = await fetch(`http://127.0.0.1:${s.port}/`, {
+      method: "POST",
+      body: rpc("ping", 2),
+    });
+    assertEquals(fine.status, 200);
+    await fine.json();
+  } finally {
+    await s.stop();
+  }
+});
+
 Deno.test("http transport answers a notification with 202 and no body", async () => {
   const server = new McpServer(new Demo());
   const s = await startHttp((m) => server.handleMessage(m));

--- a/packages/core/tests/mcp_test.ts
+++ b/packages/core/tests/mcp_test.ts
@@ -357,6 +357,32 @@ Deno.test("serveStdio processes a final line the stream never terminated", async
   assertEquals(messages().length, 1);
 });
 
+Deno.test("serveStdio survives a throwing dispatch and keeps reading", async () => {
+  const { output, messages } = capturingWriter();
+  await serveStdio(
+    (message) => {
+      // The first message blows up inside dispatch. Without a backstop the
+      // rejection escapes the read loop and every later message on the
+      // connection is silently lost.
+      if ((message as { id?: number }).id === 1) {
+        return Promise.reject(new Error("boom"));
+      }
+      return Promise.resolve({ jsonrpc: "2.0" as const, id: 2, result: {} });
+    },
+    streamOf(
+      '{"jsonrpc":"2.0","id":1,"method":"a"}\n{"jsonrpc":"2.0","id":2,"method":"b"}\n',
+    ),
+    output,
+  );
+  const out = messages();
+  assertEquals(out.length, 2);
+  // The failure is reported as an internal error correlated to its own id…
+  assertEquals((out[0] as { id: number }).id, 1);
+  assertEquals((out[0] as { error: { code: number } }).error.code, -32603);
+  // …and the connection carried on.
+  assertEquals((out[1] as { id: number }).id, 2);
+});
+
 Deno.test("serveStdio answers an unparseable line with a parse error", async () => {
   const { output, messages } = capturingWriter();
   await serveStdio(

--- a/packages/core/tests/registry_server_test.ts
+++ b/packages/core/tests/registry_server_test.ts
@@ -391,6 +391,49 @@ Deno.test("a protected target requires a valid operator token", async () => {
   assertEquals(calls.length, 1);
 });
 
+Deno.test("a registry target that depends on a protected one still needs the token", async () => {
+  const registry = new FakeRegistry();
+  // release → deploy, declared in the registered surface. Spawning `release`
+  // runs `deploy` in the child process, so protecting `deploy` has to reach it.
+  const base = descriptor("Api", ["deploy", "release"]);
+  registry.add({
+    ...base,
+    surface: {
+      ...base.surface,
+      targets: base.surface.targets.map((t) =>
+        t.name === "release" ? { ...t, dependsOn: ["deploy"] } : t
+      ),
+    },
+  });
+  const { runner, calls } = recordingRunner();
+  const server = new RegistryMcpServer(registry, {
+    allowRun: true,
+    protectPatterns: ["Api:deploy"],
+    operatorToken: "good-token",
+    runner,
+  });
+
+  // No token → denied, and nothing was spawned.
+  assertStringIncludes(
+    (await call(server, "run:Api:release")).text,
+    "missing_operator_token",
+  );
+  assertEquals(calls.length, 0);
+
+  // The advertised schema tells the client why.
+  const tools = await server.tools();
+  const release = tools.find((t) => t.name === "run:Api:release");
+  const required = (release?.inputSchema as { required?: string[] })?.required;
+  assertEquals(required?.includes("operatorToken"), true);
+
+  // With the token it spawns.
+  const okd = await call(server, "run:Api:release", {
+    operatorToken: "good-token",
+  });
+  assertEquals(okd.isError, false);
+  assertEquals(calls.length, 1);
+});
+
 Deno.test("a protected target with no server token is fail-closed", async () => {
   const registry = new FakeRegistry();
   registry.add(descriptor("Api", ["deploy"]));

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/skills/zuke-write-build/SKILL.md
+++ b/plugins/zuke/skills/zuke-write-build/SKILL.md
@@ -156,6 +156,14 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   the MCP `cancel_run` tool). Idempotent; a timed-out wait can route its
   `onTimeout` here (`"cancel-run"` or a named target). Needs a state store. See
   `docs/orchestration.md`.
+- **Durable side effects:** `.effect(name, fn)` records the intent to run `fn`
+  before it runs, so a resume re-drives an effect a dead process left owed.
+  Effects run after the body, in declaration order; a target may declare effects
+  and no body. The guarantee is **at-least-once**, so write bodies that tolerate
+  a repeat (an upsert, not an append), and read what the effect acts on from
+  `ctx.state` rather than looking up "the current value" — a re-drive happens
+  later, against a world that moved on. Needs a state store (enabled
+  automatically). See the cheatsheet / `docs/orchestration.md`.
 - **Fan-out over a list:**
   `.forEach(() => this.repos.value, (repo) => ({ checks: target()…, deploy: target()… }), (s) => s.concurrency(3).continueOnItemFailure())`
   runs the same pipeline over a runtime list — items concurrent, each item's

--- a/plugins/zuke/skills/zuke-write-build/SKILL.md
+++ b/plugins/zuke/skills/zuke-write-build/SKILL.md
@@ -190,9 +190,14 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   stdio, or over HTTP with `--http <host:port>` (loopback by default; a
   non-loopback bind needs a `ZUKE_MCP_TOKEN` bearer token). With a state store
   it also exposes `list_runs`/`show_run` (+ `signal_run`/`resume_check`). Tier
-  access with `--allow-run=<globs>` (allow-list), `--protect <globs>` +
-  `ZUKE_OPERATOR_TOKEN`, and `--confirm-destructive`; mark inspect-only targets
-  `.readOnly()`. Mutating/denied calls are audited (`zuke runs show mcp-audit`).
+  access with `--allow-run=<globs>` (an allow-list over **invocation** —
+  invoking a target runs its dependencies, and the read tools narrow to the
+  allow-listed targets' closure), `--protect <globs>` + `ZUKE_OPERATOR_TOKEN`
+  (enforced over a run's **whole plan**, so a protected target reached as a
+  dependency still needs the token), and `--confirm-destructive`; mark
+  inspect-only targets `.readOnly()`. Mutating/denied calls are audited — read
+  the trail on the host with `zuke runs show mcp-audit`; it is deliberately not
+  readable over MCP.
   A **registry-backed** server (`zuke register` then `zuke mcp --registry`)
   instead serves every registered pipeline live, each as a
   `run:<buildId>:<target>` tool that takes the build's declared parameters

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -23,12 +23,14 @@ Everything is optional except a body (`.executes`).
 | `.inputs(...p)` / `.outputs(...p)`                                                                       | Incremental cache: skip when inputs unchanged and outputs exist.                                    |
 | `.cacheKey(fn)`                                                                                          | Add a non-file value (version, git sha, param) to the cache fingerprint.                            |
 | `.onlyWhen(cond)`                                                                                        | Run only when the (possibly async) predicate holds, else skip.                                      |
+| `.whenSkipped("skip-dependencies")`                                                                      | When `onlyWhen` skips this target, also skip deps no other planned target needs. Condition is evaluated up front, so it must not read run-produced state. |
 | `.requires(...params)`                                                                                   | Fail unless the listed parameters resolved to a value.                                              |
 | `.retry(times, delayMs?)`                                                                                | Retry the body on failure.                                                                          |
 | `.timeout(ms)`                                                                                           | Fail the body if it runs longer than `ms` (per attempt).                                            |
 | `.lock((s) => s.lockKey(...).withTtl(...))`                                                              | Hold a cross-run lock while running; a second run wanting the key fails. See below.                 |
 | `.waitsFor((s) => s.on(externalSignal(...)))`                                                            | Gate (no body): suspend the run until an external event; resume later. See below.                   |
 | `.onCancel(() => this.rollback)`                                                                         | Compensation run (reverse order) iff this target succeeded when the run is cancelled. See below.    |
+| `.effect(name, fn)`                                                                                      | A side effect whose intent is recorded before it runs, so a resume re-drives it. At-least-once. See below. |
 | `.forEach(() => items, (item) => ({stage: target()…}), (s) => s.concurrency(3).continueOnItemFailure())` | Fan out a pipeline over a runtime list: items concurrent, stages sequential per item. See below.    |
 | `.proceedAfterFailure()`                                                                                 | Keep the build going if this target fails.                                                          |
 | `.always()`                                                                                              | Run even after the build failed (cleanup/teardown).                                                 |
@@ -38,6 +40,13 @@ Everything is optional except a body (`.executes`).
 | `.recoverWith(...r)` / `.recoverAttempts(n)`                                                             | Run `Remediation`s if the body fails (self-healing); re-run when one asks to. See AI section.       |
 | `.partOf(group)`                                                                                         | Join a parallel batch (see `group()`).                                                              |
 | `.produces(...p)` / `.consumes(...t)`                                                                    | Declare and consume artifact paths.                                                                 |
+
+**Lifecycle hooks** — `override` on the `Build` to observe a run without wrapping
+every target: `onStart()` once before anything runs, `onFinish(result)` once
+after (success *or* failure), `onTargetStart(name)` just before a body executes
+(not for a skipped or cached target), and `onTargetEnd(name, status)` after each
+target settles. All may be async. For exporting rather than observing, prefer a
+plugin (see `@zuke/otel`).
 
 **External ordering:** `override extraEdges(targets)` on the `Build` returns
 `[before, after]` pairs (from the discovered `targets` map) to impose soft
@@ -139,8 +148,14 @@ deploy = target().executes(async (ctx) => {
   await ctx.state.set({ where: "sit-7" }); // durable metadata — see below
   ctx.stateOf("build").get(); // read ANOTHER target's published state
   ctx.signals.get("approved"); // an external signal's payload (see waits)
+  ctx.outcomeOf("checks")?.status; // one target's settled outcome, or undefined
+  ctx.outcomes(); // every outcome settled SO FAR, keyed by dotted name
 });
 ```
+
+`ctx.outcomes()` is a snapshot, not a live view, and a target that has not
+settled is **absent** rather than present with a placeholder — so depend on what
+you intend to read (an `.always()` gate reads what ran before it).
 
 **Cancellation.** When the run is cancelled, `ctx.signal` fires and any plain
 `` $`…` `` in the body is terminated with `SIGTERM` automatically (the run's
@@ -194,6 +209,12 @@ class CD extends Build {
   non-terminal run (suspended/running) is never pruned. The FS store owns
   pruning via the CLI; for the HTTP backend retention is the server's job
   (`GET /runs` takes `limit`; `DELETE /runs/:id` is optional). See `docs/state.md`.
+- **Run leases.** A run that writes durable state takes a TTL lease on its own
+  id and heartbeats it, so two processes cannot both believe they own one run —
+  a resume that adopts a run whose lease has lapsed takes it over, and the
+  original stops. The lease is a mutual-exclusion guard, not a liveness monitor:
+  nothing currently sweeps lapsed leases, so a run whose process was killed
+  stays `running` until an operator moves it (see `.effect()` above).
 - **Never put secrets in `ctx.state`** — it is stored as plain JSON. Secret
   parameters are excluded from the record and state values are run through the
   redactor, but treat state as a non-secret channel. See `docs/state.md`.
@@ -343,6 +364,38 @@ class CD extends Build {
   cancels the run (running compensations); `.onTimeout(() => this.cleanup)` runs
   that target too. Needs a state store (a build with `.onCancel()` enables
   `.zuke/runs` by default). See `docs/orchestration.md`.
+
+## Durable side effects — `.effect()`
+
+A body that dies partway through leaves no record of what it had already done.
+`.effect(name, fn)` records the **intent** to run `fn` in the run record before
+`fn` runs, so a resume can see the effect was owed and drive it again. Effects
+run after the body, in declaration order; a target may declare effects and no
+body at all. Requires a state store, which is enabled automatically — an intent
+that cannot be recorded fails the target before the effect runs, by design.
+
+```ts
+gate = target().dependsOn(this.checks).always()
+  .effect("post-gate", async (ctx) => {
+    await postCheckRun(ctx.outcomeOf("checks")?.status === "succeeded");
+  });
+```
+
+- **At-least-once, not exactly-once.** A process that dies after the side effect
+  but before recording it repeats the effect on the re-drive. Write bodies that
+  tolerate that — either repeating is harmless, or the far side converges (an
+  upsert, not an append).
+- **Pin the inputs.** A re-drive happens later, sometimes much later, so a body
+  that looks up "the current value" of anything acts on a world that has moved
+  on. Read what the effect acts on from `ctx.state`/`ctx.stateOf(...)`, written
+  by an earlier target and replayed from the record. A parameter is nearly as
+  good: an unsupplied one keeps the value the run started with, but a resume
+  that passes one explicitly overrides it — so prefer state for a value that
+  must not drift.
+- **What re-drives it.** An effect owed by a run that suspended for any ordinary
+  reason is re-driven by the ordinary resume. A process **killed outright**
+  leaves its run `running`, so its owed effect is re-driven only once something
+  moves that run back to `suspended` — an operator, or a reaping sweep.
 
 ## Fan-out over a list — `.forEach()`
 
@@ -502,6 +555,7 @@ the full task list and settings methods of each):
 | Package                                                                                                                                        | Object                                           | Typical tasks                                                                       |
 | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------- |
 | `@zuke/core`                                                                                                                                   | `FileTasks`, `AnnounceTasks`, `ToolTasks`        | copy/move/remove files; Slack/Teams/Discord posts; install tool binaries            |
+| `@zuke/cli`                                                                                                                                    | the `zuke` command                               | not a wrapper — `deno install -A -g -n zuke jsr:@zuke/cli`, then `zuke setup` scaffolds a project |
 | `@zuke/console`                                                                                                                                | `ConsoleTasks`                                   | themed console output (headings, notices) so a build never hand-rolls `console.log` |
 | `@zuke/deno`                                                                                                                                   | `DenoTasks`                                      | `check`, `test`, `fmt`, `lint`, `cache`, `doc`, `run`, `publish`                    |
 | `@zuke/docs`                                                                                                                                   | `DocsTasks`                                      | turn generated API docs into published output                                       |
@@ -544,6 +598,13 @@ await DockerTasks.build((s) => s.tag("app").context("."));
 A model becomes part of the build graph two ways. Only the provider (`"claude"`
 | `"openai"` | `"gemini"`) and an API key (pass a `parameter().secret()`) are
 required; everything else is defaulted.
+
+Neither interface is AI-specific, and neither needs a base class: a
+**`Validation`** is any object with a `validate(context)` method (throw to fail
+the target), and a **`Remediation`** is any object with a `remediate(...)`
+method that repairs the failure and asks for the body to be re-run — the real
+build command is the verifier. Write your own wherever a check or a fix is
+mechanical rather than a model's job.
 
 **Review gate** — a reviewer is a `Validation`; attach with `.validateBefore` /
 `.validateAfter`. It scores the diff and breaks the build past a threshold.
@@ -745,5 +806,9 @@ proxy's job.
 (skipped and reported `cached` when inputs are unchanged and outputs exist). Add
 a **remote store** to share results across machines — a fresh CI checkout or a
 teammate's clone restores outputs instead of rebuilding; `--no-remote-cache`
-uses the local cache only. `--affected` limits a run to targets touched since a
-git base (great for CI job fan-out).
+uses the local cache only. Declare one with `override remoteCache()` on the
+`Build` (returning `FileSystemCacheStore` or `HttpCacheStore`), or leave it and
+the executor falls back to the `ZUKE_REMOTE_CACHE_*` environment variables; it
+applies only to targets declaring **both** `inputs` and `outputs`. A remote
+store is best-effort — an unreachable one never fails the build. `--affected`
+limits a run to targets touched since a git base (great for CI job fan-out).

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -687,12 +687,31 @@ else a friendly error.
 ./zuke mcp --http 7777 --allowed-origin https://app.example  # permit an extra browser Origin
 ./zuke mcp --allow-run=deploy,checks* --protect deploy --confirm-destructive
                               # authz tiers: allow-list, operator token, confirm
-./zuke runs show mcp-audit    # the MCP tool-call audit trail
+./zuke runs show mcp-audit    # the MCP tool-call audit trail (host only, not served over MCP)
 ./zuke register [--json]      # record this build in the build registry (idempotent)
 ./zuke doc jsr:@zuke/deno     # print a package's API (deno doc) from an isolated empty dir
 ./zuke mcp --registry --allow-run  # serve the registry: registered builds as tools, spawned
 ./zuke mcp --registry --max-concurrent-runs 4  # cap concurrent run-tool spawns (default 4)
 ```
+
+**MCP authorization** (`docs/mcp.md`): the two gates have deliberately different
+reach. `--allow-run=<globs>` is an **entry-point** control — it decides which
+targets a client may invoke, and invoking one runs its dependencies, so
+allow-listing `release` allows everything `release` does; scope it to entry
+points, not steps. The read tools narrow to match (the allow-listed targets plus
+their closure), so a target outside it is unreachable rather than merely
+undisplayed. `--protect <globs>` + `ZUKE_OPERATOR_TOKEN` is an **operation**
+control, enforced across a run's whole plan: a protected target reached as a
+dependency of an unprotected one still requires the token, and that run tool
+advertises `operatorToken` as required in its schema. Both fail closed — no
+configured token denies every protected target, and a plan that cannot be
+resolved (a run record whose root target was deleted) is denied rather than
+assumed harmless. The audit trail is operator-only: `show_run` refuses it and
+`list_runs` omits it, so the clients it audits cannot read who called what.
+`--confirm-destructive` adds a third tier: any target not marked `.readOnly()`
+returns its resolved plan until the call repeats with `confirm: true` (a
+`dryRun` is exempt) — so mark inspect-only targets `.readOnly()`, which also
+advertises MCP's `readOnlyHint` instead of `destructiveHint`.
 
 **Build registry** (`docs/registry.md`): `zuke register` writes a secret-free
 descriptor of this build — its `describeCli()` surface (targets, params) plus a

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -156,6 +156,14 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   the MCP `cancel_run` tool). Idempotent; a timed-out wait can route its
   `onTimeout` here (`"cancel-run"` or a named target). Needs a state store. See
   `docs/orchestration.md`.
+- **Durable side effects:** `.effect(name, fn)` records the intent to run `fn`
+  before it runs, so a resume re-drives an effect a dead process left owed.
+  Effects run after the body, in declaration order; a target may declare effects
+  and no body. The guarantee is **at-least-once**, so write bodies that tolerate
+  a repeat (an upsert, not an append), and read what the effect acts on from
+  `ctx.state` rather than looking up "the current value" — a re-drive happens
+  later, against a world that moved on. Needs a state store (enabled
+  automatically). See the cheatsheet / `docs/orchestration.md`.
 - **Fan-out over a list:**
   `.forEach(() => this.repos.value, (repo) => ({ checks: target()…, deploy: target()… }), (s) => s.concurrency(3).continueOnItemFailure())`
   runs the same pipeline over a runtime list — items concurrent, each item's

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -190,9 +190,14 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   stdio, or over HTTP with `--http <host:port>` (loopback by default; a
   non-loopback bind needs a `ZUKE_MCP_TOKEN` bearer token). With a state store
   it also exposes `list_runs`/`show_run` (+ `signal_run`/`resume_check`). Tier
-  access with `--allow-run=<globs>` (allow-list), `--protect <globs>` +
-  `ZUKE_OPERATOR_TOKEN`, and `--confirm-destructive`; mark inspect-only targets
-  `.readOnly()`. Mutating/denied calls are audited (`zuke runs show mcp-audit`).
+  access with `--allow-run=<globs>` (an allow-list over **invocation** —
+  invoking a target runs its dependencies, and the read tools narrow to the
+  allow-listed targets' closure), `--protect <globs>` + `ZUKE_OPERATOR_TOKEN`
+  (enforced over a run's **whole plan**, so a protected target reached as a
+  dependency still needs the token), and `--confirm-destructive`; mark
+  inspect-only targets `.readOnly()`. Mutating/denied calls are audited — read
+  the trail on the host with `zuke runs show mcp-audit`; it is deliberately not
+  readable over MCP.
   A **registry-backed** server (`zuke register` then `zuke mcp --registry`)
   instead serves every registered pipeline live, each as a
   `run:<buildId>:<target>` tool that takes the build's declared parameters

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -23,12 +23,14 @@ Everything is optional except a body (`.executes`).
 | `.inputs(...p)` / `.outputs(...p)`                                                                       | Incremental cache: skip when inputs unchanged and outputs exist.                                    |
 | `.cacheKey(fn)`                                                                                          | Add a non-file value (version, git sha, param) to the cache fingerprint.                            |
 | `.onlyWhen(cond)`                                                                                        | Run only when the (possibly async) predicate holds, else skip.                                      |
+| `.whenSkipped("skip-dependencies")`                                                                      | When `onlyWhen` skips this target, also skip deps no other planned target needs. Condition is evaluated up front, so it must not read run-produced state. |
 | `.requires(...params)`                                                                                   | Fail unless the listed parameters resolved to a value.                                              |
 | `.retry(times, delayMs?)`                                                                                | Retry the body on failure.                                                                          |
 | `.timeout(ms)`                                                                                           | Fail the body if it runs longer than `ms` (per attempt).                                            |
 | `.lock((s) => s.lockKey(...).withTtl(...))`                                                              | Hold a cross-run lock while running; a second run wanting the key fails. See below.                 |
 | `.waitsFor((s) => s.on(externalSignal(...)))`                                                            | Gate (no body): suspend the run until an external event; resume later. See below.                   |
 | `.onCancel(() => this.rollback)`                                                                         | Compensation run (reverse order) iff this target succeeded when the run is cancelled. See below.    |
+| `.effect(name, fn)`                                                                                      | A side effect whose intent is recorded before it runs, so a resume re-drives it. At-least-once. See below. |
 | `.forEach(() => items, (item) => ({stage: target()…}), (s) => s.concurrency(3).continueOnItemFailure())` | Fan out a pipeline over a runtime list: items concurrent, stages sequential per item. See below.    |
 | `.proceedAfterFailure()`                                                                                 | Keep the build going if this target fails.                                                          |
 | `.always()`                                                                                              | Run even after the build failed (cleanup/teardown).                                                 |
@@ -38,6 +40,13 @@ Everything is optional except a body (`.executes`).
 | `.recoverWith(...r)` / `.recoverAttempts(n)`                                                             | Run `Remediation`s if the body fails (self-healing); re-run when one asks to. See AI section.       |
 | `.partOf(group)`                                                                                         | Join a parallel batch (see `group()`).                                                              |
 | `.produces(...p)` / `.consumes(...t)`                                                                    | Declare and consume artifact paths.                                                                 |
+
+**Lifecycle hooks** — `override` on the `Build` to observe a run without wrapping
+every target: `onStart()` once before anything runs, `onFinish(result)` once
+after (success *or* failure), `onTargetStart(name)` just before a body executes
+(not for a skipped or cached target), and `onTargetEnd(name, status)` after each
+target settles. All may be async. For exporting rather than observing, prefer a
+plugin (see `@zuke/otel`).
 
 **External ordering:** `override extraEdges(targets)` on the `Build` returns
 `[before, after]` pairs (from the discovered `targets` map) to impose soft
@@ -139,8 +148,14 @@ deploy = target().executes(async (ctx) => {
   await ctx.state.set({ where: "sit-7" }); // durable metadata — see below
   ctx.stateOf("build").get(); // read ANOTHER target's published state
   ctx.signals.get("approved"); // an external signal's payload (see waits)
+  ctx.outcomeOf("checks")?.status; // one target's settled outcome, or undefined
+  ctx.outcomes(); // every outcome settled SO FAR, keyed by dotted name
 });
 ```
+
+`ctx.outcomes()` is a snapshot, not a live view, and a target that has not
+settled is **absent** rather than present with a placeholder — so depend on what
+you intend to read (an `.always()` gate reads what ran before it).
 
 **Cancellation.** When the run is cancelled, `ctx.signal` fires and any plain
 `` $`…` `` in the body is terminated with `SIGTERM` automatically (the run's
@@ -194,6 +209,12 @@ class CD extends Build {
   non-terminal run (suspended/running) is never pruned. The FS store owns
   pruning via the CLI; for the HTTP backend retention is the server's job
   (`GET /runs` takes `limit`; `DELETE /runs/:id` is optional). See `docs/state.md`.
+- **Run leases.** A run that writes durable state takes a TTL lease on its own
+  id and heartbeats it, so two processes cannot both believe they own one run —
+  a resume that adopts a run whose lease has lapsed takes it over, and the
+  original stops. The lease is a mutual-exclusion guard, not a liveness monitor:
+  nothing currently sweeps lapsed leases, so a run whose process was killed
+  stays `running` until an operator moves it (see `.effect()` above).
 - **Never put secrets in `ctx.state`** — it is stored as plain JSON. Secret
   parameters are excluded from the record and state values are run through the
   redactor, but treat state as a non-secret channel. See `docs/state.md`.
@@ -343,6 +364,38 @@ class CD extends Build {
   cancels the run (running compensations); `.onTimeout(() => this.cleanup)` runs
   that target too. Needs a state store (a build with `.onCancel()` enables
   `.zuke/runs` by default). See `docs/orchestration.md`.
+
+## Durable side effects — `.effect()`
+
+A body that dies partway through leaves no record of what it had already done.
+`.effect(name, fn)` records the **intent** to run `fn` in the run record before
+`fn` runs, so a resume can see the effect was owed and drive it again. Effects
+run after the body, in declaration order; a target may declare effects and no
+body at all. Requires a state store, which is enabled automatically — an intent
+that cannot be recorded fails the target before the effect runs, by design.
+
+```ts
+gate = target().dependsOn(this.checks).always()
+  .effect("post-gate", async (ctx) => {
+    await postCheckRun(ctx.outcomeOf("checks")?.status === "succeeded");
+  });
+```
+
+- **At-least-once, not exactly-once.** A process that dies after the side effect
+  but before recording it repeats the effect on the re-drive. Write bodies that
+  tolerate that — either repeating is harmless, or the far side converges (an
+  upsert, not an append).
+- **Pin the inputs.** A re-drive happens later, sometimes much later, so a body
+  that looks up "the current value" of anything acts on a world that has moved
+  on. Read what the effect acts on from `ctx.state`/`ctx.stateOf(...)`, written
+  by an earlier target and replayed from the record. A parameter is nearly as
+  good: an unsupplied one keeps the value the run started with, but a resume
+  that passes one explicitly overrides it — so prefer state for a value that
+  must not drift.
+- **What re-drives it.** An effect owed by a run that suspended for any ordinary
+  reason is re-driven by the ordinary resume. A process **killed outright**
+  leaves its run `running`, so its owed effect is re-driven only once something
+  moves that run back to `suspended` — an operator, or a reaping sweep.
 
 ## Fan-out over a list — `.forEach()`
 
@@ -502,6 +555,7 @@ the full task list and settings methods of each):
 | Package                                                                                                                                        | Object                                           | Typical tasks                                                                       |
 | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------- |
 | `@zuke/core`                                                                                                                                   | `FileTasks`, `AnnounceTasks`, `ToolTasks`        | copy/move/remove files; Slack/Teams/Discord posts; install tool binaries            |
+| `@zuke/cli`                                                                                                                                    | the `zuke` command                               | not a wrapper — `deno install -A -g -n zuke jsr:@zuke/cli`, then `zuke setup` scaffolds a project |
 | `@zuke/console`                                                                                                                                | `ConsoleTasks`                                   | themed console output (headings, notices) so a build never hand-rolls `console.log` |
 | `@zuke/deno`                                                                                                                                   | `DenoTasks`                                      | `check`, `test`, `fmt`, `lint`, `cache`, `doc`, `run`, `publish`                    |
 | `@zuke/docs`                                                                                                                                   | `DocsTasks`                                      | turn generated API docs into published output                                       |
@@ -544,6 +598,13 @@ await DockerTasks.build((s) => s.tag("app").context("."));
 A model becomes part of the build graph two ways. Only the provider (`"claude"`
 | `"openai"` | `"gemini"`) and an API key (pass a `parameter().secret()`) are
 required; everything else is defaulted.
+
+Neither interface is AI-specific, and neither needs a base class: a
+**`Validation`** is any object with a `validate(context)` method (throw to fail
+the target), and a **`Remediation`** is any object with a `remediate(...)`
+method that repairs the failure and asks for the body to be re-run — the real
+build command is the verifier. Write your own wherever a check or a fix is
+mechanical rather than a model's job.
 
 **Review gate** — a reviewer is a `Validation`; attach with `.validateBefore` /
 `.validateAfter`. It scores the diff and breaks the build past a threshold.
@@ -745,5 +806,9 @@ proxy's job.
 (skipped and reported `cached` when inputs are unchanged and outputs exist). Add
 a **remote store** to share results across machines — a fresh CI checkout or a
 teammate's clone restores outputs instead of rebuilding; `--no-remote-cache`
-uses the local cache only. `--affected` limits a run to targets touched since a
-git base (great for CI job fan-out).
+uses the local cache only. Declare one with `override remoteCache()` on the
+`Build` (returning `FileSystemCacheStore` or `HttpCacheStore`), or leave it and
+the executor falls back to the `ZUKE_REMOTE_CACHE_*` environment variables; it
+applies only to targets declaring **both** `inputs` and `outputs`. A remote
+store is best-effort — an unreachable one never fails the build. `--affected`
+limits a run to targets touched since a git base (great for CI job fan-out).

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -687,12 +687,31 @@ else a friendly error.
 ./zuke mcp --http 7777 --allowed-origin https://app.example  # permit an extra browser Origin
 ./zuke mcp --allow-run=deploy,checks* --protect deploy --confirm-destructive
                               # authz tiers: allow-list, operator token, confirm
-./zuke runs show mcp-audit    # the MCP tool-call audit trail
+./zuke runs show mcp-audit    # the MCP tool-call audit trail (host only, not served over MCP)
 ./zuke register [--json]      # record this build in the build registry (idempotent)
 ./zuke doc jsr:@zuke/deno     # print a package's API (deno doc) from an isolated empty dir
 ./zuke mcp --registry --allow-run  # serve the registry: registered builds as tools, spawned
 ./zuke mcp --registry --max-concurrent-runs 4  # cap concurrent run-tool spawns (default 4)
 ```
+
+**MCP authorization** (`docs/mcp.md`): the two gates have deliberately different
+reach. `--allow-run=<globs>` is an **entry-point** control — it decides which
+targets a client may invoke, and invoking one runs its dependencies, so
+allow-listing `release` allows everything `release` does; scope it to entry
+points, not steps. The read tools narrow to match (the allow-listed targets plus
+their closure), so a target outside it is unreachable rather than merely
+undisplayed. `--protect <globs>` + `ZUKE_OPERATOR_TOKEN` is an **operation**
+control, enforced across a run's whole plan: a protected target reached as a
+dependency of an unprotected one still requires the token, and that run tool
+advertises `operatorToken` as required in its schema. Both fail closed — no
+configured token denies every protected target, and a plan that cannot be
+resolved (a run record whose root target was deleted) is denied rather than
+assumed harmless. The audit trail is operator-only: `show_run` refuses it and
+`list_runs` omits it, so the clients it audits cannot read who called what.
+`--confirm-destructive` adds a third tier: any target not marked `.readOnly()`
+returns its resolved plan until the call repeats with `confirm: true` (a
+`dryRun` is exempt) — so mark inspect-only targets `.readOnly()`, which also
+advertises MCP's `readOnlyHint` instead of `destructiveHint`.
 
 **Build registry** (`docs/registry.md`): `zuke register` writes a secret-free
 descriptor of this build — its `describeCli()` surface (targets, params) plus a

--- a/tests/integration/mcp_authz_test.ts
+++ b/tests/integration/mcp_authz_test.ts
@@ -1,0 +1,121 @@
+/**
+ * Integration: MCP authorization over a real build, and the operator's
+ * host-side view of the trail it writes.
+ *
+ * The unit tests pin the gate's decisions; this drives the whole path — a real
+ * `Build`, a real state store, a real `McpServer`, and the real CLI `main()` —
+ * to prove two things fit together. First, that a protected target reached as a
+ * dependency is denied *and the denial is durably recorded*. Second, that
+ * closing the audit trail to MCP readers did not close it to the operator: the
+ * documented `zuke runs show mcp-audit` still renders it on the host.
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import {
+  Build,
+  defaultStateHost,
+  FileSystemStateStore,
+  target,
+} from "../../packages/core/mod.ts";
+import { McpServer } from "../../packages/core/src/mcp/server.ts";
+import { runCli, withStateDir } from "./_harness.ts";
+
+/** A build whose release path runs a protected deploy. */
+class Pipeline extends Build {
+  lint = target().description("Lint").executes(() => {});
+  deploy = target().description("Deploy").dependsOn(this.lint).executes(
+    () => {},
+  );
+  release = target().description("Release").dependsOn(this.deploy).executes(
+    () => {},
+  );
+}
+
+/** Call an MCP tool on `server`, returning its text result. */
+async function call(
+  server: McpServer,
+  name: string,
+  args: Record<string, unknown> = {},
+): Promise<{ text: string; isError: boolean }> {
+  const res = await server.handleMessage({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: { name, arguments: args },
+  });
+  const result = res?.result;
+  if (typeof result !== "object" || result === null || !("content" in result)) {
+    throw new Error("not a tool result");
+  }
+  const content = (result as { content: Array<{ text: string }> }).content;
+  return {
+    text: content[0].text,
+    isError: (result as { isError?: boolean }).isError ?? false,
+  };
+}
+
+Deno.test("a protected dependency blocks the run and the denial reaches the trail", async () => {
+  await withStateDir(async (dir) => {
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    const server = new McpServer(new Pipeline(), {
+      allowRun: true,
+      protectPatterns: ["deploy"],
+      operatorToken: "swordfish",
+      actor: "agent-7",
+      stateStore: store,
+    });
+
+    // `release` is not protected, but it runs `deploy`, which is.
+    const denied = await call(server, "run:release", {});
+    assertEquals(denied.isError, true);
+    assertEquals(JSON.parse(denied.text).reason, "missing_operator_token");
+
+    // No run record was created — the build never started.
+    const runs = await store.listRuns({});
+    assertEquals(runs.filter((r) => r.rootTarget === "release").length, 0);
+
+    // With the operator token the same call runs the whole plan.
+    const allowed = await call(server, "run:release", {
+      operatorToken: "swordfish",
+    });
+    assertEquals(allowed.isError, false);
+
+    // The operator can still read the trail on the host — the denial and the
+    // successful run, both attributed — even though MCP will not serve it.
+    const shown = await runCli(Pipeline, ["runs", "show", "mcp-audit"]);
+    assertEquals(shown.code, 0);
+    assertStringIncludes(shown.out, "Audit:");
+    assertStringIncludes(shown.out, "run:release");
+    assertStringIncludes(shown.out, "agent-7");
+    assertStringIncludes(shown.out, "denied");
+  });
+});
+
+Deno.test("the trail is unreadable over MCP while the CLI still renders it", async () => {
+  await withStateDir(async (dir) => {
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    const server = new McpServer(new Pipeline(), {
+      allowRun: true,
+      actor: "agent-7",
+      stateStore: store,
+    });
+    await call(server, "run:lint", {});
+
+    // Refused over the wire…
+    const overMcp = await call(server, "show_run", { runId: "mcp-audit" });
+    assertEquals(overMcp.isError, true);
+    assertEquals(JSON.parse(overMcp.text).error, "not_readable");
+
+    // …and absent from the run listing the agent can see.
+    const listed = await call(server, "list_runs");
+    assertEquals(listed.text.includes("mcp-audit"), false);
+
+    // …but intact for the operator on the host.
+    const shown = await runCli(Pipeline, ["runs", "show", "mcp-audit"]);
+    assertEquals(shown.code, 0);
+    assertStringIncludes(shown.out, "run:lint");
+  });
+});

--- a/tests/plugin_manifest_test.ts
+++ b/tests/plugin_manifest_test.ts
@@ -27,14 +27,16 @@ const MARKETPLACE: Record<string, unknown> = JSON.parse(
   Deno.readTextFileSync(".claude-plugin/marketplace.json"),
 );
 
+/** Whether a parsed JSON value is a plain object, narrowing it for field reads. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 /** The marketplace's entry for the `zuke` plugin. */
 function entry(): Record<string, unknown> {
   const plugins = MARKETPLACE.plugins;
   if (!Array.isArray(plugins)) throw new Error("marketplace has no plugins[]");
-  const found = plugins.find((p): p is Record<string, unknown> =>
-    typeof p === "object" && p !== null && !Array.isArray(p) &&
-    (p as Record<string, unknown>).name === "zuke"
-  );
+  const found = plugins.filter(isRecord).find((p) => p.name === "zuke");
   if (found === undefined) throw new Error("no marketplace entry named zuke");
   return found;
 }

--- a/tests/plugin_manifest_test.ts
+++ b/tests/plugin_manifest_test.ts
@@ -1,0 +1,67 @@
+/**
+ * Unit tests for the Claude Code plugin's two manifests — the plugin's own
+ * `plugins/zuke/.claude-plugin/plugin.json` and the marketplace entry in
+ * `.claude-plugin/marketplace.json` that points at it.
+ *
+ * These are asserted here because nothing else fails when they disagree.
+ * `pluginSyncCheck` guards the skills *content* (that the committed copies match
+ * `skills/`), and release-please does not manage `plugins/` at all — so the
+ * version is bumped by hand, in two files, and a bump applied to one of them
+ * ships a marketplace listing whose advertised version does not match the
+ * plugin it installs. A stale version is worse than a wrong one: clients use it
+ * to decide whether an installed plugin needs re-fetching, so skills edited
+ * without a bump simply never reach the agents that already have the old copy.
+ *
+ * @module
+ */
+
+import { assertEquals } from "../packages/core/tests/_assert.ts";
+
+/** The plugin's own manifest. */
+const PLUGIN: Record<string, unknown> = JSON.parse(
+  Deno.readTextFileSync("plugins/zuke/.claude-plugin/plugin.json"),
+);
+
+/** The marketplace manifest that lists it. */
+const MARKETPLACE: Record<string, unknown> = JSON.parse(
+  Deno.readTextFileSync(".claude-plugin/marketplace.json"),
+);
+
+/** The marketplace's entry for the `zuke` plugin. */
+function entry(): Record<string, unknown> {
+  const plugins = MARKETPLACE.plugins;
+  if (!Array.isArray(plugins)) throw new Error("marketplace has no plugins[]");
+  const found = plugins.find((p): p is Record<string, unknown> =>
+    typeof p === "object" && p !== null && !Array.isArray(p) &&
+    (p as Record<string, unknown>).name === "zuke"
+  );
+  if (found === undefined) throw new Error("no marketplace entry named zuke");
+  return found;
+}
+
+Deno.test("the plugin and its marketplace entry declare the same version", () => {
+  // The bump is manual and lives in two files. Missing one publishes a listing
+  // that advertises a version the plugin does not carry.
+  assertEquals(
+    entry().version,
+    PLUGIN.version,
+    "plugin.json and marketplace.json disagree on the plugin version",
+  );
+});
+
+Deno.test("the plugin version is a plain semver triple", () => {
+  // Clients compare these to decide whether an install is stale, so a
+  // pre-release or a two-part version is not worth discovering at publish time.
+  assertEquals(
+    /^\d+\.\d+\.\d+$/.test(String(PLUGIN.version)),
+    true,
+    `plugin version is not a semver triple: ${String(PLUGIN.version)}`,
+  );
+});
+
+Deno.test("the marketplace entry points at the plugin directory in this repo", () => {
+  // A source that drifts from the real path resolves to nothing, and the
+  // listing installs an empty plugin rather than failing loudly.
+  assertEquals(entry().source, "./plugins/zuke");
+  assertEquals(PLUGIN.name, "zuke");
+});

--- a/tests/plugin_version_check_test.ts
+++ b/tests/plugin_version_check_test.ts
@@ -1,0 +1,182 @@
+/**
+ * Unit tests for the gate's plugin-version check.
+ *
+ * The decision is separated from the git reads behind {@link GitHistory}, so
+ * every case here runs against a fake history — no repository, no subprocess,
+ * no network. What is asserted is the property that matters: the check fails
+ * exactly when the published skills moved and the version did not, and it
+ * reports itself *skipped* rather than passing when it cannot compare.
+ *
+ * @module
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../packages/core/tests/_assert.ts";
+import {
+  bumpFailure,
+  checkPluginVersionBump,
+  type GitHistory,
+  isSkillPath,
+  manifestVersion,
+  PLUGIN_MANIFEST,
+  resolveBaseRef,
+  skillPaths,
+} from "../build/plugin_version_check.ts";
+
+/** A fake history: a fixed changed-file list and a fixed base manifest. */
+function fakeGit(options: {
+  refs?: string[];
+  changed?: string[];
+  baseFiles?: Record<string, string>;
+}): GitHistory {
+  const refs = options.refs ?? ["origin/master"];
+  return {
+    hasRef: (ref) => Promise.resolve(refs.includes(ref)),
+    changedSince: () => Promise.resolve(options.changed ?? []),
+    fileAt: (_ref, path) => Promise.resolve(options.baseFiles?.[path] ?? null),
+  };
+}
+
+/** A head reader serving one manifest version. */
+function headAt(
+  version: string | null,
+): (path: string) => Promise<string | null> {
+  return () =>
+    Promise.resolve(version === null ? null : JSON.stringify({ version }));
+}
+
+Deno.test("skill paths are the two trees the marketplace serves", () => {
+  assertEquals(isSkillPath("skills/zuke-write-build/SKILL.md"), true);
+  assertEquals(isSkillPath("plugins/zuke/skills/zuke-setup/SKILL.md"), true);
+  // The manifests themselves are not "skills" — changing only the version must
+  // not itself demand another bump.
+  assertEquals(isSkillPath(PLUGIN_MANIFEST), false);
+  assertEquals(isSkillPath("docs/mcp.md"), false);
+  assertEquals(isSkillPath("packages/core/src/mcp/server.ts"), false);
+  assertEquals(
+    skillPaths(["docs/a.md", "skills/x.md", "README.md"]),
+    ["skills/x.md"],
+  );
+});
+
+Deno.test("a manifest version is read, or reported missing rather than thrown", () => {
+  assertEquals(manifestVersion('{"version":"0.3.0"}'), "0.3.0");
+  assertEquals(manifestVersion(null), undefined);
+  assertEquals(manifestVersion("not json{"), undefined);
+  assertEquals(manifestVersion('{"version":3}'), undefined);
+  assertEquals(manifestVersion("[]"), undefined);
+});
+
+Deno.test("skills changed and the version did not — the check fails", async () => {
+  const verdict = await checkPluginVersionBump(
+    fakeGit({
+      changed: ["skills/zuke-write-build/SKILL.md", "plugins/zuke/skills/x.md"],
+      baseFiles: { [PLUGIN_MANIFEST]: '{"version":"0.3.0"}' },
+    }),
+    "origin/master",
+    headAt("0.3.0"),
+  );
+  assertEquals(verdict.checked, true);
+  assertEquals(verdict.bumped, false);
+  assertEquals(verdict.changed.length, 2);
+
+  // The message has to name the fix, both files, and what actually changed.
+  const message = bumpFailure(verdict);
+  assertStringIncludes(message, "still 0.3.0");
+  assertStringIncludes(message, "skills/zuke-write-build/SKILL.md");
+  assertStringIncludes(message, PLUGIN_MANIFEST);
+  assertStringIncludes(message, ".claude-plugin/marketplace.json");
+});
+
+Deno.test("skills changed and the version moved — the check passes", async () => {
+  const verdict = await checkPluginVersionBump(
+    fakeGit({
+      changed: ["skills/zuke-write-build/references/cheatsheet.md"],
+      baseFiles: { [PLUGIN_MANIFEST]: '{"version":"0.2.0"}' },
+    }),
+    "origin/master",
+    headAt("0.3.0"),
+  );
+  assertEquals(verdict.checked, true);
+  assertEquals(verdict.bumped, true);
+  assertEquals(verdict.baseVersion, "0.2.0");
+  assertEquals(verdict.headVersion, "0.3.0");
+});
+
+Deno.test("a change that touches no skill needs no bump", async () => {
+  // The common case: an ordinary source PR must not be asked to bump a plugin
+  // it never touched.
+  const verdict = await checkPluginVersionBump(
+    fakeGit({
+      changed: ["packages/core/src/mcp/server.ts", "docs/mcp.md"],
+      baseFiles: { [PLUGIN_MANIFEST]: '{"version":"0.3.0"}' },
+    }),
+    "origin/master",
+    headAt("0.3.0"),
+  );
+  assertEquals(verdict.checked, true);
+  assertEquals(verdict.changed, []);
+  assertEquals(verdict.bumped, false); // and the caller treats this as a pass
+});
+
+Deno.test("a missing base ref is reported skipped, never passed", async () => {
+  // The one honest skip. It must not look like a success: `checked` is false,
+  // and the caller prints the reason rather than a green line.
+  const verdict = await checkPluginVersionBump(
+    fakeGit({ refs: [], changed: ["skills/x.md"] }),
+    "origin/master",
+    headAt("0.3.0"),
+  );
+  assertEquals(verdict.checked, false);
+  assertEquals(verdict.bumped, false);
+  assertStringIncludes(verdict.reason ?? "", "origin/master");
+});
+
+Deno.test("a plugin absent at the base is new, so no bump is demanded", async () => {
+  // Introducing the plugin on a branch: there is no previous version for the
+  // new one to differ from, and demanding a bump would be unsatisfiable.
+  const verdict = await checkPluginVersionBump(
+    fakeGit({ changed: ["skills/x.md"], baseFiles: {} }),
+    "origin/master",
+    headAt("0.1.0"),
+  );
+  assertEquals(verdict.checked, true);
+  assertEquals(verdict.bumped, true);
+  assertEquals(verdict.baseVersion, undefined);
+});
+
+Deno.test("an unreadable head manifest fails the check, it does not skip it", async () => {
+  // The working tree's manifest is the one file that must always be readable.
+  // Treating it as "nothing to compare" would let a corrupted manifest through.
+  const verdict = await checkPluginVersionBump(
+    fakeGit({ changed: ["skills/x.md"] }),
+    "origin/master",
+    headAt(null),
+  );
+  assertEquals(verdict.checked, true);
+  assertEquals(verdict.headVersion, undefined);
+  assertStringIncludes(verdict.reason ?? "", PLUGIN_MANIFEST);
+});
+
+Deno.test("the base ref follows the PR base, then an override, then master", () => {
+  const env = (values: Record<string, string>) => (name: string) =>
+    values[name];
+  assertEquals(resolveBaseRef(env({})), "origin/master");
+  // On a GitHub PR the base is a bare branch name; a CI checkout has it as a
+  // remote-tracking ref, so it is qualified.
+  assertEquals(
+    resolveBaseRef(env({ GITHUB_BASE_REF: "release-1" })),
+    "origin/release-1",
+  );
+  // An explicit override wins, so a local clone can point at whatever it has.
+  assertEquals(
+    resolveBaseRef(
+      env({ GITHUB_BASE_REF: "master", ZUKE_PLUGIN_BASE_REF: "HEAD~3" }),
+    ),
+    "HEAD~3",
+  );
+  // An empty value is not a value.
+  assertEquals(resolveBaseRef(env({ GITHUB_BASE_REF: "" })), "origin/master");
+});

--- a/zuke.ts
+++ b/zuke.ts
@@ -91,6 +91,12 @@ import {
   checkPluginSkillsSync,
   syncPluginSkills,
 } from "./build/plugin_sync.ts";
+import {
+  bumpFailure,
+  checkPluginVersionBump,
+  defaultGitHistory,
+  resolveBaseRef,
+} from "./build/plugin_version_check.ts";
 import { actionPin } from "./build/action_pins.ts";
 import { actionlintTool, gitleaksTool, zizmorTool } from "./build/scanners.ts";
 import { githubWorkflows } from "./build/workflows.ts";
@@ -446,6 +452,41 @@ class ZukeBuild extends Build {
       ConsoleTasks.info("plugins/zuke/skills/ is in sync with skills/.");
     });
 
+  pluginVersionCheck = target()
+    .description("Verify a skills change also bumped the plugin version")
+    .executes(async () => {
+      const base = resolveBaseRef();
+      const verdict = await checkPluginVersionBump(
+        defaultGitHistory(),
+        base,
+        (path) => Deno.readTextFile(path).catch(() => null),
+      );
+      // Unlike the rest of the gate this needs history, so it can genuinely be
+      // unable to run. Say so rather than reporting success — a check that
+      // cannot fail is worse than no check, because it looks like one.
+      if (!verdict.checked) {
+        ConsoleTasks.info(
+          `Plugin version check skipped — ${verdict.reason}. ` +
+            "Set ZUKE_PLUGIN_BASE_REF to compare against a ref you do have.",
+        );
+        return;
+      }
+      if (verdict.headVersion === undefined) {
+        throw new Error(`Plugin version check failed — ${verdict.reason}.`);
+      }
+      if (verdict.changed.length === 0) {
+        ConsoleTasks.info(
+          `No published skill changed against ${base}; nothing to bump.`,
+        );
+        return;
+      }
+      if (!verdict.bumped) throw new Error(bumpFailure(verdict));
+      ConsoleTasks.info(
+        `Skills changed against ${base} and the plugin version moved ` +
+          `${verdict.baseVersion} → ${verdict.headVersion}.`,
+      );
+    });
+
   // Only meaningful on a `pull_request`-triggered run (the workflow passes it
   // via env from `github.event.pull_request.body` — never interpolated into
   // a shell line, so an adversarial PR body can't inject a command). Unset
@@ -655,6 +696,7 @@ class ZukeBuild extends Build {
       this.snippetsCheck,
       this.hclSyncCheck,
       this.pluginSyncCheck,
+      this.pluginVersionCheck,
       this.prBodyLint,
       this.actionPinCheck,
       // In the gate now that the scanners are provisioned by the `tools`


### PR DESCRIPTION
## What & why

Protection of sensitive targets (via `--protect`) now enforces the operator token requirement across a run's entire dependency closure, not just the root target. This closes a critical authorization bypass: a protected target like `deploy` can no longer be invoked without a token by calling an unprotected dependent like `release` that depends on it.

The changes also refine the allow-list semantics:
- **Allow-list gates invocation, not execution**: invoking a target inherently runs its dependencies, so allow-listing a root allows everything that root does.
- **Read-tool visibility follows the allow-list closure**: when an allow-list is configured, the read tools (`list_targets`, `graph`, `describe_build`) narrow to the matched targets' dependency closure, making hidden targets genuinely unreachable rather than merely undisplayed.
- **Audit trail is operator-only**: the `mcp-audit` run record is no longer readable over MCP (preventing agents from confirming their own denials), but remains accessible to the operator via the CLI.

The operator token check now:
1. Resolves the full execution plan for any `run:` tool call
2. Checks whether that plan touches any protected target (by name or in the closure)
3. Advertises `operatorToken` as required in the tool schema if the plan is protected
4. Denies the call with `missing_operator_token` or `invalid_operator_token` if needed
5. Fails closed on unresolvable plans (unknown targets, graph errors)

Similar protection is extended to `signal_run` and `cancel_run` over suspended runs, and to the registry server's `run:<buildId>:<target>` tools.

## Related issues

Closes authorization bypass where protected targets were reachable through unprotected dependents.

## Checklist

- [x] The PR title is a Conventional Commit (`feat(core): ...`).
- [x] `deno task ci` passes locally.
- [x] Tests added: `mcp_authz_closure_test.ts` (390 lines, 11 test cases covering the bypass, schema advertisement, signal/cancel gating, allow-list closure, read-tool visibility, and audit trail access control) and integration test in `mcp_authz_test.ts`.
- [x] Docs updated: `docs/mcp.md` clarified on protection scope, allow-list semantics, and audit trail access.
- [x] No `any`, `as` casts, or `!` assertions in new `src/` code.
- [x] Code written with AI assistance.

https://claude.ai/code/session_01RYNxgcvdii7P8pPhD6U8q2