### PR TITLE
feat: linters and checkers report their findings on the build summary

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1556,7 +1556,7 @@
       },
       "packages/biome": {
         "dependencies": [
-          "jsr:@zuke/core@^1.25.0"
+          "jsr:@zuke/core@^1.44.0"
         ]
       },
       "packages/bun": {
@@ -1598,7 +1598,7 @@
       },
       "packages/cspell": {
         "dependencies": [
-          "jsr:@zuke/core@^1.25.0"
+          "jsr:@zuke/core@^1.44.0"
         ]
       },
       "packages/cypress": {
@@ -1633,12 +1633,12 @@
       },
       "packages/dprint": {
         "dependencies": [
-          "jsr:@zuke/core@^1.25.0"
+          "jsr:@zuke/core@^1.44.0"
         ]
       },
       "packages/eslint": {
         "dependencies": [
-          "jsr:@zuke/core@^1.25.0"
+          "jsr:@zuke/core@^1.44.0"
         ]
       },
       "packages/gcloud": {
@@ -1743,7 +1743,7 @@
       },
       "packages/oxlint": {
         "dependencies": [
-          "jsr:@zuke/core@^1.25.0"
+          "jsr:@zuke/core@^1.44.0"
         ]
       },
       "packages/playwright": {
@@ -1793,7 +1793,7 @@
       },
       "packages/tsc": {
         "dependencies": [
-          "jsr:@zuke/core@^1.25.0"
+          "jsr:@zuke/core@^1.44.0"
         ]
       },
       "packages/tsc-alias": {

--- a/docs/run-context.md
+++ b/docs/run-context.md
@@ -109,6 +109,30 @@ todo?, flaky? })` from `@zuke/core` reports `Tests` (the sum), `Passed` and
 test-runner wrapper puts the same labels on its row and a body that runs tests
 some other way can match them.
 
+### What the wrappers report
+
+| Wrapper | Notes on the row |
+| --- | --- |
+| `DenoTasks.test` | `Tests`, `Passed`, `Failed`, and `Ignored` when non-zero |
+| `DenoTasks.coverage` | `Lines`, and `Branches` when any were measured |
+| `DenoTasks.lint` | `Files`, `Problems` |
+| `DenoTasks.fmt` | `Files`, and `Unformatted` under `.check()` |
+| `DenoTasks.check` | `Errors` |
+| `EslintTasks.lint` | `Problems`, `Errors`, `Warnings` |
+| `OxlintTasks.lint` | `Errors`, `Warnings`, and `Files` when the timing line names them |
+| `BiomeTasks.check` / `lint` / `format` / `ci` | `Files`, `Errors`, `Warnings` |
+| `TscTasks.tsc` / `build` | `Errors` |
+| `CspellTasks.lint` | `Files`, `Issues` |
+| `DprintTasks.check` | `Unformatted` |
+| `DprintTasks.fmt` | `Formatted` |
+
+Each is read from the closing line the tool itself prints, on a failed run
+too, so a red row says how many. A clean run reports its zeros — a green
+`lint` row that says `Problems: 0` is the point. A run that exited non-zero
+without printing its closing line (a bad flag, a missing config) reports
+nothing rather than a misleading zero. A machine-readable reporter that
+replaces the closing line (`--format json`, JUnit) reports nothing either.
+
 ## Reading what the rest of the run did
 
 `ctx.outcomeOf(name)` reports another target's status in this run, and

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5069,6 +5069,8 @@ class DenoCheckSettings extends DenoSettings
     Exclude paths from the watcher (`--watch-exclude`).
   noClearScreen(): this
     Keep previous output when re-running under `--watch` (`--no-clear-screen`).
+  override protected onOutput(output: CommandOutput): void
+    Report `Errors`, the diagnostics printed, onto the build summary.
   override protected buildArgs(): string[]
     Assemble the `deno check` argv.
 
@@ -5298,6 +5300,8 @@ class DenoFmtSettings extends DenoSettings
     Keep previous output when re-running under `--watch` (`--no-clear-screen`).
   paths(...paths: PathLike[]): this
     Restrict formatting to specific files or directories.
+  override protected onOutput(output: CommandOutput): void
+    Report `Files` (and `Unformatted` under `--check`) onto the build summary.
   override protected buildArgs(): string[]
     Assemble the `deno fmt` argv.
 
@@ -5486,6 +5490,8 @@ class DenoLintSettings extends DenoSettings
     Keep previous output when re-running under `--watch` (`--no-clear-screen`).
   paths(...paths: PathLike[]): this
     Restrict linting to specific files or directories.
+  override protected onOutput(output: CommandOutput): void
+    Report `Files` and `Problems` onto the build summary.
   override protected buildArgs(): string[]
     Assemble the `deno lint` argv.
 
@@ -10405,6 +10411,8 @@ class OxlintSettings extends ToolSettings
     Output format, e.g. `default`, `json`, `github` (`-f`/`--format`).
   threads(count: number): this
     Number of threads to use (`--threads`).
+  override protected onOutput(output: CommandOutput): void
+    Report `Errors`, `Warnings` (and `Files` when known) onto the build summary.
   override protected buildArgs(): string[]
     Assemble the `oxlint` argv from the configured settings.
 
@@ -10473,6 +10481,8 @@ class EslintSettings extends ToolSettings
     Do not search for a config file (`--no-config-lookup`).
   reportUnusedDisableDirectives(): this
     Report unused `eslint-disable` directives (`--report-unused-disable-directives`).
+  override protected onOutput(output: CommandOutput): void
+    Report `Problems`, `Errors` and `Warnings` onto the build summary.
   override protected buildArgs(): string[]
     Assemble the `eslint` argv from the configured settings.
 
@@ -10549,6 +10559,8 @@ class CspellSettings extends ToolSettings
     Exclude files matching a glob (`-e`/`--exclude`); repeatable.
   maxDuplicateProblems(count: number): this
     Cap the number of duplicate problems reported (`--max-duplicate-problems`).
+  override protected onOutput(output: CommandOutput): void
+    Report `Files` checked and `Issues` found onto the build summary.
   override protected buildArgs(): string[]
     Assemble the `cspell lint` argv.
 
@@ -11032,6 +11044,8 @@ abstract class BiomeSettings extends ToolSettings
     The tool binary: `biome`.
   override protected defaultResolution(): ToolResolution
     Resolve the binary from `node_modules/.bin` by default — biome is an npm-distributed tool.
+  override protected onOutput(output: CommandOutput): void
+    Report `Files`, `Errors` and `Warnings` onto the build summary.
   paths(...paths: PathLike[]): this
     Files or directories to operate on; omit to use the configured includes.
   config(path: PathLike): this
@@ -11883,6 +11897,8 @@ abstract class TscBaseSettings extends ToolSettings
     The default binary these settings invoke: `tsc`.
   override protected defaultResolution(): ToolResolution
     Resolve the binary from `node_modules/.bin` by default — tsc is an npm-distributed tool.
+  override protected onOutput(output: CommandOutput): void
+    Report `Errors`, the diagnostics printed, onto the build summary.
 
 class TscBuildSettings extends TscBaseSettings
   Settings for a `tsc --build` project-references run.
@@ -12610,12 +12626,16 @@ class DprintCheckSettings extends DprintSettings
 
   override protected subcommand(): string
     The dprint subcommand this settings class runs: `check`.
+  override protected onOutput(output: CommandOutput): void
+    Report `Unformatted`, the files that need formatting, onto the build summary.
 
 class DprintFmtSettings extends DprintSettings
   Settings for `dprint fmt` (format files in place).
 
   override protected subcommand(): string
     The dprint subcommand this settings class runs: `fmt`.
+  override protected onOutput(output: CommandOutput): void
+    Report `Formatted`, the files the run changed, onto the build summary.
 
 abstract class DprintSettings extends ToolSettings
   Shared options for a `dprint` subcommand (`fmt` or `check`).

--- a/packages/biome/README.md
+++ b/packages/biome/README.md
@@ -76,6 +76,8 @@ abstract class BiomeSettings extends ToolSettings
     The tool binary: `biome`.
   override protected defaultResolution(): ToolResolution
     Resolve the binary from `node_modules/.bin` by default — biome is an npm-distributed tool.
+  override protected onOutput(output: CommandOutput): void
+    Report `Files`, `Errors` and `Warnings` onto the build summary.
   paths(...paths: PathLike[]): this
     Files or directories to operate on; omit to use the configured includes.
   config(path: PathLike): this

--- a/packages/biome/deno.json
+++ b/packages/biome/deno.json
@@ -7,7 +7,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1.25.0"
+    "@zuke/core": "jsr:@zuke/core@^1.44.0"
   },
   "publish": {
     "exclude": [

--- a/packages/biome/src/biome.ts
+++ b/packages/biome/src/biome.ts
@@ -26,6 +26,8 @@ import {
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
+import { reportSummary } from "@zuke/core";
+import { parseBiomeSummary } from "./summary.ts";
 
 /**
  * Base for all `biome` subcommand settings: the binary is `biome`, and the
@@ -47,6 +49,12 @@ export abstract class BiomeSettings extends ToolSettings {
   /** Resolve the binary from `node_modules/.bin` by default — biome is an npm-distributed tool. */
   protected override defaultResolution(): ToolResolution {
     return "node_modules";
+  }
+
+  /** Report `Files`, `Errors` and `Warnings` onto the build summary. */
+  protected override onOutput(output: CommandOutput): void {
+    const pairs = parseBiomeSummary(output);
+    if (pairs !== undefined) reportSummary(pairs);
   }
 
   /** Files or directories to operate on; omit to use the configured includes. */

--- a/packages/biome/src/summary.ts
+++ b/packages/biome/src/summary.ts
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * What a `biome` run reports onto its target's row of the build summary,
+ * read from the closing lines every subcommand prints:
+ * `Checked 120 files in 50ms. No fixes applied.`, then `Found 3 errors.`
+ * and `Found 2 warnings.` when there were any. Internal to the wrapper.
+ *
+ * @module
+ */
+
+import type { CommandOutput } from "@zuke/core/shell";
+import type { SummaryPairs } from "@zuke/core";
+import { stripAnsi } from "@zuke/core/render";
+
+/** The closing line naming how many files the run looked at. */
+const CHECKED = /^Checked (\d+) files? in /m;
+/** The optional line naming the errors found. */
+const ERRORS = /^Found (\d+) errors?\.$/m;
+/** The optional line naming the warnings found. */
+const WARNINGS = /^Found (\d+) warnings?\.$/m;
+
+/**
+ * The notes for a run: `Files`, `Errors` and `Warnings`. Biome prints
+ * the `Checked` line on every completed run and the `Found` lines only when
+ * the count is non-zero, so a run without the `Checked` line did not
+ * complete and reports nothing.
+ */
+export function parseBiomeSummary(
+  output: CommandOutput,
+): SummaryPairs | undefined {
+  const text = stripAnsi(output.stdout);
+  const checked = CHECKED.exec(text);
+  if (checked === null) return undefined;
+  const count = (re: RegExp) => {
+    const m = re.exec(text);
+    return m === null ? 0 : Number(m[1]);
+  };
+  return {
+    Files: Number(checked[1]),
+    Errors: count(ERRORS),
+    Warnings: count(WARNINGS),
+  };
+}

--- a/packages/biome/tests/summary_test.ts
+++ b/packages/biome/tests/summary_test.ts
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals } from "../../core/tests/_assert.ts";
+import {
+  TargetSummary,
+  withAmbientSummary,
+} from "../../core/src/summary_note.ts";
+import { CommandOutput } from "@zuke/core/shell";
+import { BiomeCheckSettings, BiomeFormatSettings } from "../src/biome.ts";
+import { parseBiomeSummary } from "../src/summary.ts";
+
+/** A run's output with the given streams and exit code. */
+function out(code: number, stdout = "", stderr = ""): CommandOutput {
+  return new CommandOutput(code, stdout, stderr);
+}
+
+Deno.test("biome: the Checked line yields Files, and the Found lines the counts", () => {
+  assertEquals(
+    parseBiomeSummary(
+      out(
+        1,
+        "Checked 120 files in 50ms. No fixes applied.\nFound 1 error.\nFound 2 warnings.\n",
+      ),
+    ),
+    { Files: 120, Errors: 1, Warnings: 2 },
+  );
+  assertEquals(
+    parseBiomeSummary(out(0, "Checked 1 file in 3ms. No fixes applied.\n")),
+    { Files: 1, Errors: 0, Warnings: 0 },
+  );
+  assertEquals(
+    parseBiomeSummary(
+      out(0, "Checked 12 files in 8ms. Fixed 3 files.\nFound 4 warnings.\n"),
+    ),
+    { Files: 12, Errors: 0, Warnings: 4 },
+  );
+});
+
+Deno.test("biome: a run that never printed the Checked line reports nothing", () => {
+  assertEquals(
+    parseBiomeSummary(
+      out(1, "", "× Biome exited because the configuration is invalid."),
+    ),
+    undefined,
+  );
+  assertEquals(parseBiomeSummary(out(0)), undefined);
+});
+
+/** Exposes the protected hook so the wiring can be exercised without biome. */
+class Probe extends BiomeCheckSettings {
+  probe(output: CommandOutput): void {
+    this.onOutput(output);
+  }
+}
+/** The hook lives on the shared base, so every subcommand has it. */
+class FormatProbe extends BiomeFormatSettings {
+  probe(output: CommandOutput): void {
+    this.onOutput(output);
+  }
+}
+
+Deno.test("biome: the hook on every subcommand reports the counts onto the running target", async () => {
+  const summary = new TargetSummary();
+  await withAmbientSummary(summary, () => {
+    new Probe().probe(
+      out(1, "Checked 3 files in 2ms. No fixes applied.\nFound 1 error.\n"),
+    );
+    return Promise.resolve();
+  });
+  assertEquals(summary.entries(), [
+    { key: "Files", value: "3" },
+    { key: "Errors", value: "1" },
+    { key: "Warnings", value: "0" },
+  ]);
+  const formatted = new TargetSummary();
+  await withAmbientSummary(formatted, () => {
+    new FormatProbe().probe(out(0, "Checked 5 files in 2ms. Fixed 2 files.\n"));
+    return Promise.resolve();
+  });
+  assertEquals(formatted.entries()[0], { key: "Files", value: "5" });
+});

--- a/packages/cspell/README.md
+++ b/packages/cspell/README.md
@@ -89,6 +89,8 @@ class CspellSettings extends ToolSettings
     Exclude files matching a glob (`-e`/`--exclude`); repeatable.
   maxDuplicateProblems(count: number): this
     Cap the number of duplicate problems reported (`--max-duplicate-problems`).
+  override protected onOutput(output: CommandOutput): void
+    Report `Files` checked and `Issues` found onto the build summary.
   override protected buildArgs(): string[]
     Assemble the `cspell lint` argv.
 

--- a/packages/cspell/deno.json
+++ b/packages/cspell/deno.json
@@ -7,7 +7,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1.25.0"
+    "@zuke/core": "jsr:@zuke/core@^1.44.0"
   },
   "publish": {
     "exclude": [

--- a/packages/cspell/src/cspell.ts
+++ b/packages/cspell/src/cspell.ts
@@ -26,6 +26,8 @@ import {
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
+import { reportSummary } from "@zuke/core";
+import { parseCspellSummary } from "./summary.ts";
 
 /** Settings for a `cspell lint` run. */
 export class CspellSettings extends ToolSettings {
@@ -164,6 +166,12 @@ export class CspellSettings extends ToolSettings {
   maxDuplicateProblems(count: number): this {
     this.#maxDuplicateProblems = count;
     return this;
+  }
+
+  /** Report `Files` checked and `Issues` found onto the build summary. */
+  protected override onOutput(output: CommandOutput): void {
+    const pairs = parseCspellSummary(output);
+    if (pairs !== undefined) reportSummary(pairs);
   }
 
   /** Assemble the `cspell lint` argv. */

--- a/packages/cspell/src/summary.ts
+++ b/packages/cspell/src/summary.ts
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * What a `cspell lint` run reports onto its target's row of the build
+ * summary, read from the closing line it prints on stderr:
+ * `CSpell: Files checked: 1000, Issues found: 4 in 3 files.`
+ * Internal to the wrapper.
+ *
+ * @module
+ */
+
+import type { CommandOutput } from "@zuke/core/shell";
+import type { SummaryPairs } from "@zuke/core";
+import { stripAnsi } from "@zuke/core/render";
+
+/** The closing line, printed whether or not issues were found. */
+const CLOSING =
+  /^CSpell: Files checked: (\d+), Issues found: (\d+) in (\d+) files?\.$/m;
+
+/**
+ * The notes for a run: `Files` checked and `Issues` found. A run without
+ * the closing line did not complete and reports nothing.
+ */
+export function parseCspellSummary(
+  output: CommandOutput,
+): SummaryPairs | undefined {
+  const m = CLOSING.exec(stripAnsi(output.stderr));
+  if (m === null) return undefined;
+  return { Files: Number(m[1]), Issues: Number(m[2]) };
+}

--- a/packages/cspell/tests/summary_test.ts
+++ b/packages/cspell/tests/summary_test.ts
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals } from "../../core/tests/_assert.ts";
+import {
+  TargetSummary,
+  withAmbientSummary,
+} from "../../core/src/summary_note.ts";
+import { CommandOutput } from "@zuke/core/shell";
+import { CspellSettings } from "../src/cspell.ts";
+import { parseCspellSummary } from "../src/summary.ts";
+
+/** A run's output with the given streams and exit code. */
+function out(code: number, stdout = "", stderr = ""): CommandOutput {
+  return new CommandOutput(code, stdout, stderr);
+}
+
+Deno.test("cspell: the closing line on stderr yields Files and Issues", () => {
+  assertEquals(
+    parseCspellSummary(
+      out(1, "", "CSpell: Files checked: 1000, Issues found: 4 in 3 files.\n"),
+    ),
+    { Files: 1000, Issues: 4 },
+  );
+  assertEquals(
+    parseCspellSummary(
+      out(0, "", "CSpell: Files checked: 1, Issues found: 0 in 0 files.\n"),
+    ),
+    { Files: 1, Issues: 0 },
+  );
+});
+
+Deno.test("cspell: a run without the closing line reports nothing", () => {
+  assertEquals(parseCspellSummary(out(0)), undefined);
+  assertEquals(
+    parseCspellSummary(out(1, "", "error: unknown option --no-config")),
+    undefined,
+  );
+});
+
+/** Exposes the protected hook so the wiring can be exercised without cspell. */
+class Probe extends CspellSettings {
+  probe(output: CommandOutput): void {
+    this.onOutput(output);
+  }
+}
+
+Deno.test("cspell: the hook reports the counts onto the running target", async () => {
+  const summary = new TargetSummary();
+  await withAmbientSummary(summary, () => {
+    new Probe().probe(
+      out(1, "", "CSpell: Files checked: 12, Issues found: 2 in 1 file.\n"),
+    );
+    return Promise.resolve();
+  });
+  assertEquals(summary.entries(), [
+    { key: "Files", value: "12" },
+    { key: "Issues", value: "2" },
+  ]);
+});

--- a/packages/deno/README.md
+++ b/packages/deno/README.md
@@ -244,6 +244,8 @@ class DenoCheckSettings extends DenoSettings
     Exclude paths from the watcher (`--watch-exclude`).
   noClearScreen(): this
     Keep previous output when re-running under `--watch` (`--no-clear-screen`).
+  override protected onOutput(output: CommandOutput): void
+    Report `Errors`, the diagnostics printed, onto the build summary.
   override protected buildArgs(): string[]
     Assemble the `deno check` argv.
 
@@ -473,6 +475,8 @@ class DenoFmtSettings extends DenoSettings
     Keep previous output when re-running under `--watch` (`--no-clear-screen`).
   paths(...paths: PathLike[]): this
     Restrict formatting to specific files or directories.
+  override protected onOutput(output: CommandOutput): void
+    Report `Files` (and `Unformatted` under `--check`) onto the build summary.
   override protected buildArgs(): string[]
     Assemble the `deno fmt` argv.
 
@@ -661,6 +665,8 @@ class DenoLintSettings extends DenoSettings
     Keep previous output when re-running under `--watch` (`--no-clear-screen`).
   paths(...paths: PathLike[]): this
     Restrict linting to specific files or directories.
+  override protected onOutput(output: CommandOutput): void
+    Report `Files` and `Problems` onto the build summary.
   override protected buildArgs(): string[]
     Assemble the `deno lint` argv.
 

--- a/packages/deno/src/quality.ts
+++ b/packages/deno/src/quality.ts
@@ -7,7 +7,14 @@
  */
 
 import type { PathLike } from "@zuke/core/tooling";
+import type { CommandOutput } from "@zuke/core/shell";
+import { reportSummary } from "@zuke/core";
 import { DenoSettings } from "./settings.ts";
+import {
+  parseDenoCheckSummary,
+  parseDenoFmtSummary,
+  parseDenoLintSummary,
+} from "./quality_summary.ts";
 import {
   ConfigFlags,
   DependencyFlags,
@@ -174,6 +181,12 @@ export class DenoCheckSettings extends DenoSettings {
   noClearScreen(): this {
     this.#watch.noClearScreen();
     return this;
+  }
+
+  /** Report `Errors`, the diagnostics printed, onto the build summary. */
+  protected override onOutput(output: CommandOutput): void {
+    const pairs = parseDenoCheckSummary(output);
+    if (pairs !== undefined) reportSummary(pairs);
   }
 
   /** Assemble the `deno check` argv. */
@@ -348,6 +361,12 @@ export class DenoFmtSettings extends DenoSettings {
     return this;
   }
 
+  /** Report `Files` (and `Unformatted` under `--check`) onto the build summary. */
+  protected override onOutput(output: CommandOutput): void {
+    const pairs = parseDenoFmtSummary(output);
+    if (pairs !== undefined) reportSummary(pairs);
+  }
+
   /** Assemble the `deno fmt` argv. */
   protected override buildArgs(): string[] {
     if (this.#config.contradictory) {
@@ -501,6 +520,12 @@ export class DenoLintSettings extends DenoSettings {
     }
     this.#format = format;
     return this;
+  }
+
+  /** Report `Files` and `Problems` onto the build summary. */
+  protected override onOutput(output: CommandOutput): void {
+    const pairs = parseDenoLintSummary(output);
+    if (pairs !== undefined) reportSummary(pairs);
   }
 
   /** Assemble the `deno lint` argv. */

--- a/packages/deno/src/quality_summary.ts
+++ b/packages/deno/src/quality_summary.ts
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * What `deno lint`, `deno fmt` and `deno check` report onto their
+ * target's row of the build summary, read from the closing lines each prints
+ * on stderr: `Checked 312 files` (lint and fmt, with `Found 2 problems` or
+ * `error: Found 1 not formatted file in 312 files` when there is something
+ * to say), and `Found 3 errors.` or a `TS2322 [ERROR]: …` diagnostic per
+ * error for `check`. Internal to the wrapper.
+ *
+ * @module
+ */
+
+import type { CommandOutput } from "@zuke/core/shell";
+import type { SummaryPairs } from "@zuke/core";
+import { stripAnsi } from "@zuke/core/render";
+
+/** The lint/fmt closing line. */
+const CHECKED = /^Checked (\d+) files?$/m;
+/** `deno lint`'s problem count, printed only when non-zero. */
+const PROBLEMS = /^Found (\d+) problems?$/m;
+/** `deno fmt --check`'s closing line when files need formatting. */
+const NOT_FORMATTED =
+  /^error: Found (\d+) not formatted files? in (\d+) files?$/m;
+/** `deno check`'s closing line when it found errors. */
+const ERRORS = /^Found (\d+) errors?\.$/m;
+/** One `deno check` diagnostic, for the single-error run with no closing line. */
+const DIAGNOSTIC = /^TS\d+ \[ERROR\]:/gm;
+
+/** The notes for a `deno lint` run: `Files` and `Problems`. */
+export function parseDenoLintSummary(
+  output: CommandOutput,
+): SummaryPairs | undefined {
+  const text = stripAnsi(output.stderr);
+  const checked = CHECKED.exec(text);
+  if (checked === null) return undefined;
+  const problems = PROBLEMS.exec(text);
+  return {
+    Files: Number(checked[1]),
+    Problems: problems === null ? 0 : Number(problems[1]),
+  };
+}
+
+/**
+ * The notes for a `deno fmt` run: `Files`, plus `Unformatted` under
+ * `--check`, where the closing line changes to say how many files need
+ * formatting.
+ */
+export function parseDenoFmtSummary(
+  output: CommandOutput,
+): SummaryPairs | undefined {
+  const text = stripAnsi(output.stderr);
+  const unformatted = NOT_FORMATTED.exec(text);
+  if (unformatted !== null) {
+    return {
+      Files: Number(unformatted[2]),
+      Unformatted: Number(unformatted[1]),
+    };
+  }
+  const checked = CHECKED.exec(text);
+  if (checked === null) return undefined;
+  return { Files: Number(checked[1]), Unformatted: 0 };
+}
+
+/**
+ * The notes for a `deno check` run: `Errors`. Deno closes a multi-error run
+ * with `Found N errors.` and a single-error run with just the diagnostic, so
+ * the diagnostics are counted when the closing line is absent. A run that
+ * printed nothing and exited 0 is clean; one that exited non-zero without a
+ * diagnostic reports nothing rather than a misleading zero.
+ */
+export function parseDenoCheckSummary(
+  output: CommandOutput,
+): SummaryPairs | undefined {
+  const text = stripAnsi(output.stderr);
+  const found = ERRORS.exec(text);
+  if (found !== null) return { Errors: Number(found[1]) };
+  const errors = [...text.matchAll(DIAGNOSTIC)].length;
+  if (errors > 0 || output.code === 0) return { Errors: errors };
+  return undefined;
+}

--- a/packages/deno/tests/quality_summary_test.ts
+++ b/packages/deno/tests/quality_summary_test.ts
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals, assertRejects } from "../../core/tests/_assert.ts";
+import {
+  TargetSummary,
+  withAmbientSummary,
+} from "../../core/src/summary_note.ts";
+import { CommandError, CommandOutput } from "@zuke/core/shell";
+import {
+  parseDenoCheckSummary,
+  parseDenoFmtSummary,
+  parseDenoLintSummary,
+} from "../src/quality_summary.ts";
+import { DenoTasks } from "../src/deno.ts";
+
+/** A run's output with the given streams and exit code. */
+function out(code: number, stdout = "", stderr = ""): CommandOutput {
+  return new CommandOutput(code, stdout, stderr);
+}
+
+Deno.test("deno lint: Checked yields Files, Found yields Problems", () => {
+  assertEquals(parseDenoLintSummary(out(0, "", "Checked 312 files\n")), {
+    Files: 312,
+    Problems: 0,
+  });
+  assertEquals(
+    parseDenoLintSummary(
+      out(1, "", "error[no-var]: ...\n\nFound 2 problems\nChecked 1 file\n"),
+    ),
+    { Files: 1, Problems: 2 },
+  );
+  assertEquals(
+    parseDenoLintSummary(out(1, "", "error: No target files found.")),
+    undefined,
+  );
+});
+
+Deno.test("deno fmt: Checked yields Files, and --check's closing line the Unformatted count", () => {
+  assertEquals(parseDenoFmtSummary(out(0, "", "Checked 312 files\n")), {
+    Files: 312,
+    Unformatted: 0,
+  });
+  assertEquals(
+    parseDenoFmtSummary(
+      out(1, "", "\nerror: Found 1 not formatted file in 312 files\n"),
+    ),
+    { Files: 312, Unformatted: 1 },
+  );
+  assertEquals(
+    parseDenoFmtSummary(out(1, "", "error: No target files found.")),
+    undefined,
+  );
+});
+
+Deno.test("deno check: the closing line or the diagnostics yield Errors, silence and exit 0 is zero", () => {
+  assertEquals(parseDenoCheckSummary(out(0)), { Errors: 0 });
+  assertEquals(
+    parseDenoCheckSummary(
+      out(
+        1,
+        "",
+        "TS2322 [ERROR]: Type 'string' is not assignable to type 'number'.\n",
+      ),
+    ),
+    { Errors: 1 },
+  );
+  assertEquals(
+    parseDenoCheckSummary(
+      out(
+        1,
+        "",
+        "TS2322 [ERROR]: ...\n\nTS2322 [ERROR]: ...\n\nFound 2 errors.\n",
+      ),
+    ),
+    { Errors: 2 },
+  );
+  assertEquals(
+    parseDenoCheckSummary(out(1, "", "error: Module not found")),
+    undefined,
+  );
+});
+
+// The real deno drives the wrapper end to end: it is always present under the
+// test runner, so these stay hermetic.
+Deno.test("DenoTasks.lint, fmt and check report onto the ambient summary for real", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    await Deno.writeTextFile(`${dir}/ok.ts`, "export const n: number = 1;\n");
+    await Deno.writeTextFile(`${dir}/bad.ts`, "export const s: number = 'x'\n");
+    const lint = new TargetSummary();
+    await withAmbientSummary(
+      lint,
+      () => DenoTasks.lint((s) => s.paths(`${dir}/ok.ts`).quiet()),
+    );
+    assertEquals(lint.entries(), [{ key: "Files", value: "1" }, {
+      key: "Problems",
+      value: "0",
+    }]);
+
+    const fmt = new TargetSummary();
+    await assertRejects(
+      () =>
+        withAmbientSummary(
+          fmt,
+          () => DenoTasks.fmt((s) => s.check().paths(`${dir}/bad.ts`).quiet()),
+        ),
+      CommandError,
+    );
+    assertEquals(fmt.entries(), [{ key: "Files", value: "1" }, {
+      key: "Unformatted",
+      value: "1",
+    }]);
+
+    const check = new TargetSummary();
+    await assertRejects(
+      () =>
+        withAmbientSummary(
+          check,
+          () => DenoTasks.check((s) => s.paths(`${dir}/bad.ts`).quiet()),
+        ),
+      CommandError,
+    );
+    assertEquals(check.entries(), [{ key: "Errors", value: "1" }]);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/packages/dprint/README.md
+++ b/packages/dprint/README.md
@@ -44,12 +44,16 @@ class DprintCheckSettings extends DprintSettings
 
   override protected subcommand(): string
     The dprint subcommand this settings class runs: `check`.
+  override protected onOutput(output: CommandOutput): void
+    Report `Unformatted`, the files that need formatting, onto the build summary.
 
 class DprintFmtSettings extends DprintSettings
   Settings for `dprint fmt` (format files in place).
 
   override protected subcommand(): string
     The dprint subcommand this settings class runs: `fmt`.
+  override protected onOutput(output: CommandOutput): void
+    Report `Formatted`, the files the run changed, onto the build summary.
 
 abstract class DprintSettings extends ToolSettings
   Shared options for a `dprint` subcommand (`fmt` or `check`).

--- a/packages/dprint/deno.json
+++ b/packages/dprint/deno.json
@@ -7,7 +7,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1.25.0"
+    "@zuke/core": "jsr:@zuke/core@^1.44.0"
   },
   "publish": {
     "exclude": [

--- a/packages/dprint/src/dprint.ts
+++ b/packages/dprint/src/dprint.ts
@@ -27,6 +27,8 @@ import {
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
+import { reportSummary } from "@zuke/core";
+import { parseDprintCheckSummary, parseDprintFmtSummary } from "./summary.ts";
 
 /** Shared options for a `dprint` subcommand (`fmt` or `check`). */
 export abstract class DprintSettings extends ToolSettings {
@@ -97,6 +99,12 @@ export class DprintFmtSettings extends DprintSettings {
   protected override subcommand(): string {
     return "fmt";
   }
+
+  /** Report `Formatted`, the files the run changed, onto the build summary. */
+  protected override onOutput(output: CommandOutput): void {
+    const pairs = parseDprintFmtSummary(output);
+    if (pairs !== undefined) reportSummary(pairs);
+  }
 }
 
 /** Settings for `dprint check` (verify formatting without writing). */
@@ -104,6 +112,12 @@ export class DprintCheckSettings extends DprintSettings {
   /** The dprint subcommand this settings class runs: `check`. */
   protected override subcommand(): string {
     return "check";
+  }
+
+  /** Report `Unformatted`, the files that need formatting, onto the build summary. */
+  protected override onOutput(output: CommandOutput): void {
+    const pairs = parseDprintCheckSummary(output);
+    if (pairs !== undefined) reportSummary(pairs);
   }
 }
 

--- a/packages/dprint/src/summary.ts
+++ b/packages/dprint/src/summary.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * What a `dprint` run reports onto its target's row of the build summary.
+ * `dprint check` closes with `Found 2 not formatted files. Run dprint fmt to
+ * fix.` on stderr when files need formatting and prints nothing when they do
+ * not; `dprint fmt` prints `Formatted 3 files.` on stdout when it changed
+ * any. Internal to the wrapper.
+ *
+ * @module
+ */
+
+import type { CommandOutput } from "@zuke/core/shell";
+import type { SummaryPairs } from "@zuke/core";
+import { stripAnsi } from "@zuke/core/render";
+
+/** `dprint check`'s closing line when files need formatting. */
+const NOT_FORMATTED = /^Found (\d+) not formatted files?\./m;
+/** `dprint fmt`'s closing line when it changed files. */
+const FORMATTED = /^Formatted (\d+) files?\./m;
+
+/**
+ * The notes for a `dprint check` run: `Unformatted`, the files that need
+ * formatting. Zero when the run printed no closing line and exited 0; nothing
+ * when it exited non-zero without one, since that run did not complete.
+ */
+export function parseDprintCheckSummary(
+  output: CommandOutput,
+): SummaryPairs | undefined {
+  const m = NOT_FORMATTED.exec(stripAnsi(output.stderr));
+  if (m !== null) return { Unformatted: Number(m[1]) };
+  return output.code === 0 ? { Unformatted: 0 } : undefined;
+}
+
+/**
+ * The notes for a `dprint fmt` run: `Formatted`, the files it changed.
+ * Zero when the run printed no closing line and exited 0; nothing when it
+ * exited non-zero without one.
+ */
+export function parseDprintFmtSummary(
+  output: CommandOutput,
+): SummaryPairs | undefined {
+  const m = FORMATTED.exec(stripAnsi(output.stdout));
+  if (m !== null) return { Formatted: Number(m[1]) };
+  return output.code === 0 ? { Formatted: 0 } : undefined;
+}

--- a/packages/dprint/tests/summary_test.ts
+++ b/packages/dprint/tests/summary_test.ts
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals } from "../../core/tests/_assert.ts";
+import {
+  TargetSummary,
+  withAmbientSummary,
+} from "../../core/src/summary_note.ts";
+import { CommandOutput } from "@zuke/core/shell";
+import { DprintCheckSettings, DprintFmtSettings } from "../src/dprint.ts";
+import {
+  parseDprintCheckSummary,
+  parseDprintFmtSummary,
+} from "../src/summary.ts";
+
+/** A run's output with the given streams and exit code. */
+function out(code: number, stdout = "", stderr = ""): CommandOutput {
+  return new CommandOutput(code, stdout, stderr);
+}
+
+Deno.test("dprint check: the stderr closing line yields Unformatted, silence and exit 0 is zero", () => {
+  assertEquals(
+    parseDprintCheckSummary(
+      out(20, "", "Found 2 not formatted files. Run dprint fmt to fix.\n"),
+    ),
+    { Unformatted: 2 },
+  );
+  assertEquals(
+    parseDprintCheckSummary(
+      out(
+        20,
+        "",
+        "Compiling https://plugins.dprint.dev/typescript-0.93.0.wasm\nFound 1 not formatted file. Run dprint fmt to fix.\n",
+      ),
+    ),
+    { Unformatted: 1 },
+  );
+  assertEquals(parseDprintCheckSummary(out(0)), { Unformatted: 0 });
+  assertEquals(
+    parseDprintCheckSummary(out(1, "", "error: No config file found")),
+    undefined,
+  );
+});
+
+Deno.test("dprint fmt: the stdout closing line yields Formatted, silence and exit 0 is zero", () => {
+  assertEquals(
+    parseDprintFmtSummary(out(0, "Formatted \x1b[1m3\x1b[0m files.\n")),
+    { Formatted: 3 },
+  );
+  assertEquals(parseDprintFmtSummary(out(0, "Formatted 1 file.\n")), {
+    Formatted: 1,
+  });
+  assertEquals(parseDprintFmtSummary(out(0)), { Formatted: 0 });
+  assertEquals(
+    parseDprintFmtSummary(out(1, "", "error: No config file found")),
+    undefined,
+  );
+});
+
+/** Exposes the protected hooks so the wiring can be exercised without dprint. */
+class CheckProbe extends DprintCheckSettings {
+  probe(output: CommandOutput): void {
+    this.onOutput(output);
+  }
+}
+class FmtProbe extends DprintFmtSettings {
+  probe(output: CommandOutput): void {
+    this.onOutput(output);
+  }
+}
+
+Deno.test("dprint: each subcommand reports its own figure onto the running target", async () => {
+  const summary = new TargetSummary();
+  await withAmbientSummary(summary, () => {
+    new CheckProbe().probe(
+      out(20, "", "Found 2 not formatted files. Run dprint fmt to fix.\n"),
+    );
+    new FmtProbe().probe(out(0, "Formatted 2 files.\n"));
+    return Promise.resolve();
+  });
+  assertEquals(summary.entries(), [
+    { key: "Unformatted", value: "2" },
+    { key: "Formatted", value: "2" },
+  ]);
+});

--- a/packages/eslint/README.md
+++ b/packages/eslint/README.md
@@ -81,6 +81,8 @@ class EslintSettings extends ToolSettings
     Do not search for a config file (`--no-config-lookup`).
   reportUnusedDisableDirectives(): this
     Report unused `eslint-disable` directives (`--report-unused-disable-directives`).
+  override protected onOutput(output: CommandOutput): void
+    Report `Problems`, `Errors` and `Warnings` onto the build summary.
   override protected buildArgs(): string[]
     Assemble the `eslint` argv from the configured settings.
 

--- a/packages/eslint/deno.json
+++ b/packages/eslint/deno.json
@@ -7,7 +7,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1.25.0"
+    "@zuke/core": "jsr:@zuke/core@^1.44.0"
   },
   "publish": {
     "exclude": [

--- a/packages/eslint/src/eslint.ts
+++ b/packages/eslint/src/eslint.ts
@@ -26,6 +26,8 @@ import {
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
+import { reportSummary } from "@zuke/core";
+import { parseEslintSummary } from "./summary.ts";
 
 /** Settings for an `eslint` run. */
 export class EslintSettings extends ToolSettings {
@@ -157,6 +159,12 @@ export class EslintSettings extends ToolSettings {
   reportUnusedDisableDirectives(): this {
     this.#reportUnusedDisableDirectives = true;
     return this;
+  }
+
+  /** Report `Problems`, `Errors` and `Warnings` onto the build summary. */
+  protected override onOutput(output: CommandOutput): void {
+    const pairs = parseEslintSummary(output);
+    if (pairs !== undefined) reportSummary(pairs);
   }
 
   /** Assemble the `eslint` argv from the configured settings. */

--- a/packages/eslint/src/summary.ts
+++ b/packages/eslint/src/summary.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * What an `eslint` run reports onto its target's row of the build summary,
+ * read from the closing line of the default (stylish) formatter:
+ * `✖ 5 problems (2 errors, 3 warnings)`. Internal to the wrapper.
+ *
+ * @module
+ */
+
+import type { CommandOutput } from "@zuke/core/shell";
+import type { SummaryPairs } from "@zuke/core";
+import { stripAnsi } from "@zuke/core/render";
+
+/** The stylish formatter's closing line; singular and plural nouns alike. */
+const PROBLEMS = /^✖ (\d+) problems? \((\d+) errors?, (\d+) warnings?\)/m;
+
+/**
+ * The notes for a run: `Problems`, `Errors` and `Warnings` from the closing
+ * line, or all zero when a clean run printed nothing and exited 0. A run that
+ * exited non-zero without the line (a configuration error, a formatter that
+ * prints no summary) reports nothing rather than a misleading zero.
+ */
+export function parseEslintSummary(
+  output: CommandOutput,
+): SummaryPairs | undefined {
+  const m = PROBLEMS.exec(stripAnsi(output.stdout));
+  if (m !== null) {
+    return {
+      Problems: Number(m[1]),
+      Errors: Number(m[2]),
+      Warnings: Number(m[3]),
+    };
+  }
+  return output.code === 0
+    ? { Problems: 0, Errors: 0, Warnings: 0 }
+    : undefined;
+}

--- a/packages/eslint/tests/summary_test.ts
+++ b/packages/eslint/tests/summary_test.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals } from "../../core/tests/_assert.ts";
+import {
+  TargetSummary,
+  withAmbientSummary,
+} from "../../core/src/summary_note.ts";
+import { CommandOutput } from "@zuke/core/shell";
+import { EslintSettings } from "../src/eslint.ts";
+import { parseEslintSummary } from "../src/summary.ts";
+
+/** A run's output with the given streams and exit code. */
+function out(code: number, stdout = "", stderr = ""): CommandOutput {
+  return new CommandOutput(code, stdout, stderr);
+}
+
+Deno.test("eslint: the stylish closing line yields Problems, Errors and Warnings", () => {
+  assertEquals(
+    parseEslintSummary(
+      out(
+        1,
+        "\n✖ 5 problems (2 errors, 3 warnings)\n  1 error and 1 warning potentially fixable with the `--fix` option.\n",
+      ),
+    ),
+    { Problems: 5, Errors: 2, Warnings: 3 },
+  );
+  assertEquals(
+    parseEslintSummary(out(1, "✖ 1 problem (1 error, 0 warnings)\n")),
+    { Problems: 1, Errors: 1, Warnings: 0 },
+  );
+  assertEquals(
+    parseEslintSummary(
+      out(0, "\x1b[31m✖ 2 problems (0 errors, 2 warnings)\x1b[0m\n"),
+    ),
+    { Problems: 2, Errors: 0, Warnings: 2 },
+  );
+});
+
+Deno.test("eslint: a silent clean run is zero problems, a silent failure reports nothing", () => {
+  assertEquals(parseEslintSummary(out(0)), {
+    Problems: 0,
+    Errors: 0,
+    Warnings: 0,
+  });
+  assertEquals(
+    parseEslintSummary(out(2, "", "Oops! Something went wrong!")),
+    undefined,
+  );
+});
+
+/** Exposes the protected hook so the wiring can be exercised without eslint. */
+class Probe extends EslintSettings {
+  probe(output: CommandOutput): void {
+    this.onOutput(output);
+  }
+}
+
+Deno.test("eslint: the hook reports the counts onto the running target", async () => {
+  const summary = new TargetSummary();
+  await withAmbientSummary(summary, () => {
+    new Probe().probe(out(1, "✖ 3 problems (1 error, 2 warnings)\n"));
+    return Promise.resolve();
+  });
+  assertEquals(summary.entries(), [
+    { key: "Problems", value: "3" },
+    { key: "Errors", value: "1" },
+    { key: "Warnings", value: "2" },
+  ]);
+});

--- a/packages/oxlint/README.md
+++ b/packages/oxlint/README.md
@@ -77,6 +77,8 @@ class OxlintSettings extends ToolSettings
     Output format, e.g. `default`, `json`, `github` (`-f`/`--format`).
   threads(count: number): this
     Number of threads to use (`--threads`).
+  override protected onOutput(output: CommandOutput): void
+    Report `Errors`, `Warnings` (and `Files` when known) onto the build summary.
   override protected buildArgs(): string[]
     Assemble the `oxlint` argv from the configured settings.
 

--- a/packages/oxlint/deno.json
+++ b/packages/oxlint/deno.json
@@ -7,7 +7,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1.25.0"
+    "@zuke/core": "jsr:@zuke/core@^1.44.0"
   },
   "publish": {
     "exclude": [

--- a/packages/oxlint/src/oxlint.ts
+++ b/packages/oxlint/src/oxlint.ts
@@ -26,6 +26,8 @@ import {
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
+import { reportSummary } from "@zuke/core";
+import { parseOxlintSummary } from "./summary.ts";
 
 /** Settings for an `oxlint` run. */
 export class OxlintSettings extends ToolSettings {
@@ -141,6 +143,12 @@ export class OxlintSettings extends ToolSettings {
   threads(count: number): this {
     this.#threads = count;
     return this;
+  }
+
+  /** Report `Errors`, `Warnings` (and `Files` when known) onto the build summary. */
+  protected override onOutput(output: CommandOutput): void {
+    const pairs = parseOxlintSummary(output);
+    if (pairs !== undefined) reportSummary(pairs);
   }
 
   /** Assemble the `oxlint` argv from the configured settings. */

--- a/packages/oxlint/src/summary.ts
+++ b/packages/oxlint/src/summary.ts
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * What an `oxlint` run reports onto its target's row of the build summary.
+ * On a terminal oxlint closes with `Found 3 warnings and 1 error.` (and
+ * `Finished in 12ms on 40 files …`); piped, it prints one
+ * `path:line:col: warning rule: message` line per diagnostic and no closing
+ * line, so those are counted instead. Internal to the wrapper.
+ *
+ * @module
+ */
+
+import type { CommandOutput } from "@zuke/core/shell";
+import type { SummaryPairs } from "@zuke/core";
+import { stripAnsi } from "@zuke/core/render";
+
+/** The terminal reporter's closing line. */
+const FOUND = /^Found (\d+) warnings? and (\d+) errors?\.$/m;
+/** The terminal reporter's timing line, which carries the file count. */
+const FINISHED = /^Finished in \S+ on (\d+) files?\b/m;
+/** One diagnostic of the piped (non-terminal) reporter. */
+const DIAGNOSTIC = /^.+:\d+:\d+: (warning|error)\b/gm;
+
+/**
+ * The notes for a run: `Errors` and `Warnings`, plus `Files` when the
+ * timing line names them. Read from the closing line when there is one, else
+ * counted from the per-diagnostic lines; a clean run that printed nothing and
+ * exited 0 reports zeros, and a non-zero exit with no diagnostics reports
+ * nothing rather than a misleading zero.
+ */
+export function parseOxlintSummary(
+  output: CommandOutput,
+): SummaryPairs | undefined {
+  const text = stripAnsi(output.stdout);
+  const files = FINISHED.exec(text);
+  const withFiles = (pairs: Record<string, number>): SummaryPairs =>
+    files === null ? pairs : { ...pairs, Files: Number(files[1]) };
+  const found = FOUND.exec(text);
+  if (found !== null) {
+    return withFiles({ Errors: Number(found[2]), Warnings: Number(found[1]) });
+  }
+  let errors = 0;
+  let warnings = 0;
+  for (const m of text.matchAll(DIAGNOSTIC)) {
+    if (m[1] === "error") errors++;
+    else warnings++;
+  }
+  if (errors + warnings > 0 || output.code === 0) {
+    return withFiles({ Errors: errors, Warnings: warnings });
+  }
+  return undefined;
+}

--- a/packages/oxlint/tests/summary_test.ts
+++ b/packages/oxlint/tests/summary_test.ts
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals } from "../../core/tests/_assert.ts";
+import {
+  TargetSummary,
+  withAmbientSummary,
+} from "../../core/src/summary_note.ts";
+import { CommandOutput } from "@zuke/core/shell";
+import { OxlintSettings } from "../src/oxlint.ts";
+import { parseOxlintSummary } from "../src/summary.ts";
+
+/** A run's output with the given streams and exit code. */
+function out(code: number, stdout = "", stderr = ""): CommandOutput {
+  return new CommandOutput(code, stdout, stderr);
+}
+
+Deno.test("oxlint: the terminal closing line yields Errors and Warnings, with Files when timed", () => {
+  const text =
+    "Found 3 warnings and 1 error.\nFinished in 12ms on 40 files with 90 rules using 8 threads.\n";
+  assertEquals(parseOxlintSummary(out(1, text)), {
+    Errors: 1,
+    Warnings: 3,
+    Files: 40,
+  });
+  assertEquals(
+    parseOxlintSummary(out(0, "Found 0 warnings and 0 errors.\n")),
+    { Errors: 0, Warnings: 0 },
+  );
+});
+
+Deno.test("oxlint: piped output has no closing line, so the diagnostics are counted", () => {
+  const text = [
+    "bad.js:1:7: warning eslint(no-unused-vars): Variable a is declared but never used.",
+    "bad.js:2:5: warning eslint(no-unused-vars): Variable b is declared but never used.",
+    "bad.js:3:13: error eslint(no-undef): c is not defined.",
+    "",
+  ].join("\n");
+  assertEquals(parseOxlintSummary(out(1, text)), { Errors: 1, Warnings: 2 });
+});
+
+Deno.test("oxlint: a silent clean run is zero, a silent failure reports nothing", () => {
+  assertEquals(parseOxlintSummary(out(0)), { Errors: 0, Warnings: 0 });
+  assertEquals(
+    parseOxlintSummary(out(1, "", "error: unknown option")),
+    undefined,
+  );
+});
+
+/** Exposes the protected hook so the wiring can be exercised without oxlint. */
+class Probe extends OxlintSettings {
+  probe(output: CommandOutput): void {
+    this.onOutput(output);
+  }
+}
+
+Deno.test("oxlint: the hook reports the counts onto the running target", async () => {
+  const summary = new TargetSummary();
+  await withAmbientSummary(summary, () => {
+    new Probe().probe(out(0, "Found 2 warnings and 0 errors.\n"));
+    return Promise.resolve();
+  });
+  assertEquals(summary.entries(), [
+    { key: "Errors", value: "0" },
+    { key: "Warnings", value: "2" },
+  ]);
+});

--- a/packages/tsc/README.md
+++ b/packages/tsc/README.md
@@ -60,6 +60,8 @@ abstract class TscBaseSettings extends ToolSettings
     The default binary these settings invoke: `tsc`.
   override protected defaultResolution(): ToolResolution
     Resolve the binary from `node_modules/.bin` by default — tsc is an npm-distributed tool.
+  override protected onOutput(output: CommandOutput): void
+    Report `Errors`, the diagnostics printed, onto the build summary.
 
 class TscBuildSettings extends TscBaseSettings
   Settings for a `tsc --build` project-references run.

--- a/packages/tsc/deno.json
+++ b/packages/tsc/deno.json
@@ -7,7 +7,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1.25.0"
+    "@zuke/core": "jsr:@zuke/core@^1.44.0"
   },
   "publish": {
     "exclude": [

--- a/packages/tsc/src/summary.ts
+++ b/packages/tsc/src/summary.ts
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * What a `tsc` run reports onto its target's row of the build summary: the
+ * number of diagnostics it printed. The compiler's closing `Found N errors`
+ * line only appears in pretty mode (a terminal), so the diagnostics are
+ * counted instead, which works piped and pretty alike:
+ * `src/a.ts(3,7): error TS2322: …` or `src/a.ts:3:7 - error TS2322: …`.
+ * Internal to the wrapper.
+ *
+ * @module
+ */
+
+import type { CommandOutput } from "@zuke/core/shell";
+import type { SummaryPairs } from "@zuke/core";
+import { stripAnsi } from "@zuke/core/render";
+
+/** One diagnostic line, in either the plain or the pretty layout. */
+const DIAGNOSTIC = /\berror TS\d+:/g;
+
+/**
+ * The notes for a run: `Errors`. A run that printed no diagnostic and exited
+ * 0 is clean and reports zero; one that exited non-zero without printing any
+ * (a bad flag, a missing config) reports nothing rather than a misleading zero.
+ */
+export function parseTscSummary(
+  output: CommandOutput,
+): SummaryPairs | undefined {
+  const errors = [...stripAnsi(output.stdout).matchAll(DIAGNOSTIC)].length;
+  if (errors > 0 || output.code === 0) return { Errors: errors };
+  return undefined;
+}

--- a/packages/tsc/src/tsc.ts
+++ b/packages/tsc/src/tsc.ts
@@ -32,6 +32,8 @@ import {
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
+import { reportSummary } from "@zuke/core";
+import { parseTscSummary } from "./summary.ts";
 
 /** Shared base for `tsc` settings; resolves the `tsc` binary. */
 export abstract class TscBaseSettings extends ToolSettings {
@@ -43,6 +45,12 @@ export abstract class TscBaseSettings extends ToolSettings {
   /** Resolve the binary from `node_modules/.bin` by default — tsc is an npm-distributed tool. */
   protected override defaultResolution(): ToolResolution {
     return "node_modules";
+  }
+
+  /** Report `Errors`, the diagnostics printed, onto the build summary. */
+  protected override onOutput(output: CommandOutput): void {
+    const pairs = parseTscSummary(output);
+    if (pairs !== undefined) reportSummary(pairs);
   }
 }
 

--- a/packages/tsc/tests/summary_test.ts
+++ b/packages/tsc/tests/summary_test.ts
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals } from "../../core/tests/_assert.ts";
+import {
+  TargetSummary,
+  withAmbientSummary,
+} from "../../core/src/summary_note.ts";
+import { CommandOutput } from "@zuke/core/shell";
+import { TscBuildSettings, TscSettings } from "../src/tsc.ts";
+import { parseTscSummary } from "../src/summary.ts";
+
+/** A run's output with the given streams and exit code. */
+function out(code: number, stdout = "", stderr = ""): CommandOutput {
+  return new CommandOutput(code, stdout, stderr);
+}
+
+Deno.test("tsc: the diagnostics are counted in the plain and the pretty layouts", () => {
+  const plain =
+    "src/a.ts(1,7): error TS2322: Type string is not assignable to type number.\nsrc/b.ts(4,1): error TS1005: ; expected.\n";
+  assertEquals(parseTscSummary(out(2, plain)), { Errors: 2 });
+  // The pretty layout paints the path, position and severity separately.
+  const pretty = "\x1b[96m" + "src/a.ts" +
+    "\x1b[0m:\x1b[93m1\x1b[0m:\x1b[93m7" +
+    "\x1b[0m - \x1b[91m" + "error" + "\x1b[0m\x1b[90m TS2322: \x1b[0m" +
+    "Type string is not assignable to type number.\n\n\nFound 1 error in src/a.ts:1\n";
+  assertEquals(parseTscSummary(out(2, pretty)), { Errors: 1 });
+});
+
+Deno.test("tsc: a silent clean run is zero errors, a silent failure reports nothing", () => {
+  assertEquals(parseTscSummary(out(0)), { Errors: 0 });
+  assertEquals(
+    parseTscSummary(out(1, "", "error TS5023: Unknown compiler option")),
+    undefined,
+  );
+});
+
+/** Exposes the protected hook so the wiring can be exercised without tsc. */
+class Probe extends TscSettings {
+  probe(output: CommandOutput): void {
+    this.onOutput(output);
+  }
+}
+/** The hook lives on the shared base, so `tsc --build` has it too. */
+class BuildProbe extends TscBuildSettings {
+  probe(output: CommandOutput): void {
+    this.onOutput(output);
+  }
+}
+
+Deno.test("tsc: the hook reports the error count onto the running target", async () => {
+  const summary = new TargetSummary();
+  await withAmbientSummary(summary, () => {
+    new Probe().probe(out(2, "a.ts(1,1): error TS1005: ; expected.\n"));
+    new BuildProbe().probe(out(0));
+    return Promise.resolve();
+  });
+  // The second report replaces the first: a target that runs tsc twice keeps
+  // the last run figure on its row.
+  assertEquals(summary.entries(), [{ key: "Errors", value: "0" }]);
+});


### PR DESCRIPTION
## What & why

Since #450 a target's row on the Build Summary can carry `key: value` notes, and #452 filled them in for `DenoTasks.test`. The lint, type-check, format and spell rows are the other ones a reader wants numbers on. This PR makes each of those wrappers override the `onOutput` hook and parse the closing line its own tool prints. Zuke's own gate now reads:

    check          Succeeded      7.2s
    spell          Succeeded      7.9s  // Files: 1015 · Issues: 0
    snippetsCheck  Succeeded     56.7s  // Errors: 0

What each wrapper reports, all read from the tool's own closing line:

- **eslint**: `Problems`, `Errors`, `Warnings` from the stylish formatter's closing line.
- **oxlint**: `Errors` and `Warnings` from its closing line on a terminal, or counted from its per-diagnostic lines when piped (it prints no closing line then), plus `Files` when the timing line names them.
- **biome**: `Files`, `Errors`, `Warnings` on every subcommand, from the `Checked` and `Found` lines. The hook sits on the shared base class.
- **tsc**: `Errors`, counted from the diagnostics themselves, since the `Found N errors` line is pretty-mode only and the wrapper's output is piped. On the shared base, so `tsc --build` has it too.
- **cspell**: `Files` checked and `Issues` found, from the closing line on stderr.
- **dprint**: `Unformatted` for `check`, `Formatted` for `fmt`.
- **deno lint / fmt / check**: `Files` and `Problems`; `Files` and `Unformatted` under `--check`; `Errors`.

Three rules hold across all of them. A clean run reports its zeros, because a green `lint` row that says `Problems: 0` is the point. A failed run keeps its counts, so a red row says how many. A run that exited non-zero without printing its closing line (a bad flag, a missing config) reports nothing rather than a misleading zero, and so does a machine-readable reporter that replaces the line.

Every touched package raises its `@zuke/core` floor to `^1.44.0`, the release that carries `reportSummary`; `deno.lock` follows. `docs/run-context.md` gains a table of what each wrapper reports.

Tests: each parser is asserted on captured output in its shapes (clean, findings, coloured, the silent-failure case), and each hook's wiring is exercised through a probe subclass under an ambient collector. The deno lint, fmt and check paths also run for real against a temp file, since the deno running the suite is always present.

Everything in `deno task ci` passed locally except the `security` target, which the sandbox's network proxy blocks.

## Related issues

Closes #458

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a
      [Conventional Commit](https://www.conventionalcommits.org/)
      (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell) — all targets except `security`, see above.
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour
      changed.
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`,
      `llms-full.txt`, package README `## API`).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with
      type guards instead).
- [x] No dead code: unreachable branches and can't-fire fallbacks are removed,
      with types tightened so the impossible state is unrepresentable.
- [x] No duplicated logic: an existing helper is imported rather than retyped,
      and a near-copy differing by a constant or a message is parameterised into
      one implementation. A guard, escape, or credential resolution has exactly
      one implementation.
- [x] SOLID shapes respected: one domain per file, extension via the settings
      lambda (not a behaviour-switching flag), narrow parameter types, and
      dependencies on the injectable seam (`StateHost`, an injected `fetch`,
      `EnvReader`) rather than `Deno.*` or a global.
- [ ] A new package was wired into all six places (see
      [AGENTS.md](../blob/master/AGENTS.md#good-open-source-practices-to-follow)),
      if applicable.
- [x] The code is written using AI assisted coding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrP7TrH4YPZiFmSE3mdhBT

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrP7TrH4YPZiFmSE3mdhBT)_