### PR TITLE
fix(core): fan-out jobs no longer add an unpinned checkout after the prelude

### DIFF
--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -587,7 +587,8 @@ runs only its own target (`./zuke <target>`); its dependencies run in their own
 jobs, so pair fan-out with the [remote cache](./cli.md#remote-cache) (configured
 here via `env`) to restore their outputs instead of rebuilding them. Pass
 `fanOut: true` for the defaults, or `FanOutOptions` to set the per-job
-`command`, `setupSteps` (default: a checkout), `runsOn`, `env`, or
+`command`, `setupSteps` (default: none — the prelude action already checks
+out), `runsOn`, `env`, or
 `includeUnlisted`. The `pipeline` field still supplies the workflow-level
 `name`, `triggers`, `permissions`, and `concurrency`. Targets with no body, and
 `unlisted` ones, are omitted. `fanOutPipeline(targets, base, options)` exposes

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3260,10 +3260,11 @@ interface FanOutOptions
     its own target; its dependencies run in their own jobs and are shared via
     the {@link "./remote_cache.ts" | remote cache}, so pair fan-out with one.
   setupSteps?: CiStep[]
-    Steps prepended to every job — checkout, tool setup, cache restore. Defaults
-    to a single `actions/checkout` (rendered on GitHub; GitLab and Azure check
-    out automatically). Provide `env` for `ZUKE_REMOTE_CACHE_*` here or via
-    {@link env}.
+    Steps prepended to every job — tool setup, cache restore. None by default:
+    the prelude action every job starts with already hardens the runner and
+    checks the repository out (and GitLab and Azure check out on their own), so
+    a job's steps are just `Run <target>` unless you add to them. Provide `env`
+    for `ZUKE_REMOTE_CACHE_*` here or via {@link env}.
   runsOn?: string
     The runner for every job (see {@link CiJob.runsOn}).
   includeUnlisted?: boolean

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -3314,10 +3314,11 @@ interface FanOutOptions
     its own target; its dependencies run in their own jobs and are shared via
     the {@link "./remote_cache.ts" | remote cache}, so pair fan-out with one.
   setupSteps?: CiStep[]
-    Steps prepended to every job — checkout, tool setup, cache restore. Defaults
-    to a single `actions/checkout` (rendered on GitHub; GitLab and Azure check
-    out automatically). Provide `env` for `ZUKE_REMOTE_CACHE_*` here or via
-    {@link env}.
+    Steps prepended to every job — tool setup, cache restore. None by default:
+    the prelude action every job starts with already hardens the runner and
+    checks the repository out (and GitLab and Azure check out on their own), so
+    a job's steps are just `Run <target>` unless you add to them. Provide `env`
+    for `ZUKE_REMOTE_CACHE_*` here or via {@link env}.
   runsOn?: string
     The runner for every job (see {@link CiJob.runsOn}).
   includeUnlisted?: boolean

