### PR TITLE
feat(ai): point a dismissal at the suppress list as the cross-PR override

### DIFF
--- a/docs/ai-review.md
+++ b/docs/ai-review.md
@@ -225,7 +225,11 @@ finding lifecycle:
    than hiding behind its earlier resolution.
 
 The committed `.suppress(...)` list still works as the hard override, and is
-still the right tool for a false positive you want silenced across branches.
+still the right tool for a false positive you want silenced across branches — a
+dismissal holds for its own pull request only. The dismissed section says so and
+points at the suppress list, so a finding being re-argued on PR after PR has an
+obvious end; promoting it stays a deliberate edit to your build file, never
+something the reviewer does for you.
 
 ### Reworded findings
 

--- a/packages/ai/src/report.ts
+++ b/packages/ai/src/report.ts
@@ -309,9 +309,23 @@ function refutedSection(refuted: RefutedFinding[]): string[] {
 }
 
 /**
+ * The line closing the dismissed section: a dismissal holds for this pull
+ * request only — the committed suppress list is the cross-PR override, and it
+ * stays a deliberate, reviewed edit. So the report points at it rather than
+ * promoting anything itself: a finding that keeps being re-argued on PR after
+ * PR is a repo-wide false positive, and its ID (in the table above) is what
+ * mutes it. Exported so a test can pin the wording the docs quote.
+ */
+export const SUPPRESS_HINT =
+  "_Dismissals apply to this pull request only. If one of these keeps coming " +
+  "back on other PRs, add its ID to the suppress list in your build file " +
+  '(`.suppress(suppressions((s) => s.add("…")))`) to mute it repo-wide._';
+
+/**
  * A table of the findings dismissed through the PR discussion — who refuted
  * each one and the adjudicator's reason. Dismissal mutes the gate; this
- * section keeps the record visible so it never silently buries a finding.
+ * section keeps the record visible so it never silently buries a finding, and
+ * closes with {@link SUPPRESS_HINT} pointing at the cross-PR override.
  */
 function dismissedSection(dismissed: DismissedFinding[]): string[] {
   if (dismissed.length === 0) return [];
@@ -331,7 +345,7 @@ function dismissedSection(dismissed: DismissedFinding[]): string[] {
       } |`,
     );
   }
-  parts.push("");
+  parts.push("", SUPPRESS_HINT, "");
   return parts;
 }
 

--- a/packages/ai/tests/markdown_test.ts
+++ b/packages/ai/tests/markdown_test.ts
@@ -3,7 +3,7 @@ import {
   assertStringIncludes,
 } from "../../core/tests/_assert.ts";
 import { codeSpan, fenceMarkdown } from "../src/markdown.ts";
-import { toMarkdown } from "../src/report.ts";
+import { SUPPRESS_HINT, toMarkdown } from "../src/report.ts";
 import { decodeState, encodeState } from "../src/state.ts";
 
 Deno.test("fenceMarkdown wraps plain content in a three-backtick fence", () => {
@@ -56,6 +56,56 @@ Deno.test("fenceMarkdown neutralizes a Markdown-injection payload", () => {
   const runs = [...fenced.matchAll(/`+/g)].map((m) => m[0].length);
   assertEquals(Math.max(...runs), 4);
   assertEquals(runs.filter((n) => n === 4).length, 2); // only the two fences
