### PR TITLE
feat(gh): release-asset uploads, the Gemini extension archive, and a coverage push to 98%

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,9 +364,10 @@ Gemini auto-discovers the `skills/` folder next to it):
 gemini extensions install https://github.com/zuke-build/zuke
 ```
 
-Gemini installs a GitHub extension from the repo's **latest release** snapshot
-(offering a git clone as the fallback), so the extension tracks releases rather
-than `master`.
+Gemini installs a GitHub extension from the repo's **latest release**, so the
+extension tracks releases rather than `master`. Each release carries a minimal
+extension archive (the manifest plus `skills/`, attached by the `release`
+target), so the install downloads two skills, not the whole monorepo.
 
 > The `SKILL.md` content is harness-agnostic (the open
 > [Agent Skills](https://agentskills.io) standard); each manifest above is a

--- a/build/gemini_archive.ts
+++ b/build/gemini_archive.ts
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * The Gemini CLI extension archive attached to GitHub releases.
+ *
+ * `gemini extensions install <github url>` prefers a release asset over
+ * cloning: it resolves the repository's **latest** release and picks an asset
+ * by name — `{platform}.{arch}.{name}`, then `{platform}.{name}`, then a
+ * single generic asset. Without one it downloads the whole source tarball,
+ * which for this monorepo means shipping 50+ packages to install two skill
+ * folders. This module builds a minimal, deterministic archive — the root
+ * `gemini-extension.json` plus `skills/` and the license, exactly what the
+ * extension serves — for the `release` target to attach to every release.
+ *
+ * The asset trio is platform-prefixed rather than one generic file on
+ * purpose: Gemini's fallback accepts a generic asset only when it is the
+ * *only* asset on the release, so a second file attached later (a checksum, an
+ * SBOM) would silently degrade installs back to the source tarball. Platform
+ * prefixes match deterministically regardless of what else the release
+ * carries; the extension is platform-independent, so all three names carry
+ * the same bytes.
+ *
+ * @module
+ */
+
+import { createTarGzip } from "@zuke/core";
+
+/** The extension manifest Gemini requires at the archive root. */
+export const GEMINI_MANIFEST = "gemini-extension.json";
+
+/** The skills tree the extension serves. */
+export const GEMINI_SKILLS_DIR = "skills";
+
+/**
+ * The asset names to attach to a release, one per platform Gemini matches
+ * (`os.platform()` values). All three point at identical archive bytes.
+ */
+export const GEMINI_ASSET_NAMES: readonly string[] = [
+  "darwin.zuke.tar.gz",
+  "linux.zuke.tar.gz",
+  "win32.zuke.tar.gz",
+];
+
+/** Every file under `dir`, as `dir`-prefixed paths, sorted for determinism. */
+async function walk(root: string, dir: string): Promise<string[]> {
+  const out: string[] = [];
+  for await (const entry of Deno.readDir(`${root}/${dir}`)) {
+    const path = `${dir}/${entry.name}`;
+    if (entry.isDirectory) out.push(...await walk(root, path));
+    else if (entry.isFile) out.push(path);
+  }
+  return out.sort();
+}
+
+/**
+ * The files the extension archive packs, relative to `root`, in a stable
+ * order: the manifest, the license, then every file under `skills/`.
+ */
+export async function geminiArchiveFiles(root = "."): Promise<string[]> {
+  return [GEMINI_MANIFEST, "LICENSE", ...await walk(root, GEMINI_SKILLS_DIR)];
+}
+
+/**
+ * Write the extension archive to `dest`: a `.tar.gz` with
+ * `gemini-extension.json` at the root, which is where Gemini requires it.
+ * Returns the paths that were packed.
+ */
+export async function buildGeminiArchive(
+  dest: string,
+  root = ".",
+): Promise<string[]> {
+  const files = await geminiArchiveFiles(root);
+  await createTarGzip(files, dest, { cwd: root });
+  return files;
+}

--- a/build/gemini_archive.ts
+++ b/build/gemini_archive.ts
@@ -49,6 +49,16 @@ async function walk(root: string, dir: string): Promise<string[]> {
     const path = `${dir}/${entry.name}`;
     if (entry.isDirectory) out.push(...await walk(root, path));
     else if (entry.isFile) out.push(path);
+    else {
+      // Silently dropping it would ship an archive missing content that git
+      // (and every other harness) still carries.
+      throw new Error(
+        `the Gemini extension archive cannot pack "${root}/${path}" — it is ` +
+          "neither a regular file nor a directory (a symlink?). Keep " +
+          `${GEMINI_SKILLS_DIR}/ to real files so every harness ships the ` +
+          "same content.",
+      );
+    }
   }
   return out.sort();
 }
@@ -58,7 +68,26 @@ async function walk(root: string, dir: string): Promise<string[]> {
  * order: the manifest, the license, then every file under `skills/`.
  */
 export async function geminiArchiveFiles(root = "."): Promise<string[]> {
-  return [GEMINI_MANIFEST, "LICENSE", ...await walk(root, GEMINI_SKILLS_DIR)];
+  for (const required of [GEMINI_MANIFEST, "LICENSE"]) {
+    const info = await Deno.stat(`${root}/${required}`).catch(() => null);
+    if (info?.isFile !== true) {
+      throw new Error(
+        `the Gemini extension archive requires ${required} at the extension ` +
+          `root — nothing at "${root}/${required}".`,
+      );
+    }
+  }
+  try {
+    return [GEMINI_MANIFEST, "LICENSE", ...await walk(root, GEMINI_SKILLS_DIR)];
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      throw new Error(
+        `the Gemini extension archive requires a ${GEMINI_SKILLS_DIR}/ tree ` +
+          `under "${root}" — Gemini auto-discovers skills from it.`,
+      );
+    }
+    throw error;
+  }
 }
 
 /**

--- a/cspell.json
+++ b/cspell.json
@@ -160,6 +160,7 @@
     "tfvars",
     "tmpl",
     "todorov",
+    "tokenless",
     "topo",
     "totollygeek",
     "transpiling",

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9419,6 +9419,9 @@ function readWorkflowResult(state: TargetStateHandle): WorkflowResult | undefine
 async function tagCommit(configure?: (settings: GhTagSettings) => GhTagSettings): Promise<void>
   Perform the configured tag.
 
+async function uploadReleaseAsset(configure?: Configure<GhReleaseAssetSettings>): Promise<GhReleaseAssetResult>
+  Upload the release asset the settings describe.
+
 async function uploadSarifReport(configure?: Configure<GhSarifSettings>): Promise<GhSarifUploadResult>
   Upload the SARIF report the settings describe.
 
@@ -9662,6 +9665,52 @@ class GhPullRequestSettings
     The effective `owner/repo`, from the setting or the environment.
   authToken_(): string
     The effective token, from the setting or the environment.
+
+class GhReleaseAssetSettings
+  Settings for {@link GhReleaseAssetApi.uploadReleaseAsset}.
+
+  file_?: string
+    The file to upload. Set by {@link file}.
+  name_?: string
+    The asset name on the release. Set by {@link name}.
+  contentType_?: string
+    The asset's `content-type`. Set by {@link contentType}.
+  repo_?: string
+    `owner/repo` to upload to. Set by {@link repo}.
+  tag_?: string
+    The release tag to attach to. Set by {@link tag}.
+  token_?: string
+    The token to authenticate with. Set by {@link token}.
+  baseUrl_: string
+    REST base URL. Set by {@link baseUrl}.
+  fetch_: typeof fetch
+    The `fetch` implementation. Set by {@link fetch}.
+  file(path: PathLike): this
+    The file to upload (required).
+  name(value: string): this
+    The asset's name on the release. Defaults to the file's base name.
+  contentType(value: string): this
+    The asset's `content-type`. Defaults by extension (`.tar.gz`/`.tgz`,
+    `.zip`, `.json`), then to `application/octet-stream`.
+  repo(slug: string): this
+    The `owner/repo` to upload to. Defaults to `GITHUB_REPOSITORY`.
+  tag(value: string): this
+    Attach to the release with this tag instead of the latest release.
+  token(value: string): this
+    The token to authenticate with — needs `contents: write`. Defaults to
+    `GITHUB_TOKEN` in the environment, so it never has to reach argv.
+  baseUrl(url: string): this
+    Use a different REST base (GitHub Enterprise Server).
+  fetch(fn: typeof fetch): this
+    Override the `fetch` implementation (a test seam).
+  repoSlug_(): string
+    The effective `owner/repo`, from the setting or the Actions environment.
+  filePath_(): string
+    The file to upload, or a friendly error naming the missing setting.
+  assetName_(): string
+    The effective asset name: the setting, or the file's base name.
+  effectiveContentType_(): string
+    The effective `content-type`: the setting, or inferred by extension.
 
 class GhSarifSettings
   Settings for {@link GhSarifApi.uploadSarif}.
@@ -9918,6 +9967,32 @@ interface GhPullRequestResult
     different things to a human reading a build log, even though neither is a
     failure.
 
+interface GhReleaseAssetApi
+  The shape of the release-asset task, mixed into `GhTasks`.
+
+  uploadReleaseAsset(configure?: Configure<GhReleaseAssetSettings>): Promise<GhReleaseAssetResult>
+    Attach a file to a GitHub release — the latest release by default, or the
+    one named by `.tag(...)`. Idempotent: an asset the release already
+    carries under the same name is kept as-is, and a repository with no
+    releases resolves to `state: "no-release"` rather than throwing. Needs a
+    token with `contents: write`.
+
+interface GhReleaseAssetResult
+  What became of a release-asset upload.
+
+  state: "uploaded" | "already-exists" | "no-release"
+    `uploaded` when the asset was sent; `already-exists` when the release
+    carries an asset of the same name (nothing was changed); `no-release`
+    when the repository has no release to attach to.
+  name: string
+    The asset name the call targeted.
+  releaseTag?: string
+    The tag of the release the asset belongs to, when one was resolved.
+  releaseId?: number
+    The id of the release the asset belongs to, when one was resolved.
+  url?: string
+    The asset's download URL, when it was uploaded or already present.
+
 interface GhSarifApi
   The shape of the SARIF task, mixed into `GhTasks`.
 
@@ -9933,7 +10008,7 @@ interface GhSarifUploadResult
   url: string
     The URL that reports whether GitHub finished processing the report.
 
-interface GhTasksApi extends GhAppTokenApi, GhSarifApi, GhCommitApi, GhPullRequestApi, GhCheckRunApi
+interface GhTasksApi extends GhAppTokenApi, GhSarifApi, GhReleaseAssetApi, GhCommitApi, GhPullRequestApi, GhCheckRunApi
   The shape of {@link GhTasks}: the `gh` CLI plus the GitHub operations that
   have no CLI subcommand (see {@link GhAppTokenApi}, {@link GhSarifApi}) and
   would otherwise force a build back to a marketplace action.

--- a/packages/ai/tests/agent_fixer_test.ts
+++ b/packages/ai/tests/agent_fixer_test.ts
@@ -441,3 +441,335 @@ Deno.test("commitFixes fails closed when the pre-snapshot cannot be taken", asyn
     false,
   );
 });
+
+/** A GitHub-PR env without any GITHUB_TOKEN. */
+const TOKENLESS_PR_ENV: Record<string, string> = {
+  GITHUB_ACTIONS: "true",
+  GITHUB_REPOSITORY: "o/r",
+  GITHUB_REF: "refs/pull/7/merge",
+};
+
+/** The one-hunk diff the fake agent leaves in the working tree. */
+const AGENT_DIFF = [
+  "diff --git a/zuke.ts b/zuke.ts",
+  "--- a/zuke.ts",
+  "+++ b/zuke.ts",
+  "@@ -45,1 +45,1 @@",
+  '-const X = "remove me";',
+  '+const _X = "remove me";',
+].join("\n");
+
+/** A fetch faking the GitHub PR-detail and comment endpoints, recording calls. */
+function githubFetch(): {
+  fetch: typeof fetch;
+  calls: { url: string; auth: string; body: string }[];
+} {
+  const calls: { url: string; auth: string; body: string }[] = [];
+  const impl = ((input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method ?? "GET";
+    calls.push({
+      url,
+      auth: new Headers(init?.headers).get("authorization") ?? "",
+      body: typeof init?.body === "string" ? init.body : "",
+    });
+    if (url.includes("/comments")) {
+      return Promise.resolve(
+        new Response(method === "GET" ? "[]" : "{}", { status: 200 }),
+      );
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify({ head: { sha: "abc123" } }), {
+        status: 200,
+      }),
+    );
+  }) as typeof fetch;
+  return { fetch: impl, calls };
+}
+
+Deno.test("suggest mode authenticates with an explicit commentToken", async () => {
+  // GITHUB_TOKEN is unset, so the inline suggestions can only be posted through
+  // .commentToken(...) — success pins the explicit-token resolution path.
+  const { fetch, calls } = githubFetch();
+  let statusCalls = 0;
+  const fixer = agentFixer(() => Promise.resolve(), (f) => f.suggest())
+    .allowCI().comment().commentToken("agent-tok")
+    .conventions("").readFile(() => Promise.resolve(undefined))
+    .env((n) => TOKENLESS_PR_ENV[n])
+    .exec((argv) => {
+      if (argv.includes("status")) {
+        statusCalls++;
+        return Promise.resolve(statusCalls === 1 ? "" : " M zuke.ts");
+      }
+      return Promise.resolve(argv.includes("diff") ? AGENT_DIFF : "");
+    })
+    .fetch(fetch).quiet();
+  await fixer.remediate(CTX);
+  const post = calls.find((c) =>
+    c.url.endsWith("/pulls/7/comments") && c.body.includes("```suggestion")
+  );
+  assertEquals(post?.auth, "Bearer agent-tok");
+});
+
+Deno.test("suggest mode without any token proposes nothing and calls no API", async () => {
+  const { fetch, calls } = githubFetch();
+  const lines: string[] = [];
+  const log = console.log;
+  console.log = (...a: unknown[]) => void lines.push(a.join(" "));
+  let statusCalls = 0;
+  try {
+    const fixer = agentFixer(() => Promise.resolve(), (f) => f.suggest())
+      .allowCI().conventions("").readFile(() => Promise.resolve(undefined))
+      .env((n) => TOKENLESS_PR_ENV[n])
+      .exec((argv) => {
+        if (argv.includes("status")) {
+          statusCalls++;
+          return Promise.resolve(statusCalls === 1 ? "" : " M zuke.ts");
+        }
+        return Promise.resolve(argv.includes("diff") ? AGENT_DIFF : "");
+      })
+      .fetch(fetch);
+    await fixer.remediate(CTX);
+  } finally {
+    console.log = log;
+  }
+  // Suggestions were produced but no PR context could be resolved — nothing
+  // was posted anywhere (the overview comment has no token either).
+  assertEquals(calls.length, 0);
+  assertEquals(
+    lines.some((l) => l.includes("no committable suggestions produced")),
+    true,
+  );
+});
+
+Deno.test("suggest mode fails closed when the post-agent status cannot be read", async () => {
+  const prEnv: Record<string, string> = {
+    ...TOKENLESS_PR_ENV,
+    GITHUB_TOKEN: "tok",
+  };
+  const lines: string[] = [];
+  const log = console.log;
+  console.log = (...a: unknown[]) => void lines.push(a.join(" "));
+  const git: string[][] = [];
+  let statusCalls = 0;
+  try {
+    const fixer = agentFixer(() => Promise.resolve(), (f) => f.suggest())
+      .allowCI().noComment().conventions("")
+      .readFile(() => Promise.resolve(undefined))
+      .env((n) => prEnv[n])
+      .exec((argv) => {
+        git.push(argv);
+        if (argv.includes("status")) {
+          statusCalls++;
+          // The snapshot succeeds; the post-agent status read fails.
+          if (statusCalls === 1) return Promise.resolve("");
+          return Promise.reject(new Error("index.lock exists"));
+        }
+        return Promise.resolve("");
+      });
+    const result = await fixer.remediate(CTX);
+    assertEquals(result.retry, false);
+  } finally {
+    console.log = log;
+  }
+  // Without the second status nothing can be scoped: no diff is ever taken.
+  assertEquals(git.some((a) => a.includes("diff")), false);
+  assertEquals(
+    lines.some((l) => l.includes("no committable suggestions produced")),
+    true,
+  );
+});
+
+Deno.test("suggest mode with an idle agent takes no diff and proposes nothing", async () => {
+  const prEnv: Record<string, string> = {
+    ...TOKENLESS_PR_ENV,
+    GITHUB_TOKEN: "tok",
+  };
+  const lines: string[] = [];
+  const log = console.log;
+  console.log = (...a: unknown[]) => void lines.push(a.join(" "));
+  const git: string[][] = [];
+  try {
+    const fixer = agentFixer(() => Promise.resolve(), (f) => f.suggest())
+      .allowCI().noComment().conventions("")
+      .readFile(() => Promise.resolve(undefined))
+      .env((n) => prEnv[n])
+      .exec((argv) => {
+        git.push(argv);
+        return Promise.resolve(""); // clean tree before and after the agent
+      });
+    await fixer.remediate(CTX);
+  } finally {
+    console.log = log;
+  }
+  assertEquals(git.some((a) => a.includes("diff")), false);
+  assertEquals(
+    lines.some((l) => l.includes("no committable suggestions produced")),
+    true,
+  );
+});
+
+Deno.test("a non-Error suggestion-post failure is stringified and swallowed", async () => {
+  const prEnv: Record<string, string> = {
+    ...TOKENLESS_PR_ENV,
+    GITHUB_TOKEN: "tok",
+  };
+  // The PR-detail fetch rejects with a bare string (not an Error).
+  const throwing = (() => Promise.reject("conn reset")) as typeof fetch;
+  const warnings: string[] = [];
+  const warn = console.warn;
+  console.warn = (...a: unknown[]) => void warnings.push(a.join(" "));
+  let statusCalls = 0;
+  try {
+    const fixer = agentFixer(() => Promise.resolve(), (f) => f.suggest())
+      .allowCI().noComment().conventions("")
+      .readFile(() => Promise.resolve(undefined))
+      .env((n) => prEnv[n])
+      .exec((argv) => {
+        if (argv.includes("status")) {
+          statusCalls++;
+          return Promise.resolve(statusCalls === 1 ? "" : " M zuke.ts");
+        }
+        return Promise.resolve(argv.includes("diff") ? AGENT_DIFF : "");
+      })
+      .fetch(throwing).quiet();
+    const result = await fixer.remediate(CTX);
+    assertEquals(result.retry, false);
+  } finally {
+    console.warn = warn;
+  }
+  assertEquals(
+    warnings.some((w) => w.includes("could not post suggestions: conn reset")),
+    true,
+  );
+});
+
+Deno.test("a non-Error agent failure is stringified into the warning", async () => {
+  const warnings: string[] = [];
+  const warn = console.warn;
+  console.warn = (...a: unknown[]) => void warnings.push(a.join(" "));
+  let result;
+  try {
+    // The runner rejects with a bare string, pinning the String(error) path.
+    const fixer = hermetic(agentFixer(() => Promise.reject("agent exploded")));
+    result = await fixer.remediate(CTX);
+  } finally {
+    console.warn = warn;
+  }
+  assertEquals(result.retry, false);
+  assertEquals(
+    warnings.some((w) => w.includes("agent run failed: agent exploded")),
+    true,
+  );
+});
+
+Deno.test("suggest mode skips suggestions when the pre-agent snapshot fails", async () => {
+  const lines: string[] = [];
+  const log = console.log;
+  console.log = (...a: unknown[]) => void lines.push(a.join(" "));
+  const r = recorder();
+  let result;
+  try {
+    const fixer = agentFixer(r.run, (f) => f.suggest())
+      .conventions("").readFile(() => Promise.resolve(undefined))
+      .env(() => undefined) // local run — the CI gate does not apply
+      .exec(() => Promise.reject(new Error("index.lock exists")));
+    result = await fixer.remediate(CTX);
+  } finally {
+    console.log = log;
+  }
+  assertEquals(result.retry, false);
+  assertEquals(r.calls.length, 1); // the agent still ran
+  assertEquals(
+    lines.some((l) =>
+      l.includes(
+        "skipped suggestions: could not snapshot the working tree",
+      )
+    ),
+    true,
+  );
+});
+
+Deno.test("a non-Error commit failure is stringified into the report action", async () => {
+  const lines: string[] = [];
+  const log = console.log;
+  console.log = (...a: unknown[]) => void lines.push(a.join(" "));
+  let statusCalls = 0;
+  let result;
+  try {
+    const fixer = agentFixer(() => Promise.resolve(), (f) => f.commitFixes())
+      .conventions("").readFile(() => Promise.resolve(undefined))
+      .env(() => undefined)
+      .exec((argv) => {
+        if (argv.includes("status")) {
+          statusCalls++;
+          return Promise.resolve(statusCalls === 1 ? "" : " M zuke.ts");
+        }
+        if (argv[1] === "commit") return Promise.reject("hook denied");
+        return Promise.resolve("");
+      });
+    result = await fixer.remediate(CTX);
+  } finally {
+    console.log = log;
+  }
+  assertEquals(result.retry, true); // the agent's edit still re-runs the target
+  assertEquals(
+    lines.some((l) => l.includes("commit failed: hook denied")),
+    true,
+  );
+});
+
+Deno.test("a long agent transcript is truncated in the PR comment", async () => {
+  const prEnv: Record<string, string> = {
+    ...TOKENLESS_PR_ENV,
+    GITHUB_TOKEN: "tok",
+  };
+  const { fetch, calls } = githubFetch();
+  const fixer = agentFixer(() => Promise.resolve("x".repeat(5000)))
+    .allowCI().conventions("").readFile(() => Promise.resolve(undefined))
+    .env((n) => prEnv[n]).fetch(fetch).quiet();
+  await fixer.remediate(CTX);
+  const post = calls.find((c) => c.body.includes("Agent output"));
+  if (post === undefined) throw new Error("no comment posted");
+  assertEquals(post.body.includes("… (truncated) …"), true);
+  // The capped transcript, not the full 5000 characters, travels.
+  assertEquals(post.body.includes("x".repeat(4001)), false);
+});
+
+Deno.test("an Error from the suggestion post is warned with its message", async () => {
+  const prEnv: Record<string, string> = {
+    ...TOKENLESS_PR_ENV,
+    GITHUB_TOKEN: "tok",
+  };
+  // The PR-detail fetch rejects with a real Error, whose message is reported.
+  const throwing =
+    (() => Promise.reject(new Error("api quota exhausted"))) as typeof fetch;
+  const warnings: string[] = [];
+  const warn = console.warn;
+  console.warn = (...a: unknown[]) => void warnings.push(a.join(" "));
+  let statusCalls = 0;
+  try {
+    const fixer = agentFixer(() => Promise.resolve(), (f) => f.suggest())
+      .allowCI().noComment().conventions("")
+      .readFile(() => Promise.resolve(undefined))
+      .env((n) => prEnv[n])
+      .exec((argv) => {
+        if (argv.includes("status")) {
+          statusCalls++;
+          return Promise.resolve(statusCalls === 1 ? "" : " M zuke.ts");
+        }
+        return Promise.resolve(argv.includes("diff") ? AGENT_DIFF : "");
+      })
+      .fetch(throwing).quiet();
+    const result = await fixer.remediate(CTX);
+    assertEquals(result.retry, false);
+  } finally {
+    console.warn = warn;
+  }
+  assertEquals(
+    warnings.some((w) =>
+      w.includes("could not post suggestions: api quota exhausted")
+    ),
+    true,
+  );
+});

--- a/packages/ai/tests/ai_test.ts
+++ b/packages/ai/tests/ai_test.ts
@@ -1184,3 +1184,36 @@ Deno.test("a failed PR comment never breaks the review", async () => {
     },
   );
 });
+
+Deno.test("provider_ reflects the configured provider", () => {
+  const bare = securityReviewer();
+  assertEquals(bare.provider_, undefined); // nothing configured yet
+  const configured = securityReviewer((r) => r.provider("openai"));
+  assertEquals(configured.provider_, "openai");
+});
+
+Deno.test("the fetchBase fallback is announced on the console when not quiet", async () => {
+  const { fetch } = recordFetch(
+    claude({ score: 0, severity: "none", summary: "", findings: [] }),
+  );
+  const lines = await captured(() =>
+    securityReviewer((r) =>
+      r.provider("claude").apiKey("k")
+        .diff((d) => d.fetchBase("develop"))
+        .env(() => undefined)
+        .exec((argv) => {
+          if (argv[1] === "fetch") return Promise.reject(new Error("offline"));
+          return Promise.resolve("diff --git a/w b/w\n+working tree");
+        })
+        .fetch(fetch)
+    ).validate({ target: "t" })
+  );
+  // The silent-fallback hazard is called out where the operator can see it.
+  assertEquals(
+    lines.some((l) =>
+      l.includes("fetchBase could not compute the base diff") &&
+      l.includes("falling back to the working-tree diff")
+    ),
+    true,
+  );
+});

--- a/packages/ai/tests/comment_test.ts
+++ b/packages/ai/tests/comment_test.ts
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Tests for the shared PR-comment poster: token resolution, the no-context
+ * no-op, and the best-effort error handling.
+ *
+ * @module
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../core/tests/_assert.ts";
+import { postComment } from "../src/comment.ts";
+
+/** A recorded request. */
+interface Call {
+  url: string;
+  auth: string;
+}
+
+/** A fake `fetch` recording each call's URL and Authorization header. */
+function recordFetch(): { fetch: typeof fetch; calls: Call[] } {
+  const calls: Call[] = [];
+  const impl = ((input: string | URL | Request, init?: RequestInit) => {
+    const headers = new Headers(init?.headers);
+    calls.push({
+      url: String(input),
+      auth: headers.get("authorization") ?? "",
+    });
+    const method = init?.method ?? "GET";
+    return Promise.resolve(
+      new Response(method === "GET" ? "[]" : "{}", { status: 200 }),
+    );
+  }) as typeof fetch;
+  return { fetch: impl, calls };
+}
+
+const PR_ENV: Record<string, string> = {
+  GITHUB_ACTIONS: "true",
+  GITHUB_REPOSITORY: "o/r",
+  GITHUB_REF: "refs/pull/7/merge",
+};
+
+Deno.test("postComment is a no-op off any CI host", async () => {
+  const { fetch, calls } = recordFetch();
+  await postComment("sec", "## body", { env: () => undefined, fetch });
+  assertEquals(calls.length, 0);
+});
+
+Deno.test("an explicit commentToken wins over the host env token", async () => {
+  const { fetch, calls } = recordFetch();
+  await postComment("sec", "## body", {
+    commentToken: "explicit-token",
+    env: (n) => n === "GITHUB_TOKEN" ? "env-token" : PR_ENV[n],
+    fetch,
+  });
+  assertEquals(calls.length, 2); // list, then create
+  for (const call of calls) {
+    assertEquals(call.auth, "Bearer explicit-token");
+  }
+});
+
+Deno.test("no token at all prepares no upsert — nothing is fetched", async () => {
+  const { fetch, calls } = recordFetch();
+  // The host is detected, but GITHUB_TOKEN is unset, so the empty token yields
+  // no PR context and the comment is silently skipped.
+  await postComment("sec", "## body", { env: (n) => PR_ENV[n], fetch });
+  assertEquals(calls.length, 0);
+});
+
+Deno.test("a non-Error throw from the upsert is stringified into the warning", async () => {
+  // Rejects with a bare string (not an Error), pinning the String(error)
+  // fallback in postComment's catch.
+  const throwing = (() => Promise.reject("socket torn down")) as typeof fetch;
+  const warnings: string[] = [];
+  const warn = console.warn;
+  console.warn = (...a: unknown[]) => void warnings.push(a.join(" "));
+  try {
+    await postComment("sec", "## body", {
+      commentToken: "tok",
+      env: (n) => PR_ENV[n],
+      fetch: throwing,
+    });
+  } finally {
+    console.warn = warn;
+  }
+  assertEquals(warnings.length, 1);
+  assertStringIncludes(
+    warnings[0],
+    "[sec] could not post PR comment: socket torn down",
+  );
+});

--- a/packages/ai/tests/cost_controls_test.ts
+++ b/packages/ai/tests/cost_controls_test.ts
@@ -157,6 +157,53 @@ Deno.test("reviewer skips the call once the budget is exhausted", async () => {
   assertEquals(lines.some((l) => l.includes("AI budget exhausted")), true);
 });
 
+Deno.test("the verify pass's own usage draws down the shared budget", async () => {
+  const b = budget((x) => x.maxTokens(100_000));
+  const finding = {
+    title: "weak hash",
+    severity: "high" as const,
+    file: "h.ts",
+  };
+  const id = findingFingerprint("security", {
+    title: "weak hash",
+    severity: "high",
+    file: "h.ts",
+  });
+  const responses = [
+    claude({ score: 8, severity: "high", summary: "s", findings: [finding] }, {
+      input_tokens: 10,
+      output_tokens: 5,
+    }),
+    // The verify verdict also reports usage — it must be folded in too.
+    JSON.stringify({
+      content: [{
+        type: "text",
+        text: JSON.stringify({
+          verdicts: [{ id, verdict: "refuted", reason: "not reachable" }],
+        }),
+      }],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 7, output_tokens: 3 },
+    }),
+  ];
+  let served = 0;
+  const queued: typeof fetch = () =>
+    Promise.resolve(
+      new Response(responses[Math.min(served++, responses.length - 1)], {
+        status: 200,
+      }),
+    );
+  await captured(() =>
+    // Passes: the sole finding was refuted, so nothing gates.
+    securityReviewer((r) =>
+      r.provider("claude").apiKey("k").diff((d) => d.text(DIFF))
+        .fetch(queued).budget(b).verify()
+    ).validate({ target: "t" })
+  );
+  assertEquals(b.spend_().calls, 2); // review + verify both recorded
+  assertEquals(b.spend_().totalTokens, 25);
+});
+
 // ----- Cache ---------------------------------------------------------------
 
 Deno.test("reviewer caches a response and reuses it on a repeat run", async () => {

--- a/packages/ai/tests/cost_controls_test.ts
+++ b/packages/ai/tests/cost_controls_test.ts
@@ -1,10 +1,11 @@
 // Copyright (c) 2026 the Zuke contributors
 // SPDX-License-Identifier: MIT
 
-import { assertEquals } from "../../core/tests/_assert.ts";
+import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
 import {
   aiCache,
   aiFixer,
+  AiReviewError,
   type Assessment,
   budget,
   type CacheEntry,
@@ -317,6 +318,65 @@ Deno.test("an empty suppress list leaves the findings untouched", async () => {
     ).validate({ target: "t" })
   );
   assertEquals(lines.some((l) => l.includes("suppressed")), false);
+});
+
+Deno.test("a suppress list that matches no finding drops nothing", async () => {
+  // A non-empty list whose fingerprints belong to some other finding: the
+  // assessment must pass through untouched, so the critical finding still
+  // trips the default gate.
+  const sup = suppressions((s) => s.add("ffffffffffffffff"));
+  const { fetch } = recordFetch(
+    claude({
+      score: 9,
+      severity: "critical",
+      summary: "bad",
+      findings: [{ title: "rce", severity: "critical" }],
+    }),
+  );
+  const lines = await captured(async () => {
+    await assertRejects(
+      () =>
+        securityReviewer((r) =>
+          r.provider("claude").apiKey("k").diff((d) => d.text(DIFF))
+            .fetch(fetch).suppress(sup)
+        ).validate({ target: "t" }),
+      AiReviewError, // the unrelated fingerprint muted nothing
+    );
+  });
+  assertEquals(lines.some((l) => l.includes("suppressed")), false);
+});
+
+Deno.test("the verify pass is skipped once the review call exhausts the budget", async () => {
+  // The review itself fits under the cap check (0 < 1) but its usage blows the
+  // cap, so the verify pass that follows must be skipped — visibly — and the
+  // unverified finding must keep gating.
+  const b = budget((x) => x.maxTokens(1));
+  const { fetch, calls } = recordFetch(
+    claude(
+      {
+        score: 9,
+        severity: "critical",
+        summary: "bad",
+        findings: [{ title: "rce", severity: "critical" }],
+      },
+      { input_tokens: 500, output_tokens: 100 },
+    ),
+  );
+  const lines = await captured(async () => {
+    await assertRejects(
+      () =>
+        securityReviewer((r) =>
+          r.provider("claude").apiKey("k").diff((d) => d.text(DIFF))
+            .fetch(fetch).budget(b).verify()
+        ).validate({ target: "t" }),
+      AiReviewError, // the finding was kept, not silently verified away
+    );
+  });
+  assertEquals(calls.length, 1); // the review call only — no verify call
+  assertEquals(
+    lines.some((l) => l.includes("verify pass skipped — AI budget exhausted")),
+    true,
+  );
 });
 
 // ----- Report rendering ----------------------------------------------------

--- a/packages/ai/tests/dedup_test.ts
+++ b/packages/ai/tests/dedup_test.ts
@@ -304,7 +304,7 @@ Deno.test("eligible is the one gate both resolution paths share", () => {
 });
 
 Deno.test("dedupNotes carries an empty file for a hand-built file-less pair", () => {
-  // planDedup never offers a file-less pair, but the serialiser is its own
+  // planDedup never offers a file-less pair, but the serializer is its own
   // contract: a missing file travels as "", never as the string "undefined".
   const notes = dedupNotes({
     pairs: [{

--- a/packages/ai/tests/dedup_test.ts
+++ b/packages/ai/tests/dedup_test.ts
@@ -302,3 +302,70 @@ Deno.test("eligible is the one gate both resolution paths share", () => {
     false,
   );
 });
+
+Deno.test("dedupNotes carries an empty file for a hand-built file-less pair", () => {
+  // planDedup never offers a file-less pair, but the serialiser is its own
+  // contract: a missing file travels as "", never as the string "undefined".
+  const notes = dedupNotes({
+    pairs: [{
+      label: "p1",
+      candidate: candidate("c1", { file: undefined, detail: "why" }),
+      prior: prior("p1"),
+    }],
+    dropped: 0,
+  });
+  assertEquals(notes, [{
+    label: "p1",
+    file: "",
+    title: "finding c1",
+    detail: "why",
+    priorTitle: "prior p1",
+  }]);
+});
+
+Deno.test("planDedup round-robins past a candidate with fewer matches", () => {
+  // c1 has two eligible priors, c2 (in another file) has one. At depth two the
+  // round-robin must skip c2's exhausted list and still offer c1's second pair.
+  const plan = planDedup(
+    [candidate("c1"), candidate("c2", { file: "src/other.ts" })],
+    [prior("p1"), prior("p2"), prior("p3", { file: "src/other.ts" })],
+  );
+  assertEquals(
+    plan.pairs.map((p) => [p.candidate.id, p.prior.id]),
+    [["c1", "p1"], ["c2", "p3"], ["c1", "p2"]],
+  );
+  assertEquals(plan.dropped, 0);
+});
+
+Deno.test("sameAs ignores a hand-built pair whose candidate has no identity", () => {
+  // A pair can only enter a plan through planDedup today, but sameAs guards its
+  // own input: without a candidate id there is nothing to rename, so a "same"
+  // verdict on such a pair must resolve nothing.
+  for (const id of [undefined, ""]) {
+    const plan = {
+      pairs: [{
+        label: "p1",
+        candidate: candidate("c1", { id }),
+        prior: prior("p1"),
+      }],
+      dropped: 0,
+    };
+    const result = sameAs(plan, verdicts(["p1", "same"]));
+    assertEquals(result.matches.size, 0);
+    assertEquals(result.ambiguous, []);
+  }
+});
+
+Deno.test("adoptCanonicalIds skips a finding that has no id at all", () => {
+  const bare = candidate("c1", { id: undefined });
+  const matched = candidate("c2");
+  const target = prior("p1");
+  const adoptions = adoptCanonicalIds(
+    [bare, matched],
+    new Map([["c2", target]]),
+  );
+  // Only the identified finding adopts; the bare one is left untouched.
+  assertEquals(adoptions, [{ alias: "c2", prior: target }]);
+  assertEquals(matched.id, "p1");
+  assertEquals(bare.id, undefined);
+});

--- a/packages/ai/tests/deep_review_test.ts
+++ b/packages/ai/tests/deep_review_test.ts
@@ -311,3 +311,85 @@ Deno.test("verify is skipped cleanly when there are no findings", async () => {
   ).validate({ target: "t" });
   assertEquals(calls.length, 1); // no second call to verify nothing
 });
+
+/** Capture console output with the job-summary file unset (no real writes). */
+async function captured(fn: () => Promise<void>): Promise<string[]> {
+  const lines: string[] = [];
+  const { log, warn } = console;
+  const summary = Deno.env.get("GITHUB_STEP_SUMMARY");
+  Deno.env.delete("GITHUB_STEP_SUMMARY");
+  console.log = (...a: unknown[]) => void lines.push(a.join(" "));
+  console.warn = (...a: unknown[]) => void lines.push(a.join(" "));
+  try {
+    await fn();
+  } finally {
+    console.log = log;
+    console.warn = warn;
+    if (summary !== undefined) Deno.env.set("GITHUB_STEP_SUMMARY", summary);
+  }
+  return lines;
+}
+
+Deno.test("verify candidates carry the finding's line; a reason-less refutation renders bare", async () => {
+  const finding = {
+    title: "SQL injection",
+    severity: "high",
+    file: "db.ts",
+    line: 3,
+  };
+  const id = findingFingerprint("security", {
+    title: "SQL injection",
+    severity: "high",
+    file: "db.ts",
+  });
+  const { fetch, calls } = queuedFetch([
+    claude({ score: 8, severity: "high", findings: [finding] }),
+    // A refutation with no reason — schema-valid, and must still narrow.
+    claude({ verdicts: [{ id, verdict: "refuted" }] }),
+  ]);
+  const lines = await captured(() =>
+    // Passes: the sole finding was refuted, so the score recomputes to 0.
+    securityReviewer((r) =>
+      r.provider("claude").apiKey("k")
+        .diff((d) => d.text(DIFF)).verify()
+        .fetch(fetch)
+    ).validate({ target: "t" })
+  );
+  // The verify prompt carried the line, so the verifier can find the code.
+  const verify = JSON.parse(calls[1].body);
+  assertEquals(verify.messages[0].content.includes('"line": 3'), true);
+  // The refutation is reported without inventing a reason.
+  const refutedLine = lines.find((l) => l.includes("refuted by verify"));
+  assertEquals(refutedLine?.includes("SQL injection"), true);
+  assertEquals(refutedLine?.includes("—"), false);
+});
+
+Deno.test("a failed verify pass warns on the console when not quiet", async () => {
+  const { fetch } = queuedFetch([
+    claude({
+      score: 9,
+      severity: "critical",
+      findings: [{ title: "RCE", severity: "critical" }],
+    }),
+    { status: 500 },
+  ]);
+  const lines = await captured(async () => {
+    await assertRejects(
+      () =>
+        securityReviewer((r) =>
+          r.provider("claude").apiKey("k")
+            .retry({ attempts: 1 })
+            .diff((d) => d.text(DIFF)).verify()
+            .fetch(fetch)
+        ).validate({ target: "t" }),
+      AiReviewError, // the unverified finding stayed and still gates
+    );
+  });
+  assertEquals(
+    lines.some((l) =>
+      l.includes("verify pass failed") &&
+      l.includes("keeping unverified findings")
+    ),
+    true,
+  );
+});

--- a/packages/ai/tests/deep_review_test.ts
+++ b/packages/ai/tests/deep_review_test.ts
@@ -393,3 +393,17 @@ Deno.test("a failed verify pass warns on the console when not quiet", async () =
     true,
   );
 });
+
+Deno.test("an empty file context is omitted from the prompt entirely", async () => {
+  const { fetch, calls } = queuedFetch([claude({ score: 0, findings: [] })]);
+  const git = fakeGit({}); // every `git show` fails — nothing to send
+  await genericReviewer((r) =>
+    r.provider("claude").apiKey("k").quiet()
+      .diff((d) => d.base("origin/master"))
+      .fileContext(1000)
+      .exec(git.run).fetch(fetch)
+  ).validate({ target: "t" });
+  const body = JSON.parse(calls[0].body);
+  // No empty UNTRUSTED_FILES block confuses the model when nothing was read.
+  assertEquals(body.messages[0].content.includes("UNTRUSTED_FILES"), false);
+});

--- a/packages/ai/tests/discussion_flow_test.ts
+++ b/packages/ai/tests/discussion_flow_test.ts
@@ -2854,3 +2854,396 @@ Deno.test("a thread phase that throws degrades to a note, never a failure", asyn
     true,
   );
 });
+
+Deno.test("discussion on GitHub without a PR context is skipped silently", async () => {
+  // A push build on GitHub Actions: the host can list comments, but there is
+  // no pull request to list them from — the discussion just does not run.
+  const { fetch, calls } = discussionFetch([], [
+    claude({ score: 0, severity: "none", findings: [] }),
+  ]);
+  const lines = await captured(() =>
+    inEnv(
+      {
+        GITHUB_ACTIONS: "true",
+        GITHUB_REPOSITORY: "zuke-build/zuke",
+        GITHUB_REF: "refs/heads/master", // a branch, not a PR
+        GITHUB_TOKEN: "tkn",
+      },
+      async () => {
+        await securityReviewer((r) =>
+          r.provider("claude").apiKey("k")
+            .comment().discussion()
+            .diff((d) => d.text(DIFF))
+            .fetch(fetch)
+        ).validate({ target: "t" });
+      },
+    )
+  );
+  // Not the "disabled" warning — this is the expected local/push shape.
+  assertEquals(lines.some((l) => l.includes("discussion disabled")), false);
+  // No comment listing was even attempted.
+  assertEquals(calls.every((c) => !c.url.startsWith(`${GITHUB_API}/`)), true);
+  // The comment itself is skipped with the no-PR-context warning.
+  assertEquals(lines.some((l) => l.includes("no GitHub PR context")), true);
+});
+
+Deno.test("a candidate matching a fixed and a dismissed prior reopens rather than inheriting the dismissal", async () => {
+  // Fixed entries are offered before dismissed ones exactly so that a
+  // candidate the model matches to both REOPENS (which reports) instead of
+  // inheriting a dismissal (which silences).
+  const priors = [
+    {
+      id: "oooo0001",
+      title: "Still-open concern",
+      severity: "high" as const,
+      status: "open" as const,
+      file: "src/app.ts",
+    },
+    {
+      id: "dddd0001",
+      title: "Dismissed concern",
+      severity: "high" as const,
+      status: "dismissed" as const,
+      file: "src/app.ts",
+      rationale: "argued away",
+      author: "maintainer",
+    },
+    {
+      id: "ffff0001",
+      title: "Fixed concern",
+      severity: "high" as const,
+      status: "fixed" as const,
+      file: "src/app.ts",
+    },
+  ];
+  const { fetch, calls } = discussionFetch(
+    priorComment({ findings: priors }),
+    [
+      claude({ score: 9, severity: "high", findings: [REWORDED] }),
+      // The model matches the FIRST comparison — which, by the fixed-first
+      // ordering, is the fixed entry even though it was listed last in state.
+      claude({ verdicts: [{ id: "p1", verdict: "same", reason: "same" }] }),
+    ],
+  );
+  const lines = await captured(() =>
+    inPr(async () => {
+      await assertRejects(
+        () =>
+          securityReviewer((r) =>
+            r.provider("claude").apiKey("k")
+              .comment().discussion()
+              .diff((d) => d.text(DIFF))
+              .fetch(fetch)
+          ).validate({ target: "t" }),
+        AiReviewError, // reopened — it gates again
+      );
+    })
+  );
+  assertEquals(
+    lines.some((l) => l.includes("reopened under ffff0001")),
+    true,
+  );
+  const state = postedState(calls);
+  assertEquals(
+    state?.findings.find((f) => f.id === "ffff0001")?.status,
+    "open",
+  );
+  assertEquals(
+    state?.findings.find((f) => f.id === "ffff0001")?.aliases,
+    [REWORDED_ID],
+  );
+  // The dismissal was NOT inherited and stays on its own entry.
+  assertEquals(
+    state?.findings.find((f) => f.id === "dddd0001")?.status,
+    "dismissed",
+  );
+});
+
+Deno.test("an upheld verdict without a reason records no rationale", async () => {
+  const bare = { title: "Global prototype pollution", severity: "high" };
+  const bareId = findingFingerprint("security", {
+    title: "Global prototype pollution",
+    severity: "high",
+  });
+  const comments = [
+    {
+      id: 1,
+      body: `Finding ${bareId} is fine, we own that global`,
+      user: { login: "maintainer", type: "User" },
+      author_association: "OWNER",
+    },
+  ];
+  const { fetch, calls } = discussionFetch(comments, [
+    claude({ score: 9, severity: "high", findings: [bare] }),
+    claude({ verdicts: [{ id: bareId, verdict: "upheld" }] }),
+  ]);
+  await captured(() =>
+    inPr(async () => {
+      await assertRejects(
+        () =>
+          securityReviewer((r) =>
+            r.provider("claude").apiKey("k")
+              .comment().discussion()
+              .diff((d) => d.text(DIFF))
+              .fetch(fetch)
+          ).validate({ target: "t" }),
+        AiReviewError, // upheld → still gating
+      );
+    })
+  );
+  const entry = postedState(calls)?.findings.find((f) => f.id === bareId);
+  assertEquals(entry?.status, "upheld");
+  assertEquals(entry?.rationale, undefined); // no invented reasoning
+  assertEquals(entry?.file, undefined); // and no invented location
+});
+
+Deno.test("an exhausted budget skips the adjudication; contested findings stay open", async () => {
+  const b = budget((x) => x.maxTokens(1));
+  const comments = [
+    {
+      id: 1,
+      body: `Finding ${ID} misreads the code`,
+      user: { login: "maintainer", type: "User" },
+      author_association: "MEMBER",
+    },
+  ];
+  // The review's own usage blows the cap before the adjudication would run.
+  const { fetch, calls } = discussionFetch(comments, [
+    claudeWithUsage({ score: 9, severity: "high", findings: [FINDING] }, {
+      input_tokens: 500,
+      output_tokens: 100,
+    }),
+  ]);
+  await captured(() =>
+    inPr(async () => {
+      await assertRejects(
+        () =>
+          securityReviewer((r) =>
+            r.provider("claude").apiKey("k")
+              .comment().discussion().budget(b)
+              .diff((d) => d.text(DIFF))
+              .fetch(fetch)
+          ).validate({ target: "t" }),
+        AiReviewError, // never adjudicated → still open → still gating
+      );
+    })
+  );
+  // The review call only — the maintainer's rebuttal cost nothing further.
+  assertEquals(
+    calls.filter((c) => !c.url.startsWith(`${GITHUB_API}/`)).length,
+    1,
+  );
+  assertEquals(
+    postedState(calls)?.findings.find((f) => f.id === ID)?.status,
+    "open",
+  );
+});
+
+Deno.test("a sticky dismissal with no recorded author or rationale still mutes, rendered bare", async () => {
+  const priorBody = `${MARKER}\nold report\n${
+    encodeState({
+      findings: [{
+        id: ID,
+        title: FINDING.title,
+        severity: "high",
+        status: "dismissed",
+        // No author, rationale, or file recorded — a minimal state entry.
+      }],
+    })
+  }`;
+  const comments = [{
+    id: 1,
+    body: priorBody,
+    user: { login: "github-actions[bot]", type: "Bot" },
+    author_association: "NONE",
+  }];
+  const { fetch, calls } = discussionFetch(comments, [
+    claude({ score: 9, severity: "high", findings: [FINDING] }),
+  ]);
+  const lines = await captured(() =>
+    inPr(async () => {
+      // Passes: the sticky dismissal mutes the re-reported finding.
+      await securityReviewer((r) =>
+        r.provider("claude").apiKey("k")
+          .comment().discussion()
+          .diff((d) => d.text(DIFF))
+          .fetch(fetch)
+      ).validate({ target: "t" });
+    })
+  );
+  // Rendered without inventing an author or a reason.
+  assertEquals(
+    lines.some((l) => l.includes(`dismissed via discussion: ${FINDING.title}`)),
+    true,
+  );
+  // The dismissed-findings memory rode into the prompt as the bare line.
+  const provider = calls.find((c) => !c.url.startsWith(`${GITHUB_API}/`));
+  const user = JSON.parse(provider?.body ?? "{}").messages[0].content;
+  assertEquals(user.includes(`${ID} — ${FINDING.title}`), true);
+});
+
+Deno.test("a missing token env skips the comment with the PR-context warning", async () => {
+  // A PR on GitHub Actions, but GITHUB_TOKEN is absent and no .commentToken()
+  // was configured: the comment is skipped, never posted unauthenticated.
+  const { fetch, calls } = discussionFetch([], [
+    claude({ score: 0, severity: "none", findings: [] }),
+  ]);
+  const lines = await captured(() =>
+    inEnv(
+      {
+        GITHUB_ACTIONS: "true",
+        GITHUB_REPOSITORY: "zuke-build/zuke",
+        GITHUB_REF: "refs/pull/7/merge",
+        // no GITHUB_TOKEN
+      },
+      async () => {
+        const token = Deno.env.get("GITHUB_TOKEN");
+        Deno.env.delete("GITHUB_TOKEN");
+        try {
+          await securityReviewer((r) =>
+            r.provider("claude").apiKey("k")
+              .comment()
+              .diff((d) => d.text(DIFF))
+              .fetch(fetch)
+          ).validate({ target: "t" });
+        } finally {
+          if (token !== undefined) Deno.env.set("GITHUB_TOKEN", token);
+        }
+      },
+    )
+  );
+  assertEquals(
+    lines.some((l) => l.includes("no GitHub PR context — skipping comment")),
+    true,
+  );
+  assertEquals(calls.every((c) => !c.url.startsWith(`${GITHUB_API}/`)), true);
+});
+
+Deno.test("a file-less open prior is re-assessed bare and marked fixed when gone", async () => {
+  const priorBody = `${MARKER}\nold report\n${
+    encodeState({
+      findings: [{
+        id: "bbbb0001",
+        title: "Orphan concern",
+        severity: "low",
+        status: "open",
+        // no file recorded
+      }],
+    })
+  }`;
+  const comments = [{
+    id: 1,
+    body: priorBody,
+    user: { login: "github-actions[bot]", type: "Bot" },
+    author_association: "NONE",
+  }];
+  const { fetch, calls } = discussionFetch(comments, [
+    claude({ score: 0, severity: "none", findings: [] }),
+  ]);
+  const lines = await captured(() =>
+    inPr(async () => {
+      await securityReviewer((r) =>
+        r.provider("claude").apiKey("k")
+          .comment().discussion()
+          .diff((d) => d.text(DIFF))
+          .fetch(fetch)
+      ).validate({ target: "t" });
+    })
+  );
+  // The prior rode into the prompt as the bare `id — title` line.
+  const provider = calls.find((c) => !c.url.startsWith(`${GITHUB_API}/`));
+  const user = JSON.parse(provider?.body ?? "{}").messages[0].content;
+  assertEquals(user.includes("bbbb0001 — Orphan concern"), true);
+  // Not re-reported → recorded as progress, with no invented location.
+  assertEquals(
+    lines.some((l) => l.includes("fixed: Orphan concern · bbbb0001")),
+    true,
+  );
+  assertEquals(
+    postedState(calls)?.findings.find((f) => f.id === "bbbb0001")?.status,
+    "fixed",
+  );
+});
+
+Deno.test("a dismissal of a file-less finding records no location", async () => {
+  const bare = { title: "Global prototype pollution", severity: "high" };
+  const bareId = findingFingerprint("security", {
+    title: "Global prototype pollution",
+    severity: "high",
+  });
+  const comments = [
+    {
+      id: 1,
+      body: `Finding ${bareId} cannot happen: the object is frozen at startup`,
+      user: { login: "maintainer", type: "User" },
+      author_association: "MEMBER",
+    },
+  ];
+  const { fetch, calls } = discussionFetch(comments, [
+    claude({ score: 9, severity: "high", findings: [bare] }),
+    claude({
+      verdicts: [{ id: bareId, verdict: "dismissed", reason: "frozen object" }],
+    }),
+  ]);
+  await captured(() =>
+    inPr(async () => {
+      // Dismissed → the gate does not trip.
+      await securityReviewer((r) =>
+        r.provider("claude").apiKey("k")
+          .comment().discussion()
+          .diff((d) => d.text(DIFF))
+          .fetch(fetch)
+      ).validate({ target: "t" });
+    })
+  );
+  const entry = postedState(calls)?.findings.find((f) => f.id === bareId);
+  assertEquals(entry?.status, "dismissed");
+  assertEquals(entry?.rationale, "frozen object");
+  assertEquals(entry?.file, undefined); // no invented location
+});
+
+Deno.test("a reason-less dismissal still closes its thread, without an invented reason", async () => {
+  const reply = {
+    id: 502,
+    body: "This runs in a sandboxed worker, so it cannot reach the host.",
+    in_reply_to_id: 501,
+    user: { login: "maintainer", type: "User" },
+    author_association: "MEMBER",
+  };
+  const { fetch, calls } = threadFetch(
+    [summaryComment({
+      findings: [{
+        id: ANCHORED_ID,
+        title: ANCHORED.title,
+        severity: "high",
+        status: "open",
+        file: "src/app.ts",
+      }],
+    })],
+    [threadRoot(ANCHORED_ID), reply],
+    [
+      claude({ score: 9, severity: "high", findings: [ANCHORED] }),
+      // The adjudicator dismisses but offers no reason.
+      claude({ verdicts: [{ id: ANCHORED_ID, verdict: "dismissed" }] }),
+    ],
+  );
+  await captured(() =>
+    inPr(async () => {
+      await securityReviewer((r) =>
+        r.provider("claude").apiKey("k")
+          .comment().discussion((d) => d.threads())
+          .diff((d) => d.text(ANCHORED_DIFF))
+          .fetch(fetch)
+      ).validate({ target: "t" });
+    })
+  );
+  // The outcome reply landed in the thread, bare — no fabricated rationale.
+  const posted = calls.find((c) => c.url.includes("/comments/501/replies"));
+  const body = JSON.parse(posted?.body ?? "{}").body;
+  assertEquals(
+    body.startsWith(outcomeMarker(NAME_HASH, ANCHORED_ID, "dismissed")),
+    true,
+  );
+  assertEquals(body.includes("**Dismissed via discussion**"), true);
+  assertEquals(body.includes("**Dismissed via discussion** —"), false);
+});

--- a/packages/ai/tests/discussion_flow_test.ts
+++ b/packages/ai/tests/discussion_flow_test.ts
@@ -2,11 +2,15 @@
 // SPDX-License-Identifier: MIT
 
 import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
-import { AiReviewError, securityReviewer } from "../mod.ts";
+import { AiReviewError, budget, securityReviewer } from "../mod.ts";
 import { findingFingerprint } from "../src/suppress.ts";
 import { decodeState, encodeState } from "../src/state.ts";
 import { commentMarker } from "../src/hosts/types.ts";
-import { findingMarker, outcomeMarker } from "../src/threads.ts";
+import {
+  findingMarker,
+  MAX_NEW_THREADS,
+  outcomeMarker,
+} from "../src/threads.ts";
 import { stableHash } from "../src/hash.ts";
 
 const DIFF = "diff --git a/src/app.ts b/src/app.ts\n" +
@@ -2480,4 +2484,373 @@ Deno.test("a quiet reviewer posts no threads either", async () => {
     })
   );
   assertEquals(threadPosts(calls).length, 0);
+});
+
+// ─── Degraded paths: no host, exhausted budgets, failing passes ──────────────
+
+Deno.test("comment and discussion degrade to warnings outside any CI host", async () => {
+  // An env reader that sees nothing: no CI host markers at all (a local run).
+  const { fetch, calls } = discussionFetch([], [
+    claude({ score: 0, severity: "none", findings: [] }),
+  ]);
+  const lines = await captured(() =>
+    securityReviewer((r) =>
+      r.provider("claude").apiKey("k")
+        .comment().discussion()
+        .env(() => undefined)
+        .diff((d) => d.text(DIFF))
+        .fetch(fetch)
+    ).validate({ target: "t" })
+  );
+  // The discussion is declined in code, before any listing is attempted…
+  assertEquals(
+    lines.some((l) =>
+      l.includes("discussion disabled") &&
+      l.includes("the active host cannot list PR comments")
+    ),
+    true,
+  );
+  // …and the comment is skipped with its own warning, not a crash.
+  assertEquals(
+    lines.some((l) =>
+      l.includes("no PR-comment host detected — skipping comment")
+    ),
+    true,
+  );
+  // No host traffic happened at all.
+  assertEquals(calls.every((c) => !c.url.startsWith(`${GITHUB_API}/`)), true);
+});
+
+/** Wrap a payload in a Claude response that also reports token usage. */
+function claudeWithUsage(
+  payload: unknown,
+  usage: Record<string, number>,
+): string {
+  return JSON.stringify({
+    content: [{ type: "text", text: JSON.stringify(payload) }],
+    stop_reason: "end_turn",
+    usage,
+  });
+}
+
+Deno.test("an exhausted budget skips the reworded-finding check, and says so", async () => {
+  // The review call's own usage blows the cap, so the dedup pass that would
+  // resolve the rewording must be skipped — with a note, never silently — and
+  // the finding keeps its fresh identity and gates.
+  const b = budget((x) => x.maxTokens(1));
+  const { fetch, calls } = discussionFetch(
+    priorComment(stateWith("dismissed")),
+    [claudeWithUsage({ score: 9, severity: "high", findings: [REWORDED] }, {
+      input_tokens: 500,
+      output_tokens: 100,
+    })],
+  );
+  const lines = await captured(() =>
+    inPr(async () => {
+      await assertRejects(
+        () =>
+          securityReviewer((r) =>
+            r.provider("claude").apiKey("k")
+              .comment().discussion().budget(b)
+              .diff((d) => d.text(DIFF))
+              .fetch(fetch)
+          ).validate({ target: "t" }),
+        AiReviewError, // reported under its own id — not silenced
+      );
+    })
+  );
+  // The review call only: no dedup call was paid for.
+  assertEquals(
+    calls.filter((c) => !c.url.startsWith(`${GITHUB_API}/`)).length,
+    1,
+  );
+  assertEquals(
+    lines.some((l) =>
+      l.includes("reworded-finding check skipped — AI budget exhausted")
+    ),
+    true,
+  );
+  // The finding kept its own identity in the posted state.
+  assertEquals(
+    postedState(calls)?.findings.some((f) => f.id === REWORDED_ID),
+    true,
+  );
+});
+
+Deno.test("an ambiguous rewording keeps the first match and reports the rest, with the cap named", async () => {
+  // Four earlier open findings in the same file are all eligible comparisons
+  // for one candidate; the per-candidate cap (3) drops the fourth, and the
+  // model then claims the candidate matches two of the three offered.
+  const priors = Array.from({ length: 4 }, (_, i) => ({
+    id: `aaaa000${i + 1}`,
+    title: `Earlier concern ${i + 1}`,
+    severity: "high" as const,
+    status: "open" as const,
+    file: "src/app.ts",
+  }));
+  const { fetch, calls } = discussionFetch(
+    priorComment({ findings: priors }),
+    [
+      claude({ score: 9, severity: "high", findings: [REWORDED] }),
+      claude({
+        verdicts: [
+          { id: "p1", verdict: "same", reason: "same defect" },
+          { id: "p2", verdict: "same", reason: "also this one" },
+        ],
+      }),
+    ],
+  );
+  const lines = await captured(() =>
+    inPr(async () => {
+      await assertRejects(
+        () =>
+          securityReviewer((r) =>
+            r.provider("claude").apiKey("k")
+              .comment().discussion()
+              .diff((d) => d.text(DIFF))
+              .fetch(fetch)
+          ).validate({ target: "t" }),
+        AiReviewError, // adopted an OPEN identity — still gating
+      );
+    })
+  );
+  // First offered wins: the candidate adopted the first prior's identity.
+  const state = postedState(calls);
+  assertEquals(
+    state?.findings.find((f) => f.id === "aaaa0001")?.status,
+    "open",
+  );
+  assertEquals(
+    state?.findings.find((f) => f.id === "aaaa0001")?.aliases,
+    [REWORDED_ID],
+  );
+  // The double match is reported against the candidate's fresh id…
+  assertEquals(
+    lines.some((l) =>
+      l.includes(REWORDED_ID) &&
+      l.includes("matched more than one earlier finding")
+    ),
+    true,
+  );
+  // …and the dropped fourth comparison is announced, not silent.
+  assertEquals(
+    lines.some((l) =>
+      l.includes("reworded-finding check compared 3 of 4 candidate pairs")
+    ),
+    true,
+  );
+});
+
+Deno.test("the finding's detail reaches the adjudicator, and a reason-less dismissal sticks", async () => {
+  const detailed = {
+    ...FINDING,
+    detail: "input flows straight into eval with no sanitisation",
+  };
+  const comments = [
+    {
+      id: 1,
+      body: `Finding ${ID} misreads the code: eval runs in a sandboxed worker`,
+      user: { login: "maintainer", type: "User" },
+      author_association: "MEMBER",
+    },
+  ];
+  const { fetch, calls } = discussionFetch(comments, [
+    claude({ score: 9, severity: "high", findings: [detailed] }),
+    // A dismissal verdict carrying no reason — still a valid two-key dismissal.
+    claude({ verdicts: [{ id: ID, verdict: "dismissed" }] }),
+  ]);
+  const lines = await captured(() =>
+    inPr(async () => {
+      // Dismissed, so the gate does not trip.
+      await securityReviewer((r) =>
+        r.provider("claude").apiKey("k")
+          .comment().discussion()
+          .diff((d) => d.text(DIFF))
+          .fetch(fetch)
+      ).validate({ target: "t" });
+    })
+  );
+  const providerCalls = calls.filter((c) =>
+    !c.url.startsWith(`${GITHUB_API}/`)
+  );
+  assertEquals(providerCalls.length, 2);
+  // The adjudication prompt carried the finding's detail for context.
+  assertEquals(
+    JSON.parse(providerCalls[1].body).messages[0].content.includes(
+      "input flows straight into eval with no sanitisation",
+    ),
+    true,
+  );
+  assertEquals(
+    lines.some((l) => l.includes("dismissed via discussion by maintainer")),
+    true,
+  );
+  // Recorded dismissed with the author but no invented rationale.
+  const entry = postedState(calls)?.findings.find((f) => f.id === ID);
+  assertEquals(entry?.status, "dismissed");
+  assertEquals(entry?.author, "maintainer");
+  assertEquals(entry?.rationale, undefined);
+});
+
+Deno.test("a failed adjudication keeps contested findings open with a warning", async () => {
+  const calls: Call[] = [];
+  let served = 0;
+  const failing = ((input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method ?? "GET";
+    calls.push({
+      url,
+      method,
+      body: typeof init?.body === "string" ? init.body : "",
+    });
+    if (url.startsWith(`${GITHUB_API}/`)) {
+      if (url.endsWith("/user")) {
+        return Promise.resolve(new Response("{}", { status: 403 }));
+      }
+      const payload = method === "GET"
+        ? JSON.stringify([{
+          id: 1,
+          body: `Finding ${ID} misreads the code`,
+          user: { login: "maintainer", type: "User" },
+          author_association: "MEMBER",
+        }])
+        : "{}";
+      return Promise.resolve(new Response(payload, { status: 200 }));
+    }
+    served++;
+    // The review answers; the adjudication call that follows fails outright.
+    return Promise.resolve(
+      served === 1
+        ? new Response(
+          claude({ score: 9, severity: "high", findings: [FINDING] }),
+          { status: 200 },
+        )
+        : new Response("upstream exploded", { status: 500 }),
+    );
+  }) as typeof fetch;
+  const lines = await captured(() =>
+    inPr(async () => {
+      await assertRejects(
+        () =>
+          securityReviewer((r) =>
+            r.provider("claude").apiKey("k")
+              .comment().discussion().retry({ attempts: 1 })
+              .diff((d) => d.text(DIFF))
+              .fetch(failing)
+          ).validate({ target: "t" }),
+        AiReviewError, // the contested finding stayed open and gates
+      );
+    })
+  );
+  assertEquals(
+    lines.some((l) =>
+      l.includes("adjudication failed") &&
+      l.includes("contested findings stay open")
+    ),
+    true,
+  );
+});
+
+Deno.test("findings beyond the thread cap stay in the table, and the gap is announced", async () => {
+  // One more anchorable finding than the per-run thread cap.
+  const count = MAX_NEW_THREADS + 1;
+  const bigDiff = [
+    "diff --git a/src/big.ts b/src/big.ts",
+    "--- a/src/big.ts",
+    "+++ b/src/big.ts",
+    `@@ -1,0 +1,${count} @@`,
+    ...Array.from({ length: count }, (_, i) => `+const v${i + 1} = ${i + 1};`),
+  ].join("\n");
+  const many = Array.from({ length: count }, (_, i) => ({
+    title: `Issue number ${i + 1}`,
+    severity: "high",
+    file: "src/big.ts",
+    line: i + 1,
+  }));
+  const { fetch, calls } = threadFetch([summaryComment()], [], [
+    claude({ score: 9, severity: "high", findings: many }),
+  ]);
+  await captured(() =>
+    inPr(async () => {
+      await assertRejects(
+        () =>
+          securityReviewer((r) =>
+            r.provider("claude").apiKey("k")
+              .comment().discussion((d) => d.threads())
+              .diff((d) => d.text(bigDiff))
+              .fetch(fetch)
+          ).validate({ target: "t" }),
+        AiReviewError,
+      );
+    })
+  );
+  // Exactly the cap was opened, and the leftover is promised to the next run.
+  assertEquals(threadPosts(calls).length, MAX_NEW_THREADS);
+  const write = calls.find((c) =>
+    c.url.includes("/issues/") && c.method !== "GET"
+  );
+  assertEquals(
+    JSON.parse(write?.body ?? "{}").body.includes(
+      `1 finding(s) did not get a review thread this run (cap ${MAX_NEW_THREADS})`,
+    ),
+    true,
+  );
+});
+
+Deno.test("a thread phase that throws degrades to a note, never a failure", async () => {
+  // The head-commit lookup explodes (HTTP 500) after the thread listing
+  // succeeded — the whole phase must collapse into a report note.
+  const calls: Call[] = [];
+  const doFetch = ((input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method ?? "GET";
+    calls.push({
+      url,
+      method,
+      body: typeof init?.body === "string" ? init.body : "",
+    });
+    if (url.startsWith(`${GITHUB_API}/`)) {
+      if (url.endsWith("/user")) {
+        return Promise.resolve(new Response("{}", { status: 403 }));
+      }
+      if (method !== "GET") return Promise.resolve(new Response("{}"));
+      if (url.includes("/pulls/7/comments")) {
+        return Promise.resolve(new Response("[]"));
+      }
+      if (url.includes("/pulls/7")) {
+        return Promise.resolve(new Response("boom", { status: 500 }));
+      }
+      return Promise.resolve(new Response(JSON.stringify([summaryComment()])));
+    }
+    return Promise.resolve(
+      new Response(
+        claude({ score: 9, severity: "high", findings: [ANCHORED] }),
+        { status: 200 },
+      ),
+    );
+  }) as typeof fetch;
+  await captured(() =>
+    inPr(async () => {
+      await assertRejects(
+        () =>
+          securityReviewer((r) =>
+            r.provider("claude").apiKey("k")
+              .comment().discussion((d) => d.threads())
+              .diff((d) => d.text(ANCHORED_DIFF))
+              .fetch(doFetch)
+          ).validate({ target: "t" }),
+        AiReviewError, // the gate still speaks — the finding never vanished
+      );
+    })
+  );
+  assertEquals(threadPosts(calls).length, 0);
+  const write = calls.find((c) =>
+    c.url.includes("/issues/") && c.method !== "GET"
+  );
+  assertEquals(
+    JSON.parse(write?.body ?? "{}").body.includes(
+      "review threads unavailable this run",
+    ),
+    true,
+  );
 });

--- a/packages/ai/tests/fixer_test.ts
+++ b/packages/ai/tests/fixer_test.ts
@@ -1004,3 +1004,199 @@ Deno.test("commitAndPush is a no-op when there are nothing to commit", async () 
   });
   assertEquals(git.length, 0);
 });
+
+Deno.test("aiFixer without a configure lambda returns a bare fixer", () => {
+  assertEquals(aiFixer() instanceof AiFixer, true);
+});
+
+Deno.test("an explicit commentToken authenticates the inline suggestions", async () => {
+  // GITHUB_TOKEN is deliberately unset: posting can only succeed through the
+  // configured token, so the assertion pins the commentToken resolution path.
+  const withVariedLocs: Partial<Fix> = {
+    diagnosis: "two spots",
+    rootCause: "r",
+    confidence: "high",
+    locations: [
+      // No suggestion and no endLine: a single-line deletion suggestion.
+      { file: "a.ts", line: 5, code: "const dead = 1;" },
+      // A replacement across a range.
+      {
+        file: "b.ts",
+        line: 10,
+        endLine: 12,
+        code: "let y = 2;",
+        suggestion: "const y = 2;",
+      },
+    ],
+    edits: [],
+  };
+  const { fetch, calls } = suggestFetch(claudeFix(withVariedLocs));
+  const prEnv: Record<string, string> = {
+    GITHUB_ACTIONS: "true",
+    GITHUB_REPOSITORY: "o/r",
+    GITHUB_REF: "refs/pull/7/merge",
+  };
+  const fixer = aiFixer((f) =>
+    f.provider("claude").apiKey("k").commentToken("sug-tok")
+  )
+    .conventions("").diff((d) => d.text("")).env((n) => prEnv[n]).fetch(fetch)
+    .quiet();
+  await fixer.remediate(CTX);
+  const posts = calls.filter((c) => c.url.endsWith("/pulls/7/comments"));
+  const bodies = posts.map((c) => JSON.parse(c.body));
+  assertEquals(bodies.length, 2);
+  // The suggestion-less location renders an empty (deletion) block at its line.
+  assertEquals(bodies[0].line, 5);
+  assertEquals(bodies[0].body.includes("```suggestion\n```"), true);
+  // The ranged location carries the replacement and spans start→end.
+  assertEquals(bodies[1].start_line, 10);
+  assertEquals(bodies[1].line, 12);
+  assertEquals(
+    bodies[1].body.includes("```suggestion\nconst y = 2;\n```"),
+    true,
+  );
+});
+
+Deno.test("on GitHub without any token, no comment or suggestion is attempted", async () => {
+  // The CI host is detected and locations exist, but the empty token yields no
+  // PR context: the fixer must stay silent instead of calling the API.
+  const { fetch, calls } = suggestFetch(claudeFix(FIX_WITH_LOC));
+  const prEnv: Record<string, string> = {
+    GITHUB_ACTIONS: "true",
+    GITHUB_REPOSITORY: "o/r",
+    GITHUB_REF: "refs/pull/7/merge",
+  };
+  const fixer = aiFixer((f) => f.provider("claude").apiKey("k"))
+    .conventions("").diff((d) => d.text("")).env((n) => prEnv[n]).fetch(fetch)
+    .quiet();
+  const result = await fixer.remediate(CTX);
+  assertEquals(result.retry, false);
+  assertEquals(
+    calls.some((c) => c.url.startsWith("https://api.github.com/")),
+    false,
+  );
+});
+
+Deno.test("a non-Error suggestion-post failure is stringified and falls back", async () => {
+  const prEnv: Record<string, string> = {
+    GITHUB_ACTIONS: "true",
+    GITHUB_REPOSITORY: "o/r",
+    GITHUB_REF: "refs/pull/7/merge",
+    GITHUB_TOKEN: "tok",
+  };
+  const calls: string[] = [];
+  const impl = ((input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    calls.push(url);
+    if (url.startsWith("https://api.github.com/")) {
+      // The PR-detail fetch rejects with a bare string (not an Error); the
+      // issue-comment GET/POST succeeds so the fallback can land.
+      if (!url.includes("/comments")) return Promise.reject("conn reset");
+      const method = init?.method ?? "GET";
+      return Promise.resolve(
+        new Response(method === "GET" ? "[]" : "{}", { status: 200 }),
+      );
+    }
+    return Promise.resolve(
+      new Response(claudeFix(FIX_WITH_LOC), { status: 200 }),
+    );
+  }) as typeof fetch;
+  const warnings: string[] = [];
+  const warn = console.warn;
+  console.warn = (...a: unknown[]) => void warnings.push(a.join(" "));
+  try {
+    const fixer = aiFixer((f) => f.provider("claude").apiKey("k"))
+      .conventions("").diff((d) => d.text("")).env((n) => prEnv[n]).fetch(impl)
+      .quiet();
+    await fixer.remediate(CTX);
+  } finally {
+    console.warn = warn;
+  }
+  assertEquals(
+    warnings.some((w) => w.includes("could not post suggestions: conn reset")),
+    true,
+  );
+  // Fell back to the overview issue comment.
+  assertEquals(calls.some((u) => u.includes("/issues/")), true);
+});
+
+Deno.test("a non-Error provider failure is stringified into the warning", async () => {
+  const s = seams();
+  const { fetch } = recordFetch("overloaded", 503); // always transient
+  const warnings: string[] = [];
+  const warn = console.warn;
+  console.warn = (...a: unknown[]) => void warnings.push(a.join(" "));
+  let result;
+  try {
+    const fixer = s.apply(
+      aiFixer((f) =>
+        f.provider("claude").apiKey("k")
+          // The retry's sleep seam rejects with a bare string, which escapes
+          // retryingFetch unwrapped — pinning the String(error) fallback.
+          .retry({
+            attempts: 2,
+            sleep: () => Promise.reject("sleep torn down"),
+          })
+      ),
+    ).fetch(fetch).quiet();
+    result = await fixer.remediate(CTX);
+  } finally {
+    console.warn = warn;
+  }
+  assertEquals(result.retry, false);
+  assertEquals(
+    warnings.some((w) =>
+      w.includes("could not produce a fix: sleep torn down")
+    ),
+    true,
+  );
+});
+
+Deno.test("a non-Error apply failure is stringified into the report action", async () => {
+  const { fetch } = recordFetch(claudeFix(ONE_EDIT));
+  const lines: string[] = [];
+  const log = console.log;
+  console.log = (...a: unknown[]) => void lines.push(a.join(" "));
+  let result;
+  try {
+    const fixer = aiFixer((f) => f.provider("claude").apiKey("k").autoApply())
+      .conventions("").diff((d) => d.text("")).env(() => undefined)
+      .write(() => Promise.reject("disk sealed")) // a bare string, not an Error
+      .fetch(fetch);
+    result = await fixer.remediate(CTX);
+  } finally {
+    console.log = log;
+  }
+  assertEquals(result.retry, false); // a failed apply never asks for a re-run
+  assertEquals(
+    lines.some((l) => l.includes("could not apply fix: disk sealed")),
+    true,
+  );
+});
+
+Deno.test("a non-Error commit failure is stringified into the report action", async () => {
+  const { fetch } = recordFetch(claudeFix(ONE_EDIT));
+  const lines: string[] = [];
+  const log = console.log;
+  console.log = (...a: unknown[]) => void lines.push(a.join(" "));
+  let result;
+  try {
+    const fixer = aiFixer((f) => f.provider("claude").apiKey("k").commitFixes())
+      .conventions("").diff((d) => d.text("")).env(() => undefined)
+      .write(() => Promise.resolve())
+      .exec((argv) =>
+        argv[1] === "commit"
+          ? Promise.reject("hook denied") // a bare string, not an Error
+          : Promise.resolve("")
+      )
+      .fetch(fetch);
+    result = await fixer.remediate(CTX);
+  } finally {
+    console.log = log;
+  }
+  assertEquals(result.retry, true); // the applied fix still re-runs the target
+  assertEquals(
+    lines.some((l) => l.includes("commit failed: hook denied")),
+    true,
+  );
+});

--- a/packages/ai/tests/gate_test.ts
+++ b/packages/ai/tests/gate_test.ts
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Tests for the gate: the fluent rule builder, its human description, and the
+ * trip decision.
+ *
+ * @module
+ */
+
+import { assertEquals } from "../../core/tests/_assert.ts";
+import { describeGate, GateSettings, gateTrips } from "../src/gate.ts";
+import type { Assessment } from "../src/types.ts";
+
+/** An assessment with a fixed score/severity and no findings. */
+function assessed(score: number, severity: Assessment["severity"]): Assessment {
+  return { score, severity, summary: "", findings: [] };
+}
+
+Deno.test("GateSettings collects rules in order", () => {
+  const rules = new GateSettings().scoreAbove(8).severityAtLeast("high")
+    .rules_();
+  assertEquals(rules, [
+    { kind: "score", value: 8 },
+    { kind: "severity", value: "high" },
+  ]);
+});
+
+Deno.test("describeGate names every rule, and no rules as none", () => {
+  assertEquals(describeGate([]), "none");
+  assertEquals(describeGate([{ kind: "score", value: 8 }]), "score>8");
+  assertEquals(
+    describeGate([
+      { kind: "score", value: 8 },
+      { kind: "severity", value: "high" },
+    ]),
+    "score>8, severity≥high",
+  );
+});
+
+Deno.test("gateTrips fires on score strictly above and severity at least", () => {
+  const rules = new GateSettings().scoreAbove(8).severityAtLeast("high")
+    .rules_();
+  // Score at the threshold does not trip — strictly above does.
+  assertEquals(gateTrips(assessed(8, "low"), rules).tripped, false);
+  assertEquals(gateTrips(assessed(9, "low"), rules), {
+    tripped: true,
+    reason: "risk score 9 exceeds 8",
+  });
+  // Severity at (and above) the threshold trips with the severity reason.
+  assertEquals(gateTrips(assessed(0, "high"), rules), {
+    tripped: true,
+    reason: 'severity "high" is at least "high"',
+  });
+  assertEquals(gateTrips(assessed(0, "critical"), rules).tripped, true);
+  assertEquals(gateTrips(assessed(0, "medium"), rules).tripped, false);
+  // No rules: nothing can trip.
+  assertEquals(gateTrips(assessed(10, "critical"), []), {
+    tripped: false,
+    reason: "",
+  });
+});

--- a/packages/ai/tests/hosts_test.ts
+++ b/packages/ai/tests/hosts_test.ts
@@ -1354,3 +1354,232 @@ Deno.test("listPullRequestComments treats a numeric system commentType as a bot"
   const listed = await listPullRequestComments(AZURE_CTX, fetch);
   assertEquals(listed[0].bot, true);
 });
+
+Deno.test("resolveAzureContext refuses when any variable is absent or empty", () => {
+  // Each variable individually missing — and individually empty — is fatal.
+  for (const name of Object.keys(AZURE_ENV)) {
+    const without: Record<string, string> = { ...AZURE_ENV };
+    delete without[name];
+    assertEquals(resolveAzureContext("azt", env(without)), undefined);
+    assertEquals(
+      resolveAzureContext("azt", env({ ...AZURE_ENV, [name]: "" })),
+      undefined,
+    );
+  }
+});
+
+Deno.test("an Azure identity probe returning a non-string id fails closed", async () => {
+  // connectionData answers, but with a malformed identity — the reviewer can
+  // attribute nothing to itself, so it must POST fresh, never PATCH.
+  const threads = [{
+    id: 7,
+    comments: [{
+      id: 1,
+      content: "<!-- zuke-ai-review:security review -->\nold",
+      author: { id: "build-service-id" },
+    }],
+  }];
+  const calls: Call[] = [];
+  const doFetch = ((input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method ?? "GET";
+    calls.push({
+      url,
+      method,
+      body: typeof init?.body === "string" ? init.body : "",
+    });
+    if (method !== "GET") return Promise.resolve(new Response("{}"));
+    if (url.includes("connectionData")) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ authenticatedUser: { id: 42 } })),
+      );
+    }
+    return Promise.resolve(new Response(JSON.stringify({ value: threads })));
+  }) as typeof fetch;
+  await upsertPullRequestThread(
+    AZURE_CTX,
+    "security review",
+    "## new",
+    doFetch,
+  );
+  const write = calls.find((c) => c.method !== "GET");
+  assertEquals(write?.method, "POST");
+});
+
+Deno.test("a thrown Azure identity probe fails closed to a fresh thread", async () => {
+  const threads = [{
+    id: 7,
+    comments: [{
+      id: 1,
+      content: "<!-- zuke-ai-review:security review -->\nold",
+      author: { id: "build-service-id" },
+    }],
+  }];
+  const calls: Call[] = [];
+  const doFetch = ((input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method ?? "GET";
+    calls.push({
+      url,
+      method,
+      body: typeof init?.body === "string" ? init.body : "",
+    });
+    if (url.includes("connectionData")) {
+      return Promise.reject(new Error("dns failure"));
+    }
+    if (method !== "GET") return Promise.resolve(new Response("{}"));
+    return Promise.resolve(new Response(JSON.stringify({ value: threads })));
+  }) as typeof fetch;
+  await upsertPullRequestThread(
+    AZURE_CTX,
+    "security review",
+    "## new",
+    doFetch,
+  );
+  const write = calls.find((c) => c.method !== "GET");
+  assertEquals(write?.method, "POST");
+});
+
+Deno.test("an Azure author with a non-string id and no uniqueName is empty, not trusted", async () => {
+  const threads = [{
+    id: 7,
+    comments: [{
+      id: 1,
+      content: "trust me",
+      author: { id: 99, displayName: "Impostor" },
+    }],
+  }];
+  const { fetch } = fakeAzure(threads, { self: "build-service-id" });
+  const listed = await listPullRequestComments(AZURE_CTX, fetch);
+  // No stable identity at all: the author is empty (and can never match a
+  // trustAuthors allowlist), while the display label is carried for reading.
+  assertEquals(listed[0].author, "");
+  assertEquals(listed[0].displayName, "Impostor");
+});
+
+Deno.test("upsertPullRequestThread in append mode POSTs without listing", async () => {
+  const { fetch, calls } = fakeAzure([], { self: "build-service-id" });
+  await upsertPullRequestThread(
+    AZURE_CTX,
+    "security review",
+    "## round 2",
+    fetch,
+    "append",
+  );
+  // No identity probe and no thread listing — straight to the create.
+  assertEquals(calls.length, 1);
+  assertEquals(calls[0].method, "POST");
+  assertEquals(calls[0].url.endsWith("/threads?api-version=7.1"), true);
+});
+
+Deno.test("azureHost.prepare needs a PR context", () => {
+  assertEquals(azureHost.prepare("azt", env({})), undefined);
+  assertEquals(typeof azureHost.prepare("azt", env(AZURE_ENV)), "function");
+});
+
+Deno.test("resolveBitbucketContext refuses when any variable is absent or empty", () => {
+  for (const name of Object.keys(BITBUCKET_ENV)) {
+    const without: Record<string, string> = { ...BITBUCKET_ENV };
+    delete without[name];
+    assertEquals(resolveBitbucketContext("bbt", env(without)), undefined);
+    assertEquals(
+      resolveBitbucketContext("bbt", env({ ...BITBUCKET_ENV, [name]: "" })),
+      undefined,
+    );
+  }
+});
+
+Deno.test("a refused or malformed Bitbucket /user probe fails closed", async () => {
+  const marked = [{
+    id: 18,
+    content: { raw: "<!-- zuke-ai-review:security review -->\nold" },
+    user: { uuid: "{zuke}" },
+  }];
+  // A workspace access token: /2.0/user refuses it (401 with an error body).
+  const refused = fakeBitbucket(marked);
+  await upsertBitbucketComment(
+    BITBUCKET_CTX,
+    "security review",
+    "## new",
+    refused.fetch,
+  );
+  const refusedWrite = refused.calls.find((c) => c.method !== "GET");
+  assertEquals(refusedWrite?.method, "POST"); // cannot adopt its own comment
+
+  // A /user body without a string uuid is the same failure.
+  const malformed = fakeBitbucket(marked, { self: "{zuke}" });
+  const withBadUser = ((input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    if (url.endsWith("/2.0/user")) {
+      return Promise.resolve(new Response(JSON.stringify({ uuid: 5 })));
+    }
+    return malformed.fetch(input, init);
+  }) as typeof fetch;
+  await upsertBitbucketComment(
+    BITBUCKET_CTX,
+    "security review",
+    "## new",
+    withBadUser,
+  );
+  const write = malformed.calls.find((c) => c.method !== "GET");
+  assertEquals(write?.method, "POST");
+});
+
+Deno.test("a thrown Bitbucket /user probe fails closed to a fresh comment", async () => {
+  const marked = [{
+    id: 18,
+    content: { raw: "<!-- zuke-ai-review:security review -->\nold" },
+    user: { uuid: "{zuke}" },
+  }];
+  const inner = fakeBitbucket(marked, { self: "{zuke}" });
+  const throwing = ((input: string | URL | Request, init?: RequestInit) => {
+    if (String(input).endsWith("/2.0/user")) {
+      return Promise.reject(new Error("dns failure"));
+    }
+    return inner.fetch(input, init);
+  }) as typeof fetch;
+  await upsertBitbucketComment(
+    BITBUCKET_CTX,
+    "security review",
+    "## new",
+    throwing,
+  );
+  const write = inner.calls.find((c) => c.method !== "GET");
+  assertEquals(write?.method, "POST");
+});
+
+Deno.test("listBitbucketComments drops malformed and deleted comments", async () => {
+  const values = [
+    { id: "not-a-number", content: { raw: "x" } }, // id wrong type — dropped
+    { id: 2, content: { raw: 42 } }, // body wrong type — dropped
+    { id: 3, content: { raw: "gone" }, deleted: true }, // deleted — dropped
+    { id: 4, content: { raw: "kept" }, user: { uuid: "{dev}" } },
+  ];
+  const { fetch } = fakeBitbucket(values, { self: "{zuke}", members: [] });
+  const listed = await listBitbucketComments(BITBUCKET_CTX, fetch);
+  assertEquals(listed.map((c) => c.id), [4]);
+  assertEquals(listed[0].body, "kept");
+});
+
+Deno.test("upsertBitbucketComment in append mode POSTs without listing", async () => {
+  const { fetch, calls } = fakeBitbucket([], { self: "{zuke}" });
+  await upsertBitbucketComment(
+    BITBUCKET_CTX,
+    "security review",
+    "## round 2",
+    fetch,
+    "append",
+  );
+  // No /user probe and no comment listing — straight to the create.
+  assertEquals(calls.length, 1);
+  assertEquals(calls[0].method, "POST");
+  assertEquals(calls[0].url.endsWith("/pullrequests/5/comments"), true);
+});
+
+Deno.test("bitbucketHost.prepare needs a PR context", () => {
+  assertEquals(bitbucketHost.prepare("bbt", env({})), undefined);
+  assertEquals(
+    typeof bitbucketHost.prepare("bbt", env(BITBUCKET_ENV)),
+    "function",
+  );
+});

--- a/packages/ai/tests/report_test.ts
+++ b/packages/ai/tests/report_test.ts
@@ -1,0 +1,214 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Tests for the report renderer: console lines, the job-summary Markdown, and
+ * the best-effort step-summary writer.
+ *
+ * @module
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../core/tests/_assert.ts";
+import {
+  consoleLines,
+  formatUsage,
+  reviewStartLine,
+  skipConsoleLine,
+  skipMarkdown,
+  toMarkdown,
+} from "../src/report.ts";
+import type { Assessment } from "../src/types.ts";
+
+/** A small assessment with one located, fingerprinted finding. */
+const ASSESSMENT: Assessment = {
+  score: 6,
+  severity: "medium",
+  summary: "one real issue",
+  findings: [
+    {
+      title: "sql injection",
+      severity: "high",
+      file: "db.ts",
+      line: 3,
+      id: "abc123",
+    },
+    { title: "vague worry", severity: "low" }, // no id, no location
+  ],
+};
+
+Deno.test("formatUsage renders only the counts the provider reported", () => {
+  assertEquals(formatUsage(undefined), undefined);
+  // A usage object with no counts at all is not an empty line — it is nothing.
+  assertEquals(formatUsage({}), undefined);
+  assertEquals(formatUsage({ inputTokens: 12 }), "12 in");
+  assertEquals(
+    formatUsage({ inputTokens: 1, outputTokens: 2, totalTokens: 3 }),
+    "1 in · 2 out · 3 total",
+  );
+});
+
+Deno.test("reviewStartLine echoes the gate and the comment flag", () => {
+  assertEquals(
+    reviewStartLine("sec", {
+      target: "deploy",
+      provider: "claude",
+      model: "m",
+      gate: "score>8",
+      comment: true,
+    }),
+    '[sec] reviewing "deploy" — claude/m · gate score>8 · comment',
+  );
+  assertEquals(
+    reviewStartLine("sec", {
+      target: "deploy",
+      provider: "openai",
+      model: "m",
+      gate: "none",
+      comment: false,
+    }).includes("comment"),
+    false,
+  );
+});
+
+Deno.test("consoleLines prints ids and locations only where they exist", () => {
+  const lines = consoleLines("sec", ASSESSMENT);
+  assertEquals(lines[0], "[sec] score 6/10 (medium) — 2 finding(s)");
+  // The located, fingerprinted finding carries both suffixes …
+  assertEquals(lines[1], "  - [high] sql injection (db.ts:3) · abc123");
+  // … the bare one carries neither.
+  assertEquals(lines[2], "  - [low] vague worry");
+  assertEquals(lines[3], "  one real issue");
+});
+
+Deno.test("consoleLines audits suppressed, refuted, dismissed, and fixed findings", () => {
+  const lines = consoleLines("sec", ASSESSMENT, undefined, {
+    suppressed: 2,
+    suppressedFindings: [
+      { title: "muted", severity: "low", file: "a.ts", line: 1, id: "id1" },
+      { title: "muted bare", severity: "low" }, // no id, no location
+    ],
+    refuted: [
+      { finding: { title: "not real", severity: "low" }, reason: "guarded" },
+      { finding: { title: "unexplained", severity: "low" } }, // no reason
+    ],
+    dismissed: [
+      {
+        finding: { title: "argued away", severity: "low" },
+        author: "alice",
+        reason: "intended",
+        rewordedFrom: "earlier words",
+      },
+      { finding: { title: "quietly gone", severity: "low" } }, // no author/reason
+    ],
+    fixed: [
+      {
+        id: "f1",
+        title: "fixed one",
+        severity: "high",
+        status: "open",
+        file: "b.ts",
+      },
+      { id: "f2", title: "fixed bare", severity: "low", status: "open" }, // no file
+    ],
+    notes: ["a bounded pass"],
+  });
+  const text = lines.join("\n");
+  assertStringIncludes(text, "suppressed 2 finding(s) via the suppress list");
+  assertStringIncludes(text, "    suppressed: [low] muted (a.ts:1) · id1");
+  assertStringIncludes(text, "    suppressed: [low] muted bare");
+  assertStringIncludes(text, "    refuted by verify: not real — guarded");
+  assertStringIncludes(text, "    refuted by verify: unexplained");
+  assertStringIncludes(
+    text,
+    '    dismissed via discussion by alice: argued away (reworded from "earlier words") — intended',
+  );
+  assertStringIncludes(text, "    dismissed via discussion: quietly gone");
+  assertStringIncludes(text, "    fixed: fixed one (b.ts) · f1");
+  assertStringIncludes(text, "    fixed: fixed bare · f2");
+  assertStringIncludes(text, "  note: a bounded pass");
+});
+
+Deno.test("toMarkdown fills missing audit fields with an em dash", () => {
+  const md = toMarkdown("sec", "deploy", ASSESSMENT, undefined, {
+    refuted: [{ finding: { title: "not real", severity: "low" } }],
+    dismissed: [{ finding: { title: "quietly gone", severity: "low" } }],
+    fixed: [{ id: "f2", title: "fixed bare", severity: "low", status: "open" }],
+    notes: ["pass skipped for budget"],
+  });
+  // A refuted finding with no reason, and a dismissal with no author, reason,
+  // or finding id, render as explicit dashes — never as empty cells.
+  assertStringIncludes(md, "| not real | — |");
+  assertStringIncludes(md, "| quietly gone | — | — | — |");
+  // A fixed finding without a file gets a dash location.
+  assertStringIncludes(md, "| low | fixed bare | — | f2 |");
+  assertStringIncludes(md, "- pass skipped for budget");
+});
+
+Deno.test("toMarkdown names the dismisser, the reason, and the rewording", () => {
+  const md = toMarkdown("sec", "deploy", ASSESSMENT, undefined, {
+    dismissed: [{
+      finding: { title: "argued away", severity: "low", id: "d1" },
+      author: "alice",
+      reason: "intended",
+      rewordedFrom: "earlier words",
+    }],
+  });
+  assertStringIncludes(
+    md,
+    '| argued away _(reworded from "earlier words")_ | alice | intended | d1 |',
+  );
+});
+
+Deno.test("skipMarkdown neutralises the reason like any untrusted value", () => {
+  const md = skipMarkdown("sec", "deploy", "no <!-- zuke-ai-state:x --> key");
+  assertEquals(md.includes("<!--"), false);
+  assertStringIncludes(
+    md,
+    "_Skipped — no &lt;!-- zuke-ai-state:x --&gt; key._",
+  );
+  assertEquals(skipConsoleLine("sec", "no key"), "[sec] skipped — no key");
+});
+
+Deno.test("writeStepSummary is a silent no-op without env access", async () => {
+  // The writer is best-effort: in a sandbox that denies env access it must
+  // return without throwing — and without writing — even when the variable
+  // actually points at a writable file.
+  const dir = await Deno.makeTempDir({ prefix: "zuke-report-" });
+  const summary = `${dir}/summary.md`;
+  const script = `${dir}/probe.ts`;
+  const moduleUrl = new URL("../src/report.ts", import.meta.url).href;
+  await Deno.writeTextFile(
+    script,
+    [
+      "// Copyright (c) 2026 the Zuke contributors",
+      "// SPDX-License-Identifier: MIT",
+      `import { writeStepSummary } from "${moduleUrl}";`,
+      'writeStepSummary("# never lands");',
+      'console.log("survived");',
+    ].join("\n"),
+  );
+  try {
+    const output = await new Deno.Command(Deno.execPath(), {
+      // No permissions at all: Deno.env.get throws inside writeStepSummary.
+      args: ["run", "--quiet", "--no-check", script],
+      env: { GITHUB_STEP_SUMMARY: summary, NO_COLOR: "1" },
+      stdout: "piped",
+      stderr: "piped",
+    }).output();
+    assertEquals(new TextDecoder().decode(output.stdout).trim(), "survived");
+    assertEquals(output.code, 0);
+    // The summary file was never created — the writer bailed before writing.
+    let exists = true;
+    try {
+      await Deno.stat(summary);
+    } catch {
+      exists = false;
+    }
+    assertEquals(exists, false);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/packages/core/tests/cancel_test.ts
+++ b/packages/core/tests/cancel_test.ts
@@ -1465,3 +1465,362 @@ class SettlesAfterCancelling extends FileSystemStateStore {
     return result;
   }
 }
+
+/**
+ * A store where the run finishes the instant a canceller tries to move it to
+ * `cancelling` — the transition's compare-and-swap loses, and the re-read finds
+ * the run terminal.
+ */
+class FinishesBeforeCancelling extends FileSystemStateStore {
+  #landed = false;
+  /** Land a competing `succeeded` write, then let the CAS conflict with it. */
+  override async putRun(
+    record: RunRecord,
+    expected: string | null,
+  ): Promise<PutResult> {
+    if (record.status !== "cancelling" || this.#landed) {
+      return await super.putRun(record, expected);
+    }
+    this.#landed = true;
+    const loaded = await this.getRun(record.id);
+    if (loaded !== null) {
+      const winner = structuredClone(loaded.record);
+      winner.status = "succeeded";
+      await super.putRun(winner, loaded.version);
+    }
+    return await super.putRun(record, expected); // now conflicts
+  }
+}
+
+Deno.test("a cancel that loses the transition race reports the run's terminal status", async () => {
+  // The run finished between the canceller's read and its write. The CAS
+  // conflicts, the re-read finds `succeeded`, and the cancel becomes a
+  // friendly no-op naming that status — never a walk over a finished run.
+  const dir = await Deno.makeTempDir();
+  try {
+    class B extends Build {
+      deploy = target().executes(() => {});
+    }
+    const build = new B();
+    discoverTargets(build);
+    const store = new FinishesBeforeCancelling(`${dir}/runs`, defaultStateHost);
+    const seeded: RunRecord = {
+      ...craftRecord("deploy", { deploy: { status: "succeeded", meta: {} } }),
+      id: "run-race",
+      status: "suspended",
+    };
+    assertEquals((await store.putRun(seeded, null)).ok, true);
+
+    const lines: string[] = [];
+    const result = await cancelRun(build, {
+      runId: "run-race",
+      stateStore: store,
+      reporter: { info: (l) => lines.push(l), error: (l) => lines.push(l) },
+    });
+    assertEquals(result.noop, true);
+    assertEquals(result.status, "succeeded");
+    assertEquals(
+      lines.some((l) => l.includes("already succeeded; nothing to cancel")),
+      true,
+    );
+    assertEquals((await store.getRun("run-race"))?.record.status, "succeeded");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+/** A store where the run vanishes the moment the transition CAS conflicts. */
+class VanishesOnCancel extends FileSystemStateStore {
+  #conflicted = false;
+  /** Conflict the first `cancelling` write; the run is gone after that. */
+  override putRun(
+    record: RunRecord,
+    expected: string | null,
+  ): Promise<PutResult> {
+    if (record.status === "cancelling" && !this.#conflicted) {
+      this.#conflicted = true;
+      return Promise.resolve({ ok: false, conflict: true });
+    }
+    return super.putRun(record, expected);
+  }
+  /** Pruned mid-cancel: nothing to read back. */
+  override getRun(
+    id: string,
+  ): Promise<{ record: RunRecord; version: string } | null> {
+    if (this.#conflicted) return Promise.resolve(null);
+    return super.getRun(id);
+  }
+}
+
+Deno.test("a run that vanishes mid-cancel is a no-op, not a crash", async () => {
+  // Pruned between the read and the write (a retention sweep, a manual
+  // delete): there is nothing left to cancel, and the caller is told so.
+  const dir = await Deno.makeTempDir();
+  try {
+    class B extends Build {
+      deploy = target().executes(() => {});
+    }
+    const build = new B();
+    discoverTargets(build);
+    const store = new VanishesOnCancel(`${dir}/runs`, defaultStateHost);
+    const seeded: RunRecord = {
+      ...craftRecord("deploy", { deploy: { status: "succeeded", meta: {} } }),
+      id: "run-gone",
+      status: "suspended",
+    };
+    assertEquals((await store.putRun(seeded, null)).ok, true);
+
+    const result = await cancelRun(build, {
+      runId: "run-gone",
+      stateStore: store,
+      silent: true,
+    });
+    assertEquals(result.noop, true);
+    // With nothing left to read, the status defaults to what a cancel means.
+    assertEquals(result.status, "cancelled");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+/** A store that never accepts the `cancelling` transition. */
+class RefusesCancelling extends FileSystemStateStore {
+  /** Conflict every `cancelling` write. */
+  override putRun(
+    record: RunRecord,
+    expected: string | null,
+  ): Promise<PutResult> {
+    if (record.status === "cancelling") {
+      return Promise.resolve({ ok: false, conflict: true });
+    }
+    return super.putRun(record, expected);
+  }
+}
+
+Deno.test("cancelRun surfaces a store that never accepts the transition", async () => {
+  // Bounded retries: a store outage (or a pathological writer) must produce a
+  // named error, not an infinite CAS loop.
+  const dir = await Deno.makeTempDir();
+  try {
+    class B extends Build {
+      deploy = target().executes(() => {});
+    }
+    const build = new B();
+    discoverTargets(build);
+    const store = new RefusesCancelling(`${dir}/runs`, defaultStateHost);
+    const seeded: RunRecord = {
+      ...craftRecord("deploy", { deploy: { status: "succeeded", meta: {} } }),
+      id: "run-stuck",
+      status: "suspended",
+    };
+    assertEquals((await store.putRun(seeded, null)).ok, true);
+
+    await assertRejects(
+      () =>
+        cancelRun(build, {
+          runId: "run-stuck",
+          stateStore: store,
+          silent: true,
+        }),
+      Error,
+      "gave up cancelling",
+    );
+    // The run is untouched, so a retry can still cancel it.
+    assertEquals((await store.getRun("run-stuck"))?.record.status, "suspended");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+/** A store where the run vanishes right after the `cancelling` transition lands. */
+class VanishesAfterCancelling extends FileSystemStateStore {
+  #transitioned = false;
+  /** Persist normally, remembering when the transition landed. */
+  override async putRun(
+    record: RunRecord,
+    expected: string | null,
+  ): Promise<PutResult> {
+    const result = await super.putRun(record, expected);
+    if (result.ok && record.status === "cancelling") this.#transitioned = true;
+    return result;
+  }
+  /** Gone from the store from that moment on. */
+  override getRun(
+    id: string,
+  ): Promise<{ record: RunRecord; version: string } | null> {
+    if (this.#transitioned) return Promise.resolve(null);
+    return super.getRun(id);
+  }
+}
+
+Deno.test("a run that vanishes after the transition still gets its compensations", async () => {
+  // The canceller's own snapshot is the last word when the record disappears:
+  // the walk still runs from it, and the missing settlement write is a clean
+  // return, not an error — the record it would update no longer exists.
+  const dir = await Deno.makeTempDir();
+  try {
+    const undone: string[] = [];
+    class B extends Build {
+      rollback = target().executes(() => void undone.push("deploy"));
+      deploy = target().onCancel(this.rollback).executes(() => {});
+    }
+    const build = new B();
+    discoverTargets(build);
+    const store = new VanishesAfterCancelling(`${dir}/runs`, defaultStateHost);
+    const seeded: RunRecord = {
+      ...craftRecord("deploy", { deploy: { status: "succeeded", meta: {} } }),
+      id: "run-late-gone",
+      status: "suspended",
+    };
+    assertEquals((await store.putRun(seeded, null)).ok, true);
+
+    const result = await cancelRun(build, {
+      runId: "run-late-gone",
+      stateStore: store,
+      silent: true,
+    });
+    assertEquals(result.noop, false);
+    assertEquals(result.status, "cancelled");
+    assertEquals(undone, ["deploy"]); // the walk ran from the snapshot
+    assertEquals(result.compensated, ["rollback"]);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+/** A store that never accepts a terminal settlement write. */
+class RefusesSettlement extends FileSystemStateStore {
+  /** Conflict every `cancelled` write. */
+  override putRun(
+    record: RunRecord,
+    expected: string | null,
+  ): Promise<PutResult> {
+    if (record.status === "cancelled") {
+      return Promise.resolve({ ok: false, conflict: true });
+    }
+    return super.putRun(record, expected);
+  }
+}
+
+Deno.test("cancelRun surfaces a store that never accepts the settlement", async () => {
+  // The other bounded loop: compensations ran but the terminal write cannot
+  // land. Surfacing the outage beats silently leaving the run `cancelling` —
+  // and a re-cancel then recovers it.
+  const dir = await Deno.makeTempDir();
+  try {
+    class B extends Build {
+      deploy = target().executes(() => {});
+    }
+    const build = new B();
+    discoverTargets(build);
+    const store = new RefusesSettlement(`${dir}/runs`, defaultStateHost);
+    const seeded: RunRecord = {
+      ...craftRecord("deploy", { deploy: { status: "succeeded", meta: {} } }),
+      id: "run-unsettled",
+      status: "suspended",
+    };
+    assertEquals((await store.putRun(seeded, null)).ok, true);
+
+    await assertRejects(
+      () =>
+        cancelRun(build, {
+          runId: "run-unsettled",
+          stateStore: store,
+          silent: true,
+        }),
+      Error,
+      "gave up finalizing",
+    );
+    // Left `cancelling`, which a re-cancel recovers (tested above).
+    assertEquals(
+      (await store.getRun("run-unsettled"))?.record.status,
+      "cancelling",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("an extra compensation naming a missing target is skipped, not fatal", async () => {
+  // The `also` list is how a timed-out wait's onTimeout names a specific
+  // compensation target. A build edit can remove that target before the
+  // timeout fires; the cancel must still unwind everything else.
+  await withTempStore(async (store) => {
+    const undone: string[] = [];
+    const makeBuild = () => {
+      class B extends Build {
+        deploy = target().executes(() => {}).onCancel(() => this.rollback);
+        rollback = target().executes(() => void undone.push("deploy"));
+        gate = target()
+          .dependsOn(this.deploy)
+          .waitsFor((s) => s.on(externalSignal("x")));
+      }
+      const build = new B();
+      discoverTargets(build);
+      return build;
+    };
+    const a = makeBuild();
+    await execute(a, a.gate, { silent: true, stateStore: store });
+    const id = (await store.listRuns({}))[0].id;
+
+    const result = await cancelRun(makeBuild(), {
+      runId: id,
+      stateStore: store,
+      silent: true,
+      also: ["ghost"], // no such target in this build
+    });
+    assertEquals(result.status, "cancelled");
+    assertEquals(result.compensated, ["rollback"]); // the rest still ran
+    assertEquals(result.failures, []);
+  });
+});
+
+Deno.test("the default reporter routes cancel diagnostics to the console's error stream", async () => {
+  // With no reporter and no `silent`, cancel prints through the console — and
+  // its diagnostics (a failed compensation) must land on stderr, where CI log
+  // scrapers and shell redirections expect errors.
+  await withTempStore(async (store) => {
+    const makeBuild = () => {
+      class B extends Build {
+        deploy = target().executes(() => {}).onCancel(() => this.rollback);
+        rollback = target().executes(() => {
+          throw new Error("cleanup boom");
+        });
+        gate = target()
+          .dependsOn(this.deploy)
+          .waitsFor((s) => s.on(externalSignal("x")));
+      }
+      const build = new B();
+      discoverTargets(build);
+      return build;
+    };
+    const a = makeBuild();
+    await execute(a, a.gate, { silent: true, stateStore: store });
+    const id = (await store.listRuns({}))[0].id;
+
+    const logs: string[] = [];
+    const errs: string[] = [];
+    const originalLog = console.log;
+    const originalError = console.error;
+    console.log = (...data: unknown[]) => void logs.push(data.join(" "));
+    console.error = (...data: unknown[]) => void errs.push(data.join(" "));
+    try {
+      const result = await cancelRun(makeBuild(), {
+        runId: id,
+        stateStore: store,
+      });
+      assertEquals(result.failures.length, 1);
+    } finally {
+      console.log = originalLog;
+      console.error = originalError;
+    }
+    assertEquals(
+      errs.some((l) =>
+        l.includes("compensation") && l.includes("cleanup boom")
+      ),
+      true,
+    );
+    // Progress narration stays on stdout.
+    assertEquals(logs.some((l) => l.includes("compensating")), true);
+  });
+});

--- a/packages/core/tests/cancel_test.ts
+++ b/packages/core/tests/cancel_test.ts
@@ -1824,3 +1824,28 @@ Deno.test("the default reporter routes cancel diagnostics to the console's error
     assertEquals(logs.some((l) => l.includes("compensating")), true);
   });
 });
+
+Deno.test("without a redactor, a compensation failure message is kept verbatim", async () => {
+  // The executor's in-process walk can run with no redactor (no secrets are
+  // known); the failure text must then pass through untouched — masking is
+  // opt-in, not a mangling of every message.
+  class CD extends Build {
+    deploy = target().executes(() => {}).onCancel(() => this.rollback);
+    rollback = target().executes(() => {
+      throw new Error("exact diagnostic text");
+    });
+  }
+  const build = new CD();
+  discoverTargets(build);
+  const record = craftRecord("deploy", {
+    deploy: { status: "succeeded", meta: {} },
+  });
+  const outcome = await runCompensations([build.deploy], record, {
+    runId: "run",
+    signals: new Map(),
+    reporter: { info: () => {}, error: () => {} },
+    // no redactor
+  });
+  assertEquals(outcome.failures.length, 1);
+  assertEquals(outcome.failures[0].error, "exact diagnostic text");
+});

--- a/packages/core/tests/ci_schedule_test.ts
+++ b/packages/core/tests/ci_schedule_test.ts
@@ -125,6 +125,58 @@ Deno.test("utcCronsFor rejects the unsupported cases with a friendly error", () 
   );
 });
 
+Deno.test("utcCronsFor expands a */step field over the whole range", () => {
+  // `*/15` strides the full minute range, then the hour shifts for the zone.
+  assertEquals(
+    utcCronsFor({ cron: "*/15 9 * * *", tz: "Etc/GMT-2" }),
+    ["0,15,30,45 7 * * *"],
+  );
+});
+
+Deno.test("utcCronsFor rejects malformed step syntax with a friendly error", () => {
+  // More than one slash in a field.
+  assertThrows(
+    () => utcCronsFor({ cron: "1/2/3 0 * * *" }),
+    Error,
+    "invalid cron field",
+  );
+  // A zero stride and a non-numeric stride are both named as bad steps.
+  assertThrows(
+    () => utcCronsFor({ cron: "*/0 0 * * *" }),
+    Error,
+    "invalid step in cron field",
+  );
+  assertThrows(
+    () => utcCronsFor({ cron: "5/x 0 * * *" }),
+    Error,
+    "invalid step in cron field",
+  );
+});
+
+Deno.test("utcCronsFor shifts an every-hour schedule without touching the days", () => {
+  // With hour `*` the shift is a no-op: every hour maps to every hour, so the
+  // day fields survive verbatim and no "crosses a day boundary" error can fire
+  // even though day-of-month, month, and day-of-week are all constrained.
+  assertEquals(
+    utcCronsFor({ cron: "30 * 1,15 6 1", tz: "Etc/GMT-2" }),
+    ["30 * 1,15 6 1"],
+  );
+});
+
+Deno.test("guardShell renders a wildcard field as an always-true test", () => {
+  // A `*` minute matches every wall-clock minute, so its membership test must
+  // collapse to `true` rather than an empty case list that never matches.
+  const shell = guardShell([{ cron: "* 9 * * *", tz: "Europe/Sofia" }]);
+  assertStringIncludes(shell, "if true && ");
+  assertStringIncludes(shell, 'case " 9 " in *" $hh "*)');
+});
+
+Deno.test("guardShell tests the month when the schedule restricts it", () => {
+  const shell = guardShell([{ cron: "0 12 * 6 *", tz: "Europe/Sofia" }]);
+  assertStringIncludes(shell, "TZ='Europe/Sofia' date +%m");
+  assertStringIncludes(shell, 'case " 6 " in *" $mo "*)');
+});
+
 Deno.test("anyScheduleNeedsGuard is true only when a DST zone is present", () => {
   assertEquals(
     anyScheduleNeedsGuard([{ cron: "0 6 * * *" }, {

--- a/packages/core/tests/ci_schedule_test.ts
+++ b/packages/core/tests/ci_schedule_test.ts
@@ -163,6 +163,27 @@ Deno.test("utcCronsFor shifts an every-hour schedule without touching the days",
   );
 });
 
+Deno.test("utcCronsFor collapses cron Sunday 7 to the canonical 0", () => {
+  // Cron day-of-week is 0-7 with both 0 and 7 meaning Sunday.
+  assertEquals(utcCronsFor({ cron: "0 6 * * 7", tz: "Etc/GMT-2" }), [
+    "0 4 * * 0",
+  ]);
+});
+
+Deno.test("utcCronsFor shifts a western (negative-offset) zone forward", () => {
+  // Etc/GMT+3 is UTC-3 (POSIX sign inversion): 6 local is 9 UTC.
+  assertEquals(utcCronsFor({ cron: "0 6 * * *", tz: "Etc/GMT+3" }), [
+    "0 9 * * *",
+  ]);
+});
+
+Deno.test("guardShell reads the UTC wall-clock for an entry without a tz", () => {
+  // A UTC entry in a mixed schedule still participates in the guard.
+  const shell = guardShell([{ cron: "15 8 * * *" }]);
+  assertStringIncludes(shell, "TZ='UTC' date +%M");
+  assertStringIncludes(shell, 'case " 8 " in *" $hh "*)');
+});
+
 Deno.test("guardShell renders a wildcard field as an always-true test", () => {
   // A `*` minute matches every wall-clock minute, so its membership test must
   // collapse to `true` rather than an empty case list that never matches.

--- a/packages/core/tests/ci_test.ts
+++ b/packages/core/tests/ci_test.ts
@@ -1183,6 +1183,128 @@ Deno.test("the two security-relevant inputs are always stated", () => {
   assertStringIncludes(yaml, 'persist-credentials: "false"');
 });
 
+Deno.test("github: an action ref without a version renders bare", () => {
+  const yaml = generateCi({
+    jobs: [{
+      steps: [
+        { uses: { ref: `acme/tool@${"1".repeat(40)}` } },
+        { run: "x" },
+      ],
+    }],
+  }, "github");
+  // No version comment is attached when the ref carries none.
+  assertStringIncludes(yaml, `uses: acme/tool@${"1".repeat(40)}\n`);
+});
+
+Deno.test("github: a bare job condition is wrapped when the guard ANDs on", () => {
+  // An `if:` written without the ${{ }} wrapper must still combine correctly.
+  const yaml = generateCi({
+    triggers: { schedule: [{ cron: "30 9 * * *", tz: "Europe/Sofia" }] },
+    jobs: [{ id: "test", if: "github.actor != 'bot'", steps: [{ run: "x" }] }],
+  }, "github");
+  assertStringIncludes(
+    yaml,
+    "(github.actor != 'bot') && (needs.zuke-schedule-guard.outputs.run == 'true')",
+  );
+});
+
+Deno.test("naming only the checkout action opts out of the prelude", () => {
+  // A pinned checkout (with no pinned harden) still means "those steps, by
+  // name" — the prelude action must not replace it. Rendered through a
+  // declared file, the path every build takes.
+  const file = cicd({
+    provider: "github",
+    pipeline: {
+      checkout: { action: `actions/checkout@${"7".repeat(40)}` },
+      jobs: [{ id: "gate", steps: [{ run: "x" }] }],
+    },
+  });
+  const yaml = file.render();
+  assertEquals(yaml.includes("zuke-build/zuke"), false);
+  assertStringIncludes(yaml, `actions/checkout@${"7".repeat(40)}`);
+});
+
+Deno.test("a pinned-object first step is recognised as a prelude too", () => {
+  // The prelude guard must see through the { ref, version } uses form, not
+  // just the bare string form.
+  const yaml = generateCi({
+    jobs: [{
+      id: "review",
+      steps: [
+        {
+          uses: {
+            ref: `step-security/harden-runner@${"5".repeat(40)}`,
+            version: "v2",
+          },
+        },
+        { run: "./zuke review" },
+      ],
+    }],
+  }, "github");
+  assertEquals(yaml.includes("zuke-build/zuke"), false);
+  assertStringIncludes(yaml, `harden-runner@${"5".repeat(40)}`);
+});
+
+Deno.test("pins: a job that names its own harden pin keeps separate steps", () => {
+  class B extends Build {
+    gate = target().executes(() => {});
+    wf = cicd({
+      pins: (action) => `${action}@${"6".repeat(40)}`,
+      invokes: [{
+        target: this.gate,
+        harden: { action: `step-security/harden-runner@${"4".repeat(40)}` },
+      }],
+    });
+  }
+  const yaml = discoverCiFiles(new B())[0].render();
+  // The job asked for that exact pin, so no prelude action…
+  assertEquals(yaml.includes("zuke-build/zuke"), false);
+  // …its own harden pin survives (not the resolver's)…
+  assertStringIncludes(yaml, `harden-runner@${"4".repeat(40)}`);
+  // …and the checkout still comes from the resolver.
+  assertStringIncludes(yaml, `actions/checkout@${"6".repeat(40)}`);
+});
+
+Deno.test("a job without steps gets the default step on every provider", () => {
+  const bare: CiPipeline = {
+    triggers: { push: ["main"] },
+    jobs: [{ id: "verify" }],
+  };
+  assertStringIncludes(generateCi(bare, "gitlab"), "- ./zuke");
+  assertStringIncludes(generateCi(bare, "azure"), "script: ./zuke");
+  assertStringIncludes(generateCi(bare, "bitbucket"), "- ./zuke");
+});
+
+Deno.test("bitbucket: an empty pipeline gets the default triggers and step", () => {
+  const yaml = generateCi({}, "bitbucket");
+  // The default push/PR-on-main triggers flow through as named sections.
+  assertStringIncludes(yaml, "pull-requests:\n    main:");
+  assertStringIncludes(yaml, "branches:\n    main:");
+  assertStringIncludes(yaml, "- ./zuke");
+});
+
+Deno.test("a field-named non-github file keeps the provider's single path", () => {
+  // GitLab has one conventional file, so the field name never renames it.
+  class B extends Build {
+    build = target().executes(() => {});
+    nightlyPipeline = cicd({ provider: "gitlab", invokes: [this.build] });
+  }
+  assertEquals(discoverCiFiles(new B())[0].path, ".gitlab-ci.yml");
+});
+
+Deno.test("discovery leaves a plain file untouched next to a derived one", () => {
+  class B extends Build {
+    gate = target().executes(() => {});
+    plain = cicd({ provider: "github", pipeline: { name: "Plain" } });
+    derived = cicd({ provider: "github", invokes: [this.gate] });
+  }
+  const files = discoverCiFiles(new B());
+  const plain = files.find((f) => f.path.endsWith("plain.yml"));
+  const derived = files.find((f) => f.path.endsWith("derived.yml"));
+  assertStringIncludes(plain?.render() ?? "", "name: Plain");
+  assertStringIncludes(derived?.render() ?? "", "run: ./zuke gate");
+});
+
 Deno.test("github: a checkout ref renders on the separate checkout step", () => {
   const yaml = generateCi({
     bootstrap: false,

--- a/packages/core/tests/ci_test.ts
+++ b/packages/core/tests/ci_test.ts
@@ -1,7 +1,12 @@
 // Copyright (c) 2026 the Zuke contributors
 // SPDX-License-Identifier: MIT
 
-import { assertEquals, assertStringIncludes } from "./_assert.ts";
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+  assertThrows,
+} from "./_assert.ts";
 import {
   cicd,
   CiFile,
@@ -1176,6 +1181,105 @@ Deno.test("the two security-relevant inputs are always stated", () => {
   const yaml = discoverCiFiles(new B())[0].render();
   assertStringIncludes(yaml, "egress-policy: audit");
   assertStringIncludes(yaml, 'persist-credentials: "false"');
+});
+
+Deno.test("github: a checkout ref renders on the separate checkout step", () => {
+  const yaml = generateCi({
+    bootstrap: false,
+    checkout: { action: `actions/checkout@${"a".repeat(40)}`, ref: "release" },
+    jobs: [{ id: "gate", steps: [{ run: "./zuke gate" }] }],
+  }, "github");
+  assertStringIncludes(yaml, `actions/checkout@${"a".repeat(40)}`);
+  assertStringIncludes(yaml, "ref: release");
+});
+
+Deno.test("a checkout without a pin is a friendly error when bootstrap is off", () => {
+  // Emitting `uses:` with no ref would be a floating reference; like an
+  // unpinned harden, an unpinned checkout must fail rather than degrade.
+  assertThrows(
+    () =>
+      generateCi({
+        bootstrap: false,
+        checkout: {},
+        jobs: [{ steps: [{ run: "x" }] }],
+      }, "github"),
+    Error,
+    "the checkout needs a pinned action",
+  );
+});
+
+Deno.test("bootstrap: false with no job steps still runs the default step", () => {
+  // Opting out of the prelude action must not also lose the default build step.
+  const yaml = generateCi(
+    { bootstrap: false, jobs: [{ id: "plain" }] },
+    "github",
+  );
+  assertStringIncludes(yaml, "run: ./zuke");
+  assertEquals(yaml.includes("zuke-build/zuke"), false);
+});
+
+Deno.test("azure: a schedule without a push trigger defaults to main", () => {
+  // Azure schedules need a branch filter; with no push trigger to mirror, the
+  // conventional default branch stands in.
+  const yaml = generateCi(
+    { triggers: { schedule: [{ cron: "0 6 * * *" }] } },
+    "azure",
+  );
+  assertStringIncludes(yaml, "schedules:");
+  assertStringIncludes(yaml, "branches:\n      include:\n        - main");
+});
+
+Deno.test("a job's own bootstrap pin overrides the resolver", () => {
+  // A job that names the prelude action asked for that exact pin; the resolver
+  // must not replace it.
+  class B extends Build {
+    gate = target().executes(() => {});
+    wf = cicd({
+      pins: (action) => `${action}@${"9".repeat(40)}`,
+      invokes: [{
+        target: this.gate,
+        bootstrap: { action: `my-org/zuke@${"8".repeat(40)}` },
+      }],
+    });
+  }
+  const yaml = discoverCiFiles(new B())[0].render();
+  assertStringIncludes(yaml, `my-org/zuke@${"8".repeat(40)}`);
+  assertEquals(yaml.includes("zuke-build/zuke"), false);
+});
+
+Deno.test("a field name that is all suffix keeps the provider default path", () => {
+  // `Ci` reduces to nothing once the suffix is dropped, so the provider's
+  // conventional file name stands in rather than an empty ".yml".
+  class B extends Build {
+    gate = target().executes(() => {});
+    Ci = cicd({ invokes: [this.gate] });
+  }
+  assertEquals(discoverCiFiles(new B())[0].path, ".github/workflows/ci.yml");
+});
+
+Deno.test("pipelineFor names a not-yet-discovered target by identity", () => {
+  // Before discoverTargets assigns names, an invoked target can still be
+  // resolved by identity against the map — what lets a workflow be declared
+  // with `this.ci` in a field initialiser.
+  const gate = target().description("Gate").executes(() => {});
+  const file = cicd({ provider: "github", invokes: [gate] });
+  const pipeline = file.pipelineFor(new Map([["gate", gate]]));
+  assertEquals(pipeline.jobs?.[0].id, "gate");
+  assertEquals(pipeline.jobs?.[0].name, "Gate");
+});
+
+Deno.test("syncCiFiles surfaces a read failure that is not file-absence", async () => {
+  // Only NotFound means "write it fresh"; any other read failure (here: the
+  // path is a directory) must propagate, not be mistaken for a missing file.
+  const dir = await Deno.makeTempDir();
+  try {
+    const path = `${dir}/ci.yml`;
+    await Deno.mkdir(path); // a directory where the file should be
+    const file = cicd({ provider: "github", path, pipeline: filePipeline });
+    await assertRejects(() => syncCiFiles([file], { check: true }));
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
 });
 
 Deno.test("a job whose own steps already harden or check out gets no prelude", () => {

--- a/packages/core/tests/cli_test.ts
+++ b/packages/core/tests/cli_test.ts
@@ -1121,6 +1121,213 @@ Deno.test("run forwards args and plugins to main", async () => {
   assertEquals(seen, ["finished"]);
 });
 
+Deno.test("parseArgs reads the inline = forms of --signal and --data", () => {
+  const p = parseArgs([
+    "resume",
+    "run-9",
+    "--signal=approved",
+    '--data={"by":"qa"}',
+  ]);
+  assertEquals(p.signal, "approved");
+  assertEquals(p.data, '{"by":"qa"}');
+});
+
+Deno.test("parseArgs reads --allow-run globs and --protect lists", () => {
+  // The comma list is trimmed and empties are dropped.
+  const globbed = parseArgs(["mcp", "--allow-run=deploy-*, ,test"]);
+  assertEquals(globbed.allowRun, true);
+  assertEquals(globbed.allowRunPatterns, ["deploy-*", "test"]);
+  // Bare --allow-run enables runs with no pattern restriction.
+  const bare = parseArgs(["mcp", "--allow-run"]);
+  assertEquals([bare.allowRun, bare.allowRunPatterns], [true, undefined]);
+
+  const spaced = parseArgs(["mcp", "--protect", "prod-*"]);
+  assertEquals(spaced.protectPatterns, ["prod-*"]);
+  const inline = parseArgs(["mcp", "--protect=a,b"]);
+  assertEquals(inline.protectPatterns, ["a", "b"]);
+});
+
+Deno.test("parseArgs treats an empty --parallel= value as plain --parallel", () => {
+  assertEquals(parseArgs(["build", "--parallel="]).parallel, true);
+});
+
+Deno.test("main: resume without a run id prints usage and fails", async () => {
+  const { code, err } = await capture(() => main(Demo, ["resume"]));
+  assertEquals(code, 1);
+  assertStringIncludes(err.join("\n"), "Usage: zuke resume <run-id>");
+});
+
+Deno.test("main: resume rejects invalid --data JSON without echoing it", async () => {
+  const { code, err } = await capture(() =>
+    main(Demo, ["resume", "run-x", "--data", "{oops"])
+  );
+  assertEquals(code, 1);
+  const text = err.join("\n");
+  assertStringIncludes(text, "--data is not valid JSON");
+  // The payload could be large or sensitive; it must not be quoted back.
+  assertEquals(text.includes("{oops"), false);
+});
+
+Deno.test("main: mcp --http refuses a non-loopback bind without a token", async () => {
+  // The refusal happens before any socket is bound, so the test stays hermetic.
+  const saved = Deno.env.get("ZUKE_MCP_TOKEN");
+  Deno.env.delete("ZUKE_MCP_TOKEN");
+  try {
+    const { code, err } = await capture(() =>
+      main(Demo, ["mcp", "--http", "0.0.0.0:8123"])
+    );
+    assertEquals(code, 1);
+    assertStringIncludes(err.join("\n"), "refusing to bind");
+  } finally {
+    if (saved !== undefined) Deno.env.set("ZUKE_MCP_TOKEN", saved);
+  }
+});
+
+Deno.test("main: cancel reports a missing run as a friendly error", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    class Stateful extends Build {
+      override stateStore() {
+        return store;
+      }
+      build = target().executes(() => {});
+    }
+    const { code, err } = await capture(() =>
+      main(Stateful, ["cancel", "ghost"])
+    );
+    assertEquals(code, 1);
+    assertStringIncludes(err.join("\n"), 'no run "ghost"');
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("main: runs list applies --status, --target, and --since filters", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    await store.putRun(sampleRunRecord({ id: "ok-run" }), null);
+    await store.putRun(
+      sampleRunRecord({
+        id: "old-fail",
+        status: "failed",
+        createdAt: "2020-01-01T00:00:00.000Z",
+        updatedAt: "2020-01-01T00:00:00.000Z",
+        rootTarget: "deploy",
+        graph: [{ name: "deploy", dependsOn: [] }],
+        targets: { deploy: { status: "failed", meta: {} } },
+      }),
+      null,
+    );
+    class Stateful extends Build {
+      override stateStore() {
+        return store;
+      }
+      build = target().executes(() => {});
+    }
+    const ids = async (...filters: string[]) => {
+      const { code, out } = await capture(() =>
+        main(Stateful, ["runs", "list", ...filters, "--json"])
+      );
+      assertEquals(code, 0);
+      const rows: Array<{ id: string }> = JSON.parse(out.join("\n"));
+      return rows.map((r) => r.id);
+    };
+    assertEquals(await ids("--status", "succeeded"), ["ok-run"]);
+    assertEquals(await ids("--target", "deploy"), ["old-fail"]);
+    assertEquals(await ids("--since", "2026-01-01T00:00:00.000Z"), ["ok-run"]);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("main: --affected rejects a git base that reads as a git option", async () => {
+  // A base beginning with "-" would be read by git as an option (e.g.
+  // `--output=…` writes to a file), so it is rejected before any git process
+  // is spawned. The failure is not a configuration error main knows how to
+  // present, so it propagates rather than being flattened into exit 1.
+  const error = await assertRejects(() =>
+    capture(() => main(Demo, ["build", "--affected=-o"]))
+  );
+  assertStringIncludes(error.message, "invalid git base revision");
+});
+
+Deno.test("main watchSignals: a signal cancels the run, a second force-exits", async () => {
+  const handlers: Array<() => void> = [];
+  const removed: Deno.Signal[] = [];
+  const origAdd = Deno.addSignalListener;
+  const origRemove = Deno.removeSignalListener;
+  const origExit = Deno.exit;
+  Deno.addSignalListener = (_sig: Deno.Signal, fn: () => void): void => {
+    handlers.push(fn);
+  };
+  Deno.removeSignalListener = (sig: Deno.Signal, _fn: () => void): void => {
+    removed.push(sig);
+  };
+  const ran: string[] = [];
+  class Interrupted extends Build {
+    first = target().executes(() => {
+      ran.push("first");
+      handlers[0](); // Ctrl-C arrives mid-build
+    });
+    second = target().dependsOn(this.first).executes(
+      () => void ran.push("second"),
+    );
+  }
+  try {
+    const { code } = await capture(() =>
+      main(Interrupted, ["second"], { watchSignals: true })
+    );
+    assertEquals(code, 1); // the run was cancelled, not completed
+    assertEquals(ran, ["first"]); // `second` never started
+    // Every installed handler was removed on the way out.
+    assertEquals(removed.length, handlers.length);
+
+    // A second signal while cancellation is in flight force-exits 130.
+    let exitCode: number | undefined;
+    Deno.exit = (code?: number): never => {
+      exitCode = code;
+      throw new ExitSignal();
+    };
+    try {
+      handlers[0]();
+    } catch (e) {
+      if (!(e instanceof ExitSignal)) throw e;
+    }
+    assertEquals(exitCode, 130);
+  } finally {
+    Deno.addSignalListener = origAdd;
+    Deno.removeSignalListener = origRemove;
+    Deno.exit = origExit;
+  }
+});
+
+Deno.test("main watchSignals: unsupported signals are skipped, teardown is best-effort", async () => {
+  const origAdd = Deno.addSignalListener;
+  const origRemove = Deno.removeSignalListener;
+  let installed = 0;
+  Deno.addSignalListener = (sig: Deno.Signal, _fn: () => void): void => {
+    // A platform that rejects everything but SIGINT (e.g. SIGTERM on Windows).
+    if (sig !== "SIGINT") throw new TypeError(`unsupported signal ${sig}`);
+    installed++;
+  };
+  Deno.removeSignalListener = (): void => {
+    throw new TypeError("teardown refused");
+  };
+  try {
+    const { code } = await capture(() =>
+      main(Demo, ["build"], { watchSignals: true })
+    );
+    // Neither the rejected install nor the failing teardown surfaces.
+    assertEquals(code, 0);
+    assertEquals(installed, 1);
+  } finally {
+    Deno.addSignalListener = origAdd;
+    Deno.removeSignalListener = origRemove;
+  }
+});
+
 Deno.test("main: resume rejects an oversized --data payload", async () => {
   const huge = JSON.stringify({ blob: "x".repeat(70_000) });
   const { code, err } = await capture(() =>

--- a/packages/core/tests/cli_test.ts
+++ b/packages/core/tests/cli_test.ts
@@ -19,7 +19,7 @@ import {
 import { discoverGroups, discoverTargets } from "../src/build.ts";
 import { FakeGraphHost } from "./_fakes.ts";
 import { CONFIG_FILE } from "../src/config.ts";
-import { parameter } from "../src/params.ts";
+import { discoverParameters, parameter } from "../src/params.ts";
 import { BUILTIN_FLAGS, RESERVED_COMMANDS } from "../src/cli_spec.ts";
 import { FileSystemStateStore } from "../src/state/fs_store.ts";
 import { defaultStateHost } from "../src/state/store.ts";
@@ -193,6 +193,11 @@ Deno.test("parseArgs accumulates --allowed-origin (repeatable and comma-list)", 
   ]);
   // Absent by default.
   assertEquals(parseArgs(["mcp"]).allowedOrigins, undefined);
+  // The inline form also works as the first (only) occurrence.
+  assertEquals(
+    parseArgs(["mcp", "--allowed-origin=https://solo.example"]).allowedOrigins,
+    ["https://solo.example"],
+  );
 });
 
 Deno.test("parseArgs recognises the doc command and its spec", () => {
@@ -229,12 +234,28 @@ Deno.test("main doc resolves a relative spec to an absolute path before running"
   await capture(() =>
     main(Demo, ["doc", "/abs/mod.ts"], { docRunner: runner })
   );
+  // A Windows drive-absolute path is absolute, not a URL scheme to resolve.
+  await capture(() =>
+    main(Demo, ["doc", "C:/mods/mod.ts"], { docRunner: runner })
+  );
   assertEquals(seen, [
     `${Deno.cwd()}/./mod.ts`,
     `${Deno.cwd()}/src/lib.ts`,
     "npm:cowsay",
     "/abs/mod.ts",
+    "C:/mods/mod.ts",
   ]);
+});
+
+Deno.test("main doc reports a non-Error rejection from the runner", async () => {
+  const { code, err } = await capture(() =>
+    main(Demo, ["doc", "jsr:@zuke/x"], {
+      // A non-Error rejection still surfaces as a friendly message.
+      docRunner: () => Promise.reject("doc blew up"),
+    })
+  );
+  assertEquals(code, 1);
+  assertStringIncludes(err.join("\n"), "doc blew up");
 });
 
 Deno.test("main doc returns a friendly non-zero exit when the runner throws", async () => {
@@ -1203,6 +1224,112 @@ Deno.test("main: cancel reports a missing run as a friendly error", async () => 
   }
 });
 
+Deno.test("main: cancelling an already-finished run is a no-op exit 0", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    // A terminal (succeeded) run: cancel is documented as idempotent.
+    await store.putRun(sampleRunRecord({ id: "done" }), null);
+    class Stateful extends Build {
+      override stateStore() {
+        return store;
+      }
+      build = target().executes(() => {});
+    }
+    const { code } = await capture(() => main(Stateful, ["cancel", "done"]));
+    assertEquals(code, 0);
+    // The record stays succeeded — cancel did not rewrite history.
+    const record = await store.getRun("done");
+    assertEquals(record?.record.status, "succeeded");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("main: cancel exits 1 when a compensation fails", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    class Failing extends Build {
+      override stateStore() {
+        return store;
+      }
+      build = target().executes(() => {}).onCancel(() => this.rollback);
+      rollback = target().executes(() => {
+        throw new Error("rollback exploded");
+      });
+    }
+    // A suspended run whose `build` target succeeded, so cancel compensates it.
+    await store.putRun(
+      sampleRunRecord({ id: "stuck", status: "suspended" }),
+      null,
+    );
+    const { code } = await capture(() => main(Failing, ["cancel", "stuck"]));
+    // The failed compensation surfaces non-zero so the operator notices…
+    assertEquals(code, 1);
+    // …but the run is still settled cancelled (cleanup is maximal).
+    const record = await store.getRun("stuck");
+    assertEquals(record?.record.status, "cancelled");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("run() defaults to Deno.args when no args option is given", async () => {
+  const desc = Object.getOwnPropertyDescriptor(Deno, "args");
+  const origExit = Deno.exit;
+  const origLog = console.log;
+  let captured: number | undefined;
+  Object.defineProperty(Deno, "args", {
+    value: ["--list"],
+    configurable: true,
+  });
+  Deno.exit = (code?: number): never => {
+    captured = code ?? 0;
+    throw new ExitSignal();
+  };
+  console.log = () => {};
+  try {
+    await run(Demo); // no options at all: argv comes from Deno.args
+  } catch (e) {
+    if (!(e instanceof ExitSignal)) throw e;
+  } finally {
+    Deno.exit = origExit;
+    console.log = origLog;
+    if (desc !== undefined) Object.defineProperty(Deno, "args", desc);
+  }
+  assertEquals(captured, 0);
+});
+
+Deno.test("main: --no-remote-cache flows through and the run still passes", async () => {
+  const log: string[] = [];
+  class T extends Build {
+    go = target().executes(() => void log.push("go"));
+  }
+  const { code } = await capture(() => main(T, ["go", "--no-remote-cache"]));
+  assertEquals(code, 0);
+  assertEquals(log, ["go"]);
+});
+
+Deno.test("formatGraph and formatList name an undiscovered dependency ?", () => {
+  const anon = target().executes(() => {});
+  class B extends Build {
+    build = target().dependsOn(anon).executes(() => {});
+  }
+  const targets = discoverTargets(new B());
+  assertStringIncludes(formatGraph(targets), "build → ?");
+});
+
+Deno.test("formatList renders a parameter declared without a description", () => {
+  class B extends Build {
+    quiet = parameter().boolean();
+    go = target().executes(() => {});
+  }
+  const b = new B();
+  const text = formatList(discoverTargets(b), discoverParameters(b));
+  assertStringIncludes(text, "--quiet");
+});
+
 Deno.test("main: runs list applies --status, --target, and --since filters", async () => {
   const dir = await Deno.makeTempDir();
   try {
@@ -1237,6 +1364,8 @@ Deno.test("main: runs list applies --status, --target, and --since filters", asy
     assertEquals(await ids("--status", "succeeded"), ["ok-run"]);
     assertEquals(await ids("--target", "deploy"), ["old-fail"]);
     assertEquals(await ids("--since", "2026-01-01T00:00:00.000Z"), ["ok-run"]);
+    // --limit keeps the newest run only.
+    assertEquals(await ids("--limit", "1"), ["ok-run"]);
   } finally {
     await Deno.remove(dir, { recursive: true });
   }

--- a/packages/core/tests/cli_test.ts
+++ b/packages/core/tests/cli_test.ts
@@ -1,7 +1,12 @@
 // Copyright (c) 2026 the Zuke contributors
 // SPDX-License-Identifier: MIT
 
-import { assertEquals, assertStringIncludes, assertThrows } from "./_assert.ts";
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+  assertThrows,
+} from "./_assert.ts";
 import { Build, cicd, group, type Plugin, target } from "../mod.ts";
 import {
   formatGraph,

--- a/packages/core/tests/describe_test.ts
+++ b/packages/core/tests/describe_test.ts
@@ -91,6 +91,13 @@ Deno.test("describeCli reports the property name, kind, and default", () => {
   assertEquals(params.find((p) => p.name === "region")?.default, "eu");
 });
 
+Deno.test("describeCli reports an empty description when none was set", () => {
+  class B extends Build {
+    quiet = parameter().boolean();
+  }
+  assertEquals(describeCli(new B()).parameters[0].description, "");
+});
+
 Deno.test("describeCli never surfaces a secret parameter's default value", () => {
   class WithSecret extends Build {
     // A secret's declared default could itself be a live credential.

--- a/packages/core/tests/describe_test.ts
+++ b/packages/core/tests/describe_test.ts
@@ -91,6 +91,29 @@ Deno.test("describeCli reports the property name, kind, and default", () => {
   assertEquals(params.find((p) => p.name === "region")?.default, "eu");
 });
 
+Deno.test("describeCli never surfaces a secret parameter's default value", () => {
+  class WithSecret extends Build {
+    // A secret's declared default could itself be a live credential.
+    apiKey = parameter("API key").secret().default("sk-live-real");
+    region = parameter("Region").default("eu");
+  }
+  const params = describeCli(new WithSecret()).parameters;
+  assertEquals(params.find((p) => p.name === "apiKey")?.default, undefined);
+  // A non-secret default still surfaces, so the omission is targeted.
+  assertEquals(params.find((p) => p.name === "region")?.default, "eu");
+});
+
+Deno.test("describeCli names a dependency that is not a build field with ?", () => {
+  // A dependency that was never discovered as a field has no name; the surface
+  // reports the placeholder rather than crashing or silently dropping the edge.
+  const anon = target().executes(() => {});
+  class B extends Build {
+    build = target().dependsOn(anon).executes(() => {});
+  }
+  const build = describeCli(new B()).targets.find((t) => t.name === "build");
+  assertEquals(build?.dependsOn, ["?"]);
+});
+
 Deno.test("describeCli omitSecrets drops secret parameters entirely", () => {
   class WithSecret extends Build {
     apiKey = parameter("API key").secret();

--- a/packages/core/tests/execute_cancel_test.ts
+++ b/packages/core/tests/execute_cancel_test.ts
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Unit tests for the in-process cancellation settlement — specifically the
+ * re-check after `markRunCancelling` drains the write chain: if an external
+ * `zuke cancel` won the race in that window, this process must stop without
+ * walking the compensations (the canceller owns them — F7).
+ *
+ * @module
+ */
+
+import { assertEquals } from "./_assert.ts";
+import { Build, discoverTargets } from "../src/build.ts";
+import { target } from "../src/target.ts";
+import { settleCancelledRun } from "../src/execute_cancel.ts";
+import { makeLifecycle } from "../src/lifecycle.ts";
+import { Redactor } from "../src/redact.ts";
+import { RunStateWriter } from "../src/state/writer.ts";
+import { FileSystemStateStore } from "../src/state/fs_store.ts";
+import { defaultStateHost } from "../src/state/store.ts";
+import type { RunRecord } from "../src/state/types.ts";
+import type { Reporter } from "../src/executor.ts";
+
+const NOW = "2026-08-10T12:00:00.000Z";
+
+Deno.test("the settlement stops when the cancel changes hands during the drain", async () => {
+  // The window this closes: this process initiated the cancellation, but
+  // marking the run `cancelling` drains every pending write, and a conflict in
+  // that drain can reveal another process's `zuke cancel` already landed. The
+  // re-check must then stop the walk — running it here too would compensate
+  // the same work twice.
+  const dir = await Deno.makeTempDir();
+  try {
+    const undone: string[] = [];
+    class Cd extends Build {
+      rollback = target().unlisted().executes(() => void undone.push("deploy"));
+      deploy = target().onCancel(this.rollback).executes(() => {});
+    }
+    const build = new Cd();
+    discoverTargets(build);
+
+    const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    const record: RunRecord = {
+      id: "run-1",
+      build: "Cd",
+      rootTarget: "deploy",
+      status: "running",
+      actor: "runner",
+      createdAt: NOW,
+      updatedAt: NOW,
+      graph: [{ name: "deploy", dependsOn: [] }],
+      params: {},
+      targets: { deploy: { status: "succeeded", meta: {} } },
+      signals: {},
+      events: [],
+    };
+    const writer = await RunStateWriter.open(
+      store,
+      record,
+      () => NOW,
+      new Redactor(),
+    );
+    const lines: string[] = [];
+    const reporter: Reporter = {
+      info: (l) => lines.push(l),
+      error: (l) => lines.push(l),
+    };
+
+    const settlement = await settleCancelledRun({
+      writer,
+      life: makeLifecycle(
+        build,
+        [],
+        { runId: "run-1", dryRun: false },
+        () => {},
+      ),
+      order: [build.deploy],
+      runId: "run-1",
+      actor: "runner",
+      signals: new Map(),
+      reporter,
+      redactor: new Redactor(),
+      nowIso: () => NOW,
+      // The external cancel is observed the moment the run reads `cancelling` —
+      // exactly what the drain's conflict handler latches in the executor.
+      isExternallyCancelled: () => writer.snapshot().status === "cancelling",
+    });
+
+    // This process does not own the walk: nothing was compensated and the run
+    // is left `cancelling` for the canceller to settle.
+    assertEquals(settlement, { ownedWalk: false, compensated: 0 });
+    assertEquals(undone, []);
+    assertEquals((await store.getRun("run-1"))?.record.status, "cancelling");
+    assertEquals(
+      lines.some((l) => l.includes("cancelled by another process")),
+      true,
+    );
+    // The cancel lock was released on the way out, so the real canceller (or a
+    // recovery pass) is not blocked behind a process that already stopped.
+    const reacquired = await writer.acquireCancelLock("the-canceller");
+    assertEquals(reacquired !== null, true);
+    await reacquired?.release();
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});

--- a/packages/core/tests/execute_plan_test.ts
+++ b/packages/core/tests/execute_plan_test.ts
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Unit tests for the executor's planning helpers — the interactive parameter
+ * prompt's terminal/CI gating, and the condition-skip walk that prunes a
+ * `whenSkipped("skip-dependencies")` target without dropping what a `triggers`
+ * edge still reaches.
+ *
+ * @module
+ */
+
+import { assertEquals } from "./_assert.ts";
+import { Build, discoverTargets } from "../src/build.ts";
+import { target } from "../src/target.ts";
+import { conditionSkips, defaultPrompt } from "../src/execute_plan.ts";
+
+/** Every variable {@link "../src/host.ts".detectCiHost} and `isCI` consult. */
+const CI_VARS = [
+  "GITHUB_ACTIONS",
+  "GITLAB_CI",
+  "TF_BUILD",
+  "BITBUCKET_BUILD_NUMBER",
+  "CI",
+];
+
+/** Run `fn` with every CI marker cleared, so `isCI()` reads local. */
+function withLocalHost(fn: () => void): void {
+  const saved = new Map<string, string | undefined>();
+  for (const name of CI_VARS) {
+    saved.set(name, Deno.env.get(name));
+    Deno.env.delete(name);
+  }
+  try {
+    fn();
+  } finally {
+    for (const [name, value] of saved) {
+      if (value === undefined) Deno.env.delete(name);
+      else Deno.env.set(name, value);
+    }
+  }
+}
+
+/** Run `fn` with `Deno.stdin.isTerminal` stubbed, restored afterwards. */
+function withStdinTerminal(stub: () => boolean, fn: () => void): void {
+  const original = Deno.stdin.isTerminal;
+  Deno.stdin.isTerminal = stub;
+  try {
+    fn();
+  } finally {
+    Deno.stdin.isTerminal = original;
+  }
+}
+
+/** Run `fn` with the global `prompt` stubbed, restored afterwards. */
+function withPrompt(
+  stub: (message?: string, defaultValue?: string) => string | null,
+  fn: () => void,
+): void {
+  const original = globalThis.prompt;
+  globalThis.prompt = stub;
+  try {
+    fn();
+  } finally {
+    globalThis.prompt = original;
+  }
+}
+
+Deno.test("defaultPrompt never prompts when the terminal check itself throws", () => {
+  // A runtime with no stdin (a worker, a stripped-down embed) throws from
+  // isTerminal(); that must read as "not interactive", not crash resolution.
+  withPrompt(() => {
+    throw new Error("prompt must not be reached");
+  }, () => {
+    withStdinTerminal(() => {
+      throw new Error("stdin unavailable");
+    }, () => {
+      assertEquals(defaultPrompt("env", "target environment"), undefined);
+    });
+  });
+});
+
+Deno.test("defaultPrompt asks at an interactive terminal, labelling flag and description", () => {
+  withLocalHost(() =>
+    withStdinTerminal(() => true, () => {
+      const asked: (string | undefined)[] = [];
+      withPrompt((message) => {
+        asked.push(message);
+        return "sit-7";
+      }, () => {
+        assertEquals(defaultPrompt("env", "target environment"), "sit-7");
+      });
+      // The label names the flag the operator would have passed, with the
+      // declared description so they know what is being asked for.
+      assertEquals(asked, ["--env (target environment):"]);
+    })
+  );
+});
+
+Deno.test("a dismissed prompt leaves the parameter unset", () => {
+  withLocalHost(() =>
+    withStdinTerminal(() => true, () => {
+      const asked: (string | undefined)[] = [];
+      withPrompt((message) => {
+        asked.push(message);
+        return null; // the operator hit Ctrl-D / entered nothing
+      }, () => {
+        assertEquals(defaultPrompt("env", undefined), undefined);
+      });
+      // Without a description the label is the bare flag.
+      assertEquals(asked, ["--env:"]);
+    })
+  );
+});
+
+Deno.test("conditionSkips keeps triggered targets and tolerates an unbound dependency", async () => {
+  class B extends Build {
+    helper = target().executes(() => {});
+    optional = target()
+      .dependsOn(this.helper)
+      .onlyWhen(() => false)
+      .whenSkipped("skip-dependencies")
+      .executes(() => {});
+    fire = target().executes(() => {});
+    root = target()
+      .triggers(this.fire)
+      // @ts-expect-error deliberately forward-references a later field: class
+      // fields initialise top-to-bottom, so `this.later` is undefined here and
+      // the walk's runtime guard must skip it instead of crashing on `.name_`.
+      .dependsOn(this.optional, this.later)
+      .executes(() => {});
+    later = target().executes(() => {});
+  }
+  const b = new B();
+  discoverTargets(b);
+
+  const names = await conditionSkips(b.root, [
+    b.helper,
+    b.optional,
+    b.fire,
+    b.root,
+  ]);
+  // The pruned target and the dependency only it needed are skipped; the
+  // target reachable through `triggers` survives (the walk follows trigger
+  // edges, not just dependencies); the unbound forward reference is ignored.
+  assertEquals(names, new Set(["optional", "helper"]));
+});

--- a/packages/core/tests/mcp_authz_closure_test.ts
+++ b/packages/core/tests/mcp_authz_closure_test.ts
@@ -436,3 +436,56 @@ Deno.test("a secret supplied as a non-string is still masked where it is echoed"
     },
   );
 });
+
+Deno.test("a target whose plan cannot even be resolved fails closed", async () => {
+  // A cycle the authoring API forbids, forged by mutating the (public)
+  // dependsOn_ array after construction: planGraph throws on it, so the plan
+  // is unknowable — an unknown blast radius must be treated as protected.
+  class Cyclic extends Build {
+    a = target().executes(() => {});
+    b = target().dependsOn(this.a).executes(() => {});
+  }
+  const build = new Cyclic();
+  build.a.dependsOn_.push(build.b);
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    const server = new McpServer(build, {
+      allowRun: true,
+      stateStore: store,
+      actor: "agent",
+    });
+
+    // The advertised schema fails closed too: with no resolvable plan, the
+    // run tool demands the operator token.
+    const tools = await toolList(server);
+    const runA = tools.find((t) => t.name === "run:a");
+    assertEquals(runA?.inputSchema?.required?.includes("operatorToken"), true);
+
+    // The call is denied with the collapsed reason — the caller cannot tell
+    // an unresolvable plan from a plain not-allowed target…
+    const denied = await call(server, "run:a", {});
+    assertEquals(denied.isError, true);
+    assertEquals(JSON.parse(denied.text).reason, "not_allowed");
+    assertEquals(denied.text.includes("unresolved_plan"), false);
+
+    // …while the operator-only audit trail keeps the precise reason.
+    const events = await auditEvents(store);
+    assertEquals(events.at(-1)?.tool, "run:a");
+    assertEquals(events.at(-1)?.outcome, "denied");
+    assertEquals(events.at(-1)?.detail, "unresolved_plan");
+
+    // Under an allow-list, the visibility closure of an unresolvable plan is
+    // just the root itself — the walk must not crash on it, and it must not
+    // guess at what the broken plan might have reached.
+    const narrowed = new McpServer(build, {
+      allowRun: true,
+      allowRunPatterns: ["a"],
+    });
+    const listed = await call(narrowed, "list_targets");
+    const visible: Array<{ name: string }> = JSON.parse(listed.text);
+    assertEquals(visible.map((t) => t.name), ["a"]);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/packages/core/tests/mcp_hardening_test.ts
+++ b/packages/core/tests/mcp_hardening_test.ts
@@ -627,7 +627,7 @@ Deno.test("with a store, an unknown tool still gets the opaque unknown answer", 
 /** A store whose every operation rejects (a dead state backend). */
 class BrokenStore implements StateStore {
   #die(): Promise<never> {
-    return Promise.reject(new Error("store down: s3nsitive backend detail"));
+    return Promise.reject(new Error("store down: confidential backend detail"));
   }
   getRun(): ReturnType<StateStore["getRun"]> {
     return this.#die();
@@ -674,7 +674,7 @@ Deno.test("a store fault in a read tool is a generic JSON-RPC error, detail with
   );
   assertEquals(res?.error?.code, INTERNAL_ERROR);
   // The raw store message never escapes to the client.
-  assertEquals(JSON.stringify(res).includes("s3nsitive"), false);
+  assertEquals(JSON.stringify(res).includes("confidential"), false);
   // The transport survives: the next message is answered normally.
   assertEquals((await server.handleMessage(req("ping")))?.result, {});
 });

--- a/packages/core/tests/mcp_hardening_test.ts
+++ b/packages/core/tests/mcp_hardening_test.ts
@@ -3,10 +3,14 @@
 
 import { assertEquals, assertStringIncludes } from "./_assert.ts";
 import { Build, parameter, target } from "../mod.ts";
-import { McpServer, type McpServerOptions } from "../src/mcp/server.ts";
-import type { JsonRpcResponse } from "../src/mcp/jsonrpc.ts";
+import {
+  McpServer,
+  type McpServerOptions,
+  type McpTool,
+} from "../src/mcp/server.ts";
+import { INTERNAL_ERROR, type JsonRpcResponse } from "../src/mcp/jsonrpc.ts";
 import { FileSystemStateStore } from "../src/state/fs_store.ts";
-import { defaultStateHost } from "../src/state/store.ts";
+import { defaultStateHost, type StateStore } from "../src/state/store.ts";
 import { AUDIT_RUN_ID } from "../src/mcp/audit.ts";
 import type { RunEvent, RunRecord } from "../src/state/types.ts";
 
@@ -539,6 +543,207 @@ Deno.test("a hook yielding an empty actor is rejected, never the static fallback
       assertEquals(res?.error?.message, "Unauthorized");
       // Neither audited nor attributed to the untrusted static actor.
       assertEquals((await auditEvents(store)).length, 0);
+    },
+  );
+});
+
+// ---- backstops, schemas, and audit resilience -------------------------------
+
+/** Whether a JSON value is a plain object (a string-keyed record). */
+function isRec(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** One run tool's input schema from `tools/list`, navigated without casts. */
+async function toolSchema(
+  server: McpServer,
+  name: string,
+): Promise<{ properties: Record<string, unknown>; required: string[] }> {
+  const res = await server.handleMessage(req("tools/list"));
+  if (!isRec(res) || !isRec(res.result) || !Array.isArray(res.result.tools)) {
+    throw new Error("no tools");
+  }
+  for (const tool of res.result.tools) {
+    if (!isRec(tool) || tool.name !== name || !isRec(tool.inputSchema)) {
+      continue;
+    }
+    const properties = isRec(tool.inputSchema.properties)
+      ? tool.inputSchema.properties
+      : {};
+    const required = Array.isArray(tool.inputSchema.required)
+      ? tool.inputSchema.required.filter((r): r is string =>
+        typeof r === "string"
+      )
+      : [];
+    return { properties, required };
+  }
+  throw new Error(`no tool ${name}`);
+}
+
+Deno.test("an array parameter is advertised as an array-of-strings schema", async () => {
+  class WithTags extends Build {
+    tags = parameter("Image tags").array();
+    ship = target().executes(() => {});
+  }
+  const server = new McpServer(new WithTags(), { allowRun: true });
+  const { properties } = await toolSchema(server, "run:ship");
+  assertEquals(properties.tags, { type: "array", items: { type: "string" } });
+});
+
+Deno.test("confirm-destructive advertises confirm on destructive tools only", async () => {
+  await withServer(
+    { allowRun: true, confirmDestructive: true },
+    async (server) => {
+      const deploy = await toolSchema(server, "run:deploy");
+      assertEquals(isRec(deploy.properties.confirm), true);
+      // A read-only target is never gated, so it advertises no confirm.
+      const status = await toolSchema(server, "run:status");
+      assertEquals("confirm" in status.properties, false);
+    },
+  );
+});
+
+Deno.test("a mutating run tool without --allow-run is refused with guidance", async () => {
+  await withServer({ allowRun: false }, async (server) => {
+    for (const name of ["signal_run", "resume_check", "cancel_run"]) {
+      const refused = await call(server, name, { runId: "whatever" });
+      assertEquals(refused.isError, true, `${name} was not refused`);
+      assertStringIncludes(refused.text, name);
+      assertStringIncludes(refused.text, "--allow-run");
+    }
+  });
+});
+
+Deno.test("with a store, an unknown tool still gets the opaque unknown answer", async () => {
+  // The run-state dispatcher must decline a name it does not own (returning
+  // null), so the server falls through to the standard "Unknown tool" result.
+  await withServer({ allowRun: true }, async (server) => {
+    const unknown = await call(server, "definitely_not_a_tool");
+    assertEquals(unknown.isError, true);
+    assertStringIncludes(unknown.text, "Unknown tool: definitely_not_a_tool");
+  });
+});
+
+/** A store whose every operation rejects (a dead state backend). */
+class BrokenStore implements StateStore {
+  #die(): Promise<never> {
+    return Promise.reject(new Error("store down: s3nsitive backend detail"));
+  }
+  getRun(): ReturnType<StateStore["getRun"]> {
+    return this.#die();
+  }
+  putRun(): ReturnType<StateStore["putRun"]> {
+    return this.#die();
+  }
+  listRuns(): ReturnType<StateStore["listRuns"]> {
+    return this.#die();
+  }
+  deleteRun(): Promise<void> {
+    return this.#die();
+  }
+  acquireLock(): ReturnType<StateStore["acquireLock"]> {
+    return this.#die();
+  }
+  renewLock(): Promise<boolean> {
+    return this.#die();
+  }
+  releaseLock(): Promise<void> {
+    return this.#die();
+  }
+}
+
+Deno.test("a dead audit store never blocks or fails the tool call", async () => {
+  // Auditing is best-effort: the run must succeed even though every audit
+  // write rejects.
+  const server = new McpServer(new Demo(), {
+    allowRun: true,
+    stateStore: new BrokenStore(),
+  });
+  const res = await call(server, "run:deploy", { environment: "dev" });
+  assertEquals(res.isError, false);
+  assertStringIncludes(res.text, "deploy succeeded");
+});
+
+Deno.test("a store fault in a read tool is a generic JSON-RPC error, detail withheld", async () => {
+  const server = new McpServer(new Demo(), {
+    allowRun: true,
+    stateStore: new BrokenStore(),
+  });
+  const res = await server.handleMessage(
+    req("tools/call", { name: "list_runs", arguments: {} }),
+  );
+  assertEquals(res?.error?.code, INTERNAL_ERROR);
+  // The raw store message never escapes to the client.
+  assertEquals(JSON.stringify(res).includes("s3nsitive"), false);
+  // The transport survives: the next message is answered normally.
+  assertEquals((await server.handleMessage(req("ping")))?.result, {});
+});
+
+Deno.test("a throwing tools/list is a JSON-RPC error, not a transport crash", async () => {
+  class ExplodingServer extends McpServer {
+    override tools(): McpTool[] {
+      throw new Error("tool listing exploded");
+    }
+  }
+  const server = new ExplodingServer(new Demo());
+  const res = await server.handleMessage(req("tools/list"));
+  assertEquals(res?.error?.code, INTERNAL_ERROR);
+  assertEquals(JSON.stringify(res).includes("exploded"), false);
+  assertEquals((await server.handleMessage(req("ping")))?.result, {});
+});
+
+Deno.test("an explicitly-undefined secret argument never seeds redaction", async () => {
+  // The redactor is seeded from supplied secret values. An `undefined` one
+  // must be skipped — seeding from it would redact the literal word
+  // "undefined" out of every other recorded argument.
+  await withServer(
+    { allowRun: true, actor: "agent" },
+    async (server, store) => {
+      await call(server, "run:deploy", {
+        environment: "dev",
+        secret: undefined,
+        note: "undefined is a fine word",
+      });
+      const last = (await auditEvents(store)).at(-1);
+      assertEquals(last?.args.note, "undefined is a fine word");
+      assertEquals(last?.args.secret, "[redacted]");
+    },
+  );
+});
+
+Deno.test("a non-Error framework throw is reported by kind, generically", async () => {
+  // A framework failure that is not even an Error object must still produce
+  // the structured "errored during execution" result, not a crash — and the
+  // thrown value itself is never echoed (it bypassed the reporter's redaction).
+  class BoomString extends Build {
+    override onStart(): void {
+      throw "startup exploded: hunter2";
+    }
+    go = target().executes(() => {});
+  }
+  const server = new McpServer(new BoomString(), { allowRun: true });
+  const res = await call(server, "run:go");
+  assertEquals(res.isError, true);
+  assertStringIncludes(res.text, "errored during execution (Error)");
+  assertEquals(res.text.includes("hunter2"), false);
+});
+
+Deno.test("null and object argument values are recorded faithfully in the trail", async () => {
+  await withServer(
+    { allowRun: true, actor: "agent" },
+    async (server, store) => {
+      // Both are invalid for a scalar parameter, so the call errors — and the
+      // audit record must render them distinctly: a structure as JSON, a null as
+      // its string form, never "[object Object]".
+      const res = await call(server, "run:deploy", {
+        environment: null,
+        note: { nested: 1 },
+      });
+      assertEquals(res.isError, true);
+      const last = (await auditEvents(store)).at(-1);
+      assertEquals(last?.detail, "invalid_arguments");
+      assertEquals(last?.args.environment, "null");
+      assertEquals(last?.args.note, '{"nested":1}');
     },
   );
 });

--- a/packages/core/tests/mcp_http_test.ts
+++ b/packages/core/tests/mcp_http_test.ts
@@ -360,3 +360,33 @@ Deno.test("serveMcp applies the build's identity hook to HTTP requests", async (
     await Deno.remove(dir, { recursive: true });
   }
 });
+
+Deno.test("serveMcp prints an HTTP banner naming the mode and (lack of) auth", async () => {
+  const origErr = console.error;
+  const banner: string[] = [];
+  console.error = (...a: unknown[]) => void banner.push(a.join(" "));
+  try {
+    const ac = new AbortController();
+    let setPort = (_: number) => {};
+    const portReady = new Promise<number>((r) => (setPort = r));
+    // Not quiet: the operator gets told where the server is and how open it is.
+    const finished = serveMcp(new Demo(), {
+      http: { host: "127.0.0.1", port: 0 },
+      readEnv: () => undefined, // no ZUKE_MCP_TOKEN
+      signal: ac.signal,
+      onListen: (a) => setPort(a.port),
+    });
+    await portReady;
+    ac.abort();
+    assertEquals(await finished, 0);
+  } finally {
+    console.error = origErr;
+  }
+  const text = banner.join("\n");
+  assertStringIncludes(text, "http://127.0.0.1:");
+  // Read-only, tokenless loopback: the banner says exactly that — and does not
+  // claim a registry is being served.
+  assertStringIncludes(text, "read-only");
+  assertStringIncludes(text, "no auth (loopback only)");
+  assertEquals(text.includes("registry"), false);
+});

--- a/packages/core/tests/mcp_runtools_test.ts
+++ b/packages/core/tests/mcp_runtools_test.ts
@@ -23,11 +23,7 @@ import { callRunStateTool, type RunToolDeps } from "../src/mcp/runtools.ts";
 import { acquireLease, RUN_LEASE_PREFIX } from "../src/state/run_lease.ts";
 import { LockConflictError } from "../src/state/lock.ts";
 import { FileSystemStateStore } from "../src/state/fs_store.ts";
-import {
-  defaultStateHost,
-  type StateStore,
-  type StateStoreScope,
-} from "../src/state/store.ts";
+import { defaultStateHost, type StateStore } from "../src/state/store.ts";
 import type { RunRecord } from "../src/state/types.ts";
 
 /** A JSON-RPC request with id 1. */
@@ -92,7 +88,11 @@ async function suspend(
 }
 
 /** A pipeline suspending at an `approved` gate, recording the signal payload. */
-function makePipeline(): { build: Build; root: TargetBuilder; seen: unknown[] } {
+function makePipeline(): {
+  build: Build;
+  root: TargetBuilder;
+  seen: unknown[];
+} {
   const seen: unknown[] = [];
   class Pipeline extends Build {
     gate = target().description("Gate")
@@ -137,8 +137,20 @@ Deno.test("list_runs filters by status, target, and since; an unknown status is 
   await withStore(async (store) => {
     const { build } = makePipeline();
     const server = new McpServer(build, { allowRun: true, stateStore: store });
-    await seedRun(store, "run-old", "deploy", "suspended", "2026-01-01T00:00:00.000Z");
-    await seedRun(store, "run-new", "promote", "failed", "2026-06-01T00:00:00.000Z");
+    await seedRun(
+      store,
+      "run-old",
+      "deploy",
+      "suspended",
+      "2026-01-01T00:00:00.000Z",
+    );
+    await seedRun(
+      store,
+      "run-new",
+      "promote",
+      "failed",
+      "2026-06-01T00:00:00.000Z",
+    );
 
     const byStatus = await call(server, "list_runs", { status: "failed" });
     assertEquals(byStatus.isError, false);
@@ -172,7 +184,13 @@ Deno.test("show_run returns the full record; a missing runId is a structured err
   await withStore(async (store) => {
     const { build } = makePipeline();
     const server = new McpServer(build, { allowRun: true, stateStore: store });
-    await seedRun(store, "run-a", "promote", "suspended", "2026-01-01T00:00:00.000Z");
+    await seedRun(
+      store,
+      "run-a",
+      "promote",
+      "suspended",
+      "2026-01-01T00:00:00.000Z",
+    );
 
     const shown = await call(server, "show_run", { runId: "run-a" });
     assertEquals(shown.isError, false);
@@ -365,13 +383,14 @@ Deno.test("a resume_check failure on one run is reported as structured run_faile
     const runId = await suspend(build, root, store);
     // A dependency failure inside the check itself (here: the environment
     // backend erroring mid-sweep) must come back as a structured per-run
-    // failure naming the run, not reject the whole tool call.
+    // failure naming the run, not reject the whole tool call. Thrown as a
+    // bare string, so even a non-Error failure is rendered readably.
     const deps: RunToolDeps = {
       store,
       build,
       actor: "op",
       readEnv: () => {
-        throw new Error("env backend offline");
+        throw "env backend offline";
       },
       authorize: () => null,
     };
@@ -427,7 +446,13 @@ class FlakyStore implements StateStore {
 Deno.test("a store fault mid-cancel is a structured run_failed, not a crash", async () => {
   await withStore(async (inner) => {
     const { build } = makePipeline();
-    await seedRun(inner, "run-x", "promote", "suspended", "2026-01-01T00:00:00.000Z");
+    await seedRun(
+      inner,
+      "run-x",
+      "promote",
+      "suspended",
+      "2026-01-01T00:00:00.000Z",
+    );
     // The tool's own pre-check read succeeds; the store then dies underneath
     // cancelRun. The caller still gets structured JSON naming the run.
     const flaky = new FlakyStore(inner);
@@ -438,5 +463,25 @@ Deno.test("a store fault mid-cancel is a structured run_failed, not a crash", as
     assertEquals(body.error, "run_failed");
     assertEquals(body.runId, "run-x");
     assertStringIncludes(body.message, "state backend offline");
+  });
+});
+
+Deno.test("signal_run accepts an explicit null payload and still resumes", async () => {
+  await withStore(async (store) => {
+    const { build, root, seen } = makePipeline();
+    const server = new McpServer(build, { allowRun: true, stateStore: store });
+    const runId = await suspend(build, root, store);
+    // A JSON `data: null` is accepted (not rejected as a malformed payload).
+    // `resumeRun` then normalises a nullish payload to the default `{}`, so
+    // that is what the resumed target observes.
+    const result = await call(server, "signal_run", {
+      runId,
+      signal: "approved",
+      data: null,
+    });
+    assertEquals(result.isError, false);
+    assertEquals(JSON.parse(result.text).ok, true);
+    assertEquals(seen, [{}]);
+    assertEquals((await store.getRun(runId))?.record.status, "succeeded");
   });
 });

--- a/packages/core/tests/mcp_runtools_test.ts
+++ b/packages/core/tests/mcp_runtools_test.ts
@@ -1,0 +1,442 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * The store-backed MCP run tools driven end-to-end: `list_runs` filters,
+ * `show_run`'s full record, and `signal_run`/`resume_check`/`cancel_run`
+ * advancing **real suspended runs** (created by `execute` suspending at a
+ * `waitsFor` gate). Typed failures — a lost resume race, a lock conflict, a
+ * failing resumed target, a store fault mid-operation — must come back as
+ * structured JSON tool results the client can act on, never as flattened
+ * strings or transport crashes.
+ *
+ * @module
+ */
+
+import { assertEquals, assertStringIncludes } from "./_assert.ts";
+import { Build, discoverTargets } from "../src/build.ts";
+import { target, type TargetBuilder } from "../src/target.ts";
+import { execute } from "../src/executor.ts";
+import { externalSignal } from "../src/wait.ts";
+import { McpServer } from "../src/mcp/server.ts";
+import { callRunStateTool, type RunToolDeps } from "../src/mcp/runtools.ts";
+import { acquireLease, RUN_LEASE_PREFIX } from "../src/state/run_lease.ts";
+import { LockConflictError } from "../src/state/lock.ts";
+import { FileSystemStateStore } from "../src/state/fs_store.ts";
+import {
+  defaultStateHost,
+  type StateStore,
+  type StateStoreScope,
+} from "../src/state/store.ts";
+import type { RunRecord } from "../src/state/types.ts";
+
+/** A JSON-RPC request with id 1. */
+function req(method: string, params?: unknown): Record<string, unknown> {
+  return { jsonrpc: "2.0", id: 1, method, ...(params ? { params } : {}) };
+}
+
+/** The `{ text, isError }` of a `tools/call` result (no casts). */
+function isRec(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Call a tool through the server and return its text block. */
+async function call(
+  server: McpServer,
+  name: string,
+  args: Record<string, unknown> = {},
+): Promise<{ text: string; isError: boolean }> {
+  const res = await server.handleMessage(
+    req("tools/call", { name, arguments: args }),
+  );
+  if (!isRec(res) || !isRec(res.result)) {
+    throw new Error(`expected a result: ${JSON.stringify(res)}`);
+  }
+  const content = res.result.content;
+  if (
+    !Array.isArray(content) || !isRec(content[0]) ||
+    typeof content[0].text !== "string"
+  ) {
+    throw new Error("not a tool result");
+  }
+  return { text: content[0].text, isError: res.result.isError === true };
+}
+
+/** Run `fn` with a real temp-dir store, cleaned up afterwards. */
+async function withStore(
+  fn: (store: FileSystemStateStore) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir();
+  try {
+    await fn(new FileSystemStateStore(`${dir}/runs`, defaultStateHost));
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+/** Execute `root` until it suspends at its gate, returning the run id. */
+async function suspend(
+  build: Build,
+  root: TargetBuilder,
+  store: StateStore,
+): Promise<string> {
+  const result = await execute(build, root, {
+    silent: true,
+    stateStore: store,
+    readEnv: () => undefined,
+  });
+  if (result.suspended !== true || result.runId === undefined) {
+    throw new Error("fixture did not suspend");
+  }
+  return result.runId;
+}
+
+/** A pipeline suspending at an `approved` gate, recording the signal payload. */
+function makePipeline(): { build: Build; root: TargetBuilder; seen: unknown[] } {
+  const seen: unknown[] = [];
+  class Pipeline extends Build {
+    gate = target().description("Gate")
+      .waitsFor((s) => s.on(externalSignal("approved")));
+    promote = target().dependsOn(this.gate).executes((ctx) => {
+      seen.push(ctx.signals.get("approved")?.data ?? null);
+    });
+  }
+  const build = new Pipeline();
+  discoverTargets(build);
+  return { build, root: build.promote, seen };
+}
+
+/** Persist a run record directly (for filter tests), returning its id. */
+async function seedRun(
+  store: StateStore,
+  id: string,
+  rootTarget: string,
+  status: "suspended" | "failed",
+  createdAt: string,
+): Promise<string> {
+  const record: RunRecord = {
+    id,
+    build: "Pipeline",
+    rootTarget,
+    status,
+    actor: "someone",
+    createdAt,
+    updatedAt: createdAt,
+    graph: [{ name: rootTarget, dependsOn: [] }],
+    params: {},
+    targets: { [rootTarget]: { status: "waiting", meta: {} } },
+    signals: {},
+    events: [],
+  };
+  const put = await store.putRun(record, null);
+  if (!put.ok) throw new Error("failed to seed run");
+  return id;
+}
+
+Deno.test("list_runs filters by status, target, and since; an unknown status is refused", async () => {
+  await withStore(async (store) => {
+    const { build } = makePipeline();
+    const server = new McpServer(build, { allowRun: true, stateStore: store });
+    await seedRun(store, "run-old", "deploy", "suspended", "2026-01-01T00:00:00.000Z");
+    await seedRun(store, "run-new", "promote", "failed", "2026-06-01T00:00:00.000Z");
+
+    const byStatus = await call(server, "list_runs", { status: "failed" });
+    assertEquals(byStatus.isError, false);
+    assertEquals(JSON.parse(byStatus.text).map((r: { id: string }) => r.id), [
+      "run-new",
+    ]);
+
+    const byTarget = await call(server, "list_runs", { target: "deploy" });
+    assertEquals(JSON.parse(byTarget.text).map((r: { id: string }) => r.id), [
+      "run-old",
+    ]);
+
+    const since = await call(server, "list_runs", {
+      since: "2026-03-01T00:00:00.000Z",
+    });
+    assertEquals(JSON.parse(since.text).map((r: { id: string }) => r.id), [
+      "run-new",
+    ]);
+
+    // An unknown status is a structured refusal naming the allowed values.
+    const bad = await call(server, "list_runs", { status: "bogus" });
+    assertEquals(bad.isError, true);
+    const body = JSON.parse(bad.text);
+    assertEquals(body.error, "invalid_status");
+    assertEquals(body.status, "bogus");
+    assertEquals(body.allowed.includes("suspended"), true);
+  });
+});
+
+Deno.test("show_run returns the full record; a missing runId is a structured error", async () => {
+  await withStore(async (store) => {
+    const { build } = makePipeline();
+    const server = new McpServer(build, { allowRun: true, stateStore: store });
+    await seedRun(store, "run-a", "promote", "suspended", "2026-01-01T00:00:00.000Z");
+
+    const shown = await call(server, "show_run", { runId: "run-a" });
+    assertEquals(shown.isError, false);
+    const record = JSON.parse(shown.text);
+    assertEquals(record.id, "run-a");
+    assertEquals(record.rootTarget, "promote");
+    assertEquals(record.status, "suspended");
+    assertEquals(record.targets.promote.status, "waiting");
+
+    // Each tool taking runId reports the missing argument the same way.
+    for (const tool of ["show_run", "signal_run", "cancel_run"]) {
+      const missing = await call(server, tool);
+      assertEquals(missing.isError, true, `${tool} did not error`);
+      const body = JSON.parse(missing.text);
+      assertEquals(body.error, "missing_argument");
+      assertEquals(body.argument, "runId");
+    }
+  });
+});
+
+Deno.test("signal_run delivers the payload and resumes the run to completion", async () => {
+  await withStore(async (store) => {
+    const { build, root, seen } = makePipeline();
+    const server = new McpServer(build, {
+      allowRun: true,
+      stateStore: store,
+      actor: "op",
+    });
+    const runId = await suspend(build, root, store);
+
+    const result = await call(server, "signal_run", {
+      runId,
+      signal: "approved",
+      data: { by: "qa" },
+    });
+    assertEquals(result.isError, false);
+    const body = JSON.parse(result.text);
+    assertEquals(body.ok, true);
+    assertEquals(body.runId, runId);
+    assertEquals(body.suspended, false);
+    assertEquals(body.executed.includes("promote"), true);
+    // The resumed target saw the delivered payload…
+    assertEquals(seen, [{ by: "qa" }]);
+    // …and the durable record settled.
+    const loaded = await store.getRun(runId);
+    assertEquals(loaded?.record.status, "succeeded");
+  });
+});
+
+Deno.test("signal_run with no satisfying signal re-suspends and reports it", async () => {
+  await withStore(async (store) => {
+    const { build, root, seen } = makePipeline();
+    const server = new McpServer(build, { allowRun: true, stateStore: store });
+    const runId = await suspend(build, root, store);
+
+    // No signal delivered: the gate stays unsatisfied and the run parks again.
+    const result = await call(server, "signal_run", { runId });
+    assertEquals(result.isError, false);
+    const body = JSON.parse(result.text);
+    assertEquals(body.ok, true);
+    assertEquals(body.suspended, true);
+    assertEquals(seen, []);
+    assertEquals((await store.getRun(runId))?.record.status, "suspended");
+  });
+});
+
+Deno.test("a lost resume race is a structured already_resumed, not a crash", async () => {
+  await withStore(async (store) => {
+    const { build, root } = makePipeline();
+    const server = new McpServer(build, { allowRun: true, stateStore: store });
+    const runId = await suspend(build, root, store);
+
+    // A rival process holds the run's lease, so this resumer must lose.
+    const lease = await acquireLease(
+      store,
+      RUN_LEASE_PREFIX,
+      runId,
+      "rival",
+      () => new Date().toISOString(),
+    );
+    if (lease === null) throw new Error("fixture could not take the lease");
+    try {
+      const result = await call(server, "signal_run", {
+        runId,
+        signal: "approved",
+      });
+      assertEquals(result.isError, true);
+      const body = JSON.parse(result.text);
+      assertEquals(body.error, "already_resumed");
+      assertEquals(body.runId, runId);
+      // Who has it, and since when, are part of the structured answer.
+      assertEquals(typeof body.by, "string");
+      assertEquals(typeof body.at, "string");
+    } finally {
+      await lease.release();
+    }
+  });
+});
+
+Deno.test("a lock conflict in the resumed run surfaces as structured lock_conflict", async () => {
+  await withStore(async (store) => {
+    const seenHolder = {
+      actor: "rival",
+      runId: "run-elsewhere",
+      since: "2026-01-01T00:00:00.000Z",
+    };
+    class Locked extends Build {
+      gate = target().waitsFor((s) => s.on(externalSignal("approved")));
+      promote = target().dependsOn(this.gate).executes(() => {
+        throw new LockConflictError(
+          seenHolder,
+          "deploy lock is held by rival — cancel run-elsewhere to release it",
+        );
+      });
+    }
+    const build = new Locked();
+    discoverTargets(build);
+    const server = new McpServer(build, { allowRun: true, stateStore: store });
+    const runId = await suspend(build, build.promote, store);
+
+    const result = await call(server, "signal_run", {
+      runId,
+      signal: "approved",
+    });
+    assertEquals(result.isError, true);
+    const body = JSON.parse(result.text);
+    assertEquals(body.error, "lock_conflict");
+    assertEquals(body.holder, seenHolder);
+    assertStringIncludes(body.guidance, "cancel run-elsewhere");
+  });
+});
+
+Deno.test("a failing resumed target is a structured run_failed with the message", async () => {
+  await withStore(async (store) => {
+    class Failing extends Build {
+      gate = target().waitsFor((s) => s.on(externalSignal("approved")));
+      promote = target().dependsOn(this.gate).executes(() => {
+        throw new Error("promotion exploded");
+      });
+    }
+    const build = new Failing();
+    discoverTargets(build);
+    const server = new McpServer(build, { allowRun: true, stateStore: store });
+    const runId = await suspend(build, build.promote, store);
+
+    const result = await call(server, "signal_run", {
+      runId,
+      signal: "approved",
+    });
+    assertEquals(result.isError, true);
+    const body = JSON.parse(result.text);
+    assertEquals(body.error, "run_failed");
+    assertEquals(body.runId, runId);
+    assertStringIncludes(body.message, "promotion exploded");
+  });
+});
+
+Deno.test("resume_check re-checks one run, and a sweep covers every authorized run", async () => {
+  await withStore(async (store) => {
+    const { build, root } = makePipeline();
+    const server = new McpServer(build, {
+      allowRun: true,
+      stateStore: store,
+      actor: "op",
+    });
+    const runId = await suspend(build, root, store);
+
+    // A single-run check: the signal gate is unsatisfied, so it re-suspends —
+    // checked but not failed.
+    const single = await call(server, "resume_check", { runId });
+    assertEquals(single.isError, false);
+    assertEquals(JSON.parse(single.text), { ok: true, checked: 1, failed: 0 });
+    assertEquals((await store.getRun(runId))?.record.status, "suspended");
+
+    // A sweep (no runId) finds and checks the same suspended run.
+    const sweep = await call(server, "resume_check");
+    assertEquals(sweep.isError, false);
+    assertEquals(JSON.parse(sweep.text), { ok: true, checked: 1, failed: 0 });
+
+    // A single-run check of a missing run is a structured no_run.
+    const missing = await call(server, "resume_check", { runId: "nope" });
+    assertEquals(missing.isError, true);
+    assertEquals(JSON.parse(missing.text).error, "no_run");
+  });
+});
+
+Deno.test("a resume_check failure on one run is reported as structured run_failed", async () => {
+  await withStore(async (store) => {
+    const { build, root } = makePipeline();
+    const runId = await suspend(build, root, store);
+    // A dependency failure inside the check itself (here: the environment
+    // backend erroring mid-sweep) must come back as a structured per-run
+    // failure naming the run, not reject the whole tool call.
+    const deps: RunToolDeps = {
+      store,
+      build,
+      actor: "op",
+      readEnv: () => {
+        throw new Error("env backend offline");
+      },
+      authorize: () => null,
+    };
+    const result = await callRunStateTool(deps, "resume_check", { runId });
+    assertEquals(result?.isError, true);
+    const body = JSON.parse(result?.text ?? "{}");
+    assertEquals(body.error, "run_failed");
+    assertEquals(body.runId, runId);
+    assertStringIncludes(body.message, "env backend offline");
+  });
+});
+
+/** Delegates to a real store, but `getRun` fails after the first read. */
+class FlakyStore implements StateStore {
+  #reads = 0;
+  constructor(private readonly inner: StateStore) {}
+  getRun(id: string): ReturnType<StateStore["getRun"]> {
+    this.#reads += 1;
+    if (this.#reads > 1) {
+      return Promise.reject(new Error("state backend offline"));
+    }
+    return this.inner.getRun(id);
+  }
+  putRun(
+    record: RunRecord,
+    expectedVersion: string | null,
+  ): ReturnType<StateStore["putRun"]> {
+    return this.inner.putRun(record, expectedVersion);
+  }
+  listRuns(
+    query: Parameters<StateStore["listRuns"]>[0],
+  ): ReturnType<StateStore["listRuns"]> {
+    return this.inner.listRuns(query);
+  }
+  deleteRun(id: string): Promise<void> {
+    return this.inner.deleteRun(id);
+  }
+  acquireLock(
+    key: string,
+    holder: Parameters<StateStore["acquireLock"]>[1],
+    ttlMs: number,
+  ): ReturnType<StateStore["acquireLock"]> {
+    return this.inner.acquireLock(key, holder, ttlMs);
+  }
+  renewLock(key: string, token: string, ttlMs: number): Promise<boolean> {
+    return this.inner.renewLock(key, token, ttlMs);
+  }
+  releaseLock(key: string, token: string): Promise<void> {
+    return this.inner.releaseLock(key, token);
+  }
+}
+
+Deno.test("a store fault mid-cancel is a structured run_failed, not a crash", async () => {
+  await withStore(async (inner) => {
+    const { build } = makePipeline();
+    await seedRun(inner, "run-x", "promote", "suspended", "2026-01-01T00:00:00.000Z");
+    // The tool's own pre-check read succeeds; the store then dies underneath
+    // cancelRun. The caller still gets structured JSON naming the run.
+    const flaky = new FlakyStore(inner);
+    const server = new McpServer(build, { allowRun: true, stateStore: flaky });
+    const result = await call(server, "cancel_run", { runId: "run-x" });
+    assertEquals(result.isError, true);
+    const body = JSON.parse(result.text);
+    assertEquals(body.error, "run_failed");
+    assertEquals(body.runId, "run-x");
+    assertStringIncludes(body.message, "state backend offline");
+  });
+});

--- a/packages/core/tests/mcp_test.ts
+++ b/packages/core/tests/mcp_test.ts
@@ -430,3 +430,18 @@ Deno.test("serveMcp runs the whole handshake over injected streams", async () =>
   assertStringIncludes(JSON.stringify(out[0]), "zuke");
   assertStringIncludes(JSON.stringify(out[1]), "list_targets");
 });
+
+Deno.test("the stdio banner reports read-only when running is not enabled", async () => {
+  const { output } = capturingWriter();
+  const original = console.error;
+  const banner: string[] = [];
+  console.error = (...args: unknown[]) => void banner.push(args.join(" "));
+  try {
+    await serveMcp(new Demo(), { input: streamOf(""), output });
+  } finally {
+    console.error = original;
+  }
+  const text = banner.join("\n");
+  assertStringIncludes(text, "read-only");
+  assertEquals(text.includes("run enabled"), false);
+});

--- a/packages/core/tests/reap_test.ts
+++ b/packages/core/tests/reap_test.ts
@@ -526,3 +526,154 @@ Deno.test("a shared origin does not make another build's run ours", async () => 
     assertEquals((await store.getRun("run-1"))?.record.status, "running");
   });
 });
+
+Deno.test("one bad stranded run does not strand the rest of the recovery", async () => {
+  // The same isolation the abandoned sweep has, on the stranded path: a store
+  // hiccup on one `cancelling` record must not leave every other one stuck.
+  await withStore(
+    [record("bad", "cancelling"), record("good", "cancelling")],
+    async (store) => {
+      const { reporter, lines } = capturing();
+      const realGet = store.getRun.bind(store);
+      store.getRun = (id: string) =>
+        id === "bad"
+          ? Promise.reject(new Error("the store hiccuped"))
+          : realGet(id);
+      const outcome = await recoverStranded(depsFor(store, reporter));
+      assertEquals(outcome.failed, 1);
+      assertEquals(outcome.settled, ["good"]);
+      assertEquals((await realGet("good"))?.record.status, "cancelled");
+      assertEquals(
+        lines.some((l) =>
+          l.includes("stranded run bad") && l.includes("the store hiccuped")
+        ),
+        true,
+      );
+    },
+  );
+});
+
+Deno.test("a run settled between the reaper's re-read and its write is left alone", async () => {
+  // Later than the window the earlier test closes: the run was still running
+  // at the re-read under the lease, and a canceller settled it during the
+  // suspend write's own compare-and-swap loop. The CAS notices and the reaper
+  // walks away instead of writing `suspended` over a terminal record.
+  await withStore([record("run-1", "running")], async (store) => {
+    const { reporter } = capturing();
+    const deps = depsFor(store, reporter);
+    const realGet = store.getRun.bind(store);
+    let asked = 0;
+    // Call 1: the listing's examine. Call 2: the re-read under the lease.
+    // Call 3: the suspend CAS's read — by then, a canceller has settled it.
+    store.getRun = async (id: string) => {
+      const got = await realGet(id);
+      if (++asked === 3 && got !== null) {
+        const settled = structuredClone(got.record);
+        settled.status = "cancelled";
+        await store.putRun(settled, got.version);
+        return await realGet(id);
+      }
+      return got;
+    };
+    const outcome = await reapAbandoned(deps);
+    assertEquals(outcome, { reaped: [], settled: [], failed: 0 });
+    assertEquals((await realGet("run-1"))?.record.status, "cancelled");
+  });
+});
+
+Deno.test("a store that never accepts the suspend write is reported, not looped", async () => {
+  // Bounded retries: a permanent conflict becomes one counted, named failure —
+  // the sweep carries on, and the lease is not kept.
+  await withStore([record("run-1", "running")], async (store) => {
+    const { reporter, lines } = capturing();
+    const realPut = store.putRun.bind(store);
+    store.putRun = (
+      next: RunRecord,
+      expected: string | null,
+    ) =>
+      next.status === "suspended"
+        ? Promise.resolve({ ok: false, conflict: true })
+        : realPut(next, expected);
+    const outcome = await reapAbandoned(depsFor(store, reporter));
+    assertEquals(outcome.failed, 1);
+    assertEquals(outcome.reaped, []);
+    assertEquals(
+      lines.some((l) => l.includes("gave up returning run-1 to suspended")),
+      true,
+    );
+    // The question-lease was still released on the way out.
+    const free = await store.acquireLock(
+      lockKey(RUN_LEASE_PREFIX, "run-1"),
+      { actor: "next-sweep", runId: "run-1", since: NOW },
+      60_000,
+    );
+    assertEquals(free.ok, true);
+  });
+});
+
+Deno.test("a recorded graph with a different node name is not settled", async () => {
+  // Same node count as this build's plan, but the names disagree — the
+  // residual a length check alone cannot see. Handed back, never settled.
+  await withStore(
+    [record("run-1", "running", "2026-08-10T11:00:00.000Z")],
+    async (store) => {
+      await amend(store, "run-1", (r) => {
+        r.graph = [{ name: "other", dependsOn: [] }];
+      });
+      const { reporter } = capturing();
+      const outcome = await reapAbandoned(depsFor(store, reporter));
+      assertEquals(outcome.settled, []);
+      assertEquals(outcome.reaped, ["run-1"]);
+    },
+  );
+});
+
+Deno.test("a recorded graph with a different dependency count is not settled", async () => {
+  await withStore(
+    [record("run-1", "running", "2026-08-10T11:00:00.000Z")],
+    async (store) => {
+      // The recorded `deploy` depended on something; this build's does not.
+      await amend(store, "run-1", (r) => {
+        r.graph = [{ name: "deploy", dependsOn: ["build"] }];
+      });
+      const { reporter } = capturing();
+      const outcome = await reapAbandoned(depsFor(store, reporter));
+      assertEquals(outcome.settled, []);
+      assertEquals(outcome.reaped, ["run-1"]);
+    },
+  );
+});
+
+Deno.test("a recorded graph with re-wired dependencies is not settled", async () => {
+  // Node names and dependency counts all match; only the edges point at
+  // different targets. Still another build's run for settling purposes.
+  class Pipeline extends Build {
+    prep = target().unlisted().executes(() => {});
+    deploy = target().dependsOn(this.prep).executes(() => {});
+  }
+  await withStore(
+    [record("run-1", "running", "2026-08-10T11:00:00.000Z")],
+    async (store) => {
+      await amend(store, "run-1", (r) => {
+        r.build = "Pipeline";
+        r.graph = [
+          { name: "prep", dependsOn: [] },
+          // Same length as the planned `deploy → prep`, different edge.
+          { name: "deploy", dependsOn: ["other"] },
+        ];
+      });
+      const build = new Pipeline();
+      discoverTargets(build);
+      const { reporter } = capturing();
+      const outcome = await reapAbandoned({
+        build,
+        store,
+        actor: "sweeper",
+        reporter,
+        now: () => NOW,
+      });
+      assertEquals(outcome.settled, []);
+      assertEquals(outcome.reaped, ["run-1"]);
+    },
+  );
+});

--- a/packages/core/tests/registry_server_test.ts
+++ b/packages/core/tests/registry_server_test.ts
@@ -1555,3 +1555,100 @@ Deno.test("the HTTP banner names the registry mode, run state, and auth", async 
   assertStringIncludes(text, "bearer token required");
   assertStringIncludes(text, "http://127.0.0.1:");
 });
+
+Deno.test("a valid number default is carried; a malformed boolean default is dropped", async () => {
+  const registry = new FakeRegistry();
+  const base = descriptor("Api", ["deploy"]);
+  registry.add({
+    ...base,
+    surface: {
+      ...base.surface,
+      // A described target: the run tool's description must carry it through.
+      targets: base.surface.targets.map((t) => ({
+        ...t,
+        description: "Ship it to production",
+      })),
+      parameters: [
+        {
+          name: "workers",
+          flag: "workers",
+          description: "",
+          required: false,
+          kind: "number",
+          boolean: false,
+          array: false,
+          options: [],
+          default: "4",
+        },
+        // Only "true"/"false" are honest boolean defaults; anything else came
+        // from an untrusted descriptor and is dropped to keep the schema valid.
+        {
+          name: "force",
+          flag: "force",
+          description: "",
+          required: false,
+          kind: "boolean",
+          boolean: true,
+          array: false,
+          options: [],
+          default: "yes",
+        },
+      ],
+    },
+  });
+  const server = new RegistryMcpServer(registry, { allowRun: true });
+  const res = await server.handleMessage(req("tools/list"));
+  const schema = runToolSchema(res, "run:Api:deploy");
+  const props = schemaProps(schema);
+  assertEquals(props.workers, { type: "number", default: 4 });
+  assertEquals(props.force, { type: "boolean" });
+  const tool = toolDef(res, "run:Api:deploy");
+  assertEquals(
+    typeof tool.description === "string" &&
+      tool.description.includes("Ship it to production"),
+    true,
+  );
+});
+
+Deno.test("a protected dependency the surface does not declare still gates the run", async () => {
+  const registry = new FakeRegistry();
+  // `release` names a dependency with no target entry of its own — a partial
+  // surface from an out-of-date registration. The closure walk must neither
+  // crash on it nor let it slip past the protect list.
+  const base = descriptor("Api", ["release"]);
+  registry.add({
+    ...base,
+    surface: {
+      ...base.surface,
+      targets: base.surface.targets.map((t) => ({
+        ...t,
+        dependsOn: ["ghost"],
+      })),
+    },
+  });
+  const { runner, calls } = recordingRunner();
+  const server = new RegistryMcpServer(registry, {
+    allowRun: true,
+    protectPatterns: ["Api:ghost"],
+    operatorToken: "good-token",
+    runner,
+  });
+  const denied = await call(server, "run:Api:release");
+  assertEquals(denied.isError, true);
+  assertStringIncludes(denied.text, "missing_operator_token");
+  assertEquals(calls.length, 0);
+});
+
+Deno.test("a runner rejecting with a non-Error is still a structured failure", async () => {
+  const registry = new FakeRegistry();
+  registry.add(descriptor("Api", ["deploy"]));
+  // Not an Error instance: the message must fall back to a generic kind, and
+  // the raw rejection value must not leak into the result.
+  const runner: RegistryRunner = () =>
+    Promise.reject("exec fell over: token=abc");
+  const server = new RegistryMcpServer(registry, { allowRun: true, runner });
+  const result = await call(server, "run:Api:deploy");
+  assertEquals(result.isError, true);
+  assertStringIncludes(result.text, "Failed to spawn Api:deploy (Error)");
+  assertEquals(result.text.includes("token=abc"), false);
+});

--- a/packages/core/tests/registry_server_test.ts
+++ b/packages/core/tests/registry_server_test.ts
@@ -1315,3 +1315,243 @@ Deno.test("the launch check runs before the destructive-confirmation prompt", as
   assertStringIncludes(result.text, "launch_origin_not_allowed");
   assertEquals(calls.length, 0);
 });
+
+// ---- remaining protocol edges, schema rendering, and audit resilience -------
+
+Deno.test("defaultRegistryRunner exports the resolved actor as ZUKE_ACTOR", async () => {
+  const result = await defaultRegistryRunner(
+    [
+      Deno.execPath(),
+      "eval",
+      "console.log(Deno.env.get('ZUKE_ACTOR') ?? 'NO_ACTOR')",
+    ],
+    Deno.cwd(),
+    { actor: "trusted-caller" },
+  );
+  assertEquals(result.code, 0);
+  // The spawned build attributes its run to the same actor as the audit trail.
+  assertStringIncludes(result.stdout, "trusted-caller");
+});
+
+Deno.test("a run tool's schema renders enums on arrays and typed defaults", async () => {
+  const registry = new FakeRegistry();
+  const base = descriptor("Api", ["deploy"]);
+  registry.add({
+    ...base,
+    surface: {
+      ...base.surface,
+      parameters: [
+        // An array of constrained strings: the enum rides on the items.
+        {
+          name: "levels",
+          flag: "levels",
+          description: "",
+          required: false,
+          kind: "string",
+          boolean: false,
+          array: true,
+          options: ["low", "high"],
+        },
+        // A boolean default "true" comes back as JSON true.
+        {
+          name: "verbose",
+          flag: "verbose",
+          description: "",
+          required: false,
+          kind: "boolean",
+          boolean: true,
+          array: false,
+          options: [],
+          default: "true",
+        },
+        // A string default is carried verbatim.
+        {
+          name: "region",
+          flag: "region",
+          description: "",
+          required: false,
+          kind: "string",
+          boolean: false,
+          array: false,
+          options: [],
+          default: "eu",
+        },
+      ],
+    },
+  });
+  const server = new RegistryMcpServer(registry, { allowRun: true });
+  const schema = runToolSchema(
+    await server.handleMessage(req("tools/list")),
+    "run:Api:deploy",
+  );
+  const props = schemaProps(schema);
+  assertEquals(props.levels, {
+    type: "array",
+    items: { type: "string", enum: ["low", "high"] },
+  });
+  assertEquals(props.verbose, { type: "boolean", default: true });
+  assertEquals(props.region, { type: "string", default: "eu" });
+});
+
+Deno.test("an array parameter with a mismatched element is rejected before any spawn", async () => {
+  const registry = new FakeRegistry();
+  registry.add(paramDescriptor());
+  const { runner, calls } = recordingRunner();
+  const server = new RegistryMcpServer(registry, { allowRun: true, runner });
+  // The array shape is right, but one element is not a string.
+  const result = await call(server, "run:Deploy:deploy", {
+    repos: ["expense-service", 5],
+  });
+  assertEquals(result.isError, true);
+  assertStringIncludes(result.text, "repos");
+  assertEquals(calls.length, 0);
+});
+
+Deno.test("protection reaches a dependency shared through a diamond exactly once", async () => {
+  const registry = new FakeRegistry();
+  // release → {a, b} → lint: the protected `lint` is reachable twice, and the
+  // closure walk must both dedupe it and still enforce the token.
+  const base = descriptor("Api", ["lint", "a", "b", "release"]);
+  registry.add({
+    ...base,
+    surface: {
+      ...base.surface,
+      targets: base.surface.targets.map((t) => {
+        if (t.name === "a" || t.name === "b") {
+          return { ...t, dependsOn: ["lint"] };
+        }
+        if (t.name === "release") return { ...t, dependsOn: ["a", "b"] };
+        return t;
+      }),
+    },
+  });
+  const { runner, calls } = recordingRunner();
+  const server = new RegistryMcpServer(registry, {
+    allowRun: true,
+    protectPatterns: ["Api:lint"],
+    operatorToken: "good-token",
+    runner,
+  });
+  const denied = await call(server, "run:Api:release");
+  assertEquals(denied.isError, true);
+  assertStringIncludes(denied.text, "missing_operator_token");
+  assertEquals(calls.length, 0);
+  const okd = await call(server, "run:Api:release", {
+    operatorToken: "good-token",
+  });
+  assertEquals(okd.isError, false);
+  assertEquals(calls.length, 1);
+});
+
+Deno.test("an id-less unknown method is a silent notification; a bad name errors", async () => {
+  const server = new RegistryMcpServer(new FakeRegistry());
+  // An unknown method with no id is treated as a notification: no reply.
+  assertEquals(
+    await server.handleMessage({ jsonrpc: "2.0", method: "does/not/exist" }),
+    null,
+  );
+  // A non-string tool name is an invalid-params error, not a crash.
+  const res = await server.handleMessage(req("tools/call", { name: 5 }));
+  assertEquals(
+    isRec(res) && isRec(res.error) && typeof res.error.message === "string"
+      ? res.error.message.includes("must be a string")
+      : false,
+    true,
+  );
+  // A plain unknown tool (no run: prefix) is surfaced through the result.
+  const unknown = await call(server, "no_such_tool");
+  assertEquals(unknown.isError, true);
+  assertStringIncludes(unknown.text, "Unknown tool: no_such_tool");
+});
+
+Deno.test("a dead audit store never blocks the run, and a later call retries", async () => {
+  // Reads reject too, so even *opening* the audit log fails — the failed open
+  // must be dropped (not memoized) so the next call can retry it.
+  class BrokenHost extends FakeStateHost {
+    override readText(): Promise<string | null> {
+      return Promise.reject(new Error("disk gone"));
+    }
+    override writeText(): Promise<void> {
+      return Promise.reject(new Error("disk full"));
+    }
+  }
+  const registry = new FakeRegistry();
+  registry.add(descriptor("Api", ["deploy"]));
+  const store = new FileSystemStateStore("/state", new BrokenHost());
+  const { runner, calls } = recordingRunner();
+  const server = new RegistryMcpServer(registry, {
+    allowRun: true,
+    stateStore: store,
+    runner,
+  });
+  // Auditing is best-effort: the spawn happens and the call succeeds even
+  // though every audit write rejects — twice, since a failed open is dropped
+  // so the next call can retry rather than reusing a poisoned promise.
+  const first = await call(server, "run:Api:deploy");
+  assertEquals(first.isError, false);
+  const second = await call(server, "run:Api:deploy");
+  assertEquals(second.isError, false);
+  assertEquals(calls.length, 2);
+});
+
+Deno.test("a supplied operator token is never recorded in the audit trail", async () => {
+  const registry = new FakeRegistry();
+  registry.add(descriptor("Api", ["deploy"]));
+  const store = new FileSystemStateStore("/state", new FakeStateHost());
+  const { runner } = recordingRunner();
+  const server = new RegistryMcpServer(registry, {
+    allowRun: true,
+    protectPatterns: ["Api:deploy"],
+    operatorToken: "good-token",
+    stateStore: store,
+    runner,
+  });
+  const okd = await call(server, "run:Api:deploy", {
+    operatorToken: "good-token",
+    dryRun: true,
+  });
+  assertEquals(okd.isError, false);
+  const events = (await store.getRun("mcp-audit"))?.record.events ?? [];
+  const ran = events.find((e) => e.tool === "run:Api:deploy");
+  assertEquals(ran?.outcome, "ok");
+  // The safe control flag is recorded; the token is dropped entirely — and its
+  // value appears nowhere in the durable trail.
+  assertEquals(ran?.args.dryRun, "true");
+  assertEquals("operatorToken" in (ran?.args ?? {}), false);
+  assertEquals(JSON.stringify(events).includes("good-token"), false);
+});
+
+Deno.test("the HTTP banner names the registry mode, run state, and auth", async () => {
+  const registry = new FakeRegistry();
+  registry.add(descriptor("Api", ["deploy"]));
+  const banner: string[] = [];
+  const origErr = console.error;
+  console.error = (...a: unknown[]) => void banner.push(a.join(" "));
+  try {
+    // An injected registry (the `registry` option) and the CLI's `useRegistry`
+    // flag must both be reported as registry mode.
+    for (const mode of ["injected", "resolved"] as const) {
+      const ac = new AbortController();
+      let setPort = (_: number) => {};
+      const portReady = new Promise<number>((r) => (setPort = r));
+      const finished = serveMcp(new RegistryBuild(registry), {
+        ...(mode === "injected" ? { registry } : { useRegistry: true }),
+        allowRun: true,
+        runner: recordingRunner().runner,
+        http: { host: "127.0.0.1", port: 0 },
+        token: "shh",
+        signal: ac.signal,
+        onListen: (a) => setPort(a.port),
+      });
+      await portReady;
+      ac.abort();
+      assertEquals(await finished, 0);
+    }
+  } finally {
+    console.error = origErr;
+  }
+  const text = banner.join("\n");
+  assertStringIncludes(text, "registry, run enabled");
+  assertStringIncludes(text, "bearer token required");
+  assertStringIncludes(text, "http://127.0.0.1:");
+});

--- a/packages/core/tests/resume_test.ts
+++ b/packages/core/tests/resume_test.ts
@@ -12,6 +12,8 @@ import {
   RunNotSuspendedError,
 } from "../src/resume.ts";
 import { ForeignRunError } from "../src/ownership.ts";
+import { lockKey } from "../src/state/lock.ts";
+import { RUN_LEASE_PREFIX } from "../src/state/run_lease.ts";
 import { FileSystemStateStore } from "../src/state/fs_store.ts";
 import { defaultStateHost, type PutResult } from "../src/state/store.ts";
 import type { RunRecord } from "../src/state/types.ts";
@@ -1106,5 +1108,41 @@ Deno.test("resume --check counts a run that resumed and then failed", async () =
     assertEquals(swept, { checked: 1, failed: 1 });
     const runId = (await store.listRuns({}))[0].id;
     assertEquals((await store.getRun(runId))?.record.status, "failed");
+  });
+});
+
+Deno.test("a sweep skips a run another process holds, without counting it", async () => {
+  // A live resumer holds the run's lease. The sweep's own resume attempt gets
+  // AlreadyResumedError from the other side of that race — which is a run in
+  // good hands, not a failure for the cron to alarm on.
+  await withTempStore(async (store) => {
+    const makeBuild = () => {
+      class B extends Build {
+        gate = target().waitsFor((s) => s.on(externalSignal("go")));
+        done = target().dependsOn(this.gate).executes(() => {});
+      }
+      const build = new B();
+      discoverTargets(build);
+      return build;
+    };
+    const a = makeBuild();
+    await execute(a, a.done, { silent: true, stateStore: store });
+    const runId = (await store.listRuns({}))[0].id;
+
+    // Another process's claim on the run.
+    const held = await store.acquireLock(
+      lockKey(RUN_LEASE_PREFIX, runId),
+      { actor: "the-resumer", runId, since: new Date().toISOString() },
+      60_000,
+    );
+    assertEquals(held.ok, true);
+
+    const swept = await resumeCheck(makeBuild(), {
+      stateStore: store,
+      silent: true,
+    });
+    assertEquals(swept, { checked: 1, failed: 0 });
+    // Left exactly as found — the holder is driving it.
+    assertEquals((await store.getRun(runId))?.record.status, "suspended");
   });
 });

--- a/packages/core/tests/resume_test.ts
+++ b/packages/core/tests/resume_test.ts
@@ -713,3 +713,266 @@ Deno.test("the typed error carries the status it found instead", async () => {
     assertEquals(error.status, "succeeded");
   });
 });
+
+Deno.test("resumeRun and resumeCheck refuse to start with state disabled", async () => {
+  // A resume without a store has nothing to resume from; the refusal names
+  // every way to configure one.
+  class B extends Build {
+    go = target().executes(() => {});
+  }
+  const b = new B();
+  discoverTargets(b);
+  await assertRejects(
+    () => resumeRun(b, { runId: "x", stateStore: false, silent: true }),
+    Error,
+    "no state store is configured",
+  );
+  await assertRejects(
+    () => resumeCheck(b, { stateStore: false, silent: true }),
+    Error,
+    "resume --check: no state store",
+  );
+});
+
+Deno.test("resumeRun names a target the build lost since the run suspended", async () => {
+  // The drift check's third shape: not an added or re-wired target, but one
+  // the record has and the build no longer declares. The refusal has to name
+  // it, or the operator cannot decide whether --force-graph is safe.
+  await withTempStore(async (store) => {
+    class Suspends extends Build {
+      gate = target().waitsFor((s) => s.on(externalSignal("go")));
+      done = target().dependsOn(this.gate).executes(() => {});
+    }
+    const a = new Suspends();
+    discoverTargets(a);
+    await execute(a, a.done, { silent: true, stateStore: store });
+    const runId = (await store.listRuns({}))[0].id;
+
+    // The record remembers a target this build has since deleted.
+    const loaded = await store.getRun(runId);
+    if (loaded === null) throw new Error("expected the suspended run");
+    const amended = structuredClone(loaded.record);
+    amended.graph.push({ name: "legacy", dependsOn: [] });
+    assertEquals((await store.putRun(amended, loaded.version)).ok, true);
+
+    const resumer = new Suspends();
+    discoverTargets(resumer);
+    const error = await assertRejects(
+      () =>
+        resumeRun(resumer, {
+          runId,
+          signal: "go",
+          stateStore: store,
+          silent: true,
+        }),
+      Error,
+      "graph changed",
+    );
+    assertEquals(messageOf(error).includes('removed "legacy"'), true);
+    // The refusal leaves the run suspended, so --force-graph can still resume it.
+    assertEquals((await store.getRun(runId))?.record.status, "suspended");
+  });
+});
+
+/** A store where the run vanishes the moment the resume's CAS conflicts. */
+class VanishesOnResume extends FileSystemStateStore {
+  #conflicted = false;
+  /** Conflict the first `running` write; the run is gone after that. */
+  override putRun(
+    record: RunRecord,
+    expected: string | null,
+  ): Promise<PutResult> {
+    if (record.status === "running" && !this.#conflicted) {
+      this.#conflicted = true;
+      return Promise.resolve({ ok: false, conflict: true });
+    }
+    return super.putRun(record, expected);
+  }
+  /** Pruned mid-resume: nothing to read back. */
+  override getRun(
+    id: string,
+  ): Promise<{ record: RunRecord; version: string } | null> {
+    if (this.#conflicted) return Promise.resolve(null);
+    return super.getRun(id);
+  }
+}
+
+Deno.test("a run that vanishes mid-resume is reported by name", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const makeBuild = () => {
+      class B extends Build {
+        gate = target().waitsFor((s) => s.on(externalSignal("go")));
+        done = target().dependsOn(this.gate).executes(() => {});
+      }
+      const build = new B();
+      discoverTargets(build);
+      return build;
+    };
+    // Suspend through a well-behaved store; only the resume sees the failure.
+    const seedStore = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    const a = makeBuild();
+    await execute(a, a.done, { silent: true, stateStore: seedStore });
+    const runId = (await seedStore.listRuns({}))[0].id;
+
+    const store = new VanishesOnResume(`${dir}/runs`, defaultStateHost);
+    await assertRejects(
+      () =>
+        resumeRun(makeBuild(), {
+          runId,
+          signal: "go",
+          stateStore: store,
+          silent: true,
+        }),
+      Error,
+      "vanished mid-resume",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+/** A store that never accepts the `running` transition. */
+class RefusesRunning extends FileSystemStateStore {
+  /** Conflict every `running` write. */
+  override putRun(
+    record: RunRecord,
+    expected: string | null,
+  ): Promise<PutResult> {
+    if (record.status === "running") {
+      return Promise.resolve({ ok: false, conflict: true });
+    }
+    return super.putRun(record, expected);
+  }
+}
+
+Deno.test("resumeRun surfaces a store that never accepts the transition", async () => {
+  // Bounded retries: a store outage produces a named error, not an infinite
+  // CAS loop — and the run stays suspended, so a later resume can retry.
+  const dir = await Deno.makeTempDir();
+  try {
+    const makeBuild = () => {
+      class B extends Build {
+        gate = target().waitsFor((s) => s.on(externalSignal("go")));
+        done = target().dependsOn(this.gate).executes(() => {});
+      }
+      const build = new B();
+      discoverTargets(build);
+      return build;
+    };
+    const seedStore = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    const a = makeBuild();
+    await execute(a, a.done, { silent: true, stateStore: seedStore });
+    const runId = (await seedStore.listRuns({}))[0].id;
+
+    const store = new RefusesRunning(`${dir}/runs`, defaultStateHost);
+    await assertRejects(
+      () =>
+        resumeRun(makeBuild(), {
+          runId,
+          signal: "go",
+          stateStore: store,
+          silent: true,
+        }),
+      Error,
+      "gave up resuming",
+    );
+    assertEquals((await seedStore.getRun(runId))?.record.status, "suspended");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("a throwing plugin does not break a timed-out resume", async () => {
+  // The timeout fast-path settles the run without execute()'s lifecycle, so
+  // it announces the terminal record to plugins itself — and a plugin is an
+  // observer whose throw must never change the outcome.
+  await withTempStore(async (store) => {
+    class B extends Build {
+      gate = target().waitsFor((s) => s.on(externalSignal("never")).timeout(0));
+      done = target().dependsOn(this.gate).executes(() => {});
+    }
+    const a = new B();
+    discoverTargets(a);
+    await execute(a, a.done, { silent: true, stateStore: store });
+    const runId = (await store.listRuns({}))[0].id;
+
+    const seen: string[] = [];
+    const resumer = new B();
+    discoverTargets(resumer);
+    const result = await resumeRun(resumer, {
+      runId,
+      stateStore: store,
+      silent: true,
+      plugins: [{
+        onRunStateChange: (record) => {
+          seen.push(record.status);
+          throw new Error("observer boom");
+        },
+      }],
+    });
+    // The timeout still failed the run; the observer's throw was swallowed.
+    assertEquals(result.ok, false);
+    assertEquals(messageOf(result.error).includes("timed out"), true);
+    assertEquals(seen, ["failed"]); // it did see the terminal transition
+    assertEquals((await store.getRun(runId))?.record.status, "failed");
+  });
+});
+
+/** A store where the timeout settlement's first write loses a race. */
+class ConflictsOnceOnFail extends FileSystemStateStore {
+  /** Whether the manufactured conflict has fired. */
+  conflicted = false;
+  /** Conflict the first `failed` write, then behave. */
+  override putRun(
+    record: RunRecord,
+    expected: string | null,
+  ): Promise<PutResult> {
+    if (record.status === "failed" && !this.conflicted) {
+      this.conflicted = true;
+      return Promise.resolve({ ok: false, conflict: true });
+    }
+    return super.putRun(record, expected);
+  }
+}
+
+Deno.test("a timeout settlement retries a conflicting write", async () => {
+  // Another writer (an audit append, a lock heartbeat) can land between the
+  // read and the settle. The settlement re-reads and retries rather than
+  // leaving the expired run suspended forever.
+  const dir = await Deno.makeTempDir();
+  try {
+    const makeBuild = () => {
+      class B extends Build {
+        gate = target().waitsFor((s) =>
+          s.on(externalSignal("never")).timeout(0)
+        );
+        done = target().dependsOn(this.gate).executes(() => {});
+      }
+      const build = new B();
+      discoverTargets(build);
+      return build;
+    };
+    const seedStore = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    const a = makeBuild();
+    await execute(a, a.done, { silent: true, stateStore: seedStore });
+    const runId = (await seedStore.listRuns({}))[0].id;
+
+    const store = new ConflictsOnceOnFail(`${dir}/runs`, defaultStateHost);
+    const result = await resumeRun(makeBuild(), {
+      runId,
+      stateStore: store,
+      silent: true,
+    });
+    assertEquals(result.ok, false);
+    assertEquals(store.conflicted, true); // the race really happened
+    // The retry landed: the run is failed, not stranded suspended.
+    assertEquals((await store.getRun(runId))?.record.status, "failed");
+    assertEquals(
+      (await store.getRun(runId))?.record.targets.gate.status,
+      "failed",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/packages/core/tests/resume_test.ts
+++ b/packages/core/tests/resume_test.ts
@@ -976,3 +976,135 @@ Deno.test("a timeout settlement retries a conflicting write", async () => {
     await Deno.remove(dir, { recursive: true });
   }
 });
+
+Deno.test("time parked at a gate is credited back to the run's deadline", async () => {
+  // A deadline is a budget for *running*: a 45-minute budget behind a 72-hour
+  // approval gate would otherwise be spent before anyone could approve, and
+  // the run settled the instant it woke up.
+  await withTempStore(async (store) => {
+    const makeBuild = () => {
+      class B extends Build {
+        gate = target().waitsFor((s) => s.on(externalSignal("go")));
+        done = target().dependsOn(this.gate).executes(() => {});
+      }
+      const build = new B();
+      discoverTargets(build);
+      return build;
+    };
+    const a = makeBuild();
+    await execute(a, a.done, { silent: true, stateStore: store });
+    const runId = (await store.listRuns({}))[0].id;
+
+    // The run has an hour of budget left, and has been parked for an hour:
+    // `updatedAt` is when it suspended.
+    const hourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const inAnHour = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const loaded = await store.getRun(runId);
+    if (loaded === null) throw new Error("expected the suspended run");
+    const amended = structuredClone(loaded.record);
+    amended.updatedAt = hourAgo;
+    amended.deadlineAt = inAnHour;
+    assertEquals((await store.putRun(amended, loaded.version)).ok, true);
+
+    const result = await resumeRun(makeBuild(), {
+      runId,
+      signal: "go",
+      stateStore: store,
+      silent: true,
+    });
+    assertEquals(result.ok, true);
+    const after = await store.getRun(runId);
+    const credited = Date.parse(after?.record.deadlineAt ?? "") -
+      Date.parse(inAnHour);
+    // The parked hour was given back (within scheduling slack).
+    assertEquals(credited >= 60 * 60 * 1000 - 1000, true);
+    assertEquals(credited < 2 * 60 * 60 * 1000, true);
+  });
+});
+
+/** A store where the run vanishes the moment the timeout settlement conflicts. */
+class VanishesOnFail extends FileSystemStateStore {
+  #conflicted = false;
+  /** Conflict the first `failed` write; the run is gone after that. */
+  override putRun(
+    record: RunRecord,
+    expected: string | null,
+  ): Promise<PutResult> {
+    if (record.status === "failed" && !this.#conflicted) {
+      this.#conflicted = true;
+      return Promise.resolve({ ok: false, conflict: true });
+    }
+    return super.putRun(record, expected);
+  }
+  /** Pruned mid-settlement: nothing to read back. */
+  override getRun(
+    id: string,
+  ): Promise<{ record: RunRecord; version: string } | null> {
+    if (this.#conflicted) return Promise.resolve(null);
+    return super.getRun(id);
+  }
+}
+
+Deno.test("a run that vanishes during the timeout settlement still fails cleanly", async () => {
+  // The settlement CAS conflicts and the re-read finds nothing: the record was
+  // pruned. There is nothing left to settle, but the caller still gets the
+  // timeout failure rather than a crash or a false success.
+  const dir = await Deno.makeTempDir();
+  try {
+    const makeBuild = () => {
+      class B extends Build {
+        gate = target().waitsFor((s) =>
+          s.on(externalSignal("never")).timeout(0)
+        );
+        done = target().dependsOn(this.gate).executes(() => {});
+      }
+      const build = new B();
+      discoverTargets(build);
+      return build;
+    };
+    const seedStore = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+    const a = makeBuild();
+    await execute(a, a.done, { silent: true, stateStore: seedStore });
+    const runId = (await seedStore.listRuns({}))[0].id;
+
+    const store = new VanishesOnFail(`${dir}/runs`, defaultStateHost);
+    const result = await resumeRun(makeBuild(), {
+      runId,
+      stateStore: store,
+      silent: true,
+    });
+    assertEquals(result.ok, false);
+    assertEquals(messageOf(result.error).includes("timed out"), true);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("resume --check counts a run that resumed and then failed", async () => {
+  // The sweep's exit code is what a cron watches: a run it advanced into a
+  // failure (here, a timed-out wait) must count, not just runs it could not
+  // touch at all.
+  await withTempStore(async (store) => {
+    const makeBuild = () => {
+      class B extends Build {
+        gate = target().waitsFor((s) =>
+          s.on(externalSignal("never")).timeout(0)
+        );
+        done = target().dependsOn(this.gate).executes(() => {});
+      }
+      const build = new B();
+      discoverTargets(build);
+      return build;
+    };
+    const a = makeBuild();
+    await execute(a, a.done, { silent: true, stateStore: store });
+
+    const swept = await resumeCheck(makeBuild(), {
+      stateStore: store,
+      silent: true,
+    });
+    assertEquals(swept, { checked: 1, failed: 1 });
+    const runId = (await store.listRuns({}))[0].id;
+    assertEquals((await store.getRun(runId))?.record.status, "failed");
+  });
+});

--- a/packages/core/tests/scheduler_test.ts
+++ b/packages/core/tests/scheduler_test.ts
@@ -507,3 +507,35 @@ Deno.test("a dry-runnable target runs its body in preview; a failure is reported
   assertEquals(run.aborted, true);
   assertEquals(messageOf(run.failure), "preview boom");
 });
+
+Deno.test("a store-less run still reports outcomes and holds state in memory", async () => {
+  // Without a state store there is no record to fall back to; the live
+  // settlement map alone must answer `ctx.outcomes()`, and `ctx.stateOf(...)`
+  // hands out in-memory handles so bodies written for durable runs still work.
+  let observed: ReadonlyMap<string, TargetOutcomeView> | undefined;
+  let otherMeta: unknown;
+  let ownHandleIsStable = false;
+  class B extends Build {
+    first = target().executes(() => {});
+    second = target().dependsOn(this.first).executes(async (ctx) => {
+      observed = ctx.outcomes();
+      const other = ctx.stateOf("first");
+      await other.set({ note: "in-memory" });
+      otherMeta = other.get().note;
+      // The documented invariant: stateOf(self) is the same handle as state.
+      ownHandleIsStable = ctx.stateOf("second") === ctx.state;
+    });
+  }
+  const b = new B();
+  discoverTargets(b);
+  const { ctx } = contextFor(b); // no writer
+
+  const run = await runSequential(ctx, [b.first, b.second], new Set());
+  assertEquals(run.aborted, false);
+  // The earlier target's settlement is visible from the live map alone.
+  assertEquals(observed?.get("first")?.status, "succeeded");
+  assertEquals(observed?.has("second"), false); // still running, no outcome
+  // In-memory state writes are readable back within the same handle.
+  assertEquals(otherMeta, "in-memory");
+  assertEquals(ownHandleIsStable, true);
+});

--- a/packages/core/tests/scheduler_test.ts
+++ b/packages/core/tests/scheduler_test.ts
@@ -383,3 +383,127 @@ Deno.test("teardown stranded behind a parked gate settles skipped when the run f
     assertEquals(loaded?.record.targets.boom?.status, "failed");
   });
 });
+
+Deno.test("a re-driven effect settles done and knows it is a second attempt", async () => {
+  // The at-least-once half: a previously failed effect is re-armed, its body
+  // told it is being re-driven (so it can favour idempotent variants), and a
+  // completed attempt is durably `done` for the next process to skip.
+  await withTempStore(async (store) => {
+    const drives: boolean[] = [];
+    let effectName: string | undefined;
+    class B extends Build {
+      notify = target().effect("announce", (ctx) => {
+        drives.push(ctx.redriven);
+        effectName = ctx.effect;
+      });
+    }
+    const b = new B();
+    discoverTargets(b);
+    const writer = await RunStateWriter.open(
+      store,
+      runningRecord("notify", "B", {
+        notify: {
+          status: "pending",
+          meta: {},
+          // A previous process armed the intent and recorded the failure.
+          effects: {
+            announce: {
+              status: "failed",
+              intentAt: NOW,
+              settledAt: NOW,
+              attempts: 1,
+              error: "first try boom",
+            },
+          },
+        },
+      }),
+      () => NOW,
+      new Redactor(),
+    );
+    const { ctx } = contextFor(b, writer);
+
+    const run = await runSequential(ctx, [b.notify], new Set());
+    await writer.drain();
+    assertEquals(run.aborted, false);
+    assertEquals(drives, [true]); // the body knew it was a re-drive
+    assertEquals(effectName, "announce");
+    const after = await store.getRun("run-1");
+    assertEquals(
+      after?.record.targets.notify?.effects?.announce?.status,
+      "done",
+    );
+    assertEquals(after?.record.targets.notify?.effects?.announce?.attempts, 2);
+    // A settled success clears the recorded failure.
+    assertEquals(
+      after?.record.targets.notify?.effects?.announce?.error,
+      undefined,
+    );
+  });
+});
+
+Deno.test("outcomeOf falls back to a record row this process never settled", async () => {
+  // The concurrent-writer shape: the snapshot can hold a settled row this
+  // process never ran (a conflicting write re-read adopts the fresh record).
+  // `outcomeOf` must answer from the record then — and still say nothing for a
+  // row that has no outcome yet.
+  await withTempStore(async (store) => {
+    let observed: TargetOutcomeView | undefined;
+    let all: ReadonlyMap<string, TargetOutcomeView> | undefined;
+    class B extends Build {
+      report = target().executes((ctx) => {
+        observed = ctx.outcomeOf("external");
+        all = ctx.outcomes();
+      });
+    }
+    const b = new B();
+    discoverTargets(b);
+    const writer = await RunStateWriter.open(
+      store,
+      runningRecord("report", "B", {
+        // Settled by another process; this one holds no live entry for it.
+        external: { status: "succeeded", meta: {} },
+        // No outcome yet — must stay invisible.
+        queued: { status: "pending", meta: {} },
+      }),
+      () => NOW,
+      new Redactor(),
+    );
+    const { ctx } = contextFor(b, writer);
+
+    const run = await runSequential(ctx, [b.report], new Set());
+    assertEquals(run.aborted, false);
+    assertEquals(observed?.status, "succeeded"); // read from the record
+    assertEquals(all?.get("external")?.status, "succeeded");
+    assertEquals(all?.has("queued"), false); // pending rows have no outcome
+  });
+});
+
+Deno.test("a dry-runnable target runs its body in preview; a failure is reported", async () => {
+  // `.dryRunnable()` opts a target into executing under --dry-run (with `$` in
+  // echo mode) so the operator previews the real commands; a preview body that
+  // throws must surface as a failed target, exactly like a real run.
+  class B extends Build {
+    preview = target().dryRunnable().executes((ctx) => {
+      ran.push(`preview:${ctx.dryRun}`);
+    });
+    boom = target().dryRunnable().executes(() => {
+      throw new Error("preview boom");
+    });
+    plain = target().executes(() => {
+      ran.push("plain");
+    });
+  }
+  const ran: string[] = [];
+  const b = new B();
+  discoverTargets(b);
+  const { ctx } = contextFor(b);
+  const dry: RunContext = { ...ctx, dryRun: true };
+
+  const run = await runSequential(dry, [b.preview, b.boom, b.plain], new Set());
+  // The dry-runnable body really ran, and knew it was a dry run…
+  assertEquals(ran, ["preview:true"]);
+  // …the throwing preview failed the run, and the plain target's body was
+  // never executed (an ordinary target is only reported under --dry-run).
+  assertEquals(run.aborted, true);
+  assertEquals(messageOf(run.failure), "preview boom");
+});

--- a/packages/core/tests/scheduler_test.ts
+++ b/packages/core/tests/scheduler_test.ts
@@ -1,0 +1,385 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Unit tests for the scheduler's effect driving and outcome visibility — the
+ * guard that refuses an effect with nowhere to record its intent, the skip that
+ * makes re-driving a completed effect free, the rule that a bookkeeping failure
+ * never masks the effect's own error, what a resumed body can read of an
+ * earlier process's outcomes, and how a run that both parked and failed settles
+ * every row terminally (F8).
+ *
+ * @module
+ */
+
+import { assertEquals, messageOf } from "./_assert.ts";
+import { Build, discoverTargets } from "../src/build.ts";
+import { target, type TargetOutcomeView } from "../src/target.ts";
+import { type RunContext, runSequential } from "../src/scheduler.ts";
+import { makeLifecycle } from "../src/lifecycle.ts";
+import { defaultRenderer } from "../src/renderer.ts";
+import { ServiceRegistry } from "../src/service.ts";
+import { Redactor } from "../src/redact.ts";
+import { RunStateWriter } from "../src/state/writer.ts";
+import { FileSystemStateStore } from "../src/state/fs_store.ts";
+import { defaultStateHost, type PutResult } from "../src/state/store.ts";
+import type { RunEnv } from "../src/run_support.ts";
+import type { RunRecord } from "../src/state/types.ts";
+import { execute } from "../src/executor.ts";
+import { resumeRun } from "../src/resume.ts";
+import { externalSignal } from "../src/wait.ts";
+
+const NOW = "2026-08-10T12:00:00.000Z";
+
+/** A {@link RunContext} over `build`, capturing every reported line. */
+function contextFor(
+  build: Build,
+  writer?: RunStateWriter,
+): { ctx: RunContext; lines: string[] } {
+  const lines: string[] = [];
+  const env: RunEnv = {
+    runId: "run-1",
+    signal: new AbortController().signal,
+    actor: "tester",
+    signals: new Map(),
+    statuses: new Map(),
+    ...(writer === undefined ? {} : { writer }),
+  };
+  return {
+    ctx: {
+      life: makeLifecycle(
+        build,
+        [],
+        { runId: "run-1", dryRun: false },
+        () => {},
+      ),
+      reporter: { info: (l) => lines.push(l), error: (l) => lines.push(l) },
+      renderer: defaultRenderer,
+      style: { github: false, color: false, width: 60 },
+      cache: undefined,
+      dryRun: false,
+      globalRecovery: [],
+      services: new ServiceRegistry(),
+      env,
+    },
+    lines,
+  };
+}
+
+/** A `running` record rooted at `root` with the given target rows. */
+function runningRecord(
+  root: string,
+  build: string,
+  targets: RunRecord["targets"],
+): RunRecord {
+  return {
+    id: "run-1",
+    build,
+    rootTarget: root,
+    status: "running",
+    actor: "tester",
+    createdAt: NOW,
+    updatedAt: NOW,
+    graph: [{ name: root, dependsOn: [] }],
+    params: {},
+    targets,
+    signals: {},
+    events: [],
+  };
+}
+
+/** Run `fn` with a temp filesystem store, cleaned up afterwards. */
+async function withTempStore(
+  fn: (store: FileSystemStateStore, dir: string) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir();
+  try {
+    await fn(new FileSystemStateStore(`${dir}/runs`, defaultStateHost), dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+}
+
+/** A store whose next put can be made to fail, for the settle-write path. */
+class FailsPut extends FileSystemStateStore {
+  /** Reject the next `putRun` with a store error. */
+  failNextPut = false;
+  /** Persist normally unless armed to fail. */
+  override putRun(
+    record: RunRecord,
+    expected: string | null,
+  ): Promise<PutResult> {
+    if (this.failNextPut) {
+      this.failNextPut = false;
+      return Promise.reject(new Error("store down"));
+    }
+    return super.putRun(record, expected);
+  }
+}
+
+Deno.test("an effect with no state store fails the target before its body runs", async () => {
+  // The fail-closed half of durable effects: with nowhere to record the
+  // intent, running the body would perform a side effect nothing knows was
+  // owed. execute() refuses such a run up front; this is the scheduler's own
+  // backstop for a context assembled without a writer.
+  let ran = false;
+  class B extends Build {
+    notify = target().effect("announce", () => {
+      ran = true;
+    });
+  }
+  const b = new B();
+  discoverTargets(b);
+  const { ctx } = contextFor(b);
+
+  const run = await runSequential(ctx, [b.notify], new Set());
+  assertEquals(run.aborted, true);
+  assertEquals(ran, false); // no durable intent, no side effect
+  assertEquals(
+    messageOf(run.failure).includes(
+      "needs a state store to record its intent",
+    ),
+    true,
+  );
+});
+
+Deno.test("a re-driven target skips an effect already recorded done", async () => {
+  // The no-op that makes re-driving free: a process died after the effect
+  // settled `done` but before the target did, so a resume runs the target
+  // again — and must not repeat the effect (it is at-least-once, not twice).
+  await withTempStore(async (store) => {
+    let ran = 0;
+    class B extends Build {
+      notify = target().effect("announce", () => {
+        ran += 1;
+      });
+    }
+    const b = new B();
+    discoverTargets(b);
+    const writer = await RunStateWriter.open(
+      store,
+      runningRecord("notify", "B", {
+        notify: {
+          status: "pending",
+          meta: {},
+          effects: {
+            announce: {
+              status: "done",
+              intentAt: NOW,
+              settledAt: NOW,
+              attempts: 1,
+            },
+          },
+        },
+      }),
+      () => NOW,
+      new Redactor(),
+    );
+    const { ctx } = contextFor(b, writer);
+
+    const run = await runSequential(ctx, [b.notify], new Set());
+    await writer.drain();
+    assertEquals(run.aborted, false);
+    assertEquals(ran, 0); // the completed effect was not repeated
+    const after = await store.getRun("run-1");
+    assertEquals(after?.record.targets.notify?.status, "succeeded");
+    // The row is untouched: still one attempt, still done.
+    assertEquals(after?.record.targets.notify?.effects?.announce?.attempts, 1);
+    assertEquals(
+      after?.record.targets.notify?.effects?.announce?.status,
+      "done",
+    );
+  });
+});
+
+Deno.test("a failed settle write never masks the effect's own failure", async () => {
+  // The incident-report rule: when recording an effect's failure fails too,
+  // the caller must still see the API error that actually happened — the
+  // bookkeeping failure is reported alongside, never in its place.
+  const dir = await Deno.makeTempDir();
+  try {
+    const store = new FailsPut(`${dir}/runs`, defaultStateHost);
+    class B extends Build {
+      deploy = target().effect("announce", () => {
+        store.failNextPut = true; // the settle write that follows will fail
+        throw new Error("deploy API boom");
+      });
+    }
+    const b = new B();
+    discoverTargets(b);
+    const writer = await RunStateWriter.open(
+      store,
+      runningRecord("deploy", "B", {
+        deploy: { status: "pending", meta: {} },
+      }),
+      () => NOW,
+      new Redactor(),
+    );
+    const { ctx, lines } = contextFor(b, writer);
+
+    const run = await runSequential(ctx, [b.deploy], new Set());
+    await writer.drain();
+    assertEquals(run.aborted, true);
+    // The original failure is the run's failure…
+    assertEquals(messageOf(run.failure), "deploy API boom");
+    // …and the lost bookkeeping is narrated, naming both errors.
+    assertEquals(
+      lines.some((l) =>
+        l.includes("recording that failed too") && l.includes("store down")
+      ),
+      true,
+    );
+    // The settle write really was lost: the intent is still armed, so a later
+    // resume re-drives the effect rather than trusting a phantom settlement.
+    const after = await store.getRun("run-1");
+    assertEquals(
+      after?.record.targets.deploy?.effects?.announce?.status,
+      "pending",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("a resumed body reads outcomes another process settled", async () => {
+  // A resume is a fresh process: its in-memory settlement map starts empty, so
+  // `ctx.outcomeOf`/`ctx.outcomes` must fall back to the durable record for
+  // targets an earlier process ran — and still omit rows with no outcome yet.
+  await withTempStore(async (store) => {
+    let fromRecord: TargetOutcomeView | undefined;
+    let missing: TargetOutcomeView | undefined;
+    let all: ReadonlyMap<string, TargetOutcomeView> | undefined;
+    const makeBuild = () => {
+      class CD extends Build {
+        deploy = target().executes(() => {});
+        gate = target()
+          .dependsOn(this.deploy)
+          .waitsFor((s) => s.on(externalSignal("go")));
+        verify = target().dependsOn(this.gate).executes(async (ctx) => {
+          // Write state for a target that has not run yet, so the record holds
+          // a `pending` row — which must not appear as an outcome.
+          await ctx.stateOf("finish").set({ planned: true });
+          fromRecord = ctx.outcomeOf("deploy");
+          missing = ctx.outcomeOf("ghost");
+          all = ctx.outcomes();
+        });
+        finish = target().dependsOn(this.verify).executes(() => {});
+      }
+      const build = new CD();
+      discoverTargets(build);
+      return build;
+    };
+    const a = makeBuild();
+    const first = await execute(a, a.finish, {
+      silent: true,
+      stateStore: store,
+    });
+    assertEquals(first.suspended, true);
+    const runId = (await store.listRuns({}))[0].id;
+
+    const resumed = await resumeRun(makeBuild(), {
+      runId,
+      signal: "go",
+      stateStore: store,
+      silent: true,
+    });
+    assertEquals(resumed.ok, true);
+    // deploy settled in the *previous* process — visible only via the record.
+    assertEquals(fromRecord?.status, "succeeded");
+    // A target with no row at all has no outcome.
+    assertEquals(missing, undefined);
+    // The aggregate view merges the record (deploy) with this process (gate)…
+    assertEquals(all?.get("deploy")?.status, "succeeded");
+    assertEquals(all?.get("gate")?.status, "succeeded");
+    // …and omits the pending row: a target that has not run has no outcome.
+    assertEquals(all?.has("finish"), false);
+  });
+});
+
+Deno.test("a satisfied gate whose effect fails fails the target, not silently", async () => {
+  // A `.waitsFor(...)` gate that opens is the target's real run, so its
+  // effects are owed at that moment — and an effect that throws must fail the
+  // gate rather than letting the run report success over a dropped effect.
+  await withTempStore(async (store) => {
+    let effectTried = 0;
+    const makeBuild = () => {
+      class B extends Build {
+        gate = target()
+          .waitsFor((s) => s.on(externalSignal("go")))
+          .effect("announce", () => {
+            effectTried += 1;
+            throw new Error("announce boom");
+          });
+        done = target().dependsOn(this.gate).executes(() => {});
+      }
+      const build = new B();
+      discoverTargets(build);
+      return build;
+    };
+    const a = makeBuild();
+    const first = await execute(a, a.done, { silent: true, stateStore: store });
+    assertEquals(first.suspended, true);
+    assertEquals(effectTried, 0); // a parked gate owes nothing yet
+    const runId = (await store.listRuns({}))[0].id;
+
+    const resumed = await resumeRun(makeBuild(), {
+      runId,
+      signal: "go",
+      stateStore: store,
+      silent: true,
+    });
+    assertEquals(resumed.ok, false);
+    assertEquals(messageOf(resumed.error).includes("announce boom"), true);
+    assertEquals(effectTried, 1);
+    const loaded = await store.getRun(runId);
+    assertEquals(loaded?.record.status, "failed");
+    assertEquals(loaded?.record.targets.gate?.status, "failed");
+    // The failed effect is recorded, so a later attempt re-arms it.
+    assertEquals(
+      loaded?.record.targets.gate?.effects?.announce?.status,
+      "failed",
+    );
+  });
+});
+
+Deno.test("teardown stranded behind a parked gate settles skipped when the run fails", async () => {
+  // A run that both parked a wait and failed will never resume, so nothing
+  // behind the gate can ever run — including an `always` teardown waiting for
+  // the gate to settle. The gate parked *before* the failure, so it was never
+  // abandoned and never settles; the teardown behind it can never become
+  // ready, and the final sweep must settle it terminally: a `pending` row
+  // inside a terminal `failed` record would sit in `runs show` and the resume
+  // sweep forever (F8).
+  await withTempStore(async (store) => {
+    let toreDown = false;
+    class B extends Build {
+      gate = target().waitsFor((s) => s.on(externalSignal("never")));
+      teardown = target().always().dependsOn(this.gate).executes(() => {
+        toreDown = true;
+      });
+      boom = target().executes(() => {
+        throw new Error("boom");
+      });
+      // Declared so the plan runs the gate first: it parks, *then* boom fails.
+      all = target()
+        .dependsOn(this.boom, this.teardown)
+        .executes(() => {});
+    }
+    const b = new B();
+    discoverTargets(b);
+
+    const result = await execute(b, b.all, { silent: true, stateStore: store });
+    // Failed, not suspended: a failure outranks the parked gate.
+    assertEquals(result.ok, false);
+    assertEquals(messageOf(result.error), "boom");
+
+    const runId = (await store.listRuns({}))[0].id;
+    const loaded = await store.getRun(runId);
+    assertEquals(loaded?.record.status, "failed");
+    // Every row is terminal — the never-launched teardown included.
+    assertEquals(toreDown, false); // its gate never opened, so it never ran
+    assertEquals(loaded?.record.targets.teardown?.status, "skipped");
+    assertEquals(loaded?.record.targets.gate?.status, "skipped");
+    assertEquals(loaded?.record.targets.boom?.status, "failed");
+  });
+});

--- a/packages/core/tests/state_test.ts
+++ b/packages/core/tests/state_test.ts
@@ -1706,7 +1706,7 @@ Deno.test("HttpStateStore drains response bodies a server sends on every path", 
 
   const putOk = new HttpStateStore({
     url: "https://s",
-    fetch: fakeFetch((url, init) =>
+    fetch: fakeFetch((_url, init) =>
       (init?.method ?? "GET") === "PUT"
         ? bodied(200, { etag: "v9" })
         : bodied(200)

--- a/packages/core/tests/state_test.ts
+++ b/packages/core/tests/state_test.ts
@@ -12,6 +12,7 @@ import {
   parseRunSummary,
   type RunRecord,
   stringifyRunRecord,
+  toJsonValue,
   toSummary,
 } from "../src/state/types.ts";
 import {
@@ -25,6 +26,7 @@ import { envStateStore, resolveStateStore } from "../src/state/resolve.ts";
 import { HttpError } from "../src/http.ts";
 import {
   buildRunRecord,
+  ciRunUrl,
   recordStatusOf,
   resolveActor,
 } from "../src/state/record.ts";
@@ -1461,4 +1463,284 @@ Deno.test("deleting a run leaves its lock records alone", async () => {
   } finally {
     await Deno.remove(dir, { recursive: true });
   }
+});
+
+// ------------------------------------------------- types: malformed branches
+
+Deno.test("parseRunRecord rejects malformed optional and nested fields", () => {
+  const cases: Array<[string, string]> = [
+    // An optional string field present with the wrong type.
+    [
+      JSON.stringify({ ...sampleRecord(), buildId: 5 }),
+      'field "buildId" is not a string',
+    ],
+    [
+      JSON.stringify({
+        ...sampleRecord(),
+        targets: { a: { status: "pending", meta: {}, effects: "x" } },
+      }),
+      "effects is not an object",
+    ],
+    [
+      JSON.stringify({
+        ...sampleRecord(),
+        targets: { a: { status: "pending", meta: {}, effects: { e: 5 } } },
+      }),
+      "effect state is not an object",
+    ],
+    [
+      JSON.stringify({
+        ...sampleRecord(),
+        targets: {
+          a: {
+            status: "pending",
+            meta: {},
+            effects: { e: { status: "weird", intentAt: "t", attempts: 1 } },
+          },
+        },
+      }),
+      'unknown effect status "weird"',
+    ],
+    [
+      JSON.stringify({
+        ...sampleRecord(),
+        targets: {
+          a: {
+            status: "pending",
+            meta: {},
+            effects: { e: { status: "pending", intentAt: "t", attempts: 0 } },
+          },
+        },
+      }),
+      "effect attempts is not a positive integer",
+    ],
+    [
+      JSON.stringify({
+        ...sampleRecord(),
+        targets: { a: { status: "waiting", meta: {}, waitingFor: "x" } },
+      }),
+      "waitingFor is not an object",
+    ],
+    [
+      JSON.stringify({ ...sampleRecord(), events: "x" }),
+      '"events" is not an array',
+    ],
+    [
+      JSON.stringify({ ...sampleRecord(), events: [5] }),
+      "run event is not an object",
+    ],
+    [
+      JSON.stringify({
+        ...sampleRecord(),
+        events: [{ at: "t", tool: "x", actor: "a", outcome: "weird" }],
+      }),
+      'unknown run event outcome "weird"',
+    ],
+    [
+      JSON.stringify({ ...sampleRecord(), signals: { s: 5 } }),
+      "signal record is not an object",
+    ],
+    [
+      JSON.stringify({ ...sampleRecord(), intendedTerminal: "weird" }),
+      'unknown intended terminal status "weird"',
+    ],
+  ];
+  for (const [text, needle] of cases) {
+    assertThrows(() => parseRunRecord(text), Error, needle);
+  }
+});
+
+Deno.test("parseRunRecord defaults an absent target meta and signal data", () => {
+  const parsed = parseRunRecord(JSON.stringify({
+    ...sampleRecord(),
+    // A target state written without a `meta` key still parses (empty meta),
+    // and a signal without `data` reads back as a null payload.
+    targets: { a: { status: "pending" } },
+    signals: { approved: { receivedAt: "2026-07-17T10:00:00.000Z" } },
+  }));
+  assertEquals(parsed.targets.a, { status: "pending", meta: {} });
+  assertEquals(parsed.signals.approved, {
+    data: null,
+    receivedAt: "2026-07-17T10:00:00.000Z",
+  });
+});
+
+Deno.test("parseRunRecord round-trips effects, events, and terminal intent", () => {
+  const record = sampleRecord({
+    status: "cancelling",
+    buildId: "org/app",
+    deadlineAt: "2026-07-18T10:00:00.000Z",
+    intendedTerminal: "failed",
+    targets: {
+      deploy: {
+        status: "failed",
+        meta: {},
+        error: "boom",
+        effects: {
+          notify: {
+            status: "failed",
+            intentAt: "2026-07-17T10:00:01.000Z",
+            settledAt: "2026-07-17T10:00:02.000Z",
+            error: "smtp down",
+            attempts: 2,
+          },
+          record: {
+            status: "pending",
+            intentAt: "2026-07-17T10:00:03.000Z",
+            attempts: 1,
+          },
+        },
+      },
+    },
+    events: [{
+      at: "2026-07-17T10:00:04.000Z",
+      tool: "signal_run",
+      actor: "mcp:client",
+      outcome: "denied",
+      args: { name: "approved" },
+      detail: "actor not allowed",
+    }],
+  });
+  assertEquals(parseRunRecord(stringifyRunRecord(record)), record);
+});
+
+Deno.test("toJsonValue passes JSON through and rejects a non-JSON value", () => {
+  assertEquals(toJsonValue({ a: [1, "x", true, null], b: { c: 2 } }), {
+    a: [1, "x", true, null],
+    b: { c: 2 },
+  });
+  // A value JSON cannot represent must be named, not silently dropped.
+  assertThrows(
+    () => toJsonValue(undefined),
+    Error,
+    'value of type "undefined" is not JSON',
+  );
+  assertThrows(
+    () => toJsonValue(() => 1),
+    Error,
+    'value of type "function" is not JSON',
+  );
+});
+
+// ------------------------------------------------- record: mapping branches
+
+Deno.test("recordStatusOf maps a waiting target onto the record vocabulary", () => {
+  assertEquals(recordStatusOf("waiting"), "waiting");
+});
+
+Deno.test("ciRunUrl derives the GitHub Actions run URL only when fully set", () => {
+  const full: Record<string, string> = {
+    GITHUB_SERVER_URL: "https://github.com",
+    GITHUB_REPOSITORY: "o/r",
+    GITHUB_RUN_ID: "123",
+  };
+  assertEquals(
+    ciRunUrl((n) => full[n]),
+    "https://github.com/o/r/actions/runs/123",
+  );
+  // Any missing piece means no URL — a partial one would link nowhere.
+  for (const missing of Object.keys(full)) {
+    const partial = { ...full };
+    delete partial[missing];
+    assertEquals(ciRunUrl((n) => partial[n]), undefined);
+  }
+});
+
+Deno.test("buildRunRecord tolerates an unnamed target and stamps optional fields", () => {
+  // A builder that never went through discoverTargets has no name; the record
+  // still forms (empty name) instead of crashing mid-run.
+  const anonymous = target().executes(() => {});
+  const record = buildRunRecord({
+    runId: "run-y",
+    build: "B",
+    buildId: "org/app",
+    rootTarget: "work",
+    actor: "alice",
+    now: "2026-07-17T10:00:00.000Z",
+    order: [anonymous],
+    params: [],
+    deadlineAt: "2026-07-18T10:00:00.000Z",
+  });
+  assertEquals(record.graph, [{ name: "", dependsOn: [] }]);
+  assertEquals(record.targets, { "": { status: "pending", meta: {} } });
+  assertEquals(record.buildId, "org/app");
+  assertEquals(record.deadlineAt, "2026-07-18T10:00:00.000Z");
+});
+
+// ------------------------------------------------- host: real error paths
+
+Deno.test("defaultStateHost surfaces non-NotFound filesystem errors", async () => {
+  // A genuine I/O failure must propagate, never be masked as "missing".
+  const dir = await Deno.makeTempDir();
+  try {
+    const host = defaultStateHost;
+    // Reading a directory as a file is not a miss.
+    await assertRejects(() => host.readText(dir));
+    // An exclusive create in a missing parent is not "already exists".
+    await assertRejects(() => host.createExclusive(`${dir}/missing/x.lock`));
+    // Removing a non-empty directory is a real error, not a missing file.
+    await Deno.mkdir(`${dir}/full`);
+    await Deno.writeTextFile(`${dir}/full/a.txt`, "x");
+    await assertRejects(() => host.remove(`${dir}/full`));
+    // Listing a regular file is not an absent directory.
+    await assertRejects(() => host.listDir(`${dir}/full/a.txt`));
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+// ------------------------------------------------- http store: bodied errors
+
+Deno.test("HttpStateStore drains response bodies a server sends on every path", async () => {
+  // Real servers attach error pages (and empty-object bodies) to statuses the
+  // client discards; each path must drain them and keep its behaviour.
+  const bodied = (status: number, headers?: Record<string, string>) =>
+    new Response(`{"note":"body for ${status}"}`, { status, headers });
+
+  const missing = new HttpStateStore({
+    url: "https://s",
+    fetch: fakeFetch(() => bodied(404)),
+  });
+  assertEquals(await missing.getRun("r"), null); // bodied 404 is still a miss
+  await missing.deleteRun("r"); // bodied 404 on delete is still a no-op
+
+  const putOk = new HttpStateStore({
+    url: "https://s",
+    fetch: fakeFetch((url, init) =>
+      (init?.method ?? "GET") === "PUT"
+        ? bodied(200, { etag: "v9" })
+        : bodied(200)
+    ),
+  });
+  assertEquals(await putOk.putRun(sampleRecord(), "v1"), {
+    ok: true,
+    version: "v9",
+  });
+  assertEquals(await putOk.renewLock("k", "t", 1000), true);
+  await putOk.releaseLock("k", "t");
+  await putOk.deleteRun("r");
+
+  const stale = new HttpStateStore({
+    url: "https://s",
+    fetch: fakeFetch(() => bodied(412)),
+  });
+  assertEquals(await stale.putRun(sampleRecord(), "old"), {
+    ok: false,
+    conflict: true,
+  });
+
+  const boom = new HttpStateStore({
+    url: "https://s",
+    fetch: fakeFetch(() => bodied(500)),
+  });
+  await assertRejects(() => boom.getRun("r"), HttpError);
+  await assertRejects(() => boom.putRun(sampleRecord(), "v"), HttpError);
+  await assertRejects(() => boom.listRuns({}), HttpError);
+  await assertRejects(() => boom.deleteRun("r"), HttpError);
+  await assertRejects(
+    () => boom.acquireLock("k", { actor: "a", runId: "r", since: "t" }, 1000),
+    HttpError,
+  );
+  await assertRejects(() => boom.renewLock("k", "t", 1000), HttpError);
+  await assertRejects(() => boom.releaseLock("k", "t"), HttpError);
 });

--- a/packages/gh/README.md
+++ b/packages/gh/README.md
@@ -191,6 +191,9 @@ function readWorkflowResult(state: TargetStateHandle): WorkflowResult | undefine
 async function tagCommit(configure?: (settings: GhTagSettings) => GhTagSettings): Promise<void>
   Perform the configured tag.
 
+async function uploadReleaseAsset(configure?: Configure<GhReleaseAssetSettings>): Promise<GhReleaseAssetResult>
+  Upload the release asset the settings describe.
+
 async function uploadSarifReport(configure?: Configure<GhSarifSettings>): Promise<GhSarifUploadResult>
   Upload the SARIF report the settings describe.
 
@@ -434,6 +437,52 @@ class GhPullRequestSettings
     The effective `owner/repo`, from the setting or the environment.
   authToken_(): string
     The effective token, from the setting or the environment.
+
+class GhReleaseAssetSettings
+  Settings for {@link GhReleaseAssetApi.uploadReleaseAsset}.
+
+  file_?: string
+    The file to upload. Set by {@link file}.
+  name_?: string
+    The asset name on the release. Set by {@link name}.
+  contentType_?: string
+    The asset's `content-type`. Set by {@link contentType}.
+  repo_?: string
+    `owner/repo` to upload to. Set by {@link repo}.
+  tag_?: string
+    The release tag to attach to. Set by {@link tag}.
+  token_?: string
+    The token to authenticate with. Set by {@link token}.
+  baseUrl_: string
+    REST base URL. Set by {@link baseUrl}.
+  fetch_: typeof fetch
+    The `fetch` implementation. Set by {@link fetch}.
+  file(path: PathLike): this
+    The file to upload (required).
+  name(value: string): this
+    The asset's name on the release. Defaults to the file's base name.
+  contentType(value: string): this
+    The asset's `content-type`. Defaults by extension (`.tar.gz`/`.tgz`,
+    `.zip`, `.json`), then to `application/octet-stream`.
+  repo(slug: string): this
+    The `owner/repo` to upload to. Defaults to `GITHUB_REPOSITORY`.
+  tag(value: string): this
+    Attach to the release with this tag instead of the latest release.
+  token(value: string): this
+    The token to authenticate with — needs `contents: write`. Defaults to
+    `GITHUB_TOKEN` in the environment, so it never has to reach argv.
+  baseUrl(url: string): this
+    Use a different REST base (GitHub Enterprise Server).
+  fetch(fn: typeof fetch): this
+    Override the `fetch` implementation (a test seam).
+  repoSlug_(): string
+    The effective `owner/repo`, from the setting or the Actions environment.
+  filePath_(): string
+    The file to upload, or a friendly error naming the missing setting.
+  assetName_(): string
+    The effective asset name: the setting, or the file's base name.
+  effectiveContentType_(): string
+    The effective `content-type`: the setting, or inferred by extension.
 
 class GhSarifSettings
   Settings for {@link GhSarifApi.uploadSarif}.
@@ -690,6 +739,32 @@ interface GhPullRequestResult
     different things to a human reading a build log, even though neither is a
     failure.
 
+interface GhReleaseAssetApi
+  The shape of the release-asset task, mixed into `GhTasks`.
+
+  uploadReleaseAsset(configure?: Configure<GhReleaseAssetSettings>): Promise<GhReleaseAssetResult>
+    Attach a file to a GitHub release — the latest release by default, or the
+    one named by `.tag(...)`. Idempotent: an asset the release already
+    carries under the same name is kept as-is, and a repository with no
+    releases resolves to `state: "no-release"` rather than throwing. Needs a
+    token with `contents: write`.
+
+interface GhReleaseAssetResult
+  What became of a release-asset upload.
+
+  state: "uploaded" | "already-exists" | "no-release"
+    `uploaded` when the asset was sent; `already-exists` when the release
+    carries an asset of the same name (nothing was changed); `no-release`
+    when the repository has no release to attach to.
+  name: string
+    The asset name the call targeted.
+  releaseTag?: string
+    The tag of the release the asset belongs to, when one was resolved.
+  releaseId?: number
+    The id of the release the asset belongs to, when one was resolved.
+  url?: string
+    The asset's download URL, when it was uploaded or already present.
+
 interface GhSarifApi
   The shape of the SARIF task, mixed into `GhTasks`.
 
@@ -705,7 +780,7 @@ interface GhSarifUploadResult
   url: string
     The URL that reports whether GitHub finished processing the report.
 
-interface GhTasksApi extends GhAppTokenApi, GhSarifApi, GhCommitApi, GhPullRequestApi, GhCheckRunApi
+interface GhTasksApi extends GhAppTokenApi, GhSarifApi, GhReleaseAssetApi, GhCommitApi, GhPullRequestApi, GhCheckRunApi
   The shape of {@link GhTasks}: the `gh` CLI plus the GitHub operations that
   have no CLI subcommand (see {@link GhAppTokenApi}, {@link GhSarifApi}) and
   would otherwise force a build back to a marketplace action.

--- a/packages/gh/mod.ts
+++ b/packages/gh/mod.ts
@@ -52,6 +52,12 @@ export {
   uploadSarifReport,
 } from "./src/sarif.ts";
 export {
+  type GhReleaseAssetApi,
+  type GhReleaseAssetResult,
+  GhReleaseAssetSettings,
+  uploadReleaseAsset,
+} from "./src/release_asset.ts";
+export {
   type CorrelateMode,
   githubWorkflow,
   GithubWorkflowSettings,

--- a/packages/gh/src/gh.ts
+++ b/packages/gh/src/gh.ts
@@ -64,6 +64,12 @@ import {
   type GhSarifUploadResult,
   uploadSarifReport,
 } from "./sarif.ts";
+import {
+  type GhReleaseAssetApi,
+  type GhReleaseAssetResult,
+  type GhReleaseAssetSettings,
+  uploadReleaseAsset,
+} from "./release_asset.ts";
 
 /** Settings for a `gh` invocation. */
 export class GhSettings extends SubcommandSettings {
@@ -95,6 +101,7 @@ export interface GhTasksApi
   extends
     GhAppTokenApi,
     GhSarifApi,
+    GhReleaseAssetApi,
     GhCommitApi,
     GhPullRequestApi,
     GhCheckRunApi {
@@ -139,5 +146,10 @@ export const GhTasks: GhTasksApi = {
     configure?: Configure<GhSarifSettings>,
   ): Promise<GhSarifUploadResult> {
     return uploadSarifReport(configure);
+  },
+  uploadReleaseAsset(
+    configure?: Configure<GhReleaseAssetSettings>,
+  ): Promise<GhReleaseAssetResult> {
+    return uploadReleaseAsset(configure);
   },
 };

--- a/packages/gh/src/release_asset.ts
+++ b/packages/gh/src/release_asset.ts
@@ -1,0 +1,322 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Upload an asset to a GitHub release from a build, replacing a
+ * `gh release upload` step or a marketplace action.
+ *
+ * The release is resolved first — the latest one by default, or a specific tag
+ * — and an asset the release already carries under the same name is left
+ * alone, so the call is idempotent and a published release's assets are never
+ * mutated. A repository with no releases yet is an ordinary outcome, not an
+ * error, so a release pipeline can run this unconditionally:
+ *
+ * ```ts
+ * await GhTasks.uploadReleaseAsset((s) =>
+ *   s.file("dist/extension.tar.gz").token(token)
+ * );
+ * ```
+ *
+ * @module
+ */
+
+import type { Configure, PathLike } from "@zuke/core/tooling";
+import { isRecord } from "./api.ts";
+
+/** The GitHub REST base, overridable per call for GHES. */
+const API_BASE = "https://api.github.com";
+
+/** Content types inferred from an asset name's extension. */
+const CONTENT_TYPES: Record<string, string> = {
+  ".tar.gz": "application/gzip",
+  ".tgz": "application/gzip",
+  ".zip": "application/zip",
+  ".json": "application/json",
+};
+
+/** What became of a release-asset upload. */
+export interface GhReleaseAssetResult {
+  /**
+   * `uploaded` when the asset was sent; `already-exists` when the release
+   * carries an asset of the same name (nothing was changed); `no-release`
+   * when the repository has no release to attach to.
+   */
+  state: "uploaded" | "already-exists" | "no-release";
+  /** The asset name the call targeted. */
+  name: string;
+  /** The tag of the release the asset belongs to, when one was resolved. */
+  releaseTag?: string;
+  /** The id of the release the asset belongs to, when one was resolved. */
+  releaseId?: number;
+  /** The asset's download URL, when it was uploaded or already present. */
+  url?: string;
+}
+
+/** Read an Actions-provided default, treating an absent env as unset. */
+function env(name: string): string | undefined {
+  try {
+    const value = Deno.env.get(name);
+    return value === undefined || value === "" ? undefined : value;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Settings for {@link GhReleaseAssetApi.uploadReleaseAsset}. */
+export class GhReleaseAssetSettings {
+  /** The file to upload. Set by {@link file}. */
+  file_?: string;
+  /** The asset name on the release. Set by {@link name}. */
+  name_?: string;
+  /** The asset's `content-type`. Set by {@link contentType}. */
+  contentType_?: string;
+  /** `owner/repo` to upload to. Set by {@link repo}. */
+  repo_?: string;
+  /** The release tag to attach to. Set by {@link tag}. */
+  tag_?: string;
+  /** The token to authenticate with. Set by {@link token}. */
+  token_?: string;
+  /** REST base URL. Set by {@link baseUrl}. */
+  baseUrl_: string = API_BASE;
+  /** The `fetch` implementation. Set by {@link fetch}. */
+  fetch_: typeof fetch = fetch;
+
+  /** The file to upload (required). */
+  file(path: PathLike): this {
+    this.file_ = String(path);
+    return this;
+  }
+
+  /** The asset's name on the release. Defaults to the file's base name. */
+  name(value: string): this {
+    this.name_ = value;
+    return this;
+  }
+
+  /**
+   * The asset's `content-type`. Defaults by extension (`.tar.gz`/`.tgz`,
+   * `.zip`, `.json`), then to `application/octet-stream`.
+   */
+  contentType(value: string): this {
+    this.contentType_ = value;
+    return this;
+  }
+
+  /** The `owner/repo` to upload to. Defaults to `GITHUB_REPOSITORY`. */
+  repo(slug: string): this {
+    this.repo_ = slug;
+    return this;
+  }
+
+  /** Attach to the release with this tag instead of the latest release. */
+  tag(value: string): this {
+    this.tag_ = value;
+    return this;
+  }
+
+  /**
+   * The token to authenticate with — needs `contents: write`. Defaults to
+   * `GITHUB_TOKEN` in the environment, so it never has to reach argv.
+   */
+  token(value: string): this {
+    this.token_ = value;
+    return this;
+  }
+
+  /** Use a different REST base (GitHub Enterprise Server). */
+  baseUrl(url: string): this {
+    this.baseUrl_ = url.replace(/\/+$/, "");
+    return this;
+  }
+
+  /** Override the `fetch` implementation (a test seam). */
+  fetch(fn: typeof fetch): this {
+    this.fetch_ = fn;
+    return this;
+  }
+
+  /** The effective `owner/repo`, from the setting or the Actions environment. */
+  repoSlug_(): string {
+    const slug = this.repo_ ?? env("GITHUB_REPOSITORY");
+    if (slug === undefined) {
+      throw new Error(
+        "uploading a release asset requires .repo('owner/name') (or " +
+          "GITHUB_REPOSITORY).",
+      );
+    }
+    return slug;
+  }
+
+  /** The file to upload, or a friendly error naming the missing setting. */
+  filePath_(): string {
+    if (this.file_ === undefined) {
+      throw new Error("uploading a release asset requires .file(...).");
+    }
+    return this.file_;
+  }
+
+  /** The effective asset name: the setting, or the file's base name. */
+  assetName_(): string {
+    if (this.name_ !== undefined) return this.name_;
+    const path = this.filePath_();
+    const base = path.split(/[/\\]/).pop();
+    if (base === undefined || base === "") {
+      throw new Error(
+        `the asset name cannot be derived from "${path}" — set .name(...).`,
+      );
+    }
+    return base;
+  }
+
+  /** The effective `content-type`: the setting, or inferred by extension. */
+  effectiveContentType_(): string {
+    if (this.contentType_ !== undefined) return this.contentType_;
+    const name = this.assetName_().toLowerCase();
+    for (const [suffix, type] of Object.entries(CONTENT_TYPES)) {
+      if (name.endsWith(suffix)) return type;
+    }
+    return "application/octet-stream";
+  }
+}
+
+/** The shape of the release-asset task, mixed into `GhTasks`. */
+export interface GhReleaseAssetApi {
+  /**
+   * Attach a file to a GitHub release — the latest release by default, or the
+   * one named by `.tag(...)`. Idempotent: an asset the release already
+   * carries under the same name is kept as-is, and a repository with no
+   * releases resolves to `state: "no-release"` rather than throwing. Needs a
+   * token with `contents: write`.
+   */
+  uploadReleaseAsset(
+    configure?: Configure<GhReleaseAssetSettings>,
+  ): Promise<GhReleaseAssetResult>;
+}
+
+/** A field read from a REST response without assuming the response's shape. */
+function field(value: unknown, key: string): unknown {
+  return isRecord(value) ? value[key] : undefined;
+}
+
+/** Upload the release asset the settings describe. */
+export async function uploadReleaseAsset(
+  configure?: Configure<GhReleaseAssetSettings>,
+): Promise<GhReleaseAssetResult> {
+  const settings = configure
+    ? configure(new GhReleaseAssetSettings())
+    : new GhReleaseAssetSettings();
+  const token = settings.token_ ?? env("GITHUB_TOKEN");
+  if (token === undefined) {
+    throw new Error(
+      "uploading a release asset requires .token(...) (or GITHUB_TOKEN) " +
+        "with contents: write.",
+    );
+  }
+  const slug = settings.repoSlug_();
+  const name = settings.assetName_();
+  const headers = {
+    "accept": "application/vnd.github+json",
+    "x-github-api-version": "2022-11-28",
+    "authorization": `Bearer ${token}`,
+  };
+
+  // Resolve the release first: the failure modes here (no release yet, a tag
+  // that does not exist) are the likely ones, and the file need not be read
+  // for them.
+  const releasePath = settings.tag_ === undefined
+    ? "releases/latest"
+    : `releases/tags/${encodeURIComponent(settings.tag_)}`;
+  const releaseResponse = await settings.fetch_(
+    `${settings.baseUrl_}/repos/${slug}/${releasePath}`,
+    { headers },
+  );
+  if (releaseResponse.status === 404 && settings.tag_ === undefined) {
+    // A repository with no releases is an ordinary state for a pipeline that
+    // attaches assets opportunistically — report it, do not throw.
+    await releaseResponse.body?.cancel();
+    return { state: "no-release", name };
+  }
+  const releaseText = await releaseResponse.text();
+  if (!releaseResponse.ok) {
+    throw new Error(
+      `resolving the release (${releasePath}) failed: ` +
+        `${releaseResponse.status} ${releaseResponse.statusText}. ` +
+        releaseText.slice(0, 400),
+    );
+  }
+  let release: unknown;
+  try {
+    release = JSON.parse(releaseText);
+  } catch {
+    throw new Error(
+      `the release lookup returned a non-JSON body: ${
+        releaseText.slice(0, 200)
+      }`,
+    );
+  }
+  const releaseId = field(release, "id");
+  const uploadUrlTemplate = field(release, "upload_url");
+  if (typeof releaseId !== "number" || typeof uploadUrlTemplate !== "string") {
+    throw new Error("the release lookup response carried no id/upload_url.");
+  }
+  const releaseTag = field(release, "tag_name");
+  const tag = typeof releaseTag === "string" ? releaseTag : undefined;
+
+  // Idempotence: a release that already carries the asset is left untouched —
+  // published assets are immutable history, and re-running the pipeline must
+  // not churn them.
+  const assets = field(release, "assets");
+  if (Array.isArray(assets)) {
+    for (const asset of assets) {
+      if (field(asset, "name") === name) {
+        const url = field(asset, "browser_download_url");
+        return {
+          state: "already-exists",
+          name,
+          releaseTag: tag,
+          releaseId,
+          ...(typeof url === "string" ? { url } : {}),
+        };
+      }
+    }
+  }
+
+  // The `upload_url` is an RFC 6570 template ending in `{?name,label}`;
+  // GitHub documents cutting the template off and appending a query.
+  const uploadBase = uploadUrlTemplate.replace(/\{[^}]*\}$/, "");
+  const data = await Deno.readFile(settings.filePath_());
+  const uploadResponse = await settings.fetch_(
+    `${uploadBase}?name=${encodeURIComponent(name)}`,
+    {
+      method: "POST",
+      headers: {
+        ...headers,
+        "content-type": settings.effectiveContentType_(),
+      },
+      body: data,
+    },
+  );
+  const uploadText = await uploadResponse.text();
+  if (!uploadResponse.ok) {
+    throw new Error(
+      `uploading release asset "${name}" failed: ${uploadResponse.status} ` +
+        `${uploadResponse.statusText}. ${uploadText.slice(0, 400)}`,
+    );
+  }
+  let uploaded: unknown;
+  try {
+    uploaded = JSON.parse(uploadText);
+  } catch {
+    throw new Error(
+      `the asset upload returned a non-JSON body: ${uploadText.slice(0, 200)}`,
+    );
+  }
+  const url = field(uploaded, "browser_download_url");
+  return {
+    state: "uploaded",
+    name,
+    releaseTag: tag,
+    releaseId,
+    ...(typeof url === "string" ? { url } : {}),
+  };
+}

--- a/packages/gh/src/release_asset.ts
+++ b/packages/gh/src/release_asset.ts
@@ -264,11 +264,20 @@ export async function uploadReleaseAsset(
 
   // Idempotence: a release that already carries the asset is left untouched —
   // published assets are immutable history, and re-running the pipeline must
-  // not churn them.
+  // not churn them. The one exception is an asset stuck in a non-`uploaded`
+  // state: an errored or interrupted upload reserves the name while serving
+  // nothing, and GitHub's documented recovery is delete-then-reupload — so a
+  // re-run must do exactly that rather than skip past the corpse forever.
   const assets = field(release, "assets");
   if (Array.isArray(assets)) {
     for (const asset of assets) {
-      if (field(asset, "name") === name) {
+      if (field(asset, "name") !== name) continue;
+      const state = field(asset, "state");
+      const assetId = field(asset, "id");
+      if (
+        (state === undefined || state === "uploaded") ||
+        typeof assetId !== "number"
+      ) {
         const url = field(asset, "browser_download_url");
         return {
           state: "already-exists",
@@ -277,6 +286,20 @@ export async function uploadReleaseAsset(
           releaseId,
           ...(typeof url === "string" ? { url } : {}),
         };
+      }
+      const deletion = await settings.fetch_(
+        `${settings.baseUrl_}/repos/${slug}/releases/assets/${assetId}`,
+        { method: "DELETE", headers },
+      );
+      const deletionText = await deletion.text();
+      // A 404 means the corpse was already cleaned up — the goal state.
+      if (!deletion.ok && deletion.status !== 404) {
+        throw new Error(
+          `deleting the stuck release asset "${name}" (state ${
+            String(state)
+          }) failed: ${deletion.status} ${deletion.statusText}. ` +
+            deletionText.slice(0, 400),
+        );
       }
     }
   }

--- a/packages/gh/tests/app_token_test.ts
+++ b/packages/gh/tests/app_token_test.ts
@@ -16,7 +16,28 @@ import {
   assertStringIncludes,
 } from "../../core/tests/_assert.ts";
 import { GhTasks } from "../mod.ts";
-import { GhAppTokenSettings } from "../src/app_token.ts";
+import { GhAppTokenSettings, mintAppToken } from "../src/app_token.ts";
+
+/** Run `fn` with `values` in the environment, restoring the originals after. */
+async function withEnv(
+  values: Record<string, string | undefined>,
+  fn: () => Promise<void>,
+): Promise<void> {
+  const saved = new Map<string, string | undefined>();
+  for (const [name, value] of Object.entries(values)) {
+    saved.set(name, Deno.env.get(name));
+    if (value === undefined) Deno.env.delete(name);
+    else Deno.env.set(name, value);
+  }
+  try {
+    await fn();
+  } finally {
+    for (const [name, value] of saved) {
+      if (value === undefined) Deno.env.delete(name);
+      else Deno.env.set(name, value);
+    }
+  }
+}
 
 /** A recorded request the fake `fetch` saw. */
 interface Seen {
@@ -342,6 +363,72 @@ Deno.test("an owner or repository that would redirect the mint is refused", () =
       message = error instanceof Error ? error.message : String(error);
     }
     assertStringIncludes(message, "not a valid git ref name");
+  }
+});
+
+Deno.test("appToken with no configuration is refused before any request", async () => {
+  // A bare call is legal to write, so its first missing setting must be named
+  // — and refused before the transport is touched.
+  await assertRejects(() => mintAppToken(), Error, ".appId(...)");
+});
+
+Deno.test("a 2xx body that is not a JSON object is named per endpoint", async () => {
+  const { pkcs8 } = await testKeys();
+  // Valid JSON, but a string — indexing it as the installation would surface a
+  // TypeError naming no endpoint.
+  await assertRejects(
+    () =>
+      GhTasks.appToken((s) =>
+        s.appId("1").privateKey(pkcs8).owner("acme").fetch(
+          fakeGithub([], { installation: "not an object" }),
+        )
+      ),
+    Error,
+    "resolving the app installation returned a body that is not JSON",
+  );
+
+  // Not JSON at all — a proxy or gateway answering instead of GitHub. The body
+  // is the evidence of who actually answered, so a prefix of it comes along.
+  const gateway: typeof fetch = () =>
+    Promise.resolve(new Response("<html>gateway</html>", { status: 200 }));
+  const error = await assertRejects(
+    () =>
+      GhTasks.appToken((s) =>
+        s.appId("1").privateKey(pkcs8).owner("acme").fetch(gateway)
+      ),
+    Error,
+    "returned a body that is not JSON",
+  );
+  assertStringIncludes(error.message, "<html>gateway</html>");
+});
+
+Deno.test("the minted token is masked in Actions logs, and only there", async () => {
+  // Matching what actions/create-github-app-token does: inside Actions the
+  // runner is told to mask the token, so passing it onward through env cannot
+  // leak it into a log. Outside Actions the directive would just be noise.
+  const { pkcs8 } = await testKeys();
+  const logged: string[] = [];
+  const original = console.log;
+  console.log = (...args: unknown[]): void => {
+    logged.push(args.map(String).join(" "));
+  };
+  try {
+    await withEnv({ GITHUB_ACTIONS: "true" }, async () => {
+      await GhTasks.appToken((s) =>
+        s.appId("1").privateKey(pkcs8).owner("acme").fetch(fakeGithub([]))
+      );
+    });
+    assertEquals(logged, ["::add-mask::ghs_installation"]);
+
+    logged.length = 0;
+    await withEnv({ GITHUB_ACTIONS: undefined }, async () => {
+      await GhTasks.appToken((s) =>
+        s.appId("1").privateKey(pkcs8).owner("acme").fetch(fakeGithub([]))
+      );
+    });
+    assertEquals(logged, []);
+  } finally {
+    console.log = original;
   }
 });
 

--- a/packages/gh/tests/commit_test.ts
+++ b/packages/gh/tests/commit_test.ts
@@ -13,9 +13,31 @@
 
 import {
   assertEquals,
+  assertRejects,
   assertStringIncludes,
 } from "../../core/tests/_assert.ts";
 import { commitFiles, tagCommit } from "../src/commit.ts";
+
+/** Run `fn` with `values` in the environment, restoring the originals after. */
+async function withEnv(
+  values: Record<string, string | undefined>,
+  fn: () => Promise<void>,
+): Promise<void> {
+  const saved = new Map<string, string | undefined>();
+  for (const [name, value] of Object.entries(values)) {
+    saved.set(name, Deno.env.get(name));
+    if (value === undefined) Deno.env.delete(name);
+    else Deno.env.set(name, value);
+  }
+  try {
+    await fn();
+  } finally {
+    for (const [name, value] of saved) {
+      if (value === undefined) Deno.env.delete(name);
+      else Deno.env.set(name, value);
+    }
+  }
+}
 
 /** One recorded request. */
 interface Call {
@@ -578,4 +600,196 @@ Deno.test("`.replace()` without `.from(...)` is refused rather than ignored", as
   }
   assertStringIncludes(message, ".replace() only applies together with .from(");
   assertEquals(calls.length, 0);
+});
+
+Deno.test("a commit falls back to GITHUB_REPOSITORY and GITHUB_TOKEN", async () => {
+  // A job that already has the Actions environment needs to name only what it
+  // is committing.
+  await withEnv({
+    GITHUB_REPOSITORY: "acme/app",
+    GITHUB_TOKEN: "ghs_env",
+  }, async () => {
+    const { fetch, calls } = fakeFetch({
+      "GET /git/ref/heads/topic": { object: { sha: "h" } },
+      "GET /git/commits/h": { tree: { sha: "t" } },
+      "POST /git/trees": { sha: "t2" },
+      "POST /git/commits": { sha: "c" },
+      "PATCH /git/refs/heads/topic": {},
+    });
+    const result = await commitFiles((s) =>
+      s.branch("topic").message("m").file("a.ts", "1\n").fetch(fetch)
+    );
+    assertEquals(result.sha, "c");
+    // The env-resolved slug routed the request, and the env token rode as the
+    // bearer header on every call — never through argv or a body.
+    assertEquals(calls[0].path, "/git/ref/heads/topic");
+    for (const call of calls) assertEquals(call.auth, "Bearer ghs_env");
+  });
+});
+
+Deno.test("a tag falls back to GITHUB_REPOSITORY, GITHUB_TOKEN, and GITHUB_SHA", async () => {
+  await withEnv({
+    GITHUB_REPOSITORY: "acme/app",
+    GITHUB_TOKEN: "ghs_env",
+    GITHUB_SHA: "e".repeat(40),
+  }, async () => {
+    const { fetch, calls } = fakeFetch({
+      "POST /git/tags": { sha: "obj" },
+      "POST /git/refs": {},
+    });
+    await tagCommit((s) => s.name("v9.9.9").fetch(fetch));
+    // The tag points at the commit the workflow ran for.
+    assertEquals(calls[0].path, "/git/tags");
+    assertEquals(calls[0].body.object, "e".repeat(40));
+    for (const call of calls) assertEquals(call.auth, "Bearer ghs_env");
+  });
+});
+
+Deno.test("a missing repo, token, or sha is named rather than guessed", async () => {
+  // Without the Actions environment the settings must say which setting is
+  // missing and which variable would have filled it — not fail downstream.
+  await withEnv({
+    GITHUB_REPOSITORY: undefined,
+    GITHUB_TOKEN: undefined,
+    GITHUB_SHA: undefined,
+  }, async () => {
+    const { fetch, calls } = fakeFetch({});
+    await assertRejects(
+      () =>
+        commitFiles((s) => s.token("t").branch("b").message("m").fetch(fetch)),
+      Error,
+      "committing requires .repo('owner/name') (or GITHUB_REPOSITORY)",
+    );
+    await assertRejects(
+      () =>
+        commitFiles((s) =>
+          s.repo("acme/app").branch("b").message("m").fetch(fetch)
+        ),
+      Error,
+      "committing requires .token(...) (or GITHUB_TOKEN)",
+    );
+    await assertRejects(
+      () => tagCommit((s) => s.token("t").name("v1").commit("c").fetch(fetch)),
+      Error,
+      "tagging requires .repo('owner/name') (or GITHUB_REPOSITORY)",
+    );
+    await assertRejects(
+      () =>
+        tagCommit((s) =>
+          s.repo("acme/app").name("v1").commit("c").fetch(fetch)
+        ),
+      Error,
+      "tagging requires .token(...) (or GITHUB_TOKEN)",
+    );
+    await assertRejects(
+      () =>
+        tagCommit((s) => s.repo("acme/app").token("t").name("v1").fetch(fetch)),
+      Error,
+      "tagging requires .commit(...) (or GITHUB_SHA)",
+    );
+    // Every refusal happened before anything was sent.
+    assertEquals(calls.length, 0);
+  });
+});
+
+Deno.test("the required commit and tag settings are named when absent", async () => {
+  // A bare call is legal to write, so its first missing setting must be named
+  // — and refused before the environment or the transport is consulted.
+  await assertRejects(
+    () => commitFiles(),
+    Error,
+    "committing requires .branch(...)",
+  );
+  await assertRejects(
+    () => commitFiles((s) => s.repo("acme/app").token("t").branch("topic")),
+    Error,
+    "committing requires .message(...)",
+  );
+  await assertRejects(() => tagCommit(), Error, "tagging requires .name(...)");
+});
+
+Deno.test("baseUrl retargets commits and tags at a GHES host", async () => {
+  const seen: string[] = [];
+  const capture: typeof fetch = (input) => {
+    seen.push(String(input));
+    return Promise.resolve(
+      new Response(
+        JSON.stringify({ object: { sha: "a" }, tree: { sha: "t" }, sha: "c" }),
+        { status: 200 },
+      ),
+    );
+  };
+  await commitFiles((s) =>
+    s.repo("acme/app").token("t").branch("main").message("m")
+      .baseUrl("https://ghe.example.com/api/v3/").fetch(capture)
+  );
+  // The trailing slash is trimmed, so no `//` appears in the request path.
+  assertEquals(
+    seen[0],
+    "https://ghe.example.com/api/v3/repos/acme/app/git/ref/heads/main",
+  );
+
+  seen.length = 0;
+  await tagCommit((s) =>
+    s.repo("acme/app").token("t").name("v1").commit("c")
+      .baseUrl("https://ghe.example.com/api/v3").fetch(capture)
+  );
+  assertEquals(
+    seen[0],
+    "https://ghe.example.com/api/v3/repos/acme/app/git/tags",
+  );
+});
+
+Deno.test("a response missing the field a call needs names that call", async () => {
+  // `readString` names the call whose response was malformed, rather than
+  // letting `undefined` flow into the next request's path.
+  const notRecord = fakeFetch({
+    "GET /git/ref/heads/topic": { object: "nope" },
+  });
+  await assertRejects(
+    () =>
+      commitFiles((s) =>
+        s.repo("acme/app").token("t").branch("topic").message("m")
+          .fetch(notRecord.fetch)
+      ),
+    Error,
+    "the ref response has no object.sha",
+  );
+
+  // The terminal value has to be a string, not merely present.
+  const wrongType = fakeFetch({
+    "GET /git/ref/heads/topic": { object: { sha: "h" } },
+    "GET /git/commits/h": { tree: { sha: "t" } },
+    "POST /git/trees": { sha: 42 },
+  });
+  await assertRejects(
+    () =>
+      commitFiles((s) =>
+        s.repo("acme/app").token("t").branch("topic").message("m")
+          .fetch(wrongType.fetch)
+      ),
+    Error,
+    "the tree response has no sha",
+  );
+});
+
+Deno.test("an empty 2xx body reads as an empty object, not a parse error", async () => {
+  // GitHub answers some writes with an empty body; the transport must not die
+  // parsing "" on a reply the caller never reads.
+  const empty: typeof fetch = (input, init) => {
+    if ((init?.method ?? "GET") === "PATCH") {
+      return Promise.resolve(new Response("", { status: 200 }));
+    }
+    void input;
+    return Promise.resolve(
+      new Response(
+        JSON.stringify({ object: { sha: "a" }, tree: { sha: "t" }, sha: "c" }),
+        { status: 200 },
+      ),
+    );
+  };
+  const result = await commitFiles((s) =>
+    s.repo("acme/app").token("t").branch("main").message("m").fetch(empty)
+  );
+  assertEquals(result.sha, "c");
 });

--- a/packages/gh/tests/pull_request_test.ts
+++ b/packages/gh/tests/pull_request_test.ts
@@ -13,12 +13,35 @@
 
 import {
   assertEquals,
+  assertRejects,
   assertStringIncludes,
 } from "../../core/tests/_assert.ts";
 import {
+  findPullRequest,
   type GhPullRequestSettings,
   openPullRequest,
 } from "../src/pull_request.ts";
+
+/** Run `fn` with `values` in the environment, restoring the originals after. */
+async function withEnv(
+  values: Record<string, string | undefined>,
+  fn: () => Promise<void>,
+): Promise<void> {
+  const saved = new Map<string, string | undefined>();
+  for (const [name, value] of Object.entries(values)) {
+    saved.set(name, Deno.env.get(name));
+    if (value === undefined) Deno.env.delete(name);
+    else Deno.env.set(name, value);
+  }
+  try {
+    await fn();
+  } finally {
+    for (const [name, value] of saved) {
+      if (value === undefined) Deno.env.delete(name);
+      else Deno.env.set(name, value);
+    }
+  }
+}
 
 /** One recorded request. */
 interface Call {
@@ -265,6 +288,199 @@ Deno.test("a head that is not the one asked for is not accepted", async () => {
     message = error instanceof Error ? error.message : String(error);
   }
   assertStringIncludes(message, "original 422");
+});
+
+Deno.test("findPullRequest returns the open proposal without opening one", async () => {
+  const { fetch, calls } = fakeFetch({
+    "GET /pulls?state=open&head=acme%3Atopic&base=master": {
+      status: 200,
+      body: [{
+        number: 4,
+        html_url: "https://github.com/acme/app/pull/4",
+        head: { ref: "topic" },
+        base: { ref: "master" },
+      }],
+    },
+  });
+  const result = await findPullRequest((s) =>
+    s.repo("acme/app").token("t").head("topic").base("master").fetch(fetch)
+  );
+  assertEquals(result, {
+    number: 4,
+    url: "https://github.com/acme/app/pull/4",
+    created: false,
+  });
+  // A read, and only a read: nothing was proposed on the caller's behalf.
+  assertEquals(calls.length, 1);
+  assertEquals(calls[0].method, "GET");
+});
+
+Deno.test("findPullRequest returns undefined when nothing is open", async () => {
+  const { fetch } = fakeFetch({
+    "GET /pulls?state=open&head=acme%3Atopic&base=master": {
+      status: 200,
+      body: [],
+    },
+  });
+  assertEquals(
+    await findPullRequest((s) =>
+      s.repo("acme/app").token("t").head("topic").base("master").fetch(fetch)
+    ),
+    undefined,
+  );
+});
+
+Deno.test("findPullRequest names its missing settings before any request", async () => {
+  // A bare call is legal to write, so the first missing setting is named —
+  // before the environment or the transport is consulted.
+  await assertRejects(
+    () => findPullRequest(),
+    Error,
+    "finding a pull request requires .head(...)",
+  );
+  await assertRejects(
+    () => findPullRequest((s) => s.head("topic")),
+    Error,
+    "finding a pull request requires .base(...)",
+  );
+});
+
+Deno.test("findPullRequest refuses a ref that would redirect the lookup", async () => {
+  // The head and base reach the lookup's query string, the same reason
+  // openPullRequest validates its own.
+  const { fetch, calls } = fakeFetch({});
+  await assertRejects(
+    () =>
+      findPullRequest((s) =>
+        s.repo("acme/app").token("t").head("../../../user/repos").base("master")
+          .fetch(fetch)
+      ),
+    Error,
+    "not a valid git ref name",
+  );
+  assertEquals(calls.length, 0);
+});
+
+Deno.test("a lookup entry that is not an object keeps the original error", async () => {
+  // Junk in the lookup body must fall through to the 422 that says what was
+  // refused, never be dressed up as an existing pull request.
+  const { fetch } = fakeFetch({
+    "POST /pulls": { status: 422, body: { message: "original 422" } },
+    "GET /pulls?state=open&head=acme%3Atopic&base=master": {
+      status: 200,
+      body: [null],
+    },
+  });
+  await assertRejects(
+    () =>
+      openPullRequest((s) =>
+        s.repo("acme/app").token("t").head("topic").base("master").title("t")
+          .fetch(fetch)
+      ),
+    Error,
+    "original 422",
+  );
+});
+
+Deno.test("a created response without a numeric number names the call", async () => {
+  // `readNumber` names the call whose response was malformed, rather than
+  // letting a string flow into the result as though it were the number.
+  const { fetch } = fakeFetch({
+    "POST /pulls": { status: 201, body: { number: "7", html_url: "u" } },
+  });
+  await assertRejects(
+    () =>
+      openPullRequest((s) =>
+        s.repo("acme/app").token("t").head("topic").base("master").title("t")
+          .fetch(fetch)
+      ),
+    Error,
+    "the pull request response has no number",
+  );
+});
+
+Deno.test("the repo and token fall back to the Actions environment", async () => {
+  // A job that already has GITHUB_REPOSITORY and GITHUB_TOKEN needs to name
+  // only what it is proposing.
+  await withEnv({
+    GITHUB_REPOSITORY: "acme/app",
+    GITHUB_TOKEN: "ghs_env",
+  }, async () => {
+    const seen: Array<{ url: string; auth: string | null }> = [];
+    const capture: typeof fetch = (input, init) => {
+      seen.push({
+        url: String(input),
+        auth: new Headers(init?.headers).get("authorization"),
+      });
+      return Promise.resolve(
+        new Response(JSON.stringify({ number: 7, html_url: "u" }), {
+          status: 201,
+        }),
+      );
+    };
+    const result = await openPullRequest((s) =>
+      s.head("topic").base("master").title("t").fetch(capture)
+    );
+    assertEquals(result.created, true);
+    // The env-resolved slug routed the request; the env token rode the header.
+    assertEquals(seen[0].url, "https://api.github.com/repos/acme/app/pulls");
+    assertEquals(seen[0].auth, "Bearer ghs_env");
+  });
+});
+
+Deno.test("a missing repo or token is named rather than sent empty", async () => {
+  await withEnv({
+    GITHUB_REPOSITORY: undefined,
+    GITHUB_TOKEN: undefined,
+  }, async () => {
+    const { fetch, calls } = fakeFetch({});
+    await assertRejects(
+      () =>
+        openPullRequest((s) =>
+          s.token("t").head("topic").base("master").title("t").fetch(fetch)
+        ),
+      Error,
+      ".repo('owner/name') (or GITHUB_REPOSITORY)",
+    );
+    await assertRejects(
+      () =>
+        openPullRequest((s) =>
+          s.repo("acme/app").head("topic").base("master").title("t").fetch(
+            fetch,
+          )
+        ),
+      Error,
+      ".token(...) (or GITHUB_TOKEN)",
+    );
+    // Both refusals happened before anything was sent.
+    assertEquals(calls.length, 0);
+  });
+});
+
+Deno.test("openPullRequest with no configuration names the first gap", async () => {
+  await assertRejects(
+    () => openPullRequest(),
+    Error,
+    "opening a pull request requires .head(...)",
+  );
+});
+
+Deno.test("baseUrl retargets the proposal at a GHES host", async () => {
+  const seen: string[] = [];
+  const capture: typeof fetch = (input) => {
+    seen.push(String(input));
+    return Promise.resolve(
+      new Response(JSON.stringify({ number: 1, html_url: "u" }), {
+        status: 201,
+      }),
+    );
+  };
+  await openPullRequest((s) =>
+    s.repo("acme/app").token("t").head("topic").base("master").title("t")
+      .baseUrl("https://ghe.example.com/api/v3/").fetch(capture)
+  );
+  // The trailing slash is trimmed, so no `//` appears in the request path.
+  assertEquals(seen[0], "https://ghe.example.com/api/v3/repos/acme/app/pulls");
 });
 
 Deno.test("a lookup that fails keeps the error that says what was refused", async () => {

--- a/packages/gh/tests/release_asset_test.ts
+++ b/packages/gh/tests/release_asset_test.ts
@@ -1,0 +1,375 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Unit tests for the release-asset upload. The requests go through a `fetch`
+ * seam: the release lookup is answered the way the REST API does (including
+ * the RFC 6570 `upload_url` template), so what is asserted is the real
+ * two-step flow — resolve the release, then POST the bytes to the upload host.
+ *
+ * @module
+ */
+
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "../../core/tests/_assert.ts";
+import { GhTasks } from "../mod.ts";
+
+/** A recorded request the fake `fetch` saw. */
+interface Seen {
+  url: string;
+  method: string;
+  authorization: string;
+  contentType: string | null;
+  body: Uint8Array | undefined;
+}
+
+/** A release lookup payload like the REST API's, parameterized on its assets. */
+function releasePayload(assets: { name: string }[]): Record<string, unknown> {
+  return {
+    id: 77,
+    tag_name: "core-v1.2.3",
+    upload_url:
+      "https://uploads.github.com/repos/acme/app/releases/77/assets{?name,label}",
+    assets: assets.map((a, i) => ({
+      id: 100 + i,
+      name: a.name,
+      browser_download_url:
+        `https://github.com/acme/app/releases/download/core-v1.2.3/${a.name}`,
+    })),
+  };
+}
+
+/** A `fetch` seam answering the lookup and the upload like GitHub does. */
+function fakeGithub(
+  seen: Seen[],
+  options: { releaseStatus?: number; assets?: { name: string }[] } = {},
+): typeof fetch {
+  return async (input, init) => {
+    const headers = new Headers(init?.headers);
+    const rawBody = init?.body;
+    seen.push({
+      url: String(input),
+      method: init?.method ?? "GET",
+      authorization: headers.get("authorization") ?? "",
+      contentType: headers.get("content-type"),
+      body: rawBody instanceof Uint8Array ? rawBody : undefined,
+    });
+    if (String(input).includes("uploads.github.com")) {
+      return new Response(
+        JSON.stringify({
+          id: 900,
+          name: "asset",
+          browser_download_url:
+            "https://github.com/acme/app/releases/download/core-v1.2.3/asset",
+        }),
+        { status: 201, statusText: "Created" },
+      );
+    }
+    const status = options.releaseStatus ?? 200;
+    const payload = status < 300
+      ? releasePayload(options.assets ?? [])
+      : { message: "Not Found" };
+    await Promise.resolve();
+    return new Response(JSON.stringify(payload), {
+      status,
+      statusText: status < 300 ? "OK" : "Not Found",
+    });
+  };
+}
+
+/** Write a small file to upload and return its path. */
+async function assetFixture(dir: string): Promise<string> {
+  const path = `${dir}/extension.tar.gz`;
+  await Deno.writeFile(path, new Uint8Array([1, 2, 3, 4]));
+  return path;
+}
+
+/** Run `fn` with the Actions environment variables set to `values`. */
+async function withEnv(
+  values: Record<string, string | undefined>,
+  fn: () => Promise<void>,
+): Promise<void> {
+  const saved = new Map<string, string | undefined>();
+  for (const [name, value] of Object.entries(values)) {
+    saved.set(name, Deno.env.get(name));
+    if (value === undefined) Deno.env.delete(name);
+    else Deno.env.set(name, value);
+  }
+  try {
+    await fn();
+  } finally {
+    for (const [name, value] of saved) {
+      if (value === undefined) Deno.env.delete(name);
+      else Deno.env.set(name, value);
+    }
+  }
+}
+
+Deno.test("an asset is uploaded to the latest release's upload host", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const file = await assetFixture(dir);
+    const seen: Seen[] = [];
+    const result = await GhTasks.uploadReleaseAsset((s) =>
+      s.file(file).repo("acme/app").token("tok").fetch(fakeGithub(seen))
+    );
+
+    assertEquals(result.state, "uploaded");
+    assertEquals(result.releaseTag, "core-v1.2.3");
+    assertEquals(result.releaseId, 77);
+
+    // First the lookup, then the upload — with the template cut off, the name
+    // in the query, the token on both, and the file's actual bytes as body.
+    assertEquals(seen.length, 2);
+    assertStringIncludes(seen[0].url, "/repos/acme/app/releases/latest");
+    assertEquals(
+      seen[1].url,
+      "https://uploads.github.com/repos/acme/app/releases/77/assets" +
+        "?name=extension.tar.gz",
+    );
+    assertEquals(seen[1].method, "POST");
+    assertEquals(seen[1].authorization, "Bearer tok");
+    assertEquals(seen[1].contentType, "application/gzip");
+    assertEquals(seen[1].body, new Uint8Array([1, 2, 3, 4]));
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("a tag setting resolves that release instead of latest", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const file = await assetFixture(dir);
+    const seen: Seen[] = [];
+    await GhTasks.uploadReleaseAsset((s) =>
+      s.file(file).tag("v1.0.0").repo("acme/app").token("tok")
+        .fetch(fakeGithub(seen))
+    );
+    assertStringIncludes(seen[0].url, "/repos/acme/app/releases/tags/v1.0.0");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("an asset the release already carries is kept, not re-sent", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const file = await assetFixture(dir);
+    const seen: Seen[] = [];
+    const result = await GhTasks.uploadReleaseAsset((s) =>
+      s.file(file).repo("acme/app").token("tok")
+        .fetch(fakeGithub(seen, { assets: [{ name: "extension.tar.gz" }] }))
+    );
+    assertEquals(result.state, "already-exists");
+    assertStringIncludes(result.url ?? "", "extension.tar.gz");
+    // Only the lookup went out — published assets are never churned.
+    assertEquals(seen.length, 1);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("a repository with no releases reports no-release, not an error", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const file = await assetFixture(dir);
+    const result = await GhTasks.uploadReleaseAsset((s) =>
+      s.file(file).repo("acme/app").token("tok")
+        .fetch(fakeGithub([], { releaseStatus: 404 }))
+    );
+    assertEquals(result, { state: "no-release", name: "extension.tar.gz" });
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("a missing tag IS an error — the caller named a release", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const file = await assetFixture(dir);
+    await assertRejects(
+      () =>
+        GhTasks.uploadReleaseAsset((s) =>
+          s.file(file).tag("v9.9.9").repo("acme/app").token("tok")
+            .fetch(fakeGithub([], { releaseStatus: 404 }))
+        ),
+      Error,
+      "releases/tags/v9.9.9",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("the name, content type, and their defaults follow the file", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const file = await assetFixture(dir);
+    const seen: Seen[] = [];
+    await GhTasks.uploadReleaseAsset((s) =>
+      s.file(file).name("bundle.zip").contentType("application/x-test")
+        .repo("acme/app").token("tok").fetch(fakeGithub(seen))
+    );
+    assertStringIncludes(seen[1].url, "?name=bundle.zip");
+    assertEquals(seen[1].contentType, "application/x-test");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("missing settings fail with messages that name the fix", async () => {
+  await assertRejects(
+    () => GhTasks.uploadReleaseAsset((s) => s.repo("a/b").token("t")),
+    Error,
+    ".file(...)",
+  );
+  await withEnv(
+    { GITHUB_TOKEN: undefined, GITHUB_REPOSITORY: undefined },
+    async () => {
+      await assertRejects(
+        () =>
+          GhTasks.uploadReleaseAsset((s) =>
+            s.file("x.bin").repo("a/b").fetch(() => {
+              throw new Error("no request should be made without a token");
+            })
+          ),
+        Error,
+        ".token(...)",
+      );
+      await assertRejects(
+        () => GhTasks.uploadReleaseAsset((s) => s.file("x.bin").token("t")),
+        Error,
+        "GITHUB_REPOSITORY",
+      );
+    },
+  );
+});
+
+Deno.test("the token and repo default to the Actions environment", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const file = await assetFixture(dir);
+    await withEnv(
+      { GITHUB_TOKEN: "ghs_env", GITHUB_REPOSITORY: "acme/app" },
+      async () => {
+        const seen: Seen[] = [];
+        await GhTasks.uploadReleaseAsset((s) =>
+          s.file(file).fetch(fakeGithub(seen))
+        );
+        assertStringIncludes(seen[0].url, "/repos/acme/app/releases/latest");
+        // The token rides in the header from the environment, never argv.
+        assertEquals(seen[0].authorization, "Bearer ghs_env");
+      },
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("a GHES base URL is honored, trailing slash and all", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const file = await assetFixture(dir);
+    const seen: Seen[] = [];
+    await GhTasks.uploadReleaseAsset((s) =>
+      s.file(file).name("asset.bin").repo("acme/app").token("tok")
+        .baseUrl("https://ghes.example/api/v3/").fetch(fakeGithub(seen))
+    );
+    assertStringIncludes(
+      seen[0].url,
+      "https://ghes.example/api/v3/repos/acme/app/releases/latest",
+    );
+    // An unknown extension falls back to the generic content type.
+    assertEquals(seen[1].contentType, "application/octet-stream");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("a name that cannot be derived from the file asks for .name(...)", async () => {
+  await assertRejects(
+    () =>
+      GhTasks.uploadReleaseAsset((s) =>
+        s.file("dist/").repo("a/b").token("t").fetch(fakeGithub([]))
+      ),
+    Error,
+    ".name(...)",
+  );
+});
+
+Deno.test("malformed release responses fail with what came back", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const file = await assetFixture(dir);
+    const answering = (body: string): typeof fetch => async () => {
+      await Promise.resolve();
+      return new Response(body, { status: 200 });
+    };
+    // A proxy answering instead of GitHub: not JSON at all.
+    await assertRejects(
+      () =>
+        GhTasks.uploadReleaseAsset((s) =>
+          s.file(file).repo("a/b").token("t").fetch(answering("<html>"))
+        ),
+      Error,
+      "non-JSON body",
+    );
+    // JSON, but not a release: nothing to upload to.
+    await assertRejects(
+      () =>
+        GhTasks.uploadReleaseAsset((s) =>
+          s.file(file).repo("a/b").token("t").fetch(answering("{}"))
+        ),
+      Error,
+      "no id/upload_url",
+    );
+    // The lookup succeeds but the upload host answers garbage.
+    const brokenUpload: typeof fetch = async (input) => {
+      await Promise.resolve();
+      if (String(input).includes("uploads.github.com")) {
+        return new Response("<html>", { status: 201 });
+      }
+      return new Response(JSON.stringify(releasePayload([])), { status: 200 });
+    };
+    await assertRejects(
+      () =>
+        GhTasks.uploadReleaseAsset((s) =>
+          s.file(file).repo("a/b").token("t").fetch(brokenUpload)
+        ),
+      Error,
+      "non-JSON body",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("an upload rejection surfaces GitHub's own message", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const file = await assetFixture(dir);
+    const failing: typeof fetch = async (input) => {
+      await Promise.resolve();
+      if (String(input).includes("uploads.github.com")) {
+        return new Response(JSON.stringify({ message: "asset too large" }), {
+          status: 422,
+          statusText: "Unprocessable Entity",
+        });
+      }
+      return new Response(JSON.stringify(releasePayload([])), { status: 200 });
+    };
+    await assertRejects(
+      () =>
+        GhTasks.uploadReleaseAsset((s) =>
+          s.file(file).repo("acme/app").token("tok").fetch(failing)
+        ),
+      Error,
+      "asset too large",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/packages/gh/tests/release_asset_test.ts
+++ b/packages/gh/tests/release_asset_test.ts
@@ -172,6 +172,89 @@ Deno.test("an asset the release already carries is kept, not re-sent", async () 
   }
 });
 
+Deno.test("a stuck asset (state not uploaded) is deleted and re-sent", async () => {
+  // GitHub's documented failure mode: an errored/interrupted upload reserves
+  // the asset name in a non-`uploaded` state. Skipping it would leave the
+  // release serving a corpse forever — the one case a re-run must repair.
+  const dir = await Deno.makeTempDir();
+  try {
+    const file = await assetFixture(dir);
+    const seen: Seen[] = [];
+    const github: typeof fetch = async (input, init) => {
+      const method = init?.method ?? "GET";
+      seen.push({
+        url: String(input),
+        method,
+        authorization: new Headers(init?.headers).get("authorization") ?? "",
+        contentType: new Headers(init?.headers).get("content-type"),
+        body: init?.body instanceof Uint8Array ? init.body : undefined,
+      });
+      await Promise.resolve();
+      if (method === "DELETE") return new Response(null, { status: 204 });
+      if (String(input).includes("uploads.github.com")) {
+        return new Response(
+          JSON.stringify({ id: 901, browser_download_url: "dl/fresh" }),
+          { status: 201 },
+        );
+      }
+      const release = releasePayload([]);
+      release.assets = [{
+        id: 55,
+        name: "extension.tar.gz",
+        state: "new",
+        browser_download_url: "dl/corpse",
+      }];
+      return new Response(JSON.stringify(release), { status: 200 });
+    };
+
+    const result = await GhTasks.uploadReleaseAsset((s) =>
+      s.file(file).repo("acme/app").token("tok").fetch(github)
+    );
+    assertEquals(result.state, "uploaded");
+    // Lookup, then DELETE of the stuck asset, then the fresh upload.
+    assertEquals(seen.map((s) => s.method), ["GET", "DELETE", "POST"]);
+    assertStringIncludes(seen[1].url, "/releases/assets/55");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("a failed deletion of a stuck asset surfaces, a 404 does not", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const file = await assetFixture(dir);
+    const github = (deleteStatus: number): typeof fetch => async (i, init) => {
+      await Promise.resolve();
+      if ((init?.method ?? "GET") === "DELETE") {
+        return new Response(JSON.stringify({ message: "locked" }), {
+          status: deleteStatus,
+        });
+      }
+      if (String(i).includes("uploads.github.com")) {
+        return new Response(JSON.stringify({ id: 1 }), { status: 201 });
+      }
+      const release = releasePayload([]);
+      release.assets = [{ id: 55, name: "extension.tar.gz", state: "new" }];
+      return new Response(JSON.stringify(release), { status: 200 });
+    };
+    await assertRejects(
+      () =>
+        GhTasks.uploadReleaseAsset((s) =>
+          s.file(file).repo("acme/app").token("tok").fetch(github(423))
+        ),
+      Error,
+      "locked",
+    );
+    // The corpse already being gone is the goal state, not a failure.
+    const result = await GhTasks.uploadReleaseAsset((s) =>
+      s.file(file).repo("acme/app").token("tok").fetch(github(404))
+    );
+    assertEquals(result.state, "uploaded");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
 Deno.test("a repository with no releases reports no-release, not an error", async () => {
   const dir = await Deno.makeTempDir();
   try {

--- a/packages/gh/tests/release_asset_test.ts
+++ b/packages/gh/tests/release_asset_test.ts
@@ -57,7 +57,7 @@ function fakeGithub(
       contentType: headers.get("content-type"),
       body: rawBody instanceof Uint8Array ? rawBody : undefined,
     });
-    if (String(input).includes("uploads.github.com")) {
+    if (new URL(String(input)).hostname === "uploads.github.com") {
       return new Response(
         JSON.stringify({
           id: 900,
@@ -191,7 +191,7 @@ Deno.test("a stuck asset (state not uploaded) is deleted and re-sent", async () 
       });
       await Promise.resolve();
       if (method === "DELETE") return new Response(null, { status: 204 });
-      if (String(input).includes("uploads.github.com")) {
+      if (new URL(String(input)).hostname === "uploads.github.com") {
         return new Response(
           JSON.stringify({ id: 901, browser_download_url: "dl/fresh" }),
           { status: 201 },
@@ -230,7 +230,7 @@ Deno.test("a failed deletion of a stuck asset surfaces, a 404 does not", async (
           status: deleteStatus,
         });
       }
-      if (String(i).includes("uploads.github.com")) {
+      if (new URL(String(i)).hostname === "uploads.github.com") {
         return new Response(JSON.stringify({ id: 1 }), { status: 201 });
       }
       const release = releasePayload([]);
@@ -412,7 +412,7 @@ Deno.test("malformed release responses fail with what came back", async () => {
     // The lookup succeeds but the upload host answers garbage.
     const brokenUpload: typeof fetch = async (input) => {
       await Promise.resolve();
-      if (String(input).includes("uploads.github.com")) {
+      if (new URL(String(input)).hostname === "uploads.github.com") {
         return new Response("<html>", { status: 201 });
       }
       return new Response(JSON.stringify(releasePayload([])), { status: 200 });
@@ -436,7 +436,7 @@ Deno.test("an upload rejection surfaces GitHub's own message", async () => {
     const file = await assetFixture(dir);
     const failing: typeof fetch = async (input) => {
       await Promise.resolve();
-      if (String(input).includes("uploads.github.com")) {
+      if (new URL(String(input)).hostname === "uploads.github.com") {
         return new Response(JSON.stringify({ message: "asset too large" }), {
           status: 422,
           statusText: "Unprocessable Entity",

--- a/packages/gh/tests/workflow_test.ts
+++ b/packages/gh/tests/workflow_test.ts
@@ -944,6 +944,55 @@ Deno.test("RestGhWorkflowApi aborts a hung request via its timeout", async () =>
   await assertRejects(() => api.getRun("a/b", 1)); // aborts, does not hang
 });
 
+Deno.test("the default transport reads GH_TOKEN before GITHUB_TOKEN", async () => {
+  // The same order the gh CLI resolves its token, injected through the readEnv
+  // seam so the test never touches the real environment.
+  const url = "https://api.github.com/repos/a/b/actions/workflows/w/dispatches";
+  const both = routerFetch({ [`POST ${url}`]: {} });
+  const preferGh = githubWorkflowWith((g) => g.repo("a/b").workflow("w"), {
+    fetch: both.fetch,
+    readEnv: (name) =>
+      name === "GH_TOKEN"
+        ? "gh_tok"
+        : name === "GITHUB_TOKEN"
+        ? "shadowed"
+        : undefined,
+  });
+  await preferGh.isSatisfied(NO_SIGNALS, ctx(fakeState())); // dispatch
+  assertEquals(
+    new Headers(both.calls[0].init?.headers).get("authorization"),
+    "Bearer gh_tok",
+  );
+
+  // Without GH_TOKEN the workflow token GITHUB_TOKEN fills in.
+  const fallback = routerFetch({ [`POST ${url}`]: {} });
+  const usesGithub = githubWorkflowWith((g) => g.repo("a/b").workflow("w"), {
+    fetch: fallback.fetch,
+    readEnv: (name) => name === "GITHUB_TOKEN" ? "fallback_tok" : undefined,
+  });
+  await usesGithub.isSatisfied(NO_SIGNALS, ctx(fakeState()));
+  assertEquals(
+    new Headers(fallback.calls[0].init?.headers).get("authorization"),
+    "Bearer fallback_tok",
+  );
+});
+
+Deno.test("RestGhWorkflowApi tolerates a 2xx body that is not an object", async () => {
+  // A proxy answering with a JSON array instead of the run object: the read
+  // degrades to the same defaults as an empty run, not a crash on indexing.
+  const { fetch } = routerFetch({
+    "GET https://api.github.com/repos/a/b/actions/runs/9": [],
+  });
+  assertEquals(await new RestGhWorkflowApi({ fetch }).getRun("a/b", 9), {
+    id: 0,
+    status: "unknown",
+    conclusion: null,
+    url: "",
+    createdAt: "",
+    headBranch: "",
+  });
+});
+
 Deno.test("RestGhWorkflowApi maps missing run/job fields to defaults", async () => {
   const { fetch } = routerFetch({
     "GET https://api.github.com/repos/a/b/actions/runs/9": {}, // no fields

--- a/packages/gh/tests/workflow_test.ts
+++ b/packages/gh/tests/workflow_test.ts
@@ -339,6 +339,56 @@ Deno.test("readWorkflowResult tolerates malformed jobs", () => {
   ]);
 });
 
+Deno.test("readWorkflowResult defaults malformed or absent job fields", () => {
+  // A jobs field that is not an array reads as no jobs, not a crash.
+  const notArray = fakeState({
+    githubWorkflow: {
+      result: {
+        runId: 1,
+        conclusion: "success",
+        url: "u",
+        passed: true,
+        jobs: "nope",
+      },
+    },
+  });
+  assertEquals(readWorkflowResult(notArray)?.jobs, []);
+  // A job record with no fields defaults each one, the name included.
+  const empty = fakeState({
+    githubWorkflow: {
+      result: {
+        runId: 1,
+        conclusion: "success",
+        url: "u",
+        passed: true,
+        jobs: [{}],
+      },
+    },
+  });
+  assertEquals(readWorkflowResult(empty)?.jobs, [
+    { name: "", conclusion: "", url: "" },
+  ]);
+});
+
+Deno.test("a completed run with a null conclusion is recorded as unknown", async () => {
+  // GitHub can complete a run whose conclusion the API reports as null. That
+  // is not a pass, and the recorded conclusion must still say something
+  // readable rather than serialising a null.
+  const api = new ScriptedApi();
+  api.status = "completed";
+  api.conclusion = null;
+  const state = fakeState();
+  const trigger = githubWorkflowWith((g) => g.repo("a/b").workflow("w"), {
+    api,
+  });
+  const c = ctx(state);
+  await trigger.isSatisfied(NO_SIGNALS, c); // dispatch
+  assertEquals(await trigger.isSatisfied(NO_SIGNALS, c), true);
+  const result = readWorkflowResult(state);
+  assertEquals(result?.passed, false);
+  assertEquals(result?.conclusion, "unknown");
+});
+
 // --- M18: created-window correlation and marker fast-fail -------------------
 
 const DISPATCH_AT = Date.parse("2026-07-19T00:00:00.000Z");

--- a/tests/gemini_archive_test.ts
+++ b/tests/gemini_archive_test.ts
@@ -14,6 +14,7 @@
 import { gunzip, untar } from "../packages/core/mod.ts";
 import {
   assertEquals,
+  assertRejects,
   assertStringIncludes,
 } from "../packages/core/tests/_assert.ts";
 import {
@@ -104,6 +105,53 @@ Deno.test("the asset names are platform-prefixed the way Gemini matches", () => 
   for (const name of GEMINI_ASSET_NAMES) {
     assertEquals(name.endsWith(".tar.gz"), true, `${name} is not a .tar.gz`);
   }
+});
+
+Deno.test("a broken extension root fails with errors that name the fix", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    // No manifest at all.
+    await assertRejects(
+      () => geminiArchiveFiles(root),
+      Error,
+      "requires gemini-extension.json",
+    );
+    await Deno.writeTextFile(`${root}/gemini-extension.json`, "{}");
+    await assertRejects(() => geminiArchiveFiles(root), Error, "LICENSE");
+    await Deno.writeTextFile(`${root}/LICENSE`, "MIT");
+    // Manifest and license present, but no skills tree.
+    await assertRejects(
+      () => geminiArchiveFiles(root),
+      Error,
+      "requires a skills/ tree",
+    );
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test({
+  name: "a symlink under skills/ is refused, not silently dropped",
+  // Creating symlinks on Windows needs a privilege the CI runner may lack.
+  ignore: Deno.build.os === "windows",
+  fn: async () => {
+    // Git and the other harnesses would keep the linked content; an archive
+    // that silently loses it would ship different skills to Gemini.
+    const root = await extensionFixture();
+    try {
+      await Deno.symlink(
+        `${root}/skills/a-skill/SKILL.md`,
+        `${root}/skills/a-skill/linked.md`,
+      );
+      await assertRejects(
+        () => geminiArchiveFiles(root),
+        Error,
+        "linked.md",
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
 });
 
 Deno.test("the repo's real tree packs cleanly", async () => {

--- a/tests/gemini_archive_test.ts
+++ b/tests/gemini_archive_test.ts
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Unit tests for the Gemini extension release archive. What matters is the
+ * contract Gemini's installer imposes: `gemini-extension.json` at the archive
+ * root, the asset names platform-prefixed so `findReleaseAsset` matches them
+ * deterministically, and byte-stable output so re-attaching to a release is
+ * meaningfully idempotent.
+ *
+ * @module
+ */
+
+import { gunzip, untar } from "../packages/core/mod.ts";
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../packages/core/tests/_assert.ts";
+import {
+  buildGeminiArchive,
+  GEMINI_ASSET_NAMES,
+  geminiArchiveFiles,
+} from "../build/gemini_archive.ts";
+
+/** Lay out a minimal extension root (manifest, license, two skills). */
+async function extensionFixture(): Promise<string> {
+  const root = await Deno.makeTempDir();
+  await Deno.writeTextFile(
+    `${root}/gemini-extension.json`,
+    '{"name":"zuke","version":"0.0.1"}',
+  );
+  await Deno.writeTextFile(`${root}/LICENSE`, "MIT");
+  await Deno.mkdir(`${root}/skills/b-skill`, { recursive: true });
+  await Deno.writeTextFile(`${root}/skills/b-skill/SKILL.md`, "b");
+  await Deno.mkdir(`${root}/skills/a-skill/references`, { recursive: true });
+  await Deno.writeTextFile(`${root}/skills/a-skill/SKILL.md`, "a");
+  await Deno.writeTextFile(`${root}/skills/a-skill/references/notes.md`, "n");
+  return root;
+}
+
+Deno.test("the file list is the manifest, license, and skills — sorted", async () => {
+  const root = await extensionFixture();
+  try {
+    assertEquals(await geminiArchiveFiles(root), [
+      "gemini-extension.json",
+      "LICENSE",
+      "skills/a-skill/SKILL.md",
+      "skills/a-skill/references/notes.md",
+      "skills/b-skill/SKILL.md",
+    ]);
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("the archive round-trips with the manifest at its root", async () => {
+  const root = await extensionFixture();
+  try {
+    const dest = `${root}/out.tar.gz`;
+    await buildGeminiArchive(dest, root);
+    const entries = untar(await gunzip(await Deno.readFile(dest)));
+    const names = entries.map((e) => e.name);
+    // Gemini requires the manifest at the archive root — no wrapper directory.
+    assertEquals(names[0], "gemini-extension.json");
+    assertEquals(names.includes("skills/a-skill/SKILL.md"), true);
+    const manifest = entries.find((e) => e.name === "gemini-extension.json");
+    assertStringIncludes(
+      new TextDecoder().decode(manifest?.data ?? new Uint8Array()),
+      '"name":"zuke"',
+    );
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("two builds of the same tree are byte-identical", async () => {
+  // The release upload is skip-if-present; that is only meaningful when a
+  // rebuild produces the same bytes rather than a fresh timestamped archive.
+  const root = await extensionFixture();
+  try {
+    await buildGeminiArchive(`${root}/one.tar.gz`, root);
+    await buildGeminiArchive(`${root}/two.tar.gz`, root);
+    assertEquals(
+      await Deno.readFile(`${root}/one.tar.gz`),
+      await Deno.readFile(`${root}/two.tar.gz`),
+    );
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("the asset names are platform-prefixed the way Gemini matches", () => {
+  // `findReleaseAsset` matches `{platform}.`-prefixed names case-insensitively
+  // and only falls back to a generic asset when it is alone on the release —
+  // so every supported `os.platform()` value must have its own prefix.
+  assertEquals(GEMINI_ASSET_NAMES.length, 3);
+  for (const platform of ["darwin", "linux", "win32"]) {
+    assertEquals(
+      GEMINI_ASSET_NAMES.some((n) => n.startsWith(`${platform}.`)),
+      true,
+      `no asset name for ${platform}`,
+    );
+  }
+  for (const name of GEMINI_ASSET_NAMES) {
+    assertEquals(name.endsWith(".tar.gz"), true, `${name} is not a .tar.gz`);
+  }
+});
+
+Deno.test("the repo's real tree packs cleanly", async () => {
+  // The actual release-time operation, run against this repository: the
+  // manifest, license, and both skills pack without hitting tar's 100-byte
+  // name limit.
+  const dir = await Deno.makeTempDir();
+  try {
+    const packed = await buildGeminiArchive(`${dir}/zuke.tar.gz`);
+    assertEquals(packed[0], "gemini-extension.json");
+    assertEquals(packed.includes("skills/zuke-setup/SKILL.md"), true);
+    assertEquals(packed.includes("skills/zuke-write-build/SKILL.md"), true);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/tests/integration/gemini_release_test.ts
+++ b/tests/integration/gemini_release_test.ts
@@ -1,51 +1,96 @@
-import { assertEquals, assertExists } from "@std/assert";
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Integration: the release target's Gemini-asset wiring — build the extension
+ * archive, then attach it to the latest release under each platform-prefixed
+ * name — driven through the real CLI against a fake GitHub, mirroring how
+ * `zuke.ts`'s `release` target is wired (see `build/gemini_archive.ts`).
+ */
+
 import {
-  afterAll,
-  beforeAll,
-  describe,
-  it,
-} from "@std/testing/bdd";
-import { withRequestInterceptor } from "../../test/with_request_interceptor.ts";
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import { Build, target } from "../../packages/core/mod.ts";
 import { GhTasks } from "../../packages/gh/mod.ts";
+import {
+  buildGeminiArchive,
+  GEMINI_ASSET_NAMES,
+} from "../../build/gemini_archive.ts";
+import { runCli } from "./_harness.ts";
 
-function makeJsonResponse(body: unknown, init?: ResponseInit): Response {
-  return new Response(JSON.stringify(body), {
-    headers: { "content-type": "application/json" },
-    ...init,
-  });
-}
-
-function interceptRequests(handler: Parameters<typeof withRequestInterceptor>[0]) {
+/** A fake GitHub: one release, remembering the asset names it accepts. */
+function fakeGithub(uploaded: string[]): typeof fetch {
   return async (input, _init) => {
-    return await withRequestInterceptor(handler, () => fetch(input, _init));
+    await Promise.resolve();
+    const url = String(input);
+    if (url.includes("uploads.example")) {
+      const name = new URL(url).searchParams.get("name") ?? "";
+      uploaded.push(name);
+      return new Response(
+        JSON.stringify({ id: 1, name, browser_download_url: `dl/${name}` }),
+        { status: 201 },
+      );
+    }
+    return new Response(
+      JSON.stringify({
+        id: 9,
+        tag_name: "core-v1.0.0",
+        upload_url: "https://uploads.example/assets{?name,label}",
+        // The first name is already attached, as after a partial earlier run.
+        assets: [{
+          id: 5,
+          name: GEMINI_ASSET_NAMES[0],
+          browser_download_url: "dl/existing",
+        }],
+      }),
+      { status: 200 },
+    );
   };
 }
 
-describe("Gemini release", () => {
-  let restoreFetch: (() => void) | undefined;
-
-  beforeAll(() => {
-    restoreFetch = withRequestInterceptor((request) => {
-      const url = new URL(request.url);
-      if (request.method === "GET" && url.pathname.endsWith("/releases/latest")) {
-        return makeJsonResponse({ tag_name: "v1.2.3", id: 123 });
+/** A fixture build wired like the release target's Gemini-asset step. */
+function releaseBuild(root: string, uploaded: string[]) {
+  class Release extends Build {
+    attach = target().executes(async () => {
+      const archive = `${root}/zuke.tar.gz`;
+      await buildGeminiArchive(archive, root);
+      for (const name of GEMINI_ASSET_NAMES) {
+        const result = await GhTasks.uploadReleaseAsset((s) =>
+          s.file(archive).name(name).repo("acme/app").token("tok")
+            .fetch(fakeGithub(uploaded))
+        );
+        console.log(`${name}: ${result.state}`);
       }
-      return new Response(null, { status: 404 });
     });
-  });
+  }
+  return Release;
+}
 
-  afterAll(() => {
-    restoreFetch?.();
-  });
-
-  it("resolves latest release", async () => {
-    const result = await GhTasks.uploadReleaseAsset((s) =>
-      s.file("/tmp/zuke.tar.gz").repo("owner/repo").token("token")
+Deno.test("the release wiring attaches missing assets and keeps existing ones", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    await Deno.writeTextFile(
+      `${root}/gemini-extension.json`,
+      '{"name":"zuke","version":"0.0.1"}',
     );
+    await Deno.writeTextFile(`${root}/LICENSE`, "MIT");
+    await Deno.mkdir(`${root}/skills/s`, { recursive: true });
+    await Deno.writeTextFile(`${root}/skills/s/SKILL.md`, "s");
 
-    assertEquals(result.state, "uploaded");
-    assertEquals(result.releaseTag, "v1.2.3");
-    assertEquals(result.releaseId, 123);
-    assertExists(result.url);
-  });
+    const uploaded: string[] = [];
+    const { code, out } = await runCli(releaseBuild(root, uploaded), [
+      "attach",
+    ]);
+    assertEquals(code, 0);
+
+    // The asset present from the earlier run is kept; the other two upload.
+    assertStringIncludes(out, `${GEMINI_ASSET_NAMES[0]}: already-exists`);
+    assertStringIncludes(out, `${GEMINI_ASSET_NAMES[1]}: uploaded`);
+    assertStringIncludes(out, `${GEMINI_ASSET_NAMES[2]}: uploaded`);
+    assertEquals(uploaded, GEMINI_ASSET_NAMES.slice(1));
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
 });

--- a/tests/integration/gemini_release_test.ts
+++ b/tests/integration/gemini_release_test.ts
@@ -25,7 +25,7 @@ function fakeGithub(uploaded: string[]): typeof fetch {
   return async (input, _init) => {
     await Promise.resolve();
     const url = String(input);
-    if (url.includes("uploads.example")) {
+    if (new URL(url).hostname === "uploads.example") {
       const name = new URL(url).searchParams.get("name") ?? "";
       uploaded.push(name);
       return new Response(

--- a/tests/integration/gemini_release_test.ts
+++ b/tests/integration/gemini_release_test.ts
@@ -1,0 +1,51 @@
+import { assertEquals, assertExists } from "@std/assert";
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  it,
+} from "@std/testing/bdd";
+import { withRequestInterceptor } from "../../test/with_request_interceptor.ts";
+import { GhTasks } from "../../packages/gh/mod.ts";
+
+function makeJsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json" },
+    ...init,
+  });
+}
+
+function interceptRequests(handler: Parameters<typeof withRequestInterceptor>[0]) {
+  return async (input, _init) => {
+    return await withRequestInterceptor(handler, () => fetch(input, _init));
+  };
+}
+
+describe("Gemini release", () => {
+  let restoreFetch: (() => void) | undefined;
+
+  beforeAll(() => {
+    restoreFetch = withRequestInterceptor((request) => {
+      const url = new URL(request.url);
+      if (request.method === "GET" && url.pathname.endsWith("/releases/latest")) {
+        return makeJsonResponse({ tag_name: "v1.2.3", id: 123 });
+      }
+      return new Response(null, { status: 404 });
+    });
+  });
+
+  afterAll(() => {
+    restoreFetch?.();
+  });
+
+  it("resolves latest release", async () => {
+    const result = await GhTasks.uploadReleaseAsset((s) =>
+      s.file("/tmp/zuke.tar.gz").repo("owner/repo").token("token")
+    );
+
+    assertEquals(result.state, "uploaded");
+    assertEquals(result.releaseTag, "v1.2.3");
+    assertEquals(result.releaseId, 123);
+    assertExists(result.url);
+  });
+});

--- a/zuke.ts
+++ b/zuke.ts
@@ -1086,7 +1086,11 @@ class ZukeBuild extends Build {
       // "latest" — that is the release `gemini extensions install` resolves,
       // and it changes on every package release, so each run tops it up.
       // Idempotent: a release already carrying the assets is left untouched,
-      // and a repository with no releases yet is an ordinary skip.
+      // and a repository with no releases yet is an ordinary skip. Best-effort
+      // on top: the archive is a nice-to-have for Gemini installs, not part of
+      // the release contract, and a throw here would redden the job after the
+      // releases already exist — skipping the JSR publish that `needs` this
+      // job. A warning plus the next run's top-up is the right trade.
       const scratch = await Deno.makeTempDir();
       try {
         const archive = `${scratch}/zuke.tar.gz`;
@@ -1104,6 +1108,14 @@ class ZukeBuild extends Build {
               : `${name} on ${result.releaseTag}: ${result.state}.`,
           );
         }
+      } catch (error) {
+        ConsoleTasks.warn(
+          "Attaching the Gemini extension archive failed — the releases " +
+            "themselves are unaffected and the next release run tops the " +
+            `assets up: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+        );
       } finally {
         await Deno.remove(scratch, { recursive: true });
       }

--- a/zuke.ts
+++ b/zuke.ts
@@ -103,6 +103,10 @@ import {
 } from "./build/plugin_sync.ts";
 import { checkSkillTree } from "./build/skill_check.ts";
 import {
+  buildGeminiArchive,
+  GEMINI_ASSET_NAMES,
+} from "./build/gemini_archive.ts";
+import {
   bumpFailure,
   checkPluginVersionBump,
   defaultGitHistory,
@@ -1077,6 +1081,32 @@ class ZukeBuild extends Build {
         apply(s);
         return s;
       });
+
+      // Attach the Gemini CLI extension archive to whatever release is now
+      // "latest" — that is the release `gemini extensions install` resolves,
+      // and it changes on every package release, so each run tops it up.
+      // Idempotent: a release already carrying the assets is left untouched,
+      // and a repository with no releases yet is an ordinary skip.
+      const scratch = await Deno.makeTempDir();
+      try {
+        const archive = `${scratch}/zuke.tar.gz`;
+        const packed = await buildGeminiArchive(archive);
+        ConsoleTasks.info(
+          `Built the Gemini extension archive (${packed.length} file(s)).`,
+        );
+        for (const name of GEMINI_ASSET_NAMES) {
+          const result = await GhTasks.uploadReleaseAsset((s) =>
+            s.file(archive).name(name).repo(repo).token(token)
+          );
+          ConsoleTasks.info(
+            result.state === "no-release"
+              ? `No release to attach ${name} to yet.`
+              : `${name} on ${result.releaseTag}: ${result.state}.`,
+          );
+        }
+      } finally {
+        await Deno.remove(scratch, { recursive: true });
+      }
     });
 
   actionRelease = target()


### PR DESCRIPTION
## What & why

Two related deliverables on the multi-harness skills work, plus a repo-wide test-coverage push.

**1. Releases now carry a Gemini CLI extension archive.** `gemini extensions install https://github.com/zuke-build/zuke` resolves the repo's *latest release* and prefers a release asset over cloning; without one it downloads the whole monorepo source tarball to install two skill folders. The `release` target now builds a minimal, deterministic tar.gz (`gemini-extension.json` + `LICENSE` + `skills/`) and attaches it to the latest release under three platform-prefixed names (`darwin.zuke.tar.gz`, `linux.zuke.tar.gz`, `win32.zuke.tar.gz`) — the shape Gemini's `findReleaseAsset` matches deterministically regardless of what else the release carries (a single generic asset silently degrades to the source tarball as soon as any second file is attached; verified against the gemini-cli source).

The upload is a new `GhTasks.uploadReleaseAsset` task in `@zuke/gh`, API-based like `uploadSarif`: it resolves the latest release (or a named tag), skips an asset the release already carries, deletes-and-resends an asset stuck in a non-`uploaded` state (GitHub's documented recovery for interrupted uploads), and reports a repo with no releases as an ordinary outcome. In `zuke.ts` the attach step is best-effort — a transient upload failure must not redden the release job after releases exist, which would skip the JSR publish behind it. Both failure modes were found by the pre-PR adversarial review and carry regression tests.

**2. Coverage raised from 96.8%/95.0% to 98.4% lines / 97.5% branches** (3,151 tests, 0 failed). Targeted, behavior-asserting tests for the weakest files: the AI reviewer/fixer/hosts plumbing, the MCP run-tools/registry/hardening surface, the executor (scheduler, cancel, resume, reap, execute-plan), core `cli`/`ci`/`ci_schedule`/`describe`, core state serialization/stores, and the `gh` package (now 96–100% per file). Residual uncovered branches are justified in the test files — unreachable defensive guards or paths that would require real network/ambient tools to hit.

Drive-by: `README.md` documents that the Gemini extension installs from releases; test fixture wording made dictionary-safe for the spell gate.

## Related issues

Follow-up to #351 (multi-harness skills distribution) — closes the "Gemini installs the whole monorepo" gap noted there.

## Checklist

- [x] The PR title is a [Conventional Commit](https://www.conventionalcommits.org/) (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell — `security` verified except zizmor's advisories lookup, which the sandbox proxy blocks).
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches) — now 98.4% / 97.5%.
- [x] Docs updated in the same PR (`README.md`, JSDoc) when behaviour changed.
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`, `llms-full.txt`, package README `## API`).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with type guards instead).
- [ ] A new package was wired into all seven places — not applicable, no new package.
- [x] The code is written using AI assisted coding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019As9A3ugixLQiAvcat1ZKk

---
_Generated by [Claude Code](https://claude.ai/code/session_019As9A3ugixLQiAvcat1ZKk)_