### PR TITLE
feat(core): list the locks a state store holds

### DIFF
--- a/docs/locks.md
+++ b/docs/locks.md
@@ -98,6 +98,29 @@ The loser of a conflict gets actionable guidance, on every surface:
 Provide `s.onConflict(holder => …)` to phrase the guidance for your domain; omit
 it for a sensible default that names the holder and its run.
 
+## Seeing what is held
+
+A lock's holder is visible to the run that loses a race for it. To ask without
+contending — the usual case when a shared resource looks stuck — list them:
+
+```ts
+import { listStoreLocks } from "jsr:@zuke/core";
+
+for (const { key, holder, expiresAt } of await listStoreLocks(store)) {
+  console.log(`${key}: ${holder.actor} (run ${holder.runId}) since ${holder.since}`);
+}
+```
+
+Only live locks are listed: an expired record is free, and the next acquirer
+takes it over. `expiresAt` answers the follow-up question — when it frees itself
+if the holder never comes back — and the acquisition token is never included,
+since a listing is read-only.
+
+The filesystem backend lists locks; an HTTP backend does when the server
+implements `GET /locks` (see [the contract](./state-api.md)). A backend that
+cannot enumerate fails the call with a message saying so, rather than reporting
+an empty listing that would read as "nobody holds anything".
+
 ## Requires a state store
 
 A lock needs somewhere durable to live, so a build that uses `.lock()` turns on

--- a/docs/state-api.md
+++ b/docs/state-api.md
@@ -110,7 +110,7 @@ recent runs.
 
 ## Locks (`/locks`)
 
-Three routes back everything that needs mutual exclusion: a target's
+Four routes back everything that needs mutual exclusion: a target's
 [`.lock()`](./locks.md), and the **run lease** every stateful run holds on its
 own id (key `zuke-run-<id>`, 60s TTL) — which is also what lets
 `resume --check` tell an abandoned run from a merely slow one. A service that
@@ -120,6 +120,23 @@ A lock is `{ key, holder, token, expiresAt }`. The **token** is an opaque string
 the server mints on acquire; only a caller presenting it may renew or release.
 Expiry is **server-side**: an expired lock must be treated as free, so a crashed
 holder's lock is reclaimed without anyone calling `DELETE`.
+
+### `GET /locks`
+
+List the locks currently held — the read-only answer to "who has this, and
+until when?". No body.
+
+- `200 [ { "key": "…", "holder": { … }, "expiresAt": 1700000000000 }, … ]` —
+  every **live** lock. An expired one is free and must be left out; reporting it
+  as held is worse than omitting it, since the caller is usually looking at a
+  resource they believe is stuck. Never include the token: it is the holder's
+  proof of ownership and a listing is read-only.
+- `404`/`501` — not implemented. The client tells this apart from an empty
+  listing and says the backend cannot enumerate, rather than reporting that
+  nothing is held.
+
+This route is **optional**: a service that omits it supports locking in full,
+and only loses the listing.
 
 ### `POST /locks/:key`
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -417,6 +417,17 @@ async function installTree(options: InstallTreeOptions): Promise<AbsolutePath>
 function isCI(): boolean
   Whether the build appears to be running in a CI environment.
 
+function listStoreLocks(store: StateStore): Promise<HeldLockEntry[]>
+  The locks `store` holds, or a friendly failure when the backend cannot
+  enumerate them.
+
+  An empty array reads as "nobody holds anything", which is the worst possible
+  answer to give someone looking at a wedged resource, so a store with no
+  {@link StateStore.listLocks} says so rather than answering.
+
+  @throws {Error}
+      If the store does not support listing.
+
 function lockKey(...parts: Array<string | number>): string
   Join parts into a lock key that is safe to use as a filename and URL segment.
   Each part is sanitised (non-`[A-Za-z0-9._-]` runs become `_`) and empty parts
@@ -1180,6 +1191,11 @@ class FileSystemStateStore implements StateStore
     Extend the lock `key` held under `token`; `false` if the token lost it.
   async releaseLock(key: string, token: string): Promise<void>
     Release the lock `key` if still held under `token`; a no-op otherwise.
