### PR TITLE
feat(node): exit the evaluate child once its result is written

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "zuke",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build)."
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9127,12 +9127,21 @@ class NodeEvaluateSettings extends NodeSettings
     driver exit once that write has flushed, so such a module can be evaluated
     as it is, without a `process.exit` of its own.
 
-    Two consequences, both by design: whatever the module writes after its
-    result is cut off, and the module's own exit code is no longer observed
-    (the driver exits `0`). A module that throws before producing a result is
-    unaffected — the driver never reaches its final write, so the evaluation
-    still rejects — and so is one that exits on its own, for which this is a
-    no-op.
+    What the module does after handing back its value does not happen. The
+    process ends at the write, so anything it would still print is cut off,
+    anything it would still do — a `beforeExit` handler, a teardown scheduled
+    on the next tick, a flush that has not been awaited — does not run, and its
+    own exit code is no longer observed (the driver exits `0`). That is the
+    trade the option makes, and why it is opt-in rather than the default:
+    choose it for a module whose value is the whole point of running it, and
+    whose remaining work is process teardown the operating system is about to
+    do anyway. A module whose after-the-value work matters — one that writes
+    a file, commits a transaction, or reports its own failure through an exit
+    code — should keep the default and be given a way to exit on its own.
+
+    Two shapes are unaffected either way: a module that throws before producing
+    a result still rejects the evaluation, since the driver never reaches its
+    final write, and a module that exits on its own never notices the option.
   get module(): string
     The module being evaluated, for error messages.
   override protected buildArgs(): string[]

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9117,6 +9117,22 @@ class NodeEvaluateSettings extends NodeSettings
     Named `callWith` rather than `args` because `ToolSettings.args` already
     means "append raw arguments to the `node` command line", which is a
     different thing.
+  exitAfterResult(): this
+    End the Node process as soon as the result has been written, instead of
+    waiting for the module to let Node exit on its own.
+
+    A module that leaves a live handle on the event loop — an HTTP server, a
+    database pool, a timer — never exits, and the evaluation then blocks
+    forever on a value it has already produced and written. This makes the
+    driver exit once that write has flushed, so such a module can be evaluated
+    as it is, without a `process.exit` of its own.
+
+    Two consequences, both by design: whatever the module writes after its
+    result is cut off, and the module's own exit code is no longer observed
+    (the driver exits `0`). A module that throws before producing a result is
+    unaffected — the driver never reaches its final write, so the evaluation
+    still rejects — and so is one that exits on its own, for which this is a
+    no-op.
   get module(): string
     The module being evaluated, for error messages.
   override protected buildArgs(): string[]
@@ -9202,6 +9218,12 @@ interface NodeTasksApi
     // tools/openapi.mjs: export default async () => document
     const spec = await NodeTasks.evaluate("tools/openapi.mjs");
     ```
+
+    The evaluation waits for the Node process to exit, so a module that leaves
+    a live handle on the event loop (a server, a pool, a timer) would block on
+    a value it has already produced. {@link NodeEvaluateSettings.exitAfterResult}
+    ends the process as soon as the result has been written, for modules in
+    that shape.
 
     The module runs as a real Node process with the build's own permissions —
     the same trust level as a script handed to {@link NodeTasks.run}, and the

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -81,6 +81,22 @@ class NodeEvaluateSettings extends NodeSettings
     Named `callWith` rather than `args` because `ToolSettings.args` already
     means "append raw arguments to the `node` command line", which is a
     different thing.
+  exitAfterResult(): this
+    End the Node process as soon as the result has been written, instead of
+    waiting for the module to let Node exit on its own.
+
+    A module that leaves a live handle on the event loop — an HTTP server, a
+    database pool, a timer — never exits, and the evaluation then blocks
+    forever on a value it has already produced and written. This makes the
+    driver exit once that write has flushed, so such a module can be evaluated
+    as it is, without a `process.exit` of its own.
+
+    Two consequences, both by design: whatever the module writes after its
+    result is cut off, and the module's own exit code is no longer observed
+    (the driver exits `0`). A module that throws before producing a result is
+    unaffected — the driver never reaches its final write, so the evaluation
+    still rejects — and so is one that exits on its own, for which this is a
+    no-op.
   get module(): string
     The module being evaluated, for error messages.
   override protected buildArgs(): string[]
@@ -166,6 +182,12 @@ interface NodeTasksApi
     // tools/openapi.mjs: export default async () => document
     const spec = await NodeTasks.evaluate("tools/openapi.mjs");
     ```
