### PR TITLE
feat(git): resolve a remote's default branch

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.17.0",
+      "version": "0.19.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/cspell.json
+++ b/cspell.json
@@ -16,6 +16,7 @@
     "lintstagedrc",
     "parentless",
     "redocly",
+    "symref",
     "worktree",
     "worktrees",
     "unanchorable",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "zuke",
-  "version": "0.17.0",
+  "version": "0.19.0",
   "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build)."
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9588,6 +9588,21 @@ class GitCommitSettings extends GitSettings
   override protected subcommandArgs(): string[]
     Assemble the `git commit` argv.
 
+class GitDefaultBranchSettings extends GitSettings
+  Settings for {@link "./git.ts".GitTasks.defaultBranch}: which remote to ask,
+  plus the global options every git task shares.
+
+  askRemote_: boolean
+    Ask the remote itself rather than reading the local ref. Set by the task
+    for its fallback attempt; a caller has no reason to set it, since the task
+    already tries both in the order that avoids the network when it can.
+  remote(name: string): this
+    The remote whose default branch is wanted (default `origin`).
+  get remoteName(): string
+    The remote being asked — the prefix the local ref reports it under.
+  override protected subcommandArgs(): string[]
+    Assemble either the local ref read or the remote query.
+
 class GitFetchSettings extends GitSettings
   Settings for `git fetch`.
 
@@ -9795,6 +9810,13 @@ interface GitTasksApi
 
     The lambda configures the global options (`.dir()`, `.config()`); the
     subcommand itself is fixed, since the parse depends on it.
+  defaultBranch(configure?: Configure<GitDefaultBranchSettings>): Promise<string>
+    The name of a remote's default branch — `main`, `master`, or whatever it
+    chose — so a build does not have to hardcode one.
+
+    Reads the local `refs/remotes/<remote>/HEAD` first, which costs no network,
+    and asks the remote itself when that ref was never populated. Fails when
+    neither names a branch, rather than guessing.
   run(configure?: Configure<GitRunSettings>): Promise<CommandOutput>
     Run any other git command via `.command(...)`.
 

--- a/packages/git/README.md
+++ b/packages/git/README.md
@@ -147,6 +147,21 @@ class GitCommitSettings extends GitSettings
   override protected subcommandArgs(): string[]
     Assemble the `git commit` argv.
 
+class GitDefaultBranchSettings extends GitSettings
+  Settings for {@link "./git.ts".GitTasks.defaultBranch}: which remote to ask,
+  plus the global options every git task shares.
+
+  askRemote_: boolean
+    Ask the remote itself rather than reading the local ref. Set by the task
+    for its fallback attempt; a caller has no reason to set it, since the task
+    already tries both in the order that avoids the network when it can.
+  remote(name: string): this
+    The remote whose default branch is wanted (default `origin`).
+  get remoteName(): string
+    The remote being asked — the prefix the local ref reports it under.
+  override protected subcommandArgs(): string[]
+    Assemble either the local ref read or the remote query.
+
 class GitFetchSettings extends GitSettings
   Settings for `git fetch`.
 
@@ -354,6 +369,13 @@ interface GitTasksApi
 
     The lambda configures the global options (`.dir()`, `.config()`); the
     subcommand itself is fixed, since the parse depends on it.
+  defaultBranch(configure?: Configure<GitDefaultBranchSettings>): Promise<string>
+    The name of a remote's default branch — `main`, `master`, or whatever it
+    chose — so a build does not have to hardcode one.
+
+    Reads the local `refs/remotes/<remote>/HEAD` first, which costs no network,
+    and asks the remote itself when that ref was never populated. Fails when
+    neither names a branch, rather than guessing.
   run(configure?: Configure<GitRunSettings>): Promise<CommandOutput>
     Run any other git command via `.command(...)`.
 

--- a/packages/git/mod.ts
+++ b/packages/git/mod.ts
@@ -24,3 +24,4 @@ export * from "./src/settings.ts";
 export * from "./src/git.ts";
 export * from "./src/git_info.ts";
 export { type GitWorktree, GitWorktreeSettings } from "./src/worktree.ts";
+export { GitDefaultBranchSettings } from "./src/default_branch.ts";

