### PR TITLE
docs: correct stale claims across the docs, skills and root guides

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,6 @@
 # Code owners — require review on security-sensitive paths. Pair this with a
 # branch protection rule on `master` that requires CODEOWNER review (see
 # SECURITY.md for the full settings checklist).
-#
-# Replace @zuke-build/maintainers with the real owner/team before enabling.
 
 # Default owner for everything.
 *                               @zuke-build/maintainers
@@ -17,5 +15,6 @@
 /deno.lock                      @zuke-build/maintainers
 /.release-please-config.json    @zuke-build/maintainers
 /.release-please-manifest.json  @zuke-build/maintainers
-/scripts/                       @zuke-build/maintainers
+/build/                         @zuke-build/maintainers
+/action.yml                     @zuke-build/maintainers
 **/deno.json                    @zuke-build/maintainers

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -54,7 +54,7 @@ body:
     attributes:
       label: Affected package(s)
       description: Which `@zuke/*` package(s) are involved, with versions if known.
-      placeholder: "@zuke/core 0.x, @zuke/deno 0.x"
+      placeholder: "@zuke/core 1.36.0, @zuke/deno 1.0.0"
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,9 +6,8 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for the idea! Zuke is pre-1.0 and evolving fast — if you are
-        planning a large change, opening this issue first lets us agree on the
-        direction before you invest the effort.
+        Thanks for the idea! If you are planning a large change, opening this
+        issue first lets us agree on the direction before you invest the effort.
 
         Please
         [search existing issues](https://github.com/zuke-build/zuke/issues?q=is%3Aissue)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,7 +30,7 @@ motivation, not just the mechanics. -->
 - [ ] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour changed.
 - [ ] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`, `llms-full.txt`, package README `## API`).
 - [ ] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with type guards instead).
