### PR TITLE
feat: summary notes in the run record, on the check target, and from the remaining wrappers

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.37.0",
+      "version": "0.38.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/deno.lock
+++ b/deno.lock
@@ -1628,7 +1628,7 @@
       },
       "packages/dpdm": {
         "dependencies": [
-          "jsr:@zuke/core@^1.25.0"
+          "jsr:@zuke/core@^1.44.0"
         ]
       },
       "packages/dprint": {
@@ -1683,7 +1683,7 @@
       },
       "packages/knip": {
         "dependencies": [
-          "jsr:@zuke/core@^1.25.0"
+          "jsr:@zuke/core@^1.44.0"
         ]
       },
       "packages/kubectl": {
@@ -1713,7 +1713,7 @@
       },
       "packages/npm": {
         "dependencies": [
-          "jsr:@zuke/core@^1.25.0"
+          "jsr:@zuke/core@^1.44.0"
         ]
       },
       "packages/npx": {
@@ -1753,7 +1753,7 @@
       },
       "packages/pnpm": {
         "dependencies": [
-          "jsr:@zuke/core@^1.25.0"
+          "jsr:@zuke/core@^1.44.0"
         ]
       },
       "packages/redocly": {
@@ -1773,7 +1773,7 @@
       },
       "packages/shellcheck": {
         "dependencies": [
-          "jsr:@zuke/core@^1.25.0"
+          "jsr:@zuke/core@^1.44.0"
         ]
       },
       "packages/storybook": {
@@ -1798,7 +1798,7 @@
       },
       "packages/tsc-alias": {
         "dependencies": [
-          "jsr:@zuke/core@^1.25.0"
+          "jsr:@zuke/core@^1.44.0"
         ]
       },
       "packages/tsdown": {
@@ -1833,7 +1833,7 @@
       },
       "packages/yarn": {
         "dependencies": [
-          "jsr:@zuke/core@^1.25.0"
+          "jsr:@zuke/core@^1.44.0"
         ]
       }
     }

--- a/docs/run-context.md
+++ b/docs/run-context.md
@@ -128,6 +128,14 @@ lines (JSON, JUnit, or a machine-readable format) reports nothing.
 | `CspellTasks.lint` | `Files`, `Issues` |
 | `DprintTasks.check` | `Unformatted` |
 | `DprintTasks.fmt` | `Formatted` |
+| `KnipTasks.run` | `Issues`, summed over its sections |
+| `DpdmTasks.analyze` | `Circular` |
+| `ShellcheckTasks.lint` | `Findings` |
+| `TscAliasTasks.run` | `Files` rewritten, under `.verbose()` only |
+| `NpmTasks.install` / `ci` / `uninstall` / `update` / … | `Added`, `Removed`, `Changed`, and `Vulnerabilities` when audited |
+| `PnpmTasks.install` / `add` / `remove` | `Added`, `Downloaded`, `Reused` |
+| `YarnTasks.install` / `add` / `remove` | `Added`, `Removed` (Yarn Berry; Classic prints no count) |
+| `BunTasks.install` / `add` / `remove` | `Installed`, `Removed` |
 
 Each is read from the closing line the tool itself prints, on a failed run
 too, so a red row says how many. A clean run reports its zeros — a green
@@ -135,6 +143,17 @@ too, so a red row says how many. A clean run reports its zeros — a green
 without printing its closing line (a bad flag, a missing config) reports
 nothing rather than a misleading zero. A machine-readable reporter that
 replaces the closing line (`--format json`, JUnit) reports nothing either.