--- a/packages/core/src/ci.ts
+++ b/packages/core/src/ci.ts
@@ -996,10 +996,11 @@ export interface FanOutOptions {
    */
   command?: (target: string) => string;
   /**
-   * Steps prepended to every job — checkout, tool setup, cache restore. Defaults
-   * to a single `actions/checkout` (rendered on GitHub; GitLab and Azure check
-   * out automatically). Provide `env` for `ZUKE_REMOTE_CACHE_*` here or via
-   * {@link env}.
+   * Steps prepended to every job — tool setup, cache restore. None by default:
+   * the prelude action every job starts with already hardens the runner and
+   * checks the repository out (and GitLab and Azure check out on their own), so
+   * a job's steps are just `Run <target>` unless you add to them. Provide `env`
+   * for `ZUKE_REMOTE_CACHE_*` here or via {@link env}.
    */
   setupSteps?: CiStep[];
   /** The runner for every job (see {@link CiJob.runsOn}). */
@@ -1009,9 +1010,6 @@ export interface FanOutOptions {
   /** Environment variables set on every job (e.g. the remote-cache config). */
   env?: Record<string, string>;
 }
-
-/** The default per-job setup: check out the repo (GitHub only; others auto-checkout). */
-const DEFAULT_SETUP_STEPS: CiStep[] = [{ uses: "actions/checkout@v4" }];
 
 /**
  * The workflow path a field name implies: `releaseWorkflow` →
@@ -1154,7 +1152,9 @@ export function fanOutPipeline(
   options: FanOutOptions = {},
 ): CiPipeline {
   const command = options.command ?? ((target) => `./zuke ${target}`);
-  const setup = options.setupSteps ?? DEFAULT_SETUP_STEPS;
+  // No default setup: the prelude checks out, so a second `actions/checkout`
+  // here was a redundant — and unpinned — step in every generated job.
+  const setup = options.setupSteps ?? [];
   const included = new Map<string, TargetBuilder>();
   for (const [name, t] of targets) {
     if (t.fn_ === undefined) continue; // nothing to run

--- a/packages/core/tests/ci_test.ts
+++ b/packages/core/tests/ci_test.ts
@@ -483,7 +483,7 @@ Deno.test("fanOutPipeline makes one job per runnable target, wired by dependenci
   const test = jobs.find((j) => j.id === "test");
   assertEquals(test?.needs, ["lint"]); // mirrors dependsOn
   assertEquals(test?.steps?.at(-1)?.run, "./zuke test"); // default launcher command
-  assertEquals(test?.steps?.[0]?.uses, "actions/checkout@v4"); // default setup
+  assertEquals(test?.steps?.length, 1); // no default setup: the prelude checks out
 
   const lint = jobs.find((j) => j.id === "lint");
   assertEquals(lint?.needs, undefined); // no dependencies → no needs
@@ -568,6 +568,24 @@ Deno.test("cicd fanOut expands into a per-target workflow via discoverCiFiles", 
   assertStringIncludes(yaml, "run: ./zuke lint");
   assertStringIncludes(yaml, "run: ./zuke test");
   assertStringIncludes(yaml, "needs:");
+});
+
+Deno.test("a fan-out job checks out once, through the pinned prelude", () => {
+  // Regression: the fan-out default setup used to add `actions/checkout@v4`
+  // after the prelude had already checked out — a second, unpinned checkout in
+  // every job, which zizmor flags and the pinning policy forbids.
+  class WithFanOut extends Build {
+    lint = target().executes(() => {});
+    test = target().dependsOn(this.lint).executes(() => {});
+    ci = cicd({ provider: "github", fanOut: true });
+  }
+  const yaml = discoverCiFiles(new WithFanOut())[0].render();
+  const uses = yaml.split("\n").filter((line) => line.includes("uses:"));
+  assertEquals(uses.length, 2); // one per job, and nothing else
+  for (const line of uses) {
+    assertStringIncludes(line, "uses: zuke-build/zuke@");
+  }
+  assertEquals(yaml.includes("actions/checkout"), false);
 });
 
 Deno.test("a non-fan-out cicd file is unaffected by discovery resolution", () => {


### PR DESCRIPTION
## What & why

A build declaring `cicd({ provider: "github", fanOut: true })` generated jobs that check out **twice**: the SHA-pinned `zuke-build/zuke` prelude (harden + checkout), then a bare `actions/checkout@v4`. The second step is unpinned and does not set `persist-credentials: false`, so `zizmor` flags every job (`unpinned-uses` high, `artipacked` medium) and the generated workflow breaks the pinning policy the repository enforces on its own workflows.

**Root cause:** `fanOutPipeline` prepended `DEFAULT_SETUP_STEPS = [{ uses: "actions/checkout@v4" }]` when no `setupSteps` were given. That default predates the prelude action from #413, which has supplied the checkout for every job since; the fan-out default was the one unpinned reference left in the generator, and nothing in the repository exercised fan-out and the prelude together, so it went unnoticed until the `ci-only` example for #495 was scanned.

**Fix:** drop the default. A fan-out job's steps are now just `Run <target>`, the same shape every other generated job has; `setupSteps` keeps its purpose (tool setup, cache restore) and its JSDoc now says the prelude already checked out. The constant is removed rather than emptied (no dead code).

**Tests:** the existing fan-out test now asserts a job has a single step; the new regression test `a fan-out job checks out once, through the pinned prelude` renders a fan-out workflow and asserts each job carries exactly one `uses:` line, that it is `zuke-build/zuke@…`, and that `actions/checkout` does not appear. Mutation-checked: restoring the old default fails it. `packages/core/tests/` passes in full (1581 tests).

**Docs:** `docs/authoring.md` fan-out paragraph, and `llms-full.txt` / `packages/core/README.md` regenerated by `./zuke apiDocs` for the changed JSDoc.

A related inconsistency is noted in #501 as a follow-up, deliberately not widened into here: without a `pins` resolver, a job whose own first step is a pinned checkout still receives the prelude, because `jobSteps` reads `pipeline.bootstrap` before `stepsCoverPrelude(job.steps)`.

## Related issues

Closes #501

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a [Conventional Commit](https://www.conventionalcommits.org/) (`type(scope): summary`).
- [x] `deno task ci` passes locally — `format`, `lint`, `docLint`, `apiDocsCheck`, `spell` and the full core suite; the `security` target cannot run in this sandbox (zizmor's advisory lookup gets a 403 from the proxy) and will run on CI.
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour changed.
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`, `llms-full.txt`, package README `## API`).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/`.
- [x] No dead code.
- [x] No duplicated logic.
- [x] SOLID shapes respected.
- [ ] A new package was wired into all six places — n/a.
- [x] The code is written using AI assisted coding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M1ziE5yAZ723ARSpeht9oP

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1ziE5yAZ723ARSpeht9oP)_