+
+    The evaluation waits for the Node process to exit, so a module that leaves
+    a live handle on the event loop (a server, a pool, a timer) would block on
+    a value it has already produced. {@link NodeEvaluateSettings.exitAfterResult}
+    ends the process as soon as the result has been written, for modules in
+    that shape.
 
     The module runs as a real Node process with the build's own permissions —
     the same trust level as a script handed to {@link NodeTasks.run}, and the

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -91,12 +91,21 @@ class NodeEvaluateSettings extends NodeSettings
     driver exit once that write has flushed, so such a module can be evaluated
     as it is, without a `process.exit` of its own.
 
-    Two consequences, both by design: whatever the module writes after its
-    result is cut off, and the module's own exit code is no longer observed
-    (the driver exits `0`). A module that throws before producing a result is
-    unaffected — the driver never reaches its final write, so the evaluation
-    still rejects — and so is one that exits on its own, for which this is a
-    no-op.
+    What the module does after handing back its value does not happen. The
+    process ends at the write, so anything it would still print is cut off,
+    anything it would still do — a `beforeExit` handler, a teardown scheduled
+    on the next tick, a flush that has not been awaited — does not run, and its
+    own exit code is no longer observed (the driver exits `0`). That is the
+    trade the option makes, and why it is opt-in rather than the default:
+    choose it for a module whose value is the whole point of running it, and
+    whose remaining work is process teardown the operating system is about to
+    do anyway. A module whose after-the-value work matters — one that writes
+    a file, commits a transaction, or reports its own failure through an exit
+    code — should keep the default and be given a way to exit on its own.
+
+    Two shapes are unaffected either way: a module that throws before producing
+    a result still rejects the evaluation, since the driver never reaches its
+    final write, and a module that exits on its own never notices the option.
   get module(): string
     The module being evaluated, for error messages.
   override protected buildArgs(): string[]