+  async listLocks(): Promise<HeldLockEntry[]>
+    Every live lock in the `locks/` directory, ordered by key. `<key>.acq`
+    mutex markers and anything else in there are skipped; a record that fails
+    to parse is skipped too, since one corrupt file must not hide every other
+    lock from someone trying to see who holds what.
 
 class ForEachSettings
   Fluent configuration for {@link TargetBuilder.forEach}, in the settings-lambda
@@ -1309,6 +1325,10 @@ class HttpStateStore implements StateStore
     `POST /locks/:key` → `201 { token }`, or `409` with the current holder.
   async renewLock(key: string, token: string, ttlMs: number): Promise<boolean>
     `PUT /locks/:key` renews; a `409`/`404` means the token lost the lock.
+  async listLocks(): Promise<HeldLockEntry[]>
+    `GET /locks` → the live locks the server holds. A server that has not
+    implemented the endpoint (`404`/`501`) is told apart from one that holds
+    nothing: an empty listing is an answer, and a missing endpoint is not.
   async releaseLock(key: string, token: string): Promise<void>
     `DELETE /locks/:key` releases; a missing lock (`404`) is not an error.
 
@@ -3004,6 +3024,20 @@ interface HeldLease
   release(): Promise<void>
     Stop the heartbeat and release the claim (best-effort).
 
+interface HeldLockEntry
+  One live lock, as reported by {@link "./store.ts".StateStore.listLocks} — the
+  key, who holds it, and when it lapses if the holder disappears.
+
+  Deliberately not the stored record: the acquisition token is the holder's
+  proof of ownership, and a read-only listing has no business handing it out.
+
+  key: string
+    The lock key, as it was acquired.
+  holder: LockHolder
+    Who holds it.
+  expiresAt: number
+    Epoch-millisecond expiry: when it frees itself if the holder is gone.
+
 interface HttpBuildRegistryOptions
   Configuration for an {@link HttpBuildRegistry}.
 
@@ -3675,6 +3709,16 @@ interface StateStore
     detect a lost lock.
   releaseLock(key: string, token: string): Promise<void>
     Release the lock `key` if still held under `token`; a no-op otherwise.
+  listLocks?(): Promise<HeldLockEntry[]>
+    Every lock currently held, keyed and ordered by key — the read-only answer
+    to "who holds this, and until when?". Expired records are not held locks
+    and are left out: reporting one as held is the failure this exists to
+    prevent.
+
+    Optional, so a store implemented outside this repository does not break by
+    not having one. A caller that needs the listing rather than an empty result
+    should go through {@link listStoreLocks}, which fails with a message naming
+    the backend instead of pretending the store holds nothing.
 
 interface TarEntry
   A single entry within a tar archive — a regular file or a symbolic link.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -471,6 +471,17 @@ async function installTree(options: InstallTreeOptions): Promise<AbsolutePath>
 function isCI(): boolean
   Whether the build appears to be running in a CI environment.
 
+function listStoreLocks(store: StateStore): Promise<HeldLockEntry[]>
+  The locks `store` holds, or a friendly failure when the backend cannot
+  enumerate them.
+
+  An empty array reads as "nobody holds anything", which is the worst possible
+  answer to give someone looking at a wedged resource, so a store with no
+  {@link StateStore.listLocks} says so rather than answering.
+
+  @throws {Error}
+      If the store does not support listing.
+
 function lockKey(...parts: Array<string | number>): string
   Join parts into a lock key that is safe to use as a filename and URL segment.
   Each part is sanitised (non-`[A-Za-z0-9._-]` runs become `_`) and empty parts
@@ -1234,6 +1245,11 @@ class FileSystemStateStore implements StateStore
     Extend the lock `key` held under `token`; `false` if the token lost it.
   async releaseLock(key: string, token: string): Promise<void>
     Release the lock `key` if still held under `token`; a no-op otherwise.
