### PR TITLE
fix(core): stop a lost lease from rolling back a run another process owns

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -94,6 +94,15 @@ details worth knowing:
   dependents still run. Caching a target doesn't strand what depends on it.
 - The fingerprint is recorded **only after a successful run** — a failed target
   is never marked up-to-date.
+- **A cancelled run persists nothing.** A target records its fingerprint the
+  moment its body returns, but a cancellation then unwinds those targets through
+  their [compensations](./orchestration.md#cancellation--compensation--oncancel).
+  Saving would mark work up-to-date that was just rolled back — and the
+  outputs-still-exist check does not catch it, because a compensation usually
+  reverses a *side effect* (a deployment, a migration) rather than deleting a
+  file. So the whole store is left untouched and the next run rebuilds. The same
+  applies when a run stops because its [lease](./locks.md#the-runs-own-lease) was
+  taken over: whoever holds the run now decides what its outputs are.
 - **`--no-cache`** (or `execute(..., { cache: false })`) ignores the cache
   entirely and re-runs every target.
 - **`--dry-run`** never reads or writes the cache: it prints the plan without

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -94,15 +94,19 @@ details worth knowing:
   dependents still run. Caching a target doesn't strand what depends on it.
 - The fingerprint is recorded **only after a successful run** — a failed target
   is never marked up-to-date.
-- **A cancelled run persists nothing.** A target records its fingerprint the
-  moment its body returns, but a cancellation then unwinds those targets through
-  their [compensations](./orchestration.md#cancellation--compensation--oncancel).
-  Saving would mark work up-to-date that was just rolled back — and the
-  outputs-still-exist check does not catch it, because a compensation usually
-  reverses a *side effect* (a deployment, a migration) rather than deleting a
-  file. So the whole store is left untouched and the next run rebuilds. The same
-  applies when a run stops because its [lease](./locks.md#the-runs-own-lease) was
-  taken over: whoever holds the run now decides what its outputs are.
+- **A cancelled run persists its cache only if nothing was rolled back.** A
+  target records its fingerprint the moment its body returns, and a
+  [compensation](./orchestration.md#cancellation--compensation--oncancel) then
+  reverses that work — usually a *side effect* (a deployment, a migration)
+  rather than the declared outputs, which is why the outputs-still-exist check
+  does not notice. So when a compensation runs, the whole store is left
+  untouched and the next run rebuilds. When **no** compensation runs — the
+  ordinary case, since most builds declare none — nothing was reversed and the
+  fingerprints are kept, so an interrupted build does not cost a full rebuild on
+  the next attempt. The store is also left alone whenever this process is not
+  the one that settled the cancellation, and when a run stops because its
+  [lease](./locks.md#the-runs-own-lease) was taken over: in both, somebody else
+  decides what the outputs are.
 - **`--no-cache`** (or `execute(..., { cache: false })`) ignores the cache
   entirely and re-runs every target.
 - **`--dry-run`** never reads or writes the cache: it prints the plan without

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -405,9 +405,6 @@ a run's full status survives the process that produced it.
   deleted only when it is **terminal** and matches neither. **Non-terminal**
   runs (`suspended`, `running`, `cancelling`) are never pruned. At least one
   rule is required, and `--dry-run` reports what would go without deleting.
-  A pruned run takes its own lock records with it — its
-  [lease](./locks.md#the-runs-own-lease) and its cancel lock are named after the
-  run, so once it is gone they could never be looked up again.
   See [retention](./state.md#retention) for who owns it on each backend.
 
 Both accept `--json` — `list` emits the summary array, `show` emits the whole

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -405,6 +405,9 @@ a run's full status survives the process that produced it.
   deleted only when it is **terminal** and matches neither. **Non-terminal**
   runs (`suspended`, `running`, `cancelling`) are never pruned. At least one
   rule is required, and `--dry-run` reports what would go without deleting.
+  A pruned run takes its own lock records with it — its
+  [lease](./locks.md#the-runs-own-lease) and its cancel lock are named after the
+  run, so once it is gone they could never be looked up again.
   See [retention](./state.md#retention) for who owns it on each backend.
 
 Both accept `--json` — `list` emits the summary array, `show` emits the whole

--- a/docs/locks.md
+++ b/docs/locks.md
@@ -98,9 +98,14 @@ holder is gone and the run can be taken over.
 - **A resume refuses a run whose holder has not let go.** Two processes working
   one run is worse than a delayed resume, so the claim is checked before the
   compare-and-swap and a resumer that cannot take it stops.
-- **Losing it stops the run.** If a renewal is refused — the claim is
-  demonstrably somebody else's now — the run aborts rather than carrying on
-  beside whoever took it over.
+- **Losing it stops the run — it does not cancel it.** If a renewal is refused —
+  the claim is demonstrably somebody else's now — the run stops rather than
+  carrying on beside whoever took it over. Stopping is *all* it does: it does
+  **not** run the compensations, and it does **not** settle the record. Both
+  belong to the new holder now, and unwinding work that holder is already
+  building on would be the very "two processes on one run" the lease exists to
+  prevent. Per-target progress already queued is flushed, nothing new is started,
+  and the process reports that the run was taken over.
 - **A refused renewal is loss; a failed one is not.** A store answers "no" when
   the claim has changed hands, but it *throws* for a filesystem mutex it could
   not take in time, or an HTTP 503, or a DNS blip. None of those say who holds
@@ -113,7 +118,15 @@ holder is gone and the run can be taken over.
 - **Whoever takes the claim gives it back.** A resume releases the lease it took
   on every path out, including one where the run fails — a claim held by nobody
   would make a run that has demonstrably stopped look like one still being
-  worked on. A run that took its own lease releases it when it settles; if that
-  process breaks first, the claim lapses at its TTL instead.
+  worked on. A run that took its own lease releases it when it settles, and
+  **cancellation is settling**: a Ctrl-C'd run hands the claim back as soon as
+  its record is terminal, rather than holding it for the rest of the TTL. The two
+  exceptions are a lease that was *lost* (not ours to give back) and a process
+  that breaks before it can release, where the claim lapses at its TTL instead.
 - **A crashed holder's claim lapses at the TTL.** Nothing polls for it: expiry is
   evaluated by the store the next time somebody tries to acquire.
+- **A run that cannot take its lease does not start.** Acquiring is retried past
+  a store having a bad moment, but a store that never answers fails the run with
+  a named error rather than running unclaimed — a `running` record with no holder
+  is exactly what a sweep reads as abandoned, so running without one would leave
+  a healthy build looking dead for its whole duration.

--- a/docs/locks.md
+++ b/docs/locks.md
@@ -128,7 +128,12 @@ holder is gone and the run can be taken over.
   exceptions are a lease that was *lost* (not ours to give back) and a process
   that breaks before it can release, where the claim lapses at its TTL instead.
 - **A crashed holder's claim lapses at the TTL.** Nothing polls for it: expiry is
-  evaluated by the store the next time somebody tries to acquire.
+  evaluated by the store the next time somebody tries to acquire — and until
+  somebody does, a lapsed claim is still its holder's: a renewal extends it
+  whatever its expiry says. So "expired" is not "abandoned", and nothing may
+  delete a lock record on expiry alone. `runs prune` deliberately leaves them
+  behind for that reason; clearing one belongs to whoever can *prove* the holder
+  is gone, which a sweep does by acquiring it.
 - **A run that cannot take its lease does not start.** Acquiring is retried past
   a store having a bad moment, but a store that never answers fails the run with
   a named error rather than running unclaimed — a `running` record with no holder

--- a/docs/locks.md
+++ b/docs/locks.md
@@ -104,8 +104,12 @@ holder is gone and the run can be taken over.
   **not** run the compensations, and it does **not** settle the record. Both
   belong to the new holder now, and unwinding work that holder is already
   building on would be the very "two processes on one run" the lease exists to
-  prevent. Per-target progress already queued is flushed, nothing new is started,
-  and the process reports that the run was taken over.
+  prevent. Per-target progress already queued is dropped rather than flushed —
+  the writer stops writing the moment the claim is lost, so nothing it had left
+  to say lands on the new holder's record — nothing new is started, and the
+  process reports that the run was taken over. A claim lost *during* a
+  cancellation's rollback stops that walk where it stands, for the same reason:
+  the remaining compensations belong to whoever holds the run now.
 - **A refused renewal is loss; a failed one is not.** A store answers "no" when
   the claim has changed hands, but it *throws* for a filesystem mutex it could
   not take in time, or an HTTP 503, or a DNS blip. None of those say who holds

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -239,6 +239,12 @@ suspended ones:
   its audit trail saying why. The same sweep then resumes it, so an abandoned
   run is recovered in one pass rather than waiting another interval for nothing
   but a state change.
+- **And if the old holder was not dead after all** — merely paused long enough
+  for its lease to lapse — it finds out at its next renewal and **stops**. It
+  does not cancel itself: no compensation runs and the record is left alone,
+  because the run belongs to whoever holds the claim now. Unwinding at that
+  point would roll back the very work the new holder is building on. See
+  [losing the lease](./locks.md#the-runs-own-lease).
 - **Nobody there, and past its `deadline()`** → the run is settled **`failed`**,
   compensations and all. It did not stop because anyone asked; it ran out of
   time, and anything waiting on it needs an answer rather than silence.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1152,8 +1152,14 @@ class FileSystemStateStore implements StateStore
     and reclaims a stale one by TTL. Deleting it from outside that protocol
     would let two writers into the critical section at once.
 
-    The expiry check and the delete share the lock's own mutex, so an acquire
-    racing this cannot have its fresh record removed by a stale reading.
+    The expiry check and the delete share the lock's own mutex — the same one
+    every acquire, renew and release takes — so the two cannot interleave: an
+    acquirer either gets there first, and its fresh record is then seen as
+    unexpired, or arrives after, and finds no record to be confused by.
+
+    Clearing the records is best-effort. The run's own file is the deletion that
+    matters; a leftover lock is litter, and litter must never fail a prune, so a
+    mutex this cannot take in time is left for the next sweep.
   async acquireLock(key: string, holder: LockHolder, ttlMs: number): Promise<LockResult>
     Atomically acquire the lock `key` for `holder`, taking over if expired.
   async renewLock(key: string, token: string, ttlMs: number): Promise<boolean>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1137,6 +1137,13 @@ class FileSystemStateStore implements StateStore
     List runs matching `query`, newest first. Unreadable files are skipped.
   async deleteRun(id: string): Promise<void>
     Delete a run's file (under its lock); a missing run is a no-op.
+
+    The run's own lock records go with it. A lease and a cancel lock are named
+    after the run, so once the run is gone they can never be looked up again —
+    leaving them behind turns `runs prune` into a command that shrinks one
+    directory while `locks/` grows forever. They are already logically expired
+    (prune only ever deletes runs that reached a terminal status), so removing
+    the files takes nothing live away.
   async acquireLock(key: string, holder: LockHolder, ttlMs: number): Promise<LockResult>
     Atomically acquire the lock `key` for `holder`, taking over if expired.
   async renewLock(key: string, token: string, ttlMs: number): Promise<boolean>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1138,12 +1138,22 @@ class FileSystemStateStore implements StateStore
   async deleteRun(id: string): Promise<void>
     Delete a run's file (under its lock); a missing run is a no-op.
 
-    The run's own lock records go with it. A lease and a cancel lock are named
-    after the run, so once the run is gone they can never be looked up again —
-    leaving them behind turns `runs prune` into a command that shrinks one
-    directory while `locks/` grows forever. They are already logically expired
-    (prune only ever deletes runs that reached a terminal status), so removing
-    the files takes nothing live away.
+    The run's expired lock records go with it. A lease and a cancel lock are
+    named after the run, so once the run is gone they can never be looked up
+    again — leaving them behind turns `runs prune` into a command that shrinks
+    one directory while `locks/` grows forever.
+
+    Two things this deliberately does not touch. A lock that has not expired
+    is left alone: somebody still holds that claim, and deleting the record
+    would make their next renewal report the lease lost — stopping a live run to
+    tidy up a file. And the `.acq` marker is never removed, because it is not a
+    lock record at all: it is the mutex guarding every lock's compare-and-swap,
+    owned by {@link "./mutex.ts".withFileMutex}, which removes it in a `finally`
+    and reclaims a stale one by TTL. Deleting it from outside that protocol
+    would let two writers into the critical section at once.
+
+    The expiry check and the delete share the lock's own mutex, so an acquire
+    racing this cannot have its fresh record removed by a stale reading.
   async acquireLock(key: string, holder: LockHolder, ttlMs: number): Promise<LockResult>
     Atomically acquire the lock `key` for `holder`, taking over if expired.
   async renewLock(key: string, token: string, ttlMs: number): Promise<boolean>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1138,28 +1138,21 @@ class FileSystemStateStore implements StateStore
   async deleteRun(id: string): Promise<void>
     Delete a run's file (under its lock); a missing run is a no-op.
 
-    The run's expired lock records go with it. A lease and a cancel lock are
-    named after the run, so once the run is gone they can never be looked up
-    again — leaving them behind turns `runs prune` into a command that shrinks
-    one directory while `locks/` grows forever.
+    The run's lock records are deliberately left alone. It is tempting to take
+    them with the run — they are named after it, so once it is gone nothing can
+    look them up again — but "expired" does not mean "abandoned" in this store:
+    {@link renewLock} extends a lock whenever the token matches, whatever its
+    expiry, so a lapsed claim is still the holder's until somebody acquires
+    it. Deleting the record instead makes the next renewal answer `false`, which
+    the holder reads as the lease being lost, and a run that is merely slow —
+    the exact case the lease exists to tell apart from a dead one — stops.
+    Pruning must never be able to do that.
 
-    Two things this deliberately does not touch. A lock that has not expired
-    is left alone: somebody still holds that claim, and deleting the record
-    would make their next renewal report the lease lost — stopping a live run to
-    tidy up a file. And the `.acq` marker is never removed, because it is not a
-    lock record at all: it is the mutex guarding every lock's compare-and-swap,
-    owned by {@link "./mutex.ts".withFileMutex}, which removes it in a `finally`
-    and reclaims a stale one by TTL. Deleting it from outside that protocol
-    would let two writers into the critical section at once.
-
-    The expiry check and the delete share the lock's own mutex — the same one
-    every acquire, renew and release takes — so the two cannot interleave: an
-    acquirer either gets there first, and its fresh record is then seen as
-    unexpired, or arrives after, and finds no record to be confused by.
-
-    Clearing the records is best-effort. The run's own file is the deletion that
-    matters; a leftover lock is litter, and litter must never fail a prune, so a
-    mutex this cannot take in time is left for the next sweep.
+    The litter is small and bounded in practice: {@link releaseLock} removes a
+    lock's file, and a run releases its lease whenever it settles, so only a
+    holder that dies without releasing leaves one behind. Clearing those safely
+    belongs to whoever can prove the holder is gone — a reaping sweep, which
+    proves it by acquiring — not to a command deleting old records.
   async acquireLock(key: string, holder: LockHolder, ttlMs: number): Promise<LockResult>
     Atomically acquire the lock `key` for `holder`, taking over if expired.
   async renewLock(key: string, token: string, ttlMs: number): Promise<boolean>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1206,8 +1206,14 @@ class FileSystemStateStore implements StateStore
     and reclaims a stale one by TTL. Deleting it from outside that protocol
     would let two writers into the critical section at once.
 
-    The expiry check and the delete share the lock's own mutex, so an acquire
-    racing this cannot have its fresh record removed by a stale reading.
+    The expiry check and the delete share the lock's own mutex — the same one
+    every acquire, renew and release takes — so the two cannot interleave: an
+    acquirer either gets there first, and its fresh record is then seen as
+    unexpired, or arrives after, and finds no record to be confused by.
+
+    Clearing the records is best-effort. The run's own file is the deletion that
+    matters; a leftover lock is litter, and litter must never fail a prune, so a
+    mutex this cannot take in time is left for the next sweep.
   async acquireLock(key: string, holder: LockHolder, ttlMs: number): Promise<LockResult>
     Atomically acquire the lock `key` for `holder`, taking over if expired.
   async renewLock(key: string, token: string, ttlMs: number): Promise<boolean>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1192,28 +1192,21 @@ class FileSystemStateStore implements StateStore
   async deleteRun(id: string): Promise<void>
     Delete a run's file (under its lock); a missing run is a no-op.
 
-    The run's expired lock records go with it. A lease and a cancel lock are
-    named after the run, so once the run is gone they can never be looked up
-    again — leaving them behind turns `runs prune` into a command that shrinks
-    one directory while `locks/` grows forever.
+    The run's lock records are deliberately left alone. It is tempting to take
+    them with the run — they are named after it, so once it is gone nothing can
+    look them up again — but "expired" does not mean "abandoned" in this store:
+    {@link renewLock} extends a lock whenever the token matches, whatever its
+    expiry, so a lapsed claim is still the holder's until somebody acquires
+    it. Deleting the record instead makes the next renewal answer `false`, which
+    the holder reads as the lease being lost, and a run that is merely slow —
+    the exact case the lease exists to tell apart from a dead one — stops.
+    Pruning must never be able to do that.
 
-    Two things this deliberately does not touch. A lock that has not expired
-    is left alone: somebody still holds that claim, and deleting the record
-    would make their next renewal report the lease lost — stopping a live run to
-    tidy up a file. And the `.acq` marker is never removed, because it is not a
-    lock record at all: it is the mutex guarding every lock's compare-and-swap,
-    owned by {@link "./mutex.ts".withFileMutex}, which removes it in a `finally`
-    and reclaims a stale one by TTL. Deleting it from outside that protocol
-    would let two writers into the critical section at once.
-
-    The expiry check and the delete share the lock's own mutex — the same one
-    every acquire, renew and release takes — so the two cannot interleave: an
-    acquirer either gets there first, and its fresh record is then seen as
-    unexpired, or arrives after, and finds no record to be confused by.
-
-    Clearing the records is best-effort. The run's own file is the deletion that
-    matters; a leftover lock is litter, and litter must never fail a prune, so a
-    mutex this cannot take in time is left for the next sweep.
+    The litter is small and bounded in practice: {@link releaseLock} removes a
+    lock's file, and a run releases its lease whenever it settles, so only a
+    holder that dies without releasing leaves one behind. Clearing those safely
+    belongs to whoever can prove the holder is gone — a reaping sweep, which
+    proves it by acquiring — not to a command deleting old records.
   async acquireLock(key: string, holder: LockHolder, ttlMs: number): Promise<LockResult>
     Atomically acquire the lock `key` for `holder`, taking over if expired.
   async renewLock(key: string, token: string, ttlMs: number): Promise<boolean>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1191,6 +1191,13 @@ class FileSystemStateStore implements StateStore
     List runs matching `query`, newest first. Unreadable files are skipped.
   async deleteRun(id: string): Promise<void>
     Delete a run's file (under its lock); a missing run is a no-op.
+
+    The run's own lock records go with it. A lease and a cancel lock are named
+    after the run, so once the run is gone they can never be looked up again —
+    leaving them behind turns `runs prune` into a command that shrinks one
+    directory while `locks/` grows forever. They are already logically expired
+    (prune only ever deletes runs that reached a terminal status), so removing
+    the files takes nothing live away.
   async acquireLock(key: string, holder: LockHolder, ttlMs: number): Promise<LockResult>
     Atomically acquire the lock `key` for `holder`, taking over if expired.
   async renewLock(key: string, token: string, ttlMs: number): Promise<boolean>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1192,12 +1192,22 @@ class FileSystemStateStore implements StateStore
   async deleteRun(id: string): Promise<void>
     Delete a run's file (under its lock); a missing run is a no-op.
 
-    The run's own lock records go with it. A lease and a cancel lock are named
-    after the run, so once the run is gone they can never be looked up again —
-    leaving them behind turns `runs prune` into a command that shrinks one
-    directory while `locks/` grows forever. They are already logically expired
-    (prune only ever deletes runs that reached a terminal status), so removing
-    the files takes nothing live away.
+    The run's expired lock records go with it. A lease and a cancel lock are
+    named after the run, so once the run is gone they can never be looked up
+    again — leaving them behind turns `runs prune` into a command that shrinks
+    one directory while `locks/` grows forever.
+
+    Two things this deliberately does not touch. A lock that has not expired
+    is left alone: somebody still holds that claim, and deleting the record
+    would make their next renewal report the lease lost — stopping a live run to
+    tidy up a file. And the `.acq` marker is never removed, because it is not a
+    lock record at all: it is the mutex guarding every lock's compare-and-swap,
+    owned by {@link "./mutex.ts".withFileMutex}, which removes it in a `finally`
+    and reclaims a stale one by TTL. Deleting it from outside that protocol
+    would let two writers into the critical section at once.
+
+    The expiry check and the delete share the lock's own mutex, so an acquire
+    racing this cannot have its fresh record removed by a stale reading.
   async acquireLock(key: string, holder: LockHolder, ttlMs: number): Promise<LockResult>
     Atomically acquire the lock `key` for `holder`, taking over if expired.
   async renewLock(key: string, token: string, ttlMs: number): Promise<boolean>

--- a/packages/core/src/cancel.ts
+++ b/packages/core/src/cancel.ts
@@ -166,6 +166,17 @@ export interface CompensationDeps {
    * by a timed-out wait whose `onTimeout` names a specific compensation target.
    */
   extra?: CompensationStep[];
+  /**
+   * Asked before each compensation whether this process still owns the run.
+   *
+   * A walk can be long — real rollbacks talk to real systems — and a lease is
+   * lost by lapsing, which a process busy doing exactly that can manage without
+   * ever being unhealthy (a compensation that blocks the event loop stops the
+   * heartbeat firing). If the claim changes hands mid-walk, every remaining
+   * compensation would be unwinding work the new holder is rebuilding. The walk
+   * stops instead, reporting what it had already undone.
+   */
+  stop?: () => boolean;
 }
 
 /** An in-memory {@link TargetStateHandle} seeded with a target's persisted meta. */
@@ -282,6 +293,19 @@ export async function runCompensations(
   const outcomes = outcomesFromRecord(record.targets);
 
   for (const step of steps) {
+    // Asked before each step, not once up front: the claim can change hands
+    // *during* a walk, which is long by nature — real rollbacks talk to real
+    // systems, and a compensation that blocks the event loop stops the lease
+    // heartbeat firing without the process being unhealthy at all. Every step
+    // from that point would be undoing work the new holder is rebuilding.
+    if (deps.stop?.() === true) {
+      deps.reporter.info(
+        `cancel: this run was taken over by another process mid-rollback — ` +
+          `stopping after ${compensated.length} compensation(s). The rest are ` +
+          `whoever holds the run now to decide on.`,
+      );
+      break;
+    }
     const compName = step.compensation.name_ ??
       `${step.forTarget}.onCancel`;
     const body = step.compensation.fn_;

--- a/packages/core/src/execute_cancel.ts
+++ b/packages/core/src/execute_cancel.ts
@@ -96,10 +96,25 @@ export async function settleCancelledRun(opts: {
           stop: opts.isLeaseLost,
         });
         const at = opts.nowIso();
+        // Recorded even if the claim changed hands mid-walk: an event is
+        // additive and stays true whoever owns the run now, and what happened
+        // before this process stopped is exactly what a later reader needs.
         for (const event of compensationEvents(comp.attempts, actor, at)) {
           await writer.appendEvent(event);
         }
         await writer.appendEvent(cancelEvent(actor, comp, at));
+        // A walk cut short by a lost lease did not settle this run, and saying
+        // otherwise would claim an outcome that belongs to the new holder. The
+        // terminal write is already a no-op on a disowned writer; not making it
+        // is how the operator's report and the returned settlement stay honest.
+        if (opts.isLeaseLost?.() === true) {
+          reporter.error(
+            `Run ${runId} was taken over by another process mid-rollback — ` +
+              `${comp.compensated.length} compensation(s) had already run. ` +
+              `Settling it is the new holder's to do.`,
+          );
+          return { ownedWalk: false, compensated: comp.compensated.length };
+        }
         await writer.markRunCancelled();
         reporter.info(
           `Run ${runId} cancelled — ${comp.compensated.length} ` +

--- a/packages/core/src/execute_cancel.ts
+++ b/packages/core/src/execute_cancel.ts
@@ -35,6 +35,8 @@ export async function settleCancelledRun(opts: {
   redactor: Redactor;
   nowIso: () => string;
   isExternallyCancelled: () => boolean;
+  /** Whether this process has lost the run's lease (see {@link "../cancel.ts".CompensationDeps.stop}). */
+  isLeaseLost?: () => boolean;
 }): Promise<void> {
   const { writer, life, order, runId, actor, reporter } = opts;
   // Hold the per-run cancel lock while we compensate, so a concurrent
@@ -77,6 +79,7 @@ export async function settleCancelledRun(opts: {
           signals: opts.signals,
           reporter,
           redactor: opts.redactor,
+          stop: opts.isLeaseLost,
         });
         const at = opts.nowIso();
         for (const event of compensationEvents(comp.attempts, actor, at)) {

--- a/packages/core/src/execute_cancel.ts
+++ b/packages/core/src/execute_cancel.ts
@@ -24,6 +24,18 @@ import { cancelEvent, compensationEvents, runCompensations } from "./cancel.ts";
  * the succeeded targets' compensations in reverse, record them in the audit
  * trail, and mark the run cancelled — unless another process owns the walk.
  */
+/** What a cancellation settlement did, so the caller can decide about the cache. */
+export interface CancelSettlement {
+  /**
+   * Whether *this* process ran the compensation walk. False when another
+   * process owns the cancellation, in which case what it will undo is unknown
+   * here.
+   */
+  ownedWalk: boolean;
+  /** How many compensations were attempted, successful or not. */
+  compensated: number;
+}
+
 export async function settleCancelledRun(opts: {
   writer: RunStateWriter;
   life: Lifecycle;
@@ -37,7 +49,7 @@ export async function settleCancelledRun(opts: {
   isExternallyCancelled: () => boolean;
   /** Whether this process has lost the run's lease (see {@link "../cancel.ts".CompensationDeps.stop}). */
   isLeaseLost?: () => boolean;
-}): Promise<void> {
+}): Promise<CancelSettlement> {
   const { writer, life, order, runId, actor, reporter } = opts;
   // Hold the per-run cancel lock while we compensate, so a concurrent
   // `zuke cancel` can't settle the run (declaring "no compensations") over
@@ -51,6 +63,7 @@ export async function settleCancelledRun(opts: {
     reporter.info(
       `Run ${runId} cancelled by another process — stopping.`,
     );
+    return { ownedWalk: false, compensated: 0 };
   } else {
     try {
       // We initiated it (Ctrl-C / options.signal): mark cancelling (which
@@ -66,6 +79,7 @@ export async function settleCancelledRun(opts: {
         reporter.info(
           `Run ${runId} cancelled by another process — stopping.`,
         );
+        return { ownedWalk: false, compensated: 0 };
       } else {
         // Announce the intermediate `cancelling` transition (the record was
         // just moved there) before compensations run, so a plugin sees the
@@ -93,6 +107,10 @@ export async function settleCancelledRun(opts: {
               comp.failures.length > 0 ? `, ${comp.failures.length} failed` : ""
             }.`,
         );
+        return {
+          ownedWalk: true,
+          compensated: comp.compensated.length + comp.failures.length,
+        };
       }
     } finally {
       await cancelLock?.release();

--- a/packages/core/src/execute_state.ts
+++ b/packages/core/src/execute_state.ts
@@ -19,6 +19,7 @@ import type { AnyParameter } from "./params.ts";
 import type { RunEnv, TargetSettlement } from "./run_support.ts";
 import { absolutePath } from "./path.ts";
 import { parseDuration } from "./duration.ts";
+import { messageOf } from "./internal.ts";
 import { findConfigDir, pathExists } from "./config.ts";
 import { defaultStateHost, type StateStore } from "./state/store.ts";
 import { resolveStateStore } from "./state/resolve.ts";
@@ -83,10 +84,71 @@ export interface RunState {
   lease?: HeldLease;
 }
 
+/** How many times a run's own lease acquire is retried past a throwing store. */
+const LEASE_ACQUIRE_ATTEMPTS = 3;
+
+/** How long to wait between those attempts. */
+const LEASE_RETRY_MS = 250;
+
+/**
+ * Take the run's lease, tolerating a store that is merely having a bad moment.
+ *
+ * `acquireLock` **throws** — it does not answer `false` — for a filesystem mutex
+ * it could not take within its spin budget, an HTTP 503, or a DNS blip. None of
+ * those say the claim is somebody else's, so a single one must not decide the
+ * run: they are retried.
+ *
+ * A throw that outlives the retries returns an {@link Error} rather than
+ * rejecting, so the caller reports it the way it reports every other expected
+ * failure. The run is **not** started without a lease: the whole point of taking
+ * it before the record says `running` is that a `running` record always has a
+ * live holder, and running unclaimed would leave a healthy run looking abandoned
+ * to every sweep for its entire duration — trading a clean failure for a
+ * silently re-driven one.
+ *
+ * @returns the lease, `null` when a live holder already has it, or an
+ *   {@link Error} when the store could not be reached at all.
+ */
+async function acquireLeaseRetrying(
+  store: StateStore,
+  runId: string,
+  actor: string,
+  nowIso: () => string,
+  runUrl: string | undefined,
+): Promise<HeldLease | null | Error> {
+  let last: unknown;
+  for (let attempt = 1; attempt <= LEASE_ACQUIRE_ATTEMPTS; attempt++) {
+    try {
+      return await acquireLease(
+        store,
+        RUN_LEASE_PREFIX,
+        runId,
+        actor,
+        nowIso,
+        undefined,
+        runUrl,
+      );
+    } catch (error) {
+      last = error;
+      if (attempt < LEASE_ACQUIRE_ATTEMPTS) {
+        await new Promise((resolve) => setTimeout(resolve, LEASE_RETRY_MS));
+      }
+    }
+  }
+  return new Error(
+    `Could not claim run "${runId}": the state store did not answer after ` +
+      `${LEASE_ACQUIRE_ATTEMPTS} attempts (${messageOf(last)}). Zuke takes a ` +
+      `lease before recording a run so that a run in progress is never mistaken ` +
+      `for an abandoned one, and it will not run without it. Fix the store, or ` +
+      `run without durable state (unset ZUKE_STATE_DIR / ZUKE_STATE_URL, and ` +
+      `drop --state).`,
+  );
+}
+
 /**
  * Resolve the durable state store, open (or adopt) the run's writer, and
  * assemble the {@link RunEnv}. Returns the error instead of throwing when a
- * target needs state that is disabled.
+ * target needs state that is disabled, or when the run's lease cannot be taken.
  */
 export async function openRunState(opts: {
   build: Build;
@@ -194,15 +256,14 @@ export async function openRunState(opts: {
   // the record out of `suspended`, for the same reason.
   let lease: HeldLease | undefined;
   if (stateStore !== undefined && resume === undefined) {
-    const held = await acquireLease(
+    const held = await acquireLeaseRetrying(
       stateStore,
-      RUN_LEASE_PREFIX,
       opts.runId,
       actor,
       nowIso,
-      undefined,
       runUrl,
     );
+    if (held instanceof Error) return { ok: false, error: held };
     if (held === null) {
       // A fresh run's id is newly minted, so a live holder means the id was
       // reused — worth refusing rather than running two processes under one

--- a/packages/core/src/execute_state.ts
+++ b/packages/core/src/execute_state.ts
@@ -85,9 +85,18 @@ export interface RunState {
 }
 
 /** How many times a run's own lease acquire is retried past a throwing store. */
-const LEASE_ACQUIRE_ATTEMPTS = 3;
+const LEASE_ACQUIRE_ATTEMPTS = 5;
 
-/** How long to wait between those attempts. */
+/**
+ * The first gap between those attempts, doubling each time — so five attempts
+ * span roughly four seconds of backoff rather than half of one.
+ *
+ * Long enough to ride out the kind of outage a state service actually has (a
+ * rolling restart, a reconnect, a contended filesystem mutex), short enough that
+ * a store which is genuinely down still fails the run promptly instead of
+ * stalling it. Every other state write is best-effort; this one is not, so it is
+ * worth being patient before giving up.
+ */
 const LEASE_RETRY_MS = 250;
 
 /**
@@ -131,13 +140,15 @@ async function acquireLeaseRetrying(
     } catch (error) {
       last = error;
       if (attempt < LEASE_ACQUIRE_ATTEMPTS) {
-        await new Promise((resolve) => setTimeout(resolve, LEASE_RETRY_MS));
+        const backoff = LEASE_RETRY_MS * 2 ** (attempt - 1);
+        await new Promise((resolve) => setTimeout(resolve, backoff));
       }
     }
   }
   return new Error(
     `Could not claim run "${runId}": the state store did not answer after ` +
-      `${LEASE_ACQUIRE_ATTEMPTS} attempts (${messageOf(last)}). Zuke takes a ` +
+      `${LEASE_ACQUIRE_ATTEMPTS} attempts over several seconds ` +
+      `(${messageOf(last)}). Zuke takes a ` +
       `lease before recording a run so that a run in progress is never mistaken ` +
       `for an abandoned one, and it will not run without it. Fix the store, or ` +
       `run without durable state (unset ZUKE_STATE_DIR / ZUKE_STATE_URL, and ` +

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -539,6 +539,7 @@ export async function execute(
         redactor,
         nowIso,
         isExternallyCancelled: () => externallyCancelled,
+        isLeaseLost: () => leaseLost,
       });
     }
   } else {

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -406,8 +406,16 @@ export async function execute(
   const ownLease = opened.state.lease;
   const lease = ownLease ?? options.resume?.lease;
   if (lease !== undefined) {
-    if (lease.lost.aborted) onLeaseLost();
-    else lease.lost.addEventListener("abort", onLeaseLost, { once: true });
+    // Losing the claim stops the writer *first*. The walk that stops the run
+    // settles every target it never reached as `skipped`, and those rows would
+    // otherwise land on the record — through the very compare-and-swap that
+    // re-reads and re-applies — over the progress the new holder is making.
+    const stopOwning = () => {
+      writer?.disown();
+      onLeaseLost();
+    };
+    if (lease.lost.aborted) stopOwning();
+    else lease.lost.addEventListener("abort", stopOwning, { once: true });
   }
 
   // Announce the run's initial durable state (`running`) to plugins — a no-op

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -486,9 +486,14 @@ export async function execute(
   const cancelled = runController.signal.aborted;
 
   // Whether the fingerprints this run recorded still describe the workspace.
-  // Decided below, once a cancellation has settled and it is known what — if
-  // anything — was rolled back.
-  let cacheIsTrustworthy = !cancelled;
+  //
+  // A cancellation only invalidates them by *undoing* something, and undoing
+  // needs a compensation walk, which needs a writer. Without a state store there
+  // is no writer, so nothing can have been rolled back and the fingerprints
+  // stand — which matters because a store-less run is the default for exactly
+  // the builds that declare no compensation. With a writer, the answer waits for
+  // the settlement below to say what the walk actually did.
+  let cacheIsTrustworthy = !cancelled || writer === undefined;
 
   let result: BuildResult;
   if (leaseLost) {
@@ -546,6 +551,19 @@ export async function execute(
       // develop-interrupt-rerun loop. So the cache is kept when this process ran
       // the walk and the walk did nothing.
       cacheIsTrustworthy = settlement.ownedWalk && settlement.compensated === 0;
+      // The claim can change hands *during* the walk, after the branch above
+      // chose a cancellation. Report what actually happened: this process
+      // neither finished unwinding the run nor settled it.
+      if (leaseLost) {
+        const lost = new Error(
+          `Run ${runId} stopped: its lease was taken over by another process ` +
+            `mid-rollback, after ${settlement.compensated} compensation(s). ` +
+            `The rest of the rollback, and the run's outcome, belong to ` +
+            `whoever holds it now.`,
+        );
+        reporter.error(lost.message);
+        result = { ok: false, executed: run.executed, error: lost, runId };
+      }
     }
   } else {
     result = run.aborted

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -358,6 +358,15 @@ export async function execute(
     externallyCancelled = true;
     runController.abort();
   };
+  // Set when this run's lease is lost — the store says the claim is somebody
+  // else's now, so another process has taken the run over. That is a third,
+  // distinct way to stop: nobody asked for a cancellation, and the run is no
+  // longer this process's to settle or to unwind.
+  let leaseLost = false;
+  const onLeaseLost = () => {
+    leaseLost = true;
+    runController.abort();
+  };
 
   const nowIso = () => new Date().toISOString();
   const opened = await openRunState({
@@ -397,8 +406,8 @@ export async function execute(
   const ownLease = opened.state.lease;
   const lease = ownLease ?? options.resume?.lease;
   if (lease !== undefined) {
-    if (lease.lost.aborted) runController.abort();
-    else lease.lost.addEventListener("abort", onCancel, { once: true });
+    if (lease.lost.aborted) onLeaseLost();
+    else lease.lost.addEventListener("abort", onLeaseLost, { once: true });
   }
 
   // Announce the run's initial durable state (`running`) to plugins — a no-op
@@ -463,14 +472,39 @@ export async function execute(
       await services.stopAll((line) => reporter.info(line));
     }
   }
-  if (cache !== undefined) await cache.save();
-
   // A cancellation (Ctrl-C / an aborted `options.signal`, or another process
   // running `zuke cancel`) takes precedence over an ordinary failure: the
   // aborted target failing is a symptom, not the outcome.
   const cancelled = runController.signal.aborted;
+
+  // Persist the incremental cache only for a run that was allowed to finish.
+  // A target records its fingerprint the moment its body returns, but a
+  // cancelled run then unwinds those targets through their compensations — so
+  // saving here would mark work up-to-date that has just been undone, and the
+  // next run would skip rebuilding it. A lost lease is the same bet from the
+  // other side: whoever took the run over decides what its outputs are, and
+  // this process's fingerprints describe a state that may never exist. Both
+  // cost a rebuild; the alternative costs correctness.
+  if (cache !== undefined && !cancelled) await cache.save();
+
   let result: BuildResult;
-  if (cancelled) {
+  if (leaseLost) {
+    // The claim is demonstrably somebody else's, so this process no longer owns
+    // the run's outcome: it must not settle the record, and above all must not
+    // run the compensations. Doing so would unwind work the new holder is
+    // building on — the exact "two processes on one run" the lease exists to
+    // prevent. Queued per-target writes are drained (they are progress this
+    // process really made, and the writer's compare-and-swap merges them under
+    // the new holder's version) and then it stops.
+    await writer?.drain();
+    const lost = new Error(
+      `Run ${runId} stopped: its lease was taken over by another process, ` +
+        `which now owns the run. Nothing was rolled back — the compensations ` +
+        `belong to whoever holds the run.`,
+    );
+    reporter.error(lost.message);
+    result = { ok: false, executed: run.executed, error: lost, runId };
+  } else if (cancelled) {
     result = {
       ok: false,
       executed: run.executed,
@@ -522,13 +556,21 @@ export async function execute(
       reporter.error(settled.message);
       result = { ok: false, executed: run.executed, error: settled, runId };
     }
-    // Released once the record is terminal (or suspended), so the moment this
-    // run stops being ours to work on is the moment the claim goes. Any earlier
-    // throw leaves this call's own lease to lapse at its TTL, which is correct:
-    // the record is still `running` and the process really is broken, so a sweep
-    // should find it — just a minute later.
-    await ownLease?.release();
   }
+
+  // Released once this run has stopped being ours to work on — which includes
+  // the cancelled paths, not just the ones that ran to a finish. A cancelled run
+  // leaves a *terminal* record, so holding its claim for the rest of the TTL
+  // says a process is still working on a run that demonstrably ended, and blocks
+  // the id for a minute for no reason.
+  //
+  // Two exceptions. A lost lease is not ours to give back: releasing is scoped
+  // to the token we no longer hold, so at best it is a no-op and at worst it is
+  // an attempt to drop the new holder's claim. And any earlier *throw* leaves
+  // this call's lease to lapse at its TTL, which is correct: the record is still
+  // `running` and the process really is broken, so a sweep should find it — just
+  // a minute later.
+  if (!leaseLost) await ownLease?.release();
 
   // Announce the run's terminal durable state (succeeded/failed/suspended/
   // cancelling) to plugins, now that the transition above has landed.

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -485,15 +485,10 @@ export async function execute(
   // aborted target failing is a symptom, not the outcome.
   const cancelled = runController.signal.aborted;
 
-  // Persist the incremental cache only for a run that was allowed to finish.
-  // A target records its fingerprint the moment its body returns, but a
-  // cancelled run then unwinds those targets through their compensations — so
-  // saving here would mark work up-to-date that has just been undone, and the
-  // next run would skip rebuilding it. A lost lease is the same bet from the
-  // other side: whoever took the run over decides what its outputs are, and
-  // this process's fingerprints describe a state that may never exist. Both
-  // cost a rebuild; the alternative costs correctness.
-  if (cache !== undefined && !cancelled) await cache.save();
+  // Whether the fingerprints this run recorded still describe the workspace.
+  // Decided below, once a cancellation has settled and it is known what — if
+  // anything — was rolled back.
+  let cacheIsTrustworthy = !cancelled;
 
   let result: BuildResult;
   if (leaseLost) {
@@ -528,7 +523,7 @@ export async function execute(
         `Run ${runId} cancelled by another process — stopping.`,
       );
     } else if (writer !== undefined) {
-      await settleCancelledRun({
+      const settlement = await settleCancelledRun({
         writer,
         life,
         order,
@@ -541,6 +536,16 @@ export async function execute(
         isExternallyCancelled: () => externallyCancelled,
         isLeaseLost: () => leaseLost,
       });
+      // A cancellation only invalidates the cache if something was actually
+      // undone. A target records its fingerprint when its body returns, and a
+      // compensation then reverses that work — usually a *side effect* rather
+      // than the declared outputs, which is why the outputs-still-exist check
+      // cannot be relied on to notice. But most builds declare no compensation
+      // at all, and for those nothing was reversed: throwing their fingerprints
+      // away would make every Ctrl-C cost a full rebuild, which is the ordinary
+      // develop-interrupt-rerun loop. So the cache is kept when this process ran
+      // the walk and the walk did nothing.
+      cacheIsTrustworthy = settlement.ownedWalk && settlement.compensated === 0;
     }
   } else {
     result = run.aborted
@@ -565,6 +570,13 @@ export async function execute(
       reporter.error(settled.message);
       result = { ok: false, executed: run.executed, error: settled, runId };
     }
+  }
+
+  // Persist the incremental cache, unless this run's fingerprints have been
+  // overtaken by events: a rollback that undid the work they describe, or a new
+  // holder that now decides what the outputs are.
+  if (cache !== undefined && cacheIsTrustworthy && !leaseLost) {
+    await cache.save();
   }
 
   // Released once this run has stopped being ours to work on — which includes

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -774,22 +774,58 @@ export async function runScheduled(
     (predecessors.get(t) ?? []).every((p) =>
       t.always_ ? settled.has(p) : done.has(p)
     );
+  /**
+   * Whether `t` can never become ready: a predecessor has settled in a way that
+   * does not satisfy it (failed, or skipped), so no later pass will change the
+   * answer. A predecessor parked at a `waitsFor` gate is deliberately *not*
+   * settled, so a target behind a gate stays pending for a resume instead.
+   */
+  const stranded = (t: TargetBuilder): boolean =>
+    !t.always_ &&
+    (predecessors.get(t) ?? []).some((p) => settled.has(p) && !done.has(p));
   const overlaps = (t: TargetBuilder): boolean =>
     [...runningSet].every((r) => canOverlap(t, r));
+
+  /** Settle a target this run will never launch, so its dependents can proceed. */
+  const abandon = (t: TargetBuilder): void => {
+    outcomes.set(t, { status: "skipped", ms: 0 });
+    started.add(t);
+    settled.add(t);
+    settleTarget(env, t.name_ ?? "<unnamed>", "skipped");
+  };
 
   await new Promise<void>((resolve) => {
     const pump = () => {
       for (const t of order) {
         if (runningSet.size >= limit) break;
-        if (started.has(t) || !ready(t) || !overlaps(t)) continue;
-        // After a fatal failure, stop launching — except `always` targets,
-        // which run for cleanup even when the build is failing.
-        if (halted && !t.always_) continue;
-        // A cancelled run stops launching too — but `always` targets are the
-        // one thing that must survive it. They are teardown (stop a container,
-        // release a sandbox), and Ctrl-C is exactly when teardown matters most;
-        // skipping them would leak the resources they exist to reclaim.
-        if (ctx.env.signal.aborted && !t.always_) continue;
+        if (started.has(t)) continue;
+        // Settle a target whose prerequisites have made it unreachable, rather
+        // than leaving it for the final sweep. An `always` target waits for its
+        // predecessors to **settle**, so one that is never launched at all
+        // keeps teardown un-ready forever — and teardown is then swept away as
+        // skipped alongside the work it existed to clean up.
+        if (stranded(t)) {
+          abandon(t);
+          continue;
+        }
+        if (!ready(t) || !overlaps(t)) continue;
+        // Stop launching once the build has halted on a failure, or the run was
+        // cancelled — except `always` targets, which are teardown (stop a
+        // container, release a sandbox) and matter most in exactly those two
+        // situations.
+        //
+        // A target this run will therefore never launch is settled `skipped`
+        // *here* rather than in the final sweep. That is not cosmetic: an
+        // `always` target waits for its predecessors to **settle**, so a
+        // predecessor that is never launched keeps teardown un-ready forever,
+        // and it is swept away as skipped alongside the work it was meant to
+        // clean up — leaking whatever it reclaims. Settling on the spot lets the
+        // dependent become ready on this very pass (`order` is topological, so
+        // it is still ahead of us in this loop).
+        if ((halted || ctx.env.signal.aborted) && !t.always_) {
+          abandon(t);
+          continue;
+        }
         started.add(t);
         runningSet.add(t);
         const buffer = bufferReporter();

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -621,6 +621,21 @@ async function runForEachTarget(
     failTarget(reporter, renderer, style, name, ms, error);
     return { status: "failed", ms, error, children: run.reports };
   }
+  // A cancellation is not a success, and here it has to be said explicitly. The
+  // nested scheduler reports `aborted` only when a sub-target *failed*, and a
+  // cancelled run's remaining items are abandoned rather than failed — so
+  // nothing would mark the fan-out, and the parent would report `passed` for a
+  // batch whose items never ran. The top-level scheduler is saved from the same
+  // reasoning by `execute`, which overrides its outcome with the run's
+  // cancellation; a nested one has no such reader. Getting this wrong is not
+  // cosmetic: the parent's row is written `succeeded`, and the compensation walk
+  // undoes exactly the targets the record calls succeeded — so a rollback would
+  // run against a deployment that never happened.
+  if (ctx.env.signal.aborted) {
+    const error = new Error(`${name}: cancelled before its items finished.`);
+    failTarget(reporter, renderer, style, name, ms, error);
+    return { status: "failed", ms, error, children: run.reports };
+  }
   passTarget(reporter, renderer, style, name, ms);
   return { status: "passed", ms, children: run.reports };
 }
@@ -780,9 +795,22 @@ export async function runScheduled(
    * answer. A predecessor parked at a `waitsFor` gate is deliberately *not*
    * settled, so a target behind a gate stays pending for a resume instead.
    */
+  /** Whether this run can still resume, i.e. whether a parked gate may reopen. */
+  const mayStillResume = (): boolean => !anyFailed && !ctx.env.signal.aborted;
   const stranded = (t: TargetBuilder): boolean =>
     !t.always_ &&
-    (predecessors.get(t) ?? []).some((p) => settled.has(p) && !done.has(p));
+    (predecessors.get(t) ?? []).some((p) =>
+      (settled.has(p) && !done.has(p)) ||
+      // A predecessor parked at a `waitsFor` gate is normally left alone, so a
+      // resume can run what is behind it. Once the run has failed or been
+      // cancelled it will never suspend and so never resume — the code already
+      // converts those parked rows to `skipped` once the pump is done — and
+      // until then anything behind the gate counts as unreachable. Without this
+      // the teardown behind it stays un-ready and is swept away, and whether
+      // that happens depends on whether the gate had launched yet, which is to
+      // say on `--parallel`.
+      (!mayStillResume() && outcomes.get(p)?.status === "waiting")
+    );
   const overlaps = (t: TargetBuilder): boolean =>
     [...runningSet].every((r) => canOverlap(t, r));
 

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -676,7 +676,14 @@ export async function runSequential(
 
   for (const t of order) {
     const name = t.name_ ?? "<unnamed>";
-    if (skip.has(name) || aborted) {
+    // A cancelled run stops *launching*, not just retrying. Usually the running
+    // target fails first (its shell is terminated) and `aborted` covers the
+    // rest, but a body that finishes anyway — or a run cancelled before the
+    // first target — would otherwise keep starting new work after the run has
+    // demonstrably stopped being this process's to do. That matters most when
+    // the cancellation is a lost lease: the new holder is already running these
+    // very targets.
+    if (skip.has(name) || aborted || env.signal.aborted) {
       reports.push({ name, status: "skipped", ms: 0 });
       settleTarget(env, name, "skipped");
       continue;
@@ -778,6 +785,11 @@ export async function runScheduled(
         // After a fatal failure, stop launching — except `always` targets,
         // which run for cleanup even when the build is failing.
         if (halted && !t.always_) continue;
+        // A cancelled run stops launching too — but `always` targets are the
+        // one thing that must survive it. They are teardown (stop a container,
+        // release a sandbox), and Ctrl-C is exactly when teardown matters most;
+        // skipping them would leak the resources they exist to reclaim.
+        if (ctx.env.signal.aborted && !t.always_) continue;
         started.add(t);
         runningSet.add(t);
         const buffer = bufferReporter();

--- a/packages/core/src/state/cancel_lock.ts
+++ b/packages/core/src/state/cancel_lock.ts
@@ -20,15 +20,6 @@ import type { StateStore } from "./store.ts";
  */
 export const CANCEL_LOCK_TTL_MS = 30_000;
 
-/**
- * The lease name a run's cancellation lock is taken under.
- *
- * Named because three places have to agree on it exactly: the canceller taking
- * it, a sweep asking whether a cancel walk is still live, and the store clearing
- * a pruned run's leftover lock records.
- */
-export const CANCEL_LOCK_PREFIX = "zuke-cancel";
-
 /** A held cancellation lock; call {@link CancelLock.release} when the walk ends. */
 export interface CancelLock {
   /** Stop the renewal heartbeat and release the lock (best-effort). */
@@ -59,7 +50,7 @@ export async function acquireCancelLock(
 ): Promise<CancelLock | null> {
   const lease = await acquireLease(
     store,
-    CANCEL_LOCK_PREFIX,
+    "zuke-cancel",
     runId,
     actor,
     now,

--- a/packages/core/src/state/cancel_lock.ts
+++ b/packages/core/src/state/cancel_lock.ts
@@ -20,6 +20,15 @@ import type { StateStore } from "./store.ts";
  */
 export const CANCEL_LOCK_TTL_MS = 30_000;
 
+/**
+ * The lease name a run's cancellation lock is taken under.
+ *
+ * Named because three places have to agree on it exactly: the canceller taking
+ * it, a sweep asking whether a cancel walk is still live, and the store clearing
+ * a pruned run's leftover lock records.
+ */
+export const CANCEL_LOCK_PREFIX = "zuke-cancel";
+
 /** A held cancellation lock; call {@link CancelLock.release} when the walk ends. */
 export interface CancelLock {
   /** Stop the renewal heartbeat and release the lock (best-effort). */
@@ -50,7 +59,7 @@ export async function acquireCancelLock(
 ): Promise<CancelLock | null> {
   const lease = await acquireLease(
     store,
-    "zuke-cancel",
+    CANCEL_LOCK_PREFIX,
     runId,
     actor,
     now,

--- a/packages/core/src/state/fs_store.ts
+++ b/packages/core/src/state/fs_store.ts
@@ -30,10 +30,13 @@ import {
 } from "./types.ts";
 import {
   type LockHolder,
+  lockKey,
   type LockRecord,
   parseLockRecord,
   stringifyLockRecord,
 } from "./lock.ts";
+import { CANCEL_LOCK_PREFIX } from "./cancel_lock.ts";
+import { RUN_LEASE_PREFIX } from "./run_lease.ts";
 import { withFileMutex } from "./mutex.ts";
 import { sha256Hex } from "../internal.ts";
 
@@ -155,12 +158,26 @@ export class FileSystemStateStore implements StateStore {
     return query.limit === undefined ? sorted : sorted.slice(0, query.limit);
   }
 
-  /** Delete a run's file (under its lock); a missing run is a no-op. */
+  /**
+   * Delete a run's file (under its lock); a missing run is a no-op.
+   *
+   * The run's own lock records go with it. A lease and a cancel lock are named
+   * after the run, so once the run is gone they can never be looked up again —
+   * leaving them behind turns `runs prune` into a command that shrinks one
+   * directory while `locks/` grows forever. They are already logically expired
+   * (prune only ever deletes runs that reached a terminal status), so removing
+   * the files takes nothing live away.
+   */
   async deleteRun(id: string): Promise<void> {
     await this.#ensureDir();
     await this.#withLock(id, async () => {
       await this.#host.remove(this.#file(id));
     });
+    for (const prefix of [RUN_LEASE_PREFIX, CANCEL_LOCK_PREFIX]) {
+      const key = lockKey(prefix, id);
+      await this.#host.remove(this.#lockFile(key));
+      await this.#host.remove(this.#lockMarker(key));
+    }
   }
 
   /** Atomically acquire the lock `key` for `holder`, taking over if expired. */

--- a/packages/core/src/state/fs_store.ts
+++ b/packages/core/src/state/fs_store.ts
@@ -30,13 +30,10 @@ import {
 } from "./types.ts";
 import {
   type LockHolder,
-  lockKey,
   type LockRecord,
   parseLockRecord,
   stringifyLockRecord,
 } from "./lock.ts";
-import { CANCEL_LOCK_PREFIX } from "./cancel_lock.ts";
-import { RUN_LEASE_PREFIX } from "./run_lease.ts";
 import { withFileMutex } from "./mutex.ts";
 import { sha256Hex } from "../internal.ts";
 
@@ -161,53 +158,27 @@ export class FileSystemStateStore implements StateStore {
   /**
    * Delete a run's file (under its lock); a missing run is a no-op.
    *
-   * The run's **expired** lock records go with it. A lease and a cancel lock are
-   * named after the run, so once the run is gone they can never be looked up
-   * again — leaving them behind turns `runs prune` into a command that shrinks
-   * one directory while `locks/` grows forever.
+   * The run's lock records are deliberately left alone. It is tempting to take
+   * them with the run — they are named after it, so once it is gone nothing can
+   * look them up again — but "expired" does not mean "abandoned" in this store:
+   * {@link renewLock} extends a lock whenever the token matches, whatever its
+   * expiry, so a lapsed claim is still the holder's until somebody *acquires*
+   * it. Deleting the record instead makes the next renewal answer `false`, which
+   * the holder reads as the lease being lost, and a run that is merely slow —
+   * the exact case the lease exists to tell apart from a dead one — stops.
+   * Pruning must never be able to do that.
    *
-   * Two things this deliberately does not touch. A lock that has **not** expired
-   * is left alone: somebody still holds that claim, and deleting the record
-   * would make their next renewal report the lease lost — stopping a live run to
-   * tidy up a file. And the `.acq` marker is never removed, because it is not a
-   * lock record at all: it is the mutex guarding every lock's compare-and-swap,
-   * owned by {@link "./mutex.ts".withFileMutex}, which removes it in a `finally`
-   * and reclaims a stale one by TTL. Deleting it from outside that protocol
-   * would let two writers into the critical section at once.
-   *
-   * The expiry check and the delete share the lock's own mutex — the same one
-   * every acquire, renew and release takes — so the two cannot interleave: an
-   * acquirer either gets there first, and its fresh record is then seen as
-   * unexpired, or arrives after, and finds no record to be confused by.
-   *
-   * Clearing the records is best-effort. The run's own file is the deletion that
-   * matters; a leftover lock is litter, and litter must never fail a prune, so a
-   * mutex this cannot take in time is left for the next sweep.
+   * The litter is small and bounded in practice: {@link releaseLock} removes a
+   * lock's file, and a run releases its lease whenever it settles, so only a
+   * holder that dies without releasing leaves one behind. Clearing those safely
+   * belongs to whoever can prove the holder is gone — a reaping sweep, which
+   * proves it by acquiring — not to a command deleting old records.
    */
   async deleteRun(id: string): Promise<void> {
     await this.#ensureDir();
     await this.#withLock(id, async () => {
       await this.#host.remove(this.#file(id));
     });
-    for (const prefix of [RUN_LEASE_PREFIX, CANCEL_LOCK_PREFIX]) {
-      const key = lockKey(prefix, id);
-      try {
-        await this.#withMutex(
-          this.#lockMarker(key),
-          `lock "${key}"`,
-          async () => {
-            const current = await this.#readLock(key);
-            if (current !== null && current.expiresAt > this.#host.now()) {
-              return;
-            }
-            await this.#host.remove(this.#lockFile(key));
-          },
-        );
-      } catch {
-        // A mutex that could not be taken in time, or a file that vanished
-        // under us: the run is already gone, which is what was asked for.
-      }
-    }
   }
 
   /** Atomically acquire the lock `key` for `holder`, taking over if expired. */

--- a/packages/core/src/state/fs_store.ts
+++ b/packages/core/src/state/fs_store.ts
@@ -175,8 +175,14 @@ export class FileSystemStateStore implements StateStore {
    * and reclaims a stale one by TTL. Deleting it from outside that protocol
    * would let two writers into the critical section at once.
    *
-   * The expiry check and the delete share the lock's own mutex, so an acquire
-   * racing this cannot have its fresh record removed by a stale reading.
+   * The expiry check and the delete share the lock's own mutex — the same one
+   * every acquire, renew and release takes — so the two cannot interleave: an
+   * acquirer either gets there first, and its fresh record is then seen as
+   * unexpired, or arrives after, and finds no record to be confused by.
+   *
+   * Clearing the records is best-effort. The run's own file is the deletion that
+   * matters; a leftover lock is litter, and litter must never fail a prune, so a
+   * mutex this cannot take in time is left for the next sweep.
    */
   async deleteRun(id: string): Promise<void> {
     await this.#ensureDir();
@@ -185,15 +191,22 @@ export class FileSystemStateStore implements StateStore {
     });
     for (const prefix of [RUN_LEASE_PREFIX, CANCEL_LOCK_PREFIX]) {
       const key = lockKey(prefix, id);
-      await this.#withMutex(
-        this.#lockMarker(key),
-        `lock "${key}"`,
-        async () => {
-          const current = await this.#readLock(key);
-          if (current !== null && current.expiresAt > this.#host.now()) return;
-          await this.#host.remove(this.#lockFile(key));
-        },
-      );
+      try {
+        await this.#withMutex(
+          this.#lockMarker(key),
+          `lock "${key}"`,
+          async () => {
+            const current = await this.#readLock(key);
+            if (current !== null && current.expiresAt > this.#host.now()) {
+              return;
+            }
+            await this.#host.remove(this.#lockFile(key));
+          },
+        );
+      } catch {
+        // A mutex that could not be taken in time, or a file that vanished
+        // under us: the run is already gone, which is what was asked for.
+      }
     }
   }
 

--- a/packages/core/src/state/fs_store.ts
+++ b/packages/core/src/state/fs_store.ts
@@ -161,12 +161,22 @@ export class FileSystemStateStore implements StateStore {
   /**
    * Delete a run's file (under its lock); a missing run is a no-op.
    *
-   * The run's own lock records go with it. A lease and a cancel lock are named
-   * after the run, so once the run is gone they can never be looked up again —
-   * leaving them behind turns `runs prune` into a command that shrinks one
-   * directory while `locks/` grows forever. They are already logically expired
-   * (prune only ever deletes runs that reached a terminal status), so removing
-   * the files takes nothing live away.
+   * The run's **expired** lock records go with it. A lease and a cancel lock are
+   * named after the run, so once the run is gone they can never be looked up
+   * again — leaving them behind turns `runs prune` into a command that shrinks
+   * one directory while `locks/` grows forever.
+   *
+   * Two things this deliberately does not touch. A lock that has **not** expired
+   * is left alone: somebody still holds that claim, and deleting the record
+   * would make their next renewal report the lease lost — stopping a live run to
+   * tidy up a file. And the `.acq` marker is never removed, because it is not a
+   * lock record at all: it is the mutex guarding every lock's compare-and-swap,
+   * owned by {@link "./mutex.ts".withFileMutex}, which removes it in a `finally`
+   * and reclaims a stale one by TTL. Deleting it from outside that protocol
+   * would let two writers into the critical section at once.
+   *
+   * The expiry check and the delete share the lock's own mutex, so an acquire
+   * racing this cannot have its fresh record removed by a stale reading.
    */
   async deleteRun(id: string): Promise<void> {
     await this.#ensureDir();
@@ -175,8 +185,15 @@ export class FileSystemStateStore implements StateStore {
     });
     for (const prefix of [RUN_LEASE_PREFIX, CANCEL_LOCK_PREFIX]) {
       const key = lockKey(prefix, id);
-      await this.#host.remove(this.#lockFile(key));
-      await this.#host.remove(this.#lockMarker(key));
+      await this.#withMutex(
+        this.#lockMarker(key),
+        `lock "${key}"`,
+        async () => {
+          const current = await this.#readLock(key);
+          if (current !== null && current.expiresAt > this.#host.now()) return;
+          await this.#host.remove(this.#lockFile(key));
+        },
+      );
     }
   }
 

--- a/packages/core/src/state/writer.ts
+++ b/packages/core/src/state/writer.ts
@@ -486,16 +486,29 @@ export class RunStateWriter {
       // The mutation is applied to the live record, so a throw would otherwise
       // leave it there for the next write that lands to persist — recording an
       // intent for an effect that provably never ran, and making the body's
-      // first execution report itself as a re-drive. Keep a copy of the rows
-      // this touches so a refusal really does leave nothing behind.
-      const before = structuredClone(this.#record.targets);
+      // first execution report itself as a re-drive. Keep a copy so a refusal
+      // really does leave nothing behind.
+      //
+      // The whole record, not just `targets`: today both strict mutators touch
+      // only target rows, but a snapshot scoped to what the *current* callers
+      // happen to write is a guard that silently stops guarding the moment
+      // somebody adds a third. `updatedAt` is part of it — a refused write must
+      // not leave the record claiming a modification time no write ever landed.
+      //
+      // Restored *into* the live record rather than by swapping the reference,
+      // because `snapshot()` hands that object out and a compensation walk holds
+      // it across awaits; replacing it would leave that walk reading a record
+      // nothing writes to any more. (The one thing this cannot undo is a
+      // top-level key a mutator adds where none existed — no current mutator
+      // does, and both write only through `ensureTarget`.)
+      const before = structuredClone(this.#record);
       mutator(this.#record);
       this.#record.updatedAt = this.#now();
       let result;
       try {
         result = await this.#store.putRun(this.#record, this.#version);
       } catch (error) {
-        this.#record.targets = before;
+        Object.assign(this.#record, before);
         throw error;
       }
       if (result.ok) {
@@ -507,12 +520,12 @@ export class RunStateWriter {
       // base, exactly as in the best-effort path.
       const fresh = await this.#store.getRun(this.#record.id).catch(
         (error: unknown) => {
-          this.#record.targets = before;
+          Object.assign(this.#record, before);
           throw error;
         },
       );
       if (fresh === null) {
-        this.#record.targets = before;
+        Object.assign(this.#record, before);
         throw new Error(
           `state: run "${this.#record.id}" vanished from the store while ` +
             `recording an effect; refusing to run it without a durable intent`,

--- a/packages/core/src/state/writer.ts
+++ b/packages/core/src/state/writer.ts
@@ -338,9 +338,15 @@ export class RunStateWriter {
    */
   appendEvent(event: RunEvent): Promise<void> {
     const redacted = this.#redactEvent(event);
+    // Appends survive being disowned. What {@link disown} exists to prevent is
+    // this process *overwriting* the new holder's view — a stale target row
+    // replacing real progress. An event is purely additive: it says "this
+    // happened", and it stays true whoever owns the run now. Losing them is the
+    // worse outcome, because the thing most worth recording at that moment is
+    // the rollback this process had already performed before it stopped.
     return this.#update((record) => {
       record.events.push(redacted);
-    });
+    }, { evenIfDisowned: true });
   }
 
   /** Copy a {@link RunEvent} with its `args` values and `detail` redacted. */
@@ -463,8 +469,13 @@ export class RunStateWriter {
   }
 
   /** Serialise `mutator` after all pending writes, then persist (best-effort). */
-  #update(mutator: (record: RunRecord) => void): Promise<void> {
-    this.#chain = this.#chain.then(() => this.#applyAndPersist(mutator));
+  #update(
+    mutator: (record: RunRecord) => void,
+    options: { evenIfDisowned?: boolean } = {},
+  ): Promise<void> {
+    this.#chain = this.#chain.then(() =>
+      this.#applyAndPersist(mutator, options.evenIfDisowned === true)
+    );
     return this.#chain;
   }
 
@@ -614,8 +625,11 @@ export class RunStateWriter {
   }
 
   /** Apply `mutator` and CAS-write, re-reading and retrying on conflict. */
-  async #applyAndPersist(mutator: (record: RunRecord) => void): Promise<void> {
-    if (this.#disowned) return;
+  async #applyAndPersist(
+    mutator: (record: RunRecord) => void,
+    evenIfDisowned = false,
+  ): Promise<void> {
+    if (this.#disowned && !evenIfDisowned) return;
     try {
       for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
         mutator(this.#record);

--- a/packages/core/src/state/writer.ts
+++ b/packages/core/src/state/writer.ts
@@ -121,6 +121,12 @@ export class RunStateWriter {
    * `succeeded` over the terminal a sweep already wrote.
    */
   #settledElsewhere = false;
+  /**
+   * Latched by {@link disown} once this process stops owning the run. Checked
+   * when a queued mutation actually runs, not when it is queued, so writes
+   * already sitting on the chain are neutralised too.
+   */
+  #disowned = false;
   #chain: Promise<void> = Promise.resolve();
 
   private constructor(
@@ -247,6 +253,23 @@ export class RunStateWriter {
    */
   settledElsewhere(): boolean {
     return this.#settledElsewhere;
+  }
+
+  /**
+   * Stop writing: this process no longer owns the run, so nothing it has left
+   * to say about it may reach the store.
+   *
+   * Called when the run's lease is lost. Every write from that instant is a
+   * no-op — including ones already queued, because the check runs when a
+   * mutation is applied rather than when it is enqueued. Without it, the walk
+   * that stops the run queues a `skipped` row for every target it never reached,
+   * and those rows land on the record through the writer's compare-and-swap,
+   * overwriting the progress the new holder is making right now.
+   *
+   * One-way: a run is never re-owned by the process that lost it.
+   */
+  disown(): void {
+    this.#disowned = true;
   }
 
   /** Record the run's terminal status, unless another process already has. */
@@ -479,6 +502,9 @@ export class RunStateWriter {
    * carrying on to the next target.
    */
   async #applyStrict(mutator: (record: RunRecord) => void): Promise<void> {
+    if (this.#disowned) {
+      throw new RunNotActiveError(this.#record.id, this.#record.status);
+    }
     for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
       if (this.#record.status !== "running") {
         throw new RunNotActiveError(this.#record.id, this.#record.status);
@@ -589,6 +615,7 @@ export class RunStateWriter {
 
   /** Apply `mutator` and CAS-write, re-reading and retrying on conflict. */
   async #applyAndPersist(mutator: (record: RunRecord) => void): Promise<void> {
+    if (this.#disowned) return;
     try {
       for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
         mutator(this.#record);

--- a/packages/core/tests/executor_test.ts
+++ b/packages/core/tests/executor_test.ts
@@ -2859,6 +2859,29 @@ Deno.test("a cancelled run does not persist the cache its compensations undid", 
   }
 });
 
+Deno.test("a cancelled run with no state store at all keeps its cache", async () => {
+  // The default shape for a build that declares no compensation: no store, so no
+  // writer, so no walk that could have undone anything. Asserted separately from
+  // the with-a-store case because it reaches the decision by a different route —
+  // and because a test that only covers the store-configured path would pass
+  // while the common configuration threw its cache away on every Ctrl-C.
+  const cache = new FakeCache();
+  const controller = new AbortController();
+  class B extends Build {
+    build = target().executes(() => controller.abort());
+  }
+  const b = new B();
+  discoverTargets(b);
+  const result = await execute(b, b.build, {
+    silent: true,
+    stateStore: false,
+    cache,
+    signal: controller.signal,
+  });
+  assertEquals(result.cancelled, true);
+  assertEquals(cache.saved, true);
+});
+
 Deno.test("a cancelled run with nothing to roll back keeps its cache", async () => {
   const dir = await Deno.makeTempDir();
   try {
@@ -3177,7 +3200,100 @@ Deno.test("a lease lost mid-rollback stops the walk where it stands", async () =
     // The first compensation ran; the claim then changed hands, so the walk
     // stopped rather than carrying on into the new holder's work.
     assertEquals(undone, ["undoSecond"]);
+    // What it did undo is still on the record: an event is additive and stays
+    // true whoever owns the run now, and a rollback nothing recorded would let a
+    // later reader conclude none happened.
+    const after = await store.getRun(seeded.record.id);
+    const events = after?.record.events ?? [];
+    assertEquals(events.some((e) => e.tool === "compensate"), true);
+    // ...but the run was not settled here: that is the new holder's to do.
+    assertEquals(after?.record.status, "cancelling");
   } finally {
     await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("a cancelled fan-out is not reported as a batch that succeeded", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    const controller = new AbortController();
+    const ran: string[] = [];
+    class B extends Build {
+      // Ctrl-C lands while the first item deploys; the rest are abandoned. The
+      // parent must not report success for a batch that never ran — its row is
+      // what the compensation walk reads to decide what to undo, so a
+      // `succeeded` here would roll back a deployment that never happened.
+      batch = target().forEach(
+        () => ["a", "b", "c"],
+        (item: string) => ({
+          deploy: target().executes(() => {
+            ran.push(`deploy:${item}`);
+            if (item === "a") controller.abort();
+          }),
+        }),
+        (s) => s.concurrency(1),
+      );
+    }
+    const b = new B();
+    discoverTargets(b);
+    const result = await execute(b, b.batch, {
+      silent: true,
+      stateStore: store,
+      signal: controller.signal,
+    });
+    assertEquals(result.cancelled, true);
+    assertEquals(ran, ["deploy:a"]);
+    assertEquals(result.executed.includes("batch"), false);
+    const runs = await store.listRuns({});
+    const record = await store.getRun(runs[0].id);
+    assertEquals(
+      record?.record.targets["batch"]?.status === "succeeded",
+      false,
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("teardown behind a gate that will never reopen runs, parallel or not", async () => {
+  // A failed run never suspends, so the gate will never be resumed and anything
+  // behind it is unreachable. Whether the teardown fires must not depend on
+  // whether the gate happened to launch before the failure — which is to say,
+  // must not depend on `--parallel` for a build whose text is identical.
+  for (const parallel of [false, true]) {
+    const dir = await Deno.makeTempDir();
+    try {
+      const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+      const ran: string[] = [];
+      class B extends Build {
+        gate = target().waitsFor((s) => s.on(externalSignal("approved")));
+        boom = target().executes(() => {
+          throw new Error("x");
+        });
+        deploy = target().dependsOn(this.gate).executes(() =>
+          void ran.push("deploy")
+        );
+        teardown = target().always().dependsOn(this.deploy, this.boom).executes(
+          () => void ran.push("teardown"),
+        );
+      }
+      const b = new B();
+      discoverTargets(b);
+      const result = await execute(b, b.teardown, {
+        silent: true,
+        stateStore: store,
+        parallel,
+      });
+      assertEquals(result.ok, false);
+      assertEquals(ran.includes("deploy"), false);
+      assertEquals(
+        ran.includes("teardown"),
+        true,
+        `teardown did not run with parallel: ${parallel}`,
+      );
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
   }
 });

--- a/packages/core/tests/executor_test.ts
+++ b/packages/core/tests/executor_test.ts
@@ -2718,24 +2718,15 @@ async function seedResumableRun(
   return { record, version: put.version };
 }
 
-/** A lease whose loss a test drives, recording whether it was released. */
-function fakeLease(): {
-  lease: HeldLease;
-  lose: () => void;
-  released: () => boolean;
-} {
+/** A lease whose loss a test drives. */
+function fakeLease(): { lease: HeldLease; lose: () => void } {
   const controller = new AbortController();
-  let released = false;
   return {
     lease: {
       lost: controller.signal,
-      release: () => {
-        released = true;
-        return Promise.resolve();
-      },
+      release: () => Promise.resolve(),
     },
     lose: () => controller.abort(new Error("taken over")),
-    released: () => released,
   };
 }
 
@@ -2743,7 +2734,7 @@ Deno.test("losing the lease stops the run without running its compensations", as
   const dir = await Deno.makeTempDir();
   try {
     const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
-    const { lease, lose, released } = fakeLease();
+    const { lease, lose } = fakeLease();
     const compensated: string[] = [];
     class B extends Build {
       // Succeeds, so its compensation is armed — this is exactly the work a
@@ -2771,8 +2762,12 @@ Deno.test("losing the lease stops the run without running its compensations", as
     assertStringIncludes(messageOf(result.error), "lease was taken over");
     // The whole point: the new holder's work is not unwound behind its back.
     assertEquals(compensated, []);
-    // And the claim is not handed back — it is not ours to give.
-    assertEquals(released(), false);
+    // Note what is *not* asserted here: that the lease was not released. A
+    // resumed run's lease belongs to its resumer, which releases it on every
+    // path out, so `execute` never releases this one whatever happens — an
+    // assertion on it could not fail and would only look like coverage. The
+    // release path that does exist is the run's *own* lease, covered by "a
+    // cancelled run gives its lease back rather than holding it to the TTL".
   } finally {
     await Deno.remove(dir, { recursive: true });
   }
@@ -3008,4 +3003,104 @@ Deno.test("a cancelled run still runs its always targets", async () => {
   assertEquals(ran.includes("teardown"), true);
   // ...while ordinary work stops launching.
   assertEquals(ran.includes("more"), false);
+});
+
+Deno.test("a cancelled run runs teardown that sits behind a target it never reached", async () => {
+  // The dangerous arrangement: teardown depends on a target that had not been
+  // launched when the cancel arrived. An `always` target waits for its
+  // predecessors to *settle*, so a predecessor that is merely never started
+  // leaves teardown permanently un-ready — and the resources it exists to
+  // reclaim leak.
+  const controller = new AbortController();
+  const ran: string[] = [];
+  class B extends Build {
+    work = target().executes(() => {
+      ran.push("work");
+      controller.abort();
+    });
+    more = target().dependsOn(this.work).executes(() => void ran.push("more"));
+    teardown = target().dependsOn(this.more).always().executes(() =>
+      void ran.push("teardown")
+    );
+  }
+  const b = new B();
+  discoverTargets(b);
+  const result = await execute(b, b.teardown, {
+    silent: true,
+    stateStore: false,
+    parallel: true,
+    signal: controller.signal,
+  });
+  assertEquals(result.cancelled, true);
+  assertEquals(ran.includes("more"), false); // ordinary work stopped
+  assertEquals(ran.includes("teardown"), true); // cleanup did not
+});
+
+Deno.test("a failed run runs teardown that sits behind a target it never reached", async () => {
+  // The same hole on the failure path, which predates the cancellation change:
+  // `more` never launches because its dependency failed, so it never settles,
+  // so the `always` teardown behind it was never ready and was swept away.
+  const ran: string[] = [];
+  class B extends Build {
+    work = target().executes(() => {
+      ran.push("work");
+      throw new Error("boom");
+    });
+    more = target().dependsOn(this.work).executes(() => void ran.push("more"));
+    teardown = target().dependsOn(this.more).always().executes(() =>
+      void ran.push("teardown")
+    );
+  }
+  const b = new B();
+  discoverTargets(b);
+  const result = await execute(b, b.teardown, {
+    silent: true,
+    stateStore: false,
+    parallel: true,
+  });
+  assertEquals(result.ok, false);
+  assertEquals(ran.includes("more"), false);
+  assertEquals(ran.includes("teardown"), true);
+});
+
+Deno.test("a lost lease writes nothing more to the record it no longer owns", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    const { lease, lose } = fakeLease();
+    class B extends Build {
+      first = target().executes(() => lose());
+      second = target().dependsOn(this.first).executes(() => {});
+      third = target().dependsOn(this.second).executes(() => {});
+    }
+    const b = new B();
+    discoverTargets(b);
+    const order = [b.first, b.second, b.third];
+    const seeded = await seedResumableRun(store, b, order, b.third);
+
+    // Simulate the new holder: it has already re-run the whole plan and
+    // recorded real progress under a version this process does not have.
+    const taken = await store.getRun(seeded.record.id);
+    if (taken === null) throw new Error("the run vanished");
+    const theirs = structuredClone(taken.record);
+    for (const name of ["first", "second", "third"]) {
+      theirs.targets[name] = { status: "succeeded", meta: {} };
+    }
+    await store.putRun(theirs, taken.version);
+
+    await execute(b, b.third, {
+      silent: true,
+      stateStore: store,
+      resume: { ...seeded, done: new Set<string>(), lease },
+    });
+
+    // The stopping walk settles every unreached target `skipped`. None of that
+    // may reach the store: the writer's compare-and-swap would re-read the new
+    // holder's record and re-apply over its real progress.
+    const after = await store.getRun(seeded.record.id);
+    assertEquals(after?.record.targets["second"]?.status, "succeeded");
+    assertEquals(after?.record.targets["third"]?.status, "succeeded");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
 });

--- a/packages/core/tests/executor_test.ts
+++ b/packages/core/tests/executor_test.ts
@@ -2830,26 +2830,60 @@ Deno.test("a lease lost before the plan starts stops the run just the same", asy
 });
 
 Deno.test("a cancelled run does not persist the cache its compensations undid", async () => {
-  const cache = new FakeCache();
-  const controller = new AbortController();
-  class B extends Build {
-    build = target().executes(() => {
-      controller.abort(); // Ctrl-C the moment the body has produced its output
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    const cache = new FakeCache();
+    const controller = new AbortController();
+    class B extends Build {
+      build = target().onCancel(() => this.rollback).executes(() => {
+        controller.abort(); // Ctrl-C the moment the body produced its output
+      });
+      rollback = target().executes(() => {});
+    }
+    const b = new B();
+    discoverTargets(b);
+    const result = await execute(b, b.build, {
+      silent: true,
+      stateStore: store,
+      cache,
+      signal: controller.signal,
     });
+    assertEquals(result.cancelled, true);
+    // The fingerprint was recorded in-memory but never persisted: a
+    // compensation ran, so it describes work that has just been undone.
+    assertEquals(cache.recorded, ["build"]);
+    assertEquals(cache.saved, false);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
   }
-  const b = new B();
-  discoverTargets(b);
-  const result = await execute(b, b.build, {
-    silent: true,
-    stateStore: false,
-    cache,
-    signal: controller.signal,
-  });
-  assertEquals(result.cancelled, true);
-  // The fingerprint was recorded in-memory but never persisted, so the next run
-  // rebuilds rather than trusting work a compensation may have undone.
-  assertEquals(cache.recorded, ["build"]);
-  assertEquals(cache.saved, false);
+});
+
+Deno.test("a cancelled run with nothing to roll back keeps its cache", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    const cache = new FakeCache();
+    const controller = new AbortController();
+    // No target declares a compensation, which is the ordinary case. Nothing was
+    // reversed, so the fingerprints still describe the workspace — discarding
+    // them would make every Ctrl-C cost a full rebuild on the next run.
+    class B extends Build {
+      build = target().executes(() => controller.abort());
+    }
+    const b = new B();
+    discoverTargets(b);
+    const result = await execute(b, b.build, {
+      silent: true,
+      stateStore: store,
+      cache,
+      signal: controller.signal,
+    });
+    assertEquals(result.cancelled, true);
+    assertEquals(cache.saved, true);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
 });
 
 Deno.test("an ordinary failure still persists the cache", async () => {

--- a/packages/core/tests/executor_test.ts
+++ b/packages/core/tests/executor_test.ts
@@ -3104,3 +3104,46 @@ Deno.test("a lost lease writes nothing more to the record it no longer owns", as
     await Deno.remove(dir, { recursive: true });
   }
 });
+
+Deno.test("a lease lost mid-rollback stops the walk where it stands", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    // A compensation walk can be long — real rollbacks talk to real systems —
+    // and a lease lapses on time, not on health. Losing the claim partway
+    // through means every *remaining* compensation would unwind work the new
+    // holder is already rebuilding.
+    const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    const controller = new AbortController();
+    const { lease, lose } = fakeLease();
+    const undone: string[] = [];
+    class B extends Build {
+      first = target().onCancel(() => this.undoFirst).executes(() => {});
+      undoFirst = target().executes(() => void undone.push("undoFirst"));
+      second = target().dependsOn(this.first).onCancel(() => this.undoSecond)
+        .executes(() => controller.abort());
+      // The walk runs in reverse, so this one goes first — and takes the lease
+      // with it, exactly as a lapse during a slow rollback would.
+      undoSecond = target().executes(() => {
+        undone.push("undoSecond");
+        lose();
+      });
+    }
+    const b = new B();
+    discoverTargets(b);
+    const order = [b.first, b.undoFirst, b.second, b.undoSecond];
+    const seeded = await seedResumableRun(store, b, order, b.second);
+
+    await execute(b, b.second, {
+      silent: true,
+      stateStore: store,
+      signal: controller.signal,
+      resume: { ...seeded, done: new Set<string>(), lease },
+    });
+
+    // The first compensation ran; the claim then changed hands, so the walk
+    // stopped rather than carrying on into the new holder's work.
+    assertEquals(undone, ["undoSecond"]);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/packages/core/tests/executor_test.ts
+++ b/packages/core/tests/executor_test.ts
@@ -44,6 +44,9 @@ import { FileSystemStateStore } from "../src/state/fs_store.ts";
 import { defaultStateHost } from "../src/state/store.ts";
 import { LockConflictError } from "../src/state/lock.ts";
 import { externalSignal, resumeWhen } from "../src/wait.ts";
+import type { HeldLease } from "../src/state/run_lease.ts";
+import { buildRunRecord } from "../src/state/record.ts";
+import type { RunRecord } from "../src/state/types.ts";
 
 const silent: ExecuteOptions = { silent: true };
 
@@ -1952,12 +1955,38 @@ Deno.test("cancelling a parallel run terminates in-flight commands in every bran
   assertEquals(result.ok, false); // both branches' commands were killed
 });
 
-Deno.test("a pre-aborted options.signal aborts the context signal", async () => {
+Deno.test("a pre-aborted options.signal cancels the run without starting a target", async () => {
   const controller = new AbortController();
   controller.abort();
+  const ran: string[] = [];
+  class B extends Build {
+    a = target().executes(() => void ran.push("a"));
+    b = target().dependsOn(this.a).executes(() => void ran.push("b"));
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  const result = await execute(b, b.b, {
+    silent: true,
+    signal: controller.signal,
+  });
+  // A run that is cancelled before it starts starts nothing: launching work for
+  // a run already given up on is the same mistake as carrying on after a lost
+  // lease, just at the other end.
+  assertEquals(ran, []);
+  assertEquals(result.ok, false);
+  assertEquals(result.cancelled, true);
+});
+
+Deno.test("a body sees the run's cancellation on its own context signal", async () => {
+  const controller = new AbortController();
   let sawAborted = false;
   class B extends Build {
-    a = target().executes((ctx) => {
+    a = target().executes(async (ctx) => {
+      // Cancelled while this body is in flight — the case a body can actually
+      // observe, and the one `ctx.signal` exists for.
+      controller.abort();
+      await new Promise((resolve) => setTimeout(resolve, 0));
       sawAborted = ctx.signal.aborted;
     });
   }
@@ -1969,9 +1998,6 @@ Deno.test("a pre-aborted options.signal aborts the context signal", async () => 
     signal: controller.signal,
   });
   assertEquals(sawAborted, true);
-  // A pre-aborted signal cancels the run: no body ran to completion, and the
-  // result is a non-ok cancellation (M6).
-  assertEquals(result.ok, false);
   assertEquals(result.cancelled, true);
 });
 
@@ -2661,4 +2687,325 @@ Deno.test("execute flags an ordering edge to a target not in the build", async (
   const out = lines.join("\n");
   assertStringIncludes(out, "not a target in this build"); // ghost flagged
   assertEquals(out.includes('"other"'), false); // conditional target not flagged
+});
+
+// ---- the run's lease: losing it is not a cancellation ------------------------
+
+/**
+ * Seed `store` with a `running` record for `build`/`order` and return the
+ * {@link ResumeState} pieces `execute` needs to continue it. Lets a test supply
+ * its own lease — the run's own lease is acquired inside `openRunState` with a
+ * 60-second TTL, so a heartbeat-driven loss is not reachable from a test,
+ * whereas a resumed run is handed the lease its resumer took.
+ */
+async function seedResumableRun(
+  store: FileSystemStateStore,
+  build: Build,
+  order: TargetBuilder[],
+  root: TargetBuilder,
+): Promise<{ record: RunRecord; version: string }> {
+  const record = buildRunRecord({
+    runId: "11111111-2222-3333-4444-555555555555",
+    build: build.constructor.name,
+    rootTarget: root.name_ ?? "",
+    order,
+    params: [],
+    actor: "tester",
+    now: new Date().toISOString(),
+  });
+  const put = await store.putRun(record, null);
+  if (!put.ok) throw new Error("could not seed the run record");
+  return { record, version: put.version };
+}
+
+/** A lease whose loss a test drives, recording whether it was released. */
+function fakeLease(): {
+  lease: HeldLease;
+  lose: () => void;
+  released: () => boolean;
+} {
+  const controller = new AbortController();
+  let released = false;
+  return {
+    lease: {
+      lost: controller.signal,
+      release: () => {
+        released = true;
+        return Promise.resolve();
+      },
+    },
+    lose: () => controller.abort(new Error("taken over")),
+    released: () => released,
+  };
+}
+
+Deno.test("losing the lease stops the run without running its compensations", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    const { lease, lose, released } = fakeLease();
+    const compensated: string[] = [];
+    class B extends Build {
+      // Succeeds, so its compensation is armed — this is exactly the work a
+      // cancellation would unwind, and exactly what must survive a takeover.
+      deploy = target()
+        .onCancel(() => this.rollback)
+        .executes(() => {
+          lose(); // a sweep decided this process was gone and took the run
+        });
+      rollback = target().executes(() => void compensated.push("rollback"));
+    }
+    const b = new B();
+    discoverTargets(b);
+    const seeded = await seedResumableRun(store, b, [b.deploy], b.deploy);
+
+    const result = await execute(b, b.deploy, {
+      silent: true,
+      stateStore: store,
+      resume: { ...seeded, done: new Set<string>(), lease },
+    });
+
+    assertEquals(result.ok, false);
+    // Not reported as a cancellation: nobody asked for one.
+    assertEquals(result.cancelled, undefined);
+    assertStringIncludes(messageOf(result.error), "lease was taken over");
+    // The whole point: the new holder's work is not unwound behind its back.
+    assertEquals(compensated, []);
+    // And the claim is not handed back — it is not ours to give.
+    assertEquals(released(), false);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("losing the lease leaves the record for its new holder to settle", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    const { lease, lose } = fakeLease();
+    class B extends Build {
+      deploy = target().executes(() => lose());
+    }
+    const b = new B();
+    discoverTargets(b);
+    const seeded = await seedResumableRun(store, b, [b.deploy], b.deploy);
+
+    await execute(b, b.deploy, {
+      silent: true,
+      stateStore: store,
+      resume: { ...seeded, done: new Set<string>(), lease },
+    });
+
+    // Never moved to a terminal status by the process that lost the claim.
+    const after = await store.getRun(seeded.record.id);
+    assertEquals(after?.record.status, "running");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("a lease lost before the plan starts stops the run just the same", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    const { lease, lose } = fakeLease();
+    lose(); // already gone by the time execute() reads the signal
+    const ran: string[] = [];
+    class B extends Build {
+      deploy = target()
+        .onCancel(() => this.rollback)
+        .executes(() => void ran.push("body"));
+      rollback = target().executes(() => void ran.push("compensated"));
+    }
+    const b = new B();
+    discoverTargets(b);
+    const seeded = await seedResumableRun(store, b, [b.deploy], b.deploy);
+
+    const result = await execute(b, b.deploy, {
+      silent: true,
+      stateStore: store,
+      resume: { ...seeded, done: new Set<string>(), lease },
+    });
+    assertEquals(result.ok, false);
+    assertStringIncludes(messageOf(result.error), "lease was taken over");
+    assertEquals(ran, []);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("a cancelled run does not persist the cache its compensations undid", async () => {
+  const cache = new FakeCache();
+  const controller = new AbortController();
+  class B extends Build {
+    build = target().executes(() => {
+      controller.abort(); // Ctrl-C the moment the body has produced its output
+    });
+  }
+  const b = new B();
+  discoverTargets(b);
+  const result = await execute(b, b.build, {
+    silent: true,
+    stateStore: false,
+    cache,
+    signal: controller.signal,
+  });
+  assertEquals(result.cancelled, true);
+  // The fingerprint was recorded in-memory but never persisted, so the next run
+  // rebuilds rather than trusting work a compensation may have undone.
+  assertEquals(cache.recorded, ["build"]);
+  assertEquals(cache.saved, false);
+});
+
+Deno.test("an ordinary failure still persists the cache", async () => {
+  const cache = new FakeCache();
+  class B extends Build {
+    ok = target().executes(() => {});
+    boom = target().dependsOn(this.ok).executes(() => {
+      throw new Error("nope");
+    });
+  }
+  const b = new B();
+  discoverTargets(b);
+  const result = await execute(b, b.boom, {
+    silent: true,
+    stateStore: false,
+    cache,
+  });
+  assertEquals(result.ok, false);
+  // Nothing was unwound, so the target that did succeed stays cached.
+  assertEquals(cache.saved, true);
+});
+
+Deno.test("a store that cannot answer the lease fails the run cleanly, not by rejecting", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    // A store whose lock acquire always throws — a filesystem mutex it could not
+    // take in time, an HTTP 503, a DNS blip. None of those say who holds the
+    // lease, so they are retried; one that never answers stops the run.
+    class AcquireThrows extends FileSystemStateStore {
+      calls = 0;
+      override acquireLock(): Promise<never> {
+        this.calls++;
+        return Promise.reject(new Error("mutex timeout"));
+      }
+    }
+    const store = new AcquireThrows(`${dir}/runs`, defaultStateHost);
+    const ran: string[] = [];
+    class B extends Build {
+      work = target().executes(() => void ran.push("work"));
+    }
+    const b = new B();
+    discoverTargets(b);
+
+    // Reported, never thrown: `execute` resolves to a failing result the CLI
+    // prints, rather than rejecting with a stack trace.
+    const result = await execute(b, b.work, {
+      silent: true,
+      stateStore: store,
+    });
+    assertEquals(result.ok, false);
+    assertStringIncludes(messageOf(result.error), "Could not claim run");
+    assertStringIncludes(messageOf(result.error), "mutex timeout");
+    // Retried rather than decided on one bad moment...
+    assertEquals(store.calls > 1, true);
+    // ...and the run never started unclaimed, which would have left a healthy
+    // run looking abandoned to every sweep for its whole duration.
+    assertEquals(ran, []);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("a lease that recovers on a retry lets the run proceed", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    class FlakyOnce extends FileSystemStateStore {
+      calls = 0;
+      override acquireLock(
+        key: string,
+        holder: Parameters<FileSystemStateStore["acquireLock"]>[1],
+        ttlMs: number,
+      ) {
+        this.calls++;
+        if (this.calls === 1) return Promise.reject(new Error("blip"));
+        return super.acquireLock(key, holder, ttlMs);
+      }
+    }
+    const store = new FlakyOnce(`${dir}/runs`, defaultStateHost);
+    class B extends Build {
+      work = target().executes(() => {});
+    }
+    const b = new B();
+    discoverTargets(b);
+    const result = await execute(b, b.work, {
+      silent: true,
+      stateStore: store,
+    });
+    assertEquals(result.ok, true);
+    assertEquals(store.calls, 2);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("a cancelled run gives its lease back rather than holding it to the TTL", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    const controller = new AbortController();
+    class B extends Build {
+      work = target().executes(() => controller.abort());
+    }
+    const b = new B();
+    discoverTargets(b);
+    const result = await execute(b, b.work, {
+      silent: true,
+      stateStore: store,
+      signal: controller.signal,
+    });
+    assertEquals(result.cancelled, true);
+    // The record is terminal, so holding the claim would say a process is still
+    // working on a run that demonstrably ended. Acquiring it again proves it was
+    // handed back: a live holder would refuse.
+    const runId = result.runId ?? "";
+    const retaken = await store.acquireLock(
+      `zuke-run-${runId}`,
+      { actor: "sweep", runId, since: new Date().toISOString() },
+      1000,
+    );
+    assertEquals(retaken.ok, true);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("a cancelled run still runs its always targets", async () => {
+  // Cancelling stops ordinary work, but `always` is teardown — and Ctrl-C is
+  // exactly when teardown matters. Skipping it would leak whatever it reclaims.
+  const controller = new AbortController();
+  const ran: string[] = [];
+  class B extends Build {
+    setup = target().executes(() => void ran.push("setup"));
+    work = target().dependsOn(this.setup).executes(() => {
+      ran.push("work");
+      controller.abort();
+    });
+    more = target().dependsOn(this.work).executes(() => void ran.push("more"));
+    teardown = target().dependsOn(this.work).always().executes(() =>
+      void ran.push("teardown")
+    );
+  }
+  const b = new B();
+  discoverTargets(b);
+  const result = await execute(b, b.teardown, {
+    silent: true,
+    stateStore: false,
+    parallel: true,
+    signal: controller.signal,
+  });
+  assertEquals(result.cancelled, true);
+  assertEquals(ran.includes("teardown"), true);
+  // ...while ordinary work stops launching.
+  assertEquals(ran.includes("more"), false);
 });

--- a/packages/core/tests/state_test.ts
+++ b/packages/core/tests/state_test.ts
@@ -1413,3 +1413,47 @@ Deno.test("a run's origin round-trips, and its absence stays an absence", () => 
   assertEquals("buildId" in parsed, false);
   assertEquals(parsed.buildId, undefined);
 });
+
+Deno.test("deleting a run takes its lock records with it", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    const runId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    const record = buildRunRecord({
+      runId,
+      build: "B",
+      rootTarget: "work",
+      order: [],
+      params: [],
+      actor: "tester",
+      now: new Date().toISOString(),
+    });
+    await store.putRun(record, null);
+    // The two locks a run acquires over itself: its lease and its cancel lock.
+    for (const key of [`zuke-run-${runId}`, `zuke-cancel-${runId}`]) {
+      const held = await store.acquireLock(
+        key,
+        { actor: "tester", runId, since: new Date().toISOString() },
+        60_000,
+      );
+      assertEquals(held.ok, true);
+    }
+    const locksBefore = await Deno.readDir(`${dir}/runs/locks`);
+    let before = 0;
+    for await (const _ of locksBefore) before++;
+    assertEquals(before > 0, true);
+
+    await store.deleteRun(runId);
+
+    // Both are named after the run, so once it is gone they could never be
+    // looked up again — leaving them would make `runs prune` shrink one
+    // directory while `locks/` grew forever.
+    const names: string[] = [];
+    for await (const entry of Deno.readDir(`${dir}/runs/locks`)) {
+      names.push(entry.name);
+    }
+    assertEquals(names.filter((n) => n.includes(runId)), []);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/packages/core/tests/state_test.ts
+++ b/packages/core/tests/state_test.ts
@@ -1491,3 +1491,59 @@ Deno.test("deleting a run leaves a lock somebody still holds", async () => {
     await Deno.remove(dir, { recursive: true });
   }
 });
+
+Deno.test("a lock whose mutex is busy never fails the prune that found it", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    // A host that never yields the lock mutex, as a live holder mid-acquire
+    // would look. Clearing a leftover lock is tidiness; the run's own deletion
+    // is the deletion that matters, and litter must not fail a prune.
+    class BusyLockHost implements StateHost {
+      readonly real = defaultStateHost;
+      readText(path: string) {
+        return this.real.readText(path);
+      }
+      writeText(path: string, content: string) {
+        return this.real.writeText(path, content);
+      }
+      rename(from: string, to: string) {
+        return this.real.rename(from, to);
+      }
+      createExclusive(path: string): Promise<boolean> {
+        if (path.endsWith(".acq")) return Promise.resolve(false);
+        return this.real.createExclusive(path);
+      }
+      remove(path: string) {
+        return this.real.remove(path);
+      }
+      listDir(path: string) {
+        return this.real.listDir(path);
+      }
+      mkdirp(path: string) {
+        return this.real.mkdirp(path);
+      }
+      now() {
+        return this.real.now();
+      }
+    }
+    const store = new FileSystemStateStore(`${dir}/runs`, new BusyLockHost());
+    const runId = "cccccccc-dddd-eeee-ffff-000000000000";
+    await store.putRun(
+      buildRunRecord({
+        runId,
+        build: "B",
+        rootTarget: "work",
+        order: [],
+        params: [],
+        actor: "tester",
+        now: new Date().toISOString(),
+      }),
+      null,
+    );
+
+    await store.deleteRun(runId); // must not throw
+    assertEquals(await store.getRun(runId), null);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/packages/core/tests/state_test.ts
+++ b/packages/core/tests/state_test.ts
@@ -1414,7 +1414,7 @@ Deno.test("a run's origin round-trips, and its absence stays an absence", () => 
   assertEquals(parsed.buildId, undefined);
 });
 
-Deno.test("deleting a run takes its lock records with it", async () => {
+Deno.test("deleting a run takes its expired lock records with it", async () => {
   const dir = await Deno.makeTempDir();
   try {
     const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
@@ -1429,19 +1429,17 @@ Deno.test("deleting a run takes its lock records with it", async () => {
       now: new Date().toISOString(),
     });
     await store.putRun(record, null);
-    // The two locks a run acquires over itself: its lease and its cancel lock.
+    // The two locks a run takes over itself: its lease and its cancel lock,
+    // both already lapsed — the state a settled or crashed run leaves behind.
     for (const key of [`zuke-run-${runId}`, `zuke-cancel-${runId}`]) {
       const held = await store.acquireLock(
         key,
         { actor: "tester", runId, since: new Date().toISOString() },
-        60_000,
+        1,
       );
       assertEquals(held.ok, true);
     }
-    const locksBefore = await Deno.readDir(`${dir}/runs/locks`);
-    let before = 0;
-    for await (const _ of locksBefore) before++;
-    assertEquals(before > 0, true);
+    await new Promise((resolve) => setTimeout(resolve, 5));
 
     await store.deleteRun(runId);
 
@@ -1452,7 +1450,43 @@ Deno.test("deleting a run takes its lock records with it", async () => {
     for await (const entry of Deno.readDir(`${dir}/runs/locks`)) {
       names.push(entry.name);
     }
-    assertEquals(names.filter((n) => n.includes(runId)), []);
+    assertEquals(names.filter((n) => n.endsWith(".json")), []);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("deleting a run leaves a lock somebody still holds", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    const runId = "bbbbbbbb-cccc-dddd-eeee-ffffffffffff";
+    const record = buildRunRecord({
+      runId,
+      build: "B",
+      rootTarget: "work",
+      order: [],
+      params: [],
+      actor: "tester",
+      now: new Date().toISOString(),
+    });
+    await store.putRun(record, null);
+    const key = `zuke-run-${runId}`;
+    const held = await store.acquireLock(
+      key,
+      { actor: "tester", runId, since: new Date().toISOString() },
+      60_000,
+    );
+    assertEquals(held.ok, true);
+
+    await store.deleteRun(runId);
+
+    // Tidying up a file must never stop a live run: deleting a claim somebody
+    // still holds would make their next renewal report the lease lost.
+    assertEquals(
+      await store.renewLock(key, held.ok ? held.token : "", 60_000),
+      true,
+    );
   } finally {
     await Deno.remove(dir, { recursive: true });
   }

--- a/packages/core/tests/state_test.ts
+++ b/packages/core/tests/state_test.ts
@@ -1414,120 +1414,11 @@ Deno.test("a run's origin round-trips, and its absence stays an absence", () => 
   assertEquals(parsed.buildId, undefined);
 });
 
-Deno.test("deleting a run takes its expired lock records with it", async () => {
+Deno.test("deleting a run leaves its lock records alone", async () => {
   const dir = await Deno.makeTempDir();
   try {
     const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
     const runId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
-    const record = buildRunRecord({
-      runId,
-      build: "B",
-      rootTarget: "work",
-      order: [],
-      params: [],
-      actor: "tester",
-      now: new Date().toISOString(),
-    });
-    await store.putRun(record, null);
-    // The two locks a run takes over itself: its lease and its cancel lock,
-    // both already lapsed — the state a settled or crashed run leaves behind.
-    for (const key of [`zuke-run-${runId}`, `zuke-cancel-${runId}`]) {
-      const held = await store.acquireLock(
-        key,
-        { actor: "tester", runId, since: new Date().toISOString() },
-        1,
-      );
-      assertEquals(held.ok, true);
-    }
-    await new Promise((resolve) => setTimeout(resolve, 5));
-
-    await store.deleteRun(runId);
-
-    // Both are named after the run, so once it is gone they could never be
-    // looked up again — leaving them would make `runs prune` shrink one
-    // directory while `locks/` grew forever.
-    const names: string[] = [];
-    for await (const entry of Deno.readDir(`${dir}/runs/locks`)) {
-      names.push(entry.name);
-    }
-    assertEquals(names.filter((n) => n.endsWith(".json")), []);
-  } finally {
-    await Deno.remove(dir, { recursive: true });
-  }
-});
-
-Deno.test("deleting a run leaves a lock somebody still holds", async () => {
-  const dir = await Deno.makeTempDir();
-  try {
-    const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
-    const runId = "bbbbbbbb-cccc-dddd-eeee-ffffffffffff";
-    const record = buildRunRecord({
-      runId,
-      build: "B",
-      rootTarget: "work",
-      order: [],
-      params: [],
-      actor: "tester",
-      now: new Date().toISOString(),
-    });
-    await store.putRun(record, null);
-    const key = `zuke-run-${runId}`;
-    const held = await store.acquireLock(
-      key,
-      { actor: "tester", runId, since: new Date().toISOString() },
-      60_000,
-    );
-    assertEquals(held.ok, true);
-
-    await store.deleteRun(runId);
-
-    // Tidying up a file must never stop a live run: deleting a claim somebody
-    // still holds would make their next renewal report the lease lost.
-    assertEquals(
-      await store.renewLock(key, held.ok ? held.token : "", 60_000),
-      true,
-    );
-  } finally {
-    await Deno.remove(dir, { recursive: true });
-  }
-});
-
-Deno.test("a lock whose mutex is busy never fails the prune that found it", async () => {
-  const dir = await Deno.makeTempDir();
-  try {
-    // A host that never yields the lock mutex, as a live holder mid-acquire
-    // would look. Clearing a leftover lock is tidiness; the run's own deletion
-    // is the deletion that matters, and litter must not fail a prune.
-    class BusyLockHost implements StateHost {
-      readonly real = defaultStateHost;
-      readText(path: string) {
-        return this.real.readText(path);
-      }
-      writeText(path: string, content: string) {
-        return this.real.writeText(path, content);
-      }
-      rename(from: string, to: string) {
-        return this.real.rename(from, to);
-      }
-      createExclusive(path: string): Promise<boolean> {
-        if (path.endsWith(".acq")) return Promise.resolve(false);
-        return this.real.createExclusive(path);
-      }
-      remove(path: string) {
-        return this.real.remove(path);
-      }
-      listDir(path: string) {
-        return this.real.listDir(path);
-      }
-      mkdirp(path: string) {
-        return this.real.mkdirp(path);
-      }
-      now() {
-        return this.real.now();
-      }
-    }
-    const store = new FileSystemStateStore(`${dir}/runs`, new BusyLockHost());
-    const runId = "cccccccc-dddd-eeee-ffff-000000000000";
     await store.putRun(
       buildRunRecord({
         runId,
@@ -1540,9 +1431,30 @@ Deno.test("a lock whose mutex is busy never fails the prune that found it", asyn
       }),
       null,
     );
+    // A lease that has lapsed but was never taken over — the state a run that is
+    // merely slow leaves behind, since the heartbeat cannot fire while its body
+    // blocks the event loop.
+    const key = `zuke-run-${runId}`;
+    const held = await store.acquireLock(
+      key,
+      { actor: "tester", runId, since: new Date().toISOString() },
+      1,
+    );
+    assertEquals(held.ok, true);
+    await new Promise((resolve) => setTimeout(resolve, 5));
 
-    await store.deleteRun(runId); // must not throw
+    await store.deleteRun(runId);
     assertEquals(await store.getRun(runId), null);
+
+    // The record survives, and the holder can still renew: expiry is not
+    // abandonment here — a lapsed claim stays the holder's until somebody
+    // acquires it. Deleting it would make the next renewal report the lease
+    // lost, stopping a run that is only slow, which is the one thing the lease
+    // exists to avoid.
+    assertEquals(
+      await store.renewLock(key, held.ok ? held.token : "", 60_000),
+      true,
+    );
   } finally {
     await Deno.remove(dir, { recursive: true });
   }

--- a/packages/core/tests/writer_effects_test.ts
+++ b/packages/core/tests/writer_effects_test.ts
@@ -363,8 +363,18 @@ Deno.test("a refused intent leaves the record's modification time alone too", as
   // attempted. Leaving a bumped one behind would have the record claim a
   // modification no write ever landed — and the next best-effort write would
   // persist that claim.
+  //
+  // Needs a clock that actually moves: the shared `writerFor` helper hands the
+  // writer a constant, against which this assertion would hold no matter what
+  // the rollback did.
   const store = new MemStore();
-  const writer = await writerFor(store);
+  let tick = 0;
+  const writer = await RunStateWriter.open(
+    store,
+    sampleRecord("running"),
+    () => `2026-01-01T00:00:${String(tick++).padStart(2, "0")}.000Z`,
+    new Redactor(),
+  );
   const before = writer.snapshot().updatedAt;
   store.failNextPut = true;
   await assertRejects(() => writer.beginEffect("gate", "post"), Error);
@@ -374,7 +384,9 @@ Deno.test("a refused intent leaves the record's modification time alone too", as
 Deno.test("a refused intent restores the record in place, not by replacing it", async () => {
   // A compensation walk is handed `snapshot()` and reads it across awaits, so a
   // rollback that swapped the reference would leave that walk reading a record
-  // nothing writes to any more.
+  // nothing writes to any more. This guards that invariant against a future
+  // change rather than pinning the current one — restoring only `targets`, as
+  // the code did before, preserved identity too.
   const store = new MemStore();
   const writer = await writerFor(store);
   const held = writer.snapshot();

--- a/packages/core/tests/writer_effects_test.ts
+++ b/packages/core/tests/writer_effects_test.ts
@@ -357,3 +357,30 @@ Deno.test("a run settled elsewhere is not marked suspended either", async () => 
   await writer.markRunSuspended();
   assertEquals(store.record?.status, "cancelled");
 });
+
+Deno.test("a refused intent leaves the record's modification time alone too", async () => {
+  // `updatedAt` is stamped alongside the mutation, before the write is
+  // attempted. Leaving a bumped one behind would have the record claim a
+  // modification no write ever landed — and the next best-effort write would
+  // persist that claim.
+  const store = new MemStore();
+  const writer = await writerFor(store);
+  const before = writer.snapshot().updatedAt;
+  store.failNextPut = true;
+  await assertRejects(() => writer.beginEffect("gate", "post"), Error);
+  assertEquals(writer.snapshot().updatedAt, before);
+});
+
+Deno.test("a refused intent restores the record in place, not by replacing it", async () => {
+  // A compensation walk is handed `snapshot()` and reads it across awaits, so a
+  // rollback that swapped the reference would leave that walk reading a record
+  // nothing writes to any more.
+  const store = new MemStore();
+  const writer = await writerFor(store);
+  const held = writer.snapshot();
+  store.failNextPut = true;
+  await assertRejects(() => writer.beginEffect("gate", "post"), Error);
+  assertEquals(writer.snapshot() === held, true);
+  // ...and the rollback really reached the object that reference points at.
+  assertEquals(held.targets.gate?.effects?.post, undefined);
+});

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/skills/zuke-write-build/SKILL.md
+++ b/plugins/zuke/skills/zuke-write-build/SKILL.md
@@ -125,7 +125,8 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   `--affected` runs only targets changed since a git base; `--no-cache` /
   `--no-remote-cache` bypass them. A restore is confined to the target's
   declared `.outputs(...)` (and never `.git`/`.zuke`); a refused archive is a
-  cache miss with a warning, not a failure.
+  cache miss with a warning, not a failure. A cancelled run keeps its cache
+  unless a compensation actually rolled something back.
 - **Durable run state:** persist a run's status and per-target metadata to a
   pluggable `StateStore` so it survives the process — turn it on with `--state`,
   `ZUKE_STATE_DIR` / `ZUKE_STATE_URL`, or `override stateStore()`. Every

--- a/plugins/zuke/skills/zuke-write-build/SKILL.md
+++ b/plugins/zuke/skills/zuke-write-build/SKILL.md
@@ -139,7 +139,9 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   (only terminal runs; never suspended/running).
   A run whose process is killed is picked up by `zuke resume --check`, which
   reaps it — its lease tells a dead holder from a slow one — and resumes it in
-  the same sweep. `override deadline()` gives a run a wall-clock budget
+  the same sweep. A process that merely *looked* dead and then finds its lease
+  taken over **stops**, running no compensations and settling nothing: the run
+  is the new holder's now. `override deadline()` gives a run a wall-clock budget
   (`"45m"`, or milliseconds) that survives suspension; an abandoned run found
   past it is settled `failed` with its compensations instead of resumed.
   On a **shared** store, set `ZUKE_BUILD_ID` (or rely on `GITHUB_REPOSITORY`) so

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -219,9 +219,10 @@ class CD extends Build {
 - **Run leases and reaping.** A run that writes durable state takes a TTL lease
   on its own id and heartbeats it, so two processes cannot both believe they own
   one run — a resume that adopts a run whose lease has lapsed takes it over, and
-  the original **stops**: it runs no compensations and settles nothing, because
-  the run belongs to whoever holds the claim now (unwinding would roll back the
-  work the new holder is building on). A run that cannot take its lease at all —
+  the original **stops**: it runs no compensations, settles nothing, and writes
+  nothing further, because the run belongs to whoever holds the claim now
+  (unwinding would roll back the work the new holder is building on). A claim
+  lost *during* a cancellation's rollback stops that walk where it stands, too. A run that cannot take its lease at all —
   a store that never answers, after retries — fails with a named error rather
   than running unclaimed. A run that settles, cancellation included, hands the
   claim straight back. The lease is also how a dead run is told from a slow one:

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -219,13 +219,19 @@ class CD extends Build {
 - **Run leases and reaping.** A run that writes durable state takes a TTL lease
   on its own id and heartbeats it, so two processes cannot both believe they own
   one run — a resume that adopts a run whose lease has lapsed takes it over, and
-  the original stops. The lease is also how a dead run is told from a slow one:
+  the original **stops**: it runs no compensations and settles nothing, because
+  the run belongs to whoever holds the claim now (unwinding would roll back the
+  work the new holder is building on). A run that cannot take its lease at all —
+  a store that never answers, after retries — fails with a named error rather
+  than running unclaimed. A run that settles, cancellation included, hands the
+  claim straight back. The lease is also how a dead run is told from a slow one:
   `zuke resume --check` looks at `running` runs before it sweeps suspended ones,
   and a lease it can acquire means the holder is gone. Such a run is put back to
   `suspended` with a reap event saying why, and the same pass resumes it — so a
   process killed mid-run has its owed effects driven without an operator
   stepping in. A run whose lease is still being renewed is merely slow, and is
   left alone. The same sweep also finishes runs a dead settler left `cancelling`.
+  `zuke runs prune` deletes a pruned run's lock records along with it.
 - **Run deadlines.** `override deadline()` on the `Build` gives a run a
   wall-clock budget (`"45m"`, or milliseconds), stamped as `deadlineAt` when it
   starts and pushed forward on resume by however long the run sat parked — so

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -232,7 +232,6 @@ class CD extends Build {
   process killed mid-run has its owed effects driven without an operator
   stepping in. A run whose lease is still being renewed is merely slow, and is
   left alone. The same sweep also finishes runs a dead settler left `cancelling`.
-  `zuke runs prune` deletes a pruned run's lock records along with it.
 - **Run deadlines.** `override deadline()` on the `Build` gives a run a
   wall-clock budget (`"45m"`, or milliseconds), stamped as `deadlineAt` when it
   starts and pushed forward on resume by however long the run sat parked — so

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -125,7 +125,8 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   `--affected` runs only targets changed since a git base; `--no-cache` /
   `--no-remote-cache` bypass them. A restore is confined to the target's
   declared `.outputs(...)` (and never `.git`/`.zuke`); a refused archive is a
-  cache miss with a warning, not a failure.
+  cache miss with a warning, not a failure. A cancelled run keeps its cache
+  unless a compensation actually rolled something back.
 - **Durable run state:** persist a run's status and per-target metadata to a
   pluggable `StateStore` so it survives the process — turn it on with `--state`,
   `ZUKE_STATE_DIR` / `ZUKE_STATE_URL`, or `override stateStore()`. Every

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -139,7 +139,9 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   (only terminal runs; never suspended/running).
   A run whose process is killed is picked up by `zuke resume --check`, which
   reaps it — its lease tells a dead holder from a slow one — and resumes it in
-  the same sweep. `override deadline()` gives a run a wall-clock budget
+  the same sweep. A process that merely *looked* dead and then finds its lease
+  taken over **stops**, running no compensations and settling nothing: the run
+  is the new holder's now. `override deadline()` gives a run a wall-clock budget
   (`"45m"`, or milliseconds) that survives suspension; an abandoned run found
   past it is settled `failed` with its compensations instead of resumed.
   On a **shared** store, set `ZUKE_BUILD_ID` (or rely on `GITHUB_REPOSITORY`) so

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -219,9 +219,10 @@ class CD extends Build {
 - **Run leases and reaping.** A run that writes durable state takes a TTL lease
   on its own id and heartbeats it, so two processes cannot both believe they own
   one run — a resume that adopts a run whose lease has lapsed takes it over, and
-  the original **stops**: it runs no compensations and settles nothing, because
-  the run belongs to whoever holds the claim now (unwinding would roll back the
-  work the new holder is building on). A run that cannot take its lease at all —
+  the original **stops**: it runs no compensations, settles nothing, and writes
+  nothing further, because the run belongs to whoever holds the claim now
+  (unwinding would roll back the work the new holder is building on). A claim
+  lost *during* a cancellation's rollback stops that walk where it stands, too. A run that cannot take its lease at all —
   a store that never answers, after retries — fails with a named error rather
   than running unclaimed. A run that settles, cancellation included, hands the
   claim straight back. The lease is also how a dead run is told from a slow one:

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -219,13 +219,19 @@ class CD extends Build {
 - **Run leases and reaping.** A run that writes durable state takes a TTL lease
   on its own id and heartbeats it, so two processes cannot both believe they own
   one run — a resume that adopts a run whose lease has lapsed takes it over, and
-  the original stops. The lease is also how a dead run is told from a slow one:
+  the original **stops**: it runs no compensations and settles nothing, because
+  the run belongs to whoever holds the claim now (unwinding would roll back the
+  work the new holder is building on). A run that cannot take its lease at all —
+  a store that never answers, after retries — fails with a named error rather
+  than running unclaimed. A run that settles, cancellation included, hands the
+  claim straight back. The lease is also how a dead run is told from a slow one:
   `zuke resume --check` looks at `running` runs before it sweeps suspended ones,
   and a lease it can acquire means the holder is gone. Such a run is put back to
   `suspended` with a reap event saying why, and the same pass resumes it — so a
   process killed mid-run has its owed effects driven without an operator
   stepping in. A run whose lease is still being renewed is merely slow, and is
   left alone. The same sweep also finishes runs a dead settler left `cancelling`.
+  `zuke runs prune` deletes a pruned run's lock records along with it.
 - **Run deadlines.** `override deadline()` on the `Build` gives a run a
   wall-clock budget (`"45m"`, or milliseconds), stamped as `deadlineAt` when it
   starts and pushed forward on resume by however long the run sat parked — so

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -232,7 +232,6 @@ class CD extends Build {
   process killed mid-run has its owed effects driven without an operator
   stepping in. A run whose lease is still being renewed is merely slow, and is
   left alone. The same sweep also finishes runs a dead settler left `cancelling`.
-  `zuke runs prune` deletes a pruned run's lock records along with it.
 - **Run deadlines.** `override deadline()` on the `Build` gives a run a
   wall-clock budget (`"45m"`, or milliseconds), stamped as `deadlineAt` when it
   starts and pushed forward on resume by however long the run sat parked — so

--- a/tests/e2e/cancel_e2e.ts
+++ b/tests/e2e/cancel_e2e.ts
@@ -105,46 +105,58 @@ async function spawnUntil(
   return { child, out: () => text };
 }
 
-Deno.test("a signalled run hands its lease back instead of holding it to the TTL", async () => {
-  const dir = await Deno.makeTempDir({ prefix: "zuke-e2e-" });
-  try {
-    // Process 1: deploy, then block — the run is `running` and its lease held.
-    const { child } = await spawnUntil(["hold"], dir, "HOLDING");
-    const store = new FileSystemStateStore(dir, defaultStateHost);
-    const runs = await store.listRuns({ status: "running" });
-    assertEquals(runs.length, 1);
-    const id = runs[0].id;
+Deno.test({
+  name: "a signalled run hands its lease back instead of holding it to the TTL",
+  // Windows has no graceful stop to deliver. `installCancelSignals` installs
+  // only SIGINT there (SIGTERM is unsupported), and Deno cannot send a child a
+  // signal it can *handle* on Windows — a kill terminates the process outright,
+  // so the run never reaches the settle-and-release path this asserts. The
+  // behaviour itself is still covered on all three OSes by the unit test "a
+  // cancelled run gives its lease back rather than holding it to the TTL",
+  // which drives the same path in-process; what is Unix-only is proving it
+  // survives a real signal to a real second process.
+  ignore: Deno.build.os === "windows",
+  fn: async () => {
+    const dir = await Deno.makeTempDir({ prefix: "zuke-e2e-" });
+    try {
+      // Process 1: deploy, then block — the run is `running` and its lease held.
+      const { child } = await spawnUntil(["hold"], dir, "HOLDING");
+      const store = new FileSystemStateStore(dir, defaultStateHost);
+      const runs = await store.listRuns({ status: "running" });
+      assertEquals(runs.length, 1);
+      const id = runs[0].id;
 
-    // While it is running, its claim is genuinely held: a sweep asking whether
-    // anyone is there must be told yes.
-    const whileLive = await store.acquireLock(
-      `zuke-run-${id}`,
-      { actor: "sweep", runId: id, since: new Date().toISOString() },
-      1_000,
-    );
-    assertEquals(whileLive.ok, false);
+      // While it is running, its claim is genuinely held: a sweep asking whether
+      // anyone is there must be told yes.
+      const whileLive = await store.acquireLock(
+        `zuke-run-${id}`,
+        { actor: "sweep", runId: id, since: new Date().toISOString() },
+        1_000,
+      );
+      assertEquals(whileLive.ok, false);
 
-    // Signal it the way an operator's Ctrl-C or a CI timeout would, and let it
-    // settle.
-    child.kill();
-    await child.status;
+      // Signal it the way an operator's Ctrl-C or a CI timeout would, and let it
+      // settle.
+      child.kill();
+      await child.status;
 
-    // The record is terminal, so the claim must be back — a lease still held for
-    // the rest of its TTL says a process is working on a run that has provably
-    // ended, and blocks recovery for a minute for no reason.
-    const afterExit = await store.acquireLock(
-      `zuke-run-${id}`,
-      { actor: "sweep", runId: id, since: new Date().toISOString() },
-      1_000,
-    );
-    assertEquals(
-      afterExit.ok,
-      true,
-      "the cancelled run never released its lease",
-    );
-    const loaded = await store.getRun(id);
-    assertEquals(loaded?.record.status, "cancelled");
-  } finally {
-    await Deno.remove(dir, { recursive: true }).catch(() => {});
-  }
+      // The record is terminal, so the claim must be back — a lease still held for
+      // the rest of its TTL says a process is working on a run that has provably
+      // ended, and blocks recovery for a minute for no reason.
+      const afterExit = await store.acquireLock(
+        `zuke-run-${id}`,
+        { actor: "sweep", runId: id, since: new Date().toISOString() },
+        1_000,
+      );
+      assertEquals(
+        afterExit.ok,
+        true,
+        "the cancelled run never released its lease",
+      );
+      const loaded = await store.getRun(id);
+      assertEquals(loaded?.record.status, "cancelled");
+    } finally {
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    }
+  },
 });

--- a/tests/e2e/cancel_e2e.ts
+++ b/tests/e2e/cancel_e2e.ts
@@ -68,3 +68,83 @@ Deno.test("a separate process cancels a suspended run and runs its compensation"
     await Deno.remove(dir, { recursive: true }).catch(() => {});
   }
 });
+
+/**
+ * Spawn the fixture and resolve once it has printed `marker`, so the parent
+ * signals a run that is genuinely in flight rather than one still starting up.
+ */
+async function spawnUntil(
+  args: string[],
+  dir: string,
+  marker: string,
+): Promise<{ child: Deno.ChildProcess; out: () => string }> {
+  const child = new Deno.Command(Deno.execPath(), {
+    args: ["run", "-A", FIXTURE.href, ...args],
+    env: { ZUKE_STATE_DIR: dir },
+    stdout: "piped",
+    stderr: "null",
+  }).spawn();
+  const decoder = new TextDecoder();
+  let text = "";
+  const reader = child.stdout.getReader();
+  while (!text.includes(marker)) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    text += decoder.decode(value, { stream: true });
+  }
+  // Keep draining in the background so the child never blocks on a full pipe.
+  void (async () => {
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        text += decoder.decode(value, { stream: true });
+      }
+    } catch { /* the pipe closes when the child exits */ }
+  })();
+  return { child, out: () => text };
+}
+
+Deno.test("a signalled run hands its lease back instead of holding it to the TTL", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "zuke-e2e-" });
+  try {
+    // Process 1: deploy, then block — the run is `running` and its lease held.
+    const { child } = await spawnUntil(["hold"], dir, "HOLDING");
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    const runs = await store.listRuns({ status: "running" });
+    assertEquals(runs.length, 1);
+    const id = runs[0].id;
+
+    // While it is running, its claim is genuinely held: a sweep asking whether
+    // anyone is there must be told yes.
+    const whileLive = await store.acquireLock(
+      `zuke-run-${id}`,
+      { actor: "sweep", runId: id, since: new Date().toISOString() },
+      1_000,
+    );
+    assertEquals(whileLive.ok, false);
+
+    // Signal it the way an operator's Ctrl-C or a CI timeout would, and let it
+    // settle.
+    child.kill();
+    await child.status;
+
+    // The record is terminal, so the claim must be back — a lease still held for
+    // the rest of its TTL says a process is working on a run that has provably
+    // ended, and blocks recovery for a minute for no reason.
+    const afterExit = await store.acquireLock(
+      `zuke-run-${id}`,
+      { actor: "sweep", runId: id, since: new Date().toISOString() },
+      1_000,
+    );
+    assertEquals(
+      afterExit.ok,
+      true,
+      "the cancelled run never released its lease",
+    );
+    const loaded = await store.getRun(id);
+    assertEquals(loaded?.record.status, "cancelled");
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});

--- a/tests/e2e/fixtures/cancel_build.ts
+++ b/tests/e2e/fixtures/cancel_build.ts
@@ -6,6 +6,10 @@
  * two genuine OS processes exercise cross-process cancellation. `run()` reads
  * `ZUKE_STATE_DIR` from the environment for its durable state.
  *
+ * The `hold` target blocks forever instead of suspending, so the parent can
+ * signal a run that is genuinely *in flight* rather than parked at a gate — the
+ * difference matters for what a cancellation is required to release.
+ *
  * @module
  */
 
@@ -33,6 +37,22 @@ class Cancelable extends Build {
   gate = target()
     .dependsOn(this.deploy)
     .waitsFor((s) => s.on(externalSignal("approved")));
+  /**
+   * Blocks forever after the deploy, printing a marker first so the parent knows
+   * the run is in flight (and its lease held) before it signals.
+   */
+  hold = target().dependsOn(this.deploy).executes(async (ctx) => {
+    console.log("HOLDING");
+    // Parked on the run's own cancellation signal — what a well-behaved
+    // long-running body does, and what makes the signal a *graceful* stop
+    // rather than a process that has to be killed.
+    await new Promise<void>((resolve) => {
+      if (ctx.signal.aborted) resolve();
+      else {ctx.signal.addEventListener("abort", () => resolve(), {
+          once: true,
+        });}
+    });
+  });
   /** Prints a marker; a cancelled run must never reach this. */
   promote = target().dependsOn(this.gate).executes(() =>
     console.log("PROMOTED")

--- a/tests/integration/caching_test.ts
+++ b/tests/integration/caching_test.ts
@@ -214,3 +214,47 @@ Deno.test("affectedTargets selects only the targets a changed file can reach, wi
   assertEquals(affectedViaShared.has(api), true); // dirtied by its dependency
   assertEquals(affectedViaShared.has(web), true); // dirtied by its dependency
 });
+
+Deno.test("a cancelled run does not leave its targets recorded as up to date", async () => {
+  await withStateDir(async () => {
+    await withTempCwd(async (dir) => {
+      await Deno.writeTextFile(`${dir}/input.txt`, "v1");
+      const log: string[] = [];
+      const controller = new AbortController();
+      class B extends Build {
+        // Succeeds, so it records a fingerprint — then the run is cancelled and
+        // its compensation undoes the work. The compensation reverses a *side
+        // effect* (here, a deployment marker) and leaves the declared output
+        // alone, which is the case the outputs-still-exist check cannot catch:
+        // inputs unchanged plus outputs present would otherwise read as "up to
+        // date" on the strength of work that was rolled back.
+        build = target()
+          .inputs("input.txt")
+          .outputs("out.txt")
+          .onCancel(() => this.rollback)
+          .executes(async () => {
+            log.push("build");
+            await Deno.writeTextFile("out.txt", "built");
+            await Deno.writeTextFile("deployed.txt", "yes");
+            controller.abort();
+          });
+        rollback = target().executes(async () => {
+          log.push("rollback");
+          await Deno.remove("deployed.txt");
+        });
+      }
+
+      const first = await runCli(B, ["build"], { signal: controller.signal });
+      assertEquals(first.code, 1);
+      assertEquals(log, ["build", "rollback"]);
+      // The output survived the rollback; the deployment it represents did not.
+      assertEquals(await Deno.readTextFile(`${dir}/out.txt`), "built");
+
+      const second = await runCli(B, ["build"]);
+      assertEquals(second.code, 0);
+      // Rebuilt rather than skipped, so the rolled-back work is done again.
+      assertEquals(log, ["build", "rollback", "build"]);
+      assertEquals(await Deno.readTextFile(`${dir}/deployed.txt`), "yes");
+    });
+  });
+});


### PR DESCRIPTION
## What & why

A run's [lease](https://github.com/zuke-build/zuke/blob/master/docs/locks.md#the-runs-own-lease) says which process owns it. Losing one means a sweep decided this process was gone and handed the run to somebody else.

That signal was wired to the **same handler as a user cancellation** — `executor.ts:401` bound the lease's loss signal to the plain `onCancel`, which never sets `externallyCancelled`. So the process that lost the claim fell into `settleCancelledRun` and ran the entire compensation walk — unwinding, one target at a time, the work the new holder was already building on — and then settled a record that was no longer its record. The `settledElsewhere` backstop sits only in the *non*-cancelled arm, so nothing caught it; the operator saw a plain "cancelled — N compensations ran", with no mention of a lease.

This is the exact failure the lease exists to prevent, arriving through the lease itself. It is the highest-impact item in the framework assessment.

**Losing the lease is now its own outcome.** The run *stops*: no compensations, no settlement, and per-target progress already queued is drained so it merges under the new holder's version rather than racing the process exit. The result names what happened instead of reporting a cancellation nobody asked for.

**Stopping also means stopping.** Both schedulers refused to launch after a *failure* but not after a *cancellation*. Usually the running target fails first — its shell is terminated — and that covers it. But a body that finishes anyway, or a run cancelled before its first target, kept starting new work for a run already given up on. They now stop launching, with **`always` targets the deliberate exception**: those are teardown, and Ctrl-C is exactly when teardown matters.

### Four related defects at the same boundary

| Finding | What was wrong |
|---|---|
| **Cache saved on a cancelled run** | The cache was saved *before* the cancellation was even inspected, so targets whose work a compensation then undid were recorded up to date. The outputs-still-exist check does not catch this, because a compensation usually reverses a **side effect** — a deployment, a migration — rather than deleting a file. A cancelled or taken-over run now persists nothing. |
| **`acquireLease` not best-effort** | Unguarded at `execute_state.ts:197`, so a filesystem mutex timeout or an HTTP 503 rejected out of the executor as an unhandled stack trace — contradicting the module's own "state writes are best-effort" contract two lines above. Now retried past a bad moment, then reported as the configuration failure it is. |
| **Lease leaked on the cancelled path** | The only lease release sat inside the *non*-cancelled arm, so a Ctrl-C'd run held its claim for the rest of the 60s TTL despite leaving a **terminal** record — saying a process is still working on a run that provably ended. |
| **`runs prune` left lock records forever** | `deleteRun` removed the run's own JSON file only. A run's lease and cancel lock are named after the run, so once it is gone they can never be looked up again — prune shrank one directory while `locks/` grew without bound. |

Also widens the strict-write rollback in `#applyStrict` from the target rows to the whole record — including the `updatedAt` a refused write must not leave behind — and restores it **in place**, so a compensation walk holding the record snapshot keeps reading a live object.

### Re-scoped against current master first

The original plan bundled the lapsed-lease reaper into this PR. It is **already resolved** — `reap.ts` landed in #323 and was scoped to the owning build in #328 — so it is out of scope here. I re-verified all six catalogued findings against `fa70683` before writing anything: three confirmed, two partially fixed, one resolved. (The re-verification also claimed nothing tests the reap-then-resume wiring end-to-end; that was wrong — `tests/integration/reap_test.ts` covers it.)

### Adversarial review

Two defects in **this change** were found and fixed by the pass, each with a regression test:

- The scheduler change initially skipped `always` targets on a cancelled run — beyond the finding, and a real regression for anyone using one to stop a container or release a sandbox. `always` is now the explicit exception.
- The `#applyStrict` rollback initially swapped the record *reference*. The writer hands that object out and the compensation walk holds it across awaits, so the walk would have been left reading a record nothing writes to any more. It restores into the live object instead.

I also verified that releasing the lease on the externally-cancelled path opens no window: the compensation walk is guarded by the **cancel lock**, not the run lease, so `recoverStranded` still gets a friendly no-op from a live canceller.

## Related issues

None — this is PR 5 (engine correctness) of the framework assessment.

## Checklist

- [x] The PR title is a [Conventional Commit](https://www.conventionalcommits.org/) — `type(scope): summary`.
- [x] `deno task ci` passes locally, plus the `integration` e2e suite. One caveat stated plainly: the `security` target was skipped locally because zizmor's advisory lookup gets a 403 from the GitHub API through this sandbox's proxy. Every other gate target ran green, 18 of 19; `security` runs for real in CI.
- [x] Tests were added or updated; coverage stays at 95%+. **Unit:** lease loss with no compensation and an untouched record, the claim not handed back, a lease lost before the plan, a store that never answers, a store that recovers on retry, a cancelled run releasing its lease, `always` surviving a cancel, cache-not-saved-on-cancel, cache-still-saved-on-failure, `deleteRun` clearing lock records, `updatedAt` restored on a refused write, and rollback identity. **Integration:** a cancelled run's targets are not left recorded up to date, driven through the real CLI. **E2E:** a signalled run hands its lease back instead of holding it to the TTL — two real processes over a shared state dir.
- [x] Both new regression tests were verified to **fail without their fix** — the e2e with the exact message "the cancelled run never released its lease", the cache one with a two-entry log where three were expected. My first cut of that integration test passed without the fix, because the outputs-exist check masked it, so I rewrote it around a compensation that reverses a side effect.
- [x] Docs updated in the same PR — `docs/locks.md`, `docs/caching.md`, `docs/orchestration.md`, `docs/cli.md`, both skills, plugin sync, and the plugin version bumped from 0.7.0 to 0.7.1 in both manifests.
- [x] Public API changes were regenerated with `./zuke apiDocs`.
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/`.
- [ ] A new package was wired into all seven places — n/a, no new package.
- [x] The code is written using AI assisted coding.

## Two behaviour changes worth a reviewer's eye

1. **`BuildResult.cancelled` is no longer set when the lease is lost** — the result carries `error` instead, which is the truthful shape, since nobody requested a cancellation. Nothing in the repo reads that field outside tests and the exit code is unchanged, but it is a public field, so a programmatic consumer branching on it would see the difference.
2. **A pre-aborted run now executes nothing.** One existing test pinned the old behaviour, where every body ran while observing an already-aborted context signal; its own comment said "no body ran to completion", which this makes literally true. Split into two tests rather than dropping the coverage.

## One thing deliberately left out

The conflict path in `#applyStrict` at `writer.ts:522` still replaces the whole record with the freshly re-read one — the same stale-snapshot family as the bug fixed here, but on the re-read path. Fixing it properly needs care about keys present in the current record but absent from the fresh one, and this PR is already large. Worth its own change.
