### PR TITLE
docs(readme): exclude package tags from the Marketplace badge filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://codecov.io/gh/zuke-build/zuke"><img alt="Coverage" src="https://codecov.io/gh/zuke-build/zuke/branch/master/graph/badge.svg" /></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/zuke-build/zuke"><img alt="OpenSSF Scorecard" src="https://api.scorecard.dev/projects/github.com/zuke-build/zuke/badge" /></a>
   <a href="https://www.bestpractices.dev/projects/14036"><img alt="OpenSSF Best Practices" src="https://www.bestpractices.dev/projects/14036/badge" /></a>
-  <a href="https://github.com/marketplace/actions/zuke-build"><img alt="GitHub Marketplace" src="https://img.shields.io/github/v/release/zuke-build/zuke?filter=v%2A.%2A.%2A&amp;label=Marketplace&amp;logo=github&amp;color=2ea44f" /></a>
+  <a href="https://github.com/marketplace/actions/zuke-build"><img alt="GitHub Marketplace" src="https://img.shields.io/github/v/release/zuke-build/zuke?filter=%21%2A-%2A&amp;label=Marketplace&amp;logo=github&amp;color=2ea44f" /></a>
   <a href="https://jsr.io/@zuke/core"><img alt="JSR" src="https://jsr.io/badges/@zuke/core" /></a>
   <a href="https://jsr.io/@zuke/core"><img alt="JSR score" src="https://jsr.io/badges/@zuke/core/score" /></a>
   <a href="./LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-yellow.svg" /></a>


### PR DESCRIPTION
## What & why

The Marketplace badge in the README was showing `vitest-v1.0.1` instead of the composite action's release. The badge's shields.io filter glob `v*.*.*` was meant to match only the action's own tag line, but release-please cuts component tags of the form `<package>-v<semver>`, and any package whose name starts with `v` also satisfies the glob — `vitest-v1.0.1` starts with `v` and contains two dots. Shields shows the most recently published matching release, and the latest `@zuke/vitest` release out-dated the last action release, so the badge picked it up. The `@zuke/vite` tags would collide the same way.

Shields' glob supports only `*` wildcards and `!` negation — no character classes — so the fix filters on what actually separates the two tag lines: every release-please component tag contains a hyphen, and the action's `v<major>.<minor>.<patch>` tags never do, since `parseVersion` in the action-release tooling is strictly anchored with no prerelease suffixes. The new filter `!*-*` matches exactly the hyphen-free tags. Verified against the live shields endpoint: the old filter renders `vitest-v1.0.1`, the new one renders `v1.0.2` — the actual latest action release.

## Related issues

None.

## Checklist

- [x] The PR title is a [Conventional Commit](https://www.conventionalcommits.org/) (`type(scope): summary`).
- [ ] `deno task ci` passes locally (lint, fmt, type-check, tests, spell) — ran the `format` target on this README-only URL edit; the full gate runs in CI.
- [ ] Tests were added or updated; coverage stays at 95%+ (lines and branches) — not applicable, no code changed.
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour changed.
- [ ] Public API changes were regenerated with `./zuke apiDocs` — not applicable.
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with type guards instead).
- [x] No dead code: unreachable branches and can't-fire fallbacks are removed, with types tightened so the impossible state is unrepresentable.
- [ ] A new package was wired into all seven places — not applicable.
- [x] The code is written using AI assisted coding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Evbih78e2DiD4jTyeAu2nS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Evbih78e2DiD4jTyeAu2nS)_