### PR TITLE
chore: share one AI budget across the reviewers and the lint fixer

### DIFF
--- a/docs/ai-review.md
+++ b/docs/ai-review.md
@@ -486,9 +486,13 @@ openaiKey = parameter("OpenAI API key for the AI security review")
   .secret()
   .env("OPENAI_API_KEY");
 
+// One budget for everything that spends that key in a run — a runaway guard.
+aiBudget = budget((b) => b.maxTokens(500_000));
+
 securityReview = securityReviewer((r) =>
   r.provider("openai") // default model: gpt-5.4-mini
     .apiKey(this.openaiKey)
+    .budget(this.aiBudget) // shared with the other reviewer and the lint fixer
     .skipIfKeyMissing() // skip + announce when the key is absent (local runs)
     .comment() // upsert the assessment onto the PR (uses GITHUB_TOKEN)
     .diff((d) => d.base(Deno.env.get("ZUKE_REVIEW_BASE") ?? "origin/master"))
@@ -500,6 +504,7 @@ securityReview = securityReviewer((r) =>
 generalReview = genericReviewer((r) =>
   r.provider("openai") // same provider and key as the security review
     .apiKey(this.openaiKey)
+    .budget(this.aiBudget)
     .skipIfKeyMissing()
     .comment() // a separate PR comment, keyed by the reviewer name
     // The built-in rubric covers code quality/maintainability already;
@@ -520,6 +525,15 @@ review = target()
 body and gates the target independently. Because the PR comment is keyed by the
 reviewer name, the two land as **separate comments** ("security review" and
 "generic review") rather than overwriting each other.
+
+The one `aiBudget` is passed to both reviewers **and** to the `aiFixer` that
+self-heals lint failures, so every pass drawing on that key — review, verify,
+adjudication, and the fixer — draws down the same 500k-token cap. That number is
+a runaway guard rather than a throttle: a normal run costs a small fraction of
+it (the diff alone is capped at 20k tokens), so it only bites if something
+loops. Exhausting it **skips**, never fails — the reviewer prints
+`AI budget exhausted — <spend> of 500,000 tokens` on the console and in the
+summary, and the lint failure the fixer would have healed simply stands.
 
 `.skipIfKeyMissing()` replaces an `.onlyWhen(() => this.openaiKey.isSet_())`
 gate on the target: rather than the target vanishing silently when a key is

--- a/zuke.ts
+++ b/zuke.ts
@@ -34,6 +34,7 @@ import { consoleRenderer, ConsoleTasks } from "@zuke/console";
 import {
   aiFixer,
   aiReviewWorkflow,
+  budget,
   genericReviewer,
   securityReviewer,
   suppressions,
@@ -141,6 +142,16 @@ class ZukeBuild extends Build {
     .secret()
     .env("OPENAI_API_KEY");
 
+  // One budget shared by everything that spends that key in a run: the lint
+  // fixer below and both reviewers further down. It is a runaway guard, not a
+  // throttle — 500k tokens is far above what a normal run costs (a review is a
+  // capped 20k-token diff plus file context, verify, and adjudication), so it
+  // only bites when something loops. Whatever trips it is skipped, not failed:
+  // the reviewer reports the skip on the console and in the summary, and the
+  // fixer leaves the underlying lint failure standing. Declared here because a
+  // field can only be referenced by fields declared below it.
+  aiBudget = budget((b) => b.maxTokens(500_000));
+
   lint = target()
     .description("Lint the workspace (deno lint)")
     // Self-heal lint failures with @zuke/ai, dogfooding the full loop: on a
@@ -155,6 +166,7 @@ class ZukeBuild extends Build {
         f
           .provider("openai")
           .apiKey(this.openaiKey)
+          .budget(this.aiBudget)
           .autoApply()
           .allowCI()
           .commitFixes()
@@ -763,6 +775,7 @@ class ZukeBuild extends Build {
     r
       .provider("openai")
       .apiKey(this.openaiKey)
+      .budget(this.aiBudget)
       .skipIfKeyMissing()
       // A fresh PR comment per run (uses GITHUB_TOKEN): earlier assessments —
       // and their finding ids — stay on the thread as history instead of being
@@ -871,6 +884,7 @@ class ZukeBuild extends Build {
     r
       .provider("openai")
       .apiKey(this.openaiKey)
+      .budget(this.aiBudget)
       .skipIfKeyMissing()
       // Separate comments from the security review (keyed by reviewer name),
       // appended per run for the same history-keeping reasons.


### PR DESCRIPTION
## What

One `Budget` in `zuke.ts`, passed to `securityReview`, `generalReview`, and the lint `aiFixer` — everything that spends `OPENAI_API_KEY` in a run now draws down the same 500k-token cap.

## Why

Both reviewers plus verify, adjudication, and the fixer each spent against that key independently, with nothing bounding the total. 500k is a runaway guard, not a throttle: a normal run costs a small fraction of it (the diff alone is capped at 20k tokens), so it only bites if something loops.

Exhausting it **skips**, never fails — the reviewer reports the skip on the console and in the job summary, and the fixer returns without a retry so the lint failure it would have healed still stands.

## Scope

Build wiring and `docs/ai-review.md` only. No package code changed, hence `chore:` — nothing to release.

Item 4 of `docs/superpowers/plans/aireviewv2.xplan.md`.

## Verification

`deno task ci` green (19/19). `zuke --list` unchanged — a `Budget` field is not a `TargetBuilder`, so target discovery ignores it.