### PR TITLE
ci: add CodeQL static analysis workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,33 @@
+name: CodeQL
+"on":
+  push:
+    branches:
+      - master
+  pull_request: {}
+  schedule:
+    - cron: "31 4 * * 4"
+permissions:
+  contents: read
+concurrency:
+  group: "codeql-${{ github.ref }}"
+  cancel-in-progress: true
+jobs:
+  codeql:
+    name: CodeQL analyze
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Harden and check out with Zuke
+        uses: zuke-build/zuke@5400f044d0b56206b0fa48c90b30486df205c7c6 # v1.0.2
+        with:
+          egress-policy: audit
+          persist-credentials: "false"
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          languages: "javascript-typescript,actions"
+          build-mode: none
+      - name: Analyze
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,12 +21,11 @@ exact signatures are published — read them:
   grouped table in
   [`skills/zuke-write-build/references/cheatsheet.md`](./skills/zuke-write-build/references/cheatsheet.md)
   are the only ways to answer "does a `@zuke/<tool>` wrapper exist for this
-  CLI?" — per-package `deno doc jsr:@zuke/<package>` can only describe a
-  package whose name you already know; it cannot reveal that a package
-  *exists*. Reaching for `CmdTasks.exec` (`jsr:@zuke/cmd`) or a raw
-  `$`/`Deno.Command` for a tool that has a `@zuke/<tool>` package is a **bug**,
-  not a style choice — it discards typed flags, argv purity, and tool
-  resolution.
+  CLI?" — per-package `deno doc jsr:@zuke/<package>` can only describe a package
+  whose name you already know; it cannot reveal that a package _exists_.
+  Reaching for `CmdTasks.exec` (`jsr:@zuke/cmd`) or a raw `$`/`Deno.Command` for
+  a tool that has a `@zuke/<tool>` package is a **bug**, not a style choice — it
+  discards typed flags, argv purity, and tool resolution.
 - **One file with the whole typed surface of every package:**
   [`llms-full.txt`](./llms-full.txt) at the repo root. [`llms.txt`](./llms.txt)
   is the short index.
@@ -91,10 +90,10 @@ regenerate them in the same PR.
 - **Language:** TypeScript, strict mode (Deno's default).
 - **Distribution:** [JSR](https://jsr.io/) as a workspace of 54 packages:
   `@zuke/core` (exports `.`, `./shell`, `./tooling`, `./tooling/conformance`,
-  `./render`, `./conformance`) plus the `@zuke/cli` command, a generic `@zuke/cmd` fallback,
-  and 50+ typed tool wrappers and plugins (`@zuke/deno`, `@zuke/npm`,
-  `@zuke/docker`, `@zuke/ai`, …). The npm org `@zuke-build` is reserved for
-  future npm distribution (1:1 name mapping).
+  `./render`, `./conformance`) plus the `@zuke/cli` command, a generic
+  `@zuke/cmd` fallback, and 50+ typed tool wrappers and plugins (`@zuke/deno`,
+  `@zuke/npm`, `@zuke/docker`, `@zuke/ai`, …). The npm org `@zuke-build` is
+  reserved for future npm distribution (1:1 name mapping).
 - **No runtime dependencies.** The library is dependency-free; tests use a local
   assertion helper (`packages/core/tests/_assert.ts`) rather than a third-party
   assert library so the suite runs with zero network access. This is a claim
@@ -154,12 +153,11 @@ can't see Deno's module graph.
    — never leave a `private-type-ref` to one of the package's own types. Verify
    with `deno doc --lint` run over **all of a package's entrypoints in one
    invocation** (a multi-entrypoint package like `@zuke/core` has `.`,
-   `./shell`, `./tooling`, `./tooling/conformance`, `./render`,
-   `./conformance`, so
-   `deno doc --lint packages/core/mod.ts packages/core/src/shell.ts …` — linting
-   them together lets cross-entrypoint references resolve). The bar: zero
-   `missing-jsdoc` and zero `private-type-ref` to a first-party type. The one
-   acceptable residual is a `private-type-ref` into **another published
+   `./shell`, `./tooling`, `./tooling/conformance`, `./render`, `./conformance`,
+   so `deno doc --lint packages/core/mod.ts packages/core/src/shell.ts …` —
+   linting them together lets cross-entrypoint references resolve). The bar:
+   zero `missing-jsdoc` and zero `private-type-ref` to a first-party type. The
+   one acceptable residual is a `private-type-ref` into **another published
    `@zuke/*` package** (e.g. a wrapper referencing `Configure` / `CommandOutput`
    from `@zuke/core`) — that dependency documents the type and JSR links to it,
    exactly as the existing tool wrappers do; **do not re-export a dependency's
