### PR TITLE
feat(gh): wrap the pr, issue and release commands as typed tasks

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "zuke",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build)."
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -12046,6 +12046,19 @@ async function uploadSarifReport(configure?: Configure<GhSarifSettings>): Promis
 const GhTasks: GhTasksApi
   Typed task functions for GitHub: the `gh` CLI and the REST-only operations.
 
+const ISSUE_LIST_FIELDS: readonly string[]
+  The `--json` fields {@link readIssues} asks for; gh requires the list by
+  name, so the reader pins the set {@link GhIssueEntry} describes.
+
+const PR_LIST_FIELDS: readonly string[]
+  The `--json` fields {@link readPullRequests} asks for. gh requires the list
+  by name — there is no "everything" form — so the reader pins the set its
+  {@link GhPullRequestEntry} describes.
+
+const RELEASE_LIST_FIELDS: readonly string[]
+  The `--json` fields {@link readReleases} asks for; gh requires the list by
+  name, so the reader pins the set {@link GhReleaseEntry} describes.
+
 class GhApiError extends Error
   A GitHub REST call that did not succeed, carrying the status.
 
@@ -12139,6 +12152,21 @@ class GhAppTokenSettings
   tokenRequest_(): Record<string, unknown>
     The `access_tokens` request body — only the fields that were narrowed.
 
+abstract class GhBodySettings extends GhCommandSettings
+  Base for the commands that take message text: `pr create`, `pr comment`,
+  `pr edit`, `issue create`, `issue comment`.
+
+  gh spells it `--body` for the text and `--body-file` for a file, with `-`
+  meaning standard input — the same pair on every one of them.
+
+  body(text: string): this
+    The message text (`--body`).
+  bodyFile(path: PathLike): this
+    Read the message from a file (`--body-file`); `-` reads standard input.
+  protected bodyFlags(task: string): string[]
+    The body flags, after refusing both at once: gh takes one source for the
+    text, and silently preferring one would hide which text was posted.
+
 class GhCheckRunSettings
   Settings for posting a completed check run.
 
@@ -12205,6 +12233,20 @@ class GhCheckRunSettings
   authToken_(): string
     The effective token, from the setting or the environment.
 
+abstract class GhCommandSettings extends GhSettings
+  Base for a typed `gh` subcommand: it contributes the command path (the
+  group, the verb, and any operand) and its own flags, and inherits
+  everything else from {@link "./settings.ts".GhSettings}.
+
+  abstract protected commandPath(): string[]
+    The command path — group, verb, then any positional operand.
+  abstract protected commandFlags(): string[]
+    This command's own flags, rendered after `--repo`.
+  override protected leadingTokens(): string[]
+    The command path leads the argv, before anything `.command(...)` added.
+  override protected middleTokens(): string[]
+    `--repo` first, as the package already renders it, then this command's flags.
+
 class GhCommitSettings
   Settings for committing files through the API.
 
@@ -12265,6 +12307,312 @@ class GhCommitSettings
   authToken_(): string
     The effective token, from the setting or the environment.
 
+class GhIssueCloseSettings extends GhCommandSettings
+  Settings for `gh issue close`.
+
+  selector(value: string | number): this
+    The issue — its number or URL (required).
+  comment(text: string): this
+    Leave a closing comment (`--comment`).
+  reason(value: GhCloseReason): this
+    Why it is closed (`--reason`).
+  duplicateOf(numberOrUrl: string | number): this
+    Which issue it duplicates (`--duplicate-of`), by number or URL.
+  override protected commandPath(): string[]
+    The `gh issue close` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh issue close` flags.
+
+class GhIssueCommentSettings extends GhBodySettings
+  Settings for `gh issue comment`.
+
+  selector(value: string | number): this
+    The issue — its number or URL (required).
+  editLast(): this
+    Edit your most recent comment instead of adding one (`--edit-last`).
+  createIfNone(): this
+    With {@link editLast}, post a new comment when there is none (`--create-if-none`).
+  deleteLast(): this
+    Delete your most recent comment (`--delete-last`).
+  yes(): this
+    Skip the confirmation a delete otherwise prompts for (`--yes`).
+  override protected commandPath(): string[]
+    The `gh issue comment` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh issue comment` flags.
+
+class GhIssueCreateSettings extends GhBodySettings
+  Settings for `gh issue create`.
+
+  title(text: string): this
+    The issue's title (`--title`).
+  assignee(...logins: string[]): this
+    Assign someone by login (`--assignee`), `@me` for yourself; repeatable.
+  label(...names: string[]): this
+    Add a label by name (`--label`); repeatable.
+  project(...titles: string[]): this
+    Add to a project by title (`--project`); repeatable.
+  milestone(name: string): this
+    Add to a milestone by name (`--milestone`).
+  type(name: string): this
+    Set the issue type by name (`--type`).
+  parent(numberOrUrl: string | number): this
+    File it as a sub-issue of this number or URL (`--parent`).
+  templateName(name: string): this
+    The issue template to start the body from (`--template`).
+  override protected commandPath(): string[]
+    The `gh issue create` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh issue create` flags.
+
+class GhIssueListSettings extends GhWebReadSettings
+  Settings for `gh issue list`.
+
+  state(value: "open" | "closed" | "all"): this
+    Filter by state (`--state`): `open`, `closed`, or `all`.
+  author(login: string): this
+    Filter by author (`--author`).
+  app(name: string): this
+    Filter by the GitHub App that opened it (`--app`).
+  assignee(login: string): this
+    Filter by assignee (`--assignee`).
+  mention(login: string): this
+    Filter by who is mentioned (`--mention`).
+  milestone(nameOrNumber: string): this
+    Filter by milestone number or title (`--milestone`).
+  type(name: string): this
+    Filter by issue type (`--type`).
+  label(...names: string[]): this
+    Filter by label (`--label`); repeatable.
+  limit(count: number): this
+    Cap how many are fetched (`--limit`); gh's default is 30.
+  search(query: string): this
+    Filter with a search query (`--search`).
+  override protected commandPath(): string[]
+    The `gh issue list` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh issue list` flags.
+
+class GhIssueViewSettings extends GhWebReadSettings
+  Settings for `gh issue view`.
+
+  selector(value: string | number): this
+    The issue — its number or URL (required).
+  comments(): this
+    Include the comments (`--comments`).
+  override protected commandPath(): string[]
+    The `gh issue view` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh issue view` flags.
+
+class GhPrChecksSettings extends GhPrReadSettings
+  Settings for `gh pr checks`.
+
+  watch(): this
+    Keep watching until the checks finish (`--watch`). A target that watches
+    blocks until CI is done, so pair it with `.killAfter(...)` unless the wait
+    is the point.
+  failFast(): this
+    Stop watching at the first failure (`--fail-fast`).
+  required(): this
+    Only the checks marked required (`--required`).
+  interval(seconds: number): this
+    How often to refresh while watching (`--interval`), in seconds.
+  override protected commandPath(): string[]
+    The `gh pr checks` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh pr checks` flags, refusing the flags that only mean
+    something while watching — gh ignores them otherwise, which would leave a
+    build believing it had asked for something it had not.
+
+class GhPrCloseSettings extends GhCommandSettings
+  Settings for `gh pr close`.
+
+  selector(value: string | number): this
+    The pull request — number, URL, or branch; defaults to the current branch's.
+  comment(text: string): this
+    Leave a closing comment (`--comment`).
+  deleteBranch(): this
+    Delete the branch afterwards (`--delete-branch`).
+  override protected commandPath(): string[]
+    The `gh pr close` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh pr close` flags.
+
+class GhPrCommentSettings extends GhPrTargetSettings
+  Settings for `gh pr comment`.
+
+  editLast(): this
+    Edit your most recent comment instead of adding one (`--edit-last`).
+  createIfNone(): this
+    With {@link editLast}, post a new comment when there is none (`--create-if-none`).
+  deleteLast(): this
+    Delete your most recent comment (`--delete-last`).
+  yes(): this
+    Skip the confirmation a delete otherwise prompts for (`--yes`).
+  override protected commandPath(): string[]
+    The `gh pr comment` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh pr comment` flags.
+
+class GhPrCreateSettings extends GhBodySettings
+  Settings for `gh pr create`.
+
+  title(text: string): this
+    The pull request's title (`--title`).
+  base(branch: string): this
+    The branch to merge into (`--base`).
+  head(branch: string): this
+    The branch holding the commits (`--head`).
+  assignee(...logins: string[]): this
+    Assign someone by login (`--assignee`), `@me` for yourself; repeatable.
+  label(...names: string[]): this
+    Add a label by name (`--label`); repeatable.
+  reviewer(...handles: string[]): this
+    Request a review from a person or team (`--reviewer`); repeatable.
+  milestone(name: string): this
+    Add to a milestone by name (`--milestone`).
+  project(...titles: string[]): this
+    Add to a project by title (`--project`); repeatable.
+  draft(): this
+    Open it as a draft (`--draft`).
+  fill(): this
+    Take the title and body from the commits (`--fill`).
+  fillFirst(): this
+    Take them from the first commit only (`--fill-first`).
+  fillVerbose(): this
+    Take the body from every commit's message (`--fill-verbose`).
+  dryRun(): this
+    Print what would be created without creating it (`--dry-run`).
+  noMaintainerEdit(): this
+    Refuse maintainer edits to the branch (`--no-maintainer-edit`).
+  templateFile(path: string): this
+    A template file to seed the body from (`--template`).
+  override protected commandPath(): string[]
+    The `gh pr create` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh pr create` flags.
+
+class GhPrEditSettings extends GhPrTargetSettings
+  Settings for `gh pr edit`.
+
+  title(text: string): this
+    Set the title (`--title`).
+  base(branch: string): this
+    Change the base branch (`--base`).
+  addLabel(...names: string[]): this
+    Add a label (`--add-label`); repeatable.
+  removeLabel(...names: string[]): this
+    Remove a label (`--remove-label`); repeatable.
+  addAssignee(...logins: string[]): this
+    Add an assignee (`--add-assignee`); repeatable.
+  removeAssignee(...logins: string[]): this
+    Remove an assignee (`--remove-assignee`); repeatable.
+  addReviewer(...handles: string[]): this
+    Request a review (`--add-reviewer`); repeatable.
+  removeReviewer(...handles: string[]): this
+    Drop a review request (`--remove-reviewer`); repeatable.
+  addProject(...titles: string[]): this
+    Add to a project by title (`--add-project`); repeatable.
+  removeProject(...titles: string[]): this
+    Take it off a project by title (`--remove-project`); repeatable.
+  milestone(name: string): this
+    Set the milestone (`--milestone`).
+  removeMilestone(): this
+    Clear the milestone (`--remove-milestone`).
+  override protected commandPath(): string[]
+    The `gh pr edit` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh pr edit` flags.
+
+class GhPrListSettings extends GhWebReadSettings
+  Settings for `gh pr list`.
+
+  state(value: "open" | "closed" | "merged" | "all"): this
+    Filter by state (`--state`): `open`, `closed`, `merged`, or `all`.
+  base(branch: string): this
+    Filter by base branch (`--base`).
+  head(branch: string): this
+    Filter by head branch (`--head`).
+  author(login: string): this
+    Filter by author (`--author`).
+  app(name: string): this
+    Filter by the GitHub App that opened it (`--app`).
+  assignee(login: string): this
+    Filter by assignee (`--assignee`).
+  label(...names: string[]): this
+    Filter by label (`--label`); repeatable.
+  limit(count: number): this
+    Cap how many are fetched (`--limit`); gh's default is 30.
+  search(query: string): this
+    Filter with a search query (`--search`).
+  draft(): this
+    Only draft pull requests (`--draft`).
+  override protected commandPath(): string[]
+    The `gh pr list` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh pr list` flags.
+
+class GhPrMergeSettings extends GhPrTargetSettings
+  Settings for `gh pr merge`.
+
+  merge(): this
+    Merge with a merge commit (`--merge`).
+  squash(): this
+    Squash the commits into one (`--squash`).
+  rebase(): this
+    Rebase the commits onto the base (`--rebase`).
+  auto(): this
+    Merge once the requirements are met (`--auto`).
+  disableAuto(): this
+    Turn auto-merge off again (`--disable-auto`).
+  admin(): this
+    Merge with administrator privileges (`--admin`).
+  deleteBranch(): this
+    Delete the branch afterwards (`--delete-branch`).
+  subject(text: string): this
+    The merge commit's subject (`--subject`).
+  authorEmail(address: string): this
+    The merge commit's author email (`--author-email`).
+  matchHeadCommit(sha: string): this
+    Refuse the merge unless the head is still this commit
+    (`--match-head-commit`) — the guard against merging a PR that moved
+    between the check and the merge.
+  override protected commandPath(): string[]
+    The `gh pr merge` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh pr merge` flags.
+
+abstract class GhPrReadSettings extends GhWebReadSettings
+  Base for the `pr` commands that read one pull request and can print JSON —
+  `view` and `checks` — so the operand has one implementation across them.
+
+  selector(value: string | number): this
+    The pull request — number, URL, or branch; defaults to the current branch's.
+  protected selectorArgs(): string[]
+    The operand, when one was given.
+
+abstract class GhPrTargetSettings extends GhBodySettings
+  Base for the `pr` commands that take a pull request and post text —
+  `merge`, `comment`, and `edit` — so the operand and the `--body` pair have
+  one implementation across them.
+
+  selector(value: string | number): this
+    The pull request — its number, URL, or branch name. Omit it to act on the
+    PR for the current branch, as gh does.
+  protected selectorArgs(): string[]
+    The operand, when one was given.
+
+class GhPrViewSettings extends GhPrReadSettings
+  Settings for `gh pr view`.
+
+  comments(): this
+    Include the comments (`--comments`).
+  override protected commandPath(): string[]
+    The `gh pr view` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh pr view` flags.
+
 class GhPullRequestSettings
   Settings for opening a pull request.
 
@@ -12307,6 +12655,27 @@ class GhPullRequestSettings
     The effective `owner/repo`, from the setting or the environment.
   authToken_(): string
     The effective token, from the setting or the environment.
+
+abstract class GhReadSettings extends GhCommandSettings
+  Base for the commands that can print JSON: `pr list`, `pr view`,
+  `pr checks`, `issue list`, `issue view`, `release list`, `release view`.
+
+  gh requires an explicit field list for `--json`, which is why the
+  value-returning tasks pin one rather than leaving it to the caller.
+
+  A `…ListEntries` reader parses the array `--json` prints, so `.jq(...)` and
+  `.template(...)` — which replace that array with whatever they render —
+  belong on the plain `…List` task instead.
+
+  json(...fields: string[]): this
+    Emit JSON with these fields (`--json`), which gh requires by name — there
+    is no "all fields" form.
+  jq(expression: string): this
+    Filter the JSON with a jq expression (`--jq`).
+  template(text: string): this
+    Format the JSON through a Go template (`--template`).
+  protected readFlags(): string[]
+    The read flags, for a subclass to place among its own.
 
 class GhReleaseAssetSettings
   Settings for {@link GhReleaseAssetApi.uploadReleaseAsset}.
@@ -12365,6 +12734,111 @@ class GhReleaseAssetSettings
   effectiveContentType_(): string
     The effective `content-type`: the setting, or inferred by extension.
 
+class GhReleaseCreateSettings extends GhCommandSettings
+  Settings for `gh release create`.
+
+  tag(name: string): this
+    The tag to release (required); gh creates it when it does not exist.
+  files(...paths: PathLike[]): this
+    Asset files to attach (positional); repeatable. gh reads a `#label`
+    suffix on a path as the asset's display label.
+  title(text: string): this
+    The release title (`--title`).
+  notes(text: string): this
+    The release notes (`--notes`).
+  notesFile(path: PathLike): this
+    Read the notes from a file (`--notes-file`); `-` reads standard input.
+  generateNotes(): this
+    Have GitHub write the title and notes (`--generate-notes`).
+  notesFromTag(): this
+    Take the notes from the tag's annotation (`--notes-from-tag`).
+  notesStartTag(name: string): this
+    Generate notes starting from this tag (`--notes-start-tag`).
+  draft(): this
+    Save it as a draft rather than publishing (`--draft`).
+  prerelease(): this
+    Mark it a prerelease (`--prerelease`).
+  latest(): this
+    Mark it the latest release (`--latest`).
+  target(branchOrSha: string): this
+    The branch or commit to tag (`--target`).
+  discussionCategory(name: string): this
+    Open a discussion in this category (`--discussion-category`).
+  verifyTag(): this
+    Abort unless the tag already exists on the remote (`--verify-tag`).
+  failOnNoCommits(): this
+    Fail when there are no commits since the last release (`--fail-on-no-commits`).
+  override protected commandPath(): string[]
+    The `gh release create` command path, with the tag and any assets.
+  override protected commandFlags(): string[]
+    Assemble the `gh release create` flags.
+
+class GhReleaseDeleteSettings extends GhCommandSettings
+  Settings for `gh release delete`.
+
+  tag(name: string): this
+    The release to delete, by tag (required).
+  cleanupTag(): this
+    Delete the git tag as well (`--cleanup-tag`).
+  yes(): this
+    Skip the confirmation prompt (`--yes`).
+  override protected commandPath(): string[]
+    The `gh release delete` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh release delete` flags.
+
+class GhReleaseDownloadSettings extends GhCommandSettings
+  Settings for `gh release download`.
+
+  tag(name: string): this
+    The release's tag; gh takes the latest release when it is omitted.
+  pattern(...globs: string[]): this
+    Only assets matching this glob (`--pattern`); repeatable.
+  dir(path: PathLike): this
+    The directory to download into (`--dir`).
+  output(path: PathLike): this
+    Write a single asset to this file (`--output`); `-` writes standard output.
+  archive(format: "zip" | "tar.gz"): this
+    Download the source archive instead of the assets (`--archive`).
+  clobber(): this
+    Overwrite files that already exist (`--clobber`).
+  skipExisting(): this
+    Leave files that already exist alone (`--skip-existing`).
+  override protected commandPath(): string[]
+    The `gh release download` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh release download` flags.
+
+class GhReleaseEditSettings extends GhCommandSettings
+  Settings for `gh release edit`.
+
+  tag(name: string): this
+    The release to edit, by its current tag (required).
+  newTag(name: string): this
+    Move the release to a different tag (`--tag`).
+  title(text: string): this
+    Set the title (`--title`).
+  notes(text: string): this
+    Set the notes (`--notes`).
+  notesFile(path: PathLike): this
+    Read the notes from a file (`--notes-file`); `-` reads standard input.
+  draft(): this
+    Make it a draft (`--draft`).
+  prerelease(): this
+    Mark it a prerelease (`--prerelease`).
+  latest(): this
+    Mark it the latest release (`--latest`).
+  target(branchOrSha: string): this
+    Change the target branch or commit (`--target`).
+  discussionCategory(name: string): this
+    Open a discussion in this category when publishing (`--discussion-category`).
+  verifyTag(): this
+    Abort unless the tag exists on the remote (`--verify-tag`).
+  override protected commandPath(): string[]
+    The `gh release edit` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh release edit` flags.
+
 class GhReleaseLatestSettings
   Settings for marking a release as latest.
 
@@ -12395,6 +12869,47 @@ class GhReleaseLatestSettings
     The effective `owner/repo`, from the setting or the environment.
   authToken_(): string
     The effective token, from the setting or the environment.
+
+class GhReleaseListSettings extends GhReadSettings
+  Settings for `gh release list`.
+
+  limit(count: number): this
+    Cap how many are fetched (`--limit`); gh's default is 30.
+  order(direction: "asc" | "desc"): this
+    The order they come back in (`--order`): `asc` or `desc`.
+  excludeDrafts(): this
+    Leave out drafts (`--exclude-drafts`).
+  excludePreReleases(): this
+    Leave out prereleases (`--exclude-pre-releases`).
+  override protected commandPath(): string[]
+    The `gh release list` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh release list` flags.
+
+class GhReleaseUploadSettings extends GhCommandSettings
+  Settings for `gh release upload`.
+
+  tag(name: string): this
+    The release's tag (required).
+  files(...paths: PathLike[]): this
+    Asset files to attach (required); repeatable. gh reads a `#label` suffix
+    on a path as the asset's display label.
+  clobber(): this
+    Replace an asset of the same name (`--clobber`).
+  override protected commandPath(): string[]
+    The `gh release upload` command path, with the tag and the assets.
+  override protected commandFlags(): string[]
+    Assemble the `gh release upload` flags.
+
+class GhReleaseViewSettings extends GhWebReadSettings
+  Settings for `gh release view`.
+
+  tag(name: string): this
+    The release's tag; gh shows the latest release when it is omitted.
+  override protected commandPath(): string[]
+    The `gh release view` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh release view` flags.
 
 class GhSarifSettings
   Settings for {@link GhSarifApi.uploadSarif}.
@@ -12491,6 +13006,18 @@ class GhTagSettings
     The effective `owner/repo`, from the setting or the environment.
   authToken_(): string
     The effective token, from the setting or the environment.
+
+abstract class GhWebReadSettings extends GhReadSettings
+  Base for the read commands that also take `--web`: every one of them except
+  `release list`, which gh gives no browser view. Keeping `.web()` here rather
+  than on {@link GhReadSettings} is what stops a build offering a flag gh
+  would reject.
+
+  web(): this
+    Open the result in a browser instead of printing it (`--web`). A build
+    has no browser, so this is for a developer running the target by hand.
+  override protected readFlags(): string[]
+    The read flags, with `--web` last as gh's own help lists it.
 
 class GithubWorkflowSettings
   Configuration for {@link githubWorkflow}, set through a settings lambda. Every
@@ -12614,6 +13141,62 @@ interface GhCommitResult
   branch: string
     The branch it landed on.
 
+interface GhIssueApi
+  The `gh issue` members of {@link "./gh.ts".GhTasks}.
+
+  issueCreate(configure?: Configure<GhIssueCreateSettings>): Promise<CommandOutput>
+    Open an issue: `gh issue create`.
+  issueList(configure?: Configure<GhIssueListSettings>): Promise<CommandOutput>
+    List issues: `gh issue list`.
+  issueListEntries(configure?: Configure<GhIssueListSettings>): Promise<GhIssueEntry[]>
+    The issues as parsed {@link GhIssueEntry} values. The `--json` field set
+    is pinned, since gh requires one by name.
+  issueView(configure?: Configure<GhIssueViewSettings>): Promise<CommandOutput>
+    Show an issue: `gh issue view`.
+  issueComment(configure?: Configure<GhIssueCommentSettings>): Promise<CommandOutput>
+    Comment on an issue: `gh issue comment`.
+  issueClose(configure?: Configure<GhIssueCloseSettings>): Promise<CommandOutput>
+    Close an issue: `gh issue close`.
+
+interface GhIssueEntry
+  One issue of {@link "./gh.ts".GhTasks.issueListEntries}.
+
+  number?: number
+    The issue's number.
+  title?: string
+    Its title.
+  state?: string
+    Its state, as gh reports it: `OPEN` or `CLOSED`.
+  url?: string
+    Its web URL.
+  author?: string
+    The login of whoever opened it.
+
+interface GhPrApi
+  The `gh pr` members of {@link "./gh.ts".GhTasks}.
+
+  prCreate(configure?: Configure<GhPrCreateSettings>): Promise<CommandOutput>
+    Open a pull request: `gh pr create`. Needs the `gh` binary and its auth;
+    {@link "./pull_request.ts".GhPullRequestApi.pullRequest} is the REST path,
+    which needs a token instead.
+  prList(configure?: Configure<GhPrListSettings>): Promise<CommandOutput>
+    List pull requests: `gh pr list`.
+  prListEntries(configure?: Configure<GhPrListSettings>): Promise<GhPullRequestEntry[]>
+    The pull requests as parsed {@link GhPullRequestEntry} values. The
+    `--json` field set is pinned, since gh requires one by name.
+  prView(configure?: Configure<GhPrViewSettings>): Promise<CommandOutput>
+    Show a pull request: `gh pr view`.
+  prChecks(configure?: Configure<GhPrChecksSettings>): Promise<CommandOutput>
+    Report a pull request's checks: `gh pr checks`.
+  prMerge(configure?: Configure<GhPrMergeSettings>): Promise<CommandOutput>
+    Merge a pull request: `gh pr merge`.
+  prComment(configure?: Configure<GhPrCommentSettings>): Promise<CommandOutput>
+    Comment on a pull request: `gh pr comment`.
+  prEdit(configure?: Configure<GhPrEditSettings>): Promise<CommandOutput>
+    Change a pull request's metadata: `gh pr edit`.
+  prClose(configure?: Configure<GhPrCloseSettings>): Promise<CommandOutput>
+    Close a pull request: `gh pr close`.
+
 interface GhPullRequestApi
   The pull-request operation {@link GhTasks} exposes.
 
@@ -12637,6 +13220,26 @@ interface GhPullRequestApi
     what it should report. Opening one to find out is not a substitute: by
     then the branch it would have to prepare has already been written.
 
+interface GhPullRequestEntry
+  One pull request of {@link "./gh.ts".GhTasks.prListEntries}.
+
+  number?: number
+    The pull request's number.
+  title?: string
+    Its title.
+  state?: string
+    Its state, as gh reports it: `OPEN`, `CLOSED`, or `MERGED`.
+  isDraft?: boolean
+    Whether it is still a draft.
+  headRefName?: string
+    The branch the changes are on.
+  baseRefName?: string
+    The branch they would merge into.
+  url?: string
+    Its web URL.
+  author?: string
+    The login of whoever opened it.
+
 interface GhPullRequestResult
   The pull request a {@link GhPullRequestApi.pullRequest} call resolved to.
 
@@ -12650,6 +13253,29 @@ interface GhPullRequestResult
     Worth reporting rather than hiding: "proposed" and "already proposed" are
     different things to a human reading a build log, even though neither is a
     failure.
+
+interface GhReleaseApi
+  The `gh release` members of {@link "./gh.ts".GhTasks}.
+
+  releaseCreate(configure?: Configure<GhReleaseCreateSettings>): Promise<CommandOutput>
+    Publish a release: `gh release create`.
+  releaseList(configure?: Configure<GhReleaseListSettings>): Promise<CommandOutput>
+    List releases: `gh release list`.
+  releaseListEntries(configure?: Configure<GhReleaseListSettings>): Promise<GhReleaseEntry[]>
+    The releases as parsed {@link GhReleaseEntry} values. The `--json` field
+    set is pinned, since gh requires one by name.
+  releaseView(configure?: Configure<GhReleaseViewSettings>): Promise<CommandOutput>
+    Show a release: `gh release view`.
+  releaseUpload(configure?: Configure<GhReleaseUploadSettings>): Promise<CommandOutput>
+    Attach assets to a release: `gh release upload`. Needs the `gh` binary;
+    {@link "./release_asset.ts".GhReleaseAssetApi.uploadReleaseAsset} is the
+    REST path, which needs a token instead.
+  releaseDownload(configure?: Configure<GhReleaseDownloadSettings>): Promise<CommandOutput>
+    Download a release's assets: `gh release download`.
+  releaseEdit(configure?: Configure<GhReleaseEditSettings>): Promise<CommandOutput>
+    Change a release: `gh release edit`.
+  releaseDelete(configure?: Configure<GhReleaseDeleteSettings>): Promise<CommandOutput>
+    Remove a release: `gh release delete`.
 
 interface GhReleaseAssetApi
   The shape of the release-asset task, mixed into `GhTasks`.
@@ -12679,6 +13305,22 @@ interface GhReleaseAssetResult
     The id of the release the asset belongs to, when one was resolved.
   url?: string
     The asset's download URL, when it was uploaded or already present.
+
+interface GhReleaseEntry
+  One release of {@link "./gh.ts".GhTasks.releaseListEntries}.
+
+  tagName?: string
+    The release's tag.
+  name?: string
+    Its name, which GitHub calls the title.
+  isDraft?: boolean
+    Whether it is still a draft.
+  isPrerelease?: boolean
+    Whether it is marked a prerelease.
+  isLatest?: boolean
+    Whether it is the latest release.
+  publishedAt?: string
+    When it was published, ISO 8601; absent while it is a draft.
 
 interface GhReleaseLatestApi
   The mark-latest operation {@link GhTasks} exposes.
@@ -12722,7 +13364,7 @@ interface GhSarifUploadResult
   url: string
     The URL that reports whether GitHub finished processing the report.
 
-interface GhTasksApi extends GhAppTokenApi, GhSarifApi, GhReleaseAssetApi, GhReleaseLatestApi, GhCommitApi, GhPullRequestApi, GhCheckRunApi
+interface GhTasksApi extends GhAppTokenApi, GhSarifApi, GhReleaseAssetApi, GhReleaseLatestApi, GhCommitApi, GhPullRequestApi, GhCheckRunApi, GhPrApi, GhIssueApi, GhReleaseApi
   The shape of {@link GhTasks}: the `gh` CLI plus the GitHub operations that
   have no CLI subcommand (see {@link GhAppTokenApi}, {@link GhSarifApi}) and
   would otherwise force a build back to a marketplace action.
@@ -12773,6 +13415,12 @@ type GhCheckConclusion = "success" | "failure" | "neutral" | "cancelled" | "skip
 
   `"stale"` is deliberately absent: GitHub sets it itself and rejects it from a
   caller.
+
+type GhCloseReason = "completed" | "not planned" | "duplicate"
+  Why an issue is being closed (`--reason`).
+
+type GhMergeMethod = "merge" | "squash" | "rebase"
+  How `gh pr merge` combines the commits.
 
 type GhPermissionLevel = "read" | "write" | "admin"
   A permission level an installation token can be narrowed to.

--- a/packages/gh/README.md
+++ b/packages/gh/README.md
@@ -2,23 +2,61 @@
 
 Typed [`gh`](https://cli.github.com/) (GitHub CLI) task wrapper for
 [Zuke](https://github.com/zuke-build/zuke#readme) builds, in a fluent
-settings-lambda API. `gh` is broad, so this is a flexible command builder: name
-the command with `.command(...)`, set `--repo`, and pass anything else with
-`.flag(...)`. Arguments stay a discrete argv array, so command construction is
-injection-free.
+settings-lambda API. The three groups a build reaches for — `pr`, `issue`, and
+`release` — have typed tasks with their real flags; `gh` is broad, so
+`GhTasks.run` stays the builder for everything else: name the command with
+`.command(...)`, set `--repo`, and pass anything else with `.flag(...)`.
+Arguments stay a discrete argv array, so command construction is injection-free.
 
 ```ts
 import { GhTasks } from "jsr:@zuke/gh";
 
