### PR TITLE
feat(core): role-based authorization for the MCP server

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.41.0",
+      "version": "0.42.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -715,7 +715,8 @@ that finished.
 [`stateStore()`](./state.md), [`deadline()`](./state.md),
 [`remoteCache()`](./caching.md), [`recoverWith()`](./self-healing.md),
 [`registry()`](./registry.md), [`mcpAuth()`](./mcp.md),
-[`mcpIdentity()`](./mcp.md) and [`unforceable()`](./state.md).
+[`mcpIdentity()`](./mcp.md), [`mcpAuthorize()`](./mcp.md#roles) and
+[`unforceable()`](./state.md).
 
 **External ordering — `override extraEdges(targets)`.** Return `[before, after]`
 pairs to impose soft ordering on the plan beyond the per-target `.before()` /

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -205,13 +205,17 @@ The shipped default policy:
 | Call | Needs |
 | --- | --- |
 | `list_*` / `show_*` / `describe_*` / `graph` | `read` |
-| `run:<target>` | `run`, **and** the target's `requiresRole` when it declares one |
-| `cancel_run` / `signal_run` / `force_target`, and `resume_check` on one run | the run's [initiator](./state.md#actor-and-initiator--two-different-questions), or `operator` |
+| `run:<target>` | `run`, **and** every `requiresRole` declared anywhere in the plan it would run |
+| `cancel_run` / `signal_run` / `force_target`, and `resume_check` on one run | the run's [initiator](./state.md#actor-and-initiator--two-different-questions) or `operator`, **and** every `requiresRole` in the run's plan |
 | `resume_check` sweeping every run | `operator` |
 
 `requiresRole` can only **raise** the bar — `run` is the floor for executing
 anything, so declaring `requiresRole("read")` does not let a read-only caller
-run a target.
+run a target. It is enforced **across the whole plan**, like `--protect` and for
+the same reason: invoking a target runs its dependencies, so a requirement that
+guarded only the entry point would be bypassed by invoking anything that depends
+on it. A run-scoped mutation executes the run's plan too, so the same
+requirements apply to resuming, signalling, cancelling or forcing it.
 
 A run whose initiator is a **service** may be steered by any caller holding
 `run`: a scheduler's run has no person to ask, and treating the scheduler as its
@@ -240,12 +244,21 @@ what those permit and never widen it.
 
 **Two servers are deliberately unaffected.** One with no authenticator at all
 treats every caller as holding every role, so `--allow-run`, `--protect` and the
-operator token remain exactly the gates they were. And an authenticator that
-never mentions `roles` — a header-trusting `mcpIdentity()` hook, say — does not
-speak roles, so the policy does not constrain it either. Those two are what keep
-a local stdio server, and every deployment that predates roles, working
-unchanged. Granting an **empty** role list is the opposite claim: the question
-was considered and nothing was granted, so the policy denies.
+operator token remain exactly the gates they were. And a build using the legacy
+`mcpIdentity()` hook — the header-trusting seam, which never had roles to give —
+is not constrained by the policy either. Those two are what keep a local stdio
+server, and every deployment that predates roles, working unchanged.
+
+Whether roles are enforced is a property of the **seam**, not of one identity:
+declaring `mcpAuth()` opts in, and an identity it returns without a `roles` list
+settles to none and is denied. Inferring it per identity would mean a token
+carrying *less* information bought *more* privilege. An override of
+`mcpAuthorize` still runs in every case, including the legacy seam, since a
+change window or a freeze applies whether or not roles are in play.
+
+In **registry mode** the policy decides on the tiers alone — `read` to list or
+describe a registered build, `run` to spawn one — because a registry descriptor
+carries no per-target `requiresRole`.
 
 ## Audit log
 
@@ -319,16 +332,18 @@ The identity's fields:
 | ------- | ------------------------------------------------------------------------------------------------------------ |
 | `actor` | The authenticated caller. Required and non-empty — anything else refuses the request.                        |
 | `kind`  | `"human"` or `"service"`. Omitted reads as `"human"`, so a service claim must be stated.                     |
-| `roles` | The caller's roles. Omitted reads as none, so an authenticator that says nothing about roles grants nothing. |
+| `roles` | The caller's roles, in three states. **Omitted** means this authenticator does not speak roles — only meaningful for the legacy `mcpIdentity()` seam, whose callers the [policy](#roles) leaves alone. An **empty list** means the question was considered and nothing granted, which denies. A **non-empty list** is evaluated. An `mcpAuth()` identity that omits the list settles to empty, so a token carrying less information never buys more privilege. |
 | `via`   | How the identity was established (`"oauth-proxy"`). Informational only.                                      |
 
 The resolved `actor` overrides `--actor`, the environment, and the client label
 for that call, and flows to the [audit trail](#audit-log), run records,
 lock-holder identity, and a registry-spawned child's `ZUKE_ACTOR`. `kind` and
 `roles` reach a [registry](#registry-mode-dynamic-discovery)-spawned child as
-`ZUKE_ACTOR_KIND` and `ZUKE_ACTOR_ROLES`; they are **not** an authorization
-input — the [allow-list, `--protect` and the operator token](#authorization)
-remain what gates a call.
+`ZUKE_ACTOR_KIND` and `ZUKE_ACTOR_ROLES` (each role percent-encoded, so a name
+containing the separator survives). `roles` **is** an authorization input — see
+[Roles](#roles) — alongside the
+[allow-list, `--protect` and the operator token](#authorization), which still
+gate a call first.
 
 ### `mcpIdentity()` — sugar for a proxy header
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -187,13 +187,76 @@ ZUKE_OPERATOR_TOKEN=… ./zuke mcp --http 7777 \
   --allow-run --protect promoteToProd --confirm-destructive
 ```
 
+### Roles
+
+The three flags above are **process-wide**: they say what *anyone* reaching this
+server may do. Once the server [authenticates](#authentication) its callers it
+can say what *this* caller may do, which is what roles are for.
+
+Three built-in roles are ordered — `read` < `run` < `operator` — so an operator
+satisfies a requirement for `run` without being granted it separately. Any other
+name is matched **exactly**: an identity provider's own group (`sre`,
+`release-manager`) works with `requiresRole` without being ranked into a
+hierarchy it never agreed to. Map your groups onto the three tiers for the
+general permission and use your own names for the specific one.
+
+The shipped default policy:
+
+| Call | Needs |
+| --- | --- |
+| `list_*` / `show_*` / `describe_*` / `graph` | `read` |
+| `run:<target>` | `run`, **and** the target's `requiresRole` when it declares one |
+| `cancel_run` / `signal_run` / `force_target`, and `resume_check` on one run | the run's [initiator](./state.md#actor-and-initiator--two-different-questions), or `operator` |
+| `resume_check` sweeping every run | `operator` |
+
+`requiresRole` can only **raise** the bar — `run` is the floor for executing
+anything, so declaring `requiresRole("read")` does not let a read-only caller
+run a target.
+
+A run whose initiator is a **service** may be steered by any caller holding
+`run`: a scheduler's run has no person to ask, and treating the scheduler as its
+owner would mean nobody could intervene.
+
+Presenting a valid `ZUKE_OPERATOR_TOKEN` **grants the `operator` role** for that
+call, so the shared secret and the role model are one policy rather than two
+that can disagree — and a deployment can move to roles a piece at a time.
+
+Override the whole decision with `mcpAuthorize` when the rule is something the
+engine cannot know — a change window, team ownership, a freeze:
+
+```ts
+class ControlPlane extends Build {
+  override mcpAuthorize(identity: McpIdentity, call: McpCall) {
+    if (call.tool === "run:promote" && !inChangeWindow()) {
+      return { allow: false, reason: "outside the change window" };
+    }
+    return defaultMcpAuthorize(identity, call);
+  }
+}
+```
+
+It runs **after** the allow-list and operator-token checks, so it can narrow
+what those permit and never widen it.
+
+**Two servers are deliberately unaffected.** One with no authenticator at all
+treats every caller as holding every role, so `--allow-run`, `--protect` and the
+operator token remain exactly the gates they were. And an authenticator that
+never mentions `roles` — a header-trusting `mcpIdentity()` hook, say — does not
+speak roles, so the policy does not constrain it either. Those two are what keep
+a local stdio server, and every deployment that predates roles, working
+unchanged. Granting an **empty** role list is the opposite claim: the question
+was considered and nothing was granted, so the policy denies.
+
 ## Audit log
 
 With a store configured, **every mutating or denied tool call** (`run:<target>`,
 `signal_run`, `resume_check`, `cancel_run`, `force_target`) is appended to an
 audit trail: the
 time, the tool, the resolved **actor**, the outcome (`ok` / `denied` / `error`),
-and the call's arguments. Arguments are **redacted** — the operator token is
+and the call's arguments — plus, when the server authenticated the caller, the
+**roles** they held, which is what makes a denial answerable afterwards: who was
+refused, by which rule, and what they were carrying at the time. Arguments are
+**redacted** — the operator token is
 dropped and every `.secret()` parameter's value is masked — before anything is
 persisted.
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -256,6 +256,13 @@ carrying *less* information bought *more* privilege. An override of
 `mcpAuthorize` still runs in every case, including the legacy seam, since a
 change window or a freeze applies whether or not roles are in play.
 
+`requiresRole` is the exception to "the legacy seam is left alone": a target
+that declares one is **refused** for a caller whose authenticator cannot express
+roles, naming the seam. Silently ignoring the declaration would tell you a
+target is gated when nothing is checking. A server that declares no roles — every
+server that predates this — is unaffected, since the refusal can only fire on a
+declaration someone has just added.
+
 In **registry mode** the policy decides on the tiers alone — `read` to list or
 describe a registered build, `run` to spawn one — because a registry descriptor
 carries no per-target `requiresRole`.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "zuke",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build)."
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -160,6 +160,21 @@ async function createTarGzip(files: PathLike[], dest: PathLike, options: { cwd?:
   Read `files` (relative to `cwd`), pack them into a tar archive named by their
   path relative to `cwd`, gzip it, and write the result to `dest`.
 
+function defaultMcpAuthorize(identity: McpIdentity, call: McpCall): McpAuthorization
+  The shipped default policy.
+
+  | Call | Needs |
+  | --- | --- |
+  | `list_*` / `show_*` / `describe_*` | `read` |
+  | `run:<target>` | `run`, and the target's `requiresRole` when it declares one |
+  | a run-scoped mutation | the run's initiator, or `operator` |
+  | a sweep over every run | `operator` |
+
+  A run whose initiator is a service may be steered by any caller holding
+  `run`: a scheduler's run has no person to ask, and treating the scheduler as
+  its owner would mean nobody could intervene. Documented, and overridable by
+  `Build.mcpAuthorize`.
+
 function describeCli(build: Build, options: DescribeCliOptions): CliDescription
   Describe a build's full CLI surface — reserved commands, option flags, targets
   (with descriptions and dependencies), and declared parameters — as a plain
@@ -660,6 +675,14 @@ async function run(BuildClass: new () => Build, options: RunOptions): Promise<vo
   await run(MyBuild, { plugins: [timing] });
   ```
 
+function satisfiesRole(held: readonly string[], required: string): boolean
+  Whether a caller holding `held` satisfies a requirement for `required`.
+
+  A built-in role is satisfied by any built-in at or above it; anything else is
+  satisfied only by holding that exact name. The two rules cannot be collapsed:
+  ordering a name the model does not know would mean guessing where an identity
+  provider's group sits in a hierarchy it never agreed to.
+
 function service(): ServiceBuilder
   Create a service target — a long-lived process kept running while its
   dependents execute. Configure it with {@link ServiceBuilder.start} /
@@ -754,6 +777,10 @@ const HARDEN_RUNNER_ACTION: "step-security/harden-runner"
 
 const REDACTED: "[redacted]"
   The placeholder a {@link Redactor} substitutes for each secret value.
+
+const ROLE_TIERS: readonly string[]
+  The built-in roles, least to most privileged. A caller holding one satisfies
+  a requirement for any role at or below it.
 
 const RUN_LEASE_PREFIX: "zuke-run"
   The lease name a run's own claim is taken under.
@@ -1132,6 +1159,35 @@ class Build
       applyProduction = target().executes(() => applyTerraform());
       override unforceable() {
         return [this.applyProduction];
+      }
+    }
+    ```
+  mcpAuthorize(identity: McpIdentity, call: McpCall): McpAuthorization
+    Decide whether an authenticated MCP caller may make one call — the
+    build-level half of authorization (../../docs/mcp.md#authorization).
+
+    The default implementation is {@link defaultMcpAuthorize}: read tools need
+    `read`, running a target needs `run` (or whatever the target's
+    `requiresRole` asks for), and a run-scoped mutation needs the run's
+    initiator or `operator`. Override to express what the engine cannot know —
+    a change window, team ownership, a freeze.
+
+    Only consulted when the server authenticates its callers. With no
+    `mcpAuth()`/`mcpIdentity()` every caller is treated as holding every role,
+    so `--allow-run`, `--protect` and the operator token remain exactly the
+    gates they were; a local stdio server is unchanged.
+
+    Called after the allow-list and operator-token checks, so it can only
+    narrow what those already permit — an override cannot open a target the
+    server was not started to expose.
+
+    ```ts
+    class ControlPlane extends Build {
+      override mcpAuthorize(identity: McpIdentity, call: McpCall) {
+        if (call.tool === "run:promote" && !inChangeWindow()) {
+          return { allow: false, reason: "outside the change window" };
+        }
+        return defaultMcpAuthorize(identity, call);
       }
     }
     ```
@@ -1734,6 +1790,8 @@ class TargetBuilder
     Hide this target from `--list`/`--help` (set by {@link unlisted}).
   readOnly_: boolean
     Advertise this target as query-only over MCP (set by {@link readOnly}).
+  requiresRole_?: string
+    The role an MCP caller needs to run this target (set by {@link requiresRole}).
   dryRunnable_: boolean
     Run this target's body under `--dry-run` with `$` echoed (set by {@link dryRunnable}).
   readonly cacheKeys_: Array<() => string | Promise<string>>
@@ -1860,6 +1918,23 @@ class TargetBuilder
     from `--confirm-destructive`. A hint about intent only — the target still
     runs its real body — so declare it on targets that inspect rather than
     mutate (a status check, a report).
+  requiresRole(role: string): this
+    The role an MCP caller must hold to run this target — the per-target half
+    of authorization (../../docs/mcp.md#authorization).
+
+    The built-in roles are ordered `read` < `run` < `operator`, so an operator
+    satisfies a requirement for `run`; any other name is matched exactly, so an
+    identity provider's own group (`sre`, `release-manager`) works here without
+    being ranked into a hierarchy it never agreed to.
+
+    Only meaningful when the server authenticates its callers — a build with no
+    `mcpAuth()`/`mcpIdentity()` is gated by `--allow-run` and `--protect` as
+    before, and this is inert. It raises the bar for one target; it cannot
+    lower it, so a target requiring `read` still needs `run` to be executed.
+
+    ```ts
+    promote = target().requiresRole("operator").executes(() => deployProd());
+    ```
   always(): this
     Run this target even after the build has failed — for cleanup, teardown, or
     an aggregate that has to report on the failure.
@@ -3377,6 +3452,19 @@ interface McpAuthenticator
   authenticate(ctx: McpRequestContext): Promise<McpIdentity | McpAuthReject> | McpIdentity | McpAuthReject
     Resolve the caller's identity from the request, or refuse the request.
 
+interface McpCall
+  What is being authorized — one MCP tool call, described for a policy.
+
+  tool: string
+    The tool name, e.g. `run:deploy`, `cancel_run`, `list_runs`.
+  target?: string
+    The target a `run:` call names, when it names one.
+  requiredRole?: string
+    The role that target declared with `.requiresRole(...)`, when it declared one.
+  run?: RunSummary
+    The run a run-scoped call acts on, when it acts on one. Absent for a sweep
+    over every run, which no single run's owner can authorize.
+
 interface McpIdentity
   A trusted caller identity, resolved per request by an
   {@link McpAuthenticator}. Its {@link McpIdentity.actor} is the
@@ -3390,10 +3478,17 @@ interface McpIdentity
     conservative default: a policy that treats service callers differently must
     see the claim stated rather than inferred.
   roles?: readonly string[]
-    The roles this caller holds. Absent is read as none, so an authenticator
-    that says nothing about roles grants nothing. A name containing a comma is
-    dropped: the comma separates the roles a registry-spawned child reads, so
-    such a name would reach it as two.
+    The roles this caller holds.
+
+    Omitting it means this authenticator does not speak roles: the
+    role policy (../../docs/mcp.md#authorization) then does not constrain the
+    caller, and the server's allow-list, `--protect` globs and operator token
+    remain the only gates — what a server did before roles existed. An empty
+    list is the opposite claim: the question was considered and nothing was
+    granted, so the policy denies.
+
+    A name containing a comma is dropped: the comma separates the roles a
+    registry-spawned child reads, so such a name would reach it as two.
   via?: string
     How the identity was established (e.g. `"oauth-proxy"`); informational.
 
@@ -3681,6 +3776,11 @@ interface RunEvent
     The call's arguments, redacted — secret values masked, tokens dropped.
   detail?: string
     A short, redacted human detail (e.g. a denial reason), when present.
+  roles?: readonly string[]
+    The roles the caller held, when the server authenticated them. What makes a
+    denial answerable afterwards: the actor and the reason say who was refused
+    and by which rule, and this says what they were carrying at the time.
+    Absent on a server with no authenticator, which knows of no roles.
 
 interface RunGraphNode
   One entry of a run's graph-shape snapshot.
@@ -4379,6 +4479,9 @@ type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string
 type LockResult = { ok: true; token: string; } | { ok: false; holder: LockHolder; }
   The result of {@link StateStore.acquireLock}: a `token` proving ownership, or
   the current `holder` when the lock is already held.
+
+type McpAuthorization = { readonly allow: true; } | { readonly allow: false; readonly reason: string; }
+  A policy's verdict on one call.
 
 type McpIdentityHook = (ctx: McpRequestContext) => McpIdentity
   Resolve a trusted {@link McpIdentity} from a request's context. The original,

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -778,10 +778,6 @@ const HARDEN_RUNNER_ACTION: "step-security/harden-runner"
 const REDACTED: "[redacted]"
   The placeholder a {@link Redactor} substitutes for each secret value.
 
-const ROLE_TIERS: readonly string[]
-  The built-in roles, least to most privileged. A caller holding one satisfies
-  a requirement for any role at or below it.
-
 const RUN_LEASE_PREFIX: "zuke-run"
   The lease name a run's own claim is taken under.
 
@@ -3459,8 +3455,14 @@ interface McpCall
     The tool name, e.g. `run:deploy`, `cancel_run`, `list_runs`.
   target?: string
     The target a `run:` call names, when it names one.
-  requiredRole?: string
-    The role that target declared with `.requiresRole(...)`, when it declared one.
+  requiredRoles?: readonly string[]
+    Every role declared with `.requiresRole(...)` anywhere in the plan this
+    call would execute — not just on the target it names.
+
+    Invoking a target runs its dependencies, so a requirement that only guarded
+    the entry point would be bypassed by invoking anything that depends on it.
+    This mirrors `--protect`, which is enforced across the whole plan for the
+    same reason. The caller must satisfy all of them.
   run?: RunSummary
     The run a run-scoped call acts on, when it acts on one. Absent for a sweep
     over every run, which no single run's owner can authorize.
@@ -3487,8 +3489,9 @@ interface McpIdentity
     list is the opposite claim: the question was considered and nothing was
     granted, so the policy denies.
 
-    A name containing a comma is dropped: the comma separates the roles a
-    registry-spawned child reads, so such a name would reach it as two.
+    Role names are passed through as given; the comma-separated environment
+    variable a registry-spawned child reads escapes them rather than this
+    dropping them, so sanitisation cannot turn a granted set into an empty one.
   via?: string
     How the identity was established (e.g. `"oauth-proxy"`); informational.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -832,10 +832,6 @@ const HARDEN_RUNNER_ACTION: "step-security/harden-runner"
 const REDACTED: "[redacted]"
   The placeholder a {@link Redactor} substitutes for each secret value.
 
-const ROLE_TIERS: readonly string[]
-  The built-in roles, least to most privileged. A caller holding one satisfies
-  a requirement for any role at or below it.
-
 const RUN_LEASE_PREFIX: "zuke-run"
   The lease name a run's own claim is taken under.
 
@@ -3513,8 +3509,14 @@ interface McpCall
     The tool name, e.g. `run:deploy`, `cancel_run`, `list_runs`.
   target?: string
     The target a `run:` call names, when it names one.
-  requiredRole?: string
-    The role that target declared with `.requiresRole(...)`, when it declared one.
+  requiredRoles?: readonly string[]
+    Every role declared with `.requiresRole(...)` anywhere in the plan this
+    call would execute — not just on the target it names.
+
+    Invoking a target runs its dependencies, so a requirement that only guarded
+    the entry point would be bypassed by invoking anything that depends on it.
+    This mirrors `--protect`, which is enforced across the whole plan for the
+    same reason. The caller must satisfy all of them.
   run?: RunSummary
     The run a run-scoped call acts on, when it acts on one. Absent for a sweep
     over every run, which no single run's owner can authorize.
@@ -3541,8 +3543,9 @@ interface McpIdentity
     list is the opposite claim: the question was considered and nothing was
     granted, so the policy denies.
 
-    A name containing a comma is dropped: the comma separates the roles a
-    registry-spawned child reads, so such a name would reach it as two.
+    Role names are passed through as given; the comma-separated environment
+    variable a registry-spawned child reads escapes them rather than this
+    dropping them, so sanitisation cannot turn a granted set into an empty one.
   via?: string
     How the identity was established (e.g. `"oauth-proxy"`); informational.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -214,6 +214,21 @@ async function createTarGzip(files: PathLike[], dest: PathLike, options: { cwd?:
   Read `files` (relative to `cwd`), pack them into a tar archive named by their
   path relative to `cwd`, gzip it, and write the result to `dest`.
 
+function defaultMcpAuthorize(identity: McpIdentity, call: McpCall): McpAuthorization
+  The shipped default policy.
+
+  | Call | Needs |
+  | --- | --- |
+  | `list_*` / `show_*` / `describe_*` | `read` |
+  | `run:<target>` | `run`, and the target's `requiresRole` when it declares one |
+  | a run-scoped mutation | the run's initiator, or `operator` |
+  | a sweep over every run | `operator` |
+
+  A run whose initiator is a service may be steered by any caller holding
+  `run`: a scheduler's run has no person to ask, and treating the scheduler as
+  its owner would mean nobody could intervene. Documented, and overridable by
+  `Build.mcpAuthorize`.
+
 function describeCli(build: Build, options: DescribeCliOptions): CliDescription
   Describe a build's full CLI surface — reserved commands, option flags, targets
   (with descriptions and dependencies), and declared parameters — as a plain
@@ -714,6 +729,14 @@ async function run(BuildClass: new () => Build, options: RunOptions): Promise<vo
   await run(MyBuild, { plugins: [timing] });
   ```
 
+function satisfiesRole(held: readonly string[], required: string): boolean
+  Whether a caller holding `held` satisfies a requirement for `required`.
+
+  A built-in role is satisfied by any built-in at or above it; anything else is
+  satisfied only by holding that exact name. The two rules cannot be collapsed:
+  ordering a name the model does not know would mean guessing where an identity
+  provider's group sits in a hierarchy it never agreed to.
+
 function service(): ServiceBuilder
   Create a service target — a long-lived process kept running while its
   dependents execute. Configure it with {@link ServiceBuilder.start} /
@@ -808,6 +831,10 @@ const HARDEN_RUNNER_ACTION: "step-security/harden-runner"
 
 const REDACTED: "[redacted]"
   The placeholder a {@link Redactor} substitutes for each secret value.
+
+const ROLE_TIERS: readonly string[]
+  The built-in roles, least to most privileged. A caller holding one satisfies
+  a requirement for any role at or below it.
 
 const RUN_LEASE_PREFIX: "zuke-run"
   The lease name a run's own claim is taken under.
@@ -1186,6 +1213,35 @@ class Build
       applyProduction = target().executes(() => applyTerraform());
       override unforceable() {
         return [this.applyProduction];
+      }
+    }
+    ```
+  mcpAuthorize(identity: McpIdentity, call: McpCall): McpAuthorization
+    Decide whether an authenticated MCP caller may make one call — the
+    build-level half of authorization (../../docs/mcp.md#authorization).
+
+    The default implementation is {@link defaultMcpAuthorize}: read tools need
+    `read`, running a target needs `run` (or whatever the target's
+    `requiresRole` asks for), and a run-scoped mutation needs the run's
+    initiator or `operator`. Override to express what the engine cannot know —
+    a change window, team ownership, a freeze.
+
+    Only consulted when the server authenticates its callers. With no
+    `mcpAuth()`/`mcpIdentity()` every caller is treated as holding every role,
+    so `--allow-run`, `--protect` and the operator token remain exactly the
+    gates they were; a local stdio server is unchanged.
+
+    Called after the allow-list and operator-token checks, so it can only
+    narrow what those already permit — an override cannot open a target the
+    server was not started to expose.
+
+    ```ts
+    class ControlPlane extends Build {
+      override mcpAuthorize(identity: McpIdentity, call: McpCall) {
+        if (call.tool === "run:promote" && !inChangeWindow()) {
+          return { allow: false, reason: "outside the change window" };
+        }
+        return defaultMcpAuthorize(identity, call);
       }
     }
     ```
@@ -1788,6 +1844,8 @@ class TargetBuilder
     Hide this target from `--list`/`--help` (set by {@link unlisted}).
   readOnly_: boolean
     Advertise this target as query-only over MCP (set by {@link readOnly}).
+  requiresRole_?: string
+    The role an MCP caller needs to run this target (set by {@link requiresRole}).
   dryRunnable_: boolean
     Run this target's body under `--dry-run` with `$` echoed (set by {@link dryRunnable}).
   readonly cacheKeys_: Array<() => string | Promise<string>>
@@ -1914,6 +1972,23 @@ class TargetBuilder
     from `--confirm-destructive`. A hint about intent only — the target still
     runs its real body — so declare it on targets that inspect rather than
     mutate (a status check, a report).
+  requiresRole(role: string): this
+    The role an MCP caller must hold to run this target — the per-target half
+    of authorization (../../docs/mcp.md#authorization).
+
+    The built-in roles are ordered `read` < `run` < `operator`, so an operator
+    satisfies a requirement for `run`; any other name is matched exactly, so an
+    identity provider's own group (`sre`, `release-manager`) works here without
+    being ranked into a hierarchy it never agreed to.
+
+    Only meaningful when the server authenticates its callers — a build with no
+    `mcpAuth()`/`mcpIdentity()` is gated by `--allow-run` and `--protect` as
+    before, and this is inert. It raises the bar for one target; it cannot
+    lower it, so a target requiring `read` still needs `run` to be executed.
+
+    ```ts
+    promote = target().requiresRole("operator").executes(() => deployProd());
+    ```
   always(): this
     Run this target even after the build has failed — for cleanup, teardown, or
     an aggregate that has to report on the failure.
@@ -3431,6 +3506,19 @@ interface McpAuthenticator
   authenticate(ctx: McpRequestContext): Promise<McpIdentity | McpAuthReject> | McpIdentity | McpAuthReject
     Resolve the caller's identity from the request, or refuse the request.
 
+interface McpCall
+  What is being authorized — one MCP tool call, described for a policy.
+
+  tool: string
+    The tool name, e.g. `run:deploy`, `cancel_run`, `list_runs`.
+  target?: string
+    The target a `run:` call names, when it names one.
+  requiredRole?: string
+    The role that target declared with `.requiresRole(...)`, when it declared one.
+  run?: RunSummary
+    The run a run-scoped call acts on, when it acts on one. Absent for a sweep
+    over every run, which no single run's owner can authorize.
+
 interface McpIdentity
   A trusted caller identity, resolved per request by an
   {@link McpAuthenticator}. Its {@link McpIdentity.actor} is the
@@ -3444,10 +3532,17 @@ interface McpIdentity
     conservative default: a policy that treats service callers differently must
     see the claim stated rather than inferred.
   roles?: readonly string[]
-    The roles this caller holds. Absent is read as none, so an authenticator
-    that says nothing about roles grants nothing. A name containing a comma is
-    dropped: the comma separates the roles a registry-spawned child reads, so
-    such a name would reach it as two.
+    The roles this caller holds.
+
+    Omitting it means this authenticator does not speak roles: the
+    role policy (../../docs/mcp.md#authorization) then does not constrain the
+    caller, and the server's allow-list, `--protect` globs and operator token
+    remain the only gates — what a server did before roles existed. An empty
+    list is the opposite claim: the question was considered and nothing was
+    granted, so the policy denies.
+
+    A name containing a comma is dropped: the comma separates the roles a
+    registry-spawned child reads, so such a name would reach it as two.
   via?: string
     How the identity was established (e.g. `"oauth-proxy"`); informational.
 
@@ -3735,6 +3830,11 @@ interface RunEvent
     The call's arguments, redacted — secret values masked, tokens dropped.
   detail?: string
     A short, redacted human detail (e.g. a denial reason), when present.
+  roles?: readonly string[]
+    The roles the caller held, when the server authenticated them. What makes a
+    denial answerable afterwards: the actor and the reason say who was refused
+    and by which rule, and this says what they were carrying at the time.
+    Absent on a server with no authenticator, which knows of no roles.
 
 interface RunGraphNode
   One entry of a run's graph-shape snapshot.
@@ -4433,6 +4533,9 @@ type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string
 type LockResult = { ok: true; token: string; } | { ok: false; holder: LockHolder; }
   The result of {@link StateStore.acquireLock}: a `token` proving ownership, or
   the current `holder` when the lock is already held.
+
+type McpAuthorization = { readonly allow: true; } | { readonly allow: false; readonly reason: string; }
+  A policy's verdict on one call.
 
 type McpIdentityHook = (ctx: McpRequestContext) => McpIdentity
   Resolve a trusted {@link McpIdentity} from a request's context. The original,

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -228,6 +228,13 @@ export {
   type McpIdentity,
   type McpIdentityHook,
 } from "./src/mcp/auth.ts";
+export {
+  defaultMcpAuthorize,
+  type McpAuthorization,
+  type McpCall,
+  ROLE_TIERS,
+  satisfiesRole,
+} from "./src/mcp/roles.ts";
 export { type AbsolutePath, absolutePath, type PathLike } from "./src/path.ts";
 export { CONFIG_FILE, repoRoot } from "./src/config.ts";
 export {

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -232,7 +232,6 @@ export {
   defaultMcpAuthorize,
   type McpAuthorization,
   type McpCall,
-  ROLE_TIERS,
   satisfiesRole,
 } from "./src/mcp/roles.ts";
 export { type AbsolutePath, absolutePath, type PathLike } from "./src/path.ts";

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -17,7 +17,16 @@ import type { OrderingEdge } from "./graph.ts";
 import type { RemoteCacheStore } from "./remote_cache.ts";
 import type { StateStore } from "./state/store.ts";
 import type { BuildRegistry } from "./registry/registry.ts";
-import type { McpAuthenticator, McpIdentityHook } from "./mcp/auth.ts";
+import type {
+  McpAuthenticator,
+  McpIdentity,
+  McpIdentityHook,
+} from "./mcp/auth.ts";
+import {
+  defaultMcpAuthorize,
+  type McpAuthorization,
+  type McpCall,
+} from "./mcp/roles.ts";
 
 /** Whether a value is a plain object (a component bundle), not a class instance. */
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -376,6 +385,40 @@ export class Build {
    */
   unforceable(): TargetBuilder[] {
     return [];
+  }
+
+  /**
+   * Decide whether an authenticated MCP caller may make one call — the
+   * build-level half of [authorization](../../docs/mcp.md#authorization).
+   *
+   * The default implementation is {@link defaultMcpAuthorize}: read tools need
+   * `read`, running a target needs `run` (or whatever the target's
+   * `requiresRole` asks for), and a run-scoped mutation needs the run's
+   * initiator or `operator`. Override to express what the engine cannot know —
+   * a change window, team ownership, a freeze.
+   *
+   * Only consulted when the server authenticates its callers. With no
+   * `mcpAuth()`/`mcpIdentity()` every caller is treated as holding every role,
+   * so `--allow-run`, `--protect` and the operator token remain exactly the
+   * gates they were; a local stdio server is unchanged.
+   *
+   * Called **after** the allow-list and operator-token checks, so it can only
+   * narrow what those already permit — an override cannot open a target the
+   * server was not started to expose.
+   *
+   * ```ts
+   * class ControlPlane extends Build {
+   *   override mcpAuthorize(identity: McpIdentity, call: McpCall) {
+   *     if (call.tool === "run:promote" && !inChangeWindow()) {
+   *       return { allow: false, reason: "outside the change window" };
+   *     }
+   *     return defaultMcpAuthorize(identity, call);
+   *   }
+   * }
+   * ```
+   */
+  mcpAuthorize(identity: McpIdentity, call: McpCall): McpAuthorization {
+    return defaultMcpAuthorize(identity, call);
   }
 }
 

--- a/packages/core/src/mcp/auth.ts
+++ b/packages/core/src/mcp/auth.ts
@@ -35,10 +35,17 @@ export interface McpIdentity {
    */
   kind?: "human" | "service";
   /**
-   * The roles this caller holds. Absent is read as none, so an authenticator
-   * that says nothing about roles grants nothing. A name containing a comma is
-   * dropped: the comma separates the roles a registry-spawned child reads, so
-   * such a name would reach it as two.
+   * The roles this caller holds.
+   *
+   * Omitting it means this authenticator does not speak roles: the
+   * [role policy](../../docs/mcp.md#authorization) then does not constrain the
+   * caller, and the server's allow-list, `--protect` globs and operator token
+   * remain the only gates — what a server did before roles existed. An **empty
+   * list** is the opposite claim: the question was considered and nothing was
+   * granted, so the policy denies.
+   *
+   * A name containing a comma is dropped: the comma separates the roles a
+   * registry-spawned child reads, so such a name would reach it as two.
    */
   roles?: readonly string[];
   /** How the identity was established (e.g. `"oauth-proxy"`); informational. */
@@ -55,8 +62,19 @@ export interface ResolvedIdentity {
   readonly actor: string;
   /** The caller's kind, defaulted to `"human"` when the authenticator omitted it. */
   readonly kind: "human" | "service";
-  /** The caller's roles, defaulted to empty. Each entry is a non-empty string. */
-  readonly roles: readonly string[];
+  /**
+   * The roles the authenticator claimed, or `undefined` when it claimed none at
+   * all.
+   *
+   * The distinction is load-bearing, and it is not the same as an empty list.
+   * `undefined` means this authenticator does not speak roles — a
+   * proxy-header `mcpIdentity()` hook, say — so the role policy does not
+   * constrain it and the server's own gates remain the only ones, exactly as
+   * before roles existed. `[]` means the authenticator considered the question
+   * and granted nothing, which denies. Collapsing the two would silently lock
+   * out every server whose authenticator predates the policy.
+   */
+  readonly roles?: readonly string[];
   /**
    * How the identity was established, when the authenticator said. Carried
    * through to whatever inspects the caller; not written to the audit trail,
@@ -193,11 +211,18 @@ export function normalizeIdentity(value: unknown): ResolvedIdentity | null {
   const actor = value.actor;
   if (typeof actor !== "string" || actor === "") return null;
   const kind = value.kind === "service" ? "service" : "human";
-  const roles = rolesOf(value.roles);
+  // Preserved rather than defaulted: see `ResolvedIdentity.roles` — an
+  // authenticator that never mentions roles is not the same as one that grants
+  // none, and treating it as the latter would deny every caller of a server
+  // whose authenticator predates the policy.
+  const roles = value.roles === undefined ? undefined : rolesOf(value.roles);
   const via = nonEmptyString(value.via);
-  return via === undefined
-    ? { actor, kind, roles }
-    : { actor, kind, roles, via };
+  return {
+    actor,
+    kind,
+    ...(roles === undefined ? {} : { roles }),
+    ...(via === undefined ? {} : { via }),
+  };
 }
 
 /**

--- a/packages/core/src/mcp/auth.ts
+++ b/packages/core/src/mcp/auth.ts
@@ -44,8 +44,9 @@ export interface McpIdentity {
    * list** is the opposite claim: the question was considered and nothing was
    * granted, so the policy denies.
    *
-   * A name containing a comma is dropped: the comma separates the roles a
-   * registry-spawned child reads, so such a name would reach it as two.
+   * Role names are passed through as given; the comma-separated environment
+   * variable a registry-spawned child reads escapes them rather than this
+   * dropping them, so sanitisation cannot turn a granted set into an empty one.
    */
   roles?: readonly string[];
   /** How the identity was established (e.g. `"oauth-proxy"`); informational. */
@@ -53,9 +54,10 @@ export interface McpIdentity {
 }
 
 /**
- * An {@link McpIdentity} after {@link normalizeIdentity}: `kind` and `roles` are
- * settled, so nothing downstream re-applies the defaults (and no two callers can
- * disagree about what they are).
+ * An {@link McpIdentity} after {@link normalizeIdentity}: `kind` is settled, so
+ * nothing downstream re-applies that default, while `roles` is preserved
+ * exactly as claimed — absent when the authenticator never mentioned it, which
+ * is a different claim from granting none.
  */
 export interface ResolvedIdentity {
   /** The authenticated actor. Never empty. */
@@ -184,17 +186,17 @@ function headerValue(value: unknown): string | undefined {
 /**
  * The usable role names in `value`, or an empty list when it is not an array.
  *
- * A name is usable when it is a non-empty string containing no comma. The comma
- * is the separator a registry-spawned child reads `ZUKE_ACTOR_ROLES` with, so a
- * name carrying one would arrive there as two roles — and role names can come
- * from an identity provider's group names, which the caller may influence. One
- * dropped role is a smaller wrong answer than a forged one, and dropping it here
- * keeps every consumer of the list honest rather than each escaping it again.
+ * Only empty and non-string entries are dropped. A name containing a comma is
+ * **kept**: the comma matters only to the environment variable a
+ * registry-spawned child reads, which escapes it there, and dropping the role
+ * here would let sanitisation manufacture an empty list — which the role policy
+ * reads as "granted nothing" and denies. A guard that turns a granted role set
+ * into a deny-all is a worse answer than the encoding problem it avoids.
  */
 function rolesOf(value: unknown): readonly string[] {
   if (!Array.isArray(value)) return [];
   return value.filter((role): role is string =>
-    typeof role === "string" && role !== "" && !role.includes(",")
+    typeof role === "string" && role !== ""
   );
 }
 

--- a/packages/core/src/mcp/command.ts
+++ b/packages/core/src/mcp/command.ts
@@ -162,6 +162,11 @@ export async function serveMcp(
   }
   const authenticator = options.authenticator ?? declared ??
     (hook === undefined ? undefined : authenticatorFromHook(hook));
+  // The role policy applies to a seam that was declared *as* an authenticator.
+  // The legacy `mcpIdentity()` hook never had roles to give, so a build using it
+  // keeps the allow-list and operator token as its only gates.
+  const enforceRoles = options.enforceRoles ??
+    (options.authenticator !== undefined || declared !== undefined);
   // Every authenticator runs on every request. Only one declared *as*
   // authentication also satisfies the non-loopback bind guard: `mcpIdentity()`
   // is sugar for trusting a header a proxy injected, and its whole contract
@@ -186,6 +191,7 @@ export async function serveMcp(
       stateStore: store,
       actor: options.actor,
       authenticator,
+      enforceRoles,
       readEnv,
       version: options.version,
       runner: options.runner,
@@ -197,6 +203,7 @@ export async function serveMcp(
       stateStore: store,
       operatorToken,
       authenticator,
+      enforceRoles,
     });
   if (options.http !== undefined) {
     return await serveMcpHttp(

--- a/packages/core/src/mcp/registry_server.ts
+++ b/packages/core/src/mcp/registry_server.ts
@@ -62,6 +62,7 @@ import {
   ok,
 } from "./jsonrpc.ts";
 import type { McpAuthenticator, ResolvedIdentity } from "./auth.ts";
+import { defaultMcpAuthorize, type McpCall } from "./roles.ts";
 
 /** The captured result of spawning a registered build. */
 export interface RegistryRunResult {
@@ -88,9 +89,10 @@ export interface RegistryRunOptions {
    */
   actorKind?: "human" | "service";
   /**
-   * The caller's roles, exported as `ZUKE_ACTOR_ROLES` (comma-separated), so a
-   * build can see what the caller was entitled to when it asked. Honoured only
-   * together with {@link RegistryRunOptions.actor}.
+   * The caller's roles, exported as `ZUKE_ACTOR_ROLES` — each name
+   * percent-encoded and joined with commas, so a name containing the separator
+   * survives — so a build can see what the caller was entitled to when it
+   * asked. Honoured only together with {@link RegistryRunOptions.actor}.
    *
    * The three describe one caller and are written together or not at all:
    * exporting entitlements beside an actor that came from somewhere else is the
@@ -131,7 +133,12 @@ export const defaultRegistryRunner: RegistryRunner = async (
   if (options?.actor !== undefined && options.actor !== "") {
     env.ZUKE_ACTOR = options.actor;
     env.ZUKE_ACTOR_KIND = options.actorKind ?? "human";
-    env.ZUKE_ACTOR_ROLES = (options.actorRoles ?? []).join(",");
+    // Percent-encoded per role, so a name containing the separator survives
+    // the round trip instead of arriving as two roles. A child reads this by
+    // splitting on "," and decoding each part.
+    env.ZUKE_ACTOR_ROLES = (options.actorRoles ?? [])
+      .map(encodeURIComponent)
+      .join(",");
   }
   const command = new Deno.Command(argv[0], {
     args: [...argv.slice(1)],
@@ -180,6 +187,16 @@ export interface RegistryMcpServerOptions {
    * build's `mcpAuth()` or `mcpIdentity()` (see `serveMcp`).
    */
   authenticator?: McpAuthenticator;
+  /**
+   * Whether the configured authenticator participates in the
+   * [role policy](../../../docs/mcp.md#roles). See
+   * {@link "./server.ts".McpServerOptions.enforceRoles}.
+   *
+   * A registry descriptor carries no per-target `requiresRole`, so here the
+   * policy decides on the tiers alone: `read` to list or describe a build,
+   * `run` to spawn one.
+   */
+  enforceRoles?: boolean;
   /** Reads an environment variable (injectable for tests). */
   readEnv?: (name: string) => string | undefined;
   /** The server version reported in `initialize`. Defaults to `"0.0.0"`. */
@@ -355,6 +372,8 @@ export class RegistryMcpServer {
   readonly #store?: StateStore;
   readonly #actor?: string;
   readonly #authenticator?: McpAuthenticator;
+  /** Whether the configured authenticator participates in the role policy. */
+  readonly #enforceRoles: boolean;
   readonly #readEnv: (name: string) => string | undefined;
   readonly #runner: RegistryRunner;
   readonly #maxConcurrentRuns: number;
@@ -387,6 +406,7 @@ export class RegistryMcpServer {
     this.#store = options.stateStore;
     this.#actor = options.actor;
     this.#authenticator = options.authenticator;
+    this.#enforceRoles = options.enforceRoles ?? false;
     this.#readEnv = options.readEnv ?? (() => undefined);
     this.#version = options.version ?? "0.0.0";
     this.#runner = options.runner ?? defaultRegistryRunner;
@@ -544,6 +564,17 @@ export class RegistryMcpServer {
     const call = toolCall(params);
     if ("error" in call) return err(id, INVALID_PARAMS, call.error);
     const { name, args } = call;
+
+    // The role policy, on the tiers alone: a registry descriptor carries no
+    // per-target `requiresRole`, but "a caller granted nothing can spawn every
+    // registered build" is the hole worth closing. Applied to every tool here,
+    // since all of them are either a read or a spawn.
+    const denial = this.#authorizePolicy(identity, args, { tool: name });
+    if (denial !== null) {
+      const actor = identity?.actor ?? this.#resolveActor();
+      await this.#audit(name, args, "denied", actor, denial);
+      return ok(id, unauthorizedResult(name, denial));
+    }
 
     if (name === "list_builds") {
       return ok(id, textResult(await this.#listBuilds()));
@@ -813,6 +844,36 @@ export class RegistryMcpServer {
       argv: [Deno.execPath(), "run", "-A", location.module, ...trailing],
       cwd: absolutePath(location.cwd).path,
     };
+  }
+
+  /**
+   * Apply the build's role policy to one call, or `null` when it allows it.
+   * The registry's twin of {@link "./server.ts".McpServer}'s, minus the
+   * per-target requirement its descriptors do not carry.
+   */
+  #authorizePolicy(
+    identity: ResolvedIdentity | undefined,
+    args: Record<string, unknown>,
+    call: McpCall,
+  ): string | null {
+    if (identity === undefined) return null;
+    const claimed = this.#enforceRoles ? identity.roles ?? [] : identity.roles;
+    const roles = claimed === undefined
+      ? undefined
+      : operatorTokenDenial(args, this.#operatorToken) === null
+      ? [...claimed, "operator"]
+      : claimed;
+    try {
+      const verdict = defaultMcpAuthorize(
+        { ...identity, ...(roles === undefined ? {} : { roles }) },
+        call,
+      );
+      return verdict.allow ? null : verdict.reason;
+    } catch {
+      // A policy that throws denies: it is the last thing between a caller and
+      // a spawned build.
+      return "policy_error";
+    }
   }
 
   /** Resolve the actor for audited calls: --actor → env → the client label. */

--- a/packages/core/src/mcp/roles.ts
+++ b/packages/core/src/mcp/roles.ts
@@ -20,6 +20,7 @@
 
 import type { RunSummary } from "../state/types.ts";
 import type { McpIdentity } from "./auth.ts";
+import { isMutatingRunTool } from "./runtools.ts";
 
 /**
  * The built-in roles, least to most privileged. A caller holding one satisfies
@@ -53,8 +54,16 @@ export interface McpCall {
   tool: string;
   /** The target a `run:` call names, when it names one. */
   target?: string;
-  /** The role that target declared with `.requiresRole(...)`, when it declared one. */
-  requiredRole?: string;
+  /**
+   * Every role declared with `.requiresRole(...)` **anywhere in the plan** this
+   * call would execute — not just on the target it names.
+   *
+   * Invoking a target runs its dependencies, so a requirement that only guarded
+   * the entry point would be bypassed by invoking anything that depends on it.
+   * This mirrors `--protect`, which is enforced across the whole plan for the
+   * same reason. The caller must satisfy all of them.
+   */
+  requiredRoles?: readonly string[];
   /**
    * The run a run-scoped call acts on, when it acts on one. Absent for a sweep
    * over every run, which no single run's owner can authorize.
@@ -82,14 +91,13 @@ function isReadOnlyTool(tool: string): boolean {
 }
 
 /**
- * The tools that act on **one** run, and so ask who owns it. `resume_check`
- * appears here only when the call named a run; without one it sweeps every run
- * and is handled as an operator action.
+ * The tools that act on **one** run, and so ask who owns it — the mutating
+ * run-state tools, whose membership `runtools.ts` already owns so the two
+ * classifications cannot drift apart. `resume_check` is among them; without a
+ * run named it sweeps every run and is handled as an operator action.
  */
 function isRunScopedTool(tool: string): boolean {
-  return tool === "cancel_run" || tool === "signal_run" ||
-    tool === "force_target" || tool === "retry_target" ||
-    tool === "resume_check";
+  return isMutatingRunTool(tool);
 }
 
 /**
@@ -111,9 +119,14 @@ export function defaultMcpAuthorize(
   identity: McpIdentity,
   call: McpCall,
 ): McpAuthorization {
-  // Reached only for an identity that claimed roles; the server skips the
-  // policy entirely for one that did not (see `McpIdentity.roles`).
-  const held = identity.roles ?? [];
+  // An identity that claimed no roles at all does not speak roles — a
+  // header-trusting `mcpIdentity()` hook, which predates them. There is nothing
+  // to decide with, so this policy allows and the server's own gates stand
+  // alone. The server settles an `mcpAuth()` identity's absent list to empty
+  // before calling, so that case denies here rather than arriving unclaimed:
+  // less information must never buy more privilege.
+  const held = identity.roles;
+  if (held === undefined) return ALLOW;
 
   if (isReadOnlyTool(call.tool)) {
     return satisfiesRole(held, "read")
@@ -122,6 +135,13 @@ export function defaultMcpAuthorize(
   }
 
   if (isRunScopedTool(call.tool)) {
+    // A run-scoped call still executes whatever the run's plan declares, so a
+    // target's own requirement applies here exactly as it does to `run:`.
+    for (const required of call.requiredRoles ?? []) {
+      if (!satisfiesRole(held, required)) {
+        return deny(`${call.tool} needs the "${required}" role`);
+      }
+    }
     // No run named: a sweep touches every run at once, which no single run's
     // owner is in a position to authorize.
     if (call.run === undefined) {
@@ -149,14 +169,14 @@ export function defaultMcpAuthorize(
   if (!satisfiesRole(held, "run")) {
     return deny(`${call.tool} needs the "run" role`);
   }
-  // A target's own requirement is checked *in addition*, so it can only raise
-  // the bar. Requiring it instead of `run` would let `requiresRole("read")`
+  // Each declared requirement is checked *in addition*, so they can only raise
+  // the bar. Requiring one instead of `run` would let `requiresRole("read")`
   // hand a read-only caller the ability to execute build code — a declaration
   // in the build silently widening what the server exposes.
-  if (
-    call.requiredRole !== undefined && !satisfiesRole(held, call.requiredRole)
-  ) {
-    return deny(`${call.tool} needs the "${call.requiredRole}" role`);
+  for (const required of call.requiredRoles ?? []) {
+    if (!satisfiesRole(held, required)) {
+      return deny(`${call.tool} needs the "${required}" role`);
+    }
   }
   return ALLOW;
 }

--- a/packages/core/src/mcp/roles.ts
+++ b/packages/core/src/mcp/roles.ts
@@ -1,0 +1,162 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * The role model behind MCP authorization: what a caller holds, what a call
+ * needs, and the default policy that decides between them.
+ *
+ * Three built-in roles are **ordered** — `read` < `run` < `operator` — so an
+ * operator satisfies a requirement for `run` without being granted it
+ * separately. Any other role name is matched by exact membership, because an
+ * identity provider's own group names (`sre`, `release-manager`) do not sort
+ * into three tiers and must still be usable with `requiresRole`.
+ *
+ * A run-scoped mutation is the one decision that is not about roles alone: it
+ * asks whether this caller *owns* the run, which is what
+ * {@link "../state/types.ts".RunRecord.initiator} records.
+ *
+ * @module
+ */
+
+import type { RunSummary } from "../state/types.ts";
+import type { McpIdentity } from "./auth.ts";
+
+/**
+ * The built-in roles, least to most privileged. A caller holding one satisfies
+ * a requirement for any role at or below it.
+ */
+export const ROLE_TIERS: readonly string[] = ["read", "run", "operator"];
+
+/**
+ * Whether a caller holding `held` satisfies a requirement for `required`.
+ *
+ * A built-in role is satisfied by any built-in at or above it; anything else is
+ * satisfied only by holding that exact name. The two rules cannot be collapsed:
+ * ordering a name the model does not know would mean guessing where an identity
+ * provider's group sits in a hierarchy it never agreed to.
+ */
+export function satisfiesRole(
+  held: readonly string[],
+  required: string,
+): boolean {
+  const rank = ROLE_TIERS.indexOf(required);
+  if (rank === -1) return held.includes(required);
+  return held.some((role) => {
+    const heldRank = ROLE_TIERS.indexOf(role);
+    return heldRank !== -1 && heldRank >= rank;
+  });
+}
+
+/** What is being authorized — one MCP tool call, described for a policy. */
+export interface McpCall {
+  /** The tool name, e.g. `run:deploy`, `cancel_run`, `list_runs`. */
+  tool: string;
+  /** The target a `run:` call names, when it names one. */
+  target?: string;
+  /** The role that target declared with `.requiresRole(...)`, when it declared one. */
+  requiredRole?: string;
+  /**
+   * The run a run-scoped call acts on, when it acts on one. Absent for a sweep
+   * over every run, which no single run's owner can authorize.
+   */
+  run?: RunSummary;
+}
+
+/** A policy's verdict on one call. */
+export type McpAuthorization =
+  | { readonly allow: true }
+  | { readonly allow: false; readonly reason: string };
+
+/** Allow, as a shared constant — every allow is identical. */
+const ALLOW: McpAuthorization = Object.freeze({ allow: true as const });
+
+/** Deny, with the reason that is audited and returned to the caller. */
+function deny(reason: string): McpAuthorization {
+  return { allow: false, reason };
+}
+
+/** The tools that only read, and so need no more than `read`. */
+function isReadOnlyTool(tool: string): boolean {
+  return tool.startsWith("list_") || tool.startsWith("show_") ||
+    tool.startsWith("describe_") || tool === "graph";
+}
+
+/**
+ * The tools that act on **one** run, and so ask who owns it. `resume_check`
+ * appears here only when the call named a run; without one it sweeps every run
+ * and is handled as an operator action.
+ */
+function isRunScopedTool(tool: string): boolean {
+  return tool === "cancel_run" || tool === "signal_run" ||
+    tool === "force_target" || tool === "retry_target" ||
+    tool === "resume_check";
+}
+
+/**
+ * The shipped default policy.
+ *
+ * | Call | Needs |
+ * | --- | --- |
+ * | `list_*` / `show_*` / `describe_*` | `read` |
+ * | `run:<target>` | `run`, **and** the target's `requiresRole` when it declares one |
+ * | a run-scoped mutation | the run's initiator, or `operator` |
+ * | a sweep over every run | `operator` |
+ *
+ * A run whose initiator is a **service** may be steered by any caller holding
+ * `run`: a scheduler's run has no person to ask, and treating the scheduler as
+ * its owner would mean nobody could intervene. Documented, and overridable by
+ * `Build.mcpAuthorize`.
+ */
+export function defaultMcpAuthorize(
+  identity: McpIdentity,
+  call: McpCall,
+): McpAuthorization {
+  // Reached only for an identity that claimed roles; the server skips the
+  // policy entirely for one that did not (see `McpIdentity.roles`).
+  const held = identity.roles ?? [];
+
+  if (isReadOnlyTool(call.tool)) {
+    return satisfiesRole(held, "read")
+      ? ALLOW
+      : deny(`${call.tool} needs the "read" role`);
+  }
+
+  if (isRunScopedTool(call.tool)) {
+    // No run named: a sweep touches every run at once, which no single run's
+    // owner is in a position to authorize.
+    if (call.run === undefined) {
+      return satisfiesRole(held, "operator")
+        ? ALLOW
+        : deny(`${call.tool} over every run needs the "operator" role`);
+    }
+    if (satisfiesRole(held, "operator")) return ALLOW;
+    if (!satisfiesRole(held, "run")) {
+      return deny(`${call.tool} needs at least the "run" role`);
+    }
+    const initiator = call.run.initiator;
+    // A service-initiated run is machinery: any `run` caller may steer it,
+    // because the alternative is that nobody can.
+    if (initiator?.kind === "service") return ALLOW;
+    const owner = initiator?.actor ?? call.run.actor;
+    return owner === identity.actor ? ALLOW : deny(
+      `${call.tool} on a run started by "${owner}" needs that initiator ` +
+        `or the "operator" role`,
+    );
+  }
+
+  // Everything else runs build code: `run:<target>`, and any future tool that
+  // executes rather than reads. `run` is the floor for all of them.
+  if (!satisfiesRole(held, "run")) {
+    return deny(`${call.tool} needs the "run" role`);
+  }
+  // A target's own requirement is checked *in addition*, so it can only raise
+  // the bar. Requiring it instead of `run` would let `requiresRole("read")`
+  // hand a read-only caller the ability to execute build code — a declaration
+  // in the build silently widening what the server exposes.
+  if (
+    call.requiredRole !== undefined && !satisfiesRole(held, call.requiredRole)
+  ) {
+    return deny(`${call.tool} needs the "${call.requiredRole}" role`);
+  }
+  return ALLOW;
+}

--- a/packages/core/src/mcp/runtools.ts
+++ b/packages/core/src/mcp/runtools.ts
@@ -24,7 +24,9 @@ import {
   isRunStatus,
   RUN_STATUS_NAMES,
   type RunQuery,
+  type RunSummary,
   toJsonValue,
+  toSummary,
 } from "../state/types.ts";
 import { forceTarget } from "../force.ts";
 import type { JsonValue } from "../target.ts";
@@ -49,6 +51,7 @@ export interface RunToolDeps {
   authorize: (
     targetName: string,
     args: Record<string, unknown>,
+    run?: RunSummary,
   ) => string | null;
 }
 
@@ -281,7 +284,13 @@ async function runDenial(
 ): Promise<RunToolResult | null> {
   const loaded = await deps.store.getRun(runId);
   if (loaded === null) return jsonResult({ error: "no_run", runId }, true);
-  const denied = deps.authorize(loaded.record.rootTarget, args);
+  // The run travels with the call: a policy asking "does this caller own it"
+  // needs the record's initiator, which only this layer has loaded.
+  const denied = deps.authorize(
+    loaded.record.rootTarget,
+    args,
+    toSummary(loaded.record),
+  );
   if (denied !== null) {
     return jsonResult({ error: "unauthorized", reason: denied, runId }, true);
   }

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -47,6 +47,7 @@ import {
   ok,
 } from "./jsonrpc.ts";
 import type { McpAuthenticator, ResolvedIdentity } from "./auth.ts";
+import type { McpAuthorization, McpCall } from "./roles.ts";
 import {
   confirmationResult,
   dispatchMessage,
@@ -420,6 +421,28 @@ export class McpServer {
     if ("error" in call) return err(id, INVALID_PARAMS, call.error);
     const { name, args } = call;
 
+    // The read tools are gated here, where they are dispatched. The two other
+    // families carry context the policy needs and so are gated where they have
+    // it: a `run:` tool by the target's own `requiresRole`, and a run-scoped
+    // mutation by the run it names. Gating those here as well would ask the
+    // policy about a call it cannot see properly — a `cancel_run` with no run
+    // attached reads as a sweep, which demands `operator`.
+    if (!name.startsWith(RUN_PREFIX) && !isMutatingRunTool(name)) {
+      const denial = this.#authorizePolicy(identity, args, { tool: name });
+      if (denial !== null) {
+        await this.#audit(
+          name,
+          args,
+          "denied",
+          identity?.actor ??
+            this.#resolveActor(),
+          denial,
+          identity,
+        );
+        return ok(id, unauthorizedResult(name, clientDenial(denial)));
+      }
+    }
+
     if (name === "list_targets") {
       return ok(id, textResult(this.#describe().targets));
     }
@@ -467,8 +490,12 @@ export class McpServer {
         build: this.build,
         actor,
         readEnv: this.#readEnv,
-        authorize: (targetName, callArgs) => {
-          const denial = this.#authorizeTarget(targetName, callArgs);
+        authorize: (targetName, callArgs, run) => {
+          const denial = this.#authorizeTarget(targetName, callArgs) ??
+            this.#authorizePolicy(identity, callArgs, {
+              tool: name,
+              ...(run === undefined ? {} : { run }),
+            });
           return denial === null ? null : clientDenial(denial);
         },
       },
@@ -525,11 +552,18 @@ export class McpServer {
     // protected target reached as a dependency still demands the operator
     // token. Fail-closed twice over: a plan that cannot be resolved is denied,
     // and so is a protected target with no server-side token configured.
-    const denial = this.#authorizeTarget(targetName, args);
+    const denial = this.#authorizeTarget(targetName, args) ??
+      this.#authorizePolicy(identity, args, {
+        tool: runName,
+        target: targetName,
+        ...(root.requiresRole_ === undefined
+          ? {}
+          : { requiredRole: root.requiresRole_ }),
+      });
     if (denial !== null) {
       // The precise reason goes to the audit trail, which is operator-only; the
       // caller gets the collapsed one (see clientDenial).
-      await this.#audit(runName, args, "denied", actor, denial);
+      await this.#audit(runName, args, "denied", actor, denial, identity);
       return ok(id, unauthorizedResult(runName, clientDenial(denial)));
     }
 
@@ -644,6 +678,49 @@ export class McpServer {
     return null;
   }
 
+  /**
+   * Whether the call carried a valid operator token — which grants the
+   * `operator` role for that call, so the shared secret and the role model are
+   * one policy rather than two that can disagree.
+   */
+  #hasOperatorToken(args: Record<string, unknown>): boolean {
+    return operatorTokenDenial(args, this.#operatorToken) === null;
+  }
+
+  /**
+   * Apply the build's role policy to one call, or `null` when it allows it.
+   *
+   * Skipped entirely when no caller was authenticated: with no authenticator
+   * the server cannot know who is calling, so every caller is treated as
+   * holding every role and `--allow-run`/`--protect`/the operator token remain
+   * the only gates — exactly the behaviour of a server that predates roles.
+   * Running only *after* those gates means a policy can narrow what they permit
+   * and never widen it.
+   */
+  #authorizePolicy(
+    identity: ResolvedIdentity | undefined,
+    args: Record<string, unknown>,
+    call: McpCall,
+  ): string | null {
+    if (identity === undefined) return null;
+    // An authenticator that claimed no roles at all does not speak roles, so the
+    // policy has nothing to decide with and the server's own gates stand alone
+    // — the behaviour of every server whose authenticator predates this.
+    if (identity.roles === undefined) return null;
+    const roles = this.#hasOperatorToken(args)
+      ? [...identity.roles, "operator"]
+      : identity.roles;
+    let verdict: McpAuthorization;
+    try {
+      verdict = this.build.mcpAuthorize({ ...identity, roles }, call);
+    } catch {
+      // A policy that throws denies. It is the last thing standing between a
+      // caller and the build's code, so a bug in it must not open the door.
+      return "policy_error";
+    }
+    return verdict.allow ? null : verdict.reason;
+  }
+
   /** Resolve the actor for audited calls: --actor → env → the client label. */
   #resolveActor(): string {
     return resolveActor(this.#actor, this.#readEnv, [this.#clientLabel]);
@@ -662,6 +739,7 @@ export class McpServer {
     outcome: RunEventOutcome,
     actor: string,
     detail?: string,
+    identity?: ResolvedIdentity,
   ): Promise<void> {
     const store = this.#store;
     if (store === undefined) return;
@@ -673,6 +751,9 @@ export class McpServer {
       args: this.#auditArgs(args),
     };
     if (detail !== undefined) event.detail = detail;
+    // Only when a caller was authenticated: a server with no authenticator
+    // knows of no roles, and an empty list would read as "held nothing".
+    if (identity !== undefined) event.roles = identity.roles;
     this.#trail ??= new AuditTrail(store);
     await this.#trail.append(event);
   }

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -122,6 +122,20 @@ export interface McpServerOptions {
    * build's `mcpAuth()` or `mcpIdentity()` (see `serveMcp`).
    */
   authenticator?: McpAuthenticator;
+  /**
+   * Whether the configured authenticator participates in the
+   * [role policy](../../../docs/mcp.md#roles).
+   *
+   * True for one declared with `mcpAuth()`, whose identities are expected to
+   * carry roles — an absent list then settles to none and denies. False for the
+   * legacy `mcpIdentity()` adapter, which never had roles to give, so its
+   * callers are governed by the allow-list and operator token alone.
+   *
+   * A property of the seam rather than of a single identity, so an authenticator
+   * that omits roles for one caller cannot hand that caller more privilege than
+   * one that names them.
+   */
+  enforceRoles?: boolean;
   /** Reads an environment variable (injectable for tests). */
   readEnv?: (name: string) => string | undefined;
   /** The server version reported in `initialize`. Defaults to `"0.0.0"`. */
@@ -195,6 +209,8 @@ export class McpServer {
   readonly #store?: StateStore;
   readonly #actor?: string;
   readonly #authenticator?: McpAuthenticator;
+  /** Whether the configured authenticator participates in the role policy. */
+  readonly #enforceRoles: boolean;
   readonly #readEnv: (name: string) => string | undefined;
   /** The connecting client's `initialize` name, a low-priority audit actor. */
   #clientLabel?: string;
@@ -224,6 +240,7 @@ export class McpServer {
     this.#store = options.stateStore;
     this.#actor = options.actor;
     this.#authenticator = options.authenticator;
+    this.#enforceRoles = options.enforceRoles ?? false;
     this.#readEnv = options.readEnv ?? (() => undefined);
     this.#version = options.version ?? "0.0.0";
   }
@@ -477,6 +494,8 @@ export class McpServer {
     if (store === undefined) return null;
     const actor = identity?.actor ?? this.#resolveActor();
     const mutating = isMutatingRunTool(name);
+    /** The authorization reason, when the call was refused rather than run. */
+    let refusal: string | undefined;
     if (mutating && !this.#allowRun) {
       return textResult(
         `${name} changes run state and needs execution enabled — start the ` +
@@ -494,8 +513,18 @@ export class McpServer {
           const denial = this.#authorizeTarget(targetName, callArgs) ??
             this.#authorizePolicy(identity, callArgs, {
               tool: name,
+              target: targetName,
+              // Resuming, signalling or forcing a run executes that run's plan,
+              // so the roles its targets declare apply here exactly as they do
+              // to `run:` — otherwise a caller refused `run:promote` could reach
+              // the same body through `signal_run`.
+              requiredRoles: this.#plannedRoles(targetName) ?? [],
               ...(run === undefined ? {} : { run }),
             });
+          // Remembered so the audit row can say this was a *denial* — and by
+          // which rule, and with which roles — rather than the generic "error"
+          // an unauthorized tool result would otherwise be recorded as.
+          if (denial !== null) refusal = denial;
           return denial === null ? null : clientDenial(denial);
         },
       },
@@ -503,8 +532,15 @@ export class McpServer {
       args,
     );
     if (result === null) return null;
-    if (mutating) {
-      await this.#audit(name, args, result.isError ? "error" : "ok", actor);
+    if (mutating || refusal !== undefined) {
+      await this.#audit(
+        name,
+        args,
+        refusal !== undefined ? "denied" : result.isError ? "error" : "ok",
+        actor,
+        refusal,
+        identity,
+      );
     }
     return textResult(result.text, result.isError);
   }
@@ -556,9 +592,10 @@ export class McpServer {
       this.#authorizePolicy(identity, args, {
         tool: runName,
         target: targetName,
-        ...(root.requiresRole_ === undefined
-          ? {}
-          : { requiredRole: root.requiresRole_ }),
+        // Undefined means the plan could not be resolved, which
+        // `#authorizeTarget` has already denied above; an empty list means it
+        // resolved and declared nothing.
+        requiredRoles: this.#plannedRoles(targetName) ?? [],
       });
     if (denial !== null) {
       // The precise reason goes to the audit trail, which is operator-only; the
@@ -679,6 +716,26 @@ export class McpServer {
   }
 
   /**
+   * Every role declared by any target in the plan rooted at `name`.
+   *
+   * Plan-wide for the same reason `--protect` is: invoking a target runs its
+   * dependencies, so a requirement that guarded only the entry point would be
+   * bypassed by invoking anything that depends on it. An unresolvable plan
+   * yields `undefined`, which the caller must treat as a denial rather than as
+   * "no requirements".
+   */
+  #plannedRoles(name: string): readonly string[] | undefined {
+    const planned = this.#plannedNames(name);
+    if (planned === null) return undefined;
+    const roles = new Set<string>();
+    for (const target of planned) {
+      const declared = this.#targets.get(target)?.requiresRole_;
+      if (declared !== undefined) roles.add(declared);
+    }
+    return [...roles];
+  }
+
+  /**
    * Whether the call carried a valid operator token — which grants the
    * `operator` role for that call, so the shared secret and the role model are
    * one policy rather than two that can disagree.
@@ -703,16 +760,28 @@ export class McpServer {
     call: McpCall,
   ): string | null {
     if (identity === undefined) return null;
-    // An authenticator that claimed no roles at all does not speak roles, so the
-    // policy has nothing to decide with and the server's own gates stand alone
-    // — the behaviour of every server whose authenticator predates this.
-    if (identity.roles === undefined) return null;
-    const roles = this.#hasOperatorToken(args)
-      ? [...identity.roles, "operator"]
-      : identity.roles;
+    // Whether roles are enforced is a property of the **seam**, not of one
+    // call's value. A modern `mcpAuth()` authenticator that happens to omit
+    // roles for one caller settles to none and is denied — inferring "does not
+    // speak roles" from the value would mean a token carrying *less*
+    // information bought *more* privilege. Only the legacy `mcpIdentity()`
+    // adapter, which never had roles to give, leaves them unclaimed.
+    const claimed = this.#enforceRoles ? identity.roles ?? [] : identity.roles;
+    const roles = claimed === undefined
+      ? undefined
+      : this.#hasOperatorToken(args)
+      ? [...claimed, "operator"]
+      : claimed;
     let verdict: McpAuthorization;
     try {
-      verdict = this.build.mcpAuthorize({ ...identity, roles }, call);
+      // Always consulted, even for an unclaimed identity: an override exists to
+      // express rules the engine cannot know (a change window, a freeze), and
+      // those apply whether or not the authenticator speaks roles. The default
+      // implementation is what allows the unclaimed case.
+      verdict = this.build.mcpAuthorize(
+        { ...identity, ...(roles === undefined ? {} : { roles }) },
+        call,
+      );
     } catch {
       // A policy that throws denies. It is the last thing standing between a
       // caller and the build's code, so a bug in it must not open the door.

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -767,6 +767,19 @@ export class McpServer {
     // information bought *more* privilege. Only the legacy `mcpIdentity()`
     // adapter, which never had roles to give, leaves them unclaimed.
     const claimed = this.#enforceRoles ? identity.roles ?? [] : identity.roles;
+    // The legacy seam cannot express roles, which is fine until a target
+    // actually declares one. Silently ignoring an explicit `requiresRole` would
+    // tell an author their target is gated when nothing is checking — so the
+    // call is refused, naming the seam that cannot answer it. An existing
+    // server declares no roles and is unaffected; this can only fire on a
+    // declaration the author just added.
+    const required = call.requiredRoles ?? [];
+    if (claimed === undefined && required.length > 0) {
+      return `${call.tool} requires the ${
+        required.map((role) => `"${role}"`).join(", ")
+      } role, which mcpIdentity() cannot provide — declare mcpAuth() to gate ` +
+        `by role`;
+    }
     const roles = claimed === undefined
       ? undefined
       : this.#hasOperatorToken(args)

--- a/packages/core/src/state/types.ts
+++ b/packages/core/src/state/types.ts
@@ -85,6 +85,13 @@ export interface RunEvent {
   args: Record<string, string>;
   /** A short, redacted human detail (e.g. a denial reason), when present. */
   detail?: string;
+  /**
+   * The roles the caller held, when the server authenticated them. What makes a
+   * denial answerable afterwards: the actor and the reason say who was refused
+   * and by which rule, and this says what they were carrying at the time.
+   * Absent on a server with no authenticator, which knows of no roles.
+   */
+  roles?: readonly string[];
 }
 
 /** What an operator may force a target to, without running it. */
@@ -606,6 +613,11 @@ function parseRunEvent(value: unknown): RunEvent {
   };
   const detail = optionalStr(object, "detail");
   if (detail !== undefined) event.detail = detail;
+  if (Array.isArray(object.roles)) {
+    event.roles = object.roles.filter((role): role is string =>
+      typeof role === "string"
+    );
+  }
   return event;
 }
 

