### PR TITLE
feat(docker-compose): set a pull policy on compose up

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6446,6 +6446,14 @@ class DockerComposeUpSettings extends DockerComposeSettings
     so the difference shows up only on the runs where a dependency was not
     ready — which is where a target that meant "just this service" wants to be
     explicit.
+  pull(policy: DockerComposePullPolicy): this
+    When to fetch images before starting (`--pull`). `always` keeps a stack on
+    the current published images rather than whatever was pulled last;
+    `missing` fetches only what is absent locally; `never` uses what is there.
+
+    Distinct from `DockerComposeBuildSettings.pull`, which is `build --pull`,
+    and from the `pull` task, which is the subcommand — each mirrors its own
+    command.
   exitCodeFrom(service: string): this
     Exit with this service's container's exit code (`--exit-code-from`).
   scale(service: string, instances: number): this
@@ -6492,6 +6500,10 @@ type ComposeProbe = (argv: readonly string[]) => Promise<boolean>
   Receives the binary-and-prefix argv (`["docker", "compose"]` or
   `["docker-compose"]`) and resolves to `true` when it works. Injectable so
   detection can be unit-tested without a real Docker install.
+
+type DockerComposePullPolicy = "always" | "missing" | "never"
+  When `compose up` fetches images before starting: `always` on every start,
+  `missing` only when the image is absent locally, `never` at all.
 
 ========================================================================
 # @zuke/kubectl

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6437,6 +6437,15 @@ class DockerComposeUpSettings extends DockerComposeSettings
     Wait until services are running/healthy (`--wait`).
   abortOnContainerExit(): this
     Stop all containers if any container stops (`--abort-on-container-exit`).
+  noDeps(): this
+    Start only the named services, leaving their dependencies alone
+    (`--no-deps`).
+
+    Without it compose starts or recreates a dependency that is stopped or
+    whose configuration changed. With an already-healthy stack the two agree,
+    so the difference shows up only on the runs where a dependency was not
+    ready — which is where a target that meant "just this service" wants to be
+    explicit.
   exitCodeFrom(service: string): this
     Exit with this service's container's exit code (`--exit-code-from`).
   scale(service: string, instances: number): this

--- a/packages/docker-compose/README.md
+++ b/packages/docker-compose/README.md
@@ -288,6 +288,15 @@ class DockerComposeUpSettings extends DockerComposeSettings
     Wait until services are running/healthy (`--wait`).
   abortOnContainerExit(): this
     Stop all containers if any container stops (`--abort-on-container-exit`).
+  noDeps(): this
+    Start only the named services, leaving their dependencies alone
+    (`--no-deps`).
+
+    Without it compose starts or recreates a dependency that is stopped or
+    whose configuration changed. With an already-healthy stack the two agree,
+    so the difference shows up only on the runs where a dependency was not
+    ready — which is where a target that meant "just this service" wants to be
+    explicit.
   exitCodeFrom(service: string): this
     Exit with this service's container's exit code (`--exit-code-from`).
   scale(service: string, instances: number): this

--- a/packages/docker-compose/README.md
+++ b/packages/docker-compose/README.md
@@ -297,6 +297,14 @@ class DockerComposeUpSettings extends DockerComposeSettings
     so the difference shows up only on the runs where a dependency was not
     ready — which is where a target that meant "just this service" wants to be
     explicit.
+  pull(policy: DockerComposePullPolicy): this
+    When to fetch images before starting (`--pull`). `always` keeps a stack on
+    the current published images rather than whatever was pulled last;
+    `missing` fetches only what is absent locally; `never` uses what is there.
+
+    Distinct from `DockerComposeBuildSettings.pull`, which is `build --pull`,
+    and from the `pull` task, which is the subcommand — each mirrors its own
+    command.
   exitCodeFrom(service: string): this
     Exit with this service's container's exit code (`--exit-code-from`).
   scale(service: string, instances: number): this
@@ -343,6 +351,10 @@ type ComposeProbe = (argv: readonly string[]) => Promise<boolean>
   Receives the binary-and-prefix argv (`["docker", "compose"]` or
   `["docker-compose"]`) and resolves to `true` when it works. Injectable so
   detection can be unit-tested without a real Docker install.
+
+type DockerComposePullPolicy = "always" | "missing" | "never"
+  When `compose up` fetches images before starting: `always` on every start,
+  `missing` only when the image is absent locally, `never` at all.
 ````
 
 </details>

--- a/packages/docker-compose/src/docker_compose.ts
+++ b/packages/docker-compose/src/docker_compose.ts
@@ -190,6 +190,12 @@ export abstract class DockerComposeSettings extends ToolSettings {
   }
 }
 