+  async listLocks(): Promise<HeldLockEntry[]>
+    Every live lock in the `locks/` directory, ordered by key. `<key>.acq`
+    mutex markers and anything else in there are skipped; a record that fails
+    to parse is skipped too, since one corrupt file must not hide every other
+    lock from someone trying to see who holds what.
 
 class ForEachSettings
   Fluent configuration for {@link TargetBuilder.forEach}, in the settings-lambda
@@ -1363,6 +1379,10 @@ class HttpStateStore implements StateStore
     `POST /locks/:key` → `201 { token }`, or `409` with the current holder.
   async renewLock(key: string, token: string, ttlMs: number): Promise<boolean>
     `PUT /locks/:key` renews; a `409`/`404` means the token lost the lock.
+  async listLocks(): Promise<HeldLockEntry[]>
+    `GET /locks` → the live locks the server holds. A server that has not
+    implemented the endpoint (`404`/`501`) is told apart from one that holds
+    nothing: an empty listing is an answer, and a missing endpoint is not.
   async releaseLock(key: string, token: string): Promise<void>
     `DELETE /locks/:key` releases; a missing lock (`404`) is not an error.
 
@@ -3058,6 +3078,20 @@ interface HeldLease
   release(): Promise<void>
     Stop the heartbeat and release the claim (best-effort).
 
+interface HeldLockEntry
+  One live lock, as reported by {@link "./store.ts".StateStore.listLocks} — the
+  key, who holds it, and when it lapses if the holder disappears.
+
+  Deliberately not the stored record: the acquisition token is the holder's
+  proof of ownership, and a read-only listing has no business handing it out.
+
+  key: string
+    The lock key, as it was acquired.
+  holder: LockHolder
+    Who holds it.
+  expiresAt: number
+    Epoch-millisecond expiry: when it frees itself if the holder is gone.
+
 interface HttpBuildRegistryOptions
   Configuration for an {@link HttpBuildRegistry}.
 
@@ -3729,6 +3763,16 @@ interface StateStore
     detect a lost lock.
   releaseLock(key: string, token: string): Promise<void>
     Release the lock `key` if still held under `token`; a no-op otherwise.
+  listLocks?(): Promise<HeldLockEntry[]>
+    Every lock currently held, keyed and ordered by key — the read-only answer
+    to "who holds this, and until when?". Expired records are not held locks
+    and are left out: reporting one as held is the failure this exists to
+    prevent.
+
+    Optional, so a store implemented outside this repository does not break by
+    not having one. A caller that needs the listing rather than an empty result
+    should go through {@link listStoreLocks}, which fails with a message naming
+    the backend instead of pretending the store holds nothing.
 
 interface TarEntry
   A single entry within a tar archive — a regular file or a symbolic link.

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -137,12 +137,14 @@ export {
 } from "./src/remote_cache.ts";
 export {
   defaultStateHost,
+  listStoreLocks,
   type LockResult,
   type PutResult,
   type StateHost,
   type StateStore,
 } from "./src/state/store.ts";
 export {
+  type HeldLockEntry,
   LockConflictError,
   type LockHolder,
   lockKey,

--- a/packages/core/src/state/fs_store.ts
+++ b/packages/core/src/state/fs_store.ts
@@ -32,6 +32,7 @@ import {
   toSummary,
 } from "./types.ts";
 import {
+  type HeldLockEntry,
   type LockHolder,
   type LockRecord,
   parseLockRecord,
@@ -224,6 +225,34 @@ export class FileSystemStateStore implements StateStore {
         await this.#host.remove(this.#lockFile(key));
       }
     });