+
+### Notes are durable
+
+A settled target's notes are written to its row of the
+[run record](./state.md) alongside its status and timing, redacted like every
+other stored string. So they survive the process: `zuke runs show <id>` prints
+them after each target's duration (`✔ test  succeeded  128.1s  // Tests: 4094
+· Passed: 4094 · Failed: 0`), the MCP `show_run` tool returns them in the
+record, and a target that reads a dependency's outcome sees them as
+`ctx.outcomeOf("test")?.summary` — after a resume too, since the record is
+what a resumed run reads.
 
 ## Reading what the rest of the run did
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "zuke",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build)."
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3890,6 +3890,11 @@ interface TargetOutcomeView
     When it started, ISO-8601, if it did.
   readonly endedAt?: string
     When it settled, ISO-8601, if it has.
+  readonly summary?: readonly SummaryEntry[]
+    The notes it reported into its row of the build summary (see
+    {@link TargetContext.reportSummary}), when it reported any — so an
+    aggregating target can read a dependency's test counts, not only its
+    verdict. Durable: present after a resume too.
 
 interface TargetReport
   One row of the end-of-build summary.
@@ -3923,6 +3928,12 @@ interface TargetRunState
   effects?: Record<string, EffectState>
     The declared effects of this target, keyed by effect name — present only
     once at least one has been armed.
+  summary?: SummaryEntry[]
+    The notes the target reported into its row of the build summary (see
+    {@link "../target.ts".TargetContext.reportSummary}), in the order they
+    were first reported — present only when it reported at least one, and
+    redacted like every other stored string. What lets `zuke runs show` and
+    `ctx.outcomeOf` say a target ran 4094 tests, not only that it succeeded.
 
 interface TargetStateHandle
   A target's durable, per-target metadata, surfaced on {@link TargetContext} as
@@ -6426,6 +6437,8 @@ abstract class NpmDependencySettings extends NpmWorkspaceSettings
     The package specs given, for the subclasses that must require them.
   protected dependencyArgs(): string[]
     The dependency-group and lifecycle-script flags these commands share.
+  override protected onOutput(output: CommandOutput): void
+    Report `Added`, `Removed`, `Changed` (and `Vulnerabilities` when audited) onto the build summary.
 
 class NpmDeprecateSettings extends NpmSettings
   Settings for `npm deprecate`.
@@ -7053,6 +7066,8 @@ class BunAddSettings extends BunSettings
     Pin the exact version (`--exact`).
   global(): this
     Install globally (`--global`).
+  override protected onOutput(output: CommandOutput): void
+    Report `Installed` and `Removed` onto the build summary.
   override protected buildArgs(): string[]
     Assemble the `bun add` argv.
 
@@ -7063,6 +7078,8 @@ class BunInstallSettings extends BunSettings
     Install without devDependencies (`--production`).
   frozenLockfile(): this
     Fail if the lockfile is out of date (`--frozen-lockfile`).
+  override protected onOutput(output: CommandOutput): void
+    Report `Installed` and `Removed` onto the build summary.
   override protected buildArgs(): string[]
     Assemble the `bun install` argv.
 
@@ -7071,6 +7088,8 @@ class BunRemoveSettings extends BunSettings
 
   packages(...names: string[]): this
     Package names to remove (required).
+  override protected onOutput(output: CommandOutput): void
+    Report `Installed` and `Removed` onto the build summary.
   override protected buildArgs(): string[]
     Assemble the `bun remove` argv.
 
@@ -7225,6 +7244,8 @@ abstract class PnpmSettings extends ToolSettings
 
   override protected defaultTool(): string
     The default binary: `pnpm` resolved from PATH.
+  override protected onOutput(output: CommandOutput): void
+    Report `Added`, `Downloaded` and `Reused` onto the build summary.
 
 interface PnpmTasksApi
   The shape of {@link PnpmTasks}.
@@ -7321,6 +7342,8 @@ abstract class YarnSettings extends ToolSettings
 
   override protected defaultTool(): string
     The default binary: `yarn` resolved from PATH.
+  override protected onOutput(output: CommandOutput): void
+    Report `Added` and `Removed` (Yarn Berry) onto the build summary.
 
 interface YarnTasksApi
   The shape of {@link YarnTasks}.
@@ -10618,6 +10641,8 @@ class ShellcheckSettings extends ToolSettings
     be given with or without the `SC` prefix, as ShellCheck accepts both.
   externalSources(): this
     Follow `source`d files outside the checked set (`-x`/`--external-sources`).
+  override protected onOutput(output: CommandOutput): void
+    Report `Findings` onto the build summary.
   override protected buildArgs(): string[]
     Assemble the `shellcheck` argv.
 
@@ -11125,6 +11150,8 @@ class KnipRunSettings extends ToolSettings
     Choose the reporter, e.g. `json` or `compact` (`--reporter`).
   include(...types: string[]): this
     Limit to specific issue types, e.g. `files`, `dependencies` (`--include`).
+  override protected onOutput(output: CommandOutput): void
+    Report `Issues`, the findings summed over every section, onto the build summary.
   override protected buildArgs(): string[]
     Assemble the `knip <flags>` argv.
 
@@ -11193,6 +11220,8 @@ class DpdmAnalyzeSettings extends ToolSettings
     Exit with a code when a case occurs, e.g. `circular:1` (`--exit-code`).
   entries(...paths: PathLike[]): this
     The entry files or globs to analyze (appended after all options).
+  override protected onOutput(output: CommandOutput): void
+    Report `Circular`, the cycles found, onto the build summary.
   override protected buildArgs(): string[]
     Assemble the `dpdm <flags> <entries...>` argv.
 
@@ -12031,6 +12060,8 @@ class TscAliasRunSettings extends ToolSettings
     Print debug output (`--debug`).
   silent(): this
     Suppress all output (`--silent`).
+  override protected onOutput(output: CommandOutput): void
+    Report `Files` rewritten (under `--verbose`) onto the build summary.
   override protected buildArgs(): string[]
     Assemble the `tsc-alias` argv from the configured settings.
 

--- a/packages/bun/README.md
+++ b/packages/bun/README.md
@@ -47,6 +47,8 @@ class BunAddSettings extends BunSettings
     Pin the exact version (`--exact`).
   global(): this
     Install globally (`--global`).
+  override protected onOutput(output: CommandOutput): void
+    Report `Installed` and `Removed` onto the build summary.
   override protected buildArgs(): string[]
     Assemble the `bun add` argv.
 
@@ -57,6 +59,8 @@ class BunInstallSettings extends BunSettings
     Install without devDependencies (`--production`).
   frozenLockfile(): this
     Fail if the lockfile is out of date (`--frozen-lockfile`).
+  override protected onOutput(output: CommandOutput): void
+    Report `Installed` and `Removed` onto the build summary.
   override protected buildArgs(): string[]
     Assemble the `bun install` argv.
 
@@ -65,6 +69,8 @@ class BunRemoveSettings extends BunSettings
 
   packages(...names: string[]): this
     Package names to remove (required).
+  override protected onOutput(output: CommandOutput): void
+    Report `Installed` and `Removed` onto the build summary.
   override protected buildArgs(): string[]
     Assemble the `bun remove` argv.
 

--- a/packages/bun/src/bun.ts
+++ b/packages/bun/src/bun.ts
@@ -18,8 +18,9 @@
 
 import { type Configure, runSettings, ToolSettings } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
-import { reportTestCounts } from "@zuke/core";
+import { reportSummary, reportTestCounts } from "@zuke/core";
 import { parseTestSummary } from "./test_summary.ts";
+import { parseBunInstallSummary } from "./install_summary.ts";
 
 /** Base for all `bun` subcommand settings: binary is `bun` from PATH. */
 export abstract class BunSettings extends ToolSettings {
@@ -44,6 +45,12 @@ export class BunInstallSettings extends BunSettings {
   frozenLockfile(): this {
     this.#frozenLockfile = true;
     return this;
+  }
+
+  /** Report `Installed` and `Removed` onto the build summary. */
+  protected override onOutput(output: CommandOutput): void {
+    const pairs = parseBunInstallSummary(output);
+    if (pairs !== undefined) reportSummary(pairs);
   }
 
   /** Assemble the `bun install` argv. */
@@ -93,6 +100,12 @@ export class BunAddSettings extends BunSettings {
     return this;
   }
 
+  /** Report `Installed` and `Removed` onto the build summary. */
+  protected override onOutput(output: CommandOutput): void {
+    const pairs = parseBunInstallSummary(output);
+    if (pairs !== undefined) reportSummary(pairs);
+  }
+
   /** Assemble the `bun add` argv. */
   protected override buildArgs(): string[] {
     if (this.#packages.length === 0) {
@@ -116,6 +129,12 @@ export class BunRemoveSettings extends BunSettings {
   packages(...names: string[]): this {
     this.#packages.push(...names);
     return this;
+  }
+
+  /** Report `Installed` and `Removed` onto the build summary. */
+  protected override onOutput(output: CommandOutput): void {
+    const pairs = parseBunInstallSummary(output);
+    if (pairs !== undefined) reportSummary(pairs);
   }
 
   /** Assemble the `bun remove` argv. */

--- a/packages/bun/src/install_summary.ts
+++ b/packages/bun/src/install_summary.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * What a `bun install`-family run reports onto its target's row of the build
+ * summary, read from the closing line bun prints: `120 packages installed
+ * [1.20s]`, `Checked 120 installs across 240 packages (no changes) [2ms]`,
+ * or `1 package removed [5ms]`. Internal to the wrapper.
+ *
+ * @module
+ */
+
+import type { CommandOutput } from "@zuke/core/shell";
+import type { SummaryPairs } from "@zuke/core";
+import { stripAnsi } from "@zuke/core/render";
+
+/** The closing line naming what changed. */
+const CHANGED = /^(\d+) packages? (installed|removed)\b/m;
+/** The closing line of a run that changed nothing. */
+const UNCHANGED = /^Checked \d+ installs? across \d+ packages? \(no changes\)/m;
+
+/**
+ * The notes for a run: `Installed` and `Removed`. Both zero for a run that
+ * changed nothing; nothing for a run that printed no closing line, since it
+ * did not complete.
+ */
+export function parseBunInstallSummary(
+  output: CommandOutput,
+): SummaryPairs | undefined {
+  const text = stripAnsi(output.stdout);
+  const changed = CHANGED.exec(text);
+  if (changed !== null) {
+    const n = Number(changed[1]);
+    return changed[2] === "installed"
+      ? { Installed: n, Removed: 0 }
+      : { Installed: 0, Removed: n };
+  }
+  return UNCHANGED.test(text) ? { Installed: 0, Removed: 0 } : undefined;
+}

--- a/packages/bun/tests/install_summary_test.ts
+++ b/packages/bun/tests/install_summary_test.ts
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals } from "../../core/tests/_assert.ts";
+import {
+  TargetSummary,
+  withAmbientSummary,
+} from "../../core/src/summary_note.ts";
+import { CommandOutput } from "@zuke/core/shell";
+import {
+  BunAddSettings,
+  BunInstallSettings,
+  BunRemoveSettings,
+} from "../src/bun.ts";
+import { parseBunInstallSummary } from "../src/install_summary.ts";
+
+/** A run's output with the given streams and exit code. */
+function out(code: number, stdout = "", stderr = ""): CommandOutput {
+  return new CommandOutput(code, stdout, stderr);
+}
+
+Deno.test("bun install: the closing line yields Installed and Removed", () => {
+  assertEquals(
+    parseBunInstallSummary(
+      out(
+        0,
+        "bun install v1.3.11 (af24e281)\n\n+ left-pad@1.3.0\n\n1 package installed [106.00ms]\n",
+      ),
+    ),
+    { Installed: 1, Removed: 0 },
+  );
+  assertEquals(
+    parseBunInstallSummary(
+      out(
+        0,
+        "bun install v1.3.11\n\nChecked 1 install across 2 packages (no changes) [2.00ms]\n",
+      ),
+    ),
+    { Installed: 0, Removed: 0 },
+  );
+  assertEquals(
+    parseBunInstallSummary(out(0, "\n2 packages removed [5.00ms]\n")),
+    { Installed: 0, Removed: 2 },
+  );
+});
+
+Deno.test("bun install: a run without the closing line reports nothing", () => {
+  assertEquals(parseBunInstallSummary(out(0)), undefined);
+  assertEquals(
+    parseBunInstallSummary(
+      out(1, "bun install v1.3.11\n", "error: package.json not found"),
+    ),
+    undefined,
+  );
+});
+
+/** Exposes the protected hooks so the wiring can be exercised without bun. */
+class Probe extends BunInstallSettings {
+  probe(output: CommandOutput): void {
+    this.onOutput(output);
+  }
+}
+class AddProbe extends BunAddSettings {
+  probe(output: CommandOutput): void {
+    this.onOutput(output);
+  }
+}
+class RemoveProbe extends BunRemoveSettings {
+  probe(output: CommandOutput): void {
+    this.onOutput(output);
+  }
+}
+
+Deno.test("bun install, add and remove report onto the running target", async () => {
+  const summary = new TargetSummary();
+  await withAmbientSummary(summary, () => {
+    new Probe().probe(out(0, "3 packages installed [9ms]\n"));
+    new AddProbe().probe(out(0, "1 package installed [9ms]\n"));
+    new RemoveProbe().probe(out(0, "1 package removed [9ms]\n"));
+    return Promise.resolve();
+  });
+  // Each report replaces the last: the row keeps the final command's figures.
+  assertEquals(summary.entries(), [{ key: "Installed", value: "0" }, {
+    key: "Removed",
+    value: "1",
+  }]);
+});

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -3944,6 +3944,11 @@ interface TargetOutcomeView
     When it started, ISO-8601, if it did.
   readonly endedAt?: string
     When it settled, ISO-8601, if it has.
+  readonly summary?: readonly SummaryEntry[]
+    The notes it reported into its row of the build summary (see
+    {@link TargetContext.reportSummary}), when it reported any — so an
+    aggregating target can read a dependency's test counts, not only its
+    verdict. Durable: present after a resume too.
 
 interface TargetReport
   One row of the end-of-build summary.
@@ -3977,6 +3982,12 @@ interface TargetRunState
   effects?: Record<string, EffectState>
     The declared effects of this target, keyed by effect name — present only
     once at least one has been armed.
+  summary?: SummaryEntry[]
+    The notes the target reported into its row of the build summary (see
+    {@link "../target.ts".TargetContext.reportSummary}), in the order they
+    were first reported — present only when it reported at least one, and
+    redacted like every other stored string. What lets `zuke runs show` and
+    `ctx.outcomeOf` say a target ran 4094 tests, not only that it succeeded.
 
 interface TargetStateHandle
   A target's durable, per-target metadata, surfaced on {@link TargetContext} as

--- a/packages/core/src/run_support.ts
+++ b/packages/core/src/run_support.ts
@@ -115,6 +115,8 @@ export interface TargetSettlement {
   status: TargetRunStatus;
   /** The failure's message, when it failed. */
   error?: string;
+  /** The notes it reported into its summary row, when it reported any. */
+  summary?: SummaryEntry[];
 }
 
 /**
@@ -130,11 +132,13 @@ export function outcomeView(
   row: TargetRunState | undefined,
 ): TargetOutcomeView {
   const error = settled.error ?? row?.error;
+  const summary = settled.summary ?? row?.summary;
   return {
     status: settled.status,
     ...(error === undefined ? {} : { error }),
     ...(row?.startedAt === undefined ? {} : { startedAt: row.startedAt }),
     ...(row?.endedAt === undefined ? {} : { endedAt: row.endedAt }),
+    ...(summary === undefined ? {} : { summary }),
   };
 }
 

--- a/packages/core/src/runs.ts
+++ b/packages/core/src/runs.ts
@@ -23,6 +23,7 @@ import type {
   TargetRunStatus,
 } from "./state/types.ts";
 import { formatDuration, table } from "./render.ts";
+import { formatSummary } from "./report.ts";
 
 /** Inputs for {@link runsCommand}. */
 export interface RunsOptions {
@@ -291,10 +292,16 @@ function targetDuration(state: TargetRunState): string | undefined {
   return Number.isFinite(ms) && ms >= 0 ? formatDuration(ms) : undefined;
 }
 
-/** The trailing note for one target line: a duration, error, or wait descriptor. */
+/**
+ * The trailing note for one target line: a duration, error, or wait
+ * descriptor, then the notes the target reported into its summary row, in the
+ * same `// key: value` form the build summary prints them.
+ */
 function targetNote(state: TargetRunState): string {
+  const notes = formatSummary(state.summary);
+  const trailing = notes === "" ? "" : `  // ${notes}`;
   if (state.status === "failed" && state.error !== undefined) {
-    return `  ${state.error}`;
+    return `  ${state.error}${trailing}`;
   }
   if (state.status === "waiting" && state.waitingFor !== undefined) {
     const { trigger, deadline } = state.waitingFor;
@@ -302,7 +309,7 @@ function targetNote(state: TargetRunState): string {
     return `  waiting for ${trigger}${until}`;
   }
   const duration = targetDuration(state);
-  return duration !== undefined ? `  ${duration}` : "";
+  return (duration !== undefined ? `  ${duration}` : "") + trailing;
 }
 
 /** Render `runs show <id>`: the run header, parameters, targets, and signals. */

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -27,7 +27,11 @@ import {
   type TargetOutcome,
 } from "./run_support.ts";
 import { withAmbientEcho } from "./ambient_echo.ts";
-import { TargetSummary, withAmbientSummary } from "./summary_note.ts";
+import {
+  type SummaryEntry,
+  TargetSummary,
+  withAmbientSummary,
+} from "./summary_note.ts";
 import { type Style, type TargetReport, targetWaitFooter } from "./report.ts";
 import type { Renderer } from "./renderer.ts";
 import {
@@ -706,9 +710,14 @@ function settleTarget(
   name: string,
   status: TargetStatus,
   error?: string,
+  summary?: SummaryEntry[],
 ): void {
-  env.statuses.set(name, { status: recordStatusOf(status), error });
-  void env.writer?.markTargetSettled(name, status, error);
+  env.statuses.set(name, {
+    status: recordStatusOf(status),
+    error,
+    ...(summary === undefined ? {} : { summary }),
+  });
+  void env.writer?.markTargetSettled(name, status, error, summary);
 }
 
 /** Sequentially run the plan, aborting (and skipping the rest) on first failure. */
@@ -750,7 +759,13 @@ export async function runSequential(
       failTarget(reporter, renderer, style, name, 0, error);
       outcome = { status: "failed", ms: 0, error };
     }
-    settleTarget(env, name, outcome.status, errorMessage(outcome.error));
+    settleTarget(
+      env,
+      name,
+      outcome.status,
+      errorMessage(outcome.error),
+      outcome.summary,
+    );
     if (outcome.status === "passed" || outcome.status === "failed") opened++;
     reports.push(reportOf(name, outcome));
     // A fan-out target's sub-targets appear as their own rows beneath it.
@@ -908,6 +923,7 @@ export async function runScheduled(
                   t.name_ ?? "<unnamed>",
                   outcome.status,
                   errorMessage(outcome.error),
+                  outcome.summary,
                 );
               }
               // An executed target (or a parked wait) prints a block worth

--- a/packages/core/src/state/types.ts
+++ b/packages/core/src/state/types.ts
@@ -20,6 +20,7 @@
  */
 
 import type { JsonValue } from "../target.ts";
+import type { SummaryEntry } from "../summary_note.ts";
 import { asObject, fields } from "../json_shape.ts";
 
 /** The field readers for a run record's own fields. */
@@ -148,6 +149,14 @@ export interface TargetRunState {
    * once at least one has been armed.
    */
   effects?: Record<string, EffectState>;
+  /**
+   * The notes the target reported into its row of the build summary (see
+   * {@link "../target.ts".TargetContext.reportSummary}), in the order they
+   * were first reported — present only when it reported at least one, and
+   * redacted like every other stored string. What lets `zuke runs show` and
+   * `ctx.outcomeOf` say a target ran 4094 tests, not only that it succeeded.
+   */
+  summary?: SummaryEntry[];
 }
 
 /** One entry of a run's graph-shape snapshot. */
@@ -371,7 +380,22 @@ function parseTargetState(value: unknown): TargetRunState {
   if (object.effects !== undefined) {
     state.effects = parseEffects(object.effects);
   }
+  if (object.summary !== undefined) {
+    state.summary = parseSummary(object.summary);
+  }
   return state;
+}
+
+/** Validate a target's stored summary notes: a list of `{ key, value }` strings. */
+function parseSummary(value: unknown): SummaryEntry[] {
+  if (!Array.isArray(value)) throw new Error("state: summary is not an array");
+  return value.map((entry) => {
+    const object = asObject(entry);
+    if (object === null) {
+      throw new Error("state: summary note is not an object");
+    }
+    return { key: str(object, "key"), value: str(object, "value") };
+  });
 }
 
 /** Validate a target's effect rows, keyed by effect name. */

--- a/packages/core/src/state/writer.ts
+++ b/packages/core/src/state/writer.ts
@@ -33,6 +33,7 @@ import type {
   TargetRunState,
   WaitState,
 } from "./types.ts";
+import type { SummaryEntry } from "../summary_note.ts";
 import { recordStatusOf } from "./record.ts";
 import { acquireCancelLock, type CancelLock } from "./cancel_lock.ts";
 import { messageOf } from "../internal.ts";
@@ -229,22 +230,34 @@ export class RunStateWriter {
     });
   }
 