+/**
+ * When `compose up` fetches images before starting: `always` on every start,
+ * `missing` only when the image is absent locally, `never` at all.
+ */
+export type DockerComposePullPolicy = "always" | "missing" | "never";
+
 /** Settings for `compose up`. */
 export class DockerComposeUpSettings extends DockerComposeSettings {
   #detach = false;
@@ -199,6 +205,7 @@ export class DockerComposeUpSettings extends DockerComposeSettings {
   #wait = false;
   #abortOnContainerExit = false;
   #noDeps = false;
+  #pull?: DockerComposePullPolicy;
   #exitCodeFrom?: string;
   #scale: string[] = [];
   #services: string[] = [];
@@ -254,6 +261,20 @@ export class DockerComposeUpSettings extends DockerComposeSettings {
     return this;
   }
 
+  /**
+   * When to fetch images before starting (`--pull`). `always` keeps a stack on
+   * the current published images rather than whatever was pulled last;
+   * `missing` fetches only what is absent locally; `never` uses what is there.
+   *
+   * Distinct from `DockerComposeBuildSettings.pull`, which is `build --pull`,
+   * and from the `pull` task, which is the subcommand — each mirrors its own
+   * command.
+   */
+  pull(policy: DockerComposePullPolicy): this {
+    this.#pull = policy;
+    return this;
+  }
+
   /** Exit with this service's container's exit code (`--exit-code-from`). */
   exitCodeFrom(service: string): this {
     this.#exitCodeFrom = service;
@@ -282,6 +303,7 @@ export class DockerComposeUpSettings extends DockerComposeSettings {
     if (this.#wait) argv.push("--wait");
     if (this.#abortOnContainerExit) argv.push("--abort-on-container-exit");
     if (this.#noDeps) argv.push("--no-deps");
+    if (this.#pull !== undefined) argv.push("--pull", this.#pull);
     if (this.#exitCodeFrom !== undefined) {
       argv.push("--exit-code-from", this.#exitCodeFrom);
     }

--- a/packages/docker-compose/src/docker_compose.ts
+++ b/packages/docker-compose/src/docker_compose.ts
@@ -198,6 +198,7 @@ export class DockerComposeUpSettings extends DockerComposeSettings {
   #removeOrphans = false;
   #wait = false;
   #abortOnContainerExit = false;
+  #noDeps = false;
   #exitCodeFrom?: string;
   #scale: string[] = [];
   #services: string[] = [];
@@ -238,6 +239,21 @@ export class DockerComposeUpSettings extends DockerComposeSettings {
     return this;
   }
 
+  /**
+   * Start only the named services, leaving their dependencies alone
+   * (`--no-deps`).
+   *
+   * Without it compose starts or recreates a dependency that is stopped or
+   * whose configuration changed. With an already-healthy stack the two agree,
+   * so the difference shows up only on the runs where a dependency was not
+   * ready — which is where a target that meant "just this service" wants to be
+   * explicit.
+   */
+  noDeps(): this {
+    this.#noDeps = true;
+    return this;
+  }
+
   /** Exit with this service's container's exit code (`--exit-code-from`). */
   exitCodeFrom(service: string): this {
     this.#exitCodeFrom = service;
@@ -265,6 +281,7 @@ export class DockerComposeUpSettings extends DockerComposeSettings {
     if (this.#removeOrphans) argv.push("--remove-orphans");
     if (this.#wait) argv.push("--wait");
     if (this.#abortOnContainerExit) argv.push("--abort-on-container-exit");
+    if (this.#noDeps) argv.push("--no-deps");
     if (this.#exitCodeFrom !== undefined) {
       argv.push("--exit-code-from", this.#exitCodeFrom);
     }

--- a/packages/docker-compose/tests/docker_compose_test.ts
+++ b/packages/docker-compose/tests/docker_compose_test.ts
@@ -88,6 +88,25 @@ Deno.test("up: no-deps starts the named services alone", () => {
   );
 });
 
+Deno.test("up: a pull policy reaches compose as its argument", () => {
+  assertEquals(
+    new DockerComposeUpSettings().file("base.yml").pull("always").argv(),
+    ["docker", "compose", "-f", "base.yml", "up", "--pull", "always"],
+  );
+  assertEquals(
+    new DockerComposeUpSettings().pull("never").argv(),
+    ["docker", "compose", "up", "--pull", "never"],
+  );
+  // Without one, compose keeps its own default and the argv is unchanged.
+  assertEquals(new DockerComposeUpSettings().file("base.yml").argv(), [
+    "docker",
+    "compose",
+    "-f",
+    "base.yml",
+    "up",
+  ]);
+});
+
 Deno.test("up: all flags, scale, and services", () => {
   const argv = new DockerComposeUpSettings()
     .detach().build().forceRecreate().removeOrphans().wait()

--- a/packages/docker-compose/tests/docker_compose_test.ts
+++ b/packages/docker-compose/tests/docker_compose_test.ts
@@ -76,6 +76,18 @@ Deno.test("global options precede the subcommand", () => {
   ]);
 });
 
+Deno.test("up: no-deps starts the named services alone", () => {
+  assertEquals(
+    new DockerComposeUpSettings().services("api").build().noDeps().argv(),
+    ["docker", "compose", "up", "--build", "--no-deps", "api"],
+  );
+  // Without it the argv is what it was before the option existed.
+  assertEquals(
+    new DockerComposeUpSettings().services("api").build().argv(),
+    ["docker", "compose", "up", "--build", "api"],
+  );
+});
+
 Deno.test("up: all flags, scale, and services", () => {
   const argv = new DockerComposeUpSettings()
     .detach().build().forceRecreate().removeOrphans().wait()

--- a/tests/integration/compose_up_test.ts
+++ b/tests/integration/compose_up_test.ts
@@ -23,8 +23,27 @@ class DebugBuild extends Build {
     });
 }
 
+// The other start path: every service on the current published images.
+class StackBuild extends Build {
+  stack = target()
+    .description("start the stack on freshly pulled images")
+    .executes(async () => {
+      await DockerComposeTasks.up((s) =>
+        missingTool(s.file("base.yml").pull("always").detach())
+      );
+      console.log("started");
+    });
+}
+
 Deno.test("a no-deps compose up reaches docker like any other", async () => {
   const { code, out, err } = await runCli(DebugBuild, ["debug"]);
+  assertEquals(code, 1);
+  assertStringIncludes(err, "zuke-no-such-tool-xyz");
+  assertEquals(out.includes("started"), false);
+});
+
+Deno.test("a pull policy does not change how a compose failure is reported", async () => {
+  const { code, out, err } = await runCli(StackBuild, ["stack"]);
   assertEquals(code, 1);
   assertStringIncludes(err, "zuke-no-such-tool-xyz");
   assertEquals(out.includes("started"), false);

--- a/tests/integration/compose_up_test.ts
+++ b/tests/integration/compose_up_test.ts
@@ -47,6 +47,6 @@ Deno.test("a no-deps compose up reaches docker like any other", async () => {
 Deno.test("a pull policy does not change how a compose failure is reported", async () => {
   const { code, out, err } = await runCli(StackBuild, ["stack"]);
   assertEquals(code, 1);
-  assertStringIncludes(err, "zuke-no-such-tool-xyz");
+  assertStringIncludes(err, "Tool not found");
   assertEquals(out.includes("started"), false);
 });

--- a/tests/integration/compose_up_test.ts
+++ b/tests/integration/compose_up_test.ts
@@ -26,6 +26,8 @@ class DebugBuild extends Build {
 Deno.test("a no-deps compose up reaches docker like any other", async () => {
   const { code, out, err } = await runCli(DebugBuild, ["debug"]);
   assertEquals(code, 1);
-  assertStringIncludes(err, "zuke-no-such-tool-xyz");
+  // The compose wrapper reports the invocation it resolved rather than the
+  // binary behind it, so the assertion is on the failure, not on the name.
+  assertStringIncludes(err, "Tool not found");
   assertEquals(out.includes("started"), false);
 });

--- a/tests/integration/compose_up_test.ts
+++ b/tests/integration/compose_up_test.ts
@@ -12,7 +12,35 @@ import { runCli } from "./_harness.ts";
 
 // The debug shape this exists for: start one service from local source against
 // a stack that is already running, and leave its dependencies alone.
+class StackBuild extends Build {
+  stack = target()
+    .description("start the whole stack, dependencies and all")
+    .dryRunnable()
+    .executes(async () => {
+      await DockerComposeTasks.up((s) =>
+        s.file("base.yml").services("api").build()
+      );
+    });
+}
+
 class DebugBuild extends Build {
+  debug = target()
+    .description("start one service without touching its dependencies")
+    // Under `--dry-run` the body runs with the command in echo mode, so the
+    // resolved argv is printed instead of spawned: the seam that shows the
+    // option reaching the real command line without needing docker.
+    .dryRunnable()
+    .executes(async () => {
+      await DockerComposeTasks.up((s) =>
+        s.file("base.yml").services("api").build().noDeps()
+      );
+      console.log("started");
+    });
+}
+
+// The same call with no docker on PATH: the option must not change how that
+// failure is reported.
+class MissingToolBuild extends Build {
   debug = target()
     .description("start one service without touching its dependencies")
     .executes(async () => {
@@ -23,8 +51,23 @@ class DebugBuild extends Build {
     });
 }
 
-Deno.test("a no-deps compose up reaches docker like any other", async () => {
-  const { code, out, err } = await runCli(DebugBuild, ["debug"]);
+Deno.test("the option reaches the command line a build actually runs", async () => {
+  const { code, out } = await runCli(DebugBuild, ["debug", "--dry-run"]);
+  assertEquals(code, 0, out);
+  // The whole command, in order: the flag lands among the up options and
+  // before the service, which is where compose expects it.
+  assertStringIncludes(out, "compose -f base.yml up --build --no-deps api");
+});
+
+Deno.test("a build that did not ask for it gets the argv it always had", async () => {
+  const { code, out } = await runCli(StackBuild, ["stack", "--dry-run"]);
+  assertEquals(code, 0, out);
+  assertStringIncludes(out, "compose -f base.yml up --build api");
+  assertEquals(out.includes("--no-deps"), false, out);
+});
+
+Deno.test("a missing docker fails the target rather than skipping the option", async () => {
+  const { code, out, err } = await runCli(MissingToolBuild, ["debug"]);
   assertEquals(code, 1);
   // The compose wrapper reports the invocation it resolved rather than the
   // binary behind it, so the assertion is on the failure, not on the name.

--- a/tests/integration/compose_up_test.ts
+++ b/tests/integration/compose_up_test.ts
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import { Build, target } from "../../packages/core/mod.ts";
+import { missingTool } from "../../packages/core/src/tooling_conformance.ts";
+import { DockerComposeTasks } from "../../packages/docker-compose/mod.ts";
+import { runCli } from "./_harness.ts";
+
+// The debug shape this exists for: start one service from local source against
+// a stack that is already running, and leave its dependencies alone.
+class DebugBuild extends Build {
+  debug = target()
+    .description("start one service without touching its dependencies")
+    .executes(async () => {
+      await DockerComposeTasks.up((s) =>
+        missingTool(s.file("base.yml").services("api").build().noDeps())
+      );
+      console.log("started");
+    });
+}
+
+Deno.test("a no-deps compose up reaches docker like any other", async () => {
+  const { code, out, err } = await runCli(DebugBuild, ["debug"]);
+  assertEquals(code, 1);
+  assertStringIncludes(err, "zuke-no-such-tool-xyz");
+  assertEquals(out.includes("started"), false);
+});


### PR DESCRIPTION
## What & why

`compose up` decides whether to fetch images before starting, and the wrapper could not say which policy it wanted. A stack running published images wants them pulled on every start, so a developer runs against the current images rather than whatever they happened to fetch last week.

The policy is a typed union of the three values compose accepts, so a typo fails to compile instead of reaching the command line. Without it the argv is unchanged and compose keeps its own default.

Two notes for review:

The name collides with two neighbours and still belongs here. The build settings' `pull` is `build --pull`, and the `pull` task is the subcommand; on `up` the option really is `--pull`. Each class mirrors its own command, which is the rule that settles the name — renaming this one to avoid the collision would make the wrapper harder to predict for anyone who knows the CLI.

This is the low-priority one of its pair, because a separate pull before `up` already works. The difference is one extra command and fetching everything up front rather than per service as it starts.

**Stacked on #387**, which adds the sibling option to the same class. Merge that one first, or this diff will show its changes too.

Unit tests cover the argv with each policy and without one; the integration test in the same file as the sibling's asserts a pull policy does not change how a compose failure is reported.

## Related issues

Closes #388

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a
      [Conventional Commit](https://www.conventionalcommits.org/)
      (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour
      changed. The cheatsheet documents the package rather than its individual
      flags, so it needed no change and the plugin version is unmoved.
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`,
      `llms-full.txt`, package README `## API`).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with
      type guards instead). The policy is a union type rather than a string.
- [x] No dead code: unreachable branches and can't-fire fallbacks are removed,
      with types tightened so the impossible state is unrepresentable.
- [x] No duplicated logic: an existing helper is imported rather than retyped,
      and a near-copy differing by a constant or a message is parameterised into
      one implementation. A guard, escape, or credential resolution has exactly
      one implementation.
- [x] SOLID shapes respected: one domain per file, extension via the settings
      lambda (not a behaviour-switching flag), narrow parameter types, and
      dependencies on the injectable seam (`StateHost`, an injected `fetch`,
      `EnvReader`) rather than `Deno.*` or a global.
- [ ] A new package was wired into all six places (see
      [AGENTS.md](../blob/master/AGENTS.md#good-open-source-practices-to-follow)),
      if applicable. Not applicable: no new package.
- [x] The code is written using AI assisted coding.