--- a/packages/git/src/default_branch.ts
+++ b/packages/git/src/default_branch.ts
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * `GitTasks.defaultBranch` — what a remote calls its default branch, so a build
+ * does not have to guess between `main` and `master`.
+ *
+ * Two commands answer the question and neither is enough alone. The local
+ * `refs/remotes/<remote>/HEAD` costs nothing but is often never populated by a
+ * plain clone or fetch; `ls-remote --symref` always answers but pays a network
+ * round trip. This asks the local ref first and falls back to the remote.
+ *
+ * ```ts
+ * import { GitTasks } from "jsr:@zuke/git";
+ * const base = await GitTasks.defaultBranch((s) => s.remote("origin"));
+ * ```
+ *
+ * @module
+ */
+
+import type { Configure } from "@zuke/core/tooling";
+import { GitSettings } from "./settings.ts";
+import { shortBranchName } from "./refs.ts";
+
+/**
+ * Settings for {@link "./git.ts".GitTasks.defaultBranch}: which remote to ask,
+ * plus the global options every git task shares.
+ */
+export class GitDefaultBranchSettings extends GitSettings {
+  #remote = "origin";
+
+  /**
+   * Ask the remote itself rather than reading the local ref. Set by the task
+   * for its fallback attempt; a caller has no reason to set it, since the task
+   * already tries both in the order that avoids the network when it can.
+   */
+  askRemote_ = false;
+
+  /** The remote whose default branch is wanted (default `origin`). */
+  remote(name: string): this {
+    this.#remote = name;
+    return this;
+  }
+
+  /** The remote being asked — the prefix the local ref reports it under. */
+  get remoteName(): string {
+    return this.#remote;
+  }
+
+  /** Assemble either the local ref read or the remote query. */
+  protected override subcommandArgs(): string[] {
+    return this.askRemote_ ? ["ls-remote", "--symref", this.#remote, "HEAD"] : [
+      "symbolic-ref",
+      "--quiet",
+      "--short",
+      `refs/remotes/${this.#remote}/HEAD`,
+    ];
+  }
+}
+
+/**
+ * The branch name in `symbolic-ref --short` output — `origin/main` for remote
+ * `origin` — or `undefined` when it named nothing usable.
+ *
+ * Not part of the package's public surface; exported for its unit test.
+ */
+export function parseSymbolicRef(
+  stdout: string,
+  remote: string,
+): string | undefined {
+  const ref = stdout.trim();
+  if (ref === "") return undefined;
+  const prefix = `${remote}/`;
+  // `--short` abbreviates to `<remote>/<branch>`, but an older git (or a
+  // caller's `.config(...)`) can still hand back the full ref.
+  if (ref.startsWith(prefix)) return ref.slice(prefix.length);
+  const full = `refs/remotes/${prefix}`;
+  return ref.startsWith(full) ? ref.slice(full.length) : undefined;
+}
+
+/**
+ * The branch name in `ls-remote --symref <remote> HEAD` output, whose first
+ * line reads `ref: refs/heads/main<TAB>HEAD`, or `undefined` when the remote
+ * reported no symref (a detached or empty remote `HEAD`).
+ *
+ * Not part of the package's public surface; exported for its unit test.
+ */
+export function parseSymrefListing(stdout: string): string | undefined {
+  for (const line of stdout.split("\n")) {
+    if (!line.startsWith("ref:")) continue;
+    const ref = line.slice("ref:".length).trim().split(/\s+/)[0];
+    if (ref === undefined || ref === "") continue;
+    const name = shortBranchName(ref);
+    if (name !== "") return name;
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the remote's default branch. Backs
+ * {@link "./git.ts".GitTasks.defaultBranch}.
+ *
+ * @throws {Error} If neither the local ref nor the remote names a branch.
+ */
+export async function resolveDefaultBranch(
+  configure?: Configure<GitDefaultBranchSettings>,
+): Promise<string> {
+  const settingsFor = (askRemote: boolean): GitDefaultBranchSettings => {
+    const settings = new GitDefaultBranchSettings();
+    const configured = configure ? configure(settings) : settings;
+    configured.askRemote_ = askRemote;
+    return configured;
+  };
+
+  const local = settingsFor(false);
+  try {
+    const output = await local.run();
+    const name = parseSymbolicRef(output.stdout, local.remoteName);
+    if (name !== undefined) return name;
+  } catch {
+    // The ref is absent (`--quiet` still exits non-zero), or reading it failed
+    // for a reason the remote can answer anyway. Either way, ask the remote —
+    // and let *its* failure be the one the caller sees.
+  }
+
+  const remote = settingsFor(true);
+  const output = await remote.run();
+  const name = parseSymrefListing(output.stdout);
+  if (name === undefined) {
+    throw new Error(
+      `GitTasks.defaultBranch: remote "${remote.remoteName}" reported no ` +
+        `default branch. Its HEAD is unset or detached, so there is no name ` +
+        `to resolve — pass the branch explicitly instead.`,
+    );
+  }
+  return name;
+}

--- a/packages/git/src/git.ts
+++ b/packages/git/src/git.ts
@@ -30,6 +30,10 @@ import {
   GitWorktreeSettings,
   parseWorktreeList,
 } from "./worktree.ts";
+import {
+  type GitDefaultBranchSettings,
+  resolveDefaultBranch,
+} from "./default_branch.ts";
 
 /** Settings for `git init`. */
 export class GitInitSettings extends GitSettings {
@@ -608,6 +612,17 @@ export interface GitTasksApi {
   worktreeList(
     configure?: Configure<GitWorktreeSettings>,
   ): Promise<GitWorktree[]>;
+  /**
+   * The name of a remote's default branch — `main`, `master`, or whatever it
+   * chose — so a build does not have to hardcode one.
+   *
+   * Reads the local `refs/remotes/<remote>/HEAD` first, which costs no network,
+   * and asks the remote itself when that ref was never populated. Fails when
+   * neither names a branch, rather than guessing.
+   */
+  defaultBranch(
+    configure?: Configure<GitDefaultBranchSettings>,
+  ): Promise<string>;
   /** Run any other git command via `.command(...)`. */
   run(configure?: Configure<GitRunSettings>): Promise<CommandOutput>;
 }
@@ -640,5 +655,6 @@ export const GitTasks: GitTasksApi = {
   fetch: (c) => runSettings(new GitFetchSettings(), c),
   worktree: (c) => runSettings(new GitWorktreeSettings(), c),
   worktreeList: (c) => listWorktrees(c),
+  defaultBranch: (c) => resolveDefaultBranch(c),
   run: (c) => runSettings(new GitRunSettings(), c),
 };

--- a/packages/git/src/refs.ts
+++ b/packages/git/src/refs.ts
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Ref-name handling shared by the tasks that read refs back out of git.
+ *
+ * Internal to the package: not exported from `mod.ts`. It exists so the
+ * `refs/heads/` prefix is stripped in exactly one place, whether the ref came
+ * from a worktree listing or from a remote's `HEAD`.
+ *
+ * @module
+ */
+
+/** The prefix git reports a local branch ref under. */
+const HEADS = "refs/heads/";
+
+/**
+ * A branch ref with its `refs/heads/` prefix removed. Anything else — a
+ * remote-tracking ref, a tag, a bare name — is returned unchanged, so the
+ * caller never has to guess whether stripping happened.
+ */
+export function shortBranchName(ref: string): string {
+  return ref.startsWith(HEADS) ? ref.slice(HEADS.length) : ref;
+}

--- a/packages/git/src/worktree.ts
+++ b/packages/git/src/worktree.ts
@@ -22,12 +22,10 @@
 
 import type { PathLike } from "@zuke/core/tooling";
 import { GitSettings } from "./settings.ts";
+import { shortBranchName } from "./refs.ts";
 
 /** Which `git worktree` subcommand a {@link GitWorktreeSettings} runs. */
 type WorktreeMode = "add" | "list" | "remove" | "prune";
-
-/** The `refs/heads/` prefix `--porcelain` reports a branch under. */
-const HEADS = "refs/heads/";
 
 /** One entry of `git worktree list --porcelain`. */
 export interface GitWorktree {
@@ -198,11 +196,8 @@ export function parseWorktreeList(stdout: string): GitWorktree[] {
     // An attribute before any `worktree` line belongs to nothing; skip it.
     if (current === null) continue;
     if (key === "HEAD") current.head = value;
-    else if (key === "branch") {
-      current.branch = value.startsWith(HEADS)
-        ? value.slice(HEADS.length)
-        : value;
-    } else if (key === "bare") current.bare = true;
+    else if (key === "branch") current.branch = shortBranchName(value);
+    else if (key === "bare") current.bare = true;
     else if (key === "detached") current.detached = true;
     else if (key === "locked") current.locked = true;
   }

--- a/packages/git/tests/default_branch_test.ts
+++ b/packages/git/tests/default_branch_test.ts
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import {
+  assertWrapperConformance,
+  missingTool,
+} from "@zuke/core/tooling/conformance";
+import {
+  GitDefaultBranchSettings,
+  parseSymbolicRef,
+  parseSymrefListing,
+} from "../src/default_branch.ts";
+import { GitTasks } from "../src/git.ts";
+
+Deno.test("the local read asks for the remote's HEAD ref", () => {
+  assertEquals(new GitDefaultBranchSettings().argv(), [
+    "git",
+    "symbolic-ref",
+    "--quiet",
+    "--short",
+    "refs/remotes/origin/HEAD",
+  ]);
+  assertEquals(
+    new GitDefaultBranchSettings().remote("upstream").dir("repo").argv(),
+    [
+      "git",
+      "-C",
+      "repo",
+      "symbolic-ref",
+      "--quiet",
+      "--short",
+      "refs/remotes/upstream/HEAD",
+    ],
+  );
+});
+
+Deno.test("the fallback asks the remote itself", () => {
+  const settings = new GitDefaultBranchSettings().remote("upstream");
+  settings.askRemote_ = true;
+  assertEquals(settings.argv(), [
+    "git",
+    "ls-remote",
+    "--symref",
+    "upstream",
+    "HEAD",
+  ]);
+});
+
+Deno.test("parseSymbolicRef takes the branch out of either ref form", () => {
+  assertEquals(parseSymbolicRef("origin/main\n", "origin"), "main");
+  // A branch with slashes in its name survives intact.
+  assertEquals(
+    parseSymbolicRef("origin/release/1.x\n", "origin"),
+    "release/1.x",
+  );
+  // An older git can still print the full ref.
+  assertEquals(
+    parseSymbolicRef("refs/remotes/origin/master\n", "origin"),
+    "master",
+  );
+  // Another remote's ref is not this remote's answer.
+  assertEquals(parseSymbolicRef("upstream/main\n", "origin"), undefined);
+  assertEquals(parseSymbolicRef("", "origin"), undefined);
+});
+
+Deno.test("parseSymrefListing reads the symref line of the remote listing", () => {
+  const stdout = "ref: refs/heads/main\tHEAD\n" +
+    "1111111111111111111111111111111111111111\tHEAD\n";
+  assertEquals(parseSymrefListing(stdout), "main");
+  // A remote whose HEAD is detached reports no symref at all.
+  assertEquals(
+    parseSymrefListing("1111111111111111111111111111111111111111\tHEAD\n"),
+    undefined,
+  );
+  assertEquals(parseSymrefListing(""), undefined);
+});
+
+Deno.test("defaultBranch reaches execution", async () => {
+  await assertRejects(
+    () => GitTasks.defaultBranch((s) => missingTool(s)),
+    ToolNotFoundError,
+  );
+});
+
+Deno.test("the default-branch wrapper conforms to the tool contract", async () => {
+  await assertWrapperConformance(
+    () => new GitDefaultBranchSettings(),
+    "git",
+    { resolution: "path" },
+  );
+});

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.17.0",
+  "version": "0.19.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/.codex-plugin/plugin.json
+++ b/plugins/zuke/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.17.0",
+  "version": "0.19.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -742,6 +742,12 @@ await GitTasks.worktree((s) => s.prune()); // forget trees whose directories are
 Reach for `.dir(repo)` when the build's own cwd is not the repository, as with
 every other git task.
 
+`GitTasks.defaultBranch((s) => s.remote("origin"))` returns what the remote
+calls its default branch, so a build never hardcodes `main` and breaks on the
+repositories that chose `master`. It reads the local `refs/remotes/<remote>/HEAD`
+first and asks the remote only when that ref is missing, which is the usual case
+on a fetch-only checkout.
+
 ## AI review & self-healing — `@zuke/ai`
 
 A model becomes part of the build graph two ways. Only the provider (`"claude"`

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -742,6 +742,12 @@ await GitTasks.worktree((s) => s.prune()); // forget trees whose directories are
 Reach for `.dir(repo)` when the build's own cwd is not the repository, as with
 every other git task.
 
+`GitTasks.defaultBranch((s) => s.remote("origin"))` returns what the remote
+calls its default branch, so a build never hardcodes `main` and breaks on the
+repositories that chose `master`. It reads the local `refs/remotes/<remote>/HEAD`
+first and asks the remote only when that ref is missing, which is the usual case
+on a fetch-only checkout.
+
 ## AI review & self-healing — `@zuke/ai`
 
 A model becomes part of the build graph two ways. Only the provider (`"claude"`

--- a/tests/e2e/fixtures/git_default_branch_build.ts
+++ b/tests/e2e/fixtures/git_default_branch_build.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Fixture for {@link file://../git_default_branch_e2e.ts}: resolve a remote's
+ * default branch from a real clone, both ways round. The source repository is
+ * created at `ZUKE_E2E_REPO` on a branch called neither `main` nor `master`, so
+ * a hardcoded guess cannot pass; the clone beside it is what gets asked.
+ *
+ * @module
+ */
+
+import { Build, run, target } from "../../../packages/core/mod.ts";
+import { GitTasks } from "../../../packages/git/mod.ts";
+
+/** The source repository the test prepared for this run. */
+const SOURCE = Deno.env.get("ZUKE_E2E_REPO") ?? "";
+
+/** The clone that has `origin` pointing at the source. */
+const CLONE = `${SOURCE}_clone`;
+
+/** The branch the source repository is created on. */
+const TRUNK = "trunk";
+
+class GitDefaultBranchBuild extends Build {
+  resolve = target()
+    .description("resolve the remote's default branch from a real clone")
+    .executes(async () => {
+      await GitTasks.init((s) => s.dir(SOURCE).initialBranch(TRUNK));
+      await GitTasks.commit((s) =>
+        s.dir(SOURCE)
+          .config("user.name", "Zuke Test")
+          .config("user.email", "test@zuke.build")
+          .allowEmpty()
+          .message("chore: initial commit")
+      );
+      await GitTasks.clone((s) => s.repository(SOURCE).directory(CLONE));
+
+      // A fresh clone has `refs/remotes/origin/HEAD`, so this is the local read.
+      console.log(
+        `LOCAL=${await GitTasks.defaultBranch((s) => s.dir(CLONE))}`,
+      );
+
+      // Drop that ref, as a fetch-only checkout often never has it, and ask
+      // again: this can only be answered by the remote.
+      await GitTasks.run((s) =>
+        s.dir(CLONE).command("remote", "set-head", "origin", "--delete")
+      );
+      console.log(
+        `REMOTE=${await GitTasks.defaultBranch((s) => s.dir(CLONE))}`,
+      );
+    });
+}
+
+await run(GitDefaultBranchBuild);

--- a/tests/e2e/git_default_branch_e2e.ts
+++ b/tests/e2e/git_default_branch_e2e.ts
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * End-to-end: resolving a remote's default branch, both the local read and the
+ * fallback that asks the remote. Which of the two answers is a property of the
+ * repository's refs — whether a clone kept `refs/remotes/origin/HEAD` — so only
+ * a real clone shows that the fallback is reached and still correct.
+ *
+ * The fixture's source repository is on a branch called neither `main` nor
+ * `master`, so a hardcoded guess fails the test rather than passing it.
+ *
+ * Needs a real `git` and skips without one; on CI the skip is refused.
+ */
+
+import { assertEquals } from "../../packages/core/tests/_assert.ts";
+import { runFixture } from "./_harness.ts";
+
+const FIXTURE = new URL(
+  "./fixtures/git_default_branch_build.ts",
+  import.meta.url,
+);
+
+/** Whether a usable `git` is on `PATH`. */
+async function gitAvailable(): Promise<boolean> {
+  try {
+    const { success } = await new Deno.Command("git", {
+      args: ["--version"],
+      stdout: "null",
+      stderr: "null",
+    }).output();
+    return success;
+  } catch {
+    return false;
+  }
+}
+
+const HAS_GIT = await gitAvailable();
+
+/** On CI a missing git is an environment regression, not a reason to skip. */
+const MUST_HAVE_GIT = Deno.env.get("CI") === "true";
+
+Deno.test({
+  name: "CI runs the default-branch test rather than skipping it",
+  ignore: !MUST_HAVE_GIT,
+  fn: () => {
+    assertEquals(
+      HAS_GIT,
+      true,
+      "no usable `git` on PATH: the default-branch e2e test would have been " +
+        "skipped on a runner that is supposed to provide one.",
+    );
+  },
+});
+
+Deno.test({
+  name: "the default branch resolves from the local ref and from the remote",
+  ignore: !HAS_GIT,
+  fn: async () => {
+    const repo = await Deno.makeTempDir();
+    try {
+      const { code, out, err } = await runFixture(FIXTURE, ["resolve"], {
+        GIT_CONFIG_GLOBAL: `${repo}/.gitconfig-none`,
+        GIT_CONFIG_SYSTEM: `${repo}/.gitconfig-none`,
+        ZUKE_E2E_REPO: repo,
+      });
+      const output = out + err;
+
+      assertEquals(code, 0, `expected a passing build:\n${output}`);
+      // The clone still had origin/HEAD: answered without touching the remote.
+      assertEquals(out.includes("LOCAL=trunk"), true, output);
+      // The ref was deleted, so this one could only come from the remote.
+      assertEquals(out.includes("REMOTE=trunk"), true, output);
+    } finally {
+      await Deno.remove(repo, { recursive: true });
+      await Deno.remove(`${repo}_clone`, { recursive: true }).catch(() => {});
+    }
+  },
+});

--- a/tests/integration/git_default_branch_test.ts
+++ b/tests/integration/git_default_branch_test.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import { Build, target } from "../../packages/core/mod.ts";
+import { missingTool } from "../../packages/core/src/tooling_conformance.ts";
+import { GitTasks } from "../../packages/git/mod.ts";
+import { runCli } from "./_harness.ts";
+
+// `defaultBranch` tries two commands and swallows the first one's failure to
+// reach the second. A build must still see the ordinary tool-not-found error
+// rather than a swallowed one, or an empty answer that reads as a branch name.
+class BaseBuild extends Build {
+  base = target()
+    .description("resolve the branch new work forks from")
+    .executes(async () => {
+      const branch = await GitTasks.defaultBranch((s) => missingTool(s));
+      console.log(`base=${branch}`);
+    });
+}
+
+Deno.test("a missing git fails the default-branch lookup, both attempts", async () => {
+  const { code, out, err } = await runCli(BaseBuild, ["base"]);
+  assertEquals(code, 1);
+  assertStringIncludes(err, "zuke-no-such-tool-xyz");
+  assertEquals(out.includes("base="), false);
+});


### PR DESCRIPTION
## What & why

A build that creates a branch or a worktree needs to know what the remote calls its default branch, and there was no supported way to ask. `gitInfo` reports the *local* checkout's branch, which is exactly the thing such a build is trying not to depend on, and the two commands that do answer were reachable only through the generic run task with hand-written arguments. Hardcoding `main` is how a build starts failing on the repositories that chose `master`.

The new task reads the local remote HEAD ref first, so the common case costs no network, and asks the remote itself when that ref was never populated — the case a fetch-only checkout usually lands in. Neither command is sufficient alone, which is why both are here rather than one. When neither names a branch, it fails and says why rather than guessing a name.

Two details for review:

The local attempt's failure is deliberately swallowed, because an absent ref is the normal case rather than an error, and the remote can still answer. The *remote* attempt's failure is not: a missing git, or an unreachable remote, surfaces as the package's usual typed error, which is what the integration test pins.

The internal `askRemote_` field follows the repository's trailing-underscore convention for state that is public on the class but not part of the authoring surface. The task sets it for the fallback attempt; a caller has no reason to, since the task already tries both in the order that avoids the network.

The `refs/heads/` shortening the worktree listing already did moves into a small internal module now that two tasks read branch names out of git, so the prefix is stripped in one place.

Tested at three layers. Units cover both argv forms and both parsers, including a branch whose name contains slashes, an older git printing the full ref, another remote's ref, and a remote whose HEAD is detached. An integration test drives a real build and asserts a missing git fails the lookup rather than returning an empty answer that would read as a branch name. The e2e case clones a repository whose branch is called neither `main` nor `master`, resolves it, deletes the local ref, and resolves it again — so the fallback is exercised rather than assumed, and a hardcoded guess would fail the test.

## Related issues

Closes #384

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a
      [Conventional Commit](https://www.conventionalcommits.org/)
      (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour
      changed. The cheatsheet's git section covers the new task, synced to the
      plugin, manifests at 0.19.0.
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`,
      `llms-full.txt`, package README `## API`).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with
      type guards instead).
- [x] No dead code: unreachable branches and can't-fire fallbacks are removed,
      with types tightened so the impossible state is unrepresentable.
- [x] No duplicated logic: an existing helper is imported rather than retyped,
      and a near-copy differing by a constant or a message is parameterised into
      one implementation. A guard, escape, or credential resolution has exactly
      one implementation. This PR removes the second copy of the ref-shortening
      rather than adding one.
- [x] SOLID shapes respected: one domain per file, extension via the settings
      lambda (not a behaviour-switching flag), narrow parameter types, and
      dependencies on the injectable seam (`StateHost`, an injected `fetch`,
      `EnvReader`) rather than `Deno.*` or a global.
- [ ] A new package was wired into all six places (see
      [AGENTS.md](../blob/master/AGENTS.md#good-open-source-practices-to-follow)),
      if applicable. Not applicable: no new package.
- [x] The code is written using AI assisted coding.
