### PR TITLE
feat(gcloud): type `gcloud run services update`

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.31.0",
+      "version": "0.32.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "zuke",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build)."
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -12853,6 +12853,53 @@ class GcloudRunServicesListSettings extends GcloudSettings
   override protected leadingTokens(): string[]
     Emit `run services list` with its flags.
 
+class GcloudRunServicesUpdateSettings extends GcloudSettings
+  Settings for `gcloud run services update` — amending a service that already
+  exists.
+
+  Distinct from {@link GcloudRunDeploySettings} on purpose. `run deploy`
+  creates the service when it is absent and resets settings the invocation does
+  not name; `run services update` only ever amends an existing one. A deploy
+  that points a live service at a freshly built image wants the second
+  guarantee, and getting the first by accident — a service quietly created, or
+  scaling config quietly dropped — is a worse failure than an error.
+
+  service(name: string): this
+    The service to update (positional).
+  region(value: string): this
+    The region it runs in (`--region`).
+  platform(value: string): this
+    The platform it runs on (`--platform`).
+  image(reference: string): this
+    The container image to point the service at (`--image`).
+  updateEnvVars(...pairs: string[]): this
+    Set or overwrite environment variables (`--update-env-vars`), as
+    `KEY=value`; repeatable. Variables the call does not name are left alone —
+    which is the difference from `run deploy`'s `--set-env-vars`.
+  removeEnvVars(...names: string[]): this
+    Remove environment variables by name (`--remove-env-vars`); repeatable.
+  clearEnvVars(): this
+    Remove every environment variable the service has (`--clear-env-vars`).
+  updateSecrets(...pairs: string[]): this
+    Set or overwrite Secret Manager mounts (`--update-secrets`), as
+    `KEY=secret:version`; repeatable.
+  memory(value: string): this
+    Memory per instance (`--memory`), e.g. `"512Mi"`.
+  cpu(value: string): this
+    CPU per instance (`--cpu`).
+  concurrency(value: number): this
+    Requests served concurrently per instance (`--concurrency`).
+  maxInstances(value: number): this
+    Upper bound on instances (`--max-instances`).
+  minInstances(value: number): this
+    Lower bound on instances (`--min-instances`).
+  tag(value: string): this
+    Tag the revision this update creates (`--tag`).
+  noTraffic(): this
+    Create the revision without moving traffic to it (`--no-traffic`).
+  override protected leadingTokens(): string[]
+    Emit `run services update` with its operand and flags.
+
 class GcloudRunUpdateTrafficSettings extends GcloudSettings
   Settings for `gcloud run services update-traffic`.
 
@@ -13021,6 +13068,10 @@ interface GcloudTasksApi
     `--format` to gcloud's own value projection, so gcloud extracts the field.
   runServicesList(configure?: Configure<GcloudRunServicesListSettings>): Promise<CommandOutput>
     List Cloud Run services: `gcloud run services list`.
+  runServicesUpdate(configure?: Configure<GcloudRunServicesUpdateSettings>): Promise<CommandOutput>
+    Amend an existing Cloud Run service: `gcloud run services update`. Unlike
+    {@link runDeploy}, it never creates the service and never resets settings
+    the call does not name.
   runUpdateTraffic(configure?: Configure<GcloudRunUpdateTrafficSettings>): Promise<CommandOutput>
     Move traffic between revisions: `gcloud run services update-traffic`.
   artifactsImagesList(configure?: Configure<GcloudArtifactsImagesListSettings>): Promise<CommandOutput>

--- a/packages/gcloud/README.md
+++ b/packages/gcloud/README.md
@@ -473,6 +473,53 @@ class GcloudRunServicesListSettings extends GcloudSettings
   override protected leadingTokens(): string[]
     Emit `run services list` with its flags.
 
