### PR TITLE
docs: restore README formatting and drop the stale table reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ Teams running Zuke in production:
   </picture>
 </a>
 
->Using Zuke at your company? We'd love to list you — open a pull request adding
-your logo to `assets/users/` and a row to this table, or say hello in an
-[issue](https://github.com/zuke-build/zuke/issues) and we'll add it for you.
+> Using Zuke at your company? We'd love to list you — open a pull request adding
+> your logo to `assets/users/` and an entry to this section, or say hello in an
+> [issue](https://github.com/zuke-build/zuke/issues) and we'll add it for you.
 
 ## Install
 


### PR DESCRIPTION
## What & why

Two defects in the "Who's using Zuke" section, both introduced by the
direct-to-`master` commits `034c300`, `af005b4` and `1d64011` that reworked it
after #468 merged. Those went in without a pull request, so CI never ran on
them.

**1. `README.md` had stopped passing `deno fmt --check`.** The invitation
blockquote carried its marker on the first line only. Markdown's lazy
continuation renders that correctly on GitHub, so nothing *looked* wrong — but
`deno fmt` wants the marker on every line, and the check reported one
not-formatted file.

This was the part worth fixing quickly. `format` is the first target in
`deno task ci`, so **the next pull request opened against this repository would
have failed the gate on a commit that was not its own** — a confusing few
minutes for a contributor and a wasted CI cycle, made worse by the failure
looking like it belonged to whatever PR happened to hit it.

**2. The invitation pointed at a table that no longer exists.** The same rework
replaced the table markup with a bare anchor, but the paragraph still told
contributors to add "a row to this table". It now refers to the section that
actually exists. That paragraph is the one place an outside contributor is told
how to get their company listed, so it is worth being accurate.

The Payhawk mark, its light and dark picture sources, and the committed assets
are untouched.

## Related issues

Closes #469

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a
      [Conventional Commit](https://www.conventionalcommits.org/). `docs:` — no
      release.
- [x] `deno task ci` passes locally — see the note below.
- [ ] Tests were added or updated; coverage stays at 95%+. — n/a: no code
      changed. The `coverage` target was run anyway and is green.
- [x] Docs updated in the same PR — this PR *is* the docs fix.
- [ ] Public API changes regenerated with `./zuke apiDocs`. — n/a; `apiDocsCheck`
      is green.
- [ ] No `any`, no `as` casts or `!` non-null assertions in `src/`. — n/a.
- [ ] No dead code. — n/a.
- [ ] No duplicated logic. — n/a.
- [ ] SOLID shapes respected. — n/a.
- [ ] A new package was wired into all six places. — n/a.
- [x] The code is written using AI assisted coding.

### Verification

The failure was reproduced before the fix and confirmed cleared after:
`deno fmt --check README.md` reports one not-formatted file on the current
`master` content, and reports the file checked and clean on this branch.

All fourteen runnable gate targets then pass: `format`, `lint`, `spell`,
`coverage`, `apiDocsCheck`, `docLint`, `snippetsCheck`, `hclSyncCheck`,
`pluginSyncCheck`, `skillsCheck`, `graphDocCheck`, `pluginVersionCheck`
— run against `origin/master`, so it actually ran rather than reporting itself
skipped — `actionPinCheck`, and `lockCheck`.

`security` is the one target that cannot run in the sandbox this was authored
in: its known-vulnerable-actions audit gets an HTTP 403 from the GitHub
advisories API when reaching it unauthenticated. That is environmental and
unrelated to this diff, which touches no workflow. CI has now confirmed it —
`security` passed on this PR's own run.

### Note on the first CI run

The first run failed `prBodyLint`, on this description rather than on the diff:
I had included two fenced code blocks, which is precisely what that gate exists
to catch, since the squashed body is what release-please parses. The fences are
gone and those snippets are described in prose instead. Nothing about the code
changed, and this note is the only reason the description differs from the
first version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DawVoE73Fw4DENCTzyecLr
