### PR TITLE
docs: add the security assurance case

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,7 +34,10 @@ security fixes. Depending on the caret range keeps you on it.
 
 ## Supply-chain posture
 
-What the project does to keep releases trustworthy:
+What the project does to keep releases trustworthy. The
+[security assurance case](./docs/assurance-case.md) justifies _why_ these
+measures meet the project's security requirements — the threat model, the trust
+boundaries, and the design-principle arguments behind the list below:
 
 - **Zero runtime dependencies.** Every published package declares no dependency
   but `@zuke/core`, so nothing third-party is shipped to consumers. The build

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,5 +52,9 @@
 - [Programmatic API](./programmatic-api.md) — drive Zuke from your own code.
 - [Versioning & compatibility](./versioning.md) — one semver tier across every
   package, the `@zuke/core` floor, and pinning guidance.
-- [How Zuke compares](./comparison.md) — a capability matrix against `deno task`,
-  npm scripts, Make, Nx, Turborepo, and Dagger, on the capabilities Zuke provides.
+- [Security assurance case](./assurance-case.md) — the threat model, trust
+  boundaries, and why the security requirements in
+  [`SECURITY.md`](../SECURITY.md) are met.
+- [How Zuke compares](./comparison.md) — a capability matrix against
+  `deno task`, npm scripts, Make, Nx, Turborepo, and Dagger, on the capabilities
+  Zuke provides.

