### PR TITLE
fix(core): match absolute glob patterns

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -317,10 +317,14 @@ async function gitChangedFiles(base: string, run: (args: string[]) => Promise<st
   test without a repository.
 
 async function glob(pattern: string, options: GlobOptions): Promise<string[]>
-  Expand a glob pattern to the matching paths, relative to `cwd`, sorted for
-  determinism. The walk starts at the pattern's static prefix, so anchor
-  patterns (e.g. `src/**\/*.ts`) to avoid scanning the whole tree. Symlinked
-  directories are not followed.
+  Expand a glob pattern to the matching paths, sorted for determinism. The walk
+  starts at the pattern's static prefix, so anchor patterns (e.g.
+  `src/**\/*.ts`) to avoid scanning the whole tree. Symlinked directories are
+  not followed.
+
+  A relative pattern is resolved against `cwd` and its matches are returned
+  relative to it. An absolute pattern (a leading `/`, or a `C:`-style drive)
+  names its own root: `cwd` plays no part and the matches come back absolute.
 
 function globToRegExp(pattern: string): RegExp
   Compile a glob pattern into an anchored {@link RegExp} that matches a full
@@ -2963,7 +2967,8 @@ interface GlobOptions
   Options for {@link glob}.
 
   cwd?: string
-    Directory to resolve the pattern against (default: `Deno.cwd()`).
+    Directory to resolve the pattern against (default: `Deno.cwd()`). Ignored
+    for an absolute pattern, which names its own root.
 
 interface HeldLease
   A held lease. Release it when the work it covers is over.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -371,10 +371,14 @@ async function gitChangedFiles(base: string, run: (args: string[]) => Promise<st
   test without a repository.
 
 async function glob(pattern: string, options: GlobOptions): Promise<string[]>
-  Expand a glob pattern to the matching paths, relative to `cwd`, sorted for
-  determinism. The walk starts at the pattern's static prefix, so anchor
-  patterns (e.g. `src/**\/*.ts`) to avoid scanning the whole tree. Symlinked
-  directories are not followed.
+  Expand a glob pattern to the matching paths, sorted for determinism. The walk
+  starts at the pattern's static prefix, so anchor patterns (e.g.
+  `src/**\/*.ts`) to avoid scanning the whole tree. Symlinked directories are
+  not followed.
+
+  A relative pattern is resolved against `cwd` and its matches are returned
+  relative to it. An absolute pattern (a leading `/`, or a `C:`-style drive)
+  names its own root: `cwd` plays no part and the matches come back absolute.
 
 function globToRegExp(pattern: string): RegExp
   Compile a glob pattern into an anchored {@link RegExp} that matches a full
@@ -3017,7 +3021,8 @@ interface GlobOptions
   Options for {@link glob}.
 
   cwd?: string
-    Directory to resolve the pattern against (default: `Deno.cwd()`).
+    Directory to resolve the pattern against (default: `Deno.cwd()`). Ignored
+    for an absolute pattern, which names its own root.
 
 interface HeldLease
   A held lease. Release it when the work it covers is over.

--- a/packages/core/src/glob.ts
+++ b/packages/core/src/glob.ts
@@ -17,6 +17,8 @@
  * @module
  */
 
