### PR TITLE
feat(core): advertise MCP protocol revision 2025-11-25

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -714,8 +714,10 @@ tool argument is masked in the [audit log](#audit-log) too.
   unauthenticated caller can enumerate. An absent header is fine: the
   specification says to assume `2025-03-26` then, and since nothing here
   behaves differently across these revisions that assumption changes nothing.
-  A repeated header (a proxy re-adding one the client already sent) is accepted
-  when every value it carries is supported.
+  A repeated header — a proxy re-adding one the client already sent — is
+  accepted when every copy agrees and names a supported revision; copies that
+  disagree are refused rather than resolved by picking one, since nothing here
+  could say which applies.
 - **Why not `2026-07-28`:** it is not a newer version of this protocol so much
   as a different one. It removes `initialize` and `ping` entirely, requires a
   new `server/discover` RPC, carries the protocol version and client

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -81,11 +81,14 @@ below), so one long `run:` never head-of-line-blocks another client's read.
   an authenticator runs on every bind, loopback included. The two compose: the
   token is a shared secret that gates the endpoint, the authenticator says _who_
   is calling.
-- **The order a request passes:** HTTP method (a non-`POST` gets `405`) →
-  `Origin` (`403`) → the static bearer token (`401`) → the
-  [authenticator](#authentication) (the refusal's own status) → the body (capped
-  at 1 MiB; over it, `413`). Authentication runs **before** the body is read, so
-  an unauthenticated caller never makes the server buffer its payload.
+- **The order a request passes:** the
+  [metadata document](#telling-a-client-where-to-authenticate) when one is
+  declared and the path matches (a public `GET`) → HTTP method (a non-`POST`
+  gets `405`) → `Origin` (`403`) → the static bearer token (`401`) → the
+  [authenticator](#authentication) (the refusal's own status) →
+  `MCP-Protocol-Version` (`400`) → the body (capped at 1 MiB; over it, `413`).
+  Authentication runs **before** the body is read, so an unauthenticated caller
+  never makes the server buffer its payload.
 - **Origin validation** guards against a browser drive-by / DNS-rebinding page:
   on a loopback bind, a request that carries an `Origin` header is accepted only
   when it is a loopback origin, and rejected `403` otherwise. A client that
@@ -706,9 +709,13 @@ tool argument is masked in the [audit log](#audit-log) too.
   `2025-03-26` and `2024-11-05`. A client's requested version is echoed when
   this server implements it, and otherwise answered with the newest — the
   client then proceeds or disconnects. Over HTTP, a `MCP-Protocol-Version`
-  header naming a revision this server does not implement is refused `400`; an
-  absent header is fine, since nothing here behaves differently across these
-  revisions.
+  header naming a revision this server does not implement is refused `400` —
+  after authentication, so the list of supported revisions is not something an
+  unauthenticated caller can enumerate. An absent header is fine: the
+  specification says to assume `2025-03-26` then, and since nothing here
+  behaves differently across these revisions that assumption changes nothing.
+  A repeated header (a proxy re-adding one the client already sent) is accepted
+  when every value it carries is supported.
 - **Why not `2026-07-28`:** it is not a newer version of this protocol so much
   as a different one. It removes `initialize` and `ping` entirely, requires a
   new `server/discover` RPC, carries the protocol version and client
@@ -721,6 +728,13 @@ tool argument is masked in the [audit log](#audit-log) too.
   means a second request path serving both eras, which is a project rather than
   a version-string edit. Until then, advertising it would be a claim this
   server cannot honour.
+
+  There is a side benefit to refusing the header rather than ignoring it. A
+  client that speaks both eras probes with a modern request and falls back to
+  `initialize` when it gets a `4xx` it does not recognise, so the `400` is
+  what makes that fallback work. Without it, a modern request would have been
+  answered under the older semantics — which is the specific confusion the
+  specification warns about.
 - **Errors:** a bad _tool_ call (unknown tool, unknown target, a failed run) is
   reported through the tool result (`isError: true`) so the model sees it,
   rather than as a transport-level error — matching the MCP convention. Typed

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -702,6 +702,25 @@ tool argument is masked in the [audit log](#audit-log) too.
   `protocolVersion`), `notifications/initialized` (no reply), `ping`,
   `tools/list`, and `tools/call`. Unknown requests get a JSON-RPC
   `-32601 Method not found`; notifications never get a reply.
+- **Protocol revisions:** `2025-11-25` (the newest offered), `2025-06-18`,
+  `2025-03-26` and `2024-11-05`. A client's requested version is echoed when
+  this server implements it, and otherwise answered with the newest — the
+  client then proceeds or disconnects. Over HTTP, a `MCP-Protocol-Version`
+  header naming a revision this server does not implement is refused `400`; an
+  absent header is fine, since nothing here behaves differently across these
+  revisions.
+- **Why not `2026-07-28`:** it is not a newer version of this protocol so much
+  as a different one. It removes `initialize` and `ping` entirely, requires a
+  new `server/discover` RPC, carries the protocol version and client
+  capabilities in per-request `_meta` instead of a handshake, and makes
+  `resultType` on every result and `ttlMs`/`cacheScope` on `tools/list`
+  mandatory. Those are base-protocol requirements rather than capability-gated
+  features, so a server cannot decline them and still claim the revision — the
+  specification's own compatibility matrix calls a server like this one
+  "legacy" and says a modern client talking to it simply fails. Supporting it
+  means a second request path serving both eras, which is a project rather than
+  a version-string edit. Until then, advertising it would be a claim this
+  server cannot honour.
 - **Errors:** a bad _tool_ call (unknown tool, unknown target, a failed run) is
   reported through the tool result (`isError: true`) so the model sees it,
   rather than as a transport-level error — matching the MCP convention. Typed

--- a/packages/core/src/mcp/http.ts
+++ b/packages/core/src/mcp/http.ts
@@ -32,6 +32,10 @@ import {
 } from "./jsonrpc.ts";
 import { timingSafeEqual } from "./authz.ts";
 import {
+  PROTOCOL_VERSION_HEADER,
+  unsupportedProtocolVersion,
+} from "./protocol.ts";
+import {
   authenticateRequest,
   bearerChallenge,
   INVALID_TOKEN,
@@ -426,6 +430,17 @@ export async function serveHttp(
         err(null, INVALID_REQUEST, "Forbidden: Origin not allowed."),
         403,
       );
+    }
+    // A version this server never agreed to is refused before anything acts on
+    // the message: the header exists precisely so a client cannot proceed on a
+    // revision the server does not implement, and the specification makes the
+    // `400` a MUST. An absent header is the ordinary case for a client that has
+    // not initialized yet, and is left alone.
+    const badVersion = unsupportedProtocolVersion(
+      request.headers.get(PROTOCOL_VERSION_HEADER),
+    );
+    if (badVersion !== undefined) {
+      return jsonResponse(err(null, INVALID_REQUEST, badVersion), 400);
     }
     if (token !== undefined && token !== "") {
       const provided = bearerToken(request.headers.get("authorization"));

--- a/packages/core/src/mcp/http.ts
+++ b/packages/core/src/mcp/http.ts
@@ -431,17 +431,6 @@ export async function serveHttp(
         403,
       );
     }
-    // A version this server never agreed to is refused before anything acts on
-    // the message: the header exists precisely so a client cannot proceed on a
-    // revision the server does not implement, and the specification makes the
-    // `400` a MUST. An absent header is the ordinary case for a client that has
-    // not initialized yet, and is left alone.
-    const badVersion = unsupportedProtocolVersion(
-      request.headers.get(PROTOCOL_VERSION_HEADER),
-    );
-    if (badVersion !== undefined) {
-      return jsonResponse(err(null, INVALID_REQUEST, badVersion), 400);
-    }
     if (token !== undefined && token !== "") {
       const provided = bearerToken(request.headers.get("authorization"));
       if (provided === undefined || !timingSafeEqual(provided, token)) {
@@ -466,6 +455,21 @@ export async function serveHttp(
         return refusedResponse(resolved, discovery);
       }
       identity = resolved;
+    }
+    // Placed after authentication on purpose. A version this server never
+    // agreed to must be refused — the header exists so a client cannot proceed
+    // on a revision the server does not implement, and the specification makes
+    // the `400` a MUST — but the refusal names every revision this build
+    // supports, and an unauthenticated caller has no business enumerating them.
+    // The specification does not order this against the `401`, and the check
+    // is an O(1) compare that still precedes reading the body. An absent header
+    // is left alone: it is the ordinary case before a client has initialized,
+    // and nothing here behaves differently across the supported revisions.
+    const badVersion = unsupportedProtocolVersion(
+      request.headers.get(PROTOCOL_VERSION_HEADER),
+    );
+    if (badVersion !== undefined) {
+      return jsonResponse(err(null, INVALID_REQUEST, badVersion), 400);
     }
     const body = await readBounded(request, MAX_BODY_BYTES);
     if (body === null) {

--- a/packages/core/src/mcp/protocol.ts
+++ b/packages/core/src/mcp/protocol.ts
@@ -42,10 +42,42 @@ import {
  * them; {@link PROTOCOL_VERSION} is the newest.
  */
 export const SUPPORTED_PROTOCOL_VERSIONS: readonly string[] = [
+  "2025-11-25",
   "2025-06-18",
   "2025-03-26",
   "2024-11-05",
 ];
+
+/**
+ * The HTTP header carrying the negotiated protocol version on every request
+ * after `initialize`, required of clients since `2025-06-18`.
+ */
+export const PROTOCOL_VERSION_HEADER = "mcp-protocol-version";
+
+/**
+ * The refusal message for a `MCP-Protocol-Version` header naming a version this
+ * server does not implement, or `undefined` when the header is acceptable.
+ *
+ * Absent is acceptable: the header is the client's obligation, and the
+ * specification's backwards-compatible reading is to assume `2025-03-26` when
+ * it is missing. Nothing here branches on the version — the method surface is
+ * identical across every revision in {@link SUPPORTED_PROTOCOL_VERSIONS} — so
+ * that assumption changes no behaviour and is not worth materialising. A
+ * version we do **not** implement is a different matter: the specification
+ * makes answering it `400` a MUST, because a client proceeding on a version the
+ * server never agreed to is the failure this header exists to prevent.
+ */
+export function unsupportedProtocolVersion(
+  header: string | null,
+): string | undefined {
+  if (header === null) return undefined;
+  const requested = header.trim();
+  if (requested === "" || SUPPORTED_PROTOCOL_VERSIONS.includes(requested)) {
+    return undefined;
+  }
+  return `Unsupported MCP-Protocol-Version "${requested}". This server ` +
+    `implements ${SUPPORTED_PROTOCOL_VERSIONS.join(", ")}.`;
+}
 
 /** The newest MCP protocol version these servers implement. */
 export const PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSIONS[0];

--- a/packages/core/src/mcp/protocol.ts
+++ b/packages/core/src/mcp/protocol.ts
@@ -71,20 +71,30 @@ export function unsupportedProtocolVersion(
   header: string | null,
 ): string | undefined {
   if (header === null) return undefined;
-  // Repeated header lines arrive comma-joined. A singleton field sent twice is
-  // malformed HTTP, but the way it happens in practice is a proxy re-adding a
-  // header the client already sent — and this transport expects to be fronted
-  // by one — so `2025-11-25, 2025-11-25` is a deployment accident, not a claim
-  // about an unsupported revision. Every value is checked; refusing only when
-  // one of them is genuinely unsupported keeps the guard from becoming an
-  // outage for a correctly-versioned client.
-  const requested = header.split(",").map((value) => value.trim())
-    .filter((value) => value !== "");
-  const unsupported = requested.find((value) =>
-    !SUPPORTED_PROTOCOL_VERSIONS.includes(value)
+  // Repeated header lines arrive comma-joined, and the two ways that happens
+  // want opposite answers. A proxy re-adding a header the client already sent
+  // — and this transport expects to be fronted by one — produces copies that
+  // **agree**, which is a deployment accident rather than a claim about an
+  // unsupported revision; refusing it would be a self-inflicted outage for a
+  // correctly-versioned client. Copies that **disagree** are a different thing:
+  // nothing here can say which one applies, and a header whose meaning depends
+  // on which intermediary you ask is exactly the ambiguity a version check
+  // exists to remove. So identical copies collapse, and conflicting ones are
+  // refused rather than resolved by picking one.
+  const requested = new Set(
+    header.split(",").map((value) => value.trim()).filter((value) =>
+      value !== ""
+    ),
   );
-  if (unsupported === undefined) return undefined;
-  return `Unsupported MCP-Protocol-Version "${unsupported}". This server ` +
+  if (requested.size === 0) return undefined;
+  if (requested.size > 1) {
+    return `MCP-Protocol-Version names more than one revision ` +
+      `(${[...requested].map((value) => `"${value}"`).join(", ")}). A ` +
+      `repeated header is tolerated only when every copy agrees.`;
+  }
+  const [version] = requested;
+  if (SUPPORTED_PROTOCOL_VERSIONS.includes(version)) return undefined;
+  return `Unsupported MCP-Protocol-Version "${version}". This server ` +
     `implements ${SUPPORTED_PROTOCOL_VERSIONS.join(", ")}.`;
 }
 

--- a/packages/core/src/mcp/protocol.ts
+++ b/packages/core/src/mcp/protocol.ts
@@ -71,11 +71,20 @@ export function unsupportedProtocolVersion(
   header: string | null,
 ): string | undefined {
   if (header === null) return undefined;
-  const requested = header.trim();
-  if (requested === "" || SUPPORTED_PROTOCOL_VERSIONS.includes(requested)) {
-    return undefined;
-  }
-  return `Unsupported MCP-Protocol-Version "${requested}". This server ` +
+  // Repeated header lines arrive comma-joined. A singleton field sent twice is
+  // malformed HTTP, but the way it happens in practice is a proxy re-adding a
+  // header the client already sent — and this transport expects to be fronted
+  // by one — so `2025-11-25, 2025-11-25` is a deployment accident, not a claim
+  // about an unsupported revision. Every value is checked; refusing only when
+  // one of them is genuinely unsupported keeps the guard from becoming an
+  // outage for a correctly-versioned client.
+  const requested = header.split(",").map((value) => value.trim())
+    .filter((value) => value !== "");
+  const unsupported = requested.find((value) =>
+    !SUPPORTED_PROTOCOL_VERSIONS.includes(value)
+  );
+  if (unsupported === undefined) return undefined;
+  return `Unsupported MCP-Protocol-Version "${unsupported}". This server ` +
     `implements ${SUPPORTED_PROTOCOL_VERSIONS.join(", ")}.`;
 }
 

--- a/packages/core/tests/mcp_test.ts
+++ b/packages/core/tests/mcp_test.ts
@@ -10,6 +10,7 @@ import {
 } from "../src/mcp/jsonrpc.ts";
 import { McpServer } from "../src/mcp/server.ts";
 import {
+  negotiateInitialize,
   PROTOCOL_VERSION,
   SUPPORTED_PROTOCOL_VERSIONS,
   unsupportedProtocolVersion,
@@ -460,8 +461,14 @@ Deno.test("the newest advertised revision is the newest one this server implemen
   // speak, so the list stops where the behaviour does.
   assertEquals(PROTOCOL_VERSION, "2025-11-25");
   assertEquals(SUPPORTED_PROTOCOL_VERSIONS.includes("2026-07-28"), false);
-  // Newest first: negotiation offers SUPPORTED_PROTOCOL_VERSIONS[0].
-  assertEquals(SUPPORTED_PROTOCOL_VERSIONS[0], PROTOCOL_VERSION);
+  // The list is newest-first, which is what makes the offer correct: asserted
+  // through negotiation rather than by comparing the constant to its own
+  // definition, which no edit could have made fail.
+  const { result } = negotiateInitialize(
+    { protocolVersion: "1999-01-01" },
+    "v",
+  );
+  assertEquals(result.protocolVersion, "2025-11-25");
 });
 
 Deno.test("an unsupported MCP-Protocol-Version header is refused", () => {
@@ -472,6 +479,18 @@ Deno.test("an unsupported MCP-Protocol-Version header is refused", () => {
   assertEquals(unsupportedProtocolVersion("2024-11-05"), undefined);
   // Absent in practice, but an empty header is not a claim about a version.
   assertEquals(unsupportedProtocolVersion("  "), undefined);
+  // A proxy that re-adds a header the client already sent produces a
+  // comma-joined pair. Every value is checked, so a correctly-versioned client
+  // is not refused for its proxy's duplication...
+  assertEquals(
+    unsupportedProtocolVersion("2025-11-25, 2025-11-25"),
+    undefined,
+  );
+  // ...while one genuinely unsupported value still refuses, and names itself.
+  assertStringIncludes(
+    unsupportedProtocolVersion("2025-11-25, 2026-07-28") ?? "",
+    "2026-07-28",
+  );
   const refused = unsupportedProtocolVersion("2026-07-28");
   assertStringIncludes(refused ?? "", "2026-07-28");
   assertStringIncludes(refused ?? "", "2025-11-25");

--- a/packages/core/tests/mcp_test.ts
+++ b/packages/core/tests/mcp_test.ts
@@ -9,7 +9,11 @@ import {
   serveStdio,
 } from "../src/mcp/jsonrpc.ts";
 import { McpServer } from "../src/mcp/server.ts";
-import { PROTOCOL_VERSION } from "../src/mcp/protocol.ts";
+import {
+  PROTOCOL_VERSION,
+  SUPPORTED_PROTOCOL_VERSIONS,
+  unsupportedProtocolVersion,
+} from "../src/mcp/protocol.ts";
 import { serveMcp } from "../src/mcp/command.ts";
 
 /** A small build with parameters and a dependency edge, for the server tests. */
@@ -445,4 +449,30 @@ Deno.test("the stdio banner reports read-only when running is not enabled", asyn
   const text = banner.join("\n");
   assertStringIncludes(text, "read-only");
   assertEquals(text.includes("run enabled"), false);
+});
+
+Deno.test("the newest advertised revision is the newest one this server implements", () => {
+  // Guards against the version list drifting ahead of the behaviour. The
+  // revision after this one, 2026-07-28, is not a superset: it removes
+  // `initialize` and `ping`, requires a `server/discover` RPC, and makes
+  // `resultType` and the `tools/list` caching hints mandatory. Adding it here
+  // without that work would advertise a wire protocol this server does not
+  // speak, so the list stops where the behaviour does.
+  assertEquals(PROTOCOL_VERSION, "2025-11-25");
+  assertEquals(SUPPORTED_PROTOCOL_VERSIONS.includes("2026-07-28"), false);
+  // Newest first: negotiation offers SUPPORTED_PROTOCOL_VERSIONS[0].
+  assertEquals(SUPPORTED_PROTOCOL_VERSIONS[0], PROTOCOL_VERSION);
+});
+
+Deno.test("an unsupported MCP-Protocol-Version header is refused", () => {
+  // Required of a server since 2025-06-18: a client must not proceed on a
+  // revision the server never agreed to.
+  assertEquals(unsupportedProtocolVersion(null), undefined);
+  assertEquals(unsupportedProtocolVersion("2025-11-25"), undefined);
+  assertEquals(unsupportedProtocolVersion("2024-11-05"), undefined);
+  // Absent in practice, but an empty header is not a claim about a version.
+  assertEquals(unsupportedProtocolVersion("  "), undefined);
+  const refused = unsupportedProtocolVersion("2026-07-28");
+  assertStringIncludes(refused ?? "", "2026-07-28");
+  assertStringIncludes(refused ?? "", "2025-11-25");
 });

--- a/packages/core/tests/mcp_test.ts
+++ b/packages/core/tests/mcp_test.ts
@@ -486,10 +486,21 @@ Deno.test("an unsupported MCP-Protocol-Version header is refused", () => {
     unsupportedProtocolVersion("2025-11-25, 2025-11-25"),
     undefined,
   );
-  // ...while one genuinely unsupported value still refuses, and names itself.
+  // ...while copies that disagree are refused rather than resolved by picking
+  // one. Nothing here could say which applies, and a header whose meaning
+  // depends on which intermediary you ask is the ambiguity the check removes.
+  assertStringIncludes(
+    unsupportedProtocolVersion("2025-11-25, 2025-06-18") ?? "",
+    "more than one revision",
+  );
+  // A single unsupported value still refuses, and names itself.
+  assertStringIncludes(
+    unsupportedProtocolVersion("2026-07-28") ?? "",
+    "2026-07-28",
+  );
   assertStringIncludes(
     unsupportedProtocolVersion("2025-11-25, 2026-07-28") ?? "",
-    "2026-07-28",
+    "more than one revision",
   );
   const refused = unsupportedProtocolVersion("2026-07-28");
   assertStringIncludes(refused ?? "", "2026-07-28");

--- a/tests/integration/mcp_auth_test.ts
+++ b/tests/integration/mcp_auth_test.ts
@@ -444,6 +444,47 @@ Deno.test("a preflight for the metadata document is answered", async () => {
   }
 });
 
+Deno.test("two real protocol-version header lines arrive comma-joined", async () => {
+  // The unit tests exercise the comma-joined string; this pins that a genuine
+  // duplicate header line is what produces one, so the tolerance for an
+  // agreeing proxy copy is about the wire shape rather than about a string a
+  // test made up. `fetch` cannot send a header twice, hence the raw socket.
+  const server = await startMcp(new Guarded(), {});
+  const port = Number(new URL(server.url).port);
+  const send = async (first: string, second: string): Promise<string> => {
+    const message = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/list",
+    });
+    const connection = await Deno.connect({ hostname: "127.0.0.1", port });
+    await connection.write(
+      new TextEncoder().encode(
+        "POST / HTTP/1.1\r\nHost: 127.0.0.1\r\n" +
+          `MCP-Protocol-Version: ${first}\r\n` +
+          `MCP-Protocol-Version: ${second}\r\n` +
+          "Content-Type: application/json\r\n" +
+          `Content-Length: ${message.length}\r\n` +
+          "Connection: close\r\n\r\n" + message,
+      ),
+    );
+    const buffer = new Uint8Array(512);
+    const read = await connection.read(buffer);
+    connection.close();
+    return new TextDecoder().decode(buffer.subarray(0, read ?? 0));
+  };
+  try {
+    // Copies that agree: a proxy re-adding what the client already sent.
+    assertStringIncludes(await send("2025-11-25", "2025-11-25"), "200");
+    // Copies that disagree: nothing can say which applies, so neither is used.
+    const conflicting = await send("2025-11-25", "2025-06-18");
+    assertStringIncludes(conflicting, "400");
+    assertStringIncludes(conflicting, "more than one revision");
+  } finally {
+    await server.stop();
+  }
+});
+
 Deno.test("the metadata response is a cacheable JSON document, and answers HEAD", async () => {
   // RFC 9728 3.2 makes the 200 + application/json a MUST; the cache header is
   // what stops every cold client re-fetching a constant.

--- a/tests/integration/mcp_auth_test.ts
+++ b/tests/integration/mcp_auth_test.ts
@@ -503,6 +503,35 @@ Deno.test("an unsupported protocol version header is refused over HTTP", async (
     assertEquals(refused.status, 400);
     assertStringIncludes(await refused.text(), "2026-07-28");
 
+    // ...but only once the caller is authenticated. The refusal names every
+    // revision this build supports, which an unauthenticated caller has no
+    // business enumerating, so the 401 wins.
+    const guarded = await startMcp(new Guarded(), { token: "shared-token" });
+    try {
+      const unauthenticated = await fetch(guarded.url, {
+        method: "POST",
+        headers: { "mcp-protocol-version": "2026-07-28" },
+        body,
+      });
+      assertEquals(unauthenticated.status, 401);
+      assertEquals(
+        (await unauthenticated.text()).includes("2025-06-18"),
+        false,
+      );
+      const authenticated = await fetch(guarded.url, {
+        method: "POST",
+        headers: {
+          "mcp-protocol-version": "2026-07-28",
+          authorization: "Bearer shared-token",
+        },
+        body,
+      });
+      assertEquals(authenticated.status, 400);
+      await authenticated.body?.cancel();
+    } finally {
+      await guarded.stop();
+    }
+
     // A version we do implement, and an absent header, both pass through.
     const accepted: Record<string, string>[] = [
       { "mcp-protocol-version": "2025-11-25" },

--- a/tests/integration/mcp_auth_test.ts
+++ b/tests/integration/mcp_auth_test.ts
@@ -483,3 +483,37 @@ Deno.test("an unusable protected-resource declaration stops the server starting"
   assertEquals(code, 1);
   assertStringIncludes(err, "authorization server");
 });
+
+Deno.test("an unsupported protocol version header is refused over HTTP", async () => {
+  const server = await startMcp(new Guarded(), {});
+  try {
+    const body = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/list",
+    });
+    // The next revision after the newest we implement. Refused rather than
+    // served, because a client proceeding on a protocol the server never
+    // agreed to is exactly what this header exists to prevent.
+    const refused = await fetch(server.url, {
+      method: "POST",
+      headers: { "mcp-protocol-version": "2026-07-28" },
+      body,
+    });
+    assertEquals(refused.status, 400);
+    assertStringIncludes(await refused.text(), "2026-07-28");
+
+    // A version we do implement, and an absent header, both pass through.
+    const accepted: Record<string, string>[] = [
+      { "mcp-protocol-version": "2025-11-25" },
+      {},
+    ];
+    for (const headers of accepted) {
+      const ok = await fetch(server.url, { method: "POST", headers, body });
+      assertEquals(ok.status, 200);
+      await ok.body?.cancel();
+    }
+  } finally {
+    await server.stop();
+  }
+});


### PR DESCRIPTION
## What & why

The newest MCP revision this server offered was `2025-06-18`, two behind the current specification. It now offers `2025-11-25`, and still accepts every older revision it did before.

### Why not `2026-07-28`, which is what the issue asked for

Because it would be a false claim. `2026-07-28` is not a newer version of this protocol so much as a different one:

- it removes `initialize` and `notifications/initialized` entirely, and removes `ping`;
- it requires a new `server/discover` RPC that servers **MUST** implement;
- it carries the protocol version and client capabilities in per-request `_meta` instead of a handshake;
- it makes `resultType` mandatory on every result, and `ttlMs`/`cacheScope` mandatory on `tools/list`;
- it removes protocol-level sessions, replaces the GET endpoint, and requires `Mcp-Method`/`Mcp-Name` headers on every POST.

None of those are capability-gated features a server may decline while still claiming the revision — they are the base protocol. The specification's own compatibility matrix classifies a server of this shape as **legacy** and gives the outcome against a modern client in one word: *"Fails."* Supporting it means a second request path serving both eras concurrently, which the specification anticipates and calls dual-era. That is a project, not a version-string edit.

So the honest target is `2025-11-25`, the newest legacy-era revision, and a unit test pins the list against `2026-07-28` so the advertised version cannot drift ahead of the behaviour. That test is the actual deliverable of this issue as much as the bump is.

### `2025-11-25` asks nothing new of a tools-only server

Its additions are optional or already true here: icons on a tool, an experimental `tasks` capability, JSON Schema 2020-12 as the default dialect, an optional `description` on `serverInfo`, tool-name guidance we already satisfy. Its one new transport requirement — answering an invalid `Origin` with `403` rather than merely rejecting it — this transport has always done.

### The gap the research actually found

`MCP-Protocol-Version` was never checked. Since `2025-06-18` — the revision we **already claimed** — a client must send that header on every HTTP request after `initialize`, and a server **MUST** answer `400` when it names a revision the server does not implement. Nothing validated it, so a client could proceed on a protocol this server never agreed to, which is the one thing the header exists to prevent. That is a pre-existing conformance defect against the version already advertised, and it is fixed here.

An absent header stays fine. The specification's backwards-compatible reading is to assume `2025-03-26`, and since nothing here behaves differently across any supported revision, that assumption changes no behaviour and is not worth materialising.

## Verified against a real client

Not academic: the same client rejects a server advertising `2026-07-28` outright, which is how the "not a superset" conclusion stopped being a reading of the spec and became an observation. Against a running Zuke server on this branch it negotiates `2025-11-25` and reports connected.

## What the adversarial review found

Three findings, all real, all fixed.

**A repeated header was refused even when every value was supported** (medium). Repeated header lines arrive comma-joined and the check treated the join as one opaque token, so `2025-11-25, 2025-11-25` read as an unsupported revision. Not hypothetical: this transport documents that it expects to be fronted by a proxy, and a proxy re-adding a header the client already sent produces exactly that — a hard refusal for a correctly-versioned client, self-inflicted. Every value is checked now.

**The check answered before authentication** (low). Its message names every revision this build supports, which an unauthenticated caller has no business enumerating, and answering ahead of the bearer token contradicted the rule this module states for itself — that the metadata document is the only thing reachable before authentication. It has moved below the authenticator; the specification does not order the `400` against the `401`, and it still precedes reading the body. An integration test pins the ordering.

**One of my assertions was a tautology** (medium, hygiene). It compared `SUPPORTED_PROTOCOL_VERSIONS[0]` to `PROTOCOL_VERSION`, which is that constant's definition, so no edit to either file could have made it fail. It now asserts the property it was reaching for — that an unsupported request is answered with the newest revision — through `negotiateInitialize`.

The review also surfaced an unclaimed benefit, now documented: refusing the header is precisely what lets a dual-era client fall back correctly, since it probes with a modern request and retries as legacy on an unrecognised `4xx`. Ignoring the header would have had a modern request answered under the older semantics — the specific confusion the specification warns about.

Confirmed by the review and unchanged: the `2025-11-25` conformance claim itself, freedom from regressions (no test or code path pinned the old default; both version tests read the constant), and every factual assertion in the `2026-07-28` rationale.

## Testing

Unit coverage of the version list, the negotiation offer, and every branch of the header check including the duplicate-header case; integration coverage over real HTTP for the refusal, the accepted values, the absent header, and the guard's position relative to authentication. Both new tests were mutation-tested — reverting the source fails them.

`deno task ci`: 21/21 targets, 4284 tests, 98.5% lines and 97.3% branches against a 95% gate.

## Related issues

Closes #489

## Checklist

- [x] This PR closes a tracking issue.
- [x] The PR title is a Conventional Commit.
- [x] `deno task ci` passes locally.
- [x] Tests were added or updated; coverage stays at 95%+ on lines and branches.
- [x] Docs updated in the same PR — the MCP guide's protocol notes and request-order list.
- [x] Public API regenerated — not applicable; the version list and the header helper are internal to the MCP modules.
- [x] No `any`, no `as` casts and no non-null assertions.
- [x] Agent skills unchanged — protocol revisions are not part of the build-authoring surface — so no plugin version bump.
