### PR TITLE
feat(git): add worktree tasks and a parsed worktree listing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/cspell.json
+++ b/cspell.json
@@ -17,6 +17,7 @@
     "parentless",
     "redocly",
     "worktree",
+    "worktrees",
     "unanchorable",
     "uncoverable",
     "unrepresentable",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "zuke",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build)."
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9649,6 +9649,35 @@ class GitTagSettings extends GitSettings
   override protected subcommandArgs(): string[]
     Assemble the `git tag` argv.
 
+class GitWorktreeSettings extends GitSettings
+  Settings for `git worktree`. Pick the subcommand with {@link add},
+  {@link list}, {@link remove}, or {@link prune}; the remaining methods apply
+  to the one picked, mirroring the flags git accepts for it.
+
+  add(path: PathLike): this
+    Check a new worktree out at `path` (`git worktree add <path>`).
+  list(): this
+    List the repository's worktrees (`git worktree list`).
+  remove(path: PathLike): this
+    Remove the worktree at `path` (`git worktree remove <path>`).
+  prune(): this
+    Discard records of worktrees whose directories are gone (`git worktree prune`).
+  branch(name: string): this
+    The branch to check out in the new worktree — or, with
+    {@link createBranch}, the name of the branch to create there.
+  createBranch(): this
+    Create {@link branch} rather than checking out an existing one (`-b`).
+  detach(): this
+    Check out with a detached `HEAD` (`--detach`).
+  force(): this
+    Force the operation (`--force`): check out a branch already checked out
+    elsewhere, or remove a worktree with modifications. Without it git refuses
+    both.
+  porcelain(): this
+    Emit the stable machine-readable listing (`--porcelain`).
+  override protected subcommandArgs(): string[]
+    Assemble the `git worktree` argv.
+
 interface GitInfo
   Resolved git repository information.
 
@@ -9698,8 +9727,35 @@ interface GitTasksApi
     Fetch and integrate: `git pull`.
   fetch(configure?: Configure<GitFetchSettings>): Promise<CommandOutput>
     Download objects and refs: `git fetch`.
+  worktree(configure?: Configure<GitWorktreeSettings>): Promise<CommandOutput>
+    Manage worktrees: `git worktree add|list|remove|prune`. Pick the
+    subcommand in the lambda — `s.add(path)`, `s.list()`, `s.remove(path)`, or
+    `s.prune()`. For a listing to read rather than print, use
+    {@link GitTasksApi.worktreeList}.
+  worktreeList(configure?: Configure<GitWorktreeSettings>): Promise<GitWorktree[]>
+    List the repository's worktrees as parsed {@link GitWorktree} entries,
+    from `git worktree list --porcelain`.
+
+    The lambda configures the global options (`.dir()`, `.config()`); the
+    subcommand itself is fixed, since the parse depends on it.
   run(configure?: Configure<GitRunSettings>): Promise<CommandOutput>
     Run any other git command via `.command(...)`.
+
+interface GitWorktree
+  One entry of `git worktree list --porcelain`.
+
+  path: string
+    The worktree's absolute path, as git reports it.
+  head?: string
+    The commit checked out there, or `undefined` for a bare repository.
+  branch?: string
+    The checked-out branch, without its `refs/heads/` prefix; absent when detached.
+  bare: boolean
+    Whether this entry is the bare repository rather than a working tree.
+  detached: boolean
+    Whether `HEAD` is detached there.
+  locked: boolean
+    Whether the worktree is locked (`git worktree lock`).
 
 type GitRunner = (args: string[]) => Promise<string | null>
   Runs a `git` subcommand and resolves to its trimmed stdout, or `null` when

--- a/packages/git/README.md
+++ b/packages/git/README.md
@@ -265,6 +265,35 @@ class GitTagSettings extends GitSettings
   override protected subcommandArgs(): string[]
     Assemble the `git tag` argv.
 
+class GitWorktreeSettings extends GitSettings
+  Settings for `git worktree`. Pick the subcommand with {@link add},
+  {@link list}, {@link remove}, or {@link prune}; the remaining methods apply
+  to the one picked, mirroring the flags git accepts for it.
+
+  add(path: PathLike): this
+    Check a new worktree out at `path` (`git worktree add <path>`).
+  list(): this
+    List the repository's worktrees (`git worktree list`).
+  remove(path: PathLike): this
+    Remove the worktree at `path` (`git worktree remove <path>`).
+  prune(): this
+    Discard records of worktrees whose directories are gone (`git worktree prune`).
+  branch(name: string): this
+    The branch to check out in the new worktree — or, with
+    {@link createBranch}, the name of the branch to create there.
+  createBranch(): this
+    Create {@link branch} rather than checking out an existing one (`-b`).
+  detach(): this
+    Check out with a detached `HEAD` (`--detach`).
+  force(): this
+    Force the operation (`--force`): check out a branch already checked out
+    elsewhere, or remove a worktree with modifications. Without it git refuses
+    both.
+  porcelain(): this
+    Emit the stable machine-readable listing (`--porcelain`).
+  override protected subcommandArgs(): string[]
+    Assemble the `git worktree` argv.
+
 interface GitInfo
   Resolved git repository information.
 
@@ -314,8 +343,35 @@ interface GitTasksApi
     Fetch and integrate: `git pull`.
   fetch(configure?: Configure<GitFetchSettings>): Promise<CommandOutput>
     Download objects and refs: `git fetch`.
