### PR TITLE
feat(deno): report test counts and coverage percentages into the build summary

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.34.0",
+      "version": "0.35.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/deno.lock
+++ b/deno.lock
@@ -1608,7 +1608,7 @@
       },
       "packages/deno": {
         "dependencies": [
-          "jsr:@zuke/core@^1.25.0"
+          "jsr:@zuke/core@^1.44.0"
         ]
       },
       "packages/docker": {

--- a/docs/console.md
+++ b/docs/console.md
@@ -211,8 +211,8 @@ Log.summary(reports, totalMs, ok);
 ```
 
 A report's optional `summary` entries — the notes a target reported with
-`ctx.reportSummary`, or a wrapper reported through the ambient form — trail
-its row, dimmed:
+`ctx.reportSummary`, or a wrapper reported through the ambient form
+(`DenoTasks.test`'s test counts) — trail its row, dimmed:
 `test  Succeeded  8.1s  // Passed: 837`. See
 [Notes on the summary row](./run-context.md#notes-on-the-summary-row).
 

--- a/docs/run-context.md
+++ b/docs/run-context.md
@@ -66,6 +66,24 @@ class CI extends Build {
 }
 ```
 
+A wrapper that knows what its tool printed reports for you. `DenoTasks.test`
+puts `// Tests: 837 · Passed: 837 · Failed: 0` on the row of whichever target
+ran it:
+
+<!-- check -->
+
+```ts
+import { Build, target } from "jsr:@zuke/core";
+import { DenoTasks } from "jsr:@zuke/deno";
+
+class Checks extends Build {
+  test = target().executes(async (ctx) => {
+    await DenoTasks.test((s) => s.allowAll()); // reports the counts itself
+    ctx.reportSummary({ Version: "3.6.2" }); // the body adds what it knows
+  });
+}
+```
+
 Notes accumulate across calls in one target, and reporting a key again
 replaces its value in place. Each key and value renders on a single line
 (whitespace collapsed, colour codes removed) in both the terminal table and the
@@ -79,8 +97,11 @@ calls — reports through the **ambient** form, `reportSummary(pairs)` from
 the [ambient signal](#scope-of-the-ambient-signal) to that target's async
 subtree, so concurrent targets never mix notes. Outside a running target it is
 a no-op: a wrapper never has to ask where it runs. This is the seam a tool
-wrapper reports through — a test runner's pass/fail counts, a coverage gate's
-measured percentages — so a body only adds what its tools do not.
+wrapper reports through, so a body only adds what its tools do not:
+`DenoTasks.test` reports Tests, Passed, Failed (and Ignored when non-zero)
+from deno's own result line — on a failed run too, so a red row says how many
+failed — and `DenoTasks.coverage` reports the measured line and branch
+percentages.
 
 ## Reading what the rest of the run did
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "zuke",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build)."
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5755,6 +5755,12 @@ class DenoTaskSettings extends DenoSettings
 class DenoTestSettings extends DenoPermissionSettings
   Settings for `deno test`.
 
+  A run reports its counts into the running target's row of the build
+  summary — `// Tests: 837 · Passed: 837 · Failed: 0` — read from the result
+  line the pretty and dot reporters print; a failed run reports too, so a red
+  row says how many failed. The JUnit and TAP reporters print no such line,
+  so a run under `.reporter("junit")`/`.reporter("tap")` reports nothing.
+
   paths(...paths: PathLike[]): this
     Restrict the run to specific test files or directories.
   coverage(dir: PathLike): this
@@ -5859,6 +5865,8 @@ class DenoTestSettings extends DenoPermissionSettings
     Exclude paths from the watcher (`--watch-exclude`).
   noClearScreen(): this
     Keep previous output when re-running under `--watch` (`--no-clear-screen`).
+  override protected onOutput(output: CommandOutput): void
+    Report the run's counts into the build summary (see the class docs).
   override protected buildArgs(): string[]
     Assemble the `deno test` argv.
 
@@ -5984,7 +5992,9 @@ interface DenoTasksApi
   run(configure?: Configure<DenoRunSettings>): Promise<CommandOutput>
     Run a script: `deno run`.
   test(configure?: Configure<DenoTestSettings>): Promise<CommandOutput>
-    Run tests: `deno test`.
+    Run tests: `deno test`. Reports the run's counts into the running
+    target's row of the build summary (`// Tests: 837 · Passed: 837 · Failed: 0`), read from deno's own result line — see
+    {@link DenoTestSettings}.
   check(configure?: Configure<DenoCheckSettings>): Promise<CommandOutput>
     Type-check files: `deno check`.
   fmt(configure?: Configure<DenoFmtSettings>): Promise<CommandOutput>

--- a/packages/deno/README.md
+++ b/packages/deno/README.md
@@ -963,6 +963,12 @@ class DenoTaskSettings extends DenoSettings
 class DenoTestSettings extends DenoPermissionSettings
   Settings for `deno test`.
 
+  A run reports its counts into the running target's row of the build
+  summary — `// Tests: 837 · Passed: 837 · Failed: 0` — read from the result
+  line the pretty and dot reporters print; a failed run reports too, so a red
+  row says how many failed. The JUnit and TAP reporters print no such line,
+  so a run under `.reporter("junit")`/`.reporter("tap")` reports nothing.
+
   paths(...paths: PathLike[]): this
     Restrict the run to specific test files or directories.
   coverage(dir: PathLike): this
@@ -1067,6 +1073,8 @@ class DenoTestSettings extends DenoPermissionSettings
     Exclude paths from the watcher (`--watch-exclude`).
   noClearScreen(): this
     Keep previous output when re-running under `--watch` (`--no-clear-screen`).
+  override protected onOutput(output: CommandOutput): void
+    Report the run's counts into the build summary (see the class docs).
   override protected buildArgs(): string[]
     Assemble the `deno test` argv.
 
@@ -1192,7 +1200,9 @@ interface DenoTasksApi
   run(configure?: Configure<DenoRunSettings>): Promise<CommandOutput>
     Run a script: `deno run`.
   test(configure?: Configure<DenoTestSettings>): Promise<CommandOutput>
-    Run tests: `deno test`.
+    Run tests: `deno test`. Reports the run's counts into the running
+    target's row of the build summary (`// Tests: 837 · Passed: 837 · Failed: 0`), read from deno's own result line — see
+    {@link DenoTestSettings}.
   check(configure?: Configure<DenoCheckSettings>): Promise<CommandOutput>
     Type-check files: `deno check`.
   fmt(configure?: Configure<DenoFmtSettings>): Promise<CommandOutput>

--- a/packages/deno/deno.json
+++ b/packages/deno/deno.json
@@ -7,7 +7,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1.25.0"
+    "@zuke/core": "jsr:@zuke/core@^1.44.0"
   },
   "publish": {
     "exclude": [

--- a/packages/deno/src/coverage.ts
+++ b/packages/deno/src/coverage.ts
@@ -12,6 +12,8 @@
  * @module
  */
 
+import { reportSummary } from "@zuke/core";
+
 /** Raised when measured coverage falls below a configured threshold. */
 export class CoverageThresholdError extends Error {
   /** The error name, `"CoverageThresholdError"`. */
@@ -150,6 +152,13 @@ export function enforceCoverage(
     `Coverage — lines: ${fmt(lines)}% (${t.linesHit}/${t.linesFound}), ` +
       `branches: ${fmt(branches)}% (${t.branchesHit}/${t.branchesFound})`,
   );
+  // The same figures on the target's row of the build summary, so the gate's
+  // result is readable without scrolling back — branches only when some were
+  // measured, since a branchless report scores a vacuous 100%.
+  reportSummary({
+    Lines: `${fmt(lines)}%`,
+    ...(t.branchesFound > 0 ? { Branches: `${fmt(branches)}%` } : {}),
+  });
 
   const failures: string[] = [];
   const gated = thresholds.lines !== undefined ||

--- a/packages/deno/src/deno.ts
+++ b/packages/deno/src/deno.ts
@@ -69,7 +69,12 @@ import {
 export interface DenoTasksApi {
   /** Run a script: `deno run`. */
   run(configure?: Configure<DenoRunSettings>): Promise<CommandOutput>;
-  /** Run tests: `deno test`. */
+  /**
+   * Run tests: `deno test`. Reports the run's counts into the running
+   * target's row of the build summary (`// Tests: 837 · Passed: 837 ·
+   * Failed: 0`), read from deno's own result line — see
+   * {@link DenoTestSettings}.
+   */
   test(configure?: Configure<DenoTestSettings>): Promise<CommandOutput>;
   /** Type-check files: `deno check`. */
   check(configure?: Configure<DenoCheckSettings>): Promise<CommandOutput>;
@@ -176,7 +181,8 @@ export const DenoTasks: DenoTasksApi = {
    * Report coverage: `deno coverage`. When a threshold is configured
    * (`linesThreshold`/`branchesThreshold`/`threshold`), parse the lcov report
    * and enforce it — raising a {@link CoverageThresholdError} on a shortfall
-   * unless `noThrow()` was set.
+   * unless `noThrow()` was set — and report the measured line and branch
+   * percentages into the running target's row of the build summary.
    */
   async coverage(
     configure?: Configure<DenoCoverageSettings>,

--- a/packages/deno/src/test_summary.ts
+++ b/packages/deno/src/test_summary.ts
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * The counts `deno test` prints on its result line, and how they land in a
+ * build's summary row. `DenoTasks.test` reads them from the run's captured
+ * stdout — the pretty and dot reporters both end with the same line — and
+ * reports them through `@zuke/core`'s ambient `reportSummary`, so a `test`
+ * target's row says `// Tests: 837 · Passed: 837 · Failed: 0` without the
+ * build author writing a thing. Internal to the wrapper.
+ *
+ * @module
+ */
+
+import { stripAnsi } from "@zuke/core/render";
+import type { SummaryPairs } from "@zuke/core";
+
+/** The counts on a `deno test` result line. */
+export interface DenoTestCounts {
+  /** Tests that passed. */
+  readonly passed: number;
+  /** Tests that failed. */
+  readonly failed: number;
+  /** Tests marked `ignore` (deno prints the count only when it is non-zero). */
+  readonly ignored: number;
+}
+
+/**
+ * Deno's result line: `ok | 2 passed (2 steps) | 0 failed | 1 ignored (50ms)`
+ * or `FAILED | 1 passed | 1 failed (66ms)`. `passed` and `failed` are always
+ * present; `ignored`, `measured` and `filtered out` only when non-zero; each
+ * of the first three may carry a `(N steps)` suffix.
+ */
+const RESULT_LINE =
+  /^(?:ok|FAILED) \| (\d+) passed(?: \(\d+ steps?\))? \| (\d+) failed(?: \(\d+ steps?\))?(?: \| (\d+) ignored(?: \(\d+ steps?\))?)?/gm;
+
+/**
+ * The counts from the **last** result line in `stdout`, or `undefined` when
+ * there is none — a JUnit or TAP reporter prints no such line, and neither
+ * does a run that never got as far as running tests. The last line is deno's
+ * own: it prints the result after every test's output, so a test that echoes
+ * a look-alike line cannot be mistaken for it.
+ */
+export function parseTestSummary(stdout: string): DenoTestCounts | undefined {
+  let counts: DenoTestCounts | undefined;
+  for (const m of stripAnsi(stdout).matchAll(RESULT_LINE)) {
+    counts = {
+      passed: Number(m[1]),
+      failed: Number(m[2]),
+      ignored: m[3] === undefined ? 0 : Number(m[3]),
+    };
+  }
+  return counts;
+}
+
+/**
+ * The notes a test run reports into its summary row: the total the run
+ * selected (passed, failed and ignored), the passed and failed counts, and the
+ * ignored count only when it is non-zero — mirroring the result line itself.
+ */
+export function testSummaryPairs(counts: DenoTestCounts): SummaryPairs {
+  const pairs: Record<string, number> = {
+    Tests: counts.passed + counts.failed + counts.ignored,
+    Passed: counts.passed,
+    Failed: counts.failed,
+  };
+  if (counts.ignored > 0) pairs.Ignored = counts.ignored;
+  return pairs;
+}

--- a/packages/deno/src/test_summary.ts
+++ b/packages/deno/src/test_summary.ts
@@ -27,12 +27,20 @@ export interface DenoTestCounts {
 
 /**
  * Deno's result line: `ok | 2 passed (2 steps) | 0 failed | 1 ignored (50ms)`
- * or `FAILED | 1 passed | 1 failed (66ms)`. `passed` and `failed` are always
- * present; `ignored`, `measured` and `filtered out` only when non-zero; each
- * of the first three may carry a `(N steps)` suffix.
+ * or `FAILED | 1 passed | 1 failed (66ms)`. It opens with the verdict, and the
+ * counts follow as ` | `-separated segments: `passed` and `failed` are always
+ * printed; `ignored`, `measured` and `filtered out` only when non-zero; the
+ * first three may carry a `(N steps)` suffix; and the whole line ends with the
+ * run's duration in parentheses.
  */
-const RESULT_LINE =
-  /^(?:ok|FAILED) \| (\d+) passed(?: \(\d+ steps?\))? \| (\d+) failed(?: \(\d+ steps?\))?(?: \| (\d+) ignored(?: \(\d+ steps?\))?)?/gm;
+const RESULT_LINE = /^(?:ok|FAILED) \| (.+)$/gm;
+
+/** One count segment of the result line, e.g. `2 passed (2 steps)`. */
+const SEGMENT =
+  /^(\d+) (passed|failed|ignored|measured|filtered out)(?: \(\d+ steps?\))?$/;
+
+/** The trailing `(66ms)` duration, dropped before the segments are read. */
+const DURATION = / \([^()]*\)$/;
 
 /**
  * The counts from the **last** result line in `stdout`, or `undefined` when
@@ -40,15 +48,24 @@ const RESULT_LINE =
  * does a run that never got as far as running tests. The last line is deno's
  * own: it prints the result after every test's output, so a test that echoes
  * a look-alike line cannot be mistaken for it.
+ *
+ * The segments are read by name rather than by position, so the parser does
+ * not depend on the order deno prints them in, nor on which of the optional
+ * ones (`ignored`, `measured`, `filtered out`) a run happens to include. A
+ * line without both `passed` and `failed` is not a result line.
  */
 export function parseTestSummary(stdout: string): DenoTestCounts | undefined {
   let counts: DenoTestCounts | undefined;
   for (const m of stripAnsi(stdout).matchAll(RESULT_LINE)) {
-    counts = {
-      passed: Number(m[1]),
-      failed: Number(m[2]),
-      ignored: m[3] === undefined ? 0 : Number(m[3]),
-    };
+    const found = new Map<string, number>();
+    for (const segment of m[1].replace(DURATION, "").split(" | ")) {
+      const c = SEGMENT.exec(segment.trim());
+      if (c !== null) found.set(c[2], Number(c[1]));
+    }
+    const passed = found.get("passed");
+    const failed = found.get("failed");
+    if (passed === undefined || failed === undefined) continue;
+    counts = { passed, failed, ignored: found.get("ignored") ?? 0 };
   }
   return counts;
 }

--- a/packages/deno/src/testing.ts
+++ b/packages/deno/src/testing.ts
@@ -7,7 +7,10 @@
  */
 
 import type { PathLike } from "@zuke/core/tooling";
+import type { CommandOutput } from "@zuke/core/shell";
+import { reportSummary } from "@zuke/core";
 import { DenoPermissionSettings, DenoSettings } from "./settings.ts";
+import { parseTestSummary, testSummaryPairs } from "./test_summary.ts";
 import type { CoverageThresholds } from "./coverage.ts";
 import {
   ConfigFlags,
@@ -24,7 +27,15 @@ import {
 /** The report formats `deno test --reporter` accepts. */
 export type DenoTestReporter = "pretty" | "dot" | "junit" | "tap";
 
-/** Settings for `deno test`. */
+/**
+ * Settings for `deno test`.
+ *
+ * A run reports its counts into the running target's row of the build
+ * summary — `// Tests: 837 · Passed: 837 · Failed: 0` — read from the result
+ * line the pretty and dot reporters print; a failed run reports too, so a red
+ * row says how many failed. The JUnit and TAP reporters print no such line,
+ * so a run under `.reporter("junit")`/`.reporter("tap")` reports nothing.
+ */
 export class DenoTestSettings extends DenoPermissionSettings {
   #paths: string[] = [];
   #coverage?: string;
@@ -352,6 +363,12 @@ export class DenoTestSettings extends DenoPermissionSettings {
   noClearScreen(): this {
     this.#watch.noClearScreen();
     return this;
+  }
+
+  /** Report the run's counts into the build summary (see the class docs). */
+  protected override onOutput(output: CommandOutput): void {
+    const counts = parseTestSummary(output.stdout);
+    if (counts !== undefined) reportSummary(testSummaryPairs(counts));
   }
 
   /** Assemble the `deno test` argv. */

--- a/packages/deno/tests/coverage_test.ts
+++ b/packages/deno/tests/coverage_test.ts
@@ -14,6 +14,10 @@ import {
   parseLcovPerFile,
 } from "../src/coverage.ts";
 import { DenoTasks } from "../src/deno.ts";
+import {
+  TargetSummary,
+  withAmbientSummary,
+} from "../../core/src/summary_note.ts";
 
 Deno.test("parseLcov sums LF/LH/BRF/BRH across files, skipping other tags", () => {
   const lcov = [
@@ -260,4 +264,27 @@ Deno.test("a per-file floor alone gates the run and fails a low file", async () 
   } finally {
     await Deno.remove(dir, { recursive: true });
   }
+});
+
+Deno.test("enforceCoverage reports the measured percentages into the ambient summary", async () => {
+  const summary = new TargetSummary();
+  const lcov = "SF:a.ts\nLF:10\nLH:9\nBRF:4\nBRH:3\nend_of_record\n";
+  await withAmbientSummary(summary, () => {
+    enforceCoverage(lcov, {}, true);
+    return Promise.resolve();
+  });
+  assertEquals(summary.entries(), [
+    { key: "Lines", value: "90.0%" },
+    { key: "Branches", value: "75.0%" },
+  ]);
+});
+
+Deno.test("enforceCoverage reports no branch figure for a branchless report", async () => {
+  const summary = new TargetSummary();
+  const lcov = "SF:a.ts\nLF:10\nLH:10\nend_of_record\n";
+  await withAmbientSummary(summary, () => {
+    enforceCoverage(lcov, {}, true);
+    return Promise.resolve();
+  });
+  assertEquals(summary.entries(), [{ key: "Lines", value: "100.0%" }]);
 });

--- a/packages/deno/tests/coverage_test.ts
+++ b/packages/deno/tests/coverage_test.ts
@@ -288,3 +288,20 @@ Deno.test("enforceCoverage reports no branch figure for a branchless report", as
   });
   assertEquals(summary.entries(), [{ key: "Lines", value: "100.0%" }]);
 });
+
+Deno.test("enforceCoverage outside a running target still gates, and its report goes nowhere", () => {
+  // No ambient collector is installed here: the report is a no-op, so the
+  // gate's own result is unaffected and nothing leaks into a later target.
+  const lcov = "SF:a.ts\nLF:10\nLH:9\nBRF:4\nBRH:3\nend_of_record\n";
+  assertEquals(enforceCoverage(lcov, { lines: 80 }, true), []);
+  assertThrows(
+    () => enforceCoverage(lcov, { lines: 95 }, true),
+    CoverageThresholdError,
+    "line coverage 90.0% < 95%",
+  );
+  const later = new TargetSummary();
+  return withAmbientSummary(later, () => {
+    assertEquals(later.entries(), []);
+    return Promise.resolve();
+  });
+});

--- a/packages/deno/tests/fixtures/failing_suite.ts
+++ b/packages/deno/tests/fixtures/failing_suite.ts
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * A self-contained suite with one passing and one failing test, so a failed
+ * `DenoTasks.test` run still has counts to report. Not named `*_test.ts` on
+ * purpose — the workspace's own test discovery must not pick it up.
+ */
+
+Deno.test("passes", () => {});
+
+Deno.test("fails", () => {
+  throw new Error("expected failure");
+});

--- a/packages/deno/tests/fixtures/passing_suite.ts
+++ b/packages/deno/tests/fixtures/passing_suite.ts
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * A self-contained suite `DenoTasks.test` is pointed at by explicit path: two
+ * passing tests (one with steps) and one ignored, so the result line carries
+ * every count the wrapper reports. Not named `*_test.ts` on purpose — the
+ * workspace's own test discovery must not pick it up.
+ */
+
+Deno.test("adds", () => {
+  if ([1, 1].reduce((a, b) => a + b) !== 2) throw new Error("arithmetic");
+});
+
+Deno.test("steps", async (t) => {
+  await t.step("first", () => {});
+  await t.step("second", () => {});
+});
+
+Deno.test({ name: "skipped", ignore: true, fn: () => {} });

--- a/packages/deno/tests/test_summary_test.ts
+++ b/packages/deno/tests/test_summary_test.ts
@@ -53,6 +53,25 @@ Deno.test("parseTestSummary ignores deno's colour codes and takes the last resul
   assertEquals(parseTestSummary(echoed), { passed: 1, failed: 2, ignored: 0 });
 });
 
+Deno.test("parseTestSummary reads the segments by name, whatever order they come in", () => {
+  // Deno prints ignored, then measured, then filtered out; a future release
+  // that reorders or renames nothing but shuffles them must still parse.
+  assertEquals(
+    parseTestSummary(
+      "ok | 3 filtered out | 2 measured | 1 ignored | 4 passed | 0 failed (7ms)",
+    ),
+    { passed: 4, failed: 0, ignored: 1 },
+  );
+  // A duration on the last segment must not swallow that segment's count.
+  assertEquals(
+    parseTestSummary("FAILED | 0 passed | 2 failed (1 step) (3ms)"),
+    { passed: 0, failed: 2, ignored: 0 },
+  );
+  // A verdict line without both passed and failed is not a result line.
+  assertEquals(parseTestSummary("ok | 3 filtered out (1ms)"), undefined);
+  assertEquals(parseTestSummary("ok | 3 passed (1ms)"), undefined);
+});
+
 Deno.test("parseTestSummary reports nothing for output without a result line", () => {
   assertEquals(parseTestSummary(""), undefined);
   assertEquals(

--- a/packages/deno/tests/test_summary_test.ts
+++ b/packages/deno/tests/test_summary_test.ts
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
+import {
+  TargetSummary,
+  withAmbientSummary,
+} from "../../core/src/summary_note.ts";
+import { CommandError } from "@zuke/core/shell";
+import { parseTestSummary, testSummaryPairs } from "../src/test_summary.ts";
+import { DenoTasks } from "../src/deno.ts";
+
+const PASSING =
+  new URL("./fixtures/passing_suite.ts", import.meta.url).pathname;
+const FAILING =
+  new URL("./fixtures/failing_suite.ts", import.meta.url).pathname;
+
+Deno.test("parseTestSummary reads the pretty/dot result line in each of its shapes", () => {
+  assertEquals(parseTestSummary("ok | 5 passed | 0 failed (12ms)\n"), {
+    passed: 5,
+    failed: 0,
+    ignored: 0,
+  });
+  assertEquals(
+    parseTestSummary(
+      "FAILED | 1 passed | 1 failed (66ms)\n\nerror: Test failed\n",
+    ),
+    { passed: 1, failed: 1, ignored: 0 },
+  );
+  assertEquals(
+    parseTestSummary(
+      "ok | 2 passed (2 steps) | 0 failed (1 step) | 1 ignored (3 steps) (50ms)",
+    ),
+    { passed: 2, failed: 0, ignored: 1 },
+  );
+  assertEquals(
+    parseTestSummary(
+      "ok | 1 passed | 0 failed | 2 measured | 3 filtered out (4ms)",
+    ),
+    { passed: 1, failed: 0, ignored: 0 },
+  );
+});
+
+Deno.test("parseTestSummary ignores deno's colour codes and takes the last result line", () => {
+  const styled =
+    "\x1b[0m\x1b[32mok\x1b[0m | 3 passed | 0 failed \x1b[38;5;245m(9ms)\x1b[0m\n";
+  assertEquals(parseTestSummary(styled), { passed: 3, failed: 0, ignored: 0 });
+  // A test that prints a look-alike line cannot pose as the run's result: deno
+  // prints its own line last.
+  const echoed =
+    "ok | 99 passed | 0 failed (1ms)\nFAILED | 1 passed | 2 failed (5ms)\n";
+  assertEquals(parseTestSummary(echoed), { passed: 1, failed: 2, ignored: 0 });
+});
+
+Deno.test("parseTestSummary reports nothing for output without a result line", () => {
+  assertEquals(parseTestSummary(""), undefined);
+  assertEquals(
+    parseTestSummary('<testsuites tests="3"></testsuites>'),
+    undefined,
+  );
+  assertEquals(parseTestSummary("  ok | 1 passed | 0 failed (1ms)"), undefined);
+});
+
+Deno.test("testSummaryPairs totals the selected tests and names Ignored only when non-zero", () => {
+  assertEquals(testSummaryPairs({ passed: 4, failed: 1, ignored: 0 }), {
+    Tests: 5,
+    Passed: 4,
+    Failed: 1,
+  });
+  assertEquals(testSummaryPairs({ passed: 2, failed: 0, ignored: 1 }), {
+    Tests: 3,
+    Passed: 2,
+    Failed: 0,
+    Ignored: 1,
+  });
+});
+
+Deno.test("DenoTasks.test reports a real run's counts into the ambient summary", async () => {
+  const summary = new TargetSummary();
+  const out = await withAmbientSummary(
+    summary,
+    () => DenoTasks.test((s) => s.paths(PASSING).noCheck().quiet()),
+  );
+  assertEquals(out.code, 0);
+  assertEquals(summary.entries(), [
+    { key: "Tests", value: "3" },
+    { key: "Passed", value: "2" },
+    { key: "Failed", value: "0" },
+    { key: "Ignored", value: "1" },
+  ]);
+});
+
+Deno.test("DenoTasks.test reports the counts of a failed run before it throws", async () => {
+  const summary = new TargetSummary();
+  await assertRejects(
+    () =>
+      withAmbientSummary(
+        summary,
+        () => DenoTasks.test((s) => s.paths(FAILING).noCheck().quiet()),
+      ),
+    CommandError,
+  );
+  assertEquals(summary.entries(), [
+    { key: "Tests", value: "2" },
+    { key: "Passed", value: "1" },
+    { key: "Failed", value: "1" },
+  ]);
+});
+
+Deno.test("DenoTasks.test reports nothing under a reporter that prints no result line", async () => {
+  const summary = new TargetSummary();
+  await withAmbientSummary(
+    summary,
+    () =>
+      DenoTasks.test((s) =>
+        s.paths(PASSING).noCheck().reporter("junit").quiet()
+      ),
+  );
+  assertEquals(summary.entries(), []);
+});

--- a/packages/deno/tests/test_summary_test.ts
+++ b/packages/deno/tests/test_summary_test.ts
@@ -10,10 +10,11 @@ import { CommandError } from "@zuke/core/shell";
 import { parseTestSummary, testSummaryPairs } from "../src/test_summary.ts";
 import { DenoTasks } from "../src/deno.ts";
 
-const PASSING =
-  new URL("./fixtures/passing_suite.ts", import.meta.url).pathname;
-const FAILING =
-  new URL("./fixtures/failing_suite.ts", import.meta.url).pathname;
+// The fixtures are addressed by `file://` URL, which is byte-identical on
+// every OS — a URL's `pathname` is not: on Windows it reads `/D:/…`, which
+// deno cannot open.
+const PASSING = new URL("./fixtures/passing_suite.ts", import.meta.url).href;
+const FAILING = new URL("./fixtures/failing_suite.ts", import.meta.url).href;
 
 Deno.test("parseTestSummary reads the pretty/dot result line in each of its shapes", () => {
   assertEquals(parseTestSummary("ok | 5 passed | 0 failed (12ms)\n"), {

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/.codex-plugin/plugin.json
+++ b/plugins/zuke/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/skills/zuke-write-build/SKILL.md
+++ b/plugins/zuke/skills/zuke-write-build/SKILL.md
@@ -118,8 +118,9 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   `AbortSignal` fired when the run is cancelled; a plain `` $`…` `` in the body
   is `SIGTERM`'d automatically), `ctx.state`, `ctx.dryRun`, and
   `ctx.reportSummary({ … })` (`key: value` notes on the target's own row of
-  the Build Summary; the ambient `reportSummary` does the same from code with
-  no `ctx`).
+  the Build Summary; `DenoTasks.test` reports its test counts there by
+  itself, and the ambient `reportSummary` does the same from code with no
+  `ctx`).
   Zero-argument bodies keep working unchanged. Cancel a run programmatically by
   passing `{ signal }` to `execute`. See the cheatsheet.
 - **Caching:** `.inputs(...)` / `.outputs(...)` make a target incremental. Add a

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -162,7 +162,9 @@ pairs on the target's own row of the end-of-build summary, NUKE-style:
 `test  Succeeded  8.1s  // Tests: 837 · Passed: 837 · Failed: 0`. Notes
 accumulate; a repeated key replaces its value; each renders on one line, in the
 terminal and in the Actions job summary. A failed target keeps its notes.
-Library code with no `ctx` (a wrapper reporting what its tool printed, a
+`DenoTasks.test` reports Tests/Passed/Failed (and Ignored when non-zero)
+itself, and `DenoTasks.coverage` reports the measured Lines/Branches — a body
+only adds what its tools do not. Library code with no `ctx` (a wrapper, a
 helper) uses the ambient `reportSummary(pairs)` from `@zuke/core`, which lands
 on the running target's row and is a no-op outside a run.
 

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -118,8 +118,9 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   `AbortSignal` fired when the run is cancelled; a plain `` $`…` `` in the body
   is `SIGTERM`'d automatically), `ctx.state`, `ctx.dryRun`, and
   `ctx.reportSummary({ … })` (`key: value` notes on the target's own row of
-  the Build Summary; the ambient `reportSummary` does the same from code with
-  no `ctx`).
+  the Build Summary; `DenoTasks.test` reports its test counts there by
+  itself, and the ambient `reportSummary` does the same from code with no
+  `ctx`).
   Zero-argument bodies keep working unchanged. Cancel a run programmatically by
   passing `{ signal }` to `execute`. See the cheatsheet.
 - **Caching:** `.inputs(...)` / `.outputs(...)` make a target incremental. Add a

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -162,7 +162,9 @@ pairs on the target's own row of the end-of-build summary, NUKE-style:
 `test  Succeeded  8.1s  // Tests: 837 · Passed: 837 · Failed: 0`. Notes
 accumulate; a repeated key replaces its value; each renders on one line, in the
 terminal and in the Actions job summary. A failed target keeps its notes.
-Library code with no `ctx` (a wrapper reporting what its tool printed, a
+`DenoTasks.test` reports Tests/Passed/Failed (and Ignored when non-zero)
+itself, and `DenoTasks.coverage` reports the measured Lines/Branches — a body
+only adds what its tools do not. Library code with no `ctx` (a wrapper, a
 helper) uses the ambient `reportSummary(pairs)` from `@zuke/core`, which lands
 on the running target's row and is a no-op outside a run.
 

--- a/tests/integration/deno_test_counts_test.ts
+++ b/tests/integration/deno_test_counts_test.ts
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Integration: `DenoTasks.test`'s counts on the Build Summary, end to end
+ * through the CLI `main()`. A `test` target running the wrapper on a committed
+ * fixture gets its counts on its row without the build author writing a
+ * thing; a body's own `ctx.reportSummary` lands on the same row; and a failed
+ * run still says how many failed. The fixture is run by the deno already
+ * executing the suite (the wrapper's default binary), so it stays hermetic.
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import { Build, target } from "../../packages/core/mod.ts";
+import { DenoTasks } from "../../packages/deno/mod.ts";
+import { runCli } from "./_harness.ts";
+
+const PASSING = new URL(
+  "../../packages/deno/tests/fixtures/passing_suite.ts",
+  import.meta.url,
+).pathname;
+const FAILING = new URL(
+  "../../packages/deno/tests/fixtures/failing_suite.ts",
+  import.meta.url,
+).pathname;
+
+class CI extends Build {
+  test = target()
+    .description("run the fixture suite")
+    .executes(async (ctx) => {
+      await DenoTasks.test((s) => s.paths(PASSING).noCheck().quiet());
+      ctx.reportSummary({ Version: "3.6.2" });
+    });
+
+  pack = target()
+    .description("a target that reports nothing")
+    .dependsOn(this.test)
+    .executes(() => {});
+}
+
+class Broken extends Build {
+  test = target()
+    .description("run the failing fixture suite")
+    .executes(() => DenoTasks.test((s) => s.paths(FAILING).noCheck().quiet()));
+}
+
+/** The summary row for `name`, or `""` when the table has none. */
+function row(out: string, name: string): string {
+  return out.split("\n").find((l) =>
+    l.startsWith(`${name} `) && /Succeeded|Failed/.test(l)
+  ) ?? "";
+}
+
+Deno.test("the test target's row carries the run's counts and the body's own note", async () => {
+  const r = await runCli(CI, ["pack"]);
+  assertEquals(r.code, 0, r.err);
+  assertStringIncludes(
+    row(r.out, "test"),
+    "// Tests: 3 · Passed: 2 · Failed: 0 · Ignored: 1 · Version: 3.6.2",
+  );
+  assertEquals(row(r.out, "pack").includes("//"), false);
+});
+
+Deno.test("a failed test target's row says how many tests failed", async () => {
+  const r = await runCli(Broken, ["test"]);
+  assertEquals(r.code, 1);
+  const line = row(r.out, "test");
+  assertStringIncludes(line, "Failed");
+  assertStringIncludes(line, "// Tests: 2 · Passed: 1 · Failed: 1");
+});

--- a/tests/integration/deno_test_counts_test.ts
+++ b/tests/integration/deno_test_counts_test.ts
@@ -18,14 +18,16 @@ import { Build, target } from "../../packages/core/mod.ts";
 import { DenoTasks } from "../../packages/deno/mod.ts";
 import { runCli } from "./_harness.ts";
 
+// Addressed by `file://` URL, which is byte-identical on every OS — a URL's
+// `pathname` is not: on Windows it reads `/D:/…`, which deno cannot open.
 const PASSING = new URL(
   "../../packages/deno/tests/fixtures/passing_suite.ts",
   import.meta.url,
-).pathname;
+).href;
 const FAILING = new URL(
   "../../packages/deno/tests/fixtures/failing_suite.ts",
   import.meta.url,
-).pathname;
+).href;
 
 class CI extends Build {
   test = target()


### PR DESCRIPTION
## What & why

#450 added the per-target summary-note seam to `@zuke/core`. This PR fills it in for the wrapper Zuke's own build uses, so a `test` target's row finally says what happened, NUKE-style. Zuke's own gate with this branch prints:

    test        Succeeded    128.1s  // Tests: 4049 · Passed: 4049 · Failed: 0
    coverage    Succeeded      1.8s  // Lines: 98.4% · Branches: 97.5%

- **Test counts.** The Deno test settings override the `onOutput` hook from #450 and parse deno's own result line, so the counts are reported even when the run fails and the row is red: Tests (passed plus failed plus ignored), Passed, Failed, and Ignored when non-zero. The JUnit and TAP reporters print no result line, so those runs report nothing; this is documented on the settings class.
- **Coverage.** The coverage gate reports the measured line percentage, and the branch percentage when any branches were measured, onto the row of the target that ran it.
- **Core floor.** `@zuke/deno` now declares `@zuke/core@^1.44.0`, the release that carries `reportSummary`, with `deno.lock` regenerated. `./zuke coreFloorCheck` passes against the published core.
- **Docs and skills.** `docs/run-context.md` and `docs/console.md` say the wrapper reports by itself, the `zuke-write-build` skill and cheatsheet are updated, plugin manifests are bumped to 0.35.0, and the generated API references are regenerated.

Tests: unit tests for the result-line parser in each of its shapes (steps, ignored, filtered, coloured output, a look-alike line printed by a test), a real fixture run through the wrapper on both a passing and a failing suite, the JUnit no-report case, the coverage figures, and an integration test through the CLI. The fixtures are addressed by `file://` URL so the suite passes on Windows as well.

Everything in `deno task ci` passed locally except the `security` target, which the sandbox's network proxy blocks.

## Related issues

Closes #451

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a
      [Conventional Commit](https://www.conventionalcommits.org/)
      (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell) — all targets except `security`, see above.
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour
      changed.
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`,
      `llms-full.txt`, package README `## API`).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with
      type guards instead).
- [x] No dead code: unreachable branches and can't-fire fallbacks are removed,
      with types tightened so the impossible state is unrepresentable.
- [x] No duplicated logic: an existing helper is imported rather than retyped,
      and a near-copy differing by a constant or a message is parameterised into
      one implementation. A guard, escape, or credential resolution has exactly
      one implementation.
- [x] SOLID shapes respected: one domain per file, extension via the settings
      lambda (not a behaviour-switching flag), narrow parameter types, and
      dependencies on the injectable seam (`StateHost`, an injected `fetch`,
      `EnvReader`) rather than `Deno.*` or a global.
- [ ] A new package was wired into all six places (see
      [AGENTS.md](../blob/master/AGENTS.md#good-open-source-practices-to-follow)),
      if applicable.
- [x] The code is written using AI assisted coding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrP7TrH4YPZiFmSE3mdhBT