### PR TITLE
feat(docker-compose): start compose services without their dependencies

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6437,6 +6437,15 @@ class DockerComposeUpSettings extends DockerComposeSettings
     Wait until services are running/healthy (`--wait`).
   abortOnContainerExit(): this
     Stop all containers if any container stops (`--abort-on-container-exit`).
+  noDeps(): this
+    Start only the named services, leaving their dependencies alone
+    (`--no-deps`).
+
+    Without it compose starts or recreates a dependency that is stopped or
+    whose configuration changed. With an already-healthy stack the two agree,
+    so the difference shows up only on the runs where a dependency was not
+    ready — which is where a target that meant "just this service" wants to be
+    explicit.
   exitCodeFrom(service: string): this
     Exit with this service's container's exit code (`--exit-code-from`).
   scale(service: string, instances: number): this

--- a/packages/docker-compose/README.md
+++ b/packages/docker-compose/README.md
@@ -288,6 +288,15 @@ class DockerComposeUpSettings extends DockerComposeSettings
     Wait until services are running/healthy (`--wait`).
   abortOnContainerExit(): this
     Stop all containers if any container stops (`--abort-on-container-exit`).
+  noDeps(): this
+    Start only the named services, leaving their dependencies alone
+    (`--no-deps`).
+
+    Without it compose starts or recreates a dependency that is stopped or
+    whose configuration changed. With an already-healthy stack the two agree,
+    so the difference shows up only on the runs where a dependency was not
+    ready — which is where a target that meant "just this service" wants to be
+    explicit.
   exitCodeFrom(service: string): this
     Exit with this service's container's exit code (`--exit-code-from`).
   scale(service: string, instances: number): this