+});
+
+/** A minimal assessment, so a test can vary only the extras. */
+function report(extras: Parameters<typeof toMarkdown>[4]): string {
+  return toMarkdown(
+    "security review",
+    "deploy",
+    {
+      score: 3,
+      severity: "low",
+      summary: "ok",
+      findings: [{ title: "t", severity: "low", id: "keep1" }],
+    },
+    undefined,
+    extras,
+  );
+}
+
+Deno.test("a dismissal points at the suppress list as the cross-PR override", () => {
+  // A dismissal is per-PR by design. Without this line a maintainer who has
+  // refuted the same false positive on three PRs has no signal that the
+  // committed suppress list is what ends it — the ID is right there in the
+  // table, but nothing says what to do with it.
+  const body = report({
+    discussion: true,
+    dismissed: [{
+      finding: { title: "false alarm", severity: "low", id: "d1" },
+      author: "maintainer",
+      reason: "not reachable",
+    }],
+  });
+  assertStringIncludes(body, SUPPRESS_HINT);
+  // It closes the dismissed section rather than floating loose: the ID a
+  // reader is told to copy is in the table immediately above it.
+  const table = body.indexOf("| false alarm |");
+  assertEquals(table !== -1 && table < body.indexOf(SUPPRESS_HINT), true);
+});
+
+Deno.test("no dismissal, no suppress hint", () => {
+  // The hint is advice about a thing that just happened. With nothing dismissed
+  // it is noise on every clean report — and the section it belongs to is absent
+  // entirely, so the hint must be too.
+  assertEquals(report({ discussion: true }).includes(SUPPRESS_HINT), false);
+  // Not even when other sections render: it belongs to dismissal alone.
+  const other = report({
+    discussion: true,
+    refuted: [{ finding: { title: "r", severity: "low" }, reason: "no" }],
+    suppressedFindings: [{ title: "s", severity: "low" }],
+  });
+  assertEquals(other.includes(SUPPRESS_HINT), false);
 });
 
 Deno.test("model text cannot smuggle a state block into the reviewer's comment", () => {

--- a/tests/integration/ai_review_test.ts
+++ b/tests/integration/ai_review_test.ts
@@ -5,11 +5,15 @@
  * works as a whole when driven exactly the way `./zuke <target>` drives it.
  */
 
-import { assertEquals } from "../../packages/core/tests/_assert.ts";
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
 import { Build, target } from "../../packages/core/mod.ts";
 import { securityReviewer } from "../../packages/ai/mod.ts";
 import { findingFingerprint } from "../../packages/ai/src/suppress.ts";
 import { decodeState, encodeState } from "../../packages/ai/src/state.ts";
+import { SUPPRESS_HINT } from "../../packages/ai/src/report.ts";
 import { commentMarker } from "../../packages/ai/src/hosts/types.ts";
 import { runCli } from "./_harness.ts";
 
@@ -166,8 +170,13 @@ Deno.test("a reviewer with verify + discussion gates a real build via the CLI", 
   );
   assertEquals(write?.method, "PATCH");
   assertEquals(write?.url.endsWith("/issues/comments/11"), true);
-  const state = decodeState(JSON.parse(write?.body ?? "{}").body);
+  const posted: string = JSON.parse(write?.body ?? "{}").body;
+  const state = decodeState(posted);
   assertEquals(state?.findings[0].status, "dismissed");
+  // The comment a maintainer actually reads points at the cross-PR override:
+  // this dismissal holds for this PR only, and the ID above it is what mutes
+  // the finding repo-wide if it keeps coming back.
+  assertStringIncludes(posted, SUPPRESS_HINT);
 });
 
 Deno.test("a fixed finding is reported as progress and the build passes", async () => {


### PR DESCRIPTION
## What

The "Dismissed via discussion (not gating)" section now closes with one italic line: dismissals apply to this pull request only, and if one keeps coming back on other PRs, adding its ID to the suppress list in your build file mutes it repo-wide. The line names the suppress call so a reader knows where to put the ID.

## Why

Dismissals are per-PR by design; the committed suppress list is the cross-branch override and stays a deliberate, reviewed edit. Nothing in the report bridged the two — a maintainer who had refuted the same false positive on three PRs saw the ID in the table with no indication of what ends it.

The existing collapsible id hint does not cover this case: it only renders when the assessment still has findings, and a dismissed finding is removed from that list — so a report whose only finding was dismissed mentioned the suppress list nowhere.

**Hint, not automation.** Nothing is promoted for you and the build file is never edited by the reviewer.

## Tests

- **Unit** (`markdown_test.ts`): the hint renders with a dismissal, and closes the dismissed section, so the ID it tells you to copy is in the table immediately above; it does not render with no dismissal, including when the refuted and suppressed sections do.
- **Integration** (`tests/integration/ai_review_test.ts`): the PATCHed PR-comment body from a real run through the CLI carries the hint — asserted on the wire, not on the renderer.

Item 5 of `docs/superpowers/plans/aireviewv2.xplan.md`; docs paragraph in `docs/ai-review.md`.

## Verification

`deno task ci` green (19/19), coverage gate included. No authoring-surface change, so no skill or plugin bump; `report.ts` is package-internal and not exported from the package entrypoint, so no API-doc regeneration.