### PR TITLE
feat(core): wait for a contended target lock

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.15.0",
+      "version": "0.17.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/docs/locks.md
+++ b/docs/locks.md
@@ -30,8 +30,8 @@ parameters resolve, so the key can read `this.<param>.value`.
 ## Semantics
 
 - **Exclusive.** While a run holds the lock for a `key`, any other run that
-  tries to acquire the same key **fails** with a `LockConflictError` — it does
-  not queue or block. The error's message is the rendered guidance and its
+  tries to acquire the same key **fails** with a `LockConflictError` — unless it
+  asks to wait (below). The error's message is the rendered guidance and its
   `holder` carries the structured identity (`actor`, `runId`, `since`,
   `runUrl?`).
 - **The key** is set with `s.lockKey(...parts)` (sanitised and joined, safe as a
@@ -47,6 +47,39 @@ parameters resolve, so the key can read `this.<param>.value`.
 - **Release.** The lock is released when the target settles — **success,
   failure, or cancellation** — in a `finally`, so the common path never relies
   on the TTL. The TTL is only the backstop for a killed process.
+
+## Waiting instead of failing
+
+Failing fast is right for a resource where a second run is a mistake worth
+reporting. It is the wrong answer for a resource a developer wants to *use* —
+one dev environment, one database, one port — where the useful behaviour is to
+queue and be handed the resource when it frees.
+
+```ts
+devStack = target()
+  .lock((s) =>
+    s.lockKey("dev-env")
+      .withTtl("4h")
+      .waitUpTo("30m")     // queue instead of failing
+      .pollEvery("5s"))    // how often to retry; 5s is the default
+  .executes(async (ctx) => {/* … */});
+```
+
+- `s.waitUpTo(duration)` retries until the lock frees, and raises
+  `LockConflictError` only once the wait is spent. Its message says how long it
+  waited, so a timeout is not mistaken for a lock that was never retried.
+- `s.pollEvery(duration)` paces the retries (default `"5s"`).
+- While waiting, the run prints who holds the lock and since when, once per
+  holder rather than once per retry.
+- A cancelled run stops waiting immediately; a 30-minute wait never outlives the
+  run it belongs to.
+- Omitting `waitUpTo` keeps the fail-fast behaviour exactly as it was.
+
+**Waiters are not queued in arrival order.** Each retries on its own, so a run
+that has waited twenty minutes has no claim over one that arrived a second ago.
+With few contenders that is rarely visible; with many, a waiter can be unlucky
+repeatedly. Arrival order needs the store to hand out places in a queue, which
+is not something a waiting client can arrange for itself.
 
 ## Conflicts
 

--- a/docs/locks.md
+++ b/docs/locks.md
@@ -53,7 +53,8 @@ parameters resolve, so the key can read `this.<param>.value`.
 Failing fast is right for a resource where a second run is a mistake worth
 reporting. It is the wrong answer for a resource a developer wants to *use* —
 one dev environment, one database, one port — where the useful behaviour is to
-queue and be handed the resource when it frees.
+keep asking until the resource frees, instead of making the developer run the
+command again.
 
 ```ts
 devStack = target()
@@ -68,18 +69,21 @@ devStack = target()
 - `s.waitUpTo(duration)` retries until the lock frees, and raises
   `LockConflictError` only once the wait is spent. Its message says how long it
   waited, so a timeout is not mistaken for a lock that was never retried.
-- `s.pollEvery(duration)` paces the retries (default `"5s"`).
+- `s.pollEvery(duration)` paces the retries (default `"5s"`). Nothing hands the
+  lock over: a waiter takes it on its next retry, so it starts up to one poll
+  interval after the holder released it, and only if no one else took it first.
 - While waiting, the run prints who holds the lock and since when, once per
   holder rather than once per retry.
 - A cancelled run stops waiting immediately; a 30-minute wait never outlives the
   run it belongs to.
 - Omitting `waitUpTo` keeps the fail-fast behaviour exactly as it was.
 
-**Waiters are not queued in arrival order.** Each retries on its own, so a run
-that has waited twenty minutes has no claim over one that arrived a second ago.
-With few contenders that is rarely visible; with many, a waiter can be unlucky
-repeatedly. Arrival order needs the store to hand out places in a queue, which
-is not something a waiting client can arrange for itself.
+**There is no queue.** "Waiting" is a retry loop, not a place in a line: each
+waiter races every other waiter — and every fresh run — for the lock the moment
+it frees. A run that has waited twenty minutes has no claim over one that
+arrived a second ago, and can lose the race repeatedly when contention is heavy.
+Arrival order would need the store itself to hand out places, which is not
+something a waiting client can arrange for itself.
 
 ## Conflicts
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "zuke",
-  "version": "0.15.0",
+  "version": "0.17.0",
   "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build)."
 }

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "zuke",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build)."
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1333,6 +1333,10 @@ class LockSettings
     The TTL (a duration string or milliseconds); set by {@link withTtl}.
   onConflict_?: (holder: LockHolder) => string
     The conflict-guidance renderer; set by {@link onConflict}.
+  waitUpTo_?: string | number
+    How long to wait for a held lock; set by {@link waitUpTo}.
+  pollEvery_?: string | number
+    How often to retry while waiting; set by {@link pollEvery}.
   lockKey(...parts: Array<string | number>): this
     Set the lock key from parts, sanitised and joined via
     {@link "./state/lock.ts".lockKey} — e.g. `s.lockKey("deploy", repo)`.
@@ -1342,6 +1346,23 @@ class LockSettings
     How long the lock survives a killed holder — a duration string like `"4h"`
     / `"30m"` (see the duration parser) or raw milliseconds. A live holder
     renews it while it runs, so it never expires under it.
+  waitUpTo(duration: string | number): this
+    Wait up to this long for a held lock instead of failing at once — a
+    duration string like `"30m"` or raw milliseconds. The target queues, and
+    takes the lock when the run holding it finishes; it fails with a
+    {@link "./state/lock.ts".LockConflictError} only once the wait is spent.
+
+    Set this for a shared resource a developer wants to use — one dev
+    environment, one database, one port — where failing fast just makes them
+    run the command again. Leave it off for a resource where a second run is a
+    mistake worth reporting immediately, which stays the default.
+
+    Waiting runs retry independently, so a queue of them is not served in
+    arrival order: a run that has waited longer has no claim over one that
+    arrived a moment ago.
+  pollEvery(duration: string | number): this
+    How often to retry while {@link waitUpTo} waits (default `"5s"`). Alone it
+    does nothing — without a wait there is no retry to pace.
   onConflict(render: (holder: LockHolder) => string): this
     Render the guidance shown to a run that loses the lock. Receives the
     current {@link "./state/lock.ts".LockHolder}; the returned string becomes

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1387,6 +1387,10 @@ class LockSettings
     The TTL (a duration string or milliseconds); set by {@link withTtl}.
   onConflict_?: (holder: LockHolder) => string
     The conflict-guidance renderer; set by {@link onConflict}.
+  waitUpTo_?: string | number
+    How long to wait for a held lock; set by {@link waitUpTo}.
+  pollEvery_?: string | number
+    How often to retry while waiting; set by {@link pollEvery}.
   lockKey(...parts: Array<string | number>): this
     Set the lock key from parts, sanitised and joined via
     {@link "./state/lock.ts".lockKey} — e.g. `s.lockKey("deploy", repo)`.
@@ -1396,6 +1400,23 @@ class LockSettings
     How long the lock survives a killed holder — a duration string like `"4h"`
     / `"30m"` (see the duration parser) or raw milliseconds. A live holder
     renews it while it runs, so it never expires under it.
+  waitUpTo(duration: string | number): this
+    Wait up to this long for a held lock instead of failing at once — a
+    duration string like `"30m"` or raw milliseconds. The target queues, and
+    takes the lock when the run holding it finishes; it fails with a
+    {@link "./state/lock.ts".LockConflictError} only once the wait is spent.
+
+    Set this for a shared resource a developer wants to use — one dev
+    environment, one database, one port — where failing fast just makes them
+    run the command again. Leave it off for a resource where a second run is a
+    mistake worth reporting immediately, which stays the default.
+
+    Waiting runs retry independently, so a queue of them is not served in
+    arrival order: a run that has waited longer has no claim over one that
+    arrived a moment ago.
+  pollEvery(duration: string | number): this
+    How often to retry while {@link waitUpTo} waits (default `"5s"`). Alone it
+    does nothing — without a wait there is no retry to pace.
   onConflict(render: (holder: LockHolder) => string): this
     Render the guidance shown to a run that loses the lock. Receives the
     current {@link "./state/lock.ts".LockHolder}; the returned string becomes

--- a/packages/core/src/lock.ts
+++ b/packages/core/src/lock.ts
@@ -120,8 +120,12 @@ async function acquireWithin(
     const result = await store.acquireLock(key, holderFor(env), ttlMs);
     if (result.ok) return result;
     const remaining = deadline - Date.now();
-    // No wait was declared (remaining is already negative) or it is spent —
-    // either way this conflict is the answer.
+    // No wait was declared (remaining is already negative), it is spent, or the
+    // run was cancelled — either way this conflict is the answer. The abort
+    // check belongs here rather than only inside the sleep: `addEventListener`
+    // on an already-aborted signal never fires, so a signal that aborted while
+    // the attempt above was in flight would otherwise sleep out the whole poll
+    // interval before anyone noticed.
     if (remaining <= 0 || env.signal.aborted) return result;
     if (result.holder.runId !== announced) {
       announced = result.holder.runId;

--- a/packages/core/src/lock.ts
+++ b/packages/core/src/lock.ts
@@ -6,13 +6,20 @@
  * heartbeat it at half its TTL while the body runs, and release it on every exit
  * path. Backed by the durable state store's compare-and-swap lock primitive.
  *
+ * Acquisition fails at the first conflict unless the target sets a wait, in
+ * which case it retries until the lock frees or the wait is spent.
+ *
  * @module
  */
 
 import { LockSettings, type TargetBuilder } from "./target.ts";
 import { LockConflictError, type LockHolder } from "./state/lock.ts";
+import type { LockResult, StateStore } from "./state/store.ts";
 import { parseDuration } from "./duration.ts";
 import type { RunEnv } from "./run_support.ts";
+
+/** How often a wait retries when the target names no interval. */
+const DEFAULT_POLL_MS = 5_000;
 
 /** A held cross-run lock: `release` clears its heartbeat and frees it. */
 export interface HeldLock {
@@ -20,23 +27,124 @@ export interface HeldLock {
   release(): Promise<void>;
 }
 
-/** The default conflict guidance when a target declares no `onConflict`. */
-function defaultConflictGuidance(key: string, holder: LockHolder): string {
+/** Where a message about the lock goes while a target waits for it. */
+export type LockNotice = (line: string) => void;
+
+/** Render a duration in milliseconds the way the settings accept one. */
+function renderDuration(ms: number): string {
+  if (ms % 3_600_000 === 0) return `${ms / 3_600_000}h`;
+  if (ms % 60_000 === 0) return `${ms / 60_000}m`;
+  if (ms % 1000 === 0) return `${ms / 1000}s`;
+  return `${ms}ms`;
+}
+
+/** How the holder is named in every message about the lock. */
+function describeHolder(holder: LockHolder): string {
   const url = holder.runUrl === undefined ? "" : ` — ${holder.runUrl}`;
-  return `Lock "${key}" is held by ${holder.actor} (run ${holder.runId}) ` +
-    `since ${holder.since}${url}. Wait for that run to finish, or stop it, ` +
-    `then retry.`;
+  return `${holder.actor} (run ${holder.runId}) since ${holder.since}${url}`;
+}
+
+/**
+ * The default conflict guidance when a target declares no `onConflict`. A
+ * target that waited says so, so the message is not read as a lock that was
+ * never retried.
+ */
+function defaultConflictGuidance(
+  key: string,
+  holder: LockHolder,
+  waitedMs: number,
+): string {
+  const waited = waitedMs > 0
+    ? `still held after waiting ${renderDuration(waitedMs)}. `
+    : "";
+  return `Lock "${key}" is held by ${describeHolder(holder)}. ${waited}` +
+    `Wait for that run to finish, or stop it, then retry.`;
+}
+
+/** The line printed when a target starts waiting, or the holder changes. */
+function waitingNotice(
+  key: string,
+  holder: LockHolder,
+  waitMs: number,
+  pollMs: number,
+): string {
+  return `Waiting for lock "${key}", held by ${describeHolder(holder)}. ` +
+    `Retrying every ${renderDuration(pollMs)} for up to ` +
+    `${renderDuration(waitMs)}.`;
+}
+
+/**
+ * Sleep for `ms`, or until the run is cancelled — whichever comes first. A wait
+ * of half an hour must not outlive the run it belongs to.
+ */
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    const finish = () => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", finish);
+      resolve();
+    };
+    const timer = setTimeout(finish, ms);
+    signal.addEventListener("abort", finish, { once: true });
+  });
+}
+
+/** The identity of a lock attempt: who is asking, and from which run. */
+function holderFor(env: RunEnv): LockHolder {
+  const holder: LockHolder = {
+    actor: env.actor,
+    runId: env.runId,
+    since: new Date().toISOString(),
+  };
+  if (env.runUrl !== undefined) holder.runUrl = env.runUrl;
+  return holder;
+}
+
+/**
+ * Try to take `key`, retrying until the wait is spent. Returns the successful
+ * result, or the last conflict when the deadline passes. Each attempt stamps a
+ * fresh `since`, so a lock finally taken reports when it was taken.
+ */
+async function acquireWithin(
+  store: StateStore,
+  key: string,
+  env: RunEnv,
+  ttlMs: number,
+  waitMs: number,
+  pollMs: number,
+  notify: LockNotice | undefined,
+): Promise<LockResult> {
+  const deadline = Date.now() + waitMs;
+  let announced: string | undefined;
+  for (;;) {
+    const result = await store.acquireLock(key, holderFor(env), ttlMs);
+    if (result.ok) return result;
+    const remaining = deadline - Date.now();
+    // No wait was declared (remaining is already negative) or it is spent —
+    // either way this conflict is the answer.
+    if (remaining <= 0 || env.signal.aborted) return result;
+    if (result.holder.runId !== announced) {
+      announced = result.holder.runId;
+      notify?.(waitingNotice(key, result.holder, waitMs, pollMs));
+    }
+    await sleep(Math.min(pollMs, remaining), env.signal);
+  }
 }
 
 /**
  * Acquire a target's cross-run lock, if it declares one. Returns `null` when it
  * declares no lock, or a {@link HeldLock} once acquired. Throws a
- * {@link LockConflictError} when another run holds it, or a friendly error when
- * a lock is declared but no store is configured.
+ * {@link LockConflictError} when another run holds it — at once, or after the
+ * target's wait is spent — or a friendly error when a lock is declared but no
+ * store is configured.
+ *
+ * `notify` receives a line each time the target settles in behind a new holder,
+ * so a run that is queueing says whose lock it is waiting on.
  */
 export async function acquireTargetLock(
   t: TargetBuilder,
   env: RunEnv,
+  notify?: LockNotice,
 ): Promise<HeldLock | null> {
   const configure = t.lock_;
   if (configure === undefined) return null;
@@ -64,18 +172,26 @@ export async function acquireTargetLock(
     );
   }
   const ttlMs = parseDuration(settings.ttl_);
-  const holder: LockHolder = {
-    actor: env.actor,
-    runId: env.runId,
-    since: new Date().toISOString(),
-  };
-  if (env.runUrl !== undefined) holder.runUrl = env.runUrl;
+  const waitMs = settings.waitUpTo_ === undefined
+    ? 0
+    : parseDuration(settings.waitUpTo_);
+  const pollMs = settings.pollEvery_ === undefined
+    ? DEFAULT_POLL_MS
+    : parseDuration(settings.pollEvery_);
 
-  const result = await store.acquireLock(key, holder, ttlMs);
+  const result = await acquireWithin(
+    store,
+    key,
+    env,
+    ttlMs,
+    waitMs,
+    pollMs,
+    notify,
+  );
   if (!result.ok) {
     const guidance = settings.onConflict_
       ? settings.onConflict_(result.holder)
-      : defaultConflictGuidance(key, result.holder);
+      : defaultConflictGuidance(key, result.holder, waitMs);
     throw new LockConflictError(result.holder, guidance);
   }
 

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -509,7 +509,7 @@ async function runTarget(
   // or a lock declared with no store — fails the target with the guidance.
   let lock: HeldLock | null;
   try {
-    lock = await acquireTargetLock(t, env);
+    lock = await acquireTargetLock(t, env, (line) => reporter.info(line));
   } catch (error) {
     const ms = performance.now() - start;
     failTarget(reporter, renderer, style, name, ms, error);

--- a/packages/core/src/target.ts
+++ b/packages/core/src/target.ts
@@ -52,6 +52,10 @@ export class LockSettings {
   ttl_?: string | number;
   /** The conflict-guidance renderer; set by {@link onConflict}. */
   onConflict_?: (holder: LockHolder) => string;
+  /** How long to wait for a held lock; set by {@link waitUpTo}. */
+  waitUpTo_?: string | number;
+  /** How often to retry while waiting; set by {@link pollEvery}. */
+  pollEvery_?: string | number;
 
   /**
    * Set the lock key from parts, sanitised and joined via
@@ -75,6 +79,35 @@ export class LockSettings {
    */
   withTtl(ttl: string | number): this {
     this.ttl_ = ttl;
+    return this;
+  }
+
+  /**
+   * Wait up to this long for a held lock instead of failing at once — a
+   * duration string like `"30m"` or raw milliseconds. The target queues, and
+   * takes the lock when the run holding it finishes; it fails with a
+   * {@link "./state/lock.ts".LockConflictError} only once the wait is spent.
+   *
+   * Set this for a shared resource a developer wants to *use* — one dev
+   * environment, one database, one port — where failing fast just makes them
+   * run the command again. Leave it off for a resource where a second run is a
+   * mistake worth reporting immediately, which stays the default.
+   *
+   * Waiting runs retry independently, so a queue of them is not served in
+   * arrival order: a run that has waited longer has no claim over one that
+   * arrived a moment ago.
+   */
+  waitUpTo(duration: string | number): this {
+    this.waitUpTo_ = duration;
+    return this;
+  }
+
+  /**
+   * How often to retry while {@link waitUpTo} waits (default `"5s"`). Alone it
+   * does nothing — without a wait there is no retry to pace.
+   */
+  pollEvery(duration: string | number): this {
+    this.pollEvery_ = duration;
     return this;
   }
 

--- a/packages/core/tests/lock_test.ts
+++ b/packages/core/tests/lock_test.ts
@@ -1,0 +1,195 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "./_assert.ts";
+import { acquireTargetLock } from "../src/lock.ts";
+import { target } from "../src/target.ts";
+import { LockConflictError, type LockHolder } from "../src/state/lock.ts";
+import type { LockResult, StateStore } from "../src/state/store.ts";
+import type { RunEnv } from "../src/run_support.ts";
+import type { RunQuery, RunRecord, RunSummary } from "../src/state/types.ts";
+
+/**
+ * A store whose lock is held by someone else for the first `heldFor` attempts,
+ * and free after that — enough to drive every path through the wait without a
+ * second process.
+ */
+class FakeStore implements StateStore {
+  attempts = 0;
+  released = 0;
+  constructor(
+    private heldFor: number,
+    private holder: LockHolder = {
+      actor: "alice",
+      runId: "run-1",
+      since: "2026-01-01T00:00:00.000Z",
+    },
+  ) {}
+
+  acquireLock(): Promise<LockResult> {
+    this.attempts++;
+    if (this.attempts <= this.heldFor) {
+      return Promise.resolve({ ok: false, holder: this.holder });
+    }
+    return Promise.resolve({ ok: true, token: "token" });
+  }
+  renewLock(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+  releaseLock(): Promise<void> {
+    this.released++;
+    return Promise.resolve();
+  }
+  /** Hand the lock to a different run, so the wait sees the holder change. */
+  handOverTo(holder: LockHolder): void {
+    this.holder = holder;
+  }
+  getRun(): Promise<{ record: RunRecord; version: string } | null> {
+    return Promise.resolve(null);
+  }
+  putRun(): Promise<{ ok: true; version: string }> {
+    return Promise.resolve({ ok: true, version: "1" });
+  }
+  listRuns(_query: RunQuery): Promise<RunSummary[]> {
+    return Promise.resolve([]);
+  }
+  deleteRun(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+/** A run environment carrying just what lock acquisition reads. */
+function envWith(store: StateStore, signal?: AbortSignal): RunEnv {
+  return {
+    runId: "run-2",
+    signal: signal ?? new AbortController().signal,
+    store,
+    actor: "bob",
+    signals: new Map(),
+    statuses: new Map(),
+  };
+}
+
+Deno.test("a lock with no wait fails on the first conflict", async () => {
+  const store = new FakeStore(5);
+  const t = target()
+    .lock((s) => s.key("dev-env").withTtl("1h"))
+    .executes(() => {});
+  const error = await assertRejects(
+    () => acquireTargetLock(t, envWith(store)),
+    LockConflictError,
+  );
+  assertEquals(store.attempts, 1);
+  assertStringIncludes(error.message, `Lock "dev-env" is held by alice`);
+  // Nothing was waited for, so the message must not claim otherwise.
+  assertEquals(error.message.includes("after waiting"), false);
+});
+
+Deno.test("waitUpTo queues for the lock and takes it when it frees", async () => {
+  const store = new FakeStore(2);
+  const lines: string[] = [];
+  const t = target()
+    .lock((s) =>
+      s.key("dev-env").withTtl("1h").waitUpTo("10s").pollEvery("1ms")
+    )
+    .executes(() => {});
+
+  const held = await acquireTargetLock(t, envWith(store), (l) => lines.push(l));
+  assertEquals(held === null, false);
+  assertEquals(store.attempts, 3); // two conflicts, then the lock
+  assertEquals(lines.length, 1);
+  assertStringIncludes(lines[0] ?? "", `Waiting for lock "dev-env"`);
+  assertStringIncludes(lines[0] ?? "", "held by alice (run run-1)");
+  assertStringIncludes(lines[0] ?? "", "Retrying every 1ms for up to 10s");
+
+  await held?.release();
+  assertEquals(store.released, 1);
+});
+
+Deno.test("a waiter that runs out of time fails, naming the holder and the wait", async () => {
+  const store = new FakeStore(Number.MAX_SAFE_INTEGER);
+  const t = target()
+    .lock((s) =>
+      s.key("dev-env").withTtl("1h").waitUpTo("20ms").pollEvery("1ms")
+    )
+    .executes(() => {});
+
+  const error = await assertRejects(
+    () => acquireTargetLock(t, envWith(store)),
+    LockConflictError,
+  );
+  // The structured holder travels with the error, for a programmatic caller.
+  assertEquals(
+    error instanceof LockConflictError && error.holder.actor === "alice",
+    true,
+  );
+  assertStringIncludes(error.message, "still held after waiting 20ms");
+  assertEquals(store.attempts > 1, true); // it really retried
+});
+
+Deno.test("the waiting line is reprinted only when the holder changes", async () => {
+  const store = new FakeStore(4);
+  const lines: string[] = [];
+  const t = target()
+    .lock((s) =>
+      s.key("dev-env").withTtl("1h").waitUpTo("10s").pollEvery("1ms")
+    )
+    .executes(() => {});
+
+  // Two runs hold the lock in turn while this target waits.
+  const original = store.acquireLock.bind(store);
+  let swapped = false;
+  store.acquireLock = () => {
+    if (!swapped && store.attempts === 2) {
+      swapped = true;
+      store.handOverTo({
+        actor: "carol",
+        runId: "run-9",
+        since: "2026-01-01T00:05:00.000Z",
+      });
+    }
+    return original();
+  };
+
+  await acquireTargetLock(t, envWith(store), (l) => lines.push(l));
+  assertEquals(lines.length, 2);
+  assertStringIncludes(lines[0] ?? "", "held by alice");
+  assertStringIncludes(lines[1] ?? "", "held by carol");
+});
+
+Deno.test("a cancelled run stops waiting instead of holding the run open", async () => {
+  const store = new FakeStore(Number.MAX_SAFE_INTEGER);
+  const controller = new AbortController();
+  const t = target()
+    .lock((s) => s.key("dev-env").withTtl("1h").waitUpTo("1h").pollEvery("5m"))
+    .executes(() => {});
+
+  const acquisition = assertRejects(
+    () => acquireTargetLock(t, envWith(store, controller.signal)),
+    LockConflictError,
+  );
+  controller.abort();
+  await acquisition;
+  // Two attempts at most: the first conflict, and the retry the abort released.
+  assertEquals(store.attempts <= 2, true);
+});
+
+Deno.test("a custom onConflict still renders the failure after a wait", async () => {
+  const store = new FakeStore(Number.MAX_SAFE_INTEGER);
+  const t = target()
+    .lock((s) =>
+      s.key("dev-env").withTtl("1h").waitUpTo("5ms").pollEvery("1ms")
+        .onConflict((h) => `the stack belongs to ${h.actor} right now`)
+    )
+    .executes(() => {});
+
+  const error = await assertRejects(
+    () => acquireTargetLock(t, envWith(store)),
+    LockConflictError,
+  );
+  assertEquals(error.message, "the stack belongs to alice right now");
+});

--- a/packages/core/tests/lock_test.ts
+++ b/packages/core/tests/lock_test.ts
@@ -193,3 +193,21 @@ Deno.test("a custom onConflict still renders the failure after a wait", async ()
   );
   assertEquals(error.message, "the stack belongs to alice right now");
 });
+
+Deno.test("a run cancelled before the wait starts never sleeps at all", async () => {
+  const store = new FakeStore(Number.MAX_SAFE_INTEGER);
+  const controller = new AbortController();
+  controller.abort(); // cancelled before the target is even reached
+  const t = target()
+    .lock((s) => s.key("dev-env").withTtl("1h").waitUpTo("1h").pollEvery("1h"))
+    .executes(() => {});
+
+  const started = performance.now();
+  await assertRejects(
+    () => acquireTargetLock(t, envWith(store, controller.signal)),
+    LockConflictError,
+  );
+  // An hour-long poll interval: anything but an immediate return would hang.
+  assertEquals(performance.now() - started < 1000, true);
+  assertEquals(store.attempts, 1);
+});

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.15.0",
+  "version": "0.17.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/.codex-plugin/plugin.json
+++ b/plugins/zuke/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.15.0",
+  "version": "0.17.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/.codex-plugin/plugin.json
+++ b/plugins/zuke/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/skills/zuke-write-build/SKILL.md
+++ b/plugins/zuke/skills/zuke-write-build/SKILL.md
@@ -150,7 +150,8 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   checks. See the cheatsheet.
 - **Cross-run locks:** `.lock((s) => s.lockKey(...).withTtl("4h"))` — a settings
   lambda — gives a target an exclusive claim across runs/machines; a second run
-  wanting the same key fails with a `LockConflictError` naming the holder. The
+  wanting the same key fails with a `LockConflictError` naming the holder, or
+  queues when the target adds `.waitUpTo("30m")` (paced by `.pollEvery`). The
   lambda runs after params resolve, so the key can read `this.<param>.value`.
   The lock releases when the target settles and expires after the TTL if the
   holder is killed. Needs a state store (a build with `.lock()` enables the

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -305,8 +305,9 @@ class CD extends Build {
   machines. See `docs/locks.md`.
 - `s.waitUpTo("30m")` queues for a held lock instead of failing at once, with
   `s.pollEvery("5s")` pacing the retries; the conflict is raised only once the
-  wait is spent, and the run prints who holds the lock while it waits. Waiters
-  retry independently, so they are not served in arrival order. Reach for it on
+  wait is spent, and the run prints who holds the lock while it waits. This is
+  a retry loop, not a queue: a waiter takes the lock on its next poll after it
+  frees, racing every other waiter, so there is no arrival order. Reach for it on
   a shared resource a developer wants to use, not on one where a second run is
   a mistake worth reporting.
 

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -29,7 +29,7 @@ that declares only `.effect(...)` each legitimately have no `.executes(...)`.
 | `.requires(...params)`                                                                                   | Fail unless the listed parameters resolved to a value.                                                                                                    |
 | `.retry(times, delayMs?)`                                                                                | Retry the body on failure.                                                                                                                                |
 | `.timeout(ms)`                                                                                           | Fail the body if it runs longer than `ms` (per attempt).                                                                                                  |
-| `.lock((s) => s.lockKey(...).withTtl(...))`                                                              | Hold a cross-run lock while running; a second run wanting the key fails. See below.                                                                       |
+| `.lock((s) => s.lockKey(...).withTtl(...))`                                                              | Hold a cross-run lock while running; a second run wanting the key fails, or queues with `.waitUpTo(...)`. See below.                                      |
 | `.waitsFor((s) => s.on(externalSignal(...)))`                                                            | Gate (no body): suspend the run until an external event; resume later. See below.                                                                         |
 | `.onCancel(() => this.rollback)`                                                                         | Compensation run (reverse order) iff this target succeeded when the run is cancelled. See below.                                                          |
 | `.effect(name, fn)`                                                                                      | A side effect whose intent is recorded before it runs, so a resume re-drives it. At-least-once. See below.                                                |
@@ -303,6 +303,12 @@ class CD extends Build {
 - Needs a state store — a build using `.lock()` enables the `.zuke/runs`
   filesystem store by default; use the HTTP backend to share locks across
   machines. See `docs/locks.md`.
+- `s.waitUpTo("30m")` queues for a held lock instead of failing at once, with
+  `s.pollEvery("5s")` pacing the retries; the conflict is raised only once the
+  wait is spent, and the run prints who holds the lock while it waits. Waiters
+  retry independently, so they are not served in arrival order. Reach for it on
+  a shared resource a developer wants to use, not on one where a second run is
+  a mistake worth reporting.
 
 ## External-event waits
 

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -150,7 +150,8 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   checks. See the cheatsheet.
 - **Cross-run locks:** `.lock((s) => s.lockKey(...).withTtl("4h"))` — a settings
   lambda — gives a target an exclusive claim across runs/machines; a second run
-  wanting the same key fails with a `LockConflictError` naming the holder. The
+  wanting the same key fails with a `LockConflictError` naming the holder, or
+  queues when the target adds `.waitUpTo("30m")` (paced by `.pollEvery`). The
   lambda runs after params resolve, so the key can read `this.<param>.value`.
   The lock releases when the target settles and expires after the TTL if the
   holder is killed. Needs a state store (a build with `.lock()` enables the

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -305,8 +305,9 @@ class CD extends Build {
   machines. See `docs/locks.md`.
 - `s.waitUpTo("30m")` queues for a held lock instead of failing at once, with
   `s.pollEvery("5s")` pacing the retries; the conflict is raised only once the
-  wait is spent, and the run prints who holds the lock while it waits. Waiters
-  retry independently, so they are not served in arrival order. Reach for it on
+  wait is spent, and the run prints who holds the lock while it waits. This is
+  a retry loop, not a queue: a waiter takes the lock on its next poll after it
+  frees, racing every other waiter, so there is no arrival order. Reach for it on
   a shared resource a developer wants to use, not on one where a second run is
   a mistake worth reporting.
 

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -29,7 +29,7 @@ that declares only `.effect(...)` each legitimately have no `.executes(...)`.
 | `.requires(...params)`                                                                                   | Fail unless the listed parameters resolved to a value.                                                                                                    |
 | `.retry(times, delayMs?)`                                                                                | Retry the body on failure.                                                                                                                                |
 | `.timeout(ms)`                                                                                           | Fail the body if it runs longer than `ms` (per attempt).                                                                                                  |
-| `.lock((s) => s.lockKey(...).withTtl(...))`                                                              | Hold a cross-run lock while running; a second run wanting the key fails. See below.                                                                       |
+| `.lock((s) => s.lockKey(...).withTtl(...))`                                                              | Hold a cross-run lock while running; a second run wanting the key fails, or queues with `.waitUpTo(...)`. See below.                                      |
 | `.waitsFor((s) => s.on(externalSignal(...)))`                                                            | Gate (no body): suspend the run until an external event; resume later. See below.                                                                         |
 | `.onCancel(() => this.rollback)`                                                                         | Compensation run (reverse order) iff this target succeeded when the run is cancelled. See below.                                                          |
 | `.effect(name, fn)`                                                                                      | A side effect whose intent is recorded before it runs, so a resume re-drives it. At-least-once. See below.                                                |
@@ -303,6 +303,12 @@ class CD extends Build {
 - Needs a state store — a build using `.lock()` enables the `.zuke/runs`
   filesystem store by default; use the HTTP backend to share locks across
   machines. See `docs/locks.md`.
+- `s.waitUpTo("30m")` queues for a held lock instead of failing at once, with
+  `s.pollEvery("5s")` pacing the retries; the conflict is raised only once the
+  wait is spent, and the run prints who holds the lock while it waits. Waiters
+  retry independently, so they are not served in arrival order. Reach for it on
+  a shared resource a developer wants to use, not on one where a second run is
+  a mistake worth reporting.
 
 ## External-event waits
 

--- a/tests/e2e/fixtures/lock_wait_build.ts
+++ b/tests/e2e/fixtures/lock_wait_build.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Fixture for {@link file://../lock_wait_e2e.ts}: two real processes contending
+ * for one cross-run lock. `hold` takes it and keeps it for `ZUKE_E2E_HOLD_MS`;
+ * `wait` queues for it and prints when it got in. Both run against the
+ * `ZUKE_STATE_DIR` the test provides, which is the only thing they share.
+ *
+ * @module
+ */
+
+import { Build, run, target } from "../../../packages/core/mod.ts";
+
+/** How long the holder keeps the lock, in milliseconds. */
+const HOLD_MS = Number(Deno.env.get("ZUKE_E2E_HOLD_MS") ?? "2000");
+
+class LockWaitBuild extends Build {
+  hold = target()
+    .description("take the shared lock and keep it for a while")
+    .lock((s) => s.lockKey("dev-env").withTtl("1h"))
+    .executes(async () => {
+      console.log("HOLDER_IN");
+      await new Promise((resolve) => setTimeout(resolve, HOLD_MS));
+      console.log("HOLDER_OUT");
+    });
+
+  wait = target()
+    .description("queue for the shared lock rather than failing")
+    .lock((s) =>
+      s.lockKey("dev-env").withTtl("1h").waitUpTo("60s").pollEvery("100ms")
+    )
+    .executes(() => {
+      console.log("WAITER_IN");
+    });
+}
+
+await run(LockWaitBuild);

--- a/tests/e2e/lock_wait_e2e.ts
+++ b/tests/e2e/lock_wait_e2e.ts
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * End-to-end: a target that waits for a cross-run lock has to wait for a lock
+ * held by *another process*, which is the case the feature exists for. Two real
+ * runs share nothing but a state directory: one takes the lock and keeps it,
+ * the other queues and gets in once the first is done.
+ *
+ * The in-process test proves the retry loop; only this one proves it against a
+ * holder the waiter cannot see, renew, or release.
+ */
+
+import { assertEquals } from "../../packages/core/tests/_assert.ts";
+import { runFixture, spawnFixture } from "./_harness.ts";
+
+const FIXTURE = new URL("./fixtures/lock_wait_build.ts", import.meta.url);
+
+/** How long the holder keeps the lock. */
+const HOLD_MS = 3_000;
+
+/** How long the waiter is given before it is considered stuck. */
+const START_DELAY_MS = 500;
+
+Deno.test("a run waits for a lock another process holds", async () => {
+  const stateDir = await Deno.makeTempDir({ prefix: "zuke-lock-e2e-" });
+  const env = { ZUKE_STATE_DIR: stateDir, ZUKE_E2E_HOLD_MS: String(HOLD_MS) };
+  try {
+    const holder = spawnFixture(FIXTURE, ["hold"], env);
+    // Give the holder time to reach its body and take the lock.
+    await new Promise((resolve) => setTimeout(resolve, START_DELAY_MS));
+
+    const started = performance.now();
+    const waiter = await runFixture(FIXTURE, ["wait"], env);
+    const elapsed = performance.now() - started;
+    const holderRun = await holder.output();
+    const holderOut = new TextDecoder().decode(holderRun.stdout);
+    const output = waiter.out + waiter.err;
+
+    assertEquals(holderOut.includes("HOLDER_OUT"), true, holderOut);
+    assertEquals(waiter.code, 0, `expected the waiter to succeed:\n${output}`);
+    assertEquals(waiter.out.includes("WAITER_IN"), true, output);
+    // It said what it was waiting on rather than sitting there silently.
+    assertEquals(
+      waiter.out.includes(`Waiting for lock "dev-env"`),
+      true,
+      output,
+    );
+    // And it really waited for the holder rather than taking the lock early.
+    assertEquals(
+      elapsed > HOLD_MS - START_DELAY_MS,
+      true,
+      `the waiter got in after ${Math.round(elapsed)}ms, too early to have ` +
+        `waited for a ${HOLD_MS}ms holder`,
+    );
+  } finally {
+    await Deno.remove(stateDir, { recursive: true });
+  }
+});

--- a/tests/integration/lock_wait_test.ts
+++ b/tests/integration/lock_wait_test.ts
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import { Build, target } from "../../packages/core/mod.ts";
+import { runCli, withStateDir } from "./_harness.ts";
+
+// The shared resource stands in for the ones a lock is usually guarding: one
+// dev environment, one database, one port. `order` records who was inside it
+// when, which is what the wait has to get right.
+const order: string[] = [];
+
+/** Released by the test once the first run has taken the lock. */
+let release: () => void = () => {};
+
+class HolderBuild extends Build {
+  stack = target()
+    .description("hold the shared resource until the test lets go")
+    .lock((s) => s.lockKey("dev-env").withTtl("1h"))
+    .executes(async () => {
+      order.push("holder in");
+      await new Promise<void>((resolve) => (release = resolve));
+      order.push("holder out");
+    });
+}
+
+class WaiterBuild extends Build {
+  stack = target()
+    .description("queue for the shared resource rather than failing")
+    .lock((s) =>
+      s.lockKey("dev-env").withTtl("1h").waitUpTo("30s").pollEvery("10ms")
+    )
+    .executes(() => {
+      order.push("waiter in");
+    });
+}
+
+class ImpatientBuild extends Build {
+  stack = target()
+    .description("give up quickly rather than queue")
+    .lock((s) =>
+      s.lockKey("dev-env").withTtl("1h").waitUpTo("50ms").pollEvery("10ms")
+    )
+    .executes(() => {
+      order.push("impatient in");
+    });
+}
+
+Deno.test("a second run waits for the lock and proceeds when the first finishes", async () => {
+  await withStateDir(async () => {
+    order.length = 0;
+    const holding = runCli(HolderBuild, ["stack"]);
+    // Let the holder's target reach its body and take the lock.
+    while (!order.includes("holder in")) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+
+    const waiting = runCli(WaiterBuild, ["stack"]);
+    // The waiter must still be queueing: it cannot have run yet.
+    await new Promise((r) => setTimeout(r, 50));
+    assertEquals(order.includes("waiter in"), false);
+
+    release();
+    const first = await holding;
+    const second = await waiting;
+
+    assertEquals(first.code, 0, first.err);
+    assertEquals(second.code, 0, second.err);
+    assertEquals(order, ["holder in", "holder out", "waiter in"]);
+    // While it waited, the run said whose lock it was waiting on.
+    assertStringIncludes(second.out, `Waiting for lock "dev-env"`);
+  });
+});
+
+Deno.test("a waiter that runs out of time fails and says it waited", async () => {
+  await withStateDir(async () => {
+    order.length = 0;
+    const holding = runCli(HolderBuild, ["stack"]);
+    while (!order.includes("holder in")) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+
+    const impatient = await runCli(ImpatientBuild, ["stack"]);
+    assertEquals(impatient.code, 1);
+    assertStringIncludes(impatient.err, "still held after waiting 50ms");
+    assertEquals(order.includes("impatient in"), false);
+
+    release();
+    assertEquals((await holding).code, 0);
+  });
+});


### PR DESCRIPTION
## What & why

A target's cross-run lock failed at the first conflict. That is right for a resource where a second run is a mistake worth reporting, and wrong for one a developer wants to use: a shared dev environment is one stack, one set of ports, one database, and failing fast there is a retry loop with a human in it.

A lock can now queue. `waitUpTo` retries until the lock frees and raises `LockConflictError` only once the wait is spent; `pollEvery` paces the retries and defaults to five seconds, matching the name the workflow poller in `@zuke/gh` already uses. Omitting the wait leaves the behaviour exactly as it was, down to one acquisition attempt.

Three details that mattered while writing it:

The timeout message says how long it waited, so a spent wait is not read as a lock that was never retried. A custom `onConflict` still wins, unchanged.

A cancelled run stops waiting at once. A thirty-minute wait that outlived its run would be worse than the failure it replaced, so the sleep between retries races the run's abort signal.

The waiting line names the holder and prints once per holder, not once per retry: a run that queues behind three successive holders says so three times, and one that waits ten minutes behind the same holder says it once.

**Waiters are not served in arrival order**, and the documentation says so rather than implying a fairness that is not there. Each waiter retries on its own, so a run that has waited twenty minutes has no claim over one that arrived a second ago. Arrival order needs the store to hand out places in a queue: on the HTTP backend acquisition is a server endpoint, so the guarantee has to come from the server, which makes it a state-store contract change rather than a settings change. Issue #378 records that reasoning; the wait is useful without it.

Tested at three layers. Units drive the acquisition against a fake store: no wait, a wait that succeeds, a wait that expires, the holder changing mid-wait, cancellation, and a custom conflict message. An integration test runs two real builds through the CLI against one temp state directory and asserts the second one's body runs only after the first has released. An e2e case does the same across two real processes, where the waiter cannot see, renew, or release the holder's lock, and checks it did not get in early.

## Related issues

Closes #378

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a
      [Conventional Commit](https://www.conventionalcommits.org/)
      (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour
      changed. `docs/locks.md` gained a waiting section, and the build-writing
      skill and cheatsheet were updated, synced to the plugin, with the
      manifests bumped to 0.15.0.
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`,
      `llms-full.txt`, package README `## API`).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with
      type guards instead).
- [x] No dead code: unreachable branches and can't-fire fallbacks are removed,
      with types tightened so the impossible state is unrepresentable.
- [x] No duplicated logic: an existing helper is imported rather than retyped,
      and a near-copy differing by a constant or a message is parameterised into
      one implementation. A guard, escape, or credential resolution has exactly
      one implementation. The holder is described by one function, used by both
      the waiting line and the conflict guidance.
- [x] SOLID shapes respected: one domain per file, extension via the settings
      lambda (not a behaviour-switching flag), narrow parameter types, and
      dependencies on the injectable seam (`StateHost`, an injected `fetch`,
      `EnvReader`) rather than `Deno.*` or a global. The acquisition loop takes
      the store, the key, and a notice callback rather than the scheduler's
      reporter.
- [ ] A new package was wired into all six places (see
      [AGENTS.md](../blob/master/AGENTS.md#good-open-source-practices-to-follow)),
      if applicable. Not applicable: no new package.
- [x] The code is written using AI assisted coding.