-  /** Record a target's terminal status (mapped from the executor's vocabulary). */
+  /**
+   * Record a target's terminal status (mapped from the executor's vocabulary),
+   * with the notes it reported into its summary row, if any — each value
+   * redacted like the error, since a wrapper may echo what its tool printed.
+   */
   markTargetSettled(
     name: string,
     status: TargetStatus,
     error?: string,
+    summary?: readonly SummaryEntry[],
   ): Promise<void> {
     const at = this.#now();
     const recorded = recordStatusOf(status);
     const message = error === undefined
       ? undefined
       : this.#redactor.redact(error);
+    const notes = summary === undefined || summary.length === 0
+      ? undefined
+      : summary.map((e) => ({
+        key: e.key,
+        value: this.#redactor.redact(e.value),
+      }));
     return this.#update((record) => {
       const target = ensureTarget(record, name);
       target.status = recorded;
       target.endedAt = at;
       if (message !== undefined) target.error = message;
+      if (notes !== undefined) target.summary = notes;
       // A settled target is no longer waiting (e.g. a gate satisfied on resume).
       delete target.waitingFor;
     });

--- a/packages/core/src/target.ts
+++ b/packages/core/src/target.ts
@@ -36,7 +36,7 @@ import type { Configure } from "./tooling.ts";
 import { type LockHolder, lockKey } from "./state/lock.ts";
 import type { WaitTrigger } from "./wait.ts";
 import type { SignalRecord, TargetRunStatus } from "./state/types.ts";
-import type { SummaryPairs } from "./summary_note.ts";
+import type { SummaryEntry, SummaryPairs } from "./summary_note.ts";
 
 /**
  * Fluent configuration for {@link TargetBuilder.lock}, in the settings-lambda
@@ -293,6 +293,13 @@ export interface TargetOutcomeView {
   readonly startedAt?: string;
   /** When it settled, ISO-8601, if it has. */
   readonly endedAt?: string;
