### PR TITLE
fix(core): redact a multi-line secret line by line

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -53,6 +53,17 @@ The mask is the literal text `[redacted]`. Matching is a plain substring
 replace, never a regular expression, so a secret containing regex-significant
 characters is masked literally and there is no injection surface.
 
+A **multi-line** secret — a PEM private key is the common one — is masked line
+by line as well as whole. Both sinks read a line at a time: Zuke's redactor
+rewrites one reporter line, and the Actions runner reads an `::add-mask::`
+directive to the end of *its* line. So a key registered only as one string would
+match no line of itself, and the whole of it after the header would print in the
+clear. Each of its lines is registered as its own pattern, and one directive is
+emitted per line rather than one carrying the whole key. Lines under eight
+characters are skipped, since a two-character fragment identifies nothing and
+would mask ordinary text wherever it appeared; the value as a whole stays
+registered regardless.
+
 ```ts
 token = parameter("Deploy token").secret().required();
 // --token …, or the TOKEN env var; redacted everywhere Zuke prints it.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1367,10 +1367,17 @@ class Redactor
 
   add(value: string): void
     Register a secret value to mask. Ignores empty strings and duplicates.
+
+    A multi-line value registers each of its lines as well as the whole
+    string, because redaction runs a line at a time and a whole-value pattern
+    can never match one line of it. Lines are trimmed, and a very short one is
+    skipped so it cannot mask ordinary text wherever it appears.
   redact(line: string): string
     Replace every registered secret in `line` with {@link REDACTED}.
   get size(): number
-    The number of distinct secret values registered.
+    The number of distinct patterns registered. A single-line secret
+    contributes one; a multi-line secret contributes the whole value plus each
+    of its qualifying lines.
 
 class SecretError extends Error
   Raised when a {@link SecretSource} cannot produce a value.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1421,10 +1421,17 @@ class Redactor
 
   add(value: string): void
     Register a secret value to mask. Ignores empty strings and duplicates.
+
+    A multi-line value registers each of its lines as well as the whole
+    string, because redaction runs a line at a time and a whole-value pattern
+    can never match one line of it. Lines are trimmed, and a very short one is
+    skipped so it cannot mask ordinary text wherever it appears.
   redact(line: string): string
     Replace every registered secret in `line` with {@link REDACTED}.
   get size(): number
-    The number of distinct secret values registered.
+    The number of distinct patterns registered. A single-line secret
+    contributes one; a multi-line secret contributes the whole value plus each
+    of its qualifying lines.
 
 class SecretError extends Error
   Raised when a {@link SecretSource} cannot produce a value.

--- a/packages/core/src/execute_output.ts
+++ b/packages/core/src/execute_output.ts
@@ -19,7 +19,7 @@ import {
   silentReporter,
 } from "./reporter.ts";
 import { appendJobSummary } from "./job_summary.ts";
-import { Redactor } from "./redact.ts";
+import { maskPatterns, Redactor } from "./redact.ts";
 import { detectWidth, type Style, type TargetReport } from "./report.ts";
 import { defaultRenderer, type Renderer } from "./renderer.ts";
 
@@ -123,9 +123,17 @@ export function emitActionsMasks(
 ): void {
   const maskReporter = safeReporter(baseReporter);
   for (const value of values) {
-    // Straight to the base reporter (not redacted, so the directive works),
-    // but best-effort: an EPIPE here must not abort the run either.
-    maskReporter.info(`::add-mask::${value}`);
+    for (const pattern of maskPatterns(value)) {
+      // Never emit a pattern that spans lines. The runner reads the directive
+      // to the end of the *line*, so a multi-line value would mask only its
+      // first line and print every line after it as ordinary log output — the
+      // call meant to protect the secret would be the thing that leaked it.
+      // maskPatterns already contributes each line separately.
+      if (pattern.includes("\n")) continue;
+      // Straight to the base reporter (not redacted, so the directive works),
+      // but best-effort: an EPIPE here must not abort the run either.
+      maskReporter.info(`::add-mask::${pattern}`);
+    }
   }
 }
 

--- a/packages/core/src/redact.ts
+++ b/packages/core/src/redact.ts
@@ -10,7 +10,11 @@
  *
  * Matching is a plain substring replace (never a regex), so a secret with
  * regex-significant characters is redacted literally and there is no injection
- * surface. The guarantee covers everything Zuke prints through the reporter; a
+ * surface. A **multi-line** secret registers each of its lines as well as the
+ * whole value, because the rewrite happens a line at a time and the whole value
+ * matches no single line of itself — without that, a PEM key would be masked on
+ * its header and printed in the clear from the second line on. The guarantee
+ * covers everything Zuke prints through the reporter; a
  * subprocess a target spawns writes to its own stdout/stderr directly, so a
  * command that deliberately echoes a secret is outside this boundary (GitHub
  * Actions still masks it via `::add-mask::`, which the executor also emits).
@@ -22,6 +26,43 @@
 export const REDACTED = "[redacted]";
 
 /**
+ * The shortest line of a multi-line secret worth masking on its own.
+ *
+ * Every line of a secret is registered as its own pattern (see
+ * {@link maskPatterns}), and a very short one would mask ordinary text wherever
+ * it appeared — a two-character line turns every `ok` in the log into
+ * `[redacted]`. Eight characters is long enough that an accidental collision
+ * with meaningful output is rare, and short enough to still cover a line that
+ * carries real key material. The value as a whole is always registered
+ * regardless, so nothing is lost for output that contains it intact.
+ */
+const MIN_LINE_LENGTH = 8;
+
+/**
+ * Every pattern that masking `value` must match: the value itself, plus — when
+ * it spans lines — each of its lines that clears {@link MIN_LINE_LENGTH}.
+ *
+ * Redaction is applied **per line**: a reporter masks one line at a time, and a
+ * CI host's own masker reads a directive to the end of the line. So a
+ * whole-value pattern never matches any single line of a multi-line secret, and
+ * a PEM registered only as one string has every line after its header printed
+ * in the clear. Lines are trimmed, so the pattern matches the content whatever
+ * indentation surrounds it.
+ */
+export function maskPatterns(value: string): string[] {
+  const patterns: string[] = [];
+  if (value.length > 0) patterns.push(value);
+  if (!value.includes("\n")) return patterns;
+  for (const line of value.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed.length >= MIN_LINE_LENGTH && !patterns.includes(trimmed)) {
+      patterns.push(trimmed);
+    }
+  }
+  return patterns;
+}
+
+/**
  * Collects secret values and masks them in text. Register a value with
  * {@link Redactor.add} and rewrite a line with {@link Redactor.redact}; empty
  * strings are ignored (they would match everywhere) and duplicates are recorded
@@ -31,10 +72,22 @@ export const REDACTED = "[redacted]";
 export class Redactor {
   readonly #secrets: string[] = [];
 
-  /** Register a secret value to mask. Ignores empty strings and duplicates. */
+  /**
+   * Register a secret value to mask. Ignores empty strings and duplicates.
+   *
+   * A **multi-line** value registers each of its lines as well as the whole
+   * string, because redaction runs a line at a time and a whole-value pattern
+   * can never match one line of it. Lines are trimmed, and a very short one is
+   * skipped so it cannot mask ordinary text wherever it appears.
+   */
   add(value: string): void {
-    if (value.length === 0 || this.#secrets.includes(value)) return;
-    this.#secrets.push(value);
+    for (const pattern of maskPatterns(value)) this.#addPattern(pattern);
+  }
+
+  /** Register one already-derived pattern, ignoring empties and duplicates. */
+  #addPattern(pattern: string): void {
+    if (pattern.length === 0 || this.#secrets.includes(pattern)) return;
+    this.#secrets.push(pattern);
     // Keep the list longest-first so a secret that is a substring of another
     // never masks only the inner part, leaving the rest exposed.
     this.#secrets.sort((a, b) => b.length - a.length);
@@ -47,7 +100,11 @@ export class Redactor {
     return out;
   }
 
-  /** The number of distinct secret values registered. */
+  /**
+   * The number of distinct patterns registered. A single-line secret
+   * contributes one; a multi-line secret contributes the whole value plus each
+   * of its qualifying lines.
+   */
   get size(): number {
     return this.#secrets.length;
   }

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -53,13 +53,43 @@ export interface TargetReport {
 }
 
 /**
+ * Escape a value interpolated into the body of a GitHub Actions workflow
+ * command (`::error::<data>`).
+ *
+ * A workflow command is terminated by the end of its line, so a value carrying
+ * a newline continues into what the runner parses as a *fresh* command. A
+ * target's failure message embeds a subprocess's stderr verbatim, which is not
+ * ours to trust: a tool that writes `::stop-commands::` on a line of its own
+ * would otherwise suspend the runner's command processing, and one that writes
+ * `::error::` would forge an annotation. Percent-encoding is the escape the
+ * Actions spec defines for exactly this, and `%` is encoded first so the
+ * encoding cannot be spoofed by a literal `%0A` in the input.
+ */
+export function escapeData(value: string): string {
+  return value
+    .replaceAll("%", "%25")
+    .replaceAll("\r", "%0D")
+    .replaceAll("\n", "%0A");
+}
+
+/**
+ * Escape a value interpolated into a workflow command's **property** list
+ * (`::error title=<property>::`). Properties are comma-separated and
+ * colon-terminated, so those two characters need encoding on top of what
+ * {@link escapeData} handles.
+ */
+export function escapeProperty(value: string): string {
+  return escapeData(value).replaceAll(":", "%3A").replaceAll(",", "%2C");
+}
+
+/**
  * The ruled header that opens a target's section in the terminal. Two `═` rules
  * frame the target name (bold cyan), so the stream is easy to scan into blocks.
  * In GitHub Actions, a `::group::` command is used instead — the collapsible
  * group is the visual boundary there.
  */
 export function targetHeader(style: Style, name: string): string[] {
-  if (style.github) return [`::group::${name}`];
+  if (style.github) return [`::group::${escapeData(name)}`];
   const top = line(style);
   const label = paint(style.color, SGR.bold + SGR.cyan, name);
   return [top, label, top];
@@ -102,7 +132,13 @@ export function targetFailFooter(
   if (!style.github) return { info: [], error: [line, detail] };
   return {
     info: ["::endgroup::"],
-    error: [line, detail, `::error title=${name}::${name} failed: ${message}`],
+    error: [
+      line,
+      detail,
+      `::error title=${escapeProperty(name)}::${
+        escapeData(`${name} failed: ${message}`)
+      }`,
+    ],
   };
 }
 

--- a/packages/core/tests/redact_test.ts
+++ b/packages/core/tests/redact_test.ts
@@ -1,5 +1,6 @@
-import { assertEquals } from "./_assert.ts";
+import { assertEquals, assertStringIncludes } from "./_assert.ts";
 import { REDACTED, Redactor } from "../src/redact.ts";
+import { emitActionsMasks } from "../src/execute_output.ts";
 
 Deno.test("Redactor masks a registered secret anywhere in a line", () => {
   const r = new Redactor();
@@ -42,4 +43,98 @@ Deno.test("Redactor treats regex-significant secrets literally", () => {
   // A line that would match the pattern as a regex, but does not contain it
   // literally, is left untouched.
   assertEquals(r.redact("nothing to mask"), "nothing to mask");
+});
+
+// A multi-line secret is the case a whole-value pattern cannot cover: redaction
+// rewrites one line at a time, so the registered string matches no line of
+// itself and every line after the first would print in the clear. The real-world
+// shape is a private key reached through a secret parameter from a file source.
+//
+// The fixture deliberately does not look like one. All the behaviour depends on
+// is that the value spans lines and that each line clears the length floor;
+// markers and base64 would add nothing but a problem, since a realistic fixture
+// matches gitleaks' private-key and generic-api-key rules — and that scan walks
+// git history, so it fails every open pull request until the offending commit is
+// rewritten, not merely reverted.
+const MULTI_LINE = [
+  "first-fragment-of-a-not-real-value",
+  "second-fragment-of-a-not-real-value",
+  "third-fragment-of-a-not-real-value",
+].join("\n");
+
+Deno.test("Redactor masks every line of a multi-line secret", () => {
+  const r = new Redactor();
+  r.add(MULTI_LINE);
+  // Each line, alone on a line of output, is masked — including the ones after
+  // the first, which an exact whole-value match would have missed entirely.
+  for (const line of MULTI_LINE.split("\n")) {
+    assertEquals(r.redact(line), REDACTED, `line not masked: ${line}`);
+  }
+  // And embedded in surrounding text, which is how it would actually surface.
+  assertEquals(
+    r.redact("body: second-fragment-of-a-not-real-value done"),
+    `body: ${REDACTED} done`,
+  );
+});
+
+Deno.test("Redactor still masks a multi-line secret that arrives intact", () => {
+  const r = new Redactor();
+  r.add(MULTI_LINE);
+  assertEquals(r.redact(MULTI_LINE), REDACTED);
+});
+
+Deno.test("Redactor ignores indentation when masking a secret's line", () => {
+  // Lines are trimmed before registering, so the pattern matches the content
+  // whatever wraps it — a YAML block scalar indents every line of an inlined
+  // key. Trimming only ever widens the match: the registered pattern is a
+  // substring of the indented form, so both the indented and the bare
+  // occurrence are found.
+  const r = new Redactor();
+  r.add("alpha\n    indented-fragment-of-a-not-real-value\nomega");
+  assertEquals(
+    r.redact("      indented-fragment-of-a-not-real-value"),
+    `      ${REDACTED}`,
+  );
+  assertEquals(r.redact("indented-fragment-of-a-not-real-value"), REDACTED);
+});
+
+Deno.test("Redactor does not register a trivially short line as its own pattern", () => {
+  // A two-character line would mask every `ok` in the log. The whole value is
+  // still registered, so nothing is lost for output that contains it intact.
+  const r = new Redactor();
+  r.add("ok\nno");
+  assertEquals(r.size, 1);
+  assertEquals(r.redact("ok status: no problems"), "ok status: no problems");
+});
+
+// The other half of the multi-line problem, on the CI host's side. A runner
+// reads `::add-mask::` to the end of the line, so emitting a multi-line value
+// as one directive masks only its first line — and prints every line after it
+// as ordinary log output. The call meant to protect the secret becomes the leak.
+Deno.test("emitActionsMasks emits one single-line directive per secret line", () => {
+  const lines: string[] = [];
+  emitActionsMasks([MULTI_LINE], {
+    info: (l) => void lines.push(l),
+    error: () => {},
+  });
+  assertEquals(lines.length > 0, true);
+  for (const line of lines) {
+    assertStringIncludes(line, "::add-mask::");
+    // No directive may span lines, or its tail is printed in the clear.
+    assertEquals(line.includes("\n"), false, `multi-line directive: ${line}`);
+  }
+  // Every qualifying line of the key is covered, not just the first.
+  const masked = lines.map((l) => l.slice("::add-mask::".length));
+  for (const line of MULTI_LINE.split("\n")) {
+    assertEquals(masked.includes(line), true, `line not masked: ${line}`);
+  }
+});
+
+Deno.test("emitActionsMasks still emits a single-line secret unchanged", () => {
+  const lines: string[] = [];
+  emitActionsMasks(["hunter2"], {
+    info: (l) => void lines.push(l),
+    error: () => {},
+  });
+  assertEquals(lines, ["::add-mask::hunter2"]);
 });

--- a/packages/core/tests/report_test.ts
+++ b/packages/core/tests/report_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "./_assert.ts";
+import { assertEquals, assertStringIncludes } from "./_assert.ts";
 import {
   closingLine,
   formatDuration,
@@ -171,4 +171,49 @@ Deno.test("jobSummaryMarkdown uses ✅ on a successful build", () => {
     true,
   );
   assertEquals(md.startsWith("## ✅ Zuke build — 1/1 targets in 0.0s"), true);
+});
+
+// A workflow command ends at its line break, so any value interpolated into one
+// must not be able to introduce a second. A target's failure message embeds a
+// subprocess's stderr verbatim (see CommandError), which is not ours to trust.
+Deno.test("a failure annotation cannot be broken out of with a newline", () => {
+  const hostile = new Error(
+    "build failed\n::stop-commands::abc\n::error::forged annotation",
+  );
+  const out = targetFailFooter(GITHUB, "deploy", 100, hostile);
+  const annotation = out.error.find((l) => l.startsWith("::error "));
+  assertEquals(annotation !== undefined, true);
+  // Exactly one physical line: nothing the message carried became a command.
+  // The `::stop-commands::` text itself is still there and is meant to be — a
+  // workflow command is only a command at the start of its own line, so once
+  // the newlines are encoded it is inert prose the reader can still see.
+  assertEquals(annotation?.includes("\n"), false);
+  assertEquals(annotation?.split("\n").length, 1);
+  // The text survives, percent-encoded per the Actions spec.
+  assertStringIncludes(annotation ?? "", "%0A");
+  assertStringIncludes(annotation ?? "", "stop-commands");
+});
+
+Deno.test("a percent in a failure message cannot spoof an escape", () => {
+  // `%` is encoded first, so a literal `%0A` in the input stays literal rather
+  // than being handed to the runner as an encoded newline.
+  const out = targetFailFooter(GITHUB, "deploy", 100, new Error("done 100%0A"));
+  const annotation = out.error.find((l) => l.startsWith("::error "));
+  assertStringIncludes(annotation ?? "", "100%250A");
+});
+
+Deno.test("an annotation title escapes the property separators too", () => {
+  // A property list is comma-separated and colon-terminated, so a name carrying
+  // either would otherwise end the title early and inject another property.
+  const out = targetFailFooter(GITHUB, "deploy:1,2", 100, new Error("nope"));
+  const annotation = out.error.find((l) => l.startsWith("::error "));
+  assertStringIncludes(annotation ?? "", "title=deploy%3A1%2C2::");
+});
+
+Deno.test("a group header cannot be broken out of either", () => {
+  // A fan-out child's name is derived from a runtime list, so it is not
+  // guaranteed to be an identifier.
+  const [header] = targetHeader(GITHUB, "deploy[a\n::error::forged]");
+  assertEquals(header.includes("\n"), false);
+  assertStringIncludes(header, "%0A");
 });

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -209,12 +209,16 @@ class CD extends Build {
   non-terminal run (suspended/running) is never pruned. The FS store owns
   pruning via the CLI; for the HTTP backend retention is the server's job
   (`GET /runs` takes `limit`; `DELETE /runs/:id` is optional). See `docs/state.md`.
-- **Run leases.** A run that writes durable state takes a TTL lease on its own
-  id and heartbeats it, so two processes cannot both believe they own one run —
-  a resume that adopts a run whose lease has lapsed takes it over, and the
-  original stops. The lease is a mutual-exclusion guard, not a liveness monitor:
-  nothing currently sweeps lapsed leases, so a run whose process was killed
-  stays `running` until an operator moves it (see `.effect()` above).
+- **Run leases and reaping.** A run that writes durable state takes a TTL lease
+  on its own id and heartbeats it, so two processes cannot both believe they own
+  one run — a resume that adopts a run whose lease has lapsed takes it over, and
+  the original stops. The lease is also how a dead run is told from a slow one:
+  `zuke resume --check` looks at `running` runs before it sweeps suspended ones,
+  and a lease it can acquire means the holder is gone. Such a run is put back to
+  `suspended` with a reap event saying why, and the same pass resumes it — so a
+  process killed mid-run has its owed effects driven without an operator
+  stepping in. A run whose lease is still being renewed is merely slow, and is
+  left alone.
 - **Never put secrets in `ctx.state`** — it is stored as plain JSON. Secret
   parameters are excluded from the record and state values are run through the
   redactor, but treat state as a non-secret channel. See `docs/state.md`.
@@ -394,8 +398,9 @@ gate = target().dependsOn(this.checks).always()
   must not drift.
 - **What re-drives it.** An effect owed by a run that suspended for any ordinary
   reason is re-driven by the ordinary resume. A process **killed outright**
-  leaves its run `running`, so its owed effect is re-driven only once something
-  moves that run back to `suspended` — an operator, or a reaping sweep.
+  leaves its run `running`, which `zuke resume --check` reaps: it reads the
+  run's lease to tell a dead holder from a slow one, returns an abandoned run to
+  `suspended`, and resumes it in the same pass (see Run leases above).
 
 ## Fan-out over a list — `.forEach()`
 

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -209,12 +209,16 @@ class CD extends Build {
   non-terminal run (suspended/running) is never pruned. The FS store owns
   pruning via the CLI; for the HTTP backend retention is the server's job
   (`GET /runs` takes `limit`; `DELETE /runs/:id` is optional). See `docs/state.md`.
-- **Run leases.** A run that writes durable state takes a TTL lease on its own
-  id and heartbeats it, so two processes cannot both believe they own one run —
-  a resume that adopts a run whose lease has lapsed takes it over, and the
-  original stops. The lease is a mutual-exclusion guard, not a liveness monitor:
-  nothing currently sweeps lapsed leases, so a run whose process was killed
-  stays `running` until an operator moves it (see `.effect()` above).
+- **Run leases and reaping.** A run that writes durable state takes a TTL lease
+  on its own id and heartbeats it, so two processes cannot both believe they own
+  one run — a resume that adopts a run whose lease has lapsed takes it over, and
+  the original stops. The lease is also how a dead run is told from a slow one:
+  `zuke resume --check` looks at `running` runs before it sweeps suspended ones,
+  and a lease it can acquire means the holder is gone. Such a run is put back to
+  `suspended` with a reap event saying why, and the same pass resumes it — so a
+  process killed mid-run has its owed effects driven without an operator
+  stepping in. A run whose lease is still being renewed is merely slow, and is
+  left alone.
 - **Never put secrets in `ctx.state`** — it is stored as plain JSON. Secret
   parameters are excluded from the record and state values are run through the
   redactor, but treat state as a non-secret channel. See `docs/state.md`.
@@ -394,8 +398,9 @@ gate = target().dependsOn(this.checks).always()
   must not drift.
 - **What re-drives it.** An effect owed by a run that suspended for any ordinary
   reason is re-driven by the ordinary resume. A process **killed outright**
-  leaves its run `running`, so its owed effect is re-driven only once something
-  moves that run back to `suspended` — an operator, or a reaping sweep.
+  leaves its run `running`, which `zuke resume --check` reaps: it reads the
+  run's lease to tell a dead holder from a slow one, returns an abandoned run to
+  `suspended`, and resumes it in the same pass (see Run leases above).
 
 ## Fan-out over a list — `.forEach()`
 

--- a/tests/integration/dry_run_redaction_test.ts
+++ b/tests/integration/dry_run_redaction_test.ts
@@ -83,3 +83,36 @@ Deno.test("a failing command's error message masks a secret argv token", async (
     `secret leaked:\n${err}`,
   );
 });
+
+// A multi-line secret is the case a whole-value match cannot cover. Redaction
+// runs a line at a time, so a key registered only as one string matches no line
+// of itself — masked on its header and printed in the clear from line two on.
+// Shaped like a PEM (the `.secret().from(fileSecret(...))` pattern the docs
+// invite) but deliberately not credential-like, for the gitleaks reason above.
+const MULTILINE_SECRET = [
+  "-----BEGIN FAKE TEST KEY-----",
+  "line-one-not-a-real-key-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "line-two-not-a-real-key-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "-----END FAKE TEST KEY-----",
+].join("\n");
+
+Deno.test("every line of a multi-line secret is masked in a command echo", async () => {
+  const { code, out } = await runCli(Deploy, [
+    "push",
+    "--dry-run",
+    "--token",
+    MULTILINE_SECRET,
+  ]);
+  assertEquals(code, 0);
+  const body = withoutMaskDirectives(out);
+  // No line of the key survives anywhere — the continuation lines are the ones
+  // an exact whole-value match would have missed.
+  for (const line of MULTILINE_SECRET.split("\n")) {
+    assertEquals(
+      body.includes(line),
+      false,
+      `secret line leaked: ${line}\n${out}`,
+    );
+  }
+  assertStringIncludes(out, REDACTED);
+});


### PR DESCRIPTION
## What & why

A secret was registered for masking as one whole string, but both sinks that mask it read **a line at a time**. The redactor rewrites one reporter line, and the Actions runner reads an add-mask directive to the end of its own line. So a value spanning lines matched no line of itself.

The consequence for the documented pattern — a private key supplied through a secret parameter from a file source, which the secrets guide invites for a GitHub App key — was that the key was masked on its header line and printed in the clear from the second line on.

The second half is worse: **the directive meant to protect it was itself the leak.** Emitting a multi-line value as a single add-mask directive masks only its first line and writes every line after it to the log as ordinary output. The one call whose entire purpose is to censor the key was publishing it.

Now a secret registers each of its lines as a pattern alongside the whole value, and one directive is emitted per line rather than one carrying the whole key. Lines are trimmed so indentation cannot defeat the match — a key inlined into a YAML block scalar is indented on every line. Lines under eight characters are skipped: a two-character fragment identifies nothing and would mask ordinary text wherever it appeared, and the value as a whole stays registered regardless, so nothing is lost for output containing it intact.

**Workflow-command injection.** A target's failure message embeds a subprocess's stderr verbatim, which is not ours to trust. A tool that wrote a workflow command on a line of its own could suspend the runner's command processing or forge an annotation. Values interpolated into an annotation are now percent-encoded per the Actions spec, in both data and property positions, with the percent sign encoded first so a literal encoded newline in the input cannot spoof the escape. The group header gets the same treatment, since a fan-out child's name is derived from a runtime list rather than being an identifier.

**A correction to the skills.** They claimed nothing sweeps a lapsed lease, so a killed process left its run stuck until an operator moved it. That was true when this branch started and stopped being true with the abandoned-run reaper. Both passages now describe the reaping sweep. The plugin version is bumped accordingly, which the version gate insisted on — it failed the build until it was, which is the first time that gate has earned its keep.

## Related issues

Follows #324, the second item on the remediation plan from the framework assessment.

## Checklist

- [x] The PR title is a [Conventional Commit](https://www.conventionalcommits.org/) (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell). The security target fails only in this sandbox, where the vulnerable-actions audit cannot reach the GitHub Advisories API; it passes in CI.
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches). Unit and integration layers both, and every new test was confirmed to fail against the unfixed code.
- [x] Docs updated in the same PR — the secrets guide documents the multi-line behaviour and the eight-character floor.
- [x] Public API changes were regenerated with the apiDocs target. No public surface moved; the drift check passes.
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with type guards instead).
- [ ] A new package was wired into all five places — not applicable.
- [x] The code is written using AI assisted coding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RYNxgcvdii7P8pPhD6U8q2

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYNxgcvdii7P8pPhD6U8q2)_