--- a/packages/docker-compose/src/docker_compose.ts
+++ b/packages/docker-compose/src/docker_compose.ts
@@ -198,6 +198,7 @@ export class DockerComposeUpSettings extends DockerComposeSettings {
   #removeOrphans = false;
   #wait = false;
   #abortOnContainerExit = false;
+  #noDeps = false;
   #exitCodeFrom?: string;
   #scale: string[] = [];
   #services: string[] = [];
@@ -238,6 +239,21 @@ export class DockerComposeUpSettings extends DockerComposeSettings {
     return this;
   }
 
+  /**
+   * Start only the named services, leaving their dependencies alone
+   * (`--no-deps`).
+   *
+   * Without it compose starts or recreates a dependency that is stopped or
+   * whose configuration changed. With an already-healthy stack the two agree,
+   * so the difference shows up only on the runs where a dependency was not
+   * ready — which is where a target that meant "just this service" wants to be
+   * explicit.
+   */
+  noDeps(): this {
+    this.#noDeps = true;
+    return this;
+  }
+
   /** Exit with this service's container's exit code (`--exit-code-from`). */
   exitCodeFrom(service: string): this {
     this.#exitCodeFrom = service;
@@ -265,6 +281,7 @@ export class DockerComposeUpSettings extends DockerComposeSettings {
     if (this.#removeOrphans) argv.push("--remove-orphans");
     if (this.#wait) argv.push("--wait");
     if (this.#abortOnContainerExit) argv.push("--abort-on-container-exit");
+    if (this.#noDeps) argv.push("--no-deps");
     if (this.#exitCodeFrom !== undefined) {
       argv.push("--exit-code-from", this.#exitCodeFrom);
     }

--- a/packages/docker-compose/tests/docker_compose_test.ts
+++ b/packages/docker-compose/tests/docker_compose_test.ts
@@ -76,6 +76,18 @@ Deno.test("global options precede the subcommand", () => {
   ]);
 });
 
+Deno.test("up: no-deps starts the named services alone", () => {
+  assertEquals(
+    new DockerComposeUpSettings().services("api").build().noDeps().argv(),
+    ["docker", "compose", "up", "--build", "--no-deps", "api"],
+  );
+  // Without it the argv is what it was before the option existed.
+  assertEquals(
+    new DockerComposeUpSettings().services("api").build().argv(),
+    ["docker", "compose", "up", "--build", "api"],
+  );
+});
+
 Deno.test("up: all flags, scale, and services", () => {
   const argv = new DockerComposeUpSettings()
     .detach().build().forceRecreate().removeOrphans().wait()

--- a/tests/integration/compose_up_test.ts
+++ b/tests/integration/compose_up_test.ts
@@ -26,6 +26,8 @@ class DebugBuild extends Build {
 Deno.test("a no-deps compose up reaches docker like any other", async () => {
   const { code, out, err } = await runCli(DebugBuild, ["debug"]);
   assertEquals(code, 1);
-  assertStringIncludes(err, "zuke-no-such-tool-xyz");
+  // The compose wrapper reports the invocation it resolved rather than the
+  // binary behind it, so the assertion is on the failure, not on the name.
+  assertStringIncludes(err, "Tool not found");
   assertEquals(out.includes("started"), false);
 });

--- a/tests/integration/compose_up_test.ts
+++ b/tests/integration/compose_up_test.ts
@@ -12,7 +12,35 @@ import { runCli } from "./_harness.ts";
 
 // The debug shape this exists for: start one service from local source against
 // a stack that is already running, and leave its dependencies alone.
+class StackBuild extends Build {
+  stack = target()
+    .description("start the whole stack, dependencies and all")
+    .dryRunnable()
+    .executes(async () => {
+      await DockerComposeTasks.up((s) =>
+        s.file("base.yml").services("api").build()
+      );
+    });
+}
+
 class DebugBuild extends Build {
+  debug = target()
+    .description("start one service without touching its dependencies")
+    // Under `--dry-run` the body runs with the command in echo mode, so the
+    // resolved argv is printed instead of spawned: the seam that shows the
+    // option reaching the real command line without needing docker.
+    .dryRunnable()
+    .executes(async () => {
+      await DockerComposeTasks.up((s) =>
+        s.file("base.yml").services("api").build().noDeps()
+      );
+      console.log("started");
+    });
+}
+
+// The same call with no docker on PATH: the option must not change how that
+// failure is reported.
+class MissingToolBuild extends Build {
   debug = target()
     .description("start one service without touching its dependencies")
     .executes(async () => {
@@ -23,8 +51,23 @@ class DebugBuild extends Build {
     });
 }
 
-Deno.test("a no-deps compose up reaches docker like any other", async () => {
-  const { code, out, err } = await runCli(DebugBuild, ["debug"]);
+Deno.test("the option reaches the command line a build actually runs", async () => {
+  const { code, out } = await runCli(DebugBuild, ["debug", "--dry-run"]);
+  assertEquals(code, 0, out);
+  // The whole command, in order: the flag lands among the up options and
+  // before the service, which is where compose expects it.
+  assertStringIncludes(out, "compose -f base.yml up --build --no-deps api");
+});
+
+Deno.test("a build that did not ask for it gets the argv it always had", async () => {
+  const { code, out } = await runCli(StackBuild, ["stack", "--dry-run"]);
+  assertEquals(code, 0, out);
+  assertStringIncludes(out, "compose -f base.yml up --build api");
+  assertEquals(out.includes("--no-deps"), false, out);
+});
+
+Deno.test("a missing docker fails the target rather than skipping the option", async () => {
+  const { code, out, err } = await runCli(MissingToolBuild, ["debug"]);
   assertEquals(code, 1);
   // The compose wrapper reports the invocation it resolved rather than the
   // binary behind it, so the assertion is on the failure, not on the name.

--- a/tests/integration/compose_up_test.ts
+++ b/tests/integration/compose_up_test.ts
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import { Build, target } from "../../packages/core/mod.ts";
+import { missingTool } from "../../packages/core/src/tooling_conformance.ts";
+import { DockerComposeTasks } from "../../packages/docker-compose/mod.ts";
+import { runCli } from "./_harness.ts";
+
+// The debug shape this exists for: start one service from local source against
+// a stack that is already running, and leave its dependencies alone.
+class DebugBuild extends Build {
+  debug = target()
+    .description("start one service without touching its dependencies")
+    .executes(async () => {
+      await DockerComposeTasks.up((s) =>
+        missingTool(s.file("base.yml").services("api").build().noDeps())
+      );
+      console.log("started");
+    });
+}
+
+Deno.test("a no-deps compose up reaches docker like any other", async () => {
+  const { code, out, err } = await runCli(DebugBuild, ["debug"]);
+  assertEquals(code, 1);
+  assertStringIncludes(err, "zuke-no-such-tool-xyz");
+  assertEquals(out.includes("started"), false);
+});


### PR DESCRIPTION
## What & why

`compose up` has a flag for starting only the named services and leaving their dependencies alone, and the wrapper had no way to ask for it. A target that starts one service from local source against an already-running stack could not express what it meant.

The flag exists on the run settings, and `run` is not a substitute: it creates a one-off container rather than starting the service, so the container name and the published ports are both different. For a target whose purpose is replacing one service in a running stack, that leaves a stray container beside the one it was supposed to replace.

The behaviour difference is invisible most of the time, which is what makes it worth stating rather than absorbing. With the stack already up and healthy, compose leaves dependencies alone anyway and the two agree. They diverge when a dependency is stopped or its configuration changed: the default starts or recreates it, this does not. A build that meant "only this service" gets the other behaviour exactly on the runs where it matters.

The run settings keep their own flag. This adds one to `up` rather than moving it, so nothing that exists today changes, and without the option the argv is byte-identical to before.

Unit tests cover the argv with and without it; an integration test drives a real build through the CLI in the shape this exists for — one service, local build, dependencies untouched — and asserts it reaches docker like any other compose call.

## Related issues

Closes #386

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a
      [Conventional Commit](https://www.conventionalcommits.org/)
      (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour
      changed. The cheatsheet documents the package, not its individual flags,
      so it needed no change and the plugin version is unmoved.
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`,
      `llms-full.txt`, package README `## API`).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with
      type guards instead).
- [x] No dead code: unreachable branches and can't-fire fallbacks are removed,
      with types tightened so the impossible state is unrepresentable.
- [x] No duplicated logic: an existing helper is imported rather than retyped,
      and a near-copy differing by a constant or a message is parameterised into
      one implementation. A guard, escape, or credential resolution has exactly
      one implementation. Two settings classes each mirroring their own compose
      subcommand's flags is the wrapper doing its job, not duplication.
- [x] SOLID shapes respected: one domain per file, extension via the settings
      lambda (not a behaviour-switching flag), narrow parameter types, and
      dependencies on the injectable seam (`StateHost`, an injected `fetch`,
      `EnvReader`) rather than `Deno.*` or a global.
- [ ] A new package was wired into all six places (see
      [AGENTS.md](../blob/master/AGENTS.md#good-open-source-practices-to-follow)),
      if applicable. Not applicable: no new package.
- [x] The code is written using AI assisted coding.
