### PR TITLE
feat(core): scope run recovery to the build that owns the run

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -360,6 +360,13 @@ targets are safe to repeat. `resume --check` counts a degraded run as failed on
 every sweep — it cannot make that call for you — and prints the refusal so the
 cause is visible; pass `--resume-degraded` to the sweep to let it through.
 
+**What the sweep's failure count does _not_ include.** A run another process is
+already driving, one it finished between the listing and the resume, and one
+belonging to [another build](./orchestration.md#whose-run-is-it) are all
+**skipped**, not counted — losing a race is not a fault, and a cron watching the
+exit code needs it to mean something. Each is reported through the reporter, so a
+sweep that advanced nothing still says why.
+
 ## Cancelling runs
 
 `./zuke cancel <run-id>` cancels a run and runs its

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -242,34 +242,76 @@ suspended ones:
 - **Nobody there, and past its `deadline()`** → the run is settled **`failed`**,
   compensations and all. It did not stop because anyone asked; it ran out of
   time, and anything waiting on it needs an answer rather than silence.
-- **Only this build's runs.** A state store is commonly shared, and a listing has
-  no build filter, so the sweep skips runs it does not recognise: the record's
-  build name and its root target must both be this build's. Acting on another
-  build's run would find none of its targets and settle it with its
-  compensations silently skipped.
-
-  Before *settling* a run — which is irreversible, and runs its compensations —
-  the graph has to agree as well, because a class name is not an identity and
-  `Ci` is a name half an organisation's repos will use. Handing a run back to
-  `suspended` asks only the looser question, since that is reversible and a
-  resume refuses a graph it does not recognise with an error naming the drift.
-
-  What no check here can see: two builds that share a class name, a root-target
-  name **and** a graph shape are indistinguishable in a run record, even though
-  their target *bodies* may do entirely different things. The comparison is a
-  name, so passing the build to the sweep does not settle it — a build class is
-  supplied at the call, but what gets compared is `build.constructor.name`
-  against the record's, and two repos can spell that the same.
-
-  So **give two different builds two different class names.** `Ci` in a dozen
-  repos is the whole problem; `AcmeApiCi` in one of them is the whole fix, and it
-  costs a rename. A shared state service is otherwise fine: the sweep already
-  skips what it does not recognise, so pooling runs is a question of bytes on the
-  wire rather than of correctness.
+- **Only this build's runs** — see
+  [Whose run is it?](#whose-run-is-it) below. A state store is commonly shared,
+  and a listing has no build filter, so every recovery path first asks whether
+  the run is this build's at all.
 
 A run left `cancelling` by a settlement whose own process died is finished too,
 in whichever terminal that settlement was heading for — recorded on the run,
 because the process that finishes it is not the one that began it.
+
+### Whose run is it?
+
+A shared state store means a sweep sees every build's runs. That matters more
+than it sounds: recovery does not merely *read* a foreign run. A reap hands it
+back to `suspended`, a resume then runs **this** build's target bodies against
+that record, and a settlement runs this build's compensations.
+
+The dangerous case is not two unrelated builds — it is one `zuke.ts` templated
+across a dozen services. Same class name, same target names, same graph, and only
+the bodies differ. Every shape-based check passes.
+
+So a run records an **origin**, resolved once when it is created:
+
+| Source              | When                                                     |
+| ------------------- | -------------------------------------------------------- |
+| `ZUKE_BUILD_ID`     | Whenever you set it — the explicit answer.                |
+| `GITHUB_REPOSITORY` | Otherwise, in GitHub Actions. Free, and distinct per repo. |
+| _(none)_            | Neither set.                                             |
+
+Every recovery path — `zuke resume`, `zuke resume --check`, `zuke cancel`, and the
+reaping sweep — compares it, and touches a run only when the two origins agree.
+A sweep **skips** a foreign run without counting it a failure, so a cron's exit
+code stays meaningful; `zuke resume <id>` and `zuke cancel <id>` **report** it,
+because you named one run by hand.
+
+- **A missing origin never blocks anything.** A record written before the field
+  existed has none, and a process outside CI that sets no `ZUKE_BUILD_ID`
+  resolves none — either way the comparison abstains and the shape checks below
+  decide, exactly as they did before. An origin that could strand a run would
+  trade a rare wrong execution for a common failure to recover, and a run nobody
+  recovers is the worse outcome: an effect it owed is never driven.
+- **In containers, set it.** A Kubernetes CronJob has no `GITHUB_REPOSITORY`, so
+  put `ZUKE_BUILD_ID` in the pod spec next to `ZUKE_STATE_URL`. Use the same
+  value everywhere a given build runs — its own runs must recognise each other
+  across machines.
+
+Two shape checks back it up, and still apply on their own when no origin is
+recorded:
+
+- The record's **build name and root target** must both be this build's, or the
+  sweep leaves the run alone. Acting on another build's run would find none of
+  its targets and settle it with its compensations silently skipped.
+- Before *settling* a run — irreversible, and it runs compensations — the
+  **graph** has to agree as well. Handing a run back to `suspended` asks only the
+  looser question, since that is reversible and a resume refuses a graph it does
+  not recognise with an error naming the drift.
+
+**Or namespace the store, and the question never arises.** Every path the HTTP
+store builds hangs off the URL you give it, so pointing each build at its own
+prefix on one shared service isolates them completely — no client-side check
+involved:
+
+```sh
+ZUKE_STATE_URL=https://state.internal/svc-a   # service A's runs
+ZUKE_STATE_URL=https://state.internal/svc-b   # service B's runs
+```
+
+That is stronger than comparing origins, because there is nothing to compare:
+neither build can see the other's runs to begin with. It is the right answer when
+you control the state service; the origin is what protects a genuinely pooled
+store.
 
 ### `Build.deadline()`
 

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -256,11 +256,16 @@ suspended ones:
 
   What no check here can see: two builds that share a class name, a root-target
   name **and** a graph shape are indistinguishable in a run record, even though
-  their target *bodies* may do entirely different things. If several repos share
-  one state service and any of them might collide that way, give each its own
-  store — a separate `ZUKE_STATE_DIR`, or a distinct prefix or instance behind
-  `ZUKE_STATE_URL`. That is the only way to make the question unambiguous, and it
-  costs nothing when the runs were never meant to be pooled.
+  their target *bodies* may do entirely different things. The comparison is a
+  name, so passing the build to the sweep does not settle it — a build class is
+  supplied at the call, but what gets compared is `build.constructor.name`
+  against the record's, and two repos can spell that the same.
+
+  So **give two different builds two different class names.** `Ci` in a dozen
+  repos is the whole problem; `AcmeApiCi` in one of them is the whole fix, and it
+  costs a rename. A shared state service is otherwise fine: the sweep already
+  skips what it does not recognise, so pooling runs is a question of bytes on the
+  wire rather than of correctness.
 
 A run left `cancelling` by a settlement whose own process died is finished too,
 in whichever terminal that settlement was heading for — recorded on the run,

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -286,6 +286,11 @@ because you named one run by hand.
   put `ZUKE_BUILD_ID` in the pod spec next to `ZUKE_STATE_URL`. Use the same
   value everywhere a given build runs — its own runs must recognise each other
   across machines.
+- **Two builds in one repository share the repository default**, so it separates
+  nothing between them. It does not need to: they are already separated by the
+  build name and root-target checks below, and the origin only ever *narrows*
+  what those permit — it can refuse a run, never claim one. Give each build its
+  own `ZUKE_BUILD_ID` anyway if you want them told apart by origin too.
 
 Two shape checks back it up, and still apply on their own when no origin is
 recorded:

--- a/docs/state.md
+++ b/docs/state.md
@@ -52,6 +52,7 @@ Each run is stored as one JSON document:
 {
   "id": "3f2a…", // == ctx.runId
   "build": "CD", // the Build class name
+  "buildId": "acme/api", // optional; which build instance owns it (see below)
   "rootTarget": "deploy", // the requested target
   "status": "succeeded", // running | suspended | cancelling | succeeded | failed | cancelled
   "actor": "alice", // who ran it (see below)
@@ -95,6 +96,15 @@ The executor writes the record when it is created, on each target's start and
 finish, and when the run ends. So if the process is killed mid-run, the record
 on disk shows the target that was executing as `running`, with its `startedAt`
 stamped.
+
+`buildId` is the run's **origin**: `ZUKE_BUILD_ID`, else `GITHUB_REPOSITORY`,
+resolved once when the run is created. It says which build a run belongs to when
+a store is shared, because the class name above cannot — a `zuke.ts` templated
+across services shares its name, its target names and its graph. Every recovery
+path compares it and touches a run only when the two origins agree; an absent one
+on either side abstains rather than refusing, so records written before the field
+existed stay recoverable. See
+[Whose run is it?](./orchestration.md#whose-run-is-it).
 
 A record also carries an append-only `events` array — the **audit trail** of
 [MCP](./mcp.md) tool calls against the run (time, tool, actor, outcome, redacted

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -428,6 +428,12 @@ function operatingSystem(os: typeof Deno.build.os): OperatingSystem
   if (operatingSystem() === "macos") { ... }
   ```
 
+function ownsRun(record: RunRecord, buildId: string | undefined): boolean
+  Whether a process whose origin is `buildId` may recover `record`.
+
+  True unless both origins are known and differ — see the module documentation
+  for why an absent origin abstains rather than refusing.
+
 function parameter(description?: string): Parameter<string, string | undefined>
   Create a new build parameter (a `string` by default). Configure it fluently:
   `.number()`/`.boolean()` change the kind, `.options(...)` restricts a string,
@@ -492,6 +498,14 @@ function repoRoot(...segments: string[]): AbsolutePath
 
   @throws
       if no {@link CONFIG_FILE} is found in the cwd or any ancestor.
+
+function resolveBuildId(readEnv: (name: string) => string | undefined): string | undefined
+  The origin of the build running in this process — `ZUKE_BUILD_ID`, else
+  `GITHUB_REPOSITORY`, else `undefined` when neither is set.
+
+  Recorded on a run at creation and compared by every recovery path. An empty
+  value counts as unset, so an exported-but-empty variable does not become an
+  origin that matches nothing.
 
 function resolveBuildRegistry(option: BuildRegistry | false | undefined, declared: BuildRegistry | undefined, options: ResolveRegistryOptions): BuildRegistry | undefined
   Pick the build registry by precedence: an explicit `option` wins (`false`
@@ -1133,6 +1147,20 @@ class ForEachSettings
     item's later stages are still skipped). The fan-out target still fails at
     the end if any item failed. Without this, the first item failure stops the
     batch — the default.
+
+class ForeignRunError extends Error
+  Thrown when a recovery path is handed a run that a different build owns:
+  the run's recorded origin and this process's disagree.
+
+  A sweep treats it as "not mine" and moves on rather than counting a failure,
+  the same way it treats a run another process has already resumed. A command
+  that named one run reports it, because the operator asked about a run that is
+  not this build's to touch.
+
+  constructor(readonly runId: string, readonly owner: string, readonly self: string)
+    Build the error from the run and the two disagreeing origins.
+  override name: string
+    The error name.
 
 class GraphError extends Error
   Raised when the build graph is invalid (cycle or unknown dependency).
@@ -3366,6 +3394,16 @@ interface RunRecord
     Unique run ID (matches {@link "../target.ts".TargetContext} `runId`).
   build: string
     The build class name.
+  buildId?: string
+    Which build instance this run belongs to — `ZUKE_BUILD_ID`, else
+    `GITHUB_REPOSITORY`, resolved once at creation. Absent when neither was set
+    (and on every record written before this field existed).
+
+    The class name above cannot identify a build: a `zuke.ts` templated across
+    a dozen services shares its name, its target names and its graph shape, so
+    every shape-based check passes and one service's recovery sweep would drive
+    another's runs with its own target bodies. This is what a recovery path
+    compares; see {@link "../ownership.ts"}.
   rootTarget: string
     The dotted name of the requested (root) target.
   status: RunStatus

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1407,6 +1407,22 @@ class Redactor
     contributes one; a multi-line secret contributes the whole value plus each
     of its qualifying lines.
 
+class RunNotSuspendedError extends Error
+  Raised when a run is no longer `suspended` by the time a resume reaches it —
+  it has been settled, or a cancellation is in progress.
+
+  The counterpart to {@link AlreadyResumedError}, which covers a run another
+  process is currently driving. This covers one that already finished, and a
+  sweep treats it the same way: not its run to advance, and not a failure. Two
+  sweeps racing the same run is the normal case — one wins, and the loser
+  reading `succeeded` has discovered a success, not a fault. Counting it would
+  put a false alarm in the exit code a cron watches.
+
+  constructor(readonly runId: string, readonly status: RunStatus)
+    Build the error from the run id and the status found instead.
+  override name: string
+    The error name.
+
 class SecretError extends Error
   Raised when a {@link SecretSource} cannot produce a value.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -482,6 +482,12 @@ function operatingSystem(os: typeof Deno.build.os): OperatingSystem
   if (operatingSystem() === "macos") { ... }
   ```
 
+function ownsRun(record: RunRecord, buildId: string | undefined): boolean
+  Whether a process whose origin is `buildId` may recover `record`.
+
+  True unless both origins are known and differ — see the module documentation
+  for why an absent origin abstains rather than refusing.
+
 function parameter(description?: string): Parameter<string, string | undefined>
   Create a new build parameter (a `string` by default). Configure it fluently:
   `.number()`/`.boolean()` change the kind, `.options(...)` restricts a string,
@@ -546,6 +552,14 @@ function repoRoot(...segments: string[]): AbsolutePath
 
   @throws
       if no {@link CONFIG_FILE} is found in the cwd or any ancestor.
+
+function resolveBuildId(readEnv: (name: string) => string | undefined): string | undefined
+  The origin of the build running in this process — `ZUKE_BUILD_ID`, else
+  `GITHUB_REPOSITORY`, else `undefined` when neither is set.
+
+  Recorded on a run at creation and compared by every recovery path. An empty
+  value counts as unset, so an exported-but-empty variable does not become an
+  origin that matches nothing.
 
 function resolveBuildRegistry(option: BuildRegistry | false | undefined, declared: BuildRegistry | undefined, options: ResolveRegistryOptions): BuildRegistry | undefined
   Pick the build registry by precedence: an explicit `option` wins (`false`
@@ -1187,6 +1201,20 @@ class ForEachSettings
     item's later stages are still skipped). The fan-out target still fails at
     the end if any item failed. Without this, the first item failure stops the
     batch — the default.
+
+class ForeignRunError extends Error
+  Thrown when a recovery path is handed a run that a different build owns:
+  the run's recorded origin and this process's disagree.
+
+  A sweep treats it as "not mine" and moves on rather than counting a failure,
+  the same way it treats a run another process has already resumed. A command
+  that named one run reports it, because the operator asked about a run that is
+  not this build's to touch.
+
+  constructor(readonly runId: string, readonly owner: string, readonly self: string)
+    Build the error from the run and the two disagreeing origins.
+  override name: string
+    The error name.
 
 class GraphError extends Error
   Raised when the build graph is invalid (cycle or unknown dependency).
@@ -3420,6 +3448,16 @@ interface RunRecord
     Unique run ID (matches {@link "../target.ts".TargetContext} `runId`).
   build: string
     The build class name.
+  buildId?: string
+    Which build instance this run belongs to — `ZUKE_BUILD_ID`, else
+    `GITHUB_REPOSITORY`, resolved once at creation. Absent when neither was set
+    (and on every record written before this field existed).
+
+    The class name above cannot identify a build: a `zuke.ts` templated across
+    a dozen services shares its name, its target names and its graph shape, so
+    every shape-based check passes and one service's recovery sweep would drive
+    another's runs with its own target bodies. This is what a recovery path
+    compares; see {@link "../ownership.ts"}.
   rootTarget: string
     The dotted name of the requested (root) target.
   status: RunStatus

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1461,6 +1461,22 @@ class Redactor
     contributes one; a multi-line secret contributes the whole value plus each
     of its qualifying lines.
 
+class RunNotSuspendedError extends Error
+  Raised when a run is no longer `suspended` by the time a resume reaches it —
+  it has been settled, or a cancellation is in progress.
+
+  The counterpart to {@link AlreadyResumedError}, which covers a run another
+  process is currently driving. This covers one that already finished, and a
+  sweep treats it the same way: not its run to advance, and not a failure. Two
+  sweeps racing the same run is the normal case — one wins, and the loser
+  reading `succeeded` has discovered a success, not a fault. Counting it would
+  put a false alarm in the exit code a cron watches.
+
+  constructor(readonly runId: string, readonly status: RunStatus)
+    Build the error from the run id and the status found instead.
+  override name: string
+    The error name.
+
 class SecretError extends Error
   Raised when a {@link SecretSource} cannot produce a value.
 

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -105,6 +105,7 @@ export {
   type ResumeOptions,
   resumeRun,
 } from "./src/resume.ts";
+export { ForeignRunError, ownsRun, resolveBuildId } from "./src/ownership.ts";
 export {
   type CancelOptions,
   type CancelResult,

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -104,6 +104,7 @@ export {
   resumeCheck,
   type ResumeOptions,
   resumeRun,
+  RunNotSuspendedError,
 } from "./src/resume.ts";
 export { ForeignRunError, ownsRun, resolveBuildId } from "./src/ownership.ts";
 export {

--- a/packages/core/src/cancel.ts
+++ b/packages/core/src/cancel.ts
@@ -44,6 +44,7 @@ import {
   type TargetStateHandle,
 } from "./target.ts";
 import { outcomesFromRecord } from "./run_support.ts";
+import { assertOwnsRun, resolveBuildId } from "./ownership.ts";
 import { absolutePath } from "./path.ts";
 import { findConfigDir, pathExists } from "./config.ts";
 import { defaultStateHost, type StateStore } from "./state/store.ts";
@@ -680,6 +681,11 @@ export async function settleExternally(
   if (initial === null) {
     throw new Error(`cancel: no run "${runId}" found in the store.`);
   }
+  // A settlement runs *this* build's compensations against the record, so a run
+  // another build owns is refused before the lock is taken. Reported rather than
+  // silently skipped: unlike a sweep, this path was handed one run by name, so
+  // the caller asked about a run that is not this build's to unwind.
+  assertOwnsRun(initial.record, resolveBuildId(readEnv));
   if (isTerminal(initial.record.status)) {
     reporter.info(
       `Run ${runId} is already ${initial.record.status}; nothing to ` +

--- a/packages/core/src/execute_state.ts
+++ b/packages/core/src/execute_state.ts
@@ -23,6 +23,7 @@ import { findConfigDir, pathExists } from "./config.ts";
 import { defaultStateHost, type StateStore } from "./state/store.ts";
 import { resolveStateStore } from "./state/resolve.ts";
 import { buildRunRecord, ciRunUrl, resolveActor } from "./state/record.ts";
+import { resolveBuildId } from "./ownership.ts";
 import { RunStateWriter } from "./state/writer.ts";
 import {
   acquireLease,
@@ -178,6 +179,10 @@ export async function openRunState(opts: {
     ? undefined
     : new Date(Date.parse(nowIso()) + parseDuration(budget)).toISOString();
   const actor = resolveActor(opts.actor, readEnv);
+  // Resolved once, at creation, and never recomputed: it says which build the
+  // run belongs to, and a value that could change between a run and its
+  // recovery would be no identity at all.
+  const buildId = resolveBuildId(readEnv);
   const runUrl = ciRunUrl(readEnv);
   const warn = (message: string) => opts.reporter.info(message);
   // Take the run's lease *before* the writer, because opening the writer
@@ -228,6 +233,7 @@ export async function openRunState(opts: {
       buildRunRecord({
         runId: opts.runId,
         build: opts.build.constructor.name,
+        ...(buildId === undefined ? {} : { buildId }),
         rootTarget: opts.root.name_ ?? "<unnamed>",
         actor,
         now: nowIso(),

--- a/packages/core/src/ownership.ts
+++ b/packages/core/src/ownership.ts
@@ -1,0 +1,115 @@
+/**
+ * Which build a run belongs to.
+ *
+ * A state store is commonly shared by more than one build, and a run listing has
+ * no build filter — so every recovery sweep sees every build's runs. Deciding
+ * which of them are *this* build's is what this module is for, and it matters
+ * because the recovery paths do not merely read a foreign run: a reap hands it
+ * back to be resumed, a resume then runs **this** build's target bodies against
+ * the other build's record, and a settlement runs this build's compensations.
+ *
+ * The class name in {@link "./state/types.ts".RunRecord.build} cannot answer it.
+ * Half the repositories in an organisation call their build `Ci`, and the
+ * shape-based checks that back it up — the root target exists here, the graph
+ * agrees — all pass for the case that actually happens: one `zuke.ts` templated
+ * across a dozen services, identical target names and edges, different bodies.
+ * The resume path never consults the class name at all, only the shape.
+ *
+ * So a run records an **origin** as well, and a recovery path only touches a run
+ * whose origin it shares:
+ *
+ * - `ZUKE_BUILD_ID`, when the operator sets one. The explicit answer, and what a
+ *   container or a cron job wants — it has no repository in its environment.
+ * - `GITHUB_REPOSITORY` otherwise, which every GitHub Actions job already has.
+ *   Distinct per repository, stable across commits, and free: a build templated
+ *   across services is separated with no configuration at all.
+ *
+ * **A missing origin never blocks anything.** A record written before this
+ * existed has none, and a process outside CI with no `ZUKE_BUILD_ID` resolves
+ * none, so either side being absent means the comparison abstains and the
+ * shape-based checks decide as they did before. That is deliberate: an origin
+ * that could *strand* a run would trade a rare wrong execution for a common
+ * failure to recover, and a run nobody recovers is the worse outcome — an effect
+ * it owed is never driven.
+ *
+ * @module
+ */
+
+import type { RunRecord } from "./state/types.ts";
+
+/**
+ * The origin of the build running in this process — `ZUKE_BUILD_ID`, else
+ * `GITHUB_REPOSITORY`, else `undefined` when neither is set.
+ *
+ * Recorded on a run at creation and compared by every recovery path. An empty
+ * value counts as unset, so an exported-but-empty variable does not become an
+ * origin that matches nothing.
+ */
+export function resolveBuildId(
+  readEnv: (name: string) => string | undefined,
+): string | undefined {
+  for (const name of ["ZUKE_BUILD_ID", "GITHUB_REPOSITORY"]) {
+    const value = readEnv(name);
+    if (value !== undefined && value !== "") return value;
+  }
+  return undefined;
+}
+
+/**
+ * Whether a process whose origin is `buildId` may recover `record`.
+ *
+ * True unless both origins are known and differ — see the module documentation
+ * for why an absent origin abstains rather than refusing.
+ */
+export function ownsRun(
+  record: RunRecord,
+  buildId: string | undefined,
+): boolean {
+  if (buildId === undefined || record.buildId === undefined) return true;
+  return record.buildId === buildId;
+}
+
+/**
+ * Thrown when a recovery path is handed a run that a **different** build owns:
+ * the run's recorded origin and this process's disagree.
+ *
+ * A sweep treats it as "not mine" and moves on rather than counting a failure,
+ * the same way it treats a run another process has already resumed. A command
+ * that named one run reports it, because the operator asked about a run that is
+ * not this build's to touch.
+ */
+export class ForeignRunError extends Error {
+  /** The error name. */
+  override name = "ForeignRunError";
+  /** Build the error from the run and the two disagreeing origins. */
+  constructor(
+    /** The run that was refused. */
+    readonly runId: string,
+    /** The origin recorded on the run. */
+    readonly owner: string,
+    /** The origin of the build in this process. */
+    readonly self: string,
+  ) {
+    super(
+      `run ${runId} belongs to build "${owner}", but this process is ` +
+        `"${self}". A build only recovers its own runs. Set ZUKE_BUILD_ID to ` +
+        `"${owner}" if this process really does own it.`,
+    );
+  }
+}
+
+/**
+ * {@link ownsRun}, as an assertion: throws {@link ForeignRunError} when the two
+ * origins are known and differ.
+ */
+export function assertOwnsRun(
+  record: RunRecord,
+  buildId: string | undefined,
+): void {
+  // Narrowed here rather than delegating to `ownsRun`, so both origins are
+  // `string` by the time the error is built — no unreachable fallback.
+  const owner = record.buildId;
+  if (owner === undefined || buildId === undefined) return;
+  if (owner === buildId) return;
+  throw new ForeignRunError(record.id, owner, buildId);
+}

--- a/packages/core/src/ownership.ts
+++ b/packages/core/src/ownership.ts
@@ -24,6 +24,12 @@
  *   Distinct per repository, stable across commits, and free: a build templated
  *   across services is separated with no configuration at all.
  *
+ * **An origin only ever narrows.** It is `&&`-ed with the shape checks at every
+ * call site, never substituted for them, so it can refuse a run and never claim
+ * one. That is what makes the repository default safe where it is coarse: two
+ * builds in one repository resolve the same origin, and the build-name and
+ * root-target checks separate them exactly as they did before.
+ *
  * **A missing origin never blocks anything.** A record written before this
  * existed has none, and a process outside CI with no `ZUKE_BUILD_ID` resolves
  * none, so either side being absent means the comparison abstains and the

--- a/packages/core/src/reap.ts
+++ b/packages/core/src/reap.ts
@@ -32,6 +32,7 @@ import { type Build, discoverTargets } from "./build.ts";
 import type { Reporter } from "./executor.ts";
 import { messageOf } from "./internal.ts";
 import { settleExternally } from "./cancel.ts";
+import { ownsRun } from "./ownership.ts";
 import { acquireLease, RUN_LEASE_PREFIX } from "./state/run_lease.ts";
 import type { StateStore } from "./state/store.ts";
 import { planGraph } from "./graph.ts";
@@ -62,6 +63,12 @@ export interface ReapDeps {
   reporter: Reporter;
   /** The current time, as an ISO-8601 string. */
   now: () => string;
+  /**
+   * This build's origin (see {@link "./ownership.ts".resolveBuildId}). A run
+   * that records a different one is left alone; absent on either side, the
+   * shape-based checks below decide.
+   */
+  buildId?: string;
   /** Examine only this run, rather than every `running` one. */
   runId?: string;
   /** Suppress the settlement's own output. */
@@ -215,23 +222,31 @@ async function examine(id: string, deps: ReapDeps): Promise<Examined> {
  * another build's run is worse than useless: its targets are not in this build,
  * so a settlement would find no compensations to run and would stamp the record
  * terminal with the run's side effects never unwound, and nothing would retry it
- * because the record is no longer live. The suspended sweep is safe here only
- * because a resume *refuses* a build it cannot match; a reap mutates, so it has
- * to check.
+ * because the record is no longer live.
  *
- * Two things are checked, because a class name is not an identity. `Ci` is a
- * name half the repos in an organisation will use, and a run record carries
- * nothing more specific, so the name alone would let one repo's sweep settle
- * another's runs. Requiring the record's root target to exist here as well is
- * what makes a collision harmless in practice: the compensations a settlement
- * runs are resolved by name, so a build that has the run's root target has the
- * targets that run recorded.
+ * Three things are checked, in decreasing order of how much they prove:
  *
- * Two builds that share a class name *and* a root-target name are still
- * indistinguishable to this, which is why the destructive path asks
- * {@link canSettle} as well.
+ * 1. **The run's origin**, when both it and this process have one — the only
+ *    check that identifies a *build* rather than a shape. See
+ *    {@link "./ownership.ts"} for what an origin is and why an absent one
+ *    abstains instead of refusing.
+ * 2. **The class name**, which narrows and no more: `Ci` is a name half the
+ *    repositories in an organisation will use.
+ * 3. **The record's root target exists here**, because the compensations a
+ *    settlement runs are resolved by name — a build holding the run's root
+ *    target holds the targets that run recorded.
+ *
+ * Checks 2 and 3 are about shape, so two builds templated from one `zuke.ts`
+ * satisfy both; the origin is what tells them apart, and the destructive path
+ * asks {@link canSettle} on top.
+ *
+ * Note that a reap is not the only path that needs this. Handing a run back to
+ * `suspended` leads to a resume *executing* this build's bodies against that
+ * record, and the resume path compares only shape — so it makes the same
+ * ownership check itself rather than trusting the reap that preceded it.
  */
 function belongsToBuild(record: RunRecord, deps: ReapDeps): boolean {
+  if (!ownsRun(record, deps.buildId)) return false;
   if (record.build !== deps.build.constructor.name) return false;
   return discoverTargets(deps.build).has(record.rootTarget);
 }
@@ -251,12 +266,15 @@ function belongsToBuild(record: RunRecord, deps: ReapDeps): boolean {
  * So the graph has to agree too. Where it does not, this sweep leaves the run for
  * the one that recognises it.
  *
- * Where it does, this is as far as a comparison of records reaches: two builds
+ * Where it does, a comparison of *shapes* has reached its limit: two builds
  * sharing a class name, a root-target name and a graph shape are
- * indistinguishable in one, and their target *bodies* may still do entirely
- * different things. Passing the build in does not help — that is what happens
- * already, and what it yields is a name. The answer is to name two different
- * builds differently, which costs a rename; see `docs/orchestration.md`.
+ * indistinguishable to it, and their target bodies may still do entirely
+ * different things. That is what the run's origin answers, and
+ * {@link belongsToBuild} asks it first. A run with no recorded origin — one
+ * written before the field existed, or by a process outside CI that set no
+ * `ZUKE_BUILD_ID` — has only these shape checks standing between it and a
+ * collision, which is why `docs/orchestration.md` also describes namespacing the
+ * store itself.
  *
  * Note the blast radius differs by path: a stranded run is finalised *without*
  * compensations and into the terminal its own record names, so a colliding build

--- a/packages/core/src/reap.ts
+++ b/packages/core/src/reap.ts
@@ -251,14 +251,17 @@ function belongsToBuild(record: RunRecord, deps: ReapDeps): boolean {
  * So the graph has to agree too. Where it does not, this sweep leaves the run for
  * the one that recognises it.
  *
- * Where it does, this is as far as a heuristic reaches: two builds sharing a
- * class name, a root-target name and a graph shape are indistinguishable in a
- * record, and their target *bodies* may still do entirely different things. The
- * answer to that is not a cleverer comparison but a store per build — see
- * `docs/orchestration.md`. Note the blast radius differs by path: a stranded run
- * is finalised *without* compensations and into the terminal its own record
- * names, so a colliding build settles it exactly as the owning one would; a
- * past-deadline run does run compensations, which is why this check exists.
+ * Where it does, this is as far as a comparison of records reaches: two builds
+ * sharing a class name, a root-target name and a graph shape are
+ * indistinguishable in one, and their target *bodies* may still do entirely
+ * different things. Passing the build in does not help — that is what happens
+ * already, and what it yields is a name. The answer is to name two different
+ * builds differently, which costs a rename; see `docs/orchestration.md`.
+ *
+ * Note the blast radius differs by path: a stranded run is finalised *without*
+ * compensations and into the terminal its own record names, so a colliding build
+ * settles it exactly as the owning one would; a past-deadline run does run
+ * compensations, which is why this check exists.
  */
 function canSettle(record: RunRecord, deps: ReapDeps): boolean {
   if (!belongsToBuild(record, deps)) return false;

--- a/packages/core/src/resume.ts
+++ b/packages/core/src/resume.ts
@@ -23,6 +23,7 @@ import { execute, type Reporter } from "./executor.ts";
 import type { Plugin } from "./plugin.ts";
 import { planGraph } from "./graph.ts";
 import { reapAbandoned, recoverStranded } from "./reap.ts";
+import { assertOwnsRun, ForeignRunError, resolveBuildId } from "./ownership.ts";
 import { acquireLease, RUN_LEASE_PREFIX } from "./state/run_lease.ts";
 import type { JsonValue, TargetBuilder } from "./target.ts";
 import { absolutePath } from "./path.ts";
@@ -129,6 +130,14 @@ export async function resumeRun(
   if (initial === null) {
     throw new Error(`resume: no run "${options.runId}" found in the store.`);
   }
+
+  // Before anything else, and before the shape checks below: a resume *runs this
+  // build's target bodies* against the record it is given, so a run belonging to
+  // another build is not merely out of scope, it is the wrong code executing
+  // against someone else's state. The shape checks cannot catch it — one
+  // `zuke.ts` templated across services agrees on every target name and edge and
+  // differs only in what the bodies do.
+  assertOwnsRun(initial.record, resolveBuildId(readEnv));
 
   const resumerActor = resolveActor(options.actor, readEnv);
   const now = () => new Date().toISOString();
@@ -549,11 +558,13 @@ export async function resumeCheck(
   // this same pass to resume it — otherwise every abandoned run would wait a
   // whole sweep interval for nothing but a state transition.
   const actor = resolveActor(options.actor, readEnv);
+  const buildId = resolveBuildId(readEnv);
   const reaped = await reapAbandoned({
     build,
     store,
     actor,
     reporter,
+    ...(buildId === undefined ? {} : { buildId }),
     now: () => new Date().toISOString(),
     ...(options.runId === undefined ? {} : { runId: options.runId }),
     ...(options.silent === undefined ? {} : { silent: options.silent }),
@@ -568,6 +579,7 @@ export async function resumeCheck(
     store,
     actor,
     reporter,
+    ...(buildId === undefined ? {} : { buildId }),
     now: () => new Date().toISOString(),
     ...(options.runId === undefined ? {} : { runId: options.runId }),
     ...(options.silent === undefined ? {} : { silent: options.silent }),
@@ -577,12 +589,24 @@ export async function resumeCheck(
     ? [options.runId]
     : (await store.listRuns({ status: "suspended" })).map((s) => s.id);
   let failed = reaped.failed + recovered.failed;
+  let foreign = 0;
   for (const id of ids) {
     try {
       const result = await resumeRun(build, { ...options, runId: id });
       if (!result.ok) failed += 1;
     } catch (error) {
       if (error instanceof AlreadyResumedError) continue; // another process has it
+      // Not this build's run. Skipped rather than counted: a cron watches the
+      // failure count, and a store shared with another build would otherwise
+      // report a permanent non-zero result for runs this build must not touch.
+      // Tallied, though, and reported once below — a sweep that silently skipped
+      // everything would be indistinguishable from one with nothing to do, which
+      // is exactly how a mistyped `ZUKE_BUILD_ID` would look: recovery quietly
+      // stops, and the effects those runs owe are never driven.
+      if (error instanceof ForeignRunError) {
+        foreign += 1;
+        continue;
+      }
       // Isolate a per-run failure: one run erroring (a bad graph, a throwing
       // compensation) must not abort the sweep and strand every run behind it.
       failed += 1;
@@ -592,6 +616,17 @@ export async function resumeCheck(
         }`,
       );
     }
+  }
+  // One line per sweep rather than one per run: on a store pooled across many
+  // builds most runs are somebody else's, and that is the normal case, not an
+  // error. What matters is that the number is visible at all. A skip needs an
+  // origin on both sides, so `foreign > 0` implies this process has one — tested
+  // for rather than defaulted, so the message never prints a placeholder.
+  if (foreign > 0 && buildId !== undefined) {
+    reporter.info(
+      `resume --check: skipped ${foreign} run(s) belonging to another build ` +
+        `(this build is "${buildId}").`,
+    );
   }
   return { checked: ids.length, failed };
 }

--- a/packages/core/src/resume.ts
+++ b/packages/core/src/resume.ts
@@ -34,6 +34,7 @@ import { resolveActor } from "./state/record.ts";
 import type {
   RunGraphNode,
   RunRecord,
+  RunStatus,
   WaitDisposition,
   WaitState,
 } from "./state/types.ts";
@@ -53,6 +54,31 @@ export class AlreadyResumedError extends Error {
     readonly at: string,
   ) {
     super(`run ${runId} was already resumed by ${by} at ${at}`);
+  }
+}
+
+/**
+ * Raised when a run is no longer `suspended` by the time a resume reaches it —
+ * it has been settled, or a cancellation is in progress.
+ *
+ * The counterpart to {@link AlreadyResumedError}, which covers a run another
+ * process is *currently* driving. This covers one that already finished, and a
+ * sweep treats it the same way: not its run to advance, and not a failure. Two
+ * sweeps racing the same run is the normal case — one wins, and the loser
+ * reading `succeeded` has discovered a success, not a fault. Counting it would
+ * put a false alarm in the exit code a cron watches.
+ */
+export class RunNotSuspendedError extends Error {
+  /** The error name. */
+  override name = "RunNotSuspendedError";
+  /** Build the error from the run id and the status found instead. */
+  constructor(
+    /** The run that could not be resumed. */
+    readonly runId: string,
+    /** The status it was in instead of `suspended`. */
+    readonly status: RunStatus,
+  ) {
+    super(`resume: run ${runId} is "${status}", not suspended.`);
   }
 }
 
@@ -291,9 +317,7 @@ async function transitionToRunning(
       if (record.status === "running") {
         throw new AlreadyResumedError(id, record.actor, record.updatedAt);
       }
-      throw new Error(
-        `resume: run ${id} is "${record.status}", not suspended.`,
-      );
+      throw new RunNotSuspendedError(id, record.status);
     }
     const next = structuredClone(record);
     next.status = "running";
@@ -590,6 +614,7 @@ export async function resumeCheck(
     : (await store.listRuns({ status: "suspended" })).map((s) => s.id);
   let failed = reaped.failed + recovered.failed;
   let foreign = 0;
+  let settled = 0;
   for (const id of ids) {
     try {
       const result = await resumeRun(build, { ...options, runId: id });
@@ -605,6 +630,15 @@ export async function resumeCheck(
       // stops, and the effects those runs owe are never driven.
       if (error instanceof ForeignRunError) {
         foreign += 1;
+        continue;
+      }
+      // Someone else finished it between the listing and the resume. Two sweeps
+      // racing one run is the normal case — the loser reading `succeeded` has
+      // found a success, not a fault — so it is skipped like a lost resume race
+      // rather than counted, which would put a false alarm in the exit code a
+      // cron watches.
+      if (error instanceof RunNotSuspendedError) {
+        settled += 1;
         continue;
       }
       // Isolate a per-run failure: one run erroring (a bad graph, a throwing
@@ -626,6 +660,12 @@ export async function resumeCheck(
     reporter.info(
       `resume --check: skipped ${foreign} run(s) belonging to another build ` +
         `(this build is "${buildId}").`,
+    );
+  }
+  if (settled > 0) {
+    reporter.info(
+      `resume --check: skipped ${settled} run(s) that were no longer ` +
+        `suspended — another process finished them first.`,
     );
   }
   return { checked: ids.length, failed };

--- a/packages/core/src/state/record.ts
+++ b/packages/core/src/state/record.ts
@@ -78,6 +78,11 @@ export interface RunRecordInput {
   runId: string;
   /** The build class name. */
   build: string;
+  /**
+   * The build's resolved origin (see
+   * {@link "../ownership.ts".resolveBuildId}), when one is set.
+   */
+  buildId?: string;
   /** The dotted name of the requested (root) target. */
   rootTarget: string;
   /** The resolved run actor. */
@@ -120,6 +125,10 @@ export function buildRunRecord(input: RunRecordInput): RunRecord {
   return {
     id: input.runId,
     build: input.build,
+    // Stamped only when resolved, so a record round-trips with the exact key
+    // set it was written with and an absent origin stays absent rather than
+    // becoming an origin that matches nothing.
+    ...(input.buildId === undefined ? {} : { buildId: input.buildId }),
     rootTarget: input.rootTarget,
     status: "running",
     // Stamped here and never again. A deadline that were recomputed on each

--- a/packages/core/src/state/types.ts
+++ b/packages/core/src/state/types.ts
@@ -157,6 +157,18 @@ export interface RunRecord {
   id: string;
   /** The build class name. */
   build: string;
+  /**
+   * Which build **instance** this run belongs to — `ZUKE_BUILD_ID`, else
+   * `GITHUB_REPOSITORY`, resolved once at creation. Absent when neither was set
+   * (and on every record written before this field existed).
+   *
+   * The class name above cannot identify a build: a `zuke.ts` templated across
+   * a dozen services shares its name, its target names and its graph shape, so
+   * every shape-based check passes and one service's recovery sweep would drive
+   * another's runs with its own target bodies. This is what a recovery path
+   * compares; see {@link "../ownership.ts"}.
+   */
+  buildId?: string;
   /** The dotted name of the requested (root) target. */
   rootTarget: string;
   /** The run's lifecycle status. */
@@ -627,6 +639,8 @@ export function parseRunRecord(text: string): RunRecord {
   };
   // Optional and only when present, so a round-trip preserves the exact key set
   // and a record written before these existed parses unchanged.
+  const buildId = optionalStr(object, "buildId");
+  if (buildId !== undefined) record.buildId = buildId;
   const deadlineAt = optionalStr(object, "deadlineAt");
   if (deadlineAt !== undefined) record.deadlineAt = deadlineAt;
   const intended = optionalStr(object, "intendedTerminal");

--- a/packages/core/tests/cancel_contract_test.ts
+++ b/packages/core/tests/cancel_contract_test.ts
@@ -15,7 +15,13 @@
  * @module
  */
 
-import { assertEquals } from "./_assert.ts";
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+  messageOf,
+} from "./_assert.ts";
+import { ForeignRunError } from "../src/ownership.ts";
 import { Build, discoverTargets } from "../src/build.ts";
 import { target } from "../src/target.ts";
 import { execute } from "../src/executor.ts";
@@ -266,5 +272,48 @@ Deno.test("a failing compensation is recorded but does not stop the cancel", asy
         detail: "ran 0 compensation(s), 1 failed",
       },
     ]);
+  });
+});
+
+Deno.test("cancel refuses a run another build owns, and undoes nothing", async () => {
+  // A settlement runs *this* build's compensations, so a run belonging to
+  // another build is refused before the lock is taken. Reported rather than
+  // silently skipped: this path was handed one run by name.
+  await withTempStore(async (store) => {
+    const undone: string[] = [];
+    class Cd extends Build {
+      rollback = target().unlisted().executes(() =>
+        void undone.push("rollback")
+      );
+      deploy = target().onCancel(this.rollback).executes(() => {});
+      hold = target().dependsOn(this.deploy).waitsFor((s) =>
+        s.on({ descriptor: "never", isSatisfied: () => false })
+      );
+    }
+    const build = new Cd();
+    discoverTargets(build);
+    await execute(build, build.hold, {
+      silent: true,
+      stateStore: store,
+      readEnv: (name) => name === "ZUKE_BUILD_ID" ? "acme/api" : undefined,
+    });
+    const before = await onlyRun(store);
+    assertEquals(before.buildId, "acme/api");
+
+    const error = await assertRejects(() =>
+      cancelRun(build, {
+        runId: before.id,
+        stateStore: store,
+        silent: true,
+        actor: "ops",
+        readEnv: (name) => name === "ZUKE_BUILD_ID" ? "acme/web" : undefined,
+      }), ForeignRunError);
+    assertStringIncludes(messageOf(error), "acme/api");
+
+    // No compensation ran, and the record is untouched — not even `cancelling`.
+    assertEquals(undone, []);
+    const after = await onlyRun(store);
+    assertEquals(after.status, "suspended");
+    assertEquals(after.events.length, before.events.length);
   });
 });

--- a/packages/core/tests/ownership_test.ts
+++ b/packages/core/tests/ownership_test.ts
@@ -1,0 +1,133 @@
+/**
+ * Unit tests for run ownership — which build a run belongs to.
+ *
+ * The decisions under test are the two that have consequences: resolving this
+ * process's origin from the environment, and abstaining rather than refusing
+ * when either side has none. An origin that refused on absence would strand runs
+ * written before the field existed, which is the worse failure — an effect they
+ * owed would never be driven.
+ *
+ * @module
+ */
+
+import { assertEquals, assertStringIncludes, assertThrows } from "./_assert.ts";
+import {
+  assertOwnsRun,
+  ForeignRunError,
+  ownsRun,
+  resolveBuildId,
+} from "../src/ownership.ts";
+import type { RunRecord } from "../src/state/types.ts";
+
+const NOW = "2026-08-11T09:00:00.000Z";
+
+/** A minimal record, with `buildId` set only when given. */
+function record(buildId?: string): RunRecord {
+  return {
+    id: "run-1",
+    build: "Ci",
+    rootTarget: "ci",
+    status: "running",
+    actor: "runner",
+    createdAt: NOW,
+    updatedAt: NOW,
+    graph: [{ name: "ci", dependsOn: [] }],
+    params: {},
+    targets: { ci: { status: "succeeded", meta: {} } },
+    signals: {},
+    events: [],
+    ...(buildId === undefined ? {} : { buildId }),
+  };
+}
+
+/** A `readEnv` over a fixed map. */
+function env(
+  values: Record<string, string>,
+): (name: string) => string | undefined {
+  const map = new Map(Object.entries(values));
+  return (name) => map.get(name);
+}
+
+Deno.test("ZUKE_BUILD_ID wins over the repository", () => {
+  // The explicit answer, and the one a container or cron job needs — it has no
+  // repository in its environment to fall back to.
+  assertEquals(
+    resolveBuildId(env({
+      ZUKE_BUILD_ID: "acme/api-ci",
+      GITHUB_REPOSITORY: "acme/api",
+    })),
+    "acme/api-ci",
+  );
+});
+
+Deno.test("the repository is the free default in CI", () => {
+  assertEquals(
+    resolveBuildId(env({ GITHUB_REPOSITORY: "acme/api" })),
+    "acme/api",
+  );
+});
+
+Deno.test("an empty origin counts as unset", () => {
+  // An exported-but-empty variable must not become an origin that matches
+  // nothing — that would strand every run it touched.
+  assertEquals(
+    resolveBuildId(env({ ZUKE_BUILD_ID: "", GITHUB_REPOSITORY: "acme/api" })),
+    "acme/api",
+  );
+  assertEquals(
+    resolveBuildId(env({ ZUKE_BUILD_ID: "", GITHUB_REPOSITORY: "" })),
+    undefined,
+  );
+});
+
+Deno.test("no origin at all resolves to undefined", () => {
+  assertEquals(resolveBuildId(env({})), undefined);
+});
+
+Deno.test("matching origins own the run", () => {
+  assertEquals(ownsRun(record("acme/api"), "acme/api"), true);
+});
+
+Deno.test("differing origins do not", () => {
+  assertEquals(ownsRun(record("acme/api"), "acme/web"), false);
+});
+
+Deno.test("an absent origin on either side abstains", () => {
+  // The whole reason this is a filter and not a gate: a record written before
+  // the field existed, or a process outside CI that sets nothing, must still be
+  // recoverable by the shape-based checks that came before.
+  assertEquals(ownsRun(record(), "acme/api"), true);
+  assertEquals(ownsRun(record("acme/api"), undefined), true);
+  assertEquals(ownsRun(record(), undefined), true);
+});
+
+Deno.test("the assertion names both origins and the run", () => {
+  assertThrows(
+    () => assertOwnsRun(record("acme/api"), "acme/web"),
+    ForeignRunError,
+  );
+  // Caught again to narrow: a sweep matches on the class and reads the fields,
+  // so both have to be there.
+  let caught: unknown;
+  try {
+    assertOwnsRun(record("acme/api"), "acme/web");
+  } catch (error) {
+    caught = error;
+  }
+  assertEquals(caught instanceof ForeignRunError, true);
+  if (!(caught instanceof ForeignRunError)) return;
+  assertEquals(caught.runId, "run-1");
+  assertEquals(caught.owner, "acme/api");
+  assertEquals(caught.self, "acme/web");
+  assertEquals(caught.name, "ForeignRunError");
+  // The operator has to be able to act on it, so the message says how.
+  assertStringIncludes(caught.message, "ZUKE_BUILD_ID");
+  assertStringIncludes(caught.message, "acme/api");
+  assertStringIncludes(caught.message, "acme/web");
+});
+
+Deno.test("the assertion abstains exactly where the predicate does", () => {
+  assertOwnsRun(record(), "acme/api");
+  assertOwnsRun(record("acme/api"), undefined);
+  assertOwnsRun(record("acme/api"), "acme/api");
+});

--- a/packages/core/tests/reap_test.ts
+++ b/packages/core/tests/reap_test.ts
@@ -504,3 +504,22 @@ Deno.test("a run from the same origin is reaped normally", async () => {
     assertEquals(outcome.reaped, ["run-1"]);
   });
 });
+
+Deno.test("a shared origin does not make another build's run ours", async () => {
+  // Two builds in one repository resolve the same `GITHUB_REPOSITORY`, so the
+  // origin abstains between them. It only ever narrows what the shape checks
+  // permit — it can refuse a run, never claim one — so the build name still
+  // separates them, exactly as before origins existed.
+  await withStore([record("run-1", "running")], async (store) => {
+    await amend(store, "run-1", (r) => {
+      r.build = "OtherBuild";
+      r.buildId = "acme/api";
+    });
+    const { reporter } = capturing();
+    const outcome = await reapAbandoned(
+      depsFor(store, reporter, NOW, "acme/api"),
+    );
+    assertEquals(outcome, { reaped: [], settled: [], failed: 0 });
+    assertEquals((await store.getRun("run-1"))?.record.status, "running");
+  });
+});

--- a/packages/core/tests/reap_test.ts
+++ b/packages/core/tests/reap_test.ts
@@ -76,10 +76,31 @@ function depsFor(
   store: FileSystemStateStore,
   reporter: Reporter,
   now = NOW,
+  buildId?: string,
 ): Parameters<typeof reapAbandoned>[0] {
   const build = new Cd();
   discoverTargets(build);
-  return { build, store, actor: "sweeper", reporter, now: () => now };
+  return {
+    build,
+    store,
+    actor: "sweeper",
+    reporter,
+    now: () => now,
+    ...(buildId === undefined ? {} : { buildId }),
+  };
+}
+
+/** Rewrite the seeded record with `mutate` applied. */
+async function amend(
+  store: FileSystemStateStore,
+  id: string,
+  mutate: (record: RunRecord) => void,
+): Promise<void> {
+  const loaded = await store.getRun(id);
+  if (loaded === null) throw new Error("seed missing");
+  const next = structuredClone(loaded.record);
+  mutate(next);
+  assertEquals((await store.putRun(next, loaded.version)).ok, true);
 }
 
 Deno.test("a run whose holder is still there is left alone", async () => {
@@ -404,5 +425,82 @@ Deno.test("a colliding build with a different graph does not finish a stranded r
     assertEquals(outcome.settled, []);
     // Left for the build that recognises it.
     assertEquals((await store.getRun("run-1"))?.record.status, "cancelling");
+  });
+});
+
+Deno.test("a run from another origin is not touched, whatever its shape", async () => {
+  // The case the shape checks cannot see: one `zuke.ts` templated across two
+  // services, so the class name, the root target and the graph all agree and
+  // only the target bodies differ. The recorded origin is what separates them.
+  await withStore(
+    [record("run-1", "running", "2026-08-10T11:00:00.000Z")],
+    async (store) => {
+      await amend(store, "run-1", (r) => {
+        r.buildId = "acme/web";
+      });
+      const { reporter } = capturing();
+      const outcome = await reapAbandoned(
+        depsFor(store, reporter, NOW, "acme/api"),
+      );
+      // Neither settled for its deadline nor handed back — a resume of it would
+      // run this build's bodies against the other service's run.
+      assertEquals(outcome.settled, []);
+      assertEquals(outcome.reaped, []);
+      assertEquals((await store.getRun("run-1"))?.record.status, "running");
+    },
+  );
+});
+
+Deno.test("a stranded run from another origin is left for its own build", async () => {
+  await withStore([record("run-1", "cancelling")], async (store) => {
+    await amend(store, "run-1", (r) => {
+      r.buildId = "acme/web";
+    });
+    const { reporter } = capturing();
+    const outcome = await recoverStranded(
+      depsFor(store, reporter, NOW, "acme/api"),
+    );
+    assertEquals(outcome.settled, []);
+    assertEquals((await store.getRun("run-1"))?.record.status, "cancelling");
+  });
+});
+
+Deno.test("a run with no recorded origin is still reaped", async () => {
+  // The retrofit's whole safety: a record written before the field existed has
+  // no origin, and a sweep that refused it would leave the effects it owed
+  // never driven at all.
+  await withStore([record("run-1", "running")], async (store) => {
+    const { reporter } = capturing();
+    const outcome = await reapAbandoned(
+      depsFor(store, reporter, NOW, "acme/api"),
+    );
+    assertEquals(outcome.reaped, ["run-1"]);
+    assertEquals((await store.getRun("run-1"))?.record.status, "suspended");
+  });
+});
+
+Deno.test("a sweep with no origin of its own still reaps a run that has one", async () => {
+  // The mirror case: a process outside CI that sets no ZUKE_BUILD_ID cannot
+  // claim to be a different build, so it must not refuse on that basis.
+  await withStore([record("run-1", "running")], async (store) => {
+    await amend(store, "run-1", (r) => {
+      r.buildId = "acme/api";
+    });
+    const { reporter } = capturing();
+    const outcome = await reapAbandoned(depsFor(store, reporter));
+    assertEquals(outcome.reaped, ["run-1"]);
+  });
+});
+
+Deno.test("a run from the same origin is reaped normally", async () => {
+  await withStore([record("run-1", "running")], async (store) => {
+    await amend(store, "run-1", (r) => {
+      r.buildId = "acme/api";
+    });
+    const { reporter } = capturing();
+    const outcome = await reapAbandoned(
+      depsFor(store, reporter, NOW, "acme/api"),
+    );
+    assertEquals(outcome.reaped, ["run-1"]);
   });
 });

--- a/packages/core/tests/resume_test.ts
+++ b/packages/core/tests/resume_test.ts
@@ -2,7 +2,12 @@ import { assertEquals, assertRejects, messageOf } from "./_assert.ts";
 import { Build, discoverTargets } from "../src/build.ts";
 import { target } from "../src/target.ts";
 import { execute } from "../src/executor.ts";
-import { AlreadyResumedError, resumeCheck, resumeRun } from "../src/resume.ts";
+import {
+  AlreadyResumedError,
+  resumeCheck,
+  resumeRun,
+  RunNotSuspendedError,
+} from "../src/resume.ts";
 import { ForeignRunError } from "../src/ownership.ts";
 import { FileSystemStateStore } from "../src/state/fs_store.ts";
 import { defaultStateHost, type PutResult } from "../src/state/store.ts";
@@ -648,5 +653,60 @@ Deno.test("a run recorded with no origin is still resumable", async () => {
     });
     assertEquals(result.ok, true);
     assertEquals(promoted, 1);
+  });
+});
+
+Deno.test("a sweep does not count a run another process already finished", async () => {
+  // Two sweeps racing one run is the normal case. The loser lists the run as
+  // suspended, and by the time it resumes, the winner has finished it — so it
+  // reads a terminal status. That is a discovered success, not a fault, and
+  // counting it would put a false alarm in the exit code a cron watches.
+  await withTempStore(async (store) => {
+    class B extends Build {
+      go = target().executes(() => {});
+    }
+    const b = new B();
+    discoverTargets(b);
+    await execute(b, b.go, { silent: true, stateStore: store });
+    const runId = (await store.listRuns({}))[0].id;
+    assertEquals((await store.getRun(runId))?.record.status, "succeeded");
+
+    const lines: string[] = [];
+    const outcome = await resumeCheck(b, {
+      runId,
+      stateStore: store,
+      silent: true,
+      reporter: { info: (l) => lines.push(l), error: (l) => lines.push(l) },
+    });
+    assertEquals(outcome.failed, 0);
+    // Skipped, but said out loud — a sweep that swallowed it would be
+    // indistinguishable from one that advanced the run.
+    assertEquals(
+      lines.some((l) => l.includes("no longer")),
+      true,
+    );
+  });
+});
+
+Deno.test("the typed error carries the status it found instead", async () => {
+  await withTempStore(async (store) => {
+    class B extends Build {
+      go = target().executes(() => {});
+    }
+    const b = new B();
+    discoverTargets(b);
+    await execute(b, b.go, { silent: true, stateStore: store });
+    const runId = (await store.listRuns({}))[0].id;
+
+    // Naming one run by hand still reports it: the caller asked about that run.
+    const error = await assertRejects(
+      () => resumeRun(b, { runId, stateStore: store, silent: true }),
+      RunNotSuspendedError,
+      "not suspended",
+    );
+    assertEquals(error instanceof RunNotSuspendedError, true);
+    if (!(error instanceof RunNotSuspendedError)) return;
+    assertEquals(error.runId, runId);
+    assertEquals(error.status, "succeeded");
   });
 });

--- a/packages/core/tests/resume_test.ts
+++ b/packages/core/tests/resume_test.ts
@@ -3,6 +3,7 @@ import { Build, discoverTargets } from "../src/build.ts";
 import { target } from "../src/target.ts";
 import { execute } from "../src/executor.ts";
 import { AlreadyResumedError, resumeCheck, resumeRun } from "../src/resume.ts";
+import { ForeignRunError } from "../src/ownership.ts";
 import { FileSystemStateStore } from "../src/state/fs_store.ts";
 import { defaultStateHost, type PutResult } from "../src/state/store.ts";
 import type { RunRecord } from "../src/state/types.ts";
@@ -498,5 +499,154 @@ Deno.test("resumeCheck sweeps suspended runs and advances satisfied predicates",
     });
     assertEquals(second.failed, 0);
     assertEquals(ran, true);
+  });
+});
+
+Deno.test("a resume refuses a run another build owns", async () => {
+  // The gap the shape checks leave: one `zuke.ts` templated across two services
+  // agrees on every target name and edge, so the graph check passes and the
+  // resume would run *this* service's bodies against the other's run. Only the
+  // recorded origin separates them.
+  await withTempStore(async (store) => {
+    let promoted = 0;
+    const makeBuild = () => {
+      class CD extends Build {
+        deploy = target().executes(() => {});
+        gate = target()
+          .dependsOn(this.deploy)
+          .waitsFor((s) => s.on(externalSignal("approved")));
+        promote = target().dependsOn(this.gate).executes(() => {
+          promoted += 1;
+        });
+      }
+      const build = new CD();
+      discoverTargets(build);
+      return build;
+    };
+    const envOf = (id: string) => (name: string) =>
+      name === "ZUKE_BUILD_ID" ? id : undefined;
+
+    const a = makeBuild();
+    const started = await execute(a, a.promote, {
+      silent: true,
+      stateStore: store,
+      readEnv: envOf("acme/api"),
+    });
+    assertEquals(started.suspended, true);
+    const runId = (await store.listRuns({}))[0].id;
+    assertEquals((await store.getRun(runId))?.record.buildId, "acme/api");
+
+    const other = makeBuild();
+    const error = await assertRejects(() =>
+      resumeRun(other, {
+        runId,
+        signal: "approved",
+        silent: true,
+        stateStore: store,
+        readEnv: envOf("acme/web"),
+      }), ForeignRunError);
+    assertEquals(messageOf(error).includes("acme/api"), true);
+    // Nothing ran, and the run is exactly as it was left.
+    assertEquals(promoted, 0);
+    assertEquals((await store.getRun(runId))?.record.status, "suspended");
+  });
+});
+
+Deno.test("a sweep skips another build's run without counting it failed", async () => {
+  // A cron watches the failure count. Counting a run this build must not touch
+  // would report a permanent non-zero result that no operator could ever clear.
+  await withTempStore(async (store) => {
+    const makeBuild = () => {
+      class CD extends Build {
+        deploy = target().executes(() => {});
+        gate = target()
+          .dependsOn(this.deploy)
+          .waitsFor((s) => s.on(externalSignal("approved")));
+        promote = target().dependsOn(this.gate).executes(() => {});
+      }
+      const build = new CD();
+      discoverTargets(build);
+      return build;
+    };
+    const envOf = (id: string) => (name: string) =>
+      name === "ZUKE_BUILD_ID" ? id : undefined;
+
+    const a = makeBuild();
+    await execute(a, a.promote, {
+      silent: true,
+      stateStore: store,
+      readEnv: envOf("acme/api"),
+    });
+    const runId = (await store.listRuns({}))[0].id;
+    const before = await store.getRun(runId);
+
+    const lines: string[] = [];
+    const outcome = await resumeCheck(makeBuild(), {
+      silent: true,
+      stateStore: store,
+      readEnv: envOf("acme/web"),
+      reporter: { info: (l) => lines.push(l), error: (l) => lines.push(l) },
+    });
+    // Counted and reported once. A sweep that skipped everything in silence
+    // would look exactly like one with nothing to do — which is how a mistyped
+    // ZUKE_BUILD_ID would present: recovery quietly stops.
+    assertEquals(
+      lines.some((l) =>
+        l.includes("skipped 1 run(s) belonging to another build") &&
+        l.includes("acme/web")
+      ),
+      true,
+    );
+    assertEquals(outcome.checked, 1);
+    assertEquals(outcome.failed, 0);
+    // Skipped, not driven-and-re-suspended: the record was never written, so its
+    // store version is the one the suspending process left. Comparing the status
+    // alone would not tell the two apart — a foreign resume re-suspends at the
+    // same gate and lands back on `suspended`.
+    const after = await store.getRun(runId);
+    assertEquals(after?.record.status, "suspended");
+    assertEquals(after?.version, before?.version);
+  });
+});
+
+Deno.test("a run recorded with no origin is still resumable", async () => {
+  // The retrofit's safety: a record written before the field existed has no
+  // origin, and a resume that refused it would strand whatever it owed.
+  await withTempStore(async (store) => {
+    let promoted = 0;
+    const makeBuild = () => {
+      class CD extends Build {
+        deploy = target().executes(() => {});
+        gate = target()
+          .dependsOn(this.deploy)
+          .waitsFor((s) => s.on(externalSignal("approved")));
+        promote = target().dependsOn(this.gate).executes(() => {
+          promoted += 1;
+        });
+      }
+      const build = new CD();
+      discoverTargets(build);
+      return build;
+    };
+
+    const a = makeBuild();
+    // No origin in the environment, so none is recorded.
+    await execute(a, a.promote, {
+      silent: true,
+      stateStore: store,
+      readEnv: () => undefined,
+    });
+    const runId = (await store.listRuns({}))[0].id;
+    assertEquals((await store.getRun(runId))?.record.buildId, undefined);
+
+    const result = await resumeRun(makeBuild(), {
+      runId,
+      signal: "approved",
+      silent: true,
+      stateStore: store,
+      readEnv: (name) => name === "ZUKE_BUILD_ID" ? "acme/api" : undefined,
+    });
+    assertEquals(result.ok, true);
+    assertEquals(promoted, 1);
   });
 });

--- a/packages/core/tests/state_test.ts
+++ b/packages/core/tests/state_test.ts
@@ -1399,3 +1399,17 @@ Deno.test("acquireCancelLock renews on a heartbeat and blocks a second holder", 
     await Deno.remove(dir, { recursive: true });
   }
 });
+
+Deno.test("a run's origin round-trips, and its absence stays an absence", () => {
+  const withOrigin = sampleRecord({ buildId: "acme/api" });
+  assertEquals(parseRunRecord(stringifyRunRecord(withOrigin)), withOrigin);
+
+  // An older record has no `buildId` key at all, and must parse back without
+  // one: an origin invented on read would be an origin that matches nothing,
+  // and every recovery path would refuse the run.
+  const older = sampleRecord();
+  assertEquals("buildId" in older, false);
+  const parsed = parseRunRecord(stringifyRunRecord(older));
+  assertEquals("buildId" in parsed, false);
+  assertEquals(parsed.buildId, undefined);
+});

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/skills/zuke-write-build/SKILL.md
+++ b/plugins/zuke/skills/zuke-write-build/SKILL.md
@@ -138,7 +138,10 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   the same sweep. `override deadline()` gives a run a wall-clock budget
   (`"45m"`, or milliseconds) that survives suspension; an abandoned run found
   past it is settled `failed` with its compensations instead of resumed.
-  See the cheatsheet.
+  On a **shared** store, set `ZUKE_BUILD_ID` (or rely on `GITHUB_REPOSITORY`) so
+  each build only recovers its own runs — a resume runs *this* build's bodies
+  against whatever record it is given, and a templated `zuke.ts` looks identical
+  to the shape checks. See the cheatsheet.
 - **Cross-run locks:** `.lock((s) => s.lockKey(...).withTtl("4h"))` — a settings
   lambda — gives a target an exclusive claim across runs/machines; a second run
   wanting the same key fails with a `LockConflictError` naming the holder. The

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -238,6 +238,9 @@ class CD extends Build {
   none. Every recovery path (`resume`, `resume --check`, `cancel`, the reaper)
   compares it; a sweep silently **skips** a foreign run (so a cron's exit code
   stays meaningful) and a by-name `resume <id>` / `cancel <id>` **reports** it.
+  An origin only ever **narrows** what the shape checks permit — it can refuse a
+  run, never claim one — so two builds in one repository, which share the
+  repository default, stay separated by the build-name check exactly as before.
   An absent origin on either side abstains rather than refusing, so records
   written before the field existed stay recoverable — which means in a container
   you must set `ZUKE_BUILD_ID` yourself (there is no `GITHUB_REPOSITORY` in a

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -229,6 +229,22 @@ class CD extends Build {
   **past** its deadline is not handed back: the reaper settles it `failed` and
   runs its compensations. Without a deadline a reaped run is always returned to
   `suspended` and resumed.
+- **Whose run is it — `ZUKE_BUILD_ID`.** A shared store means a sweep sees every
+  build's runs, and recovery does not merely read them: a resume runs **this**
+  build's target bodies against the record it is handed. The shape checks (build
+  class name, root target, graph) cannot separate one `zuke.ts` templated across
+  a dozen services — same names, same graph, different bodies. So a run records
+  an **origin** at creation: `ZUKE_BUILD_ID`, else `GITHUB_REPOSITORY`, else
+  none. Every recovery path (`resume`, `resume --check`, `cancel`, the reaper)
+  compares it; a sweep silently **skips** a foreign run (so a cron's exit code
+  stays meaningful) and a by-name `resume <id>` / `cancel <id>` **reports** it.
+  An absent origin on either side abstains rather than refusing, so records
+  written before the field existed stay recoverable — which means in a container
+  you must set `ZUKE_BUILD_ID` yourself (there is no `GITHUB_REPOSITORY` in a
+  CronJob), using the same value everywhere that build runs. Alternatively give
+  each build its own URL prefix on the shared service
+  (`ZUKE_STATE_URL=https://state/svc-a`) and neither can see the other's runs at
+  all. See `docs/orchestration.md`.
 - **Never put secrets in `ctx.state`** — it is stored as plain JSON. Secret
   parameters are excluded from the record and state values are run through the
   redactor, but treat state as a non-secret channel. See `docs/state.md`.
@@ -415,7 +431,9 @@ gate = target().dependsOn(this.checks).always()
   run's lease to tell a dead holder from a slow one, returns an abandoned run to
   `suspended`, and resumes it in the same pass (see Run leases above) — unless
   the run is past its `deadline()`, in which case it is settled `failed` and its
-  effects are never driven.
+  effects are never driven. On a shared store the sweep must share the run's
+  origin, or it skips the run and the effect is never driven — see
+  `ZUKE_BUILD_ID` above.
 
 ## Fan-out over a list — `.forEach()`
 

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -248,6 +248,11 @@ class CD extends Build {
   each build its own URL prefix on the shared service
   (`ZUKE_STATE_URL=https://state/svc-a`) and neither can see the other's runs at
   all. See `docs/orchestration.md`.
+- **What a sweep counts as failed.** Not a race it lost: a run another process is
+  already driving, one that process finished between the listing and the resume,
+  and a run belonging to another build are all skipped and reported, never
+  counted. A degraded record *is* counted, on every sweep, because only an
+  operator can decide whether its targets are safe to repeat.
 - **Never put secrets in `ctx.state`** — it is stored as plain JSON. Secret
   parameters are excluded from the record and state values are run through the
   redactor, but treat state as a non-secret channel. See `docs/state.md`.

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -138,7 +138,10 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   the same sweep. `override deadline()` gives a run a wall-clock budget
   (`"45m"`, or milliseconds) that survives suspension; an abandoned run found
   past it is settled `failed` with its compensations instead of resumed.
-  See the cheatsheet.
+  On a **shared** store, set `ZUKE_BUILD_ID` (or rely on `GITHUB_REPOSITORY`) so
+  each build only recovers its own runs — a resume runs *this* build's bodies
+  against whatever record it is given, and a templated `zuke.ts` looks identical
+  to the shape checks. See the cheatsheet.
 - **Cross-run locks:** `.lock((s) => s.lockKey(...).withTtl("4h"))` — a settings
   lambda — gives a target an exclusive claim across runs/machines; a second run
   wanting the same key fails with a `LockConflictError` naming the holder. The

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -238,6 +238,9 @@ class CD extends Build {
   none. Every recovery path (`resume`, `resume --check`, `cancel`, the reaper)
   compares it; a sweep silently **skips** a foreign run (so a cron's exit code
   stays meaningful) and a by-name `resume <id>` / `cancel <id>` **reports** it.
+  An origin only ever **narrows** what the shape checks permit — it can refuse a
+  run, never claim one — so two builds in one repository, which share the
+  repository default, stay separated by the build-name check exactly as before.
   An absent origin on either side abstains rather than refusing, so records
   written before the field existed stay recoverable — which means in a container
   you must set `ZUKE_BUILD_ID` yourself (there is no `GITHUB_REPOSITORY` in a

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -229,6 +229,22 @@ class CD extends Build {
   **past** its deadline is not handed back: the reaper settles it `failed` and
   runs its compensations. Without a deadline a reaped run is always returned to
   `suspended` and resumed.
+- **Whose run is it — `ZUKE_BUILD_ID`.** A shared store means a sweep sees every
+  build's runs, and recovery does not merely read them: a resume runs **this**
+  build's target bodies against the record it is handed. The shape checks (build
+  class name, root target, graph) cannot separate one `zuke.ts` templated across
+  a dozen services — same names, same graph, different bodies. So a run records
+  an **origin** at creation: `ZUKE_BUILD_ID`, else `GITHUB_REPOSITORY`, else
+  none. Every recovery path (`resume`, `resume --check`, `cancel`, the reaper)
+  compares it; a sweep silently **skips** a foreign run (so a cron's exit code
+  stays meaningful) and a by-name `resume <id>` / `cancel <id>` **reports** it.
+  An absent origin on either side abstains rather than refusing, so records
+  written before the field existed stay recoverable — which means in a container
+  you must set `ZUKE_BUILD_ID` yourself (there is no `GITHUB_REPOSITORY` in a
+  CronJob), using the same value everywhere that build runs. Alternatively give
+  each build its own URL prefix on the shared service
+  (`ZUKE_STATE_URL=https://state/svc-a`) and neither can see the other's runs at
+  all. See `docs/orchestration.md`.
 - **Never put secrets in `ctx.state`** — it is stored as plain JSON. Secret
   parameters are excluded from the record and state values are run through the
   redactor, but treat state as a non-secret channel. See `docs/state.md`.
@@ -415,7 +431,9 @@ gate = target().dependsOn(this.checks).always()
   run's lease to tell a dead holder from a slow one, returns an abandoned run to
   `suspended`, and resumes it in the same pass (see Run leases above) — unless
   the run is past its `deadline()`, in which case it is settled `failed` and its
-  effects are never driven.
+  effects are never driven. On a shared store the sweep must share the run's
+  origin, or it skips the run and the effect is never driven — see
+  `ZUKE_BUILD_ID` above.
 
 ## Fan-out over a list — `.forEach()`
 

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -248,6 +248,11 @@ class CD extends Build {
   each build its own URL prefix on the shared service
   (`ZUKE_STATE_URL=https://state/svc-a`) and neither can see the other's runs at
   all. See `docs/orchestration.md`.
+- **What a sweep counts as failed.** Not a race it lost: a run another process is
+  already driving, one that process finished between the listing and the resume,
+  and a run belonging to another build are all skipped and reported, never
+  counted. A degraded record *is* counted, on every sweep, because only an
+  operator can decide whether its targets are safe to repeat.
 - **Never put secrets in `ctx.state`** — it is stored as plain JSON. Secret
   parameters are excluded from the record and state values are run through the
   redactor, but treat state as a non-secret channel. See `docs/state.md`.

--- a/tests/e2e/reap_takeover_e2e.ts
+++ b/tests/e2e/reap_takeover_e2e.ts
@@ -18,12 +18,18 @@ import {
 
 const FIXTURE = new URL("./fixtures/effect_build.ts", import.meta.url);
 
-/** Run the fixture as a real `deno` subprocess against `dir`. */
+/**
+ * Run the fixture as a real `deno` subprocess against `dir`.
+ *
+ * Both streams are returned, because the interesting failure here is a sweeper
+ * exiting non-zero and the reason is on stderr — a race that only shows up on a
+ * slower runner is unreadable if the diagnosis is thrown away.
+ */
 async function run(
   args: string[],
   dir: string,
   marker: string,
-): Promise<{ code: number; out: string }> {
+): Promise<{ code: number; out: string; err: string }> {
   const command = new Deno.Command(Deno.execPath(), {
     // A `file://` URL rather than URL.pathname, which is `/C:/…` on Windows.
     args: ["run", "-A", FIXTURE.href, ...args],
@@ -31,8 +37,13 @@ async function run(
     stdout: "piped",
     stderr: "piped",
   });
-  const { code, stdout } = await command.output();
-  return { code, out: new TextDecoder().decode(stdout) };
+  const { code, stdout, stderr } = await command.output();
+  const decoder = new TextDecoder();
+  return {
+    code,
+    out: decoder.decode(stdout),
+    err: decoder.decode(stderr),
+  };
 }
 
 /** The marker file's lines, or an empty list if it does not exist yet. */
@@ -80,7 +91,16 @@ Deno.test("two sweepers race an abandoned run; exactly one reaps it", async () =
       run(["resume", "--check"], dir, marker),
       run(["resume", "--check"], dir, marker),
     ]);
-    assertEquals([a.code, b.code], [0, 0]);
+    // Both sweepers must exit clean. The loser has not failed — it either could
+    // not take the lease, or found the run already finished — and a sweep that
+    // reported either as a failure would put a false alarm in a cron's exit code.
+    assertEquals(
+      [a.code, b.code],
+      [0, 0],
+      `a sweeper exited non-zero: [${a.code}, ${b.code}]\n` +
+        `--- a stdout ---\n${a.out}\n--- a stderr ---\n${a.err}\n` +
+        `--- b stdout ---\n${b.out}\n--- b stderr ---\n${b.err}`,
+    );
 
     // Driven exactly once more, by exactly one of them. Two would mean both
     // sweepers took the run over, which the lease exists to prevent.

--- a/tests/integration/ownership_test.ts
+++ b/tests/integration/ownership_test.ts
@@ -1,0 +1,136 @@
+/**
+ * Integration tests for run ownership, driven through the real CLI.
+ *
+ * The hazard these close is the one the shape checks cannot see. A `zuke.ts`
+ * templated across services agrees on its class name, its target names and its
+ * graph, and differs only in what the bodies do — so one service's
+ * `zuke resume --check` against a shared state store would pick up another
+ * service's suspended run and execute its own bodies against that record.
+ * A recorded origin is what separates them, and an absent one still abstains, so
+ * a run written before the field existed remains recoverable.
+ *
+ * @module
+ */
+
+import { assertEquals } from "../../packages/core/tests/_assert.ts";
+import {
+  Build,
+  defaultStateHost,
+  FileSystemStateStore,
+  target,
+} from "../../packages/core/mod.ts";
+import type { RunRecord } from "../../packages/core/mod.ts";
+import { runCli, withStateDir } from "./_harness.ts";
+
+/** The (single) run record the CLI persisted under `dir`. */
+async function onlyRun(dir: string): Promise<RunRecord> {
+  const store = new FileSystemStateStore(dir, defaultStateHost);
+  const runs = await store.listRuns({});
+  assertEquals(runs.length, 1);
+  const got = await store.getRun(runs[0].id);
+  if (got === null) throw new Error("the run vanished");
+  return got.record;
+}
+
+/**
+ * Run `fn` with `ZUKE_BUILD_ID` set to `id`, restoring whatever was there.
+ *
+ * The same shape as the harness's own `withStateDir`: the CLI reads its origin
+ * from the environment, so an integration test has to set it there.
+ */
+async function withBuildId(id: string, fn: () => Promise<void>): Promise<void> {
+  const prev = Deno.env.get("ZUKE_BUILD_ID");
+  Deno.env.set("ZUKE_BUILD_ID", id);
+  try {
+    await fn();
+  } finally {
+    if (prev === undefined) Deno.env.delete("ZUKE_BUILD_ID");
+    else Deno.env.set("ZUKE_BUILD_ID", prev);
+  }
+}
+
+Deno.test("a sweep drives its own build's run and leaves another's alone", async () => {
+  await withStateDir(async (dir) => {
+    const promoted: string[] = [];
+    // The gate is shut on the first pass and open afterwards, so a sweep that
+    // *does* pick the run up finishes it — which is what tells a skipped run
+    // from one that was driven and merely re-suspended.
+    let gateOpen = false;
+    class Cd extends Build {
+      deploy = target().executes(() => {});
+      gate = target().dependsOn(this.deploy).waitsFor((s) =>
+        s.on({ descriptor: "the gate", isSatisfied: () => gateOpen })
+      );
+      promote = target().dependsOn(this.gate).executes(() => {
+        promoted.push("promote");
+      });
+    }
+
+    await withBuildId("acme/api", async () => {
+      assertEquals((await runCli(Cd, ["promote"])).code, 0);
+    });
+    const suspended = await onlyRun(dir);
+    assertEquals(suspended.status, "suspended");
+    assertEquals(suspended.buildId, "acme/api");
+    assertEquals(promoted, []);
+
+    gateOpen = true;
+
+    // Another service's sweep, over the same store. The gate is open, so without
+    // the ownership check this would run *this* build's `promote` against that
+    // run — and report success while doing it.
+    await withBuildId("acme/web", async () => {
+      const swept = await runCli(Cd, ["resume", "--check"]);
+      // Skipped, not failed: a cron watches the exit code, and a foreign run
+      // must not make it permanently non-zero.
+      assertEquals(swept.code, 0);
+    });
+    assertEquals(promoted, []);
+    assertEquals((await onlyRun(dir)).status, "suspended");
+
+    // The owning service's sweep finishes it.
+    await withBuildId("acme/api", async () => {
+      assertEquals((await runCli(Cd, ["resume", "--check"])).code, 0);
+    });
+    assertEquals(promoted, ["promote"]);
+    assertEquals((await onlyRun(dir)).status, "succeeded");
+  });
+});
+
+Deno.test("a run recorded with no origin is still swept", async () => {
+  // No ZUKE_BUILD_ID and no GITHUB_REPOSITORY in the environment of either pass,
+  // so nothing is recorded and nothing is compared — the behaviour every build
+  // had before the field existed, and the reason its absence abstains.
+  await withStateDir(async (dir) => {
+    const promoted: string[] = [];
+    let gateOpen = false;
+    class Cd extends Build {
+      deploy = target().executes(() => {});
+      gate = target().dependsOn(this.deploy).waitsFor((s) =>
+        s.on({ descriptor: "the gate", isSatisfied: () => gateOpen })
+      );
+      promote = target().dependsOn(this.gate).executes(() => {
+        promoted.push("promote");
+      });
+    }
+
+    const prevId = Deno.env.get("ZUKE_BUILD_ID");
+    const prevRepo = Deno.env.get("GITHUB_REPOSITORY");
+    Deno.env.delete("ZUKE_BUILD_ID");
+    Deno.env.delete("GITHUB_REPOSITORY");
+    try {
+      assertEquals((await runCli(Cd, ["promote"])).code, 0);
+      const suspended = await onlyRun(dir);
+      assertEquals(suspended.status, "suspended");
+      assertEquals(suspended.buildId, undefined);
+
+      gateOpen = true;
+      assertEquals((await runCli(Cd, ["resume", "--check"])).code, 0);
+      assertEquals(promoted, ["promote"]);
+      assertEquals((await onlyRun(dir)).status, "succeeded");
+    } finally {
+      if (prevId !== undefined) Deno.env.set("ZUKE_BUILD_ID", prevId);
+      if (prevRepo !== undefined) Deno.env.set("GITHUB_REPOSITORY", prevRepo);
+    }
+  });
+});


### PR DESCRIPTION
## The gap

A state store is commonly shared across builds, and a run listing has no build
filter — so every recovery sweep sees every build's runs. That matters more than
it sounds, because recovery does not merely read a foreign run. A reap hands it
back to suspended; a resume then runs **this** build's target bodies against that
record; a settlement runs this build's compensations.

Only the reaper compared the recorded build name. The resume path compared
nothing at all beyond shape — the root target exists here, and the graph agrees.
So the case that actually happens in practice slipped both: one build file
templated across a dozen services, agreeing on class name, target names and
graph edges, differing only in what the bodies do. One service's
`zuke resume --check` would pick up another service's suspended run and execute
its own code against it, reporting success while doing so.

No class-name collision was even required, since the resume path never consulted
the name.

## What this changes

A run records an **origin** when it is created: `ZUKE_BUILD_ID`, else
`GITHUB_REPOSITORY`, else none. Every recovery path — resume, the sweep, cancel,
and the reaper — compares it and touches a run only when the two origins agree.

- A **sweep skips** a foreign run without counting it a failure, so a cron's exit
  code stays meaningful. It reports the count once per pass, because a sweep that
  skipped everything in silence would be indistinguishable from one with nothing
  to do — which is exactly how a mistyped origin would present.
- Naming one run by hand reports the refusal instead, since the caller asked
  about a run that is not this build's to touch.
- **An absent origin abstains rather than refusing.** A record written before the
  field existed has none, and so does a process outside CI that sets nothing.
  Refusing there would trade a rare wrong execution for a common failure to
  recover, and a run nobody recovers never drives the effects it owed. That is
  the worse outcome, so absence is permissive by design.
- In a container there is no repository in the environment, so set the variable
  yourself, with the same value everywhere a given build runs.

The two shape checks stay, and still decide on their own when no origin is
recorded.

## Also documented: namespace the store

Every path the HTTP store builds hangs off the URL it is given, so pointing each
build at its own prefix on one shared service isolates them completely. That is
stronger than comparing origins, because there is nothing to compare — neither
build can see the other's runs. Now written down as the first option where the
operator controls the state service.

## Supersedes the advice in the previous commit

The earlier docs change on this branch recommended renaming the build class.
That only ever helped the reaper, the single path that compared the name, and it
left the resume path — the one that executes code — untouched. The reaper comment
asserting that a resume refuses a build it cannot match was wrong for the same
reason, and is corrected.

## Not in scope, deliberately

`zuke runs prune` still selects across every build in the store. It deletes only
terminal records, on an explicit operator command with explicit retention rules,
so it cannot cause a wrong execution — and the run summaries it works from carry
no origin, so filtering would mean widening the wire contract. Flagging it rather
than folding it in.

## Tests

Unit coverage for origin resolution and the abstain cases; reap, resume and
cancel each proved to leave a foreign run untouched and to still recover one with
no recorded origin; an integration test drives the whole thing through the real
CLI, showing one service's sweep skip a run that the owning service's sweep then
completes. Every new guard was mutation-checked by disabling it and confirming
the tests fail.

Full gate green, 19 of 19, plus the e2e suite.
