### PR TITLE
chore: make the plugin-version gate able to fail, and see a collision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           egress-policy: block
           persist-credentials: "true"
           allowed-endpoints: "deno.land:443 dl.deno.land:443 jsr.io:443 registry.npmjs.org:443 api.openai.com:443 api.github.com:443 github.com:443 codeload.github.com:443 objects.githubusercontent.com:443 release-assets.githubusercontent.com:443 cli.codecov.io:443 api.codecov.io:443 ingest.codecov.io:443 storage.googleapis.com:443"
+          fetch-depth: "0"
           ref: "${{ (github.event.pull_request.head.repo.full_name == github.repository) && github.head_ref || '' }}"
       - name: Run ci with Zuke
         run: ./zuke ci
@@ -36,6 +37,7 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
           PR_BODY: "${{ github.event_name == 'pull_request' && github.event.pull_request.body || '' }}"
+          ZUKE_PLUGIN_BASE_REF: "${{ github.event_name == 'push' && 'HEAD^' || '' }}"
   coreFloorCheck:
     name: Core version floors
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -540,11 +540,24 @@ gemini-extension.json     # Gemini CLI extension manifest (serves skills/)
 
   Two gate targets hold this up, so a miss fails the build rather than shipping
   quietly: `pluginVersionCheck` fails when a published skill changed against the
-  base branch and the version did not move, and `tests/plugin_manifest_test.ts`
-  fails when the manifests disagree. `pluginVersionCheck` is the one part of the
-  gate that needs history — it compares against `origin/<PR base>`, or
-  `ZUKE_PLUGIN_BASE_REF` when you set one — and it reports itself _skipped_,
-  never passed, in a clone that has no base to compare against.
+  base branch and the version did not move **up**, and
+  `tests/plugin_manifest_test.ts` fails when the manifests disagree.
+  `pluginVersionCheck` is the one part of the gate that needs history — it
+  compares against `origin/<PR base>`, or `ZUKE_PLUGIN_BASE_REF` when you set
+  one — and it reports itself _skipped_, never passed, in a local clone that
+  has no base to compare against. **On CI a skip is fatal**, because a gate
+  that cannot run is not a gate: it went unnoticed for months that the job's
+  shallow checkout left it with no base ref at all.
+
+  Two things it insists on beyond "the version differs". It must go **up**, so
+  that resolving a version conflict by keeping the lower number is refused. And
+  on a push to master it compares the merge commit against its parent
+  (`ZUKE_PLUGIN_BASE_REF=HEAD^`), which is the only place a **collision** is
+  visible: two branches that both bump `1.2.0` to `1.3.0` merge without a
+  conflict — each side made the identical edit — and neither pull request's
+  check ever saw the other, because GitHub does not re-run a PR's checks when
+  its base moves. When you have several skill-touching PRs open at once, give
+  each a distinct version, or bump once more after the last one lands.
 - **Always read the reviewer comments on every PR.** This repo runs AI reviewers
   (`@zuke/ai`) that post their assessments as PR comments (and human reviewers
   do too). Before considering a PR done — and again after each push — fetch and

--- a/build/action_release.ts
+++ b/build/action_release.ts
@@ -24,6 +24,7 @@
 import { parse as parseYaml } from "@std/yaml";
 
 import actionVersion from "./action_version.json" with { type: "json" };