-await GhTasks.run((s) =>
-  s.command("release", "create", "v1.2.3")
-    .repo("acme/app")
-    .flag("title", "v1.2.3")
-    .flag("generate-notes")
+await GhTasks.releaseCreate((s) =>
+  s.repo("acme/app").tag("v1.2.3").title("v1.2.3").generateNotes().latest()
 );
 
-await GhTasks.run((s) => s.command("pr", "list").flag("state", "open"));
+// Anything not yet modelled, through the builder.
+await GhTasks.run((s) => s.command("auth", "status"));
 ```
+
+## Typed pr, issue and release commands
+
+Every task takes a settings lambda mirroring the real subcommand's flags, and
+keeps `.repo(...)` plus the `.command(...)`/`.flag(...)` escape hatches it
+inherits.
+
+| Group     | Tasks                                                                                                                                   |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `pr`      | `prCreate`, `prList`, `prListEntries`, `prView`, `prChecks`, `prMerge`, `prComment`, `prEdit`, `prClose`                                |
+| `issue`   | `issueCreate`, `issueList`, `issueListEntries`, `issueView`, `issueComment`, `issueClose`                                               |
+| `release` | `releaseCreate`, `releaseList`, `releaseListEntries`, `releaseView`, `releaseUpload`, `releaseDownload`, `releaseEdit`, `releaseDelete` |
+
+```ts
+import { GhTasks } from "jsr:@zuke/gh";
+
+await GhTasks.prMerge((s) => s.selector(123).squash().deleteBranch().auto());
+await GhTasks.issueClose((s) => s.selector(42).reason("completed"));
+await GhTasks.releaseUpload((s) =>
+  s.tag("v1.2.3").files("dist/app.tgz").clobber()
+);
+```
+
+The three `…ListEntries` tasks are the value-returning readers: they ask `gh`
+for `--json` with a pinned field set and hand back parsed entries, so a build
+branches on data rather than on scraped text.
+
+```ts
+const open = await GhTasks.prListEntries((s) => s.state("open").limit(50));
+const stale = open.filter((pr) => pr.isDraft);
+```
+
+Where `gh` would prompt — deleting a release, deleting a comment — the settings
+refuse before `gh` is ever spawned, because a build has no one to answer the
+prompt; `.yes()` is how it says it means the deletion. Contradictory flag pairs
+that `gh` silently resolves in its own favour (a draft that is also the latest
+release, `--pattern` alongside `--archive`, `--clobber` alongside
+`--skip-existing`) are refused the same way, so a build never quietly gets an
+outcome other than the one it asked for.
 
 ## Wait for an external GitHub workflow
 
@@ -203,6 +241,19 @@ async function uploadSarifReport(configure?: Configure<GhSarifSettings>): Promis
 const GhTasks: GhTasksApi
   Typed task functions for GitHub: the `gh` CLI and the REST-only operations.
 
+const ISSUE_LIST_FIELDS: readonly string[]
+  The `--json` fields {@link readIssues} asks for; gh requires the list by
+  name, so the reader pins the set {@link GhIssueEntry} describes.
+
+const PR_LIST_FIELDS: readonly string[]
+  The `--json` fields {@link readPullRequests} asks for. gh requires the list
+  by name — there is no "everything" form — so the reader pins the set its
+  {@link GhPullRequestEntry} describes.
+
+const RELEASE_LIST_FIELDS: readonly string[]
+  The `--json` fields {@link readReleases} asks for; gh requires the list by
+  name, so the reader pins the set {@link GhReleaseEntry} describes.
+
 class GhApiError extends Error
   A GitHub REST call that did not succeed, carrying the status.
 
@@ -296,6 +347,21 @@ class GhAppTokenSettings
   tokenRequest_(): Record<string, unknown>
     The `access_tokens` request body — only the fields that were narrowed.
 
+abstract class GhBodySettings extends GhCommandSettings
+  Base for the commands that take message text: `pr create`, `pr comment`,
+  `pr edit`, `issue create`, `issue comment`.
+
+  gh spells it `--body` for the text and `--body-file` for a file, with `-`
+  meaning standard input — the same pair on every one of them.
+
+  body(text: string): this
+    The message text (`--body`).
+  bodyFile(path: PathLike): this
+    Read the message from a file (`--body-file`); `-` reads standard input.
+  protected bodyFlags(task: string): string[]
+    The body flags, after refusing both at once: gh takes one source for the
+    text, and silently preferring one would hide which text was posted.
+
 class GhCheckRunSettings
   Settings for posting a completed check run.
 
@@ -362,6 +428,20 @@ class GhCheckRunSettings
   authToken_(): string
     The effective token, from the setting or the environment.
 
+abstract class GhCommandSettings extends GhSettings
+  Base for a typed `gh` subcommand: it contributes the command path (the
+  group, the verb, and any operand) and its own flags, and inherits
+  everything else from {@link "./settings.ts".GhSettings}.
+
+  abstract protected commandPath(): string[]
+    The command path — group, verb, then any positional operand.
+  abstract protected commandFlags(): string[]
+    This command's own flags, rendered after `--repo`.
+  override protected leadingTokens(): string[]
+    The command path leads the argv, before anything `.command(...)` added.
+  override protected middleTokens(): string[]
+    `--repo` first, as the package already renders it, then this command's flags.
+
 class GhCommitSettings
   Settings for committing files through the API.
 
@@ -422,6 +502,312 @@ class GhCommitSettings
   authToken_(): string
     The effective token, from the setting or the environment.
 
+class GhIssueCloseSettings extends GhCommandSettings
+  Settings for `gh issue close`.
+
+  selector(value: string | number): this
+    The issue — its number or URL (required).
+  comment(text: string): this
+    Leave a closing comment (`--comment`).
+  reason(value: GhCloseReason): this
+    Why it is closed (`--reason`).
+  duplicateOf(numberOrUrl: string | number): this
+    Which issue it duplicates (`--duplicate-of`), by number or URL.
+  override protected commandPath(): string[]
+    The `gh issue close` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh issue close` flags.
+
+class GhIssueCommentSettings extends GhBodySettings
+  Settings for `gh issue comment`.
+
+  selector(value: string | number): this
+    The issue — its number or URL (required).
+  editLast(): this
+    Edit your most recent comment instead of adding one (`--edit-last`).
+  createIfNone(): this
+    With {@link editLast}, post a new comment when there is none (`--create-if-none`).
+  deleteLast(): this
+    Delete your most recent comment (`--delete-last`).
+  yes(): this
+    Skip the confirmation a delete otherwise prompts for (`--yes`).
+  override protected commandPath(): string[]
+    The `gh issue comment` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh issue comment` flags.
+
+class GhIssueCreateSettings extends GhBodySettings
+  Settings for `gh issue create`.
+
+  title(text: string): this
+    The issue's title (`--title`).
+  assignee(...logins: string[]): this
+    Assign someone by login (`--assignee`), `@me` for yourself; repeatable.
+  label(...names: string[]): this
+    Add a label by name (`--label`); repeatable.
+  project(...titles: string[]): this
+    Add to a project by title (`--project`); repeatable.
+  milestone(name: string): this
+    Add to a milestone by name (`--milestone`).
+  type(name: string): this
+    Set the issue type by name (`--type`).
+  parent(numberOrUrl: string | number): this
+    File it as a sub-issue of this number or URL (`--parent`).
+  templateName(name: string): this
+    The issue template to start the body from (`--template`).
+  override protected commandPath(): string[]
+    The `gh issue create` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh issue create` flags.
+
+class GhIssueListSettings extends GhWebReadSettings
+  Settings for `gh issue list`.
+
+  state(value: "open" | "closed" | "all"): this
+    Filter by state (`--state`): `open`, `closed`, or `all`.
+  author(login: string): this
+    Filter by author (`--author`).
+  app(name: string): this
+    Filter by the GitHub App that opened it (`--app`).
+  assignee(login: string): this
+    Filter by assignee (`--assignee`).
+  mention(login: string): this
+    Filter by who is mentioned (`--mention`).
+  milestone(nameOrNumber: string): this
+    Filter by milestone number or title (`--milestone`).
+  type(name: string): this
+    Filter by issue type (`--type`).
+  label(...names: string[]): this
+    Filter by label (`--label`); repeatable.
+  limit(count: number): this
+    Cap how many are fetched (`--limit`); gh's default is 30.
+  search(query: string): this
+    Filter with a search query (`--search`).
+  override protected commandPath(): string[]
+    The `gh issue list` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh issue list` flags.
+
+class GhIssueViewSettings extends GhWebReadSettings
+  Settings for `gh issue view`.
+
+  selector(value: string | number): this
+    The issue — its number or URL (required).
+  comments(): this
+    Include the comments (`--comments`).
+  override protected commandPath(): string[]
+    The `gh issue view` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh issue view` flags.
+
+class GhPrChecksSettings extends GhPrReadSettings
+  Settings for `gh pr checks`.
+
+  watch(): this
+    Keep watching until the checks finish (`--watch`). A target that watches
+    blocks until CI is done, so pair it with `.killAfter(...)` unless the wait
+    is the point.
+  failFast(): this
+    Stop watching at the first failure (`--fail-fast`).
+  required(): this
+    Only the checks marked required (`--required`).
+  interval(seconds: number): this
+    How often to refresh while watching (`--interval`), in seconds.
+  override protected commandPath(): string[]
+    The `gh pr checks` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh pr checks` flags, refusing the flags that only mean
+    something while watching — gh ignores them otherwise, which would leave a
+    build believing it had asked for something it had not.
+
+class GhPrCloseSettings extends GhCommandSettings
+  Settings for `gh pr close`.
+
+  selector(value: string | number): this
+    The pull request — number, URL, or branch; defaults to the current branch's.
+  comment(text: string): this
+    Leave a closing comment (`--comment`).
+  deleteBranch(): this
+    Delete the branch afterwards (`--delete-branch`).
+  override protected commandPath(): string[]
+    The `gh pr close` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh pr close` flags.
+
+class GhPrCommentSettings extends GhPrTargetSettings
+  Settings for `gh pr comment`.
+
+  editLast(): this
+    Edit your most recent comment instead of adding one (`--edit-last`).
+  createIfNone(): this
+    With {@link editLast}, post a new comment when there is none (`--create-if-none`).
+  deleteLast(): this
+    Delete your most recent comment (`--delete-last`).
+  yes(): this
+    Skip the confirmation a delete otherwise prompts for (`--yes`).
+  override protected commandPath(): string[]
+    The `gh pr comment` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh pr comment` flags.
+
+class GhPrCreateSettings extends GhBodySettings
+  Settings for `gh pr create`.
+
+  title(text: string): this
+    The pull request's title (`--title`).
+  base(branch: string): this
+    The branch to merge into (`--base`).
+  head(branch: string): this
+    The branch holding the commits (`--head`).
+  assignee(...logins: string[]): this
+    Assign someone by login (`--assignee`), `@me` for yourself; repeatable.
+  label(...names: string[]): this
+    Add a label by name (`--label`); repeatable.
+  reviewer(...handles: string[]): this
+    Request a review from a person or team (`--reviewer`); repeatable.
+  milestone(name: string): this
+    Add to a milestone by name (`--milestone`).
+  project(...titles: string[]): this
+    Add to a project by title (`--project`); repeatable.
+  draft(): this
+    Open it as a draft (`--draft`).
+  fill(): this
+    Take the title and body from the commits (`--fill`).
+  fillFirst(): this
+    Take them from the first commit only (`--fill-first`).
+  fillVerbose(): this
+    Take the body from every commit's message (`--fill-verbose`).
+  dryRun(): this
+    Print what would be created without creating it (`--dry-run`).
+  noMaintainerEdit(): this
+    Refuse maintainer edits to the branch (`--no-maintainer-edit`).
+  templateFile(path: string): this
+    A template file to seed the body from (`--template`).
+  override protected commandPath(): string[]
+    The `gh pr create` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh pr create` flags.
+
+class GhPrEditSettings extends GhPrTargetSettings
+  Settings for `gh pr edit`.
+
+  title(text: string): this
+    Set the title (`--title`).
+  base(branch: string): this
+    Change the base branch (`--base`).
+  addLabel(...names: string[]): this
+    Add a label (`--add-label`); repeatable.
+  removeLabel(...names: string[]): this
+    Remove a label (`--remove-label`); repeatable.
+  addAssignee(...logins: string[]): this
+    Add an assignee (`--add-assignee`); repeatable.
+  removeAssignee(...logins: string[]): this
+    Remove an assignee (`--remove-assignee`); repeatable.
+  addReviewer(...handles: string[]): this
+    Request a review (`--add-reviewer`); repeatable.
+  removeReviewer(...handles: string[]): this
+    Drop a review request (`--remove-reviewer`); repeatable.
+  addProject(...titles: string[]): this
+    Add to a project by title (`--add-project`); repeatable.
+  removeProject(...titles: string[]): this
+    Take it off a project by title (`--remove-project`); repeatable.
+  milestone(name: string): this
+    Set the milestone (`--milestone`).
+  removeMilestone(): this
+    Clear the milestone (`--remove-milestone`).
+  override protected commandPath(): string[]
+    The `gh pr edit` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh pr edit` flags.
+
+class GhPrListSettings extends GhWebReadSettings
+  Settings for `gh pr list`.
+
+  state(value: "open" | "closed" | "merged" | "all"): this
+    Filter by state (`--state`): `open`, `closed`, `merged`, or `all`.
+  base(branch: string): this
+    Filter by base branch (`--base`).
+  head(branch: string): this
+    Filter by head branch (`--head`).
+  author(login: string): this
+    Filter by author (`--author`).
+  app(name: string): this
+    Filter by the GitHub App that opened it (`--app`).
+  assignee(login: string): this
+    Filter by assignee (`--assignee`).
+  label(...names: string[]): this
+    Filter by label (`--label`); repeatable.
+  limit(count: number): this
+    Cap how many are fetched (`--limit`); gh's default is 30.
+  search(query: string): this
+    Filter with a search query (`--search`).
+  draft(): this
+    Only draft pull requests (`--draft`).
+  override protected commandPath(): string[]
+    The `gh pr list` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh pr list` flags.
+
+class GhPrMergeSettings extends GhPrTargetSettings
+  Settings for `gh pr merge`.
+
+  merge(): this
+    Merge with a merge commit (`--merge`).
+  squash(): this
+    Squash the commits into one (`--squash`).
+  rebase(): this
+    Rebase the commits onto the base (`--rebase`).
+  auto(): this
+    Merge once the requirements are met (`--auto`).
+  disableAuto(): this
+    Turn auto-merge off again (`--disable-auto`).
+  admin(): this
+    Merge with administrator privileges (`--admin`).
+  deleteBranch(): this
+    Delete the branch afterwards (`--delete-branch`).
+  subject(text: string): this
+    The merge commit's subject (`--subject`).
+  authorEmail(address: string): this
+    The merge commit's author email (`--author-email`).
+  matchHeadCommit(sha: string): this
+    Refuse the merge unless the head is still this commit
+    (`--match-head-commit`) — the guard against merging a PR that moved
+    between the check and the merge.
+  override protected commandPath(): string[]
+    The `gh pr merge` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh pr merge` flags.
+
+abstract class GhPrReadSettings extends GhWebReadSettings
+  Base for the `pr` commands that read one pull request and can print JSON —
+  `view` and `checks` — so the operand has one implementation across them.
+
+  selector(value: string | number): this
+    The pull request — number, URL, or branch; defaults to the current branch's.
+  protected selectorArgs(): string[]
+    The operand, when one was given.
+
+abstract class GhPrTargetSettings extends GhBodySettings
+  Base for the `pr` commands that take a pull request and post text —
+  `merge`, `comment`, and `edit` — so the operand and the `--body` pair have
+  one implementation across them.
+
+  selector(value: string | number): this
+    The pull request — its number, URL, or branch name. Omit it to act on the
+    PR for the current branch, as gh does.
+  protected selectorArgs(): string[]
+    The operand, when one was given.
+
+class GhPrViewSettings extends GhPrReadSettings
+  Settings for `gh pr view`.
+
+  comments(): this
+    Include the comments (`--comments`).
+  override protected commandPath(): string[]
+    The `gh pr view` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh pr view` flags.
+
 class GhPullRequestSettings
   Settings for opening a pull request.
 
@@ -464,6 +850,27 @@ class GhPullRequestSettings
     The effective `owner/repo`, from the setting or the environment.
   authToken_(): string
     The effective token, from the setting or the environment.
+
+abstract class GhReadSettings extends GhCommandSettings
+  Base for the commands that can print JSON: `pr list`, `pr view`,
+  `pr checks`, `issue list`, `issue view`, `release list`, `release view`.
+
+  gh requires an explicit field list for `--json`, which is why the
+  value-returning tasks pin one rather than leaving it to the caller.
+
+  A `…ListEntries` reader parses the array `--json` prints, so `.jq(...)` and
+  `.template(...)` — which replace that array with whatever they render —
+  belong on the plain `…List` task instead.
+
+  json(...fields: string[]): this
+    Emit JSON with these fields (`--json`), which gh requires by name — there
+    is no "all fields" form.
+  jq(expression: string): this
+    Filter the JSON with a jq expression (`--jq`).
+  template(text: string): this
+    Format the JSON through a Go template (`--template`).
+  protected readFlags(): string[]
+    The read flags, for a subclass to place among its own.
 
 class GhReleaseAssetSettings
   Settings for {@link GhReleaseAssetApi.uploadReleaseAsset}.
@@ -522,6 +929,111 @@ class GhReleaseAssetSettings
   effectiveContentType_(): string
     The effective `content-type`: the setting, or inferred by extension.
 
+class GhReleaseCreateSettings extends GhCommandSettings
+  Settings for `gh release create`.
+
+  tag(name: string): this
+    The tag to release (required); gh creates it when it does not exist.
+  files(...paths: PathLike[]): this
+    Asset files to attach (positional); repeatable. gh reads a `#label`
+    suffix on a path as the asset's display label.
+  title(text: string): this
+    The release title (`--title`).
+  notes(text: string): this
+    The release notes (`--notes`).
+  notesFile(path: PathLike): this
+    Read the notes from a file (`--notes-file`); `-` reads standard input.
+  generateNotes(): this
+    Have GitHub write the title and notes (`--generate-notes`).
+  notesFromTag(): this
+    Take the notes from the tag's annotation (`--notes-from-tag`).
+  notesStartTag(name: string): this
+    Generate notes starting from this tag (`--notes-start-tag`).
+  draft(): this
+    Save it as a draft rather than publishing (`--draft`).
+  prerelease(): this
+    Mark it a prerelease (`--prerelease`).
+  latest(): this
+    Mark it the latest release (`--latest`).
+  target(branchOrSha: string): this
+    The branch or commit to tag (`--target`).
+  discussionCategory(name: string): this
+    Open a discussion in this category (`--discussion-category`).
+  verifyTag(): this
+    Abort unless the tag already exists on the remote (`--verify-tag`).
+  failOnNoCommits(): this
+    Fail when there are no commits since the last release (`--fail-on-no-commits`).
+  override protected commandPath(): string[]
+    The `gh release create` command path, with the tag and any assets.
+  override protected commandFlags(): string[]
+    Assemble the `gh release create` flags.
+
+class GhReleaseDeleteSettings extends GhCommandSettings
+  Settings for `gh release delete`.
+
+  tag(name: string): this
+    The release to delete, by tag (required).
+  cleanupTag(): this
+    Delete the git tag as well (`--cleanup-tag`).
+  yes(): this
+    Skip the confirmation prompt (`--yes`).
+  override protected commandPath(): string[]
+    The `gh release delete` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh release delete` flags.
+
+class GhReleaseDownloadSettings extends GhCommandSettings
+  Settings for `gh release download`.
+
+  tag(name: string): this
+    The release's tag; gh takes the latest release when it is omitted.
+  pattern(...globs: string[]): this
+    Only assets matching this glob (`--pattern`); repeatable.
+  dir(path: PathLike): this
+    The directory to download into (`--dir`).
+  output(path: PathLike): this
+    Write a single asset to this file (`--output`); `-` writes standard output.
+  archive(format: "zip" | "tar.gz"): this
+    Download the source archive instead of the assets (`--archive`).
+  clobber(): this
+    Overwrite files that already exist (`--clobber`).
+  skipExisting(): this
+    Leave files that already exist alone (`--skip-existing`).
+  override protected commandPath(): string[]
+    The `gh release download` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh release download` flags.
+
+class GhReleaseEditSettings extends GhCommandSettings
+  Settings for `gh release edit`.
+
+  tag(name: string): this
+    The release to edit, by its current tag (required).
+  newTag(name: string): this
+    Move the release to a different tag (`--tag`).
+  title(text: string): this
+    Set the title (`--title`).
+  notes(text: string): this
+    Set the notes (`--notes`).
+  notesFile(path: PathLike): this
+    Read the notes from a file (`--notes-file`); `-` reads standard input.
+  draft(): this
+    Make it a draft (`--draft`).
+  prerelease(): this
+    Mark it a prerelease (`--prerelease`).
+  latest(): this
+    Mark it the latest release (`--latest`).
+  target(branchOrSha: string): this
+    Change the target branch or commit (`--target`).
+  discussionCategory(name: string): this
+    Open a discussion in this category when publishing (`--discussion-category`).
+  verifyTag(): this
+    Abort unless the tag exists on the remote (`--verify-tag`).
+  override protected commandPath(): string[]
+    The `gh release edit` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh release edit` flags.
+
 class GhReleaseLatestSettings
   Settings for marking a release as latest.
 
@@ -552,6 +1064,47 @@ class GhReleaseLatestSettings
     The effective `owner/repo`, from the setting or the environment.
   authToken_(): string
     The effective token, from the setting or the environment.
+
+class GhReleaseListSettings extends GhReadSettings
+  Settings for `gh release list`.
+
+  limit(count: number): this
+    Cap how many are fetched (`--limit`); gh's default is 30.
+  order(direction: "asc" | "desc"): this
+    The order they come back in (`--order`): `asc` or `desc`.
+  excludeDrafts(): this
+    Leave out drafts (`--exclude-drafts`).
+  excludePreReleases(): this
+    Leave out prereleases (`--exclude-pre-releases`).
+  override protected commandPath(): string[]
+    The `gh release list` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh release list` flags.
+
+class GhReleaseUploadSettings extends GhCommandSettings
+  Settings for `gh release upload`.
+
+  tag(name: string): this
+    The release's tag (required).
+  files(...paths: PathLike[]): this
+    Asset files to attach (required); repeatable. gh reads a `#label` suffix
+    on a path as the asset's display label.
+  clobber(): this
+    Replace an asset of the same name (`--clobber`).
+  override protected commandPath(): string[]
+    The `gh release upload` command path, with the tag and the assets.
+  override protected commandFlags(): string[]
+    Assemble the `gh release upload` flags.
+
+class GhReleaseViewSettings extends GhWebReadSettings
+  Settings for `gh release view`.
+
+  tag(name: string): this
+    The release's tag; gh shows the latest release when it is omitted.
+  override protected commandPath(): string[]
+    The `gh release view` command path.
+  override protected commandFlags(): string[]
+    Assemble the `gh release view` flags.
 
 class GhSarifSettings
   Settings for {@link GhSarifApi.uploadSarif}.
@@ -648,6 +1201,18 @@ class GhTagSettings
     The effective `owner/repo`, from the setting or the environment.
   authToken_(): string
     The effective token, from the setting or the environment.
+
+abstract class GhWebReadSettings extends GhReadSettings
+  Base for the read commands that also take `--web`: every one of them except
+  `release list`, which gh gives no browser view. Keeping `.web()` here rather
+  than on {@link GhReadSettings} is what stops a build offering a flag gh
+  would reject.
+
+  web(): this
+    Open the result in a browser instead of printing it (`--web`). A build
+    has no browser, so this is for a developer running the target by hand.
+  override protected readFlags(): string[]
+    The read flags, with `--web` last as gh's own help lists it.
 
 class GithubWorkflowSettings
   Configuration for {@link githubWorkflow}, set through a settings lambda. Every
@@ -771,6 +1336,62 @@ interface GhCommitResult
   branch: string
     The branch it landed on.
 
+interface GhIssueApi
+  The `gh issue` members of {@link "./gh.ts".GhTasks}.
+
+  issueCreate(configure?: Configure<GhIssueCreateSettings>): Promise<CommandOutput>
+    Open an issue: `gh issue create`.
+  issueList(configure?: Configure<GhIssueListSettings>): Promise<CommandOutput>
+    List issues: `gh issue list`.
+  issueListEntries(configure?: Configure<GhIssueListSettings>): Promise<GhIssueEntry[]>
+    The issues as parsed {@link GhIssueEntry} values. The `--json` field set
+    is pinned, since gh requires one by name.
+  issueView(configure?: Configure<GhIssueViewSettings>): Promise<CommandOutput>
+    Show an issue: `gh issue view`.
+  issueComment(configure?: Configure<GhIssueCommentSettings>): Promise<CommandOutput>
+    Comment on an issue: `gh issue comment`.
+  issueClose(configure?: Configure<GhIssueCloseSettings>): Promise<CommandOutput>
+    Close an issue: `gh issue close`.
+
+interface GhIssueEntry
+  One issue of {@link "./gh.ts".GhTasks.issueListEntries}.
+
+  number?: number
+    The issue's number.
+  title?: string
+    Its title.
+  state?: string
+    Its state, as gh reports it: `OPEN` or `CLOSED`.
+  url?: string
+    Its web URL.
+  author?: string
+    The login of whoever opened it.
+
+interface GhPrApi
+  The `gh pr` members of {@link "./gh.ts".GhTasks}.
+
+  prCreate(configure?: Configure<GhPrCreateSettings>): Promise<CommandOutput>
+    Open a pull request: `gh pr create`. Needs the `gh` binary and its auth;
+    {@link "./pull_request.ts".GhPullRequestApi.pullRequest} is the REST path,
+    which needs a token instead.
+  prList(configure?: Configure<GhPrListSettings>): Promise<CommandOutput>
+    List pull requests: `gh pr list`.
+  prListEntries(configure?: Configure<GhPrListSettings>): Promise<GhPullRequestEntry[]>
+    The pull requests as parsed {@link GhPullRequestEntry} values. The
+    `--json` field set is pinned, since gh requires one by name.
+  prView(configure?: Configure<GhPrViewSettings>): Promise<CommandOutput>
+    Show a pull request: `gh pr view`.
+  prChecks(configure?: Configure<GhPrChecksSettings>): Promise<CommandOutput>
+    Report a pull request's checks: `gh pr checks`.
+  prMerge(configure?: Configure<GhPrMergeSettings>): Promise<CommandOutput>
+    Merge a pull request: `gh pr merge`.
+  prComment(configure?: Configure<GhPrCommentSettings>): Promise<CommandOutput>
+    Comment on a pull request: `gh pr comment`.
+  prEdit(configure?: Configure<GhPrEditSettings>): Promise<CommandOutput>
+    Change a pull request's metadata: `gh pr edit`.
+  prClose(configure?: Configure<GhPrCloseSettings>): Promise<CommandOutput>
+    Close a pull request: `gh pr close`.
+
 interface GhPullRequestApi
   The pull-request operation {@link GhTasks} exposes.
 
@@ -794,6 +1415,26 @@ interface GhPullRequestApi
     what it should report. Opening one to find out is not a substitute: by
     then the branch it would have to prepare has already been written.
 
+interface GhPullRequestEntry
+  One pull request of {@link "./gh.ts".GhTasks.prListEntries}.
+
+  number?: number
+    The pull request's number.
+  title?: string
+    Its title.
+  state?: string
+    Its state, as gh reports it: `OPEN`, `CLOSED`, or `MERGED`.
+  isDraft?: boolean
+    Whether it is still a draft.
+  headRefName?: string
+    The branch the changes are on.
+  baseRefName?: string
+    The branch they would merge into.
+  url?: string
+    Its web URL.
+  author?: string
+    The login of whoever opened it.
+
 interface GhPullRequestResult
   The pull request a {@link GhPullRequestApi.pullRequest} call resolved to.
 
@@ -807,6 +1448,29 @@ interface GhPullRequestResult
     Worth reporting rather than hiding: "proposed" and "already proposed" are
     different things to a human reading a build log, even though neither is a
     failure.
+
+interface GhReleaseApi
+  The `gh release` members of {@link "./gh.ts".GhTasks}.
+
+  releaseCreate(configure?: Configure<GhReleaseCreateSettings>): Promise<CommandOutput>
+    Publish a release: `gh release create`.
+  releaseList(configure?: Configure<GhReleaseListSettings>): Promise<CommandOutput>
+    List releases: `gh release list`.
+  releaseListEntries(configure?: Configure<GhReleaseListSettings>): Promise<GhReleaseEntry[]>
+    The releases as parsed {@link GhReleaseEntry} values. The `--json` field
+    set is pinned, since gh requires one by name.
+  releaseView(configure?: Configure<GhReleaseViewSettings>): Promise<CommandOutput>
+    Show a release: `gh release view`.
+  releaseUpload(configure?: Configure<GhReleaseUploadSettings>): Promise<CommandOutput>
+    Attach assets to a release: `gh release upload`. Needs the `gh` binary;
+    {@link "./release_asset.ts".GhReleaseAssetApi.uploadReleaseAsset} is the
+    REST path, which needs a token instead.
+  releaseDownload(configure?: Configure<GhReleaseDownloadSettings>): Promise<CommandOutput>
+    Download a release's assets: `gh release download`.
+  releaseEdit(configure?: Configure<GhReleaseEditSettings>): Promise<CommandOutput>
+    Change a release: `gh release edit`.
+  releaseDelete(configure?: Configure<GhReleaseDeleteSettings>): Promise<CommandOutput>
+    Remove a release: `gh release delete`.
 
 interface GhReleaseAssetApi
   The shape of the release-asset task, mixed into `GhTasks`.
@@ -836,6 +1500,22 @@ interface GhReleaseAssetResult
     The id of the release the asset belongs to, when one was resolved.
   url?: string
     The asset's download URL, when it was uploaded or already present.
+
+interface GhReleaseEntry
+  One release of {@link "./gh.ts".GhTasks.releaseListEntries}.
+
+  tagName?: string
+    The release's tag.
+  name?: string
+    Its name, which GitHub calls the title.
+  isDraft?: boolean
+    Whether it is still a draft.
+  isPrerelease?: boolean
+    Whether it is marked a prerelease.
+  isLatest?: boolean
+    Whether it is the latest release.
+  publishedAt?: string
+    When it was published, ISO 8601; absent while it is a draft.
 
 interface GhReleaseLatestApi
   The mark-latest operation {@link GhTasks} exposes.
@@ -879,7 +1559,7 @@ interface GhSarifUploadResult
   url: string
     The URL that reports whether GitHub finished processing the report.
 
-interface GhTasksApi extends GhAppTokenApi, GhSarifApi, GhReleaseAssetApi, GhReleaseLatestApi, GhCommitApi, GhPullRequestApi, GhCheckRunApi
+interface GhTasksApi extends GhAppTokenApi, GhSarifApi, GhReleaseAssetApi, GhReleaseLatestApi, GhCommitApi, GhPullRequestApi, GhCheckRunApi, GhPrApi, GhIssueApi, GhReleaseApi
   The shape of {@link GhTasks}: the `gh` CLI plus the GitHub operations that
   have no CLI subcommand (see {@link GhAppTokenApi}, {@link GhSarifApi}) and
   would otherwise force a build back to a marketplace action.
@@ -930,6 +1610,12 @@ type GhCheckConclusion = "success" | "failure" | "neutral" | "cancelled" | "skip
 
   `"stale"` is deliberately absent: GitHub sets it itself and rejects it from a
   caller.
+
+type GhCloseReason = "completed" | "not planned" | "duplicate"
+  Why an issue is being closed (`--reason`).
+
+type GhMergeMethod = "merge" | "squash" | "rebase"
+  How `gh pr merge` combines the commits.
 
 type GhPermissionLevel = "read" | "write" | "admin"
   A permission level an installation token can be narrowed to.

--- a/packages/gh/mod.ts
+++ b/packages/gh/mod.ts
@@ -21,6 +21,49 @@
  */
 
 export * from "./src/gh.ts";
+export {
+  GhBodySettings,
+  GhCommandSettings,
+  GhReadSettings,
+  GhWebReadSettings,
+} from "./src/subcommand.ts";
+export type { GhIssueApi, GhPrApi, GhReleaseApi } from "./src/groups.ts";
+export {
+  type GhMergeMethod,
+  GhPrChecksSettings,
+  GhPrCloseSettings,
+  GhPrCommentSettings,
+  GhPrCreateSettings,
+  GhPrEditSettings,
+  GhPrListSettings,
+  GhPrMergeSettings,
+  GhPrReadSettings,
+  GhPrTargetSettings,
+  GhPrViewSettings,
+  type GhPullRequestEntry,
+  PR_LIST_FIELDS,
+} from "./src/pr.ts";
+export {
+  type GhCloseReason,
+  GhIssueCloseSettings,
+  GhIssueCommentSettings,
+  GhIssueCreateSettings,
+  type GhIssueEntry,
+  GhIssueListSettings,
+  GhIssueViewSettings,
+  ISSUE_LIST_FIELDS,
+} from "./src/issue.ts";
+export {
+  GhReleaseCreateSettings,
+  GhReleaseDeleteSettings,
+  GhReleaseDownloadSettings,
+  GhReleaseEditSettings,
+  type GhReleaseEntry,
+  GhReleaseListSettings,
+  GhReleaseUploadSettings,
+  GhReleaseViewSettings,
+  RELEASE_LIST_FIELDS,
+} from "./src/release.ts";
 export { GhApiSettings } from "./src/api_command.ts";
 export {
   assertRefName,

--- a/packages/gh/src/gh.ts
+++ b/packages/gh/src/gh.ts
@@ -25,11 +25,8 @@
  * @module
  */
 
-import {
-  type Configure,
-  runSettings,
-  SubcommandSettings,
-} from "@zuke/core/tooling";
+import { type Configure, runSettings } from "@zuke/core/tooling";
+import { GhSettings } from "./settings.ts";
 import type { CommandOutput } from "@zuke/core/shell";
 import {
   type GhAppTokenApi,
@@ -77,27 +74,13 @@ import {
   markReleaseLatest,
 } from "./release_latest.ts";
 import { callApi, type GhApiSettings } from "./api_command.ts";
-
-/** Settings for a `gh` invocation. */
-export class GhSettings extends SubcommandSettings {
-  #repo?: string;
-
-  /** The default executable name: `gh`. */
-  protected override defaultTool(): string {
-    return "gh";
-  }
-
-  /** Target repository as `OWNER/REPO` (`-R`/`--repo`). */
-  repo(slug: string): this {
-    this.#repo = slug;
-    return this;
-  }
-
-  /** Emit `--repo <slug>` between the command path and the flags, when set. */
-  protected override middleTokens(): string[] {
-    return this.#repo !== undefined ? ["--repo", this.#repo] : [];
-  }
-}
+export { GhSettings };
+import {
+  ghGroupTasks,
+  type GhIssueApi,
+  type GhPrApi,
+  type GhReleaseApi,
+} from "./groups.ts";
 
 /**
  * The shape of {@link GhTasks}: the `gh` CLI plus the GitHub operations that
@@ -112,7 +95,10 @@ export interface GhTasksApi
     GhReleaseLatestApi,
     GhCommitApi,
     GhPullRequestApi,
-    GhCheckRunApi {
+    GhCheckRunApi,
+    GhPrApi,
+    GhIssueApi,
+    GhReleaseApi {
   /** Run a `gh` command. */
   run(configure?: Configure<GhSettings>): Promise<CommandOutput>;
   /**
@@ -128,6 +114,7 @@ export interface GhTasksApi
 
 /** Typed task functions for GitHub: the `gh` CLI and the REST-only operations. */
 export const GhTasks: GhTasksApi = {
+  ...ghGroupTasks,
   run(configure?: Configure<GhSettings>): Promise<CommandOutput> {
     return runSettings(new GhSettings(), configure);
   },

--- a/packages/gh/src/groups.ts
+++ b/packages/gh/src/groups.ts
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * The `GhTasks` members for the typed `gh` command groups, and their
+ * implementations.
+ *
+ * The package composes {@link "./gh.ts".GhTasksApi} from one interface per
+ * concern, so the CLI groups follow that shape rather than growing one flat
+ * interface: {@link GhPrApi}, {@link GhIssueApi}, {@link GhReleaseApi}, and
+ * {@link ghGroupTasks} implementing all three.
+ *
+ * @module
+ */
+
+import { type Configure, runSettings } from "@zuke/core/tooling";
+import type { CommandOutput } from "@zuke/core/shell";
+import {
+  GhPrChecksSettings,
+  GhPrCloseSettings,
+  GhPrCommentSettings,
+  GhPrCreateSettings,
+  GhPrEditSettings,
+  GhPrListSettings,
+  GhPrMergeSettings,
+  GhPrViewSettings,
+  type GhPullRequestEntry,
+  readPullRequests,
+} from "./pr.ts";
+import {
+  GhIssueCloseSettings,
+  GhIssueCommentSettings,
+  GhIssueCreateSettings,
+  type GhIssueEntry,
+  GhIssueListSettings,
+  GhIssueViewSettings,
+  readIssues,
+} from "./issue.ts";
+import {
+  GhReleaseCreateSettings,
+  GhReleaseDeleteSettings,
+  GhReleaseDownloadSettings,
+  GhReleaseEditSettings,
+  type GhReleaseEntry,
+  GhReleaseListSettings,
+  GhReleaseUploadSettings,
+  GhReleaseViewSettings,
+  readReleases,
+} from "./release.ts";
+
+/** The `gh pr` members of {@link "./gh.ts".GhTasks}. */
+export interface GhPrApi {
+  /**
+   * Open a pull request: `gh pr create`. Needs the `gh` binary and its auth;
+   * {@link "./pull_request.ts".GhPullRequestApi.pullRequest} is the REST path,
+   * which needs a token instead.
+   */
+  prCreate(configure?: Configure<GhPrCreateSettings>): Promise<CommandOutput>;
+  /** List pull requests: `gh pr list`. */
+  prList(configure?: Configure<GhPrListSettings>): Promise<CommandOutput>;
+  /**
+   * The pull requests as parsed {@link GhPullRequestEntry} values. The
+   * `--json` field set is pinned, since gh requires one by name.
+   */
+  prListEntries(
+    configure?: Configure<GhPrListSettings>,
+  ): Promise<GhPullRequestEntry[]>;
+  /** Show a pull request: `gh pr view`. */
+  prView(configure?: Configure<GhPrViewSettings>): Promise<CommandOutput>;
+  /** Report a pull request's checks: `gh pr checks`. */
+  prChecks(configure?: Configure<GhPrChecksSettings>): Promise<CommandOutput>;
+  /** Merge a pull request: `gh pr merge`. */
+  prMerge(configure?: Configure<GhPrMergeSettings>): Promise<CommandOutput>;
+  /** Comment on a pull request: `gh pr comment`. */
+  prComment(configure?: Configure<GhPrCommentSettings>): Promise<CommandOutput>;
+  /** Change a pull request's metadata: `gh pr edit`. */
+  prEdit(configure?: Configure<GhPrEditSettings>): Promise<CommandOutput>;
+  /** Close a pull request: `gh pr close`. */
+  prClose(configure?: Configure<GhPrCloseSettings>): Promise<CommandOutput>;
+}
+
+/** The `gh issue` members of {@link "./gh.ts".GhTasks}. */
+export interface GhIssueApi {
+  /** Open an issue: `gh issue create`. */
+  issueCreate(
+    configure?: Configure<GhIssueCreateSettings>,
+  ): Promise<CommandOutput>;
+  /** List issues: `gh issue list`. */
+  issueList(configure?: Configure<GhIssueListSettings>): Promise<CommandOutput>;
+  /**
+   * The issues as parsed {@link GhIssueEntry} values. The `--json` field set
+   * is pinned, since gh requires one by name.
+   */
+  issueListEntries(
+    configure?: Configure<GhIssueListSettings>,
+  ): Promise<GhIssueEntry[]>;
+  /** Show an issue: `gh issue view`. */
+  issueView(configure?: Configure<GhIssueViewSettings>): Promise<CommandOutput>;
+  /** Comment on an issue: `gh issue comment`. */
+  issueComment(
+    configure?: Configure<GhIssueCommentSettings>,
+  ): Promise<CommandOutput>;
+  /** Close an issue: `gh issue close`. */
+  issueClose(
+    configure?: Configure<GhIssueCloseSettings>,
+  ): Promise<CommandOutput>;
+}
+
+/** The `gh release` members of {@link "./gh.ts".GhTasks}. */
+export interface GhReleaseApi {
+  /** Publish a release: `gh release create`. */
+  releaseCreate(
+    configure?: Configure<GhReleaseCreateSettings>,
+  ): Promise<CommandOutput>;
+  /** List releases: `gh release list`. */
+  releaseList(
+    configure?: Configure<GhReleaseListSettings>,
+  ): Promise<CommandOutput>;
+  /**
+   * The releases as parsed {@link GhReleaseEntry} values. The `--json` field
+   * set is pinned, since gh requires one by name.
+   */
+  releaseListEntries(
+    configure?: Configure<GhReleaseListSettings>,
+  ): Promise<GhReleaseEntry[]>;
+  /** Show a release: `gh release view`. */
+  releaseView(
+    configure?: Configure<GhReleaseViewSettings>,
+  ): Promise<CommandOutput>;
+  /**
+   * Attach assets to a release: `gh release upload`. Needs the `gh` binary;
+   * {@link "./release_asset.ts".GhReleaseAssetApi.uploadReleaseAsset} is the
+   * REST path, which needs a token instead.
+   */
+  releaseUpload(
+    configure?: Configure<GhReleaseUploadSettings>,
+  ): Promise<CommandOutput>;
+  /** Download a release's assets: `gh release download`. */
+  releaseDownload(
+    configure?: Configure<GhReleaseDownloadSettings>,
+  ): Promise<CommandOutput>;
+  /** Change a release: `gh release edit`. */
+  releaseEdit(
+    configure?: Configure<GhReleaseEditSettings>,
+  ): Promise<CommandOutput>;
+  /** Remove a release: `gh release delete`. */
+  releaseDelete(
+    configure?: Configure<GhReleaseDeleteSettings>,
+  ): Promise<CommandOutput>;
+}
+
+/**
+ * The implementations of {@link GhPrApi}, {@link GhIssueApi}, and
+ * {@link GhReleaseApi}, spread into {@link "./gh.ts".GhTasks}.
+ */
+export const ghGroupTasks: GhPrApi & GhIssueApi & GhReleaseApi = {
+  prCreate: (c) => runSettings(new GhPrCreateSettings(), c),
+  prList: (c) => runSettings(new GhPrListSettings(), c),
+  prListEntries: (c) => readPullRequests(c),
+  prView: (c) => runSettings(new GhPrViewSettings(), c),
+  prChecks: (c) => runSettings(new GhPrChecksSettings(), c),
+  prMerge: (c) => runSettings(new GhPrMergeSettings(), c),
+  prComment: (c) => runSettings(new GhPrCommentSettings(), c),
+  prEdit: (c) => runSettings(new GhPrEditSettings(), c),
+  prClose: (c) => runSettings(new GhPrCloseSettings(), c),
+  issueCreate: (c) => runSettings(new GhIssueCreateSettings(), c),
+  issueList: (c) => runSettings(new GhIssueListSettings(), c),
+  issueListEntries: (c) => readIssues(c),
+  issueView: (c) => runSettings(new GhIssueViewSettings(), c),
+  issueComment: (c) => runSettings(new GhIssueCommentSettings(), c),
+  issueClose: (c) => runSettings(new GhIssueCloseSettings(), c),
+  releaseCreate: (c) => runSettings(new GhReleaseCreateSettings(), c),
+  releaseList: (c) => runSettings(new GhReleaseListSettings(), c),
+  releaseListEntries: (c) => readReleases(c),
+  releaseView: (c) => runSettings(new GhReleaseViewSettings(), c),
+  releaseUpload: (c) => runSettings(new GhReleaseUploadSettings(), c),
+  releaseDownload: (c) => runSettings(new GhReleaseDownloadSettings(), c),
+  releaseEdit: (c) => runSettings(new GhReleaseEditSettings(), c),
+  releaseDelete: (c) => runSettings(new GhReleaseDeleteSettings(), c),
+};

--- a/packages/gh/src/issue.ts
+++ b/packages/gh/src/issue.ts
@@ -1,0 +1,450 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * `gh issue` — the issue commands a build drives: create, list, view,
+ * comment, and close.
+ *
+ * ```ts
+ * import { GhTasks } from "jsr:@zuke/gh";
+ * await GhTasks.issueCreate((s) => s.title("flaky test").body(details).label("bug"));
+ * await GhTasks.issueClose((s) => s.selector(42).reason("completed"));
+ * const bugs = await GhTasks.issueListEntries((s) => s.label("bug"));
+ * ```
+ *
+ * Unlike a pull request, gh has no "issue for the current branch", so every
+ * command here takes its number or URL — which is why `.selector(...)` is
+ * required rather than optional.
+ *
+ * @module
+ */
+
+import type { Configure } from "@zuke/core/tooling";
+import {
+  GhBodySettings,
+  GhCommandSettings,
+  GhWebReadSettings,
+} from "./subcommand.ts";
+import {
+  loginField,
+  numberField,
+  parseJsonArray,
+  stringField,
+} from "./json_array.ts";
+
+/** Settings for `gh issue create`. */
+export class GhIssueCreateSettings extends GhBodySettings {
+  #title?: string;
+  #assignees: string[] = [];
+  #labels: string[] = [];
+  #projects: string[] = [];
+  #milestone?: string;
+  #type?: string;
+  #parent?: string;
+  #template?: string;
+
+  /** The issue's title (`--title`). */
+  title(text: string): this {
+    this.#title = text;
+    return this;
+  }
+
+  /** Assign someone by login (`--assignee`), `@me` for yourself; repeatable. */
+  assignee(...logins: string[]): this {
+    this.#assignees.push(...logins);
+    return this;
+  }
+
+  /** Add a label by name (`--label`); repeatable. */
+  label(...names: string[]): this {
+    this.#labels.push(...names);
+    return this;
+  }
+
+  /** Add to a project by title (`--project`); repeatable. */
+  project(...titles: string[]): this {
+    this.#projects.push(...titles);
+    return this;
+  }
+
+  /** Add to a milestone by name (`--milestone`). */
+  milestone(name: string): this {
+    this.#milestone = name;
+    return this;
+  }
+
+  /** Set the issue type by name (`--type`). */
+  type(name: string): this {
+    this.#type = name;
+    return this;
+  }
+
+  /** File it as a sub-issue of this number or URL (`--parent`). */
+  parent(numberOrUrl: string | number): this {
+    this.#parent = String(numberOrUrl);
+    return this;
+  }
+
+  /** The issue template to start the body from (`--template`). */
+  templateName(name: string): this {
+    this.#template = name;
+    return this;
+  }
+
+  /** The `gh issue create` command path. */
+  protected override commandPath(): string[] {
+    return ["issue", "create"];
+  }
+
+  /** Assemble the `gh issue create` flags. */
+  protected override commandFlags(): string[] {
+    if (this.#title === undefined) {
+      throw new Error(
+        "GhTasks.issueCreate: .title(...) is required — without it gh prompts, " +
+          "and a build has no one to answer.",
+      );
+    }
+    const argv = ["--title", this.#title, ...this.bodyFlags("issueCreate")];
+    for (const login of this.#assignees) argv.push("--assignee", login);
+    for (const name of this.#labels) argv.push("--label", name);
+    for (const title of this.#projects) argv.push("--project", title);
+    if (this.#milestone !== undefined) {
+      argv.push("--milestone", this.#milestone);
+    }
+    if (this.#type !== undefined) argv.push("--type", this.#type);
+    if (this.#parent !== undefined) argv.push("--parent", this.#parent);
+    if (this.#template !== undefined) argv.push("--template", this.#template);
+    return argv;
+  }
+}
+
+/** Settings for `gh issue list`. */
+export class GhIssueListSettings extends GhWebReadSettings {
+  #state?: string;
+  #author?: string;
+  #app?: string;
+  #assignee?: string;
+  #mention?: string;
+  #milestone?: string;
+  #type?: string;
+  #labels: string[] = [];
+  #limit?: number;
+  #search?: string;
+
+  /** Filter by state (`--state`): `open`, `closed`, or `all`. */
+  state(value: "open" | "closed" | "all"): this {
+    this.#state = value;
+    return this;
+  }
+
+  /** Filter by author (`--author`). */
+  author(login: string): this {
+    this.#author = login;
+    return this;
+  }
+
+  /** Filter by the GitHub App that opened it (`--app`). */
+  app(name: string): this {
+    this.#app = name;
+    return this;
+  }
+
+  /** Filter by assignee (`--assignee`). */
+  assignee(login: string): this {
+    this.#assignee = login;
+    return this;
+  }
+
+  /** Filter by who is mentioned (`--mention`). */
+  mention(login: string): this {
+    this.#mention = login;
+    return this;
+  }
+
+  /** Filter by milestone number or title (`--milestone`). */
+  milestone(nameOrNumber: string): this {
+    this.#milestone = nameOrNumber;
+    return this;
+  }
+
+  /** Filter by issue type (`--type`). */
+  type(name: string): this {
+    this.#type = name;
+    return this;
+  }
+
+  /** Filter by label (`--label`); repeatable. */
+  label(...names: string[]): this {
+    this.#labels.push(...names);
+    return this;
+  }
+
+  /** Cap how many are fetched (`--limit`); gh's default is 30. */
+  limit(count: number): this {
+    this.#limit = count;
+    return this;
+  }
+
+  /** Filter with a search query (`--search`). */
+  search(query: string): this {
+    this.#search = query;
+    return this;
+  }
+
+  /** The `gh issue list` command path. */
+  protected override commandPath(): string[] {
+    return ["issue", "list"];
+  }
+
+  /** Assemble the `gh issue list` flags. */
+  protected override commandFlags(): string[] {
+    const argv: string[] = [];
+    if (this.#state !== undefined) argv.push("--state", this.#state);
+    if (this.#author !== undefined) argv.push("--author", this.#author);
+    if (this.#app !== undefined) argv.push("--app", this.#app);
+    if (this.#assignee !== undefined) argv.push("--assignee", this.#assignee);
+    if (this.#mention !== undefined) argv.push("--mention", this.#mention);
+    if (this.#milestone !== undefined) {
+      argv.push("--milestone", this.#milestone);
+    }
+    if (this.#type !== undefined) argv.push("--type", this.#type);
+    for (const name of this.#labels) argv.push("--label", name);
+    if (this.#search !== undefined) argv.push("--search", this.#search);
+    if (this.#limit !== undefined) argv.push("--limit", String(this.#limit));
+    argv.push(...this.readFlags());
+    return argv;
+  }
+}
+
+/** Settings for `gh issue view`. */
+export class GhIssueViewSettings extends GhWebReadSettings {
+  #selector?: string;
+  #comments = false;
+
+  /** The issue — its number or URL (required). */
+  selector(value: string | number): this {
+    this.#selector = String(value);
+    return this;
+  }
+
+  /** Include the comments (`--comments`). */
+  comments(): this {
+    this.#comments = true;
+    return this;
+  }
+
+  /** The `gh issue view` command path. */
+  protected override commandPath(): string[] {
+    if (this.#selector === undefined) {
+      throw new Error(
+        "GhTasks.issueView: .selector(...) is required — gh has no issue for " +
+          "the current branch the way it has a pull request.",
+      );
+    }
+    return ["issue", "view", this.#selector];
+  }
+
+  /** Assemble the `gh issue view` flags. */
+  protected override commandFlags(): string[] {
+    const argv: string[] = [];
+    if (this.#comments) argv.push("--comments");
+    argv.push(...this.readFlags());
+    return argv;
+  }
+}
+
+/** Settings for `gh issue comment`. */
+export class GhIssueCommentSettings extends GhBodySettings {
+  #selector?: string;
+  #editLast = false;
+  #createIfNone = false;
+  #deleteLast = false;
+  #yes = false;
+
+  /** The issue — its number or URL (required). */
+  selector(value: string | number): this {
+    this.#selector = String(value);
+    return this;
+  }
+
+  /** Edit your most recent comment instead of adding one (`--edit-last`). */
+  editLast(): this {
+    this.#editLast = true;
+    return this;
+  }
+
+  /** With {@link editLast}, post a new comment when there is none (`--create-if-none`). */
+  createIfNone(): this {
+    this.#createIfNone = true;
+    return this;
+  }
+
+  /** Delete your most recent comment (`--delete-last`). */
+  deleteLast(): this {
+    this.#deleteLast = true;
+    return this;
+  }
+
+  /** Skip the confirmation a delete otherwise prompts for (`--yes`). */
+  yes(): this {
+    this.#yes = true;
+    return this;
+  }
+
+  /** The `gh issue comment` command path. */
+  protected override commandPath(): string[] {
+    if (this.#selector === undefined) {
+      throw new Error(
+        "GhTasks.issueComment: .selector(...) is required — it names the " +
+          "issue to comment on.",
+      );
+    }
+    return ["issue", "comment", this.#selector];
+  }
+
+  /** Assemble the `gh issue comment` flags. */
+  protected override commandFlags(): string[] {
+    if (this.#deleteLast && !this.#yes) {
+      throw new Error(
+        "GhTasks.issueComment: .deleteLast() prompts for confirmation, which " +
+          "a build cannot answer — add .yes() to mean it.",
+      );
+    }
+    if (this.#createIfNone && !this.#editLast) {
+      throw new Error(
+        "GhTasks.issueComment: .createIfNone() qualifies .editLast() — add " +
+          "it, or drop .createIfNone().",
+      );
+    }
+    const argv = [...this.bodyFlags("issueComment")];
+    if (this.#editLast) argv.push("--edit-last");
+    if (this.#createIfNone) argv.push("--create-if-none");
+    if (this.#deleteLast) argv.push("--delete-last");
+    if (this.#yes) argv.push("--yes");
+    return argv;
+  }
+}
+
+/** Why an issue is being closed (`--reason`). */
+export type GhCloseReason = "completed" | "not planned" | "duplicate";
+
+/** Settings for `gh issue close`. */
+export class GhIssueCloseSettings extends GhCommandSettings {
+  #selector?: string;
+  #comment?: string;
+  #reason?: GhCloseReason;
+  #duplicateOf?: string;
+
+  /** The issue — its number or URL (required). */
+  selector(value: string | number): this {
+    this.#selector = String(value);
+    return this;
+  }
+
+  /** Leave a closing comment (`--comment`). */
+  comment(text: string): this {
+    this.#comment = text;
+    return this;
+  }
+
+  /** Why it is closed (`--reason`). */
+  reason(value: GhCloseReason): this {
+    this.#reason = value;
+    return this;
+  }
+
+  /** Which issue it duplicates (`--duplicate-of`), by number or URL. */
+  duplicateOf(numberOrUrl: string | number): this {
+    this.#duplicateOf = String(numberOrUrl);
+    return this;
+  }
+
+  /** The `gh issue close` command path. */
+  protected override commandPath(): string[] {
+    if (this.#selector === undefined) {
+      throw new Error(
+        "GhTasks.issueClose: .selector(...) is required — it names the issue " +
+          "to close.",
+      );
+    }
+    return ["issue", "close", this.#selector];
+  }
+
+  /** Assemble the `gh issue close` flags. */
+  protected override commandFlags(): string[] {
+    if (this.#duplicateOf !== undefined && this.#reason !== "duplicate") {
+      throw new Error(
+        'GhTasks.issueClose: .duplicateOf(...) goes with .reason("duplicate") ' +
+          "— set that reason, or drop it.",
+      );
+    }
+    const argv: string[] = [];
+    if (this.#comment !== undefined) argv.push("--comment", this.#comment);
+    if (this.#reason !== undefined) argv.push("--reason", this.#reason);
+    if (this.#duplicateOf !== undefined) {
+      argv.push("--duplicate-of", this.#duplicateOf);
+    }
+    return argv;
+  }
+}
+
+/** One issue of {@link "./gh.ts".GhTasks.issueListEntries}. */
+export interface GhIssueEntry {
+  /** The issue's number. */
+  number?: number;
+  /** Its title. */
+  title?: string;
+  /** Its state, as gh reports it: `OPEN` or `CLOSED`. */
+  state?: string;
+  /** Its web URL. */
+  url?: string;
+  /** The login of whoever opened it. */
+  author?: string;
+}
+
+/**
+ * The `--json` fields {@link readIssues} asks for; gh requires the list by
+ * name, so the reader pins the set {@link GhIssueEntry} describes.
+ */
+export const ISSUE_LIST_FIELDS: readonly string[] = [
+  "number",
+  "title",
+  "state",
+  "url",
+  "author",
+];
+
+/**
+ * Parse `gh issue list --json …` into entries.
+ *
+ * Not part of the package's public surface — exported for its unit test.
+ */
+export function parseIssues(stdout: string): GhIssueEntry[] {
+  return parseJsonArray(stdout).map((record) => {
+    const entry: GhIssueEntry = {};
+    const number = numberField(record, "number");
+    const title = stringField(record, "title");
+    const state = stringField(record, "state");
+    const url = stringField(record, "url");
+    const author = loginField(record, "author");
+    if (number !== undefined) entry.number = number;
+    if (title !== undefined) entry.title = title;
+    if (state !== undefined) entry.state = state;
+    if (url !== undefined) entry.url = url;
+    if (author !== undefined) entry.author = author;
+    return entry;
+  });
+}
+
+/**
+ * Run `gh issue list --json …` and parse it. Backs
+ * {@link "./gh.ts".GhTasks.issueListEntries}.
+ */
+export async function readIssues(
+  configure?: Configure<GhIssueListSettings>,
+): Promise<GhIssueEntry[]> {
+  const settings = new GhIssueListSettings();
+  const configured = configure ? configure(settings) : settings;
+  const output = await configured.json(...ISSUE_LIST_FIELDS).run();
+  return parseIssues(output.stdout);
+}

--- a/packages/gh/src/json_array.ts
+++ b/packages/gh/src/json_array.ts
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Reading the JSON array gh's `--json` prints.
+ *
+ * Internal to the package: not exported from `mod.ts`. Every `gh … list`
+ * answers with an array of objects when given `--json`, so the
+ * value-returning tasks share one reading of it — and one decision about what
+ * an unexpected payload means, which is "nothing to report" rather than a
+ * thrown error, because gh prints `[]` for an empty listing and a plain
+ * message when it has something else to say.
+ *
+ * @module
+ */
+
+/** A JSON object, with every value still unknown until it is narrowed. */
+export type JsonRecord = Record<string, unknown>;
+
+/** Whether `value` is a JSON object rather than an array, a scalar, or null. */
+export function isJsonRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Parse gh's `--json` output into records. A payload that is not an array of
+ * objects yields none: gh prints `[]` when a listing is empty, and prose when
+ * it is reporting something other than data.
+ */
+export function parseJsonArray(stdout: string): JsonRecord[] {
+  const text = stdout.trim();
+  if (text === "") return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  return parsed.filter(isJsonRecord);
+}
+
+/** The string at `key`, or `undefined` when it is absent or not a string. */
+export function stringField(
+  record: JsonRecord,
+  key: string,
+): string | undefined {
+  const value = record[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+/** The number at `key`, or `undefined` when it is absent or not a number. */
+export function numberField(
+  record: JsonRecord,
+  key: string,
+): number | undefined {
+  const value = record[key];
+  return typeof value === "number" ? value : undefined;
+}
+
+/** The boolean at `key`, or `undefined` when it is absent or not a boolean. */
+export function booleanField(
+  record: JsonRecord,
+  key: string,
+): boolean | undefined {
+  const value = record[key];
+  return typeof value === "boolean" ? value : undefined;
+}
+
+/**
+ * The `login` of a nested user object, as gh nests an author or an assignee —
+ * `{"author":{"login":"someone"}}`.
+ */
+export function loginField(
+  record: JsonRecord,
+  key: string,
+): string | undefined {
+  const value = record[key];
+  return isJsonRecord(value) ? stringField(value, "login") : undefined;
+}

--- a/packages/gh/src/pr.ts
+++ b/packages/gh/src/pr.ts
@@ -1,0 +1,830 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * `gh pr` — the pull-request commands a build drives: create, list, view,
+ * merge, checks, comment, edit, and close.
+ *
+ * ```ts
+ * import { GhTasks } from "jsr:@zuke/gh";
+ * await GhTasks.prMerge((s) => s.selector("123").squash().deleteBranch());
+ * const open = await GhTasks.prListEntries((s) => s.state("open"));
+ * ```
+ *
+ * Every flag here is gh's own, taken from its manual. Where a command takes a
+ * pull request, gh accepts a number, a URL, or a branch name, and falls back
+ * to the PR for the current branch when none is given — so `.selector(...)` is
+ * optional on those, exactly as on the command line.
+ *
+ * {@link "./gh.ts".GhTasks.pullRequest} remains the REST path for *creating*
+ * one: it needs a token but no `gh` binary, where {@link GhPrCreateSettings}
+ * needs `gh` and its own auth. Reach for whichever the build already has.
+ *
+ * @module
+ */
+
+import type { Configure } from "@zuke/core/tooling";
+import {
+  GhBodySettings,
+  GhCommandSettings,
+  GhWebReadSettings,
+} from "./subcommand.ts";
+import {
+  booleanField,
+  loginField,
+  numberField,
+  parseJsonArray,
+  stringField,
+} from "./json_array.ts";
+
+/**
+ * The operand naming the pull request, when one was given. gh falls back to
+ * the PR for the current branch, so an unset selector renders nothing rather
+ * than an empty argument.
+ */
+function selectorOperand(selector: string | undefined): string[] {
+  return selector === undefined ? [] : [selector];
+}
+
+/**
+ * Base for the `pr` commands that take a pull request and post text —
+ * `merge`, `comment`, and `edit` — so the operand and the `--body` pair have
+ * one implementation across them.
+ */
+export abstract class GhPrTargetSettings extends GhBodySettings {
+  #selector?: string;
+
+  /**
+   * The pull request — its number, URL, or branch name. Omit it to act on the
+   * PR for the current branch, as gh does.
+   */
+  selector(value: string | number): this {
+    this.#selector = String(value);
+    return this;
+  }
+
+  /** The operand, when one was given. */
+  protected selectorArgs(): string[] {
+    return selectorOperand(this.#selector);
+  }
+}
+
+/** Settings for `gh pr create`. */
+export class GhPrCreateSettings extends GhBodySettings {
+  #title?: string;
+  #base?: string;
+  #head?: string;
+  #assignees: string[] = [];
+  #labels: string[] = [];
+  #reviewers: string[] = [];
+  #milestone?: string;
+  #projects: string[] = [];
+  #draft = false;
+  #fill = false;
+  #fillFirst = false;
+  #fillVerbose = false;
+  #dryRun = false;
+  #noMaintainerEdit = false;
+  #template?: string;
+
+  /** The pull request's title (`--title`). */
+  title(text: string): this {
+    this.#title = text;
+    return this;
+  }
+
+  /** The branch to merge into (`--base`). */
+  base(branch: string): this {
+    this.#base = branch;
+    return this;
+  }
+
+  /** The branch holding the commits (`--head`). */
+  head(branch: string): this {
+    this.#head = branch;
+    return this;
+  }
+
+  /** Assign someone by login (`--assignee`), `@me` for yourself; repeatable. */
+  assignee(...logins: string[]): this {
+    this.#assignees.push(...logins);
+    return this;
+  }
+
+  /** Add a label by name (`--label`); repeatable. */
+  label(...names: string[]): this {
+    this.#labels.push(...names);
+    return this;
+  }
+
+  /** Request a review from a person or team (`--reviewer`); repeatable. */
+  reviewer(...handles: string[]): this {
+    this.#reviewers.push(...handles);
+    return this;
+  }
+
+  /** Add to a milestone by name (`--milestone`). */
+  milestone(name: string): this {
+    this.#milestone = name;
+    return this;
+  }
+
+  /** Add to a project by title (`--project`); repeatable. */
+  project(...titles: string[]): this {
+    this.#projects.push(...titles);
+    return this;
+  }
+
+  /** Open it as a draft (`--draft`). */
+  draft(): this {
+    this.#draft = true;
+    return this;
+  }
+
+  /** Take the title and body from the commits (`--fill`). */
+  fill(): this {
+    this.#fill = true;
+    return this;
+  }
+
+  /** Take them from the first commit only (`--fill-first`). */
+  fillFirst(): this {
+    this.#fillFirst = true;
+    return this;
+  }
+
+  /** Take the body from every commit's message (`--fill-verbose`). */
+  fillVerbose(): this {
+    this.#fillVerbose = true;
+    return this;
+  }
+
+  /** Print what would be created without creating it (`--dry-run`). */
+  dryRun(): this {
+    this.#dryRun = true;
+    return this;
+  }
+
+  /** Refuse maintainer edits to the branch (`--no-maintainer-edit`). */
+  noMaintainerEdit(): this {
+    this.#noMaintainerEdit = true;
+    return this;
+  }
+
+  /** A template file to seed the body from (`--template`). */
+  templateFile(path: string): this {
+    this.#template = path;
+    return this;
+  }
+
+  /** The `gh pr create` command path. */
+  protected override commandPath(): string[] {
+    return ["pr", "create"];
+  }
+
+  /** Assemble the `gh pr create` flags. */
+  protected override commandFlags(): string[] {
+    const fills = [this.#fill, this.#fillFirst, this.#fillVerbose]
+      .filter(Boolean).length;
+    if (fills > 1) {
+      throw new Error(
+        "GhTasks.prCreate: .fill(), .fillFirst(), and .fillVerbose() are " +
+          "three ways to take the same text from the commits — pick one.",
+      );
+    }
+    const argv: string[] = [];
+    if (this.#title !== undefined) argv.push("--title", this.#title);
+    argv.push(...this.bodyFlags("prCreate"));
+    if (this.#base !== undefined) argv.push("--base", this.#base);
+    if (this.#head !== undefined) argv.push("--head", this.#head);
+    if (this.#draft) argv.push("--draft");
+    if (this.#fill) argv.push("--fill");
+    if (this.#fillFirst) argv.push("--fill-first");
+    if (this.#fillVerbose) argv.push("--fill-verbose");
+    if (this.#dryRun) argv.push("--dry-run");
+    if (this.#noMaintainerEdit) argv.push("--no-maintainer-edit");
+    for (const login of this.#assignees) argv.push("--assignee", login);
+    for (const name of this.#labels) argv.push("--label", name);
+    for (const handle of this.#reviewers) argv.push("--reviewer", handle);
+    for (const title of this.#projects) argv.push("--project", title);
+    if (this.#milestone !== undefined) {
+      argv.push("--milestone", this.#milestone);
+    }
+    if (this.#template !== undefined) argv.push("--template", this.#template);
+    return argv;
+  }
+}
+
+/** Settings for `gh pr list`. */
+export class GhPrListSettings extends GhWebReadSettings {
+  #state?: string;
+  #base?: string;
+  #head?: string;
+  #author?: string;
+  #app?: string;
+  #assignee?: string;
+  #labels: string[] = [];
+  #limit?: number;
+  #search?: string;
+  #draft = false;
+
+  /** Filter by state (`--state`): `open`, `closed`, `merged`, or `all`. */
+  state(value: "open" | "closed" | "merged" | "all"): this {
+    this.#state = value;
+    return this;
+  }
+
+  /** Filter by base branch (`--base`). */
+  base(branch: string): this {
+    this.#base = branch;
+    return this;
+  }
+
+  /** Filter by head branch (`--head`). */
+  head(branch: string): this {
+    this.#head = branch;
+    return this;
+  }
+
+  /** Filter by author (`--author`). */
+  author(login: string): this {
+    this.#author = login;
+    return this;
+  }
+
+  /** Filter by the GitHub App that opened it (`--app`). */
+  app(name: string): this {
+    this.#app = name;
+    return this;
+  }
+
+  /** Filter by assignee (`--assignee`). */
+  assignee(login: string): this {
+    this.#assignee = login;
+    return this;
+  }
+
+  /** Filter by label (`--label`); repeatable. */
+  label(...names: string[]): this {
+    this.#labels.push(...names);
+    return this;
+  }
+
+  /** Cap how many are fetched (`--limit`); gh's default is 30. */
+  limit(count: number): this {
+    this.#limit = count;
+    return this;
+  }
+
+  /** Filter with a search query (`--search`). */
+  search(query: string): this {
+    this.#search = query;
+    return this;
+  }
+
+  /** Only draft pull requests (`--draft`). */
+  draft(): this {
+    this.#draft = true;
+    return this;
+  }
+
+  /** The `gh pr list` command path. */
+  protected override commandPath(): string[] {
+    return ["pr", "list"];
+  }
+
+  /** Assemble the `gh pr list` flags. */
+  protected override commandFlags(): string[] {
+    const argv: string[] = [];
+    if (this.#state !== undefined) argv.push("--state", this.#state);
+    if (this.#base !== undefined) argv.push("--base", this.#base);
+    if (this.#head !== undefined) argv.push("--head", this.#head);
+    if (this.#author !== undefined) argv.push("--author", this.#author);
+    if (this.#app !== undefined) argv.push("--app", this.#app);
+    if (this.#assignee !== undefined) argv.push("--assignee", this.#assignee);
+    for (const name of this.#labels) argv.push("--label", name);
+    if (this.#search !== undefined) argv.push("--search", this.#search);
+    if (this.#draft) argv.push("--draft");
+    if (this.#limit !== undefined) argv.push("--limit", String(this.#limit));
+    argv.push(...this.readFlags());
+    return argv;
+  }
+}
+
+/**
+ * Base for the `pr` commands that read one pull request and can print JSON —
+ * `view` and `checks` — so the operand has one implementation across them.
+ */
+export abstract class GhPrReadSettings extends GhWebReadSettings {
+  #selector?: string;
+
+  /** The pull request — number, URL, or branch; defaults to the current branch's. */
+  selector(value: string | number): this {
+    this.#selector = String(value);
+    return this;
+  }
+
+  /** The operand, when one was given. */
+  protected selectorArgs(): string[] {
+    return selectorOperand(this.#selector);
+  }
+}
+
+/** Settings for `gh pr view`. */
+export class GhPrViewSettings extends GhPrReadSettings {
+  #comments = false;
+
+  /** Include the comments (`--comments`). */
+  comments(): this {
+    this.#comments = true;
+    return this;
+  }
+
+  /** The `gh pr view` command path. */
+  protected override commandPath(): string[] {
+    return ["pr", "view", ...this.selectorArgs()];
+  }
+
+  /** Assemble the `gh pr view` flags. */
+  protected override commandFlags(): string[] {
+    const argv: string[] = [];
+    if (this.#comments) argv.push("--comments");
+    argv.push(...this.readFlags());
+    return argv;
+  }
+}
+
+/** Settings for `gh pr checks`. */
+export class GhPrChecksSettings extends GhPrReadSettings {
+  #watch = false;
+  #failFast = false;
+  #required = false;
+  #interval?: number;
+
+  /**
+   * Keep watching until the checks finish (`--watch`). A target that watches
+   * blocks until CI is done, so pair it with `.killAfter(...)` unless the wait
+   * is the point.
+   */
+  watch(): this {
+    this.#watch = true;
+    return this;
+  }
+
+  /** Stop watching at the first failure (`--fail-fast`). */
+  failFast(): this {
+    this.#failFast = true;
+    return this;
+  }
+
+  /** Only the checks marked required (`--required`). */
+  required(): this {
+    this.#required = true;
+    return this;
+  }
+
+  /** How often to refresh while watching (`--interval`), in seconds. */
+  interval(seconds: number): this {
+    this.#interval = seconds;
+    return this;
+  }
+
+  /** The `gh pr checks` command path. */
+  protected override commandPath(): string[] {
+    return ["pr", "checks", ...this.selectorArgs()];
+  }
+
+  /**
+   * Assemble the `gh pr checks` flags, refusing the flags that only mean
+   * something while watching — gh ignores them otherwise, which would leave a
+   * build believing it had asked for something it had not.
+   */
+  protected override commandFlags(): string[] {
+    if (!this.#watch && (this.#failFast || this.#interval !== undefined)) {
+      throw new Error(
+        "GhTasks.prChecks: .failFast()/.interval(...) describe how to watch, " +
+          "which a single check run does not do — add .watch(), or drop them.",
+      );
+    }
+    const argv: string[] = [];
+    if (this.#watch) argv.push("--watch");
+    if (this.#failFast) argv.push("--fail-fast");
+    if (this.#required) argv.push("--required");
+    if (this.#interval !== undefined) {
+      argv.push("--interval", String(this.#interval));
+    }
+    argv.push(...this.readFlags());
+    return argv;
+  }
+}
+
+/** How `gh pr merge` combines the commits. */
+export type GhMergeMethod = "merge" | "squash" | "rebase";
+
+/** Settings for `gh pr merge`. */
+export class GhPrMergeSettings extends GhPrTargetSettings {
+  #method?: GhMergeMethod;
+  #auto = false;
+  #disableAuto = false;
+  #admin = false;
+  #deleteBranch = false;
+  #subject?: string;
+  #authorEmail?: string;
+  #matchHeadCommit?: string;
+
+  /** Merge with a merge commit (`--merge`). */
+  merge(): this {
+    this.#method = "merge";
+    return this;
+  }
+
+  /** Squash the commits into one (`--squash`). */
+  squash(): this {
+    this.#method = "squash";
+    return this;
+  }
+
+  /** Rebase the commits onto the base (`--rebase`). */
+  rebase(): this {
+    this.#method = "rebase";
+    return this;
+  }
+
+  /** Merge once the requirements are met (`--auto`). */
+  auto(): this {
+    this.#auto = true;
+    return this;
+  }
+
+  /** Turn auto-merge off again (`--disable-auto`). */
+  disableAuto(): this {
+    this.#disableAuto = true;
+    return this;
+  }
+
+  /** Merge with administrator privileges (`--admin`). */
+  admin(): this {
+    this.#admin = true;
+    return this;
+  }
+
+  /** Delete the branch afterwards (`--delete-branch`). */
+  deleteBranch(): this {
+    this.#deleteBranch = true;
+    return this;
+  }
+
+  /** The merge commit's subject (`--subject`). */
+  subject(text: string): this {
+    this.#subject = text;
+    return this;
+  }
+
+  /** The merge commit's author email (`--author-email`). */
+  authorEmail(address: string): this {
+    this.#authorEmail = address;
+    return this;
+  }
+
+  /**
+   * Refuse the merge unless the head is still this commit
+   * (`--match-head-commit`) — the guard against merging a PR that moved
+   * between the check and the merge.
+   */
+  matchHeadCommit(sha: string): this {
+    this.#matchHeadCommit = sha;
+    return this;
+  }
+
+  /** The `gh pr merge` command path. */
+  protected override commandPath(): string[] {
+    return ["pr", "merge", ...this.selectorArgs()];
+  }
+
+  /** Assemble the `gh pr merge` flags. */
+  protected override commandFlags(): string[] {
+    if (this.#auto && this.#disableAuto) {
+      throw new Error(
+        "GhTasks.prMerge: .auto() enables auto-merge and .disableAuto() turns " +
+          "it off — pick one.",
+      );
+    }
+    const argv: string[] = [];
+    if (this.#method !== undefined) argv.push(`--${this.#method}`);
+    if (this.#auto) argv.push("--auto");
+    if (this.#disableAuto) argv.push("--disable-auto");
+    if (this.#admin) argv.push("--admin");
+    if (this.#deleteBranch) argv.push("--delete-branch");
+    if (this.#subject !== undefined) argv.push("--subject", this.#subject);
+    argv.push(...this.bodyFlags("prMerge"));
+    if (this.#authorEmail !== undefined) {
+      argv.push("--author-email", this.#authorEmail);
+    }
+    if (this.#matchHeadCommit !== undefined) {
+      argv.push("--match-head-commit", this.#matchHeadCommit);
+    }
+    return argv;
+  }
+}
+
+/** Settings for `gh pr comment`. */
+export class GhPrCommentSettings extends GhPrTargetSettings {
+  #editLast = false;
+  #createIfNone = false;
+  #deleteLast = false;
+  #yes = false;
+
+  /** Edit your most recent comment instead of adding one (`--edit-last`). */
+  editLast(): this {
+    this.#editLast = true;
+    return this;
+  }
+
+  /** With {@link editLast}, post a new comment when there is none (`--create-if-none`). */
+  createIfNone(): this {
+    this.#createIfNone = true;
+    return this;
+  }
+
+  /** Delete your most recent comment (`--delete-last`). */
+  deleteLast(): this {
+    this.#deleteLast = true;
+    return this;
+  }
+
+  /** Skip the confirmation a delete otherwise prompts for (`--yes`). */
+  yes(): this {
+    this.#yes = true;
+    return this;
+  }
+
+  /** The `gh pr comment` command path. */
+  protected override commandPath(): string[] {
+    return ["pr", "comment", ...this.selectorArgs()];
+  }
+
+  /** Assemble the `gh pr comment` flags. */
+  protected override commandFlags(): string[] {
+    if (this.#deleteLast && !this.#yes) {
+      throw new Error(
+        "GhTasks.prComment: .deleteLast() prompts for confirmation, which a " +
+          "build cannot answer — add .yes() to mean it.",
+      );
+    }
+    if (this.#createIfNone && !this.#editLast) {
+      throw new Error(
+        "GhTasks.prComment: .createIfNone() qualifies .editLast() — add it, " +
+          "or drop .createIfNone().",
+      );
+    }
+    const argv = [...this.bodyFlags("prComment")];
+    if (this.#editLast) argv.push("--edit-last");
+    if (this.#createIfNone) argv.push("--create-if-none");
+    if (this.#deleteLast) argv.push("--delete-last");
+    if (this.#yes) argv.push("--yes");
+    return argv;
+  }
+}
+
+/** Settings for `gh pr edit`. */
+export class GhPrEditSettings extends GhPrTargetSettings {
+  #title?: string;
+  #base?: string;
+  #addLabels: string[] = [];
+  #removeLabels: string[] = [];
+  #addAssignees: string[] = [];
+  #removeAssignees: string[] = [];
+  #addReviewers: string[] = [];
+  #removeReviewers: string[] = [];
+  #addProjects: string[] = [];
+  #removeProjects: string[] = [];
+  #milestone?: string;
+  #removeMilestone = false;
+
+  /** Set the title (`--title`). */
+  title(text: string): this {
+    this.#title = text;
+    return this;
+  }
+
+  /** Change the base branch (`--base`). */
+  base(branch: string): this {
+    this.#base = branch;
+    return this;
+  }
+
+  /** Add a label (`--add-label`); repeatable. */
+  addLabel(...names: string[]): this {
+    this.#addLabels.push(...names);
+    return this;
+  }
+
+  /** Remove a label (`--remove-label`); repeatable. */
+  removeLabel(...names: string[]): this {
+    this.#removeLabels.push(...names);
+    return this;
+  }
+
+  /** Add an assignee (`--add-assignee`); repeatable. */
+  addAssignee(...logins: string[]): this {
+    this.#addAssignees.push(...logins);
+    return this;
+  }
+
+  /** Remove an assignee (`--remove-assignee`); repeatable. */
+  removeAssignee(...logins: string[]): this {
+    this.#removeAssignees.push(...logins);
+    return this;
+  }
+
+  /** Request a review (`--add-reviewer`); repeatable. */
+  addReviewer(...handles: string[]): this {
+    this.#addReviewers.push(...handles);
+    return this;
+  }
+
+  /** Drop a review request (`--remove-reviewer`); repeatable. */
+  removeReviewer(...handles: string[]): this {
+    this.#removeReviewers.push(...handles);
+    return this;
+  }
+
+  /** Add to a project by title (`--add-project`); repeatable. */
+  addProject(...titles: string[]): this {
+    this.#addProjects.push(...titles);
+    return this;
+  }
+
+  /** Take it off a project by title (`--remove-project`); repeatable. */
+  removeProject(...titles: string[]): this {
+    this.#removeProjects.push(...titles);
+    return this;
+  }
+
+  /** Set the milestone (`--milestone`). */
+  milestone(name: string): this {
+    this.#milestone = name;
+    return this;
+  }
+
+  /** Clear the milestone (`--remove-milestone`). */
+  removeMilestone(): this {
+    this.#removeMilestone = true;
+    return this;
+  }
+
+  /** The `gh pr edit` command path. */
+  protected override commandPath(): string[] {
+    return ["pr", "edit", ...this.selectorArgs()];
+  }
+
+  /** Assemble the `gh pr edit` flags. */
+  protected override commandFlags(): string[] {
+    if (this.#milestone !== undefined && this.#removeMilestone) {
+      throw new Error(
+        "GhTasks.prEdit: .milestone(...) sets one and .removeMilestone() " +
+          "clears it — pick one.",
+      );
+    }
+    const argv: string[] = [];
+    if (this.#title !== undefined) argv.push("--title", this.#title);
+    argv.push(...this.bodyFlags("prEdit"));
+    if (this.#base !== undefined) argv.push("--base", this.#base);
+    for (const name of this.#addLabels) argv.push("--add-label", name);
+    for (const name of this.#removeLabels) argv.push("--remove-label", name);
+    for (const login of this.#addAssignees) argv.push("--add-assignee", login);
+    for (const login of this.#removeAssignees) {
+      argv.push("--remove-assignee", login);
+    }
+    for (const handle of this.#addReviewers) {
+      argv.push("--add-reviewer", handle);
+    }
+    for (const handle of this.#removeReviewers) {
+      argv.push("--remove-reviewer", handle);
+    }
+    for (const title of this.#addProjects) argv.push("--add-project", title);
+    for (const title of this.#removeProjects) {
+      argv.push("--remove-project", title);
+    }
+    if (this.#milestone !== undefined) {
+      argv.push("--milestone", this.#milestone);
+    }
+    if (this.#removeMilestone) argv.push("--remove-milestone");
+    return argv;
+  }
+}
+
+/** Settings for `gh pr close`. */
+export class GhPrCloseSettings extends GhCommandSettings {
+  #selector?: string;
+  #comment?: string;
+  #deleteBranch = false;
+
+  /** The pull request — number, URL, or branch; defaults to the current branch's. */
+  selector(value: string | number): this {
+    this.#selector = String(value);
+    return this;
+  }
+
+  /** Leave a closing comment (`--comment`). */
+  comment(text: string): this {
+    this.#comment = text;
+    return this;
+  }
+
+  /** Delete the branch afterwards (`--delete-branch`). */
+  deleteBranch(): this {
+    this.#deleteBranch = true;
+    return this;
+  }
+
+  /** The `gh pr close` command path. */
+  protected override commandPath(): string[] {
+    return ["pr", "close", ...selectorOperand(this.#selector)];
+  }
+
+  /** Assemble the `gh pr close` flags. */
+  protected override commandFlags(): string[] {
+    const argv: string[] = [];
+    if (this.#comment !== undefined) argv.push("--comment", this.#comment);
+    if (this.#deleteBranch) argv.push("--delete-branch");
+    return argv;
+  }
+}
+
+/** One pull request of {@link "./gh.ts".GhTasks.prListEntries}. */
+export interface GhPullRequestEntry {
+  /** The pull request's number. */
+  number?: number;
+  /** Its title. */
+  title?: string;
+  /** Its state, as gh reports it: `OPEN`, `CLOSED`, or `MERGED`. */
+  state?: string;
+  /** Whether it is still a draft. */
+  isDraft?: boolean;
+  /** The branch the changes are on. */
+  headRefName?: string;
+  /** The branch they would merge into. */
+  baseRefName?: string;
+  /** Its web URL. */
+  url?: string;
+  /** The login of whoever opened it. */
+  author?: string;
+}
+
+/**
+ * The `--json` fields {@link readPullRequests} asks for. gh requires the list
+ * by name — there is no "everything" form — so the reader pins the set its
+ * {@link GhPullRequestEntry} describes.
+ */
+export const PR_LIST_FIELDS: readonly string[] = [
+  "number",
+  "title",
+  "state",
+  "isDraft",
+  "headRefName",
+  "baseRefName",
+  "url",
+  "author",
+];
+
+/**
+ * Parse `gh pr list --json …` into entries.
+ *
+ * Not part of the package's public surface — exported for its unit test.
+ */
+export function parsePullRequests(stdout: string): GhPullRequestEntry[] {
+  return parseJsonArray(stdout).map((record) => {
+    const entry: GhPullRequestEntry = {};
+    const number = numberField(record, "number");
+    const title = stringField(record, "title");
+    const state = stringField(record, "state");
+    const isDraft = booleanField(record, "isDraft");
+    const head = stringField(record, "headRefName");
+    const base = stringField(record, "baseRefName");
+    const url = stringField(record, "url");
+    const author = loginField(record, "author");
+    if (number !== undefined) entry.number = number;
+    if (title !== undefined) entry.title = title;
+    if (state !== undefined) entry.state = state;
+    if (isDraft !== undefined) entry.isDraft = isDraft;
+    if (head !== undefined) entry.headRefName = head;
+    if (base !== undefined) entry.baseRefName = base;
+    if (url !== undefined) entry.url = url;
+    if (author !== undefined) entry.author = author;
+    return entry;
+  });
+}
+
+/**
+ * Run `gh pr list --json …` and parse it. Backs
+ * {@link "./gh.ts".GhTasks.prListEntries}.
+ */
+export async function readPullRequests(
+  configure?: Configure<GhPrListSettings>,
+): Promise<GhPullRequestEntry[]> {
+  const settings = new GhPrListSettings();
+  const configured = configure ? configure(settings) : settings;
+  const output = await configured.json(...PR_LIST_FIELDS).run();
+  return parsePullRequests(output.stdout);
+}

--- a/packages/gh/src/release.ts
+++ b/packages/gh/src/release.ts
@@ -1,0 +1,621 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * `gh release` — publishing and reading releases: create, list, view, upload,
+ * download, edit, and delete.
+ *
+ * ```ts
+ * import { GhTasks } from "jsr:@zuke/gh";
+ * await GhTasks.releaseCreate((s) => s.tag("v1.2.3").generateNotes().latest());
+ * await GhTasks.releaseUpload((s) => s.tag("v1.2.3").files("dist/app.tgz").clobber());
+ * const published = await GhTasks.releaseListEntries((s) => s.excludeDrafts());
+ * ```
+ *
+ * {@link "./gh.ts".GhTasks.uploadReleaseAsset} and
+ * {@link "./gh.ts".GhTasks.markReleaseLatest} remain the REST paths for two of
+ * these: they need a token but no `gh` binary, where these need `gh` and its
+ * own auth. Reach for whichever the build already has.
+ *
+ * @module
+ */
+
+import type { Configure, PathLike } from "@zuke/core/tooling";
+import {
+  GhCommandSettings,
+  GhReadSettings,
+  GhWebReadSettings,
+} from "./subcommand.ts";
+import { booleanField, parseJsonArray, stringField } from "./json_array.ts";
+
+/** Settings for `gh release create`. */
+export class GhReleaseCreateSettings extends GhCommandSettings {
+  #tag?: string;
+  #files: string[] = [];
+  #title?: string;
+  #notes?: string;
+  #notesFile?: string;
+  #notesStartTag?: string;
+  #notesFromTag = false;
+  #generateNotes = false;
+  #draft = false;
+  #prerelease = false;
+  #latest = false;
+  #target?: string;
+  #discussionCategory?: string;
+  #verifyTag = false;
+  #failOnNoCommits = false;
+
+  /** The tag to release (required); gh creates it when it does not exist. */
+  tag(name: string): this {
+    this.#tag = name;
+    return this;
+  }
+
+  /**
+   * Asset files to attach (positional); repeatable. gh reads a `#label`
+   * suffix on a path as the asset's display label.
+   */
+  files(...paths: PathLike[]): this {
+    this.#files.push(...paths.map(String));
+    return this;
+  }
+
+  /** The release title (`--title`). */
+  title(text: string): this {
+    this.#title = text;
+    return this;
+  }
+
+  /** The release notes (`--notes`). */
+  notes(text: string): this {
+    this.#notes = text;
+    return this;
+  }
+
+  /** Read the notes from a file (`--notes-file`); `-` reads standard input. */
+  notesFile(path: PathLike): this {
+    this.#notesFile = String(path);
+    return this;
+  }
+
+  /** Have GitHub write the title and notes (`--generate-notes`). */
+  generateNotes(): this {
+    this.#generateNotes = true;
+    return this;
+  }
+
+  /** Take the notes from the tag's annotation (`--notes-from-tag`). */
+  notesFromTag(): this {
+    this.#notesFromTag = true;
+    return this;
+  }
+
+  /** Generate notes starting from this tag (`--notes-start-tag`). */
+  notesStartTag(name: string): this {
+    this.#notesStartTag = name;
+    return this;
+  }
+
+  /** Save it as a draft rather than publishing (`--draft`). */
+  draft(): this {
+    this.#draft = true;
+    return this;
+  }
+
+  /** Mark it a prerelease (`--prerelease`). */
+  prerelease(): this {
+    this.#prerelease = true;
+    return this;
+  }
+
+  /** Mark it the latest release (`--latest`). */
+  latest(): this {
+    this.#latest = true;
+    return this;
+  }
+
+  /** The branch or commit to tag (`--target`). */
+  target(branchOrSha: string): this {
+    this.#target = branchOrSha;
+    return this;
+  }
+
+  /** Open a discussion in this category (`--discussion-category`). */
+  discussionCategory(name: string): this {
+    this.#discussionCategory = name;
+    return this;
+  }
+
+  /** Abort unless the tag already exists on the remote (`--verify-tag`). */
+  verifyTag(): this {
+    this.#verifyTag = true;
+    return this;
+  }
+
+  /** Fail when there are no commits since the last release (`--fail-on-no-commits`). */
+  failOnNoCommits(): this {
+    this.#failOnNoCommits = true;
+    return this;
+  }
+
+  /** The `gh release create` command path, with the tag and any assets. */
+  protected override commandPath(): string[] {
+    if (this.#tag === undefined) {
+      throw new Error("GhTasks.releaseCreate: .tag(...) is required.");
+    }
+    return ["release", "create", this.#tag, ...this.#files];
+  }
+
+  /** Assemble the `gh release create` flags. */
+  protected override commandFlags(): string[] {
+    if (this.#notes !== undefined && this.#notesFile !== undefined) {
+      throw new Error(
+        "GhTasks.releaseCreate: .notes(...) and .notesFile(...) are two " +
+          "sources for the same text — pick one.",
+      );
+    }
+    if (this.#draft && this.#latest) {
+      throw new Error(
+        "GhTasks.releaseCreate: a draft is not published, so it cannot also " +
+          "be the latest release — drop one.",
+      );
+    }
+    const argv: string[] = [];
+    if (this.#title !== undefined) argv.push("--title", this.#title);
+    if (this.#notes !== undefined) argv.push("--notes", this.#notes);
+    if (this.#notesFile !== undefined) {
+      argv.push("--notes-file", this.#notesFile);
+    }
+    if (this.#generateNotes) argv.push("--generate-notes");
+    if (this.#notesFromTag) argv.push("--notes-from-tag");
+    if (this.#notesStartTag !== undefined) {
+      argv.push("--notes-start-tag", this.#notesStartTag);
+    }
+    if (this.#draft) argv.push("--draft");
+    if (this.#prerelease) argv.push("--prerelease");
+    if (this.#latest) argv.push("--latest");
+    if (this.#target !== undefined) argv.push("--target", this.#target);
+    if (this.#discussionCategory !== undefined) {
+      argv.push("--discussion-category", this.#discussionCategory);
+    }
+    if (this.#verifyTag) argv.push("--verify-tag");
+    if (this.#failOnNoCommits) argv.push("--fail-on-no-commits");
+    return argv;
+  }
+}
+
+/** Settings for `gh release list`. */
+export class GhReleaseListSettings extends GhReadSettings {
+  #limit?: number;
+  #order?: string;
+  #excludeDrafts = false;
+  #excludePreReleases = false;
+
+  /** Cap how many are fetched (`--limit`); gh's default is 30. */
+  limit(count: number): this {
+    this.#limit = count;
+    return this;
+  }
+
+  /** The order they come back in (`--order`): `asc` or `desc`. */
+  order(direction: "asc" | "desc"): this {
+    this.#order = direction;
+    return this;
+  }
+
+  /** Leave out drafts (`--exclude-drafts`). */
+  excludeDrafts(): this {
+    this.#excludeDrafts = true;
+    return this;
+  }
+
+  /** Leave out prereleases (`--exclude-pre-releases`). */
+  excludePreReleases(): this {
+    this.#excludePreReleases = true;
+    return this;
+  }
+
+  /** The `gh release list` command path. */
+  protected override commandPath(): string[] {
+    return ["release", "list"];
+  }
+
+  /** Assemble the `gh release list` flags. */
+  protected override commandFlags(): string[] {
+    const argv: string[] = [];
+    if (this.#excludeDrafts) argv.push("--exclude-drafts");
+    if (this.#excludePreReleases) argv.push("--exclude-pre-releases");
+    if (this.#order !== undefined) argv.push("--order", this.#order);
+    if (this.#limit !== undefined) argv.push("--limit", String(this.#limit));
+    argv.push(...this.readFlags());
+    return argv;
+  }
+}
+
+/** Settings for `gh release view`. */
+export class GhReleaseViewSettings extends GhWebReadSettings {
+  #tag?: string;
+
+  /** The release's tag; gh shows the latest release when it is omitted. */
+  tag(name: string): this {
+    this.#tag = name;
+    return this;
+  }
+
+  /** The `gh release view` command path. */
+  protected override commandPath(): string[] {
+    const argv = ["release", "view"];
+    if (this.#tag !== undefined) argv.push(this.#tag);
+    return argv;
+  }
+
+  /** Assemble the `gh release view` flags. */
+  protected override commandFlags(): string[] {
+    return this.readFlags();
+  }
+}
+
+/** Settings for `gh release upload`. */
+export class GhReleaseUploadSettings extends GhCommandSettings {
+  #tag?: string;
+  #files: string[] = [];
+  #clobber = false;
+
+  /** The release's tag (required). */
+  tag(name: string): this {
+    this.#tag = name;
+    return this;
+  }
+
+  /**
+   * Asset files to attach (required); repeatable. gh reads a `#label` suffix
+   * on a path as the asset's display label.
+   */
+  files(...paths: PathLike[]): this {
+    this.#files.push(...paths.map(String));
+    return this;
+  }
+
+  /** Replace an asset of the same name (`--clobber`). */
+  clobber(): this {
+    this.#clobber = true;
+    return this;
+  }
+
+  /** The `gh release upload` command path, with the tag and the assets. */
+  protected override commandPath(): string[] {
+    if (this.#tag === undefined || this.#files.length === 0) {
+      throw new Error(
+        "GhTasks.releaseUpload: .tag(...) and .files(...) are both required — " +
+          "the release to attach to, and what to attach.",
+      );
+    }
+    return ["release", "upload", this.#tag, ...this.#files];
+  }
+
+  /** Assemble the `gh release upload` flags. */
+  protected override commandFlags(): string[] {
+    return this.#clobber ? ["--clobber"] : [];
+  }
+}
+
+/** Settings for `gh release download`. */
+export class GhReleaseDownloadSettings extends GhCommandSettings {
+  #tag?: string;
+  #patterns: string[] = [];
+  #dir?: string;
+  #output?: string;
+  #archive?: string;
+  #clobber = false;
+  #skipExisting = false;
+
+  /** The release's tag; gh takes the latest release when it is omitted. */
+  tag(name: string): this {
+    this.#tag = name;
+    return this;
+  }
+
+  /** Only assets matching this glob (`--pattern`); repeatable. */
+  pattern(...globs: string[]): this {
+    this.#patterns.push(...globs);
+    return this;
+  }
+
+  /** The directory to download into (`--dir`). */
+  dir(path: PathLike): this {
+    this.#dir = String(path);
+    return this;
+  }
+
+  /** Write a single asset to this file (`--output`); `-` writes standard output. */
+  output(path: PathLike): this {
+    this.#output = String(path);
+    return this;
+  }
+
+  /** Download the source archive instead of the assets (`--archive`). */
+  archive(format: "zip" | "tar.gz"): this {
+    this.#archive = format;
+    return this;
+  }
+
+  /** Overwrite files that already exist (`--clobber`). */
+  clobber(): this {
+    this.#clobber = true;
+    return this;
+  }
+
+  /** Leave files that already exist alone (`--skip-existing`). */
+  skipExisting(): this {
+    this.#skipExisting = true;
+    return this;
+  }
+
+  /** The `gh release download` command path. */
+  protected override commandPath(): string[] {
+    const argv = ["release", "download"];
+    if (this.#tag !== undefined) argv.push(this.#tag);
+    return argv;
+  }
+
+  /** Assemble the `gh release download` flags. */
+  protected override commandFlags(): string[] {
+    if (this.#clobber && this.#skipExisting) {
+      throw new Error(
+        "GhTasks.releaseDownload: .clobber() overwrites what exists and " +
+          ".skipExisting() leaves it — pick one.",
+      );
+    }
+    if (this.#archive !== undefined && this.#patterns.length > 0) {
+      throw new Error(
+        "GhTasks.releaseDownload: .archive(...) fetches the source archive, " +
+          "which .pattern(...) cannot filter — drop one.",
+      );
+    }
+    const argv: string[] = [];
+    for (const glob of this.#patterns) argv.push("--pattern", glob);
+    if (this.#archive !== undefined) argv.push("--archive", this.#archive);
+    if (this.#dir !== undefined) argv.push("--dir", this.#dir);
+    if (this.#output !== undefined) argv.push("--output", this.#output);
+    if (this.#clobber) argv.push("--clobber");
+    if (this.#skipExisting) argv.push("--skip-existing");
+    return argv;
+  }
+}
+
+/** Settings for `gh release edit`. */
+export class GhReleaseEditSettings extends GhCommandSettings {
+  #tag?: string;
+  #newTag?: string;
+  #title?: string;
+  #notes?: string;
+  #notesFile?: string;
+  #draft = false;
+  #prerelease = false;
+  #latest = false;
+  #target?: string;
+  #discussionCategory?: string;
+  #verifyTag = false;
+
+  /** The release to edit, by its current tag (required). */
+  tag(name: string): this {
+    this.#tag = name;
+    return this;
+  }
+
+  /** Move the release to a different tag (`--tag`). */
+  newTag(name: string): this {
+    this.#newTag = name;
+    return this;
+  }
+
+  /** Set the title (`--title`). */
+  title(text: string): this {
+    this.#title = text;
+    return this;
+  }
+
+  /** Set the notes (`--notes`). */
+  notes(text: string): this {
+    this.#notes = text;
+    return this;
+  }
+
+  /** Read the notes from a file (`--notes-file`); `-` reads standard input. */
+  notesFile(path: PathLike): this {
+    this.#notesFile = String(path);
+    return this;
+  }
+
+  /** Make it a draft (`--draft`). */
+  draft(): this {
+    this.#draft = true;
+    return this;
+  }
+
+  /** Mark it a prerelease (`--prerelease`). */
+  prerelease(): this {
+    this.#prerelease = true;
+    return this;
+  }
+
+  /** Mark it the latest release (`--latest`). */
+  latest(): this {
+    this.#latest = true;
+    return this;
+  }
+
+  /** Change the target branch or commit (`--target`). */
+  target(branchOrSha: string): this {
+    this.#target = branchOrSha;
+    return this;
+  }
+
+  /** Open a discussion in this category when publishing (`--discussion-category`). */
+  discussionCategory(name: string): this {
+    this.#discussionCategory = name;
+    return this;
+  }
+
+  /** Abort unless the tag exists on the remote (`--verify-tag`). */
+  verifyTag(): this {
+    this.#verifyTag = true;
+    return this;
+  }
+
+  /** The `gh release edit` command path. */
+  protected override commandPath(): string[] {
+    if (this.#tag === undefined) {
+      throw new Error(
+        "GhTasks.releaseEdit: .tag(...) is required — it names the release to " +
+          "edit. Use .newTag(...) to move it to another tag.",
+      );
+    }
+    return ["release", "edit", this.#tag];
+  }
+
+  /** Assemble the `gh release edit` flags. */
+  protected override commandFlags(): string[] {
+    if (this.#notes !== undefined && this.#notesFile !== undefined) {
+      throw new Error(
+        "GhTasks.releaseEdit: .notes(...) and .notesFile(...) are two sources " +
+          "for the same text — pick one.",
+      );
+    }
+    if (this.#draft && this.#latest) {
+      throw new Error(
+        "GhTasks.releaseEdit: a draft is not published, so it cannot also be " +
+          "the latest release — drop one.",
+      );
+    }
+    const argv: string[] = [];
+    if (this.#newTag !== undefined) argv.push("--tag", this.#newTag);
+    if (this.#title !== undefined) argv.push("--title", this.#title);
+    if (this.#notes !== undefined) argv.push("--notes", this.#notes);
+    if (this.#notesFile !== undefined) {
+      argv.push("--notes-file", this.#notesFile);
+    }
+    if (this.#draft) argv.push("--draft");
+    if (this.#prerelease) argv.push("--prerelease");
+    if (this.#latest) argv.push("--latest");
+    if (this.#target !== undefined) argv.push("--target", this.#target);
+    if (this.#discussionCategory !== undefined) {
+      argv.push("--discussion-category", this.#discussionCategory);
+    }
+    if (this.#verifyTag) argv.push("--verify-tag");
+    return argv;
+  }
+}
+
+/** Settings for `gh release delete`. */
+export class GhReleaseDeleteSettings extends GhCommandSettings {
+  #tag?: string;
+  #cleanupTag = false;
+  #yes = false;
+
+  /** The release to delete, by tag (required). */
+  tag(name: string): this {
+    this.#tag = name;
+    return this;
+  }
+
+  /** Delete the git tag as well (`--cleanup-tag`). */
+  cleanupTag(): this {
+    this.#cleanupTag = true;
+    return this;
+  }
+
+  /** Skip the confirmation prompt (`--yes`). */
+  yes(): this {
+    this.#yes = true;
+    return this;
+  }
+
+  /** The `gh release delete` command path. */
+  protected override commandPath(): string[] {
+    if (this.#tag === undefined) {
+      throw new Error("GhTasks.releaseDelete: .tag(...) is required.");
+    }
+    return ["release", "delete", this.#tag];
+  }
+
+  /** Assemble the `gh release delete` flags. */
+  protected override commandFlags(): string[] {
+    if (!this.#yes) {
+      throw new Error(
+        "GhTasks.releaseDelete: gh prompts before deleting, which a build " +
+          "cannot answer — add .yes() to mean it.",
+      );
+    }
+    const argv = ["--yes"];
+    if (this.#cleanupTag) argv.push("--cleanup-tag");
+    return argv;
+  }
+}
+
+/** One release of {@link "./gh.ts".GhTasks.releaseListEntries}. */
+export interface GhReleaseEntry {
+  /** The release's tag. */
+  tagName?: string;
+  /** Its name, which GitHub calls the title. */
+  name?: string;
+  /** Whether it is still a draft. */
+  isDraft?: boolean;
+  /** Whether it is marked a prerelease. */
+  isPrerelease?: boolean;
+  /** Whether it is the latest release. */
+  isLatest?: boolean;
+  /** When it was published, ISO 8601; absent while it is a draft. */
+  publishedAt?: string;
+}
+
+/**
+ * The `--json` fields {@link readReleases} asks for; gh requires the list by
+ * name, so the reader pins the set {@link GhReleaseEntry} describes.
+ */
+export const RELEASE_LIST_FIELDS: readonly string[] = [
+  "tagName",
+  "name",
+  "isDraft",
+  "isPrerelease",
+  "isLatest",
+  "publishedAt",
+];
+
+/**
+ * Parse `gh release list --json …` into entries.
+ *
+ * Not part of the package's public surface — exported for its unit test.
+ */
+export function parseReleases(stdout: string): GhReleaseEntry[] {
+  return parseJsonArray(stdout).map((record) => {
+    const entry: GhReleaseEntry = {};
+    const tagName = stringField(record, "tagName");
+    const name = stringField(record, "name");
+    const isDraft = booleanField(record, "isDraft");
+    const isPrerelease = booleanField(record, "isPrerelease");
+    const isLatest = booleanField(record, "isLatest");
+    const publishedAt = stringField(record, "publishedAt");
+    if (tagName !== undefined) entry.tagName = tagName;
+    if (name !== undefined) entry.name = name;
+    if (isDraft !== undefined) entry.isDraft = isDraft;
+    if (isPrerelease !== undefined) entry.isPrerelease = isPrerelease;
+    if (isLatest !== undefined) entry.isLatest = isLatest;
+    if (publishedAt !== undefined) entry.publishedAt = publishedAt;
+    return entry;
+  });
+}
+
+/**
+ * Run `gh release list --json …` and parse it. Backs
+ * {@link "./gh.ts".GhTasks.releaseListEntries}.
+ */
+export async function readReleases(
+  configure?: Configure<GhReleaseListSettings>,
+): Promise<GhReleaseEntry[]> {
+  const settings = new GhReleaseListSettings();
+  const configured = configure ? configure(settings) : settings;
+  const output = await configured.json(...RELEASE_LIST_FIELDS).run();
+  return parseReleases(output.stdout);
+}

--- a/packages/gh/src/settings.ts
+++ b/packages/gh/src/settings.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * {@link GhSettings} — the base every `gh` invocation's settings extend: the
+ * binary, the command builder inherited from
+ * {@link "@zuke/core/tooling".SubcommandSettings}, and the `--repo` flag every
+ * command accepts.
+ *
+ * It lives apart from the module that assembles `GhTasks` so a typed
+ * subcommand in its own file can extend it without importing that module,
+ * which imports the subcommands back — a cycle that leaves the base
+ * uninitialised at the moment a subclass is declared.
+ *
+ * @module
+ */
+
+import { SubcommandSettings } from "@zuke/core/tooling";
+
+/** Settings for a `gh` invocation. */
+export class GhSettings extends SubcommandSettings {
+  #repo?: string;
+
+  /** The default executable name: `gh`. */
+  protected override defaultTool(): string {
+    return "gh";
+  }
+
+  /** Target repository as `OWNER/REPO` (`-R`/`--repo`). */
+  repo(slug: string): this {
+    this.#repo = slug;
+    return this;
+  }
+
+  /** Emit `--repo <slug>` between the command path and the flags, when set. */
+  protected override middleTokens(): string[] {
+    return this.#repo !== undefined ? ["--repo", this.#repo] : [];
+  }
+}

--- a/packages/gh/src/subcommand.ts
+++ b/packages/gh/src/subcommand.ts
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * The bases the typed `gh` subcommand settings share.
+ *
+ * All three build on the package's existing {@link "./settings.ts".GhSettings}, so a
+ * typed command keeps `.repo()`, and keeps `.command(...)`/`.flag(...)` as
+ * escape hatches for anything not yet modelled. What they add is the shape
+ * every group repeats: a command path with its operand, the read flags gh
+ * offers on every listing and view (`--json`, `--jq`, `--template`, `--web`),
+ * and the `--body`/`--body-file` pair the writing commands share.
+ *
+ * Holding those here is what keeps twenty command classes from carrying
+ * twenty copies of the same four methods.
+ *
+ * @module
+ */
+
+import type { PathLike } from "@zuke/core/tooling";
+import { GhSettings } from "./settings.ts";
+
+/**
+ * Base for a typed `gh` subcommand: it contributes the command path (the
+ * group, the verb, and any operand) and its own flags, and inherits
+ * everything else from {@link "./settings.ts".GhSettings}.
+ */
+export abstract class GhCommandSettings extends GhSettings {
+  /** The command path — group, verb, then any positional operand. */
+  protected abstract commandPath(): string[];
+
+  /** This command's own flags, rendered after `--repo`. */
+  protected abstract commandFlags(): string[];
+
+  /** The command path leads the argv, before anything `.command(...)` added. */
+  protected override leadingTokens(): string[] {
+    return this.commandPath();
+  }
+
+  /** `--repo` first, as the package already renders it, then this command's flags. */
+  protected override middleTokens(): string[] {
+    return [...super.middleTokens(), ...this.commandFlags()];
+  }
+}
+
+/**
+ * Base for the commands that can print JSON: `pr list`, `pr view`,
+ * `pr checks`, `issue list`, `issue view`, `release list`, `release view`.
+ *
+ * gh requires an explicit field list for `--json`, which is why the
+ * value-returning tasks pin one rather than leaving it to the caller.
+ *
+ * A `…ListEntries` reader parses the array `--json` prints, so `.jq(...)` and
+ * `.template(...)` — which replace that array with whatever they render —
+ * belong on the plain `…List` task instead.
+ */
+export abstract class GhReadSettings extends GhCommandSettings {
+  #json?: string;
+  #jq?: string;
+  #template?: string;
+
+  /**
+   * Emit JSON with these fields (`--json`), which gh requires by name — there
+   * is no "all fields" form.
+   */
+  json(...fields: string[]): this {
+    this.#json = fields.join(",");
+    return this;
+  }
+
+  /** Filter the JSON with a jq expression (`--jq`). */
+  jq(expression: string): this {
+    this.#jq = expression;
+    return this;
+  }
+
+  /** Format the JSON through a Go template (`--template`). */
+  template(text: string): this {
+    this.#template = text;
+    return this;
+  }
+
+  /** The read flags, for a subclass to place among its own. */
+  protected readFlags(): string[] {
+    const argv: string[] = [];
+    if (this.#json !== undefined) argv.push("--json", this.#json);
+    if (this.#jq !== undefined) argv.push("--jq", this.#jq);
+    if (this.#template !== undefined) argv.push("--template", this.#template);
+    return argv;
+  }
+}
+
+/**
+ * Base for the read commands that also take `--web`: every one of them except
+ * `release list`, which gh gives no browser view. Keeping `.web()` here rather
+ * than on {@link GhReadSettings} is what stops a build offering a flag gh
+ * would reject.
+ */
+export abstract class GhWebReadSettings extends GhReadSettings {
+  #web = false;
+
+  /**
+   * Open the result in a browser instead of printing it (`--web`). A build
+   * has no browser, so this is for a developer running the target by hand.
+   */
+  web(): this {
+    this.#web = true;
+    return this;
+  }
+
+  /** The read flags, with `--web` last as gh's own help lists it. */
+  protected override readFlags(): string[] {
+    const argv = super.readFlags();
+    if (this.#web) argv.push("--web");
+    return argv;
+  }
+}
+
+/**
+ * Base for the commands that take message text: `pr create`, `pr comment`,
+ * `pr edit`, `issue create`, `issue comment`.
+ *
+ * gh spells it `--body` for the text and `--body-file` for a file, with `-`
+ * meaning standard input — the same pair on every one of them.
+ */
+export abstract class GhBodySettings extends GhCommandSettings {
+  #body?: string;
+  #bodyFile?: string;
+
+  /** The message text (`--body`). */
+  body(text: string): this {
+    this.#body = text;
+    return this;
+  }
+
+  /** Read the message from a file (`--body-file`); `-` reads standard input. */
+  bodyFile(path: PathLike): this {
+    this.#bodyFile = String(path);
+    return this;
+  }
+
+  /**
+   * The body flags, after refusing both at once: gh takes one source for the
+   * text, and silently preferring one would hide which text was posted.
+   */
+  protected bodyFlags(task: string): string[] {
+    if (this.#body !== undefined && this.#bodyFile !== undefined) {
+      throw new Error(
+        `GhTasks.${task}: .body(...) and .bodyFile(...) are two sources for ` +
+          `the same text — pick one.`,
+      );
+    }
+    const argv: string[] = [];
+    if (this.#body !== undefined) argv.push("--body", this.#body);
+    if (this.#bodyFile !== undefined) argv.push("--body-file", this.#bodyFile);
+    return argv;
+  }
+}

--- a/packages/gh/tests/groups_test.ts
+++ b/packages/gh/tests/groups_test.ts
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertRejects } from "../../core/tests/_assert.ts";
+import { ToolNotFoundError } from "@zuke/core/tooling";
+import {
+  assertWrapperConformance,
+  missingTool,
+} from "@zuke/core/tooling/conformance";
+import { GhTasks } from "../mod.ts";
+import { GhPrListSettings } from "../src/pr.ts";
+import { GhIssueListSettings } from "../src/issue.ts";
+import { GhReleaseListSettings } from "../src/release.ts";
+
+Deno.test("the typed command groups conform to the gh wrapper's contract", async () => {
+  for (
+    const make of [
+      () => new GhPrListSettings(),
+      () => new GhIssueListSettings(),
+      () => new GhReleaseListSettings(),
+    ]
+  ) {
+    await assertWrapperConformance(make, "gh", { resolution: "path" });
+  }
+});
+
+Deno.test("every gh pr task reaches execution", async () => {
+  await assertRejects(
+    () => GhTasks.prCreate((s) => missingTool(s.title("t").body("b"))),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => GhTasks.prList((s) => missingTool(s.state("open"))),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => GhTasks.prListEntries((s) => missingTool(s.limit(1))),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => GhTasks.prView((s) => missingTool(s.selector(1))),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => GhTasks.prChecks((s) => missingTool(s.selector(1))),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => GhTasks.prMerge((s) => missingTool(s.selector(1).squash())),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => GhTasks.prComment((s) => missingTool(s.selector(1).body("b"))),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => GhTasks.prEdit((s) => missingTool(s.selector(1).title("t"))),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => GhTasks.prClose((s) => missingTool(s.selector(1))),
+    ToolNotFoundError,
+  );
+});
+
+Deno.test("every gh issue task reaches execution", async () => {
+  await assertRejects(
+    () => GhTasks.issueCreate((s) => missingTool(s.title("t"))),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => GhTasks.issueList((s) => missingTool(s.state("open"))),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => GhTasks.issueListEntries((s) => missingTool(s.limit(1))),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => GhTasks.issueView((s) => missingTool(s.selector(1))),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => GhTasks.issueComment((s) => missingTool(s.selector(1).body("b"))),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => GhTasks.issueClose((s) => missingTool(s.selector(1))),
+    ToolNotFoundError,
+  );
+});
+
+Deno.test("every gh release task reaches execution", async () => {
+  await assertRejects(
+    () => GhTasks.releaseCreate((s) => missingTool(s.tag("v1"))),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => GhTasks.releaseList((s) => missingTool(s.limit(1))),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => GhTasks.releaseListEntries((s) => missingTool(s.limit(1))),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => GhTasks.releaseView((s) => missingTool(s.tag("v1"))),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => GhTasks.releaseUpload((s) => missingTool(s.tag("v1").files("a.tgz"))),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => GhTasks.releaseDownload((s) => missingTool(s.tag("v1"))),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => GhTasks.releaseEdit((s) => missingTool(s.tag("v1").title("t"))),
+    ToolNotFoundError,
+  );
+  await assertRejects(
+    () => GhTasks.releaseDelete((s) => missingTool(s.tag("v1").yes())),
+    ToolNotFoundError,
+  );
+});

--- a/packages/gh/tests/groups_test.ts
+++ b/packages/gh/tests/groups_test.ts
@@ -1,13 +1,18 @@
 // Copyright (c) 2026 the Zuke contributors
 // SPDX-License-Identifier: MIT
 
-import { assertRejects } from "../../core/tests/_assert.ts";
+import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
 import { ToolNotFoundError } from "@zuke/core/tooling";
 import {
   assertWrapperConformance,
   missingTool,
 } from "@zuke/core/tooling/conformance";
-import { GhTasks } from "../mod.ts";
+import {
+  GhTasks,
+  ISSUE_LIST_FIELDS,
+  PR_LIST_FIELDS,
+  RELEASE_LIST_FIELDS,
+} from "../mod.ts";
 import { GhPrListSettings } from "../src/pr.ts";
 import { GhIssueListSettings } from "../src/issue.ts";
 import { GhReleaseListSettings } from "../src/release.ts";
@@ -123,4 +128,67 @@ Deno.test("every gh release task reaches execution", async () => {
     () => GhTasks.releaseDelete((s) => missingTool(s.tag("v1").yes())),
     ToolNotFoundError,
   );
+});
+
+Deno.test("each reader pins its own field set into the argv it runs", async () => {
+  // gh requires --json fields by name, and each reader's parse only makes
+  // sense against the set its entry documents. Asserting the constants alone
+  // would not catch a reader wired to the wrong one, so capture the settings
+  // the reader configures and read back the argv it was about to spawn.
+  const runs: Array<[string, string[], readonly string[], string[]]> = [];
+
+  let pr: GhPrListSettings | undefined;
+  await assertRejects(
+    () =>
+      GhTasks.prListEntries((s) => {
+        pr = s;
+        return missingTool(s);
+      }),
+    ToolNotFoundError,
+  );
+  if (pr !== undefined) {
+    runs.push(["prListEntries", pr.argv().slice(1), PR_LIST_FIELDS, [
+      "pr",
+      "list",
+    ]]);
+  }
+
+  let issue: GhIssueListSettings | undefined;
+  await assertRejects(
+    () =>
+      GhTasks.issueListEntries((s) => {
+        issue = s;
+        return missingTool(s);
+      }),
+    ToolNotFoundError,
+  );
+  if (issue !== undefined) {
+    runs.push(["issueListEntries", issue.argv().slice(1), ISSUE_LIST_FIELDS, [
+      "issue",
+      "list",
+    ]]);
+  }
+
+  let release: GhReleaseListSettings | undefined;
+  await assertRejects(
+    () =>
+      GhTasks.releaseListEntries((s) => {
+        release = s;
+        return missingTool(s);
+      }),
+    ToolNotFoundError,
+  );
+  if (release !== undefined) {
+    runs.push([
+      "releaseListEntries",
+      release.argv().slice(1),
+      RELEASE_LIST_FIELDS,
+      ["release", "list"],
+    ]);
+  }
+
+  assertEquals(runs.length, 3);
+  for (const [task, argv, fields, path] of runs) {
+    assertEquals(argv, [...path, "--json", fields.join(",")], task);
+  }
 });

--- a/packages/gh/tests/issue_test.ts
+++ b/packages/gh/tests/issue_test.ts
@@ -1,0 +1,261 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals, assertThrows } from "../../core/tests/_assert.ts";
+import {
+  GhIssueCloseSettings,
+  GhIssueCommentSettings,
+  GhIssueCreateSettings,
+  GhIssueListSettings,
+  GhIssueViewSettings,
+  ISSUE_LIST_FIELDS,
+} from "../mod.ts";
+import { parseIssues } from "../src/issue.ts";
+
+Deno.test("issue create renders its flags", () => {
+  assertEquals(
+    new GhIssueCreateSettings()
+      .repo("acme/app")
+      .title("flaky test")
+      .body("it fails on Windows")
+      .assignee("@me")
+      .label("bug")
+      .label("ci")
+      .project("Roadmap")
+      .milestone("v2")
+      .type("Bug")
+      .parent(41)
+      .templateName("bug_report.yml")
+      .argv()
+      .slice(1),
+    [
+      "issue",
+      "create",
+      "--repo",
+      "acme/app",
+      "--title",
+      "flaky test",
+      "--body",
+      "it fails on Windows",
+      "--assignee",
+      "@me",
+      "--label",
+      "bug",
+      "--label",
+      "ci",
+      "--project",
+      "Roadmap",
+      "--milestone",
+      "v2",
+      "--type",
+      "Bug",
+      "--parent",
+      "41",
+      "--template",
+      "bug_report.yml",
+    ],
+  );
+});
+
+Deno.test("issue create insists on a title, and on one body", () => {
+  // Without --title gh opens a prompt, and a build has no one to answer it.
+  assertThrows(
+    () => new GhIssueCreateSettings().body("details").argv(),
+    Error,
+    "GhTasks.issueCreate: .title(...) is required",
+  );
+  assertThrows(
+    () =>
+      new GhIssueCreateSettings().title("t").body("a").bodyFile("b.md").argv(),
+    Error,
+    "GhTasks.issueCreate: .body(...) and .bodyFile(...) are two sources",
+  );
+  assertEquals(
+    new GhIssueCreateSettings().title("t").bodyFile("-").argv().slice(1),
+    ["issue", "create", "--title", "t", "--body-file", "-"],
+  );
+});
+
+Deno.test("issue list renders every filter", () => {
+  assertEquals(
+    new GhIssueListSettings()
+      .state("all")
+      .author("someone")
+      .app("dependabot")
+      .assignee("@me")
+      .mention("other")
+      .milestone("v2")
+      .type("Bug")
+      .label("bug")
+      .label("ci")
+      .search("sort:created")
+      .limit(10)
+      .json("number", "title")
+      .template("{{.number}}")
+      .web()
+      .argv()
+      .slice(1),
+    [
+      "issue",
+      "list",
+      "--state",
+      "all",
+      "--author",
+      "someone",
+      "--app",
+      "dependabot",
+      "--assignee",
+      "@me",
+      "--mention",
+      "other",
+      "--milestone",
+      "v2",
+      "--type",
+      "Bug",
+      "--label",
+      "bug",
+      "--label",
+      "ci",
+      "--search",
+      "sort:created",
+      "--limit",
+      "10",
+      "--json",
+      "number,title",
+      "--template",
+      "{{.number}}",
+      "--web",
+    ],
+  );
+  assertEquals(new GhIssueListSettings().argv().slice(1), ["issue", "list"]);
+});
+
+Deno.test("every issue command names its issue", () => {
+  // gh has no "issue for the current branch" the way it has a pull request,
+  // so the operand is required rather than optional.
+  assertEquals(
+    new GhIssueViewSettings().selector(42).comments().jq(".title").argv()
+      .slice(1),
+    ["issue", "view", "42", "--comments", "--jq", ".title"],
+  );
+  assertThrows(
+    () => new GhIssueViewSettings().argv(),
+    Error,
+    "GhTasks.issueView: .selector(...) is required",
+  );
+  assertThrows(
+    () => new GhIssueCommentSettings().body("hi").argv(),
+    Error,
+    "GhTasks.issueComment: .selector(...) is required",
+  );
+  assertThrows(
+    () => new GhIssueCloseSettings().argv(),
+    Error,
+    "GhTasks.issueClose: .selector(...) is required",
+  );
+});
+
+Deno.test("issue comment renders its edit and delete modes", () => {
+  assertEquals(
+    new GhIssueCommentSettings().selector(42).body("on it").argv().slice(1),
+    ["issue", "comment", "42", "--body", "on it"],
+  );
+  assertEquals(
+    new GhIssueCommentSettings().selector("https://github.com/o/r/issues/42")
+      .bodyFile("note.md").editLast().createIfNone().argv().slice(1),
+    [
+      "issue",
+      "comment",
+      "https://github.com/o/r/issues/42",
+      "--body-file",
+      "note.md",
+      "--edit-last",
+      "--create-if-none",
+    ],
+  );
+  assertEquals(
+    new GhIssueCommentSettings().selector(42).deleteLast().yes().argv()
+      .slice(1),
+    ["issue", "comment", "42", "--delete-last", "--yes"],
+  );
+  // A build cannot answer gh's confirmation prompt.
+  assertThrows(
+    () => new GhIssueCommentSettings().selector(42).deleteLast().argv(),
+    Error,
+    "GhTasks.issueComment: .deleteLast() prompts for confirmation",
+  );
+  assertThrows(
+    () => new GhIssueCommentSettings().selector(42).createIfNone().argv(),
+    Error,
+    "GhTasks.issueComment: .createIfNone() qualifies .editLast()",
+  );
+});
+
+Deno.test("issue close renders its reason, and pairs the duplicate with it", () => {
+  assertEquals(
+    new GhIssueCloseSettings().selector(42).comment("shipped").reason(
+      "completed",
+    ).argv().slice(1),
+    ["issue", "close", "42", "--comment", "shipped", "--reason", "completed"],
+  );
+  assertEquals(
+    new GhIssueCloseSettings().selector(42).reason("duplicate").duplicateOf(7)
+      .argv().slice(1),
+    ["issue", "close", "42", "--reason", "duplicate", "--duplicate-of", "7"],
+  );
+  assertEquals(
+    new GhIssueCloseSettings().selector(42).reason("not planned").argv()
+      .slice(1),
+    ["issue", "close", "42", "--reason", "not planned"],
+  );
+  // gh ignores --duplicate-of under any other reason, so the issue would close
+  // as something the build did not ask for.
+  assertThrows(
+    () => new GhIssueCloseSettings().selector(42).duplicateOf(7).argv(),
+    Error,
+    'GhTasks.issueClose: .duplicateOf(...) goes with .reason("duplicate")',
+  );
+  assertThrows(
+    () =>
+      new GhIssueCloseSettings().selector(42).reason("completed").duplicateOf(7)
+        .argv(),
+    Error,
+    'GhTasks.issueClose: .duplicateOf(...) goes with .reason("duplicate")',
+  );
+});
+
+Deno.test("parseIssues reads gh's JSON array", () => {
+  const stdout = JSON.stringify([
+    {
+      number: 406,
+      title: "feat(gh): typed pr, issue and release commands",
+      state: "OPEN",
+      url: "https://github.com/o/r/issues/406",
+      author: { login: "someone" },
+    },
+  ]);
+  assertEquals(parseIssues(stdout), [{
+    number: 406,
+    title: "feat(gh): typed pr, issue and release commands",
+    state: "OPEN",
+    url: "https://github.com/o/r/issues/406",
+    author: "someone",
+  }]);
+});
+
+Deno.test("parseIssues treats anything but an array of objects as empty", () => {
+  assertEquals(parseIssues("[]"), []);
+  assertEquals(parseIssues("  "), []);
+  assertEquals(parseIssues("no issues match your search"), []);
+  assertEquals(parseIssues('{"number":1}'), []);
+  assertEquals(parseIssues("[null]"), []);
+  // A field gh reports as the wrong type is not that field.
+  assertEquals(parseIssues('[{"title":42,"state":null}]'), [{}]);
+  assertEquals(parseIssues('[{"author":"someone"}]'), [{}]);
+});
+
+Deno.test("the pinned issue field set is what the entry documents", () => {
+  assertEquals(ISSUE_LIST_FIELDS.includes("number"), true);
+  assertEquals(ISSUE_LIST_FIELDS.includes("author"), true);
+  assertEquals(ISSUE_LIST_FIELDS.length, 5);
+});

--- a/packages/gh/tests/pr_test.ts
+++ b/packages/gh/tests/pr_test.ts
@@ -1,0 +1,386 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals, assertThrows } from "../../core/tests/_assert.ts";
+import {
+  GhPrChecksSettings,
+  GhPrCloseSettings,
+  GhPrCommentSettings,
+  GhPrCreateSettings,
+  GhPrEditSettings,
+  GhPrListSettings,
+  GhPrMergeSettings,
+  GhPrViewSettings,
+  PR_LIST_FIELDS,
+} from "../mod.ts";
+import { parsePullRequests } from "../src/pr.ts";
+
+Deno.test("the command path leads, then --repo, then the command's flags", () => {
+  // `--repo` is the package's existing placement; a typed command adds its own
+  // flags after it rather than replacing the layout.
+  assertEquals(
+    new GhPrListSettings().repo("acme/app").state("open").limit(50)
+      .argv().slice(1),
+    ["pr", "list", "--repo", "acme/app", "--state", "open", "--limit", "50"],
+  );
+});
+
+Deno.test("pr create renders its flags", () => {
+  assertEquals(
+    new GhPrCreateSettings()
+      .title("feat: thing")
+      .body("why")
+      .base("main")
+      .head("feature")
+      .draft()
+      .assignee("@me")
+      .label("enhancement")
+      .reviewer("someone")
+      .project("Roadmap")
+      .milestone("v2")
+      .templateFile(".github/pull_request_template.md")
+      .argv()
+      .slice(1),
+    [
+      "pr",
+      "create",
+      "--title",
+      "feat: thing",
+      "--body",
+      "why",
+      "--base",
+      "main",
+      "--head",
+      "feature",
+      "--draft",
+      "--assignee",
+      "@me",
+      "--label",
+      "enhancement",
+      "--reviewer",
+      "someone",
+      "--project",
+      "Roadmap",
+      "--milestone",
+      "v2",
+      "--template",
+      ".github/pull_request_template.md",
+    ],
+  );
+});
+
+Deno.test("pr create refuses two sources for the same text", () => {
+  // gh takes one; silently preferring one would hide which body was posted.
+  assertThrows(
+    () => new GhPrCreateSettings().body("a").bodyFile("b.md").argv(),
+    Error,
+    "GhTasks.prCreate: .body(...) and .bodyFile(...) are two sources",
+  );
+  assertThrows(
+    () => new GhPrCreateSettings().fill().fillFirst().argv(),
+    Error,
+    "GhTasks.prCreate: .fill(), .fillFirst(), and .fillVerbose()",
+  );
+});
+
+Deno.test("pr create renders its fill modes and its rehearsal", () => {
+  // gh's three --fill spellings differ in what they take from the commits, so
+  // each is its own flag rather than an argument to one.
+  assertEquals(
+    new GhPrCreateSettings().title("t").fillVerbose().dryRun()
+      .noMaintainerEdit().argv().slice(1),
+    [
+      "pr",
+      "create",
+      "--title",
+      "t",
+      "--fill-verbose",
+      "--dry-run",
+      "--no-maintainer-edit",
+    ],
+  );
+  assertEquals(
+    new GhPrCreateSettings().fill().argv().slice(1),
+    ["pr", "create", "--fill"],
+  );
+  assertEquals(
+    new GhPrCreateSettings().fillFirst().argv().slice(1),
+    ["pr", "create", "--fill-first"],
+  );
+});
+
+Deno.test("pr list renders every filter", () => {
+  assertEquals(
+    new GhPrListSettings()
+      .state("merged")
+      .base("main")
+      .head("feature")
+      .author("someone")
+      .app("dependabot")
+      .assignee("@me")
+      .label("bug")
+      .label("ci")
+      .search("sort:updated")
+      .draft()
+      .limit(10)
+      .json("number", "title")
+      .jq(".[].number")
+      .argv()
+      .slice(1),
+    [
+      "pr",
+      "list",
+      "--state",
+      "merged",
+      "--base",
+      "main",
+      "--head",
+      "feature",
+      "--author",
+      "someone",
+      "--app",
+      "dependabot",
+      "--assignee",
+      "@me",
+      "--label",
+      "bug",
+      "--label",
+      "ci",
+      "--search",
+      "sort:updated",
+      "--draft",
+      "--limit",
+      "10",
+      "--json",
+      "number,title",
+      "--jq",
+      ".[].number",
+    ],
+  );
+});
+
+Deno.test("the pull request operand is optional, as it is on the command line", () => {
+  // gh falls back to the PR for the current branch.
+  assertEquals(new GhPrViewSettings().argv().slice(1), ["pr", "view"]);
+  assertEquals(
+    new GhPrViewSettings().selector(123).comments().argv().slice(1),
+    ["pr", "view", "123", "--comments"],
+  );
+  assertEquals(
+    new GhPrViewSettings().selector("feature-branch").argv().slice(1),
+    ["pr", "view", "feature-branch"],
+  );
+  assertEquals(new GhPrMergeSettings().squash().argv().slice(1), [
+    "pr",
+    "merge",
+    "--squash",
+  ]);
+});
+
+Deno.test("pr merge renders each method and its guards", () => {
+  assertEquals(
+    new GhPrMergeSettings().selector(123).squash().deleteBranch()
+      .subject("feat: thing").body("notes").matchHeadCommit("abc123")
+      .authorEmail("ci@example.test").argv().slice(1),
+    [
+      "pr",
+      "merge",
+      "123",
+      "--squash",
+      "--delete-branch",
+      "--subject",
+      "feat: thing",
+      "--body",
+      "notes",
+      "--author-email",
+      "ci@example.test",
+      "--match-head-commit",
+      "abc123",
+    ],
+  );
+  assertEquals(
+    new GhPrMergeSettings().merge().auto().argv().slice(1),
+    ["pr", "merge", "--merge", "--auto"],
+  );
+  assertEquals(
+    new GhPrMergeSettings().rebase().admin().argv().slice(1),
+    ["pr", "merge", "--rebase", "--admin"],
+  );
+  assertThrows(
+    () => new GhPrMergeSettings().auto().disableAuto().argv(),
+    Error,
+    "GhTasks.prMerge: .auto() enables auto-merge",
+  );
+  assertEquals(
+    new GhPrMergeSettings().selector(123).disableAuto().argv().slice(1),
+    ["pr", "merge", "123", "--disable-auto"],
+  );
+});
+
+Deno.test("pr checks keeps the watch-only flags to watching", () => {
+  assertEquals(
+    new GhPrChecksSettings().selector(123).required().argv().slice(1),
+    ["pr", "checks", "123", "--required"],
+  );
+  assertEquals(
+    new GhPrChecksSettings().watch().failFast().interval(5).argv().slice(1),
+    ["pr", "checks", "--watch", "--fail-fast", "--interval", "5"],
+  );
+  // gh ignores them without --watch, which would leave a build believing it
+  // had asked for something it had not.
+  assertThrows(
+    () => new GhPrChecksSettings().failFast().argv(),
+    Error,
+    "GhTasks.prChecks: .failFast()/.interval(...) describe how to watch",
+  );
+});
+
+Deno.test("pr comment renders its edit and delete modes", () => {
+  assertEquals(
+    new GhPrCommentSettings().selector(123).body("CI is green").argv().slice(1),
+    ["pr", "comment", "123", "--body", "CI is green"],
+  );
+  assertEquals(
+    new GhPrCommentSettings().selector(123).body("updated").editLast()
+      .createIfNone().argv().slice(1),
+    [
+      "pr",
+      "comment",
+      "123",
+      "--body",
+      "updated",
+      "--edit-last",
+      "--create-if-none",
+    ],
+  );
+  assertEquals(
+    new GhPrCommentSettings().selector(123).deleteLast().yes().argv().slice(1),
+    ["pr", "comment", "123", "--delete-last", "--yes"],
+  );
+  // A build cannot answer gh's confirmation prompt.
+  assertThrows(
+    () => new GhPrCommentSettings().selector(1).deleteLast().argv(),
+    Error,
+    "GhTasks.prComment: .deleteLast() prompts for confirmation",
+  );
+  assertThrows(
+    () => new GhPrCommentSettings().selector(1).createIfNone().argv(),
+    Error,
+    "GhTasks.prComment: .createIfNone() qualifies .editLast()",
+  );
+});
+
+Deno.test("pr edit renders every add and remove", () => {
+  assertEquals(
+    new GhPrEditSettings()
+      .selector(123)
+      .title("new title")
+      .body("new body")
+      .base("main")
+      .addLabel("ready")
+      .removeLabel("wip")
+      .addAssignee("@me")
+      .removeAssignee("other")
+      .addReviewer("someone")
+      .removeReviewer("nobody")
+      .addProject("Roadmap")
+      .removeProject("Backlog")
+      .milestone("v2")
+      .argv()
+      .slice(1),
+    [
+      "pr",
+      "edit",
+      "123",
+      "--title",
+      "new title",
+      "--body",
+      "new body",
+      "--base",
+      "main",
+      "--add-label",
+      "ready",
+      "--remove-label",
+      "wip",
+      "--add-assignee",
+      "@me",
+      "--remove-assignee",
+      "other",
+      "--add-reviewer",
+      "someone",
+      "--remove-reviewer",
+      "nobody",
+      "--add-project",
+      "Roadmap",
+      "--remove-project",
+      "Backlog",
+      "--milestone",
+      "v2",
+    ],
+  );
+  assertEquals(
+    new GhPrEditSettings().selector(1).removeMilestone().argv().slice(1),
+    ["pr", "edit", "1", "--remove-milestone"],
+  );
+  assertThrows(
+    () => new GhPrEditSettings().milestone("v2").removeMilestone().argv(),
+    Error,
+    "GhTasks.prEdit: .milestone(...) sets one",
+  );
+});
+
+Deno.test("pr close renders its comment and branch cleanup", () => {
+  assertEquals(
+    new GhPrCloseSettings().selector(123).comment("superseded").deleteBranch()
+      .argv().slice(1),
+    ["pr", "close", "123", "--comment", "superseded", "--delete-branch"],
+  );
+  assertEquals(new GhPrCloseSettings().argv().slice(1), ["pr", "close"]);
+});
+
+Deno.test("parsePullRequests reads gh's JSON array", () => {
+  const stdout = JSON.stringify([
+    {
+      number: 404,
+      title: "feat(docker): …",
+      state: "MERGED",
+      isDraft: false,
+      headRefName: "feature",
+      baseRefName: "master",
+      url: "https://github.com/o/r/pull/404",
+      author: { login: "someone" },
+    },
+  ]);
+  assertEquals(parsePullRequests(stdout), [{
+    number: 404,
+    title: "feat(docker): …",
+    state: "MERGED",
+    isDraft: false,
+    headRefName: "feature",
+    baseRefName: "master",
+    url: "https://github.com/o/r/pull/404",
+    author: "someone",
+  }]);
+});
+
+Deno.test("parsePullRequests treats anything but an array of objects as empty", () => {
+  // gh prints `[]` for an empty listing, and prose when it has something else
+  // to say; neither is a crash.
+  assertEquals(parsePullRequests("[]"), []);
+  assertEquals(parsePullRequests(""), []);
+  assertEquals(parsePullRequests("no pull requests match"), []);
+  assertEquals(parsePullRequests('{"number":1}'), []);
+  assertEquals(parsePullRequests("[1, 2]"), []);
+  // A field gh reports as the wrong type is not that field.
+  assertEquals(parsePullRequests('[{"number":"404"}]'), [{}]);
+  // An author gh nests without a login yields no author.
+  assertEquals(parsePullRequests('[{"author":{}}]'), [{}]);
+});
+
+Deno.test("the pinned field set is what the entry documents", () => {
+  // gh requires --json fields by name, so the reader's set and the entry's
+  // shape have to stay in step.
+  assertEquals(PR_LIST_FIELDS.includes("number"), true);
+  assertEquals(PR_LIST_FIELDS.includes("author"), true);
+  assertEquals(PR_LIST_FIELDS.length, 8);
+});

--- a/packages/gh/tests/release_test.ts
+++ b/packages/gh/tests/release_test.ts
@@ -1,0 +1,305 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals, assertThrows } from "../../core/tests/_assert.ts";
+import {
+  GhReleaseCreateSettings,
+  GhReleaseDeleteSettings,
+  GhReleaseDownloadSettings,
+  GhReleaseEditSettings,
+  GhReleaseListSettings,
+  GhReleaseUploadSettings,
+  GhReleaseViewSettings,
+  RELEASE_LIST_FIELDS,
+} from "../mod.ts";
+import { parseReleases } from "../src/release.ts";
+
+Deno.test("release create renders the tag, its assets, and its flags", () => {
+  assertEquals(
+    new GhReleaseCreateSettings()
+      .repo("acme/app")
+      .tag("v1.2.3")
+      .files("dist/app.tgz", "dist/app.tgz.sig#signature")
+      .title("v1.2.3")
+      .notes("what changed")
+      .generateNotes()
+      .notesFromTag()
+      .notesStartTag("v1.2.2")
+      .prerelease()
+      .latest()
+      .target("master")
+      .discussionCategory("Announcements")
+      .verifyTag()
+      .failOnNoCommits()
+      .argv()
+      .slice(1),
+    [
+      "release",
+      "create",
+      "v1.2.3",
+      "dist/app.tgz",
+      "dist/app.tgz.sig#signature",
+      "--repo",
+      "acme/app",
+      "--title",
+      "v1.2.3",
+      "--notes",
+      "what changed",
+      "--generate-notes",
+      "--notes-from-tag",
+      "--notes-start-tag",
+      "v1.2.2",
+      "--prerelease",
+      "--latest",
+      "--target",
+      "master",
+      "--discussion-category",
+      "Announcements",
+      "--verify-tag",
+      "--fail-on-no-commits",
+    ],
+  );
+  assertEquals(
+    new GhReleaseCreateSettings().tag("v1").draft().notesFile("NOTES.md").argv()
+      .slice(1),
+    ["release", "create", "v1", "--notes-file", "NOTES.md", "--draft"],
+  );
+});
+
+Deno.test("release create guards its tag, its notes, and the draft/latest pair", () => {
+  assertThrows(
+    () => new GhReleaseCreateSettings().title("v1").argv(),
+    Error,
+    "GhTasks.releaseCreate: .tag(...) is required",
+  );
+  assertThrows(
+    () =>
+      new GhReleaseCreateSettings().tag("v1").notes("a").notesFile("n.md")
+        .argv(),
+    Error,
+    "GhTasks.releaseCreate: .notes(...) and .notesFile(...) are two sources",
+  );
+  // gh accepts both and publishes neither outcome the build asked for: a draft
+  // is unpublished, so it cannot be the latest release.
+  assertThrows(
+    () => new GhReleaseCreateSettings().tag("v1").draft().latest().argv(),
+    Error,
+    "GhTasks.releaseCreate: a draft is not published",
+  );
+});
+
+Deno.test("release list and view render their flags", () => {
+  assertEquals(
+    new GhReleaseListSettings().excludeDrafts().excludePreReleases().order(
+      "asc",
+    ).limit(5).json("tagName").argv().slice(1),
+    [
+      "release",
+      "list",
+      "--exclude-drafts",
+      "--exclude-pre-releases",
+      "--order",
+      "asc",
+      "--limit",
+      "5",
+      "--json",
+      "tagName",
+    ],
+  );
+  // gh shows the latest release when no tag is given.
+  assertEquals(new GhReleaseViewSettings().argv().slice(1), [
+    "release",
+    "view",
+  ]);
+  assertEquals(
+    new GhReleaseViewSettings().tag("v1.2.3").web().argv().slice(1),
+    ["release", "view", "v1.2.3", "--web"],
+  );
+});
+
+Deno.test("release list is the one read command gh gives no --web", () => {
+  // Every other listing and view takes --web; `gh release list` does not, and
+  // offering it would render a flag gh rejects as unknown.
+  assertEquals("web" in new GhReleaseListSettings(), false);
+  assertEquals("web" in new GhReleaseViewSettings(), true);
+});
+
+Deno.test("release upload needs both the release and what to attach", () => {
+  assertEquals(
+    new GhReleaseUploadSettings().tag("v1.2.3").files("dist/app.tgz").clobber()
+      .argv().slice(1),
+    ["release", "upload", "v1.2.3", "dist/app.tgz", "--clobber"],
+  );
+  assertThrows(
+    () => new GhReleaseUploadSettings().tag("v1.2.3").argv(),
+    Error,
+    "GhTasks.releaseUpload: .tag(...) and .files(...) are both required",
+  );
+  assertThrows(
+    () => new GhReleaseUploadSettings().files("dist/app.tgz").argv(),
+    Error,
+    "GhTasks.releaseUpload: .tag(...) and .files(...) are both required",
+  );
+});
+
+Deno.test("release download renders its filters and refuses the contradictions", () => {
+  assertEquals(
+    new GhReleaseDownloadSettings().tag("v1.2.3").pattern("*.tgz", "*.sig")
+      .dir("out").clobber().argv().slice(1),
+    [
+      "release",
+      "download",
+      "v1.2.3",
+      "--pattern",
+      "*.tgz",
+      "--pattern",
+      "*.sig",
+      "--dir",
+      "out",
+      "--clobber",
+    ],
+  );
+  assertEquals(
+    new GhReleaseDownloadSettings().archive("tar.gz").output("-").skipExisting()
+      .argv().slice(1),
+    [
+      "release",
+      "download",
+      "--archive",
+      "tar.gz",
+      "--output",
+      "-",
+      "--skip-existing",
+    ],
+  );
+  assertThrows(
+    () => new GhReleaseDownloadSettings().clobber().skipExisting().argv(),
+    Error,
+    "GhTasks.releaseDownload: .clobber() overwrites what exists",
+  );
+  // --pattern filters the assets, which the source archive is not one of.
+  assertThrows(
+    () =>
+      new GhReleaseDownloadSettings().archive("zip").pattern("*.tgz").argv(),
+    Error,
+    "GhTasks.releaseDownload: .archive(...) fetches the source archive",
+  );
+});
+
+Deno.test("release edit renames the tag with --tag, not the operand", () => {
+  assertEquals(
+    new GhReleaseEditSettings()
+      .tag("v1.2.3")
+      .newTag("v1.2.4")
+      .title("v1.2.4")
+      .notes("fixed")
+      .prerelease()
+      .latest()
+      .target("master")
+      .discussionCategory("Announcements")
+      .verifyTag()
+      .argv()
+      .slice(1),
+    [
+      "release",
+      "edit",
+      "v1.2.3",
+      "--tag",
+      "v1.2.4",
+      "--title",
+      "v1.2.4",
+      "--notes",
+      "fixed",
+      "--prerelease",
+      "--latest",
+      "--target",
+      "master",
+      "--discussion-category",
+      "Announcements",
+      "--verify-tag",
+    ],
+  );
+  assertEquals(
+    new GhReleaseEditSettings().tag("v1").draft().notesFile("-").argv().slice(
+      1,
+    ),
+    ["release", "edit", "v1", "--notes-file", "-", "--draft"],
+  );
+  assertThrows(
+    () => new GhReleaseEditSettings().newTag("v2").argv(),
+    Error,
+    "GhTasks.releaseEdit: .tag(...) is required",
+  );
+  assertThrows(
+    () =>
+      new GhReleaseEditSettings().tag("v1").notes("a").notesFile("n").argv(),
+    Error,
+    "GhTasks.releaseEdit: .notes(...) and .notesFile(...) are two sources",
+  );
+  assertThrows(
+    () => new GhReleaseEditSettings().tag("v1").draft().latest().argv(),
+    Error,
+    "GhTasks.releaseEdit: a draft is not published",
+  );
+});
+
+Deno.test("release delete makes the build mean the deletion", () => {
+  assertEquals(
+    new GhReleaseDeleteSettings().tag("v1.2.3").cleanupTag().yes().argv()
+      .slice(1),
+    ["release", "delete", "v1.2.3", "--yes", "--cleanup-tag"],
+  );
+  assertThrows(
+    () => new GhReleaseDeleteSettings().yes().argv(),
+    Error,
+    "GhTasks.releaseDelete: .tag(...) is required",
+  );
+  // gh prompts, and a build has no one to answer.
+  assertThrows(
+    () => new GhReleaseDeleteSettings().tag("v1.2.3").argv(),
+    Error,
+    "GhTasks.releaseDelete: gh prompts before deleting",
+  );
+});
+
+Deno.test("parseReleases reads gh's JSON array", () => {
+  const stdout = JSON.stringify([
+    {
+      tagName: "v1.2.3",
+      name: "v1.2.3",
+      isDraft: false,
+      isPrerelease: false,
+      isLatest: true,
+      publishedAt: "2026-08-01T10:00:00Z",
+    },
+  ]);
+  assertEquals(parseReleases(stdout), [{
+    tagName: "v1.2.3",
+    name: "v1.2.3",
+    isDraft: false,
+    isPrerelease: false,
+    isLatest: true,
+    publishedAt: "2026-08-01T10:00:00Z",
+  }]);
+  // A draft has no publishedAt, and the entry simply omits it.
+  assertEquals(parseReleases('[{"tagName":"v2","isDraft":true}]'), [{
+    tagName: "v2",
+    isDraft: true,
+  }]);
+});
+
+Deno.test("parseReleases treats anything but an array of objects as empty", () => {
+  assertEquals(parseReleases("[]"), []);
+  assertEquals(parseReleases(""), []);
+  assertEquals(parseReleases("no releases found"), []);
+  assertEquals(parseReleases('{"tagName":"v1"}'), []);
+  assertEquals(parseReleases('["v1"]'), []);
+  // A field gh reports as the wrong type is not that field.
+  assertEquals(parseReleases('[{"isDraft":"false"}]'), [{}]);
+});
+
+Deno.test("the pinned release field set is what the entry documents", () => {
+  assertEquals(RELEASE_LIST_FIELDS.includes("tagName"), true);
+  assertEquals(RELEASE_LIST_FIELDS.includes("isLatest"), true);
+  assertEquals(RELEASE_LIST_FIELDS.length, 6);
+});

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/.codex-plugin/plugin.json
+++ b/plugins/zuke/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -650,7 +650,7 @@ the full task list and settings methods of each):
 | `@zuke/npm`, `@zuke/npx`, `@zuke/bun`, `@zuke/pnpm`, `@zuke/yarn`, `@zuke/node`                                                                     | `NpmTasks`, `NpxTasks`, `BunTasks`, ...                   | JS package managers + `npx` runner + `node`. `NpmTasks` covers npm's everyday surface — install/publish/registry/inspect — and hands back values from `outdatedEntries`, `auditSummary`, `pkgGet`, `whoamiName`                                |
 | `@zuke/cmd`                                                                                                                                         | `CmdTasks`                                                | `exec` — generic fallback for any CLI                                                                                                                                                                                                          |
 | `@zuke/docker`, `@zuke/docker-compose`                                                                                                              | `DockerTasks`, ...                                        | build/run/compose. `DockerTasks` covers the everyday docker surface — containers, images, registry, and the `volume`/`network`/`system`/`context` groups — with `psEntries`, `imageEntries`, `volumeNames`, `networkNames` handing back values |
-| `@zuke/git`, `@zuke/gh`                                                                                                                             | `GitTasks`, `GhTasks`                                     | git — the everyday surface, typed (see below) — and GitHub CLI (`GhTasks.run` for subcommands, `GhTasks.api` for REST endpoints without one)                                                                                                   |
+| `@zuke/git`, `@zuke/gh`                                                                                                                             | `GitTasks`, `GhTasks`                                     | git — the everyday surface, typed (see below) — and GitHub CLI: typed `pr`/`issue`/`release` tasks (see below), `GhTasks.run` for every other subcommand, `GhTasks.api` for REST endpoints without one                                         |
 | `@zuke/cspell`, `@zuke/eslint`, `@zuke/oxlint`, `@zuke/biome`, `@zuke/dprint`, `@zuke/knip`, `@zuke/dpdm`, `@zuke/lint-staged`                      | `*Tasks`                                                  | lint/format/spell/dead-code                                                                                                                                                                                                                    |
 | `@zuke/tsc`, `@zuke/tsx`, `@zuke/tsc-alias`, `@zuke/tsup`, `@zuke/tsdown`, `@zuke/vite`, `@zuke/storybook`, `@zuke/turbo`, `@zuke/nx`, `@zuke/nest` | `*Tasks`                                                  | TS compile / bundle / monorepo / framework CLIs                                                                                                                                                                                                |
 | `@zuke/openapi-ts`, `@zuke/orval`, `@zuke/redocly`                                                                                                  | `*Tasks`                                                  | generate API clients from OpenAPI                                                                                                                                                                                                              |
@@ -791,6 +791,36 @@ calls its default branch, so a build never hardcodes `main` and breaks on the
 repositories that chose `master`. It reads the local
 `refs/remotes/<remote>/HEAD` first and asks the remote only when that ref is
 missing, which is the usual case on a fetch-only checkout.
+
+### GitHub CLI — `GhTasks`
+
+The three groups a build reaches for are typed; everything else goes through
+`GhTasks.run((s) => s.command(...))`, and REST endpoints with no CLI verb
+through `GhTasks.api(...)`.
+
+| Group     | Tasks                                                                                                                                   |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `pr`      | `prCreate`, `prList`, `prListEntries`, `prView`, `prChecks`, `prMerge`, `prComment`, `prEdit`, `prClose`                                |
+| `issue`   | `issueCreate`, `issueList`, `issueListEntries`, `issueView`, `issueComment`, `issueClose`                                               |
+| `release` | `releaseCreate`, `releaseList`, `releaseListEntries`, `releaseView`, `releaseUpload`, `releaseDownload`, `releaseEdit`, `releaseDelete` |
+
+```ts
+await GhTasks.prMerge((s) => s.selector(123).squash().deleteBranch().auto());
+await GhTasks.issueClose((s) => s.selector(42).reason("completed"));
+await GhTasks.releaseCreate((s) => s.tag("v1.2.3").generateNotes().latest());
+const open = await GhTasks.prListEntries((s) => s.state("open").limit(50));
+```
+
+Each takes `.repo("owner/name")` and keeps `.command(...)`/`.flag(...)` for a
+flag not yet modelled. The `…ListEntries` readers pin gh's `--json` field set —
+gh requires one by name — and hand back parsed entries, so a build branches on
+data rather than on scraped text.
+
+Where gh would **prompt**, the settings refuse first: `releaseDelete` and a
+comment's `.deleteLast()` need `.yes()`, and `issueCreate` needs `.title(...)`.
+Flag pairs gh resolves silently in its own favour — a draft that is also the
+latest release, `--pattern` alongside `--archive` — are refused too, so a build
+never gets an outcome other than the one it asked for.
 
 ## AI review & self-healing — `@zuke/ai`
 

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -650,7 +650,7 @@ the full task list and settings methods of each):
 | `@zuke/npm`, `@zuke/npx`, `@zuke/bun`, `@zuke/pnpm`, `@zuke/yarn`, `@zuke/node`                                                                     | `NpmTasks`, `NpxTasks`, `BunTasks`, ...                   | JS package managers + `npx` runner + `node`. `NpmTasks` covers npm's everyday surface — install/publish/registry/inspect — and hands back values from `outdatedEntries`, `auditSummary`, `pkgGet`, `whoamiName`                                |
 | `@zuke/cmd`                                                                                                                                         | `CmdTasks`                                                | `exec` — generic fallback for any CLI                                                                                                                                                                                                          |
 | `@zuke/docker`, `@zuke/docker-compose`                                                                                                              | `DockerTasks`, ...                                        | build/run/compose. `DockerTasks` covers the everyday docker surface — containers, images, registry, and the `volume`/`network`/`system`/`context` groups — with `psEntries`, `imageEntries`, `volumeNames`, `networkNames` handing back values |
-| `@zuke/git`, `@zuke/gh`                                                                                                                             | `GitTasks`, `GhTasks`                                     | git — the everyday surface, typed (see below) — and GitHub CLI (`GhTasks.run` for subcommands, `GhTasks.api` for REST endpoints without one)                                                                                                   |
+| `@zuke/git`, `@zuke/gh`                                                                                                                             | `GitTasks`, `GhTasks`                                     | git — the everyday surface, typed (see below) — and GitHub CLI: typed `pr`/`issue`/`release` tasks (see below), `GhTasks.run` for every other subcommand, `GhTasks.api` for REST endpoints without one                                         |
 | `@zuke/cspell`, `@zuke/eslint`, `@zuke/oxlint`, `@zuke/biome`, `@zuke/dprint`, `@zuke/knip`, `@zuke/dpdm`, `@zuke/lint-staged`                      | `*Tasks`                                                  | lint/format/spell/dead-code                                                                                                                                                                                                                    |
 | `@zuke/tsc`, `@zuke/tsx`, `@zuke/tsc-alias`, `@zuke/tsup`, `@zuke/tsdown`, `@zuke/vite`, `@zuke/storybook`, `@zuke/turbo`, `@zuke/nx`, `@zuke/nest` | `*Tasks`                                                  | TS compile / bundle / monorepo / framework CLIs                                                                                                                                                                                                |
 | `@zuke/openapi-ts`, `@zuke/orval`, `@zuke/redocly`                                                                                                  | `*Tasks`                                                  | generate API clients from OpenAPI                                                                                                                                                                                                              |
@@ -791,6 +791,36 @@ calls its default branch, so a build never hardcodes `main` and breaks on the
 repositories that chose `master`. It reads the local
 `refs/remotes/<remote>/HEAD` first and asks the remote only when that ref is
 missing, which is the usual case on a fetch-only checkout.
+
+### GitHub CLI — `GhTasks`
+
+The three groups a build reaches for are typed; everything else goes through
+`GhTasks.run((s) => s.command(...))`, and REST endpoints with no CLI verb
+through `GhTasks.api(...)`.
+
+| Group     | Tasks                                                                                                                                   |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `pr`      | `prCreate`, `prList`, `prListEntries`, `prView`, `prChecks`, `prMerge`, `prComment`, `prEdit`, `prClose`                                |
+| `issue`   | `issueCreate`, `issueList`, `issueListEntries`, `issueView`, `issueComment`, `issueClose`                                               |
+| `release` | `releaseCreate`, `releaseList`, `releaseListEntries`, `releaseView`, `releaseUpload`, `releaseDownload`, `releaseEdit`, `releaseDelete` |
+
+```ts
+await GhTasks.prMerge((s) => s.selector(123).squash().deleteBranch().auto());
+await GhTasks.issueClose((s) => s.selector(42).reason("completed"));
+await GhTasks.releaseCreate((s) => s.tag("v1.2.3").generateNotes().latest());
+const open = await GhTasks.prListEntries((s) => s.state("open").limit(50));
+```
+
+Each takes `.repo("owner/name")` and keeps `.command(...)`/`.flag(...)` for a
+flag not yet modelled. The `…ListEntries` readers pin gh's `--json` field set —
+gh requires one by name — and hand back parsed entries, so a build branches on
+data rather than on scraped text.
+
+Where gh would **prompt**, the settings refuse first: `releaseDelete` and a
+comment's `.deleteLast()` need `.yes()`, and `issueCreate` needs `.title(...)`.
+Flag pairs gh resolves silently in its own favour — a draft that is also the
+latest release, `--pattern` alongside `--archive` — are refused too, so a build
+never gets an outcome other than the one it asked for.
 
 ## AI review & self-healing — `@zuke/ai`
 

--- a/tests/integration/gh_commands_test.ts
+++ b/tests/integration/gh_commands_test.ts
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Integration: the typed `@zuke/gh` command groups driven from a real build
+ * through the CLI `main()`. The unit tests assert argv; this proves the tasks
+ * are reachable as a target's body — that a value-returning one fails the
+ * build when `gh` is missing rather than reporting an empty repository, and
+ * that a settings class's own validation surfaces as a failed target.
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import { Build, target } from "../../packages/core/mod.ts";
+import { missingTool } from "../../packages/core/src/tooling_conformance.ts";
+import { GhTasks } from "../../packages/gh/mod.ts";
+import { runCli } from "./_harness.ts";
+
+class ReleaseBuild extends Build {
+  open = target()
+    .description("report the pull requests still open")
+    .executes(async () => {
+      const entries = await GhTasks.prListEntries((s) =>
+        missingTool(s).state("open").limit(5)
+      );
+      console.log(`open=${entries.length}`);
+    });
+
+  triage = target()
+    .description("report the issues waiting on triage")
+    .executes(async () => {
+      const entries = await GhTasks.issueListEntries((s) =>
+        missingTool(s).label("bug")
+      );
+      console.log(`bugs=${entries.length}`);
+    });
+
+  published = target()
+    .description("report the releases already published")
+    .executes(async () => {
+      const entries = await GhTasks.releaseListEntries((s) =>
+        missingTool(s).excludeDrafts()
+      );
+      console.log(`released=${entries.length}`);
+    });
+
+  announce = target()
+    .description("publish the release for the tag just pushed")
+    .executes(async () => {
+      await GhTasks.releaseCreate((s) =>
+        missingTool(s).tag("v1.2.3").generateNotes().latest()
+      );
+      console.log("announced");
+    });
+
+  attach = target()
+    .description("attach the built artifact to the release")
+    .executes(async () => {
+      await GhTasks.releaseUpload((s) =>
+        missingTool(s).tag("v1.2.3").files("dist/app.tgz").clobber()
+      );
+      console.log("attached");
+    });
+
+  report = target()
+    .description("comment the build's result on the pull request")
+    .executes(async () => {
+      await GhTasks.prComment((s) =>
+        missingTool(s).selector(1).body("CI is green").editLast()
+      );
+      console.log("reported");
+    });
+
+  file = target()
+    .description("open an issue for the failure just seen")
+    .executes(async () => {
+      await GhTasks.issueCreate((s) =>
+        missingTool(s).title("flaky test").body("it fails on Windows")
+          .label("bug")
+      );
+      console.log("filed");
+    });
+
+  land = target()
+    .description("merge the pull request once its checks pass")
+    .executes(async () => {
+      await GhTasks.prMerge((s) => missingTool(s).selector(1).squash().auto());
+      console.log("landed");
+    });
+
+  mistake = target()
+    .description("delete a release without meaning it")
+    .executes(async () => {
+      // The settings refuse this before gh is ever spawned: gh would prompt
+      // for a confirmation the build has no one to answer.
+      await GhTasks.releaseDelete((s) => missingTool(s).tag("v1.2.3"));
+      console.log("deleted");
+    });
+}
+
+const FAILS_ON_MISSING_GH: Array<[string, string]> = [
+  ["open", "open="],
+  ["triage", "bugs="],
+  ["published", "released="],
+  ["announce", "announced"],
+  ["attach", "attached"],
+  ["report", "reported"],
+  ["file", "filed"],
+  ["land", "landed"],
+];
+
+for (const [name, marker] of FAILS_ON_MISSING_GH) {
+  Deno.test(`the ${name} target fails with the tool-not-found error`, async () => {
+    const { code, out, err } = await runCli(ReleaseBuild, [name]);
+    assertEquals(code, 1);
+    assertStringIncludes(err, "zuke-no-such-tool-xyz");
+    assertEquals(out.includes(marker), false);
+  });
+}
+
+Deno.test("a settings validation failure fails the target, naming the fix", async () => {
+  const { code, out, err } = await runCli(ReleaseBuild, ["mistake"]);
+  assertEquals(code, 1);
+  assertStringIncludes(err, "add .yes() to mean it");
+  assertEquals(out.includes("deleted"), false);
+});


### PR DESCRIPTION
## What & why

`@zuke/gh` was the odd one out among the wrappers: a rich set of REST helpers, but exactly one task for the `gh` CLI itself — the stringly-typed `GhTasks.run` builder, where nothing checks that a flag is real, that it belongs to the subcommand, or that the operand goes where it does.

This adds twenty-three typed tasks across the three groups a build reaches for: nine on `pr` (create, list, listEntries, view, checks, merge, comment, edit, close), six on `issue` (create, list, listEntries, view, comment, close), and eight on `release` (create, list, listEntries, view, upload, download, edit, delete). Every flag was verified against the published manual at cli.github.com, page by page, rather than written from memory.

The three `…ListEntries` tasks are value-returning readers: they pin the `--json` field set gh requires by name and parse the JSON array behind type guards, so a build branches on data instead of scraped text. A payload that is not an array of objects yields no entries rather than a throw — gh prints an empty array for an empty listing and prose when it has something else to say.

**Structure.** Every settings class extends the package's existing `GhSettings`, so `.repo()` and the `.command()`/`.flag()` escape hatches keep working on a typed command. Shared bases carry what these commands genuinely have in common — the command path, the read flags, and the body pair — so those have one implementation rather than twenty. `GhSettings` moved into its own module to break a circular import the group modules would otherwise create; `gh.ts` re-exports it, so nothing in the public surface moved.

**Guards.** Where gh would prompt, the settings refuse before gh is ever spawned, because a build has no one to answer: deleting a release and deleting a comment need an explicit yes, and opening an issue needs a title. Flag pairs gh resolves silently in its own favour are refused the same way — a draft that is also the latest release, a source archive filtered by a pattern, overwrite alongside skip-existing, the watch-only flags without watch, two sources for one body. Each refusal names the fix.

**The one defect the adversarial pass caught.** `gh release list` is the only read command GitHub gives no browser view, so inheriting a web flag from the shared read base would have offered a flag gh rejects as unknown. The base is now split: the web flag lives on a subclass every other read command extends, and release list stays on the plain one. A regression test asserts the method is absent there and present on release view.

**Tests.** Unit tests assert the argv each settings class builds and every refusal it makes; a reach test drives all 23 tasks through the wrapper's missing-binary path plus the conformance assertion; an integration test runs a real build through the CLI entry point and proves a value-returning task fails the build when gh is missing rather than reporting an empty repository. Package coverage is 97.5% branches and 98.1% lines; the repo gate is green at 97.6% and 98.5%.

README and cheatsheet document the new surface, the plugin version moves to 0.23.0 across its four manifests, and the generated API docs are regenerated. One unreachable getter left over from the first draft of the read base is gone.

Scope note carried over from the issue: `prCreate` sits alongside the existing REST `pullRequest`, and `releaseUpload` alongside `uploadReleaseAsset`. They are not duplicates in the guideline-12 sense — the REST helpers work from a token with no gh binary, these need gh and its own auth — and each module's docs say which to reach for. Happy to drop the two if a maintainer would rather keep one path per operation.

A follow-up covers `run`, `workflow`, `repo`, `secret`, `variable`, `label`, and `cache`.

## Related issues

Closes #406

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a
      [Conventional Commit](https://www.conventionalcommits.org/)
      (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour
      changed.
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`,
      `llms-full.txt`, package README `## API`).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with
      type guards instead).
- [x] No dead code: unreachable branches and can't-fire fallbacks are removed,
      with types tightened so the impossible state is unrepresentable.
- [x] No duplicated logic: an existing helper is imported rather than retyped,
      and a near-copy differing by a constant or a message is parameterised into
      one implementation. A guard, escape, or credential resolution has exactly
      one implementation.
- [x] SOLID shapes respected: one domain per file, extension via the settings
      lambda (not a behaviour-switching flag), narrow parameter types, and
      dependencies on the injectable seam (`StateHost`, an injected `fetch`,
      `EnvReader`) rather than `Deno.*` or a global.
- [ ] A new package was wired into all six places (see
      [AGENTS.md](../blob/master/AGENTS.md#good-open-source-practices-to-follow)),
      if applicable. — not applicable, no new package.
- [x] The code is written using AI assisted coding.

Gate caveat: every `ci` target was run individually and is green. The `security` target's zizmor scan cannot run in this sandbox — it needs api.github.com, which the environment's proxy blocks — so it is the one target verified in CI rather than locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLnXeQGXqAmQmwfvPusqMX)_