### PR TITLE
feat(core): refuse a build parameter that renders as a built-in CLI flag

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.42.0",
+      "version": "0.43.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -23,14 +23,14 @@ class Deploy extends Build {
 
   workers = parameter("Parallel upload workers").number().default(4);
 
-  dryRun = parameter("Print actions without performing them").boolean();
+  preview = parameter("Print actions without performing them").boolean();
 
   // A required list: `.required()` comes before `.array()` — the reverse order
   // does not type-check.
   repos = parameter("Repos to deploy").required().array();
 
   deploy = target().executes(() => {
-    if (this.dryRun.value) console.log("(dry run)");
+    if (this.preview.value) console.log("(preview)");
     console.log(
       `Deploying ${this.repos.value.join(", ")} to ${this.environment.value} ` +
         `with ${this.workers.value} workers`,
@@ -42,7 +42,7 @@ await run(Deploy);
 ```
 
 ```sh
-./zuke deploy --environment production --workers 8 --dry-run
+./zuke deploy --environment production --workers 8 --preview
 ENVIRONMENT=staging ./zuke deploy        # value from the environment
 ```
 
@@ -151,6 +151,25 @@ The flag and environment variable are derived from the property name:
 `environment` → `--environment` / `ENVIRONMENT`; a camelCase name like
 `targetEnv` → `--target-env` / `TARGET_ENV`. Override the environment variable
 with `.env("NAME")`.
+
+### Names a parameter may not use
+
+Two sets of names are refused when the build is loaded, with a `ParameterError`
+naming the field:
+
+- **A name that renders as a built-in CLI flag** — `actor` → `--actor`,
+  `actorKind` → `--actor-kind`, `limit` → `--limit`, and so on for every flag
+  `zuke --help` lists. The parser matches a built-in ahead of a declared
+  parameter of the same name, so such a parameter would never receive a value:
+  `--actor=alice` would attribute the run and leave the parameter unresolved.
+- **`dryRun`, `confirm` and `operatorToken`** — the control keys an MCP
+  `run:<target>` tool adds to its input schema alongside the build's
+  parameters, which would shadow a parameter of the same name.
+
+Only the rendered flag matters, so a longer or nested name is fine:
+`actorName` → `--actor-name` and a grouped `runs.limit` → `--runs-limit` both
+stay usable. Rename the field; there is no opt-out, because the alternative is
+a flag that silently belongs to something else.
 
 ## Without the CLI
 

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -42,8 +42,8 @@ await run(Deploy);
 ```
 
 ```sh
-./zuke deploy --environment production --workers 8 --preview
-ENVIRONMENT=staging ./zuke deploy        # value from the environment
+./zuke deploy --environment production --workers 8 --repos api,web --preview
+ENVIRONMENT=staging REPOS=api,web ./zuke deploy   # values from the environment
 ```
 
 ## Declaring
@@ -159,17 +159,22 @@ naming the field:
 
 - **A name that renders as a built-in CLI flag** — `actor` → `--actor`,
   `actorKind` → `--actor-kind`, `limit` → `--limit`, and so on for every flag
-  `zuke --help` lists. The parser matches a built-in ahead of a declared
-  parameter of the same name, so such a parameter would never receive a value:
-  `--actor=alice` would attribute the run and leave the parameter unresolved.
-- **`dryRun`, `confirm` and `operatorToken`** — the control keys an MCP
-  `run:<target>` tool adds to its input schema alongside the build's
-  parameters, which would shadow a parameter of the same name.
+  `zuke --help` lists. The parser matches a built-in first, so the flag means
+  the built-in and not the parameter: `--actor=alice` attributes the run and
+  leaves the parameter unresolved.
 
-Only the rendered flag matters, so a longer or nested name is fine:
-`actorName` → `--actor-name` and a grouped `runs.limit` → `--runs-limit` both
-stay usable. Rename the field; there is no opt-out, because the alternative is
-a flag that silently belongs to something else.
+  Such a parameter is not wholly dead — its environment variable still resolves
+  it, as does an MCP `run:<target>` call — and that is exactly why it is refused
+  rather than merely documented. It works until someone reaches for its flag,
+  and then the value quietly does something else.
+- **`dryRun`, `confirm` and `operatorToken`** — the control keys an MCP
+  `run:<target>` tool adds to its input schema alongside the build's parameters,
+  which would shadow a parameter of the same name.
+
+Only the rendered flag matters, so a longer or nested name is fine: `actorName`
+→ `--actor-name` and a grouped `runs.limit` → `--runs-limit` both stay usable.
+Rename the field; there is no opt-out, because the alternative is a flag that
+silently belongs to something else.
 
 ## Without the CLI
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "zuke",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build)."
 }

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -26,7 +26,12 @@ import {
   formatOutdated,
   type OutdatedOptions,
 } from "./outdated.ts";
-import { type AnyParameter, discoverParameters, flagName } from "./params.ts";
+import {
+  type AnyParameter,
+  discoverParameters,
+  flagName,
+  ParameterError,
+} from "./params.ts";
 import type { JsonValue, TargetBuilder } from "./target.ts";
 import type { Plugin } from "./plugin.ts";
 import {
@@ -1317,7 +1322,22 @@ async function runCommand(
   const graphHost = options.graphHost ?? defaultGraphHost;
   const build = new BuildClass();
   const targets = discoverTargets(build);
-  const params = discoverParameters(build);
+  let params: Map<string, AnyParameter>;
+  try {
+    params = discoverParameters(build);
+  } catch (error) {
+    // A parameter whose name is refused (a reserved MCP control key, or a
+    // name that renders as a built-in flag) is an authoring mistake, so it
+    // reads as a named message and exit 1 — the same treatment as an invalid
+    // graph — rather than as an uncaught throw with a stack trace. It has to
+    // come before `--help`, because the help text lists the parameters that
+    // discovery is what produces.
+    if (error instanceof ParameterError) {
+      console.error(error.message);
+      return 1;
+    }
+    throw error;
+  }
   discoverGroups(build); // names group batches so the graph can label them
   const paramFlags: ParamFlag[] = [...params.entries()].map(([name, p]) => ({
     name,

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -36,7 +36,7 @@ import {
   isCompletionShell,
 } from "./completions.ts";
 import {
-  BUILTIN_FLAGS,
+  BUILTIN_FLAG_NAMES,
   CANCEL_COMMAND,
   COMPLETIONS_COMMAND,
   DEFAULT_TARGET,
@@ -422,7 +422,7 @@ export function parseArgs(
   const byFlag = new Map<string, ParamFlag>();
   for (const pf of paramFlags) byFlag.set(pf.flag, pf);
   const knownFlags = [
-    ...BUILTIN_FLAGS.map((f) => f.name.slice(2)),
+    ...BUILTIN_FLAG_NAMES,
     ...paramFlags.map((pf) => pf.flag),
   ];
   // The first unrecognized flag, thrown only after the whole line is parsed so

--- a/packages/core/src/cli_spec.ts
+++ b/packages/core/src/cli_spec.ts
@@ -243,3 +243,14 @@ export const BUILTIN_FLAGS: readonly BuiltinFlag[] = [
   },
   { name: "--help", description: "Show usage" },
 ];
+
+/**
+ * Every built-in flag's name without its leading dashes (`list`, `actor`,
+ * `actor-kind`, …). The parser matches a built-in before a declared parameter
+ * of the same name, so this is also the set of flags a build parameter may not
+ * render as — {@link "./params.ts".discoverParameters} refuses one that does,
+ * rather than letting the parameter sit there unreachable.
+ */
+export const BUILTIN_FLAG_NAMES: readonly string[] = BUILTIN_FLAGS.map((flag) =>
+  flag.name.slice(2)
+);

--- a/packages/core/src/params.ts
+++ b/packages/core/src/params.ts
@@ -59,14 +59,16 @@ const RESERVED_PARAM_NAMES: ReadonlySet<string> = new Set([
 
 /**
  * The built-in CLI flags, by the name a parameter would have to render as to
- * collide with one. `parseArgs` matches a built-in ahead of a declared
- * parameter of the same name, so such a parameter is unreachable: the value
- * lands on the built-in and the parameter is left to its environment variable
- * or its default. Worse for `--actor`, which attributes the run — an MCP
- * caller passing the parameter would set the run's actor over the one the
- * registry runner resolved for it. {@link discoverParameters} refuses the
- * collision at discovery instead, so it is a build-time error naming the
- * field rather than a silent substitution at run time.
+ * collide with one. `parseArgs` matches a built-in first, so the flag means
+ * the built-in and not the parameter — for a value-taking built-in in both
+ * `--flag value` and `--flag=value` form, and for a boolean one (`--state`,
+ * `--check`) in its bare form, leaving only `--flag=value` to reach the
+ * parameter. What makes that worth refusing rather than documenting is that
+ * the parameter is still settable by its environment variable and through the
+ * MCP run tool, so it works until someone uses its flag — and then the value
+ * silently does something else. For `--actor` that something is the run's
+ * attribution. {@link discoverParameters} refuses the collision at discovery,
+ * so it is a build-time error naming the field.
  */
 const BUILTIN_FLAGS: ReadonlySet<string> = new Set(BUILTIN_FLAG_NAMES);
 
@@ -464,8 +466,9 @@ export function discoverParameters(build: object): Map<string, AnyParameter> {
       if (BUILTIN_FLAGS.has(flag)) {
         throw new ParameterError(
           `Parameter "${path}" renders as "--${flag}", which is a built-in ` +
-            `Zuke CLI flag. The built-in wins, so the parameter would never ` +
-            `receive a value. Rename the parameter field.`,
+            `Zuke CLI flag: the parser matches the built-in first, so the ` +
+            `flag would mean the built-in and not this parameter. Rename the ` +
+            `parameter field.`,
         );
       }
       value.name_ = path;

--- a/packages/core/src/params.ts
+++ b/packages/core/src/params.ts
@@ -32,6 +32,7 @@
  * @module
  */
 
+import { BUILTIN_FLAG_NAMES } from "./cli_spec.ts";
 import { messageOf } from "./internal.ts";
 import { forEachField } from "./build.ts";
 import type { Redactor } from "./redact.ts";
@@ -55,6 +56,19 @@ const RESERVED_PARAM_NAMES: ReadonlySet<string> = new Set([
   "confirm",
   "operatorToken",
 ]);
+
+/**
+ * The built-in CLI flags, by the name a parameter would have to render as to
+ * collide with one. `parseArgs` matches a built-in ahead of a declared
+ * parameter of the same name, so such a parameter is unreachable: the value
+ * lands on the built-in and the parameter is left to its environment variable
+ * or its default. Worse for `--actor`, which attributes the run — an MCP
+ * caller passing the parameter would set the run's actor over the one the
+ * registry runner resolved for it. {@link discoverParameters} refuses the
+ * collision at discovery instead, so it is a build-time error naming the
+ * field rather than a silent substitution at run time.
+ */
+const BUILTIN_FLAGS: ReadonlySet<string> = new Set(BUILTIN_FLAG_NAMES);
 
 /** Render a declared default as a display string, or `undefined` when it has none. */
 function defaultToString(value: unknown): string | undefined {
@@ -444,6 +458,14 @@ export function discoverParameters(build: object): Map<string, AnyParameter> {
         throw new ParameterError(
           `Parameter "${path}" collides with a reserved MCP control name ` +
             `(dryRun, confirm, operatorToken). Rename the parameter field.`,
+        );
+      }
+      const flag = flagName(path);
+      if (BUILTIN_FLAGS.has(flag)) {
+        throw new ParameterError(
+          `Parameter "${path}" renders as "--${flag}", which is a built-in ` +
+            `Zuke CLI flag. The built-in wins, so the parameter would never ` +
+            `receive a value. Rename the parameter field.`,
         );
       }
       value.name_ = path;

--- a/packages/core/src/registry/descriptor.ts
+++ b/packages/core/src/registry/descriptor.ts
@@ -27,7 +27,9 @@ import type {
   CliParameterInfo,
   CliTargetInfo,
 } from "../describe.ts";
+import { BUILTIN_FLAG_NAMES } from "../cli_spec.ts";
 import { asObject, fields } from "../json_shape.ts";
+import { flagName } from "../params.ts";
 
 /** The field readers for a build descriptor's fields. */
 const { optionalStr, str, strArray } = fields("registry: descriptor field");
@@ -185,7 +187,18 @@ function paramKind(
   throw new Error(`registry: descriptor field "kind" is not a valid kind`);
 }
 
-/** Validate one {@link CliParameterInfo}. */
+/**
+ * Validate one {@link CliParameterInfo}.
+ *
+ * A descriptor's `flag` is not taken on trust. The registry MCP server renders
+ * it straight onto the spawned child's argv, and the child's parser matches a
+ * built-in flag ahead of a declared parameter — so a descriptor naming a
+ * built-in would put the caller's value on that flag instead. With `--actor`
+ * that overrides the `ZUKE_ACTOR` the runner exported for the resolved caller,
+ * and the run is recorded under an actor the descriptor chose. A registry's
+ * backend is a service Zuke does not control, so both shapes are refused here,
+ * at the parse boundary every backend goes through.
+ */
 function parseParameterInfo(value: unknown): CliParameterInfo {
   const object = asObject(value);
   if (object === null) {
@@ -193,9 +206,26 @@ function parseParameterInfo(value: unknown): CliParameterInfo {
   }
   const flag = str(object, "flag");
   const boolean = bool(object, "boolean");
+  // Pre-M12 descriptors carry no `name`; the flag is the best available key.
+  const name = optionalStr(object, "name") ?? flag;
+  const derived = flagName(name);
+  if (flag !== derived) {
+    throw new Error(
+      `registry: descriptor parameter "${name}" declares flag "--${flag}", ` +
+        `but its name renders as "--${derived}". A flag that does not follow ` +
+        `from its parameter's name is refused.`,
+    );
+  }
+  if (BUILTIN_FLAG_NAMES.includes(flag)) {
+    throw new Error(
+      `registry: descriptor parameter "${name}" renders as "--${flag}", ` +
+        `which is a built-in Zuke CLI flag. A spawned run would apply the ` +
+        `value to the built-in instead of to the parameter, so the ` +
+        `descriptor is refused.`,
+    );
+  }
   const info: CliParameterInfo = {
-    // Pre-M12 descriptors carry no `name`; the flag is the best available key.
-    name: optionalStr(object, "name") ?? flag,
+    name,
     flag,
     description: str(object, "description"),
     required: bool(object, "required"),

--- a/packages/core/tests/params_test.ts
+++ b/packages/core/tests/params_test.ts
@@ -557,6 +557,10 @@ Deno.test("the built-in flag refusal covers every flag the parser knows", () => 
   // the CLI is reserved without anyone remembering to add it here too.
   for (const flag of BUILTIN_FLAG_NAMES) {
     const field = flag.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
+    // `dryRun` is also a reserved MCP control key, and that check runs first.
+    // Asserting the built-in message for it would be asserting the wrong
+    // refusal; the reserved-name test above is the one that covers it.
+    if (field === "dryRun") continue;
     const build = Object.assign(new (class extends Build {})(), {
       [field]: parameter(),
     });
@@ -564,7 +568,8 @@ Deno.test("the built-in flag refusal covers every flag the parser knows", () => 
       () => discoverParameters(build),
       ParameterError,
     );
-    assertStringIncludes(error.message, field);
+    assertStringIncludes(error.message, `renders as "--${flag}"`);
+    assertStringIncludes(error.message, "built-in");
   }
 });
 

--- a/packages/core/tests/params_test.ts
+++ b/packages/core/tests/params_test.ts
@@ -15,6 +15,7 @@ import {
   ParameterError,
   resolveParameters,
 } from "../src/params.ts";
+import { BUILTIN_FLAG_NAMES } from "../src/cli_spec.ts";
 import { REDACTED, Redactor } from "../src/redact.ts";
 import type { SecretSource } from "../src/secret.ts";
 
@@ -520,6 +521,65 @@ Deno.test("discoverParameters rejects a reserved MCP control name", () => {
     assertStringIncludes(error.message, name);
     assertStringIncludes(error.message, "reserved");
   }
+});
+
+Deno.test("discoverParameters rejects a parameter that renders as a built-in flag", () => {
+  // `parseArgs` matches a built-in ahead of a declared parameter of the same
+  // name, so `actor = parameter()` is not merely shadowed: `--actor=x` sets
+  // the run's attribution and the parameter never sees the value.
+  class BadActor extends Build {
+    actor = parameter();
+  }
+  class BadActorKind extends Build {
+    actorKind = parameter();
+  }
+  class BadLimit extends Build {
+    limit = parameter();
+  }
+  for (
+    const [Bad, field, flag] of [
+      [BadActor, "actor", "--actor"],
+      [BadActorKind, "actorKind", "--actor-kind"],
+      [BadLimit, "limit", "--limit"],
+    ] as const
+  ) {
+    const error = assertThrows(
+      () => discoverParameters(new Bad()),
+      ParameterError,
+    );
+    assertStringIncludes(error.message, field);
+    assertStringIncludes(error.message, flag);
+  }
+});
+
+Deno.test("the built-in flag refusal covers every flag the parser knows", () => {
+  // Derived from the same list `parseArgs` matches against, so a flag added to
+  // the CLI is reserved without anyone remembering to add it here too.
+  for (const flag of BUILTIN_FLAG_NAMES) {
+    const field = flag.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
+    const build = Object.assign(new (class extends Build {})(), {
+      [field]: parameter(),
+    });
+    const error = assertThrows(
+      () => discoverParameters(build),
+      ParameterError,
+    );
+    assertStringIncludes(error.message, field);
+  }
+});
+
+Deno.test("a parameter merely near a built-in flag is accepted", () => {
+  // The check is on the rendered flag, not on a substring of the field, so a
+  // longer name and a nested one both stay usable.
+  class Fine extends Build {
+    actorName = parameter();
+    runs = { limit: parameter() };
+  }
+  const params = discoverParameters(new Fine());
+  assertEquals(
+    [...params.keys()].map(flagName).sort(),
+    ["actor-name", "runs-limit"],
+  );
 });
 
 Deno.test("a parameter exposes its default as a display string", () => {

--- a/packages/core/tests/registry_test.ts
+++ b/packages/core/tests/registry_test.ts
@@ -9,7 +9,8 @@
 
 import { assertEquals, assertRejects, assertThrows } from "./_assert.ts";
 import { defaultStateHost } from "../src/state/store.ts";
-import type { CliDescription } from "../src/describe.ts";
+import { type CliDescription, describeCli } from "../src/describe.ts";
+import { Build, parameter, target } from "../mod.ts";
 import {
   type BuildDescriptor,
   parseBuildDescriptor,
@@ -605,5 +606,39 @@ Deno.test("parseBuildDescriptor refuses a parameter flag that shadows a built-in
     parseBuildDescriptor(withParam({ name: "runs.limit", flag: "runs-limit" }))
       .surface.parameters[0].name,
     "runs.limit",
+  );
+});
+
+Deno.test("any surface describeCli produces still parses, awkward names included", () => {
+  // The refusal above rejects a descriptor whose `flag` does not follow from
+  // its `name`. That is safe only while `describeCli` is the sole producer of
+  // the field and always derives it — including for a pre-M12 descriptor,
+  // where the name is recovered from the flag, so `flagName` must be
+  // idempotent. Pinned here rather than argued: a change to `flagName` that
+  // broke either property would fail this test rather than quietly start
+  // refusing descriptors a previous Zuke wrote.
+  class Awkward extends Build {
+    actorName = parameter("near a built-in");
+    xmlHttpTimeout = parameter("consecutive capitals").number();
+    runs = { keepLast: parameter("grouped"), limit: parameter("grouped") };
+    deploy = target().executes(() => {});
+  }
+  const surface = describeCli(new Awkward());
+  const descriptor = sampleDescriptor({ surface });
+  const parsed = parseBuildDescriptor(stringifyBuildDescriptor(descriptor));
+  assertEquals(parsed.surface.parameters, surface.parameters);
+
+  // The same surface with each parameter's `name` dropped is the pre-M12
+  // shape: the name is recovered from the flag, and must render back to it.
+  const legacy = JSON.stringify({
+    ...descriptor,
+    surface: {
+      ...surface,
+      parameters: surface.parameters.map(({ name: _name, ...rest }) => rest),
+    },
+  });
+  assertEquals(
+    parseBuildDescriptor(legacy).surface.parameters.map((p) => p.flag),
+    surface.parameters.map((p) => p.flag),
   );
 });

--- a/packages/core/tests/registry_test.ts
+++ b/packages/core/tests/registry_test.ts
@@ -551,3 +551,59 @@ Deno.test("envBuildRegistry prefers URL over DIR", () => {
 
   assertEquals(envBuildRegistry(() => undefined, host), undefined);
 });
+
+Deno.test("parseBuildDescriptor refuses a parameter flag that shadows a built-in", () => {
+  // A registry backend is a service Zuke does not control, and the MCP host
+  // renders a descriptor's `flag` straight onto the spawned child's argv. The
+  // child's parser matches a built-in ahead of a declared parameter, so a
+  // descriptor naming `--actor` would attribute the run to a value of its own
+  // choosing, over the ZUKE_ACTOR the runner exported for the resolved caller.
+  const withParam = (parameter: Record<string, unknown>) =>
+    JSON.stringify({
+      ...sampleDescriptor(),
+      surface: {
+        commands: [],
+        flags: [],
+        targets: [],
+        parameters: [{
+          description: "",
+          required: false,
+          boolean: false,
+          array: false,
+          options: [],
+          ...parameter,
+        }],
+      },
+    });
+
+  // A flag that does not follow from its name: the tampering shape.
+  assertThrows(
+    () => parseBuildDescriptor(withParam({ name: "message", flag: "actor" })),
+    Error,
+    "does not follow from its parameter's name",
+  );
+  // A name that honestly renders as a built-in: a build registered before the
+  // declaration itself was refused. Refused now on read, not silently honoured.
+  assertThrows(
+    () => parseBuildDescriptor(withParam({ name: "actor", flag: "actor" })),
+    Error,
+    "built-in Zuke CLI flag",
+  );
+  // Pre-M12, where the name is recovered from the flag, is checked the same way.
+  assertThrows(
+    () => parseBuildDescriptor(withParam({ flag: "limit" })),
+    Error,
+    "built-in Zuke CLI flag",
+  );
+  // A name merely near a built-in, and a grouped one, still parse.
+  assertEquals(
+    parseBuildDescriptor(withParam({ name: "actorName", flag: "actor-name" }))
+      .surface.parameters[0].flag,
+    "actor-name",
+  );
+  assertEquals(
+    parseBuildDescriptor(withParam({ name: "runs.limit", flag: "runs-limit" }))
+      .surface.parameters[0].name,
+    "runs.limit",
+  );
+});

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/.codex-plugin/plugin.json
+++ b/plugins/zuke/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/skills/zuke-write-build/SKILL.md
+++ b/plugins/zuke/skills/zuke-write-build/SKILL.md
@@ -204,7 +204,10 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   with `.requires(this.x)`. `.array()` composes and comes **last**:
   `.options(...).array()` validates each element, `.number().array()` →
   `number[]`, and a required list is `.required().array()` (required before
-  array — `.array().required()` does not typecheck).
+  array — `.array().required()` does not typecheck). A parameter may not be
+  named so that it renders as a built-in CLI flag (`actor`, `actorKind`,
+  `limit`, `target`, `output`, …) or as an MCP control key (`dryRun`,
+  `confirm`, `operatorToken`) — the build refuses to load, naming the field.
 - **Secrets from a manager:** `parameter(...).secret().from(source)` sources a
   value at run time (e.g. `execSecret(...)` shelling out to a secret CLI) and
   **redacts** it from all of Zuke's output. See the cheatsheet.

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -566,6 +566,13 @@ yields a `number[]`. Order is kind/options → `.required()` → `.array()`: put
 `.array().required()` fails to typecheck, and a non-required list defaults to
 `[]`.
 
+Reserved names: a parameter may not be named so that it renders as a built-in
+CLI flag (`actor` → `--actor`, `actorKind` → `--actor-kind`, `limit`,
+`target`, `output`, `state`, … — every flag `zuke --help` lists), nor
+`dryRun`, `confirm` or `operatorToken` (the MCP run-tool control keys). The
+build fails to load with a `ParameterError` naming the field. Only the
+rendered flag collides, so `actorName` and a grouped `runs.limit` are fine.
+
 ### Secrets from a manager — `.from(source)`
 
 A `.secret()` parameter can be **sourced at run time** so the value never lands

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -204,7 +204,10 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   with `.requires(this.x)`. `.array()` composes and comes **last**:
   `.options(...).array()` validates each element, `.number().array()` →
   `number[]`, and a required list is `.required().array()` (required before
-  array — `.array().required()` does not typecheck).
+  array — `.array().required()` does not typecheck). A parameter may not be
+  named so that it renders as a built-in CLI flag (`actor`, `actorKind`,
+  `limit`, `target`, `output`, …) or as an MCP control key (`dryRun`,
+  `confirm`, `operatorToken`) — the build refuses to load, naming the field.
 - **Secrets from a manager:** `parameter(...).secret().from(source)` sources a
   value at run time (e.g. `execSecret(...)` shelling out to a secret CLI) and
   **redacts** it from all of Zuke's output. See the cheatsheet.

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -566,6 +566,13 @@ yields a `number[]`. Order is kind/options → `.required()` → `.array()`: put
 `.array().required()` fails to typecheck, and a non-required list defaults to
 `[]`.
 
+Reserved names: a parameter may not be named so that it renders as a built-in
+CLI flag (`actor` → `--actor`, `actorKind` → `--actor-kind`, `limit`,
+`target`, `output`, `state`, … — every flag `zuke --help` lists), nor
+`dryRun`, `confirm` or `operatorToken` (the MCP run-tool control keys). The
+build fails to load with a `ParameterError` naming the field. Only the
+rendered flag collides, so `actorName` and a grouped `runs.limit` are fine.
+
 ### Secrets from a manager — `.from(source)`
 
 A `.secret()` parameter can be **sourced at run time** so the value never lands

--- a/tests/integration/params_test.ts
+++ b/tests/integration/params_test.ts
@@ -11,10 +11,12 @@
 
 import {
   assertEquals,
+  assertRejects,
   assertStringIncludes,
 } from "../../packages/core/tests/_assert.ts";
 import { Build, parameter, REDACTED, target } from "../../packages/core/mod.ts";
-import { runCli } from "./_harness.ts";
+import { ParameterError } from "../../packages/core/src/params.ts";
+import { runCli, withStateDir } from "./_harness.ts";
 
 Deno.test("a missing required parameter fails the build with a clear error", async () => {
   class Deploy extends Build {
@@ -113,4 +115,51 @@ Deno.test("a secret parameter's value is redacted if it leaks into reported outp
   assertEquals(code, 1);
   assertStringIncludes(err, REDACTED);
   assertEquals(err.includes("hunter2"), false);
+});
+
+Deno.test("a parameter that would render as a built-in flag is refused by the CLI", async () => {
+  // `--actor` attributes a run. A build declaring `actor = parameter()` used
+  // to render onto the same flag, and `parseArgs` matches the built-in first:
+  // the value set the run's actor and the parameter was left unresolved. The
+  // refusal is at discovery, so it fires before any argument is even parsed.
+  class Shadowing extends Build {
+    actor = parameter("Who to greet");
+    greet = target().executes(() => {});
+  }
+  const error = await assertRejects(
+    () => runCli(Shadowing, ["greet", "--actor=intruder"]),
+    ParameterError,
+  );
+  assertStringIncludes(error.message, `renders as "--actor"`);
+});
+
+Deno.test("a parameter beside --actor keeps its own value and the run's actor", async () => {
+  // The other half of the refusal: a name merely close to a built-in stays
+  // usable, and the two flags do not contend.
+  await withStateDir(async () => {
+    const seen: string[] = [];
+    class Deploy extends Build {
+      actorName = parameter("Display name").required();
+      deploy = target().executes(() => void seen.push(this.actorName.value));
+    }
+    const { code } = await runCli(Deploy, [
+      "deploy",
+      "--state",
+      "--actor",
+      "alice",
+      "--actor-name",
+      "bob",
+    ]);
+    assertEquals([code, seen], [0, ["bob"]]);
+    // The run is attributed to `--actor`, not to the parameter that resembles it.
+    const alice = await runCli(Deploy, [
+      "runs",
+      "list",
+      "--initiator",
+      "alice",
+    ]);
+    const bob = await runCli(Deploy, ["runs", "list", "--initiator", "bob"]);
+    assertStringIncludes(alice.out, "deploy");
+    assertEquals(bob.out.includes("deploy"), false);
+  });
 });

--- a/tests/integration/params_test.ts
+++ b/tests/integration/params_test.ts
@@ -11,11 +11,9 @@
 
 import {
   assertEquals,
-  assertRejects,
   assertStringIncludes,
 } from "../../packages/core/tests/_assert.ts";
 import { Build, parameter, REDACTED, target } from "../../packages/core/mod.ts";
-import { ParameterError } from "../../packages/core/src/params.ts";
 import { runCli, withStateDir } from "./_harness.ts";
 
 Deno.test("a missing required parameter fails the build with a clear error", async () => {
@@ -126,11 +124,18 @@ Deno.test("a parameter that would render as a built-in flag is refused by the CL
     actor = parameter("Who to greet");
     greet = target().executes(() => {});
   }
-  const error = await assertRejects(
-    () => runCli(Shadowing, ["greet", "--actor=intruder"]),
-    ParameterError,
-  );
-  assertStringIncludes(error.message, `renders as "--actor"`);
+  // It reads as a named message and exit 1, like an invalid graph — not as an
+  // uncaught throw with a stack trace, which is what it was before the refusal
+  // was given the same treatment.
+  const { code, err } = await runCli(Shadowing, ["greet", "--actor=intruder"]);
+  assertEquals(code, 1);
+  assertStringIncludes(err, `renders as "--actor"`);
+  assertStringIncludes(err, "Rename the parameter field");
+  // `--help` cannot list a surface discovery refused, so it reports the same
+  // message rather than crashing.
+  const help = await runCli(Shadowing, ["--help"]);
+  assertEquals(help.code, 1);
+  assertStringIncludes(help.err, `renders as "--actor"`);
 });
 
 Deno.test("a parameter beside --actor keeps its own value and the run's actor", async () => {


### PR DESCRIPTION
## What & why

A build could declare a parameter named after a built-in CLI flag. The parser matches a built-in ahead of a declared parameter of the same name, so the flag means the built-in and not the parameter.

For `--actor` that is an attribution hole, which is what the issue was filed about. A registered build declaring `actor = parameter(...)` has its value rendered onto the spawned child's argv, where it overrides the `ZUKE_ACTOR` the registry runner exported for the resolved caller. Reproduced on master, with the environment set exactly as the runner sets it:

- `ZUKE_ACTOR=alice zuke greet --state --actor=evil` records the run under `evil`, and the declared parameter resolves to nothing.

Discovery now refuses the collision, the way it already refuses the MCP control names, with a `ParameterError` naming both the field and the flag. The reserved set is derived from the `BUILTIN_FLAGS` list the parser and the help text already share, so a flag added to the CLI is reserved without a second list to remember. Only the rendered flag collides, so `actorName` and a grouped `runs.limit` stay usable, and no parameter in this repo changes.

### Why this is a minor and not a patch

I originally wrote this as a `fix`, on the premise that such a parameter never received a value. The adversarial review disproved that, and the distinction decides the version:

- its **environment variable** always resolved it — for all 38 names;
- an **inline `--flag=value`** reached it for the 16 boolean built-ins, which are matched by an exact comparison and so fall through to the parameter branch;
- the **in-process MCP run tool** reached it for all of them, keyed by parameter name, never touching the parser.

So a build using `state`, `check`, `limit`, `target` or `output` as a parameter and driving it by environment variable worked, and now refuses to load. That is the intended outcome — the same parameter breaks the moment anyone reaches for its flag, and then the value quietly does something else — but it is a change to the authoring surface, so it ships as a minor with the breakage stated rather than as a silent patch.

## What the adversarial review found

Two reviewers attacked this. Both found something real, and the first found the same hole the change set out to close.

**The fix guarded only the build's own process** (high). A registry descriptor carries each parameter's `flag` as a plain string that nothing validated, and the MCP host renders it straight onto the spawned child's argv without ever calling `discoverParameters`. A descriptor declaring a parameter named `message` with flag `actor` spawned `--actor=intruder`, and the run was recorded under the caller's value over the actor the host had resolved. The code's own comments describe a registry backend as a service Zuke does not control, so this was the guarded claim failing at the one boundary that most needed it. Reachable without tampering, too: a build registered by an older Zuke that legitimately declared `actor = parameter(...)` stores `flag: "actor"` honestly, and the descriptor outlives the upgrade. Descriptor parsing now refuses a flag that does not follow from its parameter's name, and a name that renders as a built-in — at the parse boundary both the filesystem and HTTP backends go through.

**The premise was wrong, and three places asserted it** (medium). The doc, the JSDoc and the thrown message all said the parameter would never receive a value. All three now say what is true, and say why partial reachability is the reason to refuse rather than to document.

**The refusal escaped as an uncaught throw** (medium-high) with a stack trace, where Zuke's convention one line below is a named message and exit 1. Worse, it ran before the help branch, so `zuke --help` and `zuke --list` crashed too and the author could not inspect the build they were being told to fix. It now reads as a named message and exit 1, like an invalid graph. That covers the pre-existing reserved-name refusal as well.

Also fixed: one iteration of the flag loop test passed on the pre-existing control-key check rather than the new one, and the second documented command line in the parameters guide omitted a required value.

Reported and deliberately not changed here: parameter environment variables can still collide with Zuke's own `ZUKE_*` names. Verified as a footgun rather than a bypass — in every channel where it could matter, the build is already trusted code in that process, and unlike the flag case the parameter does still get its value.

**Filed rather than fixed: [#485](https://github.com/zuke-build/zuke/issues/485).** The same shape of bug exists for target names against `RESERVED_COMMANDS`. A target named `graph` is discovered, listed, offered in completions and runnable over MCP, but `zuke graph` renders the dependency graph and exits 0 without running it. It is a separate surface with its own breaking-change profile, so it gets its own issue rather than riding along here.

## Documentation

The parameters guide gained a "Names a parameter may not use" section, and the same rule is in the agent skill and its cheatsheet, with the plugin version bumped in all four manifests.

Fixing a pre-existing bug found while writing it: the guide's headline example declared `dryRun`, which the existing reserved-name check has always refused, so the flagship example threw on load — and both of its documented command lines omitted a required parameter, so neither ran. The gate did not catch either, because `snippetsCheck` type-checks a snippet without constructing or running the build. Both command lines now run against the example.

## Testing

Unit coverage of the refusal, of every flag in the shared list, and of the names that stay allowed; descriptor coverage of the tampered flag, the honestly-named one and the pre-M12 shape; and integration coverage driving the real CLI, asserting the clean exit rather than a throw, and pinning that `--actor` and `--actor-name` do not contend.

The review confirmed the tests are not vacuous: reverting the source in a scratch copy fails exactly the new tests and nothing else.

`deno task ci`: 21/21 targets, 4250 tests, 98.5% lines and 97.4% branches against a 95% gate.

## Related issues

Closes #472

## Checklist

- [x] This PR closes a tracking issue.
- [x] The PR title is a Conventional Commit.
- [x] `deno task ci` passes locally.
- [x] Tests were added or updated; coverage stays at 95%+ on lines and branches.
- [x] Docs updated in the same PR: the parameters guide, JSDoc, the agent skill and its cheatsheet.
- [x] Public API regenerated — not applicable; the new list lives in an internal module that no entrypoint exports.
- [x] No `any`, no `as` casts and no non-null assertions.
- [x] Agent skills updated and the plugin version bumped in all four manifests, 0.42.0 to 0.43.0.