-- [ ] A new package was wired into all five places (see [CONTRIBUTING](../blob/master/CONTRIBUTING.md)), if applicable.
+- [ ] A new package was wired into all seven places (see [AGENTS.md](../blob/master/AGENTS.md#good-open-source-practices-to-follow)), if applicable.
 - [ ] The code is written using AI assisted coding.
 
 <!-- Keep illustrative code in this description, not in commit message bodies:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,7 +239,7 @@ ambient tools.
    CLI / wait-resume-state flow works as a whole, not just a unit seam. These
    are ordinary `*_test.ts` files, so they run in the **normal `deno test`
    lane** — every `deno task test` / `ci`, on all three OSes (Ubuntu via
-   ci.yml's `quality` job, macOS and Windows via the `test-os` matrix) — and
+   ci.yml's `ci` job, macOS and Windows via its `test` job's matrix) — and
    count toward coverage.
 
 3. **E2E — `tests/e2e/*_e2e.ts` (+ `tests/e2e/fixtures/`).** For the one thing
@@ -289,7 +289,7 @@ the three test layers above and the "read every reviewer comment" rule below.
 | Verify declared core floors   | `./zuke coreFloorCheck` (needs network)              |
 
 `deno task ci` is `deno run -A --frozen zuke.ts ci` — the exact gate the
-`quality` job in `ci.yml` runs, so there is one gate, not a hand-maintained
+`ci` job in `ci.yml` runs, so there is one gate, not a hand-maintained
 subset that can drift from it. `zuke.ts`'s `ci` target depends on: `format`
 (`deno fmt --check`), `lint` (`deno lint`), `spell` (cspell), `coverage`
 (type-check, then the test suite with the 95% coverage gate), `coverageUpload`
@@ -329,7 +329,7 @@ zuke, zuke.ps1            # bootstrap launchers (install Deno, run the build); z
 docs/                     # long-form guides (linked from the README)
 skills/                   # agent skills: zuke-write-build, zuke-setup
 plugins/zuke/             # Claude Code plugin wrapping the skills
-.github/workflows/ci.yml           # PR checks (quality + test-os matrix)
+.github/workflows/ci.yml           # PR checks (ci gate, coreFloorCheck, test matrix)
 .github/workflows/integration.yml  # e2e suite on the OS matrix (generated)
 .github/workflows/ai-review.yml    # @zuke/ai PR review
 .github/workflows/release.yml      # release-please automation
@@ -384,7 +384,8 @@ plugins/zuke/             # Claude Code plugin wrapping the skills
 - **A new package must be added everywhere.** Membership is declared in seven
   places that must stay in lock-step: the `deno.json` workspace,
   `.release-please-config.json`, `.release-please-manifest.json`, the `PACKAGES`
-  array in `zuke.ts` (the JSR publish loop), the package table in `README.md`,
+  array in `build/packages.ts` (the JSR publish loop), the package table in
+  `README.md`,
   the list in `tests/release_config_test.ts`, and the landing-page catalogue in
   `build/website_tools.ts` (`TOOL_GROUPS` for a CLI wrapper, `CORE_PACKAGES` for
   an engine or plugin package). `tests/release_config_test.ts` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ captures the milestones worth calling out.
 
 ## 2026-07-30 — every package 1.0.0 🎉
 
-All 55 packages are now `1.x`: `@zuke/core`, the `@zuke/cli` command, and all 50+
+All 54 packages are now `1.x`: `@zuke/core`, the `@zuke/cli` command, and all 50+
 tool wrappers and plugins. There is no pre-1.0 tier left — `bump-minor-pre-major`
 is off, so every package makes the same promise: a minor or patch release never
 breaks a public symbol, and a breaking change bumps the major version. Depend on

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,9 @@ By participating, you agree to abide by our
 [Code of Conduct](./CODE_OF_CONDUCT.md).
 
 > [!NOTE]
-> Zuke's packages sit at different maturity levels — see
-> [Versioning & compatibility](./docs/versioning.md) for which packages follow
-> semver and which 0.x wrappers may still change within `0.x`. If you are
+> Every Zuke package is `1.x` on full semver — see
+> [Versioning & compatibility](./docs/versioning.md) for the compatibility
+> promise, the `@zuke/core` floor, and pinning guidance. If you are
 > planning a large change, please open an issue first so we can agree on the
 > direction before you invest the effort.
 
@@ -42,7 +42,7 @@ deno task ci   # run the full gate to confirm a clean baseline
 | Full pre-commit / CI gate     | `deno task ci` / `./zuke ci`            |
 
 **Run `deno task ci` before opening a pull request — it must be green.**
-`deno task ci` is `deno run -A zuke.ts ci`, the same gate CI's `quality` job
+`deno task ci` is `deno run -A --frozen zuke.ts ci`, the same gate CI's `ci` job
 runs (see [`AGENTS.md`](./AGENTS.md#commands) for the full check list) — so a
 green `deno task ci` locally means a green CI run. If you change a public API,
 regenerate the docs in the same change (`./zuke apiDocs`) — `ci` includes
@@ -50,8 +50,8 @@ regenerate the docs in the same change (`./zuke apiDocs`) — `ci` includes
 
 ## Coding standards (non-negotiable)
 
-These mirror [`CLAUDE.md`](./CLAUDE.md), which is the source of truth for how
-code in this repo is written:
+These mirror [`AGENTS.md`](./AGENTS.md), which is the source of truth for how
+code in this repo is written (`CLAUDE.md` is a one-line pointer to it):
 
 1. **Strict, strongly-typed TypeScript.** Never use `any` (the `no-explicit-any`
    lint rule is on). Never use `as` to force a type or the non-null assertion
@@ -69,8 +69,9 @@ code in this repo is written:
    When a test needs a subprocess, invoke `Deno.execPath()` (the running
    `deno`), which is always present and shell-free.
 
-See the architecture notes in [`CLAUDE.md`](./CLAUDE.md) for how targets, the
-dependency graph, the shell `$`, and tool wrappers fit together.
+See the architecture notes in [`AGENTS.md`](./AGENTS.md#architecture-notes) for
+how targets, the dependency graph, the shell `$`, and tool wrappers fit
+together.
 
 ## Commit messages
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ latest release on JSR.
 | [`@zuke/otel`](https://jsr.io/@zuke/otel)         | [![JSR](https://jsr.io/badges/@zuke/otel)](https://jsr.io/@zuke/otel) [![JSR score](https://jsr.io/badges/@zuke/otel/score)](https://jsr.io/@zuke/otel)                 |
 
 <details>
-<summary><strong>All tool wrappers</strong> (45 packages)</summary>
+<summary><strong>All tool wrappers</strong> (44 packages)</summary>
 
 | Package                                                       | Version                                                                                                                                                                                         |
 | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -396,8 +396,8 @@ Full documentation lives in [`docs/`](./docs/):
 - [CLI reference](./docs/cli.md) — commands and flags.
 - [Programmatic API](./docs/programmatic-api.md) — drive Zuke from your own
   code.
-- [Versioning & compatibility](./docs/versioning.md) — core semver vs. 0.x
-  wrappers, the `@zuke/core` floor, and pinning guidance.
+- [Versioning & compatibility](./docs/versioning.md) — one semver tier across
+  every package, the `@zuke/core` floor, and pinning guidance.
 - [How Zuke compares](./docs/comparison.md) — a capability matrix against
   `deno task`, npm scripts, Make, Nx, Turborepo, and Dagger, on the capabilities
   Zuke provides.
@@ -412,10 +412,10 @@ deno task check       # type-check
 deno task fmt         # format (fmt:check to verify only)
 deno task lint        # lint
 deno task spell       # spell-check (cspell)
-deno task ci          # the full gate — deno run -A zuke.ts ci
+deno task ci          # the full gate — deno run -A --frozen zuke.ts ci
 ```
 
-`deno task ci` **is** `./zuke ci`, the same gate the `quality` job in
+`deno task ci` **is** `./zuke ci`, the same gate the `ci` job in
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml) runs on every push and
 pull request — see [`AGENTS.md`](./AGENTS.md#commands) for the full check list.
 
@@ -425,8 +425,9 @@ Contributions are welcome! Start with [`CONTRIBUTING.md`](./CONTRIBUTING.md) for
 the full workflow, and please be mindful of our
 [`Code of Conduct`](./CODE_OF_CONDUCT.md).
 
-- Read [`CLAUDE.md`](CLAUDE.md) for the coding standards (strict typing, no
-  `any`/`as`, 95%+ coverage, hermetic tests).
+- Read [`AGENTS.md`](AGENTS.md) for the coding standards (strict typing, no
+  `any`/`as`, 95%+ coverage, hermetic tests). `CLAUDE.md` is a one-line pointer
+  to it.
 - Run `deno task ci` before opening a PR — it must be green.
 - Add tests in the same change as the code they cover.
 - Keep commits small and descriptive; update docs when behaviour changes.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,10 +16,13 @@ request.
    first breaking change rather than absorbing it into a minor bump.
 
 2. **Zuke runs the whole release.** `.github/workflows/release.yml` is itself
-   driven by Zuke: on every push to `master` it runs a single command,
-   `./zuke publish` (the launcher installs Deno if the runner lacks it, so the
-   workflow has no separate "set up Deno" step). Because `publish` depends on
-   `release`, Zuke runs the `release` target first, then publishes.
+   driven by Zuke: on every push to `master` it runs four least-privilege jobs,
+   each invoking one target — `release`, then `actionRelease` and `publishJsr`
+   in parallel behind it, then `syncWebsite`. The launcher installs Deno if the
+   runner lacks it, so no job needs a separate "set up Deno" step. The split is
+   deliberate: `release` needs a `GITHUB_TOKEN` while `publishJsr` needs JSR
+   OIDC, and neither job should hold the other's credential. `./zuke publish` is
+   the local-only aggregate of `release` + `publishJsr`; CI never runs it.
 
 3. **`release` drives release-please.** The `release` target invokes the
    release-please CLI (`release-pr` + `github-release`). release-please
@@ -29,8 +32,8 @@ request.
    tags each release (`<component>-v<version>`, e.g. `core-v1.30.0`) and cuts
    the GitHub releases.
 
-4. **`publish` pushes to JSR.** The `publish` target walks the packages **core
-   first** (so the workspace's `jsr:@zuke/core` dependency resolves) and
+4. **`publishJsr` pushes to JSR.** The `publishJsr` target walks the packages
+   **core first** (so the workspace's `jsr:@zuke/core` dependency resolves) and
    publishes each one whose `deno.json` version is **not yet on JSR** — it
    queries each package's JSR `meta.json` first, so it is idempotent and a no-op
    on pushes that didn't release anything. Authentication is OIDC — the JSR

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,8 +12,7 @@ request.
    Conventional Commits (`feat:`, `fix:`, `feat!:` / `BREAKING CHANGE:`).
    Versions are per-package, and every package is `1.x` on full semver: a
    breaking change bumps the **major** version. `bump-minor-pre-major` is
-   **off**, so a package that starts life at `0.x` graduates to `1.0.0` on its
-   first breaking change rather than absorbing it into a minor bump.
+   **off**, so a breaking change is never absorbed into a minor bump.
 
 2. **Zuke runs the whole release.** `.github/workflows/release.yml` is itself
    driven by Zuke: on every push to `master` it runs four least-privilege jobs,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,8 +5,10 @@ pipelines and publishes itself to a public registry. Supply-chain integrity is
 therefore the primary concern, and this document describes how the project is
 hardened and how to report problems.
 
-> Zuke is pre-1.0 and largely AI-written (see the README). Review before you
-> rely on it, and prefer pinning to an exact version in your own builds.
+> Zuke is largely AI-written (see the README). Review before you rely on it.
+> Every package is `1.x` on full semver; depend on the caret range
+> (`jsr:@zuke/core@^1`) rather than an exact version, so patch fixes reach you —
+> see [Versioning & compatibility](./docs/versioning.md).
 
 ## Reporting a vulnerability
 
@@ -24,16 +26,19 @@ published once a patched version is available.
 
 ## Supported versions
 
-While the project is pre-1.0, only the **latest** published version of each
-`@zuke/*` package receives security fixes.
+Only the **latest** published version of each `@zuke/*` package receives
+security fixes. Depending on the caret range keeps you on it.
 
 ## Supply-chain posture
 
 What the project does to keep releases trustworthy:
 
-- **Zero runtime dependencies.** The library is dependency-free; the only
-  third-party tooling (`cspell`, `release-please`) is dev/release-time, pinned,
-  and never shipped to consumers.
+- **Zero runtime dependencies.** Every published package declares no dependency
+  but `@zuke/core`, so nothing third-party is shipped to consumers. The build
+  layer is separate and does have them: `@std/yaml` for `build/`, `cspell` and
+  `release-please` installed from npm on demand, and four checksum-verified
+  binaries (the Codecov CLI, zizmor, actionlint, gitleaks) provisioned by the
+  build's `toolchain()`. All of it is dev/release-time only.
 - **Injection-free command execution.** All process execution goes through
   `Deno.Command` with a discrete argv array — there is no shell string, so
   interpolated values can never be reinterpreted as shell syntax.
@@ -41,17 +46,21 @@ What the project does to keep releases trustworthy:
   OIDC token (`id-token: write`); no long-lived registry tokens or secrets are
   stored. JSR records build **provenance** for each published version.
 - **Least-privilege CI.** The default workflow token is `contents: read`. The
-  release pipeline is split so the `release-please` job (`contents` /
-  `pull-requests: write`) and the JSR `publish` job (`id-token: write`) never
+  release pipeline is split so the `release` job (`contents` /
+  `pull-requests: write`) and the `publishJsr` job (`id-token: write`) never
   hold each other's privileges.
 - **Pinned, monitored Actions.** Every GitHub Action is pinned to a full commit
-  SHA (with a version comment, kept current by Dependabot), and every job runs
-  `step-security/harden-runner` to audit outbound network egress.
+  SHA, with a version comment kept current by Dependabot. Every job that holds a
+  write-scoped token runs `step-security/harden-runner` with an
+  `egress-policy: block` allowlist, so outbound access is enforced rather than
+  merely audited. The `test` job in `ci.yml` is the exception: it holds no token
+  and only runs the test suite.
 - **Pinned toolchain.** The `./zuke` launcher bootstraps a **pinned** Deno
-  version by default (override with `DENO_VERSION`), so CI and local builds
-  install a known version rather than a moving `latest`. Dependencies are
-  resolved against a committed `deno.lock`, enforced with `--frozen`, and the
-  scanner CLIs are pinned to exact versions in the security workflow.
+  version, so CI and local builds install a known version rather than a moving
+  `latest`. Dependencies are resolved against a committed `deno.lock`, enforced
+  with `--frozen`. The scanner CLIs are pinned and checksum-verified in
+  `build/scanners.ts` and provisioned by the build itself, so the security
+  workflow needs no install step and nothing has to be present on `PATH`.
 - **Scanning via Zuke.** The supply-chain scanners run as a typed Zuke build
   target — `./zuke security` drives zizmor (Actions SAST), actionlint, and
   gitleaks (secrets) through [`@zuke/security`](./packages/security), failing
@@ -64,17 +73,18 @@ What the project does to keep releases trustworthy:
 ### Known trade-offs
 
 - **Bootstrap launchers.** `./zuke` and `./zuke.ps1` install Deno on first use
-  via the official `https://deno.land` install script (`curl … | sh`). The
-  version is pinned by default (set `DENO_VERSION=latest` or a specific version
-  to override), and `step-security/harden-runner` audits runner egress, but the
-  install *script itself* is fetched at run time. To avoid it entirely, install
-  Deno yourself so the launcher finds it on `PATH`.
+  by downloading the pinned release archive from GitHub and verifying it against
+  a per-platform SHA-256 baked into the launcher. No install script is fetched
+  or executed. `DENO_VERSION=latest` is **refused** — a moving target has no
+  checksum to pin — and overriding the version requires supplying a matching
+  `DENO_SHA256`, so the launcher never runs an unverified binary. To skip the
+  bootstrap entirely, install Deno yourself so the launcher finds it on `PATH`.
 - **`deno publish --allow-dirty`.** The publish step currently allows a dirty
   tree as a backstop. The merged release tree should already be clean; once a
   real release confirms this, drop the flag for the strongest
   "published == committed source" guarantee.
-- **`contents: write` + `persist-credentials` on the `quality` job.** The
-  `quality` job in `ci.yml` runs on `pull_request` with `contents: write` and
+- **`contents: write` + `persist-credentials` on the `ci` job.** The `ci` job in
+  `ci.yml` runs on `pull_request` with `contents: write` and
   `actions/checkout`'s `persist-credentials: true`, because the AI lint fixer may
   push a fix commit back to the PR branch. This is a deliberate trade-off, and it
   is fork-safe: `pull_request` (not `pull_request_target`) runs with the base
@@ -96,7 +106,8 @@ await SecurityTasks.osvScanner((s) => s.lockfile("package-lock.json"));
 ```
 
 In this repository, `deno task zuke security` runs the bundled set (zizmor,
-actionlint, gitleaks) once the tools are installed on `PATH`.
+actionlint, gitleaks); the target provisions each one itself, so nothing needs
+to be installed on `PATH` first.
 
 ## Recommended repository settings
 

--- a/cspell.json
+++ b/cspell.json
@@ -187,6 +187,9 @@
     "zukebox",
     "zukeeper"
   ],
+  "ignoreRegExpList": [
+    "/`[0-9a-z]{10,14}`/"
+  ],
   "flagWords": [
     "ponytail"
   ],
@@ -198,8 +201,6 @@
     "/llms-full.txt",
     "/zuke",
     "/zuke.ps1",
-    "/CHANGELOG.md",
-    "/AGENTS.md",
     "packages/*/CHANGELOG.md",
     "assets/",
     ".github/workflows/",

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,7 +50,7 @@
   compiled to UTC cron with a daylight-saving wall-clock guard.
 - [CLI reference](./cli.md) — commands and flags.
 - [Programmatic API](./programmatic-api.md) — drive Zuke from your own code.
-- [Versioning & compatibility](./versioning.md) — core semver vs. 0.x wrappers,
-  the `@zuke/core` floor, and pinning guidance.
+- [Versioning & compatibility](./versioning.md) — one semver tier across every
+  package, the `@zuke/core` floor, and pinning guidance.
 - [How Zuke compares](./comparison.md) — a capability matrix against `deno task`,
   npm scripts, Make, Nx, Turborepo, and Dagger, on the capabilities Zuke provides.

--- a/docs/ai-review.md
+++ b/docs/ai-review.md
@@ -16,6 +16,8 @@ a target with `.validateBefore(...)` (gate before the body) or
 `.validateAfter(...)` (check after a successful body). The target decides _when_
 it runs; the reviewer decides _what_ it checks.
 
+<!-- check -->
+
 ```ts
 import { Build, parameter, run, target } from "jsr:@zuke/core";
 import { securityReviewer } from "jsr:@zuke/ai";
@@ -221,7 +223,8 @@ Maintaining `.github/workflows/ai-review.yml` by hand is a chore — it has to
 stay in sync with every reviewer's secret env var, with `pull-requests: write`
 when any reviewer uses `.comment()`, with the right harden-runner + checkout
 pins, with the fork-gating `if`. `aiReviewWorkflow({...})` does it for you:
-declare it on the build and Zuke writes a [`CiFile`](authoring.md#cicd) that the
+declare it on the build and Zuke writes a
+[`CiFile`](authoring.md#ci-config-generation--cicd-and-generate-ci) that the
 standard `cicd` sync keeps current.
 
 ```ts

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -33,6 +33,12 @@ body, which is required before the target can run.
 | `.validateAfter(...v)`      | `(...v: Validation[]) => this`                        | Run checks after a successful body; a throw fails it.                                              |
 | `.recoverWith(...r)`        | `(...r: Remediation[]) => this`                       | On failure, hand it to a remediation that can re-run the body ([self-healing](./self-healing.md)). |
 | `.recoverAttempts(n)`       | `(n: number) => this`                                 | Bound how many fix-then-rerun cycles are tried (default 1).                                        |
+| `.partOf(group)`            | `(g: Group) => this`                                  | Join a [parallel batch](#group-and-partof).                                                  |
+| `.dryRunnable()`            | `() => this`                                          | Run this body under `--dry-run`, with `$` in echo mode (others stay skipped).                        |
+| `.lock(configure)`          | `(c: (s: LockSettings) => LockSettings) => this`      | Hold a [cross-run lock](./locks.md) while it runs; a second run wanting the key fails or waits.      |
+| `.waitsFor(configure)`      | `(c: (s: WaitSettings) => WaitSettings) => this`      | A gate with no body: [suspend the run](./orchestration.md) until an external event, then resume.     |
+| `.onCancel(target)`         | `(t: Target \| (() => Target)) => this`               | [Compensation](./orchestration.md#cancellation--compensation--oncancel) run if this target succeeded and the run is later cancelled. |
+| `.forEach(items, stages, c?)` | `(items, (item) => Record<string, Target>, c?) => this` | [Fan out](./orchestration.md#fan-out-over-a-list--foreach) a pipeline over a runtime list.                            |
 
 `dependsOn` pulls targets into the plan; `before`/`after` only reorder targets
 that are _already_ in the plan — they never pull new targets in.
@@ -208,7 +214,7 @@ deploy = target()
   `--confirm-destructive`. A hint about intent — the body still runs — so use it
   on targets that inspect rather than mutate.
 - **`.cacheKey(fn)`** — add a non-file value (a parameter, tool version, git
-  commit…) to the [cache](#incremental-caching-inputs--outputs) fingerprint, so
+  commit…) to the [cache](#incremental-caching--inputs--outputs) fingerprint, so
   the target also rebuilds when that value changes. Repeatable; may be async.
 - **`.produces(...paths)`** / **`.consumes(...targets)`** — declare artifact
   paths a target produces, and (on a consumer) depend on the producers.
@@ -257,7 +263,7 @@ of paths.
 
 `zuke <target> --dry-run` resolves and prints every target that **would** run —
 honouring `--skip` and `onlyWhen` conditions — without executing any body or
-touching the [cache](#incremental-caching-inputs--outputs). Use it to preview a
+touching the [cache](#incremental-caching--inputs--outputs). Use it to preview a
 plan before committing to it.
 
 **Deep dry-run — `.dryRunnable()`.** A target marked `.dryRunnable()` has its
@@ -304,6 +310,8 @@ Unlike the CLI wrappers it runs no subprocess, so each method takes direct
 arguments rather than a settings-lambda. Paths are [`PathLike`](./paths.md), so
 an `absolutePath(...)` or a plain string both work.
 
+<!-- check -->
+
 ```ts
 import { FileTasks } from "jsr:@zuke/core";
 
@@ -345,6 +353,8 @@ Fetch over HTTP from a build script, built on the platform `fetch`.
 seam makes them unit-testable) and throw an `HttpError` (carrying `.status`) on
 a non-2xx response.
 
+<!-- check -->
+
 ```ts
 import { httpDownload, httpJson } from "jsr:@zuke/core";
 
@@ -372,6 +382,8 @@ A webhook URL embeds the secret that authorises posting, so source it from a
 `parameter().secret()` build input rather than hard-coding it — Zuke redacts the
 resolved value from all of its output, and can pull it from a secret manager
 with `.from(...)` (see [Secrets](./secrets.md)).
+
+<!-- check -->
 
 ```ts
 import { AnnounceTasks, Build, parameter, target } from "jsr:@zuke/core";
@@ -453,6 +465,8 @@ the POSIX `ustar` format in memory; and the file helpers
 and unpack `.tar.gz` archives. Entry names are limited to 100 bytes and archives
 use a fixed mtime, so output is reproducible.
 
+<!-- check -->
+
 ```ts
 import { createTarGzip } from "jsr:@zuke/core";
 
@@ -504,6 +518,8 @@ single `build` job whose one step invokes the build through the `./zuke`
 launcher (which bootstraps Deno itself — no separate setup step). Override only
 what else you need:
 
+<!-- check -->
+
 ```ts
 import { Build, cicd, target } from "jsr:@zuke/core";
 
@@ -521,7 +537,7 @@ want to change:
 
 ```ts
 ci = cicd({
-  provider: "github", // or "gitlab" / "azure"
+  provider: "github", // or "gitlab" / "azure" / "bitbucket"
   pipeline: {
     jobs: [{
       matrix: { os: ["ubuntu-latest", "macos-latest"] },
@@ -630,6 +646,12 @@ fixed-offset zones (a DST zone errors — the guard is GitHub-only); **GitLab** 
 `isCI()` and `ciHost()` (e.g. `"github-actions"`, `"gitlab-ci"`, `"local"`) let
 a build branch on _where_ it runs — e.g. `deploy.onlyWhen(() => isCI())`.
 
+Prefer **`detectCiHost()`** in new code: it returns the same detection as a
+`CiHost` whose values line up with the `CiProvider` names
+[`cicd()`](#ci-config-generation--cicd-and-generate-ci) uses, so a build can
+match the host it is on against the provider it generates for. `ciHost()` is
+kept for compatibility.
+
 `operatingSystem()` answers _what_ it runs on: the `OperatingSystem` union
 `"linux" | "macos" | "windows"`, normalised from `Deno.build.os` so you branch
 on `"macos"` rather than the raw `"darwin"` (other Unixes report as `"linux"`).
@@ -659,6 +681,12 @@ class MyBuild extends Build {
   override onStart() {
     console.log("Build starting…");
   }
+  override onTargetStart(name: string) {
+    console.log(`→ ${name}`);
+  }
+  override onTargetEnd(name: string, status: TargetStatus) {
+    console.log(`${name}: ${status}`);
+  }
   override onFinish(result: BuildResult) {
     console.log(result.ok ? "All good" : "Something failed");
   }
@@ -666,7 +694,22 @@ class MyBuild extends Build {
 }
 ```
 
-`BuildResult` is `{ ok: boolean; executed: string[]; error?: unknown }`.
+All four may be async. `onTargetStart` fires just before a body executes — not
+for a skipped or cached target — and `onTargetEnd` fires after each target
+settles, with its final status. For exporting rather than observing, prefer a
+[plugin](./extending.md), whose hooks mirror these.
+
+`BuildResult` is
+`{ ok: boolean; executed: string[]; error?: unknown; suspended?: boolean; cancelled?: boolean; runId?: string }`.
+`runId` is what you point a follow-up `zuke runs show` or `zuke cancel` at, and
+`suspended` distinguishes a run parked at a [gate](./orchestration.md) from one
+that finished.
+
+**The other overridable methods.** Beyond the hooks and the ordering seams below,
+`Build` exposes one override per subsystem, each documented on its own page:
+[`stateStore()`](./state.md), [`deadline()`](./state.md),
+[`remoteCache()`](./caching.md), [`recoverWith()`](./self-healing.md),
+[`registry()`](./registry.md) and [`mcpIdentity()`](./mcp.md).
 
 **External ordering — `override extraEdges(targets)`.** Return `[before, after]`
 pairs to impose soft ordering on the plan beyond the per-target `.before()` /
@@ -725,13 +768,14 @@ is named on the command line.
 ```ts
 run(
   BuildClass: new () => Build,
-  options?: { args?: string[]; plugins?: Plugin[] },
+  options?: { args?: string[]; plugins?: Plugin[]; renderer?: Renderer },
 ): Promise<void>
 ```
 
 Instantiates the build, discovers targets, validates the graph, parses CLI
 arguments (`options.args`, defaulting to `Deno.args`), dispatches to the
-executor with any registered `options.plugins`, and calls `Deno.exit` with `0`
+executor with any registered `options.plugins` and `options.renderer` (see
+[Console output](./console.md)), and calls `Deno.exit` with `0`
 on success or `1` on failure. This is the standard entry point at the bottom of
 `zuke.ts`. See [Extending Zuke](./extending.md) for the plugin contract.
 

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -100,7 +100,7 @@ details worth knowing:
   running any body, so it can't invalidate or refresh a fingerprint.
 
 See the CLI's [Incremental builds](./cli.md#incremental-builds) section and the
-[`.inputs()`/`.outputs()`](./authoring.md#incremental-caching-inputs--outputs)
+[`.inputs()`/`.outputs()`](./authoring.md#incremental-caching--inputs--outputs)
 authoring reference for the same feature from those angles.
 
 ## Remote build cache

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,9 +24,9 @@ with `./zuke <command>`, not the bare `zuke` you installed globally.
 | `zuke --help` / `-h`        | Usage.                                                                                                    |
 | `zuke --version` / `-V`     | Print the installed `@zuke/cli` version.                                                                 |
 
-`setup` and `import` share the same flags: `--dir <path>`, `--name <Class>`,
-`--launcher-name <name>` (when a `zuke/` directory already occupies the
-launcher's name), `--force`/`-f`, `--yes`/`-y`; `import` additionally takes
+`setup` and `import` share `--dir <path>`, `--name <Class>`, `--force`/`-f` and
+`--yes`/`-y`. `--launcher-name <name>` (for when a `zuke/` directory already
+occupies the launcher's name) applies to `setup` only; `import` additionally takes
 `--from <package.json|makefile>` to pin the source instead of auto-detecting
 it. Both finish by scaffolding the launchers and `deno.json`, so the very next
 command you run is your build's own CLI, `./zuke`.
@@ -49,19 +49,23 @@ below) attach to whichever launcher word you install them for.
 | `./zuke <target> --state`                                               | Persist [durable run state](./state.md) under `.zuke/runs`.                                                 |
 | `./zuke <target> --actor <name>`                                        | Attribute the run to `<name>` in its state record.                                                          |
 | `./zuke --list` / `-l`                                                  | List all targets with descriptions and dependencies.                                                        |
+| `./zuke --list --json`                                                  | Print the whole build surface (commands, flags, targets, parameters) as JSON.                               |
 | `./zuke graph`                                                          | Print the dependency graph (`target → deps`).                                                               |
-| `./zuke graph --output=html`                                            | Render an interactive HTML graph into `.zuke/` and open it.                                                 |
+| `./zuke graph --output=html [--no-open]`                                | Render an interactive HTML graph into `.zuke/` and open it (`--no-open` writes it without launching a browser). |
 | `./zuke completions print <shell>`                                      | Print a shell-completion script (`bash`, `zsh`, or `fish`).                                                 |
 | `./zuke completions install <shell>`                                    | Write the script and wire it into the shell's startup.                                                      |
 | `./zuke generate-ci [--check]`                                          | Write the declared CI workflow files (`--check` verifies they are up to date instead of writing).           |
 | `./zuke mcp [--allow-run[=<globs>]] [--http <host:port>]`               | Run an MCP server over the build for AI agents, on stdio or HTTP ([details](./mcp.md)).                     |
+| `./zuke mcp --registry [--max-concurrent-runs <n>]`                     | Serve the [build registry](./registry.md) instead of this build — every registered pipeline as a tool.       |
+| `./zuke mcp --http <host:port> --allowed-origin <origin>`               | Permit one extra browser `Origin` on the HTTP transport (loopback is always allowed).                        |
 | `./zuke resume <id> [--signal <n>] [--data <json>]`                     | Resume a suspended run, optionally delivering a signal ([details](./orchestration.md)).                     |
-| `./zuke resume --check [<id>]`                                          | Re-check suspended runs (predicate waits, timeouts).                                                        |
-| `./zuke runs list [--status/-target/-since/-limit] [--counts] [--json]` | List persisted run records (or `--counts` for a status tally), newest first ([details](./state.md)).        |
+| `./zuke resume --check [<id>]`                                          | Reap abandoned runs, finish stranded cancellations, then re-check suspended runs (predicate waits, timeouts). |
+| `./zuke resume <id> --resume-degraded`                                  | Continue a resume whose record is degraded (a state write was permanently lost).                            |
+| `./zuke runs list [--status] [--target] [--since] [--limit] [--counts] [--json]` | List persisted run records (or `--counts` for a status tally), newest first ([details](./state.md)).        |
 | `./zuke runs show <id> [--json]`                                        | Show one run's full per-target status and metadata.                                                         |
 | `./zuke runs prune [--keep <age>] [--keep-last <n>] [--dry-run]`        | Delete old terminal run records; never touches non-terminal runs.                                           |
 | `./zuke cancel <id> [--actor <name>]`                                   | Cancel a run and run its compensations ([details](./orchestration.md#cancellation--compensation--oncancel)). |
-| `./zuke register`                                                       | Register this build in the build registry (dynamic pipeline discovery).                                     |
+| `./zuke register [--actor <name>] [--json]`                             | Register this build in the build registry (`--json` prints the written descriptor).                         |
 | `./zuke doc <spec>`                                                     | Print a package's API docs (`deno doc <spec>`) from an isolated empty directory.                            |
 | `./zuke --help` / `-h`                                                  | Usage.                                                                                                      |
 | `./zuke` (no target)                                                    | Run the `default` target if defined, else print `--list`.                                                   |
@@ -165,15 +169,22 @@ build on stdio, so an AI agent can operate the pipeline through typed tool calls
 instead of guessing shell commands. It exposes read tools (`list_targets`,
 `describe_build`, `graph`, plus `list_runs`/`show_run` when a state store
 resolves) and — only with `--allow-run` — one `run:<target>` tool per target
-(plus `signal_run`/`resume_check`). Authorization tiers layer on:
-`--allow-run=<globs>` limits which targets are runnable, `--protect <globs>`
-requires a `ZUKE_OPERATOR_TOKEN` operator token, and `--confirm-destructive`
-makes a destructive run return its plan until called with `confirm:true`. Every
-mutating or denied call is written to an audit trail
-(`./zuke runs show mcp-audit`). `--http <host:port>` serves the streamable-HTTP
-transport instead of stdio (loopback by default; a non-loopback bind requires a
-`ZUKE_MCP_TOKEN` bearer token). `mcp` is a reserved command name. See the full
-guide: [MCP server](./mcp.md).
+(plus `signal_run`, `resume_check` and `cancel_run`). Authorization tiers layer
+on: `--allow-run=<globs>` limits which targets may be **invoked**, `--protect
+<globs>` requires a `ZUKE_OPERATOR_TOKEN` for any run whose **plan** touches a
+matching target, and `--confirm-destructive` makes a destructive run return its
+plan until called with `confirm:true`. Every mutating or denied call is written
+to an audit trail, readable on the host with `./zuke runs show mcp-audit` and
+deliberately not served over MCP.
+
+`--http <host:port>` serves the streamable-HTTP transport instead of stdio
+(loopback by default; a non-loopback bind requires a `ZUKE_MCP_TOKEN` bearer
+token), and `--allowed-origin <origin>` permits one extra browser origin.
+`--registry` serves the [build registry](./registry.md) instead of this build —
+every registered pipeline becomes a `run:<buildId>:<target>` tool, spawned in
+its own process, with `--max-concurrent-runs <n>` capping how many run at once
+(default 4). `mcp` is a reserved command name. See the full guide:
+[MCP server](./mcp.md).
 
 ## `zuke doc` (the build's own)
 
@@ -216,7 +227,7 @@ group's members run concurrently even without `--parallel`.
 ## Incremental builds
 
 Targets that declare
-[`.inputs()`](./authoring.md#incremental-caching-inputs--outputs) are cached:
+[`.inputs()`](./authoring.md#incremental-caching--inputs--outputs) are cached:
 Zuke skips one (showing it `cached` in the summary) when its inputs are
 unchanged since the last successful run and its outputs still exist.
 Fingerprints live in `.zuke/cache.json`. `--no-cache` ignores the cache and
@@ -225,7 +236,7 @@ re-runs everything.
 ## Remote cache
 
 The incremental cache is local. A **remote cache** shares a target's built
-[`.outputs()`](./authoring.md#incremental-caching-inputs--outputs) across
+[`.outputs()`](./authoring.md#incremental-caching--inputs--outputs) across
 machines: on a local miss, Zuke **restores** the outputs from the store instead
 of rebuilding them; after a successful run it **uploads** them for the next
 machine. It applies to targets that declare both `inputs` and `outputs`, and is
@@ -294,7 +305,7 @@ dependency still unblocks its dependents).
 ```
 
 A target is affected when a changed file falls inside one of its declared
-[`.inputs()`](./authoring.md#incremental-caching-inputs--outputs), **or** when
+[`.inputs()`](./authoring.md#incremental-caching--inputs--outputs), **or** when
 any of its dependencies is affected (affectedness flows downstream along
 `dependsOn` and `triggers`). A target that declares **no** inputs can't be
 proven unaffected, so it is always run — declare `inputs` on the targets you
@@ -327,9 +338,13 @@ store.
 
 A run parked at a [`.waitsFor()`](./orchestration.md) gate is continued with
 `./zuke resume`. `--signal <name>` delivers a named external signal (with an
-optional `--data <json>` payload); `--check [<run-id>]` re-checks predicate
-waits and enforces timeouts across suspended runs (the cron/webhook entry
-point). Resumption is **exactly-once** — concurrent resumers race a
+optional `--data <json>` payload); `--check [<run-id>]` is the cron/webhook entry
+point and makes three passes — it **reaps abandoned runs** (a `running` record
+whose [lease](./locks.md) can be acquired belongs to a dead process, so it is
+returned to `suspended` and resumed in the same sweep, or settled `failed` with
+its compensations if it is past the build's [`deadline()`](./state.md)), then
+finishes runs left `cancelling` by a dead settler, then re-checks predicate waits
+and enforces timeouts across suspended runs. Resumption is **exactly-once** — concurrent resumers race a
 compare-and-swap and all but one get `AlreadyResumedError` — and re-runs only
 the targets that hadn't yet succeeded. `--force-graph` continues even if the
 build graph changed since the run was suspended. See

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -4,8 +4,8 @@ Zuke exists for the build that has outgrown a list of commands: a real
 dependency graph, typed inputs, external tools driven through checked argv, and
 pipelines that have to survive waiting for something outside the build.
 
-It is also a **young, single-maintainer project**, though no longer a pre-1.0
-one: all 54 JSR packages are `1.x` and follow full semver (see
+It is also a **single-maintainer project**. All 54 JSR packages are `1.x` and
+follow full semver (see
 [Versioning & compatibility](./versioning.md) for what that promises). The
 package a consumer actually installs is the `@zuke/cli` command — `1.x` too, and
 the front door to the `mcp`, `resume` and `cancel` surface below.

--- a/docs/console.md
+++ b/docs/console.md
@@ -7,6 +7,8 @@ tag-based markup and a set of layout primitives (`line`, `rule`, `box`,
 `table`) that render cleanly to a terminal and degrade gracefully in CI, so a
 build never has to reach for `console.log`.
 
+<!-- check -->
+
 ```ts
 import { ConsoleTasks as Log } from "jsr:@zuke/console";
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -78,6 +78,8 @@ Wrap a CLI as a typed, fluent task in the settings-lambda style. For a one-off,
 `defineTool` needs no class (see [Tools](./tools.md#define-your-own-tool)); a
 distributable package extends `ToolSettings` from `@zuke/core/tooling`.
 
+<!-- check -->
+
 ```ts
 import {
   type Configure,

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -100,6 +100,8 @@ the first word of the line.
 
 ## Quick start
 
+<!-- check -->
+
 ```ts
 // zuke.ts
 import { Build, run, target } from "jsr:@zuke/core";
@@ -263,7 +265,7 @@ may therefore be enforcing on one leg and recording on the others. Check
 [harden-runner's own docs](https://github.com/step-security/harden-runner) for
 the version you have pinned.
 
-#### `ref` on `pull_request_target` is refused
+#### `ref` is refused on every secret-bearing event
 
 `ref` checks out something other than what the event points at — the head
 branch of a pull request, say, so a job can push a fix back to it. On
@@ -272,21 +274,28 @@ branch of a pull request, say, so a job can push a fix back to it. On
 On **`pull_request_target`** it is not. That event runs with the base
 repository's secrets and a writable token, so a `ref` aimed at a contributor's
 head puts *their* `zuke.ts` in the workspace — and the last step executes it.
-No configuration makes that safe, so the action refuses the combination
-outright rather than warning about it:
+No configuration makes that safe, so the action refuses it outright:
 
 ```
-Error: Refusing to check out a custom ref and run a Zuke target on a
-pull_request_target event: that executes the checked-out repository's build
-file with this repository's secrets.
+Error: Refusing to check out a custom ref on a pull_request_target event: it
+runs with this repository's secrets and a writable token, so checking out a ref
+a contributor controls hands them both. Use 'pull_request', or drop the 'ref'
+input.
 ```
 
-Checking a ref out *without* running a target is not that bug, and neither is
-any of it on `pull_request`. Both keep working.
+The guard is an **allow-list, not a deny-list for one event**. A custom `ref` is
+permitted only on `pull_request`, `push`, `merge_group`, `workflow_dispatch`,
+`schedule` and `release`; every other event — `issue_comment`, `workflow_run`,
+and anything GitHub adds later — is refused. A deny-list of what is dangerous
+today would be silently wrong the moment the list grew.
 
-Zuke's own workflows do **not** use it yet — `uses: ./` resolves inside the
-workspace, so it would need the very checkout it exists to precede. They inline
-the same steps, generated from the pins in `action.yml` itself.
+It is also **not keyed on `target`**: a `ref` checkout with no target is refused
+just the same, because a caller who omits it and writes `run: ./zuke ci` in
+their own next step reaches the identical outcome.
+
+Zuke's own six workflows all start with the published action — the generated
+YAML opens with `uses: zuke-build/zuke@<sha>`, so the repository dogfoods the
+same entry point it ships.
 
 ---
 

--- a/docs/installing-tools.md
+++ b/docs/installing-tools.md
@@ -41,6 +41,8 @@ Both return the installed binary's [`AbsolutePath`](./paths.md); hand it to a
 `ToolTasks.install((s) => …)` fetches a single tool, configured through a
 `ToolInstallSettings` lambda, and resolves to the installed binary's path.
 
+<!-- check -->
+
 ```ts
 import { ToolTasks } from "jsr:@zuke/core";
 import { CmdTasks } from "jsr:@zuke/cmd";
@@ -338,6 +340,8 @@ normalised from Deno's raw values (`darwin` → `macos`) — so the common case
 needs no mapping at all. `osLabel`/`archLabel` remain for tools that spell
 things differently, and there's no `os === "darwin" ? …` ternary in sight:
 
+<!-- check -->
+
 ```ts
 type OperatingSystem = "linux" | "macos" | "windows";
 type Architecture = "x86_64" | "aarch64";
@@ -368,6 +372,8 @@ resolve a foreign one (e.g. to pre-stage a Linux binary from a Mac). Outside a
 callback, **`hostPlatform()`** returns the same `Platform` for the running
 machine, and **`operatingSystem()`** returns just the OS union — the
 counterparts of `isCI()` for "what am I running on":
+
+<!-- check -->
 
 ```ts
 import { hostPlatform, operatingSystem } from "jsr:@zuke/core";

--- a/docs/node-projects.md
+++ b/docs/node-projects.md
@@ -21,12 +21,14 @@ my-app/
 {
   "imports": {
     "@zuke/core": "jsr:@zuke/core@^1",
-    "@zuke/npm": "jsr:@zuke/npm@^0"
+    "@zuke/npm": "jsr:@zuke/npm@^1"
   }
 }
 ```
 
 3. Create `build/zuke.ts` — targets drive the repo root via `.cwd("..")`:
+
+<!-- check -->
 
 ```ts
 import { Build, run, target } from "@zuke/core";

--- a/docs/paths.md
+++ b/docs/paths.md
@@ -31,6 +31,8 @@ with `/` or a drive letter, or build from an absolute base.
 `repoRoot` is `absolutePath` anchored at your repository root, so you can build
 paths relative to the project no matter where the build is invoked from:
 
+<!-- check -->
+
 ```ts
 import { repoRoot } from "jsr:@zuke/core";
 

--- a/docs/programmatic-api.md
+++ b/docs/programmatic-api.md
@@ -3,6 +3,8 @@
 Beyond authoring, `mod.ts` exports the building blocks if you want to drive Zuke
 yourself or test a build:
 
+<!-- check -->
+
 ```ts
 import {
   discoverTargets, // (build) => Map<string, TargetBuilder>
@@ -31,6 +33,12 @@ options object mirrors the CLI flags:
 | `cache` | `boolean \| BuildCache` | Incremental [caching](./caching.md); `false` disables it (`--no-cache`). |
 | `dryRun` | `boolean` | Print the plan without running any body (`--dry-run`). |
 | `params` | `Record<string, string>` | Raw [parameter](./parameters.md) values, keyed by property name. |
+| `signal` | `AbortSignal` | Cancel the run — the programmatic equivalent of Ctrl-C, running [compensations](./orchestration.md#cancellation--compensation--oncancel). |
+| `affected` | `boolean \| string` | Limit the run to targets affected since a git base (`--affected`). |
+| `remoteCache` | `RemoteCacheStore` | Share cached outputs across machines ([caching](./caching.md)). |
+| `stateStore` | `StateStore` | Persist [durable run state](./state.md); highest-precedence source. |
+| `state` | `boolean` | Enable the default filesystem store without naming one (`--state`). |
+| `actor` | `string` | Who to attribute the run to in its record (`--actor`). |
 
 `readEnv`, `prompt`, `github`, and `color` are additional test/CI seams — see the
 `ExecuteOptions` JSDoc for the full list.
@@ -46,7 +54,10 @@ if (target) {
 }
 ```
 
-`BuildResult` is `{ ok: boolean; executed: string[]; error?: unknown }`.
+`BuildResult` is
+`{ ok: boolean; executed: string[]; error?: unknown; suspended?: boolean; cancelled?: boolean; runId?: string }`
+— `runId` is what a follow-up `zuke runs show` or [`cancelRun`](./orchestration.md)
+is pointed at, and `suspended` marks a run parked at a gate rather than finished.
 
 ## Inspecting the CLI shape — `describeCli`
 

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -121,4 +121,4 @@ The whole thing sits behind the `BuildRegistry` interface
 it against their own catalog service or database and plug it in via
 `Build.registry()` — the richer catalog stays a plugin, exactly as the pluggable
 `StateStore` and `RemoteCacheStore` do. Core ships the interface, the two
-reference backends, and (next) the `zuke mcp` integration point.
+reference backends, and the `zuke mcp --registry` integration point.

--- a/docs/run-context.md
+++ b/docs/run-context.md
@@ -5,6 +5,8 @@ the run it is part of. It is entirely optional: an existing zero-argument body
 keeps working unchanged, because a `() => …` function is assignable to the
 one-parameter body type.
 
+<!-- check -->
+
 ```ts
 import { Build, target } from "jsr:@zuke/core";
 
@@ -154,14 +156,14 @@ When the signal aborts:
   ship = target().executes(async () => {
     await $`terraform apply`; // killed with SIGTERM if the run is cancelled
   });
-  ```
+```
 
   To cancel a command explicitly (or to override the ambient signal), use
   `.signal(...)`:
 
   ```ts
   await $`long-running`.signal(ctx.signal);
-  ```
+```
 
   `.signal()` composes with [`.killAfter()`](./shell.md): whichever fires first
   — the timeout or the cancellation — terminates the process.

--- a/docs/schedules.md
+++ b/docs/schedules.md
@@ -35,6 +35,8 @@ await run(Nightly);
 `triggers.schedule` is an array of entries; each is a 5-field cron in an optional
 IANA timezone:
 
+<!-- check -->
+
 ```ts
 interface ScheduleEntry {
   cron: string; // "minute hour day-of-month month day-of-week"

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -8,6 +8,8 @@ treats a secret as a **parameter with two extra guarantees**:
 2. **Its resolved value is redacted from all of Zuke's output** — so a secret
    cannot leak into a log, a summary, or an error message, on any platform.
 
+<!-- check -->
+
 ```ts
 import { Build, execSecret, parameter, run, target } from "jsr:@zuke/core";
 
@@ -191,6 +193,8 @@ command that reports failures on stderr without echoing the secret itself
 boundary as any subprocess a target spawns.
 
 ## A complete example
+
+<!-- check -->
 
 ```ts
 import {

--- a/docs/services.md
+++ b/docs/services.md
@@ -12,6 +12,8 @@ It replaces the fragile shell dance every team writes by hand: start the server
 in the background, `sleep 5` and hope it's up, run the tests, and remember to
 kill it (which never happens when the tests fail).
 
+<!-- check -->
+
 ```ts
 import { Build, run, service, target, tcpReachable } from "jsr:@zuke/core";
 import { $ } from "jsr:@zuke/core/shell";

--- a/docs/shell.md
+++ b/docs/shell.md
@@ -3,6 +3,8 @@
 Ergonomic process execution built on `Deno.Command`, imported from the `shell`
 submodule:
 
+<!-- check -->
+
 ```ts
 import { $ } from "jsr:@zuke/core/shell";
 
@@ -23,6 +25,9 @@ await $`build`.env({ NODE_ENV: "prod" }).cwd("./app").quiet();
 | `.env(record)` | Merge environment variables.                                                                                   |
 | `.cwd(path)`   | Set the working directory.                                                                                     |
 | `.quiet()`     | Suppress live stdout/stderr streaming.                                                                         |
+| `.killAfter(ms)` | Terminate the child if it outlives `ms`, raising `CommandTimeoutError`.                                      |
+| `.signal(sig)` | The signal used to terminate it (default `SIGTERM`); composes with `.killAfter()` and run cancellation.        |
+| `.spawn()`     | Start the process **without** awaiting it, returning a handle — how [services](./services.md) stay running.    |
 
 Awaiting a command resolves to a `CommandOutput`
 (`{ code, stdout, stderr, truncated }`, plus a `.text()` helper for trimmed

--- a/docs/state-api.md
+++ b/docs/state-api.md
@@ -5,7 +5,8 @@ This is the contract a service must implement to back
 the production store for [durable run state](./state.md). Zuke ships the client;
 you host the service (a thin layer over Postgres, a key-value store, a
 k8s-annotation store, an object store, …). It is deliberately small: three
-endpoints, bearer auth, and HTTP preconditions for compare-and-swap.
+resources — runs, locks, and the build catalog — with bearer auth and HTTP
+preconditions for compare-and-swap.
 
 The client is dependency-free and talks plain HTTP, so any stack can serve it.
 
@@ -106,6 +107,48 @@ not trusted) and expects newest-first ordering is applied server-side where it
 matters; it does not re-sort the list. Ordering is **newest first** (by
 `createdAt`, then `id`); apply `limit` **after** ordering so it returns the most
 recent runs.
+
+## Locks (`/locks`)
+
+Three routes back everything that needs mutual exclusion: a target's
+[`.lock()`](./locks.md), and the **run lease** every stateful run holds on its
+own id (key `zuke-run-<id>`, 60s TTL) — which is also what lets
+`resume --check` tell an abandoned run from a merely slow one. A service that
+omits these can store run records but cannot support locks, leases, or reaping.
+
+A lock is `{ key, holder, token, expiresAt }`. The **token** is an opaque string
+the server mints on acquire; only a caller presenting it may renew or release.
+Expiry is **server-side**: an expired lock must be treated as free, so a crashed
+holder's lock is reclaimed without anyone calling `DELETE`.
+
+### `POST /locks/:key`
+
+Acquire. Body `{ holder, ttlMs }`, where `holder` is
+`{ actor?, runId?, target?, at }` — descriptive only, never an authorization
+input.
+
+- `201 { "token": "…" }` — acquired.
+- `409 { … }` — already held; the body is the **current holder**, which the
+  client surfaces in its conflict error so an operator can see who has it.
+- An expired lock must not produce a `409`; reclaim it and return `201`.
+
+### `PUT /locks/:key`
+
+Renew (the heartbeat). Body `{ token, ttlMs }`; extend the deadline to
+`now + ttlMs` only when `token` matches the current holder.
+
+- `204`/`200` — renewed.
+- `409` or `404` — the token no longer holds the lock. **Not an error:** the
+  client reads it as "someone else owns this now" and stops, which is how a
+  process that was paused long enough to lose its lease learns to stand down.
+
+### `DELETE /locks/:key`
+
+Release. Body `{ token }`; delete only when `token` matches.
+
+- `204`/`200` — released.
+- `404` — already gone, treated as success (release is idempotent, and the TTL
+  would have reclaimed it anyway).
 
 ## Build catalog (`/builds`)
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -62,6 +62,10 @@ Each run is stored as one JSON document:
     { "name": "deploy", "dependsOn": ["build"] }
   ],
   "params": { "env": "sit" }, // resolved, NON-secret parameters only
+  "deadlineAt": "2026-07-17T…Z", // optional; from Build.deadline(), enforced by the reaper
+  "intendedTerminal": "cancelled", // optional; set when a run enters `cancelling`
+  "signals": {}, // external signals delivered to a .waitsFor() gate
+  "events": [], // the audit trail (MCP tool calls, reap events)
   "targets": {
     "build": {
       "status": "succeeded",
@@ -73,7 +77,9 @@ Each run is stored as one JSON document:
       "status": "succeeded",
       "meta": { "target": "sit-7" },
       "startedAt": "…",
-      "endedAt": "…"
+      "endedAt": "…",
+      "waitingFor": null, // the gate it is parked on, when suspended
+      "effects": {} // per-effect intent + settlement, for crash re-drive
     }
   },
   "degraded": false // optional; true if a state write was lost (see below)
@@ -138,6 +144,8 @@ One JSON file per run under a directory (`.zuke/runs/<id>.json` by default).
 Writes are atomic (write-temp-then-rename) and guarded by an `O_EXCL` lock file
 so two processes on the **same host** cannot corrupt a record. The version used
 for compare-and-swap is a content hash.
+
+<!-- check -->
 
 ```ts
 import { FileSystemStateStore } from "jsr:@zuke/core";

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -5,6 +5,8 @@ object in a lambda and the task function builds the argv and runs it. Arguments
 stay a discrete array end-to-end — never a shell string — so command
 construction is injection-free.
 
+<!-- check -->
+
 ```ts
 import { DenoTasks } from "jsr:@zuke/deno";
 import { NpmTasks } from "jsr:@zuke/npm";
@@ -54,7 +56,7 @@ actually spawn (the resolved shim or the bare fallback) for diagnostics.
 
 | Package                | Tasks                                                                                                                                 |
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `@zuke/deno`           | `run`, `test`, `check`, `fmt`, `lint`, `cache`, `coverage`, `task`                                                                    |
+| `@zuke/deno`           | `run`, `test`, `check`, `fmt`, `lint`, `cache`, `coverage`, `task`, `doc`, `install`, `publish`                                       |
 | `@zuke/npm`            | `install`, `ci`, `run`, `exec`, `publish`, `version`                                                                                  |
 | `@zuke/npx`            | `npx`                                                                                                                                  |
 | `@zuke/bun`            | `install`, `add`, `remove`, `run`, `x`, `test`                                                                                        |
@@ -92,7 +94,9 @@ actually spawn (the resolved shim or the bare fallback) for diagnostics.
 | `@zuke/dprint`         | `fmt`, `check`                                                                                                                        |
 | `@zuke/gcloud`         | `run` (any command; typed `containerImagesAddTag` / `sqlInstancesDescribe` / `sqlOperationsWait`), plus `GcsTasks` and `SecretManagerTasks` REST groups |
 | `@zuke/git`            | `init`, `clone`, `add`, `commit`, `status`, `checkout`, `branch`, `tag`, `push`, `pull`, `fetch`, `run` (+ `gitInfo()` helper)        |
-| `@zuke/gh`             | `run` (any command)                                                                                                                   |
+| `@zuke/gh`             | `run` (any command), `commit`, `tag`, `pullRequest`, `findPullRequest`, `checkRun`, `appToken`, `uploadSarif`                          |
+| `@zuke/release-please` | `releasePr`, `githubRelease`                                                                                                          |
+| `@zuke/docs`           | `apiDocs` — generate `llms.txt`, `llms-full.txt` and each package README's `## API` block                                              |
 | `@zuke/codecov`        | `upload` (`codecovcli upload-process`)                                                                                                |
 | `@zuke/claude`         | `run` (headless prompt), `mcp`, `config`, `update`                                                                                    |
 | `@zuke/codex`          | `exec` (headless prompt), `mcp`                                                                                                       |
@@ -109,6 +113,8 @@ gives you a typed, fluent task in the same style — no class needed. Build the
 argv with `arg` / `flag` / `option` (in call order), and the shared chainers
 (`cwd`, `env`, `noThrow`, `quiet`, `toolPath`, `args`) all apply. An optional
 `subcommand` is prepended to every invocation.
+
+<!-- check -->
 
 ```ts
 import { defineTool } from "jsr:@zuke/core/tooling";

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -13,8 +13,8 @@ symbol, so a minor or patch upgrade is safe to take without reading the diff,
 and a breaking change bumps the **major** version. Depend on
 `jsr:@zuke/core@^1` (and `jsr:@zuke/deno@^1`, …) and let minors resolve.
 
-There is no longer a pre-1.0 tier: `release-please`'s `bump-minor-pre-major` is
-off, so nothing silently ships a breaking change under a minor bump. Read a
+`release-please`'s `bump-minor-pre-major` is off, so nothing silently ships a
+breaking change under a minor bump. Read a
 package's `CHANGELOG.md` when its major moves — that is the only release that
 can require a code change on your side.
 

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/skills/zuke-setup/SKILL.md
+++ b/plugins/zuke/skills/zuke-setup/SKILL.md
@@ -68,10 +68,15 @@ finish replacing any remaining generated `CmdTasks.exec` calls with typed
 - **`./zuke`** + **`./zuke.ps1`** — launchers that locate the project and run
   `zuke.ts` with the Deno on `PATH`. If Deno is missing they point at the
   official install docs and exit rather than piping an install script into a
-  shell, which would download and execute code unverified.
-- **`deno.json`** — merged to add a `zuke` task (and `fmt`/`lint`/`test` if
-  absent).
+  shell, which would download and execute code unverified. They pass `--frozen`
+  once a `deno.lock` exists, so the first run writes the lockfile and every run
+  after verifies it.
+- **`deno.json`** — merged to add a `zuke` task, plus `fmt`/`lint`/`test` if
+  absent. The merge is all-or-nothing: if a `zuke` task is already declared the
+  file is left alone entirely, and an unparseable one is skipped with a notice.
 - **`zuke.json`** — `{ "name": "..." }`, which marks the repo root.
+- **`.gitignore`** — created or appended so `.zuke/` is ignored (the cache and
+  durable run state live there); untouched if it already covers it.
 
 ## Running the build
 
@@ -90,14 +95,18 @@ calls, `zuke mcp` runs a Model Context Protocol server over it (register with
 `claude mcp add zuke -- deno run -A zuke.ts mcp`; add `--allow-run` to let the
 agent execute targets, not just inspect them).
 
-If Deno is already installed you can equivalently use `deno task zuke <target>`
-or `deno run -A zuke.ts <target>`. The `-A` flag grants permissions, since
-targets typically run processes and touch files.
+If Deno is already installed you can also use `deno task zuke <target>` or
+`deno run -A zuke.ts <target>`. The `-A` flag grants permissions, since targets
+typically run processes and touch files. These are not quite equivalent to the
+launcher: the scaffolded `zuke` task deliberately omits `--frozen`, so it may
+heal a stale lockfile where `./zuke` would fail on it.
 
 ## Manual setup (no CLI)
 
 Create `zuke.ts` in the project root, extend `Build`, declare targets with
 `target()`, and call `await run(MyBuild)` at the bottom:
+
+<!-- check -->
 
 ```ts
 import { Build, run, target } from "jsr:@zuke/core";

--- a/plugins/zuke/skills/zuke-write-build/SKILL.md
+++ b/plugins/zuke/skills/zuke-write-build/SKILL.md
@@ -63,10 +63,12 @@ await run(CI);
    resolution. (If a build delegates its side effects to your own tested
    modules behind injected clients, the wrapper rule still governs whatever
    those modules run in the target body.)
-4. **A body is required.** Set `.executes(...)`; it may be sync or async, and
-   its return value is ignored — `.executes(() => DenoTasks.lint())` is fine
-   as-is; never wrap a single wrapper call in an `async` block just to discard
-   its result.
+4. **A body is required**, unless the target is one of the four forms that
+   replace it: a `service()`, a `.forEach()` fan-out, a `.waitsFor()` gate, or a
+   target declaring only `.effect(...)`. Otherwise set `.executes(...)`; it may
+   be sync or async, and its return value is ignored —
+   `.executes(() => DenoTasks.lint())` is fine as-is; never wrap a single
+   wrapper call in an `async` block just to discard its result.
 
 ## Find the exact signature first
 
@@ -131,6 +133,11 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   `--status`/`--target`/`--since`/`--limit`) and `zuke runs show <id>` (`--json`
   on both). Prune old ones with `zuke runs prune --keep <age> --keep-last <n>`
   (only terminal runs; never suspended/running).
+  A run whose process is killed is picked up by `zuke resume --check`, which
+  reaps it — its lease tells a dead holder from a slow one — and resumes it in
+  the same sweep. `override deadline()` gives a run a wall-clock budget
+  (`"45m"`, or milliseconds) that survives suspension; an abandoned run found
+  past it is settled `failed` with its compensations instead of resumed.
   See the cheatsheet.
 - **Cross-run locks:** `.lock((s) => s.lockKey(...).withTtl("4h"))` — a settings
   lambda — gives a target an exclusive claim across runs/machines; a second run
@@ -197,7 +204,8 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   an AI client can list, inspect, and (with `--allow-run`) run targets — on
   stdio, or over HTTP with `--http <host:port>` (loopback by default; a
   non-loopback bind needs a `ZUKE_MCP_TOKEN` bearer token). With a state store
-  it also exposes `list_runs`/`show_run` (+ `signal_run`/`resume_check`). Tier
+  it also exposes `list_runs`/`show_run` (+ `signal_run`, `resume_check` and
+  `cancel_run`). Tier
   access with `--allow-run=<globs>` (an allow-list over **invocation** —
   invoking a target runs its dependencies, and the read tools narrow to the
   allow-listed targets' closure), `--protect <globs>` + `ZUKE_OPERATOR_TOKEN`

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -10,7 +10,9 @@ This cheatsheet is a summary, not the source of truth.
 
 ## `target()` — the fluent builder
 
-Everything is optional except a body (`.executes`).
+Everything is optional except a body (`.executes`) — with four exceptions, all
+below: a `service()`, a `.forEach()` fan-out, a `.waitsFor()` gate, and a target
+that declares only `.effect(...)` each legitimately have no `.executes(...)`.
 
 | Method                                                                                                   | Purpose                                                                                             |
 | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
@@ -40,6 +42,7 @@ Everything is optional except a body (`.executes`).
 | `.recoverWith(...r)` / `.recoverAttempts(n)`                                                             | Run `Remediation`s if the body fails (self-healing); re-run when one asks to. See AI section.       |
 | `.partOf(group)`                                                                                         | Join a parallel batch (see `group()`).                                                              |
 | `.produces(...p)` / `.consumes(...t)`                                                                    | Declare and consume artifact paths.                                                                 |
+| `.readOnly()`                                                                                            | Advertise the target as query-only over MCP (`readOnlyHint` instead of `destructiveHint`).          |
 
 **Lifecycle hooks** — `override` on the `Build` to observe a run without wrapping
 every target: `onStart()` once before anything runs, `onFinish(result)` once
@@ -218,7 +221,14 @@ class CD extends Build {
   `suspended` with a reap event saying why, and the same pass resumes it — so a
   process killed mid-run has its owed effects driven without an operator
   stepping in. A run whose lease is still being renewed is merely slow, and is
-  left alone.
+  left alone. The same sweep also finishes runs a dead settler left `cancelling`.
+- **Run deadlines.** `override deadline()` on the `Build` gives a run a
+  wall-clock budget (`"45m"`, or milliseconds), stamped as `deadlineAt` when it
+  starts and pushed forward on resume by however long the run sat parked — so
+  time spent waiting at a gate does not count against it. An abandoned run found
+  **past** its deadline is not handed back: the reaper settles it `failed` and
+  runs its compensations. Without a deadline a reaped run is always returned to
+  `suspended` and resumed.
 - **Never put secrets in `ctx.state`** — it is stored as plain JSON. Secret
   parameters are excluded from the record and state values are run through the
   redactor, but treat state as a non-secret channel. See `docs/state.md`.
@@ -388,7 +398,10 @@ gate = target().dependsOn(this.checks).always()
 - **At-least-once, not exactly-once.** A process that dies after the side effect
   but before recording it repeats the effect on the re-drive. Write bodies that
   tolerate that — either repeating is harmless, or the far side converges (an
-  upsert, not an append).
+  upsert, not an append). The body's `ctx` is an `EffectContext`: `ctx.effect`
+  is the effect's name and **`ctx.redriven`** is true when a previous attempt
+  already committed its intent, so a body that cannot be made idempotent can at
+  least detect the repeat and check the far side first.
 - **Pin the inputs.** A re-drive happens later, sometimes much later, so a body
   that looks up "the current value" of anything acts on a world that has moved
   on. Read what the effect acts on from `ctx.state`/`ctx.stateOf(...)`, written
@@ -400,12 +413,23 @@ gate = target().dependsOn(this.checks).always()
   reason is re-driven by the ordinary resume. A process **killed outright**
   leaves its run `running`, which `zuke resume --check` reaps: it reads the
   run's lease to tell a dead holder from a slow one, returns an abandoned run to
-  `suspended`, and resumes it in the same pass (see Run leases above).
+  `suspended`, and resumes it in the same pass (see Run leases above) — unless
+  the run is past its `deadline()`, in which case it is settled `failed` and its
+  effects are never driven.
 
 ## Fan-out over a list — `.forEach()`
 
 Run the same pipeline over a runtime list, with per-item isolation and bounded
-concurrency:
+concurrency.
+
+> **Four combinations throw**, loudly, when the fan-out is materialised — not at
+> type-check time, so they are easy to write by accident. A `.forEach()` parent
+> may not also declare `.waitsFor()` or `.effect()`, and **no stage** inside the
+> fan-out may declare either. A stage *can* declare `.onCancel()`, which is why
+> the restriction is worth stating: the neighbouring features do not compose the
+> way the compensation one does. Suspend or record an effect in a target
+> **before or after** the fan-out instead.
+
 
 ```ts
 import { Build, parameter, target } from "jsr:@zuke/core";
@@ -442,6 +466,8 @@ class CD extends Build {
   and validate the list before the batch runs.
 
 ## Parameters — typed build inputs
+
+<!-- check -->
 
 ```ts
 import { Build, parameter, target } from "jsr:@zuke/core";
@@ -487,6 +513,10 @@ token = parameter("Deploy token")
   );
 ```
 
+The other source is **`fileSecret((s) => s.path("/run/secrets/deploy-token"))`**,
+for a secret mounted as a file by Kubernetes, Docker, or a systemd credential —
+no subprocess, and the common shape for a multi-line value like a private key.
+
 A sourced secret is still an ordinary parameter (flag, env var, `.required()`,
 `.number()`); `.from(...)` just adds the run-time provider.
 
@@ -494,7 +524,8 @@ A sourced secret is still an ordinary parameter (flag, env var, `.required()`,
 
 Fetch pinned, checksum-verified tool binaries from the build itself instead of
 assuming they're installed. Both return the installed binary's `AbsolutePath`;
-hand it to a wrapper's `.toolPath(...)`, to `CmdTasks`, or to `defineTool`.
+hand it to a wrapper's `.toolPath(...)`, to `CmdTasks`, or to `defineTool`
+(`jsr:@zuke/core/tooling` — the submodule, not the package root).
 
 ```ts
 import { toolchain, ToolTasks } from "jsr:@zuke/core";
@@ -578,6 +609,7 @@ the full task list and settings methods of each):
 | `@zuke/security`                                                                                                                               | `*Tasks`                                         | security scanning                                                                   |
 | `@zuke/claude`, `@zuke/codex`, `@zuke/gemini`                                                                                                  | `ClaudeTasks`, ...                               | headless AI CLIs                                                                    |
 | `@zuke/ai`                                                                                                                                     | `securityReviewer`, ..., `aiFixer`, `agentFixer` | AI review gates + self-healing (see below)                                          |
+| `@zuke/otel`                                                                                                                                   | `otel` (a plugin)                                | export runs and targets as OpenTelemetry traces (see below)                          |
 
 The catalog keeps growing — the package list in `llms.txt`'s `## Packages`
 catalogue (or the table above) is the source of truth for **whether a wrapper
@@ -719,7 +751,8 @@ await run(MyBuild, {
 ci = cicd({ provider: "github" }); // .github/workflows/ci.yml, push/PR to main
 ```
 
-`provider` is the only required field (`"github"` / `"gitlab"` / `"azure"`).
+`provider` is the only required field (`"github"` / `"gitlab"` / `"azure"` /
+`"bitbucket"`).
 Running any target regenerates the YAML; on CI it _verifies_ the committed file
 is current (`zuke generate-ci --check` is a dedicated gate).
 
@@ -738,15 +771,21 @@ else a friendly error.
 ./zuke --list --json          # whole surface (commands, flags, targets) as JSON
 ./zuke <target> --dry-run     # preview the plan, run nothing
 ./zuke <target>               # run it
-./zuke <target> --parallel    # run independent targets concurrently
-./zuke <target> --affected    # run only targets changed since a git base
+./zuke <target> --parallel[=N]   # run independent targets concurrently (N caps in-flight)
+./zuke <target> --affected[=<base>]  # only targets changed since a git base (default HEAD)
+./zuke <target> --skip <dep>  # run it but skip a named dependency (repeatable)
 ./zuke <target> --no-cache    # ignore the incremental cache
 ./zuke <target> --state       # persist run state to .zuke/runs (durable state)
 ./zuke <target> --actor <who> # attribute the run in its state record
 ./zuke runs list [--status s] # list persisted runs (also --target, --since, --limit, --counts, --json)
 ./zuke runs show <id>         # one run's full per-target status (+ --json)
 ./zuke runs prune --keep 90d --keep-last 50  # delete old terminal runs (--dry-run to preview)
+./zuke graph [--output=html] [--no-open]  # print the dependency graph, or render it interactively
+./zuke generate-ci [--check]  # write the declared CI workflow files (--check verifies instead)
+./zuke completions install bash  # wire target/flag completion into your shell (or `print`)
 ./zuke resume <id> --signal <name> [--data <json>]  # continue a suspended run
+./zuke resume --check          # reap abandoned runs, then re-check suspended ones (cron entry point)
+./zuke resume <id> --resume-degraded  # continue past a degraded record (a state write was lost)
 ./zuke cancel <id>            # cancel a run and run its .onCancel() compensations
 ./zuke mcp [--allow-run]      # serve the build over MCP for an AI client (stdio)
 ./zuke mcp --http 7777        # ...or over HTTP (loopback; token off-loopback; Origin-guarded)

--- a/skills/zuke-setup/SKILL.md
+++ b/skills/zuke-setup/SKILL.md
@@ -68,10 +68,15 @@ finish replacing any remaining generated `CmdTasks.exec` calls with typed
 - **`./zuke`** + **`./zuke.ps1`** — launchers that locate the project and run
   `zuke.ts` with the Deno on `PATH`. If Deno is missing they point at the
   official install docs and exit rather than piping an install script into a
-  shell, which would download and execute code unverified.
-- **`deno.json`** — merged to add a `zuke` task (and `fmt`/`lint`/`test` if
-  absent).
+  shell, which would download and execute code unverified. They pass `--frozen`
+  once a `deno.lock` exists, so the first run writes the lockfile and every run
+  after verifies it.
+- **`deno.json`** — merged to add a `zuke` task, plus `fmt`/`lint`/`test` if
+  absent. The merge is all-or-nothing: if a `zuke` task is already declared the
+  file is left alone entirely, and an unparseable one is skipped with a notice.
 - **`zuke.json`** — `{ "name": "..." }`, which marks the repo root.
+- **`.gitignore`** — created or appended so `.zuke/` is ignored (the cache and
+  durable run state live there); untouched if it already covers it.
 
 ## Running the build
 
@@ -90,14 +95,18 @@ calls, `zuke mcp` runs a Model Context Protocol server over it (register with
 `claude mcp add zuke -- deno run -A zuke.ts mcp`; add `--allow-run` to let the
 agent execute targets, not just inspect them).
 
-If Deno is already installed you can equivalently use `deno task zuke <target>`
-or `deno run -A zuke.ts <target>`. The `-A` flag grants permissions, since
-targets typically run processes and touch files.
+If Deno is already installed you can also use `deno task zuke <target>` or
+`deno run -A zuke.ts <target>`. The `-A` flag grants permissions, since targets
+typically run processes and touch files. These are not quite equivalent to the
+launcher: the scaffolded `zuke` task deliberately omits `--frozen`, so it may
+heal a stale lockfile where `./zuke` would fail on it.
 
 ## Manual setup (no CLI)
 
 Create `zuke.ts` in the project root, extend `Build`, declare targets with
 `target()`, and call `await run(MyBuild)` at the bottom:
+
+<!-- check -->
 
 ```ts
 import { Build, run, target } from "jsr:@zuke/core";

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -63,10 +63,12 @@ await run(CI);
    resolution. (If a build delegates its side effects to your own tested
    modules behind injected clients, the wrapper rule still governs whatever
    those modules run in the target body.)
-4. **A body is required.** Set `.executes(...)`; it may be sync or async, and
-   its return value is ignored — `.executes(() => DenoTasks.lint())` is fine
-   as-is; never wrap a single wrapper call in an `async` block just to discard
-   its result.
+4. **A body is required**, unless the target is one of the four forms that
+   replace it: a `service()`, a `.forEach()` fan-out, a `.waitsFor()` gate, or a
+   target declaring only `.effect(...)`. Otherwise set `.executes(...)`; it may
+   be sync or async, and its return value is ignored —
+   `.executes(() => DenoTasks.lint())` is fine as-is; never wrap a single
+   wrapper call in an `async` block just to discard its result.
 
 ## Find the exact signature first
 
@@ -131,6 +133,11 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   `--status`/`--target`/`--since`/`--limit`) and `zuke runs show <id>` (`--json`
   on both). Prune old ones with `zuke runs prune --keep <age> --keep-last <n>`
   (only terminal runs; never suspended/running).
+  A run whose process is killed is picked up by `zuke resume --check`, which
+  reaps it — its lease tells a dead holder from a slow one — and resumes it in
+  the same sweep. `override deadline()` gives a run a wall-clock budget
+  (`"45m"`, or milliseconds) that survives suspension; an abandoned run found
+  past it is settled `failed` with its compensations instead of resumed.
   See the cheatsheet.
 - **Cross-run locks:** `.lock((s) => s.lockKey(...).withTtl("4h"))` — a settings
   lambda — gives a target an exclusive claim across runs/machines; a second run
@@ -197,7 +204,8 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   an AI client can list, inspect, and (with `--allow-run`) run targets — on
   stdio, or over HTTP with `--http <host:port>` (loopback by default; a
   non-loopback bind needs a `ZUKE_MCP_TOKEN` bearer token). With a state store
-  it also exposes `list_runs`/`show_run` (+ `signal_run`/`resume_check`). Tier
+  it also exposes `list_runs`/`show_run` (+ `signal_run`, `resume_check` and
+  `cancel_run`). Tier
   access with `--allow-run=<globs>` (an allow-list over **invocation** —
   invoking a target runs its dependencies, and the read tools narrow to the
   allow-listed targets' closure), `--protect <globs>` + `ZUKE_OPERATOR_TOKEN`

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -10,7 +10,9 @@ This cheatsheet is a summary, not the source of truth.
 
 ## `target()` — the fluent builder
 
-Everything is optional except a body (`.executes`).
+Everything is optional except a body (`.executes`) — with four exceptions, all
+below: a `service()`, a `.forEach()` fan-out, a `.waitsFor()` gate, and a target
+that declares only `.effect(...)` each legitimately have no `.executes(...)`.
 
 | Method                                                                                                   | Purpose                                                                                             |
 | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
@@ -40,6 +42,7 @@ Everything is optional except a body (`.executes`).
 | `.recoverWith(...r)` / `.recoverAttempts(n)`                                                             | Run `Remediation`s if the body fails (self-healing); re-run when one asks to. See AI section.       |
 | `.partOf(group)`                                                                                         | Join a parallel batch (see `group()`).                                                              |
 | `.produces(...p)` / `.consumes(...t)`                                                                    | Declare and consume artifact paths.                                                                 |
+| `.readOnly()`                                                                                            | Advertise the target as query-only over MCP (`readOnlyHint` instead of `destructiveHint`).          |
 
 **Lifecycle hooks** — `override` on the `Build` to observe a run without wrapping
 every target: `onStart()` once before anything runs, `onFinish(result)` once
@@ -218,7 +221,14 @@ class CD extends Build {
   `suspended` with a reap event saying why, and the same pass resumes it — so a
   process killed mid-run has its owed effects driven without an operator
   stepping in. A run whose lease is still being renewed is merely slow, and is
-  left alone.
+  left alone. The same sweep also finishes runs a dead settler left `cancelling`.
+- **Run deadlines.** `override deadline()` on the `Build` gives a run a
+  wall-clock budget (`"45m"`, or milliseconds), stamped as `deadlineAt` when it
+  starts and pushed forward on resume by however long the run sat parked — so
+  time spent waiting at a gate does not count against it. An abandoned run found
+  **past** its deadline is not handed back: the reaper settles it `failed` and
+  runs its compensations. Without a deadline a reaped run is always returned to
+  `suspended` and resumed.
 - **Never put secrets in `ctx.state`** — it is stored as plain JSON. Secret
   parameters are excluded from the record and state values are run through the
   redactor, but treat state as a non-secret channel. See `docs/state.md`.
@@ -388,7 +398,10 @@ gate = target().dependsOn(this.checks).always()
 - **At-least-once, not exactly-once.** A process that dies after the side effect
   but before recording it repeats the effect on the re-drive. Write bodies that
   tolerate that — either repeating is harmless, or the far side converges (an
-  upsert, not an append).
+  upsert, not an append). The body's `ctx` is an `EffectContext`: `ctx.effect`
+  is the effect's name and **`ctx.redriven`** is true when a previous attempt
+  already committed its intent, so a body that cannot be made idempotent can at
+  least detect the repeat and check the far side first.
 - **Pin the inputs.** A re-drive happens later, sometimes much later, so a body
   that looks up "the current value" of anything acts on a world that has moved
   on. Read what the effect acts on from `ctx.state`/`ctx.stateOf(...)`, written
@@ -400,12 +413,23 @@ gate = target().dependsOn(this.checks).always()
   reason is re-driven by the ordinary resume. A process **killed outright**
   leaves its run `running`, which `zuke resume --check` reaps: it reads the
   run's lease to tell a dead holder from a slow one, returns an abandoned run to
-  `suspended`, and resumes it in the same pass (see Run leases above).
+  `suspended`, and resumes it in the same pass (see Run leases above) — unless
+  the run is past its `deadline()`, in which case it is settled `failed` and its
+  effects are never driven.
 
 ## Fan-out over a list — `.forEach()`
 
 Run the same pipeline over a runtime list, with per-item isolation and bounded
-concurrency:
+concurrency.
+
+> **Four combinations throw**, loudly, when the fan-out is materialised — not at
+> type-check time, so they are easy to write by accident. A `.forEach()` parent
+> may not also declare `.waitsFor()` or `.effect()`, and **no stage** inside the
+> fan-out may declare either. A stage *can* declare `.onCancel()`, which is why
+> the restriction is worth stating: the neighbouring features do not compose the
+> way the compensation one does. Suspend or record an effect in a target
+> **before or after** the fan-out instead.
+
 
 ```ts
 import { Build, parameter, target } from "jsr:@zuke/core";
@@ -442,6 +466,8 @@ class CD extends Build {
   and validate the list before the batch runs.
 
 ## Parameters — typed build inputs
+
+<!-- check -->
 
 ```ts
 import { Build, parameter, target } from "jsr:@zuke/core";
@@ -487,6 +513,10 @@ token = parameter("Deploy token")
   );
 ```
 
+The other source is **`fileSecret((s) => s.path("/run/secrets/deploy-token"))`**,
+for a secret mounted as a file by Kubernetes, Docker, or a systemd credential —
+no subprocess, and the common shape for a multi-line value like a private key.
+
 A sourced secret is still an ordinary parameter (flag, env var, `.required()`,
 `.number()`); `.from(...)` just adds the run-time provider.
 
@@ -494,7 +524,8 @@ A sourced secret is still an ordinary parameter (flag, env var, `.required()`,
 
 Fetch pinned, checksum-verified tool binaries from the build itself instead of
 assuming they're installed. Both return the installed binary's `AbsolutePath`;
-hand it to a wrapper's `.toolPath(...)`, to `CmdTasks`, or to `defineTool`.
+hand it to a wrapper's `.toolPath(...)`, to `CmdTasks`, or to `defineTool`
+(`jsr:@zuke/core/tooling` — the submodule, not the package root).
 
 ```ts
 import { toolchain, ToolTasks } from "jsr:@zuke/core";
@@ -578,6 +609,7 @@ the full task list and settings methods of each):
 | `@zuke/security`                                                                                                                               | `*Tasks`                                         | security scanning                                                                   |
 | `@zuke/claude`, `@zuke/codex`, `@zuke/gemini`                                                                                                  | `ClaudeTasks`, ...                               | headless AI CLIs                                                                    |
 | `@zuke/ai`                                                                                                                                     | `securityReviewer`, ..., `aiFixer`, `agentFixer` | AI review gates + self-healing (see below)                                          |
+| `@zuke/otel`                                                                                                                                   | `otel` (a plugin)                                | export runs and targets as OpenTelemetry traces (see below)                          |
 
 The catalog keeps growing — the package list in `llms.txt`'s `## Packages`
 catalogue (or the table above) is the source of truth for **whether a wrapper
@@ -719,7 +751,8 @@ await run(MyBuild, {
 ci = cicd({ provider: "github" }); // .github/workflows/ci.yml, push/PR to main
 ```
 
-`provider` is the only required field (`"github"` / `"gitlab"` / `"azure"`).
+`provider` is the only required field (`"github"` / `"gitlab"` / `"azure"` /
+`"bitbucket"`).
 Running any target regenerates the YAML; on CI it _verifies_ the committed file
 is current (`zuke generate-ci --check` is a dedicated gate).
 
@@ -738,15 +771,21 @@ else a friendly error.
 ./zuke --list --json          # whole surface (commands, flags, targets) as JSON
 ./zuke <target> --dry-run     # preview the plan, run nothing
 ./zuke <target>               # run it
-./zuke <target> --parallel    # run independent targets concurrently
-./zuke <target> --affected    # run only targets changed since a git base
+./zuke <target> --parallel[=N]   # run independent targets concurrently (N caps in-flight)
+./zuke <target> --affected[=<base>]  # only targets changed since a git base (default HEAD)
+./zuke <target> --skip <dep>  # run it but skip a named dependency (repeatable)
 ./zuke <target> --no-cache    # ignore the incremental cache
 ./zuke <target> --state       # persist run state to .zuke/runs (durable state)
 ./zuke <target> --actor <who> # attribute the run in its state record
 ./zuke runs list [--status s] # list persisted runs (also --target, --since, --limit, --counts, --json)
 ./zuke runs show <id>         # one run's full per-target status (+ --json)
 ./zuke runs prune --keep 90d --keep-last 50  # delete old terminal runs (--dry-run to preview)
+./zuke graph [--output=html] [--no-open]  # print the dependency graph, or render it interactively
+./zuke generate-ci [--check]  # write the declared CI workflow files (--check verifies instead)
+./zuke completions install bash  # wire target/flag completion into your shell (or `print`)
 ./zuke resume <id> --signal <name> [--data <json>]  # continue a suspended run
+./zuke resume --check          # reap abandoned runs, then re-check suspended ones (cron entry point)
+./zuke resume <id> --resume-degraded  # continue past a degraded record (a state write was lost)
 ./zuke cancel <id>            # cancel a run and run its .onCancel() compensations
 ./zuke mcp [--allow-run]      # serve the build over MCP for an AI client (stdio)
 ./zuke mcp --http 7777        # ...or over HTTP (loopback; token off-loopback; Origin-guarded)


### PR DESCRIPTION
## What & why

An audit of every documentation surface against the actual code found roughly seventy statements that had drifted. They group into four kinds.

**Claims that were simply false.** `SECURITY.md` described a bootstrap that fetches and pipes an install script — both launchers download a pinned release archive, verify it against a baked-in checksum, refuse a moving version outright, and demand a matching hash for any override. The document understated the project's own strongest control. It also named release jobs and a CI job that do not exist, and asserted that every job hardens its runner when the one holding no token does not. `RELEASING.md` described the release as a single command, which is the local aggregate; CI runs four least-privilege jobs. Getting-started said the repo does not yet use its own published action, which it now does in all six workflows, and described the untrusted-checkout guard as a refusal for one event when it is an allow-list that also refuses a checkout with no target. A Node example pinned a version range that resolves to nothing.

**Guidance pointing at the wrong place.** Three files sent readers to a one-line pointer file for the coding standards and architecture notes. The PR template asked for a new package to be wired into five places and cited a document that documents none of them; the real count is seven and the real reference is `AGENTS.md`. `CODEOWNERS` still carried its own unresolved placeholder instruction, protected a directory that does not exist, and left the build helpers and the action manifest uncovered.

**Features documented nowhere a reader would look.** Six builder methods were absent from the authoring reference — including the cross-run lock and the suspend gate, which had no entry and no pointer anywhere on that page. Two of four lifecycle hooks were missing, as was every other override on the base class. The state-service contract omitted the three lock routes entirely, so a service built from it could store run records but support neither locks, nor the run lease, nor the reaper that depends on it. The command reference was missing a top-level flag, three server flags, one mutating tool, and the fact that the resume sweep now reaps abandoned runs before checking suspended ones.

**Skills.** Added the run deadline, the read-only marker, the telemetry package that was the only one missing from the catalogue, four flags and the completions command, the four combinations a fan-out rejects at materialisation time, the flag an effect body can read to detect its own re-drive, the second secret source, and the file the scaffolder writes that was never listed. Two rules that contradicted their own files — that a body is always required, and that the launcher and the task are equivalent — now state their exceptions.

**Two gates got sharper rather than just satisfied.** Six anchors pointed at a heading whose slug they got wrong; every relative link and anchor in the corpus was then verified with a checker, and all resolve. The snippet gate went from **4 checked examples to 30** — every fenced block that already type-checks standalone is now held to it, so a reader pasting one gets code that still compiles. Two root documents were excluded from the spell gate on the premise that they are generated, which neither is; both are checked now.

`llms.txt` and `llms-full.txt` needed no change: they are generated from JSDoc, this PR touches only prose, and the drift check confirms they are current.

## Related issues

Follows #324 and #326, closing out the documentation findings from the framework assessment.

## Checklist

- [x] The PR title is a [Conventional Commit](https://www.conventionalcommits.org/) (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell). The security target fails only in this sandbox, where the vulnerable-actions audit cannot reach the GitHub Advisories API; it passes in CI.
- [x] Tests were added or updated; coverage stays at 95%+ — no source changed, and the full suite is green.
- [x] Docs updated in the same PR — this PR is the docs update.
- [x] Public API changes were regenerated with the apiDocs target; no public surface moved and the drift check passes.
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/`.
- [ ] A new package was wired into all seven places — not applicable.
- [x] The code is written using AI assisted coding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RYNxgcvdii7P8pPhD6U8q2

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYNxgcvdii7P8pPhD6U8q2)_