+  worktree(configure?: Configure<GitWorktreeSettings>): Promise<CommandOutput>
+    Manage worktrees: `git worktree add|list|remove|prune`. Pick the
+    subcommand in the lambda — `s.add(path)`, `s.list()`, `s.remove(path)`, or
+    `s.prune()`. For a listing to read rather than print, use
+    {@link GitTasksApi.worktreeList}.
+  worktreeList(configure?: Configure<GitWorktreeSettings>): Promise<GitWorktree[]>
+    List the repository's worktrees as parsed {@link GitWorktree} entries,
+    from `git worktree list --porcelain`.
+
+    The lambda configures the global options (`.dir()`, `.config()`); the
+    subcommand itself is fixed, since the parse depends on it.
   run(configure?: Configure<GitRunSettings>): Promise<CommandOutput>
     Run any other git command via `.command(...)`.
+
+interface GitWorktree
+  One entry of `git worktree list --porcelain`.
+
+  path: string
+    The worktree's absolute path, as git reports it.
+  head?: string
+    The commit checked out there, or `undefined` for a bare repository.
+  branch?: string
+    The checked-out branch, without its `refs/heads/` prefix; absent when detached.
+  bare: boolean
+    Whether this entry is the bare repository rather than a working tree.
+  detached: boolean
+    Whether `HEAD` is detached there.
+  locked: boolean
+    Whether the worktree is locked (`git worktree lock`).
 
 type GitRunner = (args: string[]) => Promise<string | null>
   Runs a `git` subcommand and resolves to its trimmed stdout, or `null` when

--- a/packages/git/mod.ts
+++ b/packages/git/mod.ts
@@ -20,5 +20,7 @@
  * @module
  */
 
+export * from "./src/settings.ts";
 export * from "./src/git.ts";
 export * from "./src/git_info.ts";
+export { type GitWorktree, GitWorktreeSettings } from "./src/worktree.ts";

--- a/packages/git/src/git.ts
+++ b/packages/git/src/git.ts
@@ -22,48 +22,14 @@
  * @module
  */
 
-import {
-  type Configure,
-  type PathLike,
-  runSettings,
-  ToolSettings,
-} from "@zuke/core/tooling";
+import { type Configure, type PathLike, runSettings } from "@zuke/core/tooling";
+import { GitSettings } from "./settings.ts";
 import type { CommandOutput } from "@zuke/core/shell";
