### PR TITLE
feat(git): branch a worktree from an explicit start point

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/cspell.json
+++ b/cspell.json
@@ -16,6 +16,7 @@
     "lintstagedrc",
     "parentless",
     "redocly",
+    "commitish",
     "worktree",
     "worktrees",
     "unanchorable",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "zuke",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build)."
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9724,6 +9724,15 @@ class GitWorktreeSettings extends GitSettings
     {@link createBranch}, the name of the branch to create there.
   createBranch(): this
     Create {@link branch} rather than checking out an existing one (`-b`).
+  startPoint(ref: string): this
+    The commit the new branch forks from — git's trailing `<commit-ish>`, e.g.
+    `origin/main`. Only meaningful with {@link createBranch}: without a start
+    point git branches from the parent checkout's `HEAD`, which is whatever
+    the developer happened to have open.
+
+    Setting this and {@link branch} without {@link createBranch} is refused:
+    both want the same trailing position, and there is no reading of the
+    command where git would take them both.
   detach(): this
     Check out with a detached `HEAD` (`--detach`).
   force(): this

--- a/packages/git/README.md
+++ b/packages/git/README.md
@@ -283,6 +283,15 @@ class GitWorktreeSettings extends GitSettings
     {@link createBranch}, the name of the branch to create there.
   createBranch(): this
     Create {@link branch} rather than checking out an existing one (`-b`).
+  startPoint(ref: string): this
+    The commit the new branch forks from — git's trailing `<commit-ish>`, e.g.
+    `origin/main`. Only meaningful with {@link createBranch}: without a start
+    point git branches from the parent checkout's `HEAD`, which is whatever
+    the developer happened to have open.
+
+    Setting this and {@link branch} without {@link createBranch} is refused:
+    both want the same trailing position, and there is no reading of the
+    command where git would take them both.
   detach(): this
     Check out with a detached `HEAD` (`--detach`).
   force(): this