--- a/packages/node/src/evaluate.ts
+++ b/packages/node/src/evaluate.ts
@@ -38,6 +38,7 @@ export class NodeEvaluateSettings extends NodeSettings {
   #module: string;
   #export = "default";
   #callArgs: JsonValue[] = [];
+  #exitAfterResult = false;
 
   /** Evaluate `module`, a path resolved against the working directory. */
   constructor(module: PathLike) {
@@ -69,6 +70,28 @@ export class NodeEvaluateSettings extends NodeSettings {
     return this;
   }
 
+  /**
+   * End the Node process as soon as the result has been written, instead of
+   * waiting for the module to let Node exit on its own.
+   *
+   * A module that leaves a live handle on the event loop — an HTTP server, a
+   * database pool, a timer — never exits, and the evaluation then blocks
+   * forever on a value it has *already* produced and written. This makes the
+   * driver exit once that write has flushed, so such a module can be evaluated
+   * as it is, without a `process.exit` of its own.
+   *
+   * Two consequences, both by design: whatever the module writes *after* its
+   * result is cut off, and the module's own exit code is no longer observed
+   * (the driver exits `0`). A module that throws before producing a result is
+   * unaffected — the driver never reaches its final write, so the evaluation
+   * still rejects — and so is one that exits on its own, for which this is a
+   * no-op.
+   */
+  exitAfterResult(): this {
+    this.#exitAfterResult = true;
+    return this;
+  }
+
   /** The module being evaluated, for error messages. */
   get module(): string {
     return this.#module;
@@ -87,6 +110,10 @@ export class NodeEvaluateSettings extends NodeSettings {
     const module = JSON.stringify(this.#module);
     const name = JSON.stringify(this.#export);
     const callArgs = JSON.stringify(this.#callArgs);
+    // The write callback runs once the payload has reached the pipe, so exiting
+    // from it cannot truncate the result. Without the option the call is the
+    // plain one-argument write it has always been.
+    const thenExit = this.#exitAfterResult ? ", () => process.exit(0)" : "";
     return [
       `import { pathToFileURL } from "node:url";`,
       `const namespace = await import(pathToFileURL(${module}).href);`,
@@ -98,7 +125,7 @@ export class NodeEvaluateSettings extends NodeSettings {
       `  ? await picked(...${callArgs})`,
       `  : await picked;`,
       `const json = JSON.stringify(value);`,
-      `process.stdout.write("\\n${BEGIN}" + (json === undefined ? "null" : json) + "${END}\\n");`,
+      `process.stdout.write("\\n${BEGIN}" + (json === undefined ? "null" : json) + "${END}\\n"${thenExit});`,
     ].join("\n");
   }
 }

--- a/packages/node/src/evaluate.ts
+++ b/packages/node/src/evaluate.ts
@@ -80,12 +80,21 @@ export class NodeEvaluateSettings extends NodeSettings {
    * driver exit once that write has flushed, so such a module can be evaluated
    * as it is, without a `process.exit` of its own.
    *
-   * Two consequences, both by design: whatever the module writes *after* its
-   * result is cut off, and the module's own exit code is no longer observed
-   * (the driver exits `0`). A module that throws before producing a result is
-   * unaffected — the driver never reaches its final write, so the evaluation
-   * still rejects — and so is one that exits on its own, for which this is a
-   * no-op.
+   * What the module does *after* handing back its value does not happen. The
+   * process ends at the write, so anything it would still print is cut off,
+   * anything it would still do — a `beforeExit` handler, a teardown scheduled
+   * on the next tick, a flush that has not been awaited — does not run, and its
+   * own exit code is no longer observed (the driver exits `0`). That is the
+   * trade the option makes, and why it is opt-in rather than the default:
+   * choose it for a module whose value is the whole point of running it, and
+   * whose remaining work is process teardown the operating system is about to
+   * do anyway. A module whose after-the-value work *matters* — one that writes
+   * a file, commits a transaction, or reports its own failure through an exit
+   * code — should keep the default and be given a way to exit on its own.
+   *
+   * Two shapes are unaffected either way: a module that throws before producing
+   * a result still rejects the evaluation, since the driver never reaches its
+   * final write, and a module that exits on its own never notices the option.
    */
   exitAfterResult(): this {
     this.#exitAfterResult = true;

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -288,6 +288,12 @@ export interface NodeTasksApi {
    * const spec = await NodeTasks.evaluate("tools/openapi.mjs");
    * ```
    *
+   * The evaluation waits for the Node process to exit, so a module that leaves
+   * a live handle on the event loop (a server, a pool, a timer) would block on
+   * a value it has already produced. {@link NodeEvaluateSettings.exitAfterResult}
+   * ends the process as soon as the result has been written, for modules in
+   * that shape.
+   *
    * The module runs as a real Node process with the build's own permissions —
    * the same trust level as a script handed to {@link NodeTasks.run}, and the
    * reason this is a build-authoring API rather than an input-processing one.

--- a/packages/node/tests/evaluate_test.ts
+++ b/packages/node/tests/evaluate_test.ts
@@ -50,6 +50,33 @@ Deno.test("evaluate cannot be injected through the module path or an argument", 
   assertStringIncludes(driver, `["\\");process.exit(1);//"]`);
 });
 
+Deno.test("evaluate waits for the module's own exit by default", () => {
+  const driver = driverOf(new NodeEvaluateSettings("tools/openapi.mjs"));
+  assertStringIncludes(driver, `process.stdout.write("\\n<<<zuke:evaluate>>>"`);
+  assertEquals(driver.includes("process.exit"), false);
+});
+
+Deno.test("exitAfterResult exits from the write callback, once the payload has flushed", () => {
+  const driver = driverOf(
+    new NodeEvaluateSettings("tools/openapi.mjs").exitAfterResult(),
+  );
+  // The exit hangs off the *write*, not a statement after it: a bare
+  // `process.exit(0)` on the next line can truncate a payload still in the pipe.
+  assertStringIncludes(driver, `\\n", () => process.exit(0));`);
+});
+
+Deno.test("exitAfterResult composes with the export and the call arguments", () => {
+  const driver = driverOf(
+    new NodeEvaluateSettings("dist/app.module.js")
+      .exitAfterResult()
+      .export("buildDocument")
+      .callWith("v1"),
+  );
+  assertStringIncludes(driver, `namespace["buildDocument"]`);
+  assertStringIncludes(driver, `await picked(...["v1"])`);
+  assertStringIncludes(driver, `() => process.exit(0));`);
+});
+
 Deno.test("parsePayload reads the value between the markers", () => {
   const stdout =
     'boot log\n<<<zuke:evaluate>>>{"openapi":"3.1.0"}<<</zuke:evaluate>>>\n';

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/.codex-plugin/plugin.json
+++ b/plugins/zuke/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -709,9 +709,13 @@ const spec = await NodeTasks.evaluate("tools/openapi.mjs", (s) =>
   s.export("buildDocument").exitAfterResult());
 ```
 
-Anything the module prints after its result is cut off and its own exit code is
-no longer observed; a module that throws before producing a result still fails
-the target, and one that exits on its own is unaffected.
+What the module would do after handing back its value does not happen: output is
+cut off, a `beforeExit` handler or a not-yet-awaited teardown never runs, and its
+exit code is no longer observed. Use it for a module whose value is the point of
+running it; keep the default for one whose after-the-value work matters (writing
+a file, committing a transaction, failing through an exit code). A module that
+throws before producing a result still fails the target, and one that exits on
+its own is unaffected.
 
 ## AI review & self-healing — `@zuke/ai`
 

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -699,6 +699,20 @@ this is how a build reaches framework code (NestJS, TypeORM) it must not depend
 on itself. The value crosses the process boundary as JSON, so it — and each
 `callWith` argument — must be JSON-serialisable.
 
+**A module that never exits** — one that boots an app and leaves a server, a
+pool, or a timer on the event loop — would otherwise block the evaluation on a
+value it has already produced. `.exitAfterResult()` ends the Node process once
+the result has been written:
+
+```ts
+const spec = await NodeTasks.evaluate("tools/openapi.mjs", (s) =>
+  s.export("buildDocument").exitAfterResult());
+```
+
+Anything the module prints after its result is cut off and its own exit code is
+no longer observed; a module that throws before producing a result still fails
+the target, and one that exits on its own is unaffected.
+
 ## AI review & self-healing — `@zuke/ai`
 
 A model becomes part of the build graph two ways. Only the provider (`"claude"`

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -709,9 +709,13 @@ const spec = await NodeTasks.evaluate("tools/openapi.mjs", (s) =>
   s.export("buildDocument").exitAfterResult());
 ```
 
-Anything the module prints after its result is cut off and its own exit code is
-no longer observed; a module that throws before producing a result still fails
-the target, and one that exits on its own is unaffected.
+What the module would do after handing back its value does not happen: output is
+cut off, a `beforeExit` handler or a not-yet-awaited teardown never runs, and its
+exit code is no longer observed. Use it for a module whose value is the point of
+running it; keep the default for one whose after-the-value work matters (writing
+a file, committing a transaction, failing through an exit code). A module that
+throws before producing a result still fails the target, and one that exits on
+its own is unaffected.
 
 ## AI review & self-healing — `@zuke/ai`
 

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -699,6 +699,20 @@ this is how a build reaches framework code (NestJS, TypeORM) it must not depend
 on itself. The value crosses the process boundary as JSON, so it — and each
 `callWith` argument — must be JSON-serialisable.
 
+**A module that never exits** — one that boots an app and leaves a server, a
+pool, or a timer on the event loop — would otherwise block the evaluation on a
+value it has already produced. `.exitAfterResult()` ends the Node process once
+the result has been written:
+
+```ts
+const spec = await NodeTasks.evaluate("tools/openapi.mjs", (s) =>
+  s.export("buildDocument").exitAfterResult());
+```
+
+Anything the module prints after its result is cut off and its own exit code is
+no longer observed; a module that throws before producing a result still fails
+the target, and one that exits on its own is unaffected.
+
 ## AI review & self-healing — `@zuke/ai`
 
 A model becomes part of the build graph two ways. Only the provider (`"claude"`

--- a/tests/e2e/fixtures/hanging_module.mjs
+++ b/tests/e2e/fixtures/hanging_module.mjs
@@ -1,0 +1,13 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * A Node module that produces a value and then never lets Node exit — the
+ * shape an application factory takes once it has opened a server or a pool.
+ * The interval stands in for that handle: nothing here ever clears it, so the
+ * process only ends if something ends it.
+ */
+export function build() {
+  setInterval(() => {}, 1000);
+  return { document: "3.1.0" };
+}

--- a/tests/e2e/fixtures/node_evaluate_build.ts
+++ b/tests/e2e/fixtures/node_evaluate_build.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Fixture for {@link file://../node_evaluate_e2e.ts}: evaluate a Node module
+ * that never lets Node exit. The `hanging` target opts into
+ * `exitAfterResult`, so it must print the value and finish; `waiting` is the
+ * same evaluation without the option, which is the hang it exists to contrast
+ * with — it is only ever run under a timeout.
+ *
+ * @module
+ */
+
+import { Build, run, target } from "../../../packages/core/mod.ts";
+import { NodeTasks } from "../../../packages/node/mod.ts";
+
+/** The module to evaluate, resolved against this file rather than the cwd. */
+const MODULE = `${import.meta.dirname}/hanging_module.mjs`;
+
+class NodeEvaluateBuild extends Build {
+  hanging = target()
+    .description("evaluate a module that never exits, and stop waiting for it")
+    .executes(async () => {
+      const value = await NodeTasks.evaluate(
+        MODULE,
+        (s) => s.export("build").exitAfterResult(),
+      );
+      console.log(`VALUE=${JSON.stringify(value)}`);
+    });
+
+  waiting = target()
+    .description("the same evaluation without the option — never settles")
+    .executes(async () => {
+      const value = await NodeTasks.evaluate(MODULE, (s) => s.export("build"));
+      console.log(`VALUE=${JSON.stringify(value)}`);
+    });
+}
+
+await run(NodeEvaluateBuild);

--- a/tests/e2e/node_evaluate_e2e.ts
+++ b/tests/e2e/node_evaluate_e2e.ts
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * End-to-end: `exitAfterResult` must end a Node process that would otherwise
+ * never exit. Whether a child that holds the event loop open ever closes its
+ * stdout — and so whether the evaluation settles — is a property of two real
+ * processes, which is exactly what an in-process test cannot show. The
+ * {@link file://./fixtures/node_evaluate_build.ts} fixture evaluates
+ * {@link file://./fixtures/hanging_module.mjs}, whose export returns a value
+ * and then keeps a timer alive forever.
+ *
+ * Unlike the rest of this suite these tests need a real `node` on `PATH`, so
+ * they are skipped where there is none. CI's OS matrix has one; the fast unit
+ * gate never reaches this file (it is `*_e2e.ts`), so a developer without Node
+ * still gets a green `deno task ci`.
+ */
+
+import { assertEquals } from "../../packages/core/tests/_assert.ts";
+import { runFixture, spawnFixture } from "./_harness.ts";
+
+const FIXTURE = new URL("./fixtures/node_evaluate_build.ts", import.meta.url);
+
+/** A generous bound: the evaluation is milliseconds' work once the child exits. */
+const MAX_MS = 60_000;
+
+/** How long the un-opted-in run is given to prove it is stuck. */
+const HANG_MS = 5_000;
+
+/** Whether a usable `node` is on `PATH` — these tests are skipped without one. */
+async function nodeAvailable(): Promise<boolean> {
+  try {
+    const { success } = await new Deno.Command("node", {
+      args: ["--version"],
+      stdout: "null",
+      stderr: "null",
+    }).output();
+    return success;
+  } catch {
+    return false;
+  }
+}
+
+const HAS_NODE = await nodeAvailable();
+
+Deno.test({
+  name: "exitAfterResult finishes a build whose module never exits",
+  ignore: !HAS_NODE,
+  fn: async () => {
+    const started = performance.now();
+    const { code, out, err } = await runFixture(FIXTURE, ["hanging"], {});
+    const elapsed = performance.now() - started;
+    const output = out + err;
+
+    assertEquals(code, 0, `expected a passing build:\n${output}`);
+    assertEquals(
+      out.includes(`VALUE={"document":"3.1.0"}`),
+      true,
+      `the evaluated value never reached the target:\n${output}`,
+    );
+    assertEquals(elapsed < MAX_MS, true, `took ${Math.round(elapsed)}ms`);
+  },
+});
+
+Deno.test({
+  name: "without the option the same module hangs, which is what it fixes",
+  ignore: !HAS_NODE,
+  fn: async () => {
+    // Guards the test above from a fixture that quietly stopped hanging: if the
+    // module ever exits on its own, this run would print its value and the
+    // passing case would no longer prove anything.
+    const child = spawnFixture(FIXTURE, ["waiting"], {});
+    const timer = setTimeout(() => child.kill("SIGKILL"), HANG_MS);
+    const { stdout } = await child.output();
+    clearTimeout(timer);
+
+    assertEquals(
+      new TextDecoder().decode(stdout).includes("VALUE="),
+      false,
+      "the module exited on its own, so the fixture no longer hangs",
+    );
+  },
+});

--- a/tests/e2e/node_evaluate_e2e.ts
+++ b/tests/e2e/node_evaluate_e2e.ts
@@ -43,6 +43,27 @@ async function nodeAvailable(): Promise<boolean> {
 
 const HAS_NODE = await nodeAvailable();
 
+/**
+ * On CI the skip is not allowed: every runner in the matrix ships Node, so a
+ * missing one means the environment changed, and silently skipping would retire
+ * this coverage without anyone noticing. Locally the skip stands, which is what
+ * keeps a Node-less checkout green.
+ */
+const MUST_HAVE_NODE = Deno.env.get("CI") === "true";
+
+Deno.test({
+  name: "CI runs these tests rather than skipping them",
+  ignore: !MUST_HAVE_NODE,
+  fn: () => {
+    assertEquals(
+      HAS_NODE,
+      true,
+      "no usable `node` on PATH: the Node evaluation e2e tests would have " +
+        "been skipped on a runner that is supposed to provide one.",
+    );
+  },
+});
+
 Deno.test({
   name: "exitAfterResult finishes a build whose module never exits",
   ignore: !HAS_NODE,

--- a/tests/integration/node_evaluate_test.ts
+++ b/tests/integration/node_evaluate_test.ts
@@ -26,10 +26,31 @@ class SpecBuild extends Build {
     });
 }
 
+// `exitAfterResult` changes when the child stops, never how a failure to run it
+// at all is reported: a build that sets it must still fail the same way.
+class ExitAfterResultBuild extends Build {
+  spec = target()
+    .description("read a value out of a module that never exits on its own")
+    .executes(async () => {
+      const document = await NodeTasks.evaluate(
+        "tools/openapi.mjs",
+        (s) => missingTool(s.exitAfterResult()),
+      );
+      console.log(`document=${JSON.stringify(document)}`);
+    });
+}
+
 Deno.test("a target evaluating a Node module fails with the tool-not-found error", async () => {
   const { code, out, err } = await runCli(SpecBuild, ["spec"]);
   assertEquals(code, 1);
   assertStringIncludes(err, "zuke-no-such-tool-xyz");
   // The target never reached its value, so it printed nothing.
+  assertEquals(out.includes("document="), false);
+});
+
+Deno.test("exitAfterResult leaves the tool-not-found failure unchanged", async () => {
+  const { code, out, err } = await runCli(ExitAfterResultBuild, ["spec"]);
+  assertEquals(code, 1);
+  assertStringIncludes(err, "zuke-no-such-tool-xyz");
   assertEquals(out.includes("document="), false);
 });


### PR DESCRIPTION
## What & why

The evaluate task waits for the Node process to exit. A module that leaves a live handle on the event loop — an HTTP server, a database pool, a timer — never lets it, so the evaluation blocks forever on a value it has *already* serialised and written between the driver's markers. Modules in that shape normally end with an explicit exit call, which is exactly what a module rewritten as an exported function no longer gets to do.

The new `exitAfterResult` setting opts into ending the process as soon as the result has been written. The exit hangs off the stdout write callback, so it runs only once the payload has reached the pipe and cannot truncate it.

Doing it in the generated driver keeps the change inside `@zuke/node`. The alternative — watching the captured stream from the parent and terminating the child when the closing marker appears — needs a new streaming seam in core's shared command primitive, a signal escalation, and orphan handling, for what one argument to the write gives.

Semantics held, and covered by tests:

- a module that would have exited on its own is unaffected;
- a module that throws before producing a result still fails the target, since the driver never reaches its final write;
- output the module writes after its result is cut off, and its own exit code is no longer observed. Both are documented on the option.

Tested at three layers. Unit tests assert the generated driver: unchanged by default, and exiting from the write callback rather than from a statement after it. An integration test proves the option does not disturb how a missing `node` is reported. A new e2e case runs the real thing — a fixture module that returns a value and then keeps a timer alive forever — and asserts the build finishes with the value; its sibling case runs the same module without the option and asserts it is still stuck, so the passing case cannot quietly stop proving anything. Those two need a real `node` on `PATH` and skip without one, which keeps the hermetic gate hermetic while CI's OS matrix runs them.

## Related issues

Closes #372

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a
      [Conventional Commit](https://www.conventionalcommits.org/)
      (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour
      changed. The authoring surface changed, so the build-writing skill and its
      cheatsheet were updated, synced to the plugin, and the plugin manifests
      bumped to 0.15.0.
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`,
      `llms-full.txt`, package README `## API`).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with
      type guards instead).
- [x] No dead code: unreachable branches and can't-fire fallbacks are removed,
      with types tightened so the impossible state is unrepresentable.
- [x] No duplicated logic: an existing helper is imported rather than retyped,
      and a near-copy differing by a constant or a message is parameterised into
      one implementation. A guard, escape, or credential resolution has exactly
      one implementation. The driver keeps a single write call, with the exit
      callback appended, rather than a second copy of the write.
- [x] SOLID shapes respected: one domain per file, extension via the settings
      lambda (not a behaviour-switching flag), narrow parameter types, and
      dependencies on the injectable seam (`StateHost`, an injected `fetch`,
      `EnvReader`) rather than `Deno.*` or a global.
- [ ] A new package was wired into all six places (see
      [AGENTS.md](../blob/master/AGENTS.md#good-open-source-practices-to-follow)),
      if applicable. Not applicable: no new package.
- [x] The code is written using AI assisted coding.