+  /**
+   * The notes it reported into its row of the build summary (see
+   * {@link TargetContext.reportSummary}), when it reported any — so an
+   * aggregating target can read a dependency's test counts, not only its
+   * verdict. Durable: present after a resume too.
+   */
+  readonly summary?: readonly SummaryEntry[];
 }
 
 /**

--- a/packages/core/tests/executor_test.ts
+++ b/packages/core/tests/executor_test.ts
@@ -3261,3 +3261,34 @@ Deno.test("summary: a dry-runnable body's notes show under --dry-run", async () 
   );
   assertStringIncludes(row ?? "", "// Mode: dry · Ambient: yes");
 });
+
+Deno.test("summary: a target's notes land in the run record and in a dependent's outcomeOf", async () => {
+  await withTempStore(async (store) => {
+    let seen: readonly { key: string; value: string }[] | undefined;
+    class B extends Build {
+      test = target().executes((ctx) => {
+        ctx.reportSummary({ Tests: 3, Passed: 3 });
+      });
+      gate = target().dependsOn(this.test).executes((ctx) => {
+        seen = ctx.outcomeOf("test")?.summary;
+      });
+    }
+    const b = new B();
+    discoverTargets(b);
+    const result = await execute(b, b.gate, {
+      silent: true,
+      stateStore: store,
+    });
+    assertEquals(result.ok, true);
+    assertEquals(seen, [{ key: "Tests", value: "3" }, {
+      key: "Passed",
+      value: "3",
+    }]);
+    const loaded = await store.getRun(result.runId ?? "");
+    assertEquals(loaded?.record.targets.test.summary, [
+      { key: "Tests", value: "3" },
+      { key: "Passed", value: "3" },
+    ]);
+    assertEquals(loaded?.record.targets.gate.summary, undefined);
+  });
+});

--- a/packages/core/tests/outcome_view_test.ts
+++ b/packages/core/tests/outcome_view_test.ts
@@ -127,3 +127,17 @@ Deno.test("an effect record claiming zero attempts is refused", () => {
   }
   assertEquals(message.includes("positive integer"), true, message);
 });
+
+Deno.test("the settlement's notes win, and the row's fill in after a resume", () => {
+  const live = outcomeView(
+    { status: "succeeded", summary: [{ key: "Tests", value: "3" }] },
+    row({ summary: [{ key: "Tests", value: "2" }] }),
+  );
+  assertEquals(live.summary, [{ key: "Tests", value: "3" }]);
+  const durable = outcomeView(
+    { status: "succeeded" },
+    row({ summary: [{ key: "Lines", value: "98.4%" }] }),
+  );
+  assertEquals(durable.summary, [{ key: "Lines", value: "98.4%" }]);
+  assertEquals("summary" in outcomeView({ status: "succeeded" }, row()), false);
+});

--- a/packages/core/tests/runs_test.ts
+++ b/packages/core/tests/runs_test.ts
@@ -590,3 +590,29 @@ Deno.test("runs list honours --limit via the query", async () => {
     assertEquals(rows.length, 2);
   });
 });
+
+Deno.test("formatRunDetail trails a target's summary notes after its duration or error", () => {
+  const record = sampleRecord({
+    targets: {
+      test: {
+        status: "succeeded",
+        meta: {},
+        startedAt: "2026-07-17T10:00:00.000Z",
+        endedAt: "2026-07-17T10:00:08.000Z",
+        summary: [{ key: "Tests", value: "4094" }, {
+          key: "Failed",
+          value: "0",
+        }],
+      },
+      lint: {
+        status: "failed",
+        meta: {},
+        error: "Error: 2 problems",
+        summary: [{ key: "Problems", value: "2" }],
+      },
+    },
+  });
+  const text = formatRunDetail(record);
+  assertStringIncludes(text, "8.0s  // Tests: 4094 · Failed: 0");
+  assertStringIncludes(text, "Error: 2 problems  // Problems: 2");
+});

--- a/packages/core/tests/state_test.ts
+++ b/packages/core/tests/state_test.ts
@@ -1773,3 +1773,55 @@ Deno.test("a lock listing from the server is validated, not trusted", async () =
     await assertRejects(() => store.listLocks(), Error);
   }
 });
+
+Deno.test("RunStateWriter stores a settled target's summary notes, values redacted", async () => {
+  const store = new MemStateStore();
+  const redactor = new Redactor();
+  redactor.add("hunter2");
+  const writer = await RunStateWriter.open(
+    store,
+    sampleRecord(),
+    () => "t",
+    redactor,
+  );
+  await writer.markTargetSettled("deploy", "passed", undefined, [
+    { key: "Tests", value: "12" },
+    { key: "Token", value: "hunter2" },
+  ]);
+  assertEquals(store.record?.targets.deploy.summary, [
+    { key: "Tests", value: "12" },
+    { key: "Token", value: "[redacted]" },
+  ]);
+  // No notes, no key: a note-less row stays exactly as it was.
+  await writer.markTargetSettled("deploy", "passed", undefined, []);
+  assertEquals("summary" in (store.record?.targets.deploy ?? {}), true);
+  await writer.markTargetSettled("verify", "passed");
+  assertEquals(store.record?.targets.verify.summary, undefined);
+});
+
+Deno.test("parseRunRecord round-trips a target's summary notes and rejects malformed ones", () => {
+  const record = sampleRecord({
+    targets: {
+      test: {
+        status: "succeeded",
+        meta: {},
+        summary: [{ key: "Tests", value: "3" }, { key: "Passed", value: "3" }],
+      },
+    },
+  });
+  assertEquals(parseRunRecord(stringifyRunRecord(record)), record);
+  const base = JSON.parse(stringifyRunRecord(sampleRecord()));
+  for (
+    const [summary, needle] of [
+      [{ Tests: 3 }, "summary is not an array"],
+      [["Tests: 3"], "summary note is not an object"],
+      [[{ key: "Tests" }], "value"],
+    ] as const
+  ) {
+    const broken = {
+      ...base,
+      targets: { t: { status: "succeeded", meta: {}, summary } },
+    };
+    assertThrows(() => parseRunRecord(JSON.stringify(broken)), Error, needle);
+  }
+});

--- a/packages/dpdm/README.md
+++ b/packages/dpdm/README.md
@@ -80,6 +80,8 @@ class DpdmAnalyzeSettings extends ToolSettings
     Exit with a code when a case occurs, e.g. `circular:1` (`--exit-code`).
   entries(...paths: PathLike[]): this
     The entry files or globs to analyze (appended after all options).
+  override protected onOutput(output: CommandOutput): void
+    Report `Circular`, the cycles found, onto the build summary.
   override protected buildArgs(): string[]
     Assemble the `dpdm <flags> <entries...>` argv.
 

--- a/packages/dpdm/deno.json
+++ b/packages/dpdm/deno.json
@@ -7,7 +7,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1.25.0"
+    "@zuke/core": "jsr:@zuke/core@^1.44.0"
   },
   "publish": {
     "exclude": [

--- a/packages/dpdm/src/dpdm.ts
+++ b/packages/dpdm/src/dpdm.ts
@@ -33,6 +33,8 @@ import {
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
+import { reportSummary } from "@zuke/core";
+import { parseDpdmSummary } from "./summary.ts";
 
 /** Settings for a `dpdm` analysis run. */
 export class DpdmAnalyzeSettings extends ToolSettings {
@@ -157,6 +159,12 @@ export class DpdmAnalyzeSettings extends ToolSettings {
   entries(...paths: PathLike[]): this {
     this.#entries.push(...paths.map(String));
     return this;
+  }
+
+  /** Report `Circular`, the cycles found, onto the build summary. */
+  protected override onOutput(output: CommandOutput): void {
+    const pairs = parseDpdmSummary(output);
+    if (pairs !== undefined) reportSummary(pairs);
   }
 
   /** Assemble the `dpdm <flags> <entries...>` argv. */

--- a/packages/dpdm/src/summary.ts
+++ b/packages/dpdm/src/summary.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * What a `dpdm` run reports onto its target's row of the build summary: the
+ * circular dependencies it found, counted from the numbered entries under its
+ * `• Circular Dependencies` heading, which is printed on every completed run
+ * (with a congratulation line when there are none). Internal to the wrapper.
+ *
+ * @module
+ */
+
+import type { CommandOutput } from "@zuke/core/shell";
+import type { SummaryPairs } from "@zuke/core";
+import { stripAnsi } from "@zuke/core/render";
+
+/** The section heading every completed run prints. */
+const HEADING = /^• Circular Dependencies$/m;
+/** One numbered entry under it, e.g. `  1) a.js -> b.js`. */
+const ENTRY = /^\s+\d+\) /gm;
+
+/**
+ * The notes for a run: `Circular`, the cycles found. Only the section under
+ * the heading is counted, so a warnings section printed after it cannot
+ * inflate the figure. A run without the heading did not complete and reports
+ * nothing.
+ */
+export function parseDpdmSummary(
+  output: CommandOutput,
+): SummaryPairs | undefined {
+  const text = stripAnsi(output.stdout);
+  const heading = HEADING.exec(text);
+  if (heading === null) return undefined;
+  const rest = text.slice(heading.index + heading[0].length);
+  const next = rest.indexOf("\n•");
+  const section = next === -1 ? rest : rest.slice(0, next);
+  return { Circular: [...section.matchAll(ENTRY)].length };
+}

--- a/packages/dpdm/tests/summary_test.ts
+++ b/packages/dpdm/tests/summary_test.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals } from "../../core/tests/_assert.ts";
+import {
+  TargetSummary,
+  withAmbientSummary,
+} from "../../core/src/summary_note.ts";
+import { CommandOutput } from "@zuke/core/shell";
+import { DpdmAnalyzeSettings } from "../src/dpdm.ts";
+import { parseDpdmSummary } from "../src/summary.ts";
+
+/** A run's output with the given streams and exit code. */
+function out(code: number, stdout = "", stderr = ""): CommandOutput {
+  return new CommandOutput(code, stdout, stderr);
+}
+
+Deno.test("dpdm: the numbered entries under the circular heading are counted", () => {
+  assertEquals(
+    parseDpdmSummary(
+      out(
+        0,
+        "• Circular Dependencies\n  1) a.js -> b.js\n  2) c.js -> d.js -> c.js\n\n",
+      ),
+    ),
+    { Circular: 2 },
+  );
+  assertEquals(
+    parseDpdmSummary(
+      out(
+        0,
+        "• Circular Dependencies\n  ✅ Congratulations, no circular dependency was found in your project.\n\n",
+      ),
+    ),
+    { Circular: 0 },
+  );
+  // A later section with its own numbered entries does not inflate the figure.
+  assertEquals(
+    parseDpdmSummary(
+      out(
+        1,
+        "• Circular Dependencies\n  1) a.js -> b.js\n\n• Warnings\n  1) skip x.d.ts\n  2) skip y.d.ts\n",
+      ),
+    ),
+    { Circular: 1 },
+  );
+});
+
+Deno.test("dpdm: a run without the heading reports nothing", () => {
+  assertEquals(parseDpdmSummary(out(0)), undefined);
+  assertEquals(parseDpdmSummary(out(1, "", "Cannot find module")), undefined);
+});
+
+/** Exposes the protected hook so the wiring can be exercised without dpdm. */
+class Probe extends DpdmAnalyzeSettings {
+  probe(output: CommandOutput): void {
+    this.onOutput(output);
+  }
+}
+
+Deno.test("dpdm: the hook reports onto the running target", async () => {
+  const summary = new TargetSummary();
+  await withAmbientSummary(summary, () => {
+    new Probe().probe(out(0, "• Circular Dependencies\n  1) a.js -> b.js\n"));
+    return Promise.resolve();
+  });
+  assertEquals(summary.entries(), [{ key: "Circular", value: "1" }]);
+});

--- a/packages/knip/README.md
+++ b/packages/knip/README.md
@@ -56,6 +56,8 @@ class KnipRunSettings extends ToolSettings
     Choose the reporter, e.g. `json` or `compact` (`--reporter`).
   include(...types: string[]): this
     Limit to specific issue types, e.g. `files`, `dependencies` (`--include`).
+  override protected onOutput(output: CommandOutput): void
+    Report `Issues`, the findings summed over every section, onto the build summary.
   override protected buildArgs(): string[]
     Assemble the `knip <flags>` argv.
 