--- a/packages/git/src/worktree.ts
+++ b/packages/git/src/worktree.ts
@@ -54,6 +54,7 @@ export class GitWorktreeSettings extends GitSettings {
   #mode?: WorktreeMode;
   #path?: string;
   #branch?: string;
+  #startPoint?: string;
   #createBranch = false;
   #detach = false;
   #force = false;
@@ -97,6 +98,21 @@ export class GitWorktreeSettings extends GitSettings {
   /** Create {@link branch} rather than checking out an existing one (`-b`). */
   createBranch(): this {
     this.#createBranch = true;
+    return this;
+  }
+
+  /**
+   * The commit the new branch forks from — git's trailing `<commit-ish>`, e.g.
+   * `origin/main`. Only meaningful with {@link createBranch}: without a start
+   * point git branches from the *parent* checkout's `HEAD`, which is whatever
+   * the developer happened to have open.
+   *
+   * Setting this and {@link branch} without {@link createBranch} is refused:
+   * both want the same trailing position, and there is no reading of the
+   * command where git would take them both.
+   */
+  startPoint(ref: string): this {
+    this.#startPoint = ref;
     return this;
   }
 
@@ -149,12 +165,27 @@ export class GitWorktreeSettings extends GitSettings {
       argv.push("-b", this.#branch);
     }
     argv.push(this.#pathArg());
-    // Without `-b` a branch is the commit-ish to check out, which git takes
-    // after the path.
-    if (!this.#createBranch && this.#branch !== undefined) {
-      argv.push(this.#branch);
-    }
+    const commitish = this.#commitish();
+    if (commitish !== undefined) argv.push(commitish);
     return argv;
+  }
+
+  /**
+   * The trailing `<commit-ish>` of `worktree add`. With `-b` that is the start
+   * point the new branch forks from; without it, the branch to check out there
+   * — which is why a start point and a branch given *without* `-b` are refused
+   * rather than one of them being dropped.
+   */
+  #commitish(): string | undefined {
+    if (this.#createBranch) return this.#startPoint;
+    if (this.#branch !== undefined && this.#startPoint !== undefined) {
+      throw new Error(
+        "GitTasks.worktree: .branch(...) and .startPoint(...) both want the " +
+          "trailing commit-ish. Add .createBranch() to fork a new branch from " +
+          "the start point, or drop one of them.",
+      );
+    }
+    return this.#startPoint ?? this.#branch;
   }
 
   /** The path `add`/`remove` operate on; both set it, so this cannot be absent. */

--- a/packages/git/tests/worktree_test.ts
+++ b/packages/git/tests/worktree_test.ts
@@ -38,6 +38,37 @@ Deno.test("worktree add checks a path out, with or without a new branch", () => 
   );
 });
 
+Deno.test("a start point is where a created branch forks from", () => {
+  assertEquals(
+    new GitWorktreeSettings().add("../feature").branch("feature")
+      .createBranch().startPoint("origin/main").argv(),
+    ["git", "worktree", "add", "-b", "feature", "../feature", "origin/main"],
+  );
+  // Without one, the argv is what it was before the option existed: git falls
+  // back to the parent checkout's HEAD.
+  assertEquals(
+    new GitWorktreeSettings().add("../feature").branch("feature")
+      .createBranch().argv(),
+    ["git", "worktree", "add", "-b", "feature", "../feature"],
+  );
+  // A detached checkout takes a commit-ish in the same position.
+  assertEquals(
+    new GitWorktreeSettings().add("../review").detach()
+      .startPoint("origin/main").argv(),
+    ["git", "worktree", "add", "--detach", "../review", "origin/main"],
+  );
+});
+
+Deno.test("a branch and a start point without -b are refused, not silently merged", () => {
+  assertThrows(
+    () =>
+      new GitWorktreeSettings().add("../feature").branch("feature")
+        .startPoint("origin/main").argv(),
+    Error,
+    "both want the trailing commit-ish",
+  );
+});
+
 Deno.test("worktree list, remove, and prune build their own argv", () => {
   assertEquals(new GitWorktreeSettings().list().argv(), [
     "git",

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/.codex-plugin/plugin.json
+++ b/plugins/zuke/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -732,7 +732,8 @@ runs `git worktree list --porcelain` and hands back parsed entries, so a target
 reads them as values instead of scraping stdout.
 
 ```ts
-await GitTasks.worktree((s) => s.add(path).branch(name).createBranch());
+await GitTasks.worktree((s) => s.add(path).branch(name).createBranch()
+  .startPoint("origin/main")); // where the new branch forks from
 await GitTasks.worktree((s) => s.add(path).branch("release/1.2")); // existing branch
 const trees = await GitTasks.worktreeList(); // { path, head, branch, bare, detached, locked }[]
 await GitTasks.worktree((s) => s.remove(path).force()); // git refuses a dirty tree without it

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -732,7 +732,8 @@ runs `git worktree list --porcelain` and hands back parsed entries, so a target
 reads them as values instead of scraping stdout.
 
 ```ts
-await GitTasks.worktree((s) => s.add(path).branch(name).createBranch());
+await GitTasks.worktree((s) => s.add(path).branch(name).createBranch()
+  .startPoint("origin/main")); // where the new branch forks from
 await GitTasks.worktree((s) => s.add(path).branch("release/1.2")); // existing branch
 const trees = await GitTasks.worktreeList(); // { path, head, branch, bare, detached, locked }[]
 await GitTasks.worktree((s) => s.remove(path).force()); // git refuses a dirty tree without it

--- a/tests/e2e/fixtures/git_worktree_build.ts
+++ b/tests/e2e/fixtures/git_worktree_build.ts
@@ -13,7 +13,7 @@
  */
 
 import { Build, run, target } from "../../../packages/core/mod.ts";
-import { GitTasks } from "../../../packages/git/mod.ts";
+import { type GitCommitSettings, GitTasks } from "../../../packages/git/mod.ts";
 
 /** The repository the test prepared for this run. */
 const REPO = Deno.env.get("ZUKE_E2E_REPO") ?? "";
@@ -21,17 +21,28 @@ const REPO = Deno.env.get("ZUKE_E2E_REPO") ?? "";
 /** Where the second working tree is checked out. */
 const TREE = `${REPO}_feature`;
 
+/** Where the start-point target checks its worktree out. */
+const TICKET = `${REPO}_ticket`;
+
+/** The identity every commit in the fixture repository is made under. */
+const AUTHOR = (s: GitCommitSettings) =>
+  s.config("user.name", "Zuke Test").config("user.email", "test@zuke.build");
+
+/** `git rev-parse <ref>` in `dir`, trimmed — the commit a ref points at. */
+async function revParse(dir: string, ref: string): Promise<string> {
+  const output = await GitTasks.run((s) =>
+    s.dir(dir).command("rev-parse", ref)
+  );
+  return output.stdout.trim();
+}
+
 class GitWorktreeBuild extends Build {
   worktrees = target()
     .description("add, list, and remove a worktree in a real repository")
     .executes(async () => {
       await GitTasks.init((s) => s.dir(REPO).initialBranch("main"));
       await GitTasks.commit((s) =>
-        s.dir(REPO)
-          .config("user.name", "Zuke Test")
-          .config("user.email", "test@zuke.build")
-          .allowEmpty()
-          .message("chore: initial commit")
+        AUTHOR(s.dir(REPO)).allowEmpty().message("chore: initial commit")
       );
 
       await GitTasks.worktree((s) =>
@@ -60,6 +71,30 @@ class GitWorktreeBuild extends Build {
 
       const left = await GitTasks.worktreeList((s) => s.dir(REPO));
       console.log(`COUNT=${left.length}`);
+    });
+
+  startPoint = target()
+    .description("branch a worktree off a ref other than the parent's HEAD")
+    .executes(async () => {
+      await GitTasks.init((s) => s.dir(REPO).initialBranch("main"));
+      await GitTasks.commit((s) =>
+        AUTHOR(s.dir(REPO)).allowEmpty().message("chore: initial commit")
+      );
+      // The parent checkout moves off the default branch, as a developer's
+      // clone usually has: any new branch taken from HEAD lands here.
+      await GitTasks.checkout((s) => s.dir(REPO).create().ref("stale"));
+      await GitTasks.commit((s) =>
+        AUTHOR(s.dir(REPO)).allowEmpty().message("chore: unrelated work")
+      );
+
+      await GitTasks.worktree((s) =>
+        s.dir(REPO).add(TICKET).branch("ticket").createBranch()
+          .startPoint("main")
+      );
+
+      console.log(`MAIN=${await revParse(REPO, "main")}`);
+      console.log(`STALE=${await revParse(REPO, "stale")}`);
+      console.log(`TICKET=${await revParse(TICKET, "HEAD")}`);
     });
 }
 

--- a/tests/e2e/git_worktree_e2e.ts
+++ b/tests/e2e/git_worktree_e2e.ts
@@ -94,3 +94,38 @@ Deno.test({
     }
   },
 });
+
+Deno.test({
+  name:
+    "a start point decides where the new branch forks, not the parent's HEAD",
+  ignore: !HAS_GIT,
+  fn: async () => {
+    const repo = await Deno.makeTempDir();
+    try {
+      const { code, out, err } = await runFixture(FIXTURE, ["startPoint"], {
+        GIT_CONFIG_GLOBAL: `${repo}/.gitconfig-none`,
+        GIT_CONFIG_SYSTEM: `${repo}/.gitconfig-none`,
+        ZUKE_E2E_REPO: repo,
+      });
+      const output = out + err;
+      assertEquals(code, 0, `expected a passing build:\n${output}`);
+
+      const commitOf = (label: string) =>
+        out.split("\n").find((line) => line.startsWith(`${label}=`))
+          ?.slice(label.length + 1) ?? "";
+      const main = commitOf("MAIN");
+      const stale = commitOf("STALE");
+      const ticket = commitOf("TICKET");
+
+      // The fixture really did leave the parent on another branch, so the two
+      // commits differ and the comparison below means something.
+      assertEquals(main.length > 0 && stale.length > 0, true, output);
+      assertEquals(main === stale, false, output);
+      // The new branch forked from the start point, not from the parent's HEAD.
+      assertEquals(ticket, main, output);
+    } finally {
+      await Deno.remove(repo, { recursive: true });
+      await Deno.remove(`${repo}_ticket`, { recursive: true }).catch(() => {});
+    }
+  },
+});

--- a/tests/integration/git_worktree_test.ts
+++ b/tests/integration/git_worktree_test.ts
@@ -24,6 +24,19 @@ class SessionsBuild extends Build {
       console.log("created");
     });
 
+  ticket = target()
+    .description("branch a worktree off the remote's default")
+    .executes(async () => {
+      await GitTasks.worktree((s) =>
+        missingTool(
+          s.add("../ticket").branch("ticket").createBranch().startPoint(
+            "origin/main",
+          ),
+        )
+      );
+      console.log("created");
+    });
+
   report = target()
     .description("report the repository's worktrees")
     .executes(async () => {
@@ -34,6 +47,13 @@ class SessionsBuild extends Build {
 
 Deno.test("a target creating a worktree fails with the tool-not-found error", async () => {
   const { code, out, err } = await runCli(SessionsBuild, ["create"]);
+  assertEquals(code, 1);
+  assertStringIncludes(err, "zuke-no-such-tool-xyz");
+  assertEquals(out.includes("created"), false);
+});
+
+Deno.test("a start-point worktree reaches git like any other", async () => {
+  const { code, out, err } = await runCli(SessionsBuild, ["ticket"]);
   assertEquals(code, 1);
   assertStringIncludes(err, "zuke-no-such-tool-xyz");
   assertEquals(out.includes("created"), false);


### PR DESCRIPTION
## What & why

`git worktree add` takes a start point as its trailing commit-ish, and the wrapper had nowhere to put one. With `-b` the branch name goes to the flag and that trailing position stayed empty, so a created branch forked from whatever the parent checkout had open. For a developer's clone that is rarely the branch they meant, and nothing reports it: the worktree is created, the branch exists, and the mistake surfaces at review or at merge.

`startPoint` fills that position. With `createBranch` it is the commit the new branch forks from; without it, the branch to check out already occupies the same slot, so a branch and a start point set together without `-b` are refused rather than one of them being silently dropped. Omitted, the argv and the behaviour are exactly as before. `startPoint` is the term git's own documentation uses for this argument, which is why it beat `from` and `at`.

The refusal is worth a look in review. Rejecting the ambiguous pair rather than picking one keeps the rule statable: the trailing position holds one value, and which one it is depends only on whether `-b` is set.

Tested at three layers. Units cover the argv with a start point, without one, and on a detached checkout, plus the refusal. An integration test drives a start-point build through the CLI. The e2e case is the one that proves the fix: it leaves the parent repository on a different branch, creates a worktree from the default branch, and compares the three commits, since a start point that was ignored and one that worked produce the same exit code and differ only in where the branch points.

## Related issues

Closes #382

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a
      [Conventional Commit](https://www.conventionalcommits.org/)
      (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour
      changed. The cheatsheet's worktree example now shows the start point,
      synced to the plugin, manifests at 0.18.0.
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`,
      `llms-full.txt`, package README `## API`).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with
      type guards instead).
- [x] No dead code: unreachable branches and can't-fire fallbacks are removed,
      with types tightened so the impossible state is unrepresentable.
- [x] No duplicated logic: an existing helper is imported rather than retyped,
      and a near-copy differing by a constant or a message is parameterised into
      one implementation. A guard, escape, or credential resolution has exactly
      one implementation. The trailing commit-ish is decided in one place.
- [x] SOLID shapes respected: one domain per file, extension via the settings
      lambda (not a behaviour-switching flag), narrow parameter types, and
      dependencies on the injectable seam (`StateHost`, an injected `fetch`,
      `EnvReader`) rather than `Deno.*` or a global.
- [ ] A new package was wired into all six places (see
      [AGENTS.md](../blob/master/AGENTS.md#good-open-source-practices-to-follow)),
      if applicable. Not applicable: no new package.
- [x] The code is written using AI assisted coding.
