### PR TITLE
fix(core): close three trust gaps at the backend, registry and cache boundaries

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -207,12 +207,26 @@ target:
 - Point them only at a cache **you control**, and prefer a
   [secret parameter](./parameters.md) or an environment variable over a
   hard-coded value.
+- **`ZUKE_REMOTE_CACHE_URL` must be `https:`.** A plaintext URL is refused
+  before the first request: an on-path attacker who answers it chooses the file
+  tree that gets written into your workspace, which needs no token to steal.
+  Loopback is exempt, and `ZUKE_ALLOW_INSECURE_URL=1` opts a deliberate
+  plaintext endpoint back in.
 - On CI, **restrict egress** to the cache host, so a misconfigured or overridden
   URL can't exfiltrate build artifacts.
-- **Restore is confined to the workspace.** Every archive entry is validated
-  before anything is written — an **absolute path**, or one containing a
-  **`..`** segment, is rejected outright — so a poisoned or malicious store
-  can't plant files outside the current directory.
+- **Restore is confined to the target's declared outputs.** Every archive entry
+  is validated before anything is written, so a rejected archive leaves no
+  half-written tree. An entry is refused when it is an **absolute path** or
+  contains a **`..`** segment; when it is a **symlink or directory entry**
+  (which archiving never produces, so its presence means something else built
+  the archive); when it lands under **`.git` or `.zuke`** — a restored git hook
+  runs on the next ordinary git command; and when it falls **outside the paths
+  the target declared with `.outputs(...)`**. That last one is what stops an
+  innocuous-looking `deno.json` or lockfile riding along in an otherwise valid
+  artifact.
+- **A refused archive is a cache miss, not a build failure.** The target
+  rebuilds and the refusal is reported as a warning — so whoever can write the
+  store cannot halt every build that reads it.
 
 ### Where it fits
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -244,6 +244,18 @@ tool in an already-running server with **no restart**:
   the allow-list and `--protect` globs match the **qualified**
   `<buildId>:<target>` name (e.g. `--allow-run=Api:*`, `--protect=Api:deploy`).
   Every mutating or denied call is [audited](#audit-log).
+- **Where it spawns from is checked too.** The registry names the launch
+  location, so a registry a second party can write to would otherwise be enough
+  to run attacker-chosen code. A **remote** entry module (anything that is not a
+  local path or `file:` URL — `https:`, `jsr:`, `npm:`, `data:`) is refused
+  unless its origin appears in `ZUKE_REGISTRY_LAUNCH_HOSTS` (comma- or
+  space-separated; `*` allows any; the token is the hostname, or the scheme when
+  the specifier carries none, like `jsr:`). An allow-listed `http:` origin additionally
+  needs `ZUKE_ALLOW_INSECURE_URL=1`; loopback does not. The check runs **before**
+  the `--confirm-destructive` prompt, so a refused location fails fast: the call
+  returns a structured `launch_origin_not_allowed` (or `insecure_launch_url`)
+  error and is audited as `denied`, with nothing spawned. Locations `./zuke
+  register` writes are local, so this is invisible to the ordinary setup.
 - **Parameters.** A run tool exposes the registered build's declared parameters
   as its input schema — keyed by the parameter's property name (e.g. `skipE2e`),
   with the kind, description, enum, and default from the descriptor. Supplied
@@ -279,7 +291,8 @@ tool in an already-running server with **no restart**:
   safety rides the store's CAS, so no new coordination is introduced.
 
 The registry resolves like the run store: `ZUKE_REGISTRY_URL`/`_TOKEN` or
-`ZUKE_REGISTRY_DIR`, a build's `registry()` override, else `.zuke/builds`.
+`ZUKE_REGISTRY_DIR`, a build's `registry()` override, else `.zuke/builds`. As
+with the run store, `ZUKE_REGISTRY_URL` must be `https:`.
 
 ## Safety
 

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -57,6 +57,19 @@ The **location** is one of two forms:
   (for a build fronted by a wrapper script). Hand-authored or produced by a
   custom registry; the runner honours it in the same way.
 
+> **A location is a launch command, so whoever writes the registry chooses what
+> `zuke mcp --registry` spawns.** A **remote** entry module — anything that is
+> not a local path or a `file:` URL, so `https:`, `jsr:`, `npm:`, `data:` — is
+> therefore **refused** unless the operator names its origin in
+> `ZUKE_REGISTRY_LAUNCH_HOSTS` (comma- or space-separated; `*` allows any).
+> Otherwise a registry entry would be enough to run attacker-chosen code with
+> `deno run -A` in the operator's workspace. The allow-list token is the
+> hostname, or the scheme when the specifier carries none (`jsr:`); an allow-listed
+> `http:` origin additionally needs `ZUKE_ALLOW_INSECURE_URL=1`, and loopback
+> needs no such opt-out. A refused launch is a structured tool error and an
+> audited `launch_origin_not_allowed` event — nothing is spawned. Local modules,
+> which is what `zuke register` writes, are unaffected.
+
 ## Backends
 
 Two dependency-free backends ship, mirroring the state layer.
@@ -84,7 +97,9 @@ The registry is resolved by the same precedence as the run store:
 2. a build's `registry()` override;
 3. the environment — `ZUKE_REGISTRY_URL` (with an optional
    `ZUKE_REGISTRY_TOKEN`) selects the HTTP backend, else `ZUKE_REGISTRY_DIR`
-   selects the filesystem backend;
+   selects the filesystem backend. `ZUKE_REGISTRY_URL` must be `https:` (see
+   [durable run state](./state.md#httpstatestore--hosted-service-for-production)
+   for why, and for the `ZUKE_ALLOW_INSECURE_URL` opt-out);
 4. for `zuke register`, a filesystem registry under `.zuke/builds` as the
    default, so the command works out of the box.
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -181,6 +181,17 @@ const store = new HttpStateStore({ url: "https://zuke-state.internal", token });
 > records (with non-secret parameters and target metadata) are sent there. Point
 > it only at a store you control, and prefer a secret parameter or an
 > environment variable over a hard-coded value.
+>
+> **`ZUKE_STATE_URL` must be `https:`.** A plaintext URL is refused before the
+> first request, with a named error and exit code 1. Confidentiality is the
+> obvious half — `ZUKE_STATE_TOKEN` travels with every request, and that token
+> forges run records, the audit trail, and the [locks](./locks.md) two deploys
+> rely on being exclusive. Integrity is the half that matters more and needs no
+> token at all: an on-path attacker who answers a plaintext request chooses what
+> a resume reads back. Loopback (`localhost`, `127.0.0.0/8`, `::1`) is exempt —
+> there is no path to sit on — and a deliberate plaintext endpoint elsewhere is
+> reachable with `ZUKE_ALLOW_INSECURE_URL=1`. The same rule and the same opt-out
+> apply to `ZUKE_REGISTRY_URL` and `ZUKE_REMOTE_CACHE_URL`.
 
 ## Concurrency & compare-and-swap
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -88,6 +88,8 @@ function appendJobSummary(markdown: string): boolean
 
 async function archiveOutputs(outputs: readonly string[], host: OutputHost): Promise<Uint8Array>
   Archive a target's `outputs` into a gzipped tar of their current contents.
+  A declared output that does not exist is skipped, as is anything under a
+  `.git` or `.zuke` directory.
 
 function assert(condition: unknown, message: string): asserts condition
   Assert that `condition` is truthy, narrowing it for the rest of the scope.
@@ -528,12 +530,25 @@ function resolveStateStore(option: StateStore | false | undefined, declared: Sta
   filesystem store under `<root>/.zuke/runs`. A plain build with no durable
   feature and no configuration gets `undefined`, so it carries zero overhead.
 
-async function restoreOutputs(artifact: Uint8Array, host: OutputHost): Promise<string[]>
+async function restoreOutputs(artifact: Uint8Array, host: OutputHost, outputs?: readonly string[]): Promise<string[]>
   Restore the files in `artifact` (a gzipped tar produced by
-  {@link archiveOutputs}) to disk, returning the paths written. Entry names are
-  validated first: an absolute path or one escaping the workspace (`..`) is
-  rejected before anything is written, so a malicious archive can't plant files
-  outside the current directory.
+  {@link archiveOutputs}) to disk, returning the paths written.
+
+  Every entry is validated before anything is written, so a rejected archive
+  leaves no half-written, partially-trusted output tree. An entry is refused
+  when its name is absolute or escapes the workspace with `..`, when it is a
+  symlink or directory entry (which {@link archiveOutputs} never produces),
+  when it lands under `.git` or `.zuke`, and — when `outputs` is given — when it
+  falls outside the target's declared outputs.
+
+  @param outputs
+      The declaring target's {@link TargetBuilder.outputs}. Pass them
+      whenever they are known, which is what the executor does: an archive built
+      from those outputs can only contain paths under them, so anything else is a
+      store that has been written to by something other than a Zuke build, and
+      restoring it would let that writer choose files anywhere in the workspace —
+      a `deno.json`, a lockfile, a script a later target runs. Omitting them keeps
+      the older, name-only confinement for a caller that has no output list.
 
 async function resumeCheck(build: Build, options: Omit<ResumeOptions, "runId" | "signal" | "data"> & { runId?: string; }): Promise<{ checked: number; failed: number; }>
   Re-attempt every suspended run in the store (or just `runId`): predicate-based

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -142,6 +142,8 @@ function appendJobSummary(markdown: string): boolean
 
 async function archiveOutputs(outputs: readonly string[], host: OutputHost): Promise<Uint8Array>
   Archive a target's `outputs` into a gzipped tar of their current contents.
+  A declared output that does not exist is skipped, as is anything under a
+  `.git` or `.zuke` directory.
 
 function assert(condition: unknown, message: string): asserts condition
   Assert that `condition` is truthy, narrowing it for the rest of the scope.
@@ -582,12 +584,25 @@ function resolveStateStore(option: StateStore | false | undefined, declared: Sta
   filesystem store under `<root>/.zuke/runs`. A plain build with no durable
   feature and no configuration gets `undefined`, so it carries zero overhead.
 
-async function restoreOutputs(artifact: Uint8Array, host: OutputHost): Promise<string[]>
+async function restoreOutputs(artifact: Uint8Array, host: OutputHost, outputs?: readonly string[]): Promise<string[]>
   Restore the files in `artifact` (a gzipped tar produced by
-  {@link archiveOutputs}) to disk, returning the paths written. Entry names are
-  validated first: an absolute path or one escaping the workspace (`..`) is
-  rejected before anything is written, so a malicious archive can't plant files
-  outside the current directory.
+  {@link archiveOutputs}) to disk, returning the paths written.
+
+  Every entry is validated before anything is written, so a rejected archive
+  leaves no half-written, partially-trusted output tree. An entry is refused
+  when its name is absolute or escapes the workspace with `..`, when it is a
+  symlink or directory entry (which {@link archiveOutputs} never produces),
+  when it lands under `.git` or `.zuke`, and — when `outputs` is given — when it
+  falls outside the target's declared outputs.
+
+  @param outputs
+      The declaring target's {@link TargetBuilder.outputs}. Pass them
+      whenever they are known, which is what the executor does: an archive built
+      from those outputs can only contain paths under them, so anything else is a
+      store that has been written to by something other than a Zuke build, and
+      restoring it would let that writer choose files anywhere in the workspace —
+      a `deno.json`, a lockfile, a script a later target runs. Omitting them keeps
+      the older, name-only confinement for a caller that has no output list.
 
 async function resumeCheck(build: Build, options: Omit<ResumeOptions, "runId" | "signal" | "data"> & { runId?: string; }): Promise<{ checked: number; failed: number; }>
   Re-attempt every suspended run in the store (or just `runId`): predicate-based

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -241,7 +241,22 @@ class FsCache implements BuildCache {
         return false;
       }
       if (artifact !== null) {
-        await restoreOutputs(artifact, this.#host);
+        // A refused archive is a cache miss, not a build failure. Restore
+        // validates entry names, entry kinds, and the declared-output scope
+        // before writing anything, and every one of those refusals means the
+        // artifact is not what this target archived — so rebuild, loudly.
+        // Throwing instead would let anyone who can write the store halt every
+        // build that reads it, and the store is documented as best-effort.
+        try {
+          await restoreOutputs(artifact, this.#host, target.outputs_);
+        } catch (error) {
+          this.#warn?.(
+            `remote cache restore for "${name}" was refused, rebuilding: ${
+              messageOf(error)
+            }`,
+          );
+          return false;
+        }
         this.#store[name] = fp;
         this.#dirty = true;
         this.#restored.add(target);

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -9,6 +9,7 @@ import { isEntryModule } from "./entry.ts";
 import { messageOf } from "./internal.ts";
 import { isCI } from "./host.ts";
 import { GraphError, validateGraph } from "./graph.ts";
+import { InsecureBackendUrlError } from "./http.ts";
 import { execute } from "./executor.ts";
 import type { Renderer } from "./renderer.ts";
 import {
@@ -1122,7 +1123,30 @@ async function runRuns(build: Build, parsed: ParsedArgs): Promise<number> {
   });
 }
 
+/**
+ * Run one CLI invocation, reporting a misconfigured backend URL as the
+ * configuration mistake it is. A plaintext `ZUKE_*_URL` is refused wherever it
+ * is resolved — a build run, `runs`, `resume`, `register` — so the report is
+ * here, around every command, rather than at each resolution site.
+ */
 export async function main(
+  BuildClass: new () => Build,
+  args: string[],
+  options: MainOptions = {},
+): Promise<number> {
+  try {
+    return await runCommand(BuildClass, args, options);
+  } catch (error) {
+    if (error instanceof InsecureBackendUrlError) {
+      console.error(error.message);
+      return 1;
+    }
+    throw error;
+  }
+}
+
+/** The body of {@link main}: parse the arguments and dispatch to the command. */
+async function runCommand(
   BuildClass: new () => Build,
   args: string[],
   options: MainOptions = {},

--- a/packages/core/src/http.ts
+++ b/packages/core/src/http.ts
@@ -64,6 +64,95 @@ export function redactUrl(raw: string): string {
 }
 
 /**
+ * The environment variable that opts a deployment out of {@link
+ * assertSecureBackendUrl}'s `https:` requirement, for a plaintext endpoint on a
+ * network the operator has decided to trust.
+ */
+export const ALLOW_INSECURE_ENV = "ZUKE_ALLOW_INSECURE_URL";
+
+/** Whether a hostname is loopback, so no network path exists to sit on. */
+export function isLoopbackHost(host: string): boolean {
+  return host === "localhost" || host === "::1" || host === "[::1]" ||
+    /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host);
+}
+
+/**
+ * Raised by {@link assertSecureBackendUrl} when a backend is configured with a
+ * plaintext URL. A distinct type so the CLI can report it as the configuration
+ * mistake it is — a named message and exit code 1 — rather than letting a stack
+ * trace escape as if the build had crashed.
+ */
+export class InsecureBackendUrlError extends Error {
+  /** The error name. */
+  override name = "InsecureBackendUrlError";
+  /** The environment variable (or setting) carrying the plaintext URL. */
+  readonly setting: string;
+  /** Build the error from the offending setting and the full explanation. */
+  constructor(setting: string, message: string) {
+    super(message);
+    this.setting = setting;
+  }
+}
+
+/**
+ * Refuse a plaintext URL for a backend Zuke both authenticates to and *trusts
+ * the answers from* — the state service, the build registry, and the remote
+ * cache.
+ *
+ * Confidentiality is the obvious half: a bearer token sent over `http:` is
+ * readable by anyone on the path, and that token can forge run records, the
+ * audit trail, and the cross-run locks two deploys rely on being exclusive.
+ *
+ * **Integrity is the half that matters more**, and it does not need a token at
+ * all. A registry descriptor is a launch command the MCP host will spawn, and a
+ * cache artifact is a file tree restored into the workspace — so an on-path
+ * attacker who can answer a plaintext request reaches code execution without
+ * stealing anything. That is why this refuses `http:` whether or not a
+ * credential is configured.
+ *
+ * Loopback is exempt: there is no path to sit on, and a local dev service on
+ * `http://localhost` is the ordinary way to work on one. A deliberate plaintext
+ * endpoint elsewhere is still reachable by setting {@link ALLOW_INSECURE_ENV},
+ * which is an explicit decision rather than a silent default.
+ *
+ * This guards the **environment** path — the `ZUKE_*_URL` variables, which are
+ * set by whoever configures the CI job or the shell. Constructing a store in
+ * code (`new HttpStateStore({ url })`, a `stateStore()` override) is deliberately
+ * left alone: that URL is first-party source in the build file, so writing it is
+ * itself the trust decision, and a build author who means to talk plaintext to a
+ * service on their own network should not have to also set an env var.
+ *
+ * @throws {InsecureBackendUrlError} naming the variable that relaxes it, when
+ *   `raw` is neither `https:` nor loopback and the opt-out is unset.
+ */
+export function assertSecureBackendUrl(
+  raw: string,
+  what: string,
+  readEnv: (name: string) => string | undefined,
+): void {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    // Not a URL at all: leave the complaint to whoever tries to use it, which
+    // reports the malformed value with its own context.
+    return;
+  }
+  if (url.protocol === "https:" || isLoopbackHost(url.hostname)) return;
+  const optOut = readEnv(ALLOW_INSECURE_ENV);
+  if (optOut !== undefined && optOut !== "") return;
+  throw new InsecureBackendUrlError(
+    what,
+    `${what} must use https: ${
+      redactUrl(raw)
+    } is plaintext, so anyone on the ` +
+      `path can read the token it is sent with and — worse — choose the ` +
+      `answer it gets back. Use an https URL, or set ${ALLOW_INSECURE_ENV}=1 ` +
+      `to accept the risk on a network you trust. Loopback needs no opt-out.`,
+  );
+}
+
+/**
  * Raised when an HTTP request returns a non-2xx status. The URL appears in the
  * message and on {@link url}, so it is passed through {@link redactUrl} first —
  * userinfo and credential query params never reach a log.

--- a/packages/core/src/mcp/registry_server.ts
+++ b/packages/core/src/mcp/registry_server.ts
@@ -35,6 +35,7 @@ import type { StateStore } from "../state/store.ts";
 import type { RunStateWriter } from "../state/writer.ts";
 import type { CliParameterInfo, CliTargetInfo } from "../describe.ts";
 import type { BuildLocation } from "../registry/descriptor.ts";
+import { launchDenial } from "../registry/launch_policy.ts";
 import type { BuildRegistry } from "../registry/registry.ts";
 import { openAuditLog } from "./audit.ts";
 import { targetMatcher, timingSafeEqual } from "./authz.ts";
@@ -723,6 +724,38 @@ export class RegistryMcpServer {
         id,
         textResult(
           `Invalid argument(s): ${validated.errors.join("; ")}.`,
+          true,
+        ),
+      );
+    }
+
+    // Where the descriptor says the build lives is as much an authorization
+    // question as which target it names: a registry a second party can write to
+    // could point the launch at code fetched from the network. Checked before
+    // the confirmation prompt, so a refused location fails fast rather than
+    // asking the operator to confirm a spawn that will never happen.
+    const denial = launchDenial(loaded.descriptor.location, this.#readEnv);
+    if (denial !== null) {
+      await this.#audit(
+        runName,
+        args,
+        "denied",
+        actor,
+        denial.reason,
+        knownParams,
+      );
+      return ok(
+        id,
+        textResult(
+          JSON.stringify(
+            {
+              error: denial.reason,
+              tool: runName,
+              hint: denial.detail,
+            },
+            null,
+            2,
+          ),
           true,
         ),
       );

--- a/packages/core/src/registry/launch_policy.ts
+++ b/packages/core/src/registry/launch_policy.ts
@@ -1,0 +1,129 @@
+/**
+ * The policy that decides whether a {@link BuildLocation} read out of a build
+ * registry may be spawned.
+ *
+ * {@link "../mcp/registry_server.ts".RegistryMcpServer} runs what the registry
+ * tells it to run. That is fine when the registry is the local
+ * `<root>/.zuke/builds` directory `zuke register` writes, and it is a remote
+ * code-execution primitive when the registry is an HTTP service, a shared
+ * directory, or anything else a second party can write to: a descriptor whose
+ * module is `https://attacker.example/x.ts` becomes `deno run -A` against
+ * attacker-controlled source, with every permission, in the operator's
+ * workspace.
+ *
+ * So a **remote** entry module is refused unless the operator names its host in
+ * {@link LAUNCH_HOSTS_ENV}. A local module — a bare path, a Windows drive path,
+ * or a `file:` URL, which is what {@link Deno.mainModule} yields and therefore
+ * what `zuke register` writes — is allowed: it is already code on the machine,
+ * reachable without the registry's help.
+ *
+ * @module
+ */
+
+import { ALLOW_INSECURE_ENV, isLoopbackHost } from "../http.ts";
+import type { BuildLocation } from "./descriptor.ts";
+
+/**
+ * The environment variable listing the hosts a remote entry module may be
+ * fetched from — comma- or space-separated (`ZUKE_REGISTRY_LAUNCH_HOSTS=
+ * "builds.example.com, jsr:"`). A lone `*` allows any, for an operator who has
+ * decided the registry itself is trusted.
+ *
+ * An entry is matched against the module's **launch origin**: the hostname for
+ * a URL that has one, and the scheme otherwise (`jsr:`, `npm:`, `data:`) — so a
+ * specifier that carries no hostname can be named too, rather than being one an
+ * operator has no way to allow.
+ */
+export const LAUNCH_HOSTS_ENV = "ZUKE_REGISTRY_LAUNCH_HOSTS";
+
+/** Why a launch location was refused: a stable reason plus a human explanation. */
+export interface LaunchDenial {
+  /** The stable, machine-readable reason (audited, and returned to the client). */
+  reason: string;
+  /** The operator-facing explanation naming what to change. */
+  detail: string;
+}
+
+/**
+ * Whether `raw` is a local filesystem path rather than a remote specifier. True
+ * for anything `URL` cannot parse (`./zuke.ts`, `/srv/build/zuke.ts`), for a
+ * `file:` URL, and for a Windows drive path — `new URL("C:\\src\\zuke.ts")`
+ * parses with a single-letter "scheme", which is a drive letter, not a scheme.
+ */
+function isLocalModule(raw: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return true;
+  }
+  if (url.protocol === "file:") return true;
+  return /^[a-zA-Z]:$/.test(url.protocol) && /^[a-zA-Z]:[\\/]/.test(raw);
+}
+
+/**
+ * The token a remote module is allowed by: its hostname when it has one, else
+ * its scheme (`jsr:`, `npm:`, `data:`).
+ */
+function launchOrigin(url: URL): string {
+  return url.hostname !== "" ? url.hostname : url.protocol;
+}
+
+/** Split {@link LAUNCH_HOSTS_ENV} into its entries, dropping empties. */
+function allowedOrigins(
+  readEnv: (name: string) => string | undefined,
+): string[] {
+  const raw = readEnv(LAUNCH_HOSTS_ENV) ?? "";
+  return raw.split(/[,\s]+/).map((entry) => entry.trim().toLowerCase()).filter(
+    (entry) => entry !== "",
+  );
+}
+
+/**
+ * Decide whether `location` may be spawned, returning `null` when it may and a
+ * {@link LaunchDenial} when it may not.
+ *
+ * A `command` location is not scheme-checked: its argv names programs already
+ * installed on the machine, so there is no fetch to gate. Registering a command
+ * location is itself the trust decision, and the MCP server's `--allow-run` /
+ * `--protect` tiers are what bound it.
+ */
+export function launchDenial(
+  location: BuildLocation,
+  readEnv: (name: string) => string | undefined,
+): LaunchDenial | null {
+  if (location.kind === "command") return null;
+  if (isLocalModule(location.module)) return null;
+  let url: URL;
+  try {
+    url = new URL(location.module);
+  } catch {
+    // Unreachable: isLocalModule() already accepted anything URL cannot parse.
+    return null;
+  }
+  const origin = launchOrigin(url);
+  const allowed = allowedOrigins(readEnv);
+  if (!allowed.includes("*") && !allowed.includes(origin.toLowerCase())) {
+    return {
+      reason: "launch_origin_not_allowed",
+      detail:
+        `Refusing to spawn a remote entry module from "${origin}": running it ` +
+        `would execute code this machine fetches from the network on a ` +
+        `registry's say-so. Add the origin to ${LAUNCH_HOSTS_ENV} (or "*" to ` +
+        `allow any) if that registry is trusted to name it.`,
+    };
+  }
+  if (url.protocol === "http:" && !isLoopbackHost(url.hostname)) {
+    const optOut = readEnv(ALLOW_INSECURE_ENV);
+    if (optOut === undefined || optOut === "") {
+      return {
+        reason: "insecure_launch_url",
+        detail:
+          `Refusing to spawn a plaintext entry module from "${origin}": ` +
+          `anyone on the path chooses the source that gets executed. Use an ` +
+          `https URL, or set ${ALLOW_INSECURE_ENV}=1 to accept the risk.`,
+      };
+    }
+  }
+  return null;
+}

--- a/packages/core/src/registry/resolve.ts
+++ b/packages/core/src/registry/resolve.ts
@@ -8,6 +8,7 @@
  * @module
  */
 
+import { assertSecureBackendUrl } from "../http.ts";
 import type { StateHost } from "../state/store.ts";
 import { FileSystemBuildRegistry } from "./fs_registry.ts";
 import { HttpBuildRegistry } from "./http_registry.ts";
@@ -25,6 +26,7 @@ export function envBuildRegistry(
 ): BuildRegistry | undefined {
   const url = readEnv("ZUKE_REGISTRY_URL");
   if (url !== undefined && url !== "") {
+    assertSecureBackendUrl(url, "ZUKE_REGISTRY_URL", readEnv);
     return new HttpBuildRegistry({
       url,
       token: readEnv("ZUKE_REGISTRY_TOKEN"),

--- a/packages/core/src/remote_cache.ts
+++ b/packages/core/src/remote_cache.ts
@@ -19,7 +19,7 @@
  */
 
 import { gunzip, gzip, tar, type TarEntry, untar } from "./compression.ts";
-import { HttpError } from "./http.ts";
+import { assertSecureBackendUrl, HttpError } from "./http.ts";
 
 /**
  * A content-addressed store for archived target outputs, keyed by
@@ -56,6 +56,8 @@ function normalize(path: string): string {
 /**
  * Collect every file under `outputs` (directories walked recursively) as tar
  * entries named by their normalised path, sorted so the archive is reproducible.
+ * Paths through a {@link FORBIDDEN_DIRS} directory are skipped, mirroring what
+ * {@link restoreOutputs} refuses to write back.
  */
 async function collectEntries(
   outputs: readonly string[],
@@ -63,6 +65,10 @@ async function collectEntries(
 ): Promise<TarEntry[]> {
   const entries: TarEntry[] = [];
   const walk = async (path: string): Promise<void> => {
+    // Never archive what restore would refuse to write back (see
+    // {@link FORBIDDEN_DIRS}): uploading a `.git` to a shared store would leak
+    // its history and leave the target permanently un-restorable.
+    if (isForbiddenPath(normalize(path))) return;
     const info = await host.stat(path);
     if (info === null) return; // a declared output that isn't there — skip it
     if (!info.isDirectory) {
@@ -79,7 +85,11 @@ async function collectEntries(
   return entries;
 }
 
-/** Archive a target's `outputs` into a gzipped tar of their current contents. */
+/**
+ * Archive a target's `outputs` into a gzipped tar of their current contents.
+ * A declared output that does not exist is skipped, as is anything under a
+ * `.git` or `.zuke` directory.
+ */
 export async function archiveOutputs(
   outputs: readonly string[],
   host: OutputHost,
@@ -108,20 +118,100 @@ function assertSafeEntryName(name: string): void {
 }
 
 /**
+ * Directory names no restored entry may pass through, whatever a target declares
+ * as an output. `.git` is the one that turns a poisoned cache into code
+ * execution: a restored `.git/hooks/pre-commit` or a rewritten `.git/config`
+ * runs on the developer's next ordinary git command. `.zuke` holds the run state
+ * and cache index Zuke itself trusts.
+ */
+const FORBIDDEN_DIRS = [".git", ".zuke"];
+
+/**
+ * Whether any segment of `name` (already normalised) is a
+ * {@link FORBIDDEN_DIRS} entry. Matched per segment rather than as a prefix,
+ * because a nested one is just as dangerous: a submodule's `sub/.git/hooks/…`
+ * runs on the same ordinary git command the top-level one would.
+ */
+function isForbiddenPath(name: string): boolean {
+  return name.toLowerCase().split("/").some((segment) =>
+    FORBIDDEN_DIRS.includes(segment)
+  );
+}
+
+/**
+ * Whether `name` (already normalised) is one of `outputs`, or nested under one.
+ * A declared output of `.` — the whole workspace — matches everything, which is
+ * what declaring it asked for.
+ */
+function isDeclaredOutput(name: string, outputs: readonly string[]): boolean {
+  return outputs.some((output) => {
+    const root = normalize(output).replace(/\/+$/, "");
+    if (root === "" || root === ".") return true;
+    return name === root || name.startsWith(`${root}/`);
+  });
+}
+
+/**
+ * Reject an archive entry that a legitimate {@link archiveOutputs} could not
+ * have produced: a symlink or a directory entry. Neither is ever archived —
+ * {@link collectEntries} emits regular files only — so their presence means the
+ * archive was built by something else, and restoring a symlink is how a later
+ * entry writes through it to a path the name checks approved.
+ */
+function assertPlainFileEntry(entry: TarEntry): void {
+  if (entry.linkname !== undefined) {
+    throw new Error(
+      `remote cache: refusing to restore a symlink from an archive: "${entry.name}".`,
+    );
+  }
+  if (entry.name.endsWith("/")) {
+    throw new Error(
+      `remote cache: refusing to restore a directory entry from an archive: "${entry.name}".`,
+    );
+  }
+}
+
+/**
  * Restore the files in `artifact` (a gzipped tar produced by
- * {@link archiveOutputs}) to disk, returning the paths written. Entry names are
- * validated first: an absolute path or one escaping the workspace (`..`) is
- * rejected before anything is written, so a malicious archive can't plant files
- * outside the current directory.
+ * {@link archiveOutputs}) to disk, returning the paths written.
+ *
+ * Every entry is validated before anything is written, so a rejected archive
+ * leaves no half-written, partially-trusted output tree. An entry is refused
+ * when its name is absolute or escapes the workspace with `..`, when it is a
+ * symlink or directory entry (which {@link archiveOutputs} never produces),
+ * when it lands under `.git` or `.zuke`, and — when `outputs` is given — when it
+ * falls outside the target's declared outputs.
+ *
+ * @param outputs The declaring target's {@link TargetBuilder.outputs}. Pass them
+ *   whenever they are known, which is what the executor does: an archive built
+ *   from those outputs can only contain paths under them, so anything else is a
+ *   store that has been written to by something other than a Zuke build, and
+ *   restoring it would let that writer choose files anywhere in the workspace —
+ *   a `deno.json`, a lockfile, a script a later target runs. Omitting them keeps
+ *   the older, name-only confinement for a caller that has no output list.
  */
 export async function restoreOutputs(
   artifact: Uint8Array,
   host: OutputHost,
+  outputs?: readonly string[],
 ): Promise<string[]> {
   const entries = untar(await gunzip(artifact));
-  // Validate every entry up front so a bad name aborts the whole restore
-  // instead of leaving a half-written, partially-trusted output tree.
-  for (const entry of entries) assertSafeEntryName(entry.name);
+  for (const entry of entries) {
+    assertSafeEntryName(entry.name);
+    assertPlainFileEntry(entry);
+    const name = normalize(entry.name);
+    if (isForbiddenPath(name)) {
+      throw new Error(
+        `remote cache: refusing to restore into a protected path: "${entry.name}".`,
+      );
+    }
+    if (outputs !== undefined && !isDeclaredOutput(name, outputs)) {
+      throw new Error(
+        `remote cache: refusing to restore "${entry.name}", which is outside ` +
+          `the target's declared outputs (${outputs.join(", ")}).`,
+      );
+    }
+  }
   const written: string[] = [];
   for (const entry of entries) {
     await host.writeFile(entry.name, entry.data);
@@ -267,6 +357,7 @@ export function envCacheStore(
 ): RemoteCacheStore | undefined {
   const url = readEnv("ZUKE_REMOTE_CACHE_URL");
   if (url !== undefined && url !== "") {
+    assertSecureBackendUrl(url, "ZUKE_REMOTE_CACHE_URL", readEnv);
     return new HttpCacheStore({
       url,
       token: readEnv("ZUKE_REMOTE_CACHE_TOKEN"),

--- a/packages/core/src/state/resolve.ts
+++ b/packages/core/src/state/resolve.ts
@@ -5,6 +5,7 @@
  * @module
  */
 
+import { assertSecureBackendUrl } from "../http.ts";
 import type { StateHost, StateStore } from "./store.ts";
 import { FileSystemStateStore } from "./fs_store.ts";
 import { HttpStateStore } from "./http_store.ts";
@@ -21,6 +22,7 @@ export function envStateStore(
 ): StateStore | undefined {
   const url = readEnv("ZUKE_STATE_URL");
   if (url !== undefined && url !== "") {
+    assertSecureBackendUrl(url, "ZUKE_STATE_URL", readEnv);
     return new HttpStateStore({ url, token: readEnv("ZUKE_STATE_TOKEN") });
   }
   const dir = readEnv("ZUKE_STATE_DIR");

--- a/packages/core/tests/backend_url_test.ts
+++ b/packages/core/tests/backend_url_test.ts
@@ -1,0 +1,178 @@
+/**
+ * Unit: the transport guard on the backends Zuke authenticates to and trusts
+ * answers from — the state service, the build registry, and the remote cache.
+ * Covers {@link assertSecureBackendUrl} itself and each `env*` resolver that
+ * calls it, so a resolver that forgets the check fails here.
+ */
+
+import { assertEquals, assertThrows } from "./_assert.ts";
+import {
+  ALLOW_INSECURE_ENV,
+  assertSecureBackendUrl,
+  isLoopbackHost,
+} from "../src/http.ts";
+import { envStateStore } from "../src/state/resolve.ts";
+import { envBuildRegistry } from "../src/registry/resolve.ts";
+import { envCacheStore } from "../src/remote_cache.ts";
+import type { StateHost } from "../src/state/store.ts";
+
+/** Build a `readEnv` over a plain record. */
+function env(
+  vars: Record<string, string>,
+): (name: string) => string | undefined {
+  return (name) => vars[name];
+}
+
+/** A {@link StateHost} that is never reached — these tests resolve, they do not store. */
+const unusedHost: StateHost = {
+  readText: () => Promise.reject(new Error("unused")),
+  writeText: () => Promise.reject(new Error("unused")),
+  rename: () => Promise.reject(new Error("unused")),
+  createExclusive: () => Promise.reject(new Error("unused")),
+  remove: () => Promise.reject(new Error("unused")),
+  listDir: () => Promise.reject(new Error("unused")),
+  mkdirp: () => Promise.reject(new Error("unused")),
+  now: () => 0,
+};
+
+Deno.test("assertSecureBackendUrl accepts https and rejects plaintext", () => {
+  assertSecureBackendUrl(
+    "https://state.example/api",
+    "ZUKE_STATE_URL",
+    env({}),
+  );
+  const error = assertThrows(
+    () =>
+      assertSecureBackendUrl(
+        "http://state.example/api",
+        "ZUKE_STATE_URL",
+        env({}),
+      ),
+    Error,
+  );
+  // The message must name both the variable at fault and the way out.
+  assertEquals(error.message.includes("ZUKE_STATE_URL"), true);
+  assertEquals(error.message.includes(ALLOW_INSECURE_ENV), true);
+});
+
+Deno.test("assertSecureBackendUrl refuses plaintext even with no token configured", () => {
+  // Integrity, not just confidentiality: an on-path attacker choosing the
+  // *answer* needs no credential to steal, so the guard cannot be conditional
+  // on one being set.
+  assertThrows(
+    () =>
+      assertSecureBackendUrl(
+        "http://cache.example",
+        "ZUKE_REMOTE_CACHE_URL",
+        env({}),
+      ),
+    Error,
+  );
+});
+
+Deno.test("assertSecureBackendUrl exempts loopback and honours the opt-out", () => {
+  for (
+    const url of [
+      "http://localhost:8000",
+      "http://127.0.0.1:9000/state",
+      "http://127.15.2.1/state",
+      "http://[::1]:8080",
+    ]
+  ) {
+    assertSecureBackendUrl(url, "ZUKE_STATE_URL", env({}));
+  }
+  assertSecureBackendUrl(
+    "http://state.internal/api",
+    "ZUKE_STATE_URL",
+    env({ [ALLOW_INSECURE_ENV]: "1" }),
+  );
+  // An empty opt-out is not an opt-out.
+  assertThrows(
+    () =>
+      assertSecureBackendUrl(
+        "http://state.internal/api",
+        "ZUKE_STATE_URL",
+        env({ [ALLOW_INSECURE_ENV]: "" }),
+      ),
+    Error,
+  );
+});
+
+Deno.test("assertSecureBackendUrl redacts credentials in its message", () => {
+  const error = assertThrows(
+    () =>
+      assertSecureBackendUrl(
+        "http://user:hunter2@state.example/api?token=abcd",
+        "ZUKE_STATE_URL",
+        env({}),
+      ),
+    Error,
+  );
+  assertEquals(error.message.includes("hunter2"), false);
+  assertEquals(error.message.includes("abcd"), false);
+});
+
+Deno.test("assertSecureBackendUrl leaves a non-URL to its own consumer", () => {
+  // Not a URL at all: complaining here would report the wrong problem.
+  assertSecureBackendUrl("not a url", "ZUKE_STATE_URL", env({}));
+});
+
+Deno.test("isLoopbackHost recognises loopback names and the 127/8 block only", () => {
+  assertEquals(isLoopbackHost("localhost"), true);
+  assertEquals(isLoopbackHost("127.0.0.1"), true);
+  assertEquals(isLoopbackHost("::1"), true);
+  assertEquals(isLoopbackHost("example.com"), false);
+  assertEquals(isLoopbackHost("128.0.0.1"), false);
+  // A host that merely *contains* a loopback literal is not loopback.
+  assertEquals(isLoopbackHost("127.0.0.1.evil.example"), false);
+});
+
+Deno.test("every env-configured backend refuses a plaintext URL", () => {
+  assertThrows(
+    () =>
+      envStateStore(
+        env({ ZUKE_STATE_URL: "http://state.example" }),
+        unusedHost,
+      ),
+    Error,
+    "ZUKE_STATE_URL",
+  );
+  assertThrows(
+    () =>
+      envBuildRegistry(
+        env({ ZUKE_REGISTRY_URL: "http://registry.example" }),
+        unusedHost,
+      ),
+    Error,
+    "ZUKE_REGISTRY_URL",
+  );
+  assertThrows(
+    () => envCacheStore(env({ ZUKE_REMOTE_CACHE_URL: "http://cache.example" })),
+    Error,
+    "ZUKE_REMOTE_CACHE_URL",
+  );
+});
+
+Deno.test("every env-configured backend still resolves over https", () => {
+  assertEquals(
+    envStateStore(
+      env({ ZUKE_STATE_URL: "https://state.example" }),
+      unusedHost,
+    ) !==
+      undefined,
+    true,
+  );
+  assertEquals(
+    envBuildRegistry(
+      env({ ZUKE_REGISTRY_URL: "https://registry.example" }),
+      unusedHost,
+    ) !==
+      undefined,
+    true,
+  );
+  assertEquals(
+    envCacheStore(env({ ZUKE_REMOTE_CACHE_URL: "https://cache.example" })) !==
+      undefined,
+    true,
+  );
+});

--- a/packages/core/tests/cache_test.ts
+++ b/packages/core/tests/cache_test.ts
@@ -11,6 +11,7 @@ import {
   remoteCacheKey,
   type RemoteCacheStore,
 } from "../src/remote_cache.ts";
+import { gzip, tar } from "../src/compression.ts";
 
 const enc = (text: string) => new TextEncoder().encode(text);
 const dec = (bytes: Uint8Array) => new TextDecoder().decode(bytes);
@@ -303,4 +304,36 @@ Deno.test("targets without outputs never touch the remote store", async () => {
   await cache.record(t);
   assertEquals(store.gets, []);
   assertEquals(store.puts, []);
+});
+
+Deno.test("a poisoned remote archive is a cache miss and a warning, never a restore", async () => {
+  const host = new MemHost();
+  host.files.set("in.txt", enc("v1"));
+  const t = buildTarget(); // declares `dist` as its only output
+  const fp = await fingerprint(t, host);
+
+  // Whoever can write the store put a `deno.json` in the artifact. Restoring it
+  // would let them choose a file every later target reads.
+  const store = new MemStore();
+  store.map.set(
+    remoteCacheKey("build", fp),
+    await gzip(tar([
+      { name: "dist/app.js", data: enc("built") },
+      { name: "deno.json", data: enc('{ "tasks": { "x": "curl evil" } }') },
+    ])),
+  );
+
+  const warnings: string[] = [];
+  const cache = await openCache(STORE, host, {
+    remote: store,
+    warn: (m) => warnings.push(m),
+  });
+
+  // A miss, so the target rebuilds — the store cannot halt the build either.
+  assertEquals(await cache.upToDate(t), false);
+  assertStringIncludes(warnings.join("\n"), "refused");
+  assertStringIncludes(warnings.join("\n"), "declared outputs");
+  // Nothing from the archive landed, not even the entry that was in scope.
+  assertEquals(host.files.has("deno.json"), false);
+  assertEquals(host.files.has("dist/app.js"), false);
 });

--- a/packages/core/tests/launch_policy_test.ts
+++ b/packages/core/tests/launch_policy_test.ts
@@ -1,0 +1,163 @@
+/**
+ * Unit: {@link launchDenial} — the policy deciding whether a registry
+ * descriptor's launch location may be spawned. The registry server runs what
+ * the registry tells it to, so a descriptor pointing at a remote entry module is
+ * a remote code-execution primitive unless the operator named its origin.
+ */
+
+import { assertEquals } from "./_assert.ts";
+import {
+  LAUNCH_HOSTS_ENV,
+  launchDenial,
+} from "../src/registry/launch_policy.ts";
+import { ALLOW_INSECURE_ENV } from "../src/http.ts";
+import type { BuildLocation } from "../src/registry/descriptor.ts";
+
+/** Build a `readEnv` over a plain record. */
+function env(
+  vars: Record<string, string> = {},
+): (name: string) => string | undefined {
+  return (name) => vars[name];
+}
+
+/** A module-kind location for `module`. */
+function moduleAt(module: string): BuildLocation {
+  return { kind: "module", module, cwd: "/work" };
+}
+
+Deno.test("a local entry module is always allowed", () => {
+  for (
+    const module of [
+      "file:///srv/app/zuke.ts", // what `zuke register` writes (Deno.mainModule)
+      "/srv/app/zuke.ts",
+      "./zuke.ts",
+      "zuke.ts",
+      "C:\\src\\app\\zuke.ts",
+      "c:/src/app/zuke.ts",
+    ]
+  ) {
+    assertEquals(launchDenial(moduleAt(module), env()), null, module);
+  }
+});
+
+Deno.test("a remote entry module is refused unless its origin is allow-listed", () => {
+  const denial = launchDenial(
+    moduleAt("https://attacker.example/x.ts"),
+    env(),
+  );
+  assertEquals(denial?.reason, "launch_origin_not_allowed");
+  assertEquals(denial?.detail.includes("attacker.example"), true);
+  assertEquals(denial?.detail.includes(LAUNCH_HOSTS_ENV), true);
+
+  assertEquals(
+    launchDenial(
+      moduleAt("https://builds.example.com/zuke.ts"),
+      env({ [LAUNCH_HOSTS_ENV]: "builds.example.com" }),
+    ),
+    null,
+  );
+  // A list, with either separator, and matched case-insensitively.
+  assertEquals(
+    launchDenial(
+      moduleAt("https://Builds.Example.com/zuke.ts"),
+      env({ [LAUNCH_HOSTS_ENV]: "a.example, builds.example.com  b.example" }),
+    ),
+    null,
+  );
+  // Allow-listing one host does not admit another.
+  assertEquals(
+    launchDenial(
+      moduleAt("https://attacker.example/x.ts"),
+      env({ [LAUNCH_HOSTS_ENV]: "builds.example.com" }),
+    )?.reason,
+    "launch_origin_not_allowed",
+  );
+  // A suffix of an allow-listed host is a different host.
+  assertEquals(
+    launchDenial(
+      moduleAt("https://evil-builds.example.com/x.ts"),
+      env({ [LAUNCH_HOSTS_ENV]: "builds.example.com" }),
+    )?.reason,
+    "launch_origin_not_allowed",
+  );
+});
+
+Deno.test("a wildcard allow-list admits any origin", () => {
+  assertEquals(
+    launchDenial(
+      moduleAt("https://anywhere.example/x.ts"),
+      env({ [LAUNCH_HOSTS_ENV]: "*" }),
+    ),
+    null,
+  );
+});
+
+Deno.test("a remote specifier with no hostname is named by its scheme", () => {
+  // `deno run jsr:@scope/build` fetches and executes code just as an https URL
+  // does, but has no hostname — so the scheme is what an operator allow-lists.
+  assertEquals(
+    launchDenial(moduleAt("jsr:@scope/build"), env())?.reason,
+    "launch_origin_not_allowed",
+  );
+  assertEquals(
+    launchDenial(
+      moduleAt("jsr:@scope/build"),
+      env({ [LAUNCH_HOSTS_ENV]: "jsr:" }),
+    ),
+    null,
+  );
+  assertEquals(
+    launchDenial(moduleAt("npm:some-build"), env())?.reason,
+    "launch_origin_not_allowed",
+  );
+  assertEquals(
+    launchDenial(moduleAt("data:text/plain,console.log(1)"), env())?.reason,
+    "launch_origin_not_allowed",
+  );
+});
+
+Deno.test("an allow-listed plaintext origin still needs the insecure opt-out", () => {
+  const allowed = env({ [LAUNCH_HOSTS_ENV]: "builds.example.com" });
+  const denial = launchDenial(
+    moduleAt("http://builds.example.com/zuke.ts"),
+    allowed,
+  );
+  assertEquals(denial?.reason, "insecure_launch_url");
+  assertEquals(denial?.detail.includes(ALLOW_INSECURE_ENV), true);
+
+  assertEquals(
+    launchDenial(
+      moduleAt("http://builds.example.com/zuke.ts"),
+      env({
+        [LAUNCH_HOSTS_ENV]: "builds.example.com",
+        [ALLOW_INSECURE_ENV]: "1",
+      }),
+    ),
+    null,
+  );
+  // Loopback needs no opt-out — there is no path to sit on — but it is still
+  // remote code, so it is still allow-listed.
+  assertEquals(
+    launchDenial(
+      moduleAt("http://localhost:8000/zuke.ts"),
+      env({ [LAUNCH_HOSTS_ENV]: "localhost" }),
+    ),
+    null,
+  );
+  assertEquals(
+    launchDenial(moduleAt("http://localhost:8000/zuke.ts"), env())?.reason,
+    "launch_origin_not_allowed",
+  );
+});
+
+Deno.test("a command location is not scheme-checked", () => {
+  // Its argv names programs already on the machine; there is no fetch to gate,
+  // and `--allow-run`/`--protect` are what bound it.
+  assertEquals(
+    launchDenial(
+      { kind: "command", command: ["./zuke", "--"], cwd: "/work" },
+      env(),
+    ),
+    null,
+  );
+});

--- a/packages/core/tests/registry_server_test.ts
+++ b/packages/core/tests/registry_server_test.ts
@@ -1233,3 +1233,82 @@ Deno.test("registry HTTP serving does not head-of-line-block a read behind a run
     await finished;
   }
 });
+
+Deno.test("a descriptor pointing at a remote entry module is refused, not spawned", async () => {
+  const registry = new FakeRegistry();
+  registry.add(descriptor("Api", ["deploy"], {
+    kind: "module",
+    module: "https://attacker.example/x.ts",
+    cwd: "/r",
+  }));
+  const store = new FileSystemStateStore("/state", new FakeStateHost());
+  const { runner, calls } = recordingRunner();
+  const server = new RegistryMcpServer(registry, {
+    allowRun: true,
+    stateStore: store,
+    runner,
+    readEnv: () => undefined,
+  });
+
+  const result = await call(server, "run:Api:deploy");
+  assertEquals(result.isError, true);
+  assertStringIncludes(result.text, "launch_origin_not_allowed");
+  assertStringIncludes(result.text, "ZUKE_REGISTRY_LAUNCH_HOSTS");
+  assertEquals(calls.length, 0); // nothing was spawned
+
+  const audit = await store.getRun("mcp-audit");
+  assertEquals(
+    (audit?.record.events ?? []).some((e) =>
+      e.tool === "run:Api:deploy" && e.outcome === "denied" &&
+      e.detail === "launch_origin_not_allowed"
+    ),
+    true,
+  );
+});
+
+Deno.test("an allow-listed remote entry module spawns", async () => {
+  const registry = new FakeRegistry();
+  registry.add(descriptor("Api", ["deploy"], {
+    kind: "module",
+    module: "https://builds.example.com/zuke.ts",
+    cwd: "/r",
+  }));
+  const { runner, calls } = recordingRunner();
+  const server = new RegistryMcpServer(registry, {
+    allowRun: true,
+    runner,
+    readEnv: (name) =>
+      name === "ZUKE_REGISTRY_LAUNCH_HOSTS" ? "builds.example.com" : undefined,
+  });
+
+  const result = await call(server, "run:Api:deploy");
+  assertEquals(result.isError, false);
+  assertEquals(calls.length, 1);
+  assertEquals(
+    calls[0].argv.includes("https://builds.example.com/zuke.ts"),
+    true,
+  );
+});
+
+Deno.test("the launch check runs before the destructive-confirmation prompt", async () => {
+  // A refused location must fail fast, not ask the operator to confirm a spawn
+  // that could never happen.
+  const registry = new FakeRegistry();
+  registry.add(descriptor("Api", ["deploy"], {
+    kind: "module",
+    module: "https://attacker.example/x.ts",
+    cwd: "/r",
+  }));
+  const { runner, calls } = recordingRunner();
+  const server = new RegistryMcpServer(registry, {
+    allowRun: true,
+    confirmDestructive: true,
+    runner,
+    readEnv: () => undefined,
+  });
+
+  const result = await call(server, "run:Api:deploy", { confirm: true });
+  assertEquals(result.isError, true);
+  assertStringIncludes(result.text, "launch_origin_not_allowed");
+  assertEquals(calls.length, 0);
+});

--- a/packages/core/tests/remote_cache_test.ts
+++ b/packages/core/tests/remote_cache_test.ts
@@ -260,3 +260,105 @@ Deno.test("resolveRemoteStore honours option, then declared, then env", () => {
     undefined,
   );
 });
+
+Deno.test("restoreOutputs confines entries to the target's declared outputs", async () => {
+  const out = new MemFs();
+  // A poisoned archive stored under a legitimate key: the name is relative and
+  // has no `..`, so the older checks pass — but `deno.json` is not what this
+  // target archived, and restoring it would let whoever wrote the store choose
+  // a file every later target reads.
+  const poisoned = await gzip(
+    tar([
+      { name: "dist/app.js", data: enc("built") },
+      { name: "deno.json", data: enc("{}") },
+    ]),
+  );
+  const err = await assertRejects(() =>
+    restoreOutputs(poisoned, out, ["dist"])
+  );
+  assertStringIncludes(err.message, "outside the target's declared outputs");
+  assertEquals(out.files.size, 0); // validated up front — nothing written
+
+  // The same archive is fine when the target declares both.
+  const written = await restoreOutputs(poisoned, out, ["dist", "deno.json"]);
+  assertEquals(written, ["dist/app.js", "deno.json"]);
+});
+
+Deno.test("restoreOutputs matches a declared output by path segment, not prefix", async () => {
+  const out = new MemFs();
+  const sibling = await gzip(tar([{ name: "dist-evil/x.js", data: enc("x") }]));
+  const err = await assertRejects(() => restoreOutputs(sibling, out, ["dist"]));
+  assertStringIncludes(err.message, "outside the target's declared outputs");
+
+  // A declared output naming the whole workspace matches everything, which is
+  // what declaring it asked for.
+  assertEquals(
+    (await restoreOutputs(sibling, out, ["."])).length,
+    1,
+  );
+});
+
+Deno.test("restoreOutputs refuses protected paths whatever the outputs declare", async () => {
+  const out = new MemFs();
+  // A restored git hook runs on the developer's next ordinary git command, so
+  // `.git` is refused even by a target that declares the workspace root.
+  for (
+    const name of [
+      ".git/hooks/pre-commit",
+      ".GIT/config",
+      ".zuke/cache.json",
+      // A submodule's nested .git runs on the same ordinary git command.
+      "dist/sub/.git/hooks/pre-commit",
+    ]
+  ) {
+    const artifact = await gzip(tar([{ name, data: enc("#!/bin/sh\n") }]));
+    const err = await assertRejects(() => restoreOutputs(artifact, out, ["."]));
+    assertStringIncludes(err.message, "protected path");
+  }
+  assertEquals(out.files.size, 0);
+});
+
+Deno.test("restoreOutputs refuses entry kinds archiveOutputs never produces", async () => {
+  const out = new MemFs();
+  // A symlink is how a *later* entry writes through a name the checks approved.
+  const link = await gzip(
+    tar([{ name: "dist/link", data: new Uint8Array(0), linkname: "target" }]),
+  );
+  const linkErr = await assertRejects(() =>
+    restoreOutputs(link, out, ["dist"])
+  );
+  assertStringIncludes(linkErr.message, "symlink");
+
+  const dir = await gzip(tar([{ name: "dist/sub/", data: new Uint8Array(0) }]));
+  const dirErr = await assertRejects(() => restoreOutputs(dir, out, ["dist"]));
+  assertStringIncludes(dirErr.message, "directory entry");
+  assertEquals(out.files.size, 0);
+});
+
+Deno.test("restoreOutputs without declared outputs keeps the older confinement", async () => {
+  const out = new MemFs();
+  const artifact = await gzip(tar([{ name: "anywhere/x.js", data: enc("x") }]));
+  assertEquals(await restoreOutputs(artifact, out), ["anywhere/x.js"]);
+  // ...but the protected roots still hold.
+  const git = await gzip(tar([{ name: ".git/config", data: enc("x") }]));
+  const err = await assertRejects(() => restoreOutputs(git, out));
+  assertStringIncludes(err.message, "protected path");
+});
+
+Deno.test("archiveOutputs never archives what restore would refuse", async () => {
+  const src = new MemFs();
+  src.dirs.set("dist", ["app.js", ".git"]);
+  src.files.set("dist/app.js", enc("built"));
+  src.dirs.set("dist/.git", ["config"]);
+  src.files.set("dist/.git/config", enc("[core]"));
+
+  // Uploading a `.git` to a shared store would leak its history — and, since
+  // restore refuses it, would leave the target permanently un-restorable.
+  const out = new MemFs();
+  assertEquals(
+    await restoreOutputs(await archiveOutputs(["dist"], src), out, [
+      "dist",
+    ]),
+    ["dist/app.js"],
+  );
+});

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/skills/zuke-write-build/SKILL.md
+++ b/plugins/zuke/skills/zuke-write-build/SKILL.md
@@ -123,10 +123,14 @@ it cannot answer "does one exist for this tool?"; only the catalogue
 - **Caching:** `.inputs(...)` / `.outputs(...)` make a target incremental. Add a
   **remote store** to share results across machines (fresh CI, teammates);
   `--affected` runs only targets changed since a git base; `--no-cache` /
-  `--no-remote-cache` bypass them.
+  `--no-remote-cache` bypass them. A restore is confined to the target's
+  declared `.outputs(...)` (and never `.git`/`.zuke`); a refused archive is a
+  cache miss with a warning, not a failure.
 - **Durable run state:** persist a run's status and per-target metadata to a
   pluggable `StateStore` so it survives the process — turn it on with `--state`,
-  `ZUKE_STATE_DIR` / `ZUKE_STATE_URL`, or `override stateStore()`. In a body,
+  `ZUKE_STATE_DIR` / `ZUKE_STATE_URL`, or `override stateStore()`. Every
+  `ZUKE_*_URL` backend must be `https:` (loopback exempt; `ZUKE_ALLOW_INSECURE_URL=1`
+  opts out). In a body,
   `ctx.state.set({ … })` / `ctx.state.get()` records per-target metadata (JSON,
   **never secrets** — secret parameters and redacted values are excluded).
   Inspect persisted runs afterwards with `zuke runs list` (filter by
@@ -221,6 +225,10 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   instead serves every registered pipeline live, each as a
   `run:<buildId>:<target>` tool that takes the build's declared parameters
   (secrets excluded, validated, forwarded to the spawn) — see the cheatsheet.
+  Because the registry names *where* a build launches from, a descriptor with a
+  **remote** entry module is refused unless its origin is in
+  `ZUKE_REGISTRY_LAUNCH_HOSTS`; `zuke register` writes a local module, so this
+  only affects a hand-authored or second-party entry.
   For a shared, multi-user endpoint, `override mcpIdentity()` resolves a
   **trusted** caller per request from an authenticating proxy's header (it
   overrides the client-reported actor and flows to the audit trail, run records,

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -177,7 +177,11 @@ Persist a run's status and per-target metadata so it survives the process
 exiting. **Opt-in** — a plain build writes nothing. Enable a store by (first
 wins): `execute(..., { stateStore })` → `override stateStore()` →
 `ZUKE_STATE_URL` (+ `ZUKE_STATE_TOKEN`) → `ZUKE_STATE_DIR` → `--state` (defaults
-to `.zuke/runs`).
+to `.zuke/runs`). Every `ZUKE_*_URL` backend — state, registry, remote cache —
+**must be `https:`**: a plaintext one is refused with a named error and exit
+code 1, because an on-path attacker who answers it chooses what the build reads
+back. Loopback is exempt; `ZUKE_ALLOW_INSECURE_URL=1` opts a deliberate
+plaintext endpoint back in.
 
 ```ts
 import { Build, HttpStateStore, target } from "jsr:@zuke/core";
@@ -860,7 +864,13 @@ build as `--flag=value` arguments — validated against their kinds first (a typ
 mismatch is a clean tool error, never a failed subprocess). `.secret()`
 parameters are omitted from the descriptor entirely, so a secret can neither be
 requested nor forwarded; the child resolves it from its own environment /
-`.from()` source.
+`.from()` source. Because the registry names **where** a build is launched from,
+a descriptor whose entry module is **remote** (not a local path or `file:` URL —
+`https:`, `jsr:`, `npm:`, `data:`) is refused unless its origin is listed in
+`ZUKE_REGISTRY_LAUNCH_HOSTS` (`*` allows any); the call is denied and audited
+`launch_origin_not_allowed`, before the confirmation prompt, with nothing
+spawned. `zuke register` writes a local `file:` module, so this only bites a
+hand-authored or second-party registry entry.
 
 **Trusted per-call identity** (`docs/mcp.md`): on a shared, multi-user endpoint,
 `override mcpIdentity()` returns a hook `(ctx) => ({ actor, via? })` that
@@ -880,5 +890,10 @@ uses the local cache only. Declare one with `override remoteCache()` on the
 `Build` (returning `FileSystemCacheStore` or `HttpCacheStore`), or leave it and
 the executor falls back to the `ZUKE_REMOTE_CACHE_*` environment variables; it
 applies only to targets declaring **both** `inputs` and `outputs`. A remote
-store is best-effort — an unreachable one never fails the build. `--affected`
-limits a run to targets touched since a git base (great for CI job fan-out).
+store is best-effort — an unreachable one never fails the build. A **restore is
+confined to the target's declared `.outputs(...)`**, and refuses an absolute or
+`..` path, a symlink or directory entry, and anything under `.git`/`.zuke`; a
+refused archive is a cache miss (rebuild + warning), never a build failure, so
+whoever can write the store can neither plant files nor halt the build.
+`--affected` limits a run to targets touched since a git base (great for CI job
+fan-out).

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -123,10 +123,14 @@ it cannot answer "does one exist for this tool?"; only the catalogue
 - **Caching:** `.inputs(...)` / `.outputs(...)` make a target incremental. Add a
   **remote store** to share results across machines (fresh CI, teammates);
   `--affected` runs only targets changed since a git base; `--no-cache` /
-  `--no-remote-cache` bypass them.
+  `--no-remote-cache` bypass them. A restore is confined to the target's
+  declared `.outputs(...)` (and never `.git`/`.zuke`); a refused archive is a
+  cache miss with a warning, not a failure.
 - **Durable run state:** persist a run's status and per-target metadata to a
   pluggable `StateStore` so it survives the process — turn it on with `--state`,
-  `ZUKE_STATE_DIR` / `ZUKE_STATE_URL`, or `override stateStore()`. In a body,
+  `ZUKE_STATE_DIR` / `ZUKE_STATE_URL`, or `override stateStore()`. Every
+  `ZUKE_*_URL` backend must be `https:` (loopback exempt; `ZUKE_ALLOW_INSECURE_URL=1`
+  opts out). In a body,
   `ctx.state.set({ … })` / `ctx.state.get()` records per-target metadata (JSON,
   **never secrets** — secret parameters and redacted values are excluded).
   Inspect persisted runs afterwards with `zuke runs list` (filter by
@@ -221,6 +225,10 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   instead serves every registered pipeline live, each as a
   `run:<buildId>:<target>` tool that takes the build's declared parameters
   (secrets excluded, validated, forwarded to the spawn) — see the cheatsheet.
+  Because the registry names *where* a build launches from, a descriptor with a
+  **remote** entry module is refused unless its origin is in
+  `ZUKE_REGISTRY_LAUNCH_HOSTS`; `zuke register` writes a local module, so this
+  only affects a hand-authored or second-party entry.
   For a shared, multi-user endpoint, `override mcpIdentity()` resolves a
   **trusted** caller per request from an authenticating proxy's header (it
   overrides the client-reported actor and flows to the audit trail, run records,

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -177,7 +177,11 @@ Persist a run's status and per-target metadata so it survives the process
 exiting. **Opt-in** — a plain build writes nothing. Enable a store by (first
 wins): `execute(..., { stateStore })` → `override stateStore()` →
 `ZUKE_STATE_URL` (+ `ZUKE_STATE_TOKEN`) → `ZUKE_STATE_DIR` → `--state` (defaults
-to `.zuke/runs`).
+to `.zuke/runs`). Every `ZUKE_*_URL` backend — state, registry, remote cache —
+**must be `https:`**: a plaintext one is refused with a named error and exit
+code 1, because an on-path attacker who answers it chooses what the build reads
+back. Loopback is exempt; `ZUKE_ALLOW_INSECURE_URL=1` opts a deliberate
+plaintext endpoint back in.
 
 ```ts
 import { Build, HttpStateStore, target } from "jsr:@zuke/core";
@@ -860,7 +864,13 @@ build as `--flag=value` arguments — validated against their kinds first (a typ
 mismatch is a clean tool error, never a failed subprocess). `.secret()`
 parameters are omitted from the descriptor entirely, so a secret can neither be
 requested nor forwarded; the child resolves it from its own environment /
-`.from()` source.
+`.from()` source. Because the registry names **where** a build is launched from,
+a descriptor whose entry module is **remote** (not a local path or `file:` URL —
+`https:`, `jsr:`, `npm:`, `data:`) is refused unless its origin is listed in
+`ZUKE_REGISTRY_LAUNCH_HOSTS` (`*` allows any); the call is denied and audited
+`launch_origin_not_allowed`, before the confirmation prompt, with nothing
+spawned. `zuke register` writes a local `file:` module, so this only bites a
+hand-authored or second-party registry entry.
 
 **Trusted per-call identity** (`docs/mcp.md`): on a shared, multi-user endpoint,
 `override mcpIdentity()` returns a hook `(ctx) => ({ actor, via? })` that
@@ -880,5 +890,10 @@ uses the local cache only. Declare one with `override remoteCache()` on the
 `Build` (returning `FileSystemCacheStore` or `HttpCacheStore`), or leave it and
 the executor falls back to the `ZUKE_REMOTE_CACHE_*` environment variables; it
 applies only to targets declaring **both** `inputs` and `outputs`. A remote
-store is best-effort — an unreachable one never fails the build. `--affected`
-limits a run to targets touched since a git base (great for CI job fan-out).
+store is best-effort — an unreachable one never fails the build. A **restore is
+confined to the target's declared `.outputs(...)`**, and refuses an absolute or
+`..` path, a symlink or directory entry, and anything under `.git`/`.zuke`; a
+refused archive is a cache miss (rebuild + warning), never a build failure, so
+whoever can write the store can neither plant files nor halt the build.
+`--affected` limits a run to targets touched since a git base (great for CI job
+fan-out).

--- a/tests/integration/backend_trust_test.ts
+++ b/tests/integration/backend_trust_test.ts
@@ -1,0 +1,150 @@
+/**
+ * Integration: the two trust boundaries a build crosses without the author
+ * writing any code for them — the URL of a configured backend, and the contents
+ * of a remote-cache artifact. Both are driven through the real CLI
+ * ({@link runCli}), so the whole parse → resolve → execute path is exercised.
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import { Build, gzip, tar, target } from "../../packages/core/mod.ts";
+import { runCli, withStateDir } from "./_harness.ts";
+
+const enc = (text: string) => new TextEncoder().encode(text);
+
+/**
+ * Run `fn` with `vars` applied to the process environment, restoring each
+ * variable's previous value (or its absence) afterwards. The resolvers under
+ * test read the real environment, so a test must own it for its duration.
+ */
+async function withEnv(
+  vars: Record<string, string>,
+  fn: () => Promise<void>,
+): Promise<void> {
+  const previous = new Map<string, string | undefined>();
+  for (const [name, value] of Object.entries(vars)) {
+    previous.set(name, Deno.env.get(name));
+    Deno.env.set(name, value);
+  }
+  try {
+    await fn();
+  } finally {
+    for (const [name, value] of previous) {
+      if (value === undefined) Deno.env.delete(name);
+      else Deno.env.set(name, value);
+    }
+  }
+}
+
+/** Run `fn` inside a fresh temporary cwd, restoring and removing it after. */
+async function withTempCwd(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await Deno.makeTempDir({ prefix: "zuke-it-trust-" });
+  const original = Deno.cwd();
+  Deno.chdir(dir);
+  try {
+    await fn(dir);
+  } finally {
+    Deno.chdir(original);
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+Deno.test("a plaintext state-service URL fails the run instead of sending the token", async () => {
+  await withEnv(
+    {
+      ZUKE_STATE_URL: "http://state.example/api",
+      ZUKE_STATE_TOKEN: "tok-abc123",
+    },
+    async () => {
+      class B extends Build {
+        deploy = target().executes(() => {});
+      }
+      const result = await runCli(B, ["deploy"]);
+      assertEquals(result.code, 1);
+      const output = `${result.out}\n${result.err}`;
+      assertStringIncludes(output, "ZUKE_STATE_URL");
+      assertStringIncludes(output, "https");
+      // The message that reports the misconfiguration must not leak the token
+      // it was about to send over the wire.
+      assertEquals(output.includes("tok-abc123"), false);
+    },
+  );
+});
+
+Deno.test("a plaintext registry URL fails `register` the same way", async () => {
+  // The guard sits in every backend resolver, and the CLI reports it once,
+  // around every command — so a second command reaching a second backend gets
+  // the same named error and exit code, not a stack trace.
+  await withEnv({ ZUKE_REGISTRY_URL: "http://registry.example" }, async () => {
+    class B extends Build {
+      deploy = target().executes(() => {});
+    }
+    const result = await runCli(B, ["register"]);
+    assertEquals(result.code, 1);
+    const output = `${result.out}\n${result.err}`;
+    assertStringIncludes(output, "ZUKE_REGISTRY_URL");
+    assertStringIncludes(output, "ZUKE_ALLOW_INSECURE_URL");
+  });
+});
+
+Deno.test("a poisoned remote-cache artifact rebuilds the target instead of restoring it", async () => {
+  await withStateDir(async () => {
+    await withTempCwd(async (dir) => {
+      const remoteDir = await Deno.makeTempDir({ prefix: "zuke-it-poison-" });
+      await withEnv({ ZUKE_REMOTE_CACHE_DIR: remoteDir }, async () => {
+        try {
+          await Deno.writeTextFile(`${dir}/input.txt`, "v1");
+          const log: string[] = [];
+          class B extends Build {
+            build = target().inputs("input.txt").outputs("out.txt").executes(
+              async () => {
+                log.push("build");
+                await Deno.writeTextFile("out.txt", "built");
+              },
+            );
+          }
+
+          // A first run populates the store, so the archive lands under the key
+          // this target's fingerprint resolves to.
+          assertEquals((await runCli(B, ["build"])).code, 0);
+          assertEquals(log, ["build"]);
+
+          // Whoever can write the store replaces that archive with one carrying
+          // an extra file outside the target's declared outputs — the shape a
+          // cache-poisoning attack takes, since the name itself is innocuous.
+          const stored = [...Deno.readDirSync(remoteDir)].map((e) => e.name);
+          assertEquals(stored.length, 1);
+          await Deno.writeFile(
+            `${remoteDir}/${stored[0]}`,
+            await gzip(tar([
+              { name: "out.txt", data: enc("built") },
+              { name: "deno.json", data: enc('{"tasks":{"x":"curl evil"}}') },
+            ])),
+          );
+
+          // Simulate a fresh checkout: the local cache and output are gone, so
+          // the run reaches for the remote store.
+          await Deno.remove(`${dir}/.zuke`, { recursive: true });
+          await Deno.remove(`${dir}/out.txt`);
+
+          const second = await runCli(B, ["build"]);
+          assertEquals(second.code, 0);
+          assertEquals(log, ["build", "build"]); // rebuilt, not restored
+          assertEquals(await Deno.readTextFile(`${dir}/out.txt`), "built");
+          // The out-of-scope entry never landed, and the refusal was reported.
+          assertEquals(
+            await Deno.stat(`${dir}/deno.json`).then(() => true).catch(() =>
+              false
+            ),
+            false,
+          );
+          assertStringIncludes(`${second.out}\n${second.err}`, "refused");
+        } finally {
+          await Deno.remove(remoteDir, { recursive: true });
+        }
+      });
+    });
+  });
+});

--- a/tests/integration/registry_params_test.ts
+++ b/tests/integration/registry_params_test.ts
@@ -141,3 +141,70 @@ Deno.test("a registered build's parameters flow into the registry run tool", asy
     await Deno.remove(dir, { recursive: true });
   }
 });
+
+Deno.test("a registered remote entry module is refused by the run tool, not spawned", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "zuke-it-registry-launch-" });
+  try {
+    const registry = new FileSystemBuildRegistry(dir);
+    // Whoever can write the registry names where the build lives. Here that is
+    // a URL — the descriptor is serialized to JSON and parsed back before the
+    // server ever sees it, so this proves the location survives the round trip
+    // and is still refused.
+    await quietly(async () => {
+      const code = await registerCommand(new Deploy(), {
+        registry,
+        location: {
+          kind: "module",
+          module: "https://attacker.example/x.ts",
+          cwd: "/r",
+        },
+        readEnv: () => undefined,
+        now: () => "2026-01-01T00:00:00.000Z",
+      });
+      assertEquals(code, 0);
+    });
+
+    const calls: string[][] = [];
+    const runner: RegistryRunner = (argv) => {
+      calls.push([...argv]);
+      return Promise.resolve({ code: 0, stdout: "ok", stderr: "" });
+    };
+
+    const denied = callResult(
+      await new RegistryMcpServer(registry, {
+        allowRun: true,
+        runner,
+        readEnv: () => undefined,
+      }).handleMessage({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "run:Deploy:deploy", arguments: {} },
+      }),
+    );
+    assertEquals(denied.isError, true);
+    assertStringIncludes(denied.text, "launch_origin_not_allowed");
+    assertEquals(calls.length, 0);
+
+    // The same descriptor runs once the operator names the origin.
+    const allowed = callResult(
+      await new RegistryMcpServer(registry, {
+        allowRun: true,
+        runner,
+        readEnv: (name) =>
+          name === "ZUKE_REGISTRY_LAUNCH_HOSTS"
+            ? "attacker.example"
+            : undefined,
+      }).handleMessage({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "run:Deploy:deploy", arguments: {} },
+      }),
+    );
+    assertEquals(allowed.isError, false);
+    assertEquals(calls.length, 1);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});


### PR DESCRIPTION
## What & why

Zuke reads three things from outside the process and then *acts* on them: a backend URL from the environment, a launch location from the build registry, and a file tree from the remote cache. Each was validated for **shape** but not for **trust**. This PR closes all three — findings F6, F7 and F8 of the framework assessment — in one change, because they share a boundary and a test surface.

### F6 — every `ZUKE_*_URL` backend must be `https:`

The state service, the build registry and the remote cache were each reachable over plaintext. Confidentiality is the obvious half: the bearer token travels with every request, and that token forges run records, the audit trail, and the cross-run locks two deploys rely on being exclusive.

**Integrity is the half that matters more, and it needs no token at all.** A registry descriptor is a launch command the MCP host will spawn; a cache artifact is a file tree restored into the workspace. An on-path attacker who answers a plaintext request reaches code execution without stealing anything — which is why the guard refuses `http:` whether or not a credential is configured, rather than only when a token is set.

- Loopback (`localhost`, `127.0.0.0/8`, `::1`) is exempt — there is no path to sit on, and a local dev service is the ordinary way to work on one.
- `ZUKE_ALLOW_INSECURE_URL=1` opts a deliberate plaintext endpoint back in.
- The refusal is a named `InsecureBackendUrlError` reported **once around every command**, so a misconfiguration is exit code 1 with a message naming the variable and the way out — not a stack trace escaping `main()` as if the build had crashed. The message runs through `redactUrl`, so the token it was about to send never lands in the report.
- The guard covers the **environment** path only. Constructing a store in code (a `stateStore()` override) is deliberately left alone: that URL is first-party source in the build file, so writing it is itself the trust decision.

> ⚠️ **Behaviour change.** A deployment pointing any `ZUKE_*_URL` at a non-loopback `http://` endpoint now fails until it moves to `https:` or sets `ZUKE_ALLOW_INSECURE_URL=1`.

### F7 — allow-list where a registry descriptor may be launched from

`zuke mcp --registry` runs what the registry tells it to run. That is fine for the local `.zuke/builds` directory `zuke register` writes, and it is a remote code-execution primitive for an HTTP service or a shared directory a second party can write to: a descriptor whose entry module is a URL becomes `deno run -A` against attacker-controlled source, with every permission, in the operator's workspace.

A **remote** entry module — anything that is not a local path or a `file:` URL — is now refused unless its origin appears in `ZUKE_REGISTRY_LAUNCH_HOSTS` (comma- or space-separated; `*` allows any). The allow-list token is the hostname, or the **scheme** when the specifier carries none (`jsr:`, `npm:`, `data:`), so a hostname-less specifier is nameable rather than being one an operator has no way to permit. An allow-listed `http:` origin additionally needs `ZUKE_ALLOW_INSECURE_URL=1`; loopback does not.

The check runs **before** the `--confirm-destructive` prompt, so a refused location fails fast instead of asking the operator to confirm a spawn that could never happen. A refusal is a structured tool error plus an audited `denied` event carrying `launch_origin_not_allowed` (or `insecure_launch_url`), with nothing spawned. A `command`-kind location is not scheme-checked and this is documented rather than papered over: its argv names programs already on the machine, so there is no fetch to gate, and `--allow-run` / `--protect` are what bound it.

Locations `zuke register` writes are local, so this is invisible to the ordinary setup.

### F8 — confine a cache restore to the target's declared outputs

Restore validated entry **names** (absolute, `..`) and then wrote every entry unconditionally. So a poisoned artifact could carry an entry whose name is perfectly innocuous — a `deno.json`, a lockfile, a script a later target runs — and it would land beside the real outputs. An archive built by `archiveOutputs` can only contain paths under the declared outputs, so anything else is a store written to by something that is not a Zuke build.

Restore now additionally refuses an entry that:

- falls outside the paths the target declared with `.outputs(...)`;
- is a **symlink or directory entry** — neither is ever archived, so their presence means something else built the archive, and a restored symlink is how a *later* entry writes through a name the checks already approved;
- passes through a `.git` or `.zuke` directory, matched **per segment** rather than as a prefix, so a submodule's `sub/.git/hooks/pre-commit` is covered as well as the top-level one. A restored git hook runs on the developer's next ordinary git command.

Archiving skips the same directories, so a shared store never receives a `.git` — which would both leak its history and leave the target permanently un-restorable.

**A refused archive is a cache miss, not a build failure.** The target rebuilds and the refusal is reported as a warning. Throwing would have handed anyone who can write the store the ability to halt every build that reads it, and the remote cache is documented as best-effort throughout.

The declared-outputs parameter on `restoreOutputs` is optional rather than required: making it required would be a breaking signature change for a v1 package, for a helper whose real caller (the executor) always passes it. Omitting it keeps the older name-only confinement, and the protected-directory and entry-kind refusals apply either way.

### Adversarial review

Two defects in this change were found and fixed by the adversarial pass, each with a regression test:

- the protected-path check was prefix-based, so a nested `.git` would have slipped through — now matched per path segment;
- a refused archive threw, turning a poisoned store into a denial-of-service against every build that read it — now a cache miss plus a warning.

## Related issues

None — this comes from the framework assessment (findings F6, F7, F8).

## Checklist

- [x] The PR title is a [Conventional Commit](https://www.conventionalcommits.org/) (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell). One caveat, stated plainly: the `security` target was skipped locally because zizmor's advisory lookup gets `403` from the GitHub API through this sandbox's proxy. Every other gate target ran green (18/19); `security` runs for real in CI.
- [x] Tests were added or updated; coverage stays at 95%+ (lines 96.8%, branches 95.4%). Unit: `backend_url_test.ts` (guard + all three resolvers), `launch_policy_test.ts`, plus new cases in `remote_cache_test.ts`, `cache_test.ts` and `registry_server_test.ts`. Integration: `tests/integration/backend_trust_test.ts` drives the plaintext refusal and a poisoned-artifact rebuild through the real CLI, and `registry_params_test.ts` round-trips a remote-module descriptor through a real `FileSystemBuildRegistry` before it is refused.
- [x] Docs updated in the same PR — `docs/state.md`, `docs/caching.md`, `docs/registry.md`, `docs/mcp.md`, both skills, and the plugin copies (version bumped `0.6.0` → `0.7.0` in both manifests).
- [x] Public API changes were regenerated with `./zuke apiDocs`.
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/`.
- [ ] A new package was wired into all seven places — n/a, no new package.
- [x] The code is written using AI assisted coding.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RYNxgcvdii7P8pPhD6U8q2)_