### PR TITLE
feat(core): a `zuke outdated` command for stale JSR pins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.31.0",
+      "version": "0.32.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -231,11 +231,23 @@ has since typed.
 The **lock** is what it reads, not the import map: the lock records what a run
 actually resolves, which is the number a stale pin hides.
 
-`--exit-code` makes it exit `1` when anything is behind, so a scheduled job can
-fail on one; without it the command is a report and always exits `0`. A package
-the registry cannot answer for — a private scope, a rename, an offline runner —
-is skipped rather than failing the whole report; a missing lock file is an
-error, since "nothing is behind" and "I never read a lock" must not look alike.
+A package the registry cannot answer for — a private scope, a rename, an
+offline runner — does not fail the whole report, but it *is* named in it:
+
+```text
+1 package could not be checked:
+  @private/thing (1.0.0) — error sending request
+```
+
+That distinction is the point. A run behind a proxy that reached nothing at all
+would otherwise print "every package is at its latest release", which is the
+confident wrong answer this command exists to prevent. A missing lock file is
+an outright error, for the same reason.
+
+`--exit-code` makes it exit `1` when anything is behind **or** could not be
+checked — a gate asking "are we current?" has not been told yes by a run that
+never got an answer. Without the flag the command is a report and always exits
+`0`.
 
 It needs the network, which is why it is a command you run rather than a line in
 `--list` or the run summary: those stay offline and instant. `outdated` is a

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -67,6 +67,7 @@ below) attach to whichever launcher word you install them for.
 | `./zuke cancel <id> [--actor <name>]`                                   | Cancel a run and run its compensations ([details](./orchestration.md#cancellation--compensation--oncancel)). |
 | `./zuke register [--actor <name>] [--json]`                             | Register this build in the build registry (`--json` prints the written descriptor).                         |
 | `./zuke doc <spec>`                                                     | Print a package's API docs (`deno doc <spec>`) from an isolated empty directory.                            |
+| `./zuke outdated [--exit-code]`                                         | Report the JSR packages the lock resolves behind their latest release (needs the network).                  |
 | `./zuke --help` / `-h`                                                  | Usage.                                                                                                      |
 | `./zuke` (no target)                                                    | Run the `default` target if defined, else print `--list`.                                                   |
 
@@ -204,6 +205,47 @@ This is a different command from the global `zuke doc` above: the global one
 takes a bare package name (`zuke doc core`) and resolves it to `jsr:@zuke/core`
 for you; the build's own `./zuke doc` needs the full spec (or a relative
 path), since it is just another reserved command on your build's CLI.
+
+## `zuke outdated`
+
+`./zuke outdated` compares the versions your `deno.lock` resolves for every
+`jsr:` specifier against the latest each package publishes, and prints the ones
+that are behind:
+
+```text
+@zuke/git     1.5.0  →  1.11.0
+@zuke/gcloud  1.1.0  →  1.3.0
+
+2 packages are behind. Refresh the lock with a plain `deno cache --reload` …
+```
+
+It exists for the case nothing else covers. A build whose specifiers are
+written inline — `jsr:@zuke/git@^1` in `zuke.ts` and its helper modules, rather
+than in a `deno.json` imports map — gets no signal from `deno outdated`, which
+reads manifests. The lock keeps resolving the versions recorded when the build
+was written, and `--frozen` is content with that, because a stale-but-valid
+lock is exactly what `--frozen` is for. A build can therefore sit several minor
+versions behind a wrapper for months, still hand-rolling a command the package
+has since typed.
+
+The **lock** is what it reads, not the import map: the lock records what a run
+actually resolves, which is the number a stale pin hides.
+
+`--exit-code` makes it exit `1` when anything is behind, so a scheduled job can
+fail on one; without it the command is a report and always exits `0`. A package
+the registry cannot answer for — a private scope, a rename, an offline runner —
+is skipped rather than failing the whole report; a missing lock file is an
+error, since "nothing is behind" and "I never read a lock" must not look alike.
+
+It needs the network, which is why it is a command you run rather than a line in
+`--list` or the run summary: those stay offline and instant. `outdated` is a
+reserved command name.
+
+Two things about refreshing the lock afterwards, because the obvious move is
+wrong. In a repo that also has a `package.json`, `deno cache` resolves the whole
+npm tree and writes an `npm` section a jsr-only lock never had. And
+`--reload=jsr:` re-resolves from cached registry metadata, handing back the same
+stale versions — only a bare `--reload` actually re-resolves.
 
 ## Parallel execution
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "zuke",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build)."
 }

--- a/llms.txt
+++ b/llms.txt
@@ -71,7 +71,7 @@ Option flags:
 - `--data` — With resume --signal, the signal's JSON payload
 - `--force-graph` — With resume, continue even if the build graph changed
 - `--resume-degraded` — With resume, continue even if a state write was dropped
-- `--exit-code` — With outdated, exit non-zero when a package is behind its latest
+- `--exit-code` — With outdated, exit non-zero when a package is behind or unchecked
 - `--status` — With runs list, keep only runs with this status
 - `--target` — With runs list, keep only runs whose graph has this target
 - `--since` — With runs list, keep only runs created at/after this time

--- a/llms.txt
+++ b/llms.txt
@@ -50,6 +50,7 @@ Reserved commands:
 - `cancel` — Cancel a run and run its compensations
 - `register` — Register this build in the build registry
 - `doc` — Print a package's API docs (deno doc), isolated from the repo
+- `outdated` — Report JSR packages the lock resolves behind their latest
 
 Option flags:
 
@@ -70,6 +71,7 @@ Option flags:
 - `--data` — With resume --signal, the signal's JSON payload
 - `--force-graph` — With resume, continue even if the build graph changed
 - `--resume-degraded` — With resume, continue even if a state write was dropped
+- `--exit-code` — With outdated, exit non-zero when a package is behind its latest
 - `--status` — With runs list, keep only runs with this status
 - `--target` — With runs list, keep only runs whose graph has this target
 - `--since` — With runs list, keep only runs created at/after this time

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -20,6 +20,11 @@ import {
   graphCommand,
   type GraphHost,
 } from "./graph_view.ts";
+import {
+  findOutdated,
+  formatOutdated,
+  type OutdatedOptions,
+} from "./outdated.ts";
 import { type AnyParameter, discoverParameters, flagName } from "./params.ts";
 import type { JsonValue, TargetBuilder } from "./target.ts";
 import type { Plugin } from "./plugin.ts";
