### PR TITLE
fix(core): retry a record publish that loses to a concurrent reader

### DIFF
--- a/packages/core/src/state/fs_store.ts
+++ b/packages/core/src/state/fs_store.ts
@@ -42,6 +42,7 @@ import { withFileMutex } from "./mutex.ts";
 import {
   assertSafeId,
   casWriteJson,
+  publishFile,
   sortNewestFirst,
 } from "./json_file_cas.ts";
 import { sha256Hex } from "../internal.ts";
@@ -266,7 +267,7 @@ export class FileSystemStateStore implements StateStore {
     const file = this.#lockFile(key);
     const tmp = `${file}.tmp-${crypto.randomUUID()}`;
     await this.#host.writeText(tmp, stringifyLockRecord(record));
-    await this.#host.rename(tmp, file);
+    await publishFile(this.#host, tmp, file);
   }
 
   /** Take the run's lock (spinning briefly on contention), run `fn`, release. */

--- a/packages/core/src/state/json_file_cas.ts
+++ b/packages/core/src/state/json_file_cas.ts
@@ -22,7 +22,13 @@
  */
 
 import type { PutResult, StateHost } from "./store.ts";
-import { sha256Hex } from "../internal.ts";
+import { delay, sha256Hex } from "../internal.ts";
+
+/** How many times {@link publishFile} retries a rename that lost a race. */
+const PUBLISH_ATTEMPTS = 5;
+
+/** How long to wait between those attempts. */
+const PUBLISH_DELAY_MS = 20;
 
 /**
  * Reject an id that could escape its directory. Ids are UUIDs (runs) or build
@@ -59,8 +65,45 @@ export async function casWriteJson(
   }
   const tmp = `${file}.tmp-${crypto.randomUUID()}`;
   await host.writeText(tmp, content);
-  await host.rename(tmp, file);
+  await publishFile(host, tmp, file);
   return { ok: true, version: await sha256Hex(content) };
+}
+
+/**
+ * Publish `tmp` over `file` with an atomic rename, retrying briefly when the
+ * rename loses to a concurrent reader.
+ *
+ * The rename itself is atomic on every platform this runs on; what is not
+ * guaranteed is that it is *allowed*. On Windows, replacing a file another
+ * handle has open fails unless that handle was opened with `FILE_SHARE_DELETE`,
+ * which an ordinary file read does not use — so a writer holding the record's
+ * mutex can still lose to a reader that holds no lock at all (a compare-and-swap
+ * re-read, a listing). The loss is transient by definition: it lasts as long as
+ * the reader's handle, which is one read.
+ *
+ * Retrying is therefore correct rather than a papering-over — the write has not
+ * happened, no other writer can be inside the mutex, and the destination is the
+ * one this caller already compared. A `NotFound` is never retried: the temp file
+ * this caller just wrote is missing, which is a bug rather than a race, and
+ * waiting cannot help it. Anything still failing after the budget surfaces
+ * unchanged.
+ */
+export async function publishFile(
+  host: StateHost,
+  tmp: string,
+  file: string,
+): Promise<void> {
+  for (let attempt = 1;; attempt++) {
+    try {
+      await host.rename(tmp, file);
+      return;
+    } catch (error) {
+      const fatal = error instanceof Deno.errors.NotFound ||
+        attempt >= PUBLISH_ATTEMPTS;
+      if (fatal) throw error;
+      await delay(PUBLISH_DELAY_MS);
+    }
+  }
 }
 
 /** Sort by `createdAt` descending, then `id` descending, for stable output. */

--- a/packages/core/tests/json_file_cas_test.ts
+++ b/packages/core/tests/json_file_cas_test.ts
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals, assertRejects } from "./_assert.ts";
+import { publishFile } from "../src/state/json_file_cas.ts";
+import { FakeStateHost } from "./_fakes.ts";
+import type { StateHost } from "../src/state/store.ts";
+
+/**
+ * A host whose rename fails the first `failures` times, standing in for the
+ * Windows sharing violation a concurrent reader causes: the destination has an
+ * open handle, so the replace is refused until that read finishes.
+ */
+function flakyRenameHost(
+  failures: number,
+  error: () => Error,
+): { host: StateHost; attempts: () => number } {
+  const inner = new FakeStateHost();
+  let attempts = 0;
+  const host: StateHost = {
+    readText: (path) => inner.readText(path),
+    writeText: (path, content) => inner.writeText(path, content),
+    createExclusive: (path) => inner.createExclusive(path),
+    remove: (path) => inner.remove(path),
+    listDir: (path) => inner.listDir(path),
+    mkdirp: () => inner.mkdirp(),
+    now: () => inner.now(),
+    rename: (from, to) => {
+      attempts++;
+      if (attempts <= failures) return Promise.reject(error());
+      return inner.rename(from, to);
+    },
+  };
+  return { host, attempts: () => attempts };
+}
+
+/** What Windows raises when the destination is open elsewhere. */
+function sharingViolation(): Error {
+  return new Deno.errors.PermissionDenied("os error 32");
+}
+
+Deno.test("publishFile lands once the reader holding the destination lets go", async () => {
+  const { host, attempts } = flakyRenameHost(2, sharingViolation);
+  await host.writeText("/runs/run-1.json.tmp-x", "{}");
+
+  await publishFile(host, "/runs/run-1.json.tmp-x", "/runs/run-1.json");
+
+  assertEquals(attempts(), 3); // two refusals, then the rename
+  assertEquals(await host.readText("/runs/run-1.json"), "{}");
+});
+
+Deno.test("publishFile gives the caller the real error once the budget is spent", async () => {
+  const { host, attempts } = flakyRenameHost(
+    Number.MAX_SAFE_INTEGER,
+    sharingViolation,
+  );
+  await host.writeText("/runs/run-1.json.tmp-x", "{}");
+
+  const error = await assertRejects(
+    () => publishFile(host, "/runs/run-1.json.tmp-x", "/runs/run-1.json"),
+    Deno.errors.PermissionDenied,
+  );
+  // The platform's own message, not one this layer invented on top of it.
+  assertEquals(error.message.includes("os error 32"), true);
+  assertEquals(attempts(), 5);
+});
+
+Deno.test("publishFile does not retry a missing temp file", async () => {
+  const { host, attempts } = flakyRenameHost(
+    Number.MAX_SAFE_INTEGER,
+    () => new Deno.errors.NotFound("rename /runs/run-1.json.tmp-x"),
+  );
+
+  // Nothing to publish is a bug in the caller, not a race with a reader:
+  // waiting cannot make the temp file appear, so it fails on the first try.
+  await assertRejects(
+    () => publishFile(host, "/runs/run-1.json.tmp-x", "/runs/run-1.json"),
+    Deno.errors.NotFound,
+  );
+  assertEquals(attempts(), 1);
+});