+class GcloudRunServicesUpdateSettings extends GcloudSettings
+  Settings for `gcloud run services update` — amending a service that already
+  exists.
+
+  Distinct from {@link GcloudRunDeploySettings} on purpose. `run deploy`
+  creates the service when it is absent and resets settings the invocation does
+  not name; `run services update` only ever amends an existing one. A deploy
+  that points a live service at a freshly built image wants the second
+  guarantee, and getting the first by accident — a service quietly created, or
+  scaling config quietly dropped — is a worse failure than an error.
+
+  service(name: string): this
+    The service to update (positional).
+  region(value: string): this
+    The region it runs in (`--region`).
+  platform(value: string): this
+    The platform it runs on (`--platform`).
+  image(reference: string): this
+    The container image to point the service at (`--image`).
+  updateEnvVars(...pairs: string[]): this
+    Set or overwrite environment variables (`--update-env-vars`), as
+    `KEY=value`; repeatable. Variables the call does not name are left alone —
+    which is the difference from `run deploy`'s `--set-env-vars`.
+  removeEnvVars(...names: string[]): this
+    Remove environment variables by name (`--remove-env-vars`); repeatable.
+  clearEnvVars(): this
+    Remove every environment variable the service has (`--clear-env-vars`).
+  updateSecrets(...pairs: string[]): this
+    Set or overwrite Secret Manager mounts (`--update-secrets`), as
+    `KEY=secret:version`; repeatable.
+  memory(value: string): this
+    Memory per instance (`--memory`), e.g. `"512Mi"`.
+  cpu(value: string): this
+    CPU per instance (`--cpu`).
+  concurrency(value: number): this
+    Requests served concurrently per instance (`--concurrency`).
+  maxInstances(value: number): this
+    Upper bound on instances (`--max-instances`).
+  minInstances(value: number): this
+    Lower bound on instances (`--min-instances`).
+  tag(value: string): this
+    Tag the revision this update creates (`--tag`).
+  noTraffic(): this
+    Create the revision without moving traffic to it (`--no-traffic`).
+  override protected leadingTokens(): string[]
+    Emit `run services update` with its operand and flags.
+
 class GcloudRunUpdateTrafficSettings extends GcloudSettings
   Settings for `gcloud run services update-traffic`.
 
@@ -641,6 +688,10 @@ interface GcloudTasksApi
     `--format` to gcloud's own value projection, so gcloud extracts the field.
   runServicesList(configure?: Configure<GcloudRunServicesListSettings>): Promise<CommandOutput>
     List Cloud Run services: `gcloud run services list`.
+  runServicesUpdate(configure?: Configure<GcloudRunServicesUpdateSettings>): Promise<CommandOutput>
+    Amend an existing Cloud Run service: `gcloud run services update`. Unlike
+    {@link runDeploy}, it never creates the service and never resets settings
+    the call does not name.
   runUpdateTraffic(configure?: Configure<GcloudRunUpdateTrafficSettings>): Promise<CommandOutput>
     Move traffic between revisions: `gcloud run services update-traffic`.
   artifactsImagesList(configure?: Configure<GcloudArtifactsImagesListSettings>): Promise<CommandOutput>

--- a/packages/gcloud/mod.ts
+++ b/packages/gcloud/mod.ts
@@ -65,6 +65,7 @@ export {
   GcloudRunDeploySettings,
   GcloudRunServicesDescribeSettings,
   GcloudRunServicesListSettings,
+  GcloudRunServicesUpdateSettings,
   GcloudRunUpdateTrafficSettings,
   RUN_SERVICE_URL_FORMAT,
 } from "./src/cloud_run.ts";

--- a/packages/gcloud/src/cloud_run.ts
+++ b/packages/gcloud/src/cloud_run.ts
@@ -391,3 +391,209 @@ export class GcloudRunUpdateTrafficSettings extends GcloudSettings {
     return argv;
   }
 }
