### PR TITLE
feat(core): reportTestCounts, one summary shape for every test-runner wrapper

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.35.0",
+      "version": "0.36.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/docs/run-context.md
+++ b/docs/run-context.md
@@ -103,6 +103,12 @@ from deno's own result line — on a failed run too, so a red row says how many
 failed — and `DenoTasks.coverage` reports the measured line and branch
 percentages.
 
+Test runners share one shape. `reportTestCounts({ passed, failed, skipped?,
+todo?, flaky? })` from `@zuke/core` reports `Tests` (the sum), `Passed` and
+`Failed`, then `Skipped`, `Todo` and `Flaky` only when non-zero, so every
+test-runner wrapper puts the same labels on its row and a body that runs tests
+some other way can match them.
+
 ## Reading what the rest of the run did
 
 `ctx.outcomeOf(name)` reports another target's status in this run, and

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "zuke",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build)."
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -532,6 +532,21 @@ function reportSummary(pairs: SummaryPairs): void
   script, a compensation) there is no row to report into, so the call is a
   no-op rather than an error — a wrapper never has to ask where it runs.
 
+function reportTestCounts(counts: TestCounts): void
+  Report a test run's counts into the running target's row of the
+  end-of-build summary, in the shape every test-runner wrapper shares:
+
+  ```text
+  test        Succeeded    8.1s  // Tests: 837 · Passed: 835 · Failed: 0 · Skipped: 2
+  ```
+
+  `Tests` is the sum of every category; `Passed` and `Failed` always appear,
+  and `Skipped`, `Todo` and `Flaky` only when non-zero — mirroring the
+  runners, which print their optional counts the same way. The ambient form
+  of reporting applies (see {@link reportSummary}): a wrapper calls this from
+  its `onOutput` hook with what it parsed, and outside a running target the
+  call is a no-op.
+
 function resolveBuildId(readEnv: (name: string) => string | undefined): string | undefined
   The origin of the build running in this process — `ZUKE_BUILD_ID`, else
   `GITHUB_REPOSITORY`, else `undefined` when neither is set.
@@ -3931,6 +3946,24 @@ interface TargetTiming
     The run id (see {@link RunInfo}).
   readonly durationMs: number
     The target's wall-clock duration in milliseconds (0 for skipped/cached).
+
+interface TestCounts
+  The counts a test run produced — the one shape every test-runner wrapper
+  maps its runner's own summary line onto, so `DenoTasks.test`,
+  `VitestTasks.run`, `JestTasks.run` and the rest all put the same labels on
+  their rows. `passed` and `failed` are always known; the rest are the
+  optional categories a runner may or may not have, left out when it has none.
+
+  readonly passed: number
+    Tests that passed.
+  readonly failed: number
+    Tests that failed.
+  readonly skipped?: number
+    Tests the run selected but did not execute: skipped, ignored, pending.
+  readonly todo?: number
+    Tests marked as still to be written.
+  readonly flaky?: number
+    Tests that failed and then passed on a retry (Playwright's "flaky").
 
 interface ToolTasksApi
   The task surface of {@link ToolTasks}.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -586,6 +586,21 @@ function reportSummary(pairs: SummaryPairs): void
   script, a compensation) there is no row to report into, so the call is a
   no-op rather than an error — a wrapper never has to ask where it runs.
 
+function reportTestCounts(counts: TestCounts): void
+  Report a test run's counts into the running target's row of the
+  end-of-build summary, in the shape every test-runner wrapper shares:
+
+  ```text
+  test        Succeeded    8.1s  // Tests: 837 · Passed: 835 · Failed: 0 · Skipped: 2
+  ```
+
+  `Tests` is the sum of every category; `Passed` and `Failed` always appear,
+  and `Skipped`, `Todo` and `Flaky` only when non-zero — mirroring the
+  runners, which print their optional counts the same way. The ambient form
+  of reporting applies (see {@link reportSummary}): a wrapper calls this from
+  its `onOutput` hook with what it parsed, and outside a running target the
+  call is a no-op.
+
 function resolveBuildId(readEnv: (name: string) => string | undefined): string | undefined
   The origin of the build running in this process — `ZUKE_BUILD_ID`, else
   `GITHUB_REPOSITORY`, else `undefined` when neither is set.
@@ -3985,6 +4000,24 @@ interface TargetTiming
     The run id (see {@link RunInfo}).
   readonly durationMs: number
     The target's wall-clock duration in milliseconds (0 for skipped/cached).