+  }
+
+  /**
+   * Every live lock in the `locks/` directory, ordered by key. `<key>.acq`
+   * mutex markers and anything else in there are skipped; a record that fails
+   * to parse is skipped too, since one corrupt file must not hide every other
+   * lock from someone trying to see who holds what.
+   */
+  async listLocks(): Promise<HeldLockEntry[]> {
+    await this.#ensureDir();
+    const entries: HeldLockEntry[] = [];
+    const now = this.#host.now();
+    for (const name of await this.#host.listDir(`${this.#dir}/locks`)) {
+      if (!name.endsWith(".json")) continue;
+      const key = name.slice(0, -".json".length);
+      const text = await this.#host.readText(`${this.#dir}/locks/${name}`);
+      if (text === null) continue; // released between the listing and the read
+      let record: LockRecord;
+      try {
+        record = parseLockRecord(text);
+      } catch {
+        continue;
+      }
+      // An expired record is not a held lock: the next acquirer takes it over.
+      if (record.expiresAt <= now) continue;
+      entries.push({ key, holder: record.holder, expiresAt: record.expiresAt });
+    }
+    return entries.sort((a, b) => a.key < b.key ? -1 : a.key > b.key ? 1 : 0);
   }
 
   /** Read a lock record, or `null` when the lock is free. */

--- a/packages/core/src/state/http_store.ts
+++ b/packages/core/src/state/http_store.ts
@@ -27,7 +27,12 @@ import {
   type RunSummary,
   stringifyRunRecord,
 } from "./types.ts";
-import { type LockHolder, parseLockHolder } from "./lock.ts";
+import {
+  type HeldLockEntry,
+  type LockHolder,
+  parseLockHolder,
+} from "./lock.ts";
+import { asObject } from "../json_shape.ts";
 
 /** Configuration for an {@link HttpStateStore}. */
 export interface HttpStateStoreOptions {
@@ -134,6 +139,30 @@ export class HttpStateStore implements StateStore {
     return true;
   }
 
+  /**
+   * `GET /locks` → the live locks the server holds. A server that has not
+   * implemented the endpoint (`404`/`501`) is told apart from one that holds
+   * nothing: an empty listing is an answer, and a missing endpoint is not.
+   */
+  async listLocks(): Promise<HeldLockEntry[]> {
+    const url = `${this.#cas.base}/locks`;
+    const response = await this.#cas.request(url, {
+      headers: this.#cas.headers({}),
+    });
+    if (response.status === 404 || response.status === 501) {
+      await response.body?.cancel();
+      throw new Error(
+        `state: ${url} is not implemented by this server, so its locks ` +
+          `cannot be listed — see docs/state-api.md.`,
+      );
+    }
+    if (!response.ok) {
+      await response.body?.cancel();
+      throw new HttpError(response.status, url);
+    }
+    return parseLockListing(await response.json(), url);
+  }
+
   /** `DELETE /locks/:key` releases; a missing lock (`404`) is not an error. */
   async releaseLock(key: string, token: string): Promise<void> {
     const url = this.#lockUrl(key);
@@ -147,6 +176,32 @@ export class HttpStateStore implements StateStore {
       throw new HttpError(response.status, url);
     }
   }
+}
+
+/**
+ * Parse a `GET /locks` body: an array of `{ key, holder, expiresAt }`. The
+ * server is a remote party, so every field is checked rather than trusted, and
+ * an entry that does not parse fails the call instead of being dropped — a
+ * listing that silently loses a held lock is worse than one that errors.
+ */
+export function parseLockListing(body: unknown, url: string): HeldLockEntry[] {
+  if (!Array.isArray(body)) {
+    throw new Error(`state: ${url} did not return an array of locks`);
+  }
+  return body.map((entry) => {
+    const object = asObject(entry);
+    if (object === null) {
+      throw new Error(`state: ${url} returned a lock that is not an object`);
+    }
+    const { key, expiresAt } = object;
+    if (typeof key !== "string" || key === "") {
+      throw new Error(`state: ${url} returned a lock with no key`);
+    }
+    if (typeof expiresAt !== "number") {
+      throw new Error(`state: ${url} returned lock "${key}" with no expiry`);
+    }
+    return { key, holder: parseLockHolder(object.holder), expiresAt };
+  });
 }
 
 /** Extract a string `token` from a lock-acquire response body. */