+
+/**
+ * Settings for `gcloud run services update` — amending a service that already
+ * exists.
+ *
+ * Distinct from {@link GcloudRunDeploySettings} on purpose. `run deploy`
+ * creates the service when it is absent and resets settings the invocation does
+ * not name; `run services update` only ever amends an existing one. A deploy
+ * that points a live service at a freshly built image wants the second
+ * guarantee, and getting the first by accident — a service quietly created, or
+ * scaling config quietly dropped — is a worse failure than an error.
+ */
+export class GcloudRunServicesUpdateSettings extends GcloudSettings {
+  #service?: string;
+  #region?: string;
+  #platform?: string;
+  #image?: string;
+  #updateEnvVars: string[] = [];
+  #removeEnvVars: string[] = [];
+  #clearEnvVars = false;
+  #updateSecrets: string[] = [];
+  #memory?: string;
+  #cpu?: string;
+  #concurrency?: number;
+  #maxInstances?: number;
+  #minInstances?: number;
+  #tag?: string;
+  #noTraffic = false;
+
+  /** The service to update (positional). */
+  service(name: string): this {
+    this.#service = name;
+    return this;
+  }
+
+  /** The region it runs in (`--region`). */
+  region(value: string): this {
+    this.#region = value;
+    return this;
+  }
+
+  /** The platform it runs on (`--platform`). */
+  platform(value: string): this {
+    this.#platform = value;
+    return this;
+  }
+
+  /** The container image to point the service at (`--image`). */
+  image(reference: string): this {
+    this.#image = reference;
+    return this;
+  }
+
+  /**
+   * Set or overwrite environment variables (`--update-env-vars`), as
+   * `KEY=value`; repeatable. Variables the call does not name are left alone —
+   * which is the difference from `run deploy`'s `--set-env-vars`.
+   */
+  updateEnvVars(...pairs: string[]): this {
+    this.#updateEnvVars.push(...pairs);
+    return this;
+  }
+
+  /** Remove environment variables by name (`--remove-env-vars`); repeatable. */
+  removeEnvVars(...names: string[]): this {
+    this.#removeEnvVars.push(...names);
+    return this;
+  }
+
+  /** Remove every environment variable the service has (`--clear-env-vars`). */
+  clearEnvVars(): this {
+    this.#clearEnvVars = true;
+    return this;
+  }
+
+  /**
+   * Set or overwrite Secret Manager mounts (`--update-secrets`), as
+   * `KEY=secret:version`; repeatable.
+   */
+  updateSecrets(...pairs: string[]): this {
+    this.#updateSecrets.push(...pairs);
+    return this;
+  }
+
+  /** Memory per instance (`--memory`), e.g. `"512Mi"`. */
+  memory(value: string): this {
+    this.#memory = value;
+    return this;
+  }
+
+  /** CPU per instance (`--cpu`). */
+  cpu(value: string): this {
+    this.#cpu = value;
+    return this;
+  }
+
+  /** Requests served concurrently per instance (`--concurrency`). */
+  concurrency(value: number): this {
+    this.#concurrency = value;
+    return this;
+  }
+
+  /** Upper bound on instances (`--max-instances`). */
+  maxInstances(value: number): this {
+    this.#maxInstances = value;
+    return this;
+  }
+
+  /** Lower bound on instances (`--min-instances`). */
+  minInstances(value: number): this {
+    this.#minInstances = value;
+    return this;
+  }
+
+  /** Tag the revision this update creates (`--tag`). */
+  tag(value: string): this {
+    this.#tag = value;
+    return this;
+  }
+
+  /** Create the revision without moving traffic to it (`--no-traffic`). */
+  noTraffic(): this {
+    this.#noTraffic = true;
+    return this;
+  }
+
+  /** Emit `run services update` with its operand and flags. */
+  protected override leadingTokens(): string[] {
+    if (this.#service === undefined) {
+      throw new Error(
+        "GcloudTasks.runServicesUpdate: no service named — add " +
+          ".service('api').",
+      );
+    }
+    // gcloud: "At most one of --clear-env-vars | --set-env-vars |
+    // --update-env-vars --remove-env-vars can be specified." The two spellings
+    // differ in what survives — .clearEnvVars() drops every variable the
+    // service has, .updateEnvVars() leaves the unnamed ones alone — so which
+    // one wins is not a thing to leave to gcloud's argument parser.
+    if (this.#clearEnvVars) {
+      const paired = [
+        [".updateEnvVars()", this.#updateEnvVars.length > 0],
+        [".removeEnvVars()", this.#removeEnvVars.length > 0],
+      ].filter(([, on]) => on).map(([name]) => name);
+      if (paired.length > 0) {
+        throw new Error(
+          `GcloudTasks.runServicesUpdate: .clearEnvVars() drops every ` +
+            `environment variable the service has, so ${
+              paired.join(" and ")
+            } would have nothing left to amend — gcloud accepts at most one ` +
+            "of --clear-env-vars and the --update-env-vars/--remove-env-vars " +
+            "pair. Keep one.",
+        );
+      }
+    }
+    const argv = ["run", "services", "update", this.#service];
+    if (this.#region !== undefined) argv.push("--region", this.#region);
+    if (this.#platform !== undefined) argv.push("--platform", this.#platform);
+    if (this.#image !== undefined) argv.push("--image", this.#image);
+    if (this.#updateEnvVars.length > 0) {
+      argv.push(
+        "--update-env-vars",
+        commaJoined(
+          this.#updateEnvVars,
+          "runServicesUpdate",
+          "--update-env-vars",
+        ),
+      );
+    }
+    if (this.#removeEnvVars.length > 0) {
+      argv.push(
+        "--remove-env-vars",
+        commaJoined(
+          this.#removeEnvVars,
+          "runServicesUpdate",
+          "--remove-env-vars",
+        ),
+      );
+    }
+    if (this.#clearEnvVars) argv.push("--clear-env-vars");
+    if (this.#updateSecrets.length > 0) {
+      argv.push(
+        "--update-secrets",
+        commaJoined(
+          this.#updateSecrets,
+          "runServicesUpdate",
+          "--update-secrets",
+        ),
+      );
+    }
+    if (this.#memory !== undefined) argv.push("--memory", this.#memory);
+    if (this.#cpu !== undefined) argv.push("--cpu", this.#cpu);
+    if (this.#concurrency !== undefined) {
+      argv.push("--concurrency", String(this.#concurrency));
+    }
+    if (this.#maxInstances !== undefined) {
+      argv.push("--max-instances", String(this.#maxInstances));
+    }
+    if (this.#minInstances !== undefined) {
+      argv.push("--min-instances", String(this.#minInstances));
+    }
+    if (this.#tag !== undefined) argv.push("--tag", this.#tag);
+    if (this.#noTraffic) argv.push("--no-traffic");
+    return argv;
+  }
+}

--- a/packages/gcloud/src/gcloud.ts
+++ b/packages/gcloud/src/gcloud.ts
@@ -51,6 +51,7 @@ import {
   GcloudRunDeploySettings,
   GcloudRunServicesDescribeSettings,
   GcloudRunServicesListSettings,
+  GcloudRunServicesUpdateSettings,
   GcloudRunUpdateTrafficSettings,
   RUN_SERVICE_URL_FORMAT,
 } from "./cloud_run.ts";
@@ -191,6 +192,15 @@ export interface GcloudTasksApi {
   /** List Cloud Run services: `gcloud run services list`. */
   runServicesList(
     configure?: Configure<GcloudRunServicesListSettings>,
+  ): Promise<CommandOutput>;
+
+  /**
+   * Amend an existing Cloud Run service: `gcloud run services update`. Unlike
+   * {@link runDeploy}, it never creates the service and never resets settings
+   * the call does not name.
+   */
+  runServicesUpdate(
+    configure?: Configure<GcloudRunServicesUpdateSettings>,
   ): Promise<CommandOutput>;
 
   /** Move traffic between revisions: `gcloud run services update-traffic`. */
@@ -355,6 +365,8 @@ export const GcloudTasks: GcloudTasksApi = {
     );
   },
   runServicesList: (c) => runSettings(new GcloudRunServicesListSettings(), c),
+  runServicesUpdate: (c) =>
+    runSettings(new GcloudRunServicesUpdateSettings(), c),
   runUpdateTraffic: (c) => runSettings(new GcloudRunUpdateTrafficSettings(), c),
 
   artifactsImagesList: (c) =>

--- a/packages/gcloud/tests/commands_test.ts
+++ b/packages/gcloud/tests/commands_test.ts
@@ -29,6 +29,7 @@ import {
   GcloudRunDeploySettings,
   GcloudRunServicesDescribeSettings,
   GcloudRunServicesListSettings,
+  GcloudRunServicesUpdateSettings,
   GcloudRunUpdateTrafficSettings,
   GcloudSecretsVersionsAccessSettings,
   GcloudStorageCpSettings,
@@ -399,6 +400,80 @@ Deno.test("run update-traffic: one destination, and at least one", () => {
     () => new GcloudRunUpdateTrafficSettings().service("api").argv(),
     Error,
     "no destination",
+  );
+});
+
+Deno.test("run services update: image and env amendments", () => {
+  assertEquals(
+    new GcloudRunServicesUpdateSettings().service("api")
+      .region("europe-west1").platform("managed").image("gcr.io/p/i:tag")
+      .updateEnvVars("SECRETS_REFRESH_TIMESTAMP=2026-09-01", "MODE=live")
+      .removeEnvVars("LEGACY_FLAG")
+      .updateSecrets("DB_PASSWORD=db-password:latest")
+      .memory("512Mi").cpu("1").concurrency(40).maxInstances(10)
+      .minInstances(1).tag("candidate").noTraffic().argv(),
+    [
+      "gcloud",
+      "run",
+      "services",
+      "update",
+      "api",
+      "--region",
+      "europe-west1",
+      "--platform",
+      "managed",
+      "--image",
+      "gcr.io/p/i:tag",
+      "--update-env-vars",
+      "SECRETS_REFRESH_TIMESTAMP=2026-09-01,MODE=live",
+      "--remove-env-vars",
+      "LEGACY_FLAG",
+      "--update-secrets",
+      "DB_PASSWORD=db-password:latest",
+      "--memory",
+      "512Mi",
+      "--cpu",
+      "1",
+      "--concurrency",
+      "40",
+      "--max-instances",
+      "10",
+      "--min-instances",
+      "1",
+      "--tag",
+      "candidate",
+      "--no-traffic",
+    ],
+  );
+  // The minimal amendment — the image swap a deploy performs — carries nothing
+  // it was not asked to carry, which is the whole reason it is not `run deploy`.
+  assertEquals(
+    new GcloudRunServicesUpdateSettings().service("api").image("gcr.io/p/i")
+      .argv(),
+    ["gcloud", "run", "services", "update", "api", "--image", "gcr.io/p/i"],
+  );
+  assertEquals(
+    new GcloudRunServicesUpdateSettings().service("api").clearEnvVars().argv(),
+    ["gcloud", "run", "services", "update", "api", "--clear-env-vars"],
+  );
+});
+
+Deno.test("run services update: clearing and amending env vars are exclusive", () => {
+  // gcloud: "At most one of --clear-env-vars | --set-env-vars |
+  // --update-env-vars --remove-env-vars can be specified."
+  assertThrows(
+    () =>
+      new GcloudRunServicesUpdateSettings().service("api").clearEnvVars()
+        .updateEnvVars("A=1").argv(),
+    Error,
+    ".updateEnvVars()",
+  );
+  assertThrows(
+    () =>
+      new GcloudRunServicesUpdateSettings().service("api").clearEnvVars()
+        .removeEnvVars("A").argv(),
+    Error,
+    ".removeEnvVars()",
   );
 });
 
@@ -844,6 +919,11 @@ Deno.test("the remaining operands each command cannot do without", () => {
     "no service named",
   );
   assertThrows(
+    () => new GcloudRunServicesUpdateSettings().argv(),
+    Error,
+    "no service named",
+  );
+  assertThrows(
     () => new GcloudFunctionsDescribeSettings().argv(),
     Error,
     "no function named",
@@ -986,6 +1066,27 @@ Deno.test("a value containing a comma is refused by the flag that joins on one",
         .argv(),
     Error,
     "--set-env-vars",
+  );
+  assertThrows(
+    () =>
+      new GcloudRunServicesUpdateSettings().service("api")
+        .updateEnvVars("A=1,2").argv(),
+    Error,
+    "--update-env-vars",
+  );
+  assertThrows(
+    () =>
+      new GcloudRunServicesUpdateSettings().service("api")
+        .removeEnvVars("A,B").argv(),
+    Error,
+    "--remove-env-vars",
+  );
+  assertThrows(
+    () =>
+      new GcloudRunServicesUpdateSettings().service("api")
+        .updateSecrets("S=a,b").argv(),
+    Error,
+    "--update-secrets",
   );
   // The ordinary multi-value case still joins, which is the form gcloud takes.
   assertEquals(

--- a/packages/gcloud/tests/readers_test.ts
+++ b/packages/gcloud/tests/readers_test.ts
@@ -145,6 +145,13 @@ const REACH: Array<[string, () => Promise<unknown>]> = [
   ],
   ["runServicesList", () => GcloudTasks.runServicesList((s) => missingTool(s))],
   [
+    "runServicesUpdate",
+    () =>
+      GcloudTasks.runServicesUpdate((s) =>
+        missingTool(s).service("api").image("gcr.io/p/i")
+      ),
+  ],
+  [
     "runUpdateTraffic",
     () =>
       GcloudTasks.runUpdateTraffic((s) =>

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/.codex-plugin/plugin.json
+++ b/plugins/zuke/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -808,12 +808,17 @@ The deploy path is typed, so a build never string-builds it:
 | Auth        | `authActivateServiceAccount`, `authConfigureDocker`, `authList`, `authRevoke`        |
 | Config      | `configSet`, `configUnset`, `configGetValue`, `configList`                           |
 | Cloud Build | `buildsSubmit`, `buildsList`, `buildsDescribe`, `buildsLog`                          |
-| Cloud Run   | `runDeploy`, `runServicesDescribe`, `runServicesList`, `runUpdateTraffic`            |
+| Cloud Run   | `runDeploy`, `runServicesUpdate`, `runServicesDescribe`, `runServicesList`, `runUpdateTraffic` |
 | Registry    | `artifactsImagesList`, `artifactsImagesDelete`, `artifactsRepositoriesList/Describe` |
 | Storage     | `storageCp`, `storageRsync`, `storageLs`, `storageRm`                                |
 | GKE         | `clustersGetCredentials`, `clustersList`, `clustersDescribe`                         |
 | Functions   | `functionsDeploy`, `functionsDescribe`                                               |
 | Secrets     | `secretsAccess`                                                                      |
+
+`runDeploy` and `runServicesUpdate` are not interchangeable: `run deploy`
+creates the service when it is absent and resets settings the call does not
+name, while `run services update` only ever amends an existing one. Reach for
+the second when a pipeline points a live service at a new image.
 
 `GcloudTasks.run` with `.command(...)` remains the escape hatch for the rest of
 gcloud, which is vast — but reaching for it where a typed task exists discards

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -808,12 +808,17 @@ The deploy path is typed, so a build never string-builds it:
 | Auth        | `authActivateServiceAccount`, `authConfigureDocker`, `authList`, `authRevoke`        |
 | Config      | `configSet`, `configUnset`, `configGetValue`, `configList`                           |
 | Cloud Build | `buildsSubmit`, `buildsList`, `buildsDescribe`, `buildsLog`                          |
-| Cloud Run   | `runDeploy`, `runServicesDescribe`, `runServicesList`, `runUpdateTraffic`            |
+| Cloud Run   | `runDeploy`, `runServicesUpdate`, `runServicesDescribe`, `runServicesList`, `runUpdateTraffic` |
 | Registry    | `artifactsImagesList`, `artifactsImagesDelete`, `artifactsRepositoriesList/Describe` |
 | Storage     | `storageCp`, `storageRsync`, `storageLs`, `storageRm`                                |
 | GKE         | `clustersGetCredentials`, `clustersList`, `clustersDescribe`                         |
 | Functions   | `functionsDeploy`, `functionsDescribe`                                               |
 | Secrets     | `secretsAccess`                                                                      |
+
+`runDeploy` and `runServicesUpdate` are not interchangeable: `run deploy`
+creates the service when it is absent and resets settings the call does not
+name, while `run services update` only ever amends an existing one. Reach for
+the second when a pipeline points a live service at a new image.
 
 `GcloudTasks.run` with `.command(...)` remains the escape hatch for the rest of
 gcloud, which is vast — but reaching for it where a typed task exists discards

--- a/tests/integration/gcloud_commands_test.ts
+++ b/tests/integration/gcloud_commands_test.ts
@@ -17,7 +17,10 @@
 
 import { assertEquals } from "../../packages/core/tests/_assert.ts";
 import { Build, target } from "../../packages/core/mod.ts";
-import { GcloudTasks } from "../../packages/gcloud/mod.ts";
+import {
+  GcloudRunServicesUpdateSettings,
+  GcloudTasks,
+} from "../../packages/gcloud/mod.ts";
 import { runCli } from "./_harness.ts";
 
 /** A tool path that cannot exist, so resolution fails before any process runs. */
@@ -47,6 +50,56 @@ Deno.test("a settings refusal fails the target and names the fix", async () => {
   const deploy = await runCli(RefusalBuild, ["deploy"]);
   assertEquals(deploy.code, 1);
   assertEquals(deploy.err.includes("publicly invokable"), true);
+});
+
+Deno.test("run services update amends without deploy's create-and-reset", async () => {
+  // The two commands are not interchangeable: `run deploy` creates a missing
+  // service and resets what it does not name, `run services update` only
+  // amends. A build that reached for the wrong one would find out in
+  // production, so the argv a target actually sends is worth asserting from
+  // the CLI in.
+  const sent: string[][] = [];
+  class UpdateBuild extends Build {
+    refresh = target().executes(async () => {
+      const settings = new GcloudRunServicesUpdateSettings()
+        .service("api").project("proj").region("europe-west1")
+        .image("gcr.io/proj/api:abc123")
+        .updateEnvVars("SECRETS_REFRESH_TIMESTAMP=2026-09-01T10:00:00Z");
+      sent.push(settings.argv());
+      await GcloudTasks.runServicesUpdate((s) =>
+        s.toolPath(ABSENT).service("api").image("gcr.io/proj/api:abc123")
+      );
+    });
+    // .clearEnvVars() drops every variable; .updateEnvVars() leaves the
+    // unnamed ones alone. gcloud refuses the pair, and so does the wrapper.
+    conflicting = target().executes(async () => {
+      await GcloudTasks.runServicesUpdate((s) =>
+        s.toolPath(ABSENT).service("api").clearEnvVars().updateEnvVars("A=1")
+      );
+    });
+  }
+  const refresh = await runCli(UpdateBuild, ["refresh"]);
+  // The tool is absent, so the target fails — after the argv was assembled.
+  assertEquals(refresh.code, 1);
+  assertEquals(sent, [[
+    "gcloud",
+    "run",
+    "services",
+    "update",
+    "api",
+    "--region",
+    "europe-west1",
+    "--image",
+    "gcr.io/proj/api:abc123",
+    "--update-env-vars",
+    "SECRETS_REFRESH_TIMESTAMP=2026-09-01T10:00:00Z",
+    "--project",
+    "proj",
+  ]]);
+
+  const conflicting = await runCli(UpdateBuild, ["conflicting"]);
+  assertEquals(conflicting.code, 1);
+  assertEquals(conflicting.err.includes(".updateEnvVars()"), true);
 });
 
 Deno.test("the value readers fail on an absent gcloud rather than returning empty", async () => {


### PR DESCRIPTION
## What & why

Cloud Run had four typed commands — `runDeploy`, `runServicesDescribe`, `runServicesList`, `runUpdateTraffic` — but not `gcloud run services update`, so a build that amends an existing service dropped back to the generic command builder and raw flag strings.

`runDeploy` is not a substitute, and that is the point of the change rather than a detail of it. `gcloud run deploy` creates the service when it is absent and resets settings the invocation does not name; `gcloud run services update` only ever amends an existing service. A pipeline that silently creates a service, or quietly drops scaling and env config it never mentioned, is a worse failure than one that errors — so the two want to be separately reachable, not one behind a flag.

This adds `GcloudRunServicesUpdateSettings` alongside its Cloud Run siblings, plus the `runServicesUpdate` task. Its flags are the ones a deploy actually reaches for: the image swap, the env-var and secret amendments, the scaling knobs, and the tag/no-traffic pair that pairs with the `runUpdateTraffic` already shipped.

Two behaviours worth flagging for review:

- List values join through the package's existing `commaJoined`, so a value containing a comma is refused where it is assembled — with a message naming the offending value — rather than misread by gcloud as another entry.
- Clearing and amending environment variables are refused together. gcloud accepts at most one of `--clear-env-vars`, `--set-env-vars`, and the `--update-env-vars`/`--remove-env-vars` pair, and the spellings differ in whether variables the call does not name survive. That is the same treatment `runDeploy` gives the authenticated/unauthenticated pair.

Env vars and secrets take `KEY=value` strings rather than a record. The issue sketched a record; string pairs match `setEnvVars` and `setSecrets` on `GcloudRunDeploySettings`, and two shapes for one flag family inside a single package seemed the worse trade. Happy to switch if you would rather the record shape led.

## Related issues

Closes #432

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a [Conventional Commit](https://www.conventionalcommits.org/) (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches). Unit coverage of the full argv, the minimal amendment, both refusals and the three comma refusals; an integration test drives a real build through the CLI and asserts the argv a target sends plus the refusal reaching a failed build.
- [x] Docs updated in the same PR — the Cloud Run row in the skill cheatsheet, plus a note on when `runServicesUpdate` is the right command rather than `runDeploy`.
- [x] Public API changes were regenerated with `./zuke apiDocs`.
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/`.
- [x] No dead code.
- [x] No duplicated logic: the comma-joining and its refusal come from the package's one implementation.
- [x] SOLID shapes respected: the new class sits in the Cloud Run domain file with its siblings, and extends through the settings lambda.
- [x] Not applicable — no new package.
- [x] The code is written using AI assisted coding.

## Adversarial pass

Attacked before opening: argv injection through a service name or image reference (every value is a discrete argv token, never concatenated); a comma smuggled into an env-var, removal or secret value (refused at assembly, with the value named); the clear/update pairing that gcloud resolves silently; a missing service operand; and flag ordering, which is stable and declaration-driven. No findings survived.
