### PR TITLE
chore: fix the stale package count and test it against the workspace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,7 @@ regenerate them in the same PR.
   runner, formatter, linter, type-checker, coverage — is the built-in `deno`
   CLI. No Node, npm, or external build tools.
 - **Language:** TypeScript, strict mode (Deno's default).
-- **Distribution:** [JSR](https://jsr.io/) as a workspace of 54 packages:
+- **Distribution:** [JSR](https://jsr.io/) as a workspace of 58 packages:
   `@zuke/core` (exports `.`, `./shell`, `./tooling`, `./tooling/conformance`,
   `./render`, `./conformance`) plus the `@zuke/cli` command, a generic
   `@zuke/cmd` fallback, and 50+ typed tool wrappers and plugins (`@zuke/deno`,
@@ -415,7 +415,7 @@ packages/
   deno/                   # @zuke/deno — DenoTasks
   npm/                    # @zuke/npm  — NpmTasks
   cmd/                    # @zuke/cmd  — CmdTasks (generic fallback)
-  …                       # + 50 more: @zuke/cli, @zuke/docs, @zuke/ai, and tool wrappers (54 total)
+  …                       # + the rest: @zuke/cli, @zuke/docs, @zuke/ai, and tool wrappers (58 total)
 tests/
   integration/            # in-process: real builds via the CLI main() + _harness.ts
   e2e/                    # subprocess: *_e2e.ts + fixtures/ (run by the `integration` target)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 > made so you know what you're getting.
 
 > [!NOTE]
-> **Maturity.** Every one of the 54 packages is `1.x` and follows full semver —
+> **Maturity.** Every one of the 58 packages is `1.x` and follows full semver —
 > `@zuke/core`, the `@zuke/cli` command, and all the tool wrappers. A minor or
 > patch release never breaks a public symbol; a breaking change bumps the major.
 > See [Versioning & compatibility](./docs/versioning.md) for the pinning
@@ -194,7 +194,7 @@ latest release on JSR.
 | [`@zuke/otel`](https://jsr.io/@zuke/otel)         | [![JSR](https://jsr.io/badges/@zuke/otel)](https://jsr.io/@zuke/otel) [![JSR score](https://jsr.io/badges/@zuke/otel/score)](https://jsr.io/@zuke/otel)                 |
 
 <details>
-<summary><strong>All tool wrappers</strong> (44 packages)</summary>
+<summary><strong>All tool wrappers</strong> (48 packages)</summary>
 
 | Package                                                       | Version                                                                                                                                                                                         |
 | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing
 
-Zuke publishes 54 packages to [JSR](https://jsr.io/@zuke) from a single
+Zuke publishes 58 packages to [JSR](https://jsr.io/@zuke) from a single
 workspace — `@zuke/core`, the `@zuke/cli` command, a generic `@zuke/cmd`
 fallback, and 50+ typed tool wrappers and plugins (`@zuke/deno`, `@zuke/npm`,
 `@zuke/ai`, …). Releases are automated end to end; you only ever merge a pull

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -4,7 +4,7 @@ Zuke exists for the build that has outgrown a list of commands: a real
 dependency graph, typed inputs, external tools driven through checked argv, and
 pipelines that have to survive waiting for something outside the build.
 
-It is also a **single-maintainer project**. All 54 JSR packages are `1.x` and
+It is also a **single-maintainer project**. All 58 JSR packages are `1.x` and
 follow full semver (see
 [Versioning & compatibility](./versioning.md) for what that promises). The
 package a consumer actually installs is the `@zuke/cli` command — `1.x` too, and

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,7 @@ You need [Deno](https://deno.com/) installed. There's nothing else to install �
 Zuke is imported straight from JSR.
 
 > [!NOTE]
-> All `@zuke/*` packages — the 54-package workspace: `@zuke/core`, the
+> All `@zuke/*` packages — the 58-package workspace: `@zuke/core`, the
 > `@zuke/cli` command, a generic `@zuke/cmd` fallback, and 50+ typed tool
 > wrappers and plugins (`@zuke/deno`, `@zuke/npm`, `@zuke/docker`, `@zuke/ai`,
 > …) — publish to [JSR](https://jsr.io/@zuke) from CI via release-please and

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,13 +1,13 @@
 # Versioning & compatibility
 
-Zuke publishes 54 independent JSR packages from one workspace. They don't all
+Zuke publishes 58 independent JSR packages from one workspace. They don't all
 move at the same speed, and knowing which promise each package makes — and how
 they interlock — is what keeps an upgrade from surprising you at runtime
 instead of at `deno check` time.
 
 ## One tier: every package follows full semver
 
-**All 54 packages are `1.x`.** `@zuke/core`, the `@zuke/cli` command, and every
+**All 58 packages are `1.x`.** `@zuke/core`, the `@zuke/cli` command, and every
 tool wrapper make the same promise: a `1.x` release never breaks a public
 symbol, so a minor or patch upgrade is safe to take without reading the diff,
 and a breaking change bumps the **major** version. Depend on

--- a/tests/release_config_test.ts
+++ b/tests/release_config_test.ts
@@ -150,3 +150,70 @@ Deno.test("deno.lock captures release-please's full npm tree", async () => {
     );
   }
 });
+
+/**
+ * The files whose prose quotes the size of the workspace. The README package
+ * *table* is checked above; this is the number written in sentences ("the 58
+ * packages", "a 58-package workspace", "(58 total)"), which drifted for months
+ * because nothing compared it to the real list.
+ */
+const PACKAGE_COUNT_PROSE = [
+  "README.md",
+  "AGENTS.md",
+  "RELEASING.md",
+  "docs/versioning.md",
+  "docs/comparison.md",
+  "docs/getting-started.md",
+];
+
+/**
+ * A number that states the workspace size: `58 packages`, `58 JSR packages`,
+ * `58 independent JSR packages`, `58-package`, or `(58 total)`. A `50+`-style
+ * lower bound has no trailing count keyword and is deliberately not matched.
+ */
+const PACKAGE_COUNT =
+  /\b(\d+)(?=(?:-package\b| (?:independent )?(?:JSR )?packages\b| total\)))/g;
+
+/**
+ * The README's collapsed wrapper catalogue: its `<summary>` states how many
+ * packages the table inside holds. That is a subset count, checked against its
+ * own table below and stripped before the workspace-count scan.
+ */
+const WRAPPER_SUMMARY = /<summary>.*\((\d+) packages\)<\/summary>/;
+
+Deno.test("every prose mention of the package count matches the workspace", async () => {
+  const expected = PACKAGE_DIRS.length;
+  const wrong: string[] = [];
+  for (const path of PACKAGE_COUNT_PROSE) {
+    const text = (await Deno.readTextFile(path)).replace(WRAPPER_SUMMARY, "");
+    const counts = [...text.matchAll(PACKAGE_COUNT)].map((m) => Number(m[1]));
+    assertEquals(
+      counts.length > 0,
+      true,
+      `${path} no longer states the package count; drop it from the list`,
+    );
+    for (const count of counts) {
+      if (count !== expected) wrong.push(`${path}: ${count}`);
+    }
+  }
+  assertEquals(
+    wrong,
+    [],
+    `package count is ${expected}; stale mentions: ${wrong.join(", ")}`,
+  );
+});
+
+Deno.test("the README wrapper summary counts the rows of its own table", async () => {
+  const readme = await Deno.readTextFile("README.md");
+  const summary = readme.match(WRAPPER_SUMMARY);
+  assertEquals(summary !== null, true, "README.md wrapper <summary> not found");
+  const stated = Number(summary?.[1]);
+  const details = readme.slice(readme.indexOf("<details>"));
+  const block = details.slice(0, details.indexOf("</details>"));
+  const rows = block.match(/^\| \[`@zuke\//gm)?.length;
+  assertEquals(
+    stated,
+    rows,
+    `README.md wrapper summary says ${stated} packages; the table has ${rows}`,
+  );
+});


### PR DESCRIPTION
## What & why

The workspace has **58** packages, but the prose in `README.md`, `AGENTS.md`, `RELEASING.md`, `docs/versioning.md`, `docs/comparison.md` and `docs/getting-started.md` still said **54**, and the README's collapsed wrapper catalogue said **44 packages** while its table listed **48**. The README *table* was already test-checked against `PACKAGES`; the numbers written in sentences were not, so every new wrapper made the docs a little more wrong.

This PR corrects the seven mentions plus the wrapper summary, and adds two tests to `tests/release_config_test.ts`:

- **"every prose mention of the package count matches the workspace"** scans the six files for a stated count (`58 packages`, `58-package`, `58 JSR packages`, `(58 total)`) and asserts each equals `PACKAGES.length`. A `50+` lower bound has no count keyword and is deliberately not matched. A file that stops stating a count fails too, so the list stays honest.
- **"the README wrapper summary counts the rows of its own table"** checks the `<summary>… (N packages)</summary>` line against the `@zuke/*` rows inside its `<details>` block.

Both were mutation-tested: reverting either number makes its test fail with a message naming the file and the wrong value.

`CHANGELOG.md` also carries a "54" in an old release entry; that is history and is left as written.

First of the changes coming out of the external review feedback (#493–#497).

## Related issues

Closes #493

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a [Conventional Commit](https://www.conventionalcommits.org/) (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell). Ran `format`, `lint`, `spell` and `coverage` (98.3% lines / 97.3% branches).
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour changed.
- [ ] Public API changes were regenerated with `./zuke apiDocs` — n/a, no API change.
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/`.
- [x] No dead code.
- [x] No duplicated logic.
- [x] SOLID shapes respected.
- [ ] A new package was wired into all six places — n/a.
- [x] The code is written using AI assisted coding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M1ziE5yAZ723ARSpeht9oP

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1ziE5yAZ723ARSpeht9oP)_