--- a/docs/assurance-case.md
+++ b/docs/assurance-case.md
@@ -1,0 +1,122 @@
+# Security assurance case
+
+Why Zuke's security requirements are met: the threat model, the trust
+boundaries, and the argument that secure design principles are applied and
+common implementation weaknesses countered. [`SECURITY.md`](../SECURITY.md)
+states the policy (how to report, how releases are verified); this document
+justifies it. Both are maintained together — a change that moves a trust
+boundary updates this file in the same pull request.
+
+## Security requirements
+
+Zuke is a build-automation framework: it runs inside other projects' CI
+pipelines with their credentials in scope, and it publishes 50+ packages to a
+public registry. From that, its security requirements are:
+
+1. **What consumers install is what this repository contains.** No tampering
+   between the merged source and the published package (supply-chain integrity).
+2. **Zuke must not become an injection vector.** Values a build interpolates
+   into commands — parameters, environment values, file contents — must never be
+   reinterpreted as shell syntax or extra arguments.
+3. **The project's own pipeline must contain a compromise.** A malicious pull
+   request, a compromised third-party action, or a leaked token must be limited
+   in what it can read, write, or exfiltrate.
+4. **Secrets must not leak** — not into the repository history, not into logs,
+   not to unintended network destinations.
+
+## Threat model
+
+Adversaries considered, and the assets they target:
+
+| Adversary                            | Target                          | Primary counter                                                                                                                                     |
+| ------------------------------------ | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Malicious contributor (fork PR)      | CI secrets, write token         | Fork PRs run with a read-only token and no secrets; `pull_request` (never `pull_request_target`) triggers                                           |
+| Compromised third-party action       | CI secrets, published artifacts | Every action pinned to a full commit SHA; Dependabot bumps pins; zizmor audits workflows                                                            |
+| Compromised build-time dependency    | Release credentials, egress     | `--frozen` lockfile; zero runtime dependencies; egress **blocked** to an allowlist on every job holding a write-scoped token                        |
+| Registry-level attacker              | Consumers of `@zuke/*`          | OIDC trusted publishing; Sigstore provenance per version; no long-lived registry tokens exist                                                       |
+| Network attacker (MITM) on bootstrap | Developer/CI machines           | Launcher downloads the pinned Deno release over HTTPS and verifies a per-platform SHA-256 baked into the launcher; `DENO_VERSION=latest` is refused |
+| Careless or compromised insider      | Repository history              | gitleaks scans full history on schedule and pushes; PR-scoped scans on every pull request; secret parameters are redacted from output               |
+
+Out of scope: vulnerabilities in GitHub, JSR, or Deno themselves (they are the
+trusted computing base — see the boundaries below), and denial of service
+against public CI.
+
+## Trust boundaries
+
+1. **Pull request → gate.** Code in a PR is untrusted until the required CI gate
+   and review pass. Fork PRs cross this boundary with a read-only token and no
+   secrets. The PR _body_ is also untrusted: it reaches the build only through
+   an environment variable, never interpolated into a shell line.
+2. **Build layer → published packages.** The build layer (`build/`, `zuke.ts`)
+   may use dev dependencies; the published packages under `packages/` may not
+   depend on anything third-party. The boundary is enforced by each package's
+   `deno.json` declaring no dependencies, so nothing the build layer trusts is
+   shipped to consumers.
+3. **CI jobs → each other.** Job token scopes are disjoint by design: the
+   release job (repo write) never holds the JSR OIDC credential, and the publish
+   job (OIDC) never holds a write-scoped repo token. A compromise of one job
+   does not yield the other's authority.
+4. **CI jobs → network.** Every job that holds a write-scoped token runs with
+   egress _blocked_ to a named allowlist, so even code that reads a token has
+   nowhere unauthorized to send it.
+5. **Repository → third-party code.** Actions cross the boundary only at pinned
+   commit SHAs; scanner binaries only with verified checksums
+   (`build/scanners.ts`); modules only through the committed, frozen
+   `deno.lock`.
+6. **Trusted computing base.** GitHub (repository, Actions, OIDC issuer), JSR
+   (registry, provenance), and the pinned Deno runtime are trusted. Attacks on
+   them are acknowledged as out of scope above.
+
+## Secure design principles
+
+- **Least privilege.** The default workflow token is `contents: read`; each job
+  opts into exactly the scopes it needs (see boundary 3). The one deliberate
+  elevation — the lint fixer's `contents: write` on the `ci` job — is documented
+  as a trade-off in `SECURITY.md`, and is inert for fork PRs.
+- **Fail-safe defaults.** The lockfile is enforced with `--frozen`, so a missing
+  resolution fails the run instead of being healed silently. The launcher
+  refuses a Deno version it cannot verify against a pinned checksum. The
+  coverage gate fails the build below threshold rather than warning.
+- **Complete mediation.** One gate (`./zuke ci`) stands in front of every merge
+  — the same gate locally and in CI, so there is no unchecked path to `master`;
+  releases are cut only from `master`.
+- **Economy of mechanism.** Zero runtime dependencies and a single toolchain
+  (Deno) keep the attack surface enumerable: what ships is only this
+  repository's source.
+- **Open design.** The build, the workflows (generated from
+  `build/workflows.ts`), the scanners, and this assurance case are all public;
+  nothing relies on secrecy.
+- **Separation of privilege.** Publishing requires the release pipeline's OIDC
+  identity — a stolen personal token cannot produce a provenance-valid release,
+  and provenance names the workflow and commit for anyone to check.
+
+## Common implementation weaknesses countered
+
+- **Command injection** (the classic build-tool weakness): the `$` shell
+  tokenises interpolated values into discrete argv entries and all process
+  execution goes through `Deno.Command` — there is no shell-string concatenation
+  anywhere to inject into.
+- **Type confusion / unsafe casts:** strict TypeScript with `any`, forced `as`
+  casts, and non-null `!` assertions banned by policy and lint; runtime guards
+  are exercised by tests.
+- **Regression and logic errors:** a 95% line-and-branch coverage gate, three
+  test layers (unit, in-process integration, cross-process e2e on three OSes),
+  and an adversarial review pass on every feature.
+- **Vulnerable patterns in new code:** CodeQL's security suite analyzes every
+  pull request and push (including the `actions` pack over the workflow YAML);
+  zizmor and actionlint audit the workflows in the required gate.
+- **Secret leakage:** gitleaks in the gate and on schedule; secret parameters
+  are redacted from build output; no credentials are persisted into
+  `.git/config` in release jobs.
+- **Dependency confusion / typosquatting:** consumers install from the `@zuke`
+  JSR scope with per-version provenance; the npm-side `@zuke-build` org is
+  reserved to prevent squatting.
+
+## Residual risks
+
+The known, accepted trade-offs — the dirty-tree publish backstop, the lint
+fixer's write scope, and the bootstrap-download design — are documented with
+their mitigations in
+[`SECURITY.md` § Known trade-offs](../SECURITY.md#known-trade-offs). The
+project's largest non-technical risk, a bus factor of one, is tracked in
+[`GOVERNANCE.md`](../GOVERNANCE.md) and [`ROADMAP.md`](../ROADMAP.md).


### PR DESCRIPTION
## What & why

The OpenSSF Best Practices **silver** criterion `assurance_case` requires a URL to a document that *justifies* why the project's security requirements are met — a threat model, clearly identified trust boundaries, an argument that secure design principles are applied, and an argument that common implementation weaknesses are countered. `SECURITY.md` states the policy but is not that document.

This adds **`docs/assurance-case.md`**, grounded entirely in mechanisms the repository already enforces:

- **Security requirements** derived from what Zuke is (runs in other projects' pipelines; publishes 50+ packages).
- **Threat model** as an adversary/target/counter table (malicious fork PR, compromised action or dependency, registry attacker, bootstrap MITM, insider secret leakage) with explicit out-of-scope items.
- **Six named trust boundaries** (PR→gate, build layer→published packages, CI job↔CI job token disjointness, CI→network egress allowlists, repository→third-party code, and the trusted computing base).
- **Secure design principles** (least privilege, fail-safe defaults, complete mediation, economy of mechanism, open design, separation of privilege) each tied to a concrete mechanism.
- **Common weaknesses countered** (command injection via the argv-only shell, type confusion, regressions, vulnerable patterns via CodeQL/zizmor/actionlint, secret leakage via gitleaks/redaction, dependency confusion via scoped provenance).
- **Residual risks** pointing at the documented trade-offs and the bus-factor roadmap item.

`SECURITY.md` and the docs index now link to it.

## Related issues

Follow-up to #339 and #342 — the code-side work for the OpenSSF Scorecard and Best Practices badges.

## Checklist

- [x] The PR title is a [Conventional Commit](https://www.conventionalcommits.org/) (`docs: …` — no release bump).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated — N/A: documentation-only change; the suite runs green.
- [x] Docs updated in the same PR.
- [x] Public API changes regenerated — N/A: no API changes.
- [x] No `any`, `as` casts, or `!` assertions — N/A: no code changes.
- [x] New package wired into all seven places — N/A: no new package.
- [x] The code is written using AI assisted coding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SWEqodqknyrDiwLsmpGEq

---
_Generated by [Claude Code](https://claude.ai/code/session_011SWEqodqknyrDiwLsmpGEq)_