--- a/packages/core/src/state/lock.ts
+++ b/packages/core/src/state/lock.ts
@@ -63,6 +63,22 @@ export function lockKey(...parts: Array<string | number>): string {
     .join("-");
 }
 
+/**
+ * One live lock, as reported by {@link "./store.ts".StateStore.listLocks} — the
+ * key, who holds it, and when it lapses if the holder disappears.
+ *
+ * Deliberately not the stored record: the acquisition token is the holder's
+ * proof of ownership, and a read-only listing has no business handing it out.
+ */
+export interface HeldLockEntry {
+  /** The lock key, as it was acquired. */
+  key: string;
+  /** Who holds it. */
+  holder: LockHolder;
+  /** Epoch-millisecond expiry: when it frees itself if the holder is gone. */
+  expiresAt: number;
+}
+
 /** A stored lock: its holder, the acquisition token, and its expiry. */
 export interface LockRecord {
   /** The current holder's identity. */

--- a/packages/core/src/state/store.ts
+++ b/packages/core/src/state/store.ts
@@ -17,7 +17,7 @@
  */
 
 import type { RunQuery, RunRecord, RunSummary } from "./types.ts";
-import type { LockHolder } from "./lock.ts";
+import type { HeldLockEntry, LockHolder } from "./lock.ts";
 
 /** The result of a {@link StateStore.putRun} compare-and-swap write. */
 export type PutResult =
@@ -77,6 +77,38 @@ export interface StateStore {
   renewLock(key: string, token: string, ttlMs: number): Promise<boolean>;
   /** Release the lock `key` if still held under `token`; a no-op otherwise. */
   releaseLock(key: string, token: string): Promise<void>;
+  /**
+   * Every lock currently held, keyed and ordered by key — the read-only answer
+   * to "who holds this, and until when?". Expired records are not held locks
+   * and are left out: reporting one as held is the failure this exists to
+   * prevent.
+   *
+   * Optional, so a store implemented outside this repository does not break by
+   * not having one. A caller that needs the listing rather than an empty result
+   * should go through {@link listStoreLocks}, which fails with a message naming
+   * the backend instead of pretending the store holds nothing.
+   */
+  listLocks?(): Promise<HeldLockEntry[]>;
+}
+
+/**
+ * The locks `store` holds, or a friendly failure when the backend cannot
+ * enumerate them.
+ *
+ * An empty array reads as "nobody holds anything", which is the worst possible
+ * answer to give someone looking at a wedged resource, so a store with no
+ * {@link StateStore.listLocks} says so rather than answering.
+ *
+ * @throws {Error} If the store does not support listing.
+ */
+export function listStoreLocks(store: StateStore): Promise<HeldLockEntry[]> {
+  if (store.listLocks === undefined) {
+    throw new Error(
+      "state: this backend cannot list locks. The filesystem store and an " +
+        "HTTP backend implementing `GET /locks` both can — see docs/state-api.md.",
+    );
+  }
+  return store.listLocks();
 }
 
 /**

--- a/packages/core/tests/state_test.ts
+++ b/packages/core/tests/state_test.ts
@@ -15,7 +15,11 @@ import {
   toJsonValue,
   toSummary,
 } from "../src/state/types.ts";
-import { defaultStateHost } from "../src/state/store.ts";
+import {
+  defaultStateHost,
+  listStoreLocks,
+  type StateStore,
+} from "../src/state/store.ts";
 import { FileSystemStateStore } from "../src/state/fs_store.ts";
 import { HttpStateStore } from "../src/state/http_store.ts";
 import { envStateStore, resolveStateStore } from "../src/state/resolve.ts";
@@ -1623,4 +1627,149 @@ Deno.test("HttpStateStore drains response bodies a server sends on every path", 
   );
   await assertRejects(() => boom.renewLock("k", "t", 1000), HttpError);
   await assertRejects(() => boom.releaseLock("k", "t"), HttpError);
+});
+
+// ------------------------------------------------------------- lock listing
+
+Deno.test("FileSystemStateStore lists live locks, ordered, without their tokens", async () => {
+  const host = new FakeStateHost();
+  const store = new FileSystemStateStore("/runs", host);
+  assertEquals(await store.listLocks(), []);
+
+  await store.acquireLock("dev-env", {
+    actor: "alice",
+    runId: "run-1",
+    since: "2026-01-01T00:00:00.000Z",
+    runUrl: "https://ci.example/1",
+  }, 60_000);
+  await store.acquireLock("test-db", {
+    actor: "bob",
+    runId: "run-2",
+    since: "2026-01-01T00:01:00.000Z",
+  }, 60_000);
+
+  const held = await store.listLocks();
+  assertEquals(held.map((entry) => entry.key), ["dev-env", "test-db"]);
+  assertEquals(held[0]?.holder.actor, "alice");
+  assertEquals(held[0]?.holder.runUrl, "https://ci.example/1");
+  assertEquals(held[0]?.expiresAt, host.time + 60_000);
+  assertEquals(held[1]?.holder.actor, "bob");
+  // The token is the holder's proof of ownership and is not part of a listing.
+  assertEquals(Object.hasOwn(held[0] ?? {}, "token"), false);
+});
+
+Deno.test("FileSystemStateStore leaves expired and released locks out of the listing", async () => {
+  const host = new FakeStateHost();
+  const store = new FileSystemStateStore("/runs", host);
+  const short = await store.acquireLock("dev-env", {
+    actor: "alice",
+    runId: "run-1",
+    since: "2026-01-01T00:00:00.000Z",
+  }, 1_000);
+  await store.acquireLock("test-db", {
+    actor: "bob",
+    runId: "run-2",
+    since: "2026-01-01T00:00:00.000Z",
+  }, 60_000);
+
+  // Past its TTL the record is still on disk, but the lock is free: the next
+  // acquirer takes it over, so reporting it as held would be a lie.
+  host.time += 5_000;
+  assertEquals((await store.listLocks()).map((e) => e.key), ["test-db"]);
+
+  if (!short.ok) throw new Error("expected the lock to be acquired");
+  await store.releaseLock("dev-env", short.token);
+  assertEquals((await store.listLocks()).map((e) => e.key), ["test-db"]);
+});
+
+Deno.test("FileSystemStateStore skips a corrupt lock file rather than hiding the rest", async () => {
+  const host = new FakeStateHost();
+  const store = new FileSystemStateStore("/runs", host);
+  await store.acquireLock("dev-env", {
+    actor: "alice",
+    runId: "run-1",
+    since: "2026-01-01T00:00:00.000Z",
+  }, 60_000);
+  host.files.set("/runs/locks/broken.json", "{not json");
+  // The `.acq` mutex markers live in the same directory and are not locks.
+  host.files.set("/runs/locks/dev-env.acq", "1000000");
+
+  assertEquals((await store.listLocks()).map((e) => e.key), ["dev-env"]);
+});
+
+Deno.test("listStoreLocks fails on a backend that cannot enumerate", async () => {
+  const host = new FakeStateHost();
+  const store = new FileSystemStateStore("/runs", host);
+  assertEquals(await listStoreLocks(store), []);
+
+  // A store implemented outside this repository need not have the method: the
+  // interface makes it optional, and a caller asking anyway gets told.
+  const withoutListing: StateStore = {
+    getRun: () => Promise.resolve(null),
+    putRun: () => Promise.resolve({ ok: true, version: "1" }),
+    listRuns: () => Promise.resolve([]),
+    deleteRun: () => Promise.resolve(),
+    acquireLock: () => Promise.resolve({ ok: true, token: "t" }),
+    renewLock: () => Promise.resolve(true),
+    releaseLock: () => Promise.resolve(),
+  };
+  await assertRejects(
+    () => Promise.resolve().then(() => listStoreLocks(withoutListing)),
+    Error,
+    "cannot list locks",
+  );
+});
+
+Deno.test("HttpStateStore lists locks, and tells a missing endpoint from an empty one", async () => {
+  const listing = [{
+    key: "dev-env",
+    holder: {
+      actor: "alice",
+      runId: "run-1",
+      since: "2026-01-01T00:00:00.000Z",
+    },
+    expiresAt: 1_700_000_000_000,
+  }];
+  const store = new HttpStateStore({
+    url: "https://s.example/",
+    fetch: fakeFetch((url) => {
+      assertEquals(url, "https://s.example/locks");
+      return new Response(JSON.stringify(listing), { status: 200 });
+    }),
+  });
+  const held = await store.listLocks();
+  assertEquals(held.length, 1);
+  assertEquals(held[0]?.key, "dev-env");
+  assertEquals(held[0]?.holder.actor, "alice");
+
+  for (const status of [404, 501]) {
+    const unimplemented = new HttpStateStore({
+      url: "https://s.example",
+      fetch: fakeFetch(() => new Response(null, { status })),
+    });
+    await assertRejects(
+      () => unimplemented.listLocks(),
+      Error,
+      "is not implemented by this server",
+    );
+  }
+});
+
+Deno.test("a lock listing from the server is validated, not trusted", async () => {
+  const bodies: unknown[] = [
+    { locks: [] },
+    [{ holder: { actor: "a", runId: "r", since: "s" }, expiresAt: 1 }],
+    [{ key: "dev-env", holder: { actor: "a", runId: "r", since: "s" } }],
+    [{ key: "dev-env", holder: { actor: "a" }, expiresAt: 1 }],
+    ["dev-env"],
+  ];
+  for (const body of bodies) {
+    const store = new HttpStateStore({
+      url: "https://s.example",
+      fetch: fakeFetch(() =>
+        new Response(JSON.stringify(body), { status: 200 })
+      ),
+    });
+    await assertRejects(() => store.listLocks(), Error);
+  }
 });

--- a/tests/integration/lock_listing_test.ts
+++ b/tests/integration/lock_listing_test.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import {
+  Build,
+  defaultStateHost,
+  listStoreLocks,
+  target,
+} from "../../packages/core/mod.ts";
+import { envStateStore } from "../../packages/core/src/state/resolve.ts";
+import { runCli, withStateDir } from "./_harness.ts";
+
+/** Released by the test once the holding run has taken the lock. */
+let release: () => void = () => {};
+
+/** Set as the holder reaches its body, so the test can time the reader. */
+const held: string[] = [];
+
+class HolderBuild extends Build {
+  stack = target()
+    .description("hold the shared resource until the test lets go")
+    .lock((s) => s.lockKey("dev-env").withTtl("1h"))
+    .executes(async () => {
+      held.push("in");
+      await new Promise<void>((resolve) => (release = resolve));
+    });
+}
+
+// The question a wedged resource always raises, asked from a build: who has it,
+// and until when if they never come back?
+class ReportBuild extends Build {
+  locks = target()
+    .description("report every lock currently held")
+    .executes(async () => {
+      const store = envStateStore(
+        (name) => Deno.env.get(name),
+        defaultStateHost,
+      );
+      if (store === undefined) throw new Error("no state store configured");
+      for (const entry of await listStoreLocks(store)) {
+        console.log(
+          `LOCK ${entry.key} actor=${entry.holder.actor} ` +
+            `run=${entry.holder.runId} since=${entry.holder.since}`,
+        );
+      }
+      console.log("END");
+    });
+}
+
+Deno.test("a build can report who holds a lock while another run holds it", async () => {
+  await withStateDir(async () => {
+    held.length = 0;
+    // The actor is what a reader most wants to see, so name it: the CLI takes
+    // it from ZUKE_ACTOR.
+    Deno.env.set("ZUKE_ACTOR", "alice");
+    const holding = runCli(HolderBuild, ["stack"]);
+    while (held.length === 0) await new Promise((r) => setTimeout(r, 5));
+
+    const report = await runCli(ReportBuild, ["locks"]);
+    assertEquals(report.code, 0, report.err);
+    assertStringIncludes(report.out, "LOCK dev-env actor=alice");
+
+    release();
+    assertEquals((await holding).code, 0);
+
+    // Released, so the same question now has a different answer.
+    const after = await runCli(ReportBuild, ["locks"]);
+    assertEquals(after.code, 0, after.err);
+    assertEquals(after.out.includes("LOCK dev-env"), false, after.out);
+    assertStringIncludes(after.out, "END");
+    Deno.env.delete("ZUKE_ACTOR");
+  });
+});


### PR DESCRIPTION
## What & why

A state store could acquire, renew, and release a cross-run lock, and could not say what it was holding. The information was already on every record — actor, run id, acquisition time, run URL — and reachable only by the run that lost a race for that one key. A run that merely wanted to look had nothing to call.

That is the moment it is most wanted. A shared resource appears stuck, and the question is whether a live run is using it or a dead one is holding a lock that has not lapsed yet.

The listing reports live locks only, ordered by key, with the expiry that answers the follow-up question: when it frees itself if the holder never comes back. It never includes the acquisition token — that is the holder's proof of ownership, and a read-only listing has no business handing it out. Acquisition, renewal, and release are untouched.

Three decisions worth review:

**The method is optional on the interface.** A `StateStore` implemented outside this repository does not break by not having it. Callers go through `listStoreLocks`, which fails with a message naming the backends that can, rather than returning an empty array — an empty array reads as "nobody holds anything", which is the worst possible answer to give someone staring at a wedged resource. The HTTP backend makes the same distinction at the wire level: a `404`/`501` is an unimplemented endpoint, not an empty listing.

**Expired records are omitted.** A record past its TTL is not a held lock — the next acquirer takes it over — so reporting it as held would be the exact failure the listing exists to prevent.

**A corrupt lock file is skipped rather than fatal**, on the filesystem backend. One unparseable file must not hide every other lock from someone trying to see who holds what. The remote listing takes the opposite line and fails: there, a malformed entry means the server is not speaking the contract, and silently dropping a held lock would be worse than erroring.

`GET /locks` is added to `docs/state-api.md` as an explicitly optional route, so a service that omits it still supports locking in full.

Tested at two layers. Units cover both backends: ordering, the omitted token, expired and released locks, a corrupt file beside a good one, the `.acq` mutex markers that share the directory, the missing-method guard, an unimplemented endpoint, and five shapes of malformed server response. An integration test drives two real runs through the CLI — one holding `dev-env`, one reporting on it — and asserts the holder is named while it is held and gone once it is released.

A CLI surface for this is a natural follow-up and deliberately not here: the API is what a build needs, and a command can be built on it once it exists.

## Related issues

Closes #391

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a
      [Conventional Commit](https://www.conventionalcommits.org/)
      (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour
      changed. `docs/locks.md` gained a section and `docs/state-api.md` the
      optional route. The build-authoring surface is unchanged, so the skill and
      plugin version are untouched.
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`,
      `llms-full.txt`, package README `## API`).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with
      type guards instead). The remote listing is validated field by field.
- [x] No dead code: unreachable branches and can't-fire fallbacks are removed,
      with types tightened so the impossible state is unrepresentable.
- [x] No duplicated logic: an existing helper is imported rather than retyped,
      and a near-copy differing by a constant or a message is parameterised into
      one implementation. A guard, escape, or credential resolution has exactly
      one implementation. The listing reuses the existing holder parser and
      record parser rather than reading the fields again.
- [x] SOLID shapes respected: one domain per file, extension via the settings
      lambda (not a behaviour-switching flag), narrow parameter types, and
      dependencies on the injectable seam (`StateHost`, an injected `fetch`,
      `EnvReader`) rather than `Deno.*` or a global. Both backends list through
      their injected seam, which is what the unit tests drive.
- [ ] A new package was wired into all six places (see
      [AGENTS.md](../blob/master/AGENTS.md#good-open-source-practices-to-follow)),
      if applicable. Not applicable: no new package.
- [x] The code is written using AI assisted coding.
