### PR TITLE
feat(gh): mark a release as latest and refresh changed release assets

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9401,6 +9401,9 @@ function githubWorkflow(configure: (settings: GithubWorkflowSettings) => GithubW
   githubWorkflow((g) => g.repo("acme/app").workflow("e2e.yml").ref("main"))
   ```
 
+async function markReleaseLatest(configure?: Configure<GhReleaseLatestSettings>): Promise<GhReleaseLatestResult>
+  Perform the configured mark-latest call.
+
 async function mintAppToken(configure?: Configure<GhAppTokenSettings>): Promise<GhAppTokenResult>
   Mint an installation token from the settings a lambda configures.
 
@@ -9679,6 +9682,8 @@ class GhReleaseAssetSettings
     `owner/repo` to upload to. Set by {@link repo}.
   tag_?: string
     The release tag to attach to. Set by {@link tag}.
+  refresh_: boolean
+    Replace an existing asset whose bytes differ. Set by {@link refresh}.
   token_?: string
     The token to authenticate with. Set by {@link token}.
   baseUrl_: string
@@ -9696,6 +9701,15 @@ class GhReleaseAssetSettings
     The `owner/repo` to upload to. Defaults to `GITHUB_REPOSITORY`.
   tag(value: string): this
     Attach to the release with this tag instead of the latest release.
+  refresh(): this
+    Replace an asset the release already carries when its bytes differ from
+    the file's — compared by the sha256 digest the API reports — instead of
+    keeping it. An asset whose digest matches, or whose digest the API does
+    not report, is still kept: without a comparison to trust, replacement
+    would churn a published release's assets on every run, which is exactly
+    what the default protects. For an asset that must track its source
+    across runs (an extension archive, a docs bundle) on a long-lived
+    release.
   token(value: string): this
     The token to authenticate with — needs `contents: write`. Defaults to
     `GITHUB_TOKEN` in the environment, so it never has to reach argv.
@@ -9711,6 +9725,37 @@ class GhReleaseAssetSettings
     The effective asset name: the setting, or the file's base name.
   effectiveContentType_(): string
     The effective `content-type`: the setting, or inferred by extension.
+
+class GhReleaseLatestSettings
+  Settings for marking a release as latest.
+
+  `owner/repo` and the token fall back to the Actions environment, so a job
+  that already has them needs to name only the tag.
+
+  tag_?: string
+    The tag whose release becomes latest. Set by {@link tag}.
+  repo_?: string
+    `owner/repo`. Set by {@link repo}.
+  token_?: string
+    The token. Set by {@link token}.
+  baseUrl_: string
+    The API root. Set by {@link baseUrl}.
+  fetch_: typeof fetch
+    The `fetch` implementation. Set by {@link fetch}.
+  tag(value: string): this
+    The tag whose release the pointer should name (required).
+  repo(slug: string): this
+    `owner/repo`. Defaults to `GITHUB_REPOSITORY`.
+  token(value: string): this
+    The token to authenticate with — needs `contents: write`. Defaults to `GITHUB_TOKEN`.
+  baseUrl(url: string): this
+    The API root, for GitHub Enterprise.
+  fetch(fn: typeof fetch): this
+    Override the `fetch` implementation (a test seam).
+  repoSlug_(): string
+    The effective `owner/repo`, from the setting or the environment.
+  authToken_(): string
+    The effective token, from the setting or the environment.
 
 class GhSarifSettings
   Settings for {@link GhSarifApi.uploadSarif}.
@@ -9973,17 +10018,20 @@ interface GhReleaseAssetApi
   uploadReleaseAsset(configure?: Configure<GhReleaseAssetSettings>): Promise<GhReleaseAssetResult>
     Attach a file to a GitHub release — the latest release by default, or the
     one named by `.tag(...)`. Idempotent: an asset the release already
-    carries under the same name is kept as-is, and a repository with no
+    carries under the same name is kept as-is (unless `.refresh()` asks for
+    one with different bytes to be replaced), and a repository with no
     releases resolves to `state: "no-release"` rather than throwing. Needs a
     token with `contents: write`.
 
 interface GhReleaseAssetResult
   What became of a release-asset upload.
 
-  state: "uploaded" | "already-exists" | "no-release"
-    `uploaded` when the asset was sent; `already-exists` when the release
-    carries an asset of the same name (nothing was changed); `no-release`
-    when the repository has no release to attach to.
+  state: "uploaded" | "refreshed" | "already-exists" | "no-release"
+    `uploaded` when the asset was sent; `refreshed` when `.refresh()` found
+    the release carrying different bytes under the name and replaced them;
+    `already-exists` when the release carries an asset of the same name that
+    was kept (nothing was changed); `no-release` when the repository has no
+    release to attach to.
   name: string
     The asset name the call targeted.
   releaseTag?: string
@@ -9992,6 +10040,33 @@ interface GhReleaseAssetResult
     The id of the release the asset belongs to, when one was resolved.
   url?: string
     The asset's download URL, when it was uploaded or already present.
+
+interface GhReleaseLatestApi
+  The mark-latest operation {@link GhTasks} exposes.
+
+  markReleaseLatest(configure?: Configure<GhReleaseLatestSettings>): Promise<GhReleaseLatestResult>
+    Point the repository's "Latest release" at the release for `.tag(...)`.
+
+    Idempotent, and quiet about it: a pointer already on the tag's release is
+    left untouched rather than re-written, so an unattended pipeline can run
+    this unconditionally without churning the release's audit history. A tag
+    with no release resolves to `state: "no-release"` rather than throwing —
+    the release may be cut by a later, human step — while a tag that does not
+    exist at all is an error, because the caller named it. Needs a token with
+    `contents: write`.
+
+interface GhReleaseLatestResult
+  What became of a {@link GhReleaseLatestApi.markReleaseLatest} call.
+
+  state: "marked" | "already-latest" | "no-release"
+    `marked` when the pointer was moved onto the tag's release;
+    `already-latest` when it was there before the call (nothing was written);
+    `no-release` when the tag has no release to point at — an ordinary
+    outcome for a tag whose release is created by a later, human step.
+  tag: string
+    The tag the call targeted.
+  releaseId?: number
+    The id of the tag's release, when one was resolved.
 
 interface GhSarifApi
   The shape of the SARIF task, mixed into `GhTasks`.
@@ -10008,7 +10083,7 @@ interface GhSarifUploadResult
   url: string
     The URL that reports whether GitHub finished processing the report.
 
-interface GhTasksApi extends GhAppTokenApi, GhSarifApi, GhReleaseAssetApi, GhCommitApi, GhPullRequestApi, GhCheckRunApi
+interface GhTasksApi extends GhAppTokenApi, GhSarifApi, GhReleaseAssetApi, GhReleaseLatestApi, GhCommitApi, GhPullRequestApi, GhCheckRunApi
   The shape of {@link GhTasks}: the `gh` CLI plus the GitHub operations that
   have no CLI subcommand (see {@link GhAppTokenApi}, {@link GhSarifApi}) and
   would otherwise force a build back to a marketplace action.

--- a/packages/gh/README.md
+++ b/packages/gh/README.md
@@ -173,6 +173,9 @@ function githubWorkflow(configure: (settings: GithubWorkflowSettings) => GithubW
   githubWorkflow((g) => g.repo("acme/app").workflow("e2e.yml").ref("main"))
   ```
 
+async function markReleaseLatest(configure?: Configure<GhReleaseLatestSettings>): Promise<GhReleaseLatestResult>
+  Perform the configured mark-latest call.
+
 async function mintAppToken(configure?: Configure<GhAppTokenSettings>): Promise<GhAppTokenResult>
   Mint an installation token from the settings a lambda configures.
 
@@ -451,6 +454,8 @@ class GhReleaseAssetSettings
     `owner/repo` to upload to. Set by {@link repo}.
   tag_?: string
     The release tag to attach to. Set by {@link tag}.
+  refresh_: boolean
+    Replace an existing asset whose bytes differ. Set by {@link refresh}.
   token_?: string
     The token to authenticate with. Set by {@link token}.
   baseUrl_: string
@@ -468,6 +473,15 @@ class GhReleaseAssetSettings
     The `owner/repo` to upload to. Defaults to `GITHUB_REPOSITORY`.
   tag(value: string): this
     Attach to the release with this tag instead of the latest release.
+  refresh(): this
+    Replace an asset the release already carries when its bytes differ from
+    the file's — compared by the sha256 digest the API reports — instead of
+    keeping it. An asset whose digest matches, or whose digest the API does
+    not report, is still kept: without a comparison to trust, replacement
+    would churn a published release's assets on every run, which is exactly
+    what the default protects. For an asset that must track its source
+    across runs (an extension archive, a docs bundle) on a long-lived
+    release.
   token(value: string): this
     The token to authenticate with — needs `contents: write`. Defaults to
     `GITHUB_TOKEN` in the environment, so it never has to reach argv.
@@ -483,6 +497,37 @@ class GhReleaseAssetSettings
     The effective asset name: the setting, or the file's base name.
   effectiveContentType_(): string
     The effective `content-type`: the setting, or inferred by extension.
+
+class GhReleaseLatestSettings
+  Settings for marking a release as latest.
+
+  `owner/repo` and the token fall back to the Actions environment, so a job
+  that already has them needs to name only the tag.
+
+  tag_?: string
+    The tag whose release becomes latest. Set by {@link tag}.
+  repo_?: string
+    `owner/repo`. Set by {@link repo}.
+  token_?: string
+    The token. Set by {@link token}.
+  baseUrl_: string
+    The API root. Set by {@link baseUrl}.
+  fetch_: typeof fetch
+    The `fetch` implementation. Set by {@link fetch}.
+  tag(value: string): this
+    The tag whose release the pointer should name (required).
+  repo(slug: string): this
+    `owner/repo`. Defaults to `GITHUB_REPOSITORY`.
+  token(value: string): this
+    The token to authenticate with — needs `contents: write`. Defaults to `GITHUB_TOKEN`.
+  baseUrl(url: string): this
+    The API root, for GitHub Enterprise.
+  fetch(fn: typeof fetch): this
+    Override the `fetch` implementation (a test seam).
+  repoSlug_(): string
+    The effective `owner/repo`, from the setting or the environment.
+  authToken_(): string
+    The effective token, from the setting or the environment.
 
 class GhSarifSettings
   Settings for {@link GhSarifApi.uploadSarif}.
@@ -745,17 +790,20 @@ interface GhReleaseAssetApi
   uploadReleaseAsset(configure?: Configure<GhReleaseAssetSettings>): Promise<GhReleaseAssetResult>
     Attach a file to a GitHub release — the latest release by default, or the
     one named by `.tag(...)`. Idempotent: an asset the release already
-    carries under the same name is kept as-is, and a repository with no
+    carries under the same name is kept as-is (unless `.refresh()` asks for
+    one with different bytes to be replaced), and a repository with no
     releases resolves to `state: "no-release"` rather than throwing. Needs a
     token with `contents: write`.
 
 interface GhReleaseAssetResult
   What became of a release-asset upload.
 
-  state: "uploaded" | "already-exists" | "no-release"
-    `uploaded` when the asset was sent; `already-exists` when the release
-    carries an asset of the same name (nothing was changed); `no-release`
-    when the repository has no release to attach to.
+  state: "uploaded" | "refreshed" | "already-exists" | "no-release"
+    `uploaded` when the asset was sent; `refreshed` when `.refresh()` found
+    the release carrying different bytes under the name and replaced them;
+    `already-exists` when the release carries an asset of the same name that
+    was kept (nothing was changed); `no-release` when the repository has no
+    release to attach to.
   name: string
     The asset name the call targeted.
   releaseTag?: string
@@ -764,6 +812,33 @@ interface GhReleaseAssetResult
     The id of the release the asset belongs to, when one was resolved.
   url?: string
     The asset's download URL, when it was uploaded or already present.
+
+interface GhReleaseLatestApi
+  The mark-latest operation {@link GhTasks} exposes.
+
+  markReleaseLatest(configure?: Configure<GhReleaseLatestSettings>): Promise<GhReleaseLatestResult>
+    Point the repository's "Latest release" at the release for `.tag(...)`.
+
+    Idempotent, and quiet about it: a pointer already on the tag's release is
+    left untouched rather than re-written, so an unattended pipeline can run
+    this unconditionally without churning the release's audit history. A tag
+    with no release resolves to `state: "no-release"` rather than throwing —
+    the release may be cut by a later, human step — while a tag that does not
+    exist at all is an error, because the caller named it. Needs a token with
+    `contents: write`.
+
+interface GhReleaseLatestResult
+  What became of a {@link GhReleaseLatestApi.markReleaseLatest} call.
+
+  state: "marked" | "already-latest" | "no-release"
+    `marked` when the pointer was moved onto the tag's release;
+    `already-latest` when it was there before the call (nothing was written);
+    `no-release` when the tag has no release to point at — an ordinary
+    outcome for a tag whose release is created by a later, human step.
+  tag: string
+    The tag the call targeted.
+  releaseId?: number
+    The id of the tag's release, when one was resolved.
 
 interface GhSarifApi
   The shape of the SARIF task, mixed into `GhTasks`.
@@ -780,7 +855,7 @@ interface GhSarifUploadResult
   url: string
     The URL that reports whether GitHub finished processing the report.
 
-interface GhTasksApi extends GhAppTokenApi, GhSarifApi, GhReleaseAssetApi, GhCommitApi, GhPullRequestApi, GhCheckRunApi
+interface GhTasksApi extends GhAppTokenApi, GhSarifApi, GhReleaseAssetApi, GhReleaseLatestApi, GhCommitApi, GhPullRequestApi, GhCheckRunApi
   The shape of {@link GhTasks}: the `gh` CLI plus the GitHub operations that
   have no CLI subcommand (see {@link GhAppTokenApi}, {@link GhSarifApi}) and
   would otherwise force a build back to a marketplace action.

--- a/packages/gh/mod.ts
+++ b/packages/gh/mod.ts
@@ -58,6 +58,12 @@ export {
   uploadReleaseAsset,
 } from "./src/release_asset.ts";
 export {
+  type GhReleaseLatestApi,
+  type GhReleaseLatestResult,
+  GhReleaseLatestSettings,
+  markReleaseLatest,
+} from "./src/release_latest.ts";
+export {
   type CorrelateMode,
   githubWorkflow,
   GithubWorkflowSettings,

--- a/packages/gh/src/gh.ts
+++ b/packages/gh/src/gh.ts
@@ -70,6 +70,12 @@ import {
   type GhReleaseAssetSettings,
   uploadReleaseAsset,
 } from "./release_asset.ts";
+import {
+  type GhReleaseLatestApi,
+  type GhReleaseLatestResult,
+  type GhReleaseLatestSettings,
+  markReleaseLatest,
+} from "./release_latest.ts";
 
 /** Settings for a `gh` invocation. */
 export class GhSettings extends SubcommandSettings {
@@ -102,6 +108,7 @@ export interface GhTasksApi
     GhAppTokenApi,
     GhSarifApi,
     GhReleaseAssetApi,
+    GhReleaseLatestApi,
     GhCommitApi,
     GhPullRequestApi,
     GhCheckRunApi {
@@ -151,5 +158,10 @@ export const GhTasks: GhTasksApi = {
     configure?: Configure<GhReleaseAssetSettings>,
   ): Promise<GhReleaseAssetResult> {
     return uploadReleaseAsset(configure);
+  },
+  markReleaseLatest(
+    configure?: Configure<GhReleaseLatestSettings>,
+  ): Promise<GhReleaseLatestResult> {
+    return markReleaseLatest(configure);
   },
 };

--- a/packages/gh/src/release_asset.ts
+++ b/packages/gh/src/release_asset.ts
@@ -8,8 +8,11 @@
  * The release is resolved first — the latest one by default, or a specific tag
  * — and an asset the release already carries under the same name is left
  * alone, so the call is idempotent and a published release's assets are never
- * mutated. A repository with no releases yet is an ordinary outcome, not an
- * error, so a release pipeline can run this unconditionally:
+ * mutated. `.refresh()` opts one asset out of that stability: when the
+ * release's copy has different bytes (by its reported sha256 digest), it is
+ * replaced instead of kept, so an asset that must track its source can live
+ * on a long-lived release. A repository with no releases yet is an ordinary
+ * outcome, not an error, so a release pipeline can run this unconditionally:
  *
  * ```ts
  * await GhTasks.uploadReleaseAsset((s) =>
@@ -37,11 +40,13 @@ const CONTENT_TYPES: Record<string, string> = {
 /** What became of a release-asset upload. */
 export interface GhReleaseAssetResult {
   /**
-   * `uploaded` when the asset was sent; `already-exists` when the release
-   * carries an asset of the same name (nothing was changed); `no-release`
-   * when the repository has no release to attach to.
+   * `uploaded` when the asset was sent; `refreshed` when `.refresh()` found
+   * the release carrying different bytes under the name and replaced them;
+   * `already-exists` when the release carries an asset of the same name that
+   * was kept (nothing was changed); `no-release` when the repository has no
+   * release to attach to.
    */
-  state: "uploaded" | "already-exists" | "no-release";
+  state: "uploaded" | "refreshed" | "already-exists" | "no-release";
   /** The asset name the call targeted. */
   name: string;
   /** The tag of the release the asset belongs to, when one was resolved. */
@@ -74,6 +79,8 @@ export class GhReleaseAssetSettings {
   repo_?: string;
   /** The release tag to attach to. Set by {@link tag}. */
   tag_?: string;
+  /** Replace an existing asset whose bytes differ. Set by {@link refresh}. */
+  refresh_ = false;
   /** The token to authenticate with. Set by {@link token}. */
   token_?: string;
   /** REST base URL. Set by {@link baseUrl}. */
@@ -111,6 +118,21 @@ export class GhReleaseAssetSettings {
   /** Attach to the release with this tag instead of the latest release. */
   tag(value: string): this {
     this.tag_ = value;
+    return this;
+  }
+
+  /**
+   * Replace an asset the release already carries when its bytes differ from
+   * the file's — compared by the sha256 digest the API reports — instead of
+   * keeping it. An asset whose digest matches, or whose digest the API does
+   * not report, is still kept: without a comparison to trust, replacement
+   * would churn a published release's assets on every run, which is exactly
+   * what the default protects. For an asset that must track its source
+   * across runs (an extension archive, a docs bundle) on a long-lived
+   * release.
+   */
+  refresh(): this {
+    this.refresh_ = true;
     return this;
   }
 
@@ -184,7 +206,8 @@ export interface GhReleaseAssetApi {
   /**
    * Attach a file to a GitHub release — the latest release by default, or the
    * one named by `.tag(...)`. Idempotent: an asset the release already
-   * carries under the same name is kept as-is, and a repository with no
+   * carries under the same name is kept as-is (unless `.refresh()` asks for
+   * one with different bytes to be replaced), and a repository with no
    * releases resolves to `state: "no-release"` rather than throwing. Needs a
    * token with `contents: write`.
    */
@@ -196,6 +219,37 @@ export interface GhReleaseAssetApi {
 /** A field read from a REST response without assuming the response's shape. */
 function field(value: unknown, key: string): unknown {
   return isRecord(value) ? value[key] : undefined;
+}
+
+/** The `sha256:<hex>` digest of `data`, as the REST API reports assets. */
+async function sha256(data: Uint8Array<ArrayBuffer>): Promise<string> {
+  const hash = await crypto.subtle.digest("SHA-256", data);
+  const hex = [...new Uint8Array(hash)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+  return `sha256:${hex}`;
+}
+
+/** Delete a release asset, tolerating one that is already gone. */
+async function deleteAsset(
+  settings: GhReleaseAssetSettings,
+  headers: Record<string, string>,
+  slug: string,
+  assetId: number,
+  what: string,
+): Promise<void> {
+  const deletion = await settings.fetch_(
+    `${settings.baseUrl_}/repos/${slug}/releases/assets/${assetId}`,
+    { method: "DELETE", headers },
+  );
+  const deletionText = await deletion.text();
+  // A 404 means the asset was already cleaned up — the goal state.
+  if (!deletion.ok && deletion.status !== 404) {
+    throw new Error(
+      `deleting the ${what} failed: ${deletion.status} ` +
+        `${deletion.statusText}. ${deletionText.slice(0, 400)}`,
+    );
+  }
 }
 
 /** Upload the release asset the settings describe. */
@@ -262,22 +316,46 @@ export async function uploadReleaseAsset(
   const releaseTag = field(release, "tag_name");
   const tag = typeof releaseTag === "string" ? releaseTag : undefined;
 
+  // Read lazily: the refresh comparison and the upload both need the bytes,
+  // but the common already-exists path needs none.
+  let bytes: Uint8Array<ArrayBuffer> | undefined;
+  const fileBytes = async (): Promise<Uint8Array<ArrayBuffer>> =>
+    bytes ??= await Deno.readFile(settings.filePath_());
+
   // Idempotence: a release that already carries the asset is left untouched —
   // published assets are immutable history, and re-running the pipeline must
-  // not churn them. The one exception is an asset stuck in a non-`uploaded`
-  // state: an errored or interrupted upload reserves the name while serving
-  // nothing, and GitHub's documented recovery is delete-then-reupload — so a
-  // re-run must do exactly that rather than skip past the corpse forever.
+  // not churn them. Two exceptions, both delete-then-reupload. An asset stuck
+  // in a non-`uploaded` state: an errored or interrupted upload reserves the
+  // name while serving nothing, and GitHub's documented recovery is exactly
+  // that — a re-run must repair it rather than skip past the corpse forever.
+  // And, under `.refresh()`, a healthy asset whose digest differs from the
+  // file's: the caller declared this asset one that tracks its source.
   const assets = field(release, "assets");
+  let replaced = false;
   if (Array.isArray(assets)) {
     for (const asset of assets) {
       if (field(asset, "name") !== name) continue;
       const state = field(asset, "state");
       const assetId = field(asset, "id");
-      if (
-        (state === undefined || state === "uploaded") ||
-        typeof assetId !== "number"
-      ) {
+      const healthy = state === undefined || state === "uploaded";
+      if (healthy && settings.refresh_ && typeof assetId === "number") {
+        const digest = field(asset, "digest");
+        if (
+          typeof digest === "string" &&
+          digest !== await sha256(await fileBytes())
+        ) {
+          await deleteAsset(
+            settings,
+            headers,
+            slug,
+            assetId,
+            `stale release asset "${name}"`,
+          );
+          replaced = true;
+          continue;
+        }
+      }
+      if (healthy || typeof assetId !== "number") {
         const url = field(asset, "browser_download_url");
         return {
           state: "already-exists",
@@ -287,27 +365,20 @@ export async function uploadReleaseAsset(
           ...(typeof url === "string" ? { url } : {}),
         };
       }
-      const deletion = await settings.fetch_(
-        `${settings.baseUrl_}/repos/${slug}/releases/assets/${assetId}`,
-        { method: "DELETE", headers },
+      await deleteAsset(
+        settings,
+        headers,
+        slug,
+        assetId,
+        `stuck release asset "${name}" (state ${String(state)})`,
       );
-      const deletionText = await deletion.text();
-      // A 404 means the corpse was already cleaned up — the goal state.
-      if (!deletion.ok && deletion.status !== 404) {
-        throw new Error(
-          `deleting the stuck release asset "${name}" (state ${
-            String(state)
-          }) failed: ${deletion.status} ${deletion.statusText}. ` +
-            deletionText.slice(0, 400),
-        );
-      }
     }
   }
 
   // The `upload_url` is an RFC 6570 template ending in `{?name,label}`;
   // GitHub documents cutting the template off and appending a query.
   const uploadBase = uploadUrlTemplate.replace(/\{[^}]*\}$/, "");
-  const data = await Deno.readFile(settings.filePath_());
+  const data = await fileBytes();
   const uploadResponse = await settings.fetch_(
     `${uploadBase}?name=${encodeURIComponent(name)}`,
     {
@@ -336,7 +407,7 @@ export async function uploadReleaseAsset(
   }
   const url = field(uploaded, "browser_download_url");
   return {
-    state: "uploaded",
+    state: replaced ? "refreshed" : "uploaded",
     name,
     releaseTag: tag,
     releaseId,

--- a/packages/gh/src/release_latest.ts
+++ b/packages/gh/src/release_latest.ts
@@ -1,0 +1,192 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Keep a repository's "Latest release" pointer on a chosen release.
+ *
+ * GitHub moves the pointer to whichever non-prerelease release was published
+ * most recently, and surfaces it well beyond the releases page: the
+ * Marketplace listing of a repository's action advertises it as the action's
+ * current version, and `gemini extensions install` resolves it. In a monorepo
+ * whose packages release continuously, every package release drags the pointer
+ * away from the release a consumer should see. This operation pins it back,
+ * idempotently, from the same pipeline that cut the package releases:
+ *
+ * ```ts
+ * await GhTasks.markReleaseLatest((s) => s.tag("v1.0.2").token(token));
+ * ```
+ *
+ * @module
+ */
+
+import type { Configure } from "@zuke/core/tooling";
+import {
+  assertRefName,
+  caller,
+  DEFAULT_BASE_URL,
+  encodePath,
+  env,
+  GhApiError,
+  readNumber,
+} from "./api.ts";
+
+/** What became of a {@link GhReleaseLatestApi.markReleaseLatest} call. */
+export interface GhReleaseLatestResult {
+  /**
+   * `marked` when the pointer was moved onto the tag's release;
+   * `already-latest` when it was there before the call (nothing was written);
+   * `no-release` when the tag has no release to point at — an ordinary
+   * outcome for a tag whose release is created by a later, human step.
+   */
+  state: "marked" | "already-latest" | "no-release";
+  /** The tag the call targeted. */
+  tag: string;
+  /** The id of the tag's release, when one was resolved. */
+  releaseId?: number;
+}
+
+/**
+ * Settings for marking a release as latest.
+ *
+ * `owner/repo` and the token fall back to the Actions environment, so a job
+ * that already has them needs to name only the tag.
+ */
+export class GhReleaseLatestSettings {
+  /** The tag whose release becomes latest. Set by {@link tag}. */
+  tag_?: string;
+  /** `owner/repo`. Set by {@link repo}. */
+  repo_?: string;
+  /** The token. Set by {@link token}. */
+  token_?: string;
+  /** The API root. Set by {@link baseUrl}. */
+  baseUrl_: string = DEFAULT_BASE_URL;
+  /** The `fetch` implementation. Set by {@link fetch}. */
+  fetch_: typeof fetch = fetch;
+
+  /** The tag whose release the pointer should name (required). */
+  tag(value: string): this {
+    this.tag_ = value;
+    return this;
+  }
+
+  /** `owner/repo`. Defaults to `GITHUB_REPOSITORY`. */
+  repo(slug: string): this {
+    this.repo_ = slug;
+    return this;
+  }
+
+  /** The token to authenticate with — needs `contents: write`. Defaults to `GITHUB_TOKEN`. */
+  token(value: string): this {
+    this.token_ = value;
+    return this;
+  }
+
+  /** The API root, for GitHub Enterprise. */
+  baseUrl(url: string): this {
+    this.baseUrl_ = url.replace(/\/+$/, "");
+    return this;
+  }
+
+  /** Override the `fetch` implementation (a test seam). */
+  fetch(fn: typeof fetch): this {
+    this.fetch_ = fn;
+    return this;
+  }
+
+  /** The effective `owner/repo`, from the setting or the environment. */
+  repoSlug_(): string {
+    const slug = this.repo_ ?? env("GITHUB_REPOSITORY");
+    if (slug === undefined) {
+      throw new Error(
+        "marking a release as latest requires .repo('owner/name') (or " +
+          "GITHUB_REPOSITORY).",
+      );
+    }
+    return slug;
+  }
+
+  /** The effective token, from the setting or the environment. */
+  authToken_(): string {
+    const token = this.token_ ?? env("GITHUB_TOKEN");
+    if (token === undefined) {
+      throw new Error(
+        "marking a release as latest requires .token(...) (or GITHUB_TOKEN) " +
+          "with contents: write.",
+      );
+    }
+    return token;
+  }
+}
+
+/** The mark-latest operation {@link GhTasks} exposes. */
+export interface GhReleaseLatestApi {
+  /**
+   * Point the repository's "Latest release" at the release for `.tag(...)`.
+   *
+   * Idempotent, and quiet about it: a pointer already on the tag's release is
+   * left untouched rather than re-written, so an unattended pipeline can run
+   * this unconditionally without churning the release's audit history. A tag
+   * with no release resolves to `state: "no-release"` rather than throwing —
+   * the release may be cut by a later, human step — while a tag that does not
+   * exist at all is an error, because the caller named it. Needs a token with
+   * `contents: write`.
+   */
+  markReleaseLatest(
+    configure?: Configure<GhReleaseLatestSettings>,
+  ): Promise<GhReleaseLatestResult>;
+}
+
+/** Perform the configured mark-latest call. */
+export async function markReleaseLatest(
+  configure?: Configure<GhReleaseLatestSettings>,
+): Promise<GhReleaseLatestResult> {
+  const settings = configure?.(new GhReleaseLatestSettings()) ??
+    new GhReleaseLatestSettings();
+  const tag = settings.tag_;
+  if (tag === undefined) {
+    throw new Error("marking a release as latest requires .tag(...).");
+  }
+  // The tag is interpolated into a request path — the same reason the commit
+  // operations validate theirs.
+  assertRefName(tag, "release tag");
+  const call = caller(
+    settings.baseUrl_,
+    settings.repoSlug_(),
+    settings.authToken_(),
+    settings.fetch_,
+  );
+
+  // Resolve the tag's release first: "no release yet" is the expected soft
+  // outcome, and nothing should be written when it holds.
+  let release: unknown;
+  try {
+    release = await call("GET", `/releases/tags/${encodePath(tag)}`);
+  } catch (error) {
+    if (error instanceof GhApiError && error.status === 404) {
+      return { state: "no-release", tag };
+    }
+    throw error;
+  }
+  const releaseId = readNumber(release, "id", "release lookup");
+
+  // Skip the write when the pointer is already right. A repository whose
+  // latest-release lookup 404s has the pointer on nothing — GitHub hides
+  // drafts and prereleases from it — so the write below is what sets it.
+  let latestId: number | undefined;
+  try {
+    latestId = readNumber(
+      await call("GET", "/releases/latest"),
+      "id",
+      "latest-release lookup",
+    );
+  } catch (error) {
+    if (!(error instanceof GhApiError) || error.status !== 404) throw error;
+  }
+  if (latestId === releaseId) {
+    return { state: "already-latest", tag, releaseId };
+  }
+
+  // `make_latest` is a string enum in the REST API, not a boolean.
+  await call("PATCH", `/releases/${releaseId}`, { make_latest: "true" });
+  return { state: "marked", tag, releaseId };
+}

--- a/packages/gh/tests/release_asset_test.ts
+++ b/packages/gh/tests/release_asset_test.ts
@@ -255,6 +255,115 @@ Deno.test("a failed deletion of a stuck asset surfaces, a 404 does not", async (
   }
 });
 
+/** The `sha256:<hex>` digest the REST API would report for `data`. */
+async function digestOf(data: Uint8Array<ArrayBuffer>): Promise<string> {
+  const hash = await crypto.subtle.digest("SHA-256", data);
+  const hex = [...new Uint8Array(hash)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+  return `sha256:${hex}`;
+}
+
+Deno.test("refresh replaces an asset whose digest differs", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const file = await assetFixture(dir);
+    const seen: Seen[] = [];
+    const github: typeof fetch = async (input, init) => {
+      const method = init?.method ?? "GET";
+      seen.push({
+        url: String(input),
+        method,
+        authorization: new Headers(init?.headers).get("authorization") ?? "",
+        contentType: new Headers(init?.headers).get("content-type"),
+        body: init?.body instanceof Uint8Array ? init.body : undefined,
+      });
+      await Promise.resolve();
+      if (method === "DELETE") return new Response(null, { status: 204 });
+      if (new URL(String(input)).hostname === "uploads.github.com") {
+        return new Response(
+          JSON.stringify({ id: 901, browser_download_url: "dl/fresh" }),
+          { status: 201 },
+        );
+      }
+      const release = releasePayload([]);
+      release.assets = [{
+        id: 100,
+        name: "extension.tar.gz",
+        digest:
+          "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        browser_download_url: "dl/stale",
+      }];
+      return new Response(JSON.stringify(release), { status: 200 });
+    };
+
+    const result = await GhTasks.uploadReleaseAsset((s) =>
+      s.file(file).repo("acme/app").token("tok").refresh().fetch(github)
+    );
+    assertEquals(result.state, "refreshed");
+    // Lookup, then DELETE of the stale copy, then the fresh upload — the
+    // asset's freshness is the caller's declared contract for this name.
+    assertEquals(seen.map((s) => s.method), ["GET", "DELETE", "POST"]);
+    assertStringIncludes(seen[1].url, "/releases/assets/100");
+    assertEquals(seen[2].body, new Uint8Array([1, 2, 3, 4]));
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("refresh keeps an asset whose digest matches the file", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const file = await assetFixture(dir);
+    const digest = await digestOf(new Uint8Array([1, 2, 3, 4]));
+    const seen: Seen[] = [];
+    const github: typeof fetch = async (input, init) => {
+      seen.push({
+        url: String(input),
+        method: init?.method ?? "GET",
+        authorization: "",
+        contentType: null,
+        body: undefined,
+      });
+      await Promise.resolve();
+      const release = releasePayload([]);
+      release.assets = [{
+        id: 100,
+        name: "extension.tar.gz",
+        digest,
+        browser_download_url: "dl/current",
+      }];
+      return new Response(JSON.stringify(release), { status: 200 });
+    };
+    const result = await GhTasks.uploadReleaseAsset((s) =>
+      s.file(file).repo("acme/app").token("tok").refresh().fetch(github)
+    );
+    assertEquals(result.state, "already-exists");
+    // Only the lookup went out: same bytes, nothing to replace.
+    assertEquals(seen.length, 1);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("refresh keeps an asset whose digest the API does not report", async () => {
+  // Without a comparison to trust, replacing would churn the release's
+  // assets on every run — the exact thing the default protects against.
+  const dir = await Deno.makeTempDir();
+  try {
+    const file = await assetFixture(dir);
+    const seen: Seen[] = [];
+    const result = await GhTasks.uploadReleaseAsset((s) =>
+      s.file(file).repo("acme/app").token("tok").refresh()
+        .fetch(fakeGithub(seen, { assets: [{ name: "extension.tar.gz" }] }))
+    );
+    assertEquals(result.state, "already-exists");
+    assertEquals(seen.length, 1);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
 Deno.test("a repository with no releases reports no-release, not an error", async () => {
   const dir = await Deno.makeTempDir();
   try {

--- a/packages/gh/tests/release_latest_test.ts
+++ b/packages/gh/tests/release_latest_test.ts
@@ -1,0 +1,265 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Unit tests for marking a release as latest. The requests go through a
+ * `fetch` seam answering the way the REST API does, so what is asserted is
+ * the real three-step flow — resolve the tag's release, check where the
+ * pointer already is, and PATCH only when it must move.
+ *
+ * @module
+ */
+
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "../../core/tests/_assert.ts";
+import { GhApiError, GhTasks } from "../mod.ts";
+
+/** A recorded request the fake `fetch` saw. */
+interface Seen {
+  url: string;
+  method: string;
+  authorization: string;
+  body: string | undefined;
+}
+
+/** A fake GitHub parameterized on the two lookups' answers. */
+function fakeGithub(
+  seen: Seen[],
+  options: {
+    tagStatus?: number;
+    tagId?: number;
+    latestStatus?: number;
+    latestId?: number;
+    patchStatus?: number;
+  } = {},
+): typeof fetch {
+  return async (input, init) => {
+    const url = String(input);
+    const method = init?.method ?? "GET";
+    seen.push({
+      url,
+      method,
+      authorization: new Headers(init?.headers).get("authorization") ?? "",
+      body: typeof init?.body === "string" ? init.body : undefined,
+    });
+    await Promise.resolve();
+    const respond = (status: number, payload: unknown) =>
+      new Response(JSON.stringify(payload), {
+        status,
+        statusText: status < 300 ? "OK" : "Nope",
+      });
+    if (method === "PATCH") {
+      const status = options.patchStatus ?? 200;
+      return respond(
+        status,
+        status < 300 ? { id: options.tagId ?? 7 } : { message: "refused" },
+      );
+    }
+    if (url.includes("/releases/tags/")) {
+      const status = options.tagStatus ?? 200;
+      return respond(
+        status,
+        status < 300 ? { id: options.tagId ?? 7 } : { message: "Not Found" },
+      );
+    }
+    const status = options.latestStatus ?? 200;
+    return respond(
+      status,
+      status < 300 ? { id: options.latestId ?? 9 } : { message: "Not Found" },
+    );
+  };
+}
+
+Deno.test("a release that is not latest is marked with a PATCH", async () => {
+  const seen: Seen[] = [];
+  const result = await GhTasks.markReleaseLatest((s) =>
+    s.tag("v1.0.2").repo("acme/app").token("tok").fetch(fakeGithub(seen))
+  );
+
+  assertEquals(result, { state: "marked", tag: "v1.0.2", releaseId: 7 });
+  // The tag lookup, the pointer check, then the one write.
+  assertEquals(seen.map((s) => s.method), ["GET", "GET", "PATCH"]);
+  assertStringIncludes(seen[0].url, "/repos/acme/app/releases/tags/v1.0.2");
+  assertStringIncludes(seen[1].url, "/repos/acme/app/releases/latest");
+  assertStringIncludes(seen[2].url, "/repos/acme/app/releases/7");
+  // The REST API wants the string enum, not a boolean — and the token rides
+  // in the header, never the URL.
+  assertEquals(seen[2].body, '{"make_latest":"true"}');
+  assertEquals(seen[2].authorization, "Bearer tok");
+});
+
+Deno.test("a release that is already latest is left unwritten", async () => {
+  const seen: Seen[] = [];
+  const result = await GhTasks.markReleaseLatest((s) =>
+    s.tag("v1.0.2").repo("acme/app").token("tok")
+      .fetch(fakeGithub(seen, { tagId: 7, latestId: 7 }))
+  );
+  assertEquals(result, {
+    state: "already-latest",
+    tag: "v1.0.2",
+    releaseId: 7,
+  });
+  // Both lookups, no PATCH: an unconditional pipeline run must not churn the
+  // release's audit history.
+  assertEquals(seen.map((s) => s.method), ["GET", "GET"]);
+});
+
+Deno.test("a tag with no release reports no-release, not an error", async () => {
+  const seen: Seen[] = [];
+  const result = await GhTasks.markReleaseLatest((s) =>
+    s.tag("v1.0.3").repo("acme/app").token("tok")
+      .fetch(fakeGithub(seen, { tagStatus: 404 }))
+  );
+  assertEquals(result, { state: "no-release", tag: "v1.0.3" });
+  // Nothing was written for it either.
+  assertEquals(seen.map((s) => s.method), ["GET"]);
+});
+
+Deno.test("a repository with no latest release still gets the PATCH", async () => {
+  // GitHub hides drafts and prereleases from the latest lookup, so a 404
+  // there does not mean the tag's release is missing — the write is what
+  // gives the pointer a value.
+  const result = await GhTasks.markReleaseLatest((s) =>
+    s.tag("v1.0.2").repo("acme/app").token("tok")
+      .fetch(fakeGithub([], { latestStatus: 404 }))
+  );
+  assertEquals(result.state, "marked");
+});
+
+Deno.test("failures beyond the expected 404s surface with their status", async () => {
+  await assertRejects(
+    () =>
+      GhTasks.markReleaseLatest((s) =>
+        s.tag("v1.0.2").repo("acme/app").token("tok")
+          .fetch(fakeGithub([], { tagStatus: 500 }))
+      ),
+    GhApiError,
+    "500",
+  );
+  await assertRejects(
+    () =>
+      GhTasks.markReleaseLatest((s) =>
+        s.tag("v1.0.2").repo("acme/app").token("tok")
+          .fetch(fakeGithub([], { latestStatus: 500 }))
+      ),
+    GhApiError,
+    "500",
+  );
+  await assertRejects(
+    () =>
+      GhTasks.markReleaseLatest((s) =>
+        s.tag("v1.0.2").repo("acme/app").token("tok")
+          .fetch(fakeGithub([], { patchStatus: 403 }))
+      ),
+    GhApiError,
+    "refused",
+  );
+});
+
+Deno.test("a lookup that returns no id names the call that failed", async () => {
+  const empty: typeof fetch = async () => {
+    await Promise.resolve();
+    return new Response("{}", { status: 200 });
+  };
+  await assertRejects(
+    () =>
+      GhTasks.markReleaseLatest((s) =>
+        s.tag("v1.0.2").repo("acme/app").token("tok").fetch(empty)
+      ),
+    Error,
+    "release lookup",
+  );
+});
+
+Deno.test("a GHES base URL is honored, trailing slash and all", async () => {
+  const seen: Seen[] = [];
+  await GhTasks.markReleaseLatest((s) =>
+    s.tag("v1.0.2").repo("acme/app").token("tok")
+      .baseUrl("https://ghes.example/api/v3/").fetch(fakeGithub(seen))
+  );
+  assertStringIncludes(
+    seen[0].url,
+    "https://ghes.example/api/v3/repos/acme/app/releases/tags/v1.0.2",
+  );
+});
+
+Deno.test("a tag that is not a valid ref name is refused up front", async () => {
+  // The tag is interpolated into a request path; a `..` would redirect a
+  // token-bearing request somewhere the caller never named.
+  await assertRejects(
+    () =>
+      GhTasks.markReleaseLatest((s) =>
+        s.tag("../secrets").repo("acme/app").token("tok").fetch(() => {
+          throw new Error("no request should be made for an invalid tag");
+        })
+      ),
+    Error,
+    "not a valid git ref name",
+  );
+});
+
+/** Run `fn` with the Actions environment variables set to `values`. */
+async function withEnv(
+  values: Record<string, string | undefined>,
+  fn: () => Promise<void>,
+): Promise<void> {
+  const saved = new Map<string, string | undefined>();
+  for (const [name, value] of Object.entries(values)) {
+    saved.set(name, Deno.env.get(name));
+    if (value === undefined) Deno.env.delete(name);
+    else Deno.env.set(name, value);
+  }
+  try {
+    await fn();
+  } finally {
+    for (const [name, value] of saved) {
+      if (value === undefined) Deno.env.delete(name);
+      else Deno.env.set(name, value);
+    }
+  }
+}
+
+Deno.test("missing settings fail with messages that name the fix", async () => {
+  await assertRejects(
+    () => GhTasks.markReleaseLatest((s) => s.repo("a/b").token("t")),
+    Error,
+    ".tag(...)",
+  );
+  await withEnv(
+    { GITHUB_TOKEN: undefined, GITHUB_REPOSITORY: undefined },
+    async () => {
+      await assertRejects(
+        () =>
+          GhTasks.markReleaseLatest((s) =>
+            s.tag("v1.0.2").repo("a/b").fetch(() => {
+              throw new Error("no request should be made without a token");
+            })
+          ),
+        Error,
+        ".token(...)",
+      );
+      await assertRejects(
+        () => GhTasks.markReleaseLatest((s) => s.tag("v1.0.2").token("t")),
+        Error,
+        "GITHUB_REPOSITORY",
+      );
+    },
+  );
+});
+
+Deno.test("the token and repo default to the Actions environment", async () => {
+  await withEnv(
+    { GITHUB_TOKEN: "ghs_env", GITHUB_REPOSITORY: "acme/app" },
+    async () => {
+      const seen: Seen[] = [];
+      await GhTasks.markReleaseLatest((s) =>
+        s.tag("v1.0.2").fetch(fakeGithub(seen))
+      );
+      assertStringIncludes(seen[0].url, "/repos/acme/app/releases/tags/");
+      assertEquals(seen[0].authorization, "Bearer ghs_env");
+    },
+  );
+});

--- a/tests/integration/gemini_release_test.ts
+++ b/tests/integration/gemini_release_test.ts
@@ -57,9 +57,12 @@ function releaseBuild(root: string, uploaded: string[]) {
       const archive = `${root}/zuke.tar.gz`;
       await buildGeminiArchive(archive, root);
       for (const name of GEMINI_ASSET_NAMES) {
+        // Tag-scoped and refreshing, as the release target attaches them: an
+        // asset with no reported digest is kept, so `.refresh()` leaves the
+        // existing one alone here.
         const result = await GhTasks.uploadReleaseAsset((s) =>
-          s.file(archive).name(name).repo("acme/app").token("tok")
-            .fetch(fakeGithub(uploaded))
+          s.file(archive).name(name).tag("core-v1.0.0").repo("acme/app")
+            .token("tok").refresh().fetch(fakeGithub(uploaded))
         );
         console.log(`${name}: ${result.state}`);
       }

--- a/tests/integration/release_latest_test.ts
+++ b/tests/integration/release_latest_test.ts
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Integration: the release target's Latest-pointer wiring — pin the
+ * repository's "Latest release" back onto the action's release, then refresh
+ * the extension archive it carries — driven through the real CLI against a
+ * fake GitHub, mirroring how `zuke.ts`'s `release` target is wired.
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import { Build, target } from "../../packages/core/mod.ts";
+import { GhTasks } from "../../packages/gh/mod.ts";
+import { runCli } from "./_harness.ts";
+
+/**
+ * A fake GitHub mid-churn: the action release exists on its tag (unless the
+ * test says otherwise), but the pointer sits on a package release — as it
+ * does after any release-please run — and the action release carries a stale
+ * archive.
+ */
+function fakeGithub(
+  calls: string[],
+  options: { tagStatus?: number } = {},
+): typeof fetch {
+  return async (input, init) => {
+    const url = String(input);
+    const method = init?.method ?? "GET";
+    calls.push(`${method} ${new URL(url).pathname}`);
+    await Promise.resolve();
+    if (method === "PATCH") {
+      return new Response(JSON.stringify({ id: 7 }), { status: 200 });
+    }
+    if (method === "DELETE") return new Response(null, { status: 204 });
+    if (new URL(url).hostname === "uploads.example") {
+      return new Response(
+        JSON.stringify({ id: 901, browser_download_url: "dl/fresh" }),
+        { status: 201 },
+      );
+    }
+    if (url.includes("/releases/tags/v1.0.2")) {
+      if (options.tagStatus !== undefined && options.tagStatus >= 400) {
+        return new Response(JSON.stringify({ message: "Not Found" }), {
+          status: options.tagStatus,
+        });
+      }
+      return new Response(
+        JSON.stringify({
+          id: 7,
+          tag_name: "v1.0.2",
+          upload_url: "https://uploads.example/assets{?name,label}",
+          assets: [{
+            id: 55,
+            name: "zuke.tar.gz",
+            digest: "sha256:" + "0".repeat(64),
+            browser_download_url: "dl/stale",
+          }],
+        }),
+        { status: 200 },
+      );
+    }
+    // The latest lookup: a package release holds the pointer.
+    return new Response(
+      JSON.stringify({ id: 9, tag_name: "ai-v2.2.0" }),
+      { status: 200 },
+    );
+  };
+}
+
+/** A fixture build wired like the release target's Latest-pointer step. */
+function releaseBuild(
+  root: string,
+  calls: string[],
+  options: { tagStatus?: number } = {},
+) {
+  class Release extends Build {
+    pinLatest = target().executes(async () => {
+      const latest = await GhTasks.markReleaseLatest((s) =>
+        s.tag("v1.0.2").repo("acme/app").token("tok")
+          .fetch(fakeGithub(calls, options))
+      );
+      console.log(`latest: ${latest.state}`);
+      // As in the release target: in the window where the action tag exists
+      // but its release is not yet cut, attach nothing — an upload resolved
+      // any other way could touch a package release's assets.
+      if (latest.state === "no-release") {
+        console.log("archive: skipped");
+        return;
+      }
+      const archive = `${root}/zuke.tar.gz`;
+      await Deno.writeFile(archive, new Uint8Array([9, 9, 9]));
+      const asset = await GhTasks.uploadReleaseAsset((s) =>
+        s.file(archive).tag("v1.0.2").repo("acme/app").token("tok").refresh()
+          .fetch(fakeGithub(calls, options))
+      );
+      console.log(`archive: ${asset.state}`);
+    });
+  }
+  return Release;
+}
+
+Deno.test("the release wiring pins Latest back and refreshes the archive", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    const calls: string[] = [];
+    const { code, out } = await runCli(releaseBuild(root, calls), [
+      "pinLatest",
+    ]);
+    assertEquals(code, 0);
+
+    // The pointer was on a package release, so the run moved it — and the
+    // stale archive on the pinned release was replaced, not kept.
+    assertStringIncludes(out, "latest: marked");
+    assertStringIncludes(out, "archive: refreshed");
+    assertEquals(calls, [
+      "GET /repos/acme/app/releases/tags/v1.0.2",
+      "GET /repos/acme/app/releases/latest",
+      "PATCH /repos/acme/app/releases/7",
+      "GET /repos/acme/app/releases/tags/v1.0.2",
+      "DELETE /repos/acme/app/releases/assets/55",
+      "POST /assets",
+    ]);
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("the not-yet-cut release window writes nowhere at all", async () => {
+  // Regression: with the pointer on a package release and the action release
+  // not yet cut, a refresh resolved through "latest" would have deleted and
+  // replaced assets on that package release. The wiring must stop after the
+  // no-release answer — no PATCH, no DELETE, no upload.
+  const root = await Deno.makeTempDir();
+  try {
+    const calls: string[] = [];
+    const { code, out } = await runCli(
+      releaseBuild(root, calls, { tagStatus: 404 }),
+      ["pinLatest"],
+    );
+    assertEquals(code, 0);
+    assertStringIncludes(out, "latest: no-release");
+    assertStringIncludes(out, "archive: skipped");
+    assertEquals(calls, ["GET /repos/acme/app/releases/tags/v1.0.2"]);
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});

--- a/zuke.ts
+++ b/zuke.ts
@@ -1082,13 +1082,56 @@ class ZukeBuild extends Build {
         return s;
       });
 
-      // Attach the Gemini CLI extension archive to whatever release is now
-      // "latest" — that is the release `gemini extensions install` resolves,
-      // and it changes on every package release, so each run tops it up.
-      // Idempotent: a release already carrying the assets is left untouched,
-      // and a repository with no releases yet is an ordinary skip. Best-effort
-      // on top: the archive is a nice-to-have for Gemini installs, not part of
-      // the release contract, and a throw here would redden the job after the
+      // Keep the repository's "Latest release" pointer on the Marketplace
+      // action's own release. GitHub surfaces that pointer well beyond the
+      // releases page — the Marketplace listing advertises it as the action's
+      // current version, and `gemini extensions install` resolves it — and
+      // release-please drags it onto whichever package released last, so each
+      // run pins it back. The committed pin is the source of truth for which
+      // release that is; in the window between actionRelease cutting a new
+      // tag and its chore PR landing the pin update, this re-marks the
+      // previous action release, and the PR's merge corrects it. Best-effort
+      // like the asset step below: the releases exist either way, and a throw
+      // here would redden the job after they do — skipping the JSR publish
+      // that `needs` this job.
+      let actionReleaseExists = true;
+      try {
+        const latest = await GhTasks.markReleaseLatest((s) =>
+          s.tag(ACTION_PIN.version).repo(repo).token(token)
+        );
+        actionReleaseExists = latest.state !== "no-release";
+        ConsoleTasks.info(
+          actionReleaseExists
+            ? `Latest release pointer: ${ACTION_PIN.version} ` +
+              `(${latest.state}).`
+            : `${ACTION_PIN.version} is tagged but has no GitHub release ` +
+              `yet — actionRelease's browser step creates it. The Latest ` +
+              `pointer is unchanged.`,
+        );
+      } catch (error) {
+        ConsoleTasks.warn(
+          "Re-marking the action release as Latest failed — the releases " +
+            "themselves are unaffected and the next release run retries: " +
+            `${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+      if (!actionReleaseExists) {
+        // Nothing to attach the archive to either: the uploads below are
+        // pinned to the same release, and skipping beats three 404 warnings.
+        ConsoleTasks.info("Skipping the Gemini archive until it exists.");
+        return;
+      }
+
+      // Attach the Gemini CLI extension archive to the action's release —
+      // named by its tag, never resolved through "latest": the pointer can be
+      // elsewhere when the re-mark above failed or lost a race, and a
+      // `.refresh()` pointed at whatever release happens to be latest would
+      // churn assets on a package release. `.refresh()` replaces an attached
+      // archive whose bytes have changed, so the extension `gemini extensions
+      // install` resolves tracks the current skills instead of freezing at
+      // whatever the long-lived release was first given. Best-effort: the
+      // archive is a nice-to-have for Gemini installs, not part of the
+      // release contract, and a throw here would redden the job after the
       // releases already exist — skipping the JSR publish that `needs` this
       // job. A warning plus the next run's top-up is the right trade.
       const scratch = await Deno.makeTempDir();
@@ -1100,12 +1143,11 @@ class ZukeBuild extends Build {
         );
         for (const name of GEMINI_ASSET_NAMES) {
           const result = await GhTasks.uploadReleaseAsset((s) =>
-            s.file(archive).name(name).repo(repo).token(token)
+            s.file(archive).name(name).tag(ACTION_PIN.version).repo(repo)
+              .token(token).refresh()
           );
           ConsoleTasks.info(
-            result.state === "no-release"
-              ? `No release to attach ${name} to yet.`
-              : `${name} on ${result.releaseTag}: ${result.state}.`,
+            `${name} on ${result.releaseTag}: ${result.state}.`,
           );
         }
       } catch (error) {


### PR DESCRIPTION
## What & why

The repository's "Latest release" pointer is surfaced beyond the releases page: the GitHub Marketplace listing advertises it as the Zuke Build action's current version, and Gemini extension installs resolve it. release-please moves the pointer to whichever package released last, which is why the Marketplace listing currently advertises a package tag rather than the action's own version. release-please has no configuration to leave the pointer alone, so the durable fix is to re-assert it after every release run.

This adds a new task to the gh package, GhTasks.markReleaseLatest, which points the Latest pointer at the release for a given tag. It is idempotent and quiet about it: when the pointer already names the tag's release nothing is written, a tag whose release is not yet cut resolves to a soft no-release outcome rather than an error, since the action's releases are created by a later, human browser step, and a tag that does not exist at all is an error. The tag is validated as a git ref name and percent-encoded before it reaches a request path, matching the package's existing transport guards. The release target in the build runs it right after release-please, taking the version from the committed action pin, and treats failure as a warning so a hiccup cannot skip the JSR publish that depends on the job.

Pinning the pointer to a long-lived release exposed a second problem: the Gemini extension archive is attached to the latest release, and the existing uploader keeps any asset that already exists under the same name — so the archive would freeze at whatever the pinned release was first given. The uploader therefore gains a refresh setting: an existing asset whose sha256 digest, as the REST API reports it, differs from the file's is deleted and re-uploaded, while a matching or unreported digest keeps the asset untouched, preserving the default's no-churn guarantee.

An adversarial review of the change caught a real defect that is also fixed here: the archive uploads were still resolved through the latest pointer, so in the window where the action tag exists but its release is not yet cut, a refresh could have deleted assets on whatever package release held the pointer. The uploads are now tag-scoped to the action release and skipped entirely in that window, with an integration regression test asserting that nothing at all is written in it.

## Related issues

None — follow-up to the Marketplace listing investigation that started with the README badge fix in #355.

## Checklist

- [x] The PR title is a [Conventional Commit](https://www.conventionalcommits.org/) (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell) — every target green except the security scan, whose advisory lookup is blocked by the sandbox proxy here and runs on CI.
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches) — unit tests for the new task and the refresh branches, integration tests for the release wiring; the gate reports 98.4% lines and 97.5% branches.
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour changed.
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`, `llms-full.txt`, package README `## API`).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with type guards instead).
- [x] No dead code: unreachable branches and can't-fire fallbacks are removed, with types tightened so the impossible state is unrepresentable.
- [ ] A new package was wired into all seven places — not applicable, the new module lives in the existing gh package.
- [x] The code is written using AI assisted coding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Evbih78e2DiD4jTyeAu2nS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Evbih78e2DiD4jTyeAu2nS)_