### PR TITLE
feat(core): force a target's outcome on a live run

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.40.0",
+      "version": "0.41.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/cspell.json
+++ b/cspell.json
@@ -241,6 +241,7 @@
     "prepatch",
     "rundll",
     "strapline",
+    "unforceable",
     "WHATWG",
     "wordmark",
     "xhigh",

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -714,8 +714,8 @@ that finished.
 `Build` exposes one override per subsystem, each documented on its own page:
 [`stateStore()`](./state.md), [`deadline()`](./state.md),
 [`remoteCache()`](./caching.md), [`recoverWith()`](./self-healing.md),
-[`registry()`](./registry.md), [`mcpAuth()`](./mcp.md) and
-[`mcpIdentity()`](./mcp.md).
+[`registry()`](./registry.md), [`mcpAuth()`](./mcp.md),
+[`mcpIdentity()`](./mcp.md) and [`unforceable()`](./state.md).
 
 **External ordering — `override extraEdges(targets)`.** Return `[before, after]`
 pairs to impose soft ordering on the plan beyond the per-target `.before()` /

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -65,6 +65,7 @@ below) attach to whichever launcher word you install them for.
 | `./zuke runs show <id> [--json]`                                        | Show one run's full per-target status and metadata.                                                         |
 | `./zuke runs prune [--keep <age>] [--keep-last <n>] [--dry-run]`        | Delete old terminal run records; never touches non-terminal runs.                                           |
 | `./zuke cancel <id> [--actor <name>]`                                   | Cancel a run and run its compensations ([details](./orchestration.md#cancellation--compensation--oncancel)). |
+| `./zuke force <id> <target> --outcome skipped\|succeeded [--reason <why>]` | Settle one target of a live run without running it ([details](./state.md#forcing-a-target--overrides)). |
 | `./zuke register [--actor <name>] [--json]`                             | Register this build in the build registry (`--json` prints the written descriptor).                         |
 | `./zuke doc <spec>`                                                     | Print a package's API docs (`deno doc <spec>`) from an isolated empty directory.                            |
 | `./zuke outdated [--exit-code]`                                         | Report the JSR packages the lock resolves behind their latest release (needs the network).                  |

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -128,12 +128,14 @@ from the build's declared parameters — a `required` parameter is required,
 parameters exactly like the CLI (MCP argument → the environment → the declared
 default) and returns the target's captured output with a pass/fail marker.
 
-With `--allow-run` a store also exposes three **mutating** run-state tools:
+With `--allow-run` a store also exposes four **mutating** run-state tools:
 `signal_run` (deliver an external signal and resume a suspended run,
 exactly-once), `resume_check` (re-check suspended runs — predicate waits and
-timeouts), and `cancel_run` (cancel a run and run its
-[compensations](./orchestration.md#cancellation--compensation--oncancel)). They
-are the MCP counterparts of `./zuke resume` and `./zuke cancel`. Each runs the
+timeouts), `cancel_run` (cancel a run and run its
+[compensations](./orchestration.md#cancellation--compensation--oncancel)), and
+`force_target` (settle one target without running it — see
+[forcing a target](./state.md#forcing-a-target--overrides)). They are the MCP
+counterparts of `./zuke resume`, `./zuke cancel` and `./zuke force`. Each runs the
 target's code (a resume continues it; a cancel runs its compensations), so it is
 gated by the same [allow-list and operator-token](#authorization) policy as a
 `run:` tool and appended to the [audit log](#audit-log).
@@ -188,7 +190,8 @@ ZUKE_OPERATOR_TOKEN=… ./zuke mcp --http 7777 \
 ## Audit log
 
 With a store configured, **every mutating or denied tool call** (`run:<target>`,
-`signal_run`, `resume_check`, `cancel_run`) is appended to an audit trail: the
+`signal_run`, `resume_check`, `cancel_run`, `force_target`) is appended to an
+audit trail: the
 time, the tool, the resolved **actor**, the outcome (`ok` / `denied` / `error`),
 and the call's arguments. Arguments are **redacted** — the operator token is
 dropped and every `.secret()` parameter's value is masked — before anything is

--- a/docs/state.md
+++ b/docs/state.md
@@ -136,6 +136,44 @@ or `--status`; those still go to the store. The field is optional: a record
 written before it existed has none, and `actor` is then the closest answer —
 which is the exact one for a run nobody ever resumed.
 
+### Forcing a target — `overrides`
+
+An operator sometimes has to take a step off a live run: one that cannot
+succeed, or one a person completed by hand.
+
+```sh
+zuke force <run-id> <target> --outcome skipped|succeeded [--reason "…"]
+```
+
+That records an entry under `overrides`, keyed by target name, carrying the
+outcome, who forced it, when, and why. The executor reads it when it reaches the
+target and settles it **without running the body** — ahead of the target's
+`onlyWhen` conditions and its cache, because forcing is a decision that outranks
+what the build would work out for itself. Dependents proceed either way.
+
+The two outcomes differ in what a later cancellation does. A forced `succeeded`
+asserts the target's effects exist, so it is compensated like any other
+succeeded target; a forced `skipped` never happened, so it is not — exactly like
+a target a condition skipped.
+
+It is refused, naming the rule, when the target has already settled (the record
+is the account of what happened, and rewriting a settled outcome would make it
+untrue), when the run is terminal, when the target is not in the run's graph, or
+when the build declared it off-limits:
+
+```ts
+class CD extends Build {
+  override unforceable() {
+    return [this.applyProduction]; // references, so a rename cannot empty this
+  }
+}
+```
+
+An override lands for any target the run has not started yet, which in practice
+means the next resume — that is the process which loads the record after the
+force was written. `zuke runs show` prints every override, and over
+[MCP](./mcp.md) the same operation is the `force_target` tool.
+
 A record also carries an append-only `events` array — the **audit trail** of
 [MCP](./mcp.md) tool calls against the run (time, tool, actor, outcome, redacted
 args). It is empty for a plain run and populated by the MCP server;

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "zuke",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build)."
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1129,7 +1129,7 @@ class Build
 
     ```ts
     class CD extends Build {
-      applyProduction = target().executes(…);
+      applyProduction = target().executes(() => applyTerraform());
       override unforceable() {
         return [this.applyProduction];
       }
@@ -4365,7 +4365,7 @@ type ForEachFactory<Item> = (item: Item, index: number) => Record<string, Target
   stage implicitly depends on the one declared before it, so an item's stages
   run in insertion order.
 
-type ForceDenial = "unknown_run" | "run_terminal" | "unknown_target" | "already_settled" | "unforceable" | "write_failed"
+type ForceDenial = "unknown_run" | "run_terminal" | "unknown_target" | "already_settled" | "unforceable" | "has_effects" | "foreign_run" | "write_failed"
   Why a force was refused. Each maps to a message naming the target, so an
   operator learns which rule stopped them rather than that "it failed".
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -304,6 +304,14 @@ function findCycle(targets: Map<string, TargetBuilder>): string[] | null
   @return
       the cycle as a path of names (e.g. `["a", "b", "a"]`) or `null`.
 
+async function forceTarget(build: Build, options: ForceOptions): Promise<ForceResult>
+  Record an operator's forced outcome for one target of a run.
+
+  The write is a compare-and-swap, retried against a re-read record, so two
+  operators forcing different targets at once cannot lose each other's
+  decision. Every refusal is re-checked on each attempt, because the thing that
+  beat us to the record may be the target settling.
+
 function generateCi(pipeline: CiPipeline, provider: CiProvider): string
   Render `pipeline` as the YAML configuration for `provider`:
   `.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, or
@@ -1102,6 +1110,28 @@ class Build
             return { actor: claims.sub, kind: "human", roles: claims.roles };
           },
         };
+      }
+    }
+    ```
+  unforceable(): TargetBuilder[]
+    Targets an operator may not force with `zuke force` — the steps whose
+    body must actually run, whatever a live incident looks like.
+
+    Forcing settles a target without executing it: `skipped` takes a step off
+    the plan, `succeeded` records that a person did it by hand. That is the
+    right tool for a step that cannot succeed and the wrong one for a step
+    whose whole purpose is to be the thing that happened — a production apply,
+    a signing step, a migration. Naming those here refuses the force rather
+    than trusting an operator under pressure to remember which is which.
+
+    Returns target references, not names, so renaming a target keeps the
+    list correct instead of silently emptying it.
+
+    ```ts
+    class CD extends Build {
+      applyProduction = target().executes(…);
+      override unforceable() {
+        return [this.applyProduction];
       }
     }
     ```
@@ -3097,6 +3127,36 @@ interface ForEachSpec
   configure?: Configure<ForEachSettings>
     Optional fan-out settings (concurrency, per-item failure isolation).
 
+interface ForceOptions
+  Options for {@link forceTarget}.
+
+  runId: string
+    The run to act on.
+  target: string
+    The dotted target name to force.
+  outcome: ForcedOutcome
+    What the target should settle to without running.
+  reason?: string
+    Why — recorded on the override and shown by `zuke runs show`.
+  actor?: string
+    Who to attribute the decision to (`--actor`); resolved as for a run.
+  stateStore?: StateStore | false
+    The durable store the run lives in; resolved as for a run when absent.
+  readEnv?: (name: string) => string | undefined
+    Reads an environment variable (injectable for tests).
+
+interface ForceResult
+  The result of a {@link forceTarget} call.
+
+  ok: boolean
+    Whether the override was recorded.
+  denial?: ForceDenial
+    Why it was refused, when it was.
+  message: string
+    A message naming the target and the rule, suitable for an operator.
+  override?: TargetOverride
+    The override as recorded, when it was.
+
 interface GlobOptions
   Options for {@link glob}.
 
@@ -3718,6 +3778,13 @@ interface RunRecord
     Absent on a record written before this field existed; such a record's
     {@link RunRecord.actor} is the closest answer available, and is exactly the
     right one on a run that was never resumed.
+  overrides?: Record<string, TargetOverride>
+    Operator-forced target outcomes, keyed by dotted target name (see
+    {@link TargetOverride}). Absent until something is forced.
+
+    Read when the executor reaches the target, so an override lands for any
+    target the run has not started yet — in practice on the next resume, since
+    that is the process that loads the record after the force was written.
   createdAt: string
     ISO-8601 timestamp when the run was created.
   updatedAt: string
@@ -4032,6 +4099,25 @@ interface TargetOutcomeView
     aggregating target can read a dependency's test counts, not only its
     verdict. Durable: present after a resume too.
 
+interface TargetOverride
+  An operator's decision to settle a target without running it — recorded on
+  the run so the executor honours it and the trail says who decided.
+
+  Two shapes of intervention, both of which a build cannot express itself:
+  `skipped` takes a step off the plan that cannot succeed, and `succeeded`
+  marks one that a person completed by hand. Dependents proceed either way; the
+  difference is what a later cancellation compensates, since only the second
+  asserts that the target's effects exist.
+
+  outcome: ForcedOutcome
+    What the target settles to when the executor reaches it.
+  actor: string
+    Who forced it (a resolved actor).
+  at: string
+    ISO-8601 time the override was recorded.
+  reason?: string
+    Why, when the operator gave a reason.
+
 interface TargetReport
   One row of the end-of-build summary.
 
@@ -4278,6 +4364,13 @@ type ForEachFactory<Item> = (item: Item, index: number) => Record<string, Target
   The returned record's keys are stage names and its values are targets; each
   stage implicitly depends on the one declared before it, so an item's stages
   run in insertion order.
+
+type ForceDenial = "unknown_run" | "run_terminal" | "unknown_target" | "already_settled" | "unforceable" | "write_failed"
+  Why a force was refused. Each maps to a message naming the target, so an
+  operator learns which rule stopped them rather than that "it failed".
+
+type ForcedOutcome = "skipped" | "succeeded"
+  What an operator may force a target to, without running it.
 
 type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue; }
   A JSON-serialisable value — the only thing that may be persisted in a

--- a/llms.txt
+++ b/llms.txt
@@ -48,6 +48,7 @@ Reserved commands:
 - `resume` — Resume a suspended run (or --check all suspended runs)
 - `runs` — List, show, or prune persisted run records
 - `cancel` — Cancel a run and run its compensations
+- `force` — Force a target of a run to skipped or succeeded
 - `register` — Register this build in the build registry
 - `doc` — Print a package's API docs (deno doc), isolated from the repo
 - `outdated` — Report JSR packages the lock resolves behind their latest
@@ -78,6 +79,8 @@ Option flags:
 - `--since` — With runs list, keep only runs created at/after this time
 - `--limit` — With runs list, return at most this many runs (newest)
 - `--initiator` — With runs list, keep only runs this actor started
+- `--outcome` — With force, what the target settles to: skipped or succeeded
+- `--reason` — With force, why the target was forced (recorded on the run)
 - `--counts` — With runs list, print aggregate counts (total + per status)
 - `--keep` — With runs prune, keep runs newer than this age (e.g. 90d)
 - `--keep-last` — With runs prune, always keep the newest N terminal runs

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1183,7 +1183,7 @@ class Build
 
     ```ts
     class CD extends Build {
-      applyProduction = target().executes(…);
+      applyProduction = target().executes(() => applyTerraform());
       override unforceable() {
         return [this.applyProduction];
       }
@@ -4419,7 +4419,7 @@ type ForEachFactory<Item> = (item: Item, index: number) => Record<string, Target
   stage implicitly depends on the one declared before it, so an item's stages
   run in insertion order.
 
-type ForceDenial = "unknown_run" | "run_terminal" | "unknown_target" | "already_settled" | "unforceable" | "write_failed"
+type ForceDenial = "unknown_run" | "run_terminal" | "unknown_target" | "already_settled" | "unforceable" | "has_effects" | "foreign_run" | "write_failed"
   Why a force was refused. Each maps to a message naming the target, so an
   operator learns which rule stopped them rather than that "it failed".
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -358,6 +358,14 @@ function findCycle(targets: Map<string, TargetBuilder>): string[] | null
   @return
       the cycle as a path of names (e.g. `["a", "b", "a"]`) or `null`.
 
+async function forceTarget(build: Build, options: ForceOptions): Promise<ForceResult>
+  Record an operator's forced outcome for one target of a run.
+
+  The write is a compare-and-swap, retried against a re-read record, so two
+  operators forcing different targets at once cannot lose each other's
+  decision. Every refusal is re-checked on each attempt, because the thing that
+  beat us to the record may be the target settling.
+
 function generateCi(pipeline: CiPipeline, provider: CiProvider): string
   Render `pipeline` as the YAML configuration for `provider`:
   `.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, or
@@ -1156,6 +1164,28 @@ class Build
             return { actor: claims.sub, kind: "human", roles: claims.roles };
           },
         };
+      }
+    }
+    ```
+  unforceable(): TargetBuilder[]
+    Targets an operator may not force with `zuke force` — the steps whose
+    body must actually run, whatever a live incident looks like.
+
+    Forcing settles a target without executing it: `skipped` takes a step off
+    the plan, `succeeded` records that a person did it by hand. That is the
+    right tool for a step that cannot succeed and the wrong one for a step
+    whose whole purpose is to be the thing that happened — a production apply,
+    a signing step, a migration. Naming those here refuses the force rather
+    than trusting an operator under pressure to remember which is which.
+
+    Returns target references, not names, so renaming a target keeps the
+    list correct instead of silently emptying it.
+
+    ```ts
+    class CD extends Build {
+      applyProduction = target().executes(…);
+      override unforceable() {
+        return [this.applyProduction];
       }
     }
     ```
@@ -3151,6 +3181,36 @@ interface ForEachSpec
   configure?: Configure<ForEachSettings>
     Optional fan-out settings (concurrency, per-item failure isolation).
 
+interface ForceOptions
+  Options for {@link forceTarget}.
+
+  runId: string
+    The run to act on.
+  target: string
+    The dotted target name to force.
+  outcome: ForcedOutcome
+    What the target should settle to without running.
+  reason?: string
+    Why — recorded on the override and shown by `zuke runs show`.
+  actor?: string
+    Who to attribute the decision to (`--actor`); resolved as for a run.
+  stateStore?: StateStore | false
+    The durable store the run lives in; resolved as for a run when absent.
+  readEnv?: (name: string) => string | undefined
+    Reads an environment variable (injectable for tests).
+
+interface ForceResult
+  The result of a {@link forceTarget} call.
+
+  ok: boolean
+    Whether the override was recorded.
+  denial?: ForceDenial
+    Why it was refused, when it was.
+  message: string
+    A message naming the target and the rule, suitable for an operator.
+  override?: TargetOverride
+    The override as recorded, when it was.
+
 interface GlobOptions
   Options for {@link glob}.
 
@@ -3772,6 +3832,13 @@ interface RunRecord
     Absent on a record written before this field existed; such a record's
     {@link RunRecord.actor} is the closest answer available, and is exactly the
     right one on a run that was never resumed.
+  overrides?: Record<string, TargetOverride>
+    Operator-forced target outcomes, keyed by dotted target name (see
+    {@link TargetOverride}). Absent until something is forced.
+
+    Read when the executor reaches the target, so an override lands for any
+    target the run has not started yet — in practice on the next resume, since
+    that is the process that loads the record after the force was written.
   createdAt: string
     ISO-8601 timestamp when the run was created.
   updatedAt: string
@@ -4086,6 +4153,25 @@ interface TargetOutcomeView
     aggregating target can read a dependency's test counts, not only its
     verdict. Durable: present after a resume too.
 
+interface TargetOverride
+  An operator's decision to settle a target without running it — recorded on
+  the run so the executor honours it and the trail says who decided.
+
+  Two shapes of intervention, both of which a build cannot express itself:
+  `skipped` takes a step off the plan that cannot succeed, and `succeeded`
+  marks one that a person completed by hand. Dependents proceed either way; the
+  difference is what a later cancellation compensates, since only the second
+  asserts that the target's effects exist.
+
+  outcome: ForcedOutcome
+    What the target settles to when the executor reaches it.
+  actor: string
+    Who forced it (a resolved actor).
+  at: string
+    ISO-8601 time the override was recorded.
+  reason?: string
+    Why, when the operator gave a reason.
+
 interface TargetReport
   One row of the end-of-build summary.
 
@@ -4332,6 +4418,13 @@ type ForEachFactory<Item> = (item: Item, index: number) => Record<string, Target
   The returned record's keys are stage names and its values are targets; each
   stage implicitly depends on the one declared before it, so an item's stages
   run in insertion order.
+
+type ForceDenial = "unknown_run" | "run_terminal" | "unknown_target" | "already_settled" | "unforceable" | "write_failed"
+  Why a force was refused. Each maps to a message naming the target, so an
+  operator learns which rule stopped them rather than that "it failed".
+
+type ForcedOutcome = "skipped" | "succeeded"
+  What an operator may force a target to, without running it.
 
 type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue; }
   A JSON-serialisable value — the only thing that may be persisted in a

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -165,9 +165,16 @@ export {
 } from "./src/state/run_lease.ts";
 export { parseDuration } from "./src/duration.ts";
 export {
+  type ForceDenial,
+  type ForceOptions,
+  type ForceResult,
+  forceTarget,
+} from "./src/force.ts";
+export {
   type ActorKind,
   type EffectState,
   type EffectStatus,
+  type ForcedOutcome,
   initiatorOf,
   type RunEvent,
   type RunEventOutcome,
@@ -178,6 +185,7 @@ export {
   type RunStatus,
   type RunSummary,
   type SignalRecord,
+  type TargetOverride,
   type TargetRunState,
   type TargetRunStatus,
   type WaitDisposition,

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -350,6 +350,33 @@ export class Build {
   mcpAuth(): McpAuthenticator | undefined {
     return undefined;
   }
+
+  /**
+   * Targets an operator may **not** force with `zuke force` — the steps whose
+   * body must actually run, whatever a live incident looks like.
+   *
+   * Forcing settles a target without executing it: `skipped` takes a step off
+   * the plan, `succeeded` records that a person did it by hand. That is the
+   * right tool for a step that cannot succeed and the wrong one for a step
+   * whose whole purpose is to be the thing that happened — a production apply,
+   * a signing step, a migration. Naming those here refuses the force rather
+   * than trusting an operator under pressure to remember which is which.
+   *
+   * Returns target **references**, not names, so renaming a target keeps the
+   * list correct instead of silently emptying it.
+   *
+   * ```ts
+   * class CD extends Build {
+   *   applyProduction = target().executes(…);
+   *   override unforceable() {
+   *     return [this.applyProduction];
+   *   }
+   * }
+   * ```
+   */
+  unforceable(): TargetBuilder[] {
+    return [];
+  }
 }
 
 /**

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -367,7 +367,7 @@ export class Build {
    *
    * ```ts
    * class CD extends Build {
-   *   applyProduction = target().executes(…);
+   *   applyProduction = target().executes(() => applyTerraform());
    *   override unforceable() {
    *     return [this.applyProduction];
    *   }

--- a/packages/core/src/cancel.ts
+++ b/packages/core/src/cancel.ts
@@ -52,12 +52,13 @@ import type { StateStore } from "./state/store.ts";
 import { resolveRunStore } from "./run_store.ts";
 import { acquireCancelLock } from "./state/cancel_lock.ts";
 import { resolveActor } from "./state/record.ts";
-import type {
-  RunEvent,
-  RunRecord,
-  RunStatus,
-  SignalRecord,
-  TargetRunStatus,
+import {
+  isTerminalRunStatus,
+  type RunEvent,
+  type RunRecord,
+  type RunStatus,
+  type SignalRecord,
+  type TargetRunStatus,
 } from "./state/types.ts";
 
 /** How many times a conflicting cancel CAS is re-read and retried. */
@@ -113,12 +114,6 @@ export function compensationSummary(
  */
 export function cancelledElsewhere(runId: string): string {
   return `Run ${runId} cancelled by another process — stopping.`;
-}
-
-/** A run status past which nothing more happens. */
-function isTerminal(status: RunStatus): boolean {
-  return status === "succeeded" || status === "failed" ||
-    status === "cancelled";
 }
 
 /** An empty compensation outcome (nothing ran, nothing failed). */
@@ -275,7 +270,16 @@ export async function runCompensations(
     }
     const status = record.targets[name]?.status;
     const possiblySucceeded = degraded && isUnproven(status);
-    if (status !== "succeeded" && !possiblySucceeded) continue;
+    // A forced `succeeded` counts even before the run has reached the target.
+    // The operator asserted the target's effects exist — that is the whole
+    // difference between forcing `succeeded` and forcing `skipped` — so a
+    // cancel that lands in between must still unwind them. Reading only the
+    // status would make the two forced outcomes indistinguishable here, while
+    // the row is still `pending`.
+    const forcedSucceeded = record.overrides?.[name]?.outcome === "succeeded";
+    if (status !== "succeeded" && !possiblySucceeded && !forcedSucceeded) {
+      continue;
+    }
     if (t.onCancel_ === undefined) continue;
     // The thunk is user code: a throw here must be recorded, not allowed to
     // escape and wedge the run mid-cancel (cleanup stays maximal).
@@ -741,7 +745,7 @@ export async function settleExternally(
   // silently skipped: unlike a sweep, this path was handed one run by name, so
   // the caller asked about a run that is not this build's to unwind.
   const initial = await loadOwnedRun(store, runId, "cancel", readEnv);
-  if (isTerminal(initial.record.status)) {
+  if (isTerminalRunStatus(initial.record.status)) {
     reporter.info(
       `Run ${runId} is already ${initial.record.status}; nothing to ` +
         `${terminal === "cancelled" ? "cancel" : "settle"}.`,
@@ -941,7 +945,7 @@ async function transitionToCancelling(
   let record = initial.record;
   let version = initial.version;
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-    if (isTerminal(record.status)) return "noop";
+    if (isTerminalRunStatus(record.status)) return "noop";
     if (record.status === "cancelling") return "recover";
     const next = structuredClone(record);
     next.status = "cancelling";
@@ -981,7 +985,7 @@ async function finalizeCancelled(
 ): Promise<void> {
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     const loaded = await store.getRun(id);
-    if (loaded === null || isTerminal(loaded.record.status)) return;
+    if (loaded === null || isTerminalRunStatus(loaded.record.status)) return;
     const at = now();
     const next = structuredClone(loaded.record);
     next.status = terminal;

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -200,6 +200,8 @@ export interface ParsedArgs {
   forceRunId?: string;
   /** `force`: the target to settle (second positional). */
   forceTarget?: string;
+  /** `force`: a third positional, which the command does not take. */
+  forceExtra?: string;
   /** `force`: what the target settles to (`--outcome`). */
   outcome?: string;
   /** `force`: why it was forced (`--reason`). */
@@ -543,13 +545,18 @@ export function parseArgs(
       parsed.forceRunId = arg;
     } else if (parsed.force && parsed.forceTarget === undefined) {
       parsed.forceTarget = arg;
+    } else if (parsed.force && parsed.forceExtra === undefined) {
+      // Kept rather than ignored, so a third positional is an error naming
+      // itself instead of silently changing what the command does.
+      parsed.forceExtra = arg;
     } else if (parsed.doc && parsed.docSpec === undefined) {
       // `doc` takes the spec to document as its positional.
       parsed.docSpec = arg;
     } else if (
       parsed.target === undefined && !parsed.graph && !parsed.generateCi &&
       !parsed.completions && !parsed.mcp && !parsed.resume && !parsed.runs &&
-      !parsed.cancel && !parsed.register && !parsed.doc && !parsed.outdated
+      !parsed.cancel && !parsed.force && !parsed.register && !parsed.doc &&
+      !parsed.outdated
     ) {
       if (arg === GRAPH_COMMAND) parsed.graph = true;
       else if (arg === GENERATE_CI_COMMAND) parsed.generateCi = true;
@@ -1061,6 +1068,14 @@ async function runCancel(build: Build, parsed: ParsedArgs): Promise<number> {
  * the flags into options and the result into an exit code.
  */
 async function runForce(build: Build, parsed: ParsedArgs): Promise<number> {
+  if (parsed.forceExtra !== undefined) {
+    console.error(
+      `force: unexpected argument "${parsed.forceExtra}". ` +
+        `Usage: zuke force <run-id> <target> --outcome skipped|succeeded ` +
+        `[--reason <why>] [--actor <name>]`,
+    );
+    return 1;
+  }
   if (parsed.forceRunId === undefined || parsed.forceTarget === undefined) {
     console.error(
       "Usage: zuke force <run-id> <target> --outcome skipped|succeeded " +

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -10,6 +10,7 @@ import { type Build, discoverGroups, discoverTargets } from "./build.ts";
 import { discoverCiFiles, syncCiFiles } from "./ci.ts";
 import { isEntryModule } from "./entry.ts";
 import { messageOf } from "./internal.ts";
+import { forceTarget } from "./force.ts";
 import { isCI } from "./host.ts";
 import { GraphError, validateGraph } from "./graph.ts";
 import { InsecureBackendUrlError } from "./http.ts";
@@ -40,6 +41,7 @@ import {
   COMPLETIONS_COMMAND,
   DEFAULT_TARGET,
   DOC_COMMAND,
+  FORCE_COMMAND,
   GENERATE_CI_COMMAND,
   GRAPH_COMMAND,
   MCP_COMMAND,
@@ -56,6 +58,7 @@ import { parseDuration } from "./duration.ts";
 import { registerCommand } from "./registry/register.ts";
 import {
   ACTOR_KINDS,
+  FORCED_OUTCOMES,
   isRunStatus,
   RUN_STATUS_NAMES,
   type RunQuery,
@@ -189,8 +192,18 @@ export interface ParsedArgs {
   keepLast?: string;
   /** The `cancel` command was requested (cancel a run and run its compensations). */
   cancel: boolean;
+  /** True when the `force` command was requested. */
+  force: boolean;
   /** The run id to cancel (the positional after `cancel`). */
   cancelRunId?: string;
+  /** `force`: the run to act on (first positional). */
+  forceRunId?: string;
+  /** `force`: the target to settle (second positional). */
+  forceTarget?: string;
+  /** `force`: what the target settles to (`--outcome`). */
+  outcome?: string;
+  /** `force`: why it was forced (`--reason`). */
+  reason?: string;
   /** The `register` command was requested (record this build in the registry). */
   register: boolean;
   /** The `doc` command was requested (print a package's API docs, isolated). */
@@ -334,6 +347,8 @@ const VALUE_FLAGS: ReadonlyMap<string, ValueFlag> = new Map([
   ["actor", { set: (p, v) => (p.actor = v) }],
   ["actor-kind", { set: (p, v) => (p.actorKind = v) }],
   ["initiator", { set: (p, v) => (p.initiator = v) }],
+  ["outcome", { set: (p, v) => (p.outcome = v) }],
+  ["reason", { set: (p, v) => (p.reason = v), keepEmpty: true }],
   ["signal", { set: (p, v) => (p.signal = v) }],
   ["data", { set: (p, v) => (p.data = v), keepEmpty: true }],
   ["status", { set: (p, v) => (p.runStatus = v) }],
@@ -393,6 +408,7 @@ export function parseArgs(
     resumeDegraded: false,
     runs: false,
     cancel: false,
+    force: false,
     register: false,
     doc: false,
     outdated: false,
@@ -522,6 +538,11 @@ export function parseArgs(
     } else if (parsed.cancel && parsed.cancelRunId === undefined) {
       // `cancel` takes the run id as its positional.
       parsed.cancelRunId = arg;
+    } else if (parsed.force && parsed.forceRunId === undefined) {
+      // `force` takes the run id, then the target.
+      parsed.forceRunId = arg;
+    } else if (parsed.force && parsed.forceTarget === undefined) {
+      parsed.forceTarget = arg;
     } else if (parsed.doc && parsed.docSpec === undefined) {
       // `doc` takes the spec to document as its positional.
       parsed.docSpec = arg;
@@ -537,6 +558,7 @@ export function parseArgs(
       else if (arg === RESUME_COMMAND) parsed.resume = true;
       else if (arg === RUNS_COMMAND) parsed.runs = true;
       else if (arg === CANCEL_COMMAND) parsed.cancel = true;
+      else if (arg === FORCE_COMMAND) parsed.force = true;
       else if (arg === REGISTER_COMMAND) parsed.register = true;
       else if (arg === DOC_COMMAND) parsed.doc = true;
       else if (arg === OUTDATED_COMMAND) parsed.outdated = true;
@@ -567,6 +589,7 @@ Usage:
   deno run -A zuke.ts runs show <run-id> [--json]
   deno run -A zuke.ts runs prune [--keep <age>] [--keep-last <n>] [--dry-run]
   deno run -A zuke.ts cancel <run-id> [--actor <name>]
+  deno run -A zuke.ts force <run-id> <target> --outcome skipped|succeeded [--reason <why>]
   deno run -A zuke.ts register [--actor <name>] [--json]
   deno run -A zuke.ts doc <spec>
   deno run -A zuke.ts outdated [--exit-code]
@@ -696,6 +719,11 @@ Options:
   --initiator <n>   With runs list, keep only runs <n> started. Matches the
                     recorded initiator, falling back to the actor on a run
                     recorded before initiators existed.
+  --outcome <o>     With force, what the target settles to without running:
+                    skipped (take the step off the plan) or succeeded (a person
+                    did it by hand — a later cancel compensates it).
+  --reason <why>    With force, why — recorded on the run beside who forced it,
+                    and shown by runs show.
   --limit <n>       With runs list, return at most this many runs (the newest).
   --counts          With runs list, print aggregate counts (total + per status).
   --keep <age>      With runs prune, keep runs newer than this age (e.g. 90d);
@@ -1025,6 +1053,49 @@ async function runCancel(build: Build, parsed: ParsedArgs): Promise<number> {
   }
 }
 
+/**
+ * Run the `force` command: settle one target of a live run without running it.
+ *
+ * Validation lives in {@link forceTarget}, which re-checks it against a
+ * freshly-read record on every compare-and-swap attempt; this layer only turns
+ * the flags into options and the result into an exit code.
+ */
+async function runForce(build: Build, parsed: ParsedArgs): Promise<number> {
+  if (parsed.forceRunId === undefined || parsed.forceTarget === undefined) {
+    console.error(
+      "Usage: zuke force <run-id> <target> --outcome skipped|succeeded " +
+        "[--reason <why>] [--actor <name>]",
+    );
+    return 1;
+  }
+  const outcome = FORCED_OUTCOMES.find((o) => o === parsed.outcome);
+  if (outcome === undefined) {
+    console.error(
+      `force: --outcome must be one of: ${FORCED_OUTCOMES.join(", ")}` +
+        (parsed.outcome === undefined ? "." : ` (got "${parsed.outcome}").`),
+    );
+    return 1;
+  }
+  try {
+    const result = await forceTarget(build, {
+      runId: parsed.forceRunId,
+      target: parsed.forceTarget,
+      outcome,
+      ...(parsed.reason === undefined ? {} : { reason: parsed.reason }),
+      actor: parsed.actor,
+    });
+    if (!result.ok) {
+      console.error(result.message);
+      return 1;
+    }
+    console.log(result.message);
+    return 0;
+  } catch (error) {
+    console.error(messageOf(error));
+    return 1;
+  }
+}
+
 /** Run the `register` command: record this build in the build registry. */
 async function runRegister(build: Build, parsed: ParsedArgs): Promise<number> {
   try {
@@ -1313,6 +1384,9 @@ async function runCommand(
   }
   if (parsed.cancel) {
     return await runCancel(build, parsed);
+  }
+  if (parsed.force) {
+    return await runForce(build, parsed);
   }
   if (parsed.register) {
     return await runRegister(build, parsed);

--- a/packages/core/src/cli_spec.ts
+++ b/packages/core/src/cli_spec.ts
@@ -44,6 +44,9 @@ export const RUNS_COMMAND = "runs";
 /** The `cancel` command: cancel a run and run its compensations. */
 export const CANCEL_COMMAND = "cancel";
 
+/** The `force` command: settle a target of a live run without running it. */
+export const FORCE_COMMAND = "force";
+
 /** The `register` command: record this build in the build registry. */
 export const REGISTER_COMMAND = "register";
 
@@ -76,6 +79,10 @@ export const RESERVED_COMMANDS: readonly ReservedCommand[] = [
   {
     name: CANCEL_COMMAND,
     description: "Cancel a run and run its compensations",
+  },
+  {
+    name: FORCE_COMMAND,
+    description: "Force a target of a run to skipped or succeeded",
   },
   {
     name: REGISTER_COMMAND,
@@ -181,6 +188,14 @@ export const BUILTIN_FLAGS: readonly BuiltinFlag[] = [
   {
     name: "--initiator",
     description: "With runs list, keep only runs this actor started",
+  },
+  {
+    name: "--outcome",
+    description: "With force, what the target settles to: skipped or succeeded",
+  },
+  {
+    name: "--reason",
+    description: "With force, why the target was forced (recorded on the run)",
   },
   {
     name: "--counts",

--- a/packages/core/src/force.ts
+++ b/packages/core/src/force.ts
@@ -20,13 +20,17 @@
 import type { Build } from "./build.ts";
 import { discoverTargets } from "./build.ts";
 import { messageOf } from "./internal.ts";
+import { assertOwnsRun, resolveBuildId } from "./ownership.ts";
 import { resolveActor } from "./state/record.ts";
 import { resolveRunStore } from "./run_store.ts";
 import type { StateStore } from "./state/store.ts";
-import type {
-  ForcedOutcome,
-  RunRecord,
-  TargetOverride,
+import type { TargetBuilder } from "./target.ts";
+import {
+  type ForcedOutcome,
+  isTerminalRunStatus,
+  type RunRecord,
+  type TargetOverride,
+  type TargetRunStatus,
 } from "./state/types.ts";
 
 /** How many times a losing compare-and-swap is retried before giving up. */
@@ -60,6 +64,8 @@ export type ForceDenial =
   | "unknown_target"
   | "already_settled"
   | "unforceable"
+  | "has_effects"
+  | "foreign_run"
   | "write_failed";
 
 /** The result of a {@link forceTarget} call. */
@@ -74,15 +80,35 @@ export interface ForceResult {
   override?: TargetOverride;
 }
 
-/** Target statuses that mean the target is done and cannot be taken off the plan. */
-const SETTLED = new Set(["succeeded", "failed", "skipped"]);
+/**
+ * Target statuses a force may not touch: the three settled ones, and `running`.
+ *
+ * `running` is here because a force promises the body will not run, and for a
+ * target a live process is already executing that promise is already broken —
+ * the operator would be told the step was taken off the plan while it is
+ * finishing. A hung target belongs to the reaper, which returns it to `pending`
+ * and makes it forceable again.
+ */
+const STARTED: ReadonlySet<TargetRunStatus> = new Set<TargetRunStatus>([
+  "running",
+  "succeeded",
+  "failed",
+  "skipped",
+]);
 
-/** Run statuses that mean there is no longer a plan to act on. */
-const TERMINAL = new Set(["succeeded", "failed", "cancelled"]);
-
-/** Whether `build` declared `target` off-limits to a force. */
+/**
+ * Whether `build` declared `target` off-limits to a force.
+ *
+ * A fan-out's per-item stages are named `parent[item].stage` at run time, so no
+ * `TargetBuilder` reference can denote one. Declaring the parent unforceable
+ * therefore covers its stages too — otherwise the guard would protect the
+ * target that only schedules work while leaving the ones that do it exposed.
+ */
 function isUnforceable(build: Build, target: string): boolean {
-  return build.unforceable().some((t) => t.name_ === target);
+  return build.unforceable().some((t) =>
+    t.name_ !== undefined &&
+    (t.name_ === target || target.startsWith(`${t.name_}[`))
+  );
 }
 
 /**
@@ -97,12 +123,28 @@ function denialFor(
   build: Build,
   record: RunRecord,
   target: string,
+  buildId: string | undefined,
+  outcome: ForcedOutcome,
+  targets: ReadonlyMap<string, TargetBuilder>,
 ): { denial: ForceDenial; message: string } | null {
-  if (TERMINAL.has(record.status)) {
+  // The same ownership gate `resume` and `cancel` apply, and for a sharper
+  // reason here: `unforceable()` is read from the build in *this* process, so
+  // acting on another build's run would check the wrong safety declaration
+  // entirely — a template shared across services would let one service force a
+  // target its owner had declared off-limits.
+  try {
+    assertOwnsRun(record, buildId);
+  } catch (error) {
+    return { denial: "foreign_run", message: messageOf(error) };
+  }
+  // `cancelling` is refused alongside the terminal statuses: the run is being
+  // torn down, so a target forced onto it would be promised a settlement the
+  // cancel walk will never deliver.
+  if (isTerminalRunStatus(record.status) || record.status === "cancelling") {
     return {
       denial: "run_terminal",
-      message: `Run ${record.id} is already ${record.status}; ` +
-        `there is nothing left to force.`,
+      message: `Run ${record.id} is ${record.status}; ` +
+        `there is no longer a plan to take a target off.`,
     };
   }
   const state = record.targets[target];
@@ -112,12 +154,31 @@ function denialFor(
       message: `Run ${record.id} has no target "${target}".`,
     };
   }
-  if (SETTLED.has(state.status)) {
+  if (STARTED.has(state.status)) {
     return {
       denial: "already_settled",
-      message: `Target "${target}" already ${state.status} in run ` +
-        `${record.id}. Forcing it would make the record say something that ` +
-        `did not happen.`,
+      message: state.status === "running"
+        ? `Target "${target}" is running in run ${record.id}. Forcing it ` +
+          `cannot stop a body that has already started; cancel the run, or ` +
+          `wait for the process to be reaped.`
+        : `Target "${target}" already ${state.status} in run ${record.id}. ` +
+          `Forcing it would make the record say something that did not happen.`,
+    };
+  }
+  // The same refusal `isCacheable` and `ServiceBuilder.effect` already make: a
+  // path that settles a target without running its body drops every declared
+  // effect — not defers it, drops it, with nothing recorded as owed and the run
+  // reporting success. Forcing `skipped` is fine, because a skipped target's
+  // effects are not owed either.
+  const declared = targets.get(target);
+  if (outcome === "succeeded" && (declared?.effects_.length ?? 0) > 0) {
+    const names = declared?.effects_.map((e) => `"${e.name}"`).join(", ");
+    return {
+      denial: "has_effects",
+      message: `Target "${target}" declares effect(s) ${names}, which a ` +
+        `forced success would drop rather than defer — nothing would record ` +
+        `them as owed and the run would report success. Force it skipped, or ` +
+        `let the body run.`,
     };
   }
   if (isUnforceable(build, target)) {
@@ -156,13 +217,12 @@ export async function forceTarget(
         "ZUKE_STATE_URL, or override stateStore().",
     };
   }
-  // Called for its side effect: target names are recovered by introspecting the
-  // instance's fields, so without this a target builder's name is unset and
-  // `unforceable()` would match nothing — silently allowing a force the build
-  // declared off-limits. The targets themselves come from the record below,
-  // which is what the executor will actually read.
-  discoverTargets(build);
+  // Also binds each builder's name as a side effect, which `unforceable()`
+  // depends on: without it a target builder's name is unset, nothing matches,
+  // and a force the build declared off-limits would silently be allowed.
+  const targets = discoverTargets(build);
   const actor = resolveActor(options.actor, readEnv);
+  const buildId = resolveBuildId(readEnv);
 
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     const loaded = await store.getRun(options.runId);
@@ -173,7 +233,14 @@ export async function forceTarget(
         message: `force: no run ${options.runId} in the store.`,
       };
     }
-    const refused = denialFor(build, loaded.record, options.target);
+    const refused = denialFor(
+      build,
+      loaded.record,
+      options.target,
+      buildId,
+      options.outcome,
+      targets,
+    );
     if (refused !== null) return { ok: false, ...refused };
 
     const at = new Date().toISOString();

--- a/packages/core/src/force.ts
+++ b/packages/core/src/force.ts
@@ -1,0 +1,220 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Forcing a target's outcome on a live run: `zuke force <run-id> <target>`.
+ *
+ * An operator sometimes has to take a step off a run — one that cannot succeed,
+ * or one a person completed by hand. This records that decision on the run so
+ * the executor honours it when it reaches the target, and so the trail says who
+ * decided and why.
+ *
+ * Everything it refuses, it refuses *before* writing: a settled target, a run
+ * that has finished, a target the build declared unforceable, or one that is
+ * not in the run's graph. The record is the account of what happened, and an
+ * override that could rewrite a settled outcome would make that account untrue.
+ *
+ * @module
+ */
+
+import type { Build } from "./build.ts";
+import { discoverTargets } from "./build.ts";
+import { messageOf } from "./internal.ts";
+import { resolveActor } from "./state/record.ts";
+import { resolveRunStore } from "./run_store.ts";
+import type { StateStore } from "./state/store.ts";
+import type {
+  ForcedOutcome,
+  RunRecord,
+  TargetOverride,
+} from "./state/types.ts";
+
+/** How many times a losing compare-and-swap is retried before giving up. */
+const MAX_RETRIES = 5;
+
+/** Options for {@link forceTarget}. */
+export interface ForceOptions {
+  /** The run to act on. */
+  runId: string;
+  /** The dotted target name to force. */
+  target: string;
+  /** What the target should settle to without running. */
+  outcome: ForcedOutcome;
+  /** Why — recorded on the override and shown by `zuke runs show`. */
+  reason?: string;
+  /** Who to attribute the decision to (`--actor`); resolved as for a run. */
+  actor?: string;
+  /** The durable store the run lives in; resolved as for a run when absent. */
+  stateStore?: StateStore | false;
+  /** Reads an environment variable (injectable for tests). */
+  readEnv?: (name: string) => string | undefined;
+}
+
+/**
+ * Why a force was refused. Each maps to a message naming the target, so an
+ * operator learns which rule stopped them rather than that "it failed".
+ */
+export type ForceDenial =
+  | "unknown_run"
+  | "run_terminal"
+  | "unknown_target"
+  | "already_settled"
+  | "unforceable"
+  | "write_failed";
+
+/** The result of a {@link forceTarget} call. */
+export interface ForceResult {
+  /** Whether the override was recorded. */
+  ok: boolean;
+  /** Why it was refused, when it was. */
+  denial?: ForceDenial;
+  /** A message naming the target and the rule, suitable for an operator. */
+  message: string;
+  /** The override as recorded, when it was. */
+  override?: TargetOverride;
+}
+
+/** Target statuses that mean the target is done and cannot be taken off the plan. */
+const SETTLED = new Set(["succeeded", "failed", "skipped"]);
+
+/** Run statuses that mean there is no longer a plan to act on. */
+const TERMINAL = new Set(["succeeded", "failed", "cancelled"]);
+
+/** Whether `build` declared `target` off-limits to a force. */
+function isUnforceable(build: Build, target: string): boolean {
+  return build.unforceable().some((t) => t.name_ === target);
+}
+
+/**
+ * Everything that can refuse a force, checked against a freshly-read record.
+ * Returns the denial, or `null` when the override may be written.
+ *
+ * Re-run on every compare-and-swap attempt rather than once up front: a
+ * conflicting write may be the target settling, and forcing a target that
+ * settled while we were deciding is exactly what must not happen.
+ */
+function denialFor(
+  build: Build,
+  record: RunRecord,
+  target: string,
+): { denial: ForceDenial; message: string } | null {
+  if (TERMINAL.has(record.status)) {
+    return {
+      denial: "run_terminal",
+      message: `Run ${record.id} is already ${record.status}; ` +
+        `there is nothing left to force.`,
+    };
+  }
+  const state = record.targets[target];
+  if (state === undefined) {
+    return {
+      denial: "unknown_target",
+      message: `Run ${record.id} has no target "${target}".`,
+    };
+  }
+  if (SETTLED.has(state.status)) {
+    return {
+      denial: "already_settled",
+      message: `Target "${target}" already ${state.status} in run ` +
+        `${record.id}. Forcing it would make the record say something that ` +
+        `did not happen.`,
+    };
+  }
+  if (isUnforceable(build, target)) {
+    return {
+      denial: "unforceable",
+      message: `Target "${target}" is declared unforceable by this build, ` +
+        `so its body must run rather than be settled by hand.`,
+    };
+  }
+  return null;
+}
+
+/**
+ * Record an operator's forced outcome for one target of a run.
+ *
+ * The write is a compare-and-swap, retried against a re-read record, so two
+ * operators forcing different targets at once cannot lose each other's
+ * decision. Every refusal is re-checked on each attempt, because the thing that
+ * beat us to the record may be the target settling.
+ */
+export async function forceTarget(
+  build: Build,
+  options: ForceOptions,
+): Promise<ForceResult> {
+  const readEnv = options.readEnv ?? ((name) => Deno.env.get(name));
+  const store = resolveRunStore(
+    options.stateStore,
+    build.stateStore(),
+    readEnv,
+  );
+  if (store === undefined) {
+    return {
+      ok: false,
+      denial: "unknown_run",
+      message: "force: no state store is configured. Set ZUKE_STATE_DIR / " +
+        "ZUKE_STATE_URL, or override stateStore().",
+    };
+  }
+  // Called for its side effect: target names are recovered by introspecting the
+  // instance's fields, so without this a target builder's name is unset and
+  // `unforceable()` would match nothing — silently allowing a force the build
+  // declared off-limits. The targets themselves come from the record below,
+  // which is what the executor will actually read.
+  discoverTargets(build);
+  const actor = resolveActor(options.actor, readEnv);
+
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    const loaded = await store.getRun(options.runId);
+    if (loaded === null) {
+      return {
+        ok: false,
+        denial: "unknown_run",
+        message: `force: no run ${options.runId} in the store.`,
+      };
+    }
+    const refused = denialFor(build, loaded.record, options.target);
+    if (refused !== null) return { ok: false, ...refused };
+
+    const at = new Date().toISOString();
+    const override: TargetOverride = {
+      outcome: options.outcome,
+      actor,
+      at,
+    };
+    if (options.reason !== undefined && options.reason !== "") {
+      override.reason = options.reason;
+    }
+    const next = structuredClone(loaded.record);
+    next.overrides = { ...next.overrides, [options.target]: override };
+    next.updatedAt = at;
+
+    let result;
+    try {
+      result = await store.putRun(next, loaded.version);
+    } catch (error) {
+      return {
+        ok: false,
+        denial: "write_failed",
+        message: `force: could not record the override: ${messageOf(error)}`,
+      };
+    }
+    if (result.ok) {
+      const why = override.reason === undefined ? "" : ` (${override.reason})`;
+      return {
+        ok: true,
+        override,
+        message: `Forced "${options.target}" to ${options.outcome} in run ` +
+          `${options.runId}${why}. It will settle without running when the ` +
+          `run next reaches it.`,
+      };
+    }
+    // Someone else wrote first: loop, re-read, and re-check every refusal.
+  }
+  return {
+    ok: false,
+    denial: "write_failed",
+    message: `force: run ${options.runId} kept changing under us; ` +
+      `nothing was recorded. Try again.`,
+  };
+}

--- a/packages/core/src/mcp/runtools.ts
+++ b/packages/core/src/mcp/runtools.ts
@@ -20,11 +20,13 @@ import { AlreadyResumedError, resumeCheck, resumeRun } from "../resume.ts";
 import { LockConflictError } from "../state/lock.ts";
 import type { StateStore } from "../state/store.ts";
 import {
+  FORCED_OUTCOMES,
   isRunStatus,
   RUN_STATUS_NAMES,
   type RunQuery,
   toJsonValue,
 } from "../state/types.ts";
+import { forceTarget } from "../force.ts";
 import type { JsonValue } from "../target.ts";
 import { AUDIT_RUN_ID } from "./audit.ts";
 import type { McpTool } from "./protocol.ts";
@@ -165,6 +167,36 @@ const MUTATING_TOOLS: readonly McpTool[] = [
     },
     annotations: { title: "Cancel run", destructiveHint: true },
   },
+  {
+    name: "force_target",
+    description:
+      "Settle one target of a run without running it: skipped (take the step " +
+      "off the plan) or succeeded (a person did it by hand). Refused for a " +
+      "target that already settled, or one the build declares unforceable.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        runId: { type: "string", description: "The run to act on." },
+        target: { type: "string", description: "The dotted target name." },
+        outcome: {
+          type: "string",
+          enum: ["skipped", "succeeded"],
+          description: "What the target settles to without running.",
+        },
+        reason: {
+          type: "string",
+          description: "Why — recorded on the run beside who forced it.",
+        },
+        operatorToken: {
+          type: "string",
+          description:
+            "Operator token, required if the run's target is protected.",
+        },
+      },
+      required: ["runId", "target", "outcome"],
+    },
+    annotations: { title: "Force target", destructiveHint: true },
+  },
 ];
 
 /**
@@ -184,7 +216,7 @@ export const RUN_STATE_TOOL_NAMES: readonly string[] = [
 /** Whether `name` is one of the mutating run-state tools (audited, gated). */
 export function isMutatingRunTool(name: string): boolean {
   return name === "signal_run" || name === "resume_check" ||
-    name === "cancel_run";
+    name === "cancel_run" || name === "force_target";
 }
 
 /** Read an optional string argument, or `undefined` when absent/not a string. */
@@ -270,6 +302,7 @@ export async function callRunStateTool(
   if (name === "signal_run") return await signalRun(deps, args);
   if (name === "resume_check") return await resumeCheckTool(deps, args);
   if (name === "cancel_run") return await cancelRunTool(deps, args);
+  if (name === "force_target") return await forceTargetTool(deps, args);
   return null;
 }
 
@@ -412,6 +445,51 @@ async function resumeCheckTool(
     }
   }
   return jsonResult({ ok: failed === 0, checked, failed });
+}
+
+/** `force_target`: settle one target without running it, exactly like `zuke force`. */
+async function forceTargetTool(
+  deps: RunToolDeps,
+  args: Record<string, unknown>,
+): Promise<RunToolResult> {
+  const runId = stringArg(args, "runId");
+  if (runId === undefined) {
+    return jsonResult({ error: "missing_argument", argument: "runId" }, true);
+  }
+  const target = stringArg(args, "target");
+  if (target === undefined) {
+    return jsonResult({ error: "missing_argument", argument: "target" }, true);
+  }
+  const outcome = FORCED_OUTCOMES.find((o) => o === stringArg(args, "outcome"));
+  if (outcome === undefined) {
+    return jsonResult(
+      { error: "invalid_outcome", allowed: FORCED_OUTCOMES },
+      true,
+    );
+  }
+  const denied = await runDenial(deps, args, runId);
+  if (denied !== null) return denied;
+  const reason = stringArg(args, "reason");
+  try {
+    const result = await forceTarget(deps.build, {
+      runId,
+      target,
+      outcome,
+      ...(reason === undefined ? {} : { reason }),
+      stateStore: deps.store,
+      actor: deps.actor,
+      readEnv: deps.readEnv,
+    });
+    return jsonResult({
+      ok: result.ok,
+      runId,
+      target,
+      ...(result.denial === undefined ? {} : { error: result.denial }),
+      message: result.message,
+    }, !result.ok);
+  } catch (error) {
+    return structuredError(error, runId);
+  }
 }
 
 /** `cancel_run`: cancel a run and run its compensations, exactly like `zuke cancel`. */

--- a/packages/core/src/resume.ts
+++ b/packages/core/src/resume.ts
@@ -395,6 +395,12 @@ function expiredWait(
   nowMs: number,
 ): { name: string; waitingFor: WaitState } | null {
   for (const [name, state] of Object.entries(record.targets)) {
+    // An operator's forced outcome outranks the deadline, as it outranks the
+    // target's conditions and its cache. Timing out a gate someone has just
+    // forced would run the `onTimeout` disposition — a cancel, or a rollback
+    // target — against the decision they had already made, and the force would
+    // never take effect at all.
+    if (record.overrides?.[name] !== undefined) continue;
     const deadline = state.waitingFor?.deadline;
     if (
       state.status === "waiting" && state.waitingFor !== undefined &&

--- a/packages/core/src/runs.ts
+++ b/packages/core/src/runs.ts
@@ -351,6 +351,14 @@ export function formatRunDetail(record: RunRecord): string {
     `  created:  ${record.createdAt}`,
     `  updated:  ${record.updatedAt}`,
   ];
+  const overrides = Object.entries(record.overrides ?? {});
+  if (overrides.length > 0) {
+    lines.push("  forced:");
+    for (const [name, o] of overrides) {
+      const why = o.reason === undefined ? "" : ` — ${o.reason}`;
+      lines.push(`    ${name}: ${o.outcome} by ${o.actor} at ${o.at}${why}`);
+    }
+  }
   if (record.degraded) {
     // The one thing an operator asked to override a refused resume needs to see.
     lines.push(

--- a/packages/core/src/runs.ts
+++ b/packages/core/src/runs.ts
@@ -16,9 +16,9 @@ import type { StateStore } from "./state/store.ts";
 import { resolveRunStore } from "./run_store.ts";
 import {
   initiatorOf,
+  isTerminalRunStatus,
   type RunQuery,
   type RunRecord,
-  type RunStatus,
   type RunSummary,
   type TargetRunState,
   type TargetRunStatus,
@@ -67,18 +67,6 @@ export interface RunsOptions {
   readEnv?: (name: string) => string | undefined;
 }
 
-/** The run statuses past which nothing more happens — the only prunable ones. */
-const TERMINAL_STATUSES: readonly RunStatus[] = [
-  "succeeded",
-  "failed",
-  "cancelled",
-];
-
-/** Whether a run has reached a terminal (prunable) status. */
-function isTerminalStatus(status: RunStatus): boolean {
-  return TERMINAL_STATUSES.includes(status);
-}
-
 /** Options for {@link selectRunsToPrune}. */
 export interface PruneRules {
   /** Keep runs created within this many ms of `nowMs`; omitted means no age rule. */
@@ -101,7 +89,7 @@ export function selectRunsToPrune(
   nowMs: number,
 ): string[] {
   const cutoff = rules.keepMs === undefined ? undefined : nowMs - rules.keepMs;
-  const terminal = summaries.filter((s) => isTerminalStatus(s.status));
+  const terminal = summaries.filter((s) => isTerminalRunStatus(s.status));
   const toPrune: string[] = [];
   terminal.forEach((s, index) => {
     if (rules.keepLast !== undefined && index < rules.keepLast) return;

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -389,6 +389,23 @@ async function runTarget(
   const { services, env } = ctx;
   const name = t.name_ ?? "<unnamed>";
 
+  // An operator's forced outcome outranks everything the build would decide:
+  // the point of forcing a target is to settle it without running, so its
+  // conditions and cache are not consulted either. Read from the record the run
+  // is executing against, so a force lands for any target this process has not
+  // started yet.
+  const forced = env.writer?.snapshot().overrides?.[name];
+  if (forced !== undefined) {
+    reporter.info(
+      `${name}: forced ${forced.outcome} by ${forced.actor}` +
+        (forced.reason === undefined ? "" : ` — ${forced.reason}`),
+    );
+    return {
+      status: forced.outcome === "skipped" ? "skipped" : "passed",
+      ms: 0,
+    };
+  }
+
   for (const condition of t.onlyWhen_) {
     if (!(await condition())) return { status: "skipped", ms: 0 };
   }

--- a/packages/core/src/state/types.ts
+++ b/packages/core/src/state/types.ts
@@ -87,6 +87,36 @@ export interface RunEvent {
   detail?: string;
 }
 
+/** What an operator may force a target to, without running it. */
+export type ForcedOutcome = "skipped" | "succeeded";
+
+/** The {@link ForcedOutcome} values, for validating an untrusted string. */
+export const FORCED_OUTCOMES: readonly ForcedOutcome[] = [
+  "skipped",
+  "succeeded",
+];
+
+/**
+ * An operator's decision to settle a target without running it — recorded on
+ * the run so the executor honours it and the trail says who decided.
+ *
+ * Two shapes of intervention, both of which a build cannot express itself:
+ * `skipped` takes a step off the plan that cannot succeed, and `succeeded`
+ * marks one that a person completed by hand. Dependents proceed either way; the
+ * difference is what a later cancellation compensates, since only the second
+ * asserts that the target's effects exist.
+ */
+export interface TargetOverride {
+  /** What the target settles to when the executor reaches it. */
+  outcome: ForcedOutcome;
+  /** Who forced it (a resolved actor). */
+  actor: string;
+  /** ISO-8601 time the override was recorded. */
+  at: string;
+  /** Why, when the operator gave a reason. */
+  reason?: string;
+}
+
 /** Whether a person or a machine asked for a run (see {@link RunInitiator}). */
 export type ActorKind = "human" | "service";
 
@@ -237,6 +267,15 @@ export interface RunRecord {
    * right one on a run that was never resumed.
    */
   initiator?: RunInitiator;
+  /**
+   * Operator-forced target outcomes, keyed by dotted target name (see
+   * {@link TargetOverride}). Absent until something is forced.
+   *
+   * Read when the executor reaches the target, so an override lands for any
+   * target the run has not started yet — in practice on the next resume, since
+   * that is the process that loads the record after the force was written.
+   */
+  overrides?: Record<string, TargetOverride>;
   /** ISO-8601 timestamp when the run was created. */
   createdAt: string;
   /** ISO-8601 timestamp of the last write. */
@@ -576,6 +615,45 @@ function parseInitiator(value: unknown): RunInitiator | undefined {
   return { actor: str(object, "actor"), kind, at: str(object, "at") };
 }
 
+/**
+ * Validate and narrow the optional {@link RunRecord.overrides} map, or
+ * `undefined` when the record carries none.
+ *
+ * Strict for the same reason {@link parseInitiator} is: an override changes
+ * whether a target's body runs, so a malformed one must not be quietly read as
+ * "nothing was forced" — that would execute a step an operator had taken off
+ * the plan.
+ */
+function parseOverrides(
+  value: unknown,
+): Record<string, TargetOverride> | undefined {
+  if (value === undefined) return undefined;
+  const object = asObject(value);
+  if (object === null) throw new Error("state: run overrides is not an object");
+  const overrides: Record<string, TargetOverride> = {};
+  for (const [name, raw] of Object.entries(object)) {
+    const entry = asObject(raw);
+    if (entry === null) {
+      throw new Error(`state: override for "${name}" is not an object`);
+    }
+    const outcome = FORCED_OUTCOMES.find((o) => o === entry.outcome);
+    if (outcome === undefined) {
+      throw new Error(
+        `state: unknown forced outcome "${entry.outcome}" for "${name}"`,
+      );
+    }
+    const override: TargetOverride = {
+      outcome,
+      actor: str(entry, "actor"),
+      at: str(entry, "at"),
+    };
+    const reason = optionalStr(entry, "reason");
+    if (reason !== undefined) override.reason = reason;
+    overrides[name] = override;
+  }
+  return overrides;
+}
+
 /** Validate and narrow a {@link SignalRecord}. */
 function parseSignalRecord(value: unknown): SignalRecord {
   const object = asObject(value);
@@ -719,6 +797,8 @@ export function parseRunRecord(text: string): RunRecord {
   if (deadlineAt !== undefined) record.deadlineAt = deadlineAt;
   const initiator = parseInitiator(object.initiator);
   if (initiator !== undefined) record.initiator = initiator;
+  const overrides = parseOverrides(object.overrides);
+  if (overrides !== undefined) record.overrides = overrides;
   const intended = optionalStr(object, "intendedTerminal");
   if (intended !== undefined) {
     const found = RUN_STATUSES.find((s) => s === intended);

--- a/packages/core/src/state/types.ts
+++ b/packages/core/src/state/types.ts
@@ -400,6 +400,25 @@ const RUN_STATUSES: readonly RunStatus[] = [
 /** The {@link RunStatus} values as a list, for CLI help and error messages. */
 export const RUN_STATUS_NAMES: readonly string[] = RUN_STATUSES;
 
+/** The run statuses past which nothing more happens. */
+const TERMINAL_STATUSES: readonly RunStatus[] = [
+  "succeeded",
+  "failed",
+  "cancelled",
+];
+
+/**
+ * Whether a run has reached a status past which nothing more happens — the only
+ * prunable ones, and the ones no operator verb can act on.
+ *
+ * `cancelling` is deliberately **not** terminal: the run is still settling, and
+ * a caller that treats it as finished would act on a plan that is being torn
+ * down. Callers that must refuse it too should say so themselves.
+ */
+export function isTerminalRunStatus(status: RunStatus): boolean {
+  return TERMINAL_STATUSES.includes(status);
+}
+
 /** True when `value` is a valid {@link RunStatus} (used to validate CLI filters). */
 export function isRunStatus(value: string): value is RunStatus {
   return RUN_STATUSES.some((s) => s === value);

--- a/packages/core/tests/force_test.ts
+++ b/packages/core/tests/force_test.ts
@@ -1,0 +1,211 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals, assertStringIncludes } from "./_assert.ts";
+import { Build, target } from "../mod.ts";
+import { forceTarget } from "../src/force.ts";
+import { buildRunRecord } from "../src/state/record.ts";
+import { parseRunRecord, type RunRecord } from "../src/state/types.ts";
+import { withTempStore } from "./_store.ts";
+import type { FileSystemStateStore } from "../src/state/fs_store.ts";
+
+/** A build with one ordinary target and one the author declared off-limits. */
+class CD extends Build {
+  deploy = target().executes(() => {});
+  applyProduction = target().executes(() => {});
+  override unforceable() {
+    return [this.applyProduction];
+  }
+}
+
+/** Seed a run record with both targets pending. */
+async function seed(
+  store: FileSystemStateStore,
+  over: Partial<RunRecord> = {},
+): Promise<string> {
+  const build = new CD();
+  const record: RunRecord = {
+    ...buildRunRecord({
+      runId: "run-1",
+      build: "CD",
+      rootTarget: "deploy",
+      actor: "engineer-a",
+      actorKind: "human",
+      now: "2026-09-06T10:00:00.000Z",
+      order: [],
+      params: [],
+    }),
+    targets: {
+      deploy: { status: "pending", meta: {} },
+      applyProduction: { status: "pending", meta: {} },
+    },
+    ...over,
+  };
+  await store.putRun(record, null);
+  void build;
+  return record.id;
+}
+
+Deno.test("forcing records the outcome, the actor and the reason", async () => {
+  await withTempStore(async (store) => {
+    const runId = await seed(store);
+    const result = await forceTarget(new CD(), {
+      runId,
+      target: "deploy",
+      outcome: "skipped",
+      reason: "upstream is down",
+      actor: "operator-b",
+      stateStore: store,
+      readEnv: () => undefined,
+    });
+    assertEquals(result.ok, true);
+    assertEquals(result.override?.outcome, "skipped");
+    assertEquals(result.override?.actor, "operator-b");
+    assertEquals(result.override?.reason, "upstream is down");
+
+    const loaded = await store.getRun(runId);
+    assertEquals(loaded?.record.overrides?.deploy.outcome, "skipped");
+    assertEquals(loaded?.record.overrides?.deploy.actor, "operator-b");
+  });
+});
+
+Deno.test("a settled target cannot be forced", async () => {
+  // The record is the account of what happened; rewriting a settled outcome
+  // would make it say something untrue.
+  for (const status of ["succeeded", "failed", "skipped"] as const) {
+    await withTempStore(async (store) => {
+      const runId = await seed(store, {
+        targets: {
+          deploy: { status, meta: {} },
+          applyProduction: { status: "pending", meta: {} },
+        },
+      });
+      const result = await forceTarget(new CD(), {
+        runId,
+        target: "deploy",
+        outcome: "succeeded",
+        stateStore: store,
+        readEnv: () => undefined,
+      });
+      assertEquals(result.ok, false, status);
+      assertEquals(result.denial, "already_settled");
+      assertStringIncludes(result.message, status);
+      assertEquals((await store.getRun(runId))?.record.overrides, undefined);
+    });
+  }
+});
+
+Deno.test("a target the build declares unforceable is refused", async () => {
+  await withTempStore(async (store) => {
+    const runId = await seed(store);
+    const result = await forceTarget(new CD(), {
+      runId,
+      target: "applyProduction",
+      outcome: "succeeded",
+      stateStore: store,
+      readEnv: () => undefined,
+    });
+    assertEquals(result.ok, false);
+    assertEquals(result.denial, "unforceable");
+    assertStringIncludes(result.message, "applyProduction");
+    assertEquals((await store.getRun(runId))?.record.overrides, undefined);
+  });
+});
+
+Deno.test("a terminal run, an unknown run and an unknown target are refused", async () => {
+  await withTempStore(async (store) => {
+    const terminal = await seed(store, { status: "succeeded" });
+    assertEquals(
+      (await forceTarget(new CD(), {
+        runId: terminal,
+        target: "deploy",
+        outcome: "skipped",
+        stateStore: store,
+        readEnv: () => undefined,
+      })).denial,
+      "run_terminal",
+    );
+    assertEquals(
+      (await forceTarget(new CD(), {
+        runId: terminal,
+        target: "nope",
+        outcome: "skipped",
+        stateStore: store,
+        readEnv: () => undefined,
+      })).denial,
+      // The run is checked first: a terminal run has no plan to name a target in.
+      "run_terminal",
+    );
+    assertEquals(
+      (await forceTarget(new CD(), {
+        runId: "no-such-run",
+        target: "deploy",
+        outcome: "skipped",
+        stateStore: store,
+        readEnv: () => undefined,
+      })).denial,
+      "unknown_run",
+    );
+  });
+
+  await withTempStore(async (store) => {
+    const runId = await seed(store);
+    const result = await forceTarget(new CD(), {
+      runId,
+      target: "nope",
+      outcome: "skipped",
+      stateStore: store,
+      readEnv: () => undefined,
+    });
+    assertEquals(result.denial, "unknown_target");
+    assertStringIncludes(result.message, "nope");
+  });
+});
+
+Deno.test("two concurrent forces of different targets both land", async () => {
+  // The write is a compare-and-swap, so the loser re-reads and re-applies onto
+  // the winner's record rather than clobbering it. Both overrides must survive.
+  class Open extends Build {
+    deploy = target().executes(() => {});
+    applyProduction = target().executes(() => {});
+  }
+  await withTempStore(async (store) => {
+    const runId = await seed(store);
+    const force = (name: string) =>
+      forceTarget(new Open(), {
+        runId,
+        target: name,
+        outcome: "skipped",
+        stateStore: store,
+        readEnv: () => undefined,
+      });
+    const [a, b] = await Promise.all([
+      force("deploy"),
+      force("applyProduction"),
+    ]);
+    assertEquals(a.ok, true, a.message);
+    assertEquals(b.ok, true, b.message);
+
+    const record = (await store.getRun(runId))?.record;
+    assertEquals(record?.overrides?.deploy.outcome, "skipped");
+    assertEquals(record?.overrides?.applyProduction.outcome, "skipped");
+  });
+});
+
+Deno.test("an override round-trips through the record parser", async () => {
+  await withTempStore(async (store) => {
+    const runId = await seed(store);
+    await forceTarget(new CD(), {
+      runId,
+      target: "deploy",
+      outcome: "succeeded",
+      reason: "done by hand",
+      stateStore: store,
+      readEnv: () => undefined,
+    });
+    const loaded = await store.getRun(runId);
+    if (loaded === null) throw new Error("no record");
+    const round = parseRunRecord(JSON.stringify(loaded.record));
+    assertEquals(round.overrides?.deploy, loaded.record.overrides?.deploy);
+  });
+});

--- a/packages/core/tests/force_test.ts
+++ b/packages/core/tests/force_test.ts
@@ -209,3 +209,68 @@ Deno.test("an override round-trips through the record parser", async () => {
     assertEquals(round.overrides?.deploy, loaded.record.overrides?.deploy);
   });
 });
+
+Deno.test("declaring a fan-out parent unforceable covers its per-item stages", async () => {
+  // A fan-out's stages are named `parent[item].stage` at run time, so no target
+  // reference can denote one. Without the prefix rule the guard would protect
+  // the target that only schedules work and leave the ones that do it exposed.
+  class Fleet extends Build {
+    deploy = target().executes(() => {});
+    override unforceable() {
+      return [this.deploy];
+    }
+  }
+  await withTempStore(async (store) => {
+    const record: RunRecord = {
+      ...buildRunRecord({
+        runId: "run-fanout",
+        build: "Fleet",
+        rootTarget: "deploy",
+        actor: "engineer-a",
+        actorKind: "human",
+        now: "2026-09-06T10:00:00.000Z",
+        order: [],
+        params: [],
+      }),
+      targets: {
+        "deploy": { status: "running", meta: {} },
+        "deploy[b].apply": { status: "pending", meta: {} },
+      },
+    };
+    await store.putRun(record, null);
+
+    const result = await forceTarget(new Fleet(), {
+      runId: record.id,
+      target: "deploy[b].apply",
+      outcome: "succeeded",
+      stateStore: store,
+      readEnv: () => undefined,
+    });
+    assertEquals(result.ok, false, result.message);
+    assertEquals(result.denial, "unforceable");
+    assertEquals((await store.getRun(record.id))?.record.overrides, undefined);
+  });
+});
+
+Deno.test("a running target is refused, and the message says why", async () => {
+  // A force promises the body will not run; for a target a live process is
+  // already executing, that promise is already broken.
+  await withTempStore(async (store) => {
+    const runId = await seed(store, {
+      targets: {
+        deploy: { status: "running", meta: {} },
+        applyProduction: { status: "pending", meta: {} },
+      },
+    });
+    const result = await forceTarget(new CD(), {
+      runId,
+      target: "deploy",
+      outcome: "skipped",
+      stateStore: store,
+      readEnv: () => undefined,
+    });
+    assertEquals(result.ok, false);
+    assertEquals(result.denial, "already_settled");
+    assertStringIncludes(result.message, "is running");
+  });
+});

--- a/packages/core/tests/mcp_hardening_test.ts
+++ b/packages/core/tests/mcp_hardening_test.ts
@@ -993,3 +993,75 @@ Deno.test("a run's initiator takes its kind from the caller, not the server", as
     });
   }
 });
+
+// ---- M16: force_target is gated exactly as cancel_run is -------------------
+
+Deno.test("force_target requires the operator token for a protected run", async () => {
+  // It routes through the same `runDenial` gate `cancel_run` uses, so the
+  // operator token in the call's arguments reaches `operatorTokenDenial` and a
+  // protected plan is refused without it.
+  await withServer(
+    {
+      allowRun: true,
+      protectPatterns: ["deploy"],
+      operatorToken: "operator-secret",
+      actor: "ops",
+    },
+    async (server, store) => {
+      const id = await seedSuspended(store, "deploy");
+
+      const noToken = await call(server, "force_target", {
+        runId: id,
+        target: "deploy",
+        outcome: "skipped",
+      });
+      assertEquals(noToken.isError, true);
+      assertEquals(JSON.parse(noToken.text).reason, "missing_operator_token");
+
+      const wrongToken = await call(server, "force_target", {
+        runId: id,
+        target: "deploy",
+        outcome: "skipped",
+        operatorToken: "guess",
+      });
+      assertEquals(wrongToken.isError, true);
+      assertEquals(
+        JSON.parse(wrongToken.text).reason,
+        "invalid_operator_token",
+      );
+
+      // Nothing was written by either refusal.
+      assertEquals((await store.getRun(id))?.record.overrides, undefined);
+
+      // With the token it gets past authorization and reaches the force itself.
+      const allowed = await call(server, "force_target", {
+        runId: id,
+        target: "deploy",
+        outcome: "skipped",
+        operatorToken: "operator-secret",
+      });
+      assertEquals(allowed.isError, false, allowed.text);
+      assertEquals(
+        (await store.getRun(id))?.record.overrides?.deploy.outcome,
+        "skipped",
+      );
+
+      // …and the call is audited, with the token dropped from the trail.
+      const audit = await auditEvents(store);
+      const event = audit.find((e) => e.tool === "force_target");
+      assertEquals(event?.actor, "ops");
+      assertEquals(
+        JSON.stringify(event?.args).includes("operator-secret"),
+        false,
+        JSON.stringify(event?.args),
+      );
+    },
+  );
+});
+
+Deno.test("force_target is not exposed without execution enabled", async () => {
+  await withServer({ allowRun: false }, async (server) => {
+    const names = (await server.tools()).map((t) => t.name);
+    assertEquals(names.includes("force_target"), false);
+  });
+});

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/.codex-plugin/plugin.json
+++ b/plugins/zuke/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -1286,6 +1286,17 @@ a descriptor whose entry module is **remote** (not a local path or `file:` URL �
 spawned. `zuke register` writes a local `file:` module, so this only bites a
 hand-authored or second-party registry entry.
 
+**Forcing a target** (`docs/state.md`):
+`zuke force <run-id> <target> --outcome skipped|succeeded [--reason "…"]`
+settles one target of a live run **without running its body** — ahead of its
+`onlyWhen` conditions and its cache — and records who decided and why under
+`record.overrides`. A forced `succeeded` is compensated by a later cancel (its
+effects were asserted to exist); a forced `skipped` is not. Refused for a target
+that already settled, a terminal run, or one the build protects with
+`override unforceable() { return [this.applyProduction]; }` — target
+**references**, so a rename cannot silently empty the list. The MCP equivalent
+is the `force_target` tool.
+
 **Authentication** (`docs/mcp.md`): on a shared, multi-user endpoint,
 `override mcpAuth()` returns an `McpAuthenticator` —
 `{ authenticate: async (ctx) => … }` — that either resolves the caller

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -1286,6 +1286,17 @@ a descriptor whose entry module is **remote** (not a local path or `file:` URL �
 spawned. `zuke register` writes a local `file:` module, so this only bites a
 hand-authored or second-party registry entry.
 
+**Forcing a target** (`docs/state.md`):
+`zuke force <run-id> <target> --outcome skipped|succeeded [--reason "…"]`
+settles one target of a live run **without running its body** — ahead of its
+`onlyWhen` conditions and its cache — and records who decided and why under
+`record.overrides`. A forced `succeeded` is compensated by a later cancel (its
+effects were asserted to exist); a forced `skipped` is not. Refused for a target
+that already settled, a terminal run, or one the build protects with
+`override unforceable() { return [this.applyProduction]; }` — target
+**references**, so a rename cannot silently empty the list. The MCP equivalent
+is the `force_target` tool.
+
 **Authentication** (`docs/mcp.md`): on a shared, multi-user endpoint,
 `override mcpAuth()` returns an `McpAuthenticator` —
 `{ authenticate: async (ctx) => … }` — that either resolves the caller

--- a/tests/integration/force_target_test.ts
+++ b/tests/integration/force_target_test.ts
@@ -179,14 +179,13 @@ Deno.test("an unforceable target is refused and nothing is recorded", async () =
   });
 });
 
-Deno.test("a settled target is refused after the run has moved past it", async () => {
+Deno.test("a finished run is refused — there is no plan left to act on", async () => {
   await withStateDir(async (dir) => {
     const id = await suspended(dir);
     assertEquals(
       (await runCli(Pipeline, ["resume", id, "--signal", "go"])).code,
       0,
     );
-    // The whole run finished, so every target settled.
     const refused = await runCli(Pipeline, [
       "force",
       id,
@@ -195,7 +194,39 @@ Deno.test("a settled target is refused after the run has moved past it", async (
       "skipped",
     ]);
     assertEquals(refused.code, 1);
-    assertStringIncludes(refused.err, "already");
+    assertStringIncludes(refused.err, "is succeeded");
+    assertStringIncludes(refused.err, "no longer a plan");
+  });
+});
+
+Deno.test("a target that already settled in a live run is refused", async () => {
+  // The record is the account of what happened; rewriting a settled outcome
+  // would make it untrue. `prepare` succeeds before the gate parks the run.
+  class Staged extends Build {
+    prepare = target().executes(() => void ran.push("prepare"));
+    gate = target()
+      .dependsOn(this.prepare)
+      .waitsFor((s) => s.on(externalSignal("go")))
+      .executes(() => {});
+  }
+  await withStateDir(async (dir) => {
+    ran.length = 0;
+    assertEquals((await runCli(Staged, ["gate", "--state"])).code, 0);
+    const id = await onlyRunId(dir);
+    const record = await recordOf(dir, id);
+    assertEquals(record.status, "suspended");
+    assertEquals(record.targets.prepare.status, "succeeded");
+
+    const refused = await runCli(Staged, [
+      "force",
+      id,
+      "prepare",
+      "--outcome",
+      "skipped",
+    ]);
+    assertEquals(refused.code, 1);
+    assertStringIncludes(refused.err, "already succeeded");
+    assertEquals((await recordOf(dir, id)).overrides, undefined);
   });
 });
 
@@ -221,6 +252,224 @@ Deno.test("force validates its arguments before touching the store", async () =>
     assertEquals(noTarget.code, 1);
     assertStringIncludes(noTarget.err, "Usage: zuke force");
 
+    assertEquals((await recordOf(dir, id)).overrides, undefined);
+  });
+});
+
+// ---- Regressions from the adversarial review -------------------------------
+
+Deno.test("a foreign build cannot force another build's run", async () => {
+  // `unforceable()` is read from the build in *this* process, so acting on
+  // another build's run would check the wrong safety declaration entirely — a
+  // template shared across services would let one force what its owner forbade.
+  await withStateDir(async (dir) => {
+    const owner = { ZUKE_BUILD_ID: "org/service-b" };
+    const stranger = { ZUKE_BUILD_ID: "org/service-a" };
+    const withEnv = async <T>(
+      vars: Record<string, string>,
+      fn: () => Promise<T>,
+    ) => {
+      const prev = Object.entries(vars).map(([k]) =>
+        [k, Deno.env.get(k)] as const
+      );
+      for (const [k, v] of Object.entries(vars)) Deno.env.set(k, v);
+      try {
+        return await fn();
+      } finally {
+        for (const [k, v] of prev) {
+          if (v === undefined) Deno.env.delete(k);
+          else Deno.env.set(k, v);
+        }
+      }
+    };
+
+    const id = await withEnv(owner, async () => {
+      ran.length = 0;
+      assertEquals((await runCli(Pipeline, ["report", "--state"])).code, 0);
+      return await onlyRunId(dir);
+    });
+
+    const refused = await withEnv(
+      stranger,
+      () =>
+        runCli(Pipeline, [
+          "force",
+          id,
+          "report", // unforceable on the owner's build
+          "--outcome",
+          "succeeded",
+        ]),
+    );
+    assertEquals(refused.code, 1, refused.out);
+    assertStringIncludes(refused.err, "org/service-b");
+    assertEquals((await recordOf(dir, id)).overrides, undefined);
+  });
+});
+
+Deno.test("a forced gate outranks its own expired deadline", async () => {
+  // Forcing a gate someone is waiting on is the reason the verb exists. Timing
+  // it out afterwards would run the onTimeout disposition — here a cancel —
+  // against the decision the operator had already made.
+  class Gated extends Build {
+    approval = target()
+      .waitsFor((s) =>
+        s.on(externalSignal("go")).timeout("1ms").onTimeout(() => "cancel-run")
+      )
+      .executes(() => void ran.push("approval"));
+    deploy = target().dependsOn(this.approval).executes(() =>
+      void ran.push("deploy")
+    );
+  }
+  await withStateDir(async (dir) => {
+    ran.length = 0;
+    assertEquals((await runCli(Gated, ["deploy", "--state"])).code, 0);
+    const id = await onlyRunId(dir);
+    assertEquals((await recordOf(dir, id)).status, "suspended");
+
+    assertEquals(
+      (await runCli(Gated, [
+        "force",
+        id,
+        "approval",
+        "--outcome",
+        "succeeded",
+        "--reason",
+        "approved out of band",
+      ])).code,
+      0,
+    );
+
+    // The deadline has long passed, but the force wins.
+    const resumed = await runCli(Gated, ["resume", id]);
+    assertEquals(resumed.code, 0, resumed.err);
+    const record = await recordOf(dir, id);
+    assertEquals(record.status, "succeeded");
+    assertEquals(record.targets.approval.status, "succeeded");
+    assertEquals(ran.includes("deploy"), true, ran.join(","));
+  });
+});
+
+Deno.test("a forced success is compensated even before the run reaches it", async () => {
+  // The operator asserted the target's effects exist — that is the whole
+  // difference from forcing `skipped` — so a cancel landing in between must
+  // still unwind them, while the row is still pending.
+  class WithRollback extends Build {
+    rollback = target().executes(() => void ran.push("rollback"));
+    gate = target()
+      .waitsFor((s) => s.on(externalSignal("go")))
+      .executes(() => {});
+    deploy = target()
+      .dependsOn(this.gate)
+      .onCancel(() => this.rollback)
+      .executes(() => void ran.push("deploy"));
+  }
+  await withStateDir(async (dir) => {
+    ran.length = 0;
+    assertEquals((await runCli(WithRollback, ["deploy", "--state"])).code, 0);
+    const id = await onlyRunId(dir);
+
+    assertEquals(
+      (await runCli(WithRollback, [
+        "force",
+        id,
+        "deploy",
+        "--outcome",
+        "succeeded",
+        "--reason",
+        "deployed by hand",
+      ])).code,
+      0,
+    );
+    // Still pending: the run has not resumed past the gate.
+    assertEquals((await recordOf(dir, id)).targets.deploy.status, "pending");
+
+    assertEquals((await runCli(WithRollback, ["cancel", id])).code, 0);
+    assertEquals(ran.includes("rollback"), true, ran.join(","));
+  });
+});
+
+Deno.test("forcing a target that declares an effect to succeeded is refused", async () => {
+  // Settling without running would drop the effect rather than defer it —
+  // nothing recorded as owed, and the run reporting success. The same refusal
+  // the cache and service layers already make.
+  class WithEffect extends Build {
+    gate = target()
+      .waitsFor((s) => s.on(externalSignal("go")))
+      .executes(() => {});
+    publish = target()
+      .dependsOn(this.gate)
+      .effect("post-check", () => void ran.push("post-check"))
+      .executes(() => {});
+  }
+  await withStateDir(async (dir) => {
+    ran.length = 0;
+    assertEquals((await runCli(WithEffect, ["publish", "--state"])).code, 0);
+    const id = await onlyRunId(dir);
+
+    const refused = await runCli(WithEffect, [
+      "force",
+      id,
+      "publish",
+      "--outcome",
+      "succeeded",
+    ]);
+    assertEquals(refused.code, 1);
+    assertStringIncludes(refused.err, "post-check");
+    assertStringIncludes(refused.err, "drop");
+    assertEquals((await recordOf(dir, id)).overrides, undefined);
+
+    // Skipping is still allowed: a skipped target's effects are not owed.
+    assertEquals(
+      (await runCli(WithEffect, [
+        "force",
+        id,
+        "publish",
+        "--outcome",
+        "skipped",
+      ])).code,
+      0,
+    );
+  });
+});
+
+Deno.test("a run being cancelled is refused", async () => {
+  await withStateDir(async (dir) => {
+    const id = await suspended(dir);
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    const loaded = await store.getRun(id);
+    if (loaded === null) throw new Error("no record");
+    await store.putRun(
+      { ...loaded.record, status: "cancelling" },
+      loaded.version,
+    );
+
+    const refused = await runCli(Pipeline, [
+      "force",
+      id,
+      "migrate",
+      "--outcome",
+      "skipped",
+    ]);
+    assertEquals(refused.code, 1);
+    assertStringIncludes(refused.err, "cancelling");
+  });
+});
+
+Deno.test("a stray positional is an error, not a different command", async () => {
+  // Without the guard the third argument fell through to the target slot, so
+  // `zuke force <id> <target> oops` quietly ran the build instead of forcing.
+  await withStateDir(async (dir) => {
+    const id = await suspended(dir);
+    const strayed = await runCli(Pipeline, [
+      "force",
+      id,
+      "migrate",
+      "oops",
+      "--outcome",
+      "skipped",
+    ]);
+    assertEquals(strayed.code, 1);
+    assertStringIncludes(strayed.err, "oops");
     assertEquals((await recordOf(dir, id)).overrides, undefined);
   });
 });

--- a/tests/integration/force_target_test.ts
+++ b/tests/integration/force_target_test.ts
@@ -1,0 +1,226 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Integration tests for `zuke force` — settling a target of a live run without
+ * running it, driven through the real CLI.
+ *
+ * What these prove that a unit test cannot: the override written by one process
+ * is honoured by the executor in the next, the forced target's body genuinely
+ * never runs while its dependents do, and the refusals reach an operator as an
+ * exit code and a message rather than a silent no-op.
+ *
+ * @module
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import {
+  Build,
+  defaultStateHost,
+  externalSignal,
+  FileSystemStateStore,
+  target,
+} from "../../packages/core/mod.ts";
+import { runCli, withStateDir } from "./_harness.ts";
+
+/** Records which bodies actually executed, across every run in a test. */
+const ran: string[] = [];
+
+/**
+ * A build that parks on a gate, so a force can be written while it is
+ * suspended and honoured when it resumes. `report` depends on the gated
+ * `migrate`, so a forced `migrate` must still let `report` run.
+ */
+class Pipeline extends Build {
+  gate = target()
+    .waitsFor((s) => s.on(externalSignal("go")))
+    .executes(() => void ran.push("gate"));
+  migrate = target().dependsOn(this.gate).executes(() =>
+    void ran.push("migrate")
+  );
+  report = target().dependsOn(this.migrate).executes(() =>
+    void ran.push("report")
+  );
+  override unforceable() {
+    return [this.report];
+  }
+}
+
+/** The id of the (single) run the CLI persisted under `dir`. */
+async function onlyRunId(dir: string): Promise<string> {
+  const store = new FileSystemStateStore(dir, defaultStateHost);
+  const runs = await store.listRuns({});
+  assertEquals(runs.length, 1);
+  return runs[0].id;
+}
+
+/** The persisted record for run `id`. */
+async function recordOf(dir: string, id: string) {
+  const store = new FileSystemStateStore(dir, defaultStateHost);
+  const got = await store.getRun(id);
+  if (got === null) throw new Error(`no run record for ${id}`);
+  return got.record;
+}
+
+/** Start the pipeline and leave it suspended at the gate. */
+async function suspended(dir: string): Promise<string> {
+  ran.length = 0;
+  const { code } = await runCli(Pipeline, ["report", "--state"]);
+  assertEquals(code, 0);
+  const id = await onlyRunId(dir);
+  assertEquals((await recordOf(dir, id)).status, "suspended");
+  return id;
+}
+
+Deno.test("a forced skip settles the target without running it, and dependents run", async () => {
+  await withStateDir(async (dir) => {
+    const id = await suspended(dir);
+
+    const forced = await runCli(Pipeline, [
+      "force",
+      id,
+      "migrate",
+      "--outcome",
+      "skipped",
+      "--reason",
+      "already applied out of band",
+      "--actor",
+      "operator-b",
+    ]);
+    assertEquals(forced.code, 0, forced.err);
+    assertStringIncludes(forced.out, "skipped");
+
+    const resumed = await runCli(Pipeline, ["resume", id, "--signal", "go"]);
+    assertEquals(resumed.code, 0, resumed.err);
+
+    // The forced body never ran; the gate and the dependent did.
+    assertEquals(ran.includes("migrate"), false, ran.join(","));
+    assertEquals(ran.includes("report"), true, ran.join(","));
+
+    const record = await recordOf(dir, id);
+    assertEquals(record.targets.migrate.status, "skipped");
+    assertEquals(record.targets.report.status, "succeeded");
+    assertEquals(record.overrides?.migrate.actor, "operator-b");
+    assertEquals(
+      record.overrides?.migrate.reason,
+      "already applied out of band",
+    );
+  });
+});
+
+Deno.test("a forced success settles the target as succeeded without running it", async () => {
+  await withStateDir(async (dir) => {
+    const id = await suspended(dir);
+    assertEquals(
+      (await runCli(Pipeline, [
+        "force",
+        id,
+        "migrate",
+        "--outcome",
+        "succeeded",
+        "--reason",
+        "ran the migration by hand",
+      ])).code,
+      0,
+    );
+    assertEquals(
+      (await runCli(Pipeline, ["resume", id, "--signal", "go"])).code,
+      0,
+    );
+    assertEquals(ran.includes("migrate"), false, ran.join(","));
+    const record = await recordOf(dir, id);
+    // Recorded as succeeded, which is what makes a later cancellation
+    // compensate it — the operator asserted its effects exist.
+    assertEquals(record.targets.migrate.status, "succeeded");
+  });
+});
+
+Deno.test("runs show names the override, who set it and why", async () => {
+  await withStateDir(async (dir) => {
+    const id = await suspended(dir);
+    assertEquals(
+      (await runCli(Pipeline, [
+        "force",
+        id,
+        "migrate",
+        "--outcome",
+        "skipped",
+        "--reason",
+        "upstream is down",
+        "--actor",
+        "operator-b",
+      ])).code,
+      0,
+    );
+    const shown = await runCli(Pipeline, ["runs", "show", id]);
+    assertEquals(shown.code, 0);
+    assertStringIncludes(shown.out, "forced:");
+    assertStringIncludes(shown.out, "migrate: skipped by operator-b");
+    assertStringIncludes(shown.out, "upstream is down");
+  });
+});
+
+Deno.test("an unforceable target is refused and nothing is recorded", async () => {
+  await withStateDir(async (dir) => {
+    const id = await suspended(dir);
+    const refused = await runCli(Pipeline, [
+      "force",
+      id,
+      "report",
+      "--outcome",
+      "succeeded",
+    ]);
+    assertEquals(refused.code, 1);
+    assertStringIncludes(refused.err, "unforceable");
+    assertEquals((await recordOf(dir, id)).overrides, undefined);
+  });
+});
+
+Deno.test("a settled target is refused after the run has moved past it", async () => {
+  await withStateDir(async (dir) => {
+    const id = await suspended(dir);
+    assertEquals(
+      (await runCli(Pipeline, ["resume", id, "--signal", "go"])).code,
+      0,
+    );
+    // The whole run finished, so every target settled.
+    const refused = await runCli(Pipeline, [
+      "force",
+      id,
+      "migrate",
+      "--outcome",
+      "skipped",
+    ]);
+    assertEquals(refused.code, 1);
+    assertStringIncludes(refused.err, "already");
+  });
+});
+
+Deno.test("force validates its arguments before touching the store", async () => {
+  await withStateDir(async (dir) => {
+    const id = await suspended(dir);
+
+    const noOutcome = await runCli(Pipeline, ["force", id, "migrate"]);
+    assertEquals(noOutcome.code, 1);
+    assertStringIncludes(noOutcome.err, "--outcome must be one of");
+
+    const badOutcome = await runCli(Pipeline, [
+      "force",
+      id,
+      "migrate",
+      "--outcome",
+      "cancelled",
+    ]);
+    assertEquals(badOutcome.code, 1);
+    assertStringIncludes(badOutcome.err, "cancelled");
+
+    const noTarget = await runCli(Pipeline, ["force", id]);
+    assertEquals(noTarget.code, 1);
+    assertStringIncludes(noTarget.err, "Usage: zuke force");
+
+    assertEquals((await recordOf(dir, id)).overrides, undefined);
+  });
+});


### PR DESCRIPTION
## What & why

An operator sometimes has to take a step off a live run: skip one that cannot succeed, or mark one done that a person completed by hand. There was no verb for it.

Today that means a consumer-owned write into the run record plus a consumer-owned reader in every condition that might need to respect it — with the record shape invented locally, no check that the target was even forceable, and nothing in the trail saying who decided. The engine has the information to do all three and did none of it.

The verb is `zuke force`, taking the run id and the target as positionals, with `--outcome skipped|succeeded` and an optional `--reason`. The executor honours it where a target is decided, above `onlyWhen` and the cache, because forcing outranks what the build would work out for itself. The body never runs; dependents proceed.

### Decisions worth naming

- **The two outcomes differ only in what a cancel does.** A forced `succeeded` asserts the target's effects exist, so it is compensated; a forced `skipped` never happened, so it is not — the rule a condition-skipped target already follows, rather than a new one.
- **`unforceable()` takes target references, not names.** The proposal's sketch said names; this repo is explicit that a target is referred to by `this.<field>`, so a rename is a compile error instead of a silently empty safety list. `extraEdges` already returns references for the same reason.
- **Refusals are re-checked on every compare-and-swap attempt**, not once up front, because the write that beat us to the record may be the target settling.

This is item 2.2 of the maintainer proposal, sequenced before the MCP role policy (#480) which will gate `force_target` with `operator` instead of the operator token.

## What the adversarial review found

Four reviewers attacked it across bypass, semantics, concurrency and surface. Thirteen findings, nine distinct, **every one reproduced against the running code** before being fixed. This section is longer than I would like, because the first implementation was worse than I thought it was.

**A build could force another build's run** (critical). `forceTarget` loaded the run with a bare read instead of the ownership gate `resume` and `cancel` both apply. Worse than ordinary cross-build access: `unforceable()` is read from the build in *this* process, so acting on another build's run consulted the wrong safety declaration entirely. The reviewer's reproduction shows one service's checkout forcing a target the owning service had declared off-limits, and exiting 0 — in the same process where `cancel` is correctly refused with `ForeignRunError`.

**Two more ways past that declaration.** A fan-out's stages are named `parent[item].stage` at run time, so no target reference can denote one — naming the parent protected the target that *schedules* work while leaving the ones that *do* it forceable. And a target already `running` could be forced, telling the operator its body would not run when the body had started.

**A forced gate was thrown away** (high). The resume timeout path never consulted overrides. Forcing the gate someone is waiting on — the reason the verb exists — was accepted with a promise it would settle, then discarded by the next sweep, which timed the run out and, with an `onTimeout` naming a rollback target, would have fired that rollback moments after the operator forced the gate succeeded.

**The documented compensation rule was false in its own window** (medium). A forced `succeeded` asserts the target's effects exist, but the compensation walk read only the target's *status* — and between the force and the resume that honours it, the row is still `pending`. So a cancel landing in exactly the window the docs describe treated a forced success identically to a forced skip and unwound nothing. The rule is now true because the walk reads the override.

**A forced success dropped declared effects** (medium) — not deferred, dropped, with nothing recorded as owed and the run reporting green. `isCacheable` and `ServiceBuilder.effect` already refuse precisely this shape, with precisely this reasoning; forcing now does too, while still allowing a forced skip, whose effects are not owed either.

Smaller: a run in `cancelling` was accepted and promised a settlement the cancel walk would never deliver; a stray third positional fell through to the target slot, so `zuke force <id> <target> oops` quietly ran the build and exited 0; the terminal-status predicate existed in three hand-rolled copies, now one shared; and the new JSDoc example was not valid TypeScript.

Refuted findings are not listed — each was checked and failed to reproduce.

## Testing

21 tests. Unit coverage of every refusal including the fan-out prefix rule and the running-target case; an integration file driving real builds through the CLI, covering the forced body never running while its dependent does, the foreign-build refusal, a forced gate beating its own expired deadline, a cancel compensating a forced success while the row is still pending, and the effect refusal.

`deno task ci`: 21/21 targets, 4218 tests, 98.5% lines and 97.4% branches against a 95% gate.

## Related issues

Closes #479

Filed while working on this, both pre-existing and out of scope: #481 (`cli_args.ts` is a 501-line orphaned copy of the live argument parser — I nearly added this command to the wrong one) and #472.

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a [Conventional Commit](https://www.conventionalcommits.org/) (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (durable state, the CLI reference, the MCP guide, the authoring guide, JSDoc).
- [x] Public API changes were regenerated with the API docs target.
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with type guards instead).
- [x] Agent skills updated and the plugin version bumped in all four manifests (0.40.0 to 0.41.0).
