### PR TITLE
feat: report test counts from every test-runner wrapper

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.36.0",
+      "version": "0.37.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/deno.lock
+++ b/deno.lock
@@ -1561,7 +1561,7 @@
       },
       "packages/bun": {
         "dependencies": [
-          "jsr:@zuke/core@^1.25.0"
+          "jsr:@zuke/core@^1.45.0"
         ]
       },
       "packages/claude": {
@@ -1603,12 +1603,12 @@
       },
       "packages/cypress": {
         "dependencies": [
-          "jsr:@zuke/core@^1.25.0"
+          "jsr:@zuke/core@^1.45.0"
         ]
       },
       "packages/deno": {
         "dependencies": [
-          "jsr:@zuke/core@^1.44.0"
+          "jsr:@zuke/core@^1.45.0"
         ]
       },
       "packages/docker": {
@@ -1673,7 +1673,7 @@
       },
       "packages/jest": {
         "dependencies": [
-          "jsr:@zuke/core@^1.25.0"
+          "jsr:@zuke/core@^1.45.0"
         ]
       },
       "packages/jsr": {
@@ -1708,7 +1708,7 @@
       },
       "packages/node": {
         "dependencies": [
-          "jsr:@zuke/core@^1.32.0"
+          "jsr:@zuke/core@^1.45.0"
         ]
       },
       "packages/npm": {
@@ -1748,7 +1748,7 @@
       },
       "packages/playwright": {
         "dependencies": [
-          "jsr:@zuke/core@^1.25.0"
+          "jsr:@zuke/core@^1.45.0"
         ]
       },
       "packages/pnpm": {
@@ -1828,7 +1828,7 @@
       },
       "packages/vitest": {
         "dependencies": [
-          "jsr:@zuke/core@^1.25.0"
+          "jsr:@zuke/core@^1.45.0"
         ]
       },
       "packages/yarn": {

--- a/docs/run-context.md
+++ b/docs/run-context.md
@@ -116,7 +116,7 @@ lines (JSON, JUnit, or a machine-readable format) reports nothing.
 
 | Wrapper | Notes on the row |
 | --- | --- |
-| `DenoTasks.test` | `Tests`, `Passed`, `Failed`, and `Ignored` when non-zero |
+| `DenoTasks.test` (and every test-runner wrapper) | `Tests`, `Passed`, `Failed`, then `Skipped`, `Todo`, `Flaky` when non-zero |
 | `DenoTasks.coverage` | `Lines`, and `Branches` when any were measured |
 | `DenoTasks.lint` | `Files`, `Problems` |
 | `DenoTasks.fmt` | `Files`, and `Unformatted` under `.check()` |

--- a/docs/run-context.md
+++ b/docs/run-context.md
@@ -66,9 +66,9 @@ class CI extends Build {
 }
 ```
 
-A wrapper that knows what its tool printed reports for you. `DenoTasks.test`
-puts `// Tests: 837 · Passed: 837 · Failed: 0` on the row of whichever target
-ran it:
+A wrapper that knows what its tool printed reports for you. `DenoTasks.test`,
+like every test-runner wrapper, puts `// Tests: 837 · Passed: 837 · Failed: 0`
+on the row of whichever target ran it:
 
 <!-- check -->
 
@@ -98,16 +98,19 @@ the [ambient signal](#scope-of-the-ambient-signal) to that target's async
 subtree, so concurrent targets never mix notes. Outside a running target it is
 a no-op: a wrapper never has to ask where it runs. This is the seam a tool
 wrapper reports through, so a body only adds what its tools do not:
-`DenoTasks.test` reports Tests, Passed, Failed (and Ignored when non-zero)
-from deno's own result line — on a failed run too, so a red row says how many
-failed — and `DenoTasks.coverage` reports the measured line and branch
-percentages.
+every test-runner wrapper reports its counts from its runner's own result
+line — on a failed run too, so a red row says how many failed — and
+`DenoTasks.coverage` reports the measured line and branch percentages.
 
 Test runners share one shape. `reportTestCounts({ passed, failed, skipped?,
 todo?, flaky? })` from `@zuke/core` reports `Tests` (the sum), `Passed` and
 `Failed`, then `Skipped`, `Todo` and `Flaky` only when non-zero, so every
 test-runner wrapper puts the same labels on its row and a body that runs tests
-some other way can match them.
+some other way can match them. The wrappers that report this way, each from
+the closing lines its runner's default reporters print: `DenoTasks.test`,
+`VitestTasks.run`, `JestTasks.run`, `BunTasks.test`, `NodeTasks.test`,
+`PlaywrightTasks.test` and `CypressTasks.run`. A reporter that replaces those
+lines (JSON, JUnit, or a machine-readable format) reports nothing.
 
 ### What the wrappers report
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "zuke",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build)."
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5796,8 +5796,8 @@ class DenoTestSettings extends DenoPermissionSettings
 
   A run reports its counts into the running target's row of the build
   summary — `// Tests: 837 · Passed: 837 · Failed: 0` — read from the result
-  line the pretty and dot reporters print; a failed run reports too, so a red
-  row says how many failed. The JUnit and TAP reporters print no such line,
+  line the pretty and dot reporters print (ignored tests count as `Skipped`);
+  a failed run reports too, so a red row says how many failed. The JUnit and TAP reporters print no such line,
   so a run under `.reporter("junit")`/`.reporter("tap")` reports nothing.
 
   paths(...paths: PathLike[]): this
@@ -7099,6 +7099,8 @@ class BunTestSettings extends BunSettings
     Collect coverage (`--coverage`).
   bail(): this
     Stop after the first failure (`--bail`).
+  override protected onOutput(output: CommandOutput): void
+    Report the run's counts onto the build summary (see the module docs).
   override protected buildArgs(): string[]
     Assemble the `bun test` argv.
 
@@ -10699,6 +10701,8 @@ class JestSettings extends ToolSettings
     Restrict to named projects (`--selectProjects`); repeatable.
   reporters(...names: string[]): this
     Use the named reporters (`--reporters`); repeatable.
+  override protected onOutput(output: CommandOutput): void
+    Report the run's counts onto the build summary (see the module docs).
   override protected buildArgs(): string[]
     Assemble the `jest` argv from the configured flags and patterns.
 
@@ -10778,6 +10782,8 @@ class VitestSettings extends ToolSettings
     Pass when no tests are found (`--passWithNoTests`).
   silent(): this
     Suppress test console output (`--silent`).
+  override protected onOutput(output: CommandOutput): void
+    Report the run's counts onto the build summary (see the module docs).
   override protected buildArgs(): string[]
     Assemble the `vitest run`/`vitest watch` argv.
 
@@ -10867,6 +10873,8 @@ class PlaywrightTestSettings extends PlaywrightSettings
     Use a specific config file (`--config=`).
   paths(...filters: string[]): this
     Test file or directory filters to run; omit to run all tests.
+  override protected onOutput(output: CommandOutput): void
+    Report the run's counts onto the build summary (see the module docs).
   override protected buildArgs(): string[]
     Assemble the `playwright test` argv.
 
@@ -10935,6 +10943,8 @@ class CypressRunSettings extends CypressTestingSettings
     Tag the recorded run (`--tag`).
   port(value: number): this
     Override the server port (`--port`).
+  override protected onOutput(output: CommandOutput): void
+    Report the run's counts onto the build summary (see the module docs).
   override protected buildArgs(): string[]
     Assemble the `cypress run` argv.
 
@@ -12559,6 +12569,8 @@ class NodeTestSettings extends NodeSettings
     Re-run tests on file changes (`--watch`).
   experimentalTestCoverage(): this
     Collect and report test coverage (`--experimental-test-coverage`).
+  override protected onOutput(output: CommandOutput): void
+    Report the run's counts onto the build summary (see the module docs).
   override protected buildArgs(): string[]
     Assemble the `node --test [paths] [flags]` argv.
 

--- a/packages/bun/README.md
+++ b/packages/bun/README.md
@@ -93,6 +93,8 @@ class BunTestSettings extends BunSettings
     Collect coverage (`--coverage`).
   bail(): this
     Stop after the first failure (`--bail`).
+  override protected onOutput(output: CommandOutput): void
+    Report the run's counts onto the build summary (see the module docs).
   override protected buildArgs(): string[]
     Assemble the `bun test` argv.
 

--- a/packages/bun/deno.json
+++ b/packages/bun/deno.json
@@ -7,7 +7,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1.25.0"
+    "@zuke/core": "jsr:@zuke/core@^1.45.0"
   },
   "publish": {
     "exclude": [

--- a/packages/bun/src/bun.ts
+++ b/packages/bun/src/bun.ts
@@ -18,6 +18,8 @@
 
 import { type Configure, runSettings, ToolSettings } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
+import { reportTestCounts } from "@zuke/core";
+import { parseTestSummary } from "./test_summary.ts";
 
 /** Base for all `bun` subcommand settings: binary is `bun` from PATH. */
 export abstract class BunSettings extends ToolSettings {
@@ -201,6 +203,12 @@ export class BunTestSettings extends BunSettings {
   bail(): this {
     this.#bail = true;
     return this;
+  }
+
+  /** Report the run's counts onto the build summary (see the module docs). */
+  protected override onOutput(output: CommandOutput): void {
+    const counts = parseTestSummary(output);
+    if (counts !== undefined) reportTestCounts(counts);
   }
 
   /** Assemble the `bun test` argv. */

--- a/packages/bun/src/test_summary.ts
+++ b/packages/bun/src/test_summary.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * The counts a `bun test` run reports onto its target's row of the build
+ * summary, read from the closing lines bun prints on stderr — one per
+ * category, only when non-zero — followed by `Ran 4 tests across 1 file.`:
+ *
+ * ```text
+ *  1 pass
+ *  1 skip
+ *  1 todo
+ *  1 fail
+ * ```
+ *
+ * Internal to the wrapper.
+ *
+ * @module
+ */
+
+import type { CommandOutput } from "@zuke/core/shell";
+import type { TestCounts } from "@zuke/core";
+import { stripAnsi } from "@zuke/core/render";
+
+/** One category line of the closing block. */
+const CATEGORY = /^\s*(\d+) (pass|fail|skip|todo)$/gm;
+/** The line that says the run completed. */
+const RAN = /^Ran \d+ tests? across \d+ files?\./m;
+
+/**
+ * The counts from the closing block, or `undefined` when the run never
+ * printed its `Ran` line — it did not complete, or a reporter replaced the
+ * block.
+ */
+export function parseTestSummary(
+  output: CommandOutput,
+): TestCounts | undefined {
+  const text = stripAnsi(output.stderr);
+  if (!RAN.test(text)) return undefined;
+  const found = new Map<string, number>();
+  for (const m of text.matchAll(CATEGORY)) found.set(m[2], Number(m[1]));
+  return {
+    passed: found.get("pass") ?? 0,
+    failed: found.get("fail") ?? 0,
+    skipped: found.get("skip") ?? 0,
+    todo: found.get("todo") ?? 0,
+  };
+}

--- a/packages/bun/tests/test_summary_test.ts
+++ b/packages/bun/tests/test_summary_test.ts
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals } from "../../core/tests/_assert.ts";
+import {
+  TargetSummary,
+  withAmbientSummary,
+} from "../../core/src/summary_note.ts";
+import { CommandOutput } from "@zuke/core/shell";
+import { BunTestSettings } from "../src/bun.ts";
+import { parseTestSummary } from "../src/test_summary.ts";
+
+/** A run's output with the given streams and exit code. */
+function out(code: number, stdout = "", stderr = ""): CommandOutput {
+  return new CommandOutput(code, stdout, stderr);
+}
+
+Deno.test("bun test: the closing block on stderr yields every category", () => {
+  const text =
+    "\n 1 pass\n 1 skip\n 1 todo\n 1 fail\n 2 expect() calls\nRan 4 tests across 1 file. [114.00ms]\n";
+  assertEquals(parseTestSummary(out(1, "bun test v1.3.11\n", text)), {
+    passed: 1,
+    failed: 1,
+    skipped: 1,
+    todo: 1,
+  });
+  assertEquals(
+    parseTestSummary(
+      out(0, "", " 12 pass\n 0 fail\nRan 12 tests across 3 files. [50.00ms]\n"),
+    ),
+    { passed: 12, failed: 0, skipped: 0, todo: 0 },
+  );
+});
+
+Deno.test("bun test: a run without the Ran line did not complete and reports nothing", () => {
+  assertEquals(
+    parseTestSummary(out(1, "", "error: Cannot find module\n")),
+    undefined,
+  );
+  assertEquals(parseTestSummary(out(0)), undefined);
+});
+
+/** Exposes the protected hook so the wiring can be exercised without bun. */
+class Probe extends BunTestSettings {
+  probe(output: CommandOutput): void {
+    this.onOutput(output);
+  }
+}
+
+Deno.test("bun test: the hook reports the shared shape onto the running target", async () => {
+  const summary = new TargetSummary();
+  await withAmbientSummary(summary, () => {
+    new Probe().probe(
+      out(0, "", " 3 pass\n 1 skip\nRan 4 tests across 1 file. [9.00ms]\n"),
+    );
+    return Promise.resolve();
+  });
+  assertEquals(summary.entries(), [
+    { key: "Tests", value: "4" },
+    { key: "Passed", value: "3" },
+    { key: "Failed", value: "0" },
+    { key: "Skipped", value: "1" },
+  ]);
+});

--- a/packages/cypress/README.md
+++ b/packages/cypress/README.md
@@ -67,6 +67,8 @@ class CypressRunSettings extends CypressTestingSettings
     Tag the recorded run (`--tag`).
   port(value: number): this
     Override the server port (`--port`).
+  override protected onOutput(output: CommandOutput): void
+    Report the run's counts onto the build summary (see the module docs).
   override protected buildArgs(): string[]
     Assemble the `cypress run` argv.
 

--- a/packages/cypress/deno.json
+++ b/packages/cypress/deno.json
@@ -7,7 +7,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1.25.0"
+    "@zuke/core": "jsr:@zuke/core@^1.45.0"
   },
   "publish": {
     "exclude": [

--- a/packages/cypress/src/cypress.ts
+++ b/packages/cypress/src/cypress.ts
@@ -25,6 +25,8 @@ import {
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
+import { reportTestCounts } from "@zuke/core";
+import { parseTestSummary } from "./test_summary.ts";
 
 /** Base for all `cypress` subcommand settings: the binary is `cypress`. */
 export abstract class CypressSettings extends ToolSettings {
@@ -137,6 +139,12 @@ export class CypressRunSettings extends CypressTestingSettings {
   port(value: number): this {
     this.#port = value;
     return this;
+  }
+
+  /** Report the run's counts onto the build summary (see the module docs). */
+  protected override onOutput(output: CommandOutput): void {
+    const counts = parseTestSummary(output);
+    if (counts !== undefined) reportTestCounts(counts);
   }
 
   /** Assemble the `cypress run` argv. */

--- a/packages/cypress/src/test_summary.ts
+++ b/packages/cypress/src/test_summary.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * The counts a `cypress run` reports onto its target's row of the build
+ * summary, summed from the `(Results)` box cypress prints after each spec:
+ *
+ * ```text
+ *   │ Tests:        3                                                    │
+ *   │ Passing:      2                                                    │
+ *   │ Failing:      1                                                    │
+ *   │ Pending:      0                                                    │
+ *   │ Skipped:      0                                                    │
+ * ```
+ *
+ * Internal to the wrapper.
+ *
+ * @module
+ */
+
+import type { CommandOutput } from "@zuke/core/shell";
+import type { TestCounts } from "@zuke/core";
+import { stripAnsi } from "@zuke/core/render";
+
+/** One count row of a spec's `(Results)` box. */
+const ROW = /│\s+(Passing|Failing|Pending|Skipped):\s+(\d+)/g;
+
+/**
+ * The counts summed over every spec's box, or `undefined` when no box was
+ * printed — a run that never started a spec, or a reporter without the box.
+ * Pending tests (`it.skip`) and tests skipped after a failure both count as
+ * skipped.
+ */
+export function parseTestSummary(
+  output: CommandOutput,
+): TestCounts | undefined {
+  const totals = new Map<string, number>();
+  for (const m of stripAnsi(output.stdout).matchAll(ROW)) {
+    totals.set(m[1], (totals.get(m[1]) ?? 0) + Number(m[2]));
+  }
+  if (!totals.has("Passing")) return undefined;
+  return {
+    passed: totals.get("Passing") ?? 0,
+    failed: totals.get("Failing") ?? 0,
+    skipped: (totals.get("Pending") ?? 0) + (totals.get("Skipped") ?? 0),
+  };
+}

--- a/packages/cypress/tests/test_summary_test.ts
+++ b/packages/cypress/tests/test_summary_test.ts
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals } from "../../core/tests/_assert.ts";
+import {
+  TargetSummary,
+  withAmbientSummary,
+} from "../../core/src/summary_note.ts";
+import { CommandOutput } from "@zuke/core/shell";
+import { CypressRunSettings } from "../src/cypress.ts";
+import { parseTestSummary } from "../src/test_summary.ts";
+
+/** A run's output with the given streams and exit code. */
+function out(code: number, stdout = "", stderr = ""): CommandOutput {
+  return new CommandOutput(code, stdout, stderr);
+}
+
+/** One spec's `(Results)` box, as cypress prints it. */
+function box(
+  tests: number,
+  passing: number,
+  failing: number,
+  pending: number,
+  skipped: number,
+): string {
+  const row = (label: string, n: number) =>
+    `  │ ${label.padEnd(13)}${String(n).padEnd(52)}│\n`;
+  return "  (Results)\n\n  ┌────────────────────────────────────────────────────────────────┐\n" +
+    row("Tests:", tests) + row("Passing:", passing) + row("Failing:", failing) +
+    row("Pending:", pending) + row("Skipped:", skipped) +
+    row("Screenshots:", 0) +
+    "  └────────────────────────────────────────────────────────────────┘\n";
+}
+
+Deno.test("cypress run: the per-spec Results boxes are summed", () => {
+  const text = box(3, 2, 1, 0, 0) + "\n" + box(4, 3, 0, 1, 0) +
+    "\n  ✖  1 of 2 failed (50%)\n";
+  assertEquals(parseTestSummary(out(1, text)), {
+    passed: 5,
+    failed: 1,
+    skipped: 1,
+  });
+  assertEquals(parseTestSummary(out(0, box(2, 2, 0, 0, 0))), {
+    passed: 2,
+    failed: 0,
+    skipped: 0,
+  });
+  // Pending (it.skip) and skipped-after-failure both count as skipped.
+  assertEquals(parseTestSummary(out(1, box(5, 1, 1, 2, 1))), {
+    passed: 1,
+    failed: 1,
+    skipped: 3,
+  });
+});
+
+Deno.test("cypress run: no Results box means nothing to report", () => {
+  assertEquals(parseTestSummary(out(0)), undefined);
+  assertEquals(
+    parseTestSummary(out(1, "Could not find a Cypress configuration file.\n")),
+    undefined,
+  );
+});
+
+/** Exposes the protected hook so the wiring can be exercised without cypress. */
+class Probe extends CypressRunSettings {
+  probe(output: CommandOutput): void {
+    this.onOutput(output);
+  }
+}
+
+Deno.test("cypress run: the hook reports the shared shape onto the running target", async () => {
+  const summary = new TargetSummary();
+  await withAmbientSummary(summary, () => {
+    new Probe().probe(out(0, box(3, 3, 0, 0, 0)));
+    return Promise.resolve();
+  });
+  assertEquals(summary.entries(), [
+    { key: "Tests", value: "3" },
+    { key: "Passed", value: "3" },
+    { key: "Failed", value: "0" },
+  ]);
+});

--- a/packages/deno/README.md
+++ b/packages/deno/README.md
@@ -971,8 +971,8 @@ class DenoTestSettings extends DenoPermissionSettings
 
   A run reports its counts into the running target's row of the build
   summary — `// Tests: 837 · Passed: 837 · Failed: 0` — read from the result
-  line the pretty and dot reporters print; a failed run reports too, so a red
-  row says how many failed. The JUnit and TAP reporters print no such line,
+  line the pretty and dot reporters print (ignored tests count as `Skipped`);
+  a failed run reports too, so a red row says how many failed. The JUnit and TAP reporters print no such line,
   so a run under `.reporter("junit")`/`.reporter("tap")` reports nothing.
 
   paths(...paths: PathLike[]): this

--- a/packages/deno/deno.json
+++ b/packages/deno/deno.json
@@ -7,7 +7,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1.44.0"
+    "@zuke/core": "jsr:@zuke/core@^1.45.0"
   },
   "publish": {
     "exclude": [

--- a/packages/deno/src/test_summary.ts
+++ b/packages/deno/src/test_summary.ts
@@ -5,25 +5,15 @@
  * The counts `deno test` prints on its result line, and how they land in a
  * build's summary row. `DenoTasks.test` reads them from the run's captured
  * stdout — the pretty and dot reporters both end with the same line — and
- * reports them through `@zuke/core`'s ambient `reportSummary`, so a `test`
- * target's row says `// Tests: 837 · Passed: 837 · Failed: 0` without the
- * build author writing a thing. Internal to the wrapper.
+ * reports them through `@zuke/core`'s `reportTestCounts`, so a `test`
+ * target's row says `// Tests: 837 · Passed: 837 · Failed: 0` in the shape
+ * every test-runner wrapper shares. Internal to the wrapper.
  *
  * @module
  */
 
 import { stripAnsi } from "@zuke/core/render";
-import type { SummaryPairs } from "@zuke/core";
-
-/** The counts on a `deno test` result line. */
-export interface DenoTestCounts {
-  /** Tests that passed. */
-  readonly passed: number;
-  /** Tests that failed. */
-  readonly failed: number;
-  /** Tests marked `ignore` (deno prints the count only when it is non-zero). */
-  readonly ignored: number;
-}
+import type { TestCounts } from "@zuke/core";
 
 /**
  * Deno's result line: `ok | 2 passed (2 steps) | 0 failed | 1 ignored (50ms)`
@@ -54,8 +44,8 @@ const DURATION = / \([^()]*\)$/;
  * ones (`ignored`, `measured`, `filtered out`) a run happens to include. A
  * line without both `passed` and `failed` is not a result line.
  */
-export function parseTestSummary(stdout: string): DenoTestCounts | undefined {
-  let counts: DenoTestCounts | undefined;
+export function parseTestSummary(stdout: string): TestCounts | undefined {
+  let counts: TestCounts | undefined;
   for (const m of stripAnsi(stdout).matchAll(RESULT_LINE)) {
     const found = new Map<string, number>();
     for (const segment of m[1].replace(DURATION, "").split(" | ")) {
@@ -65,22 +55,8 @@ export function parseTestSummary(stdout: string): DenoTestCounts | undefined {
     const passed = found.get("passed");
     const failed = found.get("failed");
     if (passed === undefined || failed === undefined) continue;
-    counts = { passed, failed, ignored: found.get("ignored") ?? 0 };
+    // Deno's `ignored` is the shared shape's `skipped`.
+    counts = { passed, failed, skipped: found.get("ignored") ?? 0 };
   }
   return counts;
-}
-
-/**
- * The notes a test run reports into its summary row: the total the run
- * selected (passed, failed and ignored), the passed and failed counts, and the
- * ignored count only when it is non-zero — mirroring the result line itself.
- */
-export function testSummaryPairs(counts: DenoTestCounts): SummaryPairs {
-  const pairs: Record<string, number> = {
-    Tests: counts.passed + counts.failed + counts.ignored,
-    Passed: counts.passed,
-    Failed: counts.failed,
-  };
-  if (counts.ignored > 0) pairs.Ignored = counts.ignored;
-  return pairs;
 }

--- a/packages/deno/src/testing.ts
+++ b/packages/deno/src/testing.ts
@@ -8,9 +8,9 @@
 
 import type { PathLike } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
-import { reportSummary } from "@zuke/core";
+import { reportTestCounts } from "@zuke/core";
 import { DenoPermissionSettings, DenoSettings } from "./settings.ts";
-import { parseTestSummary, testSummaryPairs } from "./test_summary.ts";
+import { parseTestSummary } from "./test_summary.ts";
 import type { CoverageThresholds } from "./coverage.ts";
 import {
   ConfigFlags,
@@ -32,8 +32,8 @@ export type DenoTestReporter = "pretty" | "dot" | "junit" | "tap";
  *
  * A run reports its counts into the running target's row of the build
  * summary — `// Tests: 837 · Passed: 837 · Failed: 0` — read from the result
- * line the pretty and dot reporters print; a failed run reports too, so a red
- * row says how many failed. The JUnit and TAP reporters print no such line,
+ * line the pretty and dot reporters print (ignored tests count as `Skipped`);
+ * a failed run reports too, so a red row says how many failed. The JUnit and TAP reporters print no such line,
  * so a run under `.reporter("junit")`/`.reporter("tap")` reports nothing.
  */
 export class DenoTestSettings extends DenoPermissionSettings {
@@ -368,7 +368,7 @@ export class DenoTestSettings extends DenoPermissionSettings {
   /** Report the run's counts into the build summary (see the class docs). */
   protected override onOutput(output: CommandOutput): void {
     const counts = parseTestSummary(output.stdout);
-    if (counts !== undefined) reportSummary(testSummaryPairs(counts));
+    if (counts !== undefined) reportTestCounts(counts);
   }
 
   /** Assemble the `deno test` argv. */

--- a/packages/deno/tests/test_summary_test.ts
+++ b/packages/deno/tests/test_summary_test.ts
@@ -7,7 +7,7 @@ import {
   withAmbientSummary,
 } from "../../core/src/summary_note.ts";
 import { CommandError } from "@zuke/core/shell";
-import { parseTestSummary, testSummaryPairs } from "../src/test_summary.ts";
+import { parseTestSummary } from "../src/test_summary.ts";
 import { DenoTasks } from "../src/deno.ts";
 
 // The fixtures are addressed by `file://` URL, which is byte-identical on
@@ -20,37 +20,37 @@ Deno.test("parseTestSummary reads the pretty/dot result line in each of its shap
   assertEquals(parseTestSummary("ok | 5 passed | 0 failed (12ms)\n"), {
     passed: 5,
     failed: 0,
-    ignored: 0,
+    skipped: 0,
   });
   assertEquals(
     parseTestSummary(
       "FAILED | 1 passed | 1 failed (66ms)\n\nerror: Test failed\n",
     ),
-    { passed: 1, failed: 1, ignored: 0 },
+    { passed: 1, failed: 1, skipped: 0 },
   );
   assertEquals(
     parseTestSummary(
       "ok | 2 passed (2 steps) | 0 failed (1 step) | 1 ignored (3 steps) (50ms)",
     ),
-    { passed: 2, failed: 0, ignored: 1 },
+    { passed: 2, failed: 0, skipped: 1 },
   );
   assertEquals(
     parseTestSummary(
       "ok | 1 passed | 0 failed | 2 measured | 3 filtered out (4ms)",
     ),
-    { passed: 1, failed: 0, ignored: 0 },
+    { passed: 1, failed: 0, skipped: 0 },
   );
 });
 
 Deno.test("parseTestSummary ignores deno's colour codes and takes the last result line", () => {
   const styled =
     "\x1b[0m\x1b[32mok\x1b[0m | 3 passed | 0 failed \x1b[38;5;245m(9ms)\x1b[0m\n";
-  assertEquals(parseTestSummary(styled), { passed: 3, failed: 0, ignored: 0 });
+  assertEquals(parseTestSummary(styled), { passed: 3, failed: 0, skipped: 0 });
   // A test that prints a look-alike line cannot pose as the run's result: deno
   // prints its own line last.
   const echoed =
     "ok | 99 passed | 0 failed (1ms)\nFAILED | 1 passed | 2 failed (5ms)\n";
-  assertEquals(parseTestSummary(echoed), { passed: 1, failed: 2, ignored: 0 });
+  assertEquals(parseTestSummary(echoed), { passed: 1, failed: 2, skipped: 0 });
 });
 
 Deno.test("parseTestSummary reads the segments by name, whatever order they come in", () => {
@@ -60,12 +60,12 @@ Deno.test("parseTestSummary reads the segments by name, whatever order they come
     parseTestSummary(
       "ok | 3 filtered out | 2 measured | 1 ignored | 4 passed | 0 failed (7ms)",
     ),
-    { passed: 4, failed: 0, ignored: 1 },
+    { passed: 4, failed: 0, skipped: 1 },
   );
   // A duration on the last segment must not swallow that segment's count.
   assertEquals(
     parseTestSummary("FAILED | 0 passed | 2 failed (1 step) (3ms)"),
-    { passed: 0, failed: 2, ignored: 0 },
+    { passed: 0, failed: 2, skipped: 0 },
   );
   // A verdict line without both passed and failed is not a result line.
   assertEquals(parseTestSummary("ok | 3 filtered out (1ms)"), undefined);
@@ -81,20 +81,6 @@ Deno.test("parseTestSummary reports nothing for output without a result line", (
   assertEquals(parseTestSummary("  ok | 1 passed | 0 failed (1ms)"), undefined);
 });
 
-Deno.test("testSummaryPairs totals the selected tests and names Ignored only when non-zero", () => {
-  assertEquals(testSummaryPairs({ passed: 4, failed: 1, ignored: 0 }), {
-    Tests: 5,
-    Passed: 4,
-    Failed: 1,
-  });
-  assertEquals(testSummaryPairs({ passed: 2, failed: 0, ignored: 1 }), {
-    Tests: 3,
-    Passed: 2,
-    Failed: 0,
-    Ignored: 1,
-  });
-});
-
 Deno.test("DenoTasks.test reports a real run's counts into the ambient summary", async () => {
   const summary = new TargetSummary();
   const out = await withAmbientSummary(
@@ -106,7 +92,7 @@ Deno.test("DenoTasks.test reports a real run's counts into the ambient summary",
     { key: "Tests", value: "3" },
     { key: "Passed", value: "2" },
     { key: "Failed", value: "0" },
-    { key: "Ignored", value: "1" },
+    { key: "Skipped", value: "1" },
   ]);
 });
 

--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -81,6 +81,8 @@ class JestSettings extends ToolSettings
     Restrict to named projects (`--selectProjects`); repeatable.
   reporters(...names: string[]): this
     Use the named reporters (`--reporters`); repeatable.
+  override protected onOutput(output: CommandOutput): void
+    Report the run's counts onto the build summary (see the module docs).
   override protected buildArgs(): string[]
     Assemble the `jest` argv from the configured flags and patterns.
 

--- a/packages/jest/deno.json
+++ b/packages/jest/deno.json
@@ -7,7 +7,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1.25.0"
+    "@zuke/core": "jsr:@zuke/core@^1.45.0"
   },
   "publish": {
     "exclude": [

--- a/packages/jest/src/jest.ts
+++ b/packages/jest/src/jest.ts
@@ -26,6 +26,8 @@ import {
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
+import { reportTestCounts } from "@zuke/core";
+import { parseTestSummary } from "./test_summary.ts";
 
 /** Settings for a `jest` run. */
 export class JestSettings extends ToolSettings {
@@ -164,6 +166,12 @@ export class JestSettings extends ToolSettings {
   reporters(...names: string[]): this {
     this.#reporters.push(...names);
     return this;
+  }
+
+  /** Report the run's counts onto the build summary (see the module docs). */
+  protected override onOutput(output: CommandOutput): void {
+    const counts = parseTestSummary(output);
+    if (counts !== undefined) reportTestCounts(counts);
   }
 
   /** Assemble the `jest` argv from the configured flags and patterns. */

--- a/packages/jest/src/test_summary.ts
+++ b/packages/jest/src/test_summary.ts
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * The counts a `jest` run reports onto its target's row of the build
+ * summary, read from the closing `Tests:` line jest prints on stderr:
+ * `Tests:       1 failed, 1 skipped, 1 todo, 2 passed, 5 total`. Internal to
+ * the wrapper.
+ *
+ * @module
+ */
+
+import type { CommandOutput } from "@zuke/core/shell";
+import type { TestCounts } from "@zuke/core";
+import { stripAnsi } from "@zuke/core/render";
+
+/** The `Tests:` closing line: comma-separated `N category` segments. */
+const TESTS_LINE = /^Tests:\s+(.+)$/m;
+/** One segment of the closing line. */
+const SEGMENT = /^(\d+) (passed|failed|skipped|todo|total)$/;
+
+/**
+ * The counts from the `Tests:` line, or `undefined` when the run printed
+ * none — a JSON reporter, or a run that never got to its tests. The segments
+ * are read by name, so their order does not matter.
+ */
+export function parseTestSummary(
+  output: CommandOutput,
+): TestCounts | undefined {
+  const m = TESTS_LINE.exec(stripAnsi(output.stderr));
+  if (m === null) return undefined;
+  const found = new Map<string, number>();
+  for (const segment of m[1].split(",")) {
+    const c = SEGMENT.exec(segment.trim());
+    if (c !== null) found.set(c[2], Number(c[1]));
+  }
+  if (!found.has("total")) return undefined;
+  return {
+    passed: found.get("passed") ?? 0,
+    failed: found.get("failed") ?? 0,
+    skipped: found.get("skipped") ?? 0,
+    todo: found.get("todo") ?? 0,
+  };
+}

--- a/packages/jest/tests/test_summary_test.ts
+++ b/packages/jest/tests/test_summary_test.ts
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals } from "../../core/tests/_assert.ts";
+import {
+  TargetSummary,
+  withAmbientSummary,
+} from "../../core/src/summary_note.ts";
+import { CommandOutput } from "@zuke/core/shell";
+import { JestSettings } from "../src/jest.ts";
+import { parseTestSummary } from "../src/test_summary.ts";
+
+/** A run's output with the given streams and exit code. */
+function out(code: number, stdout = "", stderr = ""): CommandOutput {
+  return new CommandOutput(code, stdout, stderr);
+}
+
+Deno.test("jest: the Tests: line on stderr yields every category, in any order", () => {
+  const text =
+    "Test Suites: 1 failed, 1 passed, 2 total\nTests:       1 failed, 1 skipped, 1 todo, 2 passed, 5 total\nSnapshots:   0 total\nTime:        0.57 s\n";
+  assertEquals(parseTestSummary(out(1, "", text)), {
+    passed: 2,
+    failed: 1,
+    skipped: 1,
+    todo: 1,
+  });
+  assertEquals(
+    parseTestSummary(
+      out(
+        0,
+        "",
+        "Test Suites: 1 passed, 1 total\nTests:       1 passed, 1 total\n",
+      ),
+    ),
+    { passed: 1, failed: 0, skipped: 0, todo: 0 },
+  );
+  assertEquals(
+    parseTestSummary(
+      out(
+        0,
+        "",
+        "\x1b[1mTests:\x1b[22m       \x1b[1m\x1b[32m3 passed\x1b[39m\x1b[22m, 3 total\n",
+      ),
+    ),
+    { passed: 3, failed: 0, skipped: 0, todo: 0 },
+  );
+});
+
+Deno.test("jest: no Tests: line, or one without a total, means nothing to report", () => {
+  assertEquals(parseTestSummary(out(0)), undefined);
+  assertEquals(
+    parseTestSummary(out(1, "", "No tests found, exiting with code 1")),
+    undefined,
+  );
+  assertEquals(
+    parseTestSummary(out(0, "", "Tests: something else entirely\n")),
+    undefined,
+  );
+});
+
+/** Exposes the protected hook so the wiring can be exercised without jest. */
+class Probe extends JestSettings {
+  probe(output: CommandOutput): void {
+    this.onOutput(output);
+  }
+}
+
+Deno.test("jest: the hook reports the shared shape onto the running target", async () => {
+  const summary = new TargetSummary();
+  await withAmbientSummary(summary, () => {
+    new Probe().probe(
+      out(1, "", "Tests:       1 failed, 1 skipped, 2 passed, 4 total\n"),
+    );
+    return Promise.resolve();
+  });
+  assertEquals(summary.entries(), [
+    { key: "Tests", value: "4" },
+    { key: "Passed", value: "2" },
+    { key: "Failed", value: "1" },
+    { key: "Skipped", value: "1" },
+  ]);
+});

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -164,6 +164,8 @@ class NodeTestSettings extends NodeSettings
     Re-run tests on file changes (`--watch`).
   experimentalTestCoverage(): this
     Collect and report test coverage (`--experimental-test-coverage`).
+  override protected onOutput(output: CommandOutput): void
+    Report the run's counts onto the build summary (see the module docs).
   override protected buildArgs(): string[]
     Assemble the `node --test [paths] [flags]` argv.
 

--- a/packages/node/deno.json
+++ b/packages/node/deno.json
@@ -7,7 +7,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1.32.0"
+    "@zuke/core": "jsr:@zuke/core@^1.45.0"
   },
   "publish": {
     "exclude": [

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -31,6 +31,8 @@
 
 import { type Configure, type PathLike, runSettings } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
+import { reportTestCounts } from "@zuke/core";
+import { parseTestSummary } from "./test_summary.ts";
 import type { JsonValue } from "@zuke/core";
 import { NodeSettings } from "./settings.ts";
 import { evaluateModule, type NodeEvaluateSettings } from "./evaluate.ts";
@@ -240,6 +242,12 @@ export class NodeTestSettings extends NodeSettings {
   experimentalTestCoverage(): this {
     this.#experimentalTestCoverage = true;
     return this;
+  }
+
+  /** Report the run's counts onto the build summary (see the module docs). */
+  protected override onOutput(output: CommandOutput): void {
+    const counts = parseTestSummary(output);
+    if (counts !== undefined) reportTestCounts(counts);
   }
 
   /** Assemble the `node --test [paths] [flags]` argv. */

--- a/packages/node/src/test_summary.ts
+++ b/packages/node/src/test_summary.ts
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * The counts a `node --test` run reports onto its target's row of the build
+ * summary, read from the closing block both built-in reporters print — the
+ * TAP reporter node uses when piped (`# pass 1`) and the spec reporter it
+ * uses on a terminal (`ℹ pass 1`): `tests`, `pass`, `fail`,
+ * `cancelled`, `skipped` and `todo`. Internal to the wrapper.
+ *
+ * @module
+ */
+
+import type { CommandOutput } from "@zuke/core/shell";
+import type { TestCounts } from "@zuke/core";
+import { stripAnsi } from "@zuke/core/render";
+
+/** One line of the closing block, in either reporter's prefix. */
+const LINE = /^(?:#|ℹ) (pass|fail|cancelled|skipped|todo) (\d+)$/gm;
+
+/**
+ * The counts from the closing block, or `undefined` when the run printed no
+ * `pass` line — a JUnit or dot reporter, or a run that never got to its
+ * tests. A test cancelled because its parent failed counts as failed.
+ */
+export function parseTestSummary(
+  output: CommandOutput,
+): TestCounts | undefined {
+  const found = new Map<string, number>();
+  for (const m of stripAnsi(output.stdout).matchAll(LINE)) {
+    found.set(m[1], Number(m[2]));
+  }
+  const passed = found.get("pass");
+  if (passed === undefined) return undefined;
+  return {
+    passed,
+    failed: (found.get("fail") ?? 0) + (found.get("cancelled") ?? 0),
+    skipped: found.get("skipped") ?? 0,
+    todo: found.get("todo") ?? 0,
+  };
+}

--- a/packages/node/tests/test_summary_test.ts
+++ b/packages/node/tests/test_summary_test.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals } from "../../core/tests/_assert.ts";
+import {
+  TargetSummary,
+  withAmbientSummary,
+} from "../../core/src/summary_note.ts";
+import { CommandOutput } from "@zuke/core/shell";
+import { NodeTestSettings } from "../src/node.ts";
+import { parseTestSummary } from "../src/test_summary.ts";
+
+/** A run's output with the given streams and exit code. */
+function out(code: number, stdout = "", stderr = ""): CommandOutput {
+  return new CommandOutput(code, stdout, stderr);
+}
+
+Deno.test("node --test: the TAP block node prints when piped yields every category", () => {
+  const tap =
+    "1..4\n# tests 4\n# suites 0\n# pass 1\n# fail 1\n# cancelled 0\n# skipped 1\n# todo 1\n# duration_ms 158.3\n";
+  assertEquals(parseTestSummary(out(1, tap)), {
+    passed: 1,
+    failed: 1,
+    skipped: 1,
+    todo: 1,
+  });
+});
+
+Deno.test("node --test: the spec block it prints on a terminal is read the same way", () => {
+  const spec =
+    "ℹ tests 4\nℹ suites 0\nℹ pass 1\nℹ fail 1\nℹ cancelled 1\nℹ skipped 1\nℹ todo 0\nℹ duration_ms 89.5\n";
+  // A cancelled test is one that never got its verdict because its parent
+  // failed, so it counts as failed.
+  assertEquals(parseTestSummary(out(1, spec)), {
+    passed: 1,
+    failed: 2,
+    skipped: 1,
+    todo: 0,
+  });
+});
+
+Deno.test("node --test: no pass line means nothing to report", () => {
+  assertEquals(parseTestSummary(out(0)), undefined);
+  assertEquals(
+    parseTestSummary(out(1, "", "node: bad option: --no-such-flag")),
+    undefined,
+  );
+});
+
+/** Exposes the protected hook so the wiring can be exercised without node. */
+class Probe extends NodeTestSettings {
+  probe(output: CommandOutput): void {
+    this.onOutput(output);
+  }
+}
+
+Deno.test("node --test: the hook reports the shared shape onto the running target", async () => {
+  const summary = new TargetSummary();
+  await withAmbientSummary(summary, () => {
+    new Probe().probe(out(0, "# tests 2\n# pass 2\n# fail 0\n"));
+    return Promise.resolve();
+  });
+  assertEquals(summary.entries(), [
+    { key: "Tests", value: "2" },
+    { key: "Passed", value: "2" },
+    { key: "Failed", value: "0" },
+  ]);
+});

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -92,6 +92,8 @@ class PlaywrightTestSettings extends PlaywrightSettings
     Use a specific config file (`--config=`).
   paths(...filters: string[]): this
     Test file or directory filters to run; omit to run all tests.
+  override protected onOutput(output: CommandOutput): void
+    Report the run's counts onto the build summary (see the module docs).
   override protected buildArgs(): string[]
     Assemble the `playwright test` argv.
 

--- a/packages/playwright/deno.json
+++ b/packages/playwright/deno.json
@@ -7,7 +7,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1.25.0"
+    "@zuke/core": "jsr:@zuke/core@^1.45.0"
   },
   "publish": {
     "exclude": [

--- a/packages/playwright/src/playwright.ts
+++ b/packages/playwright/src/playwright.ts
@@ -25,6 +25,8 @@ import {
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
+import { reportTestCounts } from "@zuke/core";
+import { parseTestSummary } from "./test_summary.ts";
 
 /** Base for all Playwright subcommand settings: binary is `playwright`. */
 export abstract class PlaywrightSettings extends ToolSettings {
@@ -103,6 +105,12 @@ export class PlaywrightTestSettings extends PlaywrightSettings {
   paths(...filters: string[]): this {
     this.#paths.push(...filters);
     return this;
+  }
+
+  /** Report the run's counts onto the build summary (see the module docs). */
+  protected override onOutput(output: CommandOutput): void {
+    const counts = parseTestSummary(output);
+    if (counts !== undefined) reportTestCounts(counts);
   }
 
   /** Assemble the `playwright test` argv. */

--- a/packages/playwright/src/test_summary.ts
+++ b/packages/playwright/src/test_summary.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * The counts a `playwright test` run reports onto its target's row of the
+ * build summary, read from the closing block the list, line and dot
+ * reporters print — one line per category, only when non-zero:
+ *
+ * ```text
+ *   1 failed
+ *     tests/a.spec.ts:3:1 › two ───
+ *   1 flaky
+ *   1 skipped
+ *   2 passed (1.5s)
+ * ```
+ *
+ * Internal to the wrapper.
+ *
+ * @module
+ */
+
+import type { CommandOutput } from "@zuke/core/shell";
+import type { TestCounts } from "@zuke/core";
+import { stripAnsi } from "@zuke/core/render";
+
+/** One category line of the closing block. */
+const CATEGORY =
+  /^\s{0,2}(\d+) (passed|failed|flaky|skipped|did not run|interrupted)\b/gm;
+
+/**
+ * The counts from the closing block, or `undefined` when the run printed no
+ * `passed` or `failed` line — a JSON or JUnit reporter, or a run that never
+ * got to its tests. A test that did not run counts as skipped; an interrupted
+ * one as failed.
+ */
+export function parseTestSummary(
+  output: CommandOutput,
+): TestCounts | undefined {
+  const found = new Map<string, number>();
+  for (const m of stripAnsi(output.stdout).matchAll(CATEGORY)) {
+    found.set(m[2], Number(m[1]));
+  }
+  if (!found.has("passed") && !found.has("failed")) return undefined;
+  return {
+    passed: found.get("passed") ?? 0,
+    failed: (found.get("failed") ?? 0) + (found.get("interrupted") ?? 0),
+    skipped: (found.get("skipped") ?? 0) + (found.get("did not run") ?? 0),
+    flaky: found.get("flaky") ?? 0,
+  };
+}

--- a/packages/playwright/tests/test_summary_test.ts
+++ b/packages/playwright/tests/test_summary_test.ts
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals } from "../../core/tests/_assert.ts";
+import {
+  TargetSummary,
+  withAmbientSummary,
+} from "../../core/src/summary_note.ts";
+import { CommandOutput } from "@zuke/core/shell";
+import { PlaywrightTestSettings } from "../src/playwright.ts";
+import { parseTestSummary } from "../src/test_summary.ts";
+
+/** A run's output with the given streams and exit code. */
+function out(code: number, stdout = "", stderr = ""): CommandOutput {
+  return new CommandOutput(code, stdout, stderr);
+}
+
+Deno.test("playwright test: the closing block yields every category", () => {
+  const text =
+    "\n  1 failed\n    tests/a.spec.ts:3:1 › two ───\n  1 flaky\n    tests/a.spec.ts:9:1 › five ───\n  1 skipped\n  2 passed (1.5s)\n";
+  assertEquals(parseTestSummary(out(1, text)), {
+    passed: 2,
+    failed: 1,
+    skipped: 1,
+    flaky: 1,
+  });
+  assertEquals(parseTestSummary(out(0, "\n  3 passed (900ms)\n")), {
+    passed: 3,
+    failed: 0,
+    skipped: 0,
+    flaky: 0,
+  });
+  // Interrupted tests failed to finish; tests that did not run were skipped.
+  assertEquals(
+    parseTestSummary(
+      out(1, "  1 failed\n  2 interrupted\n  3 did not run\n  4 passed (2s)\n"),
+    ),
+    { passed: 4, failed: 3, skipped: 3, flaky: 0 },
+  );
+});
+
+Deno.test("playwright test: without a passed or failed line there is nothing to report", () => {
+  assertEquals(parseTestSummary(out(0)), undefined);
+  assertEquals(parseTestSummary(out(1, "Error: No tests found\n")), undefined);
+  // A line further indented is a failure detail, not the closing block.
+  assertEquals(
+    parseTestSummary(out(1, "      1 passed of something else\n")),
+    undefined,
+  );
+});
+
+/** Exposes the protected hook so the wiring can be exercised without playwright. */
+class Probe extends PlaywrightTestSettings {
+  probe(output: CommandOutput): void {
+    this.onOutput(output);
+  }
+}
+
+Deno.test("playwright test: the hook reports the shared shape onto the running target", async () => {
+  const summary = new TargetSummary();
+  await withAmbientSummary(summary, () => {
+    new Probe().probe(out(0, "  1 flaky\n  4 passed (3.1s)\n"));
+    return Promise.resolve();
+  });
+  assertEquals(summary.entries(), [
+    { key: "Tests", value: "5" },
+    { key: "Passed", value: "4" },
+    { key: "Failed", value: "0" },
+    { key: "Flaky", value: "1" },
+  ]);
+});

--- a/packages/vitest/README.md
+++ b/packages/vitest/README.md
@@ -94,6 +94,8 @@ class VitestSettings extends ToolSettings
     Pass when no tests are found (`--passWithNoTests`).
   silent(): this
     Suppress test console output (`--silent`).
+  override protected onOutput(output: CommandOutput): void
+    Report the run's counts onto the build summary (see the module docs).
   override protected buildArgs(): string[]
     Assemble the `vitest run`/`vitest watch` argv.
 

--- a/packages/vitest/deno.json
+++ b/packages/vitest/deno.json
@@ -7,7 +7,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1.25.0"
+    "@zuke/core": "jsr:@zuke/core@^1.45.0"
   },
   "publish": {
     "exclude": [

--- a/packages/vitest/src/test_summary.ts
+++ b/packages/vitest/src/test_summary.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * The counts a `vitest` run reports onto its target's row of the build
+ * summary, read from the closing line of the default and dot reporters:
+ * `Tests  1 failed | 2 passed | 1 skipped | 1 todo (5)`. Internal to the
+ * wrapper.
+ *
+ * @module
+ */
+
+import type { CommandOutput } from "@zuke/core/shell";
+import type { TestCounts } from "@zuke/core";
+import { stripAnsi } from "@zuke/core/render";
+
+/** The `Tests` closing line: `|`-separated `N category` segments, then the total. */
+const TESTS_LINE = /^\s*Tests\s+(.+?)\s+\((\d+)\)\s*$/m;
+/** One segment of the closing line. */
+const SEGMENT = /^(\d+) (passed|failed|skipped|todo)$/;
+
+/**
+ * The counts from the `Tests` line, or `undefined` when the run printed
+ * none — a JSON or JUnit reporter, or a run that never got to its tests. The
+ * segments are read by name, so their order does not matter.
+ */
+export function parseTestSummary(
+  output: CommandOutput,
+): TestCounts | undefined {
+  const m = TESTS_LINE.exec(stripAnsi(output.stdout));
+  if (m === null) return undefined;
+  const found = new Map<string, number>();
+  for (const segment of m[1].split(" | ")) {
+    const c = SEGMENT.exec(segment.trim());
+    if (c !== null) found.set(c[2], Number(c[1]));
+  }
+  return {
+    passed: found.get("passed") ?? 0,
+    failed: found.get("failed") ?? 0,
+    skipped: found.get("skipped") ?? 0,
+    todo: found.get("todo") ?? 0,
+  };
+}

--- a/packages/vitest/src/vitest.ts
+++ b/packages/vitest/src/vitest.ts
@@ -30,6 +30,8 @@ import {
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
+import { reportTestCounts } from "@zuke/core";
+import { parseTestSummary } from "./test_summary.ts";
 
 /** The Vitest worker pool implementation (`--pool`). */
 export type VitestPool = "threads" | "forks" | "vmThreads" | "vmForks";
@@ -199,6 +201,12 @@ export class VitestSettings extends ToolSettings {
   silent(): this {
     this.#silent = true;
     return this;
+  }
+
+  /** Report the run's counts onto the build summary (see the module docs). */
+  protected override onOutput(output: CommandOutput): void {
+    const counts = parseTestSummary(output);
+    if (counts !== undefined) reportTestCounts(counts);
   }
 
   /** Assemble the `vitest run`/`vitest watch` argv. */

--- a/packages/vitest/tests/test_summary_test.ts
+++ b/packages/vitest/tests/test_summary_test.ts
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals } from "../../core/tests/_assert.ts";
+import {
+  TargetSummary,
+  withAmbientSummary,
+} from "../../core/src/summary_note.ts";
+import { CommandOutput } from "@zuke/core/shell";
+import { VitestSettings } from "../src/vitest.ts";
+import { parseTestSummary } from "../src/test_summary.ts";
+
+/** A run's output with the given streams and exit code. */
+function out(code: number, stdout = "", stderr = ""): CommandOutput {
+  return new CommandOutput(code, stdout, stderr);
+}
+
+Deno.test("vitest: the Tests line yields every category, in any order", () => {
+  const text =
+    " Test Files  1 failed | 1 passed (2)\n      Tests  1 failed | 2 passed | 1 skipped | 1 todo (5)\n   Duration  195ms\n";
+  assertEquals(parseTestSummary(out(1, text)), {
+    passed: 2,
+    failed: 1,
+    skipped: 1,
+    todo: 1,
+  });
+  assertEquals(
+    parseTestSummary(
+      out(0, " Test Files  1 passed (1)\n      Tests  1 passed (1)\n"),
+    ),
+    { passed: 1, failed: 0, skipped: 0, todo: 0 },
+  );
+  assertEquals(
+    parseTestSummary(
+      out(
+        0,
+        "\x1b[2m      Tests \x1b[0m \x1b[1m\x1b[32m3 passed\x1b[39m\x1b[22m\x1b[90m (3)\x1b[39m\n",
+      ),
+    ),
+    { passed: 3, failed: 0, skipped: 0, todo: 0 },
+  );
+});
+
+Deno.test("vitest: no Tests line means nothing to report", () => {
+  assertEquals(
+    parseTestSummary(out(0, "No test files found, exiting with code 0\n")),
+    undefined,
+  );
+  assertEquals(
+    parseTestSummary(out(1, "", "Error: Failed to load config")),
+    undefined,
+  );
+  // The Test Files line alone is not the tests line.
+  assertEquals(
+    parseTestSummary(out(0, " Test Files  1 passed (1)\n")),
+    undefined,
+  );
+});
+
+/** Exposes the protected hook so the wiring can be exercised without vitest. */
+class Probe extends VitestSettings {
+  probe(output: CommandOutput): void {
+    this.onOutput(output);
+  }
+}
+
+Deno.test("vitest: the hook reports the shared shape onto the running target", async () => {
+  const summary = new TargetSummary();
+  await withAmbientSummary(summary, () => {
+    new Probe().probe(
+      out(1, "      Tests  1 failed | 2 passed | 1 todo (4)\n"),
+    );
+    return Promise.resolve();
+  });
+  assertEquals(summary.entries(), [
+    { key: "Tests", value: "4" },
+    { key: "Passed", value: "2" },
+    { key: "Failed", value: "1" },
+    { key: "Todo", value: "1" },
+  ]);
+});

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/.codex-plugin/plugin.json
+++ b/plugins/zuke/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/skills/zuke-write-build/SKILL.md
+++ b/plugins/zuke/skills/zuke-write-build/SKILL.md
@@ -118,8 +118,10 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   `AbortSignal` fired when the run is cancelled; a plain `` $`…` `` in the body
   is `SIGTERM`'d automatically), `ctx.state`, `ctx.dryRun`, and
   `ctx.reportSummary({ … })` (`key: value` notes on the target's own row of
-  the Build Summary; `DenoTasks.test` reports its test counts there by
-  itself, and the ambient `reportSummary` does the same from code with no
+  the Build Summary; every test-runner wrapper — `DenoTasks.test`,
+  `VitestTasks.run`, `JestTasks.run`, `BunTasks.test`, `NodeTasks.test`,
+  `PlaywrightTasks.test`, `CypressTasks.run` — reports its test counts there
+  by itself, and the ambient `reportSummary` does the same from code with no
   `ctx`).
   Zero-argument bodies keep working unchanged. Cancel a run programmatically by
   passing `{ signal }` to `execute`. See the cheatsheet.

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -162,9 +162,11 @@ pairs on the target's own row of the end-of-build summary, NUKE-style:
 `test  Succeeded  8.1s  // Tests: 837 · Passed: 837 · Failed: 0`. Notes
 accumulate; a repeated key replaces its value; each renders on one line, in the
 terminal and in the Actions job summary. A failed target keeps its notes.
-`DenoTasks.test` reports Tests/Passed/Failed (and Ignored when non-zero)
-itself, and `DenoTasks.coverage` reports the measured Lines/Branches — a body
-only adds what its tools do not. Library code with no `ctx` (a wrapper, a
+Every test-runner wrapper (`DenoTasks.test`, `VitestTasks.run`,
+`JestTasks.run`, `BunTasks.test`, `NodeTasks.test`, `PlaywrightTasks.test`,
+`CypressTasks.run`) reports Tests/Passed/Failed (and Skipped/Todo/Flaky when
+non-zero) itself, and `DenoTasks.coverage` reports the measured
+Lines/Branches — a body only adds what its tools do not. Library code with no `ctx` (a wrapper, a
 helper) uses the ambient `reportSummary(pairs)` from `@zuke/core`, which lands
 on the running target's row and is a no-op outside a run. Test counts have one
 shared shape: `reportTestCounts({ passed, failed, skipped?, todo?, flaky? })`

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -118,8 +118,10 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   `AbortSignal` fired when the run is cancelled; a plain `` $`…` `` in the body
   is `SIGTERM`'d automatically), `ctx.state`, `ctx.dryRun`, and
   `ctx.reportSummary({ … })` (`key: value` notes on the target's own row of
-  the Build Summary; `DenoTasks.test` reports its test counts there by
-  itself, and the ambient `reportSummary` does the same from code with no
+  the Build Summary; every test-runner wrapper — `DenoTasks.test`,
+  `VitestTasks.run`, `JestTasks.run`, `BunTasks.test`, `NodeTasks.test`,
+  `PlaywrightTasks.test`, `CypressTasks.run` — reports its test counts there
+  by itself, and the ambient `reportSummary` does the same from code with no
   `ctx`).
   Zero-argument bodies keep working unchanged. Cancel a run programmatically by
   passing `{ signal }` to `execute`. See the cheatsheet.

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -162,9 +162,11 @@ pairs on the target's own row of the end-of-build summary, NUKE-style:
 `test  Succeeded  8.1s  // Tests: 837 · Passed: 837 · Failed: 0`. Notes
 accumulate; a repeated key replaces its value; each renders on one line, in the
 terminal and in the Actions job summary. A failed target keeps its notes.
-`DenoTasks.test` reports Tests/Passed/Failed (and Ignored when non-zero)
-itself, and `DenoTasks.coverage` reports the measured Lines/Branches — a body
-only adds what its tools do not. Library code with no `ctx` (a wrapper, a
+Every test-runner wrapper (`DenoTasks.test`, `VitestTasks.run`,
+`JestTasks.run`, `BunTasks.test`, `NodeTasks.test`, `PlaywrightTasks.test`,
+`CypressTasks.run`) reports Tests/Passed/Failed (and Skipped/Todo/Flaky when
+non-zero) itself, and `DenoTasks.coverage` reports the measured
+Lines/Branches — a body only adds what its tools do not. Library code with no `ctx` (a wrapper, a
 helper) uses the ambient `reportSummary(pairs)` from `@zuke/core`, which lands
 on the running target's row and is a no-op outside a run. Test counts have one
 shared shape: `reportTestCounts({ passed, failed, skipped?, todo?, flaky? })`

--- a/tests/integration/deno_test_counts_test.ts
+++ b/tests/integration/deno_test_counts_test.ts
@@ -61,7 +61,7 @@ Deno.test("the test target's row carries the run's counts and the body's own not
   assertEquals(r.code, 0, r.err);
   assertStringIncludes(
     row(r.out, "test"),
-    "// Tests: 3 · Passed: 2 · Failed: 0 · Ignored: 1 · Version: 3.6.2",
+    "// Tests: 3 · Passed: 2 · Failed: 0 · Skipped: 1 · Version: 3.6.2",
   );
   assertEquals(row(r.out, "pack").includes("//"), false);
 });


### PR DESCRIPTION
## What & why

Only `DenoTasks.test` put its counts on the Build Summary (#452). A build whose tests run through vitest, jest, bun, node, Playwright or Cypress still got a bare `Succeeded  8.1s` row. Each of those wrappers now overrides the `onOutput` hook, parses the closing lines its runner's default reporters print, and reports through `reportTestCounts` from #459, so every test row carries the same labels: `Tests`, `Passed`, `Failed`, then `Skipped`, `Todo` and `Flaky` only when non-zero.

What each parser reads, captured from real runs of the runner where it ships in this image and from its documented output otherwise:

- **vitest** (stdout): the `Tests  1 failed | 2 passed | 1 skipped | 1 todo (5)` line, segments read by name.
- **jest** (stderr): the `Tests:       1 failed, 1 skipped, 1 todo, 2 passed, 5 total` line, segments read by name; a line without a total is not the result.
- **bun test** (stderr): the per-category block behind its `Ran N tests across M files` line, which marks a completed run.
- **node --test** (stdout): the TAP block node prints when piped and the spec block it prints on a terminal, read with either prefix; a cancelled test counts as failed.
- **playwright test** (stdout): the per-category block of the list, line and dot reporters; an interrupted test counts as failed and one that did not run as skipped.
- **cypress run** (stdout): the per-spec `(Results)` boxes, summed; pending and skipped both count as skipped.
- **deno test** moves from its own pairs builder to the shared shape, so its ignored tests now read `Skipped` like every other runner's.

Counts are reported on failed runs too, so a red row says how many failed. A reporter that replaces the closing lines (JSON, JUnit) reports nothing. The skill and cheatsheet name every wrapper that reports; plugin manifests bump to 0.37.0.

**Core floor.** The seven packages now declare `@zuke/core@^1.45.0`, the release that carries `reportTestCounts`, with `deno.lock` regenerated. `./zuke coreFloorCheck` passes against the published core for all 57 packages.

Tests: each parser is asserted on captured output in its shapes (pass, fail, every optional category, coloured output, the no-result cases), and each hook's wiring is exercised through a probe subclass under an ambient collector. Deno's fixture runs stay real.

Everything in `deno task ci` passed locally except the `security` target, which the sandbox's network proxy blocks.

## Related issues

Closes #457

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a
      [Conventional Commit](https://www.conventionalcommits.org/)
      (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell) — all targets except `security`, see above.
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour
      changed.
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`,
      `llms-full.txt`, package README `## API`).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with
      type guards instead).
- [x] No dead code: unreachable branches and can't-fire fallbacks are removed,
      with types tightened so the impossible state is unrepresentable.
- [x] No duplicated logic: an existing helper is imported rather than retyped,
      and a near-copy differing by a constant or a message is parameterised into
      one implementation. A guard, escape, or credential resolution has exactly
      one implementation.
- [x] SOLID shapes respected: one domain per file, extension via the settings
      lambda (not a behaviour-switching flag), narrow parameter types, and
      dependencies on the injectable seam (`StateHost`, an injected `fetch`,
      `EnvReader`) rather than `Deno.*` or a global.
- [ ] A new package was wired into all six places (see
      [AGENTS.md](../blob/master/AGENTS.md#good-open-source-practices-to-follow)),
      if applicable.
- [x] The code is written using AI assisted coding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrP7TrH4YPZiFmSE3mdhBT