### PR TITLE
docs: require a tracking issue for every change

### DIFF
--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,57 @@
+name: Chore or documentation
+description: Track documentation, refactoring, tests, or repository work.
+title: "chore: "
+labels: ["chore"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Every change in this repository starts with an issue — including docs,
+        refactors, tests, and build work. This is the template for the work that
+        is neither a new capability nor a bug.
+
+        Please
+        [search existing issues](https://github.com/zuke-build/zuke/issues?q=is%3Aissue)
+        first to avoid duplicates.
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight checklist
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: This is not a new capability or a bug report — those have their own templates.
+          required: true
+  - type: textarea
+    id: what
+    attributes:
+      label: What needs doing?
+      description: The change itself, concretely.
+      placeholder: Document the resolution order the tool wrappers use when both a local binary and a project-local install are present.
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why now?
+      description: What is harder, riskier, or more confusing than it should be until this lands?
+    validations:
+      required: true
+  - type: input
+    id: scope
+    attributes:
+      label: Affected area(s)
+      description: The packages, directories, or files involved.
+      placeholder: "docs/, AGENTS.md, .github/"
+    validations:
+      required: false
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: How a reviewer confirms this is done.
+      placeholder: |
+        - The resolution order is described in docs/tooling.md.
+        - `deno task ci` passes.
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,10 +20,13 @@ motivation, not just the mechanics. -->
 
 ## Related issues
 
-<!-- e.g. "Closes #123". Link any issue this addresses. -->
+<!-- Required: "Closes #123". Every change starts with an issue — file one from
+.github/ISSUE_TEMPLATE (feature request, bug report, or chore) before opening
+this PR. See AGENTS.md. -->
 
 ## Checklist
 
+- [ ] This PR closes a tracking issue (`Closes #<n>` above).
 - [ ] The PR title is a
       [Conventional Commit](https://www.conventionalcommits.org/)
       (`type(scope): summary`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -458,6 +458,19 @@ gemini-extension.json     # Gemini CLI extension manifest (serves skills/)
 
 ## Good open-source practices to follow
 
+- **Every change starts with an issue.** Feature, bugfix, documentation,
+  refactor, or chore — file the issue first, then open the pull request that
+  closes it. The issue is where the problem, the proposed shape, and the
+  acceptance criteria are agreed _before_ the effort is spent, and it is the
+  trail that explains a change to whoever reads it a year later. Use the
+  templates in `.github/ISSUE_TEMPLATE/`: `feature_request.yml` (`feat: …`) for
+  a new capability, `bug_report.yml` (`bug: …`) for something not working as
+  documented, and `chore.yml` (`chore: …`) for docs, tests, refactoring, and
+  repository work. Blank issues are disabled on purpose, so pick the closest
+  template rather than skipping the step. The PR body then links it with
+  `Closes #<n>`. This applies to agent-authored work exactly as it does to a
+  human's: an agent that is asked to implement something files the issue as its
+  first step, and never opens a PR that closes nothing.
 - **Small, focused changes** with clear, descriptive commit messages (imperative
   mood; explain the _why_). Keep PRs reviewable.
 - **Conventional, semantic versioning** for releases; keep a changelog as the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,15 @@ By participating, you agree to abide by our
 > [!NOTE]
 > Every Zuke package is `1.x` on full semver — see
 > [Versioning & compatibility](./docs/versioning.md) for the compatibility
-> promise, the `@zuke/core` floor, and pinning guidance. If you are planning a
-> large change, please open an issue first so we can agree on the direction
-> before you invest the effort.
+> promise, the `@zuke/core` floor, and pinning guidance.
+
+> [!IMPORTANT]
+> **Every change starts with an issue.** Before opening a pull request — for a
+> feature, a bugfix, documentation, a refactor, or any other work — file an
+> issue from
+> [the templates](https://github.com/zuke-build/zuke/issues/new/choose) so the
+> problem, the proposed shape, and the acceptance criteria are agreed before you
+> invest the effort. The pull request then closes it.
 
 ## Prerequisites
 
@@ -115,12 +121,14 @@ the squash commit that [release-please](./RELEASING.md) parses.
 
 ## Pull requests
 
-1. Fork and create a topic branch from `master`.
-2. Make your change, adding tests and docs in the same PR.
-3. Run `deno task ci` and make sure it is green.
-4. Open a pull request with a clear description of the change and its
-   motivation. Link any related issue.
-5. Update `README.md`, JSDoc, and the relevant docs in `docs/` whenever
+1. File the issue that describes the work (feature request, bug report, or
+   chore) if one does not exist yet.
+2. Fork and create a topic branch from `master`.
+3. Make your change, adding tests and docs in the same PR.
+4. Run `deno task ci` and make sure it is green.
+5. Open a pull request with a clear description of the change and its
+   motivation, closing the issue with `Closes #<n>`.
+6. Update `README.md`, JSDoc, and the relevant docs in `docs/` whenever
    behaviour changes.
 
 ## Code review


### PR DESCRIPTION
## What & why

Makes an issue the required first step for every change here, and gives the work that is neither a feature nor a bug somewhere to be filed.

Every change already reaches `master` through a pull request, but the reasoning behind a change lives only in that pull request. An issue filed first is where the problem, the proposed shape, and the acceptance criteria get agreed before the effort is spent — cheaper than discovering a wrong direction in review — and it is what makes a change legible to whoever reads it a year later. The rule was previously advisory and only for "a large change".

- `AGENTS.md` — the rule in "Good open-source practices to follow", naming the three templates and the `Closes` reference, and binding agent-authored work the same way.
- `.github/ISSUE_TEMPLATE/chore.yml` — new template for documentation, tests, refactoring, and repository work. Blank issues are disabled, so until now that work had no home: only a feature request and a bug report existed.
- `.github/pull_request_template.md` — "Related issues" is now explicitly required, with a checklist item for it.
- `CONTRIBUTING.md` — the rule replaces the "large change" suggestion, and filing the issue is step one of the pull request flow.

Documentation and repository configuration only. No package under `packages/` is touched, so no release is cut.

## Related issues

Closes #370

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a
      [Conventional Commit](https://www.conventionalcommits.org/)
      (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [ ] Tests were added or updated; coverage stays at 95%+ (lines and branches).
      Not applicable: documentation and issue/PR templates only, no source
      change to cover.
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour
      changed.
- [ ] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`,
      `llms-full.txt`, package README `## API`). Not applicable: no public API
      change.
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with
      type guards instead).
- [x] No dead code: unreachable branches and can't-fire fallbacks are removed,
      with types tightened so the impossible state is unrepresentable.
- [x] No duplicated logic: an existing helper is imported rather than retyped,
      and a near-copy differing by a constant or a message is parameterised into
      one implementation. A guard, escape, or credential resolution has exactly
      one implementation.
- [x] SOLID shapes respected: one domain per file, extension via the settings
      lambda (not a behaviour-switching flag), narrow parameter types, and
      dependencies on the injectable seam (`StateHost`, an injected `fetch`,
      `EnvReader`) rather than `Deno.*` or a global.
- [ ] A new package was wired into all six places (see
      [AGENTS.md](../blob/master/AGENTS.md#good-open-source-practices-to-follow)),
      if applicable. Not applicable: no new package.
- [x] The code is written using AI assisted coding.