--- a/packages/core/src/state/writer.ts
+++ b/packages/core/src/state/writer.ts
@@ -381,11 +381,16 @@ export class RunStateWriter {
     if (event.detail !== undefined) {
       out.detail = this.#redactor.redact(event.detail);
     }
-    // Role names are static identifiers chosen by the operator's role mapping,
-    // never caller-supplied values, so they carry nothing to redact — but they
-    // are copied explicitly, because this rebuilds the event field by field and
-    // anything not named here is silently dropped.
-    if (event.roles !== undefined) out.roles = event.roles;
+    // Copied explicitly, because this rebuilds the event field by field and
+    // anything not named here is silently dropped — and redacted like every
+    // other field. Role names are normally an operator's own identifiers, which
+    // the redactor leaves untouched since it only substitutes known secret
+    // values; running them through it anyway costs nothing and means this
+    // function has no field whose safety rests on an assumption about where its
+    // value came from.
+    if (event.roles !== undefined) {
+      out.roles = event.roles.map((role) => this.#redactor.redact(role));
+    }
     return out;
   }
 

--- a/packages/core/src/state/writer.ts
+++ b/packages/core/src/state/writer.ts
@@ -381,6 +381,11 @@ export class RunStateWriter {
     if (event.detail !== undefined) {
       out.detail = this.#redactor.redact(event.detail);
     }
+    // Role names are static identifiers chosen by the operator's role mapping,
+    // never caller-supplied values, so they carry nothing to redact — but they
+    // are copied explicitly, because this rebuilds the event field by field and
+    // anything not named here is silently dropped.
+    if (event.roles !== undefined) out.roles = event.roles;
     return out;
   }
 

--- a/packages/core/src/target.ts
+++ b/packages/core/src/target.ts
@@ -560,6 +560,8 @@ export class TargetBuilder {
   unlisted_ = false;
   /** Advertise this target as query-only over MCP (set by {@link readOnly}). */
   readOnly_ = false;
+  /** The role an MCP caller needs to run this target (set by {@link requiresRole}). */
+  requiresRole_?: string;
   /** Run this target's body under `--dry-run` with `$` echoed (set by {@link dryRunnable}). */
   dryRunnable_ = false;
   /** Extra cache-key contributors beyond input files (set by {@link cacheKey}). */
@@ -789,6 +791,29 @@ export class TargetBuilder {
    */
   readOnly(): this {
     this.readOnly_ = true;
+    return this;
+  }
+
+  /**
+   * The role an MCP caller must hold to run this target — the per-target half
+   * of [authorization](../../docs/mcp.md#authorization).
+   *
+   * The built-in roles are ordered `read` < `run` < `operator`, so an operator
+   * satisfies a requirement for `run`; any other name is matched exactly, so an
+   * identity provider's own group (`sre`, `release-manager`) works here without
+   * being ranked into a hierarchy it never agreed to.
+   *
+   * Only meaningful when the server authenticates its callers — a build with no
+   * `mcpAuth()`/`mcpIdentity()` is gated by `--allow-run` and `--protect` as
+   * before, and this is inert. It raises the bar for one target; it cannot
+   * lower it, so a target requiring `read` still needs `run` to be executed.
+   *
+   * ```ts
+   * promote = target().requiresRole("operator").executes(() => deployProd());
+   * ```
+   */
+  requiresRole(role: string): this {
+    this.requiresRole_ = role;
     return this;
   }
 

--- a/packages/core/tests/mcp_auth_test.ts
+++ b/packages/core/tests/mcp_auth_test.ts
@@ -348,11 +348,12 @@ Deno.test("a throwing property getter on the result is a refusal, not a fault", 
   );
 });
 
-Deno.test("a role name carrying the child's separator is dropped", async () => {
-  // ZUKE_ACTOR_ROLES joins the list with a comma, so a name containing one would
-  // reach a registry-spawned child as two roles. Role names can come from an
-  // identity provider's group names, so the guard belongs here rather than in
-  // each consumer.
+Deno.test("a role name carrying the child's separator is kept", async () => {
+  // It is escaped where it matters — the comma-joined environment variable a
+  // registry-spawned child reads — rather than dropped here. Dropping would let
+  // sanitisation manufacture an empty list, which the role policy reads as
+  // "granted nothing" and denies: a guard that turns a granted role set into a
+  // deny-all is worse than the encoding problem it avoids.
   const identity = await run(() => ({
     actor: "ada",
     roles: ["ops", "team,operator", "release"],
@@ -360,7 +361,7 @@ Deno.test("a role name carrying the child's separator is dropped", async () => {
   assertEquals(identity, {
     actor: "ada",
     kind: "human",
-    roles: ["ops", "release"],
+    roles: ["ops", "team,operator", "release"],
   });
 });
 

--- a/packages/core/tests/mcp_auth_test.ts
+++ b/packages/core/tests/mcp_auth_test.ts
@@ -43,10 +43,21 @@ Deno.test("normalizeIdentity refuses anything that is not an identity object", (
   assertEquals(normalizeIdentity({ actor: "" }), null); // empty actor
 });
 
-Deno.test("normalizeIdentity settles kind and roles on a minimal identity", () => {
-  // The key count is compared too, so this also pins that no `via` key is
-  // invented for an identity that carried none.
+Deno.test("normalizeIdentity settles kind, and leaves unclaimed roles unclaimed", () => {
+  // The key count is compared too, so this pins that neither `via` nor `roles`
+  // is invented for an identity that carried neither. An authenticator that
+  // never mentions roles does not speak roles, which is not the same claim as
+  // granting none — the role policy skips the former and denies the latter.
   assertEquals(normalizeIdentity({ actor: "ada" }), {
+    actor: "ada",
+    kind: "human",
+  });
+});
+
+Deno.test("normalizeIdentity keeps an explicitly empty role list", () => {
+  // The opposite claim to omitting it: the authenticator considered the
+  // question and granted nothing, so the policy has something to deny with.
+  assertEquals(normalizeIdentity({ actor: "ada", roles: [] }), {
     actor: "ada",
     kind: "human",
     roles: [],
@@ -57,7 +68,6 @@ Deno.test("normalizeIdentity honours an explicit service kind", () => {
   assertEquals(normalizeIdentity({ actor: "deploy-bot", kind: "service" }), {
     actor: "deploy-bot",
     kind: "service",
-    roles: [],
   });
 });
 
@@ -80,17 +90,21 @@ Deno.test("normalizeIdentity keeps only the non-empty string roles", () => {
 });
 
 Deno.test("normalizeIdentity yields no roles for a non-array roles", () => {
-  for (const roles of ["ops", 7, null, undefined, { ops: true }]) {
+  // A malformed claim is still a claim: the authenticator meant to say
+  // something about roles, so it settles to "none" rather than to unclaimed.
+  for (const roles of ["ops", 7, null, { ops: true }]) {
     const identity = normalizeIdentity({ actor: "ada", roles });
     assertEquals(identity?.roles, [], `roles ${JSON.stringify(roles)}`);
   }
+  // …while omitting the key entirely leaves it unclaimed.
+  const omitted = normalizeIdentity({ actor: "ada", roles: undefined });
+  assertEquals(omitted !== null && Object.hasOwn(omitted, "roles"), false);
 });
 
 Deno.test("normalizeIdentity keeps a non-empty via and omits any other", () => {
   assertEquals(normalizeIdentity({ actor: "ada", via: "oauth-proxy" }), {
     actor: "ada",
     kind: "human",
-    roles: [],
     via: "oauth-proxy",
   });
   for (const via of ["", 7, null, {}]) {
@@ -107,7 +121,7 @@ Deno.test("normalizeIdentity keeps a non-empty via and omits any other", () => {
 
 Deno.test("authenticateRequest settles a synchronous identity", async () => {
   const result = await run(() => ({ actor: "ada", kind: "service" }));
-  assertEquals(result, { actor: "ada", kind: "service", roles: [] });
+  assertEquals(result, { actor: "ada", kind: "service" });
 });
 
 Deno.test("authenticateRequest awaits an asynchronous identity", async () => {
@@ -136,7 +150,7 @@ Deno.test("authenticateRequest passes the request context through", async () => 
   );
   assertEquals(seen.length, 1);
   assertEquals(seen[0], ctx);
-  assertEquals(result, { actor: "ada", kind: "human", roles: [] });
+  assertEquals(result, { actor: "ada", kind: "human" });
 });
 
 // ---- authenticateRequest: fail-closed on a misbehaving authenticator -------

--- a/packages/core/tests/mcp_hardening_test.ts
+++ b/packages/core/tests/mcp_hardening_test.ts
@@ -1244,3 +1244,84 @@ Deno.test("a policy that throws denies rather than opening the door", async () =
     );
   });
 });
+
+Deno.test("a run-scoped tool cannot reach a target its role gate refuses", async () => {
+  // Resuming, signalling or forcing a run executes that run's plan, so the
+  // roles its targets declare apply there exactly as they do to `run:`. Without
+  // this, a caller refused `run:promote` reached the same body via signal_run.
+  class Gated extends Build {
+    promote = target().requiresRole("operator").executes(() => {});
+  }
+  await withTempStore(async (store) => {
+    const server = new McpServer(new Gated(), {
+      allowRun: true,
+      stateStore: store,
+      enforceRoles: true,
+      authenticator: withRoles("mallory", ["run"]),
+    });
+    const id = await seedSuspended(store, "promote");
+
+    for (const tool of ["signal_run", "cancel_run", "resume_check"]) {
+      const res = await server.handleMessage(
+        req("tools/call", {
+          name: tool,
+          arguments: { runId: id, signal: "go" },
+        }),
+      );
+      assertStringIncludes(JSON.stringify(res), "unauthorized", tool);
+    }
+    // The run is untouched.
+    assertEquals((await store.getRun(id))?.record.status, "suspended");
+  });
+});
+
+Deno.test("a role denial on a run-scoped tool is audited as a denial, with the roles", async () => {
+  class Gated extends Build {
+    promote = target().requiresRole("operator").executes(() => {});
+  }
+  await withTempStore(async (store) => {
+    const server = new McpServer(new Gated(), {
+      allowRun: true,
+      stateStore: store,
+      enforceRoles: true,
+      authenticator: withRoles("mallory", ["run"]),
+    });
+    const id = await seedSuspended(store, "promote");
+    await server.handleMessage(
+      req("tools/call", {
+        name: "signal_run",
+        arguments: { runId: id, signal: "go" },
+      }),
+    );
+    const row = (await auditEvents(store)).find((e) => e.tool === "signal_run");
+    // Not the generic "error" an unauthorized result would otherwise record.
+    assertEquals(row?.outcome, "denied");
+    assertEquals(row?.actor, "mallory");
+    assertEquals(row?.roles, ["run"]);
+    assertStringIncludes(row?.detail ?? "", "operator");
+  });
+});
+
+Deno.test("an overridden mcpAuthorize runs even for the legacy identity seam", async () => {
+  // The override exists to express rules the engine cannot know — a change
+  // window, a freeze — and those apply whether or not the authenticator speaks
+  // roles. Only the *default* policy steps aside for an unclaimed identity.
+  class Frozen extends Build {
+    deploy = target().executes(() => {});
+    override mcpAuthorize() {
+      return { allow: false as const, reason: "deploys are frozen" };
+    }
+  }
+  await withTempStore(async (store) => {
+    const server = new McpServer(new Frozen(), {
+      allowRun: true,
+      stateStore: store,
+      // The legacy seam: no roles, and enforcement off.
+      authenticator: withRoles("ada"),
+    });
+    const res = await server.handleMessage(
+      req("tools/call", { name: "run:deploy", arguments: {} }),
+    );
+    assertStringIncludes(JSON.stringify(res), "frozen");
+  });
+});

--- a/packages/core/tests/mcp_hardening_test.ts
+++ b/packages/core/tests/mcp_hardening_test.ts
@@ -1325,3 +1325,49 @@ Deno.test("an overridden mcpAuthorize runs even for the legacy identity seam", a
     assertStringIncludes(JSON.stringify(res), "frozen");
   });
 });
+
+Deno.test("a role-gated target is refused on a seam that cannot express roles", async () => {
+  // The legacy hook has no roles to give, so the policy leaves it alone — until
+  // a target actually declares a requirement. Ignoring that declaration would
+  // tell an author their target is gated when nothing is checking, and the
+  // refusal names the seam that cannot answer it.
+  class Mixed extends Build {
+    deploy = target().executes(() => {});
+    promote = target().requiresRole("operator").executes(() => {});
+  }
+  await withTempStore(async (store) => {
+    const server = new McpServer(new Mixed(), {
+      allowRun: true,
+      stateStore: store,
+      // The legacy seam: an identity with no roles, enforcement off.
+      authenticator: withRoles("ada"),
+    });
+
+    // A target with no declared role is untouched — an existing server declares no roles and
+    // sees no change at all.
+    const ordinary = await server.handleMessage(
+      req("tools/call", { name: "run:deploy", arguments: {} }),
+    );
+    assertEquals(JSON.stringify(ordinary).includes("unauthorized"), false);
+
+    // The gated one is refused, and says why rather than failing silently.
+    const gated = await server.handleMessage(
+      req("tools/call", { name: "run:promote", arguments: {} }),
+    );
+    const text = JSON.stringify(gated);
+    assertStringIncludes(text, "unauthorized");
+    assertStringIncludes(text, "mcpAuth()");
+
+    // …and the same holds through a run-scoped tool, which executes the same
+    // plan and so cannot be a way around the declaration.
+    const id = await seedSuspended(store, "promote");
+    const viaSignal = await server.handleMessage(
+      req("tools/call", {
+        name: "signal_run",
+        arguments: { runId: id, signal: "go" },
+      }),
+    );
+    assertStringIncludes(JSON.stringify(viaSignal), "unauthorized");
+    assertEquals((await store.getRun(id))?.record.status, "suspended");
+  });
+});

--- a/packages/core/tests/mcp_hardening_test.ts
+++ b/packages/core/tests/mcp_hardening_test.ts
@@ -926,9 +926,10 @@ Deno.test("the authenticator gates initialize, ping and tools/list too", async (
   );
 });
 
-Deno.test("an authenticator's kind, roles and via never reach the audit row", async () => {
-  // The claims exist to be authorized against, not to be persisted: the trail
-  // records the actor and the (redacted) arguments, and nothing else new.
+Deno.test("the audit row carries the roles, but not the kind or via", async () => {
+  // The roles are what makes a denial answerable afterwards — who was refused,
+  // by which rule, and what they were carrying — so they are persisted. The
+  // other claims are inputs to that decision, not part of the account of it.
   await withServer(
     { allowRun: true, authenticator: asyncProxy },
     async (server, store) => {
@@ -940,8 +941,8 @@ Deno.test("an authenticator's kind, roles and via never reach the audit row", as
       );
       assertEquals(deploy?.actor, "engineer-a");
       assertEquals(deploy?.args, { environment: "dev" });
+      assertEquals(deploy?.roles, ["deployer"]);
       const row = JSON.stringify(deploy);
-      assertEquals(row.includes("deployer"), false);
       assertEquals(row.includes("oauth-proxy"), false);
       assertEquals(row.includes("service"), false);
     },
@@ -1063,5 +1064,183 @@ Deno.test("force_target is not exposed without execution enabled", async () => {
   await withServer({ allowRun: false }, async (server) => {
     const names = (await server.tools()).map((t) => t.name);
     assertEquals(names.includes("force_target"), false);
+  });
+});
+
+// ---- M17: the role policy --------------------------------------------------
+
+/** An authenticator granting `roles` to a fixed actor. */
+function withRoles(actor: string, roles?: readonly string[]): McpAuthenticator {
+  return {
+    authenticate: () => ({
+      actor,
+      kind: "human" as const,
+      ...(roles === undefined ? {} : { roles }),
+    }),
+  };
+}
+
+Deno.test("an authenticator claiming no roles is not constrained by the policy", async () => {
+  // The compatibility guarantee: a proxy-header hook never spoke roles, so the
+  // policy has nothing to decide with and the server's own gates stand alone.
+  // Without this, every server whose authenticator predates roles would be
+  // denied everything on upgrade.
+  await withServer(
+    { allowRun: true, authenticator: withRoles("ada") },
+    async (server, store) => {
+      const ran = await call(server, "run:deploy", {});
+      assertEquals(ran.isError, false, ran.text);
+      const listed = await call(server, "list_runs");
+      assertEquals(listed.isError, false);
+      void store;
+    },
+  );
+});
+
+Deno.test("an authenticator claiming an empty role set is denied", async () => {
+  // The opposite claim: the question was considered and nothing granted.
+  await withServer(
+    { allowRun: true, authenticator: withRoles("ada", []) },
+    async (server) => {
+      const ran = await call(server, "run:deploy", {});
+      assertEquals(ran.isError, true);
+      assertStringIncludes(ran.text, "run");
+      const listed = await call(server, "list_runs");
+      assertEquals(listed.isError, true);
+    },
+  );
+});
+
+Deno.test("with no authenticator at all the policy never runs", async () => {
+  // The other half of the guarantee — an unauthenticated server is exactly what
+  // it was before roles existed.
+  await withServer({ allowRun: true }, async (server) => {
+    const ran = await call(server, "run:deploy", {});
+    assertEquals(ran.isError, false, ran.text);
+  });
+});
+
+Deno.test("the role policy gates running a target, and a denial is audited with the roles", async () => {
+  await withServer(
+    { allowRun: true, authenticator: withRoles("ada", ["read"]) },
+    async (server, store) => {
+      const denied = await call(server, "run:deploy", {});
+      assertEquals(denied.isError, true);
+
+      const audit = await auditEvents(store);
+      const row = audit.find((e) => e.tool === "run:deploy");
+      assertEquals(row?.outcome, "denied");
+      assertEquals(row?.actor, "ada");
+      // What makes a denial answerable afterwards: who, which rule, and what
+      // they were carrying at the time.
+      assertEquals(row?.roles, ["read"]);
+      assertStringIncludes(row?.detail ?? "", "run");
+    },
+  );
+  // …and `run` gets through.
+  await withServer(
+    { allowRun: true, authenticator: withRoles("ada", ["run"]) },
+    async (server) => {
+      const ran = await call(server, "run:deploy", {});
+      assertEquals(ran.isError, false, ran.text);
+    },
+  );
+});
+
+Deno.test("the operator token grants the operator role for that call", async () => {
+  // The shared secret and the role model are one policy, not two that can
+  // disagree: presenting the token is presenting the role.
+  class Guarded extends Build {
+    promote = target().requiresRole("operator").executes(() => {});
+  }
+  await withTempStore(async (store) => {
+    const server = new McpServer(new Guarded(), {
+      allowRun: true,
+      stateStore: store,
+      operatorToken: "operator-secret",
+      authenticator: withRoles("ada", ["run"]),
+    });
+    const denied = await server.handleMessage(
+      req("tools/call", { name: "run:promote", arguments: {} }),
+    );
+    assertStringIncludes(JSON.stringify(denied), "operator");
+
+    const allowed = await server.handleMessage(
+      req("tools/call", {
+        name: "run:promote",
+        arguments: { operatorToken: "operator-secret" },
+      }),
+    );
+    assertEquals(JSON.stringify(allowed).includes("unauthorized"), false);
+  });
+});
+
+Deno.test("a run-scoped mutation needs the run's initiator or an operator", async () => {
+  const initiator = {
+    actor: "ada",
+    kind: "human" as const,
+    at: "2026-09-06T10:00:00.000Z",
+  };
+  const seed = async (store: FileSystemStateStore) => {
+    const id = await seedSuspended(store, "deploy");
+    const loaded = await store.getRun(id);
+    if (loaded === null) throw new Error("no record");
+    await store.putRun({ ...loaded.record, initiator }, loaded.version);
+    return id;
+  };
+
+  // A stranger holding `run` is refused…
+  await withServer(
+    { allowRun: true, authenticator: withRoles("bob", ["run"]) },
+    async (server, store) => {
+      const id = await seed(store);
+      const denied = await call(server, "cancel_run", { runId: id });
+      assertEquals(denied.isError, true);
+      assertEquals((await store.getRun(id))?.record.status, "suspended");
+    },
+  );
+  // …the initiator is not…
+  await withServer(
+    { allowRun: true, authenticator: withRoles("ada", ["run"]) },
+    async (server, store) => {
+      const id = await seed(store);
+      const ok = await call(server, "cancel_run", { runId: id });
+      assertEquals(ok.isError, false, ok.text);
+    },
+  );
+  // …and neither is an operator.
+  await withServer(
+    { allowRun: true, authenticator: withRoles("bob", ["operator"]) },
+    async (server, store) => {
+      const id = await seed(store);
+      const ok = await call(server, "cancel_run", { runId: id });
+      assertEquals(ok.isError, false, ok.text);
+    },
+  );
+});
+
+Deno.test("a policy that throws denies rather than opening the door", async () => {
+  class Broken extends Build {
+    deploy = target().executes(() => {});
+    override mcpAuthorize(): never {
+      throw new Error("policy blew up");
+    }
+  }
+  await withTempStore(async (store) => {
+    const server = new McpServer(new Broken(), {
+      allowRun: true,
+      stateStore: store,
+      authenticator: withRoles("ada", ["operator"]),
+    });
+    const response = await server.handleMessage(
+      req("tools/call", { name: "run:deploy", arguments: {} }),
+    );
+    assertStringIncludes(JSON.stringify(response), "unauthorized");
+    // The reason reaches the trail without leaking the thrown message.
+    const audit = await auditEvents(store);
+    assertEquals(
+      audit.find((e) => e.tool === "run:deploy")?.detail,
+      "policy_error",
+    );
   });
 });

--- a/packages/core/tests/mcp_http_test.ts
+++ b/packages/core/tests/mcp_http_test.ts
@@ -528,7 +528,7 @@ Deno.test("http transport hands the resolved identity to the handler", async () 
   });
   // The defaults are settled before the handler sees them: an authenticator that
   // says nothing about kind or roles is read as a human holding none.
-  assertEquals(seen[1], { actor: "engineer-a", kind: "human", roles: [] });
+  assertEquals(seen[1], { actor: "engineer-a", kind: "human" });
   // The authenticator sees the request, but not its body — that belongs to the
   // transport, and a body can only be read once.
   assertEquals(views, [

--- a/packages/core/tests/mcp_roles_test.ts
+++ b/packages/core/tests/mcp_roles_test.ts
@@ -72,14 +72,14 @@ Deno.test("read tools need read, and running needs run", () => {
 Deno.test("a target may ask for more than run, and only more", () => {
   const runner = caller("ada", ["run"]);
   const op = caller("ada", ["operator"]);
-  const call = { tool: "run:promote", requiredRole: "operator" };
+  const call = { tool: "run:promote", requiredRoles: ["operator"] };
   assertEquals(allows(runner, call), false);
   assertEquals(allows(op, call), true);
 
   // A custom requirement is checked *in addition* to `run`, and is satisfied
   // only by that exact role — an operator does not inherit someone else's
   // group, and holding the group alone is not permission to execute anything.
-  const custom = { tool: "run:release", requiredRole: "release-manager" };
+  const custom = { tool: "run:release", requiredRoles: ["release-manager"] };
   assertEquals(allows(op, custom), false);
   assertEquals(allows(caller("ada", ["release-manager"]), custom), false);
   assertEquals(allows(caller("ada", ["run", "release-manager"]), custom), true);
@@ -87,11 +87,11 @@ Deno.test("a target may ask for more than run, and only more", () => {
   // requiresRole can only raise the bar. Requiring it *instead of* `run` would
   // let a build declaration hand a read-only caller the ability to execute.
   assertEquals(
-    allows(caller("ada", ["read"]), { tool: "run:x", requiredRole: "read" }),
+    allows(caller("ada", ["read"]), { tool: "run:x", requiredRoles: ["read"] }),
     false,
   );
   assertEquals(
-    allows(caller("ada", ["run"]), { tool: "run:x", requiredRole: "read" }),
+    allows(caller("ada", ["run"]), { tool: "run:x", requiredRoles: ["read"] }),
     true,
   );
 });
@@ -194,7 +194,7 @@ Deno.test("a denial says which rule refused, and names the owner", () => {
   // The floor is reported first for a caller who cannot run at all…
   const noRun = defaultMcpAuthorize(caller("bob", ["read"]), {
     tool: "run:promote",
-    requiredRole: "operator",
+    requiredRoles: ["operator"],
   });
   if (noRun.allow) throw new Error("expected a denial");
   assertStringIncludes(noRun.reason, '"run"');
@@ -202,7 +202,7 @@ Deno.test("a denial says which rule refused, and names the owner", () => {
   // …and the target's own requirement once they clear it.
   const needsRole = defaultMcpAuthorize(caller("bob", ["run"]), {
     tool: "run:promote",
-    requiredRole: "operator",
+    requiredRoles: ["operator"],
   });
   if (needsRole.allow) throw new Error("expected a denial");
   assertStringIncludes(needsRole.reason, '"operator"');

--- a/packages/core/tests/mcp_roles_test.ts
+++ b/packages/core/tests/mcp_roles_test.ts
@@ -1,0 +1,209 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals, assertStringIncludes } from "./_assert.ts";
+import {
+  defaultMcpAuthorize,
+  type McpCall,
+  satisfiesRole,
+} from "../src/mcp/roles.ts";
+import type { McpIdentity } from "../src/mcp/auth.ts";
+import type { RunSummary } from "../src/state/types.ts";
+
+/** A caller holding `roles`. */
+function caller(actor: string, roles: readonly string[]): McpIdentity {
+  return { actor, kind: "human", roles };
+}
+
+/** A run summary, optionally with an initiator. */
+function run(over: Partial<RunSummary> = {}): RunSummary {
+  return {
+    id: "run-1",
+    build: "CD",
+    rootTarget: "deploy",
+    status: "suspended",
+    actor: "sweep-bot",
+    createdAt: "2026-09-06T10:00:00.000Z",
+    updatedAt: "2026-09-06T10:00:00.000Z",
+    ...over,
+  };
+}
+
+/** Whether the default policy allows `call` for `identity`. */
+function allows(identity: McpIdentity, call: McpCall): boolean {
+  return defaultMcpAuthorize(identity, call).allow;
+}
+
+// ---- The role model --------------------------------------------------------
+
+Deno.test("the built-in roles are ordered, and custom names are exact", () => {
+  // An operator satisfies everything below it…
+  for (const required of ["read", "run", "operator"]) {
+    assertEquals(satisfiesRole(["operator"], required), true, required);
+  }
+  // …and `run` satisfies `read` but not `operator`.
+  assertEquals(satisfiesRole(["run"], "read"), true);
+  assertEquals(satisfiesRole(["run"], "run"), true);
+  assertEquals(satisfiesRole(["run"], "operator"), false);
+  assertEquals(satisfiesRole(["read"], "run"), false);
+
+  // A name outside the tiers is matched exactly, in both directions: holding it
+  // grants no tier, and holding a tier does not grant it. Ordering an unknown
+  // name would mean guessing where someone else's group sits in a hierarchy it
+  // never agreed to.
+  assertEquals(satisfiesRole(["sre"], "sre"), true);
+  assertEquals(satisfiesRole(["sre"], "run"), false);
+  assertEquals(satisfiesRole(["operator"], "sre"), false);
+  assertEquals(satisfiesRole([], "read"), false);
+});
+
+// ---- The default policy ----------------------------------------------------
+
+Deno.test("read tools need read, and running needs run", () => {
+  const reader = caller("ada", ["read"]);
+  for (const tool of ["list_runs", "show_run", "describe_build", "graph"]) {
+    assertEquals(allows(reader, { tool }), true, tool);
+  }
+  assertEquals(allows(reader, { tool: "run:deploy" }), false);
+  assertEquals(allows(caller("ada", ["run"]), { tool: "run:deploy" }), true);
+  assertEquals(allows(caller("ada", []), { tool: "list_runs" }), false);
+});
+
+Deno.test("a target may ask for more than run, and only more", () => {
+  const runner = caller("ada", ["run"]);
+  const op = caller("ada", ["operator"]);
+  const call = { tool: "run:promote", requiredRole: "operator" };
+  assertEquals(allows(runner, call), false);
+  assertEquals(allows(op, call), true);
+
+  // A custom requirement is checked *in addition* to `run`, and is satisfied
+  // only by that exact role — an operator does not inherit someone else's
+  // group, and holding the group alone is not permission to execute anything.
+  const custom = { tool: "run:release", requiredRole: "release-manager" };
+  assertEquals(allows(op, custom), false);
+  assertEquals(allows(caller("ada", ["release-manager"]), custom), false);
+  assertEquals(allows(caller("ada", ["run", "release-manager"]), custom), true);
+
+  // requiresRole can only raise the bar. Requiring it *instead of* `run` would
+  // let a build declaration hand a read-only caller the ability to execute.
+  assertEquals(
+    allows(caller("ada", ["read"]), { tool: "run:x", requiredRole: "read" }),
+    false,
+  );
+  assertEquals(
+    allows(caller("ada", ["run"]), { tool: "run:x", requiredRole: "read" }),
+    true,
+  );
+});
+
+Deno.test("a run-scoped mutation needs the initiator, or an operator", () => {
+  const owned = run({
+    initiator: { actor: "ada", kind: "human", at: "2026-09-06T10:00:00.000Z" },
+  });
+  for (const tool of ["cancel_run", "signal_run", "force_target"]) {
+    // The person who started it may steer it…
+    assertEquals(
+      allows(caller("ada", ["run"]), { tool, run: owned }),
+      true,
+      tool,
+    );
+    // …a stranger with the same role may not…
+    assertEquals(
+      allows(caller("bob", ["run"]), { tool, run: owned }),
+      false,
+      tool,
+    );
+    // …and an operator may.
+    assertEquals(
+      allows(caller("bob", ["operator"]), { tool, run: owned }),
+      true,
+      tool,
+    );
+    // Below `run` nobody may, not even the initiator.
+    assertEquals(
+      allows(caller("ada", ["read"]), { tool, run: owned }),
+      false,
+      tool,
+    );
+  }
+});
+
+Deno.test("a service-initiated run may be steered by any run caller", () => {
+  // A scheduler's run has no person to ask; treating the scheduler as its owner
+  // would mean nobody could intervene.
+  const machine = run({
+    initiator: {
+      actor: "nightly",
+      kind: "service",
+      at: "2026-09-06T10:00:00.000Z",
+    },
+  });
+  assertEquals(
+    allows(caller("bob", ["run"]), { tool: "cancel_run", run: machine }),
+    true,
+  );
+  assertEquals(
+    allows(caller("bob", ["read"]), { tool: "cancel_run", run: machine }),
+    false,
+  );
+});
+
+Deno.test("a run with no initiator falls back to its actor as owner", () => {
+  // A record written before initiators existed; `actor` is the closest answer.
+  const legacy = run({ actor: "ada" });
+  assertEquals(
+    allows(caller("ada", ["run"]), { tool: "cancel_run", run: legacy }),
+    true,
+  );
+  assertEquals(
+    allows(caller("bob", ["run"]), { tool: "cancel_run", run: legacy }),
+    false,
+  );
+});
+
+Deno.test("a sweep over every run needs operator", () => {
+  // No run named: it touches all of them, which no single run's owner can
+  // authorize.
+  const sweep = { tool: "resume_check" };
+  assertEquals(allows(caller("ada", ["run"]), sweep), false);
+  assertEquals(allows(caller("ada", ["operator"]), sweep), true);
+
+  // Named, it is an ordinary run-scoped call.
+  const owned = run({
+    initiator: { actor: "ada", kind: "human", at: "2026-09-06T10:00:00.000Z" },
+  });
+  assertEquals(
+    allows(caller("ada", ["run"]), { tool: "resume_check", run: owned }),
+    true,
+  );
+});
+
+Deno.test("a denial says which rule refused, and names the owner", () => {
+  const owned = run({
+    initiator: { actor: "ada", kind: "human", at: "2026-09-06T10:00:00.000Z" },
+  });
+  const verdict = defaultMcpAuthorize(caller("bob", ["run"]), {
+    tool: "cancel_run",
+    run: owned,
+  });
+  assertEquals(verdict.allow, false);
+  if (verdict.allow) throw new Error("expected a denial");
+  assertStringIncludes(verdict.reason, "ada");
+  assertStringIncludes(verdict.reason, "operator");
+
+  // The floor is reported first for a caller who cannot run at all…
+  const noRun = defaultMcpAuthorize(caller("bob", ["read"]), {
+    tool: "run:promote",
+    requiredRole: "operator",
+  });
+  if (noRun.allow) throw new Error("expected a denial");
+  assertStringIncludes(noRun.reason, '"run"');
+
+  // …and the target's own requirement once they clear it.
+  const needsRole = defaultMcpAuthorize(caller("bob", ["run"]), {
+    tool: "run:promote",
+    requiredRole: "operator",
+  });
+  if (needsRole.allow) throw new Error("expected a denial");
+  assertStringIncludes(needsRole.reason, '"operator"');
+});

--- a/packages/core/tests/registry_server_test.ts
+++ b/packages/core/tests/registry_server_test.ts
@@ -1683,7 +1683,10 @@ Deno.test("an authenticated run passes the caller's kind and roles to the runner
   assertEquals(calls.length, 2);
   assertEquals(calls[1].actor, "engineer-a");
   assertEquals(calls[1].actorKind, "human");
-  assertEquals(calls[1].actorRoles, []);
+  // The bare identity claimed no roles at all, which is not the same as
+  // claiming none — the runner passes the claim through untouched, and its own
+  // env export is what turns an unclaimed list into an empty variable.
+  assertEquals(calls[1].actorRoles, undefined);
 });
 
 Deno.test("without an authenticator the runner gets the actor and no claim", async () => {

--- a/packages/core/tests/registry_server_test.ts
+++ b/packages/core/tests/registry_server_test.ts
@@ -1663,7 +1663,9 @@ Deno.test("an authenticated run passes the caller's kind and roles to the runner
       const sub = ctx.headers.get("x-user");
       if (sub === null) throw new Error("no identity from proxy");
       return sub === "scheduler"
-        ? { actor: sub, kind: "service", roles: ["deployer", "reader"] }
+        // `run` is what the policy asks for to spawn anything; the other two
+        // are group names from the identity provider.
+        ? { actor: sub, kind: "service", roles: ["run", "deployer", "reader"] }
         : { actor: sub };
     }),
   });
@@ -1675,7 +1677,7 @@ Deno.test("an authenticated run passes the caller's kind and roles to the runner
   assertEquals(calls.length, 1);
   assertEquals(calls[0].actor, "scheduler");
   assertEquals(calls[0].actorKind, "service");
-  assertEquals(calls[0].actorRoles, ["deployer", "reader"]);
+  assertEquals(calls[0].actorRoles, ["run", "deployer", "reader"]);
 
   // A bare `{ actor }` settles to the conservative defaults before the spawn:
   // the runner never sees an unstated claim it would have to default itself.
@@ -1825,4 +1827,66 @@ Deno.test("the server's tokens are stripped beside the exported claim", async ()
       assertStringIncludes(result.stdout, "STRIPPED STRIPPED engineer-a");
     },
   );
+});
+
+Deno.test("in registry mode the role policy gates listing and spawning", async () => {
+  // Without this the registry server applied no policy at all: a caller granted
+  // nothing could list every registered build and spawn any of them, on a
+  // server that does authenticate its callers.
+  const registry = new FakeRegistry();
+  registry.add(descriptor("Api", ["deploy"]));
+  const { runner, calls } = recordingRunner();
+  const server = new RegistryMcpServer(registry, {
+    allowRun: true,
+    runner,
+    enforceRoles: true,
+    authenticator: authenticatorFromHook((ctx) => ({
+      actor: ctx.headers.get("x-user") ?? "anon",
+      roles: (ctx.headers.get("x-roles") ?? "").split(",").filter((r) =>
+        r !== ""
+      ),
+    })),
+  });
+
+  // Granted nothing: refused everything, and nothing is spawned.
+  for (const tool of ["list_builds", "run:Api:deploy"]) {
+    const res = await callWith(server, tool, { "x-user": "mallory" });
+    assertStringIncludes(JSON.stringify(res), "unauthorized", tool);
+  }
+  assertEquals(calls.length, 0);
+
+  // `read` can list but not spawn.
+  const listed = await callWith(server, "list_builds", {
+    "x-user": "ada",
+    "x-roles": "read",
+  });
+  assertEquals(JSON.stringify(listed).includes("unauthorized"), false);
+  const refused = await callWith(server, "run:Api:deploy", {
+    "x-user": "ada",
+    "x-roles": "read",
+  });
+  assertStringIncludes(JSON.stringify(refused), "unauthorized");
+  assertEquals(calls.length, 0);
+
+  // `run` can spawn.
+  await callWith(server, "run:Api:deploy", {
+    "x-user": "ada",
+    "x-roles": "run",
+  });
+  assertEquals(calls.length, 1);
+});
+
+Deno.test("a role name carrying the separator survives the child's env", async () => {
+  // Kept in the identity and escaped here, so sanitisation cannot turn a
+  // granted role set into the empty one the policy reads as "granted nothing".
+  const result = await defaultRegistryRunner(
+    [Deno.execPath(), "eval", ACTOR_ECHO],
+    Deno.cwd(),
+    { actor: "ada", actorKind: "human", actorRoles: ["team,ops", "run"] },
+  );
+  assertEquals(result.code, 0);
+  const roles = result.stdout.trim().split("|")[2];
+  assertEquals(roles, "team%2Cops,run");
+  // A child splitting on "," and decoding gets the original two names back.
+  assertEquals(roles.split(",").map(decodeURIComponent), ["team,ops", "run"]);
 });

--- a/packages/core/tests/state_test.ts
+++ b/packages/core/tests/state_test.ts
@@ -1804,6 +1804,43 @@ Deno.test("RunStateWriter stores a settled target's summary notes, values redact
   assertEquals(store.record?.targets.verify.summary, undefined);
 });
 
+Deno.test("an audit event's roles are persisted, and redacted like every other field", async () => {
+  // Role names are normally the operator's own identifiers, which the redactor
+  // leaves alone — but they go through it anyway, so no field of the trail is
+  // safe only because of an assumption about where its value came from.
+  const store = new MemStateStore();
+  const redactor = new Redactor();
+  redactor.add("hunter2");
+  const writer = await RunStateWriter.open(
+    store,
+    sampleRecord(),
+    () => "t",
+    redactor,
+  );
+  await writer.appendEvent({
+    at: "t",
+    tool: "run:deploy",
+    actor: "ada",
+    outcome: "denied",
+    args: {},
+    detail: 'needs the "operator" role',
+    roles: ["run", "hunter2"],
+  });
+  const event = store.record?.events[0];
+  assertEquals(event?.roles, ["run", "[redacted]"]);
+
+  // An event carrying none stays without the key, rather than gaining an empty
+  // list that would read as "held nothing".
+  await writer.appendEvent({
+    at: "t",
+    tool: "list_runs",
+    actor: "ada",
+    outcome: "ok",
+    args: {},
+  });
+  assertEquals("roles" in (store.record?.events[1] ?? {}), false);
+});
+
 Deno.test("parseRunRecord round-trips a target's summary notes and rejects malformed ones", () => {
   const record = sampleRecord({
     targets: {

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/.codex-plugin/plugin.json
+++ b/plugins/zuke/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/skills/zuke-write-build/SKILL.md
+++ b/plugins/zuke/skills/zuke-write-build/SKILL.md
@@ -114,6 +114,8 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   lifecycle instead of `.executes(...)`; the executor starts it, waits until
   ready, then stops it in a `finally` so it never leaks. See the cheatsheet.
 - **Target context & cancellation:** a body may take a context —
+  `.requiresRole("operator")` raises the bar for running one target over MCP
+  (see the cheatsheet), and
   `.executes((ctx) => …)` — with `ctx.runId`, `ctx.initiator` (who asked for the
   run, unchanged by a resume), `ctx.target`, `ctx.signal` (an
   `AbortSignal` fired when the run is cancelled; a plain `` $`…` `` in the body

--- a/plugins/zuke/skills/zuke-write-build/SKILL.md
+++ b/plugins/zuke/skills/zuke-write-build/SKILL.md
@@ -113,9 +113,10 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   depended on like a target, but with a `.start(...)` / `.readyWhen(...)`
   lifecycle instead of `.executes(...)`; the executor starts it, waits until
   ready, then stops it in a `finally` so it never leaks. See the cheatsheet.
+- **Authorization by role:** `.requiresRole("operator")` gates running a target
+  over MCP, enforced across the whole plan it would execute;
+  `override mcpAuthorize(identity, call)` decides the rest. See the cheatsheet.
 - **Target context & cancellation:** a body may take a context —
-  `.requiresRole("operator")` raises the bar for running one target over MCP
-  (see the cheatsheet), and
   `.executes((ctx) => …)` — with `ctx.runId`, `ctx.initiator` (who asked for the
   run, unchanged by a resume), `ctx.target`, `ctx.signal` (an
   `AbortSignal` fired when the run is cancelled; a plain `` $`…` `` in the body

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -1286,6 +1286,18 @@ a descriptor whose entry module is **remote** (not a local path or `file:` URL �
 spawned. `zuke register` writes a local `file:` module, so this only bites a
 hand-authored or second-party registry entry.
 
+**Authorization by role** (`docs/mcp.md`): once the server authenticates its
+callers, `target().requiresRole("operator")` raises the bar for one target and
+`override mcpAuthorize(identity, call)` decides the rest, defaulting to
+`defaultMcpAuthorize`. Built-ins are ordered `read` < `run` < `operator`; any
+other name matches exactly, so an identity provider's group works with
+`requiresRole`. `run` is the floor for executing anything, so `requiresRole` can
+only raise. A run-scoped mutation needs the run's initiator or `operator`; a
+sweep over every run needs `operator`; a valid `ZUKE_OPERATOR_TOKEN` grants
+`operator` for that call. A server with **no** authenticator, or one whose
+authenticator never mentions `roles`, is not constrained by the policy at all —
+`--allow-run`/`--protect` remain its only gates.
+
 **Forcing a target** (`docs/state.md`):
 `zuke force <run-id> <target> --outcome skipped|succeeded [--reason "…"]`
 settles one target of a live run **without running its body** — ahead of its

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -114,6 +114,8 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   lifecycle instead of `.executes(...)`; the executor starts it, waits until
   ready, then stops it in a `finally` so it never leaks. See the cheatsheet.
 - **Target context & cancellation:** a body may take a context —
+  `.requiresRole("operator")` raises the bar for running one target over MCP
+  (see the cheatsheet), and
   `.executes((ctx) => …)` — with `ctx.runId`, `ctx.initiator` (who asked for the
   run, unchanged by a resume), `ctx.target`, `ctx.signal` (an
   `AbortSignal` fired when the run is cancelled; a plain `` $`…` `` in the body

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -113,9 +113,10 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   depended on like a target, but with a `.start(...)` / `.readyWhen(...)`
   lifecycle instead of `.executes(...)`; the executor starts it, waits until
   ready, then stops it in a `finally` so it never leaks. See the cheatsheet.
+- **Authorization by role:** `.requiresRole("operator")` gates running a target
+  over MCP, enforced across the whole plan it would execute;
+  `override mcpAuthorize(identity, call)` decides the rest. See the cheatsheet.
 - **Target context & cancellation:** a body may take a context —
-  `.requiresRole("operator")` raises the bar for running one target over MCP
-  (see the cheatsheet), and
   `.executes((ctx) => …)` — with `ctx.runId`, `ctx.initiator` (who asked for the
   run, unchanged by a resume), `ctx.target`, `ctx.signal` (an
   `AbortSignal` fired when the run is cancelled; a plain `` $`…` `` in the body

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -1286,6 +1286,18 @@ a descriptor whose entry module is **remote** (not a local path or `file:` URL �
 spawned. `zuke register` writes a local `file:` module, so this only bites a
 hand-authored or second-party registry entry.
 
+**Authorization by role** (`docs/mcp.md`): once the server authenticates its
+callers, `target().requiresRole("operator")` raises the bar for one target and
+`override mcpAuthorize(identity, call)` decides the rest, defaulting to
+`defaultMcpAuthorize`. Built-ins are ordered `read` < `run` < `operator`; any
+other name matches exactly, so an identity provider's group works with
+`requiresRole`. `run` is the floor for executing anything, so `requiresRole` can
+only raise. A run-scoped mutation needs the run's initiator or `operator`; a
+sweep over every run needs `operator`; a valid `ZUKE_OPERATOR_TOKEN` grants
+`operator` for that call. A server with **no** authenticator, or one whose
+authenticator never mentions `roles`, is not constrained by the policy at all —
+`--allow-run`/`--protect` remain its only gates.
+
 **Forcing a target** (`docs/state.md`):
 `zuke force <run-id> <target> --outcome skipped|succeeded [--reason "…"]`
 settles one target of a live run **without running its body** — ahead of its

--- a/tests/integration/mcp_auth_test.ts
+++ b/tests/integration/mcp_auth_test.ts
@@ -65,7 +65,10 @@ class Fleet extends Build {
           ? {
             actor: "svc-releaser",
             kind: "service",
-            roles: ["deploy"],
+            // "run" is what the default policy asks for to execute a target;
+            // "deploy" is a group name from the identity provider, which only
+            // means something to a target declaring requiresRole("deploy").
+            roles: ["run", "deploy"],
             via: "api-key",
           }
           : {
@@ -241,7 +244,7 @@ Deno.test("in registry mode the caller's kind and roles reach the spawned build"
       assertEquals(spawns.length, 1);
       assertEquals(spawns[0].actor, "svc-releaser");
       assertEquals(spawns[0].actorKind, "service");
-      assertEquals(spawns[0].actorRoles, ["deploy"]);
+      assertEquals(spawns[0].actorRoles, ["run", "deploy"]);
     } finally {
       assertEquals(await server.stop(), 0);
     }

--- a/tests/integration/mcp_authz_roles_test.ts
+++ b/tests/integration/mcp_authz_roles_test.ts
@@ -1,0 +1,195 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Integration: the MCP role policy, end to end through `zuke mcp`.
+ *
+ * What these prove that a unit test cannot: the policy reaches a real HTTP
+ * server built from a real `Build`, the compatibility guarantee holds for a
+ * server whose authenticator predates roles, and a denial is refused before the
+ * build's code runs rather than after.
+ *
+ * @module
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import {
+  Build,
+  type McpAuthenticator,
+  type McpRequestContext,
+  target,
+} from "../../packages/core/mod.ts";
+import { serveMcp } from "../../packages/core/src/mcp/command.ts";
+import { withStateDir } from "./_harness.ts";
+
+/** Bodies that actually executed. */
+const ran: string[] = [];
+
+/**
+ * A control plane whose authenticator reads roles from a header — the shape an
+ * identity-provider mapping produces.
+ */
+class ControlPlane extends Build {
+  deploy = target().executes(() => void ran.push("deploy"));
+  promote = target().requiresRole("operator").executes(() =>
+    void ran.push("promote")
+  );
+  override mcpAuth(): McpAuthenticator {
+    return {
+      authenticate: (ctx: McpRequestContext) => {
+        const roles = ctx.headers.get("x-roles");
+        if (roles === null) {
+          return { status: 401, error: "no_identity", challenge: "Bearer" };
+        }
+        return {
+          actor: ctx.headers.get("x-user") ?? "anon",
+          kind: "human" as const,
+          roles: roles === "" ? [] : roles.split(","),
+        };
+      },
+    };
+  }
+}
+
+/** A build whose authenticator never mentions roles — the pre-policy shape. */
+class Legacy extends Build {
+  deploy = target().executes(() => void ran.push("deploy"));
+  override mcpAuth(): McpAuthenticator {
+    return { authenticate: () => ({ actor: "ada", kind: "human" as const }) };
+  }
+}
+
+/** Start `BuildClass` over HTTP on loopback; returns its URL and a stopper. */
+async function startMcp(
+  BuildClass: new () => Build,
+): Promise<{ url: string; stop: () => Promise<void> }> {
+  const ac = new AbortController();
+  let setPort = (_: number) => {};
+  const ready = new Promise<number>((r) => (setPort = r));
+  const finished = serveMcp(new BuildClass(), {
+    http: { host: "127.0.0.1", port: 0 },
+    allowRun: true,
+    quiet: true,
+    signal: ac.signal,
+    onListen: (a) => setPort(a.port),
+  });
+  const port = await ready;
+  return {
+    url: `http://127.0.0.1:${port}/`,
+    stop: async () => {
+      ac.abort();
+      await finished;
+    },
+  };
+}
+
+/** Call a tool with the given identity headers, returning the result body. */
+async function callTool(
+  url: string,
+  name: string,
+  headers: Record<string, string>,
+): Promise<{ status: number; text: string }> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name, arguments: {} },
+    }),
+  });
+  return { status: res.status, text: JSON.stringify(await res.json()) };
+}
+
+Deno.test("the role policy gates a real server's tools", async () => {
+  await withStateDir(async () => {
+    ran.length = 0;
+    const server = await startMcp(ControlPlane);
+    try {
+      // `read` can look but not run.
+      const looked = await callTool(server.url, "list_targets", {
+        "x-user": "ada",
+        "x-roles": "read",
+      });
+      assertEquals(looked.status, 200);
+      assertEquals(looked.text.includes("unauthorized"), false);
+
+      const refused = await callTool(server.url, "run:deploy", {
+        "x-user": "ada",
+        "x-roles": "read",
+      });
+      assertStringIncludes(refused.text, "unauthorized");
+      assertEquals(ran.includes("deploy"), false, ran.join(","));
+
+      // `run` can run an ordinary target…
+      const allowed = await callTool(server.url, "run:deploy", {
+        "x-user": "ada",
+        "x-roles": "run",
+      });
+      assertEquals(allowed.text.includes("unauthorized"), false, allowed.text);
+      assertEquals(ran.includes("deploy"), true);
+
+      // …but not one that asks for operator.
+      const promoteRefused = await callTool(server.url, "run:promote", {
+        "x-user": "ada",
+        "x-roles": "run",
+      });
+      assertStringIncludes(promoteRefused.text, "unauthorized");
+      assertEquals(ran.includes("promote"), false, ran.join(","));
+
+      // An operator can, and satisfies `run` without holding it.
+      const promoted = await callTool(server.url, "run:promote", {
+        "x-user": "ada",
+        "x-roles": "operator",
+      });
+      assertEquals(
+        promoted.text.includes("unauthorized"),
+        false,
+        promoted.text,
+      );
+      assertEquals(ran.includes("promote"), true);
+    } finally {
+      await server.stop();
+    }
+  });
+});
+
+Deno.test("an authenticator that never mentions roles is unconstrained", async () => {
+  // The compatibility guarantee, end to end: a server whose authenticator
+  // predates the policy keeps working exactly as it did.
+  await withStateDir(async () => {
+    ran.length = 0;
+    const server = await startMcp(Legacy);
+    try {
+      const called = await callTool(server.url, "run:deploy", {});
+      assertEquals(called.status, 200);
+      assertEquals(called.text.includes("unauthorized"), false, called.text);
+      assertEquals(ran.includes("deploy"), true);
+    } finally {
+      await server.stop();
+    }
+  });
+});
+
+Deno.test("a caller granted no roles at all is refused everything", async () => {
+  await withStateDir(async () => {
+    ran.length = 0;
+    const server = await startMcp(ControlPlane);
+    try {
+      for (const tool of ["list_targets", "run:deploy"]) {
+        const res = await callTool(server.url, tool, {
+          "x-user": "ada",
+          "x-roles": "",
+        });
+        assertStringIncludes(res.text, "unauthorized", tool);
+      }
+      assertEquals(ran, []);
+    } finally {
+      await server.stop();
+    }
+  });
+});

--- a/tests/integration/mcp_authz_roles_test.ts
+++ b/tests/integration/mcp_authz_roles_test.ts
@@ -54,11 +54,15 @@ class ControlPlane extends Build {
   }
 }
 
-/** A build whose authenticator never mentions roles — the pre-policy shape. */
+/**
+ * A build using the legacy proxy-header seam — the pre-policy shape. That seam
+ * never had roles to give, so the policy leaves it alone; an `mcpAuth()`
+ * authenticator omitting roles is a different claim and is denied.
+ */
 class Legacy extends Build {
   deploy = target().executes(() => void ran.push("deploy"));
-  override mcpAuth(): McpAuthenticator {
-    return { authenticate: () => ({ actor: "ada", kind: "human" as const }) };
+  override mcpIdentity() {
+    return () => ({ actor: "ada", via: "proxy" });
   }
 }
 
@@ -158,9 +162,9 @@ Deno.test("the role policy gates a real server's tools", async () => {
   });
 });
 
-Deno.test("an authenticator that never mentions roles is unconstrained", async () => {
-  // The compatibility guarantee, end to end: a server whose authenticator
-  // predates the policy keeps working exactly as it did.
+Deno.test("the legacy identity hook is unconstrained by the policy", async () => {
+  // The compatibility guarantee, end to end: a server using the seam that
+  // predates roles keeps working exactly as it did.
   await withStateDir(async () => {
     ran.length = 0;
     const server = await startMcp(Legacy);
@@ -188,6 +192,118 @@ Deno.test("a caller granted no roles at all is refused everything", async () => 
         assertStringIncludes(res.text, "unauthorized", tool);
       }
       assertEquals(ran, []);
+    } finally {
+      await server.stop();
+    }
+  });
+});
+
+// ---- Regressions from the adversarial review -------------------------------
+
+/** A build whose operator-only target sits behind an ordinary one. */
+class Chained extends Build {
+  promote = target().requiresRole("operator").executes(() =>
+    void ran.push("promote")
+  );
+  release = target().dependsOn(this.promote).executes(() =>
+    void ran.push("release")
+  );
+  override mcpAuth(): McpAuthenticator {
+    return {
+      authenticate: (ctx: McpRequestContext) => {
+        const roles = ctx.headers.get("x-roles");
+        if (roles === null) {
+          return { status: 401, error: "no_identity", challenge: "Bearer" };
+        }
+        return {
+          actor: ctx.headers.get("x-user") ?? "anon",
+          kind: "human" as const,
+          roles: roles === "" ? [] : roles.split(","),
+        };
+      },
+    };
+  }
+}
+
+Deno.test("requiresRole is enforced across the plan, not just the entry point", async () => {
+  // Invoking a target runs its dependencies, so a requirement guarding only the
+  // named target would be bypassed by invoking anything that depends on it —
+  // which is why --protect is plan-wide too.
+  await withStateDir(async () => {
+    ran.length = 0;
+    const server = await startMcp(Chained);
+    try {
+      const direct = await callTool(server.url, "run:promote", {
+        "x-user": "mallory",
+        "x-roles": "run",
+      });
+      assertStringIncludes(direct.text, "unauthorized");
+
+      // The dependency route must be refused identically.
+      const viaDependent = await callTool(server.url, "run:release", {
+        "x-user": "mallory",
+        "x-roles": "run",
+      });
+      assertStringIncludes(viaDependent.text, "unauthorized");
+      assertEquals(ran, [], `bodies ran: ${ran.join(",")}`);
+
+      // An operator gets through both.
+      const asOperator = await callTool(server.url, "run:release", {
+        "x-user": "ada",
+        "x-roles": "operator",
+      });
+      assertEquals(
+        asOperator.text.includes("unauthorized"),
+        false,
+        asOperator.text,
+      );
+      assertEquals(ran.includes("promote"), true);
+    } finally {
+      await server.stop();
+    }
+  });
+});
+
+/** An mcpAuth() authenticator that omits roles for one caller. */
+class Partial extends Build {
+  promote = target().requiresRole("operator").executes(() =>
+    void ran.push("promote")
+  );
+  override mcpAuth(): McpAuthenticator {
+    return {
+      authenticate: (ctx: McpRequestContext) => {
+        const roles = ctx.headers.get("x-roles");
+        return {
+          actor: ctx.headers.get("x-user") ?? "anon",
+          kind: "human" as const,
+          // The shape of the shipped example: a claim that is simply absent
+          // from some tokens.
+          ...(roles === null ? {} : { roles: roles.split(",") }),
+        };
+      },
+    };
+  }
+}
+
+Deno.test("a token carrying no roles gets no privilege from the omission", async () => {
+  // Less information must never buy more privilege. Whether roles are enforced
+  // is a property of the seam, so an mcpAuth() identity that omits them settles
+  // to none and is denied — rather than skipping the policy entirely.
+  await withStateDir(async () => {
+    ran.length = 0;
+    const server = await startMcp(Partial);
+    try {
+      const withRole = await callTool(server.url, "run:promote", {
+        "x-user": "ada",
+        "x-roles": "read",
+      });
+      assertStringIncludes(withRole.text, "unauthorized");
+
+      const withoutAny = await callTool(server.url, "run:promote", {
+        "x-user": "mallory",
+      });
+      assertStringIncludes(withoutAny.text, "unauthorized");
+      assertEquals(ran, [], `bodies ran: ${ran.join(",")}`);
     } finally {
       await server.stop();
     }


### PR DESCRIPTION
## What & why

#473 gave the MCP server an authenticator, so it knows *who* is calling and what roles they hold. Nothing read those roles. Authorization was still what it had been:

- **`--allow-run` and `--protect` are process-wide.** They say what *anyone* reaching this server may do, not what *this caller* may. A shared endpoint has one answer for every client.
- **One shared operator token.** A bearer secret says "the caller knows the password", not "the caller is an operator" — it cannot be attributed, cannot be revoked per person, and appears in the trail as an argument rather than an identity.
- **No notion of who may act on a *particular* run.** `cancel_run`, `signal_run` and `force_target` were gated identically for the engineer who started a run and for a stranger who found its id. The natural rule — the person who started this run, or an operator — could not be written until #476 gave the record an immutable initiator.

This adds the role model, the per-target and per-build seams, and the default policy.

### The shape

Three built-in roles are ordered `read` < `run` < `operator`, so an operator satisfies a requirement for `run` without holding it. Any other name matches **exactly**, so an identity provider's own group (`sre`, `release-manager`) is usable with `requiresRole` without being ranked into a hierarchy it never agreed to. A target raises its own bar with `requiresRole`; a build overrides the whole decision with `mcpAuthorize` when the rule is one the engine cannot know.

Decisions worth naming:

- **`requiresRole` only ever raises.** `run` is the floor for executing anything, so `requiresRole("read")` cannot hand a read-only caller the ability to run a target — a build declaration must not silently widen what the server exposes.
- **It is enforced across the plan**, like `--protect` and for the same reason: invoking a target runs its dependencies.
- **The operator token grants the `operator` role** for that call, so the shared secret and the role model are one policy rather than two that can disagree, and a deployment can move across a piece at a time.
- **Every denial is an audit row** carrying the roles the caller held, so a refusal is answerable afterwards rather than a bare "unauthorized".

### Compatibility

Two servers are deliberately unaffected, and this is the part I would most want a second opinion on:

- one with **no authenticator** treats every caller as holding every role, so the existing gates remain exactly what they were;
- a build using the legacy **`mcpIdentity()`** hook — the header-trusting seam, which never had roles to give — is not constrained by the policy either.

Whether roles are enforced is a property of the **seam**, not of one identity. Declaring `mcpAuth()` opts in, and an identity it returns without a `roles` list settles to none and is denied. An overridden `mcpAuthorize` still runs in both cases, since a change window applies whether or not roles do.

## What the adversarial review found

Four reviewers attacked this across bypass, compatibility, the policy itself, and surface. Eighteen findings, twelve distinct, **every one reproduced against a running server** before being fixed. Two of them let a caller execute code the policy had just refused them, and both were mine.

**`requiresRole` was checked only on the target a call named** (critical). `--protect` has always been plan-wide, and I did not follow it. A caller holding `run` was refused `run:promote`, then ran `promote`'s body by asking for `run:release`, which depends on it. Reproduced end to end; the requirement is now collected across the plan.

**An identity that omitted `roles` skipped the policy entirely** (critical). That was my compatibility mechanism, and deciding it from the *value* rather than the *seam* meant a token carrying **less** information bought **more** privilege. The shipped `mcpAuth()` example reads roles straight off a token's claims, so any token minted before the group mapping existed would have had unrestricted access. Enforcement is now a property of the seam.

**Run-scoped tools carried no role requirement** (high). A caller refused `run:promote` reached the same body through `signal_run` on a suspended run — and a custom policy could not have compensated, because the call object never named the target.

**The registry server applied no policy at all** (high). `serveMcp` hands it the same authenticator, so `zuke mcp --registry` with an `mcpAuth()` enforced nothing: a caller granted zero roles could list every registered build and spawn any of them. It now decides on the tiers, which is as far as a descriptor carrying no per-target role can go.

**A comma in a role name collapsed the role set** (high). A guard I added in #476 — dropping comma-bearing names so they could not forge two roles in a spawned child's environment — now manufactured the *empty* list the policy reads as "granted nothing", denying everything. The name is kept and the environment escapes it instead.

Also fixed: a role denial on a run-scoped tool was audited as a generic `error` with no reason and no roles; an overridden `mcpAuthorize` was inert on the legacy seam, making the documented change-window example do nothing; `roles.ts` classified a tool that does not exist and kept a second copy of a classification `runtools.ts` owns; `ROLE_TIERS` was exported with no caller; and the docs stated the two things this change inverts.

Refuted findings are not listed — each was checked and failed to reproduce.

Two more holes my own tests caught while I was writing them, before the review: `requiresRole` could originally *lower* the bar, and the read tools bypassed authorization entirely.

## Testing

24 new tests. Unit coverage of the role model and every branch of the default policy; server-level coverage of the compatibility guarantee, the operator-token mapping, the run-scoped rule and a throwing policy; registry coverage of the tier gate and the role-name encoding; and an integration file driving a real HTTP server, including both critical exploits as regressions.

`deno task ci`: 21/21 targets, 4242 tests, 98.5% lines and 97.4% branches against a 95% gate.

## Related issues

Closes #480

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a [Conventional Commit](https://www.conventionalcommits.org/) (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (the MCP guide, the authoring guide, JSDoc, the agent skills).
- [x] Public API changes were regenerated with the API docs target.
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with type guards instead).
- [x] Agent skills updated and the plugin version bumped in all four manifests (0.41.0 to 0.42.0).
