### PR TITLE
feat(core): serve OAuth protected resource metadata from the MCP server

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.43.0",
+      "version": "0.44.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -516,6 +516,18 @@ The `authorizationServer(...)` value is the provider's **issuer identifier**
 `issuer` in that provider's own metadata document, or a client is required to
 reject it.
 
+**Everything in this document is public.** It has to be: a caller asking where
+to authenticate has nothing to authenticate with, so the route is served before
+the bearer token and the authenticator, and it is readable cross-origin because
+browser-based clients fetch it that way. Treat the four fields you supply as
+published — the resource URI, the issuer, the scope names, and the resource name
+and documentation URL. On a machine where the server binds loopback, that also
+means a web page the developer happens to visit can read them; an internal
+hostname in the resource URI is the realistic thing to think twice about. A
+credential in the identifier is refused outright rather than left to judgement,
+since a `https://user:pass@host/mcp` would otherwise be published verbatim in a
+cacheable document.
+
 The path is derived for you, because getting it wrong is silent. The well-known
 segment is inserted **between the host and the path**, so an endpoint at `/mcp`
 publishes at `/.well-known/oauth-protected-resource/mcp` rather than the

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -516,25 +516,35 @@ The `authorizationServer(...)` value is the provider's **issuer identifier**
 `issuer` in that provider's own metadata document, or a client is required to
 reject it.
 
-Two details are handled for you, because both are silent when wrong. The
-well-known segment is inserted **between the host and the path**, so an endpoint
-at `/mcp` publishes at `/.well-known/oauth-protected-resource/mcp` rather than
-the appended form — a client fetches only the inserted one. And the identical
-document is also published at the root, because a client that had no challenge
-to follow constructs the root URL instead, and the two routes validate the
-`resource` field against different expectations.
+The path is derived for you, because getting it wrong is silent. The well-known
+segment is inserted **between the host and the path**, so an endpoint at `/mcp`
+publishes at `/.well-known/oauth-protected-resource/mcp` rather than the
+appended form — a client fetches only the inserted one.
 
-Dynamic client registration is **not** required. It was demoted to optional and
-then deprecated in the MCP specification, and a client configured with a
-pre-registered client id never asks for it — verified against a real client,
-which goes straight from discovery to `/authorize` with the id it was given. So
-a provider that does not offer registration, including a GitHub OAuth App, is
-usable: register the client once, out of band.
+It is published at exactly that one location. Serving a second copy at the root
+looks like cheap insurance and is not: RFC 9728 has a client derive the
+`resource` it expects from the URL it fetched, so a client that probed the root
+expects the bare origin and must discard a document naming a path. That copy
+would have no correct consumer — a conformant client tries the path-inserted URL
+first and never asks for the root, and one that only asks for the root would
+throw away what it found. A resource declared as a bare origin publishes at the
+root, because for that identifier the root *is* the derived location.
+
+Dynamic client registration is **not** required. The MCP specification asked for
+it in revision `2025-06-18`, demoted it to optional in `2025-11-25`, and marks
+it deprecated in the current `2026-07-28` — client id metadata documents and
+pre-registration are the sanctioned routes now. Verified against a real client:
+given a pre-registered client id it goes straight from discovery to
+`/authorize` and never touches a registration endpoint. So a provider that
+offers no registration — a GitHub OAuth App, for one — is usable: register the
+client once, out of band.
 
 Verifying tokens is still not Zuke's job. Do not hand-roll it — import a
 maintained JOSE library in your build file (the build is ordinary code and may
 depend on whatever you like, unlike the published packages) and let it do the
-signature, the claims and the key rotation:
+signature, the claims and the key rotation. The fragment below shows the shape,
+not a complete file — `UNAUTHORIZED`, `INVALID_TOKEN` and `McpAuthenticator`
+come from `jsr:@zuke/core`, and `rolesOf` is yours to write:
 
 ```ts
 import { createRemoteJWKSet, jwtVerify } from "npm:jose";

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,13 +1,13 @@
 # MCP server
 
-`./zuke mcp` — a command on **your build's own CLI**, not the globally
-installed `jsr:@zuke/cli` (see the [CLI reference](./cli.md) for the
-difference) — runs a [Model Context Protocol](https://modelcontextprotocol.io)
-server over your build. MCP is the open standard that lets an AI client — Claude
-Desktop, Claude Code, an IDE, any agent — discover a server's **tools** (typed,
-schema-described functions) and call them. Pointing a client at `./zuke mcp`
-lets an agent **operate the pipeline through typed calls** — list the targets,
-inspect the graph, run one with the right parameters — instead of guessing shell
+`./zuke mcp` — a command on **your build's own CLI**, not the globally installed
+`jsr:@zuke/cli` (see the [CLI reference](./cli.md) for the difference) — runs a
+[Model Context Protocol](https://modelcontextprotocol.io) server over your
+build. MCP is the open standard that lets an AI client — Claude Desktop, Claude
+Code, an IDE, any agent — discover a server's **tools** (typed, schema-described
+functions) and call them. Pointing a client at `./zuke mcp` lets an agent
+**operate the pipeline through typed calls** — list the targets, inspect the
+graph, run one with the right parameters — instead of guessing shell
 invocations.
 
 It's a natural extension of what Zuke already does: it publishes `llms.txt`, a
@@ -67,16 +67,16 @@ below), so one long `run:` never head-of-line-blocks another client's read.
   host.
 - Binding a **non-loopback** address requires authentication — **either** a
   bearer token (set `ZUKE_MCP_TOKEN`, and every request must send
-  `Authorization: Bearer <token>`; a missing or wrong token gets `401`) **or** an
-  [`mcpAuth()`](#mcpauth--the-general-seam) authenticator on the build. With
+  `Authorization: Bearer <token>`; a missing or wrong token gets `401`) **or**
+  an [`mcpAuth()`](#mcpauth--the-general-seam) authenticator on the build. With
   neither, Zuke **refuses to bind** a non-loopback address rather than exposing
   an unauthenticated endpoint.
 - [`mcpIdentity()`](#mcpidentity--sugar-for-a-proxy-header) does **not** satisfy
   that requirement, though it still runs on every request. It trusts a header,
   which is only an identity when something in front strips the client's copy and
   injects its own — on a directly reachable endpoint any caller sets that header
-  itself. Such a build needs the bearer token to bind off loopback, or a proxy in
-  front of a loopback bind.
+  itself. Such a build needs the bearer token to bind off loopback, or a proxy
+  in front of a loopback bind.
 - A token is also enforced on a loopback bind when `ZUKE_MCP_TOKEN` is set, and
   an authenticator runs on every bind, loopback included. The two compose: the
   token is a shared secret that gates the endpoint, the authenticator says _who_
@@ -88,9 +88,9 @@ below), so one long `run:` never head-of-line-blocks another client's read.
   an unauthenticated caller never makes the server buffer its payload.
 - **Origin validation** guards against a browser drive-by / DNS-rebinding page:
   on a loopback bind, a request that carries an `Origin` header is accepted only
-  when it is a loopback origin, and rejected `403` otherwise. A client that sends
-  no `Origin` (a CLI/MCP client — not a browser) is always allowed, so this is
-  invisible to normal use. Permit a specific extra origin with
+  when it is a loopback origin, and rejected `403` otherwise. A client that
+  sends no `Origin` (a CLI/MCP client — not a browser) is always allowed, so
+  this is invisible to normal use. Permit a specific extra origin with
   `--allowed-origin <origin>` (repeatable); when set, a present `Origin` must
   match one exactly. A non-loopback bind runs no default Origin check — front it
   with your own policy.
@@ -113,9 +113,9 @@ Read tools are always available:
 When a [state store](./state.md) resolves, two more read tools appear, so an
 agent can query runs it did not start:
 
-| Tool        | Returns                                                                             |
-| ----------- | ----------------------------------------------------------------------------------- |
-| `list_runs` | Persisted run summaries (optional `status`/`target`/`since` filters), newest first. |
+| Tool        | Returns                                                                                    |
+| ----------- | ------------------------------------------------------------------------------------------ |
+| `list_runs` | Persisted run summaries (optional `status`/`target`/`since` filters), newest first.        |
 | `show_run`  | One run's full record — status, per-target progress, and signals. Refuses the audit trail. |
 
 With `--allow-run`, the server also exposes one **`run:<target>`** tool per
@@ -135,10 +135,10 @@ timeouts), `cancel_run` (cancel a run and run its
 [compensations](./orchestration.md#cancellation--compensation--oncancel)), and
 `force_target` (settle one target without running it — see
 [forcing a target](./state.md#forcing-a-target--overrides)). They are the MCP
-counterparts of `./zuke resume`, `./zuke cancel` and `./zuke force`. Each runs the
-target's code (a resume continues it; a cancel runs its compensations), so it is
-gated by the same [allow-list and operator-token](#authorization) policy as a
-`run:` tool and appended to the [audit log](#audit-log).
+counterparts of `./zuke resume`, `./zuke cancel` and `./zuke force`. Each runs
+the target's code (a resume continues it; a cancel runs its compensations), so
+it is gated by the same [allow-list and operator-token](#authorization) policy
+as a `run:` tool and appended to the [audit log](#audit-log).
 
 ```jsonc
 // tools/call
@@ -189,9 +189,9 @@ ZUKE_OPERATOR_TOKEN=… ./zuke mcp --http 7777 \
 
 ### Roles
 
