### PR TITLE
feat(git): `--error-unmatch` on `lsFiles`

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.31.0",
+      "version": "0.32.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "zuke",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build)."
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -13719,6 +13719,14 @@ class GitLsFilesSettings extends GitSettings
     Apply the standard ignore rules (`--exclude-standard`).
   directory(): this
     Report an untracked directory once rather than every file in it (`--directory`).
+  errorUnmatch(): this
+    Exit non-zero when a pathspec matches nothing (`--error-unmatch`), which
+    is how a build asserts that a path is tracked rather than reading the
+    listing to see whether it came back empty.
+
+    git only applies it to the paths it was given, so it needs
+    {@link paths} — the flag on its own describes a whole-tree listing, which
+    always matches something.
   nulTerminated(): this
     Terminate each entry with a NUL rather than a newline (`-z`).
   override protected subcommandArgs(): string[]

--- a/packages/git/README.md
+++ b/packages/git/README.md
@@ -670,6 +670,14 @@ class GitLsFilesSettings extends GitSettings
     Apply the standard ignore rules (`--exclude-standard`).
   directory(): this
     Report an untracked directory once rather than every file in it (`--directory`).
+  errorUnmatch(): this
+    Exit non-zero when a pathspec matches nothing (`--error-unmatch`), which
+    is how a build asserts that a path is tracked rather than reading the
+    listing to see whether it came back empty.
+
+    git only applies it to the paths it was given, so it needs
+    {@link paths} — the flag on its own describes a whole-tree listing, which
+    always matches something.
   nulTerminated(): this
     Terminate each entry with a NUL rather than a newline (`-z`).
   override protected subcommandArgs(): string[]

