### PR TITLE
feat(core): record a run's initiator, distinct from its last writer

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.39.0",
+      "version": "0.40.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/docs/run-context.md
+++ b/docs/run-context.md
@@ -23,6 +23,7 @@ class Deploy extends Build {
 | Field        | Type                | What it is                                                            |
 | ------------ | ------------------- | -------------------------------------------------------------------- |
 | `runId`      | `string`            | Unique id of this run, **stable for every target** in the run.       |
+| `initiator`  | `RunInitiator?`     | Who **asked for** this run (`actor`, `kind`, `at`) — stamped once at creation, so a resume never rewrites it. Absent with no state store. See [Durable run state](./state.md). |
 | `target`     | `string`            | The executing target's dotted name.                                  |
 | `signal`     | `AbortSignal`       | Aborted when the run is cancelled (see below).                       |
 | `state`      | `TargetStateHandle` | Durable per-target metadata — see [Durable run state](./state.md).   |

--- a/docs/state-api.md
+++ b/docs/state-api.md
@@ -69,11 +69,11 @@ Delete one run. Backs `zuke runs prune`. **Optional** — a server that manages
 retention itself (see [the retention note](#notes-for-implementers)) may leave
 this unimplemented; the client only calls it from an explicit prune.
 
-| Response | Meaning                                                    |
-| -------- | ---------------------------------------------------------- |
-| `2xx`    | Deleted (or already absent).                               |
-| `404`    | No such run — treated as success (delete is idempotent).   |
-| other    | The client raises an error.                                |
+| Response | Meaning                                                  |
+| -------- | -------------------------------------------------------- |
+| `2xx`    | Deleted (or already absent).                             |
+| `404`    | No such run — treated as success (delete is idempotent). |
+| other    | The client raises an error.                              |
 
 ### `GET /runs?status=&target=&since=&limit=`
 
@@ -96,18 +96,27 @@ List runs as an array of **summaries** (a subset of the record):
 
 `initiator` is **optional but load-bearing**: it is who asked for the run, while
 `actor` is whoever wrote it last, so a store that omits it from a summary makes
-`zuke runs list --initiator` fall back to `actor` — which on a resumed run is the
-process that resumed it, not the person who started it. Project it whenever the
-record has one. It is absent only on records written before the field existed.
+`zuke runs list --initiator` fall back to `actor` — which on a resumed run is
+the process that resumed it, not the person who started it. Project it whenever
+the record has one. It is absent only on records written before the field
+existed.
 
 Query parameters (all optional, combined with AND):
 
-| Param    | Keeps runs where…                                                |
-| -------- | ---------------------------------------------------------------- |
-| `status` | the run status equals this value                                 |
-| `target` | the run's graph contains a target with this dotted name          |
-| `since`  | `createdAt` is at or after this ISO-8601 timestamp               |
+| Param    | Keeps runs where…                                                                |
+| -------- | -------------------------------------------------------------------------------- |
+| `status` | the run status equals this value                                                 |
+| `target` | the run's graph contains a target with this dotted name                          |
+| `since`  | `createdAt` is at or after this ISO-8601 timestamp                               |
 | `limit`  | at most this many are returned — the **newest**, so a large store stays listable |
+
+**With no `limit`, every matching run is returned.** A server must not impose a
+cap of its own on an unlimited list. The client relies on this whenever it has
+to filter on a field the query does not carry — `zuke runs list --initiator`
+lists without a limit precisely so it can filter and then take the newest N —
+and a silent server-side cap would hand it the wrong window to search, returning
+a confident subset that is not the newest anything. A store that cannot answer
+an unlimited list should fail the request rather than truncate it.
 
 The client validates every summary it receives (an untrusted service is checked,
 not trusted) and expects newest-first ordering is applied server-side where it
@@ -119,9 +128,9 @@ recent runs.
 
 Four routes back everything that needs mutual exclusion: a target's
 [`.lock()`](./locks.md), and the **run lease** every stateful run holds on its
-own id (key `zuke-run-<id>`, 60s TTL) — which is also what lets
-`resume --check` tell an abandoned run from a merely slow one. A service that
-omits these can store run records but cannot support locks, leases, or reaping.
+own id (key `zuke-run-<id>`, 60s TTL) — which is also what lets `resume --check`
+tell an abandoned run from a merely slow one. A service that omits these can
+store run records but cannot support locks, leases, or reaping.
 
 A lock is `{ key, holder, token, expiresAt }`. The **token** is an opaque string
 the server mints on acquire; only a caller presenting it may renew or release.
@@ -130,8 +139,8 @@ holder's lock is reclaimed without anyone calling `DELETE`.
 
 ### `GET /locks`
 
-List the locks currently held — the read-only answer to "who has this, and
-until when?". No body.
+List the locks currently held — the read-only answer to "who has this, and until
+when?". No body.
 
 - `200 [ { "key": "…", "holder": { … }, "expiresAt": 1700000000000 }, … ]` —
   every **live** lock. An expired one is free and must be left out; reporting it

--- a/docs/state-api.md
+++ b/docs/state-api.md
@@ -87,11 +87,18 @@ List runs as an array of **summaries** (a subset of the record):
     "rootTarget": "deploy",
     "status": "succeeded",
     "actor": "alice",
+    "initiator": { "actor": "alice", "kind": "human", "at": "2026-07-17T…Z" },
     "createdAt": "2026-07-17T…Z",
     "updatedAt": "2026-07-17T…Z"
   }
 ]
 ```
+
+`initiator` is **optional but load-bearing**: it is who asked for the run, while
+`actor` is whoever wrote it last, so a store that omits it from a summary makes
+`zuke runs list --initiator` fall back to `actor` — which on a resumed run is the
+process that resumed it, not the person who started it. Project it whenever the
+record has one. It is absent only on records written before the field existed.
 
 Query parameters (all optional, combined with AND):
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -55,7 +55,12 @@ Each run is stored as one JSON document:
   "buildId": "acme/api", // optional; which build instance owns it (see below)
   "rootTarget": "deploy", // the requested target
   "status": "succeeded", // running | suspended | cancelling | succeeded | failed | cancelled
-  "actor": "alice", // who ran it (see below)
+  "actor": "alice", // the run's LAST writer (see below)
+  "initiator": { // optional; who ASKED for the run, stamped once at creation
+    "actor": "alice",
+    "kind": "human", // human | service
+    "at": "2026-07-17T…Z"
+  },
   "createdAt": "2026-07-17T…Z",
   "updatedAt": "2026-07-17T…Z",
   "graph": [ // the shape it planned, in declaration order
@@ -105,6 +110,27 @@ path compares it and touches a run only when the two origins agree; an absent on
 on either side abstains rather than refusing, so records written before the field
 existed stay recoverable. See
 [Whose run is it?](./orchestration.md#whose-run-is-it).
+
+### `actor` and `initiator` — two different questions
+
+`actor` is the run's **last writer**. It resolves from `--actor`, then
+`ZUKE_ACTOR`, then the CI actor, else `"anonymous"` — and **every resume
+overwrites it** with whoever picked the run up. On a deploy that parked at a gate
+and was resumed by a sweep, `actor` is the sweep's service account.
+
+`initiator` is who **asked for** the run. It is stamped once when the run is
+created and never written again, so it still names the engineer who started that
+deploy. Its `kind` comes from `--actor-kind` (`human` or `service`), else
+`ZUKE_ACTOR_KIND` — which the [MCP](./mcp.md) registry exports into a spawned
+child, so a run launched by an authenticated caller records that caller. The
+default is `human`: a service claim is what lets a policy treat a run as unowned
+machinery, so it must be stated rather than guessed from an actor's name. A typo
+in the flag fails the run; an unrecognised environment value reads as unstated.
+
+Read it from a body as `ctx.initiator`, see it on `zuke runs show`, and filter by
+it with `zuke runs list --initiator <name>`. The field is optional: a record
+written before it existed has none, and `actor` is then the closest answer —
+which is the exact one for a run nobody ever resumed.
 
 A record also carries an append-only `events` array — the **audit trail** of
 [MCP](./mcp.md) tool calls against the run (time, tool, actor, outcome, redacted

--- a/docs/state.md
+++ b/docs/state.md
@@ -128,7 +128,11 @@ machinery, so it must be stated rather than guessed from an actor's name. A typo
 in the flag fails the run; an unrecognised environment value reads as unstated.
 
 Read it from a body as `ctx.initiator`, see it on `zuke runs show`, and filter by
-it with `zuke runs list --initiator <name>`. The field is optional: a record
+it with `zuke runs list --initiator <name>`. That filter is applied after the
+store answers, so that a store which does not project the field cannot return an
+unfiltered list that looks filtered — which also means `--limit` is applied after
+it, not by the store. On a large store, narrow server-side first with `--since`
+or `--status`; those still go to the store. The field is optional: a record
 written before it existed has none, and `actor` is then the closest answer —
 which is the exact one for a run nobody ever resumed.
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "zuke",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build)."
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -370,6 +370,14 @@ async function httpJson<T = unknown>(url: string, options: HttpOptions): Promise
 async function httpText(url: string, options: HttpOptions): Promise<string>
   Fetch `url` and return its body as text. Throws {@link HttpError} on non-2xx.
 
+function initiatorOf(run: RunRecord | RunSummary): string
+  Who a run is attributed to for a reader that wants its owner rather than
+  its last writer: the recorded initiator, else the actor.
+
+  The fallback is not a guess — on a record written before the initiator
+  existed, and on any run that was never resumed, `actor` still holds exactly
+  the value the initiator would have been stamped with.
+
 async function installNpmTool(spec: NpmToolSpec, options: InstallNpmToolOptions): Promise<AbsolutePath>
   Provision an npm-registry package as a version-pinned, cached tool and return
   the installed bin's {@link AbsolutePath} — hand it straight to a wrapper's
@@ -2974,6 +2982,10 @@ interface ExecuteOptions
   actor?: string
     Who to attribute the run to in its state record (CLI `--actor`). Falls back
     to `ZUKE_ACTOR`, then the CI actor, then `"anonymous"`.
+  actorKind?: string
+    Whether a person or a machine asked for the run (CLI `--actor-kind`). Falls
+    back to `ZUKE_ACTOR_KIND`, else `"human"`. Recorded on the run's immutable
+    initiator, never inferred from the actor's name.
   resume?: ResumeState
     Continue a suspended run instead of starting a fresh one. Set by
     {@link "./resume.ts".resumeRun} after it has transitioned the run to
@@ -3628,6 +3640,23 @@ interface RunInfo
   readonly dryRun: boolean
     True when the run is a dry run (no target body executes).
 
+interface RunInitiator
+  Who asked for a run, stamped once when it is created and never rewritten.
+
+  Distinct from {@link RunRecord.actor}, which every resume overwrites with
+  whoever picked the run up — so on a run that suspended and was resumed by a
+  sweep, `actor` is the sweep's service account and this is still the engineer
+  who started it. That is the subject a run-scoped authorization rule means by
+  "whoever started this run", and the difference a notification needs to tell a
+  person's deploy from a scheduler's.
+
+  actor: string
+    Who asked for the run, resolved once at creation.
+  kind: ActorKind
+    Whether a person or a machine asked. Stated, never inferred from the actor.
+  at: string
+    ISO-8601 time the run was created — when this attribution was fixed.
+
 interface RunOptions
   Options for {@link run}.
 
@@ -3676,7 +3705,16 @@ interface RunRecord
   status: RunStatus
     The run's lifecycle status.
   actor: string
-    Who started the run (resolved from `--actor`, `ZUKE_ACTOR`, or CI env).
+    The run's last writer (resolved from `--actor`, `ZUKE_ACTOR`, or CI
+    env). Every resume overwrites it with whoever picked the run up, so it
+    answers "who touched this most recently", not "whose run is this" — see
+    {@link RunRecord.initiator} for that.
+  initiator?: RunInitiator
+    Who asked for the run, stamped once at creation and immutable thereafter.
+
+    Absent on a record written before this field existed; such a record's
+    {@link RunRecord.actor} is the closest answer available, and is exactly the
+    right one on a run that was never resumed.
   createdAt: string
     ISO-8601 timestamp when the run was created.
   updatedAt: string
@@ -3740,7 +3778,11 @@ interface RunSummary
   status: RunStatus
     The run's lifecycle status.
   actor: string
-    Who started the run.
+    The run's last writer (see {@link RunRecord.actor}).
+  initiator?: RunInitiator
+    Who asked for the run (see {@link RunRecord.initiator}). Absent on a record
+    written before the field existed, and from a store that does not project
+    it — {@link RunSummary.actor} is the fallback in both cases.
   createdAt: string
     ISO-8601 creation timestamp.
   updatedAt: string
@@ -3898,6 +3940,13 @@ interface TargetContext
 
   readonly runId: string
     Unique ID of this run, stable for every target in the run.
+  readonly initiator?: RunInitiator
+    Who asked for this run — stamped once when the run was created, and
+    unchanged by any later resume, so it still names the engineer who started a
+    deploy that a sweep has since picked up several times.
+
+    Absent when the run has no durable record to have stamped one (no state
+    store), and on a record written before the field existed.
   readonly target: string
     Dotted name of the executing target.
   readonly signal: AbortSignal
@@ -4151,6 +4200,9 @@ interface WaitTrigger
     and a durable {@link WaitContext}. The context lets a trigger persist
     correlation state across a suspend/resume; a trigger that only inspects
     signals may ignore it (fewer parameters stay assignable).
+
+type ActorKind = "human" | "service"
+  Whether a person or a machine asked for a run (see {@link RunInitiator}).
 
 type AnnouncementLevel = "success" | "failure" | "warning" | "info"
   The outcome an announcement conveys. It drives the accent colour and the icon

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2982,7 +2982,7 @@ interface ExecuteOptions
   actor?: string
     Who to attribute the run to in its state record (CLI `--actor`). Falls back
     to `ZUKE_ACTOR`, then the CI actor, then `"anonymous"`.
-  actorKind?: string
+  actorKind?: ActorKind
     Whether a person or a machine asked for the run (CLI `--actor-kind`). Falls
     back to `ZUKE_ACTOR_KIND`, else `"human"`. Recorded on the run's immutable
     initiator, never inferred from the actor's name.
@@ -3655,7 +3655,10 @@ interface RunInitiator
   kind: ActorKind
     Whether a person or a machine asked. Stated, never inferred from the actor.
   at: string
-    ISO-8601 time the run was created — when this attribution was fixed.
+    ISO-8601 time this attribution was fixed. The run's `createdAt` for a run
+    stamped at creation, and the original run's `createdAt` for one backfilled
+    when a resume was about to overwrite the evidence — so it dates the
+    attribution, not the write that recorded it.
 
 interface RunOptions
   Options for {@link run}.

--- a/llms.txt
+++ b/llms.txt
@@ -64,6 +64,7 @@ Option flags:
 - `--dry-run` — Print the plan without running targets
 - `--state` — Persist durable run state to .zuke/runs
 - `--actor` — Attribute the run to <name> in its state record
+- `--actor-kind` — Who asked for the run: human (default) or service
 - `--output` — Graph output format: text or html
 - `--no-open` — With --output=html, do not open a browser
 - `--check` — With generate-ci verify files; with resume re-check suspended runs
@@ -76,6 +77,7 @@ Option flags:
 - `--target` — With runs list, keep only runs whose graph has this target
 - `--since` — With runs list, keep only runs created at/after this time
 - `--limit` — With runs list, return at most this many runs (newest)
+- `--initiator` — With runs list, keep only runs this actor started
 - `--counts` — With runs list, print aggregate counts (total + per status)
 - `--keep` — With runs prune, keep runs newer than this age (e.g. 90d)
 - `--keep-last` — With runs prune, always keep the newest N terminal runs

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -3036,7 +3036,7 @@ interface ExecuteOptions
   actor?: string
     Who to attribute the run to in its state record (CLI `--actor`). Falls back
     to `ZUKE_ACTOR`, then the CI actor, then `"anonymous"`.
-  actorKind?: string
+  actorKind?: ActorKind
     Whether a person or a machine asked for the run (CLI `--actor-kind`). Falls
     back to `ZUKE_ACTOR_KIND`, else `"human"`. Recorded on the run's immutable
     initiator, never inferred from the actor's name.
@@ -3709,7 +3709,10 @@ interface RunInitiator
   kind: ActorKind
     Whether a person or a machine asked. Stated, never inferred from the actor.
   at: string
-    ISO-8601 time the run was created — when this attribution was fixed.
+    ISO-8601 time this attribution was fixed. The run's `createdAt` for a run
+    stamped at creation, and the original run's `createdAt` for one backfilled
+    when a resume was about to overwrite the evidence — so it dates the
+    attribution, not the write that recorded it.
 
 interface RunOptions
   Options for {@link run}.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -424,6 +424,14 @@ async function httpJson<T = unknown>(url: string, options: HttpOptions): Promise
 async function httpText(url: string, options: HttpOptions): Promise<string>
   Fetch `url` and return its body as text. Throws {@link HttpError} on non-2xx.
 
+function initiatorOf(run: RunRecord | RunSummary): string
+  Who a run is attributed to for a reader that wants its owner rather than
+  its last writer: the recorded initiator, else the actor.
+
+  The fallback is not a guess — on a record written before the initiator
+  existed, and on any run that was never resumed, `actor` still holds exactly
+  the value the initiator would have been stamped with.
+
 async function installNpmTool(spec: NpmToolSpec, options: InstallNpmToolOptions): Promise<AbsolutePath>
   Provision an npm-registry package as a version-pinned, cached tool and return
   the installed bin's {@link AbsolutePath} — hand it straight to a wrapper's
@@ -3028,6 +3036,10 @@ interface ExecuteOptions
   actor?: string
     Who to attribute the run to in its state record (CLI `--actor`). Falls back
     to `ZUKE_ACTOR`, then the CI actor, then `"anonymous"`.
+  actorKind?: string
+    Whether a person or a machine asked for the run (CLI `--actor-kind`). Falls
+    back to `ZUKE_ACTOR_KIND`, else `"human"`. Recorded on the run's immutable
+    initiator, never inferred from the actor's name.
   resume?: ResumeState
     Continue a suspended run instead of starting a fresh one. Set by
     {@link "./resume.ts".resumeRun} after it has transitioned the run to
@@ -3682,6 +3694,23 @@ interface RunInfo
   readonly dryRun: boolean
     True when the run is a dry run (no target body executes).
 
+interface RunInitiator
+  Who asked for a run, stamped once when it is created and never rewritten.
+
+  Distinct from {@link RunRecord.actor}, which every resume overwrites with
+  whoever picked the run up — so on a run that suspended and was resumed by a
+  sweep, `actor` is the sweep's service account and this is still the engineer
+  who started it. That is the subject a run-scoped authorization rule means by
+  "whoever started this run", and the difference a notification needs to tell a
+  person's deploy from a scheduler's.
+
+  actor: string
+    Who asked for the run, resolved once at creation.
+  kind: ActorKind
+    Whether a person or a machine asked. Stated, never inferred from the actor.
+  at: string
+    ISO-8601 time the run was created — when this attribution was fixed.
+
 interface RunOptions
   Options for {@link run}.
 
@@ -3730,7 +3759,16 @@ interface RunRecord
   status: RunStatus
     The run's lifecycle status.
   actor: string
-    Who started the run (resolved from `--actor`, `ZUKE_ACTOR`, or CI env).
+    The run's last writer (resolved from `--actor`, `ZUKE_ACTOR`, or CI
+    env). Every resume overwrites it with whoever picked the run up, so it
+    answers "who touched this most recently", not "whose run is this" — see
+    {@link RunRecord.initiator} for that.
+  initiator?: RunInitiator
+    Who asked for the run, stamped once at creation and immutable thereafter.
+
+    Absent on a record written before this field existed; such a record's
+    {@link RunRecord.actor} is the closest answer available, and is exactly the
+    right one on a run that was never resumed.
   createdAt: string
     ISO-8601 timestamp when the run was created.
   updatedAt: string
@@ -3794,7 +3832,11 @@ interface RunSummary
   status: RunStatus
     The run's lifecycle status.
   actor: string
-    Who started the run.
+    The run's last writer (see {@link RunRecord.actor}).
+  initiator?: RunInitiator
+    Who asked for the run (see {@link RunRecord.initiator}). Absent on a record
+    written before the field existed, and from a store that does not project
+    it — {@link RunSummary.actor} is the fallback in both cases.
   createdAt: string
     ISO-8601 creation timestamp.
   updatedAt: string
@@ -3952,6 +3994,13 @@ interface TargetContext
 
   readonly runId: string
     Unique ID of this run, stable for every target in the run.
+  readonly initiator?: RunInitiator
+    Who asked for this run — stamped once when the run was created, and
+    unchanged by any later resume, so it still names the engineer who started a
+    deploy that a sweep has since picked up several times.
+
+    Absent when the run has no durable record to have stamped one (no state
+    store), and on a record written before the field existed.
   readonly target: string
     Dotted name of the executing target.
   readonly signal: AbortSignal
@@ -4205,6 +4254,9 @@ interface WaitTrigger
     and a durable {@link WaitContext}. The context lets a trigger persist
     correlation state across a suspend/resume; a trigger that only inspects
     signals may ignore it (fewer parameters stay assignable).
+
+type ActorKind = "human" | "service"
+  Whether a person or a machine asked for a run (see {@link RunInitiator}).
 
 type AnnouncementLevel = "success" | "failure" | "warning" | "info"
   The outcome an announcement conveys. It drives the accent colour and the icon

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -165,11 +165,14 @@ export {
 } from "./src/state/run_lease.ts";
 export { parseDuration } from "./src/duration.ts";
 export {
+  type ActorKind,
   type EffectState,
   type EffectStatus,
+  initiatorOf,
   type RunEvent,
   type RunEventOutcome,
   type RunGraphNode,
+  type RunInitiator,
   type RunQuery,
   type RunRecord,
   type RunStatus,

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -54,7 +54,12 @@ import { resumeCheck, resumeRun } from "./resume.ts";
 import { runsCommand } from "./runs.ts";
 import { parseDuration } from "./duration.ts";
 import { registerCommand } from "./registry/register.ts";
-import { isRunStatus, RUN_STATUS_NAMES, type RunQuery } from "./state/types.ts";
+import {
+  ACTOR_KINDS,
+  isRunStatus,
+  RUN_STATUS_NAMES,
+  type RunQuery,
+} from "./state/types.ts";
 import {
   installCompletions,
   type InstallOptions,
@@ -146,6 +151,10 @@ export interface ParsedArgs {
   state: boolean;
   /** Attribute the run to this actor in its state record (`--actor <name>`). */
   actor?: string;
+  /** Whether a person or a machine asked for the run (`--actor-kind <kind>`). */
+  actorKind?: string;
+  /** With `runs list`, keep only runs this actor started (`--initiator <name>`). */
+  initiator?: string;
   /** The `resume` command was requested (continue a suspended run). */
   resume: boolean;
   /** The run id to resume (the positional after `resume`). */
@@ -323,6 +332,8 @@ interface ValueFlag {
  */
 const VALUE_FLAGS: ReadonlyMap<string, ValueFlag> = new Map([
   ["actor", { set: (p, v) => (p.actor = v) }],
+  ["actor-kind", { set: (p, v) => (p.actorKind = v) }],
+  ["initiator", { set: (p, v) => (p.initiator = v) }],
   ["signal", { set: (p, v) => (p.signal = v) }],
   ["data", { set: (p, v) => (p.data = v), keepEmpty: true }],
   ["status", { set: (p, v) => (p.runStatus = v) }],
@@ -552,7 +563,7 @@ Usage:
   deno run -A zuke.ts mcp [--allow-run] [--registry] [--http <host:port>]
   deno run -A zuke.ts resume <run-id> [--signal <name>] [--data <json>]
   deno run -A zuke.ts resume --check [<run-id>]
-  deno run -A zuke.ts runs list [--status <s>] [--target <t>] [--since <iso>] [--limit <n>] [--counts] [--json]
+  deno run -A zuke.ts runs list [--status <s>] [--target <t>] [--since <iso>] [--initiator <n>] [--limit <n>] [--counts] [--json]
   deno run -A zuke.ts runs show <run-id> [--json]
   deno run -A zuke.ts runs prune [--keep <age>] [--keep-last <n>] [--dry-run]
   deno run -A zuke.ts cancel <run-id> [--actor <name>]
@@ -579,7 +590,12 @@ Options:
                     already configured via ZUKE_STATE_URL/ZUKE_STATE_DIR or the
                     build's stateStore(). See docs/state.md.
   --actor <name>    Attribute the run to <name> in its state record (else
-                    ZUKE_ACTOR, the CI actor, or "anonymous").
+                    ZUKE_ACTOR, the CI actor, or "anonymous"). Every resume
+                    rewrites it with whoever picked the run up.
+  --actor-kind <k>  Whether a person or a machine asked: human (default) or
+                    service (else ZUKE_ACTOR_KIND). Recorded on the run's
+                    initiator, which — unlike --actor — is stamped once at
+                    creation and never rewritten.
   --list, -l        List all targets with descriptions and dependencies.
   --json            With --list, print the build surface (commands, flags,
                     targets, parameters) as JSON for tools and agents.
@@ -677,6 +693,9 @@ Options:
                     target.
   --since <iso>     With runs list, keep only runs created at or after this
                     ISO-8601 timestamp.
+  --initiator <n>   With runs list, keep only runs <n> started. Matches the
+                    recorded initiator, falling back to the actor on a run
+                    recorded before initiators existed.
   --limit <n>       With runs list, return at most this many runs (the newest).
   --counts          With runs list, print aggregate counts (total + per status).
   --keep <age>      With runs prune, keep runs newer than this age (e.g. 90d);
@@ -1174,6 +1193,7 @@ async function runRuns(build: Build, parsed: ParsedArgs): Promise<number> {
     json: parsed.json,
     counts: parsed.runCounts,
     query,
+    ...(parsed.initiator === undefined ? {} : { initiator: parsed.initiator }),
     keepMs,
     keepLast,
     dryRun: parsed.dryRun,
@@ -1327,6 +1347,21 @@ async function runCommand(
     return 1;
   }
 
+  // A typo in an explicit flag is an error, not a silent default. The
+  // environment fallback stays lenient — an unrecognised ZUKE_ACTOR_KIND reads
+  // as unstated — because that value can arrive from anywhere, while this one
+  // was typed by someone who meant something by it.
+  if (
+    parsed.actorKind !== undefined &&
+    !ACTOR_KINDS.some((kind) => kind === parsed.actorKind)
+  ) {
+    console.error(
+      `--actor-kind must be one of: ${ACTOR_KINDS.join(", ")} ` +
+        `(got "${parsed.actorKind}").`,
+    );
+    return 1;
+  }
+
   // Keep declared CI config in sync as part of running the build: write
   // changes locally, but only verify on CI so an ephemeral checkout is never
   // dirtied — a drifted file fails the build there instead.
@@ -1358,6 +1393,7 @@ async function runCommand(
       dryRun: parsed.dryRun,
       state: parsed.state,
       actor: parsed.actor,
+      actorKind: parsed.actorKind,
       plugins: options.plugins,
       renderer: options.renderer,
       signal: cleanupSignals ? controller.signal : options.signal,

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -1351,10 +1351,10 @@ async function runCommand(
   // environment fallback stays lenient — an unrecognised ZUKE_ACTOR_KIND reads
   // as unstated — because that value can arrive from anywhere, while this one
   // was typed by someone who meant something by it.
-  if (
-    parsed.actorKind !== undefined &&
-    !ACTOR_KINDS.some((kind) => kind === parsed.actorKind)
-  ) {
+  // `find` both validates and narrows, so the value handed to `execute` is the
+  // union rather than a string the type system has to be told about.
+  const actorKind = ACTOR_KINDS.find((kind) => kind === parsed.actorKind);
+  if (parsed.actorKind !== undefined && actorKind === undefined) {
     console.error(
       `--actor-kind must be one of: ${ACTOR_KINDS.join(", ")} ` +
         `(got "${parsed.actorKind}").`,
@@ -1393,7 +1393,7 @@ async function runCommand(
       dryRun: parsed.dryRun,
       state: parsed.state,
       actor: parsed.actor,
-      actorKind: parsed.actorKind,
+      actorKind,
       plugins: options.plugins,
       renderer: options.renderer,
       signal: cleanupSignals ? controller.signal : options.signal,

--- a/packages/core/src/cli_spec.ts
+++ b/packages/core/src/cli_spec.ts
@@ -127,6 +127,10 @@ export const BUILTIN_FLAGS: readonly BuiltinFlag[] = [
     name: "--actor",
     description: "Attribute the run to <name> in its state record",
   },
+  {
+    name: "--actor-kind",
+    description: "Who asked for the run: human (default) or service",
+  },
   { name: "--output", description: "Graph output format: text or html" },
   {
     name: "--no-open",
@@ -173,6 +177,10 @@ export const BUILTIN_FLAGS: readonly BuiltinFlag[] = [
   {
     name: "--limit",
     description: "With runs list, return at most this many runs (newest)",
+  },
+  {
+    name: "--initiator",
+    description: "With runs list, keep only runs this actor started",
   },
   {
     name: "--counts",

--- a/packages/core/src/conformance.ts
+++ b/packages/core/src/conformance.ts
@@ -246,6 +246,20 @@ const STATE_SCENARIOS: StateScenario[] = [
         since.length === 2,
         `since filter should return the 2 at/after the cutoff, got ${since.length}`,
       );
+      // An unlimited list returns everything, which is what lets a client
+      // filter on a field the query does not carry and then take the newest N
+      // itself. A store that caps this silently would hand that client the
+      // wrong window to search. Compared against a generous explicit limit,
+      // because the realistic failure is a server that honours the limit it is
+      // given but quietly applies a default of its own when given none — a
+      // fixture this size cannot outgrow a cap directly.
+      const unlimited = await store.listRuns({});
+      const generous = await store.listRuns({ limit: 1000 });
+      expect(
+        unlimited.length === generous.length,
+        `an unlimited listRuns must not cap its result: got ` +
+          `${unlimited.length} with no limit, ${generous.length} with limit=1000`,
+      );
       const limited = await store.listRuns({ target, limit: 2 });
       expect(
         limited.length === 2,

--- a/packages/core/src/execute_state.ts
+++ b/packages/core/src/execute_state.ts
@@ -39,7 +39,12 @@ import {
   type HeldLease,
   RUN_LEASE_PREFIX,
 } from "./state/run_lease.ts";
-import type { RunRecord, SignalRecord, WaitState } from "./state/types.ts";
+import type {
+  ActorKind,
+  RunRecord,
+  SignalRecord,
+  WaitState,
+} from "./state/types.ts";
 import type { ResumeState } from "./executor.ts";
 
 /**
@@ -190,7 +195,7 @@ export async function openRunState(opts: {
   stateStore?: StateStore | false;
   state?: boolean;
   actor?: string;
-  actorKind?: string;
+  actorKind?: ActorKind;
   resume?: ResumeState;
 }): Promise<{ ok: true; state: RunState } | { ok: false; error: Error }> {
   const { dryRun, order, readEnv, nowIso, redactor, resume } = opts;

--- a/packages/core/src/execute_state.ts
+++ b/packages/core/src/execute_state.ts
@@ -26,7 +26,12 @@ import { messageOf } from "./internal.ts";
 import { ARTIFACT_DIR, findConfigDir, pathExists } from "./config.ts";
 import { defaultStateHost, type StateStore } from "./state/store.ts";
 import { resolveStateStore } from "./state/resolve.ts";
-import { buildRunRecord, ciRunUrl, resolveActor } from "./state/record.ts";
+import {
+  buildRunRecord,
+  ciRunUrl,
+  resolveActor,
+  resolveActorKind,
+} from "./state/record.ts";
 import { resolveBuildId } from "./ownership.ts";
 import { RunStateWriter } from "./state/writer.ts";
 import {
@@ -185,6 +190,7 @@ export async function openRunState(opts: {
   stateStore?: StateStore | false;
   state?: boolean;
   actor?: string;
+  actorKind?: string;
   resume?: ResumeState;
 }): Promise<{ ok: true; state: RunState } | { ok: false; error: Error }> {
   const { dryRun, order, readEnv, nowIso, redactor, resume } = opts;
@@ -310,6 +316,7 @@ export async function openRunState(opts: {
         ...(buildId === undefined ? {} : { buildId }),
         rootTarget: opts.root.name_ ?? "<unnamed>",
         actor,
+        actorKind: resolveActorKind(opts.actorKind, readEnv),
         now: nowIso(),
         order,
         params: opts.params,
@@ -320,12 +327,17 @@ export async function openRunState(opts: {
       warn,
       opts.onExternalCancel,
     );
+  // Read back from the record rather than from the options: on a resume the
+  // record is the only place the original initiator survives, and this process
+  // may be running under a completely different actor.
+  const initiator = writer?.snapshot().initiator;
   const env: RunEnv = {
     runId: opts.runId,
     signal: opts.signal,
     writer,
     store: stateStore,
     actor,
+    ...(initiator === undefined ? {} : { initiator }),
     runUrl,
     signals: writer ? writer.signals() : new Map<string, SignalRecord>(),
     // Seeded from the record so a resumed run's targets keep the outcomes an

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -192,6 +192,12 @@ export interface ExecuteOptions {
    */
   actor?: string;
   /**
+   * Whether a person or a machine asked for the run (CLI `--actor-kind`). Falls
+   * back to `ZUKE_ACTOR_KIND`, else `"human"`. Recorded on the run's immutable
+   * initiator, never inferred from the actor's name.
+   */
+  actorKind?: string;
+  /**
    * Continue a suspended run instead of starting a fresh one. Set by
    * {@link "./resume.ts".resumeRun} after it has transitioned the run to
    * `running`; carries the existing record, its store version, and the targets
@@ -382,6 +388,7 @@ export async function execute(
     stateStore: options.stateStore,
     state: options.state,
     actor: options.actor,
+    actorKind: options.actorKind,
     resume: options.resume,
   });
   if (!opened.ok) {

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -65,7 +65,7 @@ import { type RemoteCacheStore, resolveRemoteStore } from "./remote_cache.ts";
 import { ServiceRegistry } from "./service.ts";
 import { absolutePath } from "./path.ts";
 import type { TargetBuilder } from "./target.ts";
-import type { RunRecord } from "./state/types.ts";
+import type { ActorKind, RunRecord } from "./state/types.ts";
 import { withAmbientSignal } from "./ambient_signal.ts";
 import { withAmbientRedactor } from "./ambient_redactor.ts";
 import type { StateStore } from "./state/store.ts";
@@ -196,7 +196,7 @@ export interface ExecuteOptions {
    * back to `ZUKE_ACTOR_KIND`, else `"human"`. Recorded on the run's immutable
    * initiator, never inferred from the actor's name.
    */
-  actorKind?: string;
+  actorKind?: ActorKind;
   /**
    * Continue a suspended run instead of starting a fresh one. Set by
    * {@link "./resume.ts".resumeRun} after it has transitioned the run to

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -596,6 +596,11 @@ export class McpServer {
         dryRun,
         github: false,
         actor,
+        // The caller's kind travels with their actor. Without it the run's
+        // initiator would take its kind from the *server process's*
+        // environment — recording a service token as a person, or every
+        // engineer as machinery on a host where ZUKE_ACTOR_KIND is set.
+        ...(identity?.kind === undefined ? {} : { actorKind: identity.kind }),
         readEnv: this.#readEnv,
       });
     } catch (error) {

--- a/packages/core/src/resume.ts
+++ b/packages/core/src/resume.ts
@@ -306,9 +306,23 @@ async function transitionToRunning(
     }
     const next = structuredClone(record);
     next.status = "running";
-    // The resumer becomes the record's last writer. `initiator` is deliberately
-    // *not* touched: it is the answer to who asked for this run, and a sweep
-    // picking the run up is not that. The clone carries it through untouched.
+    // A record written before initiators existed still knows who started it —
+    // in `actor`, right up until the line below overwrites it. Capture it here,
+    // the one moment the evidence is about to be destroyed, so an old run keeps
+    // its owner instead of silently acquiring the sweep that resumed it. `??=`
+    // so a record that already has one is never rewritten: that is the whole
+    // guarantee of the field.
+    next.initiator ??= {
+      actor: record.actor,
+      // Unknowable for a record from before the field; `human` is the
+      // conservative reading, and never claims machinery a policy would treat
+      // as unowned.
+      kind: "human",
+      at: record.createdAt,
+    };
+    // The resumer becomes the record's last writer. `initiator` above is
+    // deliberately not touched again: it answers who asked for this run, and a
+    // sweep picking it up is not that.
     next.actor = resumerActor;
     const at = now();
     // Give back the time the run spent parked. A run's deadline is a budget for

--- a/packages/core/src/resume.ts
+++ b/packages/core/src/resume.ts
@@ -306,6 +306,9 @@ async function transitionToRunning(
     }
     const next = structuredClone(record);
     next.status = "running";
+    // The resumer becomes the record's last writer. `initiator` is deliberately
+    // *not* touched: it is the answer to who asked for this run, and a sweep
+    // picking the run up is not that. The clone carries it through untouched.
     next.actor = resumerActor;
     const at = now();
     // Give back the time the run spent parked. A run's deadline is a budget for

--- a/packages/core/src/run_support.ts
+++ b/packages/core/src/run_support.ts
@@ -19,6 +19,7 @@ import type { SummaryEntry } from "./summary_note.ts";
 import type { RunStateWriter } from "./state/writer.ts";
 import type { StateStore } from "./state/store.ts";
 import type {
+  RunInitiator,
   SignalRecord,
   TargetRunState,
   TargetRunStatus,
@@ -77,6 +78,12 @@ export interface RunEnv {
   store?: StateStore;
   /** The run's actor, stamped on a lock holder. */
   actor: string;
+  /**
+   * Who asked for the run, when the run has a durable record to have stamped
+   * one. Absent for a store-less run, and on a record written before the field
+   * existed — {@link RunEnv.actor} is the closest answer in both cases.
+   */
+  initiator?: RunInitiator;
   /** A link to this run (CI job), stamped on a lock holder when known. */
   runUrl?: string;
   /** External signals received so far, exposed to bodies via `ctx.signals`. */

--- a/packages/core/src/runs.ts
+++ b/packages/core/src/runs.ts
@@ -139,13 +139,20 @@ export async function runsCommand(
 
   const action = options.action ?? "list";
   if (action === "list") {
-    const listed = await store.listRuns(options.query ?? {});
+    const query = options.query ?? {};
+    // `--limit` is applied by the store, and the initiator filter runs here, so
+    // letting the store truncate first would answer "whose runs are among the
+    // newest N" — usually none of them — when the question was "this actor's
+    // newest N". List unbounded, filter, then take N.
+    const listed = await store.listRuns(
+      options.initiator === undefined ? query : { ...query, limit: undefined },
+    );
     // Matched against the initiator *or* the actor it falls back to, so a run
     // recorded before the field existed is still findable by the person who
     // started it.
-    const summaries = options.initiator === undefined
-      ? listed
-      : listed.filter((s) => initiatorOf(s) === options.initiator);
+    const summaries = options.initiator === undefined ? listed : listed
+      .filter((s) => initiatorOf(s) === options.initiator)
+      .slice(0, query.limit ?? listed.length);
     if (options.counts) {
       const counts = aggregateRunCounts(summaries);
       console.log(

--- a/packages/core/src/runs.ts
+++ b/packages/core/src/runs.ts
@@ -14,13 +14,14 @@ import type { Build } from "./build.ts";
 import { defaultReadEnv } from "./internal.ts";
 import type { StateStore } from "./state/store.ts";
 import { resolveRunStore } from "./run_store.ts";
-import type {
-  RunQuery,
-  RunRecord,
-  RunStatus,
-  RunSummary,
-  TargetRunState,
-  TargetRunStatus,
+import {
+  initiatorOf,
+  type RunQuery,
+  type RunRecord,
+  type RunStatus,
+  type RunSummary,
+  type TargetRunState,
+  type TargetRunStatus,
 } from "./state/types.ts";
 import { formatDuration, table } from "./render.ts";
 import { formatSummary } from "./report.ts";
@@ -37,6 +38,15 @@ export interface RunsOptions {
   counts?: boolean;
   /** Filters for `list` — status, a target in the run, a creation time, a limit. */
   query?: RunQuery;
+  /**
+   * With `list`, keep only runs this actor started (`--initiator <name>`).
+   *
+   * Applied here rather than in {@link RunQuery} deliberately: the query goes to
+   * the store, and a store that does not know the field would answer an
+   * unfiltered list that reads exactly like a filtered one. Filtering after the
+   * list costs a little more traffic and cannot silently return the wrong runs.
+   */
+  initiator?: string;
   /**
    * `prune`: keep runs created within this many milliseconds of now; older
    * terminal runs become eligible. Omitted means no age rule.
@@ -129,7 +139,13 @@ export async function runsCommand(
 
   const action = options.action ?? "list";
   if (action === "list") {
-    const summaries = await store.listRuns(options.query ?? {});
+    const listed = await store.listRuns(options.query ?? {});
+    // Matched against the initiator *or* the actor it falls back to, so a run
+    // recorded before the field existed is still findable by the person who
+    // started it.
+    const summaries = options.initiator === undefined
+      ? listed
+      : listed.filter((s) => initiatorOf(s) === options.initiator);
     if (options.counts) {
       const counts = aggregateRunCounts(summaries);
       console.log(
@@ -320,6 +336,11 @@ export function formatRunDetail(record: RunRecord): string {
     `  target:   ${record.rootTarget}`,
     `  status:   ${record.status}`,
     `  actor:    ${record.actor}`,
+    ...(record.initiator === undefined ? [] : [
+      // Only worth a line when it says something `actor` does not: on a run
+      // nobody has resumed the two are the same string.
+      `  started:  ${record.initiator.actor} (${record.initiator.kind})`,
+    ]),
     `  created:  ${record.createdAt}`,
     `  updated:  ${record.updatedAt}`,
   ];

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -223,6 +223,7 @@ function targetContextFor(
     : inMemoryStateHandle();
   return {
     runId: env.runId,
+    ...(env.initiator === undefined ? {} : { initiator: env.initiator }),
     target: name,
     signal: env.signal,
     state: ownState,

--- a/packages/core/src/state/record.ts
+++ b/packages/core/src/state/record.ts
@@ -16,7 +16,13 @@
 import type { TargetStatus } from "../build.ts";
 import type { AnyParameter } from "../params.ts";
 import type { TargetBuilder } from "../target.ts";
-import type { RunRecord, TargetRunState, TargetRunStatus } from "./types.ts";
+import {
+  ACTOR_KINDS,
+  type ActorKind,
+  type RunRecord,
+  type TargetRunState,
+  type TargetRunStatus,
+} from "./types.ts";
 
 /** Map an executor {@link TargetStatus} onto a {@link TargetRunStatus}. */
 export function recordStatusOf(status: TargetStatus): TargetRunStatus {
@@ -58,6 +64,25 @@ export function resolveActor(
 }
 
 /**
+ * Resolve whether a person or a machine asked for a run, by the same precedence
+ * as {@link resolveActor}: the explicit `--actor-kind`, then `ZUKE_ACTOR_KIND`
+ * (which the MCP registry runner exports for an authenticated caller), else
+ * `"human"`.
+ *
+ * The default is the conservative one: a service claim is what lets a policy
+ * treat a run as unowned machinery, so it must be stated rather than guessed
+ * from an actor that happens to look like a bot. An unrecognised value is
+ * treated as unstated for the same reason.
+ */
+export function resolveActorKind(
+  explicit: string | undefined,
+  readEnv: (name: string) => string | undefined,
+): ActorKind {
+  const candidate = explicit ?? readEnv("ZUKE_ACTOR_KIND");
+  return ACTOR_KINDS.find((kind) => kind === candidate) ?? "human";
+}
+
+/**
  * A URL for the current CI run, when derivable — used as a lock holder's
  * `runUrl` so a conflict can link to who holds it. GitHub Actions only for now
  * (`GITHUB_SERVER_URL`/`GITHUB_REPOSITORY`/`GITHUB_RUN_ID`); `undefined`
@@ -88,8 +113,10 @@ export interface RunRecordInput {
   buildId?: string;
   /** The dotted name of the requested (root) target. */
   rootTarget: string;
-  /** The resolved run actor. */
+  /** The resolved run actor — the record's first writer, and its initiator. */
   actor: string;
+  /** Whether a person or a machine asked for the run (see {@link resolveActorKind}). */
+  actorKind: ActorKind;
   /** ISO-8601 timestamp used for `createdAt` and the initial `updatedAt`. */
   now: string;
   /** The planned targets, in execution/declaration order. */
@@ -139,6 +166,13 @@ export function buildRunRecord(input: RunRecordInput): RunRecord {
     // the same trap the wait deadlines avoid by being recorded once.
     ...(input.deadlineAt === undefined ? {} : { deadlineAt: input.deadlineAt }),
     actor: input.actor,
+    // Stamped once, here, and never written again: this is the whole point of
+    // the field, since `actor` above is rewritten by every later resume.
+    initiator: {
+      actor: input.actor,
+      kind: input.actorKind,
+      at: input.now,
+    },
     createdAt: input.now,
     updatedAt: input.now,
     graph,

--- a/packages/core/src/state/types.ts
+++ b/packages/core/src/state/types.ts
@@ -108,7 +108,12 @@ export interface RunInitiator {
   actor: string;
   /** Whether a person or a machine asked. Stated, never inferred from the actor. */
   kind: ActorKind;
-  /** ISO-8601 time the run was created — when this attribution was fixed. */
+  /**
+   * ISO-8601 time this attribution was fixed. The run's `createdAt` for a run
+   * stamped at creation, and the *original* run's `createdAt` for one backfilled
+   * when a resume was about to overwrite the evidence — so it dates the
+   * attribution, not the write that recorded it.
+   */
   at: string;
 }
 
@@ -550,10 +555,15 @@ function parseRunEvent(value: unknown): RunEvent {
  * Validate and narrow an optional {@link RunInitiator}, or `undefined` when the
  * record carries none (every record written before the field existed).
  *
- * A present but malformed initiator throws rather than being dropped: silently
- * reading it as "no initiator" would make a record fall back to `actor`, which
- * a resume may already have rewritten — quietly answering a question about who
- * started a run with the name of whoever last resumed it.
+ * A present but malformed initiator throws rather than being dropped. Dropping
+ * it would make the record fall back to `actor`, which a resume may already have
+ * rewritten — quietly answering "who started this run" with the name of whoever
+ * last resumed it. A throw is the louder failure: the record does not parse, so
+ * the filesystem store skips that file and the run disappears from a listing
+ * rather than appearing under the wrong name. That is the intended trade — a
+ * run you cannot see prompts a look, one attributed to the wrong person does
+ * not — but it does mean a corrupted initiator costs the whole record, so the
+ * shape written here is deliberately small.
  */
 function parseInitiator(value: unknown): RunInitiator | undefined {
   if (value === undefined) return undefined;

--- a/packages/core/src/state/types.ts
+++ b/packages/core/src/state/types.ts
@@ -87,6 +87,31 @@ export interface RunEvent {
   detail?: string;
 }
 
+/** Whether a person or a machine asked for a run (see {@link RunInitiator}). */
+export type ActorKind = "human" | "service";
+
+/** The {@link ActorKind} values, for validating an untrusted string. */
+export const ACTOR_KINDS: readonly ActorKind[] = ["human", "service"];
+
+/**
+ * Who asked for a run, stamped once when it is created and never rewritten.
+ *
+ * Distinct from {@link RunRecord.actor}, which every resume overwrites with
+ * whoever picked the run up — so on a run that suspended and was resumed by a
+ * sweep, `actor` is the sweep's service account and this is still the engineer
+ * who started it. That is the subject a run-scoped authorization rule means by
+ * "whoever started this run", and the difference a notification needs to tell a
+ * person's deploy from a scheduler's.
+ */
+export interface RunInitiator {
+  /** Who asked for the run, resolved once at creation. */
+  actor: string;
+  /** Whether a person or a machine asked. Stated, never inferred from the actor. */
+  kind: ActorKind;
+  /** ISO-8601 time the run was created — when this attribution was fixed. */
+  at: string;
+}
+
 /** What a timed-out wait does: fail, cancel the run, or run a compensation target. */
 export type WaitDisposition = "fail" | "cancel-run" | { target: string };
 
@@ -192,8 +217,21 @@ export interface RunRecord {
   rootTarget: string;
   /** The run's lifecycle status. */
   status: RunStatus;
-  /** Who started the run (resolved from `--actor`, `ZUKE_ACTOR`, or CI env). */
+  /**
+   * The run's **last writer** (resolved from `--actor`, `ZUKE_ACTOR`, or CI
+   * env). Every resume overwrites it with whoever picked the run up, so it
+   * answers "who touched this most recently", not "whose run is this" — see
+   * {@link RunRecord.initiator} for that.
+   */
   actor: string;
+  /**
+   * Who asked for the run, stamped once at creation and immutable thereafter.
+   *
+   * Absent on a record written before this field existed; such a record's
+   * {@link RunRecord.actor} is the closest answer available, and is exactly the
+   * right one on a run that was never resumed.
+   */
+  initiator?: RunInitiator;
   /** ISO-8601 timestamp when the run was created. */
   createdAt: string;
   /** ISO-8601 timestamp of the last write. */
@@ -262,8 +300,14 @@ export interface RunSummary {
   rootTarget: string;
   /** The run's lifecycle status. */
   status: RunStatus;
-  /** Who started the run. */
+  /** The run's last writer (see {@link RunRecord.actor}). */
   actor: string;
+  /**
+   * Who asked for the run (see {@link RunRecord.initiator}). Absent on a record
+   * written before the field existed, and from a store that does not project
+   * it — {@link RunSummary.actor} is the fallback in both cases.
+   */
+  initiator?: RunInitiator;
   /** ISO-8601 creation timestamp. */
   createdAt: string;
   /** ISO-8601 timestamp of the last write. */
@@ -292,6 +336,7 @@ export function toSummary(record: RunRecord): RunSummary {
     build: record.build,
     rootTarget: record.rootTarget,
     status: record.status,
+    ...(record.initiator === undefined ? {} : { initiator: record.initiator }),
     actor: record.actor,
     createdAt: record.createdAt,
     updatedAt: record.updatedAt,
@@ -501,6 +546,26 @@ function parseRunEvent(value: unknown): RunEvent {
   return event;
 }
 
+/**
+ * Validate and narrow an optional {@link RunInitiator}, or `undefined` when the
+ * record carries none (every record written before the field existed).
+ *
+ * A present but malformed initiator throws rather than being dropped: silently
+ * reading it as "no initiator" would make a record fall back to `actor`, which
+ * a resume may already have rewritten — quietly answering a question about who
+ * started a run with the name of whoever last resumed it.
+ */
+function parseInitiator(value: unknown): RunInitiator | undefined {
+  if (value === undefined) return undefined;
+  const object = asObject(value);
+  if (object === null) throw new Error("state: run initiator is not an object");
+  const kind = ACTOR_KINDS.find((k) => k === object.kind);
+  if (kind === undefined) {
+    throw new Error(`state: unknown initiator kind "${object.kind}"`);
+  }
+  return { actor: str(object, "actor"), kind, at: str(object, "at") };
+}
+
 /** Validate and narrow a {@link SignalRecord}. */
 function parseSignalRecord(value: unknown): SignalRecord {
   const object = asObject(value);
@@ -642,6 +707,8 @@ export function parseRunRecord(text: string): RunRecord {
   if (buildId !== undefined) record.buildId = buildId;
   const deadlineAt = optionalStr(object, "deadlineAt");
   if (deadlineAt !== undefined) record.deadlineAt = deadlineAt;
+  const initiator = parseInitiator(object.initiator);
+  if (initiator !== undefined) record.initiator = initiator;
   const intended = optionalStr(object, "intendedTerminal");
   if (intended !== undefined) {
     const found = RUN_STATUSES.find((s) => s === intended);
@@ -665,7 +732,7 @@ export function parseRunSummary(value: unknown): RunSummary {
   if (runStatus === undefined) {
     throw new Error(`state: unknown run status "${status}"`);
   }
-  return {
+  const summary: RunSummary = {
     id: str(object, "id"),
     build: str(object, "build"),
     rootTarget: str(object, "rootTarget"),
@@ -674,4 +741,19 @@ export function parseRunSummary(value: unknown): RunSummary {
     createdAt: str(object, "createdAt"),
     updatedAt: str(object, "updatedAt"),
   };
+  const initiator = parseInitiator(object.initiator);
+  if (initiator !== undefined) summary.initiator = initiator;
+  return summary;
+}
+
+/**
+ * Who a run is attributed to for a reader that wants its *owner* rather than
+ * its last writer: the recorded initiator, else the actor.
+ *
+ * The fallback is not a guess — on a record written before the initiator
+ * existed, and on any run that was never resumed, `actor` still holds exactly
+ * the value the initiator would have been stamped with.
+ */
+export function initiatorOf(run: RunRecord | RunSummary): string {
+  return run.initiator?.actor ?? run.actor;
 }

--- a/packages/core/src/target.ts
+++ b/packages/core/src/target.ts
@@ -35,7 +35,11 @@ import type { AnyParameter } from "./params.ts";
 import type { Configure } from "./tooling.ts";
 import { type LockHolder, lockKey } from "./state/lock.ts";
 import type { WaitTrigger } from "./wait.ts";
-import type { SignalRecord, TargetRunStatus } from "./state/types.ts";
+import type {
+  RunInitiator,
+  SignalRecord,
+  TargetRunStatus,
+} from "./state/types.ts";
 import type { SummaryEntry, SummaryPairs } from "./summary_note.ts";
 
 /**
@@ -312,6 +316,15 @@ export interface TargetOutcomeView {
 export interface TargetContext {
   /** Unique ID of this run, stable for every target in the run. */
   readonly runId: string;
+  /**
+   * Who asked for this run — stamped once when the run was created, and
+   * unchanged by any later resume, so it still names the engineer who started a
+   * deploy that a sweep has since picked up several times.
+   *
+   * Absent when the run has no durable record to have stamped one (no state
+   * store), and on a record written before the field existed.
+   */
+  readonly initiator?: RunInitiator;
   /** Dotted name of the executing target. */
   readonly target: string;
   /**

--- a/packages/core/tests/executor_test.ts
+++ b/packages/core/tests/executor_test.ts
@@ -2632,6 +2632,7 @@ async function seedResumableRun(
     order,
     params: [],
     actor: "tester",
+    actorKind: "human" as const,
     now: new Date().toISOString(),
   });
   const put = await store.putRun(record, null);

--- a/packages/core/tests/mcp_hardening_test.ts
+++ b/packages/core/tests/mcp_hardening_test.ts
@@ -947,3 +947,49 @@ Deno.test("an authenticator's kind, roles and via never reach the audit row", as
     },
   );
 });
+
+// ---- M15: the caller's kind reaches the run record -------------------------
+
+Deno.test("a run's initiator takes its kind from the caller, not the server", async () => {
+  // The kind travels with the actor. Without it the initiator would take its
+  // kind from the *server process's* environment — recording a service token as
+  // a person, or, on a host where ZUKE_ACTOR_KIND is set, every engineer as
+  // machinery. Both are wrong in a way a policy would act on.
+  const callers: Array<{ kind: "human" | "service"; env: string | undefined }> =
+    [
+      // A machine caller on a server whose own environment says nothing.
+      { kind: "service", env: undefined },
+      // A human caller on a server whose environment claims service.
+      { kind: "human", env: "service" },
+    ];
+  for (const caller of callers) {
+    await withTempStore(async (store, dir) => {
+      const build = new Recording();
+      const server = new McpServer(build, {
+        allowRun: true,
+        stateStore: store,
+        // The spawned run resolves its own store from the environment, so point
+        // it at the same directory the audit trail uses.
+        readEnv: (name) =>
+          name === "ZUKE_ACTOR_KIND"
+            ? caller.env
+            : name === "ZUKE_STATE_DIR"
+            ? `${dir}/runs`
+            : undefined,
+        authenticator: {
+          authenticate: () => ({ actor: "caller-a", kind: caller.kind }),
+        },
+      });
+      await server.handleMessage(
+        req("tools/call", { name: "run:deploy", arguments: {} }),
+      );
+      assertEquals(build.ran, ["deploy"]);
+
+      const runs = await store.listRuns({});
+      const run = runs.find((s) => s.id !== AUDIT_RUN_ID);
+      if (run === undefined) throw new Error("no run record");
+      assertEquals(run.initiator?.actor, "caller-a");
+      assertEquals(run.initiator?.kind, caller.kind, JSON.stringify(caller));
+    });
+  }
+});

--- a/packages/core/tests/state_test.ts
+++ b/packages/core/tests/state_test.ts
@@ -8,6 +8,7 @@ import {
   assertThrows,
 } from "./_assert.ts";
 import {
+  initiatorOf,
   parseRunRecord,
   parseRunSummary,
   type RunRecord,
@@ -29,6 +30,7 @@ import {
   ciRunUrl,
   recordStatusOf,
   resolveActor,
+  resolveActorKind,
 } from "../src/state/record.ts";
 import { inMemoryStateHandle, RunStateWriter } from "../src/state/writer.ts";
 import { acquireCancelLock } from "../src/state/cancel_lock.ts";
@@ -666,6 +668,7 @@ Deno.test("buildRunRecord snapshots the graph, seeds targets, excludes secrets",
     build: "B",
     rootTarget: "deploy",
     actor: "alice",
+    actorKind: "human" as const,
     now: "2026-07-17T10:00:00.000Z",
     order: [build.clean, build.deploy],
     params: params.values(),
@@ -1321,6 +1324,7 @@ Deno.test("deleting a run leaves its lock records alone", async () => {
         order: [],
         params: [],
         actor: "tester",
+        actorKind: "human" as const,
         now: new Date().toISOString(),
       }),
       null,
@@ -1543,6 +1547,7 @@ Deno.test("buildRunRecord tolerates an unnamed target and stamps optional fields
     buildId: "org/app",
     rootTarget: "work",
     actor: "alice",
+    actorKind: "human" as const,
     now: "2026-07-17T10:00:00.000Z",
     order: [anonymous],
     params: [],
@@ -1824,4 +1829,116 @@ Deno.test("parseRunRecord round-trips a target's summary notes and rejects malfo
     };
     assertThrows(() => parseRunRecord(JSON.stringify(broken)), Error, needle);
   }
+});
+
+// ---- The run initiator: stamped once, never rewritten ----------------------
+
+Deno.test("buildRunRecord stamps the initiator from the actor and kind", () => {
+  const record = buildRunRecord({
+    runId: "r1",
+    build: "Demo",
+    rootTarget: "deploy",
+    actor: "engineer-a",
+    actorKind: "service",
+    now: "2026-09-06T10:00:00.000Z",
+    order: [],
+    params: [],
+  });
+  assertEquals(record.actor, "engineer-a");
+  assertEquals(record.initiator, {
+    actor: "engineer-a",
+    kind: "service",
+    at: "2026-09-06T10:00:00.000Z",
+  });
+});
+
+Deno.test("resolveActorKind states a service claim rather than guessing it", () => {
+  const env = (vars: Record<string, string>) => (name: string) => vars[name];
+  // The explicit flag wins.
+  assertEquals(resolveActorKind("service", env({})), "service");
+  assertEquals(
+    resolveActorKind("human", env({ ZUKE_ACTOR_KIND: "service" })),
+    "human",
+  );
+  // Then the environment — which is how an MCP-spawned child inherits it.
+  assertEquals(
+    resolveActorKind(undefined, env({ ZUKE_ACTOR_KIND: "service" })),
+    "service",
+  );
+  // Absent, empty or unrecognised all read as unstated, never as a service
+  // claim: the claim is what lets a policy treat a run as unowned machinery, so
+  // a typo must not grant it.
+  for (const value of ["", "Service", "SERVICE", "robot", "true", " service"]) {
+    assertEquals(
+      resolveActorKind(undefined, env({ ZUKE_ACTOR_KIND: value })),
+      "human",
+      value,
+    );
+  }
+  assertEquals(resolveActorKind(undefined, env({})), "human");
+});
+
+Deno.test("parseRunRecord round-trips an initiator and refuses a malformed one", () => {
+  const record = buildRunRecord({
+    runId: "r1",
+    build: "Demo",
+    rootTarget: "deploy",
+    actor: "engineer-a",
+    actorKind: "human",
+    now: "2026-09-06T10:00:00.000Z",
+    order: [],
+    params: [],
+  });
+  const round = parseRunRecord(JSON.stringify(record));
+  assertEquals(round.initiator, record.initiator);
+
+  // A record written before the field existed parses, with no initiator.
+  const legacy = JSON.parse(JSON.stringify(record));
+  delete legacy.initiator;
+  assertEquals(parseRunRecord(JSON.stringify(legacy)).initiator, undefined);
+
+  // A present but malformed initiator throws rather than being dropped:
+  // silently reading it as absent would fall back to `actor`, which a resume
+  // may already have rewritten — answering "who started this" with the name of
+  // whoever last resumed it.
+  for (
+    const bad of [
+      { actor: "a", kind: "robot", at: "t" },
+      { actor: "a", at: "t" },
+      { kind: "human", at: "t" },
+      { actor: "a", kind: "human" },
+      "engineer-a",
+      42,
+    ]
+  ) {
+    const broken = JSON.parse(JSON.stringify(record));
+    broken.initiator = bad;
+    assertThrows(() => parseRunRecord(JSON.stringify(broken)));
+  }
+});
+
+Deno.test("initiatorOf falls back to the actor when no initiator was recorded", () => {
+  const record = buildRunRecord({
+    runId: "r1",
+    build: "Demo",
+    rootTarget: "deploy",
+    actor: "engineer-a",
+    actorKind: "human",
+    now: "2026-09-06T10:00:00.000Z",
+    order: [],
+    params: [],
+  });
+  assertEquals(initiatorOf(record), "engineer-a");
+
+  // On a record that predates the field, `actor` is not a guess: a run nobody
+  // resumed carries exactly the value the initiator would have been stamped
+  // with.
+  const legacy: RunRecord = { ...record };
+  delete legacy.initiator;
+  assertEquals(initiatorOf(legacy), "engineer-a");
+
+  // And once a resume has rewritten `actor`, the initiator still answers.
+  const resumed: RunRecord = { ...record, actor: "sweep-bot" };
+  assertEquals(initiatorOf(resumed), "engineer-a");
+  assertEquals(toSummary(resumed).initiator?.actor, "engineer-a");
 });

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/.codex-plugin/plugin.json
+++ b/plugins/zuke/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/skills/zuke-write-build/SKILL.md
+++ b/plugins/zuke/skills/zuke-write-build/SKILL.md
@@ -114,7 +114,8 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   lifecycle instead of `.executes(...)`; the executor starts it, waits until
   ready, then stops it in a `finally` so it never leaks. See the cheatsheet.
 - **Target context & cancellation:** a body may take a context —
-  `.executes((ctx) => …)` — with `ctx.runId`, `ctx.target`, `ctx.signal` (an
+  `.executes((ctx) => …)` — with `ctx.runId`, `ctx.initiator` (who asked for the
+  run, unchanged by a resume), `ctx.target`, `ctx.signal` (an
   `AbortSignal` fired when the run is cancelled; a plain `` $`…` `` in the body
   is `SIGTERM`'d automatically), `ctx.state`, `ctx.dryRun`, and
   `ctx.reportSummary({ … })` (`key: value` notes on the target's own row of

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -145,6 +145,7 @@ parameter is optional.
 ```ts
 deploy = target().executes(async (ctx) => {
   ctx.runId; // stable id for the whole run
+  ctx.initiator; // who ASKED for the run — { actor, kind, at }, never rewritten
   ctx.target; // "deploy"
   ctx.signal; // AbortSignal, fired when the run is cancelled
   ctx.dryRun; // true under a dry run

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -114,7 +114,8 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   lifecycle instead of `.executes(...)`; the executor starts it, waits until
   ready, then stops it in a `finally` so it never leaks. See the cheatsheet.
 - **Target context & cancellation:** a body may take a context —
-  `.executes((ctx) => …)` — with `ctx.runId`, `ctx.target`, `ctx.signal` (an
+  `.executes((ctx) => …)` — with `ctx.runId`, `ctx.initiator` (who asked for the
+  run, unchanged by a resume), `ctx.target`, `ctx.signal` (an
   `AbortSignal` fired when the run is cancelled; a plain `` $`…` `` in the body
   is `SIGTERM`'d automatically), `ctx.state`, `ctx.dryRun`, and
   `ctx.reportSummary({ … })` (`key: value` notes on the target's own row of

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -145,6 +145,7 @@ parameter is optional.
 ```ts
 deploy = target().executes(async (ctx) => {
   ctx.runId; // stable id for the whole run
+  ctx.initiator; // who ASKED for the run — { actor, kind, at }, never rewritten
   ctx.target; // "deploy"
   ctx.signal; // AbortSignal, fired when the run is cancelled
   ctx.dryRun; // true under a dry run

--- a/tests/integration/run_initiator_test.ts
+++ b/tests/integration/run_initiator_test.ts
@@ -208,3 +208,118 @@ Deno.test("a resumed run is still found by the person who started it", async () 
     assertStringIncludes(sweep.out, "No runs found.");
   });
 });
+
+// ---- Regressions from the adversarial review -------------------------------
+
+Deno.test("a legacy record keeps its starter when a resume would erase it", async () => {
+  // A record written before initiators existed still knows who started it — in
+  // `actor`, right until a resume overwrites that. Without a backfill the run
+  // would silently become the sweep's, which is the exact confusion the field
+  // exists to prevent.
+  await withStateDir(async (dir) => {
+    assertEquals(
+      (await runCli(Gated, ["approve", "--state", "--actor", "engineer-a"]))
+        .code,
+      0,
+    );
+    const id = await onlyRunId(dir);
+
+    // Strip the field, so the record reads as one written before this shipped.
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    const before = await store.getRun(id);
+    if (before === null) throw new Error("no record");
+    const legacy = { ...before.record };
+    delete legacy.initiator;
+    await store.putRun(legacy, before.version);
+    assertEquals((await recordOf(dir, id)).initiator, undefined);
+
+    // A sweep resumes it under its own identity.
+    assertEquals(
+      (await runCli(Gated, [
+        "resume",
+        id,
+        "--signal",
+        "go",
+        "--actor",
+        "sweeper-bot",
+      ])).code,
+      0,
+    );
+
+    const record = await recordOf(dir, id);
+    assertEquals(record.actor, "sweeper-bot");
+    // Captured from the actor at the moment it was about to be overwritten,
+    // dated to the original run rather than to the backfill.
+    assertEquals(record.initiator?.actor, "engineer-a");
+    assertEquals(record.initiator?.kind, "human");
+    assertEquals(record.initiator?.at, record.createdAt);
+
+    // And the filter now answers correctly in both directions.
+    assertStringIncludes(
+      (await runCli(Gated, ["runs", "list", "--initiator", "engineer-a"])).out,
+      id,
+    );
+    assertStringIncludes(
+      (await runCli(Gated, ["runs", "list", "--initiator", "sweeper-bot"])).out,
+      "No runs found.",
+    );
+  });
+});
+
+Deno.test("--initiator with --limit returns that actor's newest, not nothing", async () => {
+  // `--limit` is applied by the store and the initiator filter runs after it,
+  // so truncating first would answer "whose runs are among the newest N" —
+  // usually none of them — when the question was "this actor's newest N".
+  await withStateDir(async (dir) => {
+    assertEquals(
+      (await runCli(Simple, ["deploy", "--state", "--actor", "alice"])).code,
+      0,
+    );
+    for (let i = 0; i < 3; i++) {
+      assertEquals(
+        (await runCli(Simple, ["deploy", "--state", "--actor", "bob"])).code,
+        0,
+      );
+    }
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    const all = await store.listRuns({});
+    assertEquals(all.length, 4);
+    const aliceRun = all.find((s) => s.initiator?.actor === "alice");
+    if (aliceRun === undefined) throw new Error("no run for alice");
+
+    // Alice's single run is the oldest of the four, so a store-side limit of 2
+    // would have hidden it entirely.
+    const limited = await runCli(Simple, [
+      "runs",
+      "list",
+      "--initiator",
+      "alice",
+      "--limit",
+      "2",
+    ]);
+    assertEquals(limited.code, 0);
+    assertStringIncludes(limited.out, aliceRun.id);
+
+    // The limit still bounds the result for an actor who has more than it.
+    const bobs = await runCli(Simple, [
+      "runs",
+      "list",
+      "--initiator",
+      "bob",
+      "--limit",
+      "2",
+    ]);
+    assertEquals(bobs.out.trim().split("\n").length, 3); // header + 2 rows
+  });
+});
+
+Deno.test("both new flags are in the CLI surface", async () => {
+  // They drive `--list --json` and the generated shell completions, so a flag
+  // missing from the registry is invisible to every tool that reads it.
+  const { code, out } = await runCli(Simple, ["--list", "--json"]);
+  assertEquals(code, 0);
+  const surface = JSON.parse(out);
+  const names = surface.flags.map((f: { name: string }) => f.name);
+  assertEquals(names.includes("--actor-kind"), true, out);
+  assertEquals(names.includes("--initiator"), true, out);
+});

--- a/tests/integration/run_initiator_test.ts
+++ b/tests/integration/run_initiator_test.ts
@@ -1,0 +1,210 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Integration tests for a run's **initiator** — who asked for the run, as
+ * distinct from `actor`, which every resume rewrites with whoever picked the run
+ * up.
+ *
+ * What these prove that a unit test cannot: the whole CLI path stamps the
+ * initiator once, a real suspend-and-resume under a *different* actor leaves it
+ * alone while moving `actor`, and `runs show` / `runs list --initiator` read it
+ * back from the persisted record.
+ *
+ * @module
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import {
+  Build,
+  defaultStateHost,
+  externalSignal,
+  FileSystemStateStore,
+  target,
+} from "../../packages/core/mod.ts";
+import { runCli, withStateDir } from "./_harness.ts";
+
+/** The id of the (single) run the CLI persisted under `dir`. */
+async function onlyRunId(dir: string): Promise<string> {
+  const store = new FileSystemStateStore(dir, defaultStateHost);
+  const runs = await store.listRuns({});
+  assertEquals(runs.length, 1);
+  return runs[0].id;
+}
+
+/** The persisted record for run `id`. */
+async function recordOf(dir: string, id: string) {
+  const store = new FileSystemStateStore(dir, defaultStateHost);
+  const got = await store.getRun(id);
+  if (got === null) throw new Error(`no run record for ${id}`);
+  return got.record;
+}
+
+/** A build that parks on a signal, so a second process can resume it. */
+class Gated extends Build {
+  approve = target()
+    .waitsFor((s) => s.on(externalSignal("go")))
+    .executes(() => {});
+}
+
+/** A build that just runs, for the non-suspending cases. */
+class Simple extends Build {
+  deploy = target().description("Deploy").executes(() => {});
+}
+
+Deno.test("a run records who started it, beside its last writer", async () => {
+  await withStateDir(async (dir) => {
+    const { code } = await runCli(Simple, [
+      "deploy",
+      "--state",
+      "--actor",
+      "engineer-a",
+    ]);
+    assertEquals(code, 0);
+    const record = await recordOf(dir, await onlyRunId(dir));
+    assertEquals(record.actor, "engineer-a");
+    assertEquals(record.initiator?.actor, "engineer-a");
+    // Unstated, so the conservative default — never inferred from the name.
+    assertEquals(record.initiator?.kind, "human");
+    assertEquals(record.initiator?.at, record.createdAt);
+  });
+});
+
+Deno.test("--actor-kind states a service claim", async () => {
+  await withStateDir(async (dir) => {
+    const { code } = await runCli(Simple, [
+      "deploy",
+      "--state",
+      "--actor",
+      "nightly",
+      "--actor-kind",
+      "service",
+    ]);
+    assertEquals(code, 0);
+    const record = await recordOf(dir, await onlyRunId(dir));
+    assertEquals(record.initiator?.kind, "service");
+  });
+});
+
+Deno.test("a typo in --actor-kind fails the run rather than defaulting", async () => {
+  // An explicit flag was typed by someone who meant something by it, so a
+  // misspelling is an error — unlike ZUKE_ACTOR_KIND, which stays lenient
+  // because it can arrive from anywhere.
+  const { code, err } = await runCli(Simple, [
+    "deploy",
+    "--actor-kind",
+    "robot",
+  ]);
+  assertEquals(code, 1);
+  assertStringIncludes(err, "--actor-kind must be one of: human, service");
+  assertStringIncludes(err, "robot");
+});
+
+Deno.test("a resume moves the actor and leaves the initiator alone", async () => {
+  // The guarantee the whole field exists for: an engineer starts a deploy, it
+  // parks on a gate, and a sweep's service account resumes it. `actor` becomes
+  // the sweep; the answer to "whose run is this" must not.
+  await withStateDir(async (dir) => {
+    const first = await runCli(Gated, [
+      "approve",
+      "--state",
+      "--actor",
+      "engineer-a",
+    ]);
+    assertEquals(first.code, 0);
+    const id = await onlyRunId(dir);
+    assertEquals((await recordOf(dir, id)).status, "suspended");
+
+    // A second process, under a different identity, delivers the signal.
+    const resumed = await runCli(Gated, [
+      "resume",
+      id,
+      "--signal",
+      "go",
+      "--actor",
+      "sweep-bot",
+    ]);
+    assertEquals(resumed.code, 0, resumed.err);
+
+    const record = await recordOf(dir, id);
+    assertEquals(record.status, "succeeded");
+    assertEquals(record.actor, "sweep-bot"); // the last writer moved
+    assertEquals(record.initiator?.actor, "engineer-a"); // the owner did not
+    assertEquals(record.initiator?.kind, "human");
+  });
+});
+
+Deno.test("runs show names the initiator, and runs list filters by it", async () => {
+  await withStateDir(async (dir) => {
+    assertEquals(
+      (await runCli(Simple, ["deploy", "--state", "--actor", "engineer-a"]))
+        .code,
+      0,
+    );
+    const id = await onlyRunId(dir);
+
+    const shown = await runCli(Simple, ["runs", "show", id]);
+    assertEquals(shown.code, 0);
+    assertStringIncludes(shown.out, "started:  engineer-a (human)");
+
+    // The filter matches the run its initiator started…
+    const mine = await runCli(Simple, [
+      "runs",
+      "list",
+      "--initiator",
+      "engineer-a",
+    ]);
+    assertEquals(mine.code, 0);
+    assertStringIncludes(mine.out, id);
+
+    // …and excludes it for anyone else, rather than silently listing everything.
+    const theirs = await runCli(Simple, [
+      "runs",
+      "list",
+      "--initiator",
+      "someone-else",
+    ]);
+    assertEquals(theirs.code, 0);
+    assertStringIncludes(theirs.out, "No runs found.");
+  });
+});
+
+Deno.test("a resumed run is still found by the person who started it", async () => {
+  // The filter reads the initiator, not the actor — so a run a sweep has
+  // touched is still the engineer's when they go looking for it.
+  await withStateDir(async (dir) => {
+    assertEquals(
+      (await runCli(Gated, ["approve", "--state", "--actor", "engineer-a"]))
+        .code,
+      0,
+    );
+    const id = await onlyRunId(dir);
+    assertEquals(
+      (await runCli(Gated, [
+        "resume",
+        id,
+        "--signal",
+        "go",
+        "--actor",
+        "sweep",
+      ]))
+        .code,
+      0,
+    );
+
+    const mine = await runCli(Gated, [
+      "runs",
+      "list",
+      "--initiator",
+      "engineer-a",
+    ]);
+    assertStringIncludes(mine.out, id);
+
+    // The sweep that resumed it did not become its owner.
+    const sweep = await runCli(Gated, ["runs", "list", "--initiator", "sweep"]);
+    assertStringIncludes(sweep.out, "No runs found.");
+  });
+});


### PR DESCRIPTION
## What & why

A run record had **one** attribution field meaning **two** different things.

At creation, `actor` answered "who asked for this run". Then every resume overwrote it — `resume.ts` does `next.actor = resumerActor` — so after a single sweep picked up a suspended deploy, the engineer who started it was gone from the record entirely.

That is correct for one of the two meanings: an already-resumed error and the audit trail both want the last writer. It is useless for the other:

- **A long-running deploy loses its owner.** A run that suspends on a gate and is resumed five times reports the sweep. To keep the human, a build has to record them itself in a target's meta on its first step, and every consumer has to know to look there.
- **Nothing can tell a person's run from a scheduler's.** #473 added `kind` to the MCP identity and exports it to a spawned child, but nothing read it — there was no field for it to land in.
- **Run-scoped authorization has no subject.** "The person who started this run, or an operator" is the natural rule for cancelling, signalling or forcing a target on someone else's run, and it cannot be written against a field the last sweep rewrote.

This adds an immutable `initiator` beside `actor`: who asked, whether a person or a machine, and when. Stamped once when the record is built, never written again.

### Decisions worth naming

- **Additive, not a redefinition.** Making `actor` immutable and adding a `lastWriter` would read better, but it silently changes the meaning of a shipped public field for every existing reader. `initiator` is optional, so a record written before it exists still parses — and on a run nobody resumed, its `actor` is the exact value the initiator would have held.
- **The kind is stated, never inferred.** From `--actor-kind`, else `ZUKE_ACTOR_KIND` (which the MCP registry already exports for an authenticated caller), else `human`. A service claim is what would let a policy treat a run as unowned machinery, so guessing it from an actor that happens to look like a bot is the wrong direction to be wrong in. A typo in the flag fails the run; an unrecognised environment value reads as unstated — the flag was typed by someone who meant something by it, the variable can arrive from anywhere.
- **`runs list --initiator` filters after listing, not through the store query.** A store that did not know the field would answer an unfiltered list that reads exactly like a filtered one. Filtering client-side costs a little more traffic and cannot silently return the wrong runs.

This is item 5.2 of a maintainer proposal, pulled forward because the role-policy work (15.2) needs a subject for its default rule.

## What the adversarial review found

Four reviewers attacked the change across immutability, parsing and compatibility, the CLI surface, and semantics. Every finding was reproduced against the running code before being fixed, and each fix has a regression test that was mutation-checked — removed the fix, watched the test fail, restored it.

**The MCP server recorded the wrong kind** (high). It resolved the caller's identity and used its actor, but never passed the kind — so the initiator took its kind from the *server process's* environment. Provable in both directions: an authenticated service token recorded as a person, and, on a host where the variable is set, every engineer recorded as machinery. The registry server already threaded it, so the two MCP entry points disagreed. This is the finding I would least have wanted to ship: a policy treating service-initiated runs as unowned would have acted on either error.

**Listing by initiator returned the wrong runs** (high). The store applies `--limit`, and the filter ran after it, so the limit truncated the list before the filter saw it. Asking for one actor's newest two runs answered with whichever of the newest two overall happened to be theirs — demonstrably none, in the reviewer's reproduction. The query now goes to the store without the limit, and the limit applies after filtering.

**A pre-upgrade record lost its owner on the next resume** (high). Such a record still knows who started it — in `actor`, right until a resume overwrites it. The initiator is now captured at exactly that moment, and only when absent, so a record that already has one is still never rewritten. It is dated to the original run rather than to the backfill.

**The state contract did not carry the field** (high). `docs/state-api.md` never mentioned `initiator`, so a conforming server would omit it from summaries and every listing would fall back to `actor` — wrong for precisely the resumed runs the field exists for.

Also fixed: the two new flags were missing from the flag registry, so they were absent from the JSON build surface and from generated shell completions; the executor's kind option was typed as a bare `string`, so a typo type-checked and silently recorded `human`; and two comments described intent rather than behaviour.

## Testing

19 new tests. Unit coverage of the type, the parser and the kind resolution; an integration file driving real builds through the CLI, including a genuine suspend-and-resume under a different actor proving `actor` moves to the sweep while the initiator does not; and MCP coverage proving the caller's kind reaches the record rather than the server's environment.

`deno task ci`: 21/21 targets, 4198 tests, 98.6% lines and 97.4% branches against a 95% gate.

## Related issues

Closes #474

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a [Conventional Commit](https://www.conventionalcommits.org/) (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (durable state, the run context, the state API contract, JSDoc).
- [x] Public API changes were regenerated with the API docs target.
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with type guards instead).
- [x] Agent skills updated and the plugin version bumped in all four manifests (0.39.0 to 0.40.0).
