### PR TITLE
docs: add governance, roadmap, DCO, and release verification for the silver badge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,9 @@ By participating, you agree to abide by our
 > [!NOTE]
 > Every Zuke package is `1.x` on full semver — see
 > [Versioning & compatibility](./docs/versioning.md) for the compatibility
-> promise, the `@zuke/core` floor, and pinning guidance. If you are
-> planning a large change, please open an issue first so we can agree on the
-> direction before you invest the effort.
+> promise, the `@zuke/core` floor, and pinning guidance. If you are planning a
+> large change, please open an issue first so we can agree on the direction
+> before you invest the effort.
 
 ## Prerequisites
 
@@ -108,6 +108,16 @@ the squash commit that [release-please](./RELEASING.md) parses.
 
 Please **do not** open public issues for security vulnerabilities. Follow the
 private reporting process in [`SECURITY.md`](./SECURITY.md) instead.
+
+## Developer Certificate of Origin
+
+Contributions are accepted under the
+[Developer Certificate of Origin 1.1](https://developercertificate.org/) (DCO).
+By opening a pull request you certify that you wrote the contribution (or
+otherwise have the right to submit it) and that you may license it under this
+project's [MIT License](./LICENSE). A `Signed-off-by:` trailer (`git commit -s`)
+is welcome as an explicit record, but submitting the pull request itself
+constitutes your certification.
 
 ## License
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,78 @@
+# Governance
+
+How decisions are made in Zuke, and who makes them. This document exists so that
+contributors know who to ask, what to expect, and how authority is transferred —
+not to add ceremony to a small project.
+
+## Model
+
+Zuke uses a **lead-maintainer model** (often called BDFL): a single project lead
+holds final decision authority, exercised only when ordinary discussion does not
+converge. Day-to-day, decisions are made in the open — in issues and pull
+requests — and the vast majority resolve by consensus there.
+
+## Roles
+
+### Project lead
+
+**Todor Todorov** ([@totollygeek](https://github.com/totollygeek)) is the
+project lead and currently the sole maintainer.
+
+The lead is responsible for:
+
+- Final say on design, scope, and releases when discussion does not converge.
+- Merging pull requests and cutting releases (releases are automated by
+  release-please; the lead approves and merges the release PRs).
+- The security response process described in [`SECURITY.md`](./SECURITY.md):
+  triaging private vulnerability reports, coordinating fixes and disclosure, and
+  publishing advisories.
+- Administering the GitHub organization, the JSR scope, and the
+  [Code of Conduct](./CODE_OF_CONDUCT.md) enforcement contact
+  (**contact@zuke.build**).
+
+### Maintainers
+
+Maintainers share the lead's merge and triage duties. A contributor becomes a
+maintainer by sustained, high-quality contributions and an invitation from the
+project lead. Maintainers are listed in [`CODEOWNERS`](./.github/CODEOWNERS);
+today that list is the project lead.
+
+Growing this group is an explicit goal (see [`ROADMAP.md`](./ROADMAP.md)): a bus
+factor of one is the project's biggest continuity risk, and the roadmap tracks
+fixing it.
+
+### Contributors
+
+Anyone who opens an issue or pull request. Contributions are governed by
+[`CONTRIBUTING.md`](./CONTRIBUTING.md) — including the coding standards, the
+required CI gate, and the Developer Certificate of Origin — and by the
+[Code of Conduct](./CODE_OF_CONDUCT.md).
+
+### Automated reviewers
+
+The repository runs AI reviewers (`@zuke/ai`) that post assessments on every
+pull request. Their findings are **advisory**: maintainers read and answer them,
+but they hold no authority — a human decides what merges.
+
+## Decision making
+
+1. Changes are proposed as issues or pull requests and discussed in public.
+2. Consensus among maintainers (and interested contributors) decides most
+   things.
+3. When consensus does not emerge, the project lead decides.
+4. Large or breaking changes should start as an issue before code is written, as
+   [`CONTRIBUTING.md`](./CONTRIBUTING.md) asks.
+
+## Continuity
+
+If the project lead becomes unavailable for an extended period, the remaining
+maintainers (or, while there are none, the GitHub organization's owners) assume
+the lead's responsibilities and appoint a successor. Repository and registry
+access are held by the `zuke-build` GitHub organization and the `@zuke` JSR
+scope rather than a personal account, so control transfers with organization
+membership.
+
+## Changing this document
+
+Governance changes are proposed as pull requests to this file and decided by the
+project lead.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   <a href="https://github.com/zuke-build/zuke/actions/workflows/release.yml"><img alt="Release" src="https://github.com/zuke-build/zuke/actions/workflows/release.yml/badge.svg" /></a>
   <a href="https://codecov.io/gh/zuke-build/zuke"><img alt="Coverage" src="https://codecov.io/gh/zuke-build/zuke/branch/master/graph/badge.svg" /></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/zuke-build/zuke"><img alt="OpenSSF Scorecard" src="https://api.scorecard.dev/projects/github.com/zuke-build/zuke/badge" /></a>
+  <a href="https://www.bestpractices.dev/projects/14036"><img alt="OpenSSF Best Practices" src="https://www.bestpractices.dev/projects/14036/badge" /></a>
   <a href="https://github.com/marketplace/actions/zuke-build"><img alt="GitHub Marketplace" src="https://img.shields.io/github/v/release/zuke-build/zuke?filter=v%2A.%2A.%2A&amp;label=Marketplace&amp;logo=github&amp;color=2ea44f" /></a>
   <a href="https://jsr.io/@zuke/core"><img alt="JSR" src="https://jsr.io/badges/@zuke/core" /></a>
   <a href="https://jsr.io/@zuke/core"><img alt="JSR score" src="https://jsr.io/badges/@zuke/core/score" /></a>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,59 @@
+# Roadmap
+
+What Zuke intends to do — and not do — over the next year. This is a living
+document: it is revisited at least yearly and adjusted as the project learns.
+Dates are deliberately absent; items ship when they meet the bar in
+[`AGENTS.md`](./AGENTS.md), not when a calendar says so.
+
+Last reviewed: **2026-08**.
+
+## Near term
+
+- **Harden the release pipeline further.** Drop `deno publish --allow-dirty`
+  once a production release confirms the merged release tree is clean, giving
+  the strongest "published == committed source" guarantee. Tracked as a known
+  trade-off in [`SECURITY.md`](./SECURITY.md).
+- **OpenSSF Best Practices badge: silver, then gold.** Passing is attained; the
+  remaining silver items are documented governance (done with this roadmap's
+  PR), reporter credit, and a documented release-verification process. Gold
+  requires — among other things — a second maintainer, which is also the
+  project's bus-factor fix.
+- **Grow the maintainer group beyond one.** Actively invite sustained
+  contributors into maintainership (see [`GOVERNANCE.md`](./GOVERNANCE.md)).
+  This is the single most important continuity item on this list.
+
+## Medium term
+
+- **Expand the tool wrapper catalogue.** Keep adding typed `@zuke/<tool>`
+  wrappers where real builds need them, at the existing quality bar (settings
+  lambdas mirroring the real CLI, pure `buildArgs()`, wrapper conformance
+  tests). Quality over count: a wrapper ships when it covers its tool's everyday
+  surface, not before.
+- **npm distribution.** The `@zuke-build` npm organization is reserved for a 1:1
+  mapping of the JSR packages. Publishing begins once the Node/npm consumption
+  story (module resolution, launcher behaviour outside Deno) is designed and
+  tested — not before.
+- **TypeScript 7 / native type-checking.** Adopt `deno check`'s native (`tsgo`)
+  compiler for the repository's own gate as soon as Deno declares it stable.
+  Until then the default checker stays authoritative; the unstable flag is not
+  allowed into CI. Status is tracked in
+  [`AGENTS.md`](./AGENTS.md#typescript-7--tsgo).
+
+## Explicit non-goals
+
+- **No runtime dependencies.** The published packages stay dependency-free
+  (`@zuke/core` as the only internal exception). Features that would require
+  shipping a third-party runtime dependency are rejected or redesigned.
+- **No second toolchain.** Deno remains the only required tool. No Node, npm, or
+  external build system is needed to develop or use Zuke, even after npm
+  distribution exists for consumers.
+- **No weakening of the gate.** The 95% coverage threshold, the frozen lockfile,
+  pinned actions, and the adversarial-review practice are floors, not
+  aspirations; roadmap work does not trade them away for speed.
+
+## How to influence this
+
+Open an issue — roadmap discussion happens in public, like every other decision
+(see [`GOVERNANCE.md`](./GOVERNANCE.md)). Items move onto this list when a
+maintainer commits to them, and off it when they ship or are explicitly dropped
+with a note here.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,9 @@
 # Security Policy
 
-Zuke is a build-automation framework, so it runs inside other people's
-pipelines and publishes itself to a public registry. Supply-chain integrity is
-therefore the primary concern, and this document describes how the project is
-hardened and how to report problems.
+Zuke is a build-automation framework, so it runs inside other people's pipelines
+and publishes itself to a public registry. Supply-chain integrity is therefore
+the primary concern, and this document describes how the project is hardened and
+how to report problems.
 
 > Zuke is largely AI-written (see the README). Review before you rely on it.
 > Every package is `1.x` on full semver; depend on the caret range
@@ -23,6 +23,9 @@ Please report security issues **privately** — do not open a public issue.
 We aim to acknowledge a report within a few days and to coordinate a fix and
 disclosure timeline with you. Fixes ship in a new release; the advisory is
 published once a patched version is available.
+
+**Credit:** reporters are credited by name in the published advisory (and in the
+release notes of the fix) unless they ask to remain anonymous.
 
 ## Supported versions
 
@@ -64,10 +67,12 @@ What the project does to keep releases trustworthy:
 - **Scanning via Zuke.** The supply-chain scanners run as a typed Zuke build
   target — `./zuke security` drives zizmor (Actions SAST), actionlint, and
   gitleaks (secrets) through [`@zuke/security`](./packages/security), failing
-  the build on findings. (The package also wraps osv-scanner, semgrep, and
-  Trivy for consumers whose projects have lockfiles/manifests those tools
-  support.) Code-level SARIF for the GitHub Security tab comes from CodeQL
-  (TypeScript), enabled through GitHub's default code-scanning setup, and from
+  the build on findings. (The package also wraps osv-scanner, semgrep, and Trivy
+  for consumers whose projects have lockfiles/manifests those tools support.)
+  Code-level SARIF for the GitHub Security tab comes from CodeQL, run by the
+  committed [`codeql.yml`](./.github/workflows/codeql.yml) workflow on every
+  pull request, push to master, and a weekly schedule — analyzing the TypeScript
+  sources and, via the `actions` query pack, the workflow YAML itself — and from
   OpenSSF Scorecard, which runs as a native action workflow.
 
 ### Known trade-offs
@@ -81,16 +86,41 @@ What the project does to keep releases trustworthy:
   bootstrap entirely, install Deno yourself so the launcher finds it on `PATH`.
 - **`deno publish --allow-dirty`.** The publish step currently allows a dirty
   tree as a backstop. The merged release tree should already be clean; once a
-  real release confirms this, drop the flag for the strongest
-  "published == committed source" guarantee.
+  real release confirms this, drop the flag for the strongest "published ==
+  committed source" guarantee.
 - **`contents: write` + `persist-credentials` on the `ci` job.** The `ci` job in
   `ci.yml` runs on `pull_request` with `contents: write` and
-  `actions/checkout`'s `persist-credentials: true`, because the AI lint fixer may
-  push a fix commit back to the PR branch. This is a deliberate trade-off, and it
-  is fork-safe: `pull_request` (not `pull_request_target`) runs with the base
-  repository's read-only `GITHUB_TOKEN` for a fork PR, so the elevated write and
-  persisted credential apply only to same-repository branches, never to code a
-  fork controls. Workflow egress is audited by `step-security/harden-runner`.
+  `actions/checkout`'s `persist-credentials: true`, because the AI lint fixer
+  may push a fix commit back to the PR branch. This is a deliberate trade-off,
+  and it is fork-safe: `pull_request` (not `pull_request_target`) runs with the
+  base repository's read-only `GITHUB_TOKEN` for a fork PR, so the elevated
+  write and persisted credential apply only to same-repository branches, never
+  to code a fork controls. Workflow egress is audited by
+  `step-security/harden-runner`.
+
+## Verifying a release
+
+Every published `@zuke/*` version can be verified against this repository:
+
+- **Provenance (signature).** Packages are published to JSR via OIDC trusted
+  publishing, and JSR records a [Sigstore](https://www.sigstore.dev/) provenance
+  attestation for each version — signed by the release workflow's short-lived
+  OIDC identity, so there is no long-lived private key anywhere, let alone on
+  the distribution site. To verify, open the version on
+  [jsr.io](https://jsr.io/@zuke/core) and check its **provenance** panel: it
+  names this repository, the exact commit, and the workflow run that published
+  it. A version without provenance, or with provenance naming another
+  repository, should be treated as compromised and reported (see above).
+- **Source equality.** The published artifacts are the committed source files
+  (there is no build/compile step), so a version's contents can be diffed
+  directly against its provenance-named commit.
+- **Launcher downloads.** The `./zuke` / `zuke.ps1` launchers verify the Deno
+  archive they bootstrap against a per-platform SHA-256 baked into the launcher,
+  as described under "Known trade-offs".
+
+Git tags are created by release-please through the GitHub API and are **not**
+GPG-signed; the provenance attestation above is the release signature to rely
+on.
 
 ## Running the scanners yourself
 
@@ -117,9 +147,12 @@ These cannot be set from files in the repo; configure them in GitHub settings:
   review, require CODEOWNER review, require status checks (CI, CodeQL) to pass,
   dismiss stale approvals on new commits, and disallow force-pushes.
 - **Restrict release-PR merges** to maintainers.
-- **Enable CodeQL code scanning (default setup)** with code quality. This is the
-  single source for CodeQL — do not also add an advanced CodeQL workflow file, or
-  the analysis runs twice.
+- **Keep CodeQL _code scanning_ default setup OFF.** The committed
+  [`codeql.yml`](./.github/workflows/codeql.yml) is the advanced configuration
+  and the single source of code-scanning analysis; enabling default setup for
+  the same language makes GitHub reject the workflow's SARIF uploads. The
+  GitHub-managed **Code Quality** analysis is a separate feature and can stay
+  enabled alongside it.
 - **Enable secret scanning and push protection** (free for public repos).
 - **Require 2FA** for all maintainers, on both GitHub and JSR.
 - **Scope the JSR ↔ repo OIDC link** so publishing is allowed only from this

--- a/cspell.json
+++ b/cspell.json
@@ -5,6 +5,7 @@
   "words": [
     "ACCESSTOKEN",
     "apikey",
+    "BDFL",
     "COLLECTIONURI",
     "Dependabot",
     "Dockerfiles",
@@ -21,8 +22,10 @@
     "Patrik",
     "redriven",
     "Scorecard",
+    "Sigstore",
     "Svensson",
     "TEAMPROJECT",
+    "Todor",
     "USERPROFILE",
     "userinfo",
     "Vixie",


### PR DESCRIPTION
## What & why

Closes the repo-fixable gaps in the OpenSSF Best Practices **silver** badge criteria (the project already holds the passing badge at 100%):

- **`GOVERNANCE.md`** (new) — documents the lead-maintainer model, the roles (project lead, maintainers, contributors, AI reviewers as advisory), decision making, and continuity. Covers `governance` and `roles_responsibilities`.
- **`ROADMAP.md`** (new) — the project's intentions and explicit non-goals for the next year, grounded in commitments already documented in the repo (dropping `--allow-dirty`, npm distribution, tsgo adoption, growing the maintainer group). Covers `documentation_roadmap`.
- **`SECURITY.md`** — adds a reporter-credit promise (`vulnerability_report_credit`) and a "Verifying a release" section documenting JSR's Sigstore provenance as the release signature and how to verify it (`signed_releases`). Also fixes stale CodeQL guidance: the policy still recommended default code-scanning setup and warned against an advanced workflow — the opposite of the arrangement since #339 landed `codeql.yml`.
- **`CONTRIBUTING.md`** — adopts the Developer Certificate of Origin 1.1 (`dco`).
- **`README.md`** — adds the OpenSSF Best Practices badge next to the Scorecard badge (`documentation_achievements`).
- **`cspell.json`** — three new dictionary words the docs introduce (BDFL, Sigstore, Todor).

## Related issues

Follow-up to #339 (CodeQL SAST workflow); together they are the code-side work for the OpenSSF Scorecard and Best Practices badge improvements.

## Checklist

- [x] The PR title is a [Conventional Commit](https://www.conventionalcommits.org/) (`docs: …` — no release bump, documentation only).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches). — N/A: documentation-only change, no code touched; the suite still runs green.
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour changed.
- [x] Public API changes were regenerated with `./zuke apiDocs` — N/A: no API changes.
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` — N/A: no code changes.
- [x] A new package was wired into all seven places — N/A: no new package.
- [x] The code is written using AI assisted coding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SWEqodqknyrDiwLsmpGEq

---
_Generated by [Claude Code](https://claude.ai/code/session_011SWEqodqknyrDiwLsmpGEq)_