### PR TITLE
feat(core): add an McpAuthenticator seam for the MCP server

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.38.0",
+      "version": "0.39.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/cspell.json
+++ b/cspell.json
@@ -241,6 +241,7 @@
     "prepatch",
     "rundll",
     "strapline",
+    "WHATWG",
     "wordmark",
     "xhigh",
     "xoxb",

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -714,7 +714,8 @@ that finished.
 `Build` exposes one override per subsystem, each documented on its own page:
 [`stateStore()`](./state.md), [`deadline()`](./state.md),
 [`remoteCache()`](./caching.md), [`recoverWith()`](./self-healing.md),
-[`registry()`](./registry.md) and [`mcpIdentity()`](./mcp.md).
+[`registry()`](./registry.md), [`mcpAuth()`](./mcp.md) and
+[`mcpIdentity()`](./mcp.md).
 
 **External ordering — `override extraEdges(targets)`.** Return `[before, after]`
 pairs to impose soft ordering on the plan beyond the per-target `.before()` /

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -179,8 +179,10 @@ to an audit trail, readable on the host with `./zuke runs show mcp-audit` and
 deliberately not served over MCP.
 
 `--http <host:port>` serves the streamable-HTTP transport instead of stdio
-(loopback by default; a non-loopback bind requires a `ZUKE_MCP_TOKEN` bearer
-token), and `--allowed-origin <origin>` permits one extra browser origin.
+(loopback by default; a non-loopback bind must authenticate its callers — a
+`ZUKE_MCP_TOKEN` bearer token, or an authenticator declared with
+[`mcpAuth()`](./mcp.md)), and `--allowed-origin <origin>` permits one extra
+browser origin.
 `--registry` serves the [build registry](./registry.md) instead of this build —
 every registered pipeline becomes a `run:<buildId>:<target>` tool, spawned in
 its own process, with `--max-concurrent-runs <n>` capping how many run at once

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -67,10 +67,16 @@ below), so one long `run:` never head-of-line-blocks another client's read.
   host.
 - Binding a **non-loopback** address requires authentication — **either** a
   bearer token (set `ZUKE_MCP_TOKEN`, and every request must send
-  `Authorization: Bearer <token>`; a missing or wrong token gets `401`) **or**
-  an [authenticator](#authentication) declared on the build. With neither, Zuke
-  **refuses to bind** a non-loopback address rather than exposing an
-  unauthenticated endpoint.
+  `Authorization: Bearer <token>`; a missing or wrong token gets `401`) **or** an
+  [`mcpAuth()`](#mcpauth--the-general-seam) authenticator on the build. With
+  neither, Zuke **refuses to bind** a non-loopback address rather than exposing
+  an unauthenticated endpoint.
+- [`mcpIdentity()`](#mcpidentity--sugar-for-a-proxy-header) does **not** satisfy
+  that requirement, though it still runs on every request. It trusts a header,
+  which is only an identity when something in front strips the client's copy and
+  injects its own — on a directly reachable endpoint any caller sets that header
+  itself. Such a build needs the bearer token to bind off loopback, or a proxy in
+  front of a loopback bind.
 - A token is also enforced on a loopback bind when `ZUKE_MCP_TOKEN` is set, and
   an authenticator runs on every bind, loopback included. The two compose: the
   token is a shared secret that gates the endpoint, the authenticator says _who_
@@ -216,7 +222,7 @@ may be asynchronous (verifying a token signature is), and it either returns an
 
 ```ts
 class ControlPlane extends Build {
-  override mcpAuth() {
+  override mcpAuth(): McpAuthenticator {
     return {
       authenticate: async (ctx: McpRequestContext) => {
         const claims = await verifyBearer(ctx.headers.get("authorization"));
@@ -283,6 +289,11 @@ It is the right seam when a proxy has already done the authenticating; reach for
 `mcpAuth()` when callers reach the server directly, when the check is async, or
 when you want to answer with a status and a challenge of your own.
 
+Because it authenticates nothing on its own, it does not unlock a
+[non-loopback bind](#http-transport): that still needs `ZUKE_MCP_TOKEN` or an
+`mcpAuth()` authenticator. Bind loopback and let the proxy reach it, or set the
+token as well.
+
 Declare **one or the other**. A build that declares both makes `./zuke mcp`
 print a message to stderr and **exit 1** rather than letting one silently win.
 
@@ -316,8 +327,9 @@ never tell it. A client that treats every `200` as "connected" will now see the
 refusal it should have seen all along.
 
 Over **stdio** there is no status to answer with, so a refusal is a JSON-RPC
-`-32600 Unauthorized` error — the reject's own `error`/`detail`/`challenge` have
-nowhere to go there.
+`-32600` error carrying the same reason the HTTP body does: the reject's
+`error`, and its `detail` after a colon when it has one. Only the status and the
+challenge have nowhere to go there.
 
 ### Fail-closed
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -47,7 +47,7 @@ For a client that connects over the network rather than launching the process,
 
 ```sh
 ./zuke mcp --http 7777                 # bind 127.0.0.1:7777 (local only)
-./zuke mcp --http 0.0.0.0:7777         # bind all interfaces — needs a token
+./zuke mcp --http 0.0.0.0:7777         # all interfaces — token or mcpAuth()
 ```
 
 Each request is a `POST` whose body is one JSON-RPC message; the response is
@@ -65,12 +65,21 @@ below), so one long `run:` never head-of-line-blocks another client's read.
 
 - `--http <port>` binds **loopback** (`127.0.0.1`), reachable only from the same
   host.
-- Binding a **non-loopback** address requires a bearer token: set
-  `ZUKE_MCP_TOKEN`, and every request must send `Authorization: Bearer <token>`
-  (a missing or wrong token gets `401`). Without a token, Zuke **refuses to
-  bind** a non-loopback address rather than exposing an unauthenticated
-  endpoint.
-- A token is also enforced on a loopback bind when `ZUKE_MCP_TOKEN` is set.
+- Binding a **non-loopback** address requires authentication — **either** a
+  bearer token (set `ZUKE_MCP_TOKEN`, and every request must send
+  `Authorization: Bearer <token>`; a missing or wrong token gets `401`) **or**
+  an [authenticator](#authentication) declared on the build. With neither, Zuke
+  **refuses to bind** a non-loopback address rather than exposing an
+  unauthenticated endpoint.
+- A token is also enforced on a loopback bind when `ZUKE_MCP_TOKEN` is set, and
+  an authenticator runs on every bind, loopback included. The two compose: the
+  token is a shared secret that gates the endpoint, the authenticator says _who_
+  is calling.
+- **The order a request passes:** HTTP method (a non-`POST` gets `405`) →
+  `Origin` (`403`) → the static bearer token (`401`) → the
+  [authenticator](#authentication) (the refusal's own status) → the body (capped
+  at 1 MiB; over it, `413`). Authentication runs **before** the body is read, so
+  an unauthenticated caller never makes the server buffer its payload.
 - **Origin validation** guards against a browser drive-by / DNS-rebinding page:
   on a loopback bind, a request that carries an `Origin` header is accepted only
   when it is a loopback origin, and rejected `403` otherwise. A client that sends
@@ -183,19 +192,78 @@ The trail lives in a store-level record; read it with `./zuke runs show mcp-audi
 **on the host**. It is deliberately not readable over MCP — `show_run` refuses
 it and `list_runs` omits it — because the clients it audits must not be able to
 read who called what, or to confirm which of their calls were denied. The actor
-resolves by precedence: the **identity
-hook** (below) → `--actor` → `ZUKE_ACTOR` → the CI actor → the connecting
-client's `initialize` name → `"anonymous"`. The client name is an **untrusted
-label** for the trail only — it never influences authorization. On a shared HTTP
-endpoint it reflects the most recent client to connect, so use the identity hook
-(or `--actor`) for authoritative attribution there.
+resolves by precedence: the **authenticated identity**
+([below](#authentication)) → `--actor` → `ZUKE_ACTOR` → the CI actor → the
+connecting client's `initialize` name → `"anonymous"`. The client name is an
+**untrusted label** for the trail only — it never influences authorization. On a
+shared HTTP endpoint it reflects the most recent client to connect, so declare
+an authenticator (or set `--actor`) for authoritative attribution there.
 
-### Trusted per-call identity
+## Authentication
 
-On a shared, multi-user endpoint "who did this" must not be self-reported. Front
-the server with an authenticating reverse proxy (e.g. OAuth 2.1) that injects
-the real caller in a header it strips from client input, and resolve it with a
-per-request **identity hook** — `override mcpIdentity()` on the build:
+By default the server does not identify its callers: on stdio it inherits the
+trust of the shell that launched it, and over HTTP `ZUKE_MCP_TOKEN` is a shared
+secret, not an identity. On a shared, multi-user endpoint "who did this" must
+not be self-reported, so a build can declare an **authenticator** that runs once
+per request, **before any dispatch**, on both transports.
+
+### `mcpAuth()` — the general seam
+
+`override mcpAuth()` returns an object with an `authenticate(ctx)` method. It
+may be asynchronous (verifying a token signature is), and it either returns an
+**identity** — `{ actor, kind?, roles?, via? }` — or refuses with an
+**`McpAuthReject`**:
+
+```ts
+class ControlPlane extends Build {
+  override mcpAuth() {
+    return {
+      authenticate: async (ctx: McpRequestContext) => {
+        const claims = await verifyBearer(ctx.headers.get("authorization"));
+        if (claims === null) {
+          return {
+            status: 401,
+            error: "invalid_token",
+            detail: "expired or unknown bearer token",
+            challenge: 'Bearer realm="zuke", error="invalid_token"',
+          };
+        }
+        return { actor: claims.sub, kind: "service", roles: claims.roles };
+      },
+    };
+  }
+}
+```
+
+`ctx` is the request context: its `headers`, plus the underlying `request` (so
+an authenticator can read the method and URL) when the caller arrived over HTTP.
+On **stdio** both are empty — an authenticator that insists on a header refuses
+every stdio call, which is the point: declare one for the endpoint you actually
+expose.
+
+The identity's fields:
+
+| Field   | Meaning                                                                                                      |
+| ------- | ------------------------------------------------------------------------------------------------------------ |
+| `actor` | The authenticated caller. Required and non-empty — anything else refuses the request.                        |
+| `kind`  | `"human"` or `"service"`. Omitted reads as `"human"`, so a service claim must be stated.                     |
+| `roles` | The caller's roles. Omitted reads as none, so an authenticator that says nothing about roles grants nothing. |
+| `via`   | How the identity was established (`"oauth-proxy"`). Informational only.                                      |
+
+The resolved `actor` overrides `--actor`, the environment, and the client label
+for that call, and flows to the [audit trail](#audit-log), run records,
+lock-holder identity, and a registry-spawned child's `ZUKE_ACTOR`. `kind` and
+`roles` reach a [registry](#registry-mode-dynamic-discovery)-spawned child as
+`ZUKE_ACTOR_KIND` and `ZUKE_ACTOR_ROLES`; they are **not** an authorization
+input — the [allow-list, `--protect` and the operator token](#authorization)
+remain what gates a call.
+
+### `mcpIdentity()` — sugar for a proxy header
+
+`override mcpIdentity()` is the older, synchronous seam, unchanged for authors:
+front the server with an authenticating reverse proxy (e.g. OAuth 2.1) that
+injects the real caller in a header it strips from client input, and return that
+caller. **Any throw rejects the request.**
 
 ```ts
 class ControlPlane extends Build {
@@ -209,16 +277,83 @@ class ControlPlane extends Build {
 }
 ```
 
-The hook runs **once per request, before any dispatch**. Its `actor` overrides
-`--actor`, the environment, and the client label for that call, and flows to the
-audit trail, run records, lock-holder identity, and — for a registry-spawned
-build — the child's `ZUKE_ACTOR`. It is **fail-closed**: a hook that throws _or_
-yields no usable actor (an empty string, e.g. from `headers.get(…) ?? ""` when
-the header is missing) **rejects the request** with an auth error — nothing
-executes, nothing is written, and it never falls back to the static actor, so
-the hook's precedence stays absolute. Without a hook, stdio/local behavior is
-unchanged. This is deliberately the _minimal_ seam — TLS, the OAuth flow, and
-header stripping are the proxy's job, not Zuke's.
+Internally it is adapted onto an `McpAuthenticator` and runs on exactly the same
+path, so there is one authentication code path rather than two that can drift.
+It is the right seam when a proxy has already done the authenticating; reach for
+`mcpAuth()` when callers reach the server directly, when the check is async, or
+when you want to answer with a status and a challenge of your own.
+
+Declare **one or the other**. A build that declares both makes `./zuke mcp`
+print a message to stderr and **exit 1** rather than letting one silently win.
+
+### Refusing: the `McpAuthReject` contract
+
+| Field       | Meaning                                                                                                                   |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `status`    | The HTTP status to answer with. Must be an integer **client error** (`400`–`499`) — `401` or `403` in practice.           |
+| `error`     | A short reason, machine-readable where a standard code exists (`"invalid_token"`). It becomes the JSON-RPC error message. |
+| `detail`    | Optional human-readable detail, appended as `error: detail`. Returned to the caller — never put a secret in it.           |
+| `challenge` | Optional `WWW-Authenticate` header value.                                                                                 |
+
+A `status` outside `400`–`499` — or a non-integer, or none at all — **collapses
+to a bare `401`**
+(`{ status: 401, error: "Unauthorized", challenge: "Bearer" }`). The rule exists
+so an authenticator cannot turn its own refusal into a success at the transport:
+a returned `status: 200` would otherwise answer `200` to a request the build
+meant to deny.
+
+### The refusal a client sees (behaviour change)
+
+A refused HTTP request now answers **`401`** — or the reject's own status —
+carrying its `WWW-Authenticate` challenge when it has one. It previously
+answered `200` with a JSON-RPC error. **The JSON-RPC error is still in the
+body** (`-32600`, message `error` or `error: detail`, with a `null` id since the
+body was never read), so a client that only reads JSON-RPC still sees a reason.
+
+This is the point of the change: an MCP client discovers _where_ to authenticate
+from the `401` and its challenge, which a JSON-RPC error inside a `200` can
+never tell it. A client that treats every `200` as "connected" will now see the
+refusal it should have seen all along.
+
+Over **stdio** there is no status to answer with, so a refusal is a JSON-RPC
+`-32600 Unauthorized` error — the reject's own `error`/`detail`/`challenge` have
+nowhere to go there.
+
+### Fail-closed
+
+The seam denies rather than admits, whatever the authenticator does. All of
+these refuse the request — nothing executes, nothing is written to state, and
+none of them falls back to the static actor, so the identity's precedence stays
+absolute:
+
+- the authenticator **throws** (the refusal is a bare `401`, so a throw leaks
+  nothing about why it threw);
+- it returns something that is **not an object** (`null`, a string, an array);
+- its `actor` is **empty or not a string** — e.g. `headers.get(…) ?? ""` when
+  the header is missing;
+- its rejection is **malformed** (see the status rule above).
+
+An unknown `kind` reads as `"human"` and malformed `roles` entries drop out,
+rather than refusing: a value that is _nearly_ an identity must never become a
+_more privileged_ one than the authenticator meant.
+
+Without either override, stdio/local behaviour is unchanged.
+
+### In a registry-spawned child
+
+A [registry](#registry-mode-dynamic-discovery) run spawns the registered build,
+and the resolved caller travels with it as three environment variables:
+`ZUKE_ACTOR`, `ZUKE_ACTOR_KIND` (`"human"` when the authenticator omitted it)
+and `ZUKE_ACTOR_ROLES` (comma-joined, empty when there are none). They are
+written **together**, and only when the resolved actor is non-empty, so an
+inherited kind or role set can never survive beside a fresh actor — the child
+would otherwise read one caller's actor with another's entitlements. They
+override anything inherited; the spawned build reads them itself (`ZUKE_ACTOR`
+is the usual actor source, and the other two are there for a build that wants to
+branch on who launched it).
+
+TLS, the OAuth flow, and header stripping remain the proxy's job, not Zuke's —
+this is deliberately the _minimal_ seam.
 
 ## Registry mode (dynamic discovery)
 
@@ -301,8 +436,9 @@ endpoint: it speaks only over the stdin/stdout of a process the client launches,
 so its trust boundary is the local machine — anyone who can start `./zuke mcp`
 already has a shell there and could run `deno run -A zuke.ts <target>` directly.
 The [HTTP transport](#http-transport) adds a network endpoint, so it moves that
-boundary: it binds loopback by default, requires a bearer token off loopback,
-and is meant to sit behind real TLS/authentication. Either way, treat the server
+boundary: it binds loopback by default, requires a bearer token or an
+[authenticator](#authentication) off loopback, and is meant to sit behind real
+TLS/authentication. Either way, treat the server
 like any other local developer tool and don't wire an untrusted client to it.
 
 Running a target executes real build code, so execution is **off by default**: a

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -356,7 +356,9 @@ Without either override, stdio/local behaviour is unchanged.
 A [registry](#registry-mode-dynamic-discovery) run spawns the registered build,
 and the resolved caller travels with it as three environment variables:
 `ZUKE_ACTOR`, `ZUKE_ACTOR_KIND` (`"human"` when the authenticator omitted it)
-and `ZUKE_ACTOR_ROLES` (comma-joined, empty when there are none). They are
+and `ZUKE_ACTOR_ROLES` (comma-joined, empty when there are none — a role name
+containing a comma is dropped when the identity is resolved, so splitting on the
+separator is safe). They are
 written **together**, and only when the resolved actor is non-empty, so an
 inherited kind or role set can never survive beside a fresh actor — the child
 would otherwise read one caller's actor with another's entitlements. They

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "zuke",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build)."
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1064,6 +1064,39 @@ class Build
       }
     }
     ```
+  mcpAuth(): McpAuthenticator | undefined
+    An authenticator for `zuke mcp` — the general form of
+    {@link Build.mcpIdentity}, for a server callers reach directly rather than
+    through a proxy that has already identified them.
+
+    It runs before any dispatch, may be asynchronous (verifying a signature is),
+    and refuses by returning an {@link McpAuthReject} rather than by throwing —
+    so over HTTP the refusal is answered with its own status and
+    `WWW-Authenticate` challenge, which is how an MCP client discovers where to
+    authenticate. The identity it resolves overrides `--actor`, the environment,
+    and the client label for that call, and flows to the audit trail, run
+    records, lock holders, and (for a registry-spawned build) the child's
+    `ZUKE_ACTOR`, `ZUKE_ACTOR_KIND` and `ZUKE_ACTOR_ROLES`. Throwing still
+    refuses the request: the seam is fail-closed. Default: none.
+
+    Declare either this or {@link Build.mcpIdentity}; declaring both is
+    refused when the server starts, rather than letting one silently win.
+
+    ```ts
+    class ControlPlane extends Build {
+      override mcpAuth() {
+        return {
+          authenticate: async (ctx: McpRequestContext) => {
+            const claims = await verifyBearer(ctx.headers.get("authorization"));
+            if (claims === null) {
+              return { status: 401, error: "invalid_token", challenge: "Bearer" };
+            }
+            return { actor: claims.sub, kind: "human", roles: claims.roles };
+          },
+        };
+      }
+    }
+    ```
 
 class CiFile
   A declared CI file. Assign one (via {@link cicd}) to a build field and Zuke
@@ -3238,24 +3271,71 @@ interface LockHolder
   runUrl?: string
     A link to the holding run (e.g. its CI job), when known.
 
+interface McpAuthReject
+  Why a request was refused, and how the transport should say so.
+
+  The status and challenge are what make OAuth discovery work: an MCP client
+  learns where to authenticate from a `401` carrying `WWW-Authenticate`, which a
+  JSON-RPC error inside a `200` can never tell it.
+
+  status: number
+    The HTTP status to answer with — a client error, `401` or `403` in practice.
+  error: string
+    A short reason, machine-readable where there is a standard code for it (an
+    OAuth authenticator's `"invalid_token"`, say). It becomes the JSON-RPC
+    error message on the refusal, so it is read by people too.
+  detail?: string
+    A short human-readable detail. Never a secret: it is returned to the caller.
+  challenge?: string
+    The `WWW-Authenticate` header value to challenge with, when one applies.
+
+interface McpAuthenticator
+  Authenticates one request for the MCP server.
+
+  Invoked once per message, before any dispatch: a rejection stops the request
+  outright, so nothing executes and nothing is written to state. Returning an
+  {@link McpIdentity} accepts the caller; returning an {@link McpAuthReject}
+  refuses it. Throwing also refuses it — the seam is fail-closed, so a bug in an
+  authenticator denies rather than admits.
+
+  Configure one with `override mcpAuth()` on the build.
+
+  authenticate(ctx: McpRequestContext): Promise<McpIdentity | McpAuthReject> | McpIdentity | McpAuthReject
+    Resolve the caller's identity from the request, or refuse the request.
+
 interface McpIdentity
-  A trusted caller identity, resolved per request by a {@link McpIdentityHook}
-  (typically from an authenticating reverse proxy's header). Its
-  {@link McpIdentity.actor} is the highest-precedence attribution — it overrides
-  `--actor`, the environment, and the client's self-reported label for the call.
+  A trusted caller identity, resolved per request by an
+  {@link McpAuthenticator}. Its {@link McpIdentity.actor} is the
+  highest-precedence attribution — it overrides `--actor`, the environment, and
+  the client's self-reported label for the call.
 
   actor: string
-    The authenticated actor (e.g. an OAuth subject).
+    The authenticated actor — an OAuth subject, a GitHub login, a service name.
+  kind?: "human" | "service"
+    Whether a person or a machine is calling. Absent is read as `"human"`, the
+    conservative default: a policy that treats service callers differently must
+    see the claim stated rather than inferred.
+  roles?: readonly string[]
+    The roles this caller holds. Absent is read as none, so an authenticator
+    that says nothing about roles grants nothing.
   via?: string
     How the identity was established (e.g. `"oauth-proxy"`); informational.
 
 interface McpRequestContext
-  The per-request context a transport hands the message handler. Carries the
-  request's headers, so a server's identity hook can authenticate the caller
-  from a trusted proxy header. Empty on the stdio transport (no headers).
+  The per-request context a transport hands the message handler, and the only
+  thing an authenticator sees of the request. Empty on the stdio transport,
+  which has no request to describe.
 
   readonly headers: Headers
     The request headers; an empty {@link Headers} on stdio.
+  readonly request?: Request
+    The HTTP request the caller arrived on, when it did — so an authenticator
+    can read its method and URL, not just its headers. Absent on the stdio
+    transport, which has no request.
+
+    Its body is deliberately empty: the body belongs to the transport, which
+    reads it once to parse the JSON-RPC message, and a credential never lives
+    there. Everything else — method, URL, headers — is the real request's.
 
 interface NpmToolSpec
   A specification of an npm-registry package to provision as a tool.
@@ -4149,10 +4229,11 @@ type LockResult = { ok: true; token: string; } | { ok: false; holder: LockHolder
   the current `holder` when the lock is already held.
 
 type McpIdentityHook = (ctx: McpRequestContext) => McpIdentity
-  Resolve a trusted {@link McpIdentity} from a request's context. Invoked once
-  per message, before any dispatch; throwing rejects the whole request with
-  an auth error, so nothing executes and nothing is written to state — the seam
-  a proxy in front of the server uses to inject an authenticated identity.
+  Resolve a trusted {@link McpIdentity} from a request's context. The original,
+  synchronous identity seam, kept as sugar for the common case of trusting a
+  header an authenticating reverse proxy injected: throwing rejects the whole
+  request. {@link authenticatorFromHook} adapts one onto
+  {@link McpAuthenticator}, which is what the server actually runs.
 
 type NpmRunner = (args: string[]) => Promise<void>
   Runs `npm install <args>` — the injectable subprocess seam. Defaults to

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3319,7 +3319,9 @@ interface McpIdentity
     see the claim stated rather than inferred.
   roles?: readonly string[]
     The roles this caller holds. Absent is read as none, so an authenticator
-    that says nothing about roles grants nothing.
+    that says nothing about roles grants nothing. A name containing a comma is
+    dropped: the comma separates the roles a registry-spawned child reads, so
+    such a name would reach it as two.
   via?: string
     How the identity was established (e.g. `"oauth-proxy"`); informational.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1084,7 +1084,7 @@ class Build
 
     ```ts
     class ControlPlane extends Build {
-      override mcpAuth() {
+      override mcpAuth(): McpAuthenticator {
         return {
           authenticate: async (ctx: McpRequestContext) => {
             const claims = await verifyBearer(ctx.headers.get("authorization"));
@@ -3287,7 +3287,9 @@ interface McpAuthReject
   detail?: string
     A short human-readable detail. Never a secret: it is returned to the caller.
   challenge?: string
-    The `WWW-Authenticate` header value to challenge with, when one applies.
+    The `WWW-Authenticate` header value to challenge with, when one applies. A
+    value a header cannot carry (a newline, a NUL, a character outside Latin-1)
+    is dropped rather than sent, so it cannot turn the refusal into a fault.
 
 interface McpAuthenticator
   Authenticates one request for the MCP server.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1118,6 +1118,39 @@ class Build
       }
     }
     ```
+  mcpAuth(): McpAuthenticator | undefined
+    An authenticator for `zuke mcp` — the general form of
+    {@link Build.mcpIdentity}, for a server callers reach directly rather than
+    through a proxy that has already identified them.
+
+    It runs before any dispatch, may be asynchronous (verifying a signature is),
+    and refuses by returning an {@link McpAuthReject} rather than by throwing —
+    so over HTTP the refusal is answered with its own status and
+    `WWW-Authenticate` challenge, which is how an MCP client discovers where to
+    authenticate. The identity it resolves overrides `--actor`, the environment,
+    and the client label for that call, and flows to the audit trail, run
+    records, lock holders, and (for a registry-spawned build) the child's
+    `ZUKE_ACTOR`, `ZUKE_ACTOR_KIND` and `ZUKE_ACTOR_ROLES`. Throwing still
+    refuses the request: the seam is fail-closed. Default: none.
+
+    Declare either this or {@link Build.mcpIdentity}; declaring both is
+    refused when the server starts, rather than letting one silently win.
+
+    ```ts
+    class ControlPlane extends Build {
+      override mcpAuth() {
+        return {
+          authenticate: async (ctx: McpRequestContext) => {
+            const claims = await verifyBearer(ctx.headers.get("authorization"));
+            if (claims === null) {
+              return { status: 401, error: "invalid_token", challenge: "Bearer" };
+            }
+            return { actor: claims.sub, kind: "human", roles: claims.roles };
+          },
+        };
+      }
+    }
+    ```
 
 class CiFile
   A declared CI file. Assign one (via {@link cicd}) to a build field and Zuke
@@ -3292,24 +3325,71 @@ interface LockHolder
   runUrl?: string
     A link to the holding run (e.g. its CI job), when known.
 
+interface McpAuthReject
+  Why a request was refused, and how the transport should say so.
+
+  The status and challenge are what make OAuth discovery work: an MCP client
+  learns where to authenticate from a `401` carrying `WWW-Authenticate`, which a
+  JSON-RPC error inside a `200` can never tell it.
+
+  status: number
+    The HTTP status to answer with — a client error, `401` or `403` in practice.
+  error: string
+    A short reason, machine-readable where there is a standard code for it (an
+    OAuth authenticator's `"invalid_token"`, say). It becomes the JSON-RPC
+    error message on the refusal, so it is read by people too.
+  detail?: string
+    A short human-readable detail. Never a secret: it is returned to the caller.
+  challenge?: string
+    The `WWW-Authenticate` header value to challenge with, when one applies.
+
+interface McpAuthenticator
+  Authenticates one request for the MCP server.
+
+  Invoked once per message, before any dispatch: a rejection stops the request
+  outright, so nothing executes and nothing is written to state. Returning an
+  {@link McpIdentity} accepts the caller; returning an {@link McpAuthReject}
+  refuses it. Throwing also refuses it — the seam is fail-closed, so a bug in an
+  authenticator denies rather than admits.
+
+  Configure one with `override mcpAuth()` on the build.
+
+  authenticate(ctx: McpRequestContext): Promise<McpIdentity | McpAuthReject> | McpIdentity | McpAuthReject
+    Resolve the caller's identity from the request, or refuse the request.
+
 interface McpIdentity
-  A trusted caller identity, resolved per request by a {@link McpIdentityHook}
-  (typically from an authenticating reverse proxy's header). Its
-  {@link McpIdentity.actor} is the highest-precedence attribution — it overrides
-  `--actor`, the environment, and the client's self-reported label for the call.
+  A trusted caller identity, resolved per request by an
+  {@link McpAuthenticator}. Its {@link McpIdentity.actor} is the
+  highest-precedence attribution — it overrides `--actor`, the environment, and
+  the client's self-reported label for the call.
 
   actor: string
-    The authenticated actor (e.g. an OAuth subject).
+    The authenticated actor — an OAuth subject, a GitHub login, a service name.
+  kind?: "human" | "service"
+    Whether a person or a machine is calling. Absent is read as `"human"`, the
+    conservative default: a policy that treats service callers differently must
+    see the claim stated rather than inferred.
+  roles?: readonly string[]
+    The roles this caller holds. Absent is read as none, so an authenticator
+    that says nothing about roles grants nothing.
   via?: string
     How the identity was established (e.g. `"oauth-proxy"`); informational.
 
 interface McpRequestContext
-  The per-request context a transport hands the message handler. Carries the
-  request's headers, so a server's identity hook can authenticate the caller
-  from a trusted proxy header. Empty on the stdio transport (no headers).
+  The per-request context a transport hands the message handler, and the only
+  thing an authenticator sees of the request. Empty on the stdio transport,
+  which has no request to describe.
 
   readonly headers: Headers
     The request headers; an empty {@link Headers} on stdio.
+  readonly request?: Request
+    The HTTP request the caller arrived on, when it did — so an authenticator
+    can read its method and URL, not just its headers. Absent on the stdio
+    transport, which has no request.
+
+    Its body is deliberately empty: the body belongs to the transport, which
+    reads it once to parse the JSON-RPC message, and a credential never lives
+    there. Everything else — method, URL, headers — is the real request's.
 
 interface NpmToolSpec
   A specification of an npm-registry package to provision as a tool.
@@ -4203,10 +4283,11 @@ type LockResult = { ok: true; token: string; } | { ok: false; holder: LockHolder
   the current `holder` when the lock is already held.
 
 type McpIdentityHook = (ctx: McpRequestContext) => McpIdentity
-  Resolve a trusted {@link McpIdentity} from a request's context. Invoked once
-  per message, before any dispatch; throwing rejects the whole request with
-  an auth error, so nothing executes and nothing is written to state — the seam
-  a proxy in front of the server uses to inject an authenticated identity.
+  Resolve a trusted {@link McpIdentity} from a request's context. The original,
+  synchronous identity seam, kept as sugar for the common case of trusting a
+  header an authenticating reverse proxy injected: throwing rejects the whole
+  request. {@link authenticatorFromHook} adapts one onto
+  {@link McpAuthenticator}, which is what the server actually runs.
 
 type NpmRunner = (args: string[]) => Promise<void>
   Runs `npm install <args>` — the injectable subprocess seam. Defaults to

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -3373,7 +3373,9 @@ interface McpIdentity
     see the claim stated rather than inferred.
   roles?: readonly string[]
     The roles this caller holds. Absent is read as none, so an authenticator
-    that says nothing about roles grants nothing.
+    that says nothing about roles grants nothing. A name containing a comma is
+    dropped: the comma separates the roles a registry-spawned child reads, so
+    such a name would reach it as two.
   via?: string
     How the identity was established (e.g. `"oauth-proxy"`); informational.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1138,7 +1138,7 @@ class Build
 
     ```ts
     class ControlPlane extends Build {
-      override mcpAuth() {
+      override mcpAuth(): McpAuthenticator {
         return {
           authenticate: async (ctx: McpRequestContext) => {
             const claims = await verifyBearer(ctx.headers.get("authorization"));
@@ -3341,7 +3341,9 @@ interface McpAuthReject
   detail?: string
     A short human-readable detail. Never a secret: it is returned to the caller.
   challenge?: string
-    The `WWW-Authenticate` header value to challenge with, when one applies.
+    The `WWW-Authenticate` header value to challenge with, when one applies. A
+    value a header cannot carry (a newline, a NUL, a character outside Latin-1)
+    is dropped rather than sent, so it cannot turn the refusal into a fault.
 
 interface McpAuthenticator
   Authenticates one request for the MCP server.

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -210,11 +210,13 @@ export {
   resolveBuildRegistry,
   type ResolveRegistryOptions,
 } from "./src/registry/resolve.ts";
+export { type McpRequestContext } from "./src/mcp/jsonrpc.ts";
 export {
+  type McpAuthenticator,
+  type McpAuthReject,
   type McpIdentity,
   type McpIdentityHook,
-  type McpRequestContext,
-} from "./src/mcp/jsonrpc.ts";
+} from "./src/mcp/auth.ts";
 export { type AbsolutePath, absolutePath, type PathLike } from "./src/path.ts";
 export { CONFIG_FILE, repoRoot } from "./src/config.ts";
 export {

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -333,7 +333,7 @@ export class Build {
    *
    * ```ts
    * class ControlPlane extends Build {
-   *   override mcpAuth() {
+   *   override mcpAuth(): McpAuthenticator {
    *     return {
    *       authenticate: async (ctx: McpRequestContext) => {
    *         const claims = await verifyBearer(ctx.headers.get("authorization"));

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -17,7 +17,7 @@ import type { OrderingEdge } from "./graph.ts";
 import type { RemoteCacheStore } from "./remote_cache.ts";
 import type { StateStore } from "./state/store.ts";
 import type { BuildRegistry } from "./registry/registry.ts";
-import type { McpIdentityHook } from "./mcp/jsonrpc.ts";
+import type { McpAuthenticator, McpIdentityHook } from "./mcp/auth.ts";
 
 /** Whether a value is a plain object (a component bundle), not a class instance. */
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -310,6 +310,44 @@ export class Build {
    * ```
    */
   mcpIdentity(): McpIdentityHook | undefined {
+    return undefined;
+  }
+
+  /**
+   * An authenticator for `zuke mcp` — the general form of
+   * {@link Build.mcpIdentity}, for a server callers reach directly rather than
+   * through a proxy that has already identified them.
+   *
+   * It runs before any dispatch, may be asynchronous (verifying a signature is),
+   * and refuses by returning an {@link McpAuthReject} rather than by throwing —
+   * so over HTTP the refusal is answered with its own status and
+   * `WWW-Authenticate` challenge, which is how an MCP client discovers where to
+   * authenticate. The identity it resolves overrides `--actor`, the environment,
+   * and the client label for that call, and flows to the audit trail, run
+   * records, lock holders, and (for a registry-spawned build) the child's
+   * `ZUKE_ACTOR`, `ZUKE_ACTOR_KIND` and `ZUKE_ACTOR_ROLES`. Throwing still
+   * refuses the request: the seam is fail-closed. Default: none.
+   *
+   * Declare **either** this or {@link Build.mcpIdentity}; declaring both is
+   * refused when the server starts, rather than letting one silently win.
+   *
+   * ```ts
+   * class ControlPlane extends Build {
+   *   override mcpAuth() {
+   *     return {
+   *       authenticate: async (ctx: McpRequestContext) => {
+   *         const claims = await verifyBearer(ctx.headers.get("authorization"));
+   *         if (claims === null) {
+   *           return { status: 401, error: "invalid_token", challenge: "Bearer" };
+   *         }
+   *         return { actor: claims.sub, kind: "human", roles: claims.roles };
+   *       },
+   *     };
+   *   }
+   * }
+   * ```
+   */
+  mcpAuth(): McpAuthenticator | undefined {
     return undefined;
   }
 }

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -623,8 +623,9 @@ Options:
   --http <host:port>
                     With mcp, serve the streamable-HTTP transport on the given
                     address instead of stdio. Just <port> binds 127.0.0.1. A
-                    non-loopback host requires a bearer token (ZUKE_MCP_TOKEN);
-                    put real TLS/authn in front for production. See docs/mcp.md.
+                    non-loopback host must authenticate its callers: a bearer
+                    token (ZUKE_MCP_TOKEN) or an mcpAuth() authenticator on the
+                    build. Put real TLS in front for production. See docs/mcp.md.
   --allowed-origin <origin>
                     With mcp --http, permit this browser Origin (repeatable). By
                     default a loopback bind accepts only loopback origins (the

--- a/packages/core/src/mcp/auth.ts
+++ b/packages/core/src/mcp/auth.ts
@@ -36,7 +36,9 @@ export interface McpIdentity {
   kind?: "human" | "service";
   /**
    * The roles this caller holds. Absent is read as none, so an authenticator
-   * that says nothing about roles grants nothing.
+   * that says nothing about roles grants nothing. A name containing a comma is
+   * dropped: the comma separates the roles a registry-spawned child reads, so
+   * such a name would reach it as two.
    */
   roles?: readonly string[];
   /** How the identity was established (e.g. `"oauth-proxy"`); informational. */
@@ -161,11 +163,20 @@ function headerValue(value: unknown): string | undefined {
   }
 }
 
-/** The non-empty strings in `value`, or an empty list when it is not an array. */
+/**
+ * The usable role names in `value`, or an empty list when it is not an array.
+ *
+ * A name is usable when it is a non-empty string containing no comma. The comma
+ * is the separator a registry-spawned child reads `ZUKE_ACTOR_ROLES` with, so a
+ * name carrying one would arrive there as two roles — and role names can come
+ * from an identity provider's group names, which the caller may influence. One
+ * dropped role is a smaller wrong answer than a forged one, and dropping it here
+ * keeps every consumer of the list honest rather than each escaping it again.
+ */
 function rolesOf(value: unknown): readonly string[] {
   if (!Array.isArray(value)) return [];
   return value.filter((role): role is string =>
-    typeof role === "string" && role !== ""
+    typeof role === "string" && role !== "" && !role.includes(",")
   );
 }
 

--- a/packages/core/src/mcp/auth.ts
+++ b/packages/core/src/mcp/auth.ts
@@ -1,0 +1,254 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Authentication for the MCP server: who is calling, and what to answer when
+ * the question has no good answer.
+ *
+ * One authenticator runs per request, before any dispatch, on both transports.
+ * The older {@link McpIdentityHook} is adapted onto the same interface by
+ * {@link authenticatorFromHook}, so there is exactly one authentication path
+ * rather than two that can drift apart.
+ *
+ * Everything here is fail-closed: {@link authenticateRequest} turns a throw, a
+ * non-object, an empty actor, or a malformed rejection into a refusal, so an
+ * authenticator cannot accidentally authorize a request by misbehaving.
+ *
+ * @module
+ */
+
+import type { McpRequestContext } from "./jsonrpc.ts";
+
+/**
+ * A trusted caller identity, resolved per request by an
+ * {@link McpAuthenticator}. Its {@link McpIdentity.actor} is the
+ * highest-precedence attribution — it overrides `--actor`, the environment, and
+ * the client's self-reported label for the call.
+ */
+export interface McpIdentity {
+  /** The authenticated actor — an OAuth subject, a GitHub login, a service name. */
+  actor: string;
+  /**
+   * Whether a person or a machine is calling. Absent is read as `"human"`, the
+   * conservative default: a policy that treats service callers differently must
+   * see the claim stated rather than inferred.
+   */
+  kind?: "human" | "service";
+  /**
+   * The roles this caller holds. Absent is read as none, so an authenticator
+   * that says nothing about roles grants nothing.
+   */
+  roles?: readonly string[];
+  /** How the identity was established (e.g. `"oauth-proxy"`); informational. */
+  via?: string;
+}
+
+/**
+ * An {@link McpIdentity} after {@link normalizeIdentity}: `kind` and `roles` are
+ * settled, so nothing downstream re-applies the defaults (and no two callers can
+ * disagree about what they are).
+ */
+export interface ResolvedIdentity {
+  /** The authenticated actor. Never empty. */
+  readonly actor: string;
+  /** The caller's kind, defaulted to `"human"` when the authenticator omitted it. */
+  readonly kind: "human" | "service";
+  /** The caller's roles, defaulted to empty. Each entry is a non-empty string. */
+  readonly roles: readonly string[];
+  /**
+   * How the identity was established, when the authenticator said. Carried
+   * through to whatever inspects the caller; not written to the audit trail,
+   * which records the actor.
+   */
+  readonly via?: string;
+}
+
+/**
+ * Why a request was refused, and how the transport should say so.
+ *
+ * The status and challenge are what make OAuth discovery work: an MCP client
+ * learns where to authenticate from a `401` carrying `WWW-Authenticate`, which a
+ * JSON-RPC error inside a `200` can never tell it.
+ */
+export interface McpAuthReject {
+  /** The HTTP status to answer with — a client error, `401` or `403` in practice. */
+  status: number;
+  /**
+   * A short reason, machine-readable where there is a standard code for it (an
+   * OAuth authenticator's `"invalid_token"`, say). It becomes the JSON-RPC
+   * error message on the refusal, so it is read by people too.
+   */
+  error: string;
+  /** A short human-readable detail. Never a secret: it is returned to the caller. */
+  detail?: string;
+  /** The `WWW-Authenticate` header value to challenge with, when one applies. */
+  challenge?: string;
+}
+
+/**
+ * Authenticates one request for the MCP server.
+ *
+ * Invoked once per message, before any dispatch: a rejection stops the request
+ * outright, so nothing executes and nothing is written to state. Returning an
+ * {@link McpIdentity} accepts the caller; returning an {@link McpAuthReject}
+ * refuses it. Throwing also refuses it — the seam is fail-closed, so a bug in an
+ * authenticator denies rather than admits.
+ *
+ * Configure one with `override mcpAuth()` on the build.
+ */
+export interface McpAuthenticator {
+  /** Resolve the caller's identity from the request, or refuse the request. */
+  authenticate(
+    ctx: McpRequestContext,
+  ): Promise<McpIdentity | McpAuthReject> | McpIdentity | McpAuthReject;
+}
+
+/**
+ * Resolve a trusted {@link McpIdentity} from a request's context. The original,
+ * synchronous identity seam, kept as sugar for the common case of trusting a
+ * header an authenticating reverse proxy injected: **throwing rejects the whole
+ * request**. {@link authenticatorFromHook} adapts one onto
+ * {@link McpAuthenticator}, which is what the server actually runs.
+ */
+export type McpIdentityHook = (ctx: McpRequestContext) => McpIdentity;
+
+/**
+ * The bare `401` challenge: the refusal an authenticator's own failure produces
+ * (so a throw leaks nothing about why it threw), and the one the transport
+ * answers a bad or absent static bearer token with — one shape for "you are not
+ * authenticated", rather than a second spelling per call site.
+ */
+export const UNAUTHORIZED: McpAuthReject = Object.freeze({
+  status: 401,
+  error: "Unauthorized",
+  challenge: "Bearer",
+});
+
+/** Whether `value` is a plain object (a string-keyed record). */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** `value` when it is a non-empty string, else `undefined`. */
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value !== "" ? value : undefined;
+}
+
+/** The non-empty strings in `value`, or an empty list when it is not an array. */
+function rolesOf(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((role): role is string =>
+    typeof role === "string" && role !== ""
+  );
+}
+
+/**
+ * Settle an authenticator's result into a {@link ResolvedIdentity}, or `null`
+ * when it is not a usable identity (not an object, or no non-empty `actor`).
+ *
+ * Deliberately tolerant about the rest: an unknown `kind` reads as `"human"` and
+ * malformed roles drop out, because a value that is *nearly* an identity must
+ * never become a *more privileged* one than the authenticator meant.
+ */
+export function normalizeIdentity(value: unknown): ResolvedIdentity | null {
+  if (!isRecord(value)) return null;
+  const actor = value.actor;
+  if (typeof actor !== "string" || actor === "") return null;
+  const kind = value.kind === "service" ? "service" : "human";
+  const roles = rolesOf(value.roles);
+  const via = nonEmptyString(value.via);
+  return via === undefined
+    ? { actor, kind, roles }
+    : { actor, kind, roles, via };
+}
+
+/**
+ * Settle an authenticator's result into an {@link McpAuthReject}, falling back
+ * to a bare `401` for anything malformed.
+ *
+ * The status is validated to a client-error code: an authenticator that returns
+ * `status: 200` (or a string, or nothing) must not turn its own refusal into a
+ * success at the transport.
+ */
+function normalizeReject(value: unknown): McpAuthReject {
+  if (!isRecord(value)) return UNAUTHORIZED;
+  const status = value.status;
+  if (typeof status !== "number" || !Number.isInteger(status)) {
+    return UNAUTHORIZED;
+  }
+  if (status < 400 || status > 499) return UNAUTHORIZED;
+  const reject: McpAuthReject = {
+    status,
+    error: nonEmptyString(value.error) ?? UNAUTHORIZED.error,
+  };
+  const detail = nonEmptyString(value.detail);
+  if (detail !== undefined) reject.detail = detail;
+  const challenge = nonEmptyString(value.challenge);
+  if (challenge !== undefined) reject.challenge = challenge;
+  return reject;
+}
+
+/**
+ * Run `authenticator` against `ctx`, fail-closed: the result is either a settled
+ * {@link ResolvedIdentity} or an {@link McpAuthReject}, whatever the
+ * authenticator did. A throw, a `null`, an empty actor and a malformed rejection
+ * all become a refusal.
+ *
+ * The single place an authenticator is invoked, so both transports enforce it
+ * identically.
+ */
+export async function authenticateRequest(
+  authenticator: McpAuthenticator,
+  ctx: McpRequestContext,
+): Promise<ResolvedIdentity | McpAuthReject> {
+  let result: unknown;
+  try {
+    result = await authenticator.authenticate(ctx);
+  } catch {
+    return UNAUTHORIZED;
+  }
+  // A `status` is what a refusal carries and an identity does not, so a value
+  // bearing one is read as a refusal even if it also names an actor. The typed
+  // union cannot produce that, but an authenticator built in plain JS can — and
+  // between "deny" and "admit" for a value that says both, fail-closed means
+  // deny.
+  if (isRecord(result) && "status" in result) return normalizeReject(result);
+  return normalizeIdentity(result) ?? normalizeReject(result);
+}
+
+/**
+ * The reason a refusal reports: its code, and its detail when it has one.
+ *
+ * Shared by both transports so a caller reads the same sentence over HTTP (in
+ * the JSON-RPC error beside the status) and over stdio (where there is no status
+ * to read it from).
+ */
+export function refusalReason(reject: McpAuthReject): string {
+  return reject.detail === undefined
+    ? reject.error
+    : `${reject.error}: ${reject.detail}`;
+}
+
+/**
+ * Whether {@link authenticateRequest}'s result is an identity rather than a
+ * refusal. The two are told apart by `actor`, which a refusal never carries.
+ */
+export function isResolvedIdentity(
+  result: ResolvedIdentity | McpAuthReject,
+): result is ResolvedIdentity {
+  return "actor" in result;
+}
+
+/**
+ * Adapt a synchronous {@link McpIdentityHook} onto {@link McpAuthenticator}.
+ *
+ * The hook's throw-to-reject convention is preserved by
+ * {@link authenticateRequest}, which turns any throw into a refusal — so the
+ * adapter itself needs no error handling, and the older seam runs through
+ * exactly the same code path as a modern authenticator.
+ */
+export function authenticatorFromHook(
+  hook: McpIdentityHook,
+): McpAuthenticator {
+  return { authenticate: (ctx) => hook(ctx) };
+}

--- a/packages/core/src/mcp/auth.ts
+++ b/packages/core/src/mcp/auth.ts
@@ -81,7 +81,11 @@ export interface McpAuthReject {
   error: string;
   /** A short human-readable detail. Never a secret: it is returned to the caller. */
   detail?: string;
-  /** The `WWW-Authenticate` header value to challenge with, when one applies. */
+  /**
+   * The `WWW-Authenticate` header value to challenge with, when one applies. A
+   * value a header cannot carry (a newline, a NUL, a character outside Latin-1)
+   * is dropped rather than sent, so it cannot turn the refusal into a fault.
+   */
   challenge?: string;
 }
 
@@ -134,6 +138,29 @@ function nonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value !== "" ? value : undefined;
 }
 
+/**
+ * `value` when it is a non-empty string a `Headers` can actually carry, else
+ * `undefined`.
+ *
+ * The challenge is the one field of a refusal that becomes an HTTP header, and
+ * `Headers.set` throws on a CR/LF, a NUL, or any character outside Latin-1. A
+ * throw there would turn a refusal the authenticator wrote into a transport
+ * fault carrying no challenge at all — so a challenge a header cannot carry is dropped
+ * here, exactly like an absent one, and the refusal still goes out with its own
+ * status. `Headers` itself is the oracle: a hand-written character test would
+ * have to track the same rules and would drift.
+ */
+function headerValue(value: unknown): string | undefined {
+  const candidate = nonEmptyString(value);
+  if (candidate === undefined) return undefined;
+  try {
+    new Headers({ "www-authenticate": candidate });
+    return candidate;
+  } catch {
+    return undefined;
+  }
+}
+
 /** The non-empty strings in `value`, or an empty list when it is not an array. */
 function rolesOf(value: unknown): readonly string[] {
   if (!Array.isArray(value)) return [];
@@ -183,7 +210,7 @@ function normalizeReject(value: unknown): McpAuthReject {
   };
   const detail = nonEmptyString(value.detail);
   if (detail !== undefined) reject.detail = detail;
-  const challenge = nonEmptyString(value.challenge);
+  const challenge = headerValue(value.challenge);
   if (challenge !== undefined) reject.challenge = challenge;
   return reject;
 }
@@ -201,19 +228,24 @@ export async function authenticateRequest(
   authenticator: McpAuthenticator,
   ctx: McpRequestContext,
 ): Promise<ResolvedIdentity | McpAuthReject> {
-  let result: unknown;
   try {
-    result = await authenticator.authenticate(ctx);
+    const result = await authenticator.authenticate(ctx);
+    // Every read of the untrusted result stays inside this `try`, not just the
+    // call that produced it: an authenticator may return a lazy object — claims
+    // wrapped in getters is the natural shape — and a getter that throws must
+    // refuse the request like any other failure, rather than escaping as a
+    // transport-level fault with no challenge on it.
+    //
+    // A `status` is what a refusal carries and an identity does not, so a value
+    // bearing one is read as a refusal even if it also names an actor. The typed
+    // union cannot produce that, but an authenticator built in plain JS can —
+    // and between "deny" and "admit" for a value that says both, fail-closed
+    // means deny.
+    if (isRecord(result) && "status" in result) return normalizeReject(result);
+    return normalizeIdentity(result) ?? normalizeReject(result);
   } catch {
     return UNAUTHORIZED;
   }
-  // A `status` is what a refusal carries and an identity does not, so a value
-  // bearing one is read as a refusal even if it also names an actor. The typed
-  // union cannot produce that, but an authenticator built in plain JS can — and
-  // between "deny" and "admit" for a value that says both, fail-closed means
-  // deny.
-  if (isRecord(result) && "status" in result) return normalizeReject(result);
-  return normalizeIdentity(result) ?? normalizeReject(result);
 }
 
 /**

--- a/packages/core/src/mcp/command.ts
+++ b/packages/core/src/mcp/command.ts
@@ -24,6 +24,11 @@ import {
   serveStdio,
 } from "./jsonrpc.ts";
 import { serveHttp } from "./http.ts";
+import {
+  authenticatorFromHook,
+  type McpAuthenticator,
+  type ResolvedIdentity,
+} from "./auth.ts";
 import { McpServer, type McpServerOptions } from "./server.ts";
 import { RegistryMcpServer, type RegistryRunner } from "./registry_server.ts";
 
@@ -36,6 +41,7 @@ interface McpHandler {
   handleMessage(
     message: unknown,
     ctx?: McpRequestContext,
+    identity?: ResolvedIdentity,
   ): Promise<JsonRpcResponse | null>;
   /**
    * Whether messages may be handled concurrently. The registry server sets this
@@ -140,9 +146,22 @@ export async function serveMcp(
   // then hand them to the server alongside the caller's options.
   const store = resolveMcpStore(build, options.stateStore, readEnv);
   const operatorToken = options.operatorToken ?? readEnv("ZUKE_OPERATOR_TOKEN");
-  // The trusted identity hook: an explicit option wins, else the build declares
-  // one via `override mcpIdentity()` (the CLI-reachable seam).
-  const identity = options.identity ?? build.mcpIdentity();
+  // The authenticator: an explicit option wins outright, else the build's own
+  // seams — `override mcpAuth()`, or the older `override mcpIdentity()` adapted
+  // onto it. Declaring both is refused rather than resolved, so an author never
+  // ends up with one gate live and the other only looking it.
+  const declared = build.mcpAuth();
+  const hook = build.mcpIdentity();
+  if (declared !== undefined && hook !== undefined) {
+    console.error(
+      "zuke mcp: this build declares both mcpAuth() and mcpIdentity() — keep " +
+        "one: mcpAuth() is the general seam, and mcpIdentity() is sugar for a " +
+        "header-trusting authenticator.",
+    );
+    return 1;
+  }
+  const authenticator = options.authenticator ?? declared ??
+    (hook === undefined ? undefined : authenticatorFromHook(hook));
   // An injected registry (tests) wins; otherwise `--registry` resolves one.
   const registry = options.registry ??
     (options.useRegistry ? resolveMcpRegistry(build, readEnv) : undefined);
@@ -157,7 +176,7 @@ export async function serveMcp(
       operatorToken,
       stateStore: store,
       actor: options.actor,
-      identity,
+      authenticator,
       readEnv,
       version: options.version,
       runner: options.runner,
@@ -168,10 +187,10 @@ export async function serveMcp(
       readEnv,
       stateStore: store,
       operatorToken,
-      identity,
+      authenticator,
     });
   if (options.http !== undefined) {
-    return await serveMcpHttp(server, options.http, options);
+    return await serveMcpHttp(server, options.http, options, authenticator);
   }
   if (!options.quiet) {
     const mode = options.allowRun ? "run enabled" : "read-only";
@@ -190,23 +209,28 @@ export async function serveMcp(
 
 /**
  * Serve over the HTTP transport. Enforces the security default: a non-loopback
- * bind **must** have a bearer token (from {@link ServeMcpOptions.token} or
- * `ZUKE_MCP_TOKEN`), else the server refuses to start rather than exposing an
- * unauthenticated endpoint. A loopback bind may run without one.
+ * bind **must** authenticate its callers — with a bearer token (from
+ * {@link ServeMcpOptions.token} or `ZUKE_MCP_TOKEN`) or with an authenticator
+ * (`mcpAuth()`/`mcpIdentity()`) — else the server refuses to start rather than
+ * exposing an unauthenticated endpoint. A loopback bind may run without either.
  */
 async function serveMcpHttp(
   server: McpHandler,
   address: HttpAddress,
   options: ServeMcpOptions,
+  authenticator: McpAuthenticator | undefined,
 ): Promise<number> {
   const readEnv = options.readEnv ?? defaultReadEnv;
   const token = options.token ?? readEnv("ZUKE_MCP_TOKEN");
   const hasToken = token !== undefined && token !== "";
-  if (!isLoopbackHost(address.host) && !hasToken) {
+  if (
+    !isLoopbackHost(address.host) && !hasToken && authenticator === undefined
+  ) {
     console.error(
-      `zuke mcp: refusing to bind ${address.host}:${address.port} without a ` +
-        `bearer token. A non-loopback MCP endpoint must be authenticated — set ` +
-        `ZUKE_MCP_TOKEN, or bind 127.0.0.1 for local-only access.`,
+      `zuke mcp: refusing to bind ${address.host}:${address.port} without ` +
+        `authentication. A non-loopback MCP endpoint must be authenticated — ` +
+        `set ZUKE_MCP_TOKEN, declare mcpAuth() on the build, or bind 127.0.0.1 ` +
+        `for local-only access.`,
     );
     return 1;
   }
@@ -216,20 +240,28 @@ async function serveMcpHttp(
       options.registry !== undefined || options.useRegistry === true
         ? "registry, "
         : "";
-    const auth = hasToken ? "bearer token required" : "no auth (loopback only)";
+    const auth = authenticator !== undefined
+      ? (hasToken ? "authenticator + bearer token" : "authenticator")
+      : hasToken
+      ? "bearer token required"
+      : "no auth (loopback only)";
     console.error(
       `zuke mcp: serving on http://${address.host}:${address.port} ` +
         `(${source}${mode}, ${auth}). Press Ctrl-C to stop.`,
     );
   }
-  await serveHttp((message, ctx) => server.handleMessage(message, ctx), {
-    host: address.host,
-    port: address.port,
-    token: hasToken ? token : undefined,
-    allowedOrigins: options.allowedOrigins,
-    signal: options.signal,
-    onListen: options.onListen,
-    concurrent: server.concurrent,
-  });
+  await serveHttp(
+    (message, ctx, identity) => server.handleMessage(message, ctx, identity),
+    {
+      host: address.host,
+      port: address.port,
+      token: hasToken ? token : undefined,
+      allowedOrigins: options.allowedOrigins,
+      signal: options.signal,
+      onListen: options.onListen,
+      concurrent: server.concurrent,
+      authenticator,
+    },
+  );
   return 0;
 }

--- a/packages/core/src/mcp/command.ts
+++ b/packages/core/src/mcp/command.ts
@@ -162,6 +162,15 @@ export async function serveMcp(
   }
   const authenticator = options.authenticator ?? declared ??
     (hook === undefined ? undefined : authenticatorFromHook(hook));
+  // Every authenticator runs on every request. Only one declared *as*
+  // authentication also satisfies the non-loopback bind guard: `mcpIdentity()`
+  // is sugar for trusting a header a proxy injected, and its whole contract
+  // assumes something in front has already authenticated the caller — so on a
+  // directly reachable endpoint it authenticates nobody, because any caller
+  // sets that header itself. Such a build needed a bearer token to bind before
+  // this seam existed, and still does.
+  const authenticates = options.authenticator !== undefined ||
+    declared !== undefined;
   // An injected registry (tests) wins; otherwise `--registry` resolves one.
   const registry = options.registry ??
     (options.useRegistry ? resolveMcpRegistry(build, readEnv) : undefined);
@@ -190,7 +199,13 @@ export async function serveMcp(
       authenticator,
     });
   if (options.http !== undefined) {
-    return await serveMcpHttp(server, options.http, options, authenticator);
+    return await serveMcpHttp(
+      server,
+      options.http,
+      options,
+      authenticator,
+      authenticates,
+    );
   }
   if (!options.quiet) {
     const mode = options.allowRun ? "run enabled" : "read-only";
@@ -211,26 +226,29 @@ export async function serveMcp(
  * Serve over the HTTP transport. Enforces the security default: a non-loopback
  * bind **must** authenticate its callers — with a bearer token (from
  * {@link ServeMcpOptions.token} or `ZUKE_MCP_TOKEN`) or with an authenticator
- * (`mcpAuth()`/`mcpIdentity()`) — else the server refuses to start rather than
- * exposing an unauthenticated endpoint. A loopback bind may run without either.
+ * declared as authentication (`authenticates`) — else the server refuses to
+ * start rather than exposing an unauthenticated endpoint. A loopback bind may
+ * run without either. `authenticator` is what actually runs per request, which
+ * includes a `mcpIdentity()` hook that does not itself satisfy the guard.
  */
 async function serveMcpHttp(
   server: McpHandler,
   address: HttpAddress,
   options: ServeMcpOptions,
   authenticator: McpAuthenticator | undefined,
+  authenticates: boolean,
 ): Promise<number> {
   const readEnv = options.readEnv ?? defaultReadEnv;
   const token = options.token ?? readEnv("ZUKE_MCP_TOKEN");
   const hasToken = token !== undefined && token !== "";
-  if (
-    !isLoopbackHost(address.host) && !hasToken && authenticator === undefined
-  ) {
+  if (!isLoopbackHost(address.host) && !hasToken && !authenticates) {
     console.error(
       `zuke mcp: refusing to bind ${address.host}:${address.port} without ` +
         `authentication. A non-loopback MCP endpoint must be authenticated — ` +
         `set ZUKE_MCP_TOKEN, declare mcpAuth() on the build, or bind 127.0.0.1 ` +
-        `for local-only access.`,
+        `for local-only access. (mcpIdentity() does not authenticate a ` +
+        `directly reachable endpoint: it trusts a header, which a direct ` +
+        `caller sets itself.)`,
     );
     return 1;
   }

--- a/packages/core/src/mcp/http.ts
+++ b/packages/core/src/mcp/http.ts
@@ -155,7 +155,8 @@ function bearerToken(header: string | null): string | undefined {
 }
 
 /**
- * The request as an authenticator sees it: same method, URL and headers, no body.
+ * The request as an authenticator sees it: same method, URL and headers, no
+ * body. `undefined` when no such view can be built.
  *
  * The body belongs to the transport. A request's body can be read once, so an
  * authenticator that peeked at this one would leave nothing for the dispatcher
@@ -163,12 +164,23 @@ function bearerToken(header: string | null): string | undefined {
  * code that caused it. A credential never lives in the body anyway, so handing
  * over a bodiless view costs an authenticator nothing and makes that mistake
  * impossible rather than merely documented.
+ *
+ * The constructor can refuse: Deno builds `request.url` from the raw `Host`
+ * header, and it accepts hosts the WHATWG URL parser rejects (`Host: bad host`).
+ * Such a request is still a request — its headers, which is where a credential
+ * lives, are intact — so the view is simply absent and the authenticator falls
+ * back to them, rather than the whole exchange failing on a header the server
+ * itself was willing to accept.
  */
-function authenticatorView(request: Request): Request {
-  return new Request(request.url, {
-    method: request.method,
-    headers: request.headers,
-  });
+function authenticatorView(request: Request): Request | undefined {
+  try {
+    return new Request(request.url, {
+      method: request.method,
+      headers: request.headers,
+    });
+  } catch {
+    return undefined;
+  }
 }
 
 /**

--- a/packages/core/src/mcp/http.ts
+++ b/packages/core/src/mcp/http.ts
@@ -15,9 +15,10 @@
  * serial handling — a build's parameters resolve into shared state per run, so
  * two concurrent runs of one build instance would race.
  *
- * This is a **bridge, not an internet gateway**: it binds loopback by default,
- * a non-loopback bind requires a bearer token, and production deployments should
- * put real TLS/authentication in front of it.
+ * This is a **bridge, not an internet gateway**: it binds loopback by default, a
+ * non-loopback bind must authenticate its callers (a bearer token or an
+ * {@link "./auth.ts".McpAuthenticator}), and production deployments should put
+ * real TLS in front of it.
  *
  * @module
  */

--- a/packages/core/src/mcp/http.ts
+++ b/packages/core/src/mcp/http.ts
@@ -188,6 +188,17 @@ function authenticatorView(request: Request): Request | undefined {
  * JSON-RPC error so a client that only speaks JSON-RPC still sees one, and its
  * `WWW-Authenticate` challenge when it carries one — the header an MCP client
  * reads to discover where to authenticate.
+ *
+ * The status is deliberately a real HTTP status rather than a `200` carrying a
+ * JSON-RPC error. A challenge is only meaningful on a `401`, so a refusal
+ * wrapped in a `200` cannot tell a client where to authenticate — which is the
+ * whole point of an authenticator that can be discovered rather than
+ * pre-configured. This is not a new status class for this transport either: a
+ * bad or absent bearer token has always been answered `401` here, a non-`POST`
+ * `405`, and unparseable JSON `400`, so a client that reads any non-`200` as a
+ * transport failure was already broken against a token-protected server. The
+ * body still carries the JSON-RPC error, so a client that reads it sees the
+ * same reason it saw before.
  */
 function refusedResponse(reject: McpAuthReject): Response {
   const headers = new Headers({ "content-type": "application/json" });

--- a/packages/core/src/mcp/http.ts
+++ b/packages/core/src/mcp/http.ts
@@ -30,6 +30,15 @@ import {
   PARSE_ERROR,
 } from "./jsonrpc.ts";
 import { timingSafeEqual } from "./authz.ts";
+import {
+  authenticateRequest,
+  isResolvedIdentity,
+  type McpAuthenticator,
+  type McpAuthReject,
+  refusalReason,
+  type ResolvedIdentity,
+  UNAUTHORIZED,
+} from "./auth.ts";
 import { isLoopbackHost } from "../http.ts";
 
 /** Options for {@link serveHttp}. */
@@ -66,6 +75,13 @@ export interface HttpTransportOptions {
    * the CAS store) opts in, so a long run never head-of-line-blocks a read.
    */
   concurrent?: boolean;
+  /**
+   * Authenticates every request before its body is read, when the server has
+   * one. A refusal becomes a real HTTP status and `WWW-Authenticate` challenge
+   * here rather than a JSON-RPC error inside a `200`, which is what lets an MCP
+   * client discover where to authenticate.
+   */
+  authenticator?: McpAuthenticator;
 }
 
 /** A JSON `Response` with the given status and `application/json` content type. */
@@ -137,6 +153,40 @@ function bearerToken(header: string | null): string | undefined {
   return parts[1];
 }
 
+/**
+ * The request as an authenticator sees it: same method, URL and headers, no body.
+ *
+ * The body belongs to the transport. A request's body can be read once, so an
+ * authenticator that peeked at this one would leave nothing for the dispatcher
+ * to parse — and the next read fails with a bare `TypeError`, nowhere near the
+ * code that caused it. A credential never lives in the body anyway, so handing
+ * over a bodiless view costs an authenticator nothing and makes that mistake
+ * impossible rather than merely documented.
+ */
+function authenticatorView(request: Request): Request {
+  return new Request(request.url, {
+    method: request.method,
+    headers: request.headers,
+  });
+}
+
+/**
+ * The response for a refused request: the refusal's status, its reason as a
+ * JSON-RPC error so a client that only speaks JSON-RPC still sees one, and its
+ * `WWW-Authenticate` challenge when it carries one — the header an MCP client
+ * reads to discover where to authenticate.
+ */
+function refusedResponse(reject: McpAuthReject): Response {
+  const headers = new Headers({ "content-type": "application/json" });
+  if (reject.challenge !== undefined) {
+    headers.set("www-authenticate", reject.challenge);
+  }
+  return new Response(
+    JSON.stringify(err(null, INVALID_REQUEST, refusalReason(reject))),
+    { status: reject.status, headers },
+  );
+}
+
 /** The hostname of an `Origin` value, or `null` if it can't be parsed. */
 function originHost(origin: string): string | null {
   try {
@@ -170,7 +220,8 @@ export function originAllowed(
  * body, `handle` produces the response, and it is returned as JSON. A
  * notification (`handle` returns `null`) is answered `202 Accepted` with no
  * body. Unparseable JSON gets a `400` JSON-RPC parse error; a non-`POST` gets
- * `405`; a bad/absent bearer token (when one is configured) gets `401`.
+ * `405`; a bad/absent bearer token (when one is configured) gets `401`; an
+ * authenticator's refusal gets that refusal's own status and challenge.
  *
  * Resolves when the server closes (abort {@link HttpTransportOptions.signal}).
  */
@@ -178,11 +229,20 @@ export async function serveHttp(
   handle: (
     message: unknown,
     ctx: McpRequestContext,
+    identity?: ResolvedIdentity,
   ) => Promise<JsonRpcResponse | null>,
   options: HttpTransportOptions,
 ): Promise<void> {
-  const { host, port, token, signal, onListen, concurrent, allowedOrigins } =
-    options;
+  const {
+    host,
+    port,
+    token,
+    signal,
+    onListen,
+    concurrent,
+    allowedOrigins,
+    authenticator,
+  } = options;
 
   // By default, process messages one at a time: the single-build server/execute
   // path mutates per-run parameter state, so concurrent handling of two POSTs
@@ -192,8 +252,9 @@ export async function serveHttp(
   const serial = (
     message: unknown,
     ctx: McpRequestContext,
+    identity?: ResolvedIdentity,
   ): Promise<JsonRpcResponse | null> => {
-    const result = queue.then(() => handle(message, ctx));
+    const result = queue.then(() => handle(message, ctx, identity));
     queue = result.then(() => {}, () => {});
     return result;
   };
@@ -221,17 +282,20 @@ export async function serveHttp(
     if (token !== undefined && token !== "") {
       const provided = bearerToken(request.headers.get("authorization"));
       if (provided === undefined || !timingSafeEqual(provided, token)) {
-        return new Response(
-          JSON.stringify(err(null, INVALID_REQUEST, "Unauthorized")),
-          {
-            status: 401,
-            headers: {
-              "content-type": "application/json",
-              "www-authenticate": "Bearer",
-            },
-          },
-        );
+        return refusedResponse(UNAUTHORIZED);
       }
+    }
+    // Authenticate before reading the body: an unauthenticated caller never gets
+    // to make the server buffer a megabyte for it.
+    const ctx: McpRequestContext = {
+      headers: request.headers,
+      request: authenticatorView(request),
+    };
+    let identity: ResolvedIdentity | undefined;
+    if (authenticator !== undefined) {
+      const resolved = await authenticateRequest(authenticator, ctx);
+      if (!isResolvedIdentity(resolved)) return refusedResponse(resolved);
+      identity = resolved;
     }
     const body = await readBounded(request, MAX_BODY_BYTES);
     if (body === null) {
@@ -246,7 +310,7 @@ export async function serveHttp(
     } catch {
       return jsonResponse(err(null, PARSE_ERROR, "Parse error"), 400);
     }
-    const response = await dispatch(message, { headers: request.headers });
+    const response = await dispatch(message, ctx, identity);
     if (response === null) return new Response(null, { status: 202 });
     return jsonResponse(response, 200);
   };

--- a/packages/core/src/mcp/jsonrpc.ts
+++ b/packages/core/src/mcp/jsonrpc.ts
@@ -76,56 +76,23 @@ export interface ByteWriter {
 }
 
 /**
- * The per-request context a transport hands the message handler. Carries the
- * request's headers, so a server's identity hook can authenticate the caller
- * from a trusted proxy header. Empty on the stdio transport (no headers).
+ * The per-request context a transport hands the message handler, and the only
+ * thing an authenticator sees of the request. Empty on the stdio transport,
+ * which has no request to describe.
  */
 export interface McpRequestContext {
   /** The request headers; an empty {@link Headers} on stdio. */
   readonly headers: Headers;
-}
-
-/**
- * A trusted caller identity, resolved per request by a {@link McpIdentityHook}
- * (typically from an authenticating reverse proxy's header). Its
- * {@link McpIdentity.actor} is the highest-precedence attribution — it overrides
- * `--actor`, the environment, and the client's self-reported label for the call.
- */
-export interface McpIdentity {
-  /** The authenticated actor (e.g. an OAuth subject). */
-  actor: string;
-  /** How the identity was established (e.g. `"oauth-proxy"`); informational. */
-  via?: string;
-}
-
-/**
- * Resolve a trusted {@link McpIdentity} from a request's context. Invoked once
- * per message, before any dispatch; **throwing rejects the whole request** with
- * an auth error, so nothing executes and nothing is written to state — the seam
- * a proxy in front of the server uses to inject an authenticated identity.
- */
-export type McpIdentityHook = (ctx: McpRequestContext) => McpIdentity;
-
-/**
- * Run an identity `hook` and return its trusted actor, or `null` when the hook
- * throws or yields an unusable actor (empty, or not a string). A caller must
- * reject the request on `null` rather than fall back to a static actor — the
- * hook's precedence is absolute and fail-closed, so a missing identity is a
- * rejection, never an anonymous/spoofable attribution.
- */
-export function resolveIdentity(
-  hook: McpIdentityHook,
-  ctx: McpRequestContext,
-): string | null {
-  let actor: unknown;
-  try {
-    // Guard both the call and the property read: a hook returning `undefined`
-    // (looser JS typing) must be rejected, not throw out of the dispatch loop.
-    actor = hook(ctx).actor;
-  } catch {
-    return null;
-  }
-  return typeof actor === "string" && actor !== "" ? actor : null;
+  /**
+   * The HTTP request the caller arrived on, when it did — so an authenticator
+   * can read its method and URL, not just its headers. Absent on the stdio
+   * transport, which has no request.
+   *
+   * Its **body is deliberately empty**: the body belongs to the transport, which
+   * reads it once to parse the JSON-RPC message, and a credential never lives
+   * there. Everything else — method, URL, headers — is the real request's.
+   */
+  readonly request?: Request;
 }
 
 /**

--- a/packages/core/src/mcp/protocol.ts
+++ b/packages/core/src/mcp/protocol.ts
@@ -23,13 +23,18 @@ import {
   INVALID_PARAMS,
   INVALID_REQUEST,
   type JsonRpcResponse,
-  type McpIdentityHook,
   type McpRequestContext,
   messageId,
   METHOD_NOT_FOUND,
   ok,
-  resolveIdentity,
 } from "./jsonrpc.ts";
+import {
+  authenticateRequest,
+  isResolvedIdentity,
+  type McpAuthenticator,
+  refusalReason,
+  type ResolvedIdentity,
+} from "./auth.ts";
 
 /**
  * The MCP protocol versions these servers implement, newest first. The method
@@ -79,11 +84,12 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 /** What {@link dispatchMessage} needs from a server to answer one message. */
 export interface McpDispatchHooks {
   /**
-   * Resolve a trusted caller identity per request, when the server has one
-   * configured. A hook that throws or yields no usable actor rejects the whole
-   * request before any dispatch.
+   * Authenticate the caller per request, when the server has one configured.
+   * An authenticator that refuses — or throws — rejects the whole request before
+   * any dispatch. Skipped when the transport already authenticated (see the
+   * `identity` argument of {@link dispatchMessage}).
    */
-  readonly identity?: McpIdentityHook;
+  readonly authenticator?: McpAuthenticator;
   /** The `initialize` result (and the side effect of noting the client label). */
   initialize(params: unknown): Record<string, unknown>;
   /**
@@ -92,11 +98,11 @@ export interface McpDispatchHooks {
    * this dispatcher.
    */
   tools(): McpTool[] | Promise<McpTool[]>;
-  /** Dispatch a `tools/call`, attributed to the resolved caller `actor`. */
+  /** Dispatch a `tools/call`, attributed to the resolved caller `identity`. */
   callTool(
     id: string | number | null,
     params: unknown,
-    actor: string | undefined,
+    identity: ResolvedIdentity | undefined,
   ): Promise<JsonRpcResponse>;
 }
 
@@ -104,17 +110,24 @@ export interface McpDispatchHooks {
  * Handle one parsed JSON-RPC message against `hooks`. Returns the response to
  * send, or `null` for a notification (which takes no reply).
  *
- * The identity hook runs once, before any dispatch: a hook that yields no
+ * Authentication runs once, before any dispatch: an authenticator that yields no
  * trusted actor rejects the request outright — nothing runs, nothing is written,
- * and it never falls back to the (untrusted) static actor, so the hook's
- * precedence stays absolute. `tools/list` and `tools/call` are each wrapped in a
- * backstop, because neither may crash the transport for every later message on
- * the connection; the error is generic so no raw detail escapes.
+ * and it never falls back to the (untrusted) static actor, so its precedence
+ * stays absolute. `identity` is the transport's own already-authenticated
+ * caller (the HTTP transport authenticates at its edge, so a refusal becomes a
+ * real status and challenge); when it is absent and an authenticator is
+ * configured, this dispatcher runs it — so neither transport can dispatch a
+ * request nobody authenticated.
+ *
+ * `tools/list` and `tools/call` are each wrapped in a backstop, because neither
+ * may crash the transport for every later message on the connection; the error
+ * is generic so no raw detail escapes.
  */
 export async function dispatchMessage(
   message: unknown,
   ctx: McpRequestContext,
   hooks: McpDispatchHooks,
+  identity?: ResolvedIdentity,
 ): Promise<JsonRpcResponse | null> {
   if (
     typeof message !== "object" || message === null ||
@@ -129,11 +142,15 @@ export async function dispatchMessage(
   // Notifications (no id) never receive a response.
   if (id === null && method.startsWith("notifications/")) return null;
 
-  let identityActor: string | undefined;
-  if (hooks.identity !== undefined) {
-    const resolved = resolveIdentity(hooks.identity, ctx);
-    if (resolved === null) return err(id, INVALID_REQUEST, "Unauthorized");
-    identityActor = resolved;
+  let caller = identity;
+  if (caller === undefined && hooks.authenticator !== undefined) {
+    const resolved = await authenticateRequest(hooks.authenticator, ctx);
+    if (!isResolvedIdentity(resolved)) {
+      // JSON-RPC carries no status, so a stdio caller learns only the reason —
+      // the same sentence the HTTP transport writes beside the status.
+      return err(id, INVALID_REQUEST, refusalReason(resolved));
+    }
+    caller = resolved;
   }
 
   switch (method) {
@@ -149,7 +166,7 @@ export async function dispatchMessage(
       }
     case "tools/call":
       try {
-        return await hooks.callTool(id, params, identityActor);
+        return await hooks.callTool(id, params, caller);
       } catch {
         return err(id, INTERNAL_ERROR, "Internal error handling the tool call");
       }

--- a/packages/core/src/mcp/registry_server.ts
+++ b/packages/core/src/mcp/registry_server.ts
@@ -58,10 +58,10 @@ import {
   err,
   INVALID_PARAMS,
   type JsonRpcResponse,
-  type McpIdentityHook,
   type McpRequestContext,
   ok,
 } from "./jsonrpc.ts";
+import type { McpAuthenticator, ResolvedIdentity } from "./auth.ts";
 
 /** The captured result of spawning a registered build. */
 export interface RegistryRunResult {
@@ -78,9 +78,20 @@ export interface RegistryRunOptions {
   /**
    * The resolved caller actor. The default runner exports it as `ZUKE_ACTOR` in
    * the child environment so the spawned build attributes its run to the same
-   * (trusted, when an identity hook is active) actor as the MCP audit trail.
+   * (trusted, when an authenticator is active) actor as the MCP audit trail.
    */
   actor?: string;
+  /**
+   * Whether a person or a machine asked for the run, exported as
+   * `ZUKE_ACTOR_KIND`, so a build can tell an engineer's launch from a
+   * scheduler's.
+   */
+  actorKind?: "human" | "service";
+  /**
+   * The caller's roles, exported as `ZUKE_ACTOR_ROLES` (comma-separated), so a
+   * build can see what the caller was entitled to when it asked.
+   */
+  actorRoles?: readonly string[];
 }
 
 /**
@@ -106,10 +117,15 @@ export const defaultRegistryRunner: RegistryRunner = async (
   const env = Deno.env.toObject();
   delete env.ZUKE_OPERATOR_TOKEN;
   delete env.ZUKE_MCP_TOKEN;
-  // Attribute the child run to the resolved caller (a trusted identity when a
-  // hook is active), overriding any inherited ZUKE_ACTOR.
+  // Attribute the child run to the resolved caller (a trusted identity when an
+  // authenticator is active), overriding any inherited ZUKE_ACTOR. The three
+  // travel together: an inherited kind or role set must not survive beside a
+  // fresh actor, or the child would read one caller's actor with another's
+  // entitlements.
   if (options?.actor !== undefined && options.actor !== "") {
     env.ZUKE_ACTOR = options.actor;
+    env.ZUKE_ACTOR_KIND = options.actorKind ?? "human";
+    env.ZUKE_ACTOR_ROLES = (options.actorRoles ?? []).join(",");
   }
   const command = new Deno.Command(argv[0], {
     args: [...argv.slice(1)],
@@ -147,16 +163,17 @@ export interface RegistryMcpServerOptions {
   confirmDestructive?: boolean;
   /** The durable store; when set, every mutating/denied call is audited. */
   stateStore?: StateStore;
-  /** Who to attribute audited calls to (`--actor`); below {@link identity}. */
+  /** Who to attribute audited calls to (`--actor`); below {@link authenticator}. */
   actor?: string;
   /**
-   * Resolve a trusted caller identity per request (e.g. from an authenticating
-   * reverse proxy's header). When set, its actor overrides `--actor`, the
-   * environment, and the client label for every call — flowing to the audit
-   * trail and to the spawned build (as `ZUKE_ACTOR`) — and a throwing hook
-   * rejects the request before anything spawns. Off by default.
+   * Authenticate the caller per request. When set, the identity it resolves
+   * overrides `--actor`, the environment, and the client label for every call —
+   * flowing to the audit trail and to the spawned build (as `ZUKE_ACTOR`,
+   * `ZUKE_ACTOR_KIND` and `ZUKE_ACTOR_ROLES`) — and a refusal stops the request
+   * before anything spawns. Off by default. The CLI builds this from the
+   * build's `mcpAuth()` or `mcpIdentity()` (see `serveMcp`).
    */
-  identity?: McpIdentityHook;
+  authenticator?: McpAuthenticator;
   /** Reads an environment variable (injectable for tests). */
   readEnv?: (name: string) => string | undefined;
   /** The server version reported in `initialize`. Defaults to `"0.0.0"`. */
@@ -331,7 +348,7 @@ export class RegistryMcpServer {
   readonly #confirmDestructive: boolean;
   readonly #store?: StateStore;
   readonly #actor?: string;
-  readonly #identity?: McpIdentityHook;
+  readonly #authenticator?: McpAuthenticator;
   readonly #readEnv: (name: string) => string | undefined;
   readonly #runner: RegistryRunner;
   readonly #maxConcurrentRuns: number;
@@ -363,7 +380,7 @@ export class RegistryMcpServer {
     this.#confirmDestructive = options.confirmDestructive ?? false;
     this.#store = options.stateStore;
     this.#actor = options.actor;
-    this.#identity = options.identity;
+    this.#authenticator = options.authenticator;
     this.#readEnv = options.readEnv ?? (() => undefined);
     this.#version = options.version ?? "0.0.0";
     this.#runner = options.runner ?? defaultRegistryRunner;
@@ -378,17 +395,18 @@ export class RegistryMcpServer {
   handleMessage(
     message: unknown,
     ctx: McpRequestContext = EMPTY_CONTEXT,
+    identity?: ResolvedIdentity,
   ): Promise<JsonRpcResponse | null> {
     // `tools/list` reads the registry live (a hosted backend can throw on a
     // transient fault or a malformed descriptor); the shared dispatcher guards
     // it, and `tools/call`, so one hiccup returns an error instead of tearing
     // down the transport for every client.
     return dispatchMessage(message, ctx, {
-      identity: this.#identity,
+      authenticator: this.#authenticator,
       initialize: (params) => this.#initialize(params),
       tools: () => this.tools(),
-      callTool: (id, params, actor) => this.#callTool(id, params, actor),
-    });
+      callTool: (id, params, caller) => this.#callTool(id, params, caller),
+    }, identity);
   }
 
   /**
@@ -511,11 +529,11 @@ export class RegistryMcpServer {
     return result;
   }
 
-  /** Dispatch a `tools/call`, attributed to `actor` (the resolved caller). */
+  /** Dispatch a `tools/call`, attributed to `identity` (the resolved caller). */
   async #callTool(
     id: string | number | null,
     params: unknown,
-    actor: string | undefined,
+    identity: ResolvedIdentity | undefined,
   ): Promise<JsonRpcResponse> {
     const call = toolCall(params);
     if ("error" in call) return err(id, INVALID_PARAMS, call.error);
@@ -528,7 +546,7 @@ export class RegistryMcpServer {
       return ok(id, await this.#describeBuild(args));
     }
     if (name.startsWith(RUN_PREFIX)) {
-      return await this.#run(id, name.slice(RUN_PREFIX.length), args, actor);
+      return await this.#run(id, name.slice(RUN_PREFIX.length), args, identity);
     }
     return ok(id, textResult(`Unknown tool: ${name}`, true));
   }
@@ -558,10 +576,10 @@ export class RegistryMcpServer {
     id: string | number | null,
     qualified: string,
     args: Record<string, unknown>,
-    identityActor: string | undefined,
+    identity: ResolvedIdentity | undefined,
   ): Promise<JsonRpcResponse> {
     const runName = `${RUN_PREFIX}${qualified}`;
-    const actor = identityActor ?? this.#resolveActor();
+    const actor = identity?.actor ?? this.#resolveActor();
     if (!this.#allowRun) {
       await this.#audit(runName, args, "denied", actor, "run_disabled");
       return ok(id, runDisabledResult("--registry --allow-run"));
@@ -732,7 +750,11 @@ export class RegistryMcpServer {
     this.#inFlightRuns++;
     let result: RegistryRunResult;
     try {
-      result = await this.#runner(launch.argv, launch.cwd, { actor });
+      result = await this.#runner(launch.argv, launch.cwd, {
+        actor,
+        actorKind: identity?.kind,
+        actorRoles: identity?.roles,
+      });
     } catch (error) {
       await this.#audit(
         runName,

--- a/packages/core/src/mcp/registry_server.ts
+++ b/packages/core/src/mcp/registry_server.ts
@@ -84,12 +84,18 @@ export interface RegistryRunOptions {
   /**
    * Whether a person or a machine asked for the run, exported as
    * `ZUKE_ACTOR_KIND`, so a build can tell an engineer's launch from a
-   * scheduler's.
+   * scheduler's. Honoured only together with {@link RegistryRunOptions.actor}.
    */
   actorKind?: "human" | "service";
   /**
    * The caller's roles, exported as `ZUKE_ACTOR_ROLES` (comma-separated), so a
-   * build can see what the caller was entitled to when it asked.
+   * build can see what the caller was entitled to when it asked. Honoured only
+   * together with {@link RegistryRunOptions.actor}.
+   *
+   * The three describe one caller and are written together or not at all:
+   * exporting entitlements beside an actor that came from somewhere else is the
+   * mismatch the coupling exists to prevent. Supplying these without an actor
+   * therefore changes nothing rather than half-describing a caller.
    */
   actorRoles?: readonly string[];
 }

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -111,7 +111,7 @@ export interface McpServerOptions {
    * tool call is written to the audit log.
    */
   stateStore?: StateStore;
-  /** Who to attribute audited calls to (`--actor`); below {@link identity}. */
+  /** Who to attribute audited calls to (`--actor`); below {@link authenticator}. */
   actor?: string;
   /**
    * Authenticate the caller per request. When set, the identity it resolves

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -43,10 +43,10 @@ import {
   err,
   INVALID_PARAMS,
   type JsonRpcResponse,
-  type McpIdentityHook,
   type McpRequestContext,
   ok,
 } from "./jsonrpc.ts";
+import type { McpAuthenticator, ResolvedIdentity } from "./auth.ts";
 import {
   confirmationResult,
   dispatchMessage,
@@ -114,13 +114,13 @@ export interface McpServerOptions {
   /** Who to attribute audited calls to (`--actor`); below {@link identity}. */
   actor?: string;
   /**
-   * Resolve a trusted caller identity per request (e.g. from an authenticating
-   * reverse proxy's header). When set, its actor overrides `--actor`, the
-   * environment, and the client's self-reported label for every call, and a
-   * throwing hook rejects the request before anything runs. Off by default, so
-   * stdio/local use is unchanged.
+   * Authenticate the caller per request. When set, the identity it resolves
+   * overrides `--actor`, the environment, and the client's self-reported label
+   * for every call, and a refusal stops the request before anything runs. Off by
+   * default, so stdio/local use is unchanged. The CLI builds this from the
+   * build's `mcpAuth()` or `mcpIdentity()` (see `serveMcp`).
    */
-  identity?: McpIdentityHook;
+  authenticator?: McpAuthenticator;
   /** Reads an environment variable (injectable for tests). */
   readEnv?: (name: string) => string | undefined;
   /** The server version reported in `initialize`. Defaults to `"0.0.0"`. */
@@ -193,7 +193,7 @@ export class McpServer {
   readonly #confirmDestructive: boolean;
   readonly #store?: StateStore;
   readonly #actor?: string;
-  readonly #identity?: McpIdentityHook;
+  readonly #authenticator?: McpAuthenticator;
   readonly #readEnv: (name: string) => string | undefined;
   /** The connecting client's `initialize` name, a low-priority audit actor. */
   #clientLabel?: string;
@@ -222,7 +222,7 @@ export class McpServer {
     this.#confirmDestructive = options.confirmDestructive ?? false;
     this.#store = options.stateStore;
     this.#actor = options.actor;
-    this.#identity = options.identity;
+    this.#authenticator = options.authenticator;
     this.#readEnv = options.readEnv ?? (() => undefined);
     this.#version = options.version ?? "0.0.0";
   }
@@ -387,13 +387,14 @@ export class McpServer {
   handleMessage(
     message: unknown,
     ctx: McpRequestContext = EMPTY_CONTEXT,
+    identity?: ResolvedIdentity,
   ): Promise<JsonRpcResponse | null> {
     return dispatchMessage(message, ctx, {
-      identity: this.#identity,
+      authenticator: this.#authenticator,
       initialize: (params) => this.#initialize(params),
       tools: () => this.tools(),
-      callTool: (id, params, actor) => this.#callTool(id, params, actor),
-    });
+      callTool: (id, params, caller) => this.#callTool(id, params, caller),
+    }, identity);
   }
 
   /**
@@ -409,11 +410,11 @@ export class McpServer {
     return result;
   }
 
-  /** Dispatch a `tools/call`, attributed to `actor` (the resolved caller). */
+  /** Dispatch a `tools/call`, attributed to `identity` (the resolved caller). */
   async #callTool(
     id: string | number | null,
     params: unknown,
-    actor: string | undefined,
+    identity: ResolvedIdentity | undefined,
   ): Promise<JsonRpcResponse> {
     const call = toolCall(params);
     if ("error" in call) return err(id, INVALID_PARAMS, call.error);
@@ -429,9 +430,9 @@ export class McpServer {
       return ok(id, textResult(this.#describe().graph));
     }
     if (name.startsWith(RUN_PREFIX)) {
-      return await this.#run(id, name.slice(RUN_PREFIX.length), args, actor);
+      return await this.#run(id, name.slice(RUN_PREFIX.length), args, identity);
     }
-    const runStateResult = await this.#callRunStateTool(name, args, actor);
+    const runStateResult = await this.#callRunStateTool(name, args, identity);
     if (runStateResult !== null) return ok(id, runStateResult);
     // An unknown tool is reported through the result (isError), per MCP, so the
     // model sees it rather than a transport-level failure.
@@ -447,11 +448,11 @@ export class McpServer {
   async #callRunStateTool(
     name: string,
     args: Record<string, unknown>,
-    identityActor: string | undefined,
+    identity: ResolvedIdentity | undefined,
   ): Promise<Record<string, unknown> | null> {
     const store = this.#store;
     if (store === undefined) return null;
-    const actor = identityActor ?? this.#resolveActor();
+    const actor = identity?.actor ?? this.#resolveActor();
     const mutating = isMutatingRunTool(name);
     if (mutating && !this.#allowRun) {
       return textResult(
@@ -503,10 +504,10 @@ export class McpServer {
     id: string | number | null,
     targetName: string,
     args: Record<string, unknown>,
-    identityActor: string | undefined,
+    identity: ResolvedIdentity | undefined,
   ): Promise<JsonRpcResponse> {
     const runName = `${RUN_PREFIX}${targetName}`;
-    const actor = identityActor ?? this.#resolveActor();
+    const actor = identity?.actor ?? this.#resolveActor();
     // Execution off entirely: a generic message (reveals no specific target).
     if (!this.#allowRun) {
       await this.#audit(runName, args, "denied", actor, "run_disabled");

--- a/packages/core/tests/mcp_auth_test.ts
+++ b/packages/core/tests/mcp_auth_test.ts
@@ -1,0 +1,305 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals } from "./_assert.ts";
+import {
+  authenticateRequest,
+  authenticatorFromHook,
+  isResolvedIdentity,
+  type McpAuthenticator,
+  type McpAuthReject,
+  normalizeIdentity,
+  type ResolvedIdentity,
+  UNAUTHORIZED,
+} from "../src/mcp/auth.ts";
+import { EMPTY_CONTEXT, type McpRequestContext } from "../src/mcp/jsonrpc.ts";
+
+/** Wrap an `authenticate` implementation as an {@link McpAuthenticator}. */
+function authenticator(
+  authenticate: McpAuthenticator["authenticate"],
+): McpAuthenticator {
+  return { authenticate };
+}
+
+/** Run `authenticate` against the empty (stdio-shaped) context. */
+function run(
+  authenticate: McpAuthenticator["authenticate"],
+): Promise<ResolvedIdentity | McpAuthReject> {
+  return authenticateRequest(authenticator(authenticate), EMPTY_CONTEXT);
+}
+
+// ---- normalizeIdentity: what is, and is not, an identity -------------------
+
+Deno.test("normalizeIdentity refuses anything that is not an identity object", () => {
+  assertEquals(normalizeIdentity(null), null);
+  assertEquals(normalizeIdentity(undefined), null);
+  assertEquals(normalizeIdentity("ada"), null);
+  assertEquals(normalizeIdentity(42), null);
+  assertEquals(normalizeIdentity([]), null); // an array is not a record
+  assertEquals(normalizeIdentity([{ actor: "ada" }]), null);
+  assertEquals(normalizeIdentity({}), null); // no actor at all
+  assertEquals(normalizeIdentity({ actor: 42 }), null); // non-string actor
+  assertEquals(normalizeIdentity({ actor: null }), null);
+  assertEquals(normalizeIdentity({ actor: "" }), null); // empty actor
+});
+
+Deno.test("normalizeIdentity settles kind and roles on a minimal identity", () => {
+  // The key count is compared too, so this also pins that no `via` key is
+  // invented for an identity that carried none.
+  assertEquals(normalizeIdentity({ actor: "ada" }), {
+    actor: "ada",
+    kind: "human",
+    roles: [],
+  });
+});
+
+Deno.test("normalizeIdentity honours an explicit service kind", () => {
+  assertEquals(normalizeIdentity({ actor: "deploy-bot", kind: "service" }), {
+    actor: "deploy-bot",
+    kind: "service",
+    roles: [],
+  });
+});
+
+Deno.test("normalizeIdentity reads an unknown kind as human, never service", () => {
+  // The conservative default: only the exact literal `"service"` grants the
+  // service kind, so a garbage value can never buy the more-privileged claim.
+  for (
+    const kind of ["admin", "Service", "SERVICE", " service", 1, null, {}, []]
+  ) {
+    const identity = normalizeIdentity({ actor: "ada", kind });
+    assertEquals(identity?.kind, "human", `kind ${JSON.stringify(kind)}`);
+  }
+});
+
+Deno.test("normalizeIdentity keeps only the non-empty string roles", () => {
+  assertEquals(
+    normalizeIdentity({ actor: "ada", roles: ["ops", "", 7, null, "deploy"] }),
+    { actor: "ada", kind: "human", roles: ["ops", "deploy"] },
+  );
+});
+
+Deno.test("normalizeIdentity yields no roles for a non-array roles", () => {
+  for (const roles of ["ops", 7, null, undefined, { ops: true }]) {
+    const identity = normalizeIdentity({ actor: "ada", roles });
+    assertEquals(identity?.roles, [], `roles ${JSON.stringify(roles)}`);
+  }
+});
+
+Deno.test("normalizeIdentity keeps a non-empty via and omits any other", () => {
+  assertEquals(normalizeIdentity({ actor: "ada", via: "oauth-proxy" }), {
+    actor: "ada",
+    kind: "human",
+    roles: [],
+    via: "oauth-proxy",
+  });
+  for (const via of ["", 7, null, {}]) {
+    const identity = normalizeIdentity({ actor: "ada", via });
+    assertEquals(
+      identity !== null && Object.hasOwn(identity, "via"),
+      false,
+      `via ${JSON.stringify(via)}`,
+    );
+  }
+});
+
+// ---- authenticateRequest: accepting a caller -------------------------------
+
+Deno.test("authenticateRequest settles a synchronous identity", async () => {
+  const result = await run(() => ({ actor: "ada", kind: "service" }));
+  assertEquals(result, { actor: "ada", kind: "service", roles: [] });
+});
+
+Deno.test("authenticateRequest awaits an asynchronous identity", async () => {
+  const result = await run(() =>
+    Promise.resolve({ actor: "ada", roles: ["ops"], via: "oauth-proxy" })
+  );
+  assertEquals(result, {
+    actor: "ada",
+    kind: "human",
+    roles: ["ops"],
+    via: "oauth-proxy",
+  });
+});
+
+Deno.test("authenticateRequest passes the request context through", async () => {
+  const ctx: McpRequestContext = {
+    headers: new Headers({ "x-forwarded-user": "ada" }),
+  };
+  const seen: McpRequestContext[] = [];
+  const result = await authenticateRequest(
+    authenticator((received) => {
+      seen.push(received);
+      return { actor: received.headers.get("x-forwarded-user") ?? "" };
+    }),
+    ctx,
+  );
+  assertEquals(seen.length, 1);
+  assertEquals(seen[0], ctx);
+  assertEquals(result, { actor: "ada", kind: "human", roles: [] });
+});
+
+// ---- authenticateRequest: fail-closed on a misbehaving authenticator -------
+
+Deno.test("authenticateRequest turns a throw into the bare 401", async () => {
+  const result = await run(() => {
+    throw new Error("upstream token endpoint is down");
+  });
+  assertEquals(result, UNAUTHORIZED);
+});
+
+Deno.test("authenticateRequest turns a rejected promise into the bare 401", async () => {
+  const result = await run(() => Promise.reject(new Error("timeout")));
+  assertEquals(result, UNAUTHORIZED);
+});
+
+Deno.test("authenticateRequest refuses a result that is neither identity nor reject", async () => {
+  // @ts-expect-error - a misbehaving authenticator returning `null`; the runtime guard must refuse it.
+  assertEquals(await run(() => null), UNAUTHORIZED);
+  // @ts-expect-error - likewise `undefined`, the value a forgotten `return` produces.
+  assertEquals(await run(() => undefined), UNAUTHORIZED);
+  // @ts-expect-error - likewise a bare string, e.g. an actor name returned unwrapped.
+  assertEquals(await run(() => "ada"), UNAUTHORIZED);
+  // @ts-expect-error - likewise an array, which is an object but not a record.
+  assertEquals(await run(() => ["ada"]), UNAUTHORIZED);
+  // @ts-expect-error - likewise a number.
+  assertEquals(await run(() => 401), UNAUTHORIZED);
+  assertEquals(await run(() => ({ actor: "" })), UNAUTHORIZED);
+});
+
+// ---- authenticateRequest: rejections cannot be laundered into successes ----
+
+Deno.test("authenticateRequest keeps a well-formed rejection intact", async () => {
+  const result = await run(() => ({
+    status: 403,
+    error: "insufficient_scope",
+    detail: "needs the deploy role",
+    challenge: `Bearer error="insufficient_scope"`,
+  }));
+  assertEquals(result, {
+    status: 403,
+    error: "insufficient_scope",
+    detail: "needs the deploy role",
+    challenge: `Bearer error="insufficient_scope"`,
+  });
+});
+
+Deno.test("authenticateRequest accepts the client-error status range's ends", async () => {
+  assertEquals(await run(() => ({ status: 400, error: "bad_request" })), {
+    status: 400,
+    error: "bad_request",
+  });
+  assertEquals(await run(() => ({ status: 499, error: "closed" })), {
+    status: 499,
+    error: "closed",
+  });
+});
+
+Deno.test("authenticateRequest collapses a non-client-error status to the bare 401", async () => {
+  // The security-critical arm: a refusal must never become a success (200), a
+  // redirect (302), or a server error (500) at the transport, whatever the
+  // authenticator put in `status`.
+  assertEquals(await run(() => ({ status: 200, error: "ok" })), UNAUTHORIZED);
+  assertEquals(await run(() => ({ status: 302, error: "go" })), UNAUTHORIZED);
+  assertEquals(await run(() => ({ status: 399, error: "no" })), UNAUTHORIZED);
+  assertEquals(await run(() => ({ status: 500, error: "boom" })), UNAUTHORIZED);
+  assertEquals(await run(() => ({ status: 0, error: "none" })), UNAUTHORIZED);
+  assertEquals(await run(() => ({ status: -401, error: "neg" })), UNAUTHORIZED);
+  assertEquals(await run(() => ({ status: 401.5, error: "x" })), UNAUTHORIZED);
+  assertEquals(await run(() => ({ status: NaN, error: "x" })), UNAUTHORIZED);
+  // @ts-expect-error - a status given as a string must not sneak past the check.
+  assertEquals(await run(() => ({ status: "401", error: "x" })), UNAUTHORIZED);
+  // @ts-expect-error - nor a rejection that forgot its status entirely.
+  assertEquals(await run(() => ({ error: "nope" })), UNAUTHORIZED);
+});
+
+Deno.test("authenticateRequest drops empty rejection strings", async () => {
+  const result = await run(() => ({
+    status: 403,
+    error: "",
+    detail: "",
+    challenge: "",
+  }));
+  // The empty `error` falls back to the shared message; empty `detail` and
+  // `challenge` are omitted rather than emitted as blanks on the wire.
+  assertEquals(result, { status: 403, error: "Unauthorized" });
+});
+
+// ---- isResolvedIdentity ----------------------------------------------------
+
+Deno.test("a result that is both an identity and a refusal is refused", async () => {
+  // The typed union cannot produce this; an authenticator written in plain JS
+  // can. A value carrying a `status` is a refusal even though it also names an
+  // actor — between "deny" and "admit" for a value that says both, fail-closed
+  // means deny.
+  const confused = await run(() => ({
+    actor: "ada",
+    status: 403,
+    error: "forbidden",
+  }));
+  assertEquals(confused, { status: 403, error: "forbidden" });
+
+  // A malformed status on such a value still collapses to the bare challenge —
+  // it never falls back through to the identity arm and becomes an admission.
+  assertEquals(await run(() => ({ actor: "ada", status: 200 })), UNAUTHORIZED);
+});
+
+Deno.test("isResolvedIdentity tells an identity from a refusal", () => {
+  assertEquals(
+    isResolvedIdentity({ actor: "ada", kind: "human", roles: [] }),
+    true,
+  );
+  assertEquals(isResolvedIdentity(UNAUTHORIZED), false);
+  assertEquals(
+    isResolvedIdentity({ status: 403, error: "insufficient_scope" }),
+    false,
+  );
+});
+
+// ---- authenticatorFromHook: the older synchronous seam ---------------------
+
+Deno.test("authenticatorFromHook passes a hook's identity through", async () => {
+  const auth = authenticatorFromHook((ctx) => ({
+    actor: ctx.headers.get("x-forwarded-user") ?? "",
+    kind: "service",
+    roles: ["ops"],
+  }));
+  const result = await authenticateRequest(auth, {
+    headers: new Headers({ "x-forwarded-user": "deploy-bot" }),
+  });
+  assertEquals(result, {
+    actor: "deploy-bot",
+    kind: "service",
+    roles: ["ops"],
+  });
+});
+
+Deno.test("authenticatorFromHook turns a throwing hook into the bare 401", async () => {
+  const auth = authenticatorFromHook(() => {
+    throw new Error("no trusted header");
+  });
+  assertEquals(await authenticateRequest(auth, EMPTY_CONTEXT), UNAUTHORIZED);
+});
+
+Deno.test("authenticatorFromHook refuses a hook that yields an empty actor", async () => {
+  // The `headers.get(x) ?? ""` idiom: a hook that reads a header the proxy did
+  // not set must refuse the request, not admit an anonymous caller under "".
+  const auth = authenticatorFromHook((ctx) => ({
+    actor: ctx.headers.get("x-forwarded-user") ?? "",
+  }));
+  assertEquals(await authenticateRequest(auth, EMPTY_CONTEXT), UNAUTHORIZED);
+});
+
+// ---- the shared refusal ----------------------------------------------------
+
+Deno.test("UNAUTHORIZED is the bare 401 Bearer challenge", () => {
+  // Pinned because the static-bearer path and the authenticator path share it:
+  // a wrong token and a failed authenticator answer identically, so neither
+  // tells a prober which of the two it got past.
+  assertEquals(UNAUTHORIZED.status, 401);
+  assertEquals(UNAUTHORIZED.error, "Unauthorized");
+  assertEquals(UNAUTHORIZED.challenge, "Bearer");
+  // No detail, so the reason the HTTP transport writes into the JSON-RPC error
+  // body is exactly `error` — "Unauthorized", with nothing about why.
+  assertEquals(UNAUTHORIZED.detail, undefined);
+});

--- a/packages/core/tests/mcp_auth_test.ts
+++ b/packages/core/tests/mcp_auth_test.ts
@@ -334,6 +334,22 @@ Deno.test("a throwing property getter on the result is a refusal, not a fault", 
   );
 });
 
+Deno.test("a role name carrying the child's separator is dropped", async () => {
+  // ZUKE_ACTOR_ROLES joins the list with a comma, so a name containing one would
+  // reach a registry-spawned child as two roles. Role names can come from an
+  // identity provider's group names, so the guard belongs here rather than in
+  // each consumer.
+  const identity = await run(() => ({
+    actor: "ada",
+    roles: ["ops", "team,operator", "release"],
+  }));
+  assertEquals(identity, {
+    actor: "ada",
+    kind: "human",
+    roles: ["ops", "release"],
+  });
+});
+
 Deno.test("a challenge a header cannot carry is dropped, not sent", async () => {
   // `Headers.set` throws on CR/LF, NUL and anything outside Latin-1. The
   // challenge is the one field of a refusal that becomes a header, so an

--- a/packages/core/tests/mcp_auth_test.ts
+++ b/packages/core/tests/mcp_auth_test.ts
@@ -303,3 +303,71 @@ Deno.test("UNAUTHORIZED is the bare 401 Bearer challenge", () => {
   // body is exactly `error` — "Unauthorized", with nothing about why.
   assertEquals(UNAUTHORIZED.detail, undefined);
 });
+
+// ---- Regressions: an authenticator's own failure is still a refusal ---------
+
+Deno.test("a throwing property getter on the result is a refusal, not a fault", async () => {
+  // Wrapping verified claims in getters is the natural shape for an OAuth
+  // authenticator, and a getter can throw — a missing `scope` claim, say. Every
+  // read of the result must therefore be guarded, not just the call that
+  // produced it, or the throw escapes as a transport fault carrying no
+  // challenge instead of the refusal this seam promises.
+  const throwing = (field: string): McpAuthenticator["authenticate"] => () => ({
+    actor: "ada",
+    get [field](): never {
+      throw new Error(`no ${field} claim`);
+    },
+  });
+  for (const field of ["actor", "kind", "roles", "via", "status"]) {
+    assertEquals(await run(throwing(field)), UNAUTHORIZED, field);
+  }
+
+  // Including the reject arm: a refusal whose own fields throw still refuses.
+  assertEquals(
+    await run(() => ({
+      status: 403,
+      get error(): never {
+        throw new Error("boom");
+      },
+    })),
+    UNAUTHORIZED,
+  );
+});
+
+Deno.test("a challenge a header cannot carry is dropped, not sent", async () => {
+  // `Headers.set` throws on CR/LF, NUL and anything outside Latin-1. The
+  // challenge is the one field of a refusal that becomes a header, so an
+  // one that cannot be sent is dropped exactly like an absent one — the refusal still
+  // goes out with its own status, rather than becoming a fault with no
+  // challenge at all. (A CR/LF value would otherwise be a header-injection
+  // attempt; `Headers` rejects it and so do we.)
+  for (
+    const challenge of [
+      'Bearer realm="x"\r\nX-Injected: 1',
+      "Bearer\nSet-Cookie: a=b",
+      "Bearer\u0000",
+      "Bearer \u{1f510}", // outside Latin-1
+    ]
+  ) {
+    assertEquals(
+      await run(() => ({ status: 401, error: "invalid_token", challenge })),
+      { status: 401, error: "invalid_token" },
+      JSON.stringify(challenge),
+    );
+  }
+
+  // A challenge that *is* sendable survives untouched — including a Latin-1
+  // character, which a header can carry, so the guard must not over-reject.
+  for (
+    const challenge of [
+      'Bearer realm="zuke", error="invalid_token"',
+      "Bearer é",
+    ]
+  ) {
+    assertEquals(
+      await run(() => ({ status: 401, error: "invalid_token", challenge })),
+      { status: 401, error: "invalid_token", challenge },
+      challenge,
+    );
+  }
+});

--- a/packages/core/tests/mcp_hardening_test.ts
+++ b/packages/core/tests/mcp_hardening_test.ts
@@ -4,8 +4,17 @@
 import { assertEquals, assertStringIncludes } from "./_assert.ts";
 import { Build, parameter, target } from "../mod.ts";
 import { McpServer, type McpServerOptions } from "../src/mcp/server.ts";
+import {
+  authenticatorFromHook,
+  type McpAuthenticator,
+  UNAUTHORIZED,
+} from "../src/mcp/auth.ts";
 import type { McpTool } from "../src/mcp/protocol.ts";
-import { INTERNAL_ERROR, type JsonRpcResponse } from "../src/mcp/jsonrpc.ts";
+import {
+  EMPTY_CONTEXT,
+  INTERNAL_ERROR,
+  type JsonRpcResponse,
+} from "../src/mcp/jsonrpc.ts";
 import type { FileSystemStateStore } from "../src/state/fs_store.ts";
 import type { StateStore } from "../src/state/store.ts";
 import { AUDIT_RUN_ID } from "../src/mcp/audit.ts";
@@ -452,7 +461,11 @@ const xUser = (ctx: { headers: Headers }): { actor: string } => {
 };
 
 Deno.test("an identity hook overrides --actor and the client label", async () => {
-  await withServer({ allowRun: true, actor: "ci-bot", identity: xUser }, async (
+  await withServer({
+    allowRun: true,
+    actor: "ci-bot",
+    authenticator: authenticatorFromHook(xUser),
+  }, async (
     server,
     store,
   ) => {
@@ -473,7 +486,7 @@ Deno.test("an identity hook overrides --actor and the client label", async () =>
 
 Deno.test("a run and a later signal are attributed to their own callers", async () => {
   await withServer(
-    { allowRun: true, identity: xUser },
+    { allowRun: true, authenticator: authenticatorFromHook(xUser) },
     async (server, store) => {
       // Engineer A runs deploy…
       await callWith(server, "run:deploy", { "x-user": "engineer-a" }, {
@@ -500,7 +513,7 @@ Deno.test("a run and a later signal are attributed to their own callers", async 
 
 Deno.test("a throwing identity hook rejects the request and writes nothing", async () => {
   await withServer(
-    { allowRun: true, identity: xUser },
+    { allowRun: true, authenticator: authenticatorFromHook(xUser) },
     async (server, store) => {
       // No `x-user` header → the hook throws → a JSON-RPC auth error.
       const res = await callWith(server, "run:deploy", {}, {
@@ -522,7 +535,9 @@ Deno.test("a hook yielding an empty actor is rejected, never the static fallback
     {
       allowRun: true,
       actor: "ci-bot",
-      identity: (ctx) => ({ actor: ctx.headers.get("x-user") ?? "" }),
+      authenticator: authenticatorFromHook(
+        (ctx) => ({ actor: ctx.headers.get("x-user") ?? "" }),
+      ),
     },
     async (server, store) => {
       const res = await callWith(server, "run:deploy", {}, {
@@ -732,6 +747,203 @@ Deno.test("null and object argument values are recorded faithfully in the trail"
       assertEquals(last?.detail, "invalid_arguments");
       assertEquals(last?.args.environment, "null");
       assertEquals(last?.args.note, '{"nested":1}');
+    },
+  );
+});
+
+// ---- M15: the authenticator seam ------------------------------------------
+
+/**
+ * An authenticator that settles only on a later microtask — the shape a real
+ * one has (a token introspection call, a key-set lookup), and header-trusting,
+ * so it refuses wherever there are no headers.
+ */
+const asyncProxy: McpAuthenticator = {
+  authenticate: async (ctx) => {
+    const sub = await Promise.resolve(ctx.headers.get("x-user"));
+    return sub === null ? UNAUTHORIZED : {
+      actor: sub,
+      kind: "service",
+      roles: ["deployer"],
+      via: "oauth-proxy",
+    };
+  },
+};
+
+/** A build whose target records that it really ran. */
+class Recording extends Build {
+  readonly ran: string[] = [];
+  deploy = target().executes(() => void this.ran.push("deploy"));
+}
+
+Deno.test("an async authenticator attributes the run to its resolved actor", async () => {
+  await withServer(
+    { allowRun: true, actor: "ci-bot", authenticator: asyncProxy },
+    async (server, store) => {
+      await callWith(server, "run:deploy", { "x-user": "engineer-a" }, {
+        environment: "dev",
+      });
+      const deploy = (await auditEvents(store)).find((e) =>
+        e.tool === "run:deploy"
+      );
+      // Awaited, not dropped on the floor: the static --actor never applies.
+      assertEquals(deploy?.actor, "engineer-a");
+    },
+  );
+});
+
+Deno.test("a returned rejection refuses exactly as a throw does", async () => {
+  // The modern seam refuses by *returning* a reject; the older hook refuses by
+  // throwing. The *effect* must be identical — nothing executed, nothing
+  // audited, no result — while each still reports its own reason: a throw leaks
+  // nothing and collapses to the bare "Unauthorized", and an explicit reject
+  // says what it said. (Only the HTTP transport also carries the status and the
+  // challenge; JSON-RPC has nowhere to put them.)
+  const reject403: McpAuthenticator = {
+    authenticate: () => ({
+      status: 403,
+      error: "forbidden",
+      detail: "role missing",
+      challenge: 'Bearer realm="zuke"',
+    }),
+  };
+  const refusals: Array<JsonRpcResponse | null> = [];
+  for (const authenticator of [reject403, authenticatorFromHook(xUser)]) {
+    await withTempStore(async (store) => {
+      const build = new Recording();
+      const server = new McpServer(build, {
+        allowRun: true,
+        actor: "ci-bot",
+        stateStore: store,
+        authenticator,
+      });
+      refusals.push(
+        await server.handleMessage(
+          req("tools/call", { name: "run:deploy", arguments: {} }),
+        ),
+      );
+      assertEquals(build.ran, []); // nothing executed
+      assertEquals((await auditEvents(store)).length, 0); // nothing audited
+    });
+  }
+  assertEquals(refusals[0]?.result, undefined);
+  assertEquals(refusals[1]?.result, undefined);
+  assertEquals(refusals[0]?.error?.message, "forbidden: role missing");
+  assertEquals(refusals[1]?.error?.message, "Unauthorized");
+  assertEquals(refusals[0]?.error?.code, refusals[1]?.error?.code);
+});
+
+Deno.test("a transport-authenticated identity is used and skips the authenticator", async () => {
+  // The HTTP transport authenticates at its edge so a refusal can carry a real
+  // status; dispatch must then trust that caller and not authenticate twice.
+  let calls = 0;
+  const counting: McpAuthenticator = {
+    authenticate: () => {
+      calls += 1;
+      return { actor: "server-side" };
+    },
+  };
+  await withServer(
+    { allowRun: true, actor: "ci-bot", authenticator: counting },
+    async (server, store) => {
+      await server.handleMessage(
+        req("tools/call", {
+          name: "run:deploy",
+          arguments: { environment: "dev" },
+        }),
+        EMPTY_CONTEXT,
+        { actor: "edge-user", kind: "human", roles: [] },
+      );
+      assertEquals(calls, 0);
+      const deploy = (await auditEvents(store)).find((e) =>
+        e.tool === "run:deploy"
+      );
+      assertEquals(deploy?.actor, "edge-user");
+    },
+  );
+});
+
+Deno.test("without an authenticator, a transport identity still attributes the call", async () => {
+  await withServer(
+    { allowRun: true, actor: "ci-bot" },
+    async (server, store) => {
+      await server.handleMessage(
+        req("tools/call", {
+          name: "run:deploy",
+          arguments: { environment: "dev" },
+        }),
+        EMPTY_CONTEXT,
+        { actor: "edge-user", kind: "service", roles: ["deployer"] },
+      );
+      const deploy = (await auditEvents(store)).find((e) =>
+        e.tool === "run:deploy"
+      );
+      assertEquals(deploy?.actor, "edge-user");
+    },
+  );
+});
+
+Deno.test("on stdio the authenticator still runs, so a header-trusting one refuses", async () => {
+  // The stdio transport has no request to describe, so it hands the handler
+  // EMPTY_CONTEXT. Authentication is not skipped there: an authenticator that
+  // needs a header finds none and refuses, which is the fail-closed answer.
+  await withServer(
+    { allowRun: true, actor: "ci-bot", authenticator: asyncProxy },
+    async (server, store) => {
+      const res = await server.handleMessage(
+        req("tools/call", {
+          name: "run:deploy",
+          arguments: { environment: "dev" },
+        }),
+      );
+      assertEquals(res?.result, undefined);
+      assertEquals(res?.error?.message, "Unauthorized");
+      assertEquals((await auditEvents(store)).length, 0);
+    },
+  );
+});
+
+Deno.test("the authenticator gates initialize, ping and tools/list too", async () => {
+  await withServer(
+    { allowRun: true, authenticator: authenticatorFromHook(xUser) },
+    async (server) => {
+      for (const method of ["initialize", "ping", "tools/list"]) {
+        const refused = await server.handleMessage(req(method));
+        assertEquals(refused?.result, undefined, `${method} was answered`);
+        assertEquals(refused?.error?.message, "Unauthorized", method);
+      }
+      // With the header, every one of them answers normally.
+      const ctx = { headers: new Headers({ "x-user": "engineer-a" }) };
+      const init = (await server.handleMessage(req("initialize"), ctx))?.result;
+      assertEquals(
+        isRec(init) && typeof init.protocolVersion === "string",
+        true,
+      );
+      assertEquals((await server.handleMessage(req("ping"), ctx))?.result, {});
+      const listed = await server.handleMessage(req("tools/list"), ctx);
+      assertEquals(listed?.error, undefined);
+    },
+  );
+});
+
+Deno.test("an authenticator's kind, roles and via never reach the audit row", async () => {
+  // The claims exist to be authorized against, not to be persisted: the trail
+  // records the actor and the (redacted) arguments, and nothing else new.
+  await withServer(
+    { allowRun: true, authenticator: asyncProxy },
+    async (server, store) => {
+      await callWith(server, "run:deploy", { "x-user": "engineer-a" }, {
+        environment: "dev",
+      });
+      const deploy = (await auditEvents(store)).find((e) =>
+        e.tool === "run:deploy"
+      );
+      assertEquals(deploy?.actor, "engineer-a");
+      assertEquals(deploy?.args, { environment: "dev" });
+      const row = JSON.stringify(deploy);
+      assertEquals(row.includes("deployer"), false);
+      assertEquals(row.includes("oauth-proxy"), false);
+      assertEquals(row.includes("service"), false);
     },
   );
 });

--- a/packages/core/tests/mcp_http_test.ts
+++ b/packages/core/tests/mcp_http_test.ts
@@ -6,6 +6,7 @@ import { Build, type McpRequestContext, target } from "../mod.ts";
 import type { JsonRpcResponse } from "../src/mcp/jsonrpc.ts";
 import { McpServer } from "../src/mcp/server.ts";
 import { originAllowed, serveHttp } from "../src/mcp/http.ts";
+import type { McpAuthenticator, ResolvedIdentity } from "../src/mcp/auth.ts";
 import { serveMcp } from "../src/mcp/command.ts";
 import { FileSystemStateStore } from "../src/state/fs_store.ts";
 import { defaultStateHost } from "../src/state/store.ts";
@@ -27,8 +28,12 @@ function rpc(method: string, id?: number, params?: unknown): string {
 
 /** Start `serveHttp` on an ephemeral loopback port; returns the port and a stop. */
 async function startHttp(
-  handle: (m: unknown) => Promise<JsonRpcResponse | null>,
-  opts: { token?: string } = {},
+  handle: (
+    m: unknown,
+    ctx: McpRequestContext,
+    identity?: ResolvedIdentity,
+  ) => Promise<JsonRpcResponse | null>,
+  opts: { token?: string; authenticator?: McpAuthenticator } = {},
 ): Promise<{ port: number; stop: () => Promise<void> }> {
   const ac = new AbortController();
   let setPort = (_: number) => {};
@@ -37,6 +42,7 @@ async function startHttp(
     host: "127.0.0.1",
     port: 0,
     token: opts.token,
+    authenticator: opts.authenticator,
     signal: ac.signal,
     onListen: (a) => setPort(a.port),
   });
@@ -339,11 +345,15 @@ Deno.test("serveMcp applies the build's identity hook to HTTP requests", async (
     await ok.json();
 
     // A request WITHOUT the header is rejected — the hook throws, nothing runs.
+    // The refusal is a real 401 with a challenge (what an MCP client needs to
+    // discover where to authenticate), and still carries the JSON-RPC error so a
+    // client that only reads the body sees a reason.
     const denied = await fetch(url, {
       method: "POST",
       body: rpc("tools/call", 2, { name: "run:deploy", arguments: {} }),
     });
-    assertEquals(denied.status, 200); // JSON-RPC error travels in the 200 body
+    assertEquals(denied.status, 401);
+    assertEquals(denied.headers.get("www-authenticate"), "Bearer");
     const deniedBody = await denied.json();
     assertEquals(deniedBody.error.message, "Unauthorized");
 
@@ -389,4 +399,412 @@ Deno.test("serveMcp prints an HTTP banner naming the mode and (lack of) auth", a
   assertStringIncludes(text, "read-only");
   assertStringIncludes(text, "no auth (loopback only)");
   assertEquals(text.includes("registry"), false);
+});
+
+Deno.test("http transport answers a refusal with the authenticator's own status", async () => {
+  const server = new McpServer(new Demo());
+  const s = await startHttp((m) => server.handleMessage(m), {
+    authenticator: {
+      authenticate: (ctx) => {
+        switch (ctx.headers.get("x-case")) {
+          case "forbidden":
+            return {
+              status: 403,
+              error: "insufficient_scope",
+              challenge: 'Bearer error="insufficient_scope"',
+            };
+          case "bare":
+            return { status: 403, error: "insufficient_scope" };
+          case "detail":
+            return {
+              status: 401,
+              error: "invalid_token",
+              detail: "token expired",
+              challenge: "Bearer",
+            };
+          default:
+            return { actor: "engineer-a" };
+        }
+      },
+    },
+  });
+  const url = `http://127.0.0.1:${s.port}/`;
+  try {
+    // The status and the challenge are the refusal's own — a 403 proves neither
+    // is a constant baked into the transport.
+    const forbidden = await fetch(url, {
+      method: "POST",
+      headers: { "x-case": "forbidden" },
+      body: rpc("ping", 1),
+    });
+    assertEquals(forbidden.status, 403);
+    assertEquals(
+      forbidden.headers.get("www-authenticate"),
+      'Bearer error="insufficient_scope"',
+    );
+    // The reason still reaches a client that only reads the JSON-RPC body.
+    const forbiddenBody = await forbidden.json();
+    assertEquals(forbiddenBody.error.message, "insufficient_scope");
+
+    // A refusal that carries no challenge gets no invented WWW-Authenticate.
+    const bare = await fetch(url, {
+      method: "POST",
+      headers: { "x-case": "bare" },
+      body: rpc("ping", 2),
+    });
+    assertEquals(bare.status, 403);
+    assertEquals(bare.headers.get("www-authenticate"), null);
+    await bare.json();
+
+    // A detail is appended to the reason as "<error>: <detail>".
+    const detail = await fetch(url, {
+      method: "POST",
+      headers: { "x-case": "detail" },
+      body: rpc("ping", 3),
+    });
+    assertEquals(detail.status, 401);
+    assertEquals(detail.headers.get("www-authenticate"), "Bearer");
+    const detailBody = await detail.json();
+    assertEquals(detailBody.error.message, "invalid_token: token expired");
+
+    // An accepted caller is dispatched normally.
+    const ok = await fetch(url, { method: "POST", body: rpc("ping", 4) });
+    assertEquals(ok.status, 200);
+    await ok.json();
+  } finally {
+    await s.stop();
+  }
+});
+
+Deno.test("http transport hands the resolved identity to the handler", async () => {
+  const server = new McpServer(new Demo());
+  const seen: (ResolvedIdentity | undefined)[] = [];
+  const views: { method: string; hasBody: boolean }[] = [];
+  const s = await startHttp((m, _ctx, identity) => {
+    seen.push(identity);
+    return server.handleMessage(m);
+  }, {
+    authenticator: {
+      authenticate: (ctx) => {
+        const request = ctx.request;
+        if (request !== undefined) {
+          views.push({
+            method: request.method,
+            hasBody: request.body !== null,
+          });
+        }
+        return ctx.headers.get("x-kind") === "service"
+          ? {
+            actor: "deploy-bot",
+            kind: "service",
+            roles: ["deploy", "read"],
+            via: "oidc",
+          }
+          : { actor: "engineer-a" };
+      },
+    },
+  });
+  const url = `http://127.0.0.1:${s.port}/`;
+  try {
+    const service = await fetch(url, {
+      method: "POST",
+      headers: { "x-kind": "service" },
+      body: rpc("ping", 1),
+    });
+    assertEquals(service.status, 200);
+    await service.json();
+
+    const human = await fetch(url, { method: "POST", body: rpc("ping", 2) });
+    assertEquals(human.status, 200);
+    await human.json();
+  } finally {
+    await s.stop();
+  }
+  assertEquals(seen[0], {
+    actor: "deploy-bot",
+    kind: "service",
+    roles: ["deploy", "read"],
+    via: "oidc",
+  });
+  // The defaults are settled before the handler sees them: an authenticator that
+  // says nothing about kind or roles is read as a human holding none.
+  assertEquals(seen[1], { actor: "engineer-a", kind: "human", roles: [] });
+  // The authenticator sees the request, but not its body — that belongs to the
+  // transport, and a body can only be read once.
+  assertEquals(views, [
+    { method: "POST", hasBody: false },
+    { method: "POST", hasBody: false },
+  ]);
+});
+
+Deno.test("http transport authenticates after the method, Origin and token checks", async () => {
+  const server = new McpServer(new Demo());
+  let calls = 0;
+  const s = await startHttp((m) => server.handleMessage(m), {
+    token: "swordfish",
+    authenticator: {
+      authenticate: () => {
+        calls += 1;
+        return { actor: "engineer-a" };
+      },
+    },
+  });
+  const url = `http://127.0.0.1:${s.port}/`;
+  const authorized = { authorization: "Bearer swordfish" };
+  try {
+    // A non-POST is refused before the authenticator runs …
+    const get = await fetch(url, { headers: authorized });
+    assertEquals(get.status, 405);
+    await get.json();
+    assertEquals(calls, 0);
+
+    // … so is a cross-origin browser request …
+    const origin = await fetch(url, {
+      method: "POST",
+      headers: { ...authorized, origin: "https://evil.example" },
+      body: rpc("ping", 1),
+    });
+    assertEquals(origin.status, 403);
+    await origin.json();
+    assertEquals(calls, 0);
+
+    // … and so is a bad static bearer token: a caller who fails the cheap,
+    // constant-time check never reaches the (possibly expensive) authenticator.
+    const badToken = await fetch(url, {
+      method: "POST",
+      headers: { authorization: "Bearer nope" },
+      body: rpc("ping", 2),
+    });
+    assertEquals(badToken.status, 401);
+    await badToken.json();
+    assertEquals(calls, 0);
+
+    // Past all three, it runs exactly once.
+    const ok = await fetch(url, {
+      method: "POST",
+      headers: authorized,
+      body: rpc("ping", 3),
+    });
+    assertEquals(ok.status, 200);
+    await ok.json();
+    assertEquals(calls, 1);
+  } finally {
+    await s.stop();
+  }
+});
+
+Deno.test("http transport refuses an unauthenticated caller before reading its body", async () => {
+  const server = new McpServer(new Demo());
+  const s = await startHttp((m) => server.handleMessage(m), {
+    authenticator: {
+      authenticate: () => ({
+        status: 401,
+        error: "invalid_token",
+        challenge: "Bearer",
+      }),
+    },
+  });
+  try {
+    // Over the 1 MiB body cap: were the body read first this would be a 413.
+    // It is a 401, so an unauthenticated caller never makes the server buffer
+    // a megabyte for it.
+    const huge = `{"jsonrpc":"2.0","id":1,"method":"ping","params":"${
+      "x".repeat(1024 * 1024 + 64)
+    }"}`;
+    const res = await fetch(`http://127.0.0.1:${s.port}/`, {
+      method: "POST",
+      body: huge,
+    });
+    assertEquals(res.status, 401);
+    const body = await res.json();
+    assertEquals(body.error.message, "invalid_token");
+  } finally {
+    await s.stop();
+  }
+});
+
+Deno.test("http transport answers a throwing authenticator with the bare 401", async () => {
+  const server = new McpServer(new Demo());
+  const s = await startHttp((m) => server.handleMessage(m), {
+    authenticator: {
+      authenticate: () => {
+        throw new Error("jwks fetch failed: https://idp.example/keys");
+      },
+    },
+  });
+  try {
+    const res = await fetch(`http://127.0.0.1:${s.port}/`, {
+      method: "POST",
+      body: rpc("ping", 1),
+    });
+    assertEquals(res.status, 401);
+    assertEquals(res.headers.get("www-authenticate"), "Bearer");
+    // The generic refusal, so a broken authenticator leaks nothing about why.
+    const body = await res.json();
+    assertEquals(body.error.message, "Unauthorized");
+  } finally {
+    await s.stop();
+  }
+});
+
+Deno.test("serveMcp refuses a build declaring both mcpAuth() and mcpIdentity()", async () => {
+  // Two gates on one build: one would silently win, so the server refuses to
+  // start instead of leaving the other one only *looking* enforced.
+  class Ambiguous extends Build {
+    deploy = target().description("Deploy").executes(() => {});
+    override mcpIdentity() {
+      return () => ({ actor: "from-hook" });
+    }
+    override mcpAuth(): McpAuthenticator {
+      return { authenticate: () => ({ actor: "from-authenticator" }) };
+    }
+  }
+  const origErr = console.error;
+  const errs: string[] = [];
+  console.error = (...a: unknown[]) => void errs.push(a.join(" "));
+  try {
+    const code = await serveMcp(new Ambiguous(), { quiet: true });
+    assertEquals(code, 1);
+    const text = errs.join("\n");
+    assertStringIncludes(text, "mcpAuth()");
+    assertStringIncludes(text, "mcpIdentity()");
+  } finally {
+    console.error = origErr;
+  }
+});
+
+Deno.test("serveMcp accepts a non-loopback bind authenticated by mcpAuth()", async () => {
+  class Guarded extends Build {
+    lint = target().description("Lint").executes(() => {});
+    override mcpAuth(): McpAuthenticator {
+      return { authenticate: () => ({ actor: "engineer-a" }) };
+    }
+  }
+  const ac = new AbortController();
+  let setPort = (_: number) => {};
+  const portReady = new Promise<number>((r) => (setPort = r));
+  // No ZUKE_MCP_TOKEN: the authenticator alone satisfies the rule that a
+  // non-loopback endpoint must authenticate its callers.
+  const finished = serveMcp(new Guarded(), {
+    http: { host: "0.0.0.0", port: 0 },
+    quiet: true,
+    readEnv: () => undefined,
+    signal: ac.signal,
+    onListen: (a) => setPort(a.port),
+  });
+  await portReady; // it bound rather than exiting 1
+  ac.abort();
+  assertEquals(await finished, 0);
+});
+
+Deno.test("serveMcp's HTTP banner names the authenticator", async () => {
+  class Guarded extends Build {
+    lint = target().description("Lint").executes(() => {});
+    override mcpAuth(): McpAuthenticator {
+      return { authenticate: () => ({ actor: "engineer-a" }) };
+    }
+  }
+  const bannerFor = async (token?: string): Promise<string> => {
+    const origErr = console.error;
+    const lines: string[] = [];
+    console.error = (...a: unknown[]) => void lines.push(a.join(" "));
+    try {
+      const ac = new AbortController();
+      let setPort = (_: number) => {};
+      const portReady = new Promise<number>((r) => (setPort = r));
+      const finished = serveMcp(new Guarded(), {
+        http: { host: "127.0.0.1", port: 0 },
+        token,
+        readEnv: () => undefined, // no ZUKE_MCP_TOKEN
+        signal: ac.signal,
+        onListen: (a) => setPort(a.port),
+      });
+      await portReady;
+      ac.abort();
+      assertEquals(await finished, 0);
+    } finally {
+      console.error = origErr;
+    }
+    return lines.join("\n");
+  };
+
+  // An authenticator alone: the operator is told the endpoint is guarded, and
+  // not told about a token that isn't configured.
+  const authOnly = await bannerFor();
+  assertStringIncludes(authOnly, "authenticator");
+  assertEquals(authOnly.includes("bearer token"), false);
+
+  // Both gates configured: the banner names both.
+  const both = await bannerFor("swordfish");
+  assertStringIncludes(both, "authenticator + bearer token");
+});
+
+Deno.test("serveMcp applies the build's mcpAuth() to HTTP requests", async () => {
+  // The general seam, refusing by *returning* a rejection rather than throwing.
+  class Guarded extends Build {
+    deploy = target().description("Deploy").executes(() => {});
+    override mcpAuth(): McpAuthenticator {
+      return {
+        authenticate: (ctx) => {
+          const user = ctx.headers.get("x-user");
+          return user === null
+            ? {
+              status: 403,
+              error: "insufficient_scope",
+              detail: "no x-user header",
+            }
+            : { actor: user, kind: "service", roles: ["deploy"] };
+        },
+      };
+    }
+  }
+  const dir = await Deno.makeTempDir();
+  const store = new FileSystemStateStore(`${dir}/runs`, defaultStateHost);
+  const ac = new AbortController();
+  let setPort = (_: number) => {};
+  const portReady = new Promise<number>((r) => (setPort = r));
+  const finished = serveMcp(new Guarded(), {
+    http: { host: "127.0.0.1", port: 0 },
+    allowRun: true,
+    stateStore: store,
+    quiet: true,
+    signal: ac.signal,
+    onListen: (a) => setPort(a.port),
+  });
+  const url = `http://127.0.0.1:${await portReady}/`;
+  try {
+    // Accepted: the target runs, attributed to the authenticated actor.
+    const ok = await fetch(url, {
+      method: "POST",
+      headers: { "x-user": "deploy-bot" },
+      body: rpc("tools/call", 1, { name: "run:deploy", arguments: {} }),
+    });
+    assertEquals(ok.status, 200);
+    await ok.json();
+
+    // Refused: the rejection's own status, no challenge (it offered none), and
+    // the reason in the body.
+    const denied = await fetch(url, {
+      method: "POST",
+      body: rpc("tools/call", 2, { name: "run:deploy", arguments: {} }),
+    });
+    assertEquals(denied.status, 403);
+    assertEquals(denied.headers.get("www-authenticate"), null);
+    const deniedBody = await denied.json();
+    assertEquals(
+      deniedBody.error.message,
+      "insufficient_scope: no x-user header",
+    );
+
+    // Nothing ran for the refused call, so the audit trail holds the accepted
+    // one and nothing else.
+    const events = (await store.getRun("mcp-audit"))?.record.events ?? [];
+    assertEquals(events.length, 1);
+    assertEquals(events[0].tool, "run:deploy");
+    assertEquals(events[0].actor, "deploy-bot");
+  } finally {
+    ac.abort();
+    await finished;
+    await Deno.remove(dir, { recursive: true });
+  }
 });

--- a/packages/core/tests/mcp_http_test.ts
+++ b/packages/core/tests/mcp_http_test.ts
@@ -808,3 +808,123 @@ Deno.test("serveMcp applies the build's mcpAuth() to HTTP requests", async () =>
     await Deno.remove(dir, { recursive: true });
   }
 });
+
+// ---- Regressions: a malformed Host, and what unlocks a non-loopback bind ----
+
+Deno.test("a Host the URL parser rejects still serves, with no request view", async () => {
+  // Deno builds `request.url` from the raw Host header and accepts hosts the
+  // WHATWG parser rejects (`Host: bad host`). Building the authenticator's view
+  // of such a request throws, so the view is simply absent — the headers, where
+  // a credential lives, are intact, and the exchange completes rather than
+  // failing on a header the server itself accepted.
+  const seen: Array<{ hasRequest: boolean; token: string | null }> = [];
+  const authenticator: McpAuthenticator = {
+    authenticate: (ctx) => {
+      seen.push({
+        hasRequest: ctx.request !== undefined,
+        token: ctx.headers.get("x-token"),
+      });
+      return { actor: "ada" };
+    },
+  };
+  const s = await startHttp(
+    (_m, _ctx, identity) =>
+      Promise.resolve({
+        jsonrpc: "2.0" as const,
+        id: 1,
+        result: { actor: identity?.actor ?? null },
+      }),
+    { authenticator },
+  );
+  try {
+    // A raw socket, because `fetch` will not send a Host this malformed.
+    const conn = await Deno.connect({ hostname: "127.0.0.1", port: s.port });
+    const body = '{"jsonrpc":"2.0","id":1,"method":"tools/call"}';
+    await conn.write(
+      new TextEncoder().encode(
+        `POST / HTTP/1.1\r\nHost: bad host\r\nx-token: t\r\n` +
+          `Content-Length: ${body.length}\r\n\r\n${body}`,
+      ),
+    );
+    const buf = new Uint8Array(1024);
+    const n = await conn.read(buf);
+    const response = new TextDecoder().decode(buf.subarray(0, n ?? 0));
+    conn.close();
+
+    assertStringIncludes(response, "200 OK");
+    assertStringIncludes(response, '"actor":"ada"');
+    // The authenticator ran, saw no request view, and still read its header.
+    assertEquals(seen, [{ hasRequest: false, token: "t" }]);
+  } finally {
+    await s.stop();
+  }
+});
+
+Deno.test("mcpIdentity() alone does not unlock a non-loopback bind", async () => {
+  // The hook trusts a header, which is an identity only when something in front
+  // strips the client's copy. On a directly reachable endpoint any caller sets
+  // it, so the hook authenticates nobody and the bind guard must still demand a
+  // token — exactly as it did before the authenticator seam existed.
+  class ProxyTrusting extends Build {
+    deploy = target().description("Deploy").executes(() => {});
+    override mcpIdentity() {
+      return (ctx: McpRequestContext) => {
+        const sub = ctx.headers.get("x-forwarded-user");
+        if (sub === null) throw new Error("no identity from proxy");
+        return { actor: sub };
+      };
+    }
+  }
+  const origErr = console.error;
+  const errs: string[] = [];
+  console.error = (...a: unknown[]) => void errs.push(a.join(" "));
+  try {
+    const code = await serveMcp(new ProxyTrusting(), {
+      http: { host: "0.0.0.0", port: 0 },
+      quiet: true,
+      readEnv: () => undefined, // no ZUKE_MCP_TOKEN
+    });
+    assertEquals(code, 1);
+    assertStringIncludes(errs.join("\n"), "must be authenticated");
+    // …and the message says why the hook did not count.
+    assertStringIncludes(
+      errs.join("\n"),
+      "mcpIdentity() does not authenticate",
+    );
+  } finally {
+    console.error = origErr;
+  }
+});
+
+Deno.test("mcpAuth() unlocks a non-loopback bind, and still runs the hook path", async () => {
+  // The general seam is a deliberate declaration of authentication, so it does
+  // satisfy the guard where the proxy hook does not.
+  class Guarded extends Build {
+    deploy = target().description("Deploy").executes(() => {});
+    override mcpAuth(): McpAuthenticator {
+      return { authenticate: () => ({ actor: "svc", kind: "service" }) };
+    }
+  }
+  const ac = new AbortController();
+  let setPort = (_: number) => {};
+  const portReady = new Promise<number>((r) => (setPort = r));
+  const finished = serveMcp(new Guarded(), {
+    http: { host: "0.0.0.0", port: 0 },
+    quiet: true,
+    signal: ac.signal,
+    readEnv: () => undefined, // no ZUKE_MCP_TOKEN
+    onListen: (a) => setPort(a.port),
+  });
+  const port = await portReady;
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/`, {
+      method: "POST",
+      body: rpc("tools/list", 1),
+    });
+    assertEquals(res.status, 200);
+    await res.json();
+  } finally {
+    ac.abort();
+    assertEquals(await finished, 0);
+  }
+});

--- a/packages/core/tests/registry_server_test.ts
+++ b/packages/core/tests/registry_server_test.ts
@@ -1766,6 +1766,42 @@ Deno.test("with no actor the inherited environment is left alone", async () => {
   );
 });
 
+Deno.test("kind and roles without an actor change nothing", async () => {
+  // The three describe one caller, so they are written together or not at all.
+  // Honouring a supplied kind/roles here would pair one caller's entitlements
+  // with the *inherited* actor — exactly the mismatch the coupling exists to
+  // prevent — so they are ignored, and the inherited triple stays internally
+  // consistent. Unreachable from the server (its actor floors at "anonymous"),
+  // but `defaultRegistryRunner` is exported, so the contract is pinned here.
+  await withEnv(
+    {
+      ZUKE_ACTOR: "inherited-actor",
+      ZUKE_ACTOR_KIND: "service",
+      ZUKE_ACTOR_ROLES: "operator",
+    },
+    async () => {
+      for (
+        const options of [
+          { actorKind: "service" as const, actorRoles: ["admin"] },
+          { actor: "", actorKind: "service" as const, actorRoles: ["admin"] },
+        ]
+      ) {
+        const result = await defaultRegistryRunner(
+          [Deno.execPath(), "eval", ACTOR_ECHO],
+          Deno.cwd(),
+          options,
+        );
+        assertEquals(result.code, 0);
+        assertEquals(
+          result.stdout.trim(),
+          "inherited-actor|service|operator",
+          JSON.stringify(options),
+        );
+      }
+    },
+  );
+});
+
 Deno.test("the server's tokens are stripped beside the exported claim", async () => {
   await withEnv(
     { ZUKE_OPERATOR_TOKEN: "server-secret", ZUKE_MCP_TOKEN: "bearer-secret" },

--- a/packages/core/tests/registry_server_test.ts
+++ b/packages/core/tests/registry_server_test.ts
@@ -15,11 +15,13 @@ import {
   METHOD_NOT_FOUND,
 } from "../src/mcp/jsonrpc.ts";
 import { PROTOCOL_VERSION } from "../src/mcp/protocol.ts";
+import { authenticatorFromHook } from "../src/mcp/auth.ts";
 import { serveMcp } from "../src/mcp/command.ts";
 import {
   defaultRegistryRunner,
   RegistryMcpServer,
   type RegistryRunner,
+  type RegistryRunOptions,
   type RegistryRunResult,
 } from "../src/mcp/registry_server.ts";
 import {
@@ -90,16 +92,19 @@ function descriptor(
   };
 }
 
-/** A runner that records every spawn (argv, cwd, actor) and returns a fixed result. */
+/** One recorded spawn: where it ran, and the caller claims it carried. */
+type RecordedRun = { argv: string[]; cwd: string } & RegistryRunOptions;
+
+/** A runner that records every spawn (argv, cwd, claims) and returns a fixed result. */
 function recordingRunner(
   result: RegistryRunResult = { code: 0, stdout: "ran", stderr: "" },
 ): {
   runner: RegistryRunner;
-  calls: { argv: string[]; cwd: string; actor?: string }[];
+  calls: RecordedRun[];
 } {
-  const calls: { argv: string[]; cwd: string; actor?: string }[] = [];
+  const calls: RecordedRun[] = [];
   const runner: RegistryRunner = (argv, cwd, options) => {
-    calls.push({ argv: [...argv], cwd, actor: options?.actor });
+    calls.push({ argv: [...argv], cwd, ...options });
     return Promise.resolve(result);
   };
   return { runner, calls };
@@ -987,11 +992,11 @@ Deno.test("an identity hook attributes the call to the trusted actor, not the la
     runner,
     stateStore: store,
     actor: "config-actor", // even an explicit --actor is overridden by the hook
-    identity: (ctx) => {
+    authenticator: authenticatorFromHook((ctx) => {
       const sub = ctx.headers.get("x-user");
       if (sub === null) throw new Error("no identity from proxy");
       return { actor: sub, via: "oauth-proxy" };
-    },
+    }),
   });
 
   // The client self-reports a name; the hook must win over it.
@@ -1021,11 +1026,11 @@ Deno.test("a throwing identity hook rejects the request and writes nothing", asy
     allowRun: true,
     runner,
     stateStore: store,
-    identity: (ctx) => {
+    authenticator: authenticatorFromHook((ctx) => {
       const sub = ctx.headers.get("x-user");
       if (sub === null) throw new Error("no identity from proxy");
       return { actor: sub };
-    },
+    }),
   });
 
   // No `x-user` header → the hook throws → a JSON-RPC auth error, no dispatch.
@@ -1064,7 +1069,9 @@ Deno.test("a hook yielding an empty actor is rejected, never a spawn", async () 
     stateStore: store,
     actor: "ci-bot", // the static fallback that must NOT be used
     // `headers.get(...) ?? ""` yields `{ actor: "" }` on a missing header.
-    identity: (ctx) => ({ actor: ctx.headers.get("x-user") ?? "" }),
+    authenticator: authenticatorFromHook(
+      (ctx) => ({ actor: ctx.headers.get("x-user") ?? "" }),
+    ),
   });
   const res = await callWith(server, "run:Api:deploy", {});
   assertEquals(res?.error?.message, "Unauthorized");
@@ -1611,4 +1618,172 @@ Deno.test("a runner rejecting with a non-Error is still a structured failure", a
   assertEquals(result.isError, true);
   assertStringIncludes(result.text, "Failed to spawn Api:deploy (Error)");
   assertEquals(result.text.includes("token=abc"), false);
+});
+
+// ---- M15: the caller's kind and roles reach the child -----------------------
+
+/**
+ * A child program printing the three actor variables as `actor|kind|roles`.
+ * An unset variable prints `-`, but an empty role list prints `NONE`: Windows
+ * can drop an empty-valued variable from a spawned environment altogether, so
+ * "no roles" is asserted as unset-or-empty rather than exactly `""`.
+ */
+const ACTOR_ECHO = "const v = (n: string) => Deno.env.get(n) ?? '-'; " +
+  "console.log([v('ZUKE_ACTOR'), v('ZUKE_ACTOR_KIND'), " +
+  "Deno.env.get('ZUKE_ACTOR_ROLES') || 'NONE'].join('|'))";
+
+/** Run `fn` with `vars` set in this process's environment, restoring them after. */
+async function withEnv(
+  vars: Record<string, string>,
+  fn: () => Promise<void>,
+): Promise<void> {
+  const prev = Object.keys(vars).map((
+    k,
+  ): [string, string | undefined] => [k, Deno.env.get(k)]);
+  for (const [k, v] of Object.entries(vars)) Deno.env.set(k, v);
+  try {
+    await fn();
+  } finally {
+    for (const [k, v] of prev) {
+      if (v === undefined) Deno.env.delete(k);
+      else Deno.env.set(k, v);
+    }
+  }
+}
+
+Deno.test("an authenticated run passes the caller's kind and roles to the runner", async () => {
+  const registry = new FakeRegistry();
+  registry.add(descriptor("Api", ["deploy"]));
+  const { runner, calls } = recordingRunner();
+  const server = new RegistryMcpServer(registry, {
+    allowRun: true,
+    runner,
+    actor: "config-actor", // overridden by the authenticator, as for the actor
+    authenticator: authenticatorFromHook((ctx) => {
+      const sub = ctx.headers.get("x-user");
+      if (sub === null) throw new Error("no identity from proxy");
+      return sub === "scheduler"
+        ? { actor: sub, kind: "service", roles: ["deployer", "reader"] }
+        : { actor: sub };
+    }),
+  });
+
+  const res = await callWith(server, "run:Api:deploy", {
+    "x-user": "scheduler",
+  });
+  assertEquals(res?.result !== undefined, true);
+  assertEquals(calls.length, 1);
+  assertEquals(calls[0].actor, "scheduler");
+  assertEquals(calls[0].actorKind, "service");
+  assertEquals(calls[0].actorRoles, ["deployer", "reader"]);
+
+  // A bare `{ actor }` settles to the conservative defaults before the spawn:
+  // the runner never sees an unstated claim it would have to default itself.
+  await callWith(server, "run:Api:deploy", { "x-user": "engineer-a" });
+  assertEquals(calls.length, 2);
+  assertEquals(calls[1].actor, "engineer-a");
+  assertEquals(calls[1].actorKind, "human");
+  assertEquals(calls[1].actorRoles, []);
+});
+
+Deno.test("without an authenticator the runner gets the actor and no claim", async () => {
+  const registry = new FakeRegistry();
+  registry.add(descriptor("Api", ["deploy"]));
+  const { runner, calls } = recordingRunner();
+  const server = new RegistryMcpServer(registry, {
+    allowRun: true,
+    runner,
+    actor: "ci-bot",
+  });
+  assertEquals((await call(server, "run:Api:deploy")).isError, false);
+  assertEquals(calls.length, 1);
+  // The resolved actor still flows; kind and roles are left unstated, so the
+  // defaults are the runner's to apply rather than the server's to invent.
+  assertEquals(calls[0].actor, "ci-bot");
+  assertEquals(calls[0].actorKind, undefined);
+  assertEquals(calls[0].actorRoles, undefined);
+});
+
+Deno.test("defaultRegistryRunner exports the actor, kind and roles", async () => {
+  const withRoles = await defaultRegistryRunner(
+    [Deno.execPath(), "eval", ACTOR_ECHO],
+    Deno.cwd(),
+    {
+      actor: "scheduler",
+      actorKind: "service",
+      actorRoles: ["deployer", "reader"],
+    },
+  );
+  assertEquals(withRoles.code, 0);
+  assertEquals(withRoles.stdout.trim(), "scheduler|service|deployer,reader");
+
+  // A caller with no roles: the variable is still exported, and it is empty.
+  const noRoles = await defaultRegistryRunner(
+    [Deno.execPath(), "eval", ACTOR_ECHO],
+    Deno.cwd(),
+    { actor: "engineer-a", actorKind: "human", actorRoles: [] },
+  );
+  assertEquals(noRoles.code, 0);
+  assertEquals(noRoles.stdout.trim(), "engineer-a|human|NONE");
+});
+
+Deno.test("a fresh actor never inherits the parent's kind and roles", async () => {
+  // The privilege-inheritance case: the server process itself runs as a
+  // privileged service, and a spawn for an unprivileged human caller must not
+  // hand the child that actor beside the parent's entitlements.
+  await withEnv(
+    { ZUKE_ACTOR_KIND: "service", ZUKE_ACTOR_ROLES: "operator" },
+    async () => {
+      const result = await defaultRegistryRunner(
+        [Deno.execPath(), "eval", ACTOR_ECHO],
+        Deno.cwd(),
+        { actor: "engineer-a" },
+      );
+      assertEquals(result.code, 0);
+      // The three moved together: neither inherited value survived.
+      assertEquals(result.stdout.trim(), "engineer-a|human|NONE");
+    },
+  );
+});
+
+Deno.test("with no actor the inherited environment is left alone", async () => {
+  // No actor means no claim to overwrite the inherited one with — a local
+  // stdio server keeps attributing runs the way the environment already did.
+  await withEnv(
+    {
+      ZUKE_ACTOR: "inherited-actor",
+      ZUKE_ACTOR_KIND: "service",
+      ZUKE_ACTOR_ROLES: "operator",
+    },
+    async () => {
+      const result = await defaultRegistryRunner(
+        [Deno.execPath(), "eval", ACTOR_ECHO],
+        Deno.cwd(),
+      );
+      assertEquals(result.code, 0);
+      assertEquals(result.stdout.trim(), "inherited-actor|service|operator");
+    },
+  );
+});
+
+Deno.test("the server's tokens are stripped beside the exported claim", async () => {
+  await withEnv(
+    { ZUKE_OPERATOR_TOKEN: "server-secret", ZUKE_MCP_TOKEN: "bearer-secret" },
+    async () => {
+      const result = await defaultRegistryRunner(
+        [
+          Deno.execPath(),
+          "eval",
+          "console.log(Deno.env.get('ZUKE_OPERATOR_TOKEN') ?? 'STRIPPED', " +
+          "Deno.env.get('ZUKE_MCP_TOKEN') ?? 'STRIPPED', " +
+          "Deno.env.get('ZUKE_ACTOR') ?? '-')",
+        ],
+        Deno.cwd(),
+        { actor: "engineer-a", actorKind: "service", actorRoles: ["ops"] },
+      );
+      assertEquals(result.code, 0);
+      // Exporting the caller's claim does not reopen the secrets it replaced.
+      assertStringIncludes(result.stdout, "STRIPPED STRIPPED engineer-a");
+    },
+  );
 });

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/.codex-plugin/plugin.json
+++ b/plugins/zuke/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/skills/zuke-write-build/SKILL.md
+++ b/plugins/zuke/skills/zuke-write-build/SKILL.md
@@ -219,14 +219,15 @@ it cannot answer "does one exist for this tool?"; only the catalogue
 - **Operate the build from an agent:** `zuke mcp` serves the build over MCP so
   an AI client can list, inspect, and (with `--allow-run`) run targets — on
   stdio, or over HTTP with `--http <host:port>` (loopback by default; a
-  non-loopback bind needs a `ZUKE_MCP_TOKEN` bearer token). With a state store
-  it also exposes `list_runs`/`show_run` (+ `signal_run`, `resume_check` and
-  `cancel_run`). Tier access with `--allow-run=<globs>` (an allow-list over
-  **invocation** — invoking a target runs its dependencies, and the read tools
-  narrow to the allow-listed targets' closure), `--protect <globs>` +
-  `ZUKE_OPERATOR_TOKEN` (enforced over a run's **whole plan**, so a protected
-  target reached as a dependency still needs the token), and
-  `--confirm-destructive`; mark inspect-only targets `.readOnly()`.
+  non-loopback bind needs a `ZUKE_MCP_TOKEN` bearer token **or** an
+  `mcpAuth()`/`mcpIdentity()` authenticator, else the server exits 1). With a
+  state store it also exposes `list_runs`/`show_run` (+ `signal_run`,
+  `resume_check` and `cancel_run`). Tier access with `--allow-run=<globs>` (an
+  allow-list over **invocation** — invoking a target runs its dependencies, and
+  the read tools narrow to the allow-listed targets' closure),
+  `--protect <globs>` + `ZUKE_OPERATOR_TOKEN` (enforced over a run's **whole
+  plan**, so a protected target reached as a dependency still needs the token),
+  and `--confirm-destructive`; mark inspect-only targets `.readOnly()`.
   Mutating/denied calls are audited — read the trail on the host with
   `zuke runs show mcp-audit`; it is deliberately not readable over MCP. A
   **registry-backed** server (`zuke register` then `zuke mcp --registry`)
@@ -237,10 +238,17 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   **remote** entry module is refused unless its origin is in
   `ZUKE_REGISTRY_LAUNCH_HOSTS`; `zuke register` writes a local module, so this
   only affects a hand-authored or second-party entry. For a shared, multi-user
-  endpoint, `override mcpIdentity()` resolves a **trusted** caller per request
-  from an authenticating proxy's header (it overrides the client-reported actor
-  and flows to the audit trail, run records, and lock holders; a throwing hook
-  rejects the request).
+  endpoint, `override mcpAuth()` authenticates a **trusted** caller per request
+  — an async `authenticate(ctx)` returning `{ actor, kind?, roles?, via? }` or
+  an `McpAuthReject` (`{ status, error, detail?, challenge? }`), so a refused
+  HTTP request answers that status with `WWW-Authenticate` instead of a `200`.
+  `override mcpIdentity()` is the sugar for the proxy-header case (a sync hook
+  reading a header; any throw rejects), adapted onto the same path — declare one
+  or the other, never both, or the server exits 1. Either overrides the
+  client-reported actor and flows to the audit trail, run records, lock holders,
+  and a registry-spawned child's `ZUKE_ACTOR`/`ZUKE_ACTOR_KIND`/
+  `ZUKE_ACTOR_ROLES`. Both are fail-closed: a throw, a non-object, or an empty
+  actor refuses the request, and nothing runs.
 - **AI review & self-healing (`@zuke/ai`):** gate a target on a structured LLM
   review of the diff (`securityReviewer(...)` etc. via `.validateBefore`), or
   attach `aiFixer(...)` with `.recoverWith(...)` so a failing target is

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -1285,15 +1285,34 @@ a descriptor whose entry module is **remote** (not a local path or `file:` URL �
 spawned. `zuke register` writes a local `file:` module, so this only bites a
 hand-authored or second-party registry entry.
 
-**Trusted per-call identity** (`docs/mcp.md`): on a shared, multi-user endpoint,
-`override mcpIdentity()` returns a hook `(ctx) => ({ actor, via? })` that
-resolves the **real** caller from a request header an authenticating reverse
-proxy injects (`ctx.headers.get("x-forwarded-user")`). It runs once per request
-before any dispatch; its actor overrides `--actor`/env/the client label and
-flows to the audit trail, run records, lock holders, and a registry-spawned
-child's `ZUKE_ACTOR`. A **throwing hook rejects the request** (nothing runs,
-nothing is written). The minimal seam — TLS/OAuth/header-stripping is the
-proxy's job.
+**Authentication** (`docs/mcp.md`): on a shared, multi-user endpoint,
+`override mcpAuth()` returns an `McpAuthenticator` —
+`{ authenticate: async (ctx) => … }` — that either resolves the caller
+(`{ actor, kind?, roles?, via? }`; `kind` defaults `"human"`, `roles` defaults
+none) or refuses with an `McpAuthReject`
+(`{ status, error, detail?, challenge? }`). `ctx` carries the request `headers`
+and, over HTTP, the `request` itself. `override mcpIdentity()` is the sugar for
+the proxy-header case — a sync hook `(ctx) => ({ actor, via? })` reading a
+header an authenticating reverse proxy injects
+(`ctx.headers.get("x-forwarded-user")`), where **any throw rejects the request**
+— adapted onto the same authenticator internally. Declare **one or the other**:
+a build declaring both makes `zuke mcp` exit 1.
+
+Either runs once per request before any dispatch; the resolved actor overrides
+`--actor`/env/the client label and flows to the audit trail, run records, lock
+holders, and a registry-spawned child's `ZUKE_ACTOR` (with `ZUKE_ACTOR_KIND` and
+comma-joined `ZUKE_ACTOR_ROLES` written beside it, so an inherited claim never
+outlives a fresh actor). `roles` are **not** an authorization input — the
+allow-list/`--protect`/operator token still gate a call. Fail-closed: a throw, a
+non-object, an empty actor, or a rejection whose `status` is outside `400`–`499`
+all refuse, each collapsing to a bare `401`
+(`{ status: 401, error: "Unauthorized", challenge: "Bearer" }`), so an
+authenticator can never turn its own refusal into a success. Over HTTP a refusal
+answers that **status** with its `WWW-Authenticate` challenge (the JSON-RPC
+error is still in the body) — previously a `200` — which is how an MCP client
+discovers where to authenticate; either override also satisfies the
+authentication a non-loopback bind requires, in place of `ZUKE_MCP_TOKEN`. The
+minimal seam — TLS/OAuth/header-stripping is the proxy's job.
 
 **Caching:** a target with `.inputs(...)`/`.outputs(...)` is incremental
 (skipped and reported `cached` when inputs are unchanged and outputs exist). Add

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -219,14 +219,15 @@ it cannot answer "does one exist for this tool?"; only the catalogue
 - **Operate the build from an agent:** `zuke mcp` serves the build over MCP so
   an AI client can list, inspect, and (with `--allow-run`) run targets — on
   stdio, or over HTTP with `--http <host:port>` (loopback by default; a
-  non-loopback bind needs a `ZUKE_MCP_TOKEN` bearer token). With a state store
-  it also exposes `list_runs`/`show_run` (+ `signal_run`, `resume_check` and
-  `cancel_run`). Tier access with `--allow-run=<globs>` (an allow-list over
-  **invocation** — invoking a target runs its dependencies, and the read tools
-  narrow to the allow-listed targets' closure), `--protect <globs>` +
-  `ZUKE_OPERATOR_TOKEN` (enforced over a run's **whole plan**, so a protected
-  target reached as a dependency still needs the token), and
-  `--confirm-destructive`; mark inspect-only targets `.readOnly()`.
+  non-loopback bind needs a `ZUKE_MCP_TOKEN` bearer token **or** an
+  `mcpAuth()`/`mcpIdentity()` authenticator, else the server exits 1). With a
+  state store it also exposes `list_runs`/`show_run` (+ `signal_run`,
+  `resume_check` and `cancel_run`). Tier access with `--allow-run=<globs>` (an
+  allow-list over **invocation** — invoking a target runs its dependencies, and
+  the read tools narrow to the allow-listed targets' closure),
+  `--protect <globs>` + `ZUKE_OPERATOR_TOKEN` (enforced over a run's **whole
+  plan**, so a protected target reached as a dependency still needs the token),
+  and `--confirm-destructive`; mark inspect-only targets `.readOnly()`.
   Mutating/denied calls are audited — read the trail on the host with
   `zuke runs show mcp-audit`; it is deliberately not readable over MCP. A
   **registry-backed** server (`zuke register` then `zuke mcp --registry`)
@@ -237,10 +238,17 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   **remote** entry module is refused unless its origin is in
   `ZUKE_REGISTRY_LAUNCH_HOSTS`; `zuke register` writes a local module, so this
   only affects a hand-authored or second-party entry. For a shared, multi-user
-  endpoint, `override mcpIdentity()` resolves a **trusted** caller per request
-  from an authenticating proxy's header (it overrides the client-reported actor
-  and flows to the audit trail, run records, and lock holders; a throwing hook
-  rejects the request).
+  endpoint, `override mcpAuth()` authenticates a **trusted** caller per request
+  — an async `authenticate(ctx)` returning `{ actor, kind?, roles?, via? }` or
+  an `McpAuthReject` (`{ status, error, detail?, challenge? }`), so a refused
+  HTTP request answers that status with `WWW-Authenticate` instead of a `200`.
+  `override mcpIdentity()` is the sugar for the proxy-header case (a sync hook
+  reading a header; any throw rejects), adapted onto the same path — declare one
+  or the other, never both, or the server exits 1. Either overrides the
+  client-reported actor and flows to the audit trail, run records, lock holders,
+  and a registry-spawned child's `ZUKE_ACTOR`/`ZUKE_ACTOR_KIND`/
+  `ZUKE_ACTOR_ROLES`. Both are fail-closed: a throw, a non-object, or an empty
+  actor refuses the request, and nothing runs.
 - **AI review & self-healing (`@zuke/ai`):** gate a target on a structured LLM
   review of the diff (`securityReviewer(...)` etc. via `.validateBefore`), or
   attach `aiFixer(...)` with `.recoverWith(...)` so a failing target is

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -1285,15 +1285,34 @@ a descriptor whose entry module is **remote** (not a local path or `file:` URL �
 spawned. `zuke register` writes a local `file:` module, so this only bites a
 hand-authored or second-party registry entry.
 
-**Trusted per-call identity** (`docs/mcp.md`): on a shared, multi-user endpoint,
-`override mcpIdentity()` returns a hook `(ctx) => ({ actor, via? })` that
-resolves the **real** caller from a request header an authenticating reverse
-proxy injects (`ctx.headers.get("x-forwarded-user")`). It runs once per request
-before any dispatch; its actor overrides `--actor`/env/the client label and
-flows to the audit trail, run records, lock holders, and a registry-spawned
-child's `ZUKE_ACTOR`. A **throwing hook rejects the request** (nothing runs,
-nothing is written). The minimal seam — TLS/OAuth/header-stripping is the
-proxy's job.
+**Authentication** (`docs/mcp.md`): on a shared, multi-user endpoint,
+`override mcpAuth()` returns an `McpAuthenticator` —
+`{ authenticate: async (ctx) => … }` — that either resolves the caller
+(`{ actor, kind?, roles?, via? }`; `kind` defaults `"human"`, `roles` defaults
+none) or refuses with an `McpAuthReject`
+(`{ status, error, detail?, challenge? }`). `ctx` carries the request `headers`
+and, over HTTP, the `request` itself. `override mcpIdentity()` is the sugar for
+the proxy-header case — a sync hook `(ctx) => ({ actor, via? })` reading a
+header an authenticating reverse proxy injects
+(`ctx.headers.get("x-forwarded-user")`), where **any throw rejects the request**
+— adapted onto the same authenticator internally. Declare **one or the other**:
+a build declaring both makes `zuke mcp` exit 1.
+
+Either runs once per request before any dispatch; the resolved actor overrides
+`--actor`/env/the client label and flows to the audit trail, run records, lock
+holders, and a registry-spawned child's `ZUKE_ACTOR` (with `ZUKE_ACTOR_KIND` and
+comma-joined `ZUKE_ACTOR_ROLES` written beside it, so an inherited claim never
+outlives a fresh actor). `roles` are **not** an authorization input — the
+allow-list/`--protect`/operator token still gate a call. Fail-closed: a throw, a
+non-object, an empty actor, or a rejection whose `status` is outside `400`–`499`
+all refuse, each collapsing to a bare `401`
+(`{ status: 401, error: "Unauthorized", challenge: "Bearer" }`), so an
+authenticator can never turn its own refusal into a success. Over HTTP a refusal
+answers that **status** with its `WWW-Authenticate` challenge (the JSON-RPC
+error is still in the body) — previously a `200` — which is how an MCP client
+discovers where to authenticate; either override also satisfies the
+authentication a non-loopback bind requires, in place of `ZUKE_MCP_TOKEN`. The
+minimal seam — TLS/OAuth/header-stripping is the proxy's job.
 
 **Caching:** a target with `.inputs(...)`/`.outputs(...)` is incremental
 (skipped and reported `cached` when inputs are unchanged and outputs exist). Add

--- a/tests/integration/mcp_auth_test.ts
+++ b/tests/integration/mcp_auth_test.ts
@@ -1,0 +1,270 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Integration: a build's `mcpAuth()` authenticator, end to end.
+ *
+ * The unit tests pin the seam's own normalisation; this drives the whole path —
+ * a real `Build`, the real `zuke mcp` command, its HTTP transport, a real state
+ * store — and then reads the result back through the CLI `main()`. It proves
+ * three things fit together: an accepted call runs the target and the *resolved*
+ * actor (not `--actor`) reaches the run record and the audit trail an operator
+ * reads; a refusal is answered with its own status and `WWW-Authenticate`
+ * challenge and writes nothing at all; and in registry mode the caller's kind
+ * and roles reach the spawned build.
+ *
+ * The HTTP cases enter one level below `main()`, at `serveMcp` — the function
+ * the `mcp` command *is*. That command forwards neither an abort signal nor an
+ * `onListen` hook, so an in-process `runCli(Fleet, ["mcp", "--http", …])` could
+ * neither learn its ephemeral port nor ever be stopped. The startup refusal,
+ * which exits before binding anything, does go through `runCli`.
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import {
+  Build,
+  defaultStateHost,
+  FileSystemStateStore,
+  type McpAuthenticator,
+  type McpIdentityHook,
+  type McpRequestContext,
+  target,
+} from "../../packages/core/mod.ts";
+import {
+  serveMcp,
+  type ServeMcpOptions,
+} from "../../packages/core/src/mcp/command.ts";
+import { FileSystemBuildRegistry } from "../../packages/core/src/registry/fs_registry.ts";
+import { registerCommand } from "../../packages/core/src/registry/register.ts";
+import type {
+  RegistryRunner,
+  RegistryRunOptions,
+} from "../../packages/core/src/mcp/registry_server.ts";
+import { silence } from "../../packages/core/tests/_console.ts";
+import { runCli, withStateDir } from "./_harness.ts";
+
+/** The key the fixture trusts — a stand-in for a verified credential. */
+const API_KEY = "kestrel";
+
+/**
+ * A build that authenticates its own MCP callers: the key names a service
+ * account holding one role; anything else is refused with a `403` and a
+ * challenge, so the refusal's own status — not a `200` carrying an error —
+ * is what a client sees.
+ */
+class Fleet extends Build {
+  deploy = target().description("Deploy the fleet").executes(() => {});
+
+  override mcpAuth(): McpAuthenticator {
+    return {
+      authenticate: (ctx: McpRequestContext) =>
+        ctx.headers.get("x-api-key") === API_KEY
+          ? {
+            actor: "svc-releaser",
+            kind: "service",
+            roles: ["deploy"],
+            via: "api-key",
+          }
+          : {
+            status: 403,
+            error: "invalid_key",
+            detail: "unknown API key",
+            challenge: 'Bearer realm="zuke"',
+          },
+    };
+  }
+}
+
+/** Start `serveMcp` over HTTP on an ephemeral loopback port. */
+async function startMcp(
+  build: Build,
+  options: ServeMcpOptions,
+): Promise<{ url: string; stop: () => Promise<number> }> {
+  const aborter = new AbortController();
+  let setPort = (_: number) => {};
+  const portReady = new Promise<number>((resolve) => (setPort = resolve));
+  const finished = serveMcp(build, {
+    ...options,
+    http: { host: "127.0.0.1", port: 0 },
+    quiet: true,
+    signal: aborter.signal,
+    onListen: (address) => setPort(address.port),
+  });
+  const url = `http://127.0.0.1:${await portReady}/`;
+  return {
+    url,
+    stop: () => {
+      aborter.abort();
+      return finished;
+    },
+  };
+}
+
+/** POST one `tools/call` for `name`, with whatever headers the caller offers. */
+async function callTool(
+  url: string,
+  name: string,
+  headers: Record<string, string> = {},
+): Promise<{ status: number; challenge: string | null; body: unknown }> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name, arguments: {} },
+    }),
+  });
+  return {
+    status: response.status,
+    challenge: response.headers.get("www-authenticate"),
+    body: await response.json(),
+  };
+}
+
+/** Whether `value` is a plain object (a string-keyed record). */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** The JSON-RPC error message in a response body, or `""` if it carries none. */
+function rpcErrorMessage(body: unknown): string {
+  const error = isRecord(body) ? body.error : undefined;
+  const message = isRecord(error) ? error.message : undefined;
+  return typeof message === "string" ? message : "";
+}
+
+Deno.test("an authenticated call runs the target, attributed to the resolved actor", async () => {
+  await withStateDir(async (dir) => {
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    // `--actor` is set too: the authenticated identity must outrank it.
+    const server = await startMcp(new Fleet(), {
+      allowRun: true,
+      actor: "cli-default",
+    });
+    try {
+      const called = await callTool(server.url, "run:deploy", {
+        "x-api-key": API_KEY,
+      });
+      assertEquals(called.status, 200);
+
+      // The build really ran, and its record names the authenticator's actor.
+      const runs = (await store.listRuns({})).filter((r) =>
+        r.rootTarget === "deploy"
+      );
+      assertEquals(runs.length, 1);
+
+      const shown = await runCli(Fleet, ["runs", "show", runs[0].id]);
+      assertEquals(shown.code, 0);
+      assertStringIncludes(shown.out, "status:   succeeded");
+      assertStringIncludes(shown.out, "actor:    svc-releaser");
+      assertEquals(shown.out.includes("cli-default"), false);
+
+      // …and so does the trail the operator reads on the host.
+      const audit = await runCli(Fleet, ["runs", "show", "mcp-audit"]);
+      assertEquals(audit.code, 0);
+      assertStringIncludes(audit.out, "Audit:");
+      assertStringIncludes(audit.out, "run:deploy");
+      assertStringIncludes(audit.out, "svc-releaser");
+      assertEquals(audit.out.includes("cli-default"), false);
+    } finally {
+      assertEquals(await server.stop(), 0);
+    }
+  });
+});
+
+Deno.test("a refused call gets the refusal's status and challenge, and writes nothing", async () => {
+  await withStateDir(async (dir) => {
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    const server = await startMcp(new Fleet(), { allowRun: true });
+    try {
+      // No key: the authenticator refuses before the body is even read.
+      const refused = await callTool(server.url, "run:deploy");
+      assertEquals(refused.status, 403);
+      assertEquals(refused.challenge, 'Bearer realm="zuke"');
+      // The reason still reaches a client that only speaks JSON-RPC.
+      assertEquals(
+        rpcErrorMessage(refused.body),
+        "invalid_key: unknown API key",
+      );
+
+      // Nothing ran and nothing was recorded — not even an audit event, which
+      // would mean the request had reached dispatch.
+      assertEquals(await store.listRuns({}), []);
+      assertEquals(await store.getRun("mcp-audit"), null);
+      const audit = await runCli(Fleet, ["runs", "show", "mcp-audit"]);
+      assertEquals(audit.code, 1);
+      assertStringIncludes(audit.err, 'no run "mcp-audit"');
+    } finally {
+      assertEquals(await server.stop(), 0);
+    }
+  });
+});
+
+Deno.test("in registry mode the caller's kind and roles reach the spawned build", async () => {
+  await withStateDir(async (dir) => {
+    const registry = new FileSystemBuildRegistry(`${dir}/builds`);
+    await silence(async () => {
+      const code = await registerCommand(new Fleet(), {
+        registry,
+        location: { kind: "module", module: "file:///r/fleet.ts", cwd: "/r" },
+        readEnv: () => undefined,
+        now: () => "2026-01-01T00:00:00.000Z",
+      });
+      assertEquals(code, 0);
+    });
+
+    // A fake runner: no subprocess, just what the spawn would have been told.
+    const spawns: RegistryRunOptions[] = [];
+    const runner: RegistryRunner = (_argv, _cwd, options) => {
+      spawns.push({ ...options });
+      return Promise.resolve({ code: 0, stdout: "ok", stderr: "" });
+    };
+    const server = await startMcp(new Fleet(), {
+      allowRun: true,
+      actor: "cli-default",
+      registry,
+      runner,
+    });
+    try {
+      const called = await callTool(server.url, "run:Fleet:deploy", {
+        "x-api-key": API_KEY,
+      });
+      assertEquals(called.status, 200);
+
+      // All three travel together, so the child never reads one caller's actor
+      // with another's entitlements.
+      assertEquals(spawns.length, 1);
+      assertEquals(spawns[0].actor, "svc-releaser");
+      assertEquals(spawns[0].actorKind, "service");
+      assertEquals(spawns[0].actorRoles, ["deploy"]);
+    } finally {
+      assertEquals(await server.stop(), 0);
+    }
+  });
+});
+
+Deno.test("a build declaring both mcpAuth() and mcpIdentity() refuses to start", async () => {
+  class Confused extends Build {
+    deploy = target().executes(() => {});
+
+    override mcpAuth(): McpAuthenticator {
+      return { authenticate: () => ({ actor: "svc-releaser" }) };
+    }
+
+    override mcpIdentity(): McpIdentityHook {
+      return () => ({ actor: "proxy-user" });
+    }
+  }
+
+  // Through the real CLI: the server exits before binding a transport, so the
+  // whole command runs in-process.
+  const { code, err } = await runCli(Confused, ["mcp"]);
+  assertEquals(code, 1);
+  assertStringIncludes(err, "mcpAuth() and mcpIdentity()");
+  assertStringIncludes(err, "keep");
+});

--- a/zuke.ts
+++ b/zuke.ts
@@ -1021,8 +1021,30 @@ class ZukeBuild extends Build {
       // prompt_markers_test.ts, which pins the full announced-marker inventory
       // against the actual prompts (its earlier wordings were q4wvfi90ig3c
       // and 3mcvjgd95cj96).
+      // `23ldpwpbdzryb` claims `defaultRegistryRunner` drops the child's
+      // inherited actor metadata when only a kind/roles are supplied. It does
+      // the opposite: the whole three-variable write sits inside the
+      // `options.actor` guard, so with no actor nothing is written and the
+      // inherited triple reaches the child untouched — pinned by the test
+      // "kind and roles without an actor change nothing", which spawns a real
+      // child under a different caller's claim. Honouring the supplied values
+      // there is the unsafe option, since it would pair one caller's actor with
+      // another's entitlements. Its round-2 rewording (`3e30ptl9ksk1y`,
+      // "inherited actor metadata can still be dropped") inverts the behaviour
+      // rather than describing it, and escalated 4/10 to 5/10 against a JSDoc
+      // and a regression test, so it is pinned here.
       // cspell:ignore tz9w4ef nal6fieqlp q4wvfi90ig mcvjgd95cj mzsyzzio
-      .suppress(suppressions((s) => s.add("31ce99tz9w4ef", "nal6fieqlp45")))
+      // cspell:ignore ldpwpbdzryb ptl9ksk1y
+      .suppress(
+        suppressions((s) =>
+          s.add(
+            "31ce99tz9w4ef",
+            "nal6fieqlp45",
+            "23ldpwpbdzryb",
+            "3e30ptl9ksk1y",
+          )
+        ),
+      )
       .failWhen((g) => g.scoreAbove(5))
       .onError("warn")
   );


### PR DESCRIPTION
## What & why

Zuke's MCP server resolved a caller through one seam: a **synchronous** identity hook that saw only `Headers` and could refuse only by throwing. That is right behind a reverse proxy that has already authenticated the caller. It is not enough for a control plane agents connect to directly, which is how a production consumer runs Zuke today:

- **Nothing could authenticate asynchronously.** Verifying a token signature is WebCrypto, which is async. A synchronous hook cannot do it, so every real authenticator had to live outside Zuke.
- **A refusal could not reach the wire correctly.** A failed hook became a JSON-RPC `Unauthorized` inside an HTTP **200**. An MCP client discovers where to authenticate from a **401** carrying `WWW-Authenticate` — a JSON-RPC error in a 200 body can never tell it that. The transport already answered exactly that way for the static bearer token; the identity seam had no way to.
- **An identity was one string.** The resolver collapsed the identity down to a string, so `via` was read by nobody and there was nowhere to carry "is this a person or a scheduler" or "what roles does this caller hold" — the two facts any authorization policy needs.
- **A non-loopback bind demanded `ZUKE_MCP_TOKEN`** even when a real authenticator was configured, so an authenticated server could not start without also pasting a shared secret.

This adds the seam. It is item 15.1 of a maintainer proposal from that consumer; the role policy, the OAuth package and the dispatcher identity build on it.

### The shape

A new `mcpAuth()` override returns an authenticator: one `authenticate` method, may be async, returning either an identity or a structured refusal carrying its own status, reason and challenge. The identity type gains an optional `kind` and `roles` beside `actor`.

Four decisions worth naming:

- **`actor` is kept, not renamed to `subject`.** It is Zuke's vocabulary everywhere already — the run record, the resolver, the CLI flag, the environment variable — and renaming a shipped public field would break the 1.x promise for no gain.
- **`mcpIdentity()` becomes sugar.** It is adapted onto the same authenticator internally, so there is one authentication path rather than two that can drift. Declaring both hooks is refused when the server starts, rather than letting one silently win.
- **HTTP authenticates at the transport edge**, before the request body is read, so an unauthenticated caller never makes the server buffer a megabyte. Stdio authenticates in the dispatcher, so neither transport can dispatch a request nobody authenticated.
- **The authenticator is handed a bodiless view of the request.** A body can be read once; an authenticator that peeked would leave nothing for the dispatcher to parse, and the next read fails far from the cause. A credential never lives in the body, so the view costs nothing and makes the mistake impossible rather than merely documented.

A registry-spawned build now inherits the caller's kind and roles beside its actor. The three are written **together**, so an inherited claim cannot outlive a fresh actor — otherwise a child would read one caller's actor with another's entitlements.

### One visible behaviour change

A refused HTTP request now answers **401** — or the refusal's own status — with a `WWW-Authenticate` challenge, where it previously answered 200 with a JSON-RPC error. The JSON-RPC error is still in the body, and stdio now reports the same reason. This follows directly from moving authentication to the transport edge, and it is the point: without it, OAuth discovery cannot work. It is documented in the transport section of the MCP guide.

A non-loopback bind is now satisfied by a bearer token **or** an authenticator declared as authentication. A `mcpIdentity()` hook deliberately does **not** satisfy it — see below.

### What the adversarial review found

Seven independent reviewers attacked the change across bypass, fail-closed behaviour, transport, the child environment, compatibility, documentation truth and the repository's design guidelines. Every finding was then verified against the running code by independent skeptics, defaulting to refuted. Seven survived and are fixed here, each with a regression test:

- **The fail-closed guarantee did not hold.** The guard wrapped only the call to the authenticator, so every read of the value it returned happened outside it. An authenticator wrapping verified claims in getters — the natural shape for one — made a throwing getter escape as a transport fault with no challenge, rather than the refusal the seam promises. Reproduced end to end as a 500. This restores the "guard both the call and the property read" intent of the resolver it replaced.
- **A refusal could destroy itself.** The challenge is the one field of a rejection that becomes an HTTP header, and it was unvalidated where the status is carefully validated. Setting a header throws on CR/LF, NUL, and anything outside Latin-1, so a bad challenge turned a 401 into a 500 carrying no challenge at all. Such a value is now dropped like an absent one, with the platform header type itself as the oracle rather than a hand-written character test that would drift.
- **The request view could throw.** Deno builds the request URL from the raw `Host` header and accepts hosts the URL parser rejects. Building the view failed for requests the server had already accepted, and it ran even with no authenticator configured — a regression affecting every HTTP server, not only authenticated ones. Reproduced with a raw socket. The view is now simply absent for such a request; its headers, where a credential lives, are untouched.
- **A header-trusting hook unlocked a non-loopback bind.** Three reviewers found this independently. The proxy hook assumes something in front has already authenticated the caller, so on a directly reachable endpoint it authenticates nobody: any caller sets the header itself. Such a build needed a bearer token to bind before this seam existed, and needs one again. Only an authenticator declared as authentication satisfies the guard; both still run on every request.
- **The documented example did not compile.** Without a return-type annotation the kind literal widens and the override is rejected with TS2416 — confirmed by type-checking it. The same broken example appeared in the guide, the JSDoc, and both generated API blocks.
- **The stdio refusal was documented as a fixed message,** which stopped being true once both transports began reporting the rejection's own reason.
- **A role name could carry the separator its consumer splits on.** Role names can come from an identity provider's group names, so one containing a comma would reach a spawned child as two roles. Nothing reads roles today only because they are not yet an authorization input, which is exactly why it is worth closing before they are.

Refuted findings are not listed; each was checked and failed to reproduce. One real defect the review surfaced is **pre-existing** and filed separately as #472 rather than expanded into this PR: a build parameter named `actor` shadows the reserved flag on a registry spawn.

### Testing

48 new tests across four files: unit coverage of the authenticator module at 100% of its branches, the HTTP transport including check ordering and the body-read boundary, the single-build and registry servers, and an integration layer driving a real build through the CLI. The registry environment tests spawn a real child to prove an inherited kind or role set cannot survive beside a fresh actor.

## Related issues

Closes #471

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a [Conventional Commit](https://www.conventionalcommits.org/) (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell). 21/21 targets, 4177 tests, 98.6% lines and 97.4% branches.
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (the MCP guide, the CLI reference, the authoring guide, JSDoc).
- [x] Public API changes were regenerated with the API docs target.
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with type guards instead).
- [x] Agent skills updated and the plugin version bumped in all four manifests (0.38.0 to 0.39.0).