@@ -38,6 +43,7 @@ import {
   GENERATE_CI_COMMAND,
   GRAPH_COMMAND,
   MCP_COMMAND,
+  OUTDATED_COMMAND,
   REGISTER_COMMAND,
   RESUME_COMMAND,
   RUNS_COMMAND,
@@ -182,6 +188,10 @@ export interface ParsedArgs {
   doc: boolean;
   /** The spec to document (the positional after `doc`): a `jsr:`/`npm:` URL or a path. */
   docSpec?: string;
+  /** The `outdated` command was requested (report JSR packages behind their latest). */
+  outdated: boolean;
+  /** Exit non-zero when `outdated` found something (`--exit-code`). */
+  exitCode: boolean;
   /** Raw parameter values from declared flags, keyed by property name. */
   values: Record<string, string>;
   help: boolean;
@@ -374,6 +384,8 @@ export function parseArgs(
     cancel: false,
     register: false,
     doc: false,
+    outdated: false,
+    exitCode: false,
     confirmDestructive: false,
     mcpRegistry: false,
     help: false,
@@ -417,6 +429,8 @@ export function parseArgs(
       parsed.runCounts = true;
     } else if (arg === "--check") {
       parsed.check = true;
+    } else if (arg === "--exit-code") {
+      parsed.exitCode = true;
     } else if (arg === "--allow-run") {
       parsed.allowRun = true;
     } else if (arg.startsWith("--allow-run=")) {
@@ -503,7 +517,7 @@ export function parseArgs(
     } else if (
       parsed.target === undefined && !parsed.graph && !parsed.generateCi &&
       !parsed.completions && !parsed.mcp && !parsed.resume && !parsed.runs &&
-      !parsed.cancel && !parsed.register && !parsed.doc
+      !parsed.cancel && !parsed.register && !parsed.doc && !parsed.outdated
     ) {
       if (arg === GRAPH_COMMAND) parsed.graph = true;
       else if (arg === GENERATE_CI_COMMAND) parsed.generateCi = true;
@@ -514,6 +528,7 @@ export function parseArgs(
       else if (arg === CANCEL_COMMAND) parsed.cancel = true;
       else if (arg === REGISTER_COMMAND) parsed.register = true;
       else if (arg === DOC_COMMAND) parsed.doc = true;
+      else if (arg === OUTDATED_COMMAND) parsed.outdated = true;
       else parsed.target = arg;
     }
   }
@@ -543,6 +558,7 @@ Usage:
   deno run -A zuke.ts cancel <run-id> [--actor <name>]
   deno run -A zuke.ts register [--actor <name>] [--json]
   deno run -A zuke.ts doc <spec>
+  deno run -A zuke.ts outdated [--exit-code]
 
 Options:
   <target>          Run the target and its transitive dependencies.
@@ -646,6 +662,13 @@ Options:
                     and buries the API under type-resolution warnings; the empty
                     cwd has nothing to resolve. A relative path (./mod.ts) is
                     resolved against the real working directory first.
+  outdated          Report the JSR packages the lock resolves to a version
+                    older than the registry's latest. Needs the network, which
+                    is why it is a command rather than a line in --list: a
+                    build whose specifiers are written inline (jsr:@zuke/x@^1)
+                    gets no signal from deno outdated, which reads manifests.
+  --exit-code       With outdated, exit non-zero when a package is behind, so a
+                    gate can fail on one.
   --status <s>      With runs list, keep only runs with this status (running,
                     suspended, succeeded, failed, cancelled).
   --target <t>      With runs list, keep only runs whose graph contains this
@@ -776,6 +799,11 @@ export interface MainOptions {
   graphHost?: GraphHost;
   /** Runner for the `doc` command's `deno doc` spawn (injected in tests). */
   docRunner?: DocRunner;
+  /**
+   * Lock path, registry origin and `fetch` for the `outdated` command
+   * (injected in tests, which have neither a lock nor a network).
+   */
+  outdatedOptions?: OutdatedOptions;
   /** Lifecycle observers to run alongside the build's own hooks. */
   plugins?: Plugin[];
   /** Overrides for `completions install` (home/config dir), injected in tests. */
@@ -1062,6 +1090,29 @@ async function runDoc(
   }
 }
 
+/**
+ * Run the `outdated` command: compare the versions the lock resolves against
+ * the registry's latest, print the report, and — with `--exit-code` — report a
+ * finding as a non-zero exit so a gate can fail on one.
+ *
+ * A failure to read the lock is an exit 1 with the reason, matching the other
+ * commands; being unable to reach the registry for one package is not, since
+ * the report still speaks for the rest.
+ */
+async function runOutdated(
+  parsed: ParsedArgs,
+  options: OutdatedOptions = {},
+): Promise<number> {
+  try {
+    const behind = await findOutdated(options);
+    console.log(formatOutdated(behind));
+    return parsed.exitCode && behind.length > 0 ? 1 : 0;
+  } catch (error) {
+    console.error(messageOf(error));
+    return 1;
+  }
+}
+
 /** Run the `runs` command: build the query (validating `--status`) and dispatch. */
 async function runRuns(build: Build, parsed: ParsedArgs): Promise<number> {
   const query: RunQuery = {};
@@ -1239,6 +1290,9 @@ async function runCommand(
   }
   if (parsed.doc) {
     return await runDoc(parsed, options.docRunner);
+  }
+  if (parsed.outdated) {
+    return await runOutdated(parsed, options.outdatedOptions);
   }
 
   let name = parsed.target;

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -667,8 +667,9 @@ Options:
                     is why it is a command rather than a line in --list: a
                     build whose specifiers are written inline (jsr:@zuke/x@^1)
                     gets no signal from deno outdated, which reads manifests.
-  --exit-code       With outdated, exit non-zero when a package is behind, so a
-                    gate can fail on one.
+  --exit-code       With outdated, exit non-zero when a package is behind or
+                    could not be checked, so a gate can fail on either — a run
+                    that reached nothing has not answered the question.
   --status <s>      With runs list, keep only runs with this status (running,
                     suspended, succeeded, failed, cancelled).
   --target <t>      With runs list, keep only runs whose graph contains this
@@ -1096,17 +1097,24 @@ async function runDoc(
  * finding as a non-zero exit so a gate can fail on one.
  *
  * A failure to read the lock is an exit 1 with the reason, matching the other
- * commands; being unable to reach the registry for one package is not, since
- * the report still speaks for the rest.
+ * commands. Being unable to reach the registry for a package is not: the
+ * report still speaks for the rest, and names the ones it could not check —
+ * which `--exit-code` also treats as a finding, since an unanswered question
+ * is not a "yes".
  */
 async function runOutdated(
   parsed: ParsedArgs,
   options: OutdatedOptions = {},
 ): Promise<number> {
   try {
-    const behind = await findOutdated(options);
-    console.log(formatOutdated(behind));
-    return parsed.exitCode && behind.length > 0 ? 1 : 0;
+    const report = await findOutdated(options);
+    console.log(formatOutdated(report));
+    // A package that could not be checked counts as a failure under
+    // --exit-code: a gate asking "are we current?" has not been told yes, and
+    // an offline runner passing quietly is the silence this command exists to
+    // break. Without the flag it stays a report and exits 0.
+    const unresolved = report.behind.length + report.unchecked.length;
+    return parsed.exitCode && unresolved > 0 ? 1 : 0;
   } catch (error) {
     console.error(messageOf(error));
     return 1;

--- a/packages/core/src/cli_spec.ts
+++ b/packages/core/src/cli_spec.ts
@@ -156,7 +156,7 @@ export const BUILTIN_FLAGS: readonly BuiltinFlag[] = [
   {
     name: "--exit-code",
     description:
-      "With outdated, exit non-zero when a package is behind its latest",
+      "With outdated, exit non-zero when a package is behind or unchecked",
   },
   {
     name: "--status",

--- a/packages/core/src/cli_spec.ts
+++ b/packages/core/src/cli_spec.ts
@@ -50,6 +50,9 @@ export const REGISTER_COMMAND = "register";
 /** The `doc` command: print a package's API docs, isolated from the repo. */
 export const DOC_COMMAND = "doc";
 
+/** The `outdated` command: report JSR packages the lock resolves behind. */
+export const OUTDATED_COMMAND = "outdated";
+
 /** Every reserved command, in help and completion order. */
 export const RESERVED_COMMANDS: readonly ReservedCommand[] = [
   { name: GRAPH_COMMAND, description: "Show the dependency graph" },
@@ -82,6 +85,10 @@ export const RESERVED_COMMANDS: readonly ReservedCommand[] = [
     name: DOC_COMMAND,
     description:
       "Print a package's API docs (deno doc), isolated from the repo",
+  },
+  {
+    name: OUTDATED_COMMAND,
+    description: "Report JSR packages the lock resolves behind their latest",
   },
 ];
 
@@ -145,6 +152,11 @@ export const BUILTIN_FLAGS: readonly BuiltinFlag[] = [
   {
     name: "--resume-degraded",
     description: "With resume, continue even if a state write was dropped",
+  },
+  {
+    name: "--exit-code",
+    description:
+      "With outdated, exit non-zero when a package is behind its latest",
   },
   {
     name: "--status",

--- a/packages/core/src/outdated.ts
+++ b/packages/core/src/outdated.ts
@@ -1,0 +1,215 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * The `outdated` command: which JSR packages the lock resolves are behind
+ * their latest release.
+ *
+ * It exists because nothing else answers that question for a build whose
+ * specifiers are written inline (`jsr:@zuke/git@^1` in `zuke.ts`) rather than
+ * in an import map. `deno outdated` reads manifests, so it says nothing about
+ * them; the lock keeps resolving the versions recorded when the build was
+ * written, and `--frozen` is perfectly happy with that, because a stale-but-
+ * valid lock is exactly what `--frozen` is for. The result is a build that can
+ * sit several minor versions behind a wrapper for months, still hand-rolling a
+ * command the package has since typed, with no signal of any kind.
+ *
+ * The lock is the source of truth here rather than the import map: it records
+ * what a run *actually resolves*, which is the number a stale pin hides.
+ *
+ * It needs the network, which is why it is a command a person runs rather than
+ * a line in `--list` or the run summary — those must stay offline and instant.
+ *
+ * @module
+ */
+
+import { httpJson } from "./http.ts";
+import { readTextOrNull } from "./internal.ts";
+
+/** The default JSR registry origin; overridden in tests. */
+export const JSR_REGISTRY = "https://jsr.io";
+
+/** The lock file an unqualified run reads. */
+export const DEFAULT_LOCK_PATH = "deno.lock";
+
+/** A JSR package whose resolved version is behind the registry's latest. */
+export interface OutdatedPackage {
+  /** The package name, e.g. `@zuke/git`. */
+  name: string;
+  /** The specifier as written, e.g. `jsr:@zuke/git@^1`. */
+  specifier: string;
+  /** The version the lock resolves that specifier to. */
+  resolved: string;
+  /** The latest version the registry publishes. */
+  latest: string;
+}
+
+/** Options for {@link findOutdated}. */
+export interface OutdatedOptions {
+  /** The lock file to read (default {@link DEFAULT_LOCK_PATH}). */
+  lockPath?: string;
+  /** The registry origin to query (default {@link JSR_REGISTRY}). */
+  registry?: string;
+  /** The `fetch` to use; injected so the command is testable without network. */
+  fetch?: typeof fetch;
+}
+
+/** One `jsr:` entry of a lock file's `specifiers` map. */
+interface LockedSpecifier {
+  /** The specifier as written, e.g. `jsr:@zuke/git@^1`. */
+  specifier: string;
+  /** The package it names, e.g. `@zuke/git`. */
+  name: string;
+  /** The version the lock resolves it to. */
+  resolved: string;
+}
+
+/** A `jsr:` specifier: the scoped name, then the range the author wrote. */
+const JSR_SPECIFIER = /^jsr:(@[^/@]+\/[^@]+)(?:@(.*))?$/;
+
+/** A version's numeric core, ignoring any prerelease or build suffix. */
+const VERSION_CORE = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/;
+
+/**
+ * The `jsr:` specifiers a lock resolves, in the order the lock lists them.
+ *
+ * Tolerant by design: a lock whose shape is unfamiliar yields no entries
+ * rather than throwing, because "I could not read your lock" is a worse answer
+ * to `zuke outdated` than "nothing to report" only if it is silent — and the
+ * caller distinguishes the two by the specifier count, not by an exception.
+ */
+export function lockedJsrSpecifiers(lockText: string): LockedSpecifier[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(lockText);
+  } catch {
+    return [];
+  }
+  if (parsed === null || typeof parsed !== "object") return [];
+  const specifiers: unknown = Reflect.get(parsed, "specifiers");
+  if (specifiers === null || typeof specifiers !== "object") return [];
+  const entries: LockedSpecifier[] = [];
+  for (const [specifier, resolved] of Object.entries(specifiers)) {
+    if (typeof resolved !== "string") continue;
+    const match = JSR_SPECIFIER.exec(specifier);
+    if (match === null) continue;
+    entries.push({ specifier, name: match[1], resolved });
+  }
+  return entries;
+}
+
+/**
+ * Whether `resolved` is behind `latest`, comparing major, minor and patch
+ * numerically — so `1.10.0` counts as newer than `1.9.0`, which a string
+ * comparison gets wrong exactly once the tenth release lands.
+ *
+ * A version either side cannot parse as a numeric core is reported as *not*
+ * behind: the honest answer to two versions this cannot order is silence, and
+ * a wrong "you are behind" would send someone bumping a pin that is already
+ * current. A prerelease sorts below the release it precedes.
+ */
+export function isBehind(resolved: string, latest: string): boolean {
+  const a = VERSION_CORE.exec(resolved);
+  const b = VERSION_CORE.exec(latest);
+  if (a === null || b === null) return false;
+  for (let i = 1; i <= 3; i++) {
+    const mine = Number(a[i]);
+    const theirs = Number(b[i]);
+    if (mine !== theirs) return mine < theirs;
+  }
+  // Same numeric core: a prerelease (1.2.0-rc.1) is behind the release itself.
+  return resolved !== latest && resolved.includes("-") && !latest.includes("-");
+}
+
+/** The `latest` field of a JSR package's `meta.json`, or `undefined`. */
+function latestOf(meta: unknown): string | undefined {
+  if (meta === null || typeof meta !== "object") return undefined;
+  const latest: unknown = Reflect.get(meta, "latest");
+  return typeof latest === "string" ? latest : undefined;
+}
+
+/**
+ * The JSR packages the lock at `lockPath` resolves to a version older than the
+ * registry's latest.
+ *
+ * One registry request per distinct package name, whatever the number of
+ * specifiers pointing at it. A package the registry cannot answer for is
+ * skipped rather than failing the whole report — one unpublished or renamed
+ * dependency should not hide the news about the others.
+ */
+export async function findOutdated(
+  options: OutdatedOptions = {},
+): Promise<OutdatedPackage[]> {
+  const lockPath = options.lockPath ?? DEFAULT_LOCK_PATH;
+  const lockText = await readTextOrNull(lockPath);
+  if (lockText === null) {
+    throw new Error(
+      `outdated: no lock file at "${lockPath}", so there are no resolved ` +
+        "versions to compare. Run the build once, or `deno install`, to " +
+        "write one.",
+    );
+  }
+  const registry = options.registry ?? JSR_REGISTRY;
+  const behind: OutdatedPackage[] = [];
+  const latestByName = new Map<string, string | undefined>();
+  for (const entry of lockedJsrSpecifiers(lockText)) {
+    if (!latestByName.has(entry.name)) {
+      latestByName.set(
+        entry.name,
+        await readLatest(registry, entry.name, options.fetch),
+      );
+    }
+    const latest = latestByName.get(entry.name);
+    if (latest === undefined || !isBehind(entry.resolved, latest)) continue;
+    behind.push({
+      name: entry.name,
+      specifier: entry.specifier,
+      resolved: entry.resolved,
+      latest,
+    });
+  }
+  return behind;
+}
+
+/** The registry's latest version for `name`, or `undefined` if it cannot say. */
+async function readLatest(
+  registry: string,
+  name: string,
+  fetchImpl?: typeof fetch,
+): Promise<string | undefined> {
+  try {
+    const meta = await httpJson<unknown>(
+      `${registry}/${name}/meta.json`,
+      fetchImpl === undefined ? {} : { fetch: fetchImpl },
+    );
+    return latestOf(meta);
+  } catch {
+    // A 404, a rename, a private scope, or an offline runner. The command's
+    // job is to surface the packages it *can* speak for.
+    return undefined;
+  }
+}
+
+/**
+ * The report `zuke outdated` prints: one aligned line per package that is
+ * behind, or a single line saying everything is current.
+ */
+export function formatOutdated(packages: readonly OutdatedPackage[]): string {
+  if (packages.length === 0) {
+    return "Every JSR package the lock resolves is at its latest release.";
+  }
+  const width = Math.max(...packages.map((p) => p.name.length));
+  const lines = packages.map((p) =>
+    `${p.name.padEnd(width)}  ${p.resolved}  →  ${p.latest}`
+  );
+  const count = packages.length === 1
+    ? "1 package is"
+    : `${packages.length} packages are`;
+  lines.push(
+    "",
+    `${count} behind. Refresh the lock with a plain \`deno cache --reload\` ` +
+      "— `--reload=jsr:` re-resolves from cached registry metadata and hands " +
+      "back the same versions.",
+  );
+  return lines.join("\n");
+}

--- a/packages/core/src/outdated.ts
+++ b/packages/core/src/outdated.ts
@@ -24,7 +24,7 @@
  */
 
 import { httpJson } from "./http.ts";
-import { readTextOrNull } from "./internal.ts";
+import { messageOf, readTextOrNull } from "./internal.ts";
 
 /** The default JSR registry origin; overridden in tests. */
 export const JSR_REGISTRY = "https://jsr.io";
@@ -42,6 +42,32 @@ export interface OutdatedPackage {
   resolved: string;
   /** The latest version the registry publishes. */
   latest: string;
+}
+
+/** A package the registry could not be asked about, and why. */
+export interface UncheckedPackage {
+  /** The package name, e.g. `@zuke/git`. */
+  name: string;
+  /** The version the lock resolves — reported so the line is still useful. */
+  resolved: string;
+  /** Why there is no answer: the transport error, or a meta document with no `latest`. */
+  reason: string;
+}
+
+/** What {@link findOutdated} found: the stale packages, and the unanswered ones. */
+export interface OutdatedReport {
+  /** Packages resolved to a version older than the registry's latest. */
+  behind: OutdatedPackage[];
+  /**
+   * Packages the registry could not answer for — a private scope, a rename, or
+   * a runner with no network.
+   *
+   * Reported rather than dropped, because "nothing is behind" and "I could not
+   * ask" must not look the same: a build offline behind a proxy would
+   * otherwise be told, confidently, that every pin is current — which is the
+   * exact silence this command exists to break.
+   */
+  unchecked: UncheckedPackage[];
 }
 
 /** Options for {@link findOutdated}. */
@@ -130,16 +156,17 @@ function latestOf(meta: unknown): string | undefined {
 
 /**
  * The JSR packages the lock at `lockPath` resolves to a version older than the
- * registry's latest.
+ * registry's latest, and the ones the registry could not answer for.
  *
  * One registry request per distinct package name, whatever the number of
- * specifiers pointing at it. A package the registry cannot answer for is
- * skipped rather than failing the whole report — one unpublished or renamed
- * dependency should not hide the news about the others.
+ * specifiers pointing at it. A package that cannot be checked does not fail
+ * the whole report — one unpublished or renamed dependency should not hide the
+ * news about the others — but it is *reported*, because a run that reached
+ * nothing at all must not read as "everything is current".
  */
 export async function findOutdated(
   options: OutdatedOptions = {},
-): Promise<OutdatedPackage[]> {
+): Promise<OutdatedReport> {
   const lockPath = options.lockPath ?? DEFAULT_LOCK_PATH;
   const lockText = await readTextOrNull(lockPath);
   if (lockText === null) {
@@ -151,65 +178,99 @@ export async function findOutdated(
   }
   const registry = options.registry ?? JSR_REGISTRY;
   const behind: OutdatedPackage[] = [];
-  const latestByName = new Map<string, string | undefined>();
+  const unchecked: UncheckedPackage[] = [];
+  const answers = new Map<string, string | Error>();
   for (const entry of lockedJsrSpecifiers(lockText)) {
-    if (!latestByName.has(entry.name)) {
-      latestByName.set(
-        entry.name,
-        await readLatest(registry, entry.name, options.fetch),
-      );
+    let answer = answers.get(entry.name);
+    if (answer === undefined) {
+      answer = await readLatest(registry, entry.name, options.fetch);
+      answers.set(entry.name, answer);
     }
-    const latest = latestByName.get(entry.name);
-    if (latest === undefined || !isBehind(entry.resolved, latest)) continue;
+    if (answer instanceof Error) {
+      // Once per package name, not once per specifier pointing at it.
+      if (!unchecked.some((p) => p.name === entry.name)) {
+        unchecked.push({
+          name: entry.name,
+          resolved: entry.resolved,
+          reason: messageOf(answer),
+        });
+      }
+      continue;
+    }
+    if (!isBehind(entry.resolved, answer)) continue;
     behind.push({
       name: entry.name,
       specifier: entry.specifier,
       resolved: entry.resolved,
-      latest,
+      latest: answer,
     });
   }
-  return behind;
+  return { behind, unchecked };
 }
 
-/** The registry's latest version for `name`, or `undefined` if it cannot say. */
+/**
+ * The registry's latest version for `name`, or the reason there is none.
+ *
+ * An `Error` rather than `undefined`: a transport failure and a 404 are both
+ * "no answer", and the difference between them is exactly what the caller has
+ * to print — an offline runner reported as an up-to-date one is the failure
+ * this command exists to prevent.
+ */
 async function readLatest(
   registry: string,
   name: string,
   fetchImpl?: typeof fetch,
-): Promise<string | undefined> {
+): Promise<string | Error> {
   try {
     const meta = await httpJson<unknown>(
       `${registry}/${name}/meta.json`,
       fetchImpl === undefined ? {} : { fetch: fetchImpl },
     );
-    return latestOf(meta);
-  } catch {
-    // A 404, a rename, a private scope, or an offline runner. The command's
-    // job is to surface the packages it *can* speak for.
-    return undefined;
+    const latest = latestOf(meta);
+    return latest ?? new Error(
+      "the registry's meta.json carries no latest version",
+    );
+  } catch (error) {
+    // A 404, a rename, a private scope, or an offline runner — each of which
+    // the caller reports as unchecked, with this as the reason.
+    return error instanceof Error ? error : new Error(String(error));
   }
 }
 
 /**
  * The report `zuke outdated` prints: one aligned line per package that is
- * behind, or a single line saying everything is current.
+ * behind, then one per package that could not be checked, and a line saying
+ * everything is current when there is neither.
  */
-export function formatOutdated(packages: readonly OutdatedPackage[]): string {
-  if (packages.length === 0) {
+export function formatOutdated(report: OutdatedReport): string {
+  const { behind, unchecked } = report;
+  const lines: string[] = [];
+  if (behind.length > 0) {
+    const width = Math.max(...behind.map((p) => p.name.length));
+    for (const p of behind) {
+      lines.push(`${p.name.padEnd(width)}  ${p.resolved}  →  ${p.latest}`);
+    }
+    const count = behind.length === 1
+      ? "1 package is"
+      : `${behind.length} packages are`;
+    lines.push(
+      "",
+      `${count} behind. Refresh the lock with a plain \`deno cache --reload\` ` +
+        "— `--reload=jsr:` re-resolves from cached registry metadata and hands " +
+        "back the same versions.",
+    );
+  } else if (unchecked.length === 0) {
     return "Every JSR package the lock resolves is at its latest release.";
   }
-  const width = Math.max(...packages.map((p) => p.name.length));
-  const lines = packages.map((p) =>
-    `${p.name.padEnd(width)}  ${p.resolved}  →  ${p.latest}`
-  );
-  const count = packages.length === 1
-    ? "1 package is"
-    : `${packages.length} packages are`;
-  lines.push(
-    "",
-    `${count} behind. Refresh the lock with a plain \`deno cache --reload\` ` +
-      "— `--reload=jsr:` re-resolves from cached registry metadata and hands " +
-      "back the same versions.",
-  );
+  if (unchecked.length > 0) {
+    if (lines.length > 0) lines.push("");
+    const count = unchecked.length === 1
+      ? "1 package"
+      : `${unchecked.length} packages`;
+    lines.push(`${count} could not be checked:`);
+    for (const p of unchecked) {
+      lines.push(`  ${p.name} (${p.resolved}) — ${p.reason}`);
+    }
+  }
   return lines.join("\n");
 }

--- a/packages/core/tests/outdated_test.ts
+++ b/packages/core/tests/outdated_test.ts
@@ -123,7 +123,7 @@ Deno.test("findOutdated reports only the packages that are behind", async () => 
       "npm:typescript@^5": "5.9.2",
     });
     const seen: string[] = [];
-    const behind = await findOutdated({
+    const report = await findOutdated({
       lockPath,
       registry: "https://registry.test",
       fetch: registryFetch(
@@ -131,12 +131,13 @@ Deno.test("findOutdated reports only the packages that are behind", async () => 
         seen,
       ),
     });
-    assertEquals(behind, [{
+    assertEquals(report.behind, [{
       name: "@zuke/git",
       specifier: "jsr:@zuke/git@^1",
       resolved: "1.5.0",
       latest: "1.11.0",
     }]);
+    assertEquals(report.unchecked, []);
     // The npm specifier is never asked about, and each jsr package once.
     assertEquals(seen, [
       "https://registry.test/@zuke/git/meta.json",
@@ -154,7 +155,7 @@ Deno.test("findOutdated asks the registry once per package name", async () => {
       "jsr:@std/yaml@^1.2.0": "1.2.0",
     });
     const seen: string[] = [];
-    const behind = await findOutdated({
+    const { behind } = await findOutdated({
       lockPath,
       registry: "https://registry.test",
       fetch: registryFetch({ "@std/yaml": "1.3.0" }, seen),
@@ -165,35 +166,97 @@ Deno.test("findOutdated asks the registry once per package name", async () => {
   });
 });
 
-Deno.test("findOutdated skips a package the registry cannot answer for", async () => {
+Deno.test("findOutdated reports a package it could not check, and still checks the rest", async () => {
   await withTemp(async (dir) => {
     // A private scope, a rename, or an offline runner. The report still speaks
-    // for the packages it could reach.
+    // for the packages it could reach — and says so about the one it could not,
+    // rather than letting it pass as current.
     const lockPath = await lockWith(dir, {
       "jsr:@private/thing@^1": "1.0.0",
       "jsr:@zuke/git@^1": "1.5.0",
     });
-    const behind = await findOutdated({
+    const report = await findOutdated({
       lockPath,
       registry: "https://registry.test",
       fetch: registryFetch({ "@zuke/git": "1.11.0" }),
     });
-    assertEquals(behind.map((p) => p.name), ["@zuke/git"]);
+    assertEquals(report.behind.map((p) => p.name), ["@zuke/git"]);
+    assertEquals(report.unchecked.map((p) => p.name), ["@private/thing"]);
+    assertEquals(report.unchecked[0].resolved, "1.0.0");
+    assertEquals(report.unchecked[0].reason.includes("404"), true);
   });
 });
 
-Deno.test("findOutdated skips a meta document with no usable latest", async () => {
+Deno.test("a transport failure is reported as unchecked, not as current", async () => {
+  await withTemp(async (dir) => {
+    // The whole point: a runner with no network must not be told every pin is
+    // at its latest release.
+    const lockPath = await lockWith(dir, {
+      "jsr:@zuke/git@^1": "1.5.0",
+      "jsr:@zuke/core@^1": "1.42.1",
+    });
+    const report = await findOutdated({
+      lockPath,
+      registry: "https://registry.test",
+      fetch: () => Promise.reject(new TypeError("error sending request")),
+    });
+    assertEquals(report.behind, []);
+    assertEquals(report.unchecked.map((p) => p.name), [
+      "@zuke/git",
+      "@zuke/core",
+    ]);
+    assertEquals(
+      report.unchecked[0].reason.includes("error sending request"),
+      true,
+    );
+  });
+});
+
+Deno.test("a thrown non-Error still yields a readable reason", async () => {
+  await withTemp(async (dir) => {
+    const lockPath = await lockWith(dir, { "jsr:@zuke/git@^1": "1.5.0" });
+    const report = await findOutdated({
+      lockPath,
+      registry: "https://registry.test",
+      fetch: () => Promise.reject("just a string"),
+    });
+    assertEquals(report.unchecked[0].reason, "just a string");
+  });
+});
+
+Deno.test("findOutdated reports a meta document with no usable latest", async () => {
   await withTemp(async (dir) => {
     const lockPath = await lockWith(dir, { "jsr:@zuke/git@^1": "1.5.0" });
     const bodies = ["null", "{}", JSON.stringify({ latest: 7 })];
     for (const body of bodies) {
-      const behind = await findOutdated({
+      const report = await findOutdated({
         lockPath,
         registry: "https://registry.test",
         fetch: () => Promise.resolve(new Response(body)),
       });
-      assertEquals(behind, [], body);
+      assertEquals(report.behind, [], body);
+      assertEquals(report.unchecked.length, 1, body);
+      assertEquals(
+        report.unchecked[0].reason.includes("no latest version"),
+        true,
+        body,
+      );
     }
+  });
+});
+
+Deno.test("an unreachable package is reported once, not once per specifier", async () => {
+  await withTemp(async (dir) => {
+    const lockPath = await lockWith(dir, {
+      "jsr:@private/thing@*": "1.0.0",
+      "jsr:@private/thing@^1.0.0": "1.0.0",
+    });
+    const report = await findOutdated({
+      lockPath,
+      registry: "https://registry.test",
+      fetch: registryFetch({}),
+    });
+    assertEquals(report.unchecked.length, 1);
   });
 });
 
@@ -210,38 +273,87 @@ Deno.test("findOutdated names the missing lock rather than reporting nothing", a
 
 Deno.test("formatOutdated aligns the report and says how to refresh", () => {
   assertEquals(
-    formatOutdated([]),
+    formatOutdated({ behind: [], unchecked: [] }),
     "Every JSR package the lock resolves is at its latest release.",
   );
-  const one = formatOutdated([
-    {
-      name: "@zuke/git",
-      specifier: "jsr:@zuke/git@^1",
-      resolved: "1.5.0",
-      latest: "1.11.0",
-    },
-  ]);
+  const one = formatOutdated({
+    behind: [
+      {
+        name: "@zuke/git",
+        specifier: "jsr:@zuke/git@^1",
+        resolved: "1.5.0",
+        latest: "1.11.0",
+      },
+    ],
+    unchecked: [],
+  });
   assertEquals(one.includes("@zuke/git  1.5.0  →  1.11.0"), true);
   assertEquals(one.includes("1 package is behind"), true);
   // The refresh hint is the part that is not obvious: --reload=jsr: hands back
   // the same versions from cached registry metadata.
   assertEquals(one.includes("--reload=jsr:"), true);
 
-  const two = formatOutdated([
-    {
+  const two = formatOutdated({
+    behind: [
+      {
+        name: "@zuke/git",
+        specifier: "jsr:@zuke/git@^1",
+        resolved: "1.5.0",
+        latest: "1.11.0",
+      },
+      {
+        name: "@zuke/gcloud",
+        specifier: "jsr:@zuke/gcloud@^1",
+        resolved: "1.1.0",
+        latest: "1.3.0",
+      },
+    ],
+    unchecked: [],
+  });
+  assertEquals(two.includes("2 packages are behind"), true);
+  // Padded to the longest name, so the versions line up.
+  assertEquals(two.includes("@zuke/git     1.5.0"), true);
+});
+
+Deno.test("formatOutdated names what it could not check, however the run went", () => {
+  const unchecked = [{
+    name: "@private/thing",
+    resolved: "1.0.0",
+    reason: "error sending request",
+  }];
+  // Nothing behind, but nothing answered either: the current-everything line
+  // must not appear, because it would be a confident wrong answer.
+  const offline = formatOutdated({ behind: [], unchecked });
+  assertEquals(offline.includes("at its latest release"), false);
+  assertEquals(offline.includes("1 package could not be checked:"), true);
+  assertEquals(
+    offline.includes("@private/thing (1.0.0) — error sending request"),
+    true,
+  );
+
+  // Both sections, in order, separated by a blank line.
+  const mixed = formatOutdated({
+    behind: [{
       name: "@zuke/git",
       specifier: "jsr:@zuke/git@^1",
       resolved: "1.5.0",
       latest: "1.11.0",
-    },
-    {
-      name: "@zuke/gcloud",
-      specifier: "jsr:@zuke/gcloud@^1",
-      resolved: "1.1.0",
-      latest: "1.3.0",
-    },
-  ]);
-  assertEquals(two.includes("2 packages are behind"), true);
-  // Padded to the longest name, so the versions line up.
-  assertEquals(two.includes("@zuke/git     1.5.0"), true);
+    }],
+    unchecked,
+  });
+  assertEquals(mixed.includes("1 package is behind"), true);
+  assertEquals(mixed.includes("1 package could not be checked:"), true);
+  assertEquals(
+    mixed.indexOf("behind.") < mixed.indexOf("could not be checked"),
+    true,
+  );
+
+  const many = formatOutdated({
+    behind: [],
+    unchecked: [
+      ...unchecked,
+      { name: "@other/thing", resolved: "2.0.0", reason: "404" },
+    ],
+  });
+  assertEquals(many.includes("2 packages could not be checked:"), true);
 });

--- a/packages/core/tests/outdated_test.ts
+++ b/packages/core/tests/outdated_test.ts
@@ -1,0 +1,247 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals, assertRejects } from "./_assert.ts";
+import {
+  findOutdated,
+  formatOutdated,
+  isBehind,
+  lockedJsrSpecifiers,
+} from "../src/outdated.ts";
+import { withTemp } from "./_temp.ts";
+
+/** A `fetch` that answers `meta.json` from a name → latest-version map. */
+function registryFetch(
+  latest: Record<string, string>,
+  seen: string[] = [],
+): typeof fetch {
+  return (input: string | URL | Request) => {
+    const url = String(input instanceof Request ? input.url : input);
+    seen.push(url);
+    const match = /\/(@[^/]+\/[^/]+)\/meta\.json$/.exec(url);
+    const name = match === null ? undefined : match[1];
+    const version = name === undefined ? undefined : latest[name];
+    if (version === undefined) {
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify({ scope: "x", latest: version })),
+    );
+  };
+}
+
+/** Write a lock file carrying `specifiers` and return its path. */
+async function lockWith(
+  dir: string,
+  specifiers: Record<string, unknown>,
+): Promise<string> {
+  const path = `${dir}/deno.lock`;
+  await Deno.writeTextFile(
+    path,
+    JSON.stringify({ version: "5", specifiers }, null, 2),
+  );
+  return path;
+}
+
+Deno.test("lockedJsrSpecifiers reads the jsr entries and skips the rest", () => {
+  const text = JSON.stringify({
+    specifiers: {
+      "jsr:@zuke/git@^1": "1.5.0",
+      "jsr:@std/yaml@^1.2.0": "1.2.0",
+      "npm:typescript@^5": "5.9.2",
+    },
+  });
+  assertEquals(lockedJsrSpecifiers(text), [
+    { specifier: "jsr:@zuke/git@^1", name: "@zuke/git", resolved: "1.5.0" },
+    { specifier: "jsr:@std/yaml@^1.2.0", name: "@std/yaml", resolved: "1.2.0" },
+  ]);
+});
+
+Deno.test("lockedJsrSpecifiers yields nothing for a lock it cannot read", () => {
+  // Every shape that is not "an object with a specifiers object of strings":
+  // an unreadable lock reports no packages rather than throwing, and the
+  // caller distinguishes that from "all current" by the count.
+  assertEquals(lockedJsrSpecifiers("{ not json"), []);
+  assertEquals(lockedJsrSpecifiers("null"), []);
+  assertEquals(lockedJsrSpecifiers("[]").length, 0);
+  assertEquals(lockedJsrSpecifiers(JSON.stringify({})), []);
+  assertEquals(
+    lockedJsrSpecifiers(JSON.stringify({ specifiers: "nope" })),
+    [],
+  );
+  assertEquals(
+    lockedJsrSpecifiers(JSON.stringify({ specifiers: { "jsr:@a/b@^1": 3 } })),
+    [],
+  );
+  // A bare (unscoped) jsr specifier is not a package JSR can be asked about.
+  assertEquals(
+    lockedJsrSpecifiers(JSON.stringify({ specifiers: { "jsr:nope@^1": "1" } })),
+    [],
+  );
+});
+
+Deno.test("lockedJsrSpecifiers keeps a specifier written without a range", () => {
+  assertEquals(
+    lockedJsrSpecifiers(
+      JSON.stringify({ specifiers: { "jsr:@zuke/git": "1.5.0" } }),
+    ),
+    [{ specifier: "jsr:@zuke/git", name: "@zuke/git", resolved: "1.5.0" }],
+  );
+});
+
+Deno.test("isBehind orders versions numerically, not lexically", () => {
+  assertEquals(isBehind("1.9.0", "1.10.0"), true); // the string sort's mistake
+  assertEquals(isBehind("1.10.0", "1.9.0"), false);
+  assertEquals(isBehind("1.5.0", "1.11.0"), true);
+  assertEquals(isBehind("1.2.3", "1.2.3"), false);
+  assertEquals(isBehind("1.2.3", "2.0.0"), true);
+  assertEquals(isBehind("2.0.0", "1.99.99"), false);
+  assertEquals(isBehind("1.2.3", "1.2.4"), true);
+});
+
+Deno.test("isBehind puts a prerelease behind the release it precedes", () => {
+  assertEquals(isBehind("1.2.0-rc.1", "1.2.0"), true);
+  assertEquals(isBehind("1.2.0", "1.2.0-rc.1"), false);
+  // Two prereleases of the same core cannot be ordered by the numeric core
+  // alone, so they are reported as not behind rather than guessed at.
+  assertEquals(isBehind("1.2.0-rc.1", "1.2.0-rc.2"), false);
+});
+
+Deno.test("isBehind reports a version it cannot parse as not behind", () => {
+  // Silence beats a wrong "you are behind", which would send someone bumping
+  // a pin that is already current.
+  assertEquals(isBehind("latest", "1.2.3"), false);
+  assertEquals(isBehind("1.2.3", "unknown"), false);
+  assertEquals(isBehind("1.2", "1.3"), false);
+});
+
+Deno.test("findOutdated reports only the packages that are behind", async () => {
+  await withTemp(async (dir) => {
+    const lockPath = await lockWith(dir, {
+      "jsr:@zuke/git@^1": "1.5.0",
+      "jsr:@zuke/core@^1": "1.42.1",
+      "npm:typescript@^5": "5.9.2",
+    });
+    const seen: string[] = [];
+    const behind = await findOutdated({
+      lockPath,
+      registry: "https://registry.test",
+      fetch: registryFetch(
+        { "@zuke/git": "1.11.0", "@zuke/core": "1.42.1" },
+        seen,
+      ),
+    });
+    assertEquals(behind, [{
+      name: "@zuke/git",
+      specifier: "jsr:@zuke/git@^1",
+      resolved: "1.5.0",
+      latest: "1.11.0",
+    }]);
+    // The npm specifier is never asked about, and each jsr package once.
+    assertEquals(seen, [
+      "https://registry.test/@zuke/git/meta.json",
+      "https://registry.test/@zuke/core/meta.json",
+    ]);
+  });
+});
+
+Deno.test("findOutdated asks the registry once per package name", async () => {
+  await withTemp(async (dir) => {
+    // Two ranges resolving to different versions of one package: one request,
+    // both stale specifiers reported, so the caller sees which pin to move.
+    const lockPath = await lockWith(dir, {
+      "jsr:@std/yaml@*": "1.1.1",
+      "jsr:@std/yaml@^1.2.0": "1.2.0",
+    });
+    const seen: string[] = [];
+    const behind = await findOutdated({
+      lockPath,
+      registry: "https://registry.test",
+      fetch: registryFetch({ "@std/yaml": "1.3.0" }, seen),
+    });
+    assertEquals(seen.length, 1);
+    assertEquals(behind.map((p) => p.resolved), ["1.1.1", "1.2.0"]);
+    assertEquals(behind.every((p) => p.latest === "1.3.0"), true);
+  });
+});
+
+Deno.test("findOutdated skips a package the registry cannot answer for", async () => {
+  await withTemp(async (dir) => {
+    // A private scope, a rename, or an offline runner. The report still speaks
+    // for the packages it could reach.
+    const lockPath = await lockWith(dir, {
+      "jsr:@private/thing@^1": "1.0.0",
+      "jsr:@zuke/git@^1": "1.5.0",
+    });
+    const behind = await findOutdated({
+      lockPath,
+      registry: "https://registry.test",
+      fetch: registryFetch({ "@zuke/git": "1.11.0" }),
+    });
+    assertEquals(behind.map((p) => p.name), ["@zuke/git"]);
+  });
+});
+
+Deno.test("findOutdated skips a meta document with no usable latest", async () => {
+  await withTemp(async (dir) => {
+    const lockPath = await lockWith(dir, { "jsr:@zuke/git@^1": "1.5.0" });
+    const bodies = ["null", "{}", JSON.stringify({ latest: 7 })];
+    for (const body of bodies) {
+      const behind = await findOutdated({
+        lockPath,
+        registry: "https://registry.test",
+        fetch: () => Promise.resolve(new Response(body)),
+      });
+      assertEquals(behind, [], body);
+    }
+  });
+});
+
+Deno.test("findOutdated names the missing lock rather than reporting nothing", async () => {
+  await withTemp(async (dir) => {
+    // "Nothing is behind" and "I never read a lock" must not look the same.
+    await assertRejects(
+      () => findOutdated({ lockPath: `${dir}/absent.lock` }),
+      Error,
+      "no lock file at",
+    );
+  });
+});
+
+Deno.test("formatOutdated aligns the report and says how to refresh", () => {
+  assertEquals(
+    formatOutdated([]),
+    "Every JSR package the lock resolves is at its latest release.",
+  );
+  const one = formatOutdated([
+    {
+      name: "@zuke/git",
+      specifier: "jsr:@zuke/git@^1",
+      resolved: "1.5.0",
+      latest: "1.11.0",
+    },
+  ]);
+  assertEquals(one.includes("@zuke/git  1.5.0  →  1.11.0"), true);
+  assertEquals(one.includes("1 package is behind"), true);
+  // The refresh hint is the part that is not obvious: --reload=jsr: hands back
+  // the same versions from cached registry metadata.
+  assertEquals(one.includes("--reload=jsr:"), true);
+
+  const two = formatOutdated([
+    {
+      name: "@zuke/git",
+      specifier: "jsr:@zuke/git@^1",
+      resolved: "1.5.0",
+      latest: "1.11.0",
+    },
+    {
+      name: "@zuke/gcloud",
+      specifier: "jsr:@zuke/gcloud@^1",
+      resolved: "1.1.0",
+      latest: "1.3.0",
+    },
+  ]);
+  assertEquals(two.includes("2 packages are behind"), true);
+  // Padded to the longest name, so the versions line up.
+  assertEquals(two.includes("@zuke/git     1.5.0"), true);
+});

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/.codex-plugin/plugin.json
+++ b/plugins/zuke/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -1208,6 +1208,7 @@ else a friendly error.
 ./zuke runs show mcp-audit    # the MCP tool-call audit trail (host only, not served over MCP)
 ./zuke register [--json]      # record this build in the build registry (idempotent)
 ./zuke doc jsr:@zuke/deno     # print a package's API (deno doc) from an isolated empty dir
+./zuke outdated [--exit-code]  # jsr packages the lock resolves behind their latest (network)
 ./zuke mcp --registry --allow-run  # serve the registry: registered builds as tools, spawned
 ./zuke mcp --registry --max-concurrent-runs 4  # cap concurrent run-tool spawns (default 4)
 ```

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -1208,6 +1208,7 @@ else a friendly error.
 ./zuke runs show mcp-audit    # the MCP tool-call audit trail (host only, not served over MCP)
 ./zuke register [--json]      # record this build in the build registry (idempotent)
 ./zuke doc jsr:@zuke/deno     # print a package's API (deno doc) from an isolated empty dir
+./zuke outdated [--exit-code]  # jsr packages the lock resolves behind their latest (network)
 ./zuke mcp --registry --allow-run  # serve the registry: registered builds as tools, spawned
 ./zuke mcp --registry --max-concurrent-runs 4  # cap concurrent run-tool spawns (default 4)
 ```

--- a/tests/integration/outdated_test.ts
+++ b/tests/integration/outdated_test.ts
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Integration coverage for the `outdated` command: a real build driven through
+ * the CLI `main()` entry point, with the lock path, registry origin and
+ * `fetch` injected — so the command's own wiring (the reserved word, the
+ * `--exit-code` flag, the exit codes, the report on stdout) is exercised
+ * without network access.
+ *
+ * @module
+ */
+
+import { assertEquals } from "../../packages/core/tests/_assert.ts";
+import { Build, target } from "../../packages/core/mod.ts";
+import { runCli } from "./_harness.ts";
+
+/** A build with a target, so `outdated` is proven not to be read as one. */
+class OutdatedBuild extends Build {
+  outdated = target().description("a target that shares the command's name")
+    .executes(() => {
+      throw new Error("the reserved command must win over this target");
+    });
+  build = target().description("something to run").executes(() => {});
+}
+
+/** A `fetch` answering JSR `meta.json` from a name → latest map. */
+function registryFetch(latest: Record<string, string>): typeof fetch {
+  return (input: string | URL | Request) => {
+    const url = String(input instanceof Request ? input.url : input);
+    const match = /\/(@[^/]+\/[^/]+)\/meta\.json$/.exec(url);
+    const version = match === null ? undefined : latest[match[1]];
+    if (version === undefined) {
+      return Promise.resolve(new Response("nope", { status: 404 }));
+    }
+    return Promise.resolve(new Response(JSON.stringify({ latest: version })));
+  };
+}
+
+/** Run a temp-lock `outdated`, returning the CLI result. */
+async function runOutdated(
+  specifiers: Record<string, string>,
+  latest: Record<string, string>,
+  args: string[] = [],
+) {
+  const dir = await Deno.makeTempDir();
+  try {
+    const lockPath = `${dir}/deno.lock`;
+    await Deno.writeTextFile(
+      lockPath,
+      JSON.stringify({ version: "5", specifiers }),
+    );
+    return await runCli(OutdatedBuild, ["outdated", ...args], {
+      outdatedOptions: {
+        lockPath,
+        registry: "https://registry.test",
+        fetch: registryFetch(latest),
+      },
+    });
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+Deno.test("outdated reports a stale pin and exits 0 by default", async () => {
+  const { code, out } = await runOutdated(
+    { "jsr:@zuke/git@^1": "1.5.0" },
+    { "@zuke/git": "1.11.0" },
+  );
+  // Exit 0: the default is a report, not a gate.
+  assertEquals(code, 0);
+  assertEquals(out.includes("@zuke/git"), true);
+  assertEquals(out.includes("1.5.0"), true);
+  assertEquals(out.includes("1.11.0"), true);
+});
+
+Deno.test("outdated --exit-code fails when something is behind, not otherwise", async () => {
+  const stale = await runOutdated(
+    { "jsr:@zuke/git@^1": "1.5.0" },
+    { "@zuke/git": "1.11.0" },
+    ["--exit-code"],
+  );
+  assertEquals(stale.code, 1);
+
+  const current = await runOutdated(
+    { "jsr:@zuke/git@^1": "1.11.0" },
+    { "@zuke/git": "1.11.0" },
+    ["--exit-code"],
+  );
+  assertEquals(current.code, 0);
+  assertEquals(current.out.includes("at its latest release"), true);
+});
+
+Deno.test("outdated names a missing lock and fails", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const { code, err } = await runCli(OutdatedBuild, ["outdated"], {
+      outdatedOptions: { lockPath: `${dir}/absent.lock` },
+    });
+    // "Nothing is behind" and "I never read a lock" must not look the same.
+    assertEquals(code, 1);
+    assertEquals(err.includes("no lock file at"), true);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("outdated is a reserved word, and the help and listing say so", async () => {
+  // The build above declares a target called `outdated`; the reserved command
+  // has to win, or a build could shadow a command by naming a target after it.
+  const help = await runCli(OutdatedBuild, ["--help"]);
+  assertEquals(help.code, 0);
+  assertEquals(help.out.includes("outdated"), true);
+  assertEquals(help.out.includes("--exit-code"), true);
+
+  const surface = await runCli(OutdatedBuild, ["--list", "--json"]);
+  assertEquals(surface.code, 0);
+  const parsed: unknown = JSON.parse(surface.out);
+  const commands = parsed !== null && typeof parsed === "object"
+    ? Reflect.get(parsed, "commands")
+    : undefined;
+  const names = Array.isArray(commands)
+    ? commands.map((c: unknown) =>
+      c !== null && typeof c === "object" ? Reflect.get(c, "name") : undefined
+    )
+    : [];
+  assertEquals(names.includes("outdated"), true);
+});

--- a/tests/integration/outdated_test.ts
+++ b/tests/integration/outdated_test.ts
@@ -91,6 +91,39 @@ Deno.test("outdated --exit-code fails when something is behind, not otherwise", 
   assertEquals(current.out.includes("at its latest release"), true);
 });
 
+Deno.test("an offline run is reported as unchecked, and --exit-code fails on it", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const lockPath = `${dir}/deno.lock`;
+    await Deno.writeTextFile(
+      lockPath,
+      JSON.stringify({ specifiers: { "jsr:@zuke/git@^1": "1.5.0" } }),
+    );
+    const options = {
+      lockPath,
+      registry: "https://registry.test",
+      fetch: () => Promise.reject(new TypeError("error sending request")),
+    };
+    // A runner that reached nothing must not be told every pin is current —
+    // that confident wrong answer is the silence this command exists to break.
+    const report = await runCli(OutdatedBuild, ["outdated"], {
+      outdatedOptions: options,
+    });
+    assertEquals(report.code, 0);
+    assertEquals(report.out.includes("at its latest release"), false);
+    assertEquals(report.out.includes("could not be checked"), true);
+    assertEquals(report.out.includes("error sending request"), true);
+
+    // Under --exit-code an unanswered question is not a "yes".
+    const gated = await runCli(OutdatedBuild, ["outdated", "--exit-code"], {
+      outdatedOptions: options,
+    });
+    assertEquals(gated.code, 1);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
 Deno.test("outdated names a missing lock and fails", async () => {
   const dir = await Deno.makeTempDir();
   try {


### PR DESCRIPTION
## What & why

Nothing told a build that newer releases exist than the ones its lock resolves.

A build whose specifiers are written inline — a `jsr:` specifier in `zuke.ts` and its helper modules, rather than in a `deno.json` imports map — gets no signal from anywhere. `deno outdated` reads manifests, so it reports npm dependencies and says nothing about them. The lock keeps resolving the versions recorded when the build was first written, and `--frozen` is perfectly content with that, because a stale-but-valid lock is exactly what `--frozen` is for. The failure mode is silent and long-lived: a build can sit several minor versions behind a wrapper for months, still hand-rolling a command that package typed three releases ago.

`zuke outdated` reads the lock's `jsr:` specifiers, asks the registry for each package's latest, and prints the ones that are behind. The **lock** is deliberately the source of truth rather than the import map: it records what a run actually resolves, which is the number a stale pin hides.

Design decisions worth a look:

- **A command, not a line in `--list` or the run summary.** It needs the network; those must stay offline and instant, and would fail on an air-gapped runner.
- **Every `jsr:` specifier, not just one scope.** There is no self-referential special case in the CLI, and the answer is more useful for it.
- **Numeric version ordering.** `1.10.0` is newer than `1.9.0` — the comparison a string sort gets wrong exactly once the tenth release lands. A prerelease sorts below the release it precedes, and two versions the comparison cannot order are reported as current, because a wrong "you are behind" sends someone bumping a pin that is already up to date.
- **A registry that cannot answer for one package is skipped**, so a private scope or a rename does not hide the news about everything else. A missing lock file, by contrast, is an error — "nothing is behind" and "I never read a lock" must not look the same.
- **`--exit-code`** turns a finding into a non-zero exit, so a scheduled job can fail on one; the default is a report that exits 0.

The lock path, registry origin and `fetch` come in through `MainOptions`, so the whole command is exercised end-to-end in tests with no network and no lock of its own.

One observation, not fixed here to keep the diff honest: `packages/core/src/cli_args.ts` appears to be an unreferenced copy of the parser — nothing imports it, and it does not show up in coverage. `cli.ts` carries the live parser, which is what this change extends. Worth its own chore issue rather than a drive-by deletion inside a feature PR; say the word and I will file one.

## Related issues

Closes #436

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a [Conventional Commit](https://www.conventionalcommits.org/) (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches). Twelve unit tests cover lock parsing and every shape it refuses, the version ordering including prereleases and unparsable versions, the per-package request caching, the skipped-registry and missing-lock paths, and the report formatting. Four integration tests drive the command through the CLI with an injected registry: the report and its exit 0, `--exit-code` both ways, the missing-lock failure, and that the reserved word wins over a target with the same name and appears in `--help` and the `--list --json` surface.
- [x] Docs updated in the same PR — a `zuke outdated` section in `docs/cli.md` with the refresh footguns, the command table, and the skill cheatsheet.
- [x] Public API changes were regenerated with `./zuke apiDocs`.
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/`.
- [x] No dead code.
- [x] No duplicated logic: the request goes through the existing core HTTP helper with its injected `fetch`, and the lock read through the existing read-or-null helper.
- [x] SOLID shapes respected: one new domain module, pure parsing and comparison split from the fetching, and the network arrives as an injected seam rather than a global.
- [x] Not applicable — no new package.
- [x] The code is written using AI assisted coding.

## Adversarial pass

Attacked before opening: a malformed or hostile lock file, including a non-object, a non-object `specifiers`, non-string resolutions and an unscoped `jsr:` name (all yield no entries rather than throwing, each with a test); a registry answering something that is not a meta document, or a `latest` that is not a string (skipped, tested with three bodies); a version string the comparison cannot parse, which must not be reported as behind; the tenth-release string-sort bug; a build declaring a target named `outdated`, which must not shadow the reserved command; and the exit-code path, where a report-only default must not fail a gate. Registry responses are treated as data throughout — nothing from `meta.json` reaches a shell, a path, or a URL.