+
+interface TestCounts
+  The counts a test run produced — the one shape every test-runner wrapper
+  maps its runner's own summary line onto, so `DenoTasks.test`,
+  `VitestTasks.run`, `JestTasks.run` and the rest all put the same labels on
+  their rows. `passed` and `failed` are always known; the rest are the
+  optional categories a runner may or may not have, left out when it has none.
+
+  readonly passed: number
+    Tests that passed.
+  readonly failed: number
+    Tests that failed.
+  readonly skipped?: number
+    Tests the run selected but did not execute: skipped, ignored, pending.
+  readonly todo?: number
+    Tests marked as still to be written.
+  readonly flaky?: number
+    Tests that failed and then passed on a retry (Playwright's "flaky").
 
 interface ToolTasksApi
   The task surface of {@link ToolTasks}.

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -123,9 +123,11 @@ export {
 } from "./src/renderer.ts";
 export {
   reportSummary,
+  reportTestCounts,
   type SummaryEntry,
   type SummaryPairs,
   type SummaryValue,
+  type TestCounts,
 } from "./src/summary_note.ts";
 export type { Style } from "./src/render.ts";
 export type { BuildCache, OpenCacheOptions } from "./src/cache.ts";

--- a/packages/core/src/summary_note.ts
+++ b/packages/core/src/summary_note.ts
@@ -116,3 +116,53 @@ export function withAmbientSummary<T>(
 export function reportSummary(pairs: SummaryPairs): void {
   storage.getStore()?.add(pairs);
 }
+
+/**
+ * The counts a test run produced — the one shape every test-runner wrapper
+ * maps its runner's own summary line onto, so `DenoTasks.test`,
+ * `VitestTasks.run`, `JestTasks.run` and the rest all put the same labels on
+ * their rows. `passed` and `failed` are always known; the rest are the
+ * optional categories a runner may or may not have, left out when it has none.
+ */
+export interface TestCounts {
+  /** Tests that passed. */
+  readonly passed: number;
+  /** Tests that failed. */
+  readonly failed: number;
+  /** Tests the run selected but did not execute: skipped, ignored, pending. */
+  readonly skipped?: number;
+  /** Tests marked as still to be written. */
+  readonly todo?: number;
+  /** Tests that failed and then passed on a retry (Playwright's "flaky"). */
+  readonly flaky?: number;
+}
+
+/**
+ * Report a test run's counts into the **running target's** row of the
+ * end-of-build summary, in the shape every test-runner wrapper shares:
+ *
+ * ```text
+ * test        Succeeded    8.1s  // Tests: 837 · Passed: 835 · Failed: 0 · Skipped: 2
+ * ```
+ *
+ * `Tests` is the sum of every category; `Passed` and `Failed` always appear,
+ * and `Skipped`, `Todo` and `Flaky` only when non-zero — mirroring the
+ * runners, which print their optional counts the same way. The ambient form
+ * of reporting applies (see {@link reportSummary}): a wrapper calls this from
+ * its `onOutput` hook with what it parsed, and outside a running target the
+ * call is a no-op.
+ */
+export function reportTestCounts(counts: TestCounts): void {
+  const skipped = counts.skipped ?? 0;
+  const todo = counts.todo ?? 0;
+  const flaky = counts.flaky ?? 0;
+  const pairs: Record<string, number> = {
+    Tests: counts.passed + counts.failed + skipped + todo + flaky,
+    Passed: counts.passed,
+    Failed: counts.failed,
+  };
+  if (skipped > 0) pairs.Skipped = skipped;
+  if (todo > 0) pairs.Todo = todo;
+  if (flaky > 0) pairs.Flaky = flaky;
+  reportSummary(pairs);
+}

--- a/packages/core/tests/summary_note_test.ts
+++ b/packages/core/tests/summary_note_test.ts
@@ -4,6 +4,7 @@
 import { assertEquals } from "./_assert.ts";
 import {
   reportSummary,
+  reportTestCounts,
   TargetSummary,
   withAmbientSummary,
 } from "../src/summary_note.ts";
@@ -79,4 +80,52 @@ Deno.test("withAmbientSummary returns the function's result and unwinds the coll
   assertEquals(value, 42);
   reportSummary({ After: "scope" });
   assertEquals(s.entries(), []);
+});
+
+Deno.test("reportTestCounts totals every category and names the optional ones only when non-zero", async () => {
+  const bare = new TargetSummary();
+  await withAmbientSummary(bare, () => {
+    reportTestCounts({ passed: 4, failed: 1 });
+    return Promise.resolve();
+  });
+  assertEquals(bare.entries(), [
+    { key: "Tests", value: "5" },
+    { key: "Passed", value: "4" },
+    { key: "Failed", value: "1" },
+  ]);
+
+  const full = new TargetSummary();
+  await withAmbientSummary(full, () => {
+    reportTestCounts({ passed: 2, failed: 0, skipped: 1, todo: 3, flaky: 1 });
+    return Promise.resolve();
+  });
+  assertEquals(full.entries(), [
+    { key: "Tests", value: "7" },
+    { key: "Passed", value: "2" },
+    { key: "Failed", value: "0" },
+    { key: "Skipped", value: "1" },
+    { key: "Todo", value: "3" },
+    { key: "Flaky", value: "1" },
+  ]);
+
+  // An explicit zero for an optional category is the same as leaving it out.
+  const zeros = new TargetSummary();
+  await withAmbientSummary(zeros, () => {
+    reportTestCounts({ passed: 1, failed: 0, skipped: 0, todo: 0, flaky: 0 });
+    return Promise.resolve();
+  });
+  assertEquals(zeros.entries().map((e) => e.key), [
+    "Tests",
+    "Passed",
+    "Failed",
+  ]);
+});
+
+Deno.test("reportTestCounts outside a running target is a no-op", () => {
+  reportTestCounts({ passed: 1, failed: 0 });
+  const s = new TargetSummary();
+  return withAmbientSummary(s, async () => {
+    await Promise.resolve();
+    assertEquals(s.entries(), []);
+  });
 });

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/.codex-plugin/plugin.json
+++ b/plugins/zuke/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -166,7 +166,10 @@ terminal and in the Actions job summary. A failed target keeps its notes.
 itself, and `DenoTasks.coverage` reports the measured Lines/Branches — a body
 only adds what its tools do not. Library code with no `ctx` (a wrapper, a
 helper) uses the ambient `reportSummary(pairs)` from `@zuke/core`, which lands
-on the running target's row and is a no-op outside a run.
+on the running target's row and is a no-op outside a run. Test counts have one
+shared shape: `reportTestCounts({ passed, failed, skipped?, todo?, flaky? })`
+reports `Tests` (the sum), `Passed`, `Failed`, then `Skipped`/`Todo`/`Flaky`
+only when non-zero — the labels every test-runner wrapper uses.
 
 `ctx.outcomes()` is a snapshot, not a live view, and a target that has not
 settled is **absent** rather than present with a placeholder — so depend on what

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -166,7 +166,10 @@ terminal and in the Actions job summary. A failed target keeps its notes.
 itself, and `DenoTasks.coverage` reports the measured Lines/Branches — a body
 only adds what its tools do not. Library code with no `ctx` (a wrapper, a
 helper) uses the ambient `reportSummary(pairs)` from `@zuke/core`, which lands
-on the running target's row and is a no-op outside a run.
+on the running target's row and is a no-op outside a run. Test counts have one
+shared shape: `reportTestCounts({ passed, failed, skipped?, todo?, flaky? })`
+reports `Tests` (the sum), `Passed`, `Failed`, then `Skipped`/`Todo`/`Flaky`
+only when non-zero — the labels every test-runner wrapper uses.
 
 `ctx.outcomes()` is a snapshot, not a live view, and a target that has not
 settled is **absent** rather than present with a placeholder — so depend on what


### PR DESCRIPTION
## What & why

Every test-runner wrapper is about to put its counts on the Build Summary the way `DenoTasks.test` does since #452, and the six of them have to agree on the labels and on which optional categories show up. Today the mapping from counts to notes lives in `@zuke/deno` alone; copying it into five more packages would be the near-copy `AGENTS.md` forbids, and a wrapper may depend only on `@zuke/core`, so the shared piece is a core export.

This adds, next to `reportSummary`:

- **`TestCounts`**: `passed` and `failed` always, `skipped`, `todo` and `flaky` optional.
- **`reportTestCounts`**: reports `Tests` as the sum, `Passed` and `Failed` always, and `Skipped`, `Todo`, `Flaky` only when non-zero, through the ambient summary, so a wrapper calls it from its `onOutput` hook with what it parsed and a call outside a running target is a no-op.

The wrappers keep their own parsers, since the grammars differ, and share the labels. Docs and the cheatsheet name the shared shape; plugin manifests bump to 0.36.0.

Tests cover the sum, the optional categories appearing only when non-zero (an explicit zero counts as absent), and the no-target no-op.

Everything in `deno task ci` passed locally except the `security` target, which the sandbox's network proxy blocks.

## Related issues

Closes #456

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a
      [Conventional Commit](https://www.conventionalcommits.org/)
      (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell) — all targets except `security`, see above.
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour
      changed.
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`,
      `llms-full.txt`, package README `## API`).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with
      type guards instead).
- [x] No dead code: unreachable branches and can't-fire fallbacks are removed,
      with types tightened so the impossible state is unrepresentable.
- [x] No duplicated logic: an existing helper is imported rather than retyped,
      and a near-copy differing by a constant or a message is parameterised into
      one implementation. A guard, escape, or credential resolution has exactly
      one implementation.
- [x] SOLID shapes respected: one domain per file, extension via the settings
      lambda (not a behaviour-switching flag), narrow parameter types, and
      dependencies on the injectable seam (`StateHost`, an injected `fetch`,
      `EnvReader`) rather than `Deno.*` or a global.
- [ ] A new package was wired into all six places (see
      [AGENTS.md](../blob/master/AGENTS.md#good-open-source-practices-to-follow)),
      if applicable.
- [x] The code is written using AI assisted coding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrP7TrH4YPZiFmSE3mdhBT

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrP7TrH4YPZiFmSE3mdhBT)_