### PR TITLE
fix(ai): compare a reworded finding against still-open findings too

### DIFF
--- a/packages/ai/src/reviewer.ts
+++ b/packages/ai/src/reviewer.ts
@@ -733,19 +733,24 @@ export class Reviewer implements Validation {
       record(adoptCanonicalIds(findings, known));
     }
     // Paid path: only findings whose identity is still unknown to the state,
-    // compared against the decided entries a rename could inherit from.
+    // compared against every entry a rename could resolve onto — including the
+    // ones still open. A reworded finding that is merely still open must be
+    // recognised too: left unmatched, its old id goes unreported this round and
+    // the progress pass records it as fixed, so the report claims a resolution
+    // that never happened and lists the same concern twice.
     const ids = new Set(priorState.findings.map((finding) => finding.id));
     const candidates = findings.filter((finding) =>
       finding.id !== undefined && !ids.has(finding.id)
     );
-    const priors = priorState.findings.filter((finding) =>
-      finding.status === "fixed" || finding.status === "dismissed"
-    );
-    // Fixed entries first, so a candidate matching both reopens (reports)
-    // rather than inheriting a dismissal (silences).
-    priors.sort((a, b) =>
-      (a.status === "fixed" ? 0 : 1) - (b.status === "fixed" ? 0 : 1)
-    );
+    const priors = [...priorState.findings];
+    // Fixed first, then dismissed, then the still-open ones. Fixed before
+    // dismissed keeps a candidate matching both reopening (which reports)
+    // rather than inheriting a dismissal (which silences); decided entries
+    // before open ones keeps the newcomers from crowding a sticky dismissal out
+    // of the per-candidate comparison cap.
+    const order = (finding: StoredFinding): number =>
+      finding.status === "fixed" ? 0 : finding.status === "dismissed" ? 1 : 2;
+    priors.sort((a, b) => order(a) - order(b));
     if (candidates.length === 0 || priors.length === 0) return result;
     const plan = planDedup(candidates, priors);
     if (plan.pairs.length === 0) return result;

--- a/packages/ai/tests/discussion_flow_test.ts
+++ b/packages/ai/tests/discussion_flow_test.ts
@@ -1448,3 +1448,47 @@ Deno.test("an aliased identity cannot silence a more severe finding", async () =
     1,
   );
 });
+
+Deno.test("a reworded finding that is merely still open is not claimed as fixed", async () => {
+  // The previous round left this finding open — neither dismissed nor fixed.
+  // The model now restates it in different words, so it arrives with a fresh
+  // fingerprint. If identity resolution only considered decided entries, the
+  // old id would go unreported, the progress pass would record it as fixed, and
+  // the report would claim a resolution that never happened while listing the
+  // same concern again as new.
+  const open = {
+    findings: [{
+      id: ID,
+      title: FINDING.title,
+      severity: "high" as const,
+      status: "open" as const,
+      file: "src/app.ts",
+    }],
+  };
+  const { fetch, calls } = discussionFetch(priorComment(open), [
+    claude({ score: 9, severity: "high", findings: [REWORDED] }),
+    claude({ verdicts: [{ id: "p1", verdict: "same", reason: "same eval" }] }),
+  ]);
+  const lines = await captured(() =>
+    inPr(async () => {
+      // Still a live finding, so it still gates.
+      await assertRejects(
+        () =>
+          securityReviewer((r) =>
+            r.provider("claude").apiKey("k")
+              .comment().discussion()
+              .diff((d) => d.text(DIFF))
+              .fetch(fetch)
+          ).validate({ target: "t" }),
+        AiReviewError,
+      );
+    })
+  );
+  // No phantom progress, and no second identity for the same concern.
+  assertEquals(lines.some((l) => l.includes("fixed:")), false);
+  const state = postedState(calls);
+  assertEquals(state?.findings.length, 1);
+  assertEquals(state?.findings[0].id, ID);
+  assertEquals(state?.findings[0].status, "open");
+  assertEquals(state?.findings[0].aliases, [REWORDED_ID]);
+});


### PR DESCRIPTION
## What & why

Identity resolution — which maps a reworded finding back onto the identity the
review state already holds — only ever considered entries the state had
**decided**: dismissed or fixed. A finding that was merely still **open** and
came back reworded was not compared against anything.

That has a worse consequence than a missed optimisation. The reworded finding
keeps its fresh id, so the old id is not reported this round; the progress pass
then sees an open entry that no longer appears and records it as **fixed, no
longer reproduces against the current diff**. The report tells the maintainer a
finding was resolved and, immediately below, lists the very same concern as a new
finding — and the state block now carries two identities for one problem, which
compounds every round after.

The false claim is the damaging half. A maintainer reading "✅ Fixed since first
review" is being told a live issue is gone.

Observed on `master` before the fix, from a real run through the reviewer: the
console printed `fixed: Eval of user input` while reporting the reworded wording
as a live finding, and the posted state held both ids. After the fix the same
inputs yield one entry, still open, with the rewording recorded as its alias.

## The ordering, made explicit

Open entries now take part in the comparison, and the sort is spelled out rather
than left incidental: **fixed, then dismissed, then still-open**. Both halves
matter and are commented in the code:

- Fixed before dismissed keeps the existing precedence — a candidate matching
  both reopens, which reports, rather than inheriting a dismissal, which
  silences.
- Decided entries before open ones stops the newcomers crowding a sticky
  dismissal out of the per-candidate comparison cap.

**The risk this adds, stated plainly:** two genuinely distinct open findings in
one file can now be merged by a wrong "same" verdict. It is bounded by the
existing same-file rule and severity ceiling, and by the refusal to collapse two
findings onto one identity. The failure direction is one merged row rather than a
silenced finding — where the bug being fixed produces a false claim of
resolution, which is worse.

## Testing

A flow test drives the real reviewer with a still-open prior finding and a
reworded re-report, asserting there is no "fixed" line anywhere in the report,
that the state holds exactly one entry, that it is still `open`, that it still
gates, and that the rewording is recorded as an alias so later rounds resolve it
for free.

`deno task ci` is green, run with GITHUB_ACTIONS set so host detection matches
CI.

## Related issues

A regression from the reworded-finding work in #338, found while designing item 2
of the `@zuke/ai` v2.x follow-up plan — inline review threads would have turned
this into a "✅ Fixed" reply posted into a maintainer's live conversation, so it
is fixed first and on its own.

## Checklist

- [x] The PR title is a [Conventional Commit](https://www.conventionalcommits.org/) (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour changed.
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`, `llms-full.txt`, package README `## API`).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with type guards instead).
- [ ] A new package was wired into all seven places (see [AGENTS.md](../blob/master/AGENTS.md#good-open-source-practices-to-follow)), if applicable.
- [x] The code is written using AI assisted coding.