+import { compareSemver } from "./semver.ts";
 
 /** A parsed `v<major>.<minor>.<patch>` action tag. */
 export interface ActionVersion {
@@ -134,16 +135,11 @@ export function latestVersion(
   for (const tag of tags) {
     const version = parseVersion(tag);
     if (version === undefined) continue;
-    if (newest === undefined || compareVersions(version, newest) > 0) {
+    if (newest === undefined || compareSemver(version, newest) > 0) {
       newest = version;
     }
   }
   return newest;
-}
-
-/** Order two versions by major, then minor, then patch. */
-function compareVersions(a: ActionVersion, b: ActionVersion): number {
-  return a.major - b.major || a.minor - b.minor || a.patch - b.patch;
 }
 
 /**

--- a/build/plugin_version_check.ts
+++ b/build/plugin_version_check.ts
@@ -18,6 +18,14 @@
  * `plugins/zuke/skills/` match `skills/`. It cannot help here, because both
  * sides move together and the version sits outside them.
  *
+ * Two things it insists on beyond "the version differs". The version must go
+ * **up**, because resolving a conflict by keeping a lower number would ship the
+ * skills under a version clients already hold. And on a push to master the base
+ * is the previous commit (`ZUKE_PLUGIN_BASE_REF=HEAD^`), which is the only
+ * place a *collision* is visible: two branches that both bump 1.2.0 to 1.3.0
+ * merge without a conflict, since each side made the identical edit, and each
+ * one's pull-request check was computed against a base that had not moved yet.
+ *
  * This check needs history, which is what makes it different from the rest of
  * the gate: "the content changed but the version did not" is not a property of
  * one snapshot. It compares against a base ref, so it does real work in CI (and
@@ -29,6 +37,7 @@
  */
 
 import { GitTasks } from "@zuke/git";
+import { isNewerSemver } from "./semver.ts";
 
 /** The skills tree that is the source of truth for the plugin. */
 export const SKILLS_DIR = "skills/";
@@ -115,7 +124,14 @@ export interface BumpVerdict {
   baseVersion?: string;
   /** The plugin version in the working tree. */
   headVersion?: string;
-  /** Whether the version moved. Meaningless unless `checked` and `changed`. */
+  /**
+   * Whether the version moved **up**. Meaningless unless `checked` and
+   * `changed`.
+   *
+   * Up, not merely away from: resolving a version conflict by keeping your own
+   * lower number over the base's would otherwise read as a bump, and ship the
+   * skills under a version clients already have.
+   */
   bumped: boolean;
 }
 
@@ -156,7 +172,8 @@ export async function checkPluginVersionBump(
   const baseVersion = manifestVersion(await git.fileAt(base, PLUGIN_MANIFEST));
   // No manifest at the base means the plugin is new on this branch; there is
   // no previous version to differ from, so the bump requirement cannot apply.
-  const bumped = baseVersion === undefined || baseVersion !== headVersion;
+  const bumped = baseVersion === undefined ||
+    isNewerSemver(headVersion, baseVersion);
   return { checked: true, changed, baseVersion, headVersion, bumped };
 }
 
@@ -166,9 +183,15 @@ export function bumpFailure(verdict: BumpVerdict): string {
   const more = verdict.changed.length > 5
     ? `\n  …and ${verdict.changed.length - 5} more`
     : "";
+  const moved = verdict.baseVersion !== verdict.headVersion;
+  const headline = moved
+    ? `The published skills changed and the plugin version moved the wrong ` +
+      `way: ${verdict.baseVersion} → ${verdict.headVersion}, which is not an ` +
+      "increase."
+    : `The published skills changed but the plugin version did not (still ` +
+      `${verdict.headVersion}).`;
   return [
-    `The published skills changed but the plugin version did not (still ` +
-    `${verdict.headVersion}).`,
+    headline,
     "",
     "Changed:",
     `${listed}${more}`,
@@ -176,9 +199,15 @@ export function bumpFailure(verdict: BumpVerdict): string {
     "Clients use this version to decide whether an installed plugin is stale,",
     "so skills shipped without a bump never reach agents holding the old copy.",
     "",
-    `Bump the version in ALL of these manifests (they must agree):`,
+    `Set a version above ${verdict.baseVersion} in ALL of these manifests ` +
+    "(they must agree):",
     ...VERSIONED_MANIFESTS.map((path) => `  ${path}`),
     "Additive skill content is a minor bump; a correction is a patch.",
+    "",
+    "If another branch already shipped the version you picked, take the next",
+    "one above what the base branch now holds rather than matching it: two",
+    "branches landing the same version leave the second change invisible to",
+    "every client that already fetched the first.",
   ].join("\n");
 }
 

--- a/build/plugin_version_check.ts
+++ b/build/plugin_version_check.ts
@@ -177,6 +177,65 @@ export async function checkPluginVersionBump(
   return { checked: true, changed, baseVersion, headVersion, bumped };
 }
 
+/** What the caller should do with a verdict: print it, or fail the build. */
+export interface VerdictReport {
+  /** `"error"` fails the target; `"info"` is ordinary output. */
+  level: "info" | "error";
+  /** The line to print, or the message to fail with. */
+  message: string;
+}
+
+/**
+ * Turn a verdict into the report its caller should act on.
+ *
+ * The decision lives here rather than in the build file so every branch is
+ * testable — including the one that fails a run, which is the branch a build
+ * file cannot easily be asked about.
+ *
+ * `onCI` is the whole reason a skip has two outcomes. Locally a skip is
+ * ordinary: a shallow clone, a fresh worktree, a branch whose base is not
+ * fetched. On CI it means the gate silently stopped guarding the thing it
+ * exists for, which is exactly what a shallow checkout did to it — so there it
+ * is a failure, naming the fix.
+ */
+export function reportFor(
+  verdict: BumpVerdict,
+  base: string,
+  onCI: boolean,
+): VerdictReport {
+  if (!verdict.checked) {
+    const message = `Plugin version check skipped — ${verdict.reason}. ` +
+      "Set ZUKE_PLUGIN_BASE_REF to compare against a ref you do have.";
+    return onCI
+      ? {
+        level: "error",
+        message: `${message} On CI the base ref must be fetchable: check out ` +
+          "with full history (fetch-depth 0) so this check can run.",
+      }
+      : { level: "info", message };
+  }
+  if (verdict.headVersion === undefined) {
+    return {
+      level: "error",
+      message: `Plugin version check failed — ${verdict.reason}.`,
+    };
+  }
+  if (verdict.changed.length === 0) {
+    return {
+      level: "info",
+      message: `No published skill changed against ${base}; nothing to bump.`,
+    };
+  }
+  if (!verdict.bumped) {
+    return { level: "error", message: bumpFailure(verdict) };
+  }
+  return {
+    level: "info",
+    message: `Skills changed against ${base} and the plugin version moved ` +
+      `${verdict.baseVersion} → ${verdict.headVersion}.`,
+  };
+}
+
 /** The failure message for a verdict whose skills moved without a bump. */
 export function bumpFailure(verdict: BumpVerdict): string {
   const listed = verdict.changed.slice(0, 5).map((p) => `  ${p}`).join("\n");

--- a/build/semver.ts
+++ b/build/semver.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Ordering plain `<major>.<minor>.<patch>` versions.
+ *
+ * One implementation, because the interesting part is the mistake it prevents:
+ * `1.10.0` sorts *below* `1.9.0` as text, and that comparison is wrong exactly
+ * once the tenth release lands — late enough to be an unpleasant surprise, and
+ * quiet enough that a second copy of the logic would keep it. The build has two
+ * callers that need this order: picking the newest action release tag
+ * (`action_release.ts`) and asserting that a plugin version moved *up*
+ * (`plugin_version_check.ts`).
+ *
+ * Deliberately not a semver library: no ranges, no prerelease ordering, no
+ * build metadata. Both callers compare two exact versions this repository
+ * produced, and a prerelease has never been one of them. A version that does
+ * not parse is reported as such, for the caller to refuse or ignore as its own
+ * contract requires.
+ *
+ * @module
+ */
+
+/** A parsed `<major>.<minor>.<patch>` version. */
+export interface Semver {
+  /** The major component. */
+  major: number;
+  /** The minor component. */
+  minor: number;
+  /** The patch component. */
+  patch: number;
+}
+
+/** A plain three-component version, with nothing before or after it. */
+const TRIPLE = /^(\d+)\.(\d+)\.(\d+)$/;
+
+/**
+ * Parse `<major>.<minor>.<patch>`, or `undefined` when `text` is not one.
+ *
+ * A leading `v` is not accepted: a caller whose input carries one (a release
+ * tag) strips it, so this stays a single unambiguous shape.
+ */
+export function parseSemver(text: string): Semver | undefined {
+  const match = TRIPLE.exec(text.trim());
+  if (match === null) return undefined;
+  const [, major, minor, patch] = match;
+  return { major: Number(major), minor: Number(minor), patch: Number(patch) };
+}
+
+/**
+ * Order two parsed versions by major, then minor, then patch: negative when `a`
+ * is older, positive when it is newer, zero when they are the same.
+ */
+export function compareSemver(a: Semver, b: Semver): number {
+  return a.major - b.major || a.minor - b.minor || a.patch - b.patch;
+}
+
+/**
+ * Whether `candidate` is strictly newer than `previous`.
+ *
+ * `false` when either side does not parse — the honest answer for two versions
+ * this cannot order, and the safe one for a caller using it as a gate, since it
+ * refuses rather than waving through what it did not understand.
+ */
+export function isNewerSemver(candidate: string, previous: string): boolean {
+  const a = parseSemver(candidate);
+  const b = parseSemver(previous);
+  if (a === undefined || b === undefined) return false;
+  return compareSemver(a, b) > 0;
+}

--- a/build/workflows.ts
+++ b/build/workflows.ts
@@ -179,6 +179,10 @@ export function githubWorkflows(
             persistCredentials: true,
             ref:
               "${{ (github.event.pull_request.head.repo.full_name == github.repository) && github.head_ref || '' }}",
+            // Full history, because `pluginVersionCheck` compares against a base
+            // ref. A shallow checkout has no `origin/<base>` at all, so the check
+            // reported itself skipped on every run — honestly, and invisibly.
+            fetchDepth: 0,
           },
           env: {
             OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}",
@@ -189,6 +193,15 @@ export function githubWorkflows(
             // body cannot inject a command.
             PR_BODY:
               "${{ github.event_name == 'pull_request' && github.event.pull_request.body || '' }}",
+            // On a pull request the check compares against the base branch, which
+            // it resolves itself. On a push there is no base — and the push is
+            // the one moment a *collision* is visible: two branches that both
+            // bump the same version merge cleanly, because each side made the
+            // identical edit, and neither pull request's check ever saw the
+            // other. Comparing the merge commit against its parent catches it.
+            // Empty on a pull request, which leaves the default resolution.
+            ZUKE_PLUGIN_BASE_REF:
+              "${{ github.event_name == 'push' && 'HEAD^' || '' }}",
           },
         },
         {

--- a/tests/plugin_version_check_test.ts
+++ b/tests/plugin_version_check_test.ts
@@ -24,6 +24,7 @@ import {
   isSkillPath,
   manifestVersion,
   PLUGIN_MANIFEST,
+  reportFor,
   resolveBaseRef,
   skillPaths,
   VERSIONED_MANIFESTS,
@@ -250,6 +251,78 @@ Deno.test("the base ref follows the PR base, then an override, then master", () 
   );
   // An empty value is not a value.
   assertEquals(resolveBaseRef(env({ GITHUB_BASE_REF: "" })), "origin/master");
+});
+
+Deno.test("a skip is information locally and a failure on CI", async () => {
+  // The gate stopped guarding anything for months because a skip reads as
+  // green. Locally — a shallow clone, a worktree whose base is not fetched —
+  // it is still ordinary, so the two outcomes are asserted together.
+  const verdict = await checkPluginVersionBump(
+    fakeGit({ refs: [] }),
+    "origin/master",
+    headAt("0.33.0"),
+  );
+  assertEquals(verdict.checked, false);
+
+  const local = reportFor(verdict, "origin/master", false);
+  assertEquals(local.level, "info");
+  assertStringIncludes(local.message, "skipped");
+  assertStringIncludes(local.message, "ZUKE_PLUGIN_BASE_REF");
+
+  const ci = reportFor(verdict, "origin/master", true);
+  assertEquals(ci.level, "error");
+  // Naming the fix matters: the cause is a checkout setting, nowhere near the
+  // check itself.
+  assertStringIncludes(ci.message, "fetch-depth 0");
+});
+
+Deno.test("every other verdict reports the level its outcome deserves", async () => {
+  const changed = ["skills/zuke-write-build/SKILL.md"];
+  const base = "origin/master";
+
+  // Skills moved, version did not: the failure carries the bump instructions.
+  const stale = await checkPluginVersionBump(
+    fakeGit({
+      changed,
+      baseFiles: { [PLUGIN_MANIFEST]: '{"version":"0.3.0"}' },
+    }),
+    base,
+    headAt("0.3.0"),
+  );
+  const staleReport = reportFor(stale, base, false);
+  assertEquals(staleReport.level, "error");
+  assertStringIncludes(staleReport.message, "still 0.3.0");
+
+  // Skills moved and the version went up: information, naming both versions.
+  const bumped = await checkPluginVersionBump(
+    fakeGit({
+      changed,
+      baseFiles: { [PLUGIN_MANIFEST]: '{"version":"0.3.0"}' },
+    }),
+    base,
+    headAt("0.4.0"),
+  );
+  const bumpedReport = reportFor(bumped, base, true);
+  assertEquals(bumpedReport.level, "info");
+  assertStringIncludes(bumpedReport.message, "0.3.0 → 0.4.0");
+
+  // No skill touched: the common case, and never a demand to bump.
+  const untouched = await checkPluginVersionBump(
+    fakeGit({ changed: ["docs/cli.md"] }),
+    base,
+    headAt("0.3.0"),
+  );
+  const untouchedReport = reportFor(untouched, base, true);
+  assertEquals(untouchedReport.level, "info");
+  assertStringIncludes(untouchedReport.message, "nothing to bump");
+
+  // An unreadable head manifest is a real problem, on CI or not.
+  const unreadable = await checkPluginVersionBump(
+    fakeGit({ changed }),
+    base,
+    headAt(null),
+  );
+  assertEquals(reportFor(unreadable, base, false).level, "error");
 });
 
 /**

--- a/tests/plugin_version_check_test.ts
+++ b/tests/plugin_version_check_test.ts
@@ -115,6 +115,67 @@ Deno.test("skills changed and the version moved — the check passes", async () 
   assertEquals(verdict.headVersion, "0.3.0");
 });
 
+Deno.test("a version that moved down is not a bump", async () => {
+  // The shape a badly resolved conflict takes: the branch keeps its own lower
+  // number over the base's. It "differs", and shipping it would put the skills
+  // under a version clients already hold.
+  const verdict = await checkPluginVersionBump(
+    fakeGit({
+      changed: ["skills/zuke-write-build/references/cheatsheet.md"],
+      baseFiles: { [PLUGIN_MANIFEST]: '{"version":"0.33.0"}' },
+    }),
+    "origin/master",
+    headAt("0.32.0"),
+  );
+  assertEquals(verdict.checked, true);
+  assertEquals(verdict.bumped, false);
+  const message = bumpFailure(verdict);
+  assertStringIncludes(message, "the wrong way: 0.33.0 → 0.32.0");
+  assertStringIncludes(message, "Set a version above 0.33.0");
+});
+
+Deno.test("the same version on two branches is a collision, not a bump", async () => {
+  // What a push-to-master run sees after the second of two branches that each
+  // bumped 0.31.0 to 0.32.0 lands: the merge changed skills, and the version
+  // is what the previous commit already had. Neither branch's own check could
+  // see this — each compared against a base that had not moved yet.
+  const verdict = await checkPluginVersionBump(
+    fakeGit({
+      refs: ["HEAD^"],
+      changed: ["skills/zuke-write-build/references/cheatsheet.md"],
+      baseFiles: { [PLUGIN_MANIFEST]: '{"version":"0.32.0"}' },
+    }),
+    "HEAD^",
+    headAt("0.32.0"),
+  );
+  assertEquals(verdict.checked, true);
+  assertEquals(verdict.bumped, false);
+  assertStringIncludes(bumpFailure(verdict), "still 0.32.0");
+  // The hint that names this exact situation (wrapped across lines in the
+  // message, so match the part that stays on one).
+  assertStringIncludes(
+    bumpFailure(verdict),
+    "leave the second change invisible",
+  );
+});
+
+Deno.test("a version that cannot be ordered is refused, not waved through", async () => {
+  // A manifest version that is not a plain triple cannot be compared, so it
+  // cannot be shown to be an increase. The gate refuses what it did not
+  // understand instead of assuming the best.
+  for (const [base, head] of [["0.32.0", "0.33"], ["latest", "0.33.0"]]) {
+    const verdict = await checkPluginVersionBump(
+      fakeGit({
+        changed: ["skills/zuke-write-build/SKILL.md"],
+        baseFiles: { [PLUGIN_MANIFEST]: JSON.stringify({ version: base }) },
+      }),
+      "origin/master",
+      headAt(head),
+    );
+    assertEquals(verdict.bumped, false, `${base} → ${head}`);
+  }
+});
+
 Deno.test("a change that touches no skill needs no bump", async () => {
   // The common case: an ordinary source PR must not be asked to bump a plugin
   // it never touched.
@@ -189,4 +250,38 @@ Deno.test("the base ref follows the PR base, then an override, then master", () 
   );
   // An empty value is not a value.
   assertEquals(resolveBaseRef(env({ GITHUB_BASE_REF: "" })), "origin/master");
+});
+
+/**
+ * The generated CI workflow, because the artifact is what GitHub runs: the
+ * decision above is only a check if the job it runs in can actually reach a
+ * base ref, and for months it could not.
+ */
+const CI_WORKFLOW = await Deno.readTextFile(".github/workflows/ci.yml");
+
+Deno.test("the gate job checks out enough history for this check to run", () => {
+  // A shallow checkout has no `origin/<base>` at all, so the check reported
+  // itself skipped on every CI run — honestly, and invisibly. Full history is
+  // what makes it able to fail.
+  const job = CI_WORKFLOW.slice(
+    CI_WORKFLOW.indexOf("  ci:"),
+    CI_WORKFLOW.indexOf("  coreFloorCheck:"),
+  );
+  assertStringIncludes(job, 'fetch-depth: "0"');
+});
+
+Deno.test("a push to master compares against the previous commit", () => {
+  // The one place a same-version collision between two branches is visible:
+  // neither pull request's check could see the other, because each compared
+  // against a base that had not moved yet.
+  assertStringIncludes(
+    CI_WORKFLOW,
+    "ZUKE_PLUGIN_BASE_REF: \"${{ github.event_name == 'push' && 'HEAD^' || '' }}\"",
+  );
+  // Empty on a pull request, which leaves the base resolution to the check.
+  assertEquals(resolveBaseRef(() => ""), "origin/master");
+  assertEquals(
+    resolveBaseRef((n) => n === "ZUKE_PLUGIN_BASE_REF" ? "HEAD^" : ""),
+    "HEAD^",
+  );
 });

--- a/tests/semver_test.ts
+++ b/tests/semver_test.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Unit tests for the build's version ordering.
+ *
+ * The property worth pinning is the one a string comparison gets wrong:
+ * `1.10.0` is newer than `1.9.0`, not older. Everything else here is about
+ * refusing what cannot be ordered rather than guessing at it.
+ *
+ * @module
+ */
+
+import { assertEquals } from "../packages/core/tests/_assert.ts";
+import { compareSemver, isNewerSemver, parseSemver } from "../build/semver.ts";
+
+Deno.test("a plain triple parses, and anything else does not", () => {
+  assertEquals(parseSemver("1.2.3"), { major: 1, minor: 2, patch: 3 });
+  assertEquals(parseSemver(" 0.33.0 "), { major: 0, minor: 33, patch: 0 });
+  // A leading `v` belongs to the caller's input shape, not to this parser.
+  assertEquals(parseSemver("v1.2.3"), undefined);
+  assertEquals(parseSemver("1.2"), undefined);
+  assertEquals(parseSemver("1.2.3-rc.1"), undefined);
+  assertEquals(parseSemver("latest"), undefined);
+  assertEquals(parseSemver(""), undefined);
+});
+
+Deno.test("versions order numerically, not lexically", () => {
+  const of = (text: string) => {
+    const parsed = parseSemver(text);
+    if (parsed === undefined) throw new Error(`unparsable: ${text}`);
+    return parsed;
+  };
+  // The mistake a string sort makes, once the tenth release lands.
+  assertEquals(compareSemver(of("1.10.0"), of("1.9.0")) > 0, true);
+  assertEquals(compareSemver(of("1.9.0"), of("1.10.0")) < 0, true);
+  assertEquals(compareSemver(of("1.2.3"), of("1.2.3")), 0);
+  assertEquals(compareSemver(of("2.0.0"), of("1.99.99")) > 0, true);
+  assertEquals(compareSemver(of("1.2.4"), of("1.2.3")) > 0, true);
+});
+
+Deno.test("isNewerSemver is strict, and refuses what it cannot order", () => {
+  assertEquals(isNewerSemver("0.33.0", "0.32.0"), true);
+  assertEquals(isNewerSemver("0.32.0", "0.32.0"), false);
+  assertEquals(isNewerSemver("0.32.0", "0.33.0"), false);
+  // Neither side is ordered against a value this cannot parse: false is the
+  // safe answer for a caller using it as a gate.
+  assertEquals(isNewerSemver("0.33", "0.32.0"), false);
+  assertEquals(isNewerSemver("0.33.0", "nightly"), false);
+});

--- a/zuke.ts
+++ b/zuke.ts
@@ -107,9 +107,9 @@ import {
   GEMINI_ASSET_NAMES,
 } from "./build/gemini_archive.ts";
 import {
-  bumpFailure,
   checkPluginVersionBump,
   defaultGitHistory,
+  reportFor,
   resolveBaseRef,
 } from "./build/plugin_version_check.ts";
 import { actionPin } from "./build/action_pins.ts";
@@ -540,39 +540,12 @@ class ZukeBuild extends Build {
         (path) => Deno.readTextFile(path).catch(() => null),
       );
       // Unlike the rest of the gate this needs history, so it can genuinely be
-      // unable to run. Say so rather than reporting success — a check that
-      // cannot fail is worse than no check, because it looks like one.
-      //
-      // On CI it is not merely reported: a skip there means the gate silently
-      // stopped guarding the thing it exists for, which is exactly what a
-      // shallow checkout did to it for months. Locally — a shallow clone, a
-      // fresh worktree, a branch with no base — the skip stays informational.
-      if (!verdict.checked) {
-        const message = `Plugin version check skipped — ${verdict.reason}. ` +
-          "Set ZUKE_PLUGIN_BASE_REF to compare against a ref you do have.";
-        if (isCI()) {
-          throw new Error(
-            `${message} On CI the base ref must be fetchable: check out with ` +
-              "full history (fetch-depth 0) so this check can run.",
-          );
-        }
-        ConsoleTasks.info(message);
-        return;
-      }
-      if (verdict.headVersion === undefined) {
-        throw new Error(`Plugin version check failed — ${verdict.reason}.`);
-      }
-      if (verdict.changed.length === 0) {
-        ConsoleTasks.info(
-          `No published skill changed against ${base}; nothing to bump.`,
-        );
-        return;
-      }
-      if (!verdict.bumped) throw new Error(bumpFailure(verdict));
-      ConsoleTasks.info(
-        `Skills changed against ${base} and the plugin version moved ` +
-          `${verdict.baseVersion} → ${verdict.headVersion}.`,
-      );
+      // unable to run — and on CI that inability is itself the failure. The
+      // decision, including which outcome a skip gets, lives in the module so
+      // every branch of it is tested; this stays the dispatch.
+      const report = reportFor(verdict, base, isCI());
+      if (report.level === "error") throw new Error(report.message);
+      ConsoleTasks.info(report.message);
     });
 
   // Only meaningful on a `pull_request`-triggered run (the workflow passes it

--- a/zuke.ts
+++ b/zuke.ts
@@ -542,11 +542,21 @@ class ZukeBuild extends Build {
       // Unlike the rest of the gate this needs history, so it can genuinely be
       // unable to run. Say so rather than reporting success — a check that
       // cannot fail is worse than no check, because it looks like one.
+      //
+      // On CI it is not merely reported: a skip there means the gate silently
+      // stopped guarding the thing it exists for, which is exactly what a
+      // shallow checkout did to it for months. Locally — a shallow clone, a
+      // fresh worktree, a branch with no base — the skip stays informational.
       if (!verdict.checked) {
-        ConsoleTasks.info(
-          `Plugin version check skipped — ${verdict.reason}. ` +
-            "Set ZUKE_PLUGIN_BASE_REF to compare against a ref you do have.",
-        );
+        const message = `Plugin version check skipped — ${verdict.reason}. ` +
+          "Set ZUKE_PLUGIN_BASE_REF to compare against a ref you do have.";
+        if (isCI()) {
+          throw new Error(
+            `${message} On CI the base ref must be fetchable: check out with ` +
+              "full history (fetch-depth 0) so this check can run.",
+          );
+        }
+        ConsoleTasks.info(message);
         return;
       }
       if (verdict.headVersion === undefined) {


### PR DESCRIPTION
## What & why

The plugin-version check exists for exactly the failure that just happened — five branches each bumping `0.31.0 → 0.32.0` from the same base, merging cleanly because every side made the identical edit, leaving master at one version carrying five distinct skill changes. Every PR was green. This makes the check able to catch it.

Three separate defects, in order of severity.

**It has never run in CI.** The gate job checks out with the action's default `fetch-depth: 1`, so `origin/master` is not present as a remote-tracking ref. `checkPluginVersionBump` correctly reported itself skipped rather than silently passing — but skipped is not failed, and nobody reads the line. From a green run on #440:

> ℹ Plugin version check skipped — the base ref "origin/master" is not present in this clone.

The job now checks out full history, and a skip **on CI** is fatal. Locally — a shallow clone, a fresh worktree, a branch with no base — a skip stays informational, which is the case that reporting honestly was built for. A check that cannot fail is worse than no check, as the module's own doc says; this is that sentence enforced.

**Nothing looked at the merge result.** A PR's answer is computed against the base tip at the time the checks ran, and GitHub does not re-run a PR's checks when its base moves — so a green computed before the first merge stays green and mergeable afterwards. The collision only becomes visible on master. A push to master now sets `ZUKE_PLUGIN_BASE_REF` to `HEAD^`, comparing the merge commit against its parent. That needed no change to the decision function: the merge base of `HEAD^` and `HEAD` is `HEAD^`.

**A version that went down counted as a bump.** The verdict was `baseVersion !== headVersion`, so resolving a version conflict by keeping your lower number over the base's passed. It now requires the version to increase, and the failure message names the situation and tells you to take the next version above what the base holds rather than matching it.

On the shared comparison: ordering `<major>.<minor>.<patch>` numerically already existed privately in `build/action_release.ts`, for picking the newest release tag. Rather than a second copy, `build/semver.ts` now holds it and the tag scanner delegates. The JSR version comparison in `@zuke/core` stays separate — a published package cannot import from `build/`, and exporting it from core to serve a build-internal need would expand the public API for no consumer.

**Merge #445 first.** That one bumps master to `0.33.0`, which is the state this check should be enforcing on top of.

## Verification

`deno task ci` green locally, and `./zuke pluginVersionCheck` on this branch now reports what it should rather than skipping:

> ℹ No published skill changed against origin/master; nothing to bump.

The one thing unit tests cannot prove is that CI itself can now reach the base ref. This PR's own CI run is that evidence: the step log must show a real verdict line, not the skip. I will confirm it on the run and report back here.

## Related issues

Closes #444

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a [Conventional Commit](https://www.conventionalcommits.org/) (`type(scope): summary`). `chore`: build tooling, no published package changes, nothing to release.
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated; coverage stays at 95%+. New: the down-version refusal, the same-version collision as a push-to-master verdict, versions that cannot be ordered, the full `build/semver.ts` surface, and two guards on the generated workflow — that the gate job checks out full history and that a push compares against the previous commit. The workflow assertions follow the precedent in `tests/pr_body_lint_test.ts`: the artifact is what GitHub runs, so the wiring a check depends on is asserted against the generated file.
- [x] Docs updated in the same PR — AGENTS.md's plugin section now states that the version must move up, that a CI skip is fatal, and what to do when several skill-touching PRs are open at once.
- [x] Public API changes were regenerated — not applicable, nothing published changed.
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/`.
- [x] No dead code — the private `compareVersions` in the tag scanner is gone, replaced by the shared one.
- [x] No duplicated logic: the ordering comparison has one implementation in `build/`, with the reason the core one stays separate written above.
- [x] SOLID shapes respected: the decision stays a pure function over an injectable `GitHistory`; only the base ref and the fatality of a skip changed around it.
- [x] Not applicable — no new package.
- [x] The code is written using AI assisted coding.

## Adversarial pass

Attacked before opening: a version that cannot be parsed on either side, which must not be waved through as an increase (refused, tested); the plugin being new on a branch with no manifest at the base, which must still be exempt (unchanged, still tested); a local shallow clone, which must keep skipping rather than failing a contributor's gate (guarded by `isCI`); and the push-event expression, which must leave the PR path's resolution untouched — it evaluates to an empty string there, which `resolveBaseRef` treats as unset, asserted directly.
