### PR TITLE
chore: bump the plugin version to 0.33.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.32.0",
+      "version": "0.33.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "zuke",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build)."
 }

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/.codex-plugin/plugin.json
+++ b/plugins/zuke/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",


### PR DESCRIPTION
## What & why

Bumps the plugin version in all four manifests to `0.33.0`. Version only — no skill content in this PR.

The five wrapper PRs (#437–#441) each edited the skill cheatsheet, and each was branched from the same base, so all five bumped `0.31.0 → 0.32.0`. Both sides of every merge made the identical edit to that line, so git resolved it silently — and master now sits at `0.32.0` carrying five distinct skill changes, which is exactly what happened. Anyone who installed `0.32.0` after the first merge is marked current and never sees the content from the other four.

This one bump re-marks the tree as new for anyone who fetched mid-sequence.

Rebased onto the merged master, so the diff is now `0.32.0 → 0.33.0` and nothing else.

Why the gate did not stop the collision is a separate defect, tracked in #444 and fixed in #447: the check has never actually run in CI, because the gate job's checkout is shallow and the base ref is therefore absent, so it reported itself skipped on every run. Land this one first — #447 makes the check enforce, and it should go in on top of a tree whose version is already correct.

## Related issues

Closes #443

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a [Conventional Commit](https://www.conventionalcommits.org/) (`type(scope): summary`). `chore` on purpose: `plugins/` is not a workspace package and release-please does not manage it, so no version should be cut for this.
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated — not applicable; `tests/plugin_manifest_test.ts` already enforces that the four manifests agree and that the version is a plain semver triple, and it covers this change.
- [x] Docs updated in the same PR — not applicable.
- [x] Public API changes were regenerated — not applicable, no API change.
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/`.
- [x] No dead code.
- [x] No duplicated logic.
- [x] SOLID shapes respected.
- [x] Not applicable — no new package.
- [x] The code is written using AI assisted coding.