-
-/** Shared base for every `git` subcommand: the binary and global options. */
-export abstract class GitSettings extends ToolSettings {
-  #dir?: string;
-  #configs: string[] = [];
-
-  /** The default tool binary: `git`. */
-  protected override defaultTool(): string {
-    return "git";
-  }
-
-  /** The subcommand argv (after the global options). */
-  protected abstract subcommandArgs(): string[];
-
-  /** Run git as if started in `path` (`-C <path>`). */
-  dir(path: PathLike): this {
-    this.#dir = String(path);
-    return this;
-  }
-
-  /** Set a one-off config value (`-c key=value`); repeatable. */
-  config(key: string, value: string): this {
-    this.#configs.push("-c", `${key}=${value}`);
-    return this;
-  }
-
-  /** Assemble the `git` argv: global options followed by the subcommand. */
-  protected override buildArgs(): string[] {
-    const argv: string[] = [];
-    if (this.#dir !== undefined) argv.push("-C", this.#dir);
-    argv.push(...this.#configs);
-    argv.push(...this.subcommandArgs());
-    return argv;
-  }
-}
+import {
+  type GitWorktree,
+  GitWorktreeSettings,
+  parseWorktreeList,
+} from "./worktree.ts";
 
 /** Settings for `git init`. */
 export class GitInitSettings extends GitSettings {
@@ -625,8 +591,38 @@ export interface GitTasksApi {
   pull(configure?: Configure<GitPullSettings>): Promise<CommandOutput>;
   /** Download objects and refs: `git fetch`. */
   fetch(configure?: Configure<GitFetchSettings>): Promise<CommandOutput>;
+  /**
+   * Manage worktrees: `git worktree add|list|remove|prune`. Pick the
+   * subcommand in the lambda — `s.add(path)`, `s.list()`, `s.remove(path)`, or
+   * `s.prune()`. For a listing to read rather than print, use
+   * {@link GitTasksApi.worktreeList}.
+   */
+  worktree(configure?: Configure<GitWorktreeSettings>): Promise<CommandOutput>;
+  /**
+   * List the repository's worktrees as parsed {@link GitWorktree} entries,
+   * from `git worktree list --porcelain`.
+   *
+   * The lambda configures the global options (`.dir()`, `.config()`); the
+   * subcommand itself is fixed, since the parse depends on it.
+   */
+  worktreeList(
+    configure?: Configure<GitWorktreeSettings>,
+  ): Promise<GitWorktree[]>;
   /** Run any other git command via `.command(...)`. */
   run(configure?: Configure<GitRunSettings>): Promise<CommandOutput>;
+}
+
+/**
+ * Run `git worktree list --porcelain` and parse it. Backs
+ * {@link GitTasksApi.worktreeList}.
+ */
+async function listWorktrees(
+  configure?: Configure<GitWorktreeSettings>,
+): Promise<GitWorktree[]> {
+  const settings = new GitWorktreeSettings();
+  const configured = configure ? configure(settings) : settings;
+  const output = await configured.list().porcelain().run();
+  return parseWorktreeList(output.stdout);
 }
 
 /** Typed task functions for the common `git` commands. */
@@ -642,5 +638,7 @@ export const GitTasks: GitTasksApi = {
   push: (c) => runSettings(new GitPushSettings(), c),
   pull: (c) => runSettings(new GitPullSettings(), c),
   fetch: (c) => runSettings(new GitFetchSettings(), c),
+  worktree: (c) => runSettings(new GitWorktreeSettings(), c),
+  worktreeList: (c) => listWorktrees(c),
   run: (c) => runSettings(new GitRunSettings(), c),
 };

--- a/packages/git/src/settings.ts
+++ b/packages/git/src/settings.ts
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * {@link GitSettings} — the base every `git` subcommand's settings extend: the
+ * `git` binary itself and the global options that precede any subcommand
+ * (`-C <path>`, `-c key=value`).
+ *
+ * It lives apart from the subcommands so a subcommand in its own module (see
+ * `worktree.ts`) can extend it without importing the module that assembles
+ * `GitTasks`, which would import it back.
+ *
+ * @module
+ */
+
+import { type PathLike, ToolSettings } from "@zuke/core/tooling";
+
+/** Shared base for every `git` subcommand: the binary and global options. */
+export abstract class GitSettings extends ToolSettings {
+  #dir?: string;
+  #configs: string[] = [];
+
+  /** The default tool binary: `git`. */
+  protected override defaultTool(): string {
+    return "git";
+  }
+
+  /** The subcommand argv (after the global options). */
+  protected abstract subcommandArgs(): string[];
+
+  /** Run git as if started in `path` (`-C <path>`). */
+  dir(path: PathLike): this {
+    this.#dir = String(path);
+    return this;
+  }
+
+  /** Set a one-off config value (`-c key=value`); repeatable. */
+  config(key: string, value: string): this {
+    this.#configs.push("-c", `${key}=${value}`);
+    return this;
+  }
+
+  /** Assemble the `git` argv: global options followed by the subcommand. */
+  protected override buildArgs(): string[] {
+    const argv: string[] = [];
+    if (this.#dir !== undefined) argv.push("-C", this.#dir);
+    argv.push(...this.#configs);
+    argv.push(...this.subcommandArgs());
+    return argv;
+  }
+}

--- a/packages/git/src/worktree.ts
+++ b/packages/git/src/worktree.ts
@@ -1,0 +1,211 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * `git worktree` — the subcommand that checks a second working tree out of one
+ * repository, so several branches can be worked on at once without cloning
+ * again or stashing.
+ *
+ * ```ts
+ * import { GitTasks } from "jsr:@zuke/git";
+ * await GitTasks.worktree((s) => s.add("../feature").branch("feature").createBranch());
+ * const trees = await GitTasks.worktreeList();
+ * await GitTasks.worktree((s) => s.remove("../feature"));
+ * ```
+ *
+ * {@link "./git.ts".GitTasks.worktreeList} is the one that hands back parsed
+ * entries rather than raw output — a target that reports on, or cleans up,
+ * existing worktrees reads them as values instead of scraping stdout.
+ *
+ * @module
+ */
+
+import type { PathLike } from "@zuke/core/tooling";
+import { GitSettings } from "./settings.ts";
+
+/** Which `git worktree` subcommand a {@link GitWorktreeSettings} runs. */
+type WorktreeMode = "add" | "list" | "remove" | "prune";
+
+/** The `refs/heads/` prefix `--porcelain` reports a branch under. */
+const HEADS = "refs/heads/";
+
+/** One entry of `git worktree list --porcelain`. */
+export interface GitWorktree {
+  /** The worktree's absolute path, as git reports it. */
+  path: string;
+  /** The commit checked out there, or `undefined` for a bare repository. */
+  head?: string;
+  /** The checked-out branch, without its `refs/heads/` prefix; absent when detached. */
+  branch?: string;
+  /** Whether this entry is the bare repository rather than a working tree. */
+  bare: boolean;
+  /** Whether `HEAD` is detached there. */
+  detached: boolean;
+  /** Whether the worktree is locked (`git worktree lock`). */
+  locked: boolean;
+}
+
+/**
+ * Settings for `git worktree`. Pick the subcommand with {@link add},
+ * {@link list}, {@link remove}, or {@link prune}; the remaining methods apply
+ * to the one picked, mirroring the flags git accepts for it.
+ */
+export class GitWorktreeSettings extends GitSettings {
+  #mode?: WorktreeMode;
+  #path?: string;
+  #branch?: string;
+  #createBranch = false;
+  #detach = false;
+  #force = false;
+  #porcelain = false;
+
+  /** Check a new worktree out at `path` (`git worktree add <path>`). */
+  add(path: PathLike): this {
+    this.#mode = "add";
+    this.#path = String(path);
+    return this;
+  }
+
+  /** List the repository's worktrees (`git worktree list`). */
+  list(): this {
+    this.#mode = "list";
+    return this;
+  }
+
+  /** Remove the worktree at `path` (`git worktree remove <path>`). */
+  remove(path: PathLike): this {
+    this.#mode = "remove";
+    this.#path = String(path);
+    return this;
+  }
+
+  /** Discard records of worktrees whose directories are gone (`git worktree prune`). */
+  prune(): this {
+    this.#mode = "prune";
+    return this;
+  }
+
+  /**
+   * The branch to check out in the new worktree — or, with
+   * {@link createBranch}, the name of the branch to create there.
+   */
+  branch(name: string): this {
+    this.#branch = name;
+    return this;
+  }
+
+  /** Create {@link branch} rather than checking out an existing one (`-b`). */
+  createBranch(): this {
+    this.#createBranch = true;
+    return this;
+  }
+
+  /** Check out with a detached `HEAD` (`--detach`). */
+  detach(): this {
+    this.#detach = true;
+    return this;
+  }
+
+  /**
+   * Force the operation (`--force`): check out a branch already checked out
+   * elsewhere, or remove a worktree with modifications. Without it git refuses
+   * both.
+   */
+  force(): this {
+    this.#force = true;
+    return this;
+  }
+
+  /** Emit the stable machine-readable listing (`--porcelain`). */
+  porcelain(): this {
+    this.#porcelain = true;
+    return this;
+  }
+
+  /** Assemble the `git worktree` argv. */
+  protected override subcommandArgs(): string[] {
+    if (this.#mode === undefined) {
+      throw new Error(
+        "GitTasks.worktree: no subcommand — call .add(path), .list(), " +
+          ".remove(path), or .prune().",
+      );
+    }
+    const argv = ["worktree", this.#mode];
+    if (this.#mode === "list") {
+      if (this.#porcelain) argv.push("--porcelain");
+      return argv;
+    }
+    if (this.#mode === "prune") return argv;
+    if (this.#force) argv.push("--force");
+    if (this.#mode === "remove") return [...argv, this.#pathArg()];
+    if (this.#detach) argv.push("--detach");
+    if (this.#createBranch) {
+      if (this.#branch === undefined) {
+        throw new Error(
+          "GitTasks.worktree: .createBranch() needs the name to create — " +
+            "call .branch(name).",
+        );
+      }
+      argv.push("-b", this.#branch);
+    }
+    argv.push(this.#pathArg());
+    // Without `-b` a branch is the commit-ish to check out, which git takes
+    // after the path.
+    if (!this.#createBranch && this.#branch !== undefined) {
+      argv.push(this.#branch);
+    }
+    return argv;
+  }
+
+  /** The path `add`/`remove` operate on; both set it, so this cannot be absent. */
+  #pathArg(): string {
+    if (this.#path === undefined) {
+      throw new Error("GitTasks.worktree: no path was given.");
+    }
+    return this.#path;
+  }
+}
+
+/**
+ * Parse `git worktree list --porcelain` into entries. Records are separated by
+ * a blank line and start with a `worktree <path>` line; attributes that carry
+ * no value (`bare`, `detached`, `locked`) appear alone. Unknown attributes are
+ * ignored, so a newer git reporting more of them still parses.
+ *
+ * Not part of the package's public surface — exported for its unit test.
+ */
+export function parseWorktreeList(stdout: string): GitWorktree[] {
+  const entries: GitWorktree[] = [];
+  let current: GitWorktree | null = null;
+  const flush = () => {
+    if (current !== null) entries.push(current);
+    current = null;
+  };
+  for (const raw of stdout.split("\n")) {
+    const line = raw.trimEnd(); // tolerate CRLF
+    if (line === "") {
+      flush();
+      continue;
+    }
+    const space = line.indexOf(" ");
+    const key = space === -1 ? line : line.slice(0, space);
+    const value = space === -1 ? "" : line.slice(space + 1);
+    if (key === "worktree") {
+      flush();
+      current = { path: value, bare: false, detached: false, locked: false };
+      continue;
+    }
+    // An attribute before any `worktree` line belongs to nothing; skip it.
+    if (current === null) continue;
+    if (key === "HEAD") current.head = value;
+    else if (key === "branch") {
+      current.branch = value.startsWith(HEADS)
+        ? value.slice(HEADS.length)
+        : value;
+    } else if (key === "bare") current.bare = true;
+    else if (key === "detached") current.detached = true;
+    else if (key === "locked") current.locked = true;
+  }
+  flush();
+  return entries;
+}

--- a/packages/git/tests/worktree_test.ts
+++ b/packages/git/tests/worktree_test.ts
@@ -1,0 +1,195 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import {
+  assertEquals,
+  assertRejects,
+  assertThrows,
+} from "../../core/tests/_assert.ts";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import {
+  assertWrapperConformance,
+  missingTool,
+} from "@zuke/core/tooling/conformance";
+import { GitWorktreeSettings, parseWorktreeList } from "../src/worktree.ts";
+import { GitTasks } from "../src/git.ts";
+
+Deno.test("worktree add checks a path out, with or without a new branch", () => {
+  assertEquals(new GitWorktreeSettings().add("../feature").argv(), [
+    "git",
+    "worktree",
+    "add",
+    "../feature",
+  ]);
+  // `-b` creates the branch; the path still comes last.
+  assertEquals(
+    new GitWorktreeSettings().add("../feature").branch("feature")
+      .createBranch().argv(),
+    ["git", "worktree", "add", "-b", "feature", "../feature"],
+  );
+  // Without `-b` the branch is the commit-ish, which git takes after the path.
+  assertEquals(
+    new GitWorktreeSettings().add("../hotfix").branch("release/1.2").argv(),
+    ["git", "worktree", "add", "../hotfix", "release/1.2"],
+  );
+  assertEquals(
+    new GitWorktreeSettings().add("../detached").detach().force().argv(),
+    ["git", "worktree", "add", "--force", "--detach", "../detached"],
+  );
+});
+
+Deno.test("worktree list, remove, and prune build their own argv", () => {
+  assertEquals(new GitWorktreeSettings().list().argv(), [
+    "git",
+    "worktree",
+    "list",
+  ]);
+  assertEquals(new GitWorktreeSettings().list().porcelain().argv(), [
+    "git",
+    "worktree",
+    "list",
+    "--porcelain",
+  ]);
+  assertEquals(new GitWorktreeSettings().remove("../feature").argv(), [
+    "git",
+    "worktree",
+    "remove",
+    "../feature",
+  ]);
+  // A dirty worktree needs `--force`; git refuses it otherwise.
+  assertEquals(
+    new GitWorktreeSettings().remove("../feature").force().argv(),
+    ["git", "worktree", "remove", "--force", "../feature"],
+  );
+  assertEquals(new GitWorktreeSettings().prune().argv(), [
+    "git",
+    "worktree",
+    "prune",
+  ]);
+  // The global options apply here as they do to every other subcommand.
+  assertEquals(new GitWorktreeSettings().dir("repo").prune().argv(), [
+    "git",
+    "-C",
+    "repo",
+    "worktree",
+    "prune",
+  ]);
+});
+
+Deno.test("a worktree call with no subcommand says which ones exist", () => {
+  assertThrows(
+    () => new GitWorktreeSettings().argv(),
+    Error,
+    "no subcommand",
+  );
+});
+
+Deno.test("createBranch without a name is refused rather than sent to git", () => {
+  assertThrows(
+    () => new GitWorktreeSettings().add("../feature").createBranch().argv(),
+    Error,
+    ".createBranch() needs the name to create",
+  );
+});
+
+Deno.test("parseWorktreeList reads paths, heads, branches, and flags", () => {
+  const stdout = [
+    "worktree /repo",
+    "HEAD 1111111111111111111111111111111111111111",
+    "branch refs/heads/master",
+    "",
+    "worktree /repo/../feature",
+    "HEAD 2222222222222222222222222222222222222222",
+    "branch refs/heads/feature",
+    "locked",
+    "",
+    "worktree /repo/../review",
+    "HEAD 3333333333333333333333333333333333333333",
+    "detached",
+    "",
+  ].join("\n");
+
+  assertEquals(parseWorktreeList(stdout), [
+    {
+      path: "/repo",
+      head: "1111111111111111111111111111111111111111",
+      branch: "master",
+      bare: false,
+      detached: false,
+      locked: false,
+    },
+    {
+      path: "/repo/../feature",
+      head: "2222222222222222222222222222222222222222",
+      branch: "feature",
+      bare: false,
+      detached: false,
+      locked: true,
+    },
+    {
+      path: "/repo/../review",
+      head: "3333333333333333333333333333333333333333",
+      bare: false,
+      detached: true,
+      locked: false,
+    },
+  ]);
+});
+
+Deno.test("parseWorktreeList handles the bare entry, CRLF, and a missing final blank line", () => {
+  const stdout = "worktree /repo.git\r\nbare\r\n\r\nworktree /repo\r\n" +
+    "HEAD 4444444444444444444444444444444444444444\r\n" +
+    "branch refs/heads/main\r\nsomething-new value\r\n";
+
+  assertEquals(parseWorktreeList(stdout), [
+    { path: "/repo.git", bare: true, detached: false, locked: false },
+    {
+      path: "/repo",
+      head: "4444444444444444444444444444444444444444",
+      branch: "main",
+      bare: false,
+      detached: false,
+      locked: false,
+    },
+  ]);
+});
+
+Deno.test("parseWorktreeList yields nothing for empty or headless output", () => {
+  assertEquals(parseWorktreeList(""), []);
+  // An attribute with no `worktree` line above it belongs to no entry.
+  assertEquals(parseWorktreeList("bare\ndetached\n"), []);
+});
+
+Deno.test("a branch ref outside refs/heads keeps its full name", () => {
+  assertEquals(
+    parseWorktreeList("worktree /repo\nbranch refs/remotes/origin/main\n"),
+    [{
+      path: "/repo",
+      branch: "refs/remotes/origin/main",
+      bare: false,
+      detached: false,
+      locked: false,
+    }],
+  );
+});
+
+Deno.test("both worktree tasks reach execution", async () => {
+  await assertRejects(
+    () => GitTasks.worktree((s) => missingTool(s.prune())),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => GitTasks.worktreeList((s) => missingTool(s)),
+    ToolNotFoundError,
+  );
+});
+
+Deno.test("the worktree wrapper conforms to the tool contract", async () => {
+  await assertWrapperConformance(
+    () => new GitWorktreeSettings().prune(),
+    "git",
+    {
+      resolution: "path",
+    },
+  );
+});

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/.codex-plugin/plugin.json
+++ b/plugins/zuke/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -643,7 +643,7 @@ the full task list and settings methods of each):
 | `@zuke/npm`, `@zuke/npx`, `@zuke/bun`, `@zuke/pnpm`, `@zuke/yarn`, `@zuke/node`                                                                     | `NpmTasks`, `NpxTasks`, `BunTasks`, ...          | JS package managers + `npx` runner + `node`                                                       |
 | `@zuke/cmd`                                                                                                                                         | `CmdTasks`                                       | `exec` — generic fallback for any CLI                                                             |
 | `@zuke/docker`, `@zuke/docker-compose`                                                                                                              | `DockerTasks`, ...                               | build/run/compose                                                                                 |
-| `@zuke/git`, `@zuke/gh`                                                                                                                             | `GitTasks`, `GhTasks`                            | git and GitHub CLI (`GhTasks.run` for subcommands, `GhTasks.api` for REST endpoints without one)  |
+| `@zuke/git`, `@zuke/gh`                                                                                                                             | `GitTasks`, `GhTasks`                            | git (including worktrees) and GitHub CLI (`GhTasks.run` for subcommands, `GhTasks.api` for REST endpoints without one) |
 | `@zuke/cspell`, `@zuke/eslint`, `@zuke/oxlint`, `@zuke/biome`, `@zuke/dprint`, `@zuke/knip`, `@zuke/dpdm`, `@zuke/lint-staged`                      | `*Tasks`                                         | lint/format/spell/dead-code                                                                       |
 | `@zuke/tsc`, `@zuke/tsx`, `@zuke/tsc-alias`, `@zuke/tsup`, `@zuke/tsdown`, `@zuke/vite`, `@zuke/storybook`, `@zuke/turbo`, `@zuke/nx`, `@zuke/nest` | `*Tasks`                                         | TS compile / bundle / monorepo / framework CLIs                                                   |
 | `@zuke/openapi-ts`, `@zuke/orval`, `@zuke/redocly`                                                                                                  | `*Tasks`                                         | generate API clients from OpenAPI                                                                 |
@@ -698,6 +698,24 @@ it); the module resolves its own imports from the surrounding `node_modules`, so
 this is how a build reaches framework code (NestJS, TypeORM) it must not depend
 on itself. The value crosses the process boundary as JSON, so it — and each
 `callWith` argument — must be JSON-serialisable.
+
+### Worktrees — `GitTasks.worktree`
+
+A second working tree lets one repository have several branches checked out at
+once. `GitTasks.worktree` picks the subcommand in the lambda; `worktreeList`
+runs `git worktree list --porcelain` and hands back parsed entries, so a target
+reads them as values instead of scraping stdout.
+
+```ts
+await GitTasks.worktree((s) => s.add(path).branch(name).createBranch());
+await GitTasks.worktree((s) => s.add(path).branch("release/1.2")); // existing branch
+const trees = await GitTasks.worktreeList(); // { path, head, branch, bare, detached, locked }[]
+await GitTasks.worktree((s) => s.remove(path).force()); // git refuses a dirty tree without it
+await GitTasks.worktree((s) => s.prune()); // forget trees whose directories are gone
+```
+
+Reach for `.dir(repo)` when the build's own cwd is not the repository, as with
+every other git task.
 
 ## AI review & self-healing — `@zuke/ai`
 

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -643,7 +643,7 @@ the full task list and settings methods of each):
 | `@zuke/npm`, `@zuke/npx`, `@zuke/bun`, `@zuke/pnpm`, `@zuke/yarn`, `@zuke/node`                                                                     | `NpmTasks`, `NpxTasks`, `BunTasks`, ...          | JS package managers + `npx` runner + `node`                                                       |
 | `@zuke/cmd`                                                                                                                                         | `CmdTasks`                                       | `exec` — generic fallback for any CLI                                                             |
 | `@zuke/docker`, `@zuke/docker-compose`                                                                                                              | `DockerTasks`, ...                               | build/run/compose                                                                                 |
-| `@zuke/git`, `@zuke/gh`                                                                                                                             | `GitTasks`, `GhTasks`                            | git and GitHub CLI (`GhTasks.run` for subcommands, `GhTasks.api` for REST endpoints without one)  |
+| `@zuke/git`, `@zuke/gh`                                                                                                                             | `GitTasks`, `GhTasks`                            | git (including worktrees) and GitHub CLI (`GhTasks.run` for subcommands, `GhTasks.api` for REST endpoints without one) |
 | `@zuke/cspell`, `@zuke/eslint`, `@zuke/oxlint`, `@zuke/biome`, `@zuke/dprint`, `@zuke/knip`, `@zuke/dpdm`, `@zuke/lint-staged`                      | `*Tasks`                                         | lint/format/spell/dead-code                                                                       |
 | `@zuke/tsc`, `@zuke/tsx`, `@zuke/tsc-alias`, `@zuke/tsup`, `@zuke/tsdown`, `@zuke/vite`, `@zuke/storybook`, `@zuke/turbo`, `@zuke/nx`, `@zuke/nest` | `*Tasks`                                         | TS compile / bundle / monorepo / framework CLIs                                                   |
 | `@zuke/openapi-ts`, `@zuke/orval`, `@zuke/redocly`                                                                                                  | `*Tasks`                                         | generate API clients from OpenAPI                                                                 |
@@ -698,6 +698,24 @@ it); the module resolves its own imports from the surrounding `node_modules`, so
 this is how a build reaches framework code (NestJS, TypeORM) it must not depend
 on itself. The value crosses the process boundary as JSON, so it — and each
 `callWith` argument — must be JSON-serialisable.
+
+### Worktrees — `GitTasks.worktree`
+
+A second working tree lets one repository have several branches checked out at
+once. `GitTasks.worktree` picks the subcommand in the lambda; `worktreeList`
+runs `git worktree list --porcelain` and hands back parsed entries, so a target
+reads them as values instead of scraping stdout.
+
+```ts
+await GitTasks.worktree((s) => s.add(path).branch(name).createBranch());
+await GitTasks.worktree((s) => s.add(path).branch("release/1.2")); // existing branch
+const trees = await GitTasks.worktreeList(); // { path, head, branch, bare, detached, locked }[]
+await GitTasks.worktree((s) => s.remove(path).force()); // git refuses a dirty tree without it
+await GitTasks.worktree((s) => s.prune()); // forget trees whose directories are gone
+```
+
+Reach for `.dir(repo)` when the build's own cwd is not the repository, as with
+every other git task.
 
 ## AI review & self-healing — `@zuke/ai`
 

--- a/tests/e2e/fixtures/git_worktree_build.ts
+++ b/tests/e2e/fixtures/git_worktree_build.ts
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Fixture for {@link file://../git_worktree_e2e.ts}: drive `git worktree`
+ * against a real repository. The repository is `ZUKE_E2E_REPO`, created by the
+ * test; the second working tree is checked out beside it.
+ *
+ * Each step prints a marker the test asserts on, so a failure names the step
+ * that produced it rather than a diff of the whole output.
+ *
+ * @module
+ */
+
+import { Build, run, target } from "../../../packages/core/mod.ts";
+import { GitTasks } from "../../../packages/git/mod.ts";
+
+/** The repository the test prepared for this run. */
+const REPO = Deno.env.get("ZUKE_E2E_REPO") ?? "";
+
+/** Where the second working tree is checked out. */
+const TREE = `${REPO}_feature`;
+
+class GitWorktreeBuild extends Build {
+  worktrees = target()
+    .description("add, list, and remove a worktree in a real repository")
+    .executes(async () => {
+      await GitTasks.init((s) => s.dir(REPO).initialBranch("main"));
+      await GitTasks.commit((s) =>
+        s.dir(REPO)
+          .config("user.name", "Zuke Test")
+          .config("user.email", "test@zuke.build")
+          .allowEmpty()
+          .message("chore: initial commit")
+      );
+
+      await GitTasks.worktree((s) =>
+        s.dir(REPO).add(TREE).branch("feature").createBranch()
+      );
+      console.log("ADDED");
+
+      const added = await GitTasks.worktreeList((s) => s.dir(REPO));
+      for (const tree of added) {
+        console.log(
+          `TREE ${tree.path} branch=${tree.branch} bare=${tree.bare}`,
+        );
+      }
+
+      // A modified worktree must not disappear on a plain remove.
+      await Deno.writeTextFile(`${TREE}/uncommitted.txt`, "work in progress\n");
+      try {
+        await GitTasks.worktree((s) => s.dir(REPO).remove(TREE));
+        console.log("REMOVED_DIRTY");
+      } catch {
+        console.log("REFUSED_DIRTY");
+      }
+
+      await GitTasks.worktree((s) => s.dir(REPO).remove(TREE).force());
+      console.log("REMOVED");
+
+      const left = await GitTasks.worktreeList((s) => s.dir(REPO));
+      console.log(`COUNT=${left.length}`);
+    });
+}
+
+await run(GitWorktreeBuild);

--- a/tests/e2e/git_worktree_e2e.ts
+++ b/tests/e2e/git_worktree_e2e.ts
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * End-to-end: `git worktree` against a real repository. Whether git accepts the
+ * argv, and whether it refuses to remove a modified worktree, are facts about
+ * git rather than about the argv builder, so only a real invocation shows them.
+ * The {@link file://./fixtures/git_worktree_build.ts} fixture runs the whole
+ * sequence in one build: init, add, list, a refused remove, a forced remove,
+ * and a final listing.
+ *
+ * Like the Node evaluation suite, these tests need a real `git` and skip where
+ * there is none, so a checkout without it stays green. On CI the skip is
+ * refused: every runner ships git, and skipping quietly would retire the
+ * coverage unnoticed.
+ */
+
+import { assertEquals } from "../../packages/core/tests/_assert.ts";
+import { runFixture } from "./_harness.ts";
+
+const FIXTURE = new URL("./fixtures/git_worktree_build.ts", import.meta.url);
+
+/** Whether a usable `git` is on `PATH`. */
+async function gitAvailable(): Promise<boolean> {
+  try {
+    const { success } = await new Deno.Command("git", {
+      args: ["--version"],
+      stdout: "null",
+      stderr: "null",
+    }).output();
+    return success;
+  } catch {
+    return false;
+  }
+}
+
+const HAS_GIT = await gitAvailable();
+
+/** On CI a missing git is an environment regression, not a reason to skip. */
+const MUST_HAVE_GIT = Deno.env.get("CI") === "true";
+
+Deno.test({
+  name: "CI runs the git worktree tests rather than skipping them",
+  ignore: !MUST_HAVE_GIT,
+  fn: () => {
+    assertEquals(
+      HAS_GIT,
+      true,
+      "no usable `git` on PATH: the worktree e2e test would have been " +
+        "skipped on a runner that is supposed to provide one.",
+    );
+  },
+});
+
+Deno.test({
+  name: "a build adds, lists, and removes a real worktree",
+  ignore: !HAS_GIT,
+  fn: async () => {
+    const repo = await Deno.makeTempDir();
+    try {
+      const { code, out, err } = await runFixture(FIXTURE, ["worktrees"], {
+        ZUKE_E2E_REPO: repo,
+        // git reads the ambient home for config; keep the run out of it.
+        GIT_CONFIG_GLOBAL: `${repo}/.gitconfig-none`,
+        GIT_CONFIG_SYSTEM: `${repo}/.gitconfig-none`,
+      });
+      const output = out + err;
+
+      assertEquals(code, 0, `expected a passing build:\n${output}`);
+      assertEquals(out.includes("ADDED"), true, output);
+      // The listing carries both trees, with the branch each has checked out.
+      // Compared by the directory name rather than the whole path: git reports
+      // the resolved path, and a macOS temp directory reaches it through a
+      // symlink (`/var/…` against `/private/var/…`).
+      const slashed = repo.replace(/\\/g, "/");
+      const name = slashed.slice(slashed.lastIndexOf("/") + 1);
+      assertEquals(
+        out.includes(`/${name} branch=main bare=false`),
+        true,
+        output,
+      );
+      assertEquals(
+        out.includes(`/${name}_feature branch=feature bare=false`),
+        true,
+        output,
+      );
+      // A modified worktree survives a plain remove and yields to a forced one.
+      assertEquals(out.includes("REFUSED_DIRTY"), true, output);
+      assertEquals(out.includes("REMOVED"), true, output);
+      assertEquals(out.includes("COUNT=1"), true, output);
+    } finally {
+      await Deno.remove(repo, { recursive: true });
+      await Deno.remove(`${repo}_feature`, { recursive: true }).catch(() => {});
+    }
+  },
+});

--- a/tests/integration/git_worktree_test.ts
+++ b/tests/integration/git_worktree_test.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import { Build, target } from "../../packages/core/mod.ts";
+import { missingTool } from "../../packages/core/src/tooling_conformance.ts";
+import { GitTasks } from "../../packages/git/mod.ts";
+import { runCli } from "./_harness.ts";
+
+// `worktreeList` is the task that hands a *value* back to the target rather
+// than a `CommandOutput`, so a build has to see the ordinary tool-not-found
+// failure when git is missing, not a parse of empty output that reports zero
+// worktrees and carries on.
+class SessionsBuild extends Build {
+  create = target()
+    .description("check a second working tree out of this repository")
+    .executes(async () => {
+      await GitTasks.worktree((s) =>
+        missingTool(s.add("../feature").branch("feature").createBranch())
+      );
+      console.log("created");
+    });
+
+  report = target()
+    .description("report the repository's worktrees")
+    .executes(async () => {
+      const trees = await GitTasks.worktreeList((s) => missingTool(s));
+      console.log(`count=${trees.length}`);
+    });
+}
+
+Deno.test("a target creating a worktree fails with the tool-not-found error", async () => {
+  const { code, out, err } = await runCli(SessionsBuild, ["create"]);
+  assertEquals(code, 1);
+  assertStringIncludes(err, "zuke-no-such-tool-xyz");
+  assertEquals(out.includes("created"), false);
+});
+
+Deno.test("a missing git fails the listing rather than reporting no worktrees", async () => {
+  const { code, out, err } = await runCli(SessionsBuild, ["report"]);
+  assertEquals(code, 1);
+  assertStringIncludes(err, "zuke-no-such-tool-xyz");
+  assertEquals(out.includes("count="), false);
+});


### PR DESCRIPTION
## What & why

`GitTasksApi` covered thirteen subcommands and not `worktree`, so a build that manages parallel working trees had to reach for the generic run task and hand-written argument strings. That is the untyped escape the wrapper exists to remove.

The new `worktree` task picks its subcommand in the settings lambda — `add`, `list`, `remove`, `prune` — with the flags git accepts for each: `-b` and a detached checkout for add, `--force` where git otherwise refuses, `--porcelain` for the listing. A branch given without `createBranch` is the commit-ish to check out, which git takes after the path, and a `createBranch` with no name is refused before it reaches git rather than after.

`worktreeList` is the second task, and the one that earns its keep: it runs the porcelain listing and parses it into entries, so a target that reports on worktrees or cleans up stale ones reads values instead of scraping stdout. The parser tolerates CRLF, a bare repository entry, a missing final blank line, and attributes a newer git might add.

The shared settings base moves into its own module. A subcommand living in its own file has to extend it, and importing the module that assembles the task object would import that module back — a cycle that fails at load time depending on which entrypoint gets there first. The public surface is unchanged: the base is exported from the package root as before.

Tested at three layers. Units cover the argv of every subcommand, both refusals, and the porcelain parse. An integration test drives a real build through the CLI and asserts a missing git fails the listing rather than quietly reporting no worktrees. A new e2e case runs the whole sequence against a real repository — init, add, list, a remove that git refuses because the tree is modified, a forced remove, and a final listing — since git's own refusal is a fact about git, not about the argv builder. Those cases skip where there is no git on PATH, and refuse to skip on CI, the same arrangement the Node evaluation e2e tests use.

## Related issues

Closes #376

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a
      [Conventional Commit](https://www.conventionalcommits.org/)
      (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour
      changed. The build-writing skill and its cheatsheet gained a worktree
      section, synced to the plugin, with the manifests bumped to 0.15.0.
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`,
      `llms-full.txt`, package README `## API`).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with
      type guards instead).
- [x] No dead code: unreachable branches and can't-fire fallbacks are removed,
      with types tightened so the impossible state is unrepresentable.
- [x] No duplicated logic: an existing helper is imported rather than retyped,
      and a near-copy differing by a constant or a message is parameterised into
      one implementation. A guard, escape, or credential resolution has exactly
      one implementation.
- [x] SOLID shapes respected: one domain per file, extension via the settings
      lambda (not a behaviour-switching flag), narrow parameter types, and
      dependencies on the injectable seam (`StateHost`, an injected `fetch`,
      `EnvReader`) rather than `Deno.*` or a global.
- [ ] A new package was wired into all six places (see
      [AGENTS.md](../blob/master/AGENTS.md#good-open-source-practices-to-follow)),
      if applicable. Not applicable: no new package.
- [x] The code is written using AI assisted coding.
