### PR TITLE
feat(core): ctx.state.trySet reports whether a durable write landed

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/docs/state.md
+++ b/docs/state.md
@@ -204,6 +204,35 @@ in-memory no-op — `set`/`get` are consistent within the run, but nothing is
 persisted. It is the carrier for anything that must survive a
 [suspend/resume](./orchestration.md) boundary.
 
+### Checking that a write landed
+
+`set` resolves when the write has been attempted, whether or not it landed.
+When a body needs to *know*, use **`trySet`**, which resolves `true` when the
+patch reached the store and `false` when the write was dropped — conflicted
+away for good, or refused by a store that errored:
+
+```ts
+deploy = target().executes(async (ctx) => {
+  const slot = await lease();
+  if (!await ctx.state.trySet({ slot })) {
+    // Nothing has been deployed yet, so failing here is cheap. Going ahead
+    // would leave a slot held that no compensation can find again.
+    throw new Error(`could not record the leased slot ${slot}`);
+  }
+  await deployTo(slot);
+});
+```
+
+Treat `false` as **not recorded**: a dropped write is sometimes re-persisted by
+a later one, but nothing guarantees it. A dropped write also warns, and one
+that is definitely unrecoverable marks the record `degraded` so a later resume
+refuses it rather than repeating a step against state it cannot trust.
+
+Two contexts have nothing durable behind them and so always answer `true`: a
+build with no state store, and a compensation body, whose `ctx.state` is seeded
+from the original target's metadata and kept in memory (the run is ending, so
+cleanup state is not persisted).
+
 ### Secrets never touch state
 
 State is persisted in plain JSON and read back by later runs and by anyone who

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "zuke",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build)."
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4424,6 +4424,26 @@ interface TargetStateHandle
 
   set(patch: Record<string, JsonValue>): Promise<void>
     Merge a JSON patch into this target's persisted metadata (awaits the write).
+  trySet(patch: Record<string, JsonValue>): Promise<boolean>
+    {@link set}, reporting whether the patch was recorded: `true` when it
+    reached the store, `false` when the write was dropped.
+
+    A write can be dropped — conflicted away for good, or refused by a store
+    that errored — and {@link set} resolves the same either way, so a body
+    that needs the value to be durable cannot tell. This is the seam for the
+    cases that do need to know: before an irreversible step that depends on
+    the value, or before handing a compensation something it will have to read
+    back.
+
+    Do not read `false` as "it may still land": a dropped write is sometimes
+    re-persisted by a later one, but nothing guarantees it, so treat `false`
+    as not recorded. A dropped write also warns, and one that is definitely
+    unrecoverable marks the run {@link "./state/types.ts".RunRecord.degraded}
+    so a later resume knows the record is missing something.
+
+    A handle with nothing durable behind it always answers `true` — a build
+    with no state store, and a compensation, whose state is in-memory by
+    design. Nothing is persisted, but nothing is dropped either.
   get(): Record<string, JsonValue>
     Read this target's persisted metadata (from prior attempts/runs too).
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4478,6 +4478,26 @@ interface TargetStateHandle
 
   set(patch: Record<string, JsonValue>): Promise<void>
     Merge a JSON patch into this target's persisted metadata (awaits the write).
+  trySet(patch: Record<string, JsonValue>): Promise<boolean>
+    {@link set}, reporting whether the patch was recorded: `true` when it
+    reached the store, `false` when the write was dropped.
+
+    A write can be dropped — conflicted away for good, or refused by a store
+    that errored — and {@link set} resolves the same either way, so a body
+    that needs the value to be durable cannot tell. This is the seam for the
+    cases that do need to know: before an irreversible step that depends on
+    the value, or before handing a compensation something it will have to read
+    back.
+
+    Do not read `false` as "it may still land": a dropped write is sometimes
+    re-persisted by a later one, but nothing guarantees it, so treat `false`
+    as not recorded. A dropped write also warns, and one that is definitely
+    unrecoverable marks the run {@link "./state/types.ts".RunRecord.degraded}
+    so a later resume knows the record is missing something.
+
+    A handle with nothing durable behind it always answers `true` — a build
+    with no state store, and a compensation, whose state is in-memory by
+    design. Nothing is persisted, but nothing is dropped either.
   get(): Record<string, JsonValue>
     Read this target's persisted metadata (from prior attempts/runs too).
 

--- a/packages/core/src/cancel.ts
+++ b/packages/core/src/cancel.ts
@@ -214,6 +214,15 @@ function seededStateHandle(seed: Record<string, JsonValue>): TargetStateHandle {
       Object.assign(meta, patch);
       return Promise.resolve();
     },
+    // In-memory by design, so the patch is never dropped and `true` is the
+    // honest answer — see the note above about not persisting cleanup state.
+    // A compensation runs only for a run that HAS a store, so this is the one
+    // durable-run context whose writes never reach it; `TargetStateHandle`
+    // names compensations in its carve-out for exactly that reason.
+    trySet: (patch) => {
+      Object.assign(meta, patch);
+      return Promise.resolve(true);
+    },
   };
 }
 
@@ -349,15 +358,27 @@ export async function runCompensations(
       );
       continue;
     }