+import { isAbsolutePath } from "./internal.ts";
+
 /** Escape a literal substring for use inside a regular expression. */
 function escapeRegExp(text: string): string {
   return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -72,35 +74,51 @@ function staticBase(pattern: string): string {
 
 /** Options for {@link glob}. */
 export interface GlobOptions {
-  /** Directory to resolve the pattern against (default: `Deno.cwd()`). */
+  /**
+   * Directory to resolve the pattern against (default: `Deno.cwd()`). Ignored
+   * for an absolute pattern, which names its own root.
+   */
   cwd?: string;
 }
 
 /**
- * Expand a glob pattern to the matching paths, relative to `cwd`, sorted for
- * determinism. The walk starts at the pattern's static prefix, so anchor
- * patterns (e.g. `src/**\/*.ts`) to avoid scanning the whole tree. Symlinked
- * directories are not followed.
+ * Expand a glob pattern to the matching paths, sorted for determinism. The walk
+ * starts at the pattern's static prefix, so anchor patterns (e.g.
+ * `src/**\/*.ts`) to avoid scanning the whole tree. Symlinked directories are
+ * not followed.
+ *
+ * A relative pattern is resolved against `cwd` and its matches are returned
+ * relative to it. An **absolute** pattern (a leading `/`, or a `C:`-style drive)
+ * names its own root: `cwd` plays no part and the matches come back absolute.
  */
 export async function glob(
   pattern: string,
   options: GlobOptions = {},
 ): Promise<string[]> {
   const cwd = options.cwd ?? Deno.cwd();
+  // An absolute pattern is already rooted. Joining it onto `cwd` would walk a
+  // path that exists nowhere and return nothing at all — no files, no error.
+  const absolute = isAbsolutePath(pattern);
   const re = globToRegExp(pattern);
   const results: string[] = [];
 
-  const absOf = (rel: string) => rel === "" ? cwd : `${cwd}/${rel}`;
+  const absOf = (rel: string) =>
+    absolute ? rel : rel === "" ? cwd : `${cwd}/${rel}`;
   const walk = async (rel: string, isDirectory: boolean) => {
     if (rel !== "" && re.test(rel)) results.push(rel);
     if (!isDirectory) return;
     for await (const entry of Deno.readDir(absOf(rel))) {
-      const childRel = rel === "" ? entry.name : `${rel}/${entry.name}`;
+      const childRel = rel === "" || rel === "/"
+        ? `${rel}${entry.name}`
+        : `${rel}/${entry.name}`;
       await walk(childRel, entry.isDirectory);
     }
   };
 
-  const base = staticBase(pattern);
+  // `staticBase` returns "" for a pattern that globs from its very first
+  // segment; for an absolute one that root is the filesystem root, not the cwd.
+  const staticPrefix = staticBase(pattern);
+  const base = absolute && staticPrefix === "" ? "/" : staticPrefix;
   if (base === "") {
     await walk("", true);
   } else {

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -25,6 +25,17 @@ export function defaultReadEnv(name: string): string | undefined {
   }
 }
 
+/**
+ * Whether a forward-slashed path is already absolute — a leading `/` (POSIX,
+ * and a UNC share) or a `C:`-style drive letter. The one implementation of the
+ * test: a path composer that joins an already-absolute path onto a base
+ * produces something that exists nowhere, which is a silent empty result rather
+ * than an error.
+ */
+export function isAbsolutePath(slashed: string): boolean {
+  return slashed.startsWith("/") || /^[A-Za-z]:/.test(slashed);
+}
+
 /** The message of an `Error`, or the `String(...)` form of any other value. */
 export function messageOf(value: unknown): string {
   return value instanceof Error ? value.message : String(value);

--- a/packages/core/src/path.ts
+++ b/packages/core/src/path.ts
@@ -32,6 +32,8 @@
  * @module
  */
 
+import { isAbsolutePath } from "./internal.ts";
+
 /**
  * A filesystem path accepted by Zuke APIs: either a plain string or an
  * {@link AbsolutePath}. Anywhere a tool wrapper or build helper takes a path,
@@ -220,6 +222,7 @@ export function absolutePath(first: string, ...rest: string[]): AbsolutePath {
  */
 export function resolveDir(dir: string): AbsolutePath {
   const slashed = dir.replace(/\\/g, "/");
-  const isAbsolute = slashed.startsWith("/") || /^[A-Za-z]:/.test(slashed);
-  return absolutePath(isAbsolute ? slashed : `${Deno.cwd()}/${slashed}`);
+  return absolutePath(
+    isAbsolutePath(slashed) ? slashed : `${Deno.cwd()}/${slashed}`,
+  );
 }

--- a/packages/core/tests/glob_test.ts
+++ b/packages/core/tests/glob_test.ts
@@ -53,6 +53,33 @@ Deno.test("glob with no static base walks from cwd; missing base yields nothing"
   });
 });
 
+Deno.test("glob matches an absolute pattern, whatever the cwd", async () => {
+  await withTemp(async (dir) => {
+    await Deno.mkdir(`${dir}/g/a`, { recursive: true });
+    await Deno.mkdir(`${dir}/g/b`, { recursive: true });
+    await Deno.writeTextFile(`${dir}/g/a/tsconfig.json`, "{}");
+    await Deno.writeTextFile(`${dir}/g/b/tsconfig.json`, "{}");
+
+    // The matches come back absolute, and are the same files the relative
+    // pattern finds against the same directory.
+    assertEquals(await glob(`${dir}/g/*/tsconfig.json`), [
+      `${dir}/g/a/tsconfig.json`,
+      `${dir}/g/b/tsconfig.json`,
+    ]);
+    assertEquals(await glob("g/*/tsconfig.json", { cwd: dir }), [
+      "g/a/tsconfig.json",
+      "g/b/tsconfig.json",
+    ]);
+    // An absolute pattern names its own root, so a cwd cannot redirect it.
+    assertEquals(await glob(`${dir}/g/*/tsconfig.json`, { cwd: "/nowhere" }), [
+      `${dir}/g/a/tsconfig.json`,
+      `${dir}/g/b/tsconfig.json`,
+    ]);
+    // A non-existent absolute base still matches nothing, as before.
+    assertEquals(await glob(`${dir}/missing/*.ts`), []);
+  });
+});
+
 Deno.test("glob defaults cwd to Deno.cwd()", async () => {
   const original = Deno.cwd();
   const dir = await Deno.makeTempDir();

--- a/tests/integration/glob_absolute_test.ts
+++ b/tests/integration/glob_absolute_test.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals } from "../../packages/core/tests/_assert.ts";
+import { withTemp } from "../../packages/core/tests/_temp.ts";
+import { Build, glob, target } from "../../packages/core/mod.ts";
+import { runCli } from "./_harness.ts";
+
+// A build that globs a *computed* absolute path — a directory it was told about
+// rather than one under its own cwd — is where an absolute pattern silently
+// matching nothing does its damage: the target finds no files, does nothing,
+// and the run still reports success.
+let root = "";
+
+class ManifestBuild extends Build {
+  manifests = target()
+    .description("collect every manifest under an absolute root")
+    .executes(async () => {
+      const found = await glob(`${root}/*/deno.json`);
+      console.log(`found=${found.length}`);
+      for (const path of found) console.log(`path=${path}`);
+    });
+}
+
+Deno.test("a target globbing an absolute path finds its files", async () => {
+  await withTemp(async (dir) => {
+    root = dir;
+    await Deno.mkdir(`${dir}/one`);
+    await Deno.mkdir(`${dir}/two`);
+    await Deno.writeTextFile(`${dir}/one/deno.json`, "{}");
+    await Deno.writeTextFile(`${dir}/two/deno.json`, "{}");
+
+    const { code, out } = await runCli(ManifestBuild, ["manifests"]);
+    assertEquals(code, 0, out);
+    assertEquals(out.includes("found=2"), true, out);
+    assertEquals(out.includes(`path=${dir}/one/deno.json`), true, out);
+  });
+});


### PR DESCRIPTION
## What & why

The `glob` helper composed every walked path by joining onto `cwd`, so an absolute pattern was resolved against a path that exists nowhere and matched nothing — no files, and no error either. A build that globs a computed absolute path then finds no work to do and still reports success, which is the worst of the three possible outcomes: worse than matching, and worse than refusing.

An absolute pattern (a leading slash, or a drive letter) now names its own root. `cwd` plays no part in it and the matches come back absolute — the same result the pattern already produced when it was handed the filesystem root as its `cwd`, but without walking the whole filesystem to get there, since the walk still starts at the pattern's static prefix. Relative patterns and the `cwd` option behave exactly as before.

One detail worth a look in review: a pattern that globs from its very first segment has no static prefix, and for an absolute pattern that root is the filesystem root rather than the working directory. That case is handled where the walk root is chosen, and the child-path join no longer doubles the separator underneath it.

The absolute-path test now lives once, in the internal helpers. The path resolver had its own inline copy; both call the shared one, so they cannot drift.

## Related issues

Closes #374

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a
      [Conventional Commit](https://www.conventionalcommits.org/)
      (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
      A unit test covers the absolute pattern, the ignored `cwd`, and a
      non-existent absolute base; an integration test drives a real build whose
      target globs an absolute root through the CLI.
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour
      changed.
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`,
      `llms-full.txt`, package README `## API`).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with
      type guards instead).
- [x] No dead code: unreachable branches and can't-fire fallbacks are removed,
      with types tightened so the impossible state is unrepresentable.
- [x] No duplicated logic: an existing helper is imported rather than retyped,
      and a near-copy differing by a constant or a message is parameterised into
      one implementation. A guard, escape, or credential resolution has exactly
      one implementation. This PR removes one such near-copy rather than adding
      one.
- [x] SOLID shapes respected: one domain per file, extension via the settings
      lambda (not a behaviour-switching flag), narrow parameter types, and
      dependencies on the injectable seam (`StateHost`, an injected `fetch`,
      `EnvReader`) rather than `Deno.*` or a global.
- [ ] A new package was wired into all six places (see
      [AGENTS.md](../blob/master/AGENTS.md#good-open-source-practices-to-follow)),
      if applicable. Not applicable: no new package.
- [x] The code is written using AI assisted coding.