--- a/packages/git/src/ls_files.ts
+++ b/packages/git/src/ls_files.ts
@@ -37,6 +37,7 @@ export class GitLsFilesSettings extends GitSettings {
   #excludeStandard = false;
   #directory = false;
   #nul = false;
+  #errorUnmatch = false;
 
   /** Limit the listing to these pathspecs (positional); repeatable. */
   paths(...values: PathLike[]): this {
@@ -95,6 +96,20 @@ export class GitLsFilesSettings extends GitSettings {
     return this;
   }
 
+  /**
+   * Exit non-zero when a pathspec matches nothing (`--error-unmatch`), which
+   * is how a build asserts that a path is tracked rather than reading the
+   * listing to see whether it came back empty.
+   *
+   * git only applies it to the paths it was given, so it needs
+   * {@link paths} — the flag on its own describes a whole-tree listing, which
+   * always matches something.
+   */
+  errorUnmatch(): this {
+    this.#errorUnmatch = true;
+    return this;
+  }
+
   /** Terminate each entry with a NUL rather than a newline (`-z`). */
   nulTerminated(): this {
     this.#nul = true;
@@ -103,6 +118,13 @@ export class GitLsFilesSettings extends GitSettings {
 
   /** Assemble the `git ls-files` argv. */
   protected override subcommandArgs(): string[] {
+    if (this.#errorUnmatch && this.#paths.length === 0) {
+      throw new Error(
+        "GitTasks.lsFiles: .errorUnmatch() makes git fail when a pathspec " +
+          "matches nothing, so it needs the pathspecs — add .paths(...). " +
+          "Without them the listing covers the whole tree and always matches.",
+      );
+    }
     if (this.#ignored && !this.#others) {
       throw new Error(
         "GitTasks.lsFiles: .ignored() filters an untracked listing — add " +
@@ -118,6 +140,7 @@ export class GitLsFilesSettings extends GitSettings {
     if (this.#stage) argv.push("--stage");
     if (this.#excludeStandard) argv.push("--exclude-standard");
     if (this.#directory) argv.push("--directory");
+    if (this.#errorUnmatch) argv.push("--error-unmatch");
     if (this.#nul) argv.push("-z");
     if (this.#paths.length > 0) argv.push("--", ...this.#paths);
     return argv;

--- a/packages/git/tests/history_test.ts
+++ b/packages/git/tests/history_test.ts
@@ -182,6 +182,29 @@ Deno.test("ls-files renders its selectors", () => {
   );
 });
 
+Deno.test("ls-files --error-unmatch asserts a path is tracked", () => {
+  assertEquals(
+    new GitLsFilesSettings().cached().errorUnmatch().paths("openapi.json")
+      .argv(),
+    [
+      "git",
+      "ls-files",
+      "--cached",
+      "--error-unmatch",
+      "--",
+      "openapi.json",
+    ],
+  );
+  // The flag only applies to the paths git was given: without them the
+  // listing covers the whole tree and always matches, so the assertion the
+  // caller wanted would silently never fire.
+  assertThrows(
+    () => new GitLsFilesSettings().cached().errorUnmatch().argv(),
+    Error,
+    ".paths(",
+  );
+});
+
 Deno.test("rev-parse renders its resolution flags", () => {
   assertEquals(
     new GitRevParseSettings().verify().short().rev("HEAD").argv(),

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/.codex-plugin/plugin.json
+++ b/plugins/zuke/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -768,6 +768,12 @@ const url = await GitTasks.configGet((s) => s.get("remote.origin.url")); // unde
 They pin the machine-readable form (`-z`, a separator-based `--format`), so a
 path with a space in it or a multi-line commit message parses correctly.
 
+To assert that a generated file is tracked — which a drift check has to do
+before it diffs, since `git diff` reports nothing at all about an untracked
+file — either read the listing and check it is non-empty, or let git decide the
+exit code with `lsFiles` and `.errorUnmatch()`, which needs `.paths(...)` to
+have anything to assert about.
+
 The interrogation commands add the answers CI asks for most — a base ref, a
 commit count, whether one ref is contained in another:
 

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -768,6 +768,12 @@ const url = await GitTasks.configGet((s) => s.get("remote.origin.url")); // unde
 They pin the machine-readable form (`-z`, a separator-based `--format`), so a
 path with a space in it or a multi-line commit message parses correctly.
 
+To assert that a generated file is tracked — which a drift check has to do
+before it diffs, since `git diff` reports nothing at all about an untracked
+file — either read the listing and check it is non-empty, or let git decide the
+exit code with `lsFiles` and `.errorUnmatch()`, which needs `.paths(...)` to
+have anything to assert about.
+
 The interrogation commands add the answers CI asks for most — a base ref, a
 commit count, whether one ref is contained in another:
 

--- a/tests/integration/git_interrogation_test.ts
+++ b/tests/integration/git_interrogation_test.ts
@@ -17,7 +17,7 @@
 
 import { assertEquals } from "../../packages/core/tests/_assert.ts";
 import { Build, target } from "../../packages/core/mod.ts";
-import { GitTasks } from "../../packages/git/mod.ts";
+import { GitLsFilesSettings, GitTasks } from "../../packages/git/mod.ts";
 import { runCli } from "./_harness.ts";
 
 /** A tool path that cannot exist, so resolution fails before any process runs. */
@@ -35,6 +35,45 @@ Deno.test("a settings refusal fails the target and names the fix", async () => {
   const { code, err } = await runCli(RefusalBuild, ["ancestor"]);
   assertEquals(code, 1);
   assertEquals(err.includes("exactly two commits"), true);
+});
+
+Deno.test("--error-unmatch needs the pathspecs it asserts about", async () => {
+  // The drift check this flag exists for has an order: git diff reports
+  // nothing at all about an untracked file, so "is it tracked?" has to be
+  // asked first. A caller who reached for the flag and forgot the pathspecs
+  // would get a whole-tree listing that always matches — the assertion
+  // silently never firing — so the settings refuse it, and the refusal has to
+  // reach the target rather than being swallowed by the executor.
+  const settings = new GitLsFilesSettings().cached().errorUnmatch()
+    .paths("openapi.json");
+  class DriftBuild extends Build {
+    tracked = target().executes(async () => {
+      await GitTasks.lsFiles((s) =>
+        s.toolPath(ABSENT).cached().errorUnmatch().paths("openapi.json")
+      );
+    });
+    unscoped = target().executes(async () => {
+      await GitTasks.lsFiles((s) => s.toolPath(ABSENT).cached().errorUnmatch());
+    });
+  }
+  assertEquals(settings.argv(), [
+    "git",
+    "ls-files",
+    "--cached",
+    "--error-unmatch",
+    "--",
+    "openapi.json",
+  ]);
+
+  // Scoped to a path, the task is well-formed and fails only because the tool
+  // is absent — the flag itself is not what stopped it.
+  const tracked = await runCli(DriftBuild, ["tracked"]);
+  assertEquals(tracked.code, 1);
+  assertEquals(tracked.err.includes(".paths("), false);
+
+  const unscoped = await runCli(DriftBuild, ["unscoped"]);
+  assertEquals(unscoped.code, 1);
+  assertEquals(unscoped.err.includes(".paths("), true);
 });
 
 Deno.test("a reader refuses the option that would misreport its result", async () => {


### PR DESCRIPTION
## What & why

`GitLsFilesSettings` carried every selector except `--error-unmatch`, the one that turns "this pathspec matched nothing" into a non-zero exit instead of empty output. It is the flag for asserting that a path is tracked.

That assertion has an order to it, which is the reason it is worth having at all: `git diff` reports nothing whatsoever about an untracked file, so a generated artifact that was never committed sails through a diff-only drift check. "Is it tracked?" has to be asked before "has it changed?".

One refusal comes with it. `--error-unmatch` only applies to the pathspecs git was given — on its own the listing covers the whole tree and always matches, so a caller who reached for the flag and forgot the paths would be left with an assertion that can never fire. The settings refuse that case and name the fix, the same treatment the ignored-without-others pairing already gets.

Worth saying plainly: the workaround this replaces is fine, and arguably reads better. Listing with `.cached()` and checking the result is non-empty is unambiguous, and a caller's own error message beats git's `did not match any file(s) known to git`. This is for flag-completeness and for callers who want the exit code — in particular anything piping git's own diagnostic straight to a log — not because anything was blocked. The cheatsheet now names both approaches rather than steering to the new one.

## Related issues

Closes #434

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a [Conventional Commit](https://www.conventionalcommits.org/) (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches). A unit test pins the argv and the refusal; an integration test proves the refusal reaches a target as a failed build, and that a properly scoped call is stopped only by the absent tool rather than by the flag.
- [x] Docs updated in the same PR — the skill cheatsheet gains the tracked-then-diffed ordering and both ways to assert it.
- [x] Public API changes were regenerated with `./zuke apiDocs`.
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/`.
- [x] No dead code.
- [x] No duplicated logic.
- [x] SOLID shapes respected: one more flag on the existing settings class, in the flag order it already establishes.
- [x] Not applicable — no new package.
- [x] The code is written using AI assisted coding.

## Adversarial pass

Attacked before opening: the flag emitted without pathspecs, which would silently never assert (refused, tested both as a unit and through a build); flag ordering relative to the `--` separator, since anything after it is a pathspec and a flag landing there would be read as a filename (it is emitted before, pinned by the argv assertion); and the interaction with the `lsFileNames` reader, whose `-z` and `--stage` guard are untouched by this. No findings survived.