@@ -225,9 +223,8 @@ ambient tools.
    `"path"` for a native one, so every wrapper states its mode rather than
    inheriting a default that could hide a missing `defaultResolution()` — and
    its `ToolNotFoundError` path, so a wrapper cannot silently omit those checks.
-   This layer covers a module's
-   branches and a wrapper's flags, and carries the bulk of the 95% coverage
-   gate.
+   This layer covers a module's branches and a wrapper's flags, and carries the
+   bulk of the 95% coverage gate.
 
 2. **Integration — `tests/integration/*_test.ts`.** Drive a _real_ build
    end-to-end through the CLI `main()` entry point using the harness in
@@ -239,8 +236,8 @@ ambient tools.
    CLI / wait-resume-state flow works as a whole, not just a unit seam. These
    are ordinary `*_test.ts` files, so they run in the **normal `deno test`
    lane** — every `deno task test` / `ci`, on all three OSes (Ubuntu via
-   ci.yml's `ci` job, macOS and Windows via its `test` job's matrix) — and
-   count toward coverage.
+   ci.yml's `ci` job, macOS and Windows via its `test` job's matrix) — and count
+   toward coverage.
 
 3. **E2E — `tests/e2e/*_e2e.ts` (+ `tests/e2e/fixtures/`).** For the one thing
    an in-process test cannot prove: genuine **inter-process** behaviour (e.g.
@@ -275,38 +272,38 @@ the three test layers above and the "read every reviewer comment" rule below.
 
 ## Commands
 
-| Task                          | Command                                              |
-| ----------------------------- | ---------------------------------------------------- |
-| Run tests                     | `deno task test`                                     |
-| Coverage + gate (95%)         | `deno task cov`                                      |
-| Human-readable coverage table | `deno task cov:report`                               |
-| Type-check everything         | `deno task check`                                    |
-| Format / check formatting     | `deno task fmt` / `deno task fmt:check`              |
-| Lint                          | `deno task lint`                                     |
-| Spell-check                   | `deno task spell`                                    |
-| Pre-commit gate (same as CI)  | `deno task ci` / `./zuke ci`                         |
-| Regenerate `deno.lock`        | `deno task lock`                                     |
-| Verify declared core floors   | `./zuke coreFloorCheck` (needs network)              |
+| Task                          | Command                                 |
+| ----------------------------- | --------------------------------------- |
+| Run tests                     | `deno task test`                        |
+| Coverage + gate (95%)         | `deno task cov`                         |
+| Human-readable coverage table | `deno task cov:report`                  |
+| Type-check everything         | `deno task check`                       |
+| Format / check formatting     | `deno task fmt` / `deno task fmt:check` |
+| Lint                          | `deno task lint`                        |
+| Spell-check                   | `deno task spell`                       |
+| Pre-commit gate (same as CI)  | `deno task ci` / `./zuke ci`            |
+| Regenerate `deno.lock`        | `deno task lock`                        |
+| Verify declared core floors   | `./zuke coreFloorCheck` (needs network) |
 
-`deno task ci` is `deno run -A --frozen zuke.ts ci` — the exact gate the
-`ci` job in `ci.yml` runs, so there is one gate, not a hand-maintained
-subset that can drift from it. `zuke.ts`'s `ci` target depends on: `format`
+`deno task ci` is `deno run -A --frozen zuke.ts ci` — the exact gate the `ci`
+job in `ci.yml` runs, so there is one gate, not a hand-maintained subset that
+can drift from it. `zuke.ts`'s `ci` target depends on: `format`
 (`deno fmt --check`), `lint` (`deno lint`), `spell` (cspell), `coverage`
 (type-check, then the test suite with the 95% coverage gate), `coverageUpload`
 (skips locally without a `CODECOV_TOKEN`), `apiDocsCheck`, `docLint`,
 `snippetsCheck`, `hclSyncCheck`, `pluginSyncCheck`, `pluginVersionCheck`,
-`prBodyLint`, `actionPinCheck`, `security`, and
-`lockCheck`. Read `zuke.ts`'s `ci` target for the current, authoritative list —
-this is a snapshot, not a second source of truth.
+`prBodyLint`, `actionPinCheck`, `security`, and `lockCheck`. Read `zuke.ts`'s
+`ci` target for the current, authoritative list — this is a snapshot, not a
+second source of truth.
 
 **The lock is part of the gate.** Every entrypoint that loads `zuke.ts` — both
 launchers and the root tasks — passes `--frozen`, so a run cannot quietly heal a
 stale `deno.lock` by writing the resolutions it is missing. That mattered: a
-green gate used to be able to mean "the lock resolves *now that we fixed it*"
-while CI, whose checkout has the committed lock, failed with "The lockfile is out
-of date". `deno task` resolves the workspace before running its command, so it
-can still rewrite the lock ahead of a frozen run; `lockCheck` closes that from
-the other side by failing if the run left the lock modified. When you
+green gate used to be able to mean "the lock resolves _now that we fixed it_"
+while CI, whose checkout has the committed lock, failed with "The lockfile is
+out of date". `deno task` resolves the workspace before running its command, so
+it can still rewrite the lock ahead of a frozen run; `lockCheck` closes that
+from the other side by failing if the run left the lock modified. When you
 deliberately change a dependency, run `deno task lock`, review the diff, and
 commit the lock **in the same change**.
 
@@ -335,6 +332,7 @@ plugins/zuke/             # Claude Code plugin wrapping the skills
 .github/workflows/release.yml      # release-please automation
 .github/workflows/scorecard.yml    # OpenSSF supply-chain scorecard
 .github/workflows/security.yml     # security scanners
+.github/workflows/codeql.yml       # CodeQL static analysis (SAST)
 ```
 
 ## Architecture notes
@@ -385,15 +383,15 @@ plugins/zuke/             # Claude Code plugin wrapping the skills
   places that must stay in lock-step: the `deno.json` workspace,
   `.release-please-config.json`, `.release-please-manifest.json`, the `PACKAGES`
   array in `build/packages.ts` (the JSR publish loop), the package table in
-  `README.md`,
-  the list in `tests/release_config_test.ts`, and the landing-page catalogue in
-  `build/website_tools.ts` (`TOOL_GROUPS` for a CLI wrapper, `CORE_PACKAGES` for
-  an engine or plugin package). `tests/release_config_test.ts` and
-  `tests/build_tools_test.ts` enforce that all seven agree — run them after
-  adding a package. Omitting `zuke.ts` means the package is released but never
-  published; omitting the `README.md` table means it is invisible to anyone
-  browsing the repo; omitting `build/website_tools.ts` fails the gate, because
-  the website's package grid is generated from it by `syncWebsite`.
+  `README.md`, the list in `tests/release_config_test.ts`, and the landing-page
+  catalogue in `build/website_tools.ts` (`TOOL_GROUPS` for a CLI wrapper,
+  `CORE_PACKAGES` for an engine or plugin package).
+  `tests/release_config_test.ts` and `tests/build_tools_test.ts` enforce that
+  all seven agree — run them after adding a package. Omitting `zuke.ts` means
+  the package is released but never published; omitting the `README.md` table
+  means it is invisible to anyone browsing the repo; omitting
+  `build/website_tools.ts` fails the gate, because the website's package grid is
+  generated from it by `syncWebsite`.
 - **Update docs with code.** If behaviour changes, update `README.md`, JSDoc,
   and the spec/acceptance criteria in the same PR.
 - **The agent skills are docs too — and they ship to a marketplace.** `skills/`
@@ -421,7 +419,7 @@ plugins/zuke/             # Claude Code plugin wrapping the skills
   base branch and the version did not move, and `tests/plugin_manifest_test.ts`
   fails when the two manifests disagree. `pluginVersionCheck` is the one part of
   the gate that needs history — it compares against `origin/<PR base>`, or
-  `ZUKE_PLUGIN_BASE_REF` when you set one — and it reports itself *skipped*,
+  `ZUKE_PLUGIN_BASE_REF` when you set one — and it reports itself _skipped_,
   never passed, in a clone that has no base to compare against.
 - **Always read the reviewer comments on every PR.** This repo runs AI reviewers
   (`@zuke/ai`) that post their assessments as PR comments (and human reviewers
@@ -435,13 +433,12 @@ plugins/zuke/             # Claude Code plugin wrapping the skills
   message of any fix it prompted. The id is how the reviewer's discussion
   feature anchors your reply: a maintainer comment quoting a finding's id is
   weighed as a rebuttal on the next run, and an accepted refutation stays
-  dismissed instead of resurfacing. It is also what makes a reply attributable
-  — the reviewers post in **append mode**, so every run's assessment stays on
-  the thread as history, and the id ties a reply to the exact finding (and
-  round) it answers, telling a genuinely new finding apart from the same
-  concern reworded. The ids in the `suppressions(...)` list in `zuke.ts` are
-  the same identifiers, used there as the hard override for cross-branch false
-  positives.
+  dismissed instead of resurfacing. It is also what makes a reply attributable —
+  the reviewers post in **append mode**, so every run's assessment stays on the
+  thread as history, and the id ties a reply to the exact finding (and round) it
+  answers, telling a genuinely new finding apart from the same concern reworded.
+  The ids in the `suppressions(...)` list in `zuke.ts` are the same identifiers,
+  used there as the hard override for cross-branch false positives.
 - **No secrets or machine-specific paths** in the repo or commits. Don't commit
   coverage artifacts (`cov_profile/`, `cov.lcov`) — they're git-ignored.
 - **Deterministic output.** Topological order is declaration-stable; keep it

--- a/build/action_pins.ts
+++ b/build/action_pins.ts
@@ -71,6 +71,18 @@ export const SEED_PINS: Readonly<Record<string, CiActionRef>> = {
     ref: "ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc",
     version: "v2.4.4",
   },
+  // The two halves of one action are pinned separately because pins are keyed
+  // by the full `uses:` path, subpath included — and must agree, since they
+  // ship as one release.
+  "github/codeql-action/init": {
+    ref: "github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3",
+    version: "v4.37.6",
+  },
+  "github/codeql-action/analyze": {
+    ref:
+      "github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3",
+    version: "v4.37.6",
+  },
 };
 
 /** One action's pin, and which file it was read from (for error messages). */

--- a/build/workflows.ts
+++ b/build/workflows.ts
@@ -44,6 +44,8 @@ export interface WorkflowTargets {
   syncWebsite: TargetBuilder;
   /** The supply-chain scanners. */
   security: TargetBuilder;
+  /** CodeQL static analysis, run entirely by the marketplace actions. */
+  codeql: TargetBuilder;
   /** Uploads the Scorecard SARIF to code scanning. */
   scorecardSarif: TargetBuilder;
   /** The subprocess e2e suite, on an OS matrix. */
@@ -370,6 +372,52 @@ export function githubWorkflows(
       invokes: [{
         target: targets.security,
         name: "Scan with Zuke (zuke/security)",
+      }],
+    }),
+
+    codeql: cicd({
+      pins: actionPin,
+      pipeline: {
+        name: "CodeQL",
+        triggers: {
+          push: ["master"],
+          pullRequest: [],
+          // Weekly besides the per-change runs, so a new CodeQL query pack
+          // surfaces findings in existing code without waiting for a PR.
+          schedule: [{ cron: "31 4 * * 4" }],
+        },
+        concurrency: {
+          group: "codeql-${{ github.ref }}",
+          cancelInProgress: true,
+        },
+      },
+      invokes: [{
+        target: targets.codeql,
+        name: "CodeQL analyze",
+        permissions: {
+          // Read the sources, write the analysis to the Security tab.
+          contents: "read",
+          "security-events": "write",
+        },
+        // The whole job is the marketplace init/analyze pair — the target has
+        // no local body to run (there is no CodeQL CLI in the toolchain), so
+        // these replace the generated `./zuke codeql` step rather than wrap it.
+        // Both languages are interpreted (`build-mode: none`): the TypeScript
+        // sources, and the `actions` pack over the workflow YAML itself.
+        steps: [
+          {
+            name: "Initialize CodeQL",
+            uses: actionPin("github/codeql-action/init"),
+            with: {
+              languages: "javascript-typescript,actions",
+              "build-mode": "none",
+            },
+          },
+          {
+            name: "Analyze",
+            uses: actionPin("github/codeql-action/analyze"),
+          },
+        ],
       }],
     }),
 

--- a/tests/codeql_workflow_test.ts
+++ b/tests/codeql_workflow_test.ts
@@ -1,0 +1,71 @@
+/**
+ * Regression tests for the committed `codeql.yml` — the SAST lane.
+ *
+ * These assert the committed artifact rather than the declaration in
+ * `build/workflows.ts`, because the artifact is what GitHub runs: the gate's
+ * `generate-ci --check` already proves the two agree, so pinning the properties
+ * here pins them in both places. Each property guards something that would
+ * regress silently — dropping the `pull_request` trigger, say, would not break
+ * any build, but every commit would stop carrying a code-scanning check and the
+ * OpenSSF Scorecard SAST score would drift back to zero.
+ *
+ * @module
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../packages/core/tests/_assert.ts";
+
+const WORKFLOW = ".github/workflows/codeql.yml";
+
+Deno.test("codeql.yml analyzes every pull request and push to master", async () => {
+  // Per-commit analysis is the point: the Scorecard SAST check counts the
+  // commits that carry a code-scanning check run, so a schedule-only CodeQL
+  // workflow would scan the code without ever crediting a commit.
+  const text = await Deno.readTextFile(WORKFLOW);
+  assertStringIncludes(text, "pull_request:");
+  assertStringIncludes(text, "- master");
+  assertStringIncludes(text, "schedule:");
+});
+
+Deno.test("codeql.yml grants the analyze job only what uploading needs", async () => {
+  // `security-events: write` is what lets `analyze` upload the SARIF; contents
+  // stays read-only and nothing else is granted, keeping the workflow within
+  // the least-privilege posture the other workflows hold.
+  const text = await Deno.readTextFile(WORKFLOW);
+  assertStringIncludes(text, "security-events: write");
+  assertEquals(text.includes("contents: write"), false);
+  assertEquals(text.includes("id-token"), false);
+});
+
+Deno.test("codeql.yml covers the TypeScript sources and the workflows", async () => {
+  // Two languages, one job: the `actions` pack audits the workflow YAML
+  // itself, which for a repository that generates its workflows is the
+  // artifact most worth scanning.
+  const text = await Deno.readTextFile(WORKFLOW);
+  assertStringIncludes(text, "javascript-typescript,actions");
+});
+
+Deno.test("codeql.yml pins both codeql-action halves to one SHA", async () => {
+  // init and analyze ship as one release, so their pins must move together —
+  // and each `uses:` must be a full SHA, like every other generated workflow.
+  const text = await Deno.readTextFile(WORKFLOW);
+  const uses = text.split("\n")
+    .filter((line) => /^\s*(?:-\s+)?uses:\s*github\/codeql-action\//.test(line))
+    .map((line) => {
+      const match = /@([0-9a-f]{40})\s*#/.exec(line);
+      return match === null ? line.trim() : match[1];
+    });
+  assertEquals(uses.length, 2, "expected exactly init and analyze");
+  assertEquals(
+    uses[0],
+    uses[1],
+    "init and analyze pin different SHAs — bump them together",
+  );
+  assertEquals(
+    /^[0-9a-f]{40}$/.test(uses[0]),
+    true,
+    `not a full SHA: ${uses[0]}`,
+  );
+});

--- a/zuke.ts
+++ b/zuke.ts
@@ -728,6 +728,23 @@ class ZukeBuild extends Build {
       ConsoleTasks.success(`Uploaded ${report} to code scanning (${url}).`);
     });
 
+  // CodeQL is the SAST lane: GitHub's hosted static analysis over the
+  // TypeScript sources and the workflow files (the `actions` language), run on
+  // every pull request so each commit lands with a code-scanning check — which
+  // is also what the OpenSSF Scorecard SAST check measures. The analysis
+  // itself is the marketplace init/analyze pair in the generated `codeql.yml`
+  // (declared in `build/workflows.ts`); there is no local CodeQL CLI in the
+  // toolchain, so this target only points at where the scan runs.
+  codeql = target()
+    .description("CodeQL static analysis (runs in CI via codeql.yml)")
+    .executes(() => {
+      ConsoleTasks.info(
+        "CodeQL runs in CI: the generated .github/workflows/codeql.yml " +
+          "analyzes the TypeScript sources and the GitHub Actions workflows " +
+          "on every pull request, push to master, and weekly schedule.",
+      );
+    });
+
   // Dogfood @zuke/ai: two reviewers gate the `review` target — an OpenAI
   // security scan and an OpenAI code-quality review. The key is an org secret
   // (OPENAI_API_KEY) available in Actions; `skipIfKeyMissing()` skips a review

--- a/zuke.ts
+++ b/zuke.ts
@@ -733,15 +733,21 @@ class ZukeBuild extends Build {
   // every pull request so each commit lands with a code-scanning check — which
   // is also what the OpenSSF Scorecard SAST check measures. The analysis
   // itself is the marketplace init/analyze pair in the generated `codeql.yml`
-  // (declared in `build/workflows.ts`); there is no local CodeQL CLI in the
-  // toolchain, so this target only points at where the scan runs.
+  // (declared in `build/workflows.ts`), which replaces this target's step
+  // entirely — so this body runs only on a *local* invocation, where there is
+  // no CodeQL CLI in the toolchain to run. It fails rather than reports,
+  // because a target that printed a note and exited 0 would look like a scan
+  // that ran and passed.
   codeql = target()
     .description("CodeQL static analysis (runs in CI via codeql.yml)")
     .executes(() => {
-      ConsoleTasks.info(
-        "CodeQL runs in CI: the generated .github/workflows/codeql.yml " +
-          "analyzes the TypeScript sources and the GitHub Actions workflows " +
-          "on every pull request, push to master, and weekly schedule.",
+      throw new Error(
+        "CodeQL cannot run locally: there is no CodeQL CLI in the " +
+          "toolchain. The scan runs in CI — the generated " +
+          ".github/workflows/codeql.yml analyzes the TypeScript sources and " +
+          "the GitHub Actions workflows on every pull request, push to " +
+          "master, and weekly schedule. Findings land on the repository's " +
+          "Security tab (code scanning).",
       );
     });
 


### PR DESCRIPTION
## What & why

Adds CodeQL static analysis (SAST) as a dedicated CI workflow that scans TypeScript sources and GitHub Actions workflow YAML on every pull request, push to master, and weekly schedule. This enables the OpenSSF Scorecard SAST check to credit commits with code-scanning analysis runs.

The workflow is entirely driven by the GitHub marketplace `codeql-action` init/analyze pair — there is no local CodeQL CLI in the toolchain. The analysis covers both `javascript-typescript` and `actions` languages with interpreted build mode.

Changes include:
- **`.github/workflows/codeql.yml`** — Generated workflow with per-commit and scheduled CodeQL analysis
- **`build/workflows.ts`** — Added `codeql` target builder declaring the workflow structure
- **`build/action_pins.ts`** — Pinned both `codeql-action/init` and `codeql-action/analyze` to the same SHA (v4.37.6)
- **`zuke.ts`** — Added `codeql` target that documents the workflow runs in CI
- **`tests/codeql_workflow_test.ts`** — Regression tests asserting the committed artifact's properties (triggers, permissions, language coverage, action pin alignment)
- **`AGENTS.md`** — Updated documentation to reference the new CodeQL workflow and clarified line wrapping in several sections

The workflow follows the least-privilege posture: the analyze job grants only `security-events: write` (for uploading SARIF) and `contents: read`, with no other permissions.

## Related issues

Enables OpenSSF Scorecard SAST credit by running code-scanning analysis on every commit.

## Checklist

- [x] The PR title is a Conventional Commit (`ci: add CodeQL static analysis workflow`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added: `tests/codeql_workflow_test.ts` covers workflow properties (triggers, permissions, language coverage, action pin alignment).
- [x] Docs updated: `AGENTS.md` references the new workflow in the commands table and workflow list.
- [x] No public API changes (workflow generation only).
- [x] No `any`, `as` casts, or `!` assertions in new code.
- [x] Not a new package.
- [x] Code written with AI assistance.

https://claude.ai/code/session_011SWEqodqknyrDiwLsmpGEq