+    // Built once each, so `stateOf(self) === state` holds here too — the
+    // invariant `TargetContext.stateOf` documents.
+    const ownState = seededStateHandle(step.meta);
+    const otherState = new Map<string, TargetStateHandle>();
     const ctx: TargetContext = {
       runId: deps.runId,
       target: compName,
       signal: NEVER_ABORTED,
-      state: seededStateHandle(step.meta),
+      state: ownState,
       // A compensation runs off the durable graph, so only its own seeded state
-      // is available; other targets read as empty here.
-      stateOf: (t) =>
-        t === compName ? seededStateHandle(step.meta) : seededStateHandle({}),
+      // is available; other targets read as empty here. One handle per name,
+      // because a fresh one per call drops every write into a throwaway the
+      // next call cannot see — and reports that drop as a successful write.
+      stateOf: (t) => {
+        if (t === compName) return ownState;
+        const existing = otherState.get(t);
+        if (existing !== undefined) return existing;
+        const handle = seededStateHandle({});
+        otherState.set(t, handle);
+        return handle;
+      },
       // Outcomes, unlike state, come from the record the walk is reading — so a
       // compensation can ask what actually happened to the run it is undoing,
       // including in a process that never executed any of it.

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -256,8 +256,10 @@ function targetContextFor(
   dryRun: boolean,
   summary: TargetSummary,
 ): TargetContext {
-  // `stateOf(self)` returns this very handle, so the invariant documented on
-  // `TargetContext.stateOf` holds by construction rather than by a name check.
+  // One own-state handle, reused for `stateOf(this target)`. The name check
+  // below is what holds the documented `stateOf(self) === state` invariant:
+  // the writer builds a fresh handle object per call, so asking it twice would
+  // otherwise hand a body two different objects for its own state.
   const ownState = stateHandleFor(env, name);
   return {
     runId: env.runId,
@@ -265,7 +267,7 @@ function targetContextFor(
     target: name,
     signal: env.signal,
     state: ownState,
-    stateOf: (t) => stateHandleFor(env, t),
+    stateOf: (t) => t === name ? ownState : stateHandleFor(env, t),
     outcomeOf: (t) => outcomeOf(env, t),
     outcomes: () => allOutcomes(env),
     signals: env.signals,

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -44,6 +44,7 @@ import {
   type TargetBuilder,
   type TargetContext,
   type TargetOutcomeView,
+  type TargetStateHandle,
 } from "./target.ts";
 import type { BuildCache } from "./cache.ts";
 import { ServiceBuilder, type ServiceRegistry } from "./service.ts";
@@ -209,28 +210,62 @@ async function runBodyWithRecovery(
  * `.waitsFor(...)` gate whose trigger is already satisfied — that gate returns
  * early, and its effects are owed at exactly that moment.
  */
+/**
+ * A family of in-memory state handles, one per target, created on demand.
+ *
+ * The handles have to be *stable*: a fresh {@link inMemoryStateHandle} per
+ * `stateOf(...)` call writes into a throwaway the next call cannot see, and
+ * because such a write cannot fail it reports that drop as a successful write.
+ * Keeping one per target is also what makes `stateOf(self) === state` hold
+ * store-less, which {@link "./target.ts".TargetContext.stateOf} documents.
+ */
+function inMemoryHandles(): (target: string) => TargetStateHandle {
+  const byTarget = new Map<string, TargetStateHandle>();
+  return (target) => {
+    const existing = byTarget.get(target);
+    if (existing !== undefined) return existing;
+    const handle = inMemoryStateHandle();
+    byTarget.set(target, handle);
+    return handle;
+  };
+}
+
+/**
+ * The store-less handles of one run, keyed by its env so they live exactly as
+ * long as the run does.
+ */
+const noStoreHandles = new WeakMap<
+  RunEnv,
+  (target: string) => TargetStateHandle
+>();
+
+/** The state handle for `target`: durable when the run has a writer. */
+function stateHandleFor(env: RunEnv, target: string): TargetStateHandle {
+  if (env.writer) return env.writer.stateHandle(target);
+  let handles = noStoreHandles.get(env);
+  if (handles === undefined) {
+    handles = inMemoryHandles();
+    noStoreHandles.set(env, handles);
+  }
+  return handles(target);
+}
+
 function targetContextFor(
   name: string,
   env: RunEnv,
   dryRun: boolean,
   summary: TargetSummary,
 ): TargetContext {
-  // One own-state handle, reused for `stateOf(this target)` so the documented
-  // `stateOf(self) === state` invariant holds even store-less (a fresh
-  // inMemoryStateHandle per call would drop writes).
-  const ownState = env.writer
-    ? env.writer.stateHandle(name)
-    : inMemoryStateHandle();
+  // `stateOf(self)` returns this very handle, so the invariant documented on
+  // `TargetContext.stateOf` holds by construction rather than by a name check.
+  const ownState = stateHandleFor(env, name);
   return {
     runId: env.runId,
     ...(env.initiator === undefined ? {} : { initiator: env.initiator }),
     target: name,
     signal: env.signal,
     state: ownState,
-    stateOf: (t) =>
-      t === name
-        ? ownState
-        : (env.writer ? env.writer.stateHandle(t) : inMemoryStateHandle()),
+    stateOf: (t) => stateHandleFor(env, t),
     outcomeOf: (t) => outcomeOf(env, t),
     outcomes: () => allOutcomes(env),
     signals: env.signals,
@@ -428,14 +463,17 @@ async function runTarget(
     // execute. State is in-memory only (a dry run persists nothing), and no lock
     // or cache is taken.
     if (t.dryRunnable_ && t.fn_ !== undefined) {
-      const echoState = inMemoryStateHandle();
+      // Echoed, never persisted — but still one handle per target, so a dry
+      // run does not report writes it silently discarded.
+      const echo = inMemoryHandles();
+      const echoState = echo(name);
       const summary = new TargetSummary();
       const targetCtx: TargetContext = {
         runId: env.runId,
         target: name,
         signal: env.signal,
         state: echoState,
-        stateOf: (t2) => t2 === name ? echoState : inMemoryStateHandle(),
+        stateOf: (t2) => echo(t2),
         outcomeOf: (t2) => outcomeOf(env, t2),
         outcomes: () => allOutcomes(env),
         signals: env.signals,

--- a/packages/core/src/state/writer.ts
+++ b/packages/core/src/state/writer.ts
@@ -132,7 +132,7 @@ export class RunStateWriter {
    * already sitting on the chain are neutralised too.
    */
   #disowned = false;
-  #chain: Promise<void> = Promise.resolve();
+  #chain: Promise<unknown> = Promise.resolve();
 
   private constructor(
     store: StateStore,
@@ -218,13 +218,13 @@ export class RunStateWriter {
 
   /** Await every write queued so far, so nothing is still persisting on return. */
   drain(): Promise<void> {
-    return this.#chain;
+    return this.#chain.then(() => {});
   }
 
   /** Mark a target `running` and stamp its start time. */
   markTargetRunning(name: string): Promise<void> {
     const at = this.#now();
-    return this.#update((record) => {
+    return this.#updateVoid((record) => {
       const target = ensureTarget(record, name);
       target.status = "running";
       target.startedAt = at;
@@ -253,7 +253,7 @@ export class RunStateWriter {
         key: e.key,
         value: this.#redactor.redact(e.value),
       }));
-    return this.#update((record) => {
+    return this.#updateVoid((record) => {
       const target = ensureTarget(record, name);
       // Settling drops the target's `waitingFor` (e.g. a gate satisfied on
       // resume) — see `settleTargetRow`.
@@ -290,7 +290,7 @@ export class RunStateWriter {
 
   /** Record the run's terminal status, unless another process already has. */
   markRunFinished(ok: boolean): Promise<void> {
-    return this.#update((record) => {
+    return this.#updateVoid((record) => {
       // Whoever settled this run owns how it ended. The per-target progress
       // recorded alongside is still worth keeping, so this is a no-op rather
       // than a refusal.
@@ -301,7 +301,7 @@ export class RunStateWriter {
 
   /** Record a target as waiting on an external event, with its pending wait. */
   markTargetWaiting(name: string, wait: WaitState): Promise<void> {
-    return this.#update((record) => {
+    return this.#updateVoid((record) => {
       // A run someone else has already settled has no gate left to park on.
       // Without this, the settled-elsewhere re-apply below would put `waiting`
       // back onto a terminal record — the one window where a `zuke cancel`
@@ -323,7 +323,7 @@ export class RunStateWriter {
 
   /** Record the run as suspended, unless another process already settled it. */
   markRunSuspended(): Promise<void> {
-    return this.#update((record) => {
+    return this.#updateVoid((record) => {
       if (this.#settledElsewhere) return;
       record.status = "suspended";
     });
@@ -331,7 +331,7 @@ export class RunStateWriter {
 
   /** Record the run as `cancelling` — asked to stop; compensations are running. */
   markRunCancelling(): Promise<void> {
-    return this.#update((record) => {
+    return this.#updateVoid((record) => {
       record.status = "cancelling";
     });
   }
@@ -339,7 +339,7 @@ export class RunStateWriter {
   /** Record the run as `cancelled` — the terminal state after compensations. */
   markRunCancelled(): Promise<void> {
     const at = this.#now();
-    return this.#update((record) => {
+    return this.#updateVoid((record) => {
       record.status = "cancelled";
       // The in-process half of the same sweep `finalizeCancelled` runs for an
       // out-of-process `zuke cancel`: a cancelled run has no live waiter, and
@@ -371,7 +371,7 @@ export class RunStateWriter {
     // happened", and it stays true whoever owns the run now. Losing them is the
     // worse outcome, because the thing most worth recording at that moment is
     // the rollback this process had already performed before it stopped.
-    return this.#update((record) => {
+    return this.#updateVoid((record) => {
       record.events.push(redacted);
     }, { evenIfDisowned: true });
   }
@@ -412,18 +412,22 @@ export class RunStateWriter {
 
   /** A {@link TargetStateHandle} bound to `name`, persisting through this writer. */
   stateHandle(name: string): TargetStateHandle {
+    const write = (patch: Record<string, JsonValue>): Promise<boolean> => {
+      const redacted: Record<string, JsonValue> = {};
+      for (const [key, value] of Object.entries(patch)) {
+        redacted[key] = redactJson(value, this.#redactor);
+      }
+      return this.#update((record) => {
+        const target = ensureTarget(record, name);
+        target.meta = { ...target.meta, ...redacted };
+      });
+    };
     return {
       get: () => ({ ...(this.#record.targets[name]?.meta ?? {}) }),
-      set: (patch) => {
-        const redacted: Record<string, JsonValue> = {};
-        for (const [key, value] of Object.entries(patch)) {
-          redacted[key] = redactJson(value, this.#redactor);
-        }
-        return this.#update((record) => {
-          const target = ensureTarget(record, name);
-          target.meta = { ...target.meta, ...redacted };
-        });
-      },
+      // One write, two ways to ask about it: `set` discards the answer, which
+      // is what almost every body wants.
+      set: async (patch) => void await write(patch),
+      trySet: write,
     };
   }
 
@@ -506,14 +510,34 @@ export class RunStateWriter {
   }
 
   /** Serialise `mutator` after all pending writes, then persist (best-effort). */
-  #update(
+  /**
+   * {@link "#update"} for the transitions whose caller has no use for whether
+   * the write landed — the run's own status bookkeeping, which reports a
+   * dropped write through the warning and the `degraded` flag rather than to a
+   * caller. Only a target's `set` hands the answer back to a build body.
+   */
+  #updateVoid(
     mutator: (record: RunRecord) => void,
     options: { evenIfDisowned?: boolean } = {},
   ): Promise<void> {
-    this.#chain = this.#chain.then(() =>
+    return this.#update(mutator, options).then(() => {});
+  }
+
+  #update(
+    mutator: (record: RunRecord) => void,
+    options: { evenIfDisowned?: boolean } = {},
+  ): Promise<boolean> {
+    // Stored and returned as the *same* promise, as it always was. Deriving a
+    // second one for the chain would leave that copy's rejection unhandled —
+    // and `#applyAndPersist` can reject, because the warning callback it calls
+    // is outside its try (a reporter writing to a closed pipe throws). Deno
+    // kills the process on an unhandled rejection, so `zuke build | head -1`
+    // would exit 1 for want of a `.catch` nobody could see.
+    const landed = this.#chain.then(() =>
       this.#applyAndPersist(mutator, options.evenIfDisowned === true)
     );
-    return this.#chain;
+    this.#chain = landed;
+    return landed;
   }
 
   /**
@@ -665,8 +689,8 @@ export class RunStateWriter {
   async #applyAndPersist(
     mutator: (record: RunRecord) => void,
     evenIfDisowned = false,
-  ): Promise<void> {
-    if (this.#disowned && !evenIfDisowned) return;
+  ): Promise<boolean> {
+    if (this.#disowned && !evenIfDisowned) return false;
     try {
       for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
         mutator(this.#record);
@@ -674,7 +698,7 @@ export class RunStateWriter {
         const result = await this.#store.putRun(this.#record, this.#version);
         if (result.ok) {
           this.#version = result.version;
-          return;
+          return true;
         }
         // Another writer moved the record on: re-read a FRESH base and re-apply
         // the mutator to it on the next iteration. If the run has vanished
@@ -688,7 +712,7 @@ export class RunStateWriter {
             `state: run "${this.#record.id}" vanished from the store ` +
               `mid-write; dropping one update`,
           );
-          return;
+          return false;
         }
         // Adopt the fresh base, but carry a degraded flag across: whoever wrote
         // the record in the store never saw the write we already lost.
@@ -729,19 +753,21 @@ export class RunStateWriter {
             );
           }
           this.#onExternalCancel?.();
-          return;
+          return reapply.ok;
         }
       }
       this.#lostWrite(
         `state: gave up persisting run "${this.#record.id}" after ` +
           `${MAX_RETRIES} conflicting writes`,
       );
+      return false;
     } catch (error) {
       this.#retainedWrite(
         `state: failed to persist run "${this.#record.id}": ${
           messageOf(error)
         }`,
       );
+      return false;
     }
   }
 }
@@ -758,6 +784,13 @@ export function inMemoryStateHandle(): TargetStateHandle {
     set: (patch) => {
       Object.assign(meta, patch);
       return Promise.resolve();
+    },
+    // Nothing is persisted, but nothing is dropped either: the patch is
+    // retained for this process, which is all a build with no store asked for.
+    // Answering `false` here would make every such write look failed.
+    trySet: (patch) => {
+      Object.assign(meta, patch);
+      return Promise.resolve(true);
     },
   };
 }

--- a/packages/core/src/target.ts
+++ b/packages/core/src/target.ts
@@ -275,6 +275,28 @@ export type JsonValue =
 export interface TargetStateHandle {
   /** Merge a JSON patch into this target's persisted metadata (awaits the write). */
   set(patch: Record<string, JsonValue>): Promise<void>;
+  /**
+   * {@link set}, reporting whether the patch was recorded: `true` when it
+   * reached the store, `false` when the write was dropped.
+   *
+   * A write can be dropped — conflicted away for good, or refused by a store
+   * that errored — and {@link set} resolves the same either way, so a body
+   * that needs the value to be durable cannot tell. This is the seam for the
+   * cases that do need to know: before an irreversible step that depends on
+   * the value, or before handing a compensation something it will have to read
+   * back.
+   *
+   * Do not read `false` as "it may still land": a dropped write is sometimes
+   * re-persisted by a later one, but nothing guarantees it, so treat `false`
+   * as not recorded. A dropped write also warns, and one that is definitely
+   * unrecoverable marks the run {@link "./state/types.ts".RunRecord.degraded}
+   * so a later resume knows the record is missing something.
+   *
+   * A handle with nothing durable behind it always answers `true` — a build
+   * with no state store, and a compensation, whose state is in-memory by
+   * design. Nothing is persisted, but nothing is dropped either.
+   */
+  trySet(patch: Record<string, JsonValue>): Promise<boolean>;
   /** Read this target's persisted metadata (from prior attempts/runs too). */
   get(): Record<string, JsonValue>;
 }

--- a/packages/core/tests/state_set_result_test.ts
+++ b/packages/core/tests/state_set_result_test.ts
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Unit tests for what `ctx.state.set` reports back: `true` only when the patch
+ * reached the store. Every way a write can be dropped — conflicted away,
+ * errored, written onto a run this process no longer owns — answers `false`,
+ * because a body checking the result is asking whether the value is durable
+ * now, and each of those says it is not.
+ *
+ * @module
+ */
+
+import { assertEquals } from "./_assert.ts";
+import { Redactor } from "../src/redact.ts";
+import { inMemoryStateHandle, RunStateWriter } from "../src/state/writer.ts";
+import { MemStateStore, runRecord } from "./_fakes.ts";
+import type { TargetStateHandle } from "../src/target.ts";
+
+const NOW = "2026-09-08T12:00:00.000Z";
+
+/** A writer over `store`, adopted on a running one-target run. */
+async function adopted(
+  store: MemStateStore,
+  warn?: (message: string) => void,
+): Promise<{ writer: RunStateWriter; handle: TargetStateHandle }> {
+  const record = runRecord({
+    id: "r1",
+    rootTarget: "deploy",
+    status: "running",
+    targets: { deploy: { status: "running", meta: {} } },
+  });
+  const put = await store.putRun(record, null);
+  assertEquals(put.ok, true);
+  if (!put.ok) throw new Error("unreachable: the first put cannot conflict");
+  const writer = RunStateWriter.adopt(
+    store,
+    structuredClone(record),
+    put.version,
+    () => NOW,
+    new Redactor(),
+    warn,
+  );
+  return { writer, handle: writer.stateHandle("deploy") };
+}
+
+Deno.test("a write that reaches the store reports true", async () => {
+  const store = new MemStateStore();
+  const { handle } = await adopted(store);
+  assertEquals(await handle.trySet({ slot: "sit-7" }), true);
+  assertEquals(store.record?.targets.deploy.meta, { slot: "sit-7" });
+});
+
+Deno.test("a write conflicted away for good reports false", async () => {
+  const store = new MemStateStore();
+  const warnings: string[] = [];
+  const { writer, handle } = await adopted(store, (m) => warnings.push(m));
+  store.forceConflicts = 99; // never lands
+
+  // The failure a body most needs to hear about: the patch went with a base
+  // that was replaced, so nothing carries it forward.
+  assertEquals(await handle.trySet({ slot: "sit-7" }), false);
+  assertEquals(writer.snapshot().degraded, true);
+  assertEquals(warnings.length, 1);
+  assertEquals(store.record?.targets.deploy.meta, {});
+});
+
+Deno.test("a write the store errored on reports false", async () => {
+  const store = new MemStateStore();
+  const { writer, handle } = await adopted(store);
+  store.failNextPut = true;
+
+  // Retained rather than lost — a later write may carry it — but it is not
+  // durable now, which is the question `set` answers. So no `degraded` flag,
+  // and still `false`.
+  assertEquals(await handle.trySet({ slot: "sit-7" }), false);
+  assertEquals(writer.snapshot().degraded, undefined);
+});
+
+Deno.test("a write onto a vanished run reports false", async () => {
+  const store = new MemStateStore();
+  const { handle } = await adopted(store);
+  store.forceConflicts = 1;
+  store.vanish = true; // pruned between the conflict and the re-read
+
+  assertEquals(await handle.trySet({ slot: "sit-7" }), false);
+});
+
+Deno.test("a write from a process that no longer owns the run reports false", async () => {
+  const store = new MemStateStore();
+  const { handle, writer } = await adopted(store);
+  writer.disown();
+
+  // A disowned writer drops every write by design: the run has a new holder,
+  // and this process must not claim its patch was recorded.
+  assertEquals(await handle.trySet({ slot: "sit-7" }), false);
+  assertEquals(store.record?.targets.deploy.meta, {});
+});
+
+Deno.test("a build with no state store always reports true", async () => {
+  const handle = inMemoryStateHandle();
+  // Nothing is persisted, but nothing is dropped either — answering `false`
+  // would make every write of a store-less build look failed.
+  assertEquals(await handle.trySet({ slot: "sit-7" }), true);
+  assertEquals(handle.get(), { slot: "sit-7" });
+});
+
+Deno.test("a write re-applied onto a run settled elsewhere reports true", async () => {
+  const store = new MemStateStore();
+  const { handle } = await adopted(store);
+  store.forceConflicts = 1;
+  store.freshStatus = "cancelled"; // another process settled it mid-write
+
+  // The writer deliberately re-applies target-level work onto the settler's
+  // record so it is not lost to the compensation walk. That re-apply landed,
+  // so the patch is durable and the body is told so.
+  assertEquals(await handle.trySet({ slot: "sit-7" }), true);
+  assertEquals(store.record?.targets.deploy.meta, { slot: "sit-7" });
+});
+
+Deno.test("a write whose re-apply also conflicts reports false", async () => {
+  const store = new MemStateStore();
+  const warnings: string[] = [];
+  const { writer, handle } = await adopted(store, (m) => warnings.push(m));
+  store.forceConflicts = 2; // the write conflicts, and so does the re-apply
+  store.freshStatus = "cancelled";
+
+  // The settler finalises from here, so no later write of ours carries it.
+  assertEquals(await handle.trySet({ slot: "sit-7" }), false);
+  assertEquals(writer.snapshot().degraded, true);
+  assertEquals(warnings.length, 1);
+});
+
+Deno.test("a rejecting write is not also an unhandled rejection", async () => {
+  const store = new MemStateStore();
+  // The warning callback is called outside the persist try, so it can reject
+  // the write — in production it writes to the reporter, which throws on a
+  // closed pipe (`zuke build | head -1`). Deno kills the process on an
+  // unhandled rejection, so the chain must not hold a second, unwatched copy.
+  const { handle } = await adopted(store, () => {
+    throw new Error("reporter is gone");
+  });
+  store.failNextPut = true;
+
+  let caught: string | undefined;
+  try {
+    await handle.trySet({ slot: "sit-7" });
+  } catch (error) {
+    caught = error instanceof Error ? error.message : String(error);
+  }
+  // The caller sees it, which is what makes it handled.
+  assertEquals(caught, "reporter is gone");
+});

--- a/packages/gh/tests/workflow_test.ts
+++ b/packages/gh/tests/workflow_test.ts
@@ -47,6 +47,10 @@ function fakeState(
       meta = { ...meta, ...patch };
       return Promise.resolve();
     },
+    trySet: (patch) => {
+      meta = { ...meta, ...patch };
+      return Promise.resolve(true);
+    },
   };
 }
 

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/.codex-plugin/plugin.json
+++ b/plugins/zuke/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/skills/zuke-write-build/SKILL.md
+++ b/plugins/zuke/skills/zuke-write-build/SKILL.md
@@ -142,7 +142,11 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   `ZUKE_*_URL` backend must be `https:` (loopback exempt;
   `ZUKE_ALLOW_INSECURE_URL=1` opts out). In a body, `ctx.state.set({ … })` /
   `ctx.state.get()` records per-target metadata (JSON, **never secrets** —
-  secret parameters and redacted values are excluded). Inspect persisted runs
+  secret parameters and redacted values are excluded). `set` awaits the
+  write; `ctx.state.trySet({ … })` is the same write reporting `true` when it
+  reached the store and `false` when it was dropped — use it before an
+  irreversible step that depends on the value. A store-less build and a
+  compensation body always see `true` (nothing durable behind them). Inspect persisted runs
   afterwards with `zuke runs list` (filter by
   `--status`/`--target`/`--since`/`--limit`) and `zuke runs show <id>` (`--json`
   on both). Prune old ones with `zuke runs prune --keep <age> --keep-last <n>`

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -150,6 +150,7 @@ deploy = target().executes(async (ctx) => {
   ctx.signal; // AbortSignal, fired when the run is cancelled
   ctx.dryRun; // true under a dry run
   await ctx.state.set({ where: "sit-7" }); // durable metadata — see below
+  await ctx.state.trySet({ where: "sit-7" }); // ...same write, false if dropped
   ctx.stateOf("build").get(); // read ANOTHER target's published state
   ctx.signals.get("approved"); // an external signal's payload (see waits)
   ctx.outcomeOf("checks")?.status; // one target's settled outcome, or undefined
@@ -210,7 +211,9 @@ class CD extends Build {
     return new HttpStateStore({ url: this.url.value, token: this.token.value });
   }
   deploy = target().executes(async (ctx) => {
-    await ctx.state.set({ image: tag }); // JSON patch, merged and persisted
+    // trySet resolves true when the patch reached the store, false when the
+    // write was dropped. Check it before an irreversible step that needs it.
+    if (!await ctx.state.trySet({ image: tag })) throw new Error("not recorded");
     const meta = ctx.state.get(); // read back (this run and later ones)
   });
 }

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -142,7 +142,11 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   `ZUKE_*_URL` backend must be `https:` (loopback exempt;
   `ZUKE_ALLOW_INSECURE_URL=1` opts out). In a body, `ctx.state.set({ … })` /
   `ctx.state.get()` records per-target metadata (JSON, **never secrets** —
-  secret parameters and redacted values are excluded). Inspect persisted runs
+  secret parameters and redacted values are excluded). `set` awaits the
+  write; `ctx.state.trySet({ … })` is the same write reporting `true` when it
+  reached the store and `false` when it was dropped — use it before an
+  irreversible step that depends on the value. A store-less build and a
+  compensation body always see `true` (nothing durable behind them). Inspect persisted runs
   afterwards with `zuke runs list` (filter by
   `--status`/`--target`/`--since`/`--limit`) and `zuke runs show <id>` (`--json`
   on both). Prune old ones with `zuke runs prune --keep <age> --keep-last <n>`

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -150,6 +150,7 @@ deploy = target().executes(async (ctx) => {
   ctx.signal; // AbortSignal, fired when the run is cancelled
   ctx.dryRun; // true under a dry run
   await ctx.state.set({ where: "sit-7" }); // durable metadata — see below
+  await ctx.state.trySet({ where: "sit-7" }); // ...same write, false if dropped
   ctx.stateOf("build").get(); // read ANOTHER target's published state
   ctx.signals.get("approved"); // an external signal's payload (see waits)
   ctx.outcomeOf("checks")?.status; // one target's settled outcome, or undefined
@@ -210,7 +211,9 @@ class CD extends Build {
     return new HttpStateStore({ url: this.url.value, token: this.token.value });
   }
   deploy = target().executes(async (ctx) => {
-    await ctx.state.set({ image: tag }); // JSON patch, merged and persisted
+    // trySet resolves true when the patch reached the store, false when the
+    // write was dropped. Check it before an irreversible step that needs it.
+    if (!await ctx.state.trySet({ image: tag })) throw new Error("not recorded");
     const meta = ctx.state.get(); // read back (this run and later ones)
   });
 }

--- a/tests/integration/_harness.ts
+++ b/tests/integration/_harness.ts
@@ -80,6 +80,28 @@ export async function runCli(
  * suspend a run and a later call resume it. Restores the previous env var and
  * removes the directory afterwards, even on failure.
  */
+/**
+ * Run `fn` with **no** state store configured, whatever the ambient
+ * environment says.
+ *
+ * A test asserting store-less behaviour is otherwise at the mercy of a
+ * developer's or a runner's `ZUKE_STATE_DIR`: the run quietly gets a real
+ * store, the premise evaporates, and the test either fails for a reason that
+ * has nothing to do with it or passes while proving something else.
+ */
+export async function withoutStateDir(fn: () => Promise<void>): Promise<void> {
+  const prev = Deno.env.get("ZUKE_STATE_DIR");
+  const prevUrl = Deno.env.get("ZUKE_STATE_URL");
+  Deno.env.delete("ZUKE_STATE_DIR");
+  Deno.env.delete("ZUKE_STATE_URL");
+  try {
+    await fn();
+  } finally {
+    if (prev !== undefined) Deno.env.set("ZUKE_STATE_DIR", prev);
+    if (prevUrl !== undefined) Deno.env.set("ZUKE_STATE_URL", prevUrl);
+  }
+}
+
 export async function withStateDir(
   fn: (dir: string) => Promise<void>,
 ): Promise<void> {

--- a/tests/integration/state_test.ts
+++ b/tests/integration/state_test.ts
@@ -19,7 +19,7 @@ import {
   FileSystemStateStore,
   target,
 } from "../../packages/core/mod.ts";
-import { runCli, withStateDir } from "./_harness.ts";
+import { runCli, withoutStateDir, withStateDir } from "./_harness.ts";
 
 /** Open a store over the temp state dir the harness configured. */
 function storeAt(dir: string): FileSystemStateStore {
@@ -273,37 +273,57 @@ Deno.test("a body reads back whether its durable write landed", async () => {
 });
 
 Deno.test("a store-less build still reports its write as recorded", async () => {
-  const reported: boolean[] = [];
-  class B extends Build {
-    // No wait, no lock, no effect: nothing turns the state store on, so the
-    // handle is the in-memory one. Its writes are never dropped, so telling
-    // the body they failed would be a lie in the unhelpful direction.
-    build = target().executes(async (ctx) => {
-      reported.push(await ctx.state.trySet({ tag: "v1" }));
-    });
-  }
-  const run = await runCli(B, ["build"]);
-  assertEquals(run.code, 0);
-  assertEquals(reported, [true]);
+  await withoutStateDir(async () => {
+    const reported: boolean[] = [];
+    class B extends Build {
+      // No wait, no lock, no effect: nothing turns the state store on, so the
+      // handle is the in-memory one. Its writes are never dropped, so telling
+      // the body they failed would be a lie in the unhelpful direction.
+      build = target().executes(async (ctx) => {
+        reported.push(await ctx.state.trySet({ tag: "v1" }));
+      });
+    }
+    const run = await runCli(B, ["build"]);
+    assertEquals(run.code, 0);
+    assertEquals(reported, [true]);
+  });
 });
 
 Deno.test("a store-less run keeps one state handle per target", async () => {
-  const seen: Record<string, unknown>[] = [];
-  let sameObject = false;
-  class B extends Build {
-    build = target().executes(async (ctx) => {
-      sameObject = ctx.stateOf("build") === ctx.state;
-      await ctx.stateOf("build").trySet({ tag: "v1" });
-    });
-    ship = target().dependsOn(this.build).executes(async (ctx) => {
-      await ctx.stateOf("build").trySet({ note: "x" });
-      // Read through a *second* call: a fresh handle per call would drop the
-      // write above and answer {}, while reporting that write as successful.
-      seen.push(ctx.stateOf("build").get());
-    });
-  }
-  const run = await runCli(B, ["ship"]);
-  assertEquals(run.code, 0);
-  assertEquals(sameObject, true); // stateOf(self) === state, as documented
-  assertEquals(seen, [{ tag: "v1", note: "x" }]);
+  await withoutStateDir(async () => {
+    const seen: Record<string, unknown>[] = [];
+    let sameObject = false;
+    class B extends Build {
+      build = target().executes(async (ctx) => {
+        sameObject = ctx.stateOf("build") === ctx.state;
+        await ctx.stateOf("build").trySet({ tag: "v1" });
+      });
+      ship = target().dependsOn(this.build).executes(async (ctx) => {
+        await ctx.stateOf("build").trySet({ note: "x" });
+        // Read through a *second* call: a fresh handle per call would drop the
+        // write above and answer {}, while reporting it as a successful write.
+        seen.push(ctx.stateOf("build").get());
+      });
+    }
+    const run = await runCli(B, ["ship"]);
+    assertEquals(run.code, 0);
+    assertEquals(sameObject, true); // stateOf(self) === state, as documented
+    assertEquals(seen, [{ tag: "v1", note: "x" }]);
+  });
+});
+
+Deno.test("a run WITH a store also hands a body one handle for its own state", async () => {
+  await withStateDir(async () => {
+    let sameObject = false;
+    class B extends Build {
+      // The writer builds a fresh handle object per call, so this invariant is
+      // held by the context's own name check, not by the writer.
+      deploy = target().executes((ctx) => {
+        sameObject = ctx.stateOf("deploy") === ctx.state;
+      });
+    }
+    const run = await runCli(B, ["deploy"]);
+    assertEquals(run.code, 0);
+    assertEquals(sameObject, true);
+  });
 });

--- a/tests/integration/state_test.ts
+++ b/tests/integration/state_test.ts
@@ -250,3 +250,60 @@ Deno.test("a target loses a held lock and fails with the conflict guidance", asy
     assertEquals(log.includes("deploy"), false); // body never ran
   });
 });
+
+Deno.test("a body reads back whether its durable write landed", async () => {
+  await withStateDir(async (dir) => {
+    const reported: boolean[] = [];
+    class B extends Build {
+      deploy = target().executes(async (ctx) => {
+        // The result is what a body checks before doing something irreversible
+        // that depends on the value having been recorded.
+        reported.push(await ctx.state.trySet({ slot: "sit-7" }));
+      });
+    }
+    const run = await runCli(B, ["deploy"]);
+    assertEquals(run.code, 0);
+    assertEquals(reported, [true]);
+
+    // And the value really is in the record the next process would read.
+    const id = (await storeAt(dir).listRuns({}))[0].id;
+    const meta = (await storeAt(dir).getRun(id))?.record.targets["deploy"].meta;
+    assertEquals(meta, { slot: "sit-7" });
+  });
+});
+
+Deno.test("a store-less build still reports its write as recorded", async () => {
+  const reported: boolean[] = [];
+  class B extends Build {
+    // No wait, no lock, no effect: nothing turns the state store on, so the
+    // handle is the in-memory one. Its writes are never dropped, so telling
+    // the body they failed would be a lie in the unhelpful direction.
+    build = target().executes(async (ctx) => {
+      reported.push(await ctx.state.trySet({ tag: "v1" }));
+    });
+  }
+  const run = await runCli(B, ["build"]);
+  assertEquals(run.code, 0);
+  assertEquals(reported, [true]);
+});
+
+Deno.test("a store-less run keeps one state handle per target", async () => {
+  const seen: Record<string, unknown>[] = [];
+  let sameObject = false;
+  class B extends Build {
+    build = target().executes(async (ctx) => {
+      sameObject = ctx.stateOf("build") === ctx.state;
+      await ctx.stateOf("build").trySet({ tag: "v1" });
+    });
+    ship = target().dependsOn(this.build).executes(async (ctx) => {
+      await ctx.stateOf("build").trySet({ note: "x" });
+      // Read through a *second* call: a fresh handle per call would drop the
+      // write above and answer {}, while reporting that write as successful.
+      seen.push(ctx.stateOf("build").get());
+    });
+  }
+  const run = await runCli(B, ["ship"]);
+  assertEquals(run.code, 0);
+  assertEquals(sameObject, true); // stateOf(self) === state, as documented
+  assertEquals(seen, [{ tag: "v1", note: "x" }]);
+});


### PR DESCRIPTION
### The problem

`ctx.state.set` resolves the same way whether the patch was persisted or permanently lost, so a body cannot tell that its durable write did not happen.

`RunStateWriter` has three outcomes and one return type. The write lands; or it is **held back** — a store error left the mutation in memory; or it is **permanently lost** — the mutation went with a base that was replaced, or a re-apply onto a record another process settled failed. The lossy paths mark the record `degraded` and warn on the console. All three resolved `Promise<void>`.

The read-back makes it concrete. After a lost write the body's own `ctx.state.get` no longer sees the value it just set, because the in-memory record was replaced by the fresh read:

    set resolved with: undefined
    warnings: 1 · state: gave up persisting run "r1" after 5 conflicting writes
    degraded: true
    read-back:  {}

This is item 14.2 of the maintainer proposal.

### The shape, and why it is not a widened `set`

The obvious change is to make `set` return the boolean. **That is a breaking change under this repo's own promise**, and I had built it that way before an adversarial pass showed it. `docs/versioning.md` says a `1.x` release never breaks a public symbol and a breaking change bumps the **major**; `bump-minor-pre-major` is off. `TargetStateHandle` is exported from `mod.ts`, is the parameter type of `@zuke/gh`'s public `readWorkflowResult`, and is the type of `WaitContext.state` — so a consumer testing a gate writes exactly that shape.

The repo was its own witness: making `set` return a boolean broke `packages/gh/src/workflow.ts`, where a helper declared `Promise<void>` ended in a bare return of the state write, and broke a hand-written handle fake in `packages/gh/tests/`. Both had to be edited to make the change compile. `Promise<boolean>` is not assignable to `Promise<void>` — the void-return bivariance exemption applies to a bare `void` return, not a wrapped one.

So `set` keeps its signature and its behaviour, and `trySet` sits beside it. One write, two ways to ask about it. Both caller shapes that broke under the widening compile untouched now; the only residual is that a consumer who **implements** `TargetStateHandle` — you would only do that to fake a state handle in a test — gets a compile error naming the missing member, with a one-line fix. That is the trade the second method buys instead of a `@zuke/core` 2.0.0 that moves 57 wrappers' `^1` floors.

`false` deliberately covers a held-back write as well as a lost one. `true` claims the value is durable *now*, which is the question a body asks before an irreversible step; for that decision "not yet" and "never" are the same answer.

### What the adversarial review found

Two reviewers attacked the change across the truth of the boolean and the published contract. Every finding was reproduced against the running code before being fixed, and each fix is mutation-checked — removed the fix, watched the test fail, restored it.

**The signature change was breaking** (high). Described above. It is the reason this PR is titled `feat` and not `fix`, and the reason `set` is untouched.

**An unhandled rejection killed the process** (medium, a regression this change introduced). Threading the flag through meant deriving a second promise for the writer's serialisation chain, and nothing watched that copy. The warning callback runs outside the persist `try`, and in production it writes to the reporter — which throws on a closed pipe. So `zuke build` piped into `head -1` exited 1 for want of a `.catch` nobody could see. The chain stores and returns the same promise again.

**`true` was a lie for every store-less `stateOf` write** (medium). A fresh in-memory handle was minted per call, so the write went into a throwaway the next call could not see. That drop was silent before; the new answer would have reported it as a successful write. Fixed the drop rather than reporting it: one handle per target per run. It was already false inside a compensation, where a fresh seeded handle was built even for the target's own state.

**Removing the name check broke that same invariant on the writer path** (medium, a second regression of mine, caught by re-reading the first fix). Memoizing the store-less handles looked like it made `stateOf(self) === state` hold by construction, so I dropped the check that had been holding it. It does not: the writer builds a fresh handle object per call, so with a store configured a body asking for its own state twice got two different objects. The check is back, and a new test pins the invariant on the writer path.

It surfaced only because the two store-less tests read an ambient `ZUKE_STATE_DIR` rather than guaranteeing there is none — so on a machine or runner that sets one they silently exercised the writer path. The harness gained a helper that clears it, which is the more useful half of the finding.

**A held-back write is silently destroyed** (medium, pre-existing). The internal contract says a later write carries it; the conflict path replaces the whole in-memory record, taking it with it, and leaves the record un-`degraded` so a resume trusts it. Not fixed here — filed as #511 — but the documentation no longer promises the recovery that does not happen.

**A compensation reported `true` for a write reaching no store** (high). Compensations only run for a run that *has* a store, so the "no state store" carve-out did not describe them, and a compensation following the cheatsheet's advice would have trusted a write that is in-memory by design. The carve-out now names compensations explicitly, in the JSDoc, the guide and the skill.

### Testing

12 new tests. Unit coverage of every outcome of the persist path — landed, conflicted away, store error, vanished run, disowned writer, re-applied onto a run settled elsewhere and its failure — each of the six returns individually mutation-checked; a regression for the unhandled rejection; and integration tests driving real builds through the CLI for the reported result, the store-less answer, and the one-handle-per-target fix.

`deno task ci`: 22/22 targets, 4339 tests, 98.4% lines and 97.4% branches against a 95% gate.

### Related issues

Closes #510

### Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a Conventional Commit.
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (the durable state guide, JSDoc).
- [x] Public API changes were regenerated with the API docs target.
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/`.
- [x] Agent skills updated and the plugin version bumped in all four manifests (0.46.0 to 0.47.0).