--- a/tests/e2e/registry_e2e.ts
+++ b/tests/e2e/registry_e2e.ts
@@ -33,8 +33,11 @@ Deno.test("two real processes register concurrently; no torn write", async () =>
       runFixture(FIXTURE, ["register"], env),
       runFixture(FIXTURE, ["register"], env),
     ]);
-    assertEquals(a.code, 0);
-    assertEquals(b.code, 0);
+    // Report what the process said, not just that it failed: this race is the
+    // one case in the suite that has flaked on a single OS, and an exit code
+    // alone leaves the next occurrence as unexplained as the last.
+    assertEquals(a.code, 0, `first registration failed:\n${a.err}${a.out}`);
+    assertEquals(b.code, 0, `second registration failed:\n${b.err}${b.out}`);
     assertStringIncludes(a.out, "Registered build");
 
     // A separate reader loads exactly one, well-formed descriptor — proving the


### PR DESCRIPTION
## What & why

The registry race e2e has flaked on the Windows runner: one of two concurrent `zuke register` processes exits `1`, the other succeeds, and a re-run of the same commit passes. Ubuntu and macOS have not reproduced it.

**The mechanism.** Both single-host backends publish a record by writing a temp file and renaming it over the destination. The mutex serialises *writers* and says nothing about *readers* — the compare-and-swap re-read in `writeDescriptor` happens outside the lock, and a listing takes no lock at all. On Windows, replacing a file that another handle has open is refused unless that handle was opened with `FILE_SHARE_DELETE`, which an ordinary file read does not use. So a writer holding the record's mutex can lose its rename to a reader holding nothing. That matches every property of the failure: Windows only, intermittent, and it fails the writer rather than the reader.

**The fix.** The publish step retries briefly. This is a race, not a papering-over: the refusal lasts exactly as long as one reader's handle, the write has not happened, no other writer can be inside the mutex, and the destination is the one this caller already compared. A missing temp file is never retried — that is a bug rather than a race, and waiting cannot make it appear — and an error that outlives the budget reaches the caller unchanged, with the platform's own message.

The two backends each had their own copy of the write-then-rename pair. They now share one, so the retry cannot end up in only one of them, which is how the pair would have drifted.

**Honest about the evidence.** The mechanism is inferred from documented Windows semantics and fits the failure exactly; I could not reproduce it directly, since the rename is permitted on macOS and Linux regardless of open readers. So the same PR makes the e2e report the failing subprocess's output, which it captured and threw away in favour of asserting the exit code alone. If something else is at play, the next occurrence names itself instead of printing `1 != 0`.

Unit tests drive the retry through the injected host: a rename refused twice then allowed, one refused past the budget (the platform error surfaces, not a wrapped one), and a `NotFound` that fails on the first attempt. The race e2e passed 15 consecutive local runs after the change.

## Related issues

Closes #394

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a
      [Conventional Commit](https://www.conventionalcommits.org/)
      (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour
      changed. The behaviour change is internal to the write path and documented
      where it lives; no public surface moved.
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`,
      `llms-full.txt`, package README `## API`). No public API change.
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with
      type guards instead).
- [x] No dead code: unreachable branches and can't-fire fallbacks are removed,
      with types tightened so the impossible state is unrepresentable.
- [x] No duplicated logic: an existing helper is imported rather than retyped,
      and a near-copy differing by a constant or a message is parameterised into
      one implementation. A guard, escape, or credential resolution has exactly
      one implementation. This PR removes the second copy of the publish step.
- [x] SOLID shapes respected: one domain per file, extension via the settings
      lambda (not a behaviour-switching flag), narrow parameter types, and
      dependencies on the injectable seam (`StateHost`, an injected `fetch`,
      `EnvReader`) rather than `Deno.*` or a global. The retry goes through the
      host, which is what makes it testable without a Windows machine.
- [ ] A new package was wired into all six places (see
      [AGENTS.md](../blob/master/AGENTS.md#good-open-source-practices-to-follow)),
      if applicable. Not applicable: no new package.
- [x] The code is written using AI assisted coding.