--- a/packages/knip/deno.json
+++ b/packages/knip/deno.json
@@ -7,7 +7,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1.25.0"
+    "@zuke/core": "jsr:@zuke/core@^1.44.0"
   },
   "publish": {
     "exclude": [

--- a/packages/knip/src/knip.ts
+++ b/packages/knip/src/knip.ts
@@ -28,6 +28,8 @@ import {
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
+import { reportSummary } from "@zuke/core";
+import { parseKnipSummary } from "./summary.ts";
 
 /** Settings for a `knip` run. */
 export class KnipRunSettings extends ToolSettings {
@@ -103,6 +105,12 @@ export class KnipRunSettings extends ToolSettings {
   include(...types: string[]): this {
     this.#include.push(...types);
     return this;
+  }
+
+  /** Report `Issues`, the findings summed over every section, onto the build summary. */
+  protected override onOutput(output: CommandOutput): void {
+    const pairs = parseKnipSummary(output);
+    if (pairs !== undefined) reportSummary(pairs);
   }
 
   /** Assemble the `knip <flags>` argv. */

--- a/packages/knip/src/summary.ts
+++ b/packages/knip/src/summary.ts
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * What a `knip` run reports onto its target's row of the build summary: the
+ * issues it found, summed over the sections of its default reporter —
+ * `Unused files (1)`, `Unused dependencies (2)`, `Unused exports (3)` and the
+ * rest. A clean run prints nothing and exits 0. Internal to the wrapper.
+ *
+ * @module
+ */
+
+import type { CommandOutput } from "@zuke/core/shell";
+import type { SummaryPairs } from "@zuke/core";
+import { stripAnsi } from "@zuke/core/render";
+
+/** A section heading of the default reporter, with its count. */
+const SECTION = /^[A-Z][A-Za-z]*(?: [a-z]+)* \((\d+)\)$/gm;
+
+/**
+ * The notes for a run: `Issues`, the sum of every section's count. A run that
+ * printed no section and exited 0 is clean; one that exited non-zero without
+ * a section (a configuration error) reports nothing rather than a misleading
+ * zero.
+ */
+export function parseKnipSummary(
+  output: CommandOutput,
+): SummaryPairs | undefined {
+  let issues = 0;
+  let sections = 0;
+  for (const m of stripAnsi(output.stdout).matchAll(SECTION)) {
+    issues += Number(m[1]);
+    sections++;
+  }
+  if (sections > 0 || output.code === 0) return { Issues: issues };
+  return undefined;
+}

--- a/packages/knip/tests/summary_test.ts
+++ b/packages/knip/tests/summary_test.ts
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals } from "../../core/tests/_assert.ts";
+import {
+  TargetSummary,
+  withAmbientSummary,
+} from "../../core/src/summary_note.ts";
+import { CommandOutput } from "@zuke/core/shell";
+import { KnipRunSettings } from "../src/knip.ts";
+import { parseKnipSummary } from "../src/summary.ts";
+
+/** A run's output with the given streams and exit code. */
+function out(code: number, stdout = "", stderr = ""): CommandOutput {
+  return new CommandOutput(code, stdout, stderr);
+}
+
+Deno.test("knip: the section counts are summed into Issues", () => {
+  const text =
+    "Unused files (1)\norphan.js\nUnused dependencies (1)\nleft-pad  package.json\nUnused exports (2)\na.js: x\nb.js: y\n";
+  assertEquals(parseKnipSummary(out(1, text)), { Issues: 4 });
+  assertEquals(parseKnipSummary(out(1, "Unlisted dependencies (3)\n")), {
+    Issues: 3,
+  });
+});
+
+Deno.test("knip: a silent clean run is zero, a silent failure reports nothing", () => {
+  assertEquals(parseKnipSummary(out(0)), { Issues: 0 });
+  assertEquals(
+    parseKnipSummary(out(2, "", "Unable to find a config")),
+    undefined,
+  );
+});
+
+/** Exposes the protected hook so the wiring can be exercised without knip. */
+class Probe extends KnipRunSettings {
+  probe(output: CommandOutput): void {
+    this.onOutput(output);
+  }
+}
+
+Deno.test("knip: the hook reports onto the running target", async () => {
+  const summary = new TargetSummary();
+  await withAmbientSummary(summary, () => {
+    new Probe().probe(out(1, "Unused files (2)\na.js\nb.js\n"));
+    return Promise.resolve();
+  });
+  assertEquals(summary.entries(), [{ key: "Issues", value: "2" }]);
+});

--- a/packages/npm/README.md
+++ b/packages/npm/README.md
@@ -237,6 +237,8 @@ abstract class NpmDependencySettings extends NpmWorkspaceSettings
     The package specs given, for the subclasses that must require them.
   protected dependencyArgs(): string[]
     The dependency-group and lifecycle-script flags these commands share.
+  override protected onOutput(output: CommandOutput): void
+    Report `Added`, `Removed`, `Changed` (and `Vulnerabilities` when audited) onto the build summary.
 
 class NpmDeprecateSettings extends NpmSettings
   Settings for `npm deprecate`.

--- a/packages/npm/deno.json
+++ b/packages/npm/deno.json
@@ -7,7 +7,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1.25.0"
+    "@zuke/core": "jsr:@zuke/core@^1.44.0"
   },
   "publish": {
     "exclude": [

--- a/packages/npm/src/install.ts
+++ b/packages/npm/src/install.ts
@@ -22,6 +22,9 @@ import {
   NpmWorkspaceSettings,
 } from "./settings.ts";
 import { dependencyGroupArgs } from "./flags.ts";
+import type { CommandOutput } from "@zuke/core/shell";
+import { reportSummary } from "@zuke/core";
+import { parseNpmSummary } from "./summary.ts";
 
 /**
  * Shared base for the install-shaped commands: the `--omit`/`--include`
@@ -76,6 +79,12 @@ export abstract class NpmDependencySettings extends NpmWorkspaceSettings {
     if (this.#ignoreScripts) argv.push("--ignore-scripts");
     if (this.#foregroundScripts) argv.push("--foreground-scripts");
     return argv;
+  }
+
+  /** Report `Added`, `Removed`, `Changed` (and `Vulnerabilities` when audited) onto the build summary. */
+  protected override onOutput(output: CommandOutput): void {
+    const pairs = parseNpmSummary(output);
+    if (pairs !== undefined) reportSummary(pairs);
   }
 }
 

--- a/packages/npm/src/summary.ts
+++ b/packages/npm/src/summary.ts
@@ -22,7 +22,7 @@ const CLOSING =
 /** One counted phrase of the closing line. */
 const COUNT = /\b(added|removed|changed) (\d+) packages?/g;
 /** The audit line, printed when the command audited. */
-const VULNERABILITIES = /^found (\d+) vulnerabilit(?:y|ies)/m;
+const VULNERABILITIES = /^found (\d+) (?:vulnerability|vulnerabilities)/m;
 
 /**
  * The notes for a run: `Added`, `Removed` and `Changed` (zero when the

--- a/packages/npm/src/summary.ts
+++ b/packages/npm/src/summary.ts
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * What an `npm install`-family run reports onto its target's row of the build
+ * summary, read from the closing line npm prints on every completed
+ * dependency command: `added 120 packages, and audited 121 packages in 4s`,
+ * `removed 1 package in 213ms`, `changed 3 packages …`, or `up to date in
+ * 206ms` — plus `found 0 vulnerabilities` when it audited. Internal to the
+ * wrapper.
+ *
+ * @module
+ */
+
+import type { CommandOutput } from "@zuke/core/shell";
+import type { SummaryPairs } from "@zuke/core";
+import { stripAnsi } from "@zuke/core/render";
+
+/** The closing line, which starts with the first of its counted phrases. */
+const CLOSING =
+  /^(?:added|removed|changed|up to date)\b.*\bin \d+(?:\.\d+)?m?s$/m;
+/** One counted phrase of the closing line. */
+const COUNT = /\b(added|removed|changed) (\d+) packages?/g;
+/** The audit line, printed when the command audited. */
+const VULNERABILITIES = /^found (\d+) vulnerabilit(?:y|ies)/m;
+
+/**
+ * The notes for a run: `Added`, `Removed` and `Changed` (zero when the
+ * closing line names none, as `up to date` does), plus `Vulnerabilities`
+ * when the run audited. A run without the closing line did not complete and
+ * reports nothing.
+ */
+export function parseNpmSummary(
+  output: CommandOutput,
+): SummaryPairs | undefined {
+  const text = stripAnsi(output.stdout);
+  const closing = CLOSING.exec(text);
+  if (closing === null) return undefined;
+  const counts = new Map<string, number>();
+  for (const m of closing[0].matchAll(COUNT)) counts.set(m[1], Number(m[2]));
+  const pairs: Record<string, number> = {
+    Added: counts.get("added") ?? 0,
+    Removed: counts.get("removed") ?? 0,
+    Changed: counts.get("changed") ?? 0,
+  };
+  const audit = VULNERABILITIES.exec(text);
+  if (audit !== null) pairs.Vulnerabilities = Number(audit[1]);
+  return pairs;
+}

--- a/packages/npm/tests/summary_test.ts
+++ b/packages/npm/tests/summary_test.ts
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals } from "../../core/tests/_assert.ts";
+import {
+  TargetSummary,
+  withAmbientSummary,
+} from "../../core/src/summary_note.ts";
+import { CommandOutput } from "@zuke/core/shell";
+import { NpmCiSettings, NpmInstallSettings } from "../src/install.ts";
+import { parseNpmSummary } from "../src/summary.ts";
+
+/** A run's output with the given streams and exit code. */
+function out(code: number, stdout = "", stderr = ""): CommandOutput {
+  return new CommandOutput(code, stdout, stderr);
+}
+
+Deno.test("npm: the closing line yields Added, Removed and Changed, plus Vulnerabilities when audited", () => {
+  assertEquals(parseNpmSummary(out(0, "\nadded 1 package in 441ms\n")), {
+    Added: 1,
+    Removed: 0,
+    Changed: 0,
+  });
+  assertEquals(parseNpmSummary(out(0, "\nremoved 1 package in 213ms\n")), {
+    Added: 0,
+    Removed: 1,
+    Changed: 0,
+  });
+  assertEquals(parseNpmSummary(out(0, "\nup to date in 206ms\n")), {
+    Added: 0,
+    Removed: 0,
+    Changed: 0,
+  });
+  assertEquals(
+    parseNpmSummary(
+      out(
+        0,
+        "\nadded 120 packages, removed 2 packages, changed 3 packages, and audited 121 packages in 4s\n\nfound 0 vulnerabilities\n",
+      ),
+    ),
+    { Added: 120, Removed: 2, Changed: 3, Vulnerabilities: 0 },
+  );
+  assertEquals(
+    parseNpmSummary(
+      out(
+        0,
+        "up to date, audited 2 packages in 1.2s\n\nfound 1 vulnerability\n",
+      ),
+    ),
+    { Added: 0, Removed: 0, Changed: 0, Vulnerabilities: 1 },
+  );
+});
+
+Deno.test("npm: a run without the closing line reports nothing", () => {
+  assertEquals(parseNpmSummary(out(0)), undefined);
+  assertEquals(parseNpmSummary(out(1, "", "npm error code ENOENT")), undefined);
+});
+
+/** Exposes the protected hook so the wiring can be exercised without npm. */
+class Probe extends NpmInstallSettings {
+  probe(output: CommandOutput): void {
+    this.onOutput(output);
+  }
+}
+/** The hook lives on the dependency base, so `npm ci` has it too. */
+class CiProbe extends NpmCiSettings {
+  probe(output: CommandOutput): void {
+    this.onOutput(output);
+  }
+}
+
+Deno.test("npm: the hook on every dependency command reports onto the running target", async () => {
+  const summary = new TargetSummary();
+  await withAmbientSummary(summary, () => {
+    new Probe().probe(out(0, "added 3 packages in 1s\n"));
+    return Promise.resolve();
+  });
+  assertEquals(summary.entries()[0], { key: "Added", value: "3" });
+  const ci = new TargetSummary();
+  await withAmbientSummary(ci, () => {
+    new CiProbe().probe(out(0, "added 120 packages in 4s\n"));
+    return Promise.resolve();
+  });
+  assertEquals(ci.entries()[0], { key: "Added", value: "120" });
+});

--- a/packages/pnpm/README.md
+++ b/packages/pnpm/README.md
@@ -110,6 +110,8 @@ abstract class PnpmSettings extends ToolSettings
 
   override protected defaultTool(): string
     The default binary: `pnpm` resolved from PATH.
+  override protected onOutput(output: CommandOutput): void
+    Report `Added`, `Downloaded` and `Reused` onto the build summary.
 
 interface PnpmTasksApi
   The shape of {@link PnpmTasks}.

--- a/packages/pnpm/deno.json
+++ b/packages/pnpm/deno.json
@@ -7,7 +7,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1.25.0"
+    "@zuke/core": "jsr:@zuke/core@^1.44.0"
   },
   "publish": {
     "exclude": [

--- a/packages/pnpm/src/pnpm.ts
+++ b/packages/pnpm/src/pnpm.ts
@@ -18,6 +18,8 @@
 
 import { type Configure, runSettings, ToolSettings } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
+import { reportSummary } from "@zuke/core";
+import { parsePnpmSummary } from "./summary.ts";
 
 /** An access level accepted by pnpm's `--access` flag. */
 export type PnpmAccess = "public" | "restricted";
@@ -27,6 +29,12 @@ export abstract class PnpmSettings extends ToolSettings {
   /** The default binary: `pnpm` resolved from PATH. */
   protected override defaultTool(): string {
     return "pnpm";
+  }
+
+  /** Report `Added`, `Downloaded` and `Reused` onto the build summary. */
+  protected override onOutput(output: CommandOutput): void {
+    const pairs = parsePnpmSummary(output);
+    if (pairs !== undefined) reportSummary(pairs);
   }
 }
 

--- a/packages/pnpm/src/summary.ts
+++ b/packages/pnpm/src/summary.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * What a `pnpm install`-family run reports onto its target's row of the build
+ * summary, read from the progress line pnpm settles on:
+ * `Progress: resolved 120, reused 100, downloaded 20, added 120, done`, or
+ * `Already up to date` when the lockfile needed nothing. Internal to the
+ * wrapper.
+ *
+ * @module
+ */
+
+import type { CommandOutput } from "@zuke/core/shell";
+import type { SummaryPairs } from "@zuke/core";
+import { stripAnsi } from "@zuke/core/render";
+
+/** The settled progress line. */
+const PROGRESS = /^Progress: (.*), done$/m;
+/** One counted phrase of the progress line. */
+const COUNT = /\b(resolved|reused|downloaded|added) (\d+)/g;
+/** The line printed instead when nothing needed doing. */
+const UP_TO_DATE = /^Already up to date$/m;
+
+/**
+ * The notes for a run: `Added`, `Downloaded` and `Reused`. All zero for a
+ * run that was already up to date; nothing for a run that printed neither
+ * line, since it did not complete.
+ */
+export function parsePnpmSummary(
+  output: CommandOutput,
+): SummaryPairs | undefined {
+  const text = stripAnsi(output.stdout);
+  const progress = PROGRESS.exec(text);
+  if (progress === null) {
+    return UP_TO_DATE.test(text)
+      ? { Added: 0, Downloaded: 0, Reused: 0 }
+      : undefined;
+  }
+  const counts = new Map<string, number>();
+  for (const m of progress[1].matchAll(COUNT)) counts.set(m[1], Number(m[2]));
+  return {
+    Added: counts.get("added") ?? 0,
+    Downloaded: counts.get("downloaded") ?? 0,
+    Reused: counts.get("reused") ?? 0,
+  };
+}

--- a/packages/pnpm/tests/summary_test.ts
+++ b/packages/pnpm/tests/summary_test.ts
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals } from "../../core/tests/_assert.ts";
+import {
+  TargetSummary,
+  withAmbientSummary,
+} from "../../core/src/summary_note.ts";
+import { CommandOutput } from "@zuke/core/shell";
+import { PnpmInstallSettings, PnpmRunSettings } from "../src/pnpm.ts";
+import { parsePnpmSummary } from "../src/summary.ts";
+
+/** A run's output with the given streams and exit code. */
+function out(code: number, stdout = "", stderr = ""): CommandOutput {
+  return new CommandOutput(code, stdout, stderr);
+}
+
+Deno.test("pnpm: the settled progress line yields Added, Downloaded and Reused", () => {
+  const text =
+    "Progress: resolved 120, reused 100, downloaded 20, added 120, done\n\ndependencies:\n+ left-pad 1.3.0\n\nDone in 883ms using pnpm v11.25.0\n";
+  assertEquals(parsePnpmSummary(out(0, text)), {
+    Added: 120,
+    Downloaded: 20,
+    Reused: 100,
+  });
+  assertEquals(
+    parsePnpmSummary(
+      out(
+        0,
+        "Lockfile is up to date, resolution step is skipped\nAlready up to date\nDone in 200ms\n",
+      ),
+    ),
+    { Added: 0, Downloaded: 0, Reused: 0 },
+  );
+});
+
+Deno.test("pnpm: a run without either line reports nothing", () => {
+  assertEquals(parsePnpmSummary(out(0)), undefined);
+  assertEquals(
+    parsePnpmSummary(out(0, "> app@1.0.0 build\n> tsc\n")),
+    undefined,
+  );
+  assertEquals(
+    parsePnpmSummary(out(1, "", " ERR_PNPM_NO_PKG_MANIFEST")),
+    undefined,
+  );
+});
+
+/** Exposes the protected hook so the wiring can be exercised without pnpm. */
+class Probe extends PnpmInstallSettings {
+  probe(output: CommandOutput): void {
+    this.onOutput(output);
+  }
+}
+/** The hook lives on the base; a script run prints no progress line and reports nothing. */
+class RunProbe extends PnpmRunSettings {
+  probe(output: CommandOutput): void {
+    this.onOutput(output);
+  }
+}
+
+Deno.test("pnpm: the hook reports onto the running target, and a script run stays silent", async () => {
+  const summary = new TargetSummary();
+  await withAmbientSummary(summary, () => {
+    new Probe().probe(
+      out(0, "Progress: resolved 3, reused 3, downloaded 0, added 3, done\n"),
+    );
+    new RunProbe().probe(out(0, "> app@1.0.0 build\n"));
+    return Promise.resolve();
+  });
+  assertEquals(summary.entries(), [
+    { key: "Added", value: "3" },
+    { key: "Downloaded", value: "0" },
+    { key: "Reused", value: "3" },
+  ]);
+});

--- a/packages/shellcheck/README.md
+++ b/packages/shellcheck/README.md
@@ -85,6 +85,8 @@ class ShellcheckSettings extends ToolSettings
     be given with or without the `SC` prefix, as ShellCheck accepts both.
   externalSources(): this
     Follow `source`d files outside the checked set (`-x`/`--external-sources`).
+  override protected onOutput(output: CommandOutput): void
+    Report `Findings` onto the build summary.
   override protected buildArgs(): string[]
     Assemble the `shellcheck` argv.
 

--- a/packages/shellcheck/deno.json
+++ b/packages/shellcheck/deno.json
@@ -7,7 +7,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1.25.0"
+    "@zuke/core": "jsr:@zuke/core@^1.44.0"
   },
   "publish": {
     "exclude": [

--- a/packages/shellcheck/src/shellcheck.ts
+++ b/packages/shellcheck/src/shellcheck.ts
@@ -29,6 +29,8 @@ import {
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
+import { reportSummary } from "@zuke/core";
+import { parseShellcheckSummary } from "./summary.ts";
 
 /**
  * A shell dialect ShellCheck can analyse (`-s`), overriding the shebang.
@@ -117,6 +119,12 @@ export class ShellcheckSettings extends ToolSettings {
   externalSources(): this {
     this.#externalSources = true;
     return this;
+  }
+
+  /** Report `Findings` onto the build summary. */
+  protected override onOutput(output: CommandOutput): void {
+    const pairs = parseShellcheckSummary(output);
+    if (pairs !== undefined) reportSummary(pairs);
   }
 
   /** Assemble the `shellcheck` argv. */

--- a/packages/shellcheck/src/summary.ts
+++ b/packages/shellcheck/src/summary.ts
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * What a `shellcheck` run reports onto its target's row of the build summary:
+ * the findings it printed, counted in the default `tty` layout (one
+ * `In script.sh line 3:` header per finding) and in the `gcc` layout
+ * (`script.sh:3:6: warning: … [SC2086]`). A clean run prints nothing and
+ * exits 0. Internal to the wrapper.
+ *
+ * @module
+ */
+
+import type { CommandOutput } from "@zuke/core/shell";
+import type { SummaryPairs } from "@zuke/core";
+import { stripAnsi } from "@zuke/core/render";
+
+/** One finding's header in the default `tty` layout. */
+const TTY_FINDING = /^In .+ line \d+:$/gm;
+/** One finding in the `gcc` layout. */
+const GCC_FINDING = /^.+:\d+:\d+: (?:error|warning|note): .*\[SC\d+\]$/gm;
+
+/**
+ * The notes for a run: `Findings`. Counted from whichever layout the run
+ * printed; a run that printed none and exited 0 is clean, and one that exited
+ * non-zero without any (a missing file, a bad flag, a layout with no lines to
+ * count such as `json`) reports nothing rather than a misleading zero.
+ */
+export function parseShellcheckSummary(
+  output: CommandOutput,
+): SummaryPairs | undefined {
+  const text = stripAnsi(output.stdout);
+  const findings = [...text.matchAll(TTY_FINDING)].length +
+    [...text.matchAll(GCC_FINDING)].length;
+  if (findings > 0 || output.code === 0) return { Findings: findings };
+  return undefined;
+}

--- a/packages/shellcheck/tests/summary_test.ts
+++ b/packages/shellcheck/tests/summary_test.ts
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals } from "../../core/tests/_assert.ts";
+import {
+  TargetSummary,
+  withAmbientSummary,
+} from "../../core/src/summary_note.ts";
+import { CommandOutput } from "@zuke/core/shell";
+import { ShellcheckSettings } from "../src/shellcheck.ts";
+import { parseShellcheckSummary } from "../src/summary.ts";
+
+/** A run's output with the given streams and exit code. */
+function out(code: number, stdout = "", stderr = ""): CommandOutput {
+  return new CommandOutput(code, stdout, stderr);
+}
+
+Deno.test("shellcheck: findings are counted in the tty and gcc layouts", () => {
+  const tty = [
+    "",
+    "In bad.sh line 2:",
+    "echo $1",
+    "     ^-- SC2086 (info): Double quote to prevent globbing.",
+    "",
+    "",
+    "In bad.sh line 3:",
+    "foo=`ls`",
+    "    ^--^ SC2006 (style): Use $(...) notation.",
+    "",
+    "For more information:",
+    "  https://www.shellcheck.net/wiki/SC2086",
+  ].join("\n");
+  assertEquals(parseShellcheckSummary(out(1, tty)), { Findings: 2 });
+  const gcc =
+    "bad.sh:2:6: note: Double quote to prevent globbing. [SC2086]\nbad.sh:3:5: warning: Use $(...) notation. [SC2006]\nbad.sh:4:1: error: Unexpected end. [SC1056]\n";
+  assertEquals(parseShellcheckSummary(out(1, gcc)), { Findings: 3 });
+});
+
+Deno.test("shellcheck: a silent clean run is zero, a silent failure reports nothing", () => {
+  assertEquals(parseShellcheckSummary(out(0)), { Findings: 0 });
+  assertEquals(
+    parseShellcheckSummary(
+      out(2, "", "bad.sh: bad.sh: openBinaryFile: does not exist"),
+    ),
+    undefined,
+  );
+  // A layout with nothing to count, such as json, reports nothing on a failure.
+  assertEquals(parseShellcheckSummary(out(1, '[{"line":2}]')), undefined);
+});
+
+/** Exposes the protected hook so the wiring can be exercised without shellcheck. */
+class Probe extends ShellcheckSettings {
+  probe(output: CommandOutput): void {
+    this.onOutput(output);
+  }
+}
+
+Deno.test("shellcheck: the hook reports onto the running target", async () => {
+  const summary = new TargetSummary();
+  await withAmbientSummary(summary, () => {
+    new Probe().probe(out(0));
+    return Promise.resolve();
+  });
+  assertEquals(summary.entries(), [{ key: "Findings", value: "0" }]);
+});

--- a/packages/tsc-alias/README.md
+++ b/packages/tsc-alias/README.md
@@ -77,6 +77,8 @@ class TscAliasRunSettings extends ToolSettings
     Print debug output (`--debug`).
   silent(): this
     Suppress all output (`--silent`).
+  override protected onOutput(output: CommandOutput): void
+    Report `Files` rewritten (under `--verbose`) onto the build summary.
   override protected buildArgs(): string[]
     Assemble the `tsc-alias` argv from the configured settings.
 

--- a/packages/tsc-alias/deno.json
+++ b/packages/tsc-alias/deno.json
@@ -7,7 +7,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1.25.0"
+    "@zuke/core": "jsr:@zuke/core@^1.44.0"
   },
   "publish": {
     "exclude": [

--- a/packages/tsc-alias/src/summary.ts
+++ b/packages/tsc-alias/src/summary.ts
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * What a `tsc-alias` run reports onto its target's row of the build summary:
+ * the files it rewrote, from the `tsc-alias info: 3 files were affected!`
+ * line it prints under `--verbose`. Without that flag the tool prints
+ * nothing, so a run reports nothing. Internal to the wrapper.
+ *
+ * @module
+ */
+
+import type { CommandOutput } from "@zuke/core/shell";
+import type { SummaryPairs } from "@zuke/core";
+import { stripAnsi } from "@zuke/core/render";
+
+/** The verbose closing line. */
+const AFFECTED = /^tsc-alias info: (\d+) files? (?:were|was) affected!$/m;
+
+/** The notes for a verbose run: `Files`, the files rewritten. */
+export function parseTscAliasSummary(
+  output: CommandOutput,
+): SummaryPairs | undefined {
+  const m = AFFECTED.exec(stripAnsi(output.stdout));
+  return m === null ? undefined : { Files: Number(m[1]) };
+}

--- a/packages/tsc-alias/src/tsc_alias.ts
+++ b/packages/tsc-alias/src/tsc_alias.ts
@@ -31,6 +31,8 @@ import {
   ToolSettings,
 } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
+import { reportSummary } from "@zuke/core";
+import { parseTscAliasSummary } from "./summary.ts";
 
 /** Settings for a `tsc-alias` run. */
 export class TscAliasRunSettings extends ToolSettings {
@@ -129,6 +131,12 @@ export class TscAliasRunSettings extends ToolSettings {
   silent(): this {
     this.#silent = true;
     return this;
+  }
+
+  /** Report `Files` rewritten (under `--verbose`) onto the build summary. */
+  protected override onOutput(output: CommandOutput): void {
+    const pairs = parseTscAliasSummary(output);
+    if (pairs !== undefined) reportSummary(pairs);
   }
 
   /** Assemble the `tsc-alias` argv from the configured settings. */

--- a/packages/tsc-alias/tests/summary_test.ts
+++ b/packages/tsc-alias/tests/summary_test.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals } from "../../core/tests/_assert.ts";
+import {
+  TargetSummary,
+  withAmbientSummary,
+} from "../../core/src/summary_note.ts";
+import { CommandOutput } from "@zuke/core/shell";
+import { TscAliasRunSettings } from "../src/tsc_alias.ts";
+import { parseTscAliasSummary } from "../src/summary.ts";
+
+/** A run's output with the given streams and exit code. */
+function out(code: number, stdout = "", stderr = ""): CommandOutput {
+  return new CommandOutput(code, stdout, stderr);
+}
+
+Deno.test("tsc-alias: the verbose closing line yields Files, silence yields nothing", () => {
+  assertEquals(
+    parseTscAliasSummary(out(0, "tsc-alias info: 3 files were affected!\n")),
+    { Files: 3 },
+  );
+  assertEquals(
+    parseTscAliasSummary(out(0, "tsc-alias info: 1 files were affected!\n")),
+    { Files: 1 },
+  );
+  assertEquals(parseTscAliasSummary(out(0)), undefined);
+  assertEquals(
+    parseTscAliasSummary(out(1, "", "tsc-alias error: no tsconfig")),
+    undefined,
+  );
+});
+
+/** Exposes the protected hook so the wiring can be exercised without tsc-alias. */
+class Probe extends TscAliasRunSettings {
+  probe(output: CommandOutput): void {
+    this.onOutput(output);
+  }
+}
+
+Deno.test("tsc-alias: the hook reports onto the running target", async () => {
+  const summary = new TargetSummary();
+  await withAmbientSummary(summary, () => {
+    new Probe().probe(out(0, "tsc-alias info: 2 files were affected!\n"));
+    return Promise.resolve();
+  });
+  assertEquals(summary.entries(), [{ key: "Files", value: "2" }]);
+});

--- a/packages/yarn/README.md
+++ b/packages/yarn/README.md
@@ -95,6 +95,8 @@ abstract class YarnSettings extends ToolSettings
 
   override protected defaultTool(): string
     The default binary: `yarn` resolved from PATH.
+  override protected onOutput(output: CommandOutput): void
+    Report `Added` and `Removed` (Yarn Berry) onto the build summary.
 
 interface YarnTasksApi
   The shape of {@link YarnTasks}.

--- a/packages/yarn/deno.json
+++ b/packages/yarn/deno.json
@@ -7,7 +7,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1.25.0"
+    "@zuke/core": "jsr:@zuke/core@^1.44.0"
   },
   "publish": {
     "exclude": [

--- a/packages/yarn/src/summary.ts
+++ b/packages/yarn/src/summary.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * What a `yarn install`-family run reports onto its target's row of the build
+ * summary, read from the fetch-step line Yarn Berry prints:
+ * `➤ YN0013: │ 2 packages were added to the project (+ 46.4 KiB).` and its
+ * `removed` counterpart. Yarn Classic prints no count, so a Classic run
+ * reports nothing. Internal to the wrapper.
+ *
+ * @module
+ */
+
+import type { CommandOutput } from "@zuke/core/shell";
+import type { SummaryPairs } from "@zuke/core";
+import { stripAnsi } from "@zuke/core/render";
+
+/** One of Berry's counted fetch-step lines. */
+const COUNT =
+  /(\d+) packages? (?:were|was) (added to|removed from) the project/g;
+
+/**
+ * The notes for a Berry run: `Added` and `Removed`. A run that printed
+ * neither line — Classic, or a Berry run that fetched nothing — reports
+ * nothing.
+ */
+export function parseYarnSummary(
+  output: CommandOutput,
+): SummaryPairs | undefined {
+  const counts = new Map<string, number>();
+  for (const m of stripAnsi(output.stdout).matchAll(COUNT)) {
+    counts.set(m[2], Number(m[1]));
+  }
+  if (counts.size === 0) return undefined;
+  return {
+    Added: counts.get("added to") ?? 0,
+    Removed: counts.get("removed from") ?? 0,
+  };
+}

--- a/packages/yarn/src/yarn.ts
+++ b/packages/yarn/src/yarn.ts
@@ -22,12 +22,20 @@
 
 import { type Configure, runSettings, ToolSettings } from "@zuke/core/tooling";
 import type { CommandOutput } from "@zuke/core/shell";
+import { reportSummary } from "@zuke/core";
+import { parseYarnSummary } from "./summary.ts";
 
 /** Base for all `yarn` subcommand settings: binary is `yarn` from PATH. */
 export abstract class YarnSettings extends ToolSettings {
   /** The default binary: `yarn` resolved from PATH. */
   protected override defaultTool(): string {
     return "yarn";
+  }
+
+  /** Report `Added` and `Removed` (Yarn Berry) onto the build summary. */
+  protected override onOutput(output: CommandOutput): void {
+    const pairs = parseYarnSummary(output);
+    if (pairs !== undefined) reportSummary(pairs);
   }
 }
 

--- a/packages/yarn/tests/summary_test.ts
+++ b/packages/yarn/tests/summary_test.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals } from "../../core/tests/_assert.ts";
+import {
+  TargetSummary,
+  withAmbientSummary,
+} from "../../core/src/summary_note.ts";
+import { CommandOutput } from "@zuke/core/shell";
+import { YarnInstallSettings } from "../src/yarn.ts";
+import { parseYarnSummary } from "../src/summary.ts";
+
+/** A run's output with the given streams and exit code. */
+function out(code: number, stdout = "", stderr = ""): CommandOutput {
+  return new CommandOutput(code, stdout, stderr);
+}
+
+Deno.test("yarn: Berry fetch-step counts yield Added and Removed; Classic prints none", () => {
+  const berry =
+    "➤ YN0000: ┌ Resolution step\n➤ YN0000: └ Completed\n➤ YN0000: ┌ Fetch step\n➤ YN0013: │ 2 packages were added to the project (+ 46.4 KiB).\n➤ YN0013: │ 1 package was removed from the project (- 1.2 KiB).\n➤ YN0000: └ Completed\n➤ YN0000: · Done in 1s 2ms\n";
+  assertEquals(parseYarnSummary(out(0, berry)), { Added: 2, Removed: 1 });
+  const classic =
+    "yarn install v1.22.22\n[1/4] Resolving packages...\n[4/4] Building fresh packages...\nsuccess Saved lockfile.\nDone in 1.23s.\n";
+  assertEquals(parseYarnSummary(out(0, classic)), undefined);
+  assertEquals(
+    parseYarnSummary(out(1, "", "error Couldn't find package.json")),
+    undefined,
+  );
+});
+
+/** Exposes the protected hook so the wiring can be exercised without yarn. */
+class Probe extends YarnInstallSettings {
+  probe(output: CommandOutput): void {
+    this.onOutput(output);
+  }
+}
+
+Deno.test("yarn: the hook reports onto the running target", async () => {
+  const summary = new TargetSummary();
+  await withAmbientSummary(summary, () => {
+    new Probe().probe(
+      out(0, "➤ YN0013: │ 5 packages were added to the project (+ 1 MiB).\n"),
+    );
+    return Promise.resolve();
+  });
+  assertEquals(summary.entries(), [{ key: "Added", value: "5" }, {
+    key: "Removed",
+    value: "0",
+  }]);
+});

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/.codex-plugin/plugin.json
+++ b/plugins/zuke/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -152,6 +152,7 @@ deploy = target().executes(async (ctx) => {
   ctx.stateOf("build").get(); // read ANOTHER target's published state
   ctx.signals.get("approved"); // an external signal's payload (see waits)
   ctx.outcomeOf("checks")?.status; // one target's settled outcome, or undefined
+  ctx.outcomeOf("test")?.summary; // its Build Summary notes (durable, e.g. Tests/Passed)
   ctx.outcomes(); // every outcome settled SO FAR, keyed by dotted name
   ctx.reportSummary({ Version: "3.6.2" }); // a note on THIS row of the Build Summary
 });

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -152,6 +152,7 @@ deploy = target().executes(async (ctx) => {
   ctx.stateOf("build").get(); // read ANOTHER target's published state
   ctx.signals.get("approved"); // an external signal's payload (see waits)
   ctx.outcomeOf("checks")?.status; // one target's settled outcome, or undefined
+  ctx.outcomeOf("test")?.summary; // its Build Summary notes (durable, e.g. Tests/Passed)
   ctx.outcomes(); // every outcome settled SO FAR, keyed by dotted name
   ctx.reportSummary({ Version: "3.6.2" }); // a note on THIS row of the Build Summary
 });

--- a/tests/integration/summary_record_test.ts
+++ b/tests/integration/summary_record_test.ts
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Integration: a target's summary notes are durable, end to end through the
+ * CLI `main()`. The notes a body reports land in the run record the build
+ * writes, `zuke runs show` prints them on the target's line, and a dependent
+ * target reads them back through `ctx.outcomeOf(...)`. A secret a note happens
+ * to carry is redacted before it is written, like every other string in the
+ * record.
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import {
+  Build,
+  defaultStateHost,
+  FileSystemStateStore,
+  type RunRecord,
+  target,
+} from "../../packages/core/mod.ts";
+import { runCli, withStateDir } from "./_harness.ts";
+
+/** The id of the single run recorded under `dir`. */
+async function onlyRunId(dir: string): Promise<string> {
+  const runs = await new FileSystemStateStore(dir, defaultStateHost).listRuns(
+    {},
+  );
+  assertEquals(runs.length, 1);
+  return runs[0].id;
+}
+
+/** The full persisted record of run `id` under `dir`. */
+async function loadRun(dir: string, id: string): Promise<RunRecord> {
+  const store = new FileSystemStateStore(dir, defaultStateHost);
+  const got = await store.getRun(id);
+  if (got === null) throw new Error(`run ${id} not found`);
+  return got.record;
+}
+
+Deno.test("summary notes land in the run record, in runs show, and in outcomeOf", async () => {
+  await withStateDir(async (dir) => {
+    const seen: string[] = [];
+    class CI extends Build {
+      test = target().executes((ctx) => {
+        ctx.reportSummary({ Tests: 4094, Failed: 0 });
+      });
+      report = target().dependsOn(this.test).executes((ctx) => {
+        for (const note of ctx.outcomeOf("test")?.summary ?? []) {
+          seen.push(`${note.key}=${note.value}`);
+        }
+      });
+    }
+    const run = await runCli(CI, ["report"]);
+    assertEquals(run.code, 0, run.err);
+    assertEquals(seen, ["Tests=4094", "Failed=0"]);
+
+    const id = await onlyRunId(dir);
+    const record = await loadRun(dir, id);
+    assertEquals(record.targets.test.summary, [
+      { key: "Tests", value: "4094" },
+      { key: "Failed", value: "0" },
+    ]);
+    assertEquals(record.targets.report.summary, undefined);
+
+    const show = await runCli(CI, ["runs", "show", id]);
+    assertEquals(show.code, 0);
+    assertStringIncludes(show.out, "// Tests: 4094 · Failed: 0");
+  });
+});
+
+Deno.test("a failed target's notes survive next to its error in runs show", async () => {
+  await withStateDir(async (dir) => {
+    class CI extends Build {
+      test = target().executes((ctx) => {
+        ctx.reportSummary({ Tests: 3, Failed: 1 });
+        throw new Error("1 test failed");
+      });
+    }
+    const run = await runCli(CI, ["test"]);
+    assertEquals(run.code, 1);
+
+    const id = await onlyRunId(dir);
+    const record = await loadRun(dir, id);
+    assertEquals(record.targets.test.status, "failed");
+    assertEquals(record.targets.test.summary, [
+      { key: "Tests", value: "3" },
+      { key: "Failed", value: "1" },
+    ]);
+
+    const show = await runCli(CI, ["runs", "show", id]);
+    assertEquals(show.code, 0);
+    assertStringIncludes(show.out, "1 test failed  // Tests: 3 · Failed: 1");
+  });
+});

--- a/zuke.ts
+++ b/zuke.ts
@@ -123,6 +123,19 @@ import { githubWorkflows } from "./build/workflows.ts";
  */
 const GITLEAKS_REPORT = "gitleaks-report.json";
 
+/**
+ * The files the `check` target type-checks: the globs of the root `check` task
+ * in `deno.json`, which stays the entry point for a plain `deno task check`.
+ */
+const CHECK_GLOBS = [
+  "zuke.ts",
+  "build/*.ts",
+  "tests/**/*.ts",
+  "packages/*/mod.ts",
+  "packages/*/src/**/*.ts",
+  "packages/*/tests/**/*.ts",
+];
+
 class ZukeBuild extends Build {
   clean = target()
     .description("Remove build artifacts")
@@ -219,7 +232,11 @@ class ZukeBuild extends Build {
     .description("Type-check the whole workspace")
     .dependsOn(this.restore)
     .executes(async () => {
-      await DenoTasks.task((s) => s.name("check"));
+      // The same files the root `check` task names, run through the wrapper
+      // rather than `deno task` so the row can say `// Errors: 0`: the task
+      // runner's shell would expand the globs, so they are expanded here.
+      const files = (await Promise.all(CHECK_GLOBS.map((g) => glob(g)))).flat();
+      await DenoTasks.check((s) => s.frozen().paths(...files));
     });
 
   test = target()


### PR DESCRIPTION
## What & why

Three follow-ups to the summary-notes work (#450, #452, #459, #460, #461), in one PR as agreed on the issue.

**Notes are durable.** A target's summary notes now live on its entry in the run record. The state writer stores them when the target settles, redacted like every other string in the record, and the parser reads them back and rejects a malformed array. `zuke runs show` prints them after the duration on a succeeded line and after the error on a failed one, in the same `// Tests: 4094 · Failed: 0` form the Build Summary uses, and the MCP `show_run` tool carries them in the raw record it returns. A dependent target reads them through the new `summary` field on the outcome view, filled from the in-process settlement first and from the persisted row on a resume.

**Zuke's own `check` row says `Errors: 0`.** The `check` target now expands the same globs the root `check` task names and runs them through the deno wrapper's check task with `--frozen`, so the type-check output passes through the wrapper's hook and the row carries its count.

**The remaining wrappers report.** Each parses its tool's own closing output and reports through the ambient hook: knip sums its issue sections into `Issues`, dpdm counts the numbered entries under its circular-dependencies heading into `Circular`, shellcheck counts findings in both its tty and gcc formats, tsc-alias reports the files it rewrote when run verbose, and the install commands of npm, pnpm, yarn (Berry) and bun report packages added, removed, changed, downloaded or reused as their tools print them. A clean run reports zeros where a silent success is meaningful; a run that never printed its closing line reports nothing. Their core floors move to 1.44.0, the release that introduced the ambient reporter, and the lock is regenerated. Docker is left out on purpose: `docker build` streams BuildKit progress with no stable closing line.

Docs: `docs/run-context.md` lists the eight new wrappers and gains a "Notes are durable" section, the cheatsheet shows the outcome view's `summary`, the plugin manifests move to 0.38.0, and the API docs are regenerated.

Tests: unit tests for the writer, parser, outcome view, `runs show` rendering and each new parser and hook; an executor test that a note lands in the record and in a dependent's outcome; and a new integration test, `tests/integration/summary_record_test.ts`, driving a real build through the CLI, reading the record back, and showing it through `runs show` for both a succeeded and a failed target.

`deno task ci` was run locally with the `security` target skipped, since the scanner downloads are blocked in this sandbox; every other target is green, coverage is at 98.4% lines and 97.4% branches, and `./zuke coreFloorCheck` passes.

## Related issues

Closes #464

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a
      [Conventional Commit](https://www.conventionalcommits.org/)
      (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour
      changed.
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`,
      `llms-full.txt`, package README `## API`).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with
      type guards instead).
- [x] No dead code: unreachable branches and can't-fire fallbacks are removed,
      with types tightened so the impossible state is unrepresentable.
- [x] No duplicated logic: an existing helper is imported rather than retyped,
      and a near-copy differing by a constant or a message is parameterised into
      one implementation. A guard, escape, or credential resolution has exactly
      one implementation.
- [x] SOLID shapes respected: one domain per file, extension via the settings
      lambda (not a behaviour-switching flag), narrow parameter types, and
      dependencies on the injectable seam (`StateHost`, an injected `fetch`,
      `EnvReader`) rather than `Deno.*` or a global.
- [ ] A new package was wired into all six places (see
      [AGENTS.md](../blob/master/AGENTS.md#good-open-source-practices-to-follow)),
      if applicable.
- [x] The code is written using AI assisted coding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrP7TrH4YPZiFmSE3mdhBT

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrP7TrH4YPZiFmSE3mdhBT)_