-The three flags above are **process-wide**: they say what *anyone* reaching this
+The three flags above are **process-wide**: they say what _anyone_ reaching this
 server may do. Once the server [authenticates](#authentication) its callers it
-can say what *this* caller may do, which is what roles are for.
+can say what _this_ caller may do, which is what roles are for.
 
 Three built-in roles are ordered — `read` < `run` < `operator` — so an operator
 satisfies a requirement for `run` without being granted it separately. Any other
@@ -202,12 +202,12 @@ general permission and use your own names for the specific one.
 
 The shipped default policy:
 
-| Call | Needs |
-| --- | --- |
-| `list_*` / `show_*` / `describe_*` / `graph` | `read` |
-| `run:<target>` | `run`, **and** every `requiresRole` declared anywhere in the plan it would run |
+| Call                                                                        | Needs                                                                                                                                        |
+| --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `list_*` / `show_*` / `describe_*` / `graph`                                | `read`                                                                                                                                       |
+| `run:<target>`                                                              | `run`, **and** every `requiresRole` declared anywhere in the plan it would run                                                               |
 | `cancel_run` / `signal_run` / `force_target`, and `resume_check` on one run | the run's [initiator](./state.md#actor-and-initiator--two-different-questions) or `operator`, **and** every `requiresRole` in the run's plan |
-| `resume_check` sweeping every run | `operator` |
+| `resume_check` sweeping every run                                           | `operator`                                                                                                                                   |
 
 `requiresRole` can only **raise** the bar — `run` is the floor for executing
 anything, so declaring `requiresRole("read")` does not let a read-only caller
@@ -252,16 +252,16 @@ server, and every deployment that predates roles, working unchanged.
 Whether roles are enforced is a property of the **seam**, not of one identity:
 declaring `mcpAuth()` opts in, and an identity it returns without a `roles` list
 settles to none and is denied. Inferring it per identity would mean a token
-carrying *less* information bought *more* privilege. An override of
+carrying _less_ information bought _more_ privilege. An override of
 `mcpAuthorize` still runs in every case, including the legacy seam, since a
 change window or a freeze applies whether or not roles are in play.
 
 `requiresRole` is the exception to "the legacy seam is left alone": a target
 that declares one is **refused** for a caller whose authenticator cannot express
 roles, naming the seam. Silently ignoring the declaration would tell you a
-target is gated when nothing is checking. A server that declares no roles — every
-server that predates this — is unaffected, since the refusal can only fire on a
-declaration someone has just added.
+target is gated when nothing is checking. A server that declares no roles —
+every server that predates this — is unaffected, since the refusal can only fire
+on a declaration someone has just added.
 
 In **registry mode** the policy decides on the tiers alone — `read` to list or
 describe a registered build, `run` to spawn one — because a registry descriptor
@@ -271,25 +271,24 @@ carries no per-target `requiresRole`.
 
 With a store configured, **every mutating or denied tool call** (`run:<target>`,
 `signal_run`, `resume_check`, `cancel_run`, `force_target`) is appended to an
-audit trail: the
-time, the tool, the resolved **actor**, the outcome (`ok` / `denied` / `error`),
-and the call's arguments — plus, when the server authenticated the caller, the
-**roles** they held, which is what makes a denial answerable afterwards: who was
-refused, by which rule, and what they were carrying at the time. Arguments are
-**redacted** — the operator token is
-dropped and every `.secret()` parameter's value is masked — before anything is
+audit trail: the time, the tool, the resolved **actor**, the outcome (`ok` /
+`denied` / `error`), and the call's arguments — plus, when the server
+authenticated the caller, the **roles** they held, which is what makes a denial
+answerable afterwards: who was refused, by which rule, and what they were
+carrying at the time. Arguments are **redacted** — the operator token is dropped
+and every `.secret()` parameter's value is masked — before anything is
 persisted.
 
-The trail lives in a store-level record; read it with `./zuke runs show mcp-audit`
-**on the host**. It is deliberately not readable over MCP — `show_run` refuses
-it and `list_runs` omits it — because the clients it audits must not be able to
-read who called what, or to confirm which of their calls were denied. The actor
-resolves by precedence: the **authenticated identity**
-([below](#authentication)) → `--actor` → `ZUKE_ACTOR` → the CI actor → the
-connecting client's `initialize` name → `"anonymous"`. The client name is an
-**untrusted label** for the trail only — it never influences authorization. On a
-shared HTTP endpoint it reflects the most recent client to connect, so declare
-an authenticator (or set `--actor`) for authoritative attribution there.
+The trail lives in a store-level record; read it with
+`./zuke runs show mcp-audit` **on the host**. It is deliberately not readable
+over MCP — `show_run` refuses it and `list_runs` omits it — because the clients
+it audits must not be able to read who called what, or to confirm which of their
+calls were denied. The actor resolves by precedence: the **authenticated
+identity** ([below](#authentication)) → `--actor` → `ZUKE_ACTOR` → the CI actor
+→ the connecting client's `initialize` name → `"anonymous"`. The client name is
+an **untrusted label** for the trail only — it never influences authorization.
+On a shared HTTP endpoint it reflects the most recent client to connect, so
+declare an authenticator (or set `--actor`) for authoritative attribution there.
 
 ## Authentication
 
@@ -335,12 +334,12 @@ expose.
 
 The identity's fields:
 
-| Field   | Meaning                                                                                                      |
-| ------- | ------------------------------------------------------------------------------------------------------------ |
-| `actor` | The authenticated caller. Required and non-empty — anything else refuses the request.                        |
-| `kind`  | `"human"` or `"service"`. Omitted reads as `"human"`, so a service claim must be stated.                     |
+| Field   | Meaning                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `actor` | The authenticated caller. Required and non-empty — anything else refuses the request.                                                                                                                                                                                                                                                                                                                                                                          |
+| `kind`  | `"human"` or `"service"`. Omitted reads as `"human"`, so a service claim must be stated.                                                                                                                                                                                                                                                                                                                                                                       |
 | `roles` | The caller's roles, in three states. **Omitted** means this authenticator does not speak roles — only meaningful for the legacy `mcpIdentity()` seam, whose callers the [policy](#roles) leaves alone. An **empty list** means the question was considered and nothing granted, which denies. A **non-empty list** is evaluated. An `mcpAuth()` identity that omits the list settles to empty, so a token carrying less information never buys more privilege. |
-| `via`   | How the identity was established (`"oauth-proxy"`). Informational only.                                      |
+| `via`   | How the identity was established (`"oauth-proxy"`). Informational only.                                                                                                                                                                                                                                                                                                                                                                                        |
 
 The resolved `actor` overrides `--actor`, the environment, and the client label
 for that call, and flows to the [audit trail](#audit-log), run records,
@@ -446,16 +445,132 @@ and the resolved caller travels with it as three environment variables:
 `ZUKE_ACTOR`, `ZUKE_ACTOR_KIND` (`"human"` when the authenticator omitted it)
 and `ZUKE_ACTOR_ROLES` (comma-joined, empty when there are none — a role name
 containing a comma is dropped when the identity is resolved, so splitting on the
-separator is safe). They are
-written **together**, and only when the resolved actor is non-empty, so an
-inherited kind or role set can never survive beside a fresh actor — the child
-would otherwise read one caller's actor with another's entitlements. They
-override anything inherited; the spawned build reads them itself (`ZUKE_ACTOR`
-is the usual actor source, and the other two are there for a build that wants to
-branch on who launched it).
+separator is safe). They are written **together**, and only when the resolved
+actor is non-empty, so an inherited kind or role set can never survive beside a
+fresh actor — the child would otherwise read one caller's actor with another's
+entitlements. They override anything inherited; the spawned build reads them
+itself (`ZUKE_ACTOR` is the usual actor source, and the other two are there for
+a build that wants to branch on who launched it).
 
-TLS, the OAuth flow, and header stripping remain the proxy's job, not Zuke's —
-this is deliberately the _minimal_ seam.
+### Telling a client where to authenticate
+
+Verifying a token only helps a client that already has one. A fresh
+`claude mcp add --transport http <url>` has nothing, and no way to guess where
+to get one — so it asks, the way OAuth 2.0 defines: it reads the
+`WWW-Authenticate` challenge on the `401`, fetches the metadata document that
+challenge names, and finds the authorization server there.
+
+`mcpProtectedResource()` publishes that document. Zuke is only ever the
+**resource**: it issues no tokens and hosts no `/authorize`, `/token` or
+`/register` endpoint. Those belong to whatever identity provider you already run
+— Auth0, Okta, Entra, Keycloak, Dex — and `mcpAuth()` above is where the tokens
+it mints are verified.
+
+<!-- check -->
+
+```ts
+import { Build, protectedResource, run, target } from "jsr:@zuke/core";
+
+class ControlPlane extends Build {
+  deploy = target().executes(() => {});
+
+  override mcpProtectedResource() {
+    return protectedResource("https://build.example.com/mcp")
+      .authorizationServer("https://acme.eu.auth0.com")
+      .scopes("zuke:run")
+      .name("Acme build server");
+  }
+}
+
+await run(ControlPlane);
+```
+
+That is the whole configuration. The server then answers an unauthenticated call
+with
+
+```http
+401 Unauthorized
+WWW-Authenticate: Bearer resource_metadata="https://build.example.com/.well-known/oauth-protected-resource/mcp"
+```
+
+and serves the document that URL names.
+
+**Three strings must agree, byte for byte.** This is the one thing that goes
+wrong, and when it does, every token fails validation and nothing in the error
+says why:
+
+1. the `resource` in the document — what you pass to `protectedResource(...)`;
+2. the `resource` parameter the client sends on both the authorization and the
+   token request, which is this same string echoed back;
+3. the **audience** your identity provider puts in the token — Auth0's API
+   Identifier, Okta's audience, Entra's `api://{app-id-uri}`.
+
+Set all three to the canonical URI of the MCP endpoint, with no trailing slash
+and no fragment. Your `mcpAuth()` verifier must then check that `aud` really is
+this server: a resource server that skips the audience check accepts tokens
+minted for some other service, which is the confused-deputy hole the MCP
+specification prohibits outright.
+
+The `authorizationServer(...)` value is the provider's **issuer identifier**
+(`https://acme.eu.auth0.com`), not its metadata URL. It has to string-match the
+`issuer` in that provider's own metadata document, or a client is required to
+reject it.
+
+Two details are handled for you, because both are silent when wrong. The
+well-known segment is inserted **between the host and the path**, so an endpoint
+at `/mcp` publishes at `/.well-known/oauth-protected-resource/mcp` rather than
+the appended form — a client fetches only the inserted one. And the identical
+document is also published at the root, because a client that had no challenge
+to follow constructs the root URL instead, and the two routes validate the
+`resource` field against different expectations.
+
+Dynamic client registration is **not** required. It was demoted to optional and
+then deprecated in the MCP specification, and a client configured with a
+pre-registered client id never asks for it — verified against a real client,
+which goes straight from discovery to `/authorize` with the id it was given. So
+a provider that does not offer registration, including a GitHub OAuth App, is
+usable: register the client once, out of band.
+
+Verifying tokens is still not Zuke's job. Do not hand-roll it — import a
+maintained JOSE library in your build file (the build is ordinary code and may
+depend on whatever you like, unlike the published packages) and let it do the
+signature, the claims and the key rotation:
+
+```ts
+import { createRemoteJWKSet, jwtVerify } from "npm:jose";
+
+const jwks = createRemoteJWKSet(
+  new URL("https://acme.eu.auth0.com/.well-known/jwks.json"),
+);
+
+override mcpAuth(): McpAuthenticator {
+  return {
+    authenticate: async (ctx) => {
+      const token = (ctx.headers.get("authorization") ?? "").replace(/^Bearer /i, "");
+      if (token === "") return UNAUTHORIZED;
+      try {
+        const { payload } = await jwtVerify(token, jwks, {
+          issuer: "https://acme.eu.auth0.com",
+          audience: "https://build.example.com/mcp", // the same third string
+        });
+        return { actor: String(payload.sub), kind: "human", roles: rolesOf(payload) };
+      } catch {
+        return INVALID_TOKEN;
+      }
+    },
+  };
+}
+```
+
+`UNAUTHORIZED` and `INVALID_TOKEN` are two refusals on purpose. A caller that
+presented nothing is told only that it must authenticate; one whose token was
+rejected is told that much. Sending `invalid_token` to a client that has simply
+never logged in tells it its stored credential was refused, which is both untrue
+and the wrong thing to act on.
+
+TLS and header stripping remain the proxy's job, and the OAuth flow itself
+remains the identity provider's. Zuke authenticates, authorizes and says where
+to go — deliberately nothing more.
 
 ## Registry mode (dynamic discovery)
 
@@ -475,10 +590,10 @@ tool in an already-running server with **no restart**:
   a `run:<buildId>:<target>` tool, re-read live.
 - **Execution is a spawn.** A registered build has no live instance in the
   server, so a run tool **spawns the build's registered launch location** (the
-  `deno run <module> <target>` `./zuke register` recorded, or an explicit command)
-  and returns its captured output. This is code execution, so it is off unless
-  `--allow-run`, and it honours the same [authorization](#authorization) tiers —
-  the allow-list and `--protect` globs match the **qualified**
+  `deno run <module> <target>` `./zuke register` recorded, or an explicit
+  command) and returns its captured output. This is code execution, so it is off
+  unless `--allow-run`, and it honours the same [authorization](#authorization)
+  tiers — the allow-list and `--protect` globs match the **qualified**
   `<buildId>:<target>` name (e.g. `--allow-run=Api:*`, `--protect=Api:deploy`).
   Every mutating or denied call is [audited](#audit-log).
 - **Where it spawns from is checked too.** The registry names the launch
@@ -487,12 +602,14 @@ tool in an already-running server with **no restart**:
   local path or `file:` URL — `https:`, `jsr:`, `npm:`, `data:`) is refused
   unless its origin appears in `ZUKE_REGISTRY_LAUNCH_HOSTS` (comma- or
   space-separated; `*` allows any; the token is the hostname, or the scheme when
-  the specifier carries none, like `jsr:`). An allow-listed `http:` origin additionally
-  needs `ZUKE_ALLOW_INSECURE_URL=1`; loopback does not. The check runs **before**
-  the `--confirm-destructive` prompt, so a refused location fails fast: the call
-  returns a structured `launch_origin_not_allowed` (or `insecure_launch_url`)
-  error and is audited as `denied`, with nothing spawned. Locations `./zuke
-  register` writes are local, so this is invisible to the ordinary setup.
+  the specifier carries none, like `jsr:`). An allow-listed `http:` origin
+  additionally needs `ZUKE_ALLOW_INSECURE_URL=1`; loopback does not. The check
+  runs **before** the `--confirm-destructive` prompt, so a refused location
+  fails fast: the call returns a structured `launch_origin_not_allowed` (or
+  `insecure_launch_url`) error and is audited as `denied`, with nothing spawned.
+  Locations `./zuke
+  register` writes are local, so this is invisible to the
+  ordinary setup.
 - **Parameters.** A run tool exposes the registered build's declared parameters
   as its input schema — keyed by the parameter's property name (e.g. `skipE2e`),
   with the kind, description, enum, and default from the descriptor. Supplied
@@ -504,8 +621,8 @@ tool in an already-running server with **no restart**:
   call omits it. Because a descriptor does not record whether a target is
   read-only, every registry run tool is treated as destructive.
 - **Secrets never cross the boundary.** `.secret()` parameters are omitted from
-  the descriptor entirely (`./zuke register` writes the secret-free surface), so a
-  secret can neither be requested nor forwarded — it is rejected as an unknown
+  the descriptor entirely (`./zuke register` writes the secret-free surface), so
+  a secret can neither be requested nor forwarded — it is rejected as an unknown
   parameter if a client tries. The spawned build resolves a secret from its own
   environment / `.from()` source instead. In the [audit log](#audit-log) only a
   recognised parameter's value is recorded; any unknown argument keeps its name
@@ -540,8 +657,8 @@ already has a shell there and could run `deno run -A zuke.ts <target>` directly.
 The [HTTP transport](#http-transport) adds a network endpoint, so it moves that
 boundary: it binds loopback by default, requires a bearer token or an
 [authenticator](#authentication) off loopback, and is meant to sit behind real
-TLS/authentication. Either way, treat the server
-like any other local developer tool and don't wire an untrusted client to it.
+TLS/authentication. Either way, treat the server like any other local developer
+tool and don't wire an untrusted client to it.
 
 Running a target executes real build code, so execution is **off by default**: a
 freshly-connected agent can only _inspect_ the build. Add `--allow-run`

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "zuke",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build)."
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -121,6 +121,13 @@ function assertSafeLinkTarget(entryName: string, target: string): void
   name is bounded by {@link assertSafeEntryName}; a symlink adds a second escape
   vector (its target), so a poisoned tarball can't plant `bin/x -> ../../etc`.
 
+function bearerChallenge(parts: BearerChallenge): string
+  A `WWW-Authenticate: Bearer` challenge built from `parts`.
+
+  Returns a bare `Bearer` when nothing usable is supplied, and drops any single
+  part that survives filtering as empty, so a caller cannot produce a malformed
+  header by passing an odd string.
+
 async function cancelRun(build: Build, options: CancelOptions): Promise<CancelResult>
   Cancel the run `options.runId` for `build`: transition it to `cancelling`
   (exactly one canceller drives the walk; a live owning process observes the
@@ -464,6 +471,26 @@ function lockKey(...parts: Array<string | number>): string
   Each part is sanitised (non-`[A-Za-z0-9._-]` runs become `_`) and empty parts
   are dropped, so `lockKey("deploy", repo)` is stable and injection-free.
 
+function metadataDocument(settings: ProtectedResourceSettings): Record<string, unknown>
+  The metadata document itself, as the JSON object RFC 9728 §2 defines.
+
+  Fields with no values are omitted rather than serialised empty — §3.2 makes
+  that a MUST, and an empty `scopes_supported` would in any case advertise
+  "this resource accepts no scopes".
+
+function metadataPaths(resource: string): string[]
+  Every path the metadata document is published at, most specific first.
+
+  For a resource with a path this is the path-inserted location followed by the
+  root one; for a resource that is a bare origin the two coincide and only one
+  is returned. A trailing slash on the resource is dropped before insertion, as
+  RFC 9728 §3.1 requires.
+
+function metadataUrl(resource: string): string
+  The absolute URL a `WWW-Authenticate` challenge points at: always the
+  path-inserted location, which is the one a client can validate under both
+  halves of RFC 9728 §3.3.
+
 function operatingSystem(os: typeof Deno.build.os): OperatingSystem
   The operating system as a Zuke {@link OperatingSystem}: `darwin` becomes
   `macos`, `windows` stays `windows`, and every other Unix (`linux`, the BSDs,
@@ -525,6 +552,23 @@ function prependPath(dir: PathLike, os: typeof Deno.build.os): string
 
   @return
       the resulting `PATH` string.
+
+function protectedResource(resource: string): ProtectedResourceSettings
+  Begin a protected-resource declaration for `resource`, the canonical URI of
+  this MCP endpoint (`https://build.example.com/mcp`).
+
+  ```ts
+  import { Build, protectedResource } from "jsr:@zuke/core";
+
+  class CI extends Build {
+    override mcpProtectedResource() {
+      return protectedResource("https://build.example.com/mcp")
+        .authorizationServer("https://acme.eu.auth0.com")
+        .scopes("zuke:run")
+        .name("Acme build server");
+    }
+  }
+  ```
 
 function remoteCacheKey(name: string, fingerprint: string): string
   The store key for a target's outputs: its name and input `fingerprint`. The
@@ -775,6 +819,16 @@ const FileTasks: FileTasksApi
 const HARDEN_RUNNER_ACTION: "step-security/harden-runner"
   The action a {@link CiHardenRunner} is generated from when pins are resolved.
 
+const INVALID_TOKEN: McpAuthReject
+  The refusal for a request that presented a token which did not hold up —
+  expired, wrong signature, wrong audience.
+
+  Distinct from {@link UNAUTHORIZED} on purpose: OAuth 2.1 §5.3.2 says a
+  challenge SHOULD NOT carry error information when the request had no
+  credentials at all, because there is nothing yet to have been wrong. Sending
+  `invalid_token` to a client that simply has not logged in tells it its stored
+  token was rejected, which is a different and misleading thing.
+
 const REDACTED: "[redacted]"
   The placeholder a {@link Redactor} substitutes for each secret value.
 
@@ -798,6 +852,12 @@ const ToolTasks: ToolTasksApi
   Provision external CLIs from a build. `ToolTasks.install((s) => …)` fetches a
   single release binary and `ToolTasks.npm(...)` a single npm package; group
   several of either with {@link toolchain}.
+
+const UNAUTHORIZED: McpAuthReject
+  The bare `401` challenge: the refusal an authenticator's own failure produces
+  (so a throw leaks nothing about why it threw), and the one the transport
+  answers a bad or absent static bearer token with — one shape for "you are not
+  authenticated", rather than a second spelling per call site.
 
 const ZUKE_ACTION: "zuke-build/zuke"
   The name a {@link CiPinResolver} is asked for the prelude action, so a
@@ -1133,6 +1193,34 @@ class Build
             return { actor: claims.sub, kind: "human", roles: claims.roles };
           },
         };
+      }
+    }
+    ```
+  mcpProtectedResource(): ProtectedResourceSettings | undefined
+    Declares this MCP endpoint an OAuth 2.0 protected resource, so a client
+    that has never authenticated can find out where to get a token.
+
+    `zuke mcp --http` then publishes the RFC 9728 metadata document and names
+    it in every `WWW-Authenticate` challenge, which is the whole of what
+    `claude mcp add --transport http <url>` needs to open a browser and
+    authenticate with nothing pasted. Zuke issues no tokens and hosts no
+    `/authorize`, `/token` or `/register` endpoint — those belong to the
+    identity provider named here, and {@link Build.mcpAuth} is where the tokens
+    it mints are verified. Default: none, and the server behaves exactly as
+    before.
+
+    The one thing to get right is that three strings must agree byte for
+    byte: the resource identifier below, the `resource` parameter the client
+    sends, and the audience the identity provider puts in the token. When they
+    differ every token fails validation, and nothing in the error says why.
+
+    ```ts
+    class ControlPlane extends Build {
+      override mcpProtectedResource(): ProtectedResourceSettings {
+        return protectedResource("https://build.example.com/mcp")
+          .authorizationServer("https://acme.eu.auth0.com")
+          .scopes("zuke:run")
+          .name("Acme build server");
       }
     }
     ```
@@ -1632,6 +1720,52 @@ class ParameterError extends Error
 
   override name: string
     The error name.
+
+class ProtectedResourceError extends Error
+  Raised when a protected-resource declaration cannot produce a valid document.
+
+  constructor(message: string)
+    Construct the error with `message`.
+  override name: string
+    The error name.
+
+class ProtectedResourceSettings
+  A build's protected-resource declaration, configured fluently.
+
+  The resource identifier is the single value everything else has to agree
+  with, so it is a direct argument to {@link protectedResource}; the rest are
+  setters. It must be the canonical URI of this MCP endpoint — the same
+  string the client sends as its RFC 8707 `resource` parameter, and the same
+  string the identity provider mints into the token's `aud`. Those three
+  agreeing byte for byte is the whole contract; when they disagree every token
+  fails validation, and the error says nothing about why.
+
+  constructor(resource: string)
+    Construct the settings for `resource`, the canonical endpoint URI.
+  resource_: string
+    The canonical resource identifier of this MCP endpoint.
+  authorizationServers_: string[]
+    Issuer identifiers of the authorization servers that issue for it.
+  scopes_: string[]
+    Scope values a caller may request for this resource.
+  resourceName_?: string
+    Human-readable name of the resource, for a consent screen.
+  documentation_?: string
+    URL of human-readable documentation for the resource.
+  authorizationServer(issuer: string): this
+    Add an authorization server by its issuer identifier — `https://acme.eu.auth0.com`,
+    not its metadata URL. It must string-match the `issuer` in that server's own
+    metadata document, or a client is required to reject it. At least one is
+    required: RFC 9728 marks the field optional, but MCP raises it to required.
+  scopes(...values: string[]): this
+    Declare the scope values a caller may request. These are advertised to
+    clients, which request them wholesale when a challenge names none, so keep
+    the list to what this server actually distinguishes rather than the whole
+    catalogue of a shared identity provider.
+  name(value: string): this
+    Set the human-readable resource name shown on a consent screen.
+  documentation(url: string): this
+    Set the URL of human-readable documentation for this resource.
 
 class Redactor
   Collects secret values and masks them in text. Register a value with
@@ -2367,6 +2501,18 @@ interface AnyParameter
     Whether the parameter resolved to a defined value (used by `.requires()`).
   stringValue_(): string | undefined
     The resolved value as a string, or `undefined` if unset (for masking).
+
+interface BearerChallenge
+  The parts of a `WWW-Authenticate: Bearer` challenge Zuke emits.
+
+  metadataUrl?: string
+    Absolute URL of the protected resource metadata document (RFC 9728).
+  scopes?: readonly string[]
+    Scopes required for the attempted operation — all of them, in one go.
+  error?: ChallengeError
+    The failure, omitted for a request that presented no credentials.
+  description?: string
+    Developer-facing explanation; never shown to an end user.
 
 interface BrowserTasksApi
   The shape of {@link BrowserTasks}.
@@ -4411,6 +4557,9 @@ type BuildLocation = { kind: "module"; module: string; cwd: string; repo?: strin
   `module` (the entry file `deno run` executes — the form `zuke register`
   writes) or an explicit `command` (a launch argv, for a build fronted by a
   wrapper script). Both carry the working directory and, in CI, the repository.
+
+type ChallengeError = "invalid_token" | "insufficient_scope"
+  How a bearer challenge names the failure, when there is one to name.
 
 type ChangedFilesFn = (base: string) => Promise<string[]>
   Lists the files changed since `base` (a git revision), each path relative to

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -478,13 +478,13 @@ function metadataDocument(settings: ProtectedResourceSettings): Record<string, u
   that a MUST, and an empty `scopes_supported` would in any case advertise
   "this resource accepts no scopes".
 
-function metadataPaths(resource: string): string[]
-  Every path the metadata document is published at, most specific first.
+function metadataPath(resource: string): string
+  The path the metadata document is published at: the well-known suffix with
+  the resource's own path inserted after it.
 
-  For a resource with a path this is the path-inserted location followed by the
-  root one; for a resource that is a bare origin the two coincide and only one
-  is returned. A trailing slash on the resource is dropped before insertion, as
-  RFC 9728 §3.1 requires.
+  For a resource that is a bare origin this is the root well-known path, which
+  is then the conformant location for that identifier. A trailing slash is
+  dropped before insertion, as RFC 9728 §3.1 requires.
 
 function metadataUrl(resource: string): string
   The absolute URL a `WWW-Authenticate` challenge points at: always the
@@ -823,7 +823,7 @@ const INVALID_TOKEN: McpAuthReject
   The refusal for a request that presented a token which did not hold up —
   expired, wrong signature, wrong audience.
 
-  Distinct from {@link UNAUTHORIZED} on purpose: OAuth 2.1 §5.3.2 says a
+  Distinct from {@link UNAUTHORIZED} on purpose: OAuth 2.1 §5.3.1 says a
   challenge SHOULD NOT carry error information when the request had no
   credentials at all, because there is nothing yet to have been wrong. Sending
   `invalid_token` to a client that simply has not logged in tells it its stored
@@ -856,8 +856,9 @@ const ToolTasks: ToolTasksApi
 const UNAUTHORIZED: McpAuthReject
   The bare `401` challenge: the refusal an authenticator's own failure produces
   (so a throw leaks nothing about why it threw), and the one the transport
-  answers a bad or absent static bearer token with — one shape for "you are not
-  authenticated", rather than a second spelling per call site.
+  answers an absent static bearer token with. A token that was presented
+  and rejected gets {@link INVALID_TOKEN} instead: the two are different facts
+  about the caller, and only the second one is about a credential.
 
 const ZUKE_ACTION: "zuke-build/zuke"
   The name a {@link CiPinResolver} is asked for the prelude action, so a

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -175,6 +175,13 @@ function assertSafeLinkTarget(entryName: string, target: string): void
   name is bounded by {@link assertSafeEntryName}; a symlink adds a second escape
   vector (its target), so a poisoned tarball can't plant `bin/x -> ../../etc`.
 
+function bearerChallenge(parts: BearerChallenge): string
+  A `WWW-Authenticate: Bearer` challenge built from `parts`.
+
+  Returns a bare `Bearer` when nothing usable is supplied, and drops any single
+  part that survives filtering as empty, so a caller cannot produce a malformed
+  header by passing an odd string.
+
 async function cancelRun(build: Build, options: CancelOptions): Promise<CancelResult>
   Cancel the run `options.runId` for `build`: transition it to `cancelling`
   (exactly one canceller drives the walk; a live owning process observes the
@@ -518,6 +525,26 @@ function lockKey(...parts: Array<string | number>): string
   Each part is sanitised (non-`[A-Za-z0-9._-]` runs become `_`) and empty parts
   are dropped, so `lockKey("deploy", repo)` is stable and injection-free.
 
+function metadataDocument(settings: ProtectedResourceSettings): Record<string, unknown>
+  The metadata document itself, as the JSON object RFC 9728 §2 defines.
+
+  Fields with no values are omitted rather than serialised empty — §3.2 makes
+  that a MUST, and an empty `scopes_supported` would in any case advertise
+  "this resource accepts no scopes".
+
+function metadataPaths(resource: string): string[]
+  Every path the metadata document is published at, most specific first.
+
+  For a resource with a path this is the path-inserted location followed by the
+  root one; for a resource that is a bare origin the two coincide and only one
+  is returned. A trailing slash on the resource is dropped before insertion, as
+  RFC 9728 §3.1 requires.
+
+function metadataUrl(resource: string): string
+  The absolute URL a `WWW-Authenticate` challenge points at: always the
+  path-inserted location, which is the one a client can validate under both
+  halves of RFC 9728 §3.3.
+
 function operatingSystem(os: typeof Deno.build.os): OperatingSystem
   The operating system as a Zuke {@link OperatingSystem}: `darwin` becomes
   `macos`, `windows` stays `windows`, and every other Unix (`linux`, the BSDs,
@@ -579,6 +606,23 @@ function prependPath(dir: PathLike, os: typeof Deno.build.os): string
 
   @return
       the resulting `PATH` string.
+
+function protectedResource(resource: string): ProtectedResourceSettings
+  Begin a protected-resource declaration for `resource`, the canonical URI of
+  this MCP endpoint (`https://build.example.com/mcp`).
+
+  ```ts
+  import { Build, protectedResource } from "jsr:@zuke/core";
+
+  class CI extends Build {
+    override mcpProtectedResource() {
+      return protectedResource("https://build.example.com/mcp")
+        .authorizationServer("https://acme.eu.auth0.com")
+        .scopes("zuke:run")
+        .name("Acme build server");
+    }
+  }
+  ```
 
 function remoteCacheKey(name: string, fingerprint: string): string
   The store key for a target's outputs: its name and input `fingerprint`. The
@@ -829,6 +873,16 @@ const FileTasks: FileTasksApi
 const HARDEN_RUNNER_ACTION: "step-security/harden-runner"
   The action a {@link CiHardenRunner} is generated from when pins are resolved.
 
+const INVALID_TOKEN: McpAuthReject
+  The refusal for a request that presented a token which did not hold up —
+  expired, wrong signature, wrong audience.
+
+  Distinct from {@link UNAUTHORIZED} on purpose: OAuth 2.1 §5.3.2 says a
+  challenge SHOULD NOT carry error information when the request had no
+  credentials at all, because there is nothing yet to have been wrong. Sending
+  `invalid_token` to a client that simply has not logged in tells it its stored
+  token was rejected, which is a different and misleading thing.
+
 const REDACTED: "[redacted]"
   The placeholder a {@link Redactor} substitutes for each secret value.
 
@@ -852,6 +906,12 @@ const ToolTasks: ToolTasksApi
   Provision external CLIs from a build. `ToolTasks.install((s) => …)` fetches a
   single release binary and `ToolTasks.npm(...)` a single npm package; group
   several of either with {@link toolchain}.
+
+const UNAUTHORIZED: McpAuthReject
+  The bare `401` challenge: the refusal an authenticator's own failure produces
+  (so a throw leaks nothing about why it threw), and the one the transport
+  answers a bad or absent static bearer token with — one shape for "you are not
+  authenticated", rather than a second spelling per call site.
 
 const ZUKE_ACTION: "zuke-build/zuke"
   The name a {@link CiPinResolver} is asked for the prelude action, so a
@@ -1187,6 +1247,34 @@ class Build
             return { actor: claims.sub, kind: "human", roles: claims.roles };
           },
         };
+      }
+    }
+    ```
+  mcpProtectedResource(): ProtectedResourceSettings | undefined
+    Declares this MCP endpoint an OAuth 2.0 protected resource, so a client
+    that has never authenticated can find out where to get a token.
+
+    `zuke mcp --http` then publishes the RFC 9728 metadata document and names
+    it in every `WWW-Authenticate` challenge, which is the whole of what
+    `claude mcp add --transport http <url>` needs to open a browser and
+    authenticate with nothing pasted. Zuke issues no tokens and hosts no
+    `/authorize`, `/token` or `/register` endpoint — those belong to the
+    identity provider named here, and {@link Build.mcpAuth} is where the tokens
+    it mints are verified. Default: none, and the server behaves exactly as
+    before.
+
+    The one thing to get right is that three strings must agree byte for
+    byte: the resource identifier below, the `resource` parameter the client
+    sends, and the audience the identity provider puts in the token. When they
+    differ every token fails validation, and nothing in the error says why.
+
+    ```ts
+    class ControlPlane extends Build {
+      override mcpProtectedResource(): ProtectedResourceSettings {
+        return protectedResource("https://build.example.com/mcp")
+          .authorizationServer("https://acme.eu.auth0.com")
+          .scopes("zuke:run")
+          .name("Acme build server");
       }
     }
     ```
@@ -1686,6 +1774,52 @@ class ParameterError extends Error
 
   override name: string
     The error name.
+
+class ProtectedResourceError extends Error
+  Raised when a protected-resource declaration cannot produce a valid document.
+
+  constructor(message: string)
+    Construct the error with `message`.
+  override name: string
+    The error name.
+
+class ProtectedResourceSettings
+  A build's protected-resource declaration, configured fluently.
+
+  The resource identifier is the single value everything else has to agree
+  with, so it is a direct argument to {@link protectedResource}; the rest are
+  setters. It must be the canonical URI of this MCP endpoint — the same
+  string the client sends as its RFC 8707 `resource` parameter, and the same
+  string the identity provider mints into the token's `aud`. Those three
+  agreeing byte for byte is the whole contract; when they disagree every token
+  fails validation, and the error says nothing about why.
+
+  constructor(resource: string)
+    Construct the settings for `resource`, the canonical endpoint URI.
+  resource_: string
+    The canonical resource identifier of this MCP endpoint.
+  authorizationServers_: string[]
+    Issuer identifiers of the authorization servers that issue for it.
+  scopes_: string[]
+    Scope values a caller may request for this resource.
+  resourceName_?: string
+    Human-readable name of the resource, for a consent screen.
+  documentation_?: string
+    URL of human-readable documentation for the resource.
+  authorizationServer(issuer: string): this
+    Add an authorization server by its issuer identifier — `https://acme.eu.auth0.com`,
+    not its metadata URL. It must string-match the `issuer` in that server's own
+    metadata document, or a client is required to reject it. At least one is
+    required: RFC 9728 marks the field optional, but MCP raises it to required.
+  scopes(...values: string[]): this
+    Declare the scope values a caller may request. These are advertised to
+    clients, which request them wholesale when a challenge names none, so keep
+    the list to what this server actually distinguishes rather than the whole
+    catalogue of a shared identity provider.
+  name(value: string): this
+    Set the human-readable resource name shown on a consent screen.
+  documentation(url: string): this
+    Set the URL of human-readable documentation for this resource.
 
 class Redactor
   Collects secret values and masks them in text. Register a value with
@@ -2421,6 +2555,18 @@ interface AnyParameter
     Whether the parameter resolved to a defined value (used by `.requires()`).
   stringValue_(): string | undefined
     The resolved value as a string, or `undefined` if unset (for masking).
+
+interface BearerChallenge
+  The parts of a `WWW-Authenticate: Bearer` challenge Zuke emits.
+
+  metadataUrl?: string
+    Absolute URL of the protected resource metadata document (RFC 9728).
+  scopes?: readonly string[]
+    Scopes required for the attempted operation — all of them, in one go.
+  error?: ChallengeError
+    The failure, omitted for a request that presented no credentials.
+  description?: string
+    Developer-facing explanation; never shown to an end user.
 
 interface BrowserTasksApi
   The shape of {@link BrowserTasks}.
@@ -4465,6 +4611,9 @@ type BuildLocation = { kind: "module"; module: string; cwd: string; repo?: strin
   `module` (the entry file `deno run` executes — the form `zuke register`
   writes) or an explicit `command` (a launch argv, for a build fronted by a
   wrapper script). Both carry the working directory and, in CI, the repository.
+
+type ChallengeError = "invalid_token" | "insufficient_scope"
+  How a bearer challenge names the failure, when there is one to name.
 
 type ChangedFilesFn = (base: string) => Promise<string[]>
   Lists the files changed since `base` (a git revision), each path relative to

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -532,13 +532,13 @@ function metadataDocument(settings: ProtectedResourceSettings): Record<string, u
   that a MUST, and an empty `scopes_supported` would in any case advertise
   "this resource accepts no scopes".
 
-function metadataPaths(resource: string): string[]
-  Every path the metadata document is published at, most specific first.
+function metadataPath(resource: string): string
+  The path the metadata document is published at: the well-known suffix with
+  the resource's own path inserted after it.
 
-  For a resource with a path this is the path-inserted location followed by the
-  root one; for a resource that is a bare origin the two coincide and only one
-  is returned. A trailing slash on the resource is dropped before insertion, as
-  RFC 9728 §3.1 requires.
+  For a resource that is a bare origin this is the root well-known path, which
+  is then the conformant location for that identifier. A trailing slash is
+  dropped before insertion, as RFC 9728 §3.1 requires.
 
 function metadataUrl(resource: string): string
   The absolute URL a `WWW-Authenticate` challenge points at: always the
@@ -877,7 +877,7 @@ const INVALID_TOKEN: McpAuthReject
   The refusal for a request that presented a token which did not hold up —
   expired, wrong signature, wrong audience.
 
-  Distinct from {@link UNAUTHORIZED} on purpose: OAuth 2.1 §5.3.2 says a
+  Distinct from {@link UNAUTHORIZED} on purpose: OAuth 2.1 §5.3.1 says a
   challenge SHOULD NOT carry error information when the request had no
   credentials at all, because there is nothing yet to have been wrong. Sending
   `invalid_token` to a client that simply has not logged in tells it its stored
@@ -910,8 +910,9 @@ const ToolTasks: ToolTasksApi
 const UNAUTHORIZED: McpAuthReject
   The bare `401` challenge: the refusal an authenticator's own failure produces
   (so a throw leaks nothing about why it threw), and the one the transport
-  answers a bad or absent static bearer token with — one shape for "you are not
-  authenticated", rather than a second spelling per call site.
+  answers an absent static bearer token with. A token that was presented
+  and rejected gets {@link INVALID_TOKEN} instead: the two are different facts
+  about the caller, and only the second one is about a credential.
 
 const ZUKE_ACTION: "zuke-build/zuke"
   The name a {@link CiPinResolver} is asked for the prelude action, so a

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -223,11 +223,24 @@ export {
 } from "./src/registry/resolve.ts";
 export { type McpRequestContext } from "./src/mcp/jsonrpc.ts";
 export {
+  type BearerChallenge,
+  bearerChallenge,
+  type ChallengeError,
+  INVALID_TOKEN,
   type McpAuthenticator,
   type McpAuthReject,
   type McpIdentity,
   type McpIdentityHook,
+  UNAUTHORIZED,
 } from "./src/mcp/auth.ts";
+export {
+  metadataDocument,
+  metadataPaths,
+  metadataUrl,
+  protectedResource,
+  ProtectedResourceError,
+  ProtectedResourceSettings,
+} from "./src/mcp/resource_metadata.ts";
 export {
   defaultMcpAuthorize,
   type McpAuthorization,

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -235,7 +235,7 @@ export {
 } from "./src/mcp/auth.ts";
 export {
   metadataDocument,
-  metadataPaths,
+  metadataPath,
   metadataUrl,
   protectedResource,
   ProtectedResourceError,

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -13,6 +13,7 @@
  */
 
 import { Group, type Remediation, TargetBuilder } from "./target.ts";
+import type { ProtectedResourceSettings } from "./mcp/resource_metadata.ts";
 import type { OrderingEdge } from "./graph.ts";
 import type { RemoteCacheStore } from "./remote_cache.ts";
 import type { StateStore } from "./state/store.ts";
@@ -357,6 +358,39 @@ export class Build {
    * ```
    */
   mcpAuth(): McpAuthenticator | undefined {
+    return undefined;
+  }
+
+  /**
+   * Declares this MCP endpoint an OAuth 2.0 **protected resource**, so a client
+   * that has never authenticated can find out where to get a token.
+   *
+   * `zuke mcp --http` then publishes the RFC 9728 metadata document and names
+   * it in every `WWW-Authenticate` challenge, which is the whole of what
+   * `claude mcp add --transport http <url>` needs to open a browser and
+   * authenticate with nothing pasted. Zuke issues no tokens and hosts no
+   * `/authorize`, `/token` or `/register` endpoint — those belong to the
+   * identity provider named here, and {@link Build.mcpAuth} is where the tokens
+   * it mints are verified. Default: none, and the server behaves exactly as
+   * before.
+   *
+   * The one thing to get right is that **three strings must agree byte for
+   * byte**: the resource identifier below, the `resource` parameter the client
+   * sends, and the audience the identity provider puts in the token. When they
+   * differ every token fails validation, and nothing in the error says why.
+   *
+   * ```ts
+   * class ControlPlane extends Build {
+   *   override mcpProtectedResource(): ProtectedResourceSettings {
+   *     return protectedResource("https://build.example.com/mcp")
+   *       .authorizationServer("https://acme.eu.auth0.com")
+   *       .scopes("zuke:run")
+   *       .name("Acme build server");
+   *   }
+   * }
+   * ```
+   */
+  mcpProtectedResource(): ProtectedResourceSettings | undefined {
     return undefined;
   }
 

--- a/packages/core/src/mcp/auth.ts
+++ b/packages/core/src/mcp/auth.ts
@@ -141,8 +141,9 @@ export type McpIdentityHook = (ctx: McpRequestContext) => McpIdentity;
 /**
  * The bare `401` challenge: the refusal an authenticator's own failure produces
  * (so a throw leaks nothing about why it threw), and the one the transport
- * answers a bad or absent static bearer token with — one shape for "you are not
- * authenticated", rather than a second spelling per call site.
+ * answers an **absent** static bearer token with. A token that was presented
+ * and rejected gets {@link INVALID_TOKEN} instead: the two are different facts
+ * about the caller, and only the second one is about a credential.
  */
 export const UNAUTHORIZED: McpAuthReject = Object.freeze({
   status: 401,
@@ -154,7 +155,7 @@ export const UNAUTHORIZED: McpAuthReject = Object.freeze({
  * The refusal for a request that **presented** a token which did not hold up —
  * expired, wrong signature, wrong audience.
  *
- * Distinct from {@link UNAUTHORIZED} on purpose: OAuth 2.1 §5.3.2 says a
+ * Distinct from {@link UNAUTHORIZED} on purpose: OAuth 2.1 §5.3.1 says a
  * challenge SHOULD NOT carry error information when the request had no
  * credentials at all, because there is nothing yet to have been wrong. Sending
  * `invalid_token` to a client that simply has not logged in tells it its stored
@@ -230,9 +231,18 @@ export function withResourceMetadata(
   challenge: string,
   metadataUrl: string,
 ): string {
-  if (challenge.includes("resource_metadata=")) return challenge;
+  // Matched as a parameter, not as a substring, and only outside quoted
+  // values — a plain `includes` was wrong in both directions. An
+  // `error_description` merely mentioning the word suppressed a real URL,
+  // silently killing discovery; and a challenge spelling the parameter
+  // `Resource_Metadata =` (auth-param names are case-insensitive, and RFC 7235
+  // permits space around the `=`) got a second copy, which RFC 7235 §2.1
+  // forbids and leaves clients to resolve however they like. Blanking the
+  // quoted strings first is what separates the two cases: a value can contain
+  // anything, a parameter name cannot.
+  const outsideValues = challenge.replace(/"(?:[^"\\]|\\.)*"/g, `""`);
+  if (/(^|[\s,])resource_metadata\s*=/i.test(outsideValues)) return challenge;
   const url = paramValue(metadataUrl);
-  if (url === "") return challenge;
   const separator = challenge.trim() === "Bearer" ? " " : ", ";
   const merged = `${challenge}${separator}resource_metadata="${url}"`;
   return headerValue(merged) ?? challenge;

--- a/packages/core/src/mcp/auth.ts
+++ b/packages/core/src/mcp/auth.ts
@@ -150,6 +150,94 @@ export const UNAUTHORIZED: McpAuthReject = Object.freeze({
   challenge: "Bearer",
 });
 
+/**
+ * The refusal for a request that **presented** a token which did not hold up —
+ * expired, wrong signature, wrong audience.
+ *
+ * Distinct from {@link UNAUTHORIZED} on purpose: OAuth 2.1 §5.3.2 says a
+ * challenge SHOULD NOT carry error information when the request had no
+ * credentials at all, because there is nothing yet to have been wrong. Sending
+ * `invalid_token` to a client that simply has not logged in tells it its stored
+ * token was rejected, which is a different and misleading thing.
+ */
+export const INVALID_TOKEN: McpAuthReject = Object.freeze({
+  status: 401,
+  error: "invalid_token",
+  challenge: `Bearer error="invalid_token"`,
+});
+
+/** How a bearer challenge names the failure, when there is one to name. */
+export type ChallengeError = "invalid_token" | "insufficient_scope";
+
+/** The parts of a `WWW-Authenticate: Bearer` challenge Zuke emits. */
+export interface BearerChallenge {
+  /** Absolute URL of the protected resource metadata document (RFC 9728). */
+  metadataUrl?: string;
+  /** Scopes required for the attempted operation — all of them, in one go. */
+  scopes?: readonly string[];
+  /** The failure, omitted for a request that presented no credentials. */
+  error?: ChallengeError;
+  /** Developer-facing explanation; never shown to an end user. */
+  description?: string;
+}
+
+/**
+ * Characters an `auth-param` value may carry, per OAuth 2.1 §5.3.1: the set
+ * excludes `"` and `\`, so anything interpolated into a challenge has to be
+ * filtered or it is a header-injection bug. Dropping the offending characters
+ * beats escaping them, because nothing downstream needs the original back.
+ */
+function paramValue(value: string): string {
+  return value.replace(/[^\x20-\x21\x23-\x5B\x5D-\x7E]/g, "");
+}
+
+/**
+ * A `WWW-Authenticate: Bearer` challenge built from `parts`.
+ *
+ * Returns a bare `Bearer` when nothing usable is supplied, and drops any single
+ * part that survives filtering as empty, so a caller cannot produce a malformed
+ * header by passing an odd string.
+ */
+export function bearerChallenge(parts: BearerChallenge = {}): string {
+  const params: string[] = [];
+  const add = (name: string, raw: string | undefined) => {
+    const value = raw === undefined ? "" : paramValue(raw);
+    if (value !== "") params.push(`${name}="${value}"`);
+  };
+  add("error", parts.error);
+  add("error_description", parts.description);
+  // Space-delimited, and each value filtered the same way; an empty result is
+  // dropped by `add` rather than emitted as `scope=""`.
+  add("scope", parts.scopes?.join(" "));
+  add("resource_metadata", parts.metadataUrl);
+  const challenge = params.length === 0
+    ? "Bearer"
+    : `Bearer ${params.join(", ")}`;
+  return headerValue(challenge) ?? "Bearer";
+}
+
+/**
+ * `challenge` with a `resource_metadata` parameter naming `metadataUrl`, unless
+ * it already carries one.
+ *
+ * The refusal constants and an authenticator's own challenge are both written
+ * without knowing the server's public URL, which is configuration the transport
+ * holds — so the parameter is added here, at the point the response is built,
+ * rather than threaded through every place a refusal is constructed. An
+ * authenticator that set its own is left alone.
+ */
+export function withResourceMetadata(
+  challenge: string,
+  metadataUrl: string,
+): string {
+  if (challenge.includes("resource_metadata=")) return challenge;
+  const url = paramValue(metadataUrl);
+  if (url === "") return challenge;
+  const separator = challenge.trim() === "Bearer" ? " " : ", ";
+  const merged = `${challenge}${separator}resource_metadata="${url}"`;
+  return headerValue(merged) ?? challenge;
+}
+
 /** Whether `value` is a plain object (a string-keyed record). */
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);

--- a/packages/core/src/mcp/command.ts
+++ b/packages/core/src/mcp/command.ts
@@ -10,7 +10,7 @@
 
 import type { Build } from "../build.ts";
 import { isLoopbackHost } from "../http.ts";
-import { defaultReadEnv } from "../internal.ts";
+import { defaultReadEnv, messageOf } from "../internal.ts";
 import { absolutePath } from "../path.ts";
 import { findConfigDir, pathExists } from "../config.ts";
 import { defaultStateHost, type StateStore } from "../state/store.ts";
@@ -24,6 +24,10 @@ import {
   serveStdio,
 } from "./jsonrpc.ts";
 import { serveHttp } from "./http.ts";
+import {
+  metadataDocument,
+  type ProtectedResourceSettings,
+} from "./resource_metadata.ts";
 import {
   authenticatorFromHook,
   type McpAuthenticator,
@@ -162,6 +166,18 @@ export async function serveMcp(
   }
   const authenticator = options.authenticator ?? declared ??
     (hook === undefined ? undefined : authenticatorFromHook(hook));
+  // Validated here rather than on first request: a malformed resource
+  // identifier is an authoring mistake, and discovering it when a client
+  // finally asks means discovering it as a client that cannot authenticate.
+  const protectedResource = build.mcpProtectedResource();
+  if (protectedResource !== undefined) {
+    try {
+      metadataDocument(protectedResource);
+    } catch (error) {
+      console.error(`zuke mcp: ${messageOf(error)}`);
+      return 1;
+    }
+  }
   // The role policy applies to a seam that was declared *as* an authenticator.
   // The legacy `mcpIdentity()` hook never had roles to give, so a build using it
   // keeps the allow-list and operator token as its only gates.
@@ -212,6 +228,7 @@ export async function serveMcp(
       options,
       authenticator,
       authenticates,
+      protectedResource,
     );
   }
   if (!options.quiet) {
@@ -244,6 +261,7 @@ async function serveMcpHttp(
   options: ServeMcpOptions,
   authenticator: McpAuthenticator | undefined,
   authenticates: boolean,
+  protectedResource: ProtectedResourceSettings | undefined,
 ): Promise<number> {
   const readEnv = options.readEnv ?? defaultReadEnv;
   const token = options.token ?? readEnv("ZUKE_MCP_TOKEN");
@@ -286,6 +304,7 @@ async function serveMcpHttp(
       onListen: options.onListen,
       concurrent: server.concurrent,
       authenticator,
+      protectedResource,
     },
   );
   return 0;

--- a/packages/core/src/mcp/http.ts
+++ b/packages/core/src/mcp/http.ts
@@ -33,13 +33,21 @@ import {
 import { timingSafeEqual } from "./authz.ts";
 import {
   authenticateRequest,
+  INVALID_TOKEN,
   isResolvedIdentity,
   type McpAuthenticator,
   type McpAuthReject,
   refusalReason,
   type ResolvedIdentity,
   UNAUTHORIZED,
+  withResourceMetadata,
 } from "./auth.ts";
+import {
+  metadataDocument,
+  metadataPaths,
+  metadataUrl,
+  type ProtectedResourceSettings,
+} from "./resource_metadata.ts";
 import { isLoopbackHost } from "../http.ts";
 
 /** Options for {@link serveHttp}. */
@@ -83,6 +91,20 @@ export interface HttpTransportOptions {
    * client discover where to authenticate.
    */
   authenticator?: McpAuthenticator;
+  /**
+   * Publishes this endpoint's OAuth 2.0 Protected Resource Metadata (RFC 9728)
+   * and names it in every `WWW-Authenticate` challenge, so a client that has
+   * never authenticated can discover where to get a token.
+   *
+   * The document is served on unauthenticated `GET`s — necessarily, since a
+   * caller asking where to authenticate has nothing to authenticate with — at
+   * the paths {@link "./resource_metadata.ts".metadataPaths} derives. There is
+   * deliberately no general "extra routes" hook here: this document is the only
+   * thing that has to be reachable before authentication, and a seam that let
+   * anything else in would be a seam whose entries are unauthenticated by
+   * construction.
+   */
+  protectedResource?: ProtectedResourceSettings;
 }
 
 /** A JSON `Response` with the given status and `application/json` content type. */
@@ -200,15 +222,49 @@ function authenticatorView(request: Request): Request | undefined {
  * body still carries the JSON-RPC error, so a client that reads it sees the
  * same reason it saw before.
  */
-function refusedResponse(reject: McpAuthReject): Response {
+function refusedResponse(
+  reject: McpAuthReject,
+  metadataUrl?: string,
+): Response {
   const headers = new Headers({ "content-type": "application/json" });
   if (reject.challenge !== undefined) {
-    headers.set("www-authenticate", reject.challenge);
+    headers.set(
+      "www-authenticate",
+      metadataUrl === undefined
+        ? reject.challenge
+        : withResourceMetadata(reject.challenge, metadataUrl),
+    );
+    // A browser-based client reads the challenge to learn where to
+    // authenticate, and cannot see a response header across origins unless it
+    // is exposed. Without this the whole discovery mechanism is invisible to
+    // exactly the clients that need a redirect.
+    headers.set("access-control-expose-headers", "WWW-Authenticate");
   }
   return new Response(
     JSON.stringify(err(null, INVALID_REQUEST, refusalReason(reject))),
     { status: reject.status, headers },
   );
+}
+
+/**
+ * The metadata document as a public, cacheable, cross-origin-readable
+ * response.
+ *
+ * No `Origin` check runs on this one. The document is public by definition —
+ * it names authorization servers and scopes, and carries nothing a caller could
+ * not learn by attempting to authenticate — and browser-based MCP clients fetch
+ * it cross-origin, so gating it on `Origin` would break them while protecting
+ * nothing.
+ */
+function metadataResponse(settings: ProtectedResourceSettings): Response {
+  return new Response(JSON.stringify(metadataDocument(settings), null, 2), {
+    status: 200,
+    headers: {
+      "content-type": "application/json",
+      "access-control-allow-origin": "*",
+      "cache-control": "public, max-age=3600",
+    },
+  });
 }
 
 /** The hostname of an `Origin` value, or `null` if it can't be parsed. */
@@ -266,6 +322,7 @@ export async function serveHttp(
     concurrent,
     allowedOrigins,
     authenticator,
+    protectedResource,
   } = options;
 
   // By default, process messages one at a time: the single-build server/execute
@@ -284,7 +341,35 @@ export async function serveHttp(
   };
   const dispatch = concurrent === true ? handle : serial;
 
+  const metadataAt = protectedResource === undefined
+    ? new Set<string>()
+    : new Set(metadataPaths(protectedResource.resource_));
+  const resourceMetadataUrl = protectedResource === undefined
+    ? undefined
+    : metadataUrl(protectedResource.resource_);
+
   const onRequest = async (request: Request): Promise<Response> => {
+    // Before every other check, including the method one: this is the document
+    // an unauthenticated client reads to find out where to authenticate, and it
+    // is fetched with GET.
+    if (protectedResource !== undefined) {
+      const path = new URL(request.url).pathname;
+      if (metadataAt.has(path)) {
+        if (request.method === "GET" || request.method === "HEAD") {
+          return metadataResponse(protectedResource);
+        }
+        if (request.method === "OPTIONS") {
+          return new Response(null, {
+            status: 204,
+            headers: {
+              "access-control-allow-origin": "*",
+              "access-control-allow-methods": "GET, HEAD, OPTIONS",
+              "access-control-allow-headers": "authorization, content-type",
+            },
+          });
+        }
+      }
+    }
     if (request.method !== "POST") {
       return jsonResponse(
         err(null, INVALID_REQUEST, "This MCP endpoint accepts POST only."),
@@ -306,7 +391,12 @@ export async function serveHttp(
     if (token !== undefined && token !== "") {
       const provided = bearerToken(request.headers.get("authorization"));
       if (provided === undefined || !timingSafeEqual(provided, token)) {
-        return refusedResponse(UNAUTHORIZED);
+        // A caller that sent nothing is told only that it must authenticate; a
+        // caller whose token was rejected is told that much and no more.
+        return refusedResponse(
+          provided === undefined ? UNAUTHORIZED : INVALID_TOKEN,
+          resourceMetadataUrl,
+        );
       }
     }
     // Authenticate before reading the body: an unauthenticated caller never gets
@@ -318,7 +408,9 @@ export async function serveHttp(
     let identity: ResolvedIdentity | undefined;
     if (authenticator !== undefined) {
       const resolved = await authenticateRequest(authenticator, ctx);
-      if (!isResolvedIdentity(resolved)) return refusedResponse(resolved);
+      if (!isResolvedIdentity(resolved)) {
+        return refusedResponse(resolved, resourceMetadataUrl);
+      }
       identity = resolved;
     }
     const body = await readBounded(request, MAX_BODY_BYTES);

--- a/packages/core/src/mcp/http.ts
+++ b/packages/core/src/mcp/http.ts
@@ -33,6 +33,7 @@ import {
 import { timingSafeEqual } from "./authz.ts";
 import {
   authenticateRequest,
+  bearerChallenge,
   INVALID_TOKEN,
   isResolvedIdentity,
   type McpAuthenticator,
@@ -44,7 +45,7 @@ import {
 } from "./auth.ts";
 import {
   metadataDocument,
-  metadataPaths,
+  metadataPath,
   metadataUrl,
   type ProtectedResourceSettings,
 } from "./resource_metadata.ts";
@@ -98,7 +99,7 @@ export interface HttpTransportOptions {
    *
    * The document is served on unauthenticated `GET`s — necessarily, since a
    * caller asking where to authenticate has nothing to authenticate with — at
-   * the paths {@link "./resource_metadata.ts".metadataPaths} derives. There is
+   * the path {@link "./resource_metadata.ts".metadataPath} derives. There is
    * deliberately no general "extra routes" hook here: this document is the only
    * thing that has to be reachable before authentication, and a seam that let
    * anything else in would be a seam whose entries are unauthenticated by
@@ -219,31 +220,50 @@ function authenticatorView(request: Request): Request | undefined {
  * bad or absent bearer token has always been answered `401` here, a non-`POST`
  * `405`, and unparseable JSON `400`, so a client that reads any non-`200` as a
  * transport failure was already broken against a token-protected server. The
- * body still carries the JSON-RPC error, so a client that reads it sees the
- * same reason it saw before.
+ * body still carries the JSON-RPC error. One reason did change: a bearer token
+ * that was presented and rejected now reads `invalid_token` rather than the
+ * generic `Unauthorized`, which is what OAuth defines it as and what tells a
+ * client its stored credential — rather than its absence — is the problem.
  */
 function refusedResponse(
   reject: McpAuthReject,
-  metadataUrl?: string,
+  discovery?: { metadataUrl: string; scopes: readonly string[] },
 ): Response {
   const headers = new Headers({ "content-type": "application/json" });
   if (reject.challenge !== undefined) {
-    headers.set(
-      "www-authenticate",
-      metadataUrl === undefined
-        ? reject.challenge
-        : withResourceMetadata(reject.challenge, metadataUrl),
-    );
-    // A browser-based client reads the challenge to learn where to
-    // authenticate, and cannot see a response header across origins unless it
-    // is exposed. Without this the whole discovery mechanism is invisible to
-    // exactly the clients that need a redirect.
-    headers.set("access-control-expose-headers", "WWW-Authenticate");
+    headers.set("www-authenticate", challengeFor(reject, discovery));
   }
   return new Response(
     JSON.stringify(err(null, INVALID_REQUEST, refusalReason(reject))),
     { status: reject.status, headers },
   );
+}
+
+/**
+ * The challenge to send with `reject`.
+ *
+ * Zuke's own two refusals are **rebuilt** rather than patched, so the declared
+ * scopes go in as a proper `scope` parameter — the specification asks a
+ * protected resource to name what the operation needs, and a client with no
+ * challenge scope falls back to requesting the entire advertised catalogue. An
+ * authenticator's own challenge is a string this code did not write and cannot
+ * safely re-derive, so that one is only given the metadata URL it lacks.
+ */
+function challengeFor(
+  reject: McpAuthReject,
+  discovery?: { metadataUrl: string; scopes: readonly string[] },
+): string {
+  const challenge = reject.challenge ?? "Bearer";
+  if (discovery === undefined) return challenge;
+  const ours = reject === UNAUTHORIZED || reject === INVALID_TOKEN;
+  if (!ours) return withResourceMetadata(challenge, discovery.metadataUrl);
+  return bearerChallenge({
+    metadataUrl: discovery.metadataUrl,
+    scopes: discovery.scopes,
+    // Only a token that was presented and rejected names an error; a request
+    // that carried no credentials has had nothing of its own refused yet.
+    ...(reject === INVALID_TOKEN ? { error: "invalid_token" as const } : {}),
+  });
 }
 
 /**
@@ -256,8 +276,8 @@ function refusedResponse(
  * it cross-origin, so gating it on `Origin` would break them while protecting
  * nothing.
  */
-function metadataResponse(settings: ProtectedResourceSettings): Response {
-  return new Response(JSON.stringify(metadataDocument(settings), null, 2), {
+function metadataResponse(body: string): Response {
+  return new Response(body, {
     status: 200,
     headers: {
       "content-type": "application/json",
@@ -342,21 +362,40 @@ export async function serveHttp(
   const dispatch = concurrent === true ? handle : serial;
 
   const metadataAt = protectedResource === undefined
-    ? new Set<string>()
-    : new Set(metadataPaths(protectedResource.resource_));
-  const resourceMetadataUrl = protectedResource === undefined
     ? undefined
-    : metadataUrl(protectedResource.resource_);
+    : metadataPath(protectedResource.resource_);
+  const discovery = protectedResource === undefined ? undefined : {
+    metadataUrl: metadataUrl(protectedResource.resource_),
+    scopes: protectedResource.scopes_,
+  };
+  // Rendered once, here, rather than per request. Building it in the handler
+  // would put a throw on an unauthenticated public path — a declaration mutated
+  // after startup, say — where it becomes a 500 with no error boundary. It is
+  // also a constant, so re-serialising it for every caller was pure waste.
+  const metadataBody = protectedResource === undefined
+    ? undefined
+    : JSON.stringify(metadataDocument(protectedResource), null, 2);
 
   const onRequest = async (request: Request): Promise<Response> => {
     // Before every other check, including the method one: this is the document
     // an unauthenticated client reads to find out where to authenticate, and it
     // is fetched with GET.
-    if (protectedResource !== undefined) {
-      const path = new URL(request.url).pathname;
-      if (metadataAt.has(path)) {
+    if (metadataBody !== undefined) {
+      // Guarded, because Deno builds `request.url` from the raw `Host` header
+      // and accepts hosts the WHATWG parser rejects (`Host: bad host`). This
+      // runs before every other check, so an unguarded throw here would answer
+      // *every* request — authenticated ones included — with a 500. That is the
+      // same trap `authenticatorView` below already documents; it is one call
+      // earlier, and it must be caught the same way.
+      let path: string;
+      try {
+        path = new URL(request.url).pathname;
+      } catch {
+        path = "";
+      }
+      if (path === metadataAt) {
         if (request.method === "GET" || request.method === "HEAD") {
-          return metadataResponse(protectedResource);
+          return metadataResponse(metadataBody);
         }
         if (request.method === "OPTIONS") {
           return new Response(null, {
@@ -395,7 +434,7 @@ export async function serveHttp(
         // caller whose token was rejected is told that much and no more.
         return refusedResponse(
           provided === undefined ? UNAUTHORIZED : INVALID_TOKEN,
-          resourceMetadataUrl,
+          discovery,
         );
       }
     }
@@ -409,7 +448,7 @@ export async function serveHttp(
     if (authenticator !== undefined) {
       const resolved = await authenticateRequest(authenticator, ctx);
       if (!isResolvedIdentity(resolved)) {
-        return refusedResponse(resolved, resourceMetadataUrl);
+        return refusedResponse(resolved, discovery);
       }
       identity = resolved;
     }

--- a/packages/core/src/mcp/resource_metadata.ts
+++ b/packages/core/src/mcp/resource_metadata.ts
@@ -14,19 +14,20 @@
  * the tokens it mints are verified.
  *
  * Two details in here are easy to get wrong and silent when wrong, so both are
- * handled by {@link metadataPaths} rather than left to a caller:
+ * handled by {@link metadataPath} rather than left to a caller:
  *
  * - The well-known segment is inserted **between the host and the path**, so a
  *   resource at `/mcp` publishes at `/.well-known/oauth-protected-resource/mcp`.
  *   Appending it to the path instead is the common bug, and a client that finds
  *   nothing there simply never authenticates.
- * - RFC 9728 §3.3 pulls two ways for a resource whose identifier has a path. A
- *   client that probed the root expects `resource` to be the bare origin; one
- *   that followed the challenge expects it to equal the URL it called. Each is
- *   told it MUST discard the document on a mismatch, so the same document is
- *   published at both locations — §3 permits exactly that ("The same protected
- *   resource MAY choose to publish its metadata at multiple well-known
- *   locations") — while the challenge always names the path-inserted one.
+ * - The document is published at **one** location, the path-inserted one, and
+ *   the challenge names it. Publishing a copy at the root as well is a tempting
+ *   belt-and-braces move, and it is wrong: RFC 9728 §3.3 has a client derive
+ *   the expected `resource` from the URL it fetched, so a client that probed
+ *   the root expects the bare origin and MUST discard a document naming a path.
+ *   Such a copy therefore has no correct consumer — a conformant client tries
+ *   the path-inserted URL first and never asks for the root, and one that only
+ *   asks for the root would discard what it found there.
  *
  * @module
  */
@@ -145,26 +146,52 @@ function resourceUrl(resource: string): URL {
         `"https://build.example.com/mcp".`,
     );
   }
+  // Only http(s) has an origin, and everything downstream — the well-known
+  // path, the absolute challenge URL — is derived from one. A `urn:` or `file:`
+  // identifier parses happily and then produces `origin === "null"`, so
+  // refusing it here is what keeps the startup check and the serving path from
+  // disagreeing.
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new ProtectedResourceError(
+      `The protected resource identifier "${resource}" is not an http(s) ` +
+        `URL. RFC 9728 requires https (http is tolerated only for local ` +
+        `development).`,
+    );
+  }
   if (url.hash !== "") {
     throw new ProtectedResourceError(
       `The protected resource identifier "${resource}" has a fragment, which ` +
         `RFC 9728 forbids. Drop everything from the "#".`,
     );
   }
+  if (url.search !== "") {
+    throw new ProtectedResourceError(
+      `The protected resource identifier "${resource}" has a query string. ` +
+        `RFC 8707 says a resource identifier should not carry one, and the ` +
+        `well-known path derived from it would not round-trip. Drop it.`,
+    );
+  }
+  if (url.username !== "" || url.password !== "") {
+    throw new ProtectedResourceError(
+      `The protected resource identifier "${resource}" carries userinfo. The ` +
+        `metadata document is served publicly and unauthenticated, so a ` +
+        `credential in the identifier would be published. Drop it.`,
+    );
+  }
   return url;
 }
 
 /**
- * Every path the metadata document is published at, most specific first.
+ * The path the metadata document is published at: the well-known suffix with
+ * the resource's own path inserted after it.
  *
- * For a resource with a path this is the path-inserted location followed by the
- * root one; for a resource that is a bare origin the two coincide and only one
- * is returned. A trailing slash on the resource is dropped before insertion, as
- * RFC 9728 §3.1 requires.
+ * For a resource that is a bare origin this is the root well-known path, which
+ * is then the conformant location for that identifier. A trailing slash is
+ * dropped before insertion, as RFC 9728 §3.1 requires.
  */
-export function metadataPaths(resource: string): string[] {
+export function metadataPath(resource: string): string {
   const path = resourceUrl(resource).pathname.replace(/\/+$/, "");
-  return path === "" ? [WELL_KNOWN] : [`${WELL_KNOWN}${path}`, WELL_KNOWN];
+  return `${WELL_KNOWN}${path}`;
 }
 
 /**
@@ -174,7 +201,7 @@ export function metadataPaths(resource: string): string[] {
  */
 export function metadataUrl(resource: string): string {
   const url = resourceUrl(resource);
-  return new URL(metadataPaths(resource)[0], url.origin).toString();
+  return new URL(metadataPath(resource), url.origin).toString();
 }
 
 /**
@@ -187,10 +214,13 @@ export function metadataUrl(resource: string): string {
 export function metadataDocument(
   settings: ProtectedResourceSettings,
 ): Record<string, unknown> {
-  const resource = resourceUrl(settings.resource_).toString().replace(
-    /\/$/,
-    "",
-  );
+  // Validated, then emitted **verbatim**. RFC 9728 §3.3 makes a client discard
+  // the document unless `resource` is byte-identical to the URL it called, and
+  // `new URL(...).toString()` is not byte-preserving — it appends a slash to a
+  // bare origin — so re-serialising here would break the very agreement this
+  // field exists to state.
+  resourceUrl(settings.resource_);
+  const resource = settings.resource_;
   if (settings.authorizationServers_.length === 0) {
     throw new ProtectedResourceError(
       `The protected resource "${settings.resource_}" declares no ` +

--- a/packages/core/src/mcp/resource_metadata.ts
+++ b/packages/core/src/mcp/resource_metadata.ts
@@ -1,0 +1,218 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * OAuth 2.0 Protected Resource Metadata (RFC 9728) for the MCP HTTP server.
+ *
+ * A client that has never authenticated has no token, and no way to guess where
+ * to get one. RFC 9728 is how it asks: the server answers `401` with a
+ * `WWW-Authenticate` challenge naming a metadata URL, and that document names
+ * the authorization servers that issue tokens for this resource. Zuke is only
+ * ever the **resource** — it issues nothing, and hosts no `/authorize`,
+ * `/token` or `/register` endpoint. Those belong to whatever identity provider
+ * an operator already runs, and {@link "./auth.ts".McpAuthenticator} is where
+ * the tokens it mints are verified.
+ *
+ * Two details in here are easy to get wrong and silent when wrong, so both are
+ * handled by {@link metadataPaths} rather than left to a caller:
+ *
+ * - The well-known segment is inserted **between the host and the path**, so a
+ *   resource at `/mcp` publishes at `/.well-known/oauth-protected-resource/mcp`.
+ *   Appending it to the path instead is the common bug, and a client that finds
+ *   nothing there simply never authenticates.
+ * - RFC 9728 §3.3 pulls two ways for a resource whose identifier has a path. A
+ *   client that probed the root expects `resource` to be the bare origin; one
+ *   that followed the challenge expects it to equal the URL it called. Each is
+ *   told it MUST discard the document on a mismatch, so the same document is
+ *   published at both locations — §3 permits exactly that ("The same protected
+ *   resource MAY choose to publish its metadata at multiple well-known
+ *   locations") — while the challenge always names the path-inserted one.
+ *
+ * @module
+ */
+
+/** The well-known URI suffix RFC 9728 reserves for this document. */
+const WELL_KNOWN = "/.well-known/oauth-protected-resource";
+
+/** Raised when a protected-resource declaration cannot produce a valid document. */
+export class ProtectedResourceError extends Error {
+  /** The error name. */
+  override name = "ProtectedResourceError";
+
+  /** Construct the error with `message`. */
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+/**
+ * A build's protected-resource declaration, configured fluently.
+ *
+ * The resource identifier is the single value everything else has to agree
+ * with, so it is a direct argument to {@link protectedResource}; the rest are
+ * setters. It must be the **canonical URI of this MCP endpoint** — the same
+ * string the client sends as its RFC 8707 `resource` parameter, and the same
+ * string the identity provider mints into the token's `aud`. Those three
+ * agreeing byte for byte is the whole contract; when they disagree every token
+ * fails validation, and the error says nothing about why.
+ */
+export class ProtectedResourceSettings {
+  /** The canonical resource identifier of this MCP endpoint. */
+  resource_: string;
+  /** Issuer identifiers of the authorization servers that issue for it. */
+  authorizationServers_: string[] = [];
+  /** Scope values a caller may request for this resource. */
+  scopes_: string[] = [];
+  /** Human-readable name of the resource, for a consent screen. */
+  resourceName_?: string;
+  /** URL of human-readable documentation for the resource. */
+  documentation_?: string;
+
+  /** Construct the settings for `resource`, the canonical endpoint URI. */
+  constructor(resource: string) {
+    this.resource_ = resource;
+  }
+
+  /**
+   * Add an authorization server by its **issuer identifier** — `https://acme.eu.auth0.com`,
+   * not its metadata URL. It must string-match the `issuer` in that server's own
+   * metadata document, or a client is required to reject it. At least one is
+   * required: RFC 9728 marks the field optional, but MCP raises it to required.
+   */
+  authorizationServer(issuer: string): this {
+    this.authorizationServers_.push(issuer);
+    return this;
+  }
+
+  /**
+   * Declare the scope values a caller may request. These are advertised to
+   * clients, which request them wholesale when a challenge names none, so keep
+   * the list to what this server actually distinguishes rather than the whole
+   * catalogue of a shared identity provider.
+   */
+  scopes(...values: string[]): this {
+    this.scopes_.push(...values);
+    return this;
+  }
+
+  /** Set the human-readable resource name shown on a consent screen. */
+  name(value: string): this {
+    this.resourceName_ = value;
+    return this;
+  }
+
+  /** Set the URL of human-readable documentation for this resource. */
+  documentation(url: string): this {
+    this.documentation_ = url;
+    return this;
+  }
+}
+
+/**
+ * Begin a protected-resource declaration for `resource`, the canonical URI of
+ * this MCP endpoint (`https://build.example.com/mcp`).
+ *
+ * ```ts
+ * import { Build, protectedResource } from "jsr:@zuke/core";
+ *
+ * class CI extends Build {
+ *   override mcpProtectedResource() {
+ *     return protectedResource("https://build.example.com/mcp")
+ *       .authorizationServer("https://acme.eu.auth0.com")
+ *       .scopes("zuke:run")
+ *       .name("Acme build server");
+ *   }
+ * }
+ * ```
+ */
+export function protectedResource(resource: string): ProtectedResourceSettings {
+  return new ProtectedResourceSettings(resource);
+}
+
+/**
+ * The resource identifier parsed, with the checks RFC 9728 §1.2 requires of it:
+ * an absolute URL carrying no fragment. Throws {@link ProtectedResourceError}
+ * naming the offending value, since this is a build-authoring mistake.
+ */
+function resourceUrl(resource: string): URL {
+  let url: URL;
+  try {
+    url = new URL(resource);
+  } catch {
+    throw new ProtectedResourceError(
+      `The protected resource identifier "${resource}" is not an absolute ` +
+        `URL. Use the full URI of the MCP endpoint, e.g. ` +
+        `"https://build.example.com/mcp".`,
+    );
+  }
+  if (url.hash !== "") {
+    throw new ProtectedResourceError(
+      `The protected resource identifier "${resource}" has a fragment, which ` +
+        `RFC 9728 forbids. Drop everything from the "#".`,
+    );
+  }
+  return url;
+}
+
+/**
+ * Every path the metadata document is published at, most specific first.
+ *
+ * For a resource with a path this is the path-inserted location followed by the
+ * root one; for a resource that is a bare origin the two coincide and only one
+ * is returned. A trailing slash on the resource is dropped before insertion, as
+ * RFC 9728 §3.1 requires.
+ */
+export function metadataPaths(resource: string): string[] {
+  const path = resourceUrl(resource).pathname.replace(/\/+$/, "");
+  return path === "" ? [WELL_KNOWN] : [`${WELL_KNOWN}${path}`, WELL_KNOWN];
+}
+
+/**
+ * The absolute URL a `WWW-Authenticate` challenge points at: always the
+ * path-inserted location, which is the one a client can validate under both
+ * halves of RFC 9728 §3.3.
+ */
+export function metadataUrl(resource: string): string {
+  const url = resourceUrl(resource);
+  return new URL(metadataPaths(resource)[0], url.origin).toString();
+}
+
+/**
+ * The metadata document itself, as the JSON object RFC 9728 §2 defines.
+ *
+ * Fields with no values are omitted rather than serialised empty — §3.2 makes
+ * that a MUST, and an empty `scopes_supported` would in any case advertise
+ * "this resource accepts no scopes".
+ */
+export function metadataDocument(
+  settings: ProtectedResourceSettings,
+): Record<string, unknown> {
+  const resource = resourceUrl(settings.resource_).toString().replace(
+    /\/$/,
+    "",
+  );
+  if (settings.authorizationServers_.length === 0) {
+    throw new ProtectedResourceError(
+      `The protected resource "${settings.resource_}" declares no ` +
+        `authorization server. MCP requires at least one — call ` +
+        `.authorizationServer(issuer) with your identity provider's issuer URL.`,
+    );
+  }
+  const document: Record<string, unknown> = {
+    resource,
+    authorization_servers: [...settings.authorizationServers_],
+    // Zuke reads the token from the header only; RFC 6750's query form is
+    // forbidden by MCP outright, and the body form is meaningless for JSON-RPC.
+    bearer_methods_supported: ["header"],
+  };
+  if (settings.scopes_.length > 0) {
+    document.scopes_supported = [...settings.scopes_];
+  }
+  if (settings.resourceName_ !== undefined) {
+    document.resource_name = settings.resourceName_;
+  }
+  if (settings.documentation_ !== undefined) {
+    document.resource_documentation = settings.documentation_;
+  }
+  return document;
+}

--- a/packages/core/src/mcp/resource_metadata.ts
+++ b/packages/core/src/mcp/resource_metadata.ts
@@ -32,6 +32,13 @@
  * @module
  */
 
+/**
+ * The scope that asks an authorization server for a refresh token. It is a
+ * request about the *session*, not about access to this resource, which is why
+ * MCP tells a protected resource not to advertise it.
+ */
+const OFFLINE_ACCESS = "offline_access";
+
 /** The well-known URI suffix RFC 9728 reserves for this document. */
 const WELL_KNOWN = "/.well-known/oauth-protected-resource";
 
@@ -235,6 +242,16 @@ export function metadataDocument(
     // forbidden by MCP outright, and the body form is meaningless for JSON-RPC.
     bearer_methods_supported: ["header"],
   };
+  if (settings.scopes_.includes(OFFLINE_ACCESS)) {
+    throw new ProtectedResourceError(
+      `The protected resource "${settings.resource_}" advertises the ` +
+        `"${OFFLINE_ACCESS}" scope. That scope asks the authorization server ` +
+        `for a refresh token; it says nothing about access to this resource, ` +
+        `and MCP says a protected resource should not advertise it. Drop it ` +
+        `— a client that needs a refresh token requests it of the ` +
+        `authorization server itself.`,
+    );
+  }
   if (settings.scopes_.length > 0) {
     document.scopes_supported = [...settings.scopes_];
   }

--- a/packages/core/tests/mcp_resource_metadata_test.ts
+++ b/packages/core/tests/mcp_resource_metadata_test.ts
@@ -229,3 +229,20 @@ Deno.test("the metadata parameter is matched as a parameter, not a substring", (
     );
   }
 });
+
+Deno.test("advertising offline_access is refused", () => {
+  // It asks the authorization server for a refresh token and says nothing
+  // about access to this resource; MCP tells a protected resource not to
+  // advertise it. Refused rather than dropped, so the declaration does not
+  // quietly mean something other than what it says.
+  const error = assertThrows(
+    () =>
+      metadataDocument(
+        protectedResource("https://build.example.com/mcp")
+          .authorizationServer("https://idp.example.com")
+          .scopes("zuke:run", "offline_access"),
+      ),
+    ProtectedResourceError,
+  );
+  assertStringIncludes(error.message, "offline_access");
+});

--- a/packages/core/tests/mcp_resource_metadata_test.ts
+++ b/packages/core/tests/mcp_resource_metadata_test.ts
@@ -1,0 +1,161 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import { assertEquals, assertStringIncludes, assertThrows } from "./_assert.ts";
+import {
+  metadataDocument,
+  metadataPaths,
+  metadataUrl,
+  protectedResource,
+  ProtectedResourceError,
+} from "../src/mcp/resource_metadata.ts";
+import {
+  bearerChallenge,
+  INVALID_TOKEN,
+  UNAUTHORIZED,
+  withResourceMetadata,
+} from "../src/mcp/auth.ts";
+
+Deno.test("the well-known segment is inserted between host and path", () => {
+  // The bug this pins: appending the well-known suffix to the path instead of
+  // inserting it. A client fetches only the inserted form, so the appended one
+  // is a 404 and discovery silently never happens.
+  assertEquals(metadataPaths("https://build.example.com/mcp"), [
+    "/.well-known/oauth-protected-resource/mcp",
+    "/.well-known/oauth-protected-resource",
+  ]);
+  assertEquals(
+    metadataUrl("https://build.example.com/mcp"),
+    "https://build.example.com/.well-known/oauth-protected-resource/mcp",
+  );
+});
+
+Deno.test("a resource with no path publishes at one location only", () => {
+  // The two locations coincide, and RFC 9728 has no notion of publishing the
+  // same document twice at the same URL.
+  assertEquals(metadataPaths("https://build.example.com"), [
+    "/.well-known/oauth-protected-resource",
+  ]);
+  assertEquals(metadataPaths("https://build.example.com/"), [
+    "/.well-known/oauth-protected-resource",
+  ]);
+});
+
+Deno.test("a deeper path and a trailing slash both insert correctly", () => {
+  assertEquals(
+    metadataPaths("https://build.example.com/team/mcp/")[0],
+    [
+      "/.well-known/oauth-protected-resource/team/mcp",
+    ][0],
+  );
+});
+
+Deno.test("the document carries what RFC 9728 and MCP require", () => {
+  const document = metadataDocument(
+    protectedResource("https://build.example.com/mcp")
+      .authorizationServer("https://acme.eu.auth0.com")
+      .scopes("zuke:run", "zuke:read")
+      .name("Acme build server")
+      .documentation("https://build.example.com/docs"),
+  );
+  assertEquals(document, {
+    resource: "https://build.example.com/mcp",
+    authorization_servers: ["https://acme.eu.auth0.com"],
+    bearer_methods_supported: ["header"],
+    scopes_supported: ["zuke:run", "zuke:read"],
+    resource_name: "Acme build server",
+    resource_documentation: "https://build.example.com/docs",
+  });
+});
+
+Deno.test("a field with no values is omitted, not serialised empty", () => {
+  // RFC 9728 3.2 makes this a MUST, and an empty `scopes_supported` would in
+  // any case advertise "this resource accepts no scopes".
+  const document = metadataDocument(
+    protectedResource("https://build.example.com/mcp")
+      .authorizationServer("https://acme.eu.auth0.com"),
+  );
+  assertEquals(Object.keys(document).includes("scopes_supported"), false);
+  assertEquals(Object.keys(document).includes("resource_name"), false);
+  assertEquals(Object.keys(document).includes("resource_documentation"), false);
+});
+
+Deno.test("a declaration with no authorization server is refused", () => {
+  // Optional in RFC 9728, required by MCP — and a document without one tells a
+  // client nothing it can act on.
+  const error = assertThrows(
+    () => metadataDocument(protectedResource("https://build.example.com/mcp")),
+    ProtectedResourceError,
+  );
+  assertStringIncludes(error.message, "authorization server");
+});
+
+Deno.test("a resource identifier that is not a usable URL is refused", () => {
+  assertThrows(
+    () => metadataPaths("build.example.com/mcp"),
+    ProtectedResourceError,
+    "absolute URL",
+  );
+  assertThrows(
+    () => metadataPaths("https://build.example.com/mcp#frag"),
+    ProtectedResourceError,
+    "fragment",
+  );
+});
+
+Deno.test("a bare challenge carries no error, an invalid token does", () => {
+  // OAuth 2.1 5.3.2: a request that presented no credentials gets no error
+  // information, because nothing of the client's has been rejected yet.
+  assertEquals(UNAUTHORIZED.challenge, "Bearer");
+  assertEquals(bearerChallenge(), "Bearer");
+  assertStringIncludes(INVALID_TOKEN.challenge ?? "", `error="invalid_token"`);
+});
+
+Deno.test("a challenge names the failure, the scopes and the metadata URL", () => {
+  assertEquals(
+    bearerChallenge({
+      error: "insufficient_scope",
+      scopes: ["zuke:run", "zuke:operate"],
+      metadataUrl: "https://build.example.com/.well-known/x",
+      description: "operator role required",
+    }),
+    `Bearer error="insufficient_scope", error_description="operator role ` +
+      `required", scope="zuke:run zuke:operate", ` +
+      `resource_metadata="https://build.example.com/.well-known/x"`,
+  );
+});
+
+Deno.test("a value that would break out of the header is filtered", () => {
+  // The allowed auth-param set excludes `"` and `\`, so interpolating an
+  // unfiltered string is header injection — an exception message reaching
+  // `description` is the realistic way that happens.
+  const challenge = bearerChallenge({
+    error: "invalid_token",
+    description: `bad "quoted" \\ value`,
+  });
+  assertEquals(challenge.includes(`\\`), false);
+  assertEquals(
+    challenge,
+    `Bearer error="invalid_token", error_description="bad quoted  value"`,
+  );
+  // Filtering to nothing drops the parameter rather than emitting an empty one.
+  assertEquals(bearerChallenge({ description: `"""` }), "Bearer");
+});
+
+Deno.test("the metadata URL is added to a challenge, once", () => {
+  assertEquals(
+    withResourceMetadata("Bearer", "https://x.example.com/.well-known/y"),
+    `Bearer resource_metadata="https://x.example.com/.well-known/y"`,
+  );
+  assertEquals(
+    withResourceMetadata(
+      `Bearer error="invalid_token"`,
+      "https://x.example.com/.well-known/y",
+    ),
+    `Bearer error="invalid_token", ` +
+      `resource_metadata="https://x.example.com/.well-known/y"`,
+  );
+  // An authenticator that set its own is left alone rather than given a second.
+  const own = `Bearer resource_metadata="https://other.example.com/doc"`;
+  assertEquals(withResourceMetadata(own, "https://x.example.com/y"), own);
+});

--- a/packages/core/tests/mcp_resource_metadata_test.ts
+++ b/packages/core/tests/mcp_resource_metadata_test.ts
@@ -4,7 +4,7 @@
 import { assertEquals, assertStringIncludes, assertThrows } from "./_assert.ts";
 import {
   metadataDocument,
-  metadataPaths,
+  metadataPath,
   metadataUrl,
   protectedResource,
   ProtectedResourceError,
@@ -20,33 +20,36 @@ Deno.test("the well-known segment is inserted between host and path", () => {
   // The bug this pins: appending the well-known suffix to the path instead of
   // inserting it. A client fetches only the inserted form, so the appended one
   // is a 404 and discovery silently never happens.
-  assertEquals(metadataPaths("https://build.example.com/mcp"), [
+  assertEquals(
+    metadataPath("https://build.example.com/mcp"),
     "/.well-known/oauth-protected-resource/mcp",
-    "/.well-known/oauth-protected-resource",
-  ]);
+  );
   assertEquals(
     metadataUrl("https://build.example.com/mcp"),
     "https://build.example.com/.well-known/oauth-protected-resource/mcp",
   );
 });
 
-Deno.test("a resource with no path publishes at one location only", () => {
-  // The two locations coincide, and RFC 9728 has no notion of publishing the
-  // same document twice at the same URL.
-  assertEquals(metadataPaths("https://build.example.com"), [
+Deno.test("a resource that is a bare origin publishes at the root", () => {
+  // Which is the conformant location *for that identifier* — not a second copy.
+  // A path-bearing resource publishes only at its inserted path: a client that
+  // probed the root would derive the bare origin as the expected `resource`
+  // and, per RFC 9728 3.3, discard a document naming a path. Such a copy has no
+  // correct consumer, so there is not one.
+  assertEquals(
+    metadataPath("https://build.example.com"),
     "/.well-known/oauth-protected-resource",
-  ]);
-  assertEquals(metadataPaths("https://build.example.com/"), [
+  );
+  assertEquals(
+    metadataPath("https://build.example.com/"),
     "/.well-known/oauth-protected-resource",
-  ]);
+  );
 });
 
 Deno.test("a deeper path and a trailing slash both insert correctly", () => {
   assertEquals(
-    metadataPaths("https://build.example.com/team/mcp/")[0],
-    [
-      "/.well-known/oauth-protected-resource/team/mcp",
-    ][0],
+    metadataPath("https://build.example.com/team/mcp/"),
+    "/.well-known/oauth-protected-resource/team/mcp",
   );
 });
 
@@ -92,19 +95,19 @@ Deno.test("a declaration with no authorization server is refused", () => {
 
 Deno.test("a resource identifier that is not a usable URL is refused", () => {
   assertThrows(
-    () => metadataPaths("build.example.com/mcp"),
+    () => metadataPath("build.example.com/mcp"),
     ProtectedResourceError,
     "absolute URL",
   );
   assertThrows(
-    () => metadataPaths("https://build.example.com/mcp#frag"),
+    () => metadataPath("https://build.example.com/mcp#frag"),
     ProtectedResourceError,
     "fragment",
   );
 });
 
 Deno.test("a bare challenge carries no error, an invalid token does", () => {
-  // OAuth 2.1 5.3.2: a request that presented no credentials gets no error
+  // OAuth 2.1 5.3.1: a request that presented no credentials gets no error
   // information, because nothing of the client's has been rejected yet.
   assertEquals(UNAUTHORIZED.challenge, "Bearer");
   assertEquals(bearerChallenge(), "Bearer");
@@ -158,4 +161,71 @@ Deno.test("the metadata URL is added to a challenge, once", () => {
   // An authenticator that set its own is left alone rather than given a second.
   const own = `Bearer resource_metadata="https://other.example.com/doc"`;
   assertEquals(withResourceMetadata(own, "https://x.example.com/y"), own);
+});
+
+Deno.test("the resource is emitted exactly as declared, not re-serialised", () => {
+  // RFC 9728 3.3 has a client discard the document unless `resource` is
+  // byte-identical to the URL it called. `new URL(x).toString()` is not
+  // byte-preserving — it appends a slash to a bare origin — so normalising here
+  // would break the very agreement the field exists to state.
+  for (
+    const declared of [
+      "https://build.example.com/mcp",
+      "https://build.example.com/mcp/",
+      "https://build.example.com",
+      "https://build.example.com/",
+      "https://build.example.com:8443/mcp",
+    ]
+  ) {
+    const document = metadataDocument(
+      protectedResource(declared).authorizationServer(
+        "https://idp.example.com",
+      ),
+    );
+    assertEquals(document.resource, declared);
+  }
+});
+
+Deno.test("an identifier that cannot make a well-known URL is refused at declaration", () => {
+  // Each of these parses as a URL and would otherwise pass the startup check,
+  // then fail when the transport derived a path or an absolute URL from it —
+  // a throw on a public, unauthenticated route rather than a startup error.
+  for (
+    const [resource, expected] of [
+      ["urn:example:zuke", "http(s)"],
+      ["file:///srv/mcp", "http(s)"],
+      ["https://build.example.com/mcp?tenant=a", "query string"],
+      ["https://svc:hunter2@build.example.com/mcp", "userinfo"],
+    ] as const
+  ) {
+    const error = assertThrows(
+      () => metadataPath(resource),
+      ProtectedResourceError,
+    );
+    assertStringIncludes(error.message, expected);
+  }
+});
+
+Deno.test("the metadata parameter is matched as a parameter, not a substring", () => {
+  // Both directions were wrong with a plain `includes`. A description merely
+  // mentioning the word suppressed a real URL, silently killing discovery...
+  const mentions = `Bearer error_description="see resource_metadata= docs"`;
+  assertStringIncludes(
+    withResourceMetadata(mentions, "https://x.example.com/doc"),
+    `resource_metadata="https://x.example.com/doc"`,
+  );
+  // ...and a challenge that spelled the parameter differently got a second
+  // copy, which RFC 7235 forbids and leaves clients to resolve as they like.
+  // Auth-param names are case-insensitive and space around `=` is legal.
+  for (
+    const existing of [
+      `Bearer resource_metadata = "https://attacker.example.com/as"`,
+      `Bearer Resource_Metadata="https://attacker.example.com/as"`,
+    ]
+  ) {
+    assertEquals(
+      withResourceMetadata(existing, "https://x.example.com/y"),
+      existing,
+    );
+  }
 });

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/.codex-plugin/plugin.json
+++ b/plugins/zuke/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/skills/zuke-write-build/SKILL.md
+++ b/plugins/zuke/skills/zuke-write-build/SKILL.md
@@ -255,7 +255,10 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   client-reported actor and flows to the audit trail, run records, lock holders,
   and a registry-spawned child's `ZUKE_ACTOR`/`ZUKE_ACTOR_KIND`/
   `ZUKE_ACTOR_ROLES`. Both are fail-closed: a throw, a non-object, or an empty
-  actor refuses the request, and nothing runs.
+  actor refuses the request, and nothing runs. `override mcpProtectedResource()`
+  publishes the RFC 9728 metadata document and names it in every challenge, so a
+  client that has no token can discover the identity provider — Zuke is the
+  resource only, and hosts no OAuth endpoints of its own. See the cheatsheet.
 - **AI review & self-healing (`@zuke/ai`):** gate a target on a structured LLM
   review of the diff (`securityReviewer(...)` etc. via `.validateBefore`), or
   attach `aiFixer(...)` with `.recoverWith(...)` so a failing target is

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -1360,3 +1360,29 @@ refused archive is a cache miss (rebuild + warning), never a build failure, so
 whoever can write the store can neither plant files nor halt the build.
 `--affected` limits a run to targets touched since a git base (great for CI job
 fan-out).
+
+**Telling a client where to authenticate** (`docs/mcp.md`): verifying a token
+only helps a caller that already has one. `override mcpProtectedResource()`
+returns `protectedResource(canonicalUri).authorizationServer(issuer)` (plus
+optional `.scopes(...)`, `.name(...)`, `.documentation(...)`), which makes
+`zuke mcp --http` an OAuth 2.0 **protected resource**: it publishes the RFC 9728
+metadata document and names it in every `WWW-Authenticate` challenge, so
+`claude mcp add --transport http <url>` can discover the identity provider and
+authenticate in a browser. Zuke issues no tokens and hosts no `/authorize`,
+`/token` or `/register` — those belong to the provider named here, and
+`mcpAuth()` verifies what it mints. Dynamic client registration is **not**
+required (deprecated in the MCP spec; a pre-registered client id works).
+
+Three strings must agree byte for byte or every token fails validation: the
+`resource` you declare, the `resource` parameter the client sends, and the
+**audience** the provider puts in the token. Your `mcpAuth()` verifier must
+check `aud` — a resource server that skips it accepts tokens minted for other
+services. Do not hand-roll JWT verification: a build file may depend on a
+maintained JOSE library even though the published packages may not.
+
+`authorizationServer(...)` takes the provider's **issuer identifier**, not its
+metadata URL. The well-known path insertion (`/mcp` publishes at
+`/.well-known/oauth-protected-resource/mcp`, plus the root fallback) is handled
+for you. `UNAUTHORIZED` and `INVALID_TOKEN` are separate refusals on purpose:
+a caller that presented nothing gets no `error` parameter, one whose token was
+rejected gets `error="invalid_token"`.

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -1382,7 +1382,8 @@ maintained JOSE library even though the published packages may not.
 
 `authorizationServer(...)` takes the provider's **issuer identifier**, not its
 metadata URL. The well-known path insertion (`/mcp` publishes at
-`/.well-known/oauth-protected-resource/mcp`, plus the root fallback) is handled
-for you. `UNAUTHORIZED` and `INVALID_TOKEN` are separate refusals on purpose:
+`/.well-known/oauth-protected-resource/mcp`) is handled for you, and only that
+one location is served — a root copy would name a path the root route does not
+expect, so a conformant client must discard it. `UNAUTHORIZED` and `INVALID_TOKEN` are separate refusals on purpose:
 a caller that presented nothing gets no `error` parameter, one whose token was
 rejected gets `error="invalid_token"`.

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -255,7 +255,10 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   client-reported actor and flows to the audit trail, run records, lock holders,
   and a registry-spawned child's `ZUKE_ACTOR`/`ZUKE_ACTOR_KIND`/
   `ZUKE_ACTOR_ROLES`. Both are fail-closed: a throw, a non-object, or an empty
-  actor refuses the request, and nothing runs.
+  actor refuses the request, and nothing runs. `override mcpProtectedResource()`
+  publishes the RFC 9728 metadata document and names it in every challenge, so a
+  client that has no token can discover the identity provider — Zuke is the
+  resource only, and hosts no OAuth endpoints of its own. See the cheatsheet.
 - **AI review & self-healing (`@zuke/ai`):** gate a target on a structured LLM
   review of the diff (`securityReviewer(...)` etc. via `.validateBefore`), or
   attach `aiFixer(...)` with `.recoverWith(...)` so a failing target is

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -1360,3 +1360,29 @@ refused archive is a cache miss (rebuild + warning), never a build failure, so
 whoever can write the store can neither plant files nor halt the build.
 `--affected` limits a run to targets touched since a git base (great for CI job
 fan-out).
+
+**Telling a client where to authenticate** (`docs/mcp.md`): verifying a token
+only helps a caller that already has one. `override mcpProtectedResource()`
+returns `protectedResource(canonicalUri).authorizationServer(issuer)` (plus
+optional `.scopes(...)`, `.name(...)`, `.documentation(...)`), which makes
+`zuke mcp --http` an OAuth 2.0 **protected resource**: it publishes the RFC 9728
+metadata document and names it in every `WWW-Authenticate` challenge, so
+`claude mcp add --transport http <url>` can discover the identity provider and
+authenticate in a browser. Zuke issues no tokens and hosts no `/authorize`,
+`/token` or `/register` — those belong to the provider named here, and
+`mcpAuth()` verifies what it mints. Dynamic client registration is **not**
+required (deprecated in the MCP spec; a pre-registered client id works).
+
+Three strings must agree byte for byte or every token fails validation: the
+`resource` you declare, the `resource` parameter the client sends, and the
+**audience** the provider puts in the token. Your `mcpAuth()` verifier must
+check `aud` — a resource server that skips it accepts tokens minted for other
+services. Do not hand-roll JWT verification: a build file may depend on a
+maintained JOSE library even though the published packages may not.
+
+`authorizationServer(...)` takes the provider's **issuer identifier**, not its
+metadata URL. The well-known path insertion (`/mcp` publishes at
+`/.well-known/oauth-protected-resource/mcp`, plus the root fallback) is handled
+for you. `UNAUTHORIZED` and `INVALID_TOKEN` are separate refusals on purpose:
+a caller that presented nothing gets no `error` parameter, one whose token was
+rejected gets `error="invalid_token"`.

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -1382,7 +1382,8 @@ maintained JOSE library even though the published packages may not.
 
 `authorizationServer(...)` takes the provider's **issuer identifier**, not its
 metadata URL. The well-known path insertion (`/mcp` publishes at
-`/.well-known/oauth-protected-resource/mcp`, plus the root fallback) is handled
-for you. `UNAUTHORIZED` and `INVALID_TOKEN` are separate refusals on purpose:
+`/.well-known/oauth-protected-resource/mcp`) is handled for you, and only that
+one location is served — a root copy would name a path the root route does not
+expect, so a conformant client must discard it. `UNAUTHORIZED` and `INVALID_TOKEN` are separate refusals on purpose:
 a caller that presented nothing gets no `error` parameter, one whose token was
 rejected gets `error="invalid_token"`.

--- a/tests/integration/mcp_auth_test.ts
+++ b/tests/integration/mcp_auth_test.ts
@@ -31,6 +31,8 @@ import {
   type McpAuthenticator,
   type McpIdentityHook,
   type McpRequestContext,
+  protectedResource,
+  type ProtectedResourceSettings,
   target,
 } from "../../packages/core/mod.ts";
 import {
@@ -270,4 +272,125 @@ Deno.test("a build declaring both mcpAuth() and mcpIdentity() refuses to start",
   assertEquals(code, 1);
   assertStringIncludes(err, "mcpAuth() and mcpIdentity()");
   assertStringIncludes(err, "keep");
+});
+
+/** A build that declares itself an OAuth protected resource. */
+class Guarded extends Build {
+  deploy = target().description("Deploy").executes(() => {});
+
+  override mcpProtectedResource(): ProtectedResourceSettings {
+    return protectedResource("https://build.example.com/mcp")
+      .authorizationServer("https://acme.eu.auth0.com")
+      .scopes("zuke:run")
+      .name("Acme build server");
+  }
+}
+
+Deno.test("the metadata document is served at both well-known paths", async () => {
+  const server = await startMcp(new Guarded(), {});
+  try {
+    // Path-inserted is the one a client reaches from the challenge; the root is
+    // the fallback it constructs when there is no challenge to follow. RFC 9728
+    // 3.3 validates `resource` differently on each route, so both must answer.
+    for (
+      const path of [
+        ".well-known/oauth-protected-resource/mcp",
+        ".well-known/oauth-protected-resource",
+      ]
+    ) {
+      const response = await fetch(`${server.url}${path}`);
+      assertEquals(response.status, 200);
+      // Public and cross-origin readable: a browser-based client fetches this
+      // before it has any credential to be checked.
+      assertEquals(response.headers.get("access-control-allow-origin"), "*");
+      assertEquals(await response.json(), {
+        resource: "https://build.example.com/mcp",
+        authorization_servers: ["https://acme.eu.auth0.com"],
+        bearer_methods_supported: ["header"],
+        scopes_supported: ["zuke:run"],
+        resource_name: "Acme build server",
+      });
+    }
+  } finally {
+    await server.stop();
+  }
+});
+
+Deno.test("an unauthenticated call is refused with a challenge naming the document", async () => {
+  const server = await startMcp(new Guarded(), { token: "shared-token" });
+  try {
+    const bare = await fetch(`${server.url}`, {
+      method: "POST",
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    });
+    assertEquals(bare.status, 401);
+    const challenge = bare.headers.get("www-authenticate") ?? "";
+    assertStringIncludes(
+      challenge,
+      `resource_metadata="https://build.example.com` +
+        `/.well-known/oauth-protected-resource/mcp"`,
+    );
+    // Nothing was presented, so nothing of the client's has been rejected.
+    assertEquals(challenge.includes("error="), false);
+    // And the header is readable across origins, or a browser client cannot
+    // act on it at all.
+    assertEquals(
+      bare.headers.get("access-control-expose-headers"),
+      "WWW-Authenticate",
+    );
+
+    // A token that was presented and rejected says so, which is a different
+    // thing for a client to act on than "you have not logged in".
+    const wrong = await fetch(`${server.url}`, {
+      method: "POST",
+      headers: { authorization: "Bearer nope" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    });
+    assertEquals(wrong.status, 401);
+    const rejected = wrong.headers.get("www-authenticate") ?? "";
+    assertStringIncludes(rejected, `error="invalid_token"`);
+    assertStringIncludes(rejected, "resource_metadata=");
+  } finally {
+    await server.stop();
+  }
+});
+
+Deno.test("a build declaring no protected resource is unchanged", async () => {
+  // The whole surface is opt-in: nothing is published, and the challenge stays
+  // the bare one a token-protected server has always sent.
+  const server = await startMcp(new Fleet(), { token: "shared-token" });
+  try {
+    const document = await fetch(
+      `${server.url}.well-known/oauth-protected-resource`,
+    );
+    assertEquals(document.status, 405);
+    await document.body?.cancel();
+    const refused = await fetch(`${server.url}`, {
+      method: "POST",
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    });
+    assertEquals(refused.status, 401);
+    assertEquals(refused.headers.get("www-authenticate"), "Bearer");
+    await refused.body?.cancel();
+  } finally {
+    await server.stop();
+  }
+});
+
+Deno.test("a preflight for the metadata document is answered", async () => {
+  const server = await startMcp(new Guarded(), {});
+  try {
+    const response = await fetch(
+      `${server.url}.well-known/oauth-protected-resource/mcp`,
+      { method: "OPTIONS" },
+    );
+    assertEquals(response.status, 204);
+    assertEquals(response.headers.get("access-control-allow-origin"), "*");
+    assertStringIncludes(
+      response.headers.get("access-control-allow-methods") ?? "",
+      "GET",
+    );
+  } finally {
+    await server.stop();
+  }
 });

--- a/tests/integration/mcp_auth_test.ts
+++ b/tests/integration/mcp_auth_test.ts
@@ -286,18 +286,14 @@ class Guarded extends Build {
   }
 }
 
-Deno.test("the metadata document is served at both well-known paths", async () => {
+Deno.test("the metadata document is served at the path-inserted location", async () => {
   const server = await startMcp(new Guarded(), {});
   try {
-    // Path-inserted is the one a client reaches from the challenge; the root is
-    // the fallback it constructs when there is no challenge to follow. RFC 9728
-    // 3.3 validates `resource` differently on each route, so both must answer.
-    for (
-      const path of [
-        ".well-known/oauth-protected-resource/mcp",
-        ".well-known/oauth-protected-resource",
-      ]
-    ) {
+    // Only there. A client that probed the root would derive the bare origin as
+    // the expected `resource` and, per RFC 9728 3.3, discard a document naming
+    // a path — so a copy at the root would have no correct consumer.
+    {
+      const path = ".well-known/oauth-protected-resource/mcp";
       const response = await fetch(`${server.url}${path}`);
       assertEquals(response.status, 200);
       // Public and cross-origin readable: a browser-based client fetches this
@@ -311,6 +307,39 @@ Deno.test("the metadata document is served at both well-known paths", async () =
         resource_name: "Acme build server",
       });
     }
+    const root = await fetch(
+      `${server.url}.well-known/oauth-protected-resource`,
+    );
+    assertEquals(root.status, 405);
+    await root.body?.cancel();
+  } finally {
+    await server.stop();
+  }
+});
+
+Deno.test("a malformed Host header does not fault the server", async () => {
+  // The metadata branch runs before every other check and parses the request
+  // URL, which Deno builds from the raw Host header — and it accepts hosts the
+  // WHATWG parser rejects. Unguarded, that answered *every* request with a 500,
+  // authenticated ones included: an unauthenticated caller could fault the
+  // whole endpoint just by declaring a protected resource on it.
+  const server = await startMcp(new Guarded(), {});
+  try {
+    const port = Number(new URL(server.url).port);
+    const connection = await Deno.connect({ hostname: "127.0.0.1", port });
+    await connection.write(
+      new TextEncoder().encode(
+        "GET / HTTP/1.1\r\nHost: bad host\r\nConnection: close\r\n\r\n",
+      ),
+    );
+    const buffer = new Uint8Array(256);
+    const read = await connection.read(buffer);
+    connection.close();
+    const statusLine = new TextDecoder()
+      .decode(buffer.subarray(0, read ?? 0))
+      .split("\r\n")[0];
+    // The ordinary refusal for a GET on the MCP endpoint — not a fault.
+    assertStringIncludes(statusLine, "405");
   } finally {
     await server.stop();
   }
@@ -332,12 +361,9 @@ Deno.test("an unauthenticated call is refused with a challenge naming the docume
     );
     // Nothing was presented, so nothing of the client's has been rejected.
     assertEquals(challenge.includes("error="), false);
-    // And the header is readable across origins, or a browser client cannot
-    // act on it at all.
-    assertEquals(
-      bare.headers.get("access-control-expose-headers"),
-      "WWW-Authenticate",
-    );
+    // The declared scopes are named, rather than left for the client to guess
+    // by requesting the whole advertised catalogue.
+    assertStringIncludes(challenge, `scope="zuke:run"`);
 
     // A token that was presented and rejected says so, which is a different
     // thing for a client to act on than "you have not logged in".
@@ -355,9 +381,10 @@ Deno.test("an unauthenticated call is refused with a challenge naming the docume
   }
 });
 
-Deno.test("a build declaring no protected resource is unchanged", async () => {
-  // The whole surface is opt-in: nothing is published, and the challenge stays
-  // the bare one a token-protected server has always sent.
+Deno.test("a build declaring no protected resource publishes nothing", async () => {
+  // The surface is opt-in: no document, and no discovery parameters on any
+  // challenge. The one thing that did change for such a build is deliberate —
+  // a token that was presented and rejected now says so.
   const server = await startMcp(new Fleet(), { token: "shared-token" });
   try {
     const document = await fetch(
@@ -372,6 +399,28 @@ Deno.test("a build declaring no protected resource is unchanged", async () => {
     assertEquals(refused.status, 401);
     assertEquals(refused.headers.get("www-authenticate"), "Bearer");
     await refused.body?.cancel();
+
+    // A wrong token names itself. This is the one behaviour that changed for a
+    // build declaring nothing, and it is the OAuth-defined answer: the client
+    // learns its stored credential was refused rather than that it has none.
+    const wrong = await fetch(`${server.url}`, {
+      method: "POST",
+      headers: { authorization: "Bearer nope" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    });
+    assertEquals(wrong.status, 401);
+    assertEquals(
+      wrong.headers.get("www-authenticate"),
+      `Bearer error="invalid_token"`,
+    );
+    // ...and still no discovery, because none was declared.
+    assertEquals(
+      (wrong.headers.get("www-authenticate") ?? "").includes(
+        "resource_metadata",
+      ),
+      false,
+    );
+    await wrong.body?.cancel();
   } finally {
     await server.stop();
   }
@@ -393,4 +442,44 @@ Deno.test("a preflight for the metadata document is answered", async () => {
   } finally {
     await server.stop();
   }
+});
+
+Deno.test("the metadata response is a cacheable JSON document, and answers HEAD", async () => {
+  // RFC 9728 3.2 makes the 200 + application/json a MUST; the cache header is
+  // what stops every cold client re-fetching a constant.
+  const server = await startMcp(new Guarded(), {});
+  try {
+    const url = `${server.url}.well-known/oauth-protected-resource/mcp`;
+    const response = await fetch(url);
+    assertEquals(response.headers.get("content-type"), "application/json");
+    assertStringIncludes(
+      response.headers.get("cache-control") ?? "",
+      "max-age=3600",
+    );
+    await response.body?.cancel();
+
+    const head = await fetch(url, { method: "HEAD" });
+    assertEquals(head.status, 200);
+    assertEquals(head.headers.get("content-type"), "application/json");
+    await head.body?.cancel();
+  } finally {
+    await server.stop();
+  }
+});
+
+Deno.test("an unusable protected-resource declaration stops the server starting", async () => {
+  // Validated once at startup rather than per request: a client discovering the
+  // mistake would be a client that cannot authenticate, and the throw would
+  // land on a public route as a 500.
+  class Broken extends Build {
+    deploy = target().executes(() => {});
+    override mcpProtectedResource(): ProtectedResourceSettings {
+      return protectedResource("https://build.example.com/mcp");
+    }
+  }
+  // Through the real CLI: it exits before binding a transport, so the whole
+  // command runs in-process, exactly like the both-seams refusal above.
+  const { code, err } = await runCli(Broken, ["mcp"]);
+  assertEquals(code, 1);
+  assertStringIncludes(err, "authorization server");
 });


### PR DESCRIPTION
## What & why

This is epic 15.3 from the customer plan, and it is much smaller than that plan asked for — deliberately.

The proposal was for Zuke to become its own OAuth 2.1 **authorization server**: dynamic client registration, PKCE, refresh families with single-use identifiers, a GitHub and a generic OIDC upstream leg, a pluggable auth store, a stubbed-IdP conformance suite. Dependency-free, in a new package, size L. That is the half of OAuth where a subtle bug is an authentication bypass rather than a broken feature.

It was proposed because a GitHub OAuth App is not an authorization server for our resource, and something has to bridge it. Two facts, both checked rather than assumed, removed the need:

- **Dynamic client registration is no longer required.** MCP asked for it in `2025-06-18`, demoted it to optional in `2025-11-25`, and marks it **deprecated** in the current `2026-07-28`. The sanctioned routes now are a pre-registered client id or a client id metadata document.
- **A pre-registered client id genuinely works.** Driven end to end against a stub authorization server with a real client: discovery, `/authorize` with the configured id, code exchange with a PKCE verifier, authenticated — and **zero** calls to a registration endpoint. Without a configured id it falls through to registration and fails hard, which is what the older bug reports describe.

So Zuke can be a plain OAuth 2.0 **protected resource** pointing at whatever identity provider an operator already runs, and implement none of the dangerous half. Token verification was already pluggable through the `mcpAuth()` seam from #473, and a build file is ordinary code that may import a maintained JOSE library even though the published packages may not — so that half is neither ours to write nor ours to ship.

### What was actually missing

Discovery. A client that has never authenticated has no token, and asks over unauthenticated `GET`s that the transport rejected — its first check is POST-only.

`mcpProtectedResource()` declares the endpoint a protected resource. The RFC 9728 document is published, and named in every `WWW-Authenticate` challenge — a 401 now carries a Bearer challenge with the declared `scope` and a `resource_metadata` parameter naming the document, which is the whole of what a client needs to find the identity provider. Zuke hosts no authorize, token or register endpoint. Those stay with the provider.

### Verified against a real client, not only against the RFC

A real MCP client, pointed at a running Zuke server: it followed the challenge, fetched the document, read the authorization server out of it, fetched that server's metadata, and settled on "needs authentication". The observed discovery order was `POST /mcp` → `/.well-known/oauth-protected-resource/mcp` → the authorization server's metadata → `/authorize`.

That is also how the **path-insertion** rule got pinned. The well-known segment goes *between host and path*, so `/mcp` publishes at `/.well-known/oauth-protected-resource/mcp`. Appending it instead is the common bug in the wild, it is what the RFC's name suggests, and a client fetches only the inserted form — so getting it wrong means discovery silently never happens.

## What the adversarial review found

Two reviewers. Both found real defects; the worst was a repeat of one I had already fixed.

**An unguarded `new URL(request.url)` ran before every other check** (high). Deno builds that URL from the raw `Host` header and accepts hosts the WHATWG parser rejects, so `Host: bad host` faulted **every** request with a `500` — authenticated ones included — and wrote a stack trace per request into the operator's log. Declaring a protected resource was enough to hand any unauthenticated caller a denial of service. The identical trap is documented four functions below in the same file, where it was fixed during the authenticator-seam work; this reintroduced it one call earlier. The regression drives a raw socket and fails without the guard.

**The root copy of the document was published on a rationale that was backwards** (medium). I had it serving at both the path-inserted and root locations, reasoning that the two routes validate differently. They do — and that is the argument against it: RFC 9728 has a client derive the `resource` it expects from the URL it fetched, so a client that probed the root expects the bare origin and **must discard** a document naming a path. A conformant client tries the path-inserted URL first and never asks for the root. That copy had no correct consumer, so it is gone. A resource declared as a bare origin still publishes at the root, because for that identifier the root *is* the derived location.

**The `resource` field was re-serialised rather than emitted as declared** (medium). `new URL(x).toString()` is not byte-preserving — it appends a slash to a bare origin — and this is the field whose entire purpose is to state a byte-for-byte agreement between three strings. Normalising it broke the contract it documents.

**`withResourceMetadata` matched its own parameter with a substring test** (medium), wrong in both directions: an `error_description` merely mentioning the word suppressed a real metadata URL and silently killed discovery, and a challenge spelling it `Resource_Metadata =` — auth-param names are case-insensitive and space around `=` is legal — got a second copy, which RFC 7235 forbids and leaves clients to resolve however they like. My first fix, a word-boundary regex, still matched inside the quoted value; it now blanks quoted strings first.

**Identifiers that parse but cannot produce a well-known URL passed startup and threw per request** (medium-low) — a `urn:` or `file:` scheme, where `origin` is the string `"null"`. That turned a startup check into a `500` on a public route. Scheme, query string and userinfo are all refused at declaration now; userinfo especially, since it would otherwise be published verbatim in an unauthenticated, cacheable, publicly readable document.

**`Access-Control-Expose-Headers` was inert** (low). The `401` carries no `Access-Control-Allow-Origin`, so a browser rejects the whole response before any header is readable. A comment claimed it was what made discovery visible to browser clients, and a test asserting its presence made the no-op look covered. Both removed.

Also fixed: challenges now name the declared scopes, which the specification asks for and which is what finally gives `bearerChallenge` a caller — it was exported with none; a dead branch whose condition no call site can meet; an OAuth 2.1 citation that was §5.3.1, not §5.3.2; and the document response, `HEAD`, and the startup refusal had no tests at all.

**One claim of mine was wrong and is corrected rather than quietly dropped.** The first commit said a build declaring no protected resource behaves exactly as before. It does not: a bearer token that was *presented and rejected* now answers `invalid_token` rather than a generic `Unauthorized`. That is what OAuth defines it as, and it tells a client its stored credential — rather than its absence — is the problem, so the change is kept. But the test whose name promised "unchanged" never sent a wrong token, which is the one case that changed. It does now, and it says what actually holds.

## Scope note

The issue also proposed answering authorization denials with `403` and `insufficient_scope`. The challenge builder and the transport support it, and an authenticator refusing for insufficient scope emits a correct `403`. Per-tool **role** denials are deliberately left in band: an MCP `tools/call` denial returned as a transport-level `403` is indistinguishable to a client from a session-level failure, so it would provoke a re-authentication on every denied call — the loop the `403` exists to avoid. The specification does define a step-up flow for this, so it is a judgement call rather than a settled one, and worth revisiting if a client ever wants it.

## Testing

14 unit tests over the document, the path derivation and the challenge builder; 11 integration tests driving a real HTTP server, including the malformed-`Host` regression over a raw socket. Each regression was mutation-tested — reverting the fix fails the test.

`deno task ci`: 21/21 targets, 4278 tests, 98.5% lines and 97.3% branches against a 95% gate.

## Related issues

Closes #487. Filed separately and not in this PR: Zuke advertises MCP protocol `2025-06-18` while the current revision is `2026-07-28`.

## Checklist

- [x] This PR closes a tracking issue.
- [x] The PR title is a Conventional Commit.
- [x] `deno task ci` passes locally.
- [x] Tests were added or updated; coverage stays at 95%+ on lines and branches.
- [x] Docs updated in the same PR: the MCP guide, JSDoc, the agent skill and its cheatsheet.
- [x] Public API changes were regenerated with the API docs target.
- [x] No `any`, no `as` casts and no non-null assertions.
- [x] Agent skills updated and the plugin version bumped in all four manifests, 0.43.0 to 0.44.0.
