### PR TITLE
fix(ci): keep the scorecard job within the allowlist scorecard.dev publishes from

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -9,17 +9,20 @@ name: Scorecard supply-chain
 permissions:
   contents: read
 jobs:
-  scorecardSarif:
+  scorecard:
     name: OpenSSF Scorecard
     runs-on: ubuntu-latest
     permissions:
       security-events: write
       id-token: write
     steps:
-      - name: Harden and check out with Zuke
-        uses: zuke-build/zuke@ec0b756878572e04145cd766e2268e55b8577abf # v1.0.3
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
           persist-credentials: "false"
       - name: Run Scorecard
         uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
@@ -27,7 +30,7 @@ jobs:
           results_file: results.sarif
           results_format: sarif
           publish_results: "true"
-      - name: Run scorecardSarif with Zuke
-        run: ./zuke scorecardSarif
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Upload the SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          sarif_file: results.sarif

--- a/build/action_pins.ts
+++ b/build/action_pins.ts
@@ -74,17 +74,22 @@ export const SEED_PINS: Readonly<Record<string, CiActionRef>> = {
     ref: "ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc",
     version: "v2.4.4",
   },
-  // The two halves of one action are pinned separately because pins are keyed
-  // by the full `uses:` path, subpath included — and must agree, since they
-  // ship as one release.
+  // The three subpaths of one action are pinned separately because pins are
+  // keyed by the full `uses:` path, subpath included — and must agree, since
+  // they ship as one release.
   "github/codeql-action/init": {
-    ref: "github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3",
-    version: "v4.37.6",
+    ref: "github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938",
+    version: "v4.37.9",
   },
   "github/codeql-action/analyze": {
     ref:
-      "github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3",
-    version: "v4.37.6",
+      "github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938",
+    version: "v4.37.9",
+  },
+  "github/codeql-action/upload-sarif": {
+    ref:
+      "github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938",
+    version: "v4.37.9",
   },
 };
 

--- a/build/workflows.ts
+++ b/build/workflows.ts
@@ -49,8 +49,8 @@ export interface WorkflowTargets {
   security: TargetBuilder;
   /** CodeQL static analysis, run entirely by the marketplace actions. */
   codeql: TargetBuilder;
-  /** Uploads the Scorecard SARIF to code scanning. */
-  scorecardSarif: TargetBuilder;
+  /** The OpenSSF Scorecard, run entirely by the marketplace actions. */
+  scorecard: TargetBuilder;
   /** The subprocess e2e suite, on an OS matrix. */
   integration: TargetBuilder;
 }
@@ -449,7 +449,7 @@ export function githubWorkflows(
         },
       },
       invokes: [{
-        target: targets.scorecardSarif,
+        target: targets.scorecard,
         name: "OpenSSF Scorecard",
         permissions: {
           // Upload the SARIF to the Security tab, and publish the score to the
@@ -457,19 +457,44 @@ export function githubWorkflows(
           "security-events": "write",
           "id-token": "write",
         },
-        // The one marketplace action that stays: publishing the public score is
-        // something only it can do, and it must run before the target that
-        // uploads its output.
-        before: [{
-          name: "Run Scorecard",
-          uses: actionPin("ossf/scorecard-action"),
-          with: {
-            results_file: "results.sarif",
-            results_format: "sarif",
-            publish_results: "true",
+        // scorecard.dev verifies this workflow before it accepts a published
+        // score, and the job holding `ossf/scorecard-action` must consist only
+        // of `uses:` steps from a short allowlist — checkout, harden-runner,
+        // upload-artifact, upload-sarif, and the scorecard action itself — with
+        // no `run:` step and no job-level `env`. Anything else is rejected with
+        // a 400 the action reports as a warning, so the job stays green while
+        // the badge silently stops moving. That happened here: the Zuke prelude
+        // and a `./zuke` step kept every publish since 2026-08-06 out.
+        //
+        // So this job opts out of the prelude — naming the two actions renders
+        // them as separate pinned steps — and the marketplace pair replaces
+        // the target's own step, exactly as the CodeQL job above does.
+        // `tests/scorecard_workflow_test.ts` holds the committed file to the
+        // allowlist. See https://github.com/ossf/scorecard-action#workflow-restrictions.
+        harden: {
+          action: actionPin("step-security/harden-runner"),
+          egress: "audit",
+        },
+        checkout: {
+          action: actionPin("actions/checkout"),
+          persistCredentials: false,
+        },
+        steps: [
+          {
+            name: "Run Scorecard",
+            uses: actionPin("ossf/scorecard-action"),
+            with: {
+              results_file: "results.sarif",
+              results_format: "sarif",
+              publish_results: "true",
+            },
           },
-        }],
-        env: { GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}" },
+          {
+            name: "Upload the SARIF to code scanning",
+            uses: actionPin("github/codeql-action/upload-sarif"),
+            with: { sarif_file: "results.sarif" },
+          },
+        ],
       }],
     }),
 

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -39,7 +39,7 @@ flowchart TD
   t28["security"]
   t29["actionPinCheck"]
   t30["ci"]
-  t31["scorecardSarif"]
+  t31["scorecard"]
   t32["codeql"]
   t33["reviewBase"]
   t34["review"]
@@ -111,7 +111,7 @@ flowchart TD
 | `security` | Run supply-chain security scanners (zuke/security) | — |
 | `actionPinCheck` | Verify the workflows only use inputs the released action has | — |
 | `ci` | Full pre-commit / CI gate | `format`, `lint`, `spell`, `coverage`, `coverageUpload`, `apiDocsCheck`, `docLint`, `snippetsCheck`, `examplesCheck`, `hclSyncCheck`, `pluginSyncCheck`, `skillsCheck`, `graphDocCheck`, `pluginVersionCheck`, `prBodyLint`, `actionPinCheck`, `security`, `lockCheck` |
-| `scorecardSarif` | Upload the Scorecard SARIF to GitHub code scanning | — |
+| `scorecard` | OpenSSF Scorecard (runs in CI via scorecard.yml) | — |
 | `codeql` | CodeQL static analysis (runs in CI via codeql.yml) | — |
 | `reviewBase` | Fetch the base branch the AI review diffs against | — |
 | `review` | AI review of the diff (security + code quality) | `reviewBase` |

--- a/tests/_workflow.ts
+++ b/tests/_workflow.ts
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Shared readers for the committed GitHub workflows, for the tests that assert
+ * a property of a generated file rather than of the declaration behind it.
+ *
+ * The gate's `generate-ci --check` proves each committed workflow matches its
+ * declaration in `build/workflows.ts`, so a test that pins a property of the
+ * committed YAML pins it in both places — and the committed file is what
+ * GitHub actually runs. Every such test parses the same shape (a workflow, its
+ * jobs, their steps, the action a `uses:` names), so the parsing lives here
+ * once rather than being retyped, and drifting, per test.
+ *
+ * @module
+ */
+
+import { parse } from "@std/yaml";
+
+/** Whether a parsed YAML value is an object that can be indexed. */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/** A committed workflow, parsed. */
+export function readWorkflow(path: string): Record<string, unknown> {
+  const parsed = parse(Deno.readTextFileSync(path));
+  if (!isRecord(parsed)) throw new Error(`${path} is not a YAML mapping`);
+  return parsed;
+}
+
+/** Every job in a parsed workflow, keyed by id. */
+export function jobsOf(
+  workflow: Record<string, unknown>,
+): Map<string, Record<string, unknown>> {
+  const { jobs } = workflow;
+  if (!isRecord(jobs)) throw new Error("the workflow has no jobs");
+  return new Map(
+    Object.entries(jobs).flatMap(([id, job]) =>
+      isRecord(job) ? [[id, job]] : []
+    ),
+  );
+}
+
+/** The job with `id` in a committed workflow. */
+export function jobIn(path: string, id: string): Record<string, unknown> {
+  const job = jobsOf(readWorkflow(path)).get(id);
+  if (job === undefined) throw new Error(`${path} has no ${id} job`);
+  return job;
+}
+
+/** A job's steps, each as a record. */
+export function stepsOf(
+  job: Record<string, unknown>,
+): Record<string, unknown>[] {
+  const { steps } = job;
+  if (!Array.isArray(steps)) throw new Error("the job has no steps");
+  return steps.filter(isRecord);
+}
+
+/**
+ * The action a step's `uses:` names, without its pin — or `undefined` for a
+ * step that has none, which on GitHub means a `run:` step.
+ */
+export function actionOf(step: Record<string, unknown>): string | undefined {
+  return typeof step.uses === "string" ? step.uses.split("@")[0] : undefined;
+}

--- a/tests/action_pins_test.ts
+++ b/tests/action_pins_test.ts
@@ -179,6 +179,19 @@ Deno.test("every seed pin is a full SHA with a version", () => {
   }
 });
 
+Deno.test("the codeql-action seeds pin one SHA for every subpath", () => {
+  // init, analyze and upload-sarif are one action reached by three subpaths,
+  // and pins are keyed by the full path — so nothing else holds them together.
+  // Seeding two of them from one release and the third from another would
+  // generate a workflow that mixes releases of the same action.
+  const shas = new Set(
+    Object.entries(SEED_PINS)
+      .filter(([action]) => action.startsWith("github/codeql-action/"))
+      .map(([, pin]) => pin.ref.split("@")[1]),
+  );
+  assertEquals(shas.size, 1, `codeql-action seeds disagree: ${[...shas]}`);
+});
+
 Deno.test("no declared workflow hardcodes an action SHA", async () => {
   // The trap this module exists to remove, asserted rather than trusted: a
   // generated workflow whose SHA is a literal in the build (or in a published

--- a/tests/action_release_job_test.ts
+++ b/tests/action_release_job_test.ts
@@ -16,25 +16,12 @@
  * @module
  */
 
-import { parse } from "@std/yaml";
 import { assertEquals } from "../packages/core/tests/_assert.ts";
-
-/** Whether a parsed YAML value is an object that can be indexed. */
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
+import { actionOf, isRecord, jobIn, stepsOf } from "./_workflow.ts";
 
 /** The `actionRelease` job as the committed workflow declares it. */
 function actionReleaseJob(): Record<string, unknown> {
-  const workflow = parse(
-    Deno.readTextFileSync(".github/workflows/release.yml"),
-  );
-  if (!isRecord(workflow) || !isRecord(workflow.jobs)) {
-    throw new Error("release.yml has no jobs");
-  }
-  const job = workflow.jobs.actionRelease;
-  if (!isRecord(job)) throw new Error("release.yml has no actionRelease job");
-  return job;
+  return jobIn(".github/workflows/release.yml", "actionRelease");
 }
 
 Deno.test("the action release job is granted no write permission", () => {
@@ -51,11 +38,8 @@ Deno.test("the action release job holds no GITHUB_TOKEN", () => {
   // pull request it opened would trigger no checks and so could never satisfy
   // the ruleset requiring them. Passing one anyway would mean a run that half
   // works and fails somewhere less obvious.
-  const job = actionReleaseJob();
-  const steps = job.steps;
-  if (!Array.isArray(steps)) throw new Error("the job has no steps");
-  const env = steps.flatMap((step) =>
-    isRecord(step) && isRecord(step.env) ? Object.keys(step.env) : []
+  const env = stepsOf(actionReleaseJob()).flatMap((step) =>
+    isRecord(step.env) ? Object.keys(step.env) : []
   );
   assertEquals(env.includes("GITHUB_TOKEN"), false);
   assertEquals(env.includes("ZUKE_BUILD_APP_ID"), true);
@@ -66,14 +50,10 @@ Deno.test("the action release job blocks egress and persists no credential", () 
   // The block bounds where a credential read out of this job could be sent; it
   // is not what stops the credential existing, which is what the API-based
   // writes address. Both, because neither is sufficient alone.
-  const job = actionReleaseJob();
-  const steps = job.steps;
-  if (!Array.isArray(steps)) throw new Error("the job has no steps");
-  const checkout = steps.find((step) =>
-    isRecord(step) && typeof step.uses === "string" &&
-    step.uses.startsWith("zuke-build/zuke@")
+  const checkout = stepsOf(actionReleaseJob()).find((step) =>
+    actionOf(step) === "zuke-build/zuke"
   );
-  if (!isRecord(checkout) || !isRecord(checkout.with)) {
+  if (checkout === undefined || !isRecord(checkout.with)) {
     throw new Error("the job does not check out with the Zuke action");
   }
   assertEquals(checkout.with["egress-policy"], "block");
@@ -89,14 +69,10 @@ Deno.test("the action release job can reach what it actually calls", () => {
   // the tags, the branch, the pull request. A blocked allowlist that omits it
   // would fail the job at its first write, after the release job has already
   // run.
-  const job = actionReleaseJob();
-  const steps = job.steps;
-  if (!Array.isArray(steps)) throw new Error("the job has no steps");
-  const checkout = steps.find((step) =>
-    isRecord(step) && isRecord(step.with) &&
-    typeof step.with["allowed-endpoints"] === "string"
+  const checkout = stepsOf(actionReleaseJob()).find((step) =>
+    isRecord(step.with) && typeof step.with["allowed-endpoints"] === "string"
   );
-  if (!isRecord(checkout) || !isRecord(checkout.with)) {
+  if (checkout === undefined || !isRecord(checkout.with)) {
     throw new Error("the job declares no allowed endpoints");
   }
   const allowed = String(checkout.with["allowed-endpoints"]).split(/\s+/);

--- a/tests/scorecard_workflow_test.ts
+++ b/tests/scorecard_workflow_test.ts
@@ -1,0 +1,195 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Regression tests for the committed `scorecard.yml` — the job that publishes
+ * the OpenSSF Scorecard behind the README badge.
+ *
+ * scorecard.dev verifies the workflow before it accepts a published score, and
+ * the job that holds `ossf/scorecard-action` may consist only of `uses:` steps
+ * from a short allowlist: no `run:` step, no other action, no job-level `env`,
+ * an Ubuntu runner, and `id-token: write` on that job alone. A violation is
+ * rejected with a 400 that the action reports as a *warning*, so the job stays
+ * green while the badge silently stops moving — which is exactly what happened
+ * when the Zuke prelude and a `./zuke` step replaced the allowlisted actions
+ * (issue #514): every publish from 2026-08-06 on was refused, and nothing
+ * noticed for a month.
+ *
+ * These assert the committed artifact rather than the declaration in
+ * `build/workflows.ts`, because the artifact is what GitHub runs: the gate's
+ * `generate-ci --check` already proves the two agree, so pinning the
+ * properties here pins them in both places. The allowlist is the one in
+ * https://github.com/ossf/scorecard-action#workflow-restrictions.
+ *
+ * @module
+ */
+
+import { parse } from "@std/yaml";
+import { assertEquals } from "../packages/core/tests/_assert.ts";
+
+const WORKFLOW = ".github/workflows/scorecard.yml";
+
+/** The action that computes and publishes the score. */
+const SCORECARD_ACTION = "ossf/scorecard-action";
+
+/**
+ * The only actions scorecard.dev permits in the publishing job — the action
+ * itself, the two prelude halves, and the two ways of getting its report out.
+ */
+const ALLOWED_ACTIONS: ReadonlySet<string> = new Set([
+  SCORECARD_ACTION,
+  "actions/checkout",
+  "actions/create-github-app-token",
+  "actions/upload-artifact",
+  "github/codeql-action/upload-sarif",
+  "step-security/harden-runner",
+]);
+
+/** Whether a parsed YAML value is an object that can be indexed. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/** The committed workflow, parsed. */
+function workflow(): Record<string, unknown> {
+  const parsed = parse(Deno.readTextFileSync(WORKFLOW));
+  if (!isRecord(parsed) || !isRecord(parsed.jobs)) {
+    throw new Error(`${WORKFLOW} has no jobs`);
+  }
+  return parsed;
+}
+
+/** Every job in the workflow, keyed by id. */
+function jobs(): Map<string, Record<string, unknown>> {
+  const { jobs } = workflow();
+  if (!isRecord(jobs)) throw new Error(`${WORKFLOW} has no jobs`);
+  return new Map(
+    Object.entries(jobs).flatMap(([id, job]) =>
+      isRecord(job) ? [[id, job]] : []
+    ),
+  );
+}
+
+/** A job's steps, each as a record. */
+function stepsOf(job: Record<string, unknown>): Record<string, unknown>[] {
+  const { steps } = job;
+  if (!Array.isArray(steps)) throw new Error("the job has no steps");
+  return steps.filter(isRecord);
+}
+
+/** The action a `uses:` names, without its pin. */
+function actionOf(uses: unknown): string {
+  if (typeof uses !== "string") throw new Error(`uses is not a string`);
+  return uses.split("@")[0];
+}
+
+/**
+ * The id of the one job that runs the scorecard action, found the way
+ * scorecard.dev's verifier finds it: by the step, not by the job id.
+ */
+function scorecardJobId(all: Map<string, Record<string, unknown>>): string {
+  for (const [id, job] of all) {
+    const runs = stepsOf(job).some((step) =>
+      actionOf(step.uses ?? "") === SCORECARD_ACTION
+    );
+    if (runs) return id;
+  }
+  throw new Error(`${WORKFLOW} has no job that runs ${SCORECARD_ACTION}`);
+}
+
+/** The job that runs the scorecard action. */
+function scorecardJob(): Record<string, unknown> {
+  const all = jobs();
+  const job = all.get(scorecardJobId(all));
+  if (job === undefined) throw new Error("unreachable: the id came from all");
+  return job;
+}
+
+Deno.test("the scorecard job runs only allowlisted actions, and no `run:` step", () => {
+  // The rule that was broken: the Zuke prelude is not on the list, and a
+  // `./zuke` step is a `run:`. Either one turns every publish into a 400.
+  const offending = stepsOf(scorecardJob()).flatMap((step) => {
+    if (step.run !== undefined) return [`run: ${String(step.run)}`];
+    const action = actionOf(step.uses);
+    return ALLOWED_ACTIONS.has(action) ? [] : [`uses: ${action}`];
+  });
+  assertEquals(
+    offending,
+    [],
+    `scorecard.dev would refuse to publish: ${offending.join(", ")}`,
+  );
+});
+
+Deno.test("the scorecard job carries no job-level env, container, or services", () => {
+  const job = scorecardJob();
+  assertEquals(job.env, undefined);
+  assertEquals(job.container, undefined);
+  assertEquals(job.services, undefined);
+  assertEquals(job.defaults, undefined);
+});
+
+Deno.test("the scorecard job runs on a hosted Ubuntu runner", () => {
+  const runsOn = scorecardJob()["runs-on"];
+  assertEquals(typeof runsOn, "string");
+  assertEquals(/^ubuntu-(latest|\d{2}\.\d{2})$/.test(String(runsOn)), true);
+});
+
+Deno.test("only the scorecard job may hold id-token: write", () => {
+  // The verifier rejects a workflow where any *other* job can mint an OIDC
+  // token, and any workflow-level write permission at all.
+  const file = workflow();
+  const top = file.permissions;
+  if (isRecord(top)) {
+    assertEquals(Object.values(top).includes("write"), false);
+    assertEquals(Object.values(top).includes("write-all"), false);
+  } else {
+    assertEquals(top, undefined);
+  }
+  assertEquals(file.env, undefined);
+  assertEquals(file.defaults, undefined);
+  const all = jobs();
+  const scorecard = scorecardJobId(all);
+  for (const [id, job] of all) {
+    const perms = isRecord(job.permissions) ? job.permissions : {};
+    assertEquals(
+      perms["id-token"] === "write",
+      id === scorecard,
+      "id-token: write belongs to the scorecard job and no other",
+    );
+  }
+});
+
+Deno.test("the scorecard job publishes its score and uploads the same SARIF", () => {
+  // `publish_results` is what refreshes the badge; `upload-sarif` reading the
+  // file the scorecard step wrote is what puts the findings on the Security
+  // tab. The two names must agree or the upload fails after the score is
+  // already published.
+  const steps = stepsOf(scorecardJob());
+  const scorecard = steps.find((step) =>
+    actionOf(step.uses) === SCORECARD_ACTION
+  );
+  const upload = steps.find((step) =>
+    actionOf(step.uses) === "github/codeql-action/upload-sarif"
+  );
+  if (scorecard === undefined || upload === undefined) {
+    throw new Error("the scorecard or upload-sarif step is missing");
+  }
+  const scorecardWith = isRecord(scorecard.with) ? scorecard.with : {};
+  const uploadWith = isRecord(upload.with) ? upload.with : {};
+  assertEquals(scorecardWith.publish_results, "true");
+  assertEquals(scorecardWith.results_format, "sarif");
+  assertEquals(uploadWith.sarif_file, scorecardWith.results_file);
+});
+
+Deno.test("every action in scorecard.yml is pinned to a full SHA", () => {
+  for (const job of jobs().values()) {
+    for (const step of stepsOf(job)) {
+      const uses = String(step.uses);
+      assertEquals(
+        /@[0-9a-f]{40}$/.test(uses),
+        true,
+        `not pinned to a full SHA: ${uses}`,
+      );
+    }
+  }
+});

--- a/tests/scorecard_workflow_test.ts
+++ b/tests/scorecard_workflow_test.ts
@@ -15,17 +15,22 @@
  * (issue #514): every publish from 2026-08-06 on was refused, and nothing
  * noticed for a month.
  *
- * These assert the committed artifact rather than the declaration in
- * `build/workflows.ts`, because the artifact is what GitHub runs: the gate's
- * `generate-ci --check` already proves the two agree, so pinning the
- * properties here pins them in both places. The allowlist is the one in
+ * Only the Scorecard-specific rules live here. That every `uses:` is pinned to
+ * a full SHA is the security gate's job (zizmor's unpinned-uses audit), and the
+ * YAML reading is the shared `_workflow.ts`. The allowlist is the one in
  * https://github.com/ossf/scorecard-action#workflow-restrictions.
  *
  * @module
  */
 
-import { parse } from "@std/yaml";
 import { assertEquals } from "../packages/core/tests/_assert.ts";
+import {
+  actionOf,
+  isRecord,
+  jobsOf,
+  readWorkflow,
+  stepsOf,
+} from "./_workflow.ts";
 
 const WORKFLOW = ".github/workflows/scorecard.yml";
 
@@ -45,61 +50,22 @@ const ALLOWED_ACTIONS: ReadonlySet<string> = new Set([
   "step-security/harden-runner",
 ]);
 
-/** Whether a parsed YAML value is an object that can be indexed. */
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-/** The committed workflow, parsed. */
-function workflow(): Record<string, unknown> {
-  const parsed = parse(Deno.readTextFileSync(WORKFLOW));
-  if (!isRecord(parsed) || !isRecord(parsed.jobs)) {
-    throw new Error(`${WORKFLOW} has no jobs`);
-  }
-  return parsed;
-}
-
-/** Every job in the workflow, keyed by id. */
-function jobs(): Map<string, Record<string, unknown>> {
-  const { jobs } = workflow();
-  if (!isRecord(jobs)) throw new Error(`${WORKFLOW} has no jobs`);
-  return new Map(
-    Object.entries(jobs).flatMap(([id, job]) =>
-      isRecord(job) ? [[id, job]] : []
-    ),
-  );
-}
-
-/** A job's steps, each as a record. */
-function stepsOf(job: Record<string, unknown>): Record<string, unknown>[] {
-  const { steps } = job;
-  if (!Array.isArray(steps)) throw new Error("the job has no steps");
-  return steps.filter(isRecord);
-}
-
-/** The action a `uses:` names, without its pin. */
-function actionOf(uses: unknown): string {
-  if (typeof uses !== "string") throw new Error(`uses is not a string`);
-  return uses.split("@")[0];
-}
-
 /**
  * The id of the one job that runs the scorecard action, found the way
  * scorecard.dev's verifier finds it: by the step, not by the job id.
  */
 function scorecardJobId(all: Map<string, Record<string, unknown>>): string {
   for (const [id, job] of all) {
-    const runs = stepsOf(job).some((step) =>
-      actionOf(step.uses ?? "") === SCORECARD_ACTION
-    );
-    if (runs) return id;
+    if (stepsOf(job).some((step) => actionOf(step) === SCORECARD_ACTION)) {
+      return id;
+    }
   }
   throw new Error(`${WORKFLOW} has no job that runs ${SCORECARD_ACTION}`);
 }
 
 /** The job that runs the scorecard action. */
 function scorecardJob(): Record<string, unknown> {
-  const all = jobs();
+  const all = jobsOf(readWorkflow(WORKFLOW));
   const job = all.get(scorecardJobId(all));
   if (job === undefined) throw new Error("unreachable: the id came from all");
   return job;
@@ -109,8 +75,8 @@ Deno.test("the scorecard job runs only allowlisted actions, and no `run:` step",
   // The rule that was broken: the Zuke prelude is not on the list, and a
   // `./zuke` step is a `run:`. Either one turns every publish into a 400.
   const offending = stepsOf(scorecardJob()).flatMap((step) => {
-    if (step.run !== undefined) return [`run: ${String(step.run)}`];
-    const action = actionOf(step.uses);
+    const action = actionOf(step);
+    if (action === undefined) return [`run: ${String(step.run)}`];
     return ALLOWED_ACTIONS.has(action) ? [] : [`uses: ${action}`];
   });
   assertEquals(
@@ -137,7 +103,7 @@ Deno.test("the scorecard job runs on a hosted Ubuntu runner", () => {
 Deno.test("only the scorecard job may hold id-token: write", () => {
   // The verifier rejects a workflow where any *other* job can mint an OIDC
   // token, and any workflow-level write permission at all.
-  const file = workflow();
+  const file = readWorkflow(WORKFLOW);
   const top = file.permissions;
   if (isRecord(top)) {
     assertEquals(Object.values(top).includes("write"), false);
@@ -147,7 +113,7 @@ Deno.test("only the scorecard job may hold id-token: write", () => {
   }
   assertEquals(file.env, undefined);
   assertEquals(file.defaults, undefined);
-  const all = jobs();
+  const all = jobsOf(file);
   const scorecard = scorecardJobId(all);
   for (const [id, job] of all) {
     const perms = isRecord(job.permissions) ? job.permissions : {};
@@ -165,11 +131,9 @@ Deno.test("the scorecard job publishes its score and uploads the same SARIF", ()
   // tab. The two names must agree or the upload fails after the score is
   // already published.
   const steps = stepsOf(scorecardJob());
-  const scorecard = steps.find((step) =>
-    actionOf(step.uses) === SCORECARD_ACTION
-  );
+  const scorecard = steps.find((step) => actionOf(step) === SCORECARD_ACTION);
   const upload = steps.find((step) =>
-    actionOf(step.uses) === "github/codeql-action/upload-sarif"
+    actionOf(step) === "github/codeql-action/upload-sarif"
   );
   if (scorecard === undefined || upload === undefined) {
     throw new Error("the scorecard or upload-sarif step is missing");
@@ -179,17 +143,4 @@ Deno.test("the scorecard job publishes its score and uploads the same SARIF", ()
   assertEquals(scorecardWith.publish_results, "true");
   assertEquals(scorecardWith.results_format, "sarif");
   assertEquals(uploadWith.sarif_file, scorecardWith.results_file);
-});
-
-Deno.test("every action in scorecard.yml is pinned to a full SHA", () => {
-  for (const job of jobs().values()) {
-    for (const step of stepsOf(job)) {
-      const uses = String(step.uses);
-      assertEquals(
-        /@[0-9a-f]{40}$/.test(uses),
-        true,
-        `not pinned to a full SHA: ${uses}`,
-      );
-    }
-  }
 });

--- a/zuke.ts
+++ b/zuke.ts
@@ -818,22 +818,27 @@ class ZukeBuild extends Build {
     )
     .executes(() => {});
 
-  // Publish the OpenSSF Scorecard run's SARIF to code scanning, dogfooding
-  // @zuke/gh's `uploadSarif`. This replaced two steps in scorecard.yml — the
-  // `upload-artifact` and the `codeql-action/upload-sarif` — with one target;
-  // the scorecard action itself stays, because publishing the public score
-  // (`publish_results`) is something only it can do.
-  scorecardSarif = target()
-    .description("Upload the Scorecard SARIF to GitHub code scanning")
-    .executes(async () => {
-      const report = "results.sarif";
-      if (!await FileTasks.exists(report)) {
-        throw new Error(
-          `${report} is missing — run the scorecard step before this target.`,
-        );
-      }
-      const { url } = await GhTasks.uploadSarif((s) => s.file(report));
-      ConsoleTasks.success(`Uploaded ${report} to code scanning (${url}).`);
+  // The OpenSSF Scorecard is the supply-chain score behind the README badge.
+  // Like `codeql` below, the job in the generated `scorecard.yml` (declared in
+  // `build/workflows.ts`) is the marketplace actions and nothing else: the
+  // scorecard action computes and publishes the score, and `upload-sarif` puts
+  // its report on the Security tab. That is not a choice — scorecard.dev only
+  // accepts a score from a job made of a short allowlist of actions, so the
+  // Zuke prelude and a `./zuke` step that used to upload the SARIF through
+  // @zuke/gh both kept the badge frozen (issue #514). This body therefore runs
+  // only on a *local* invocation, where there is no scorecard CLI in the
+  // toolchain, and it fails rather than reports for the same reason `codeql`
+  // does.
+  scorecard = target()
+    .description("OpenSSF Scorecard (runs in CI via scorecard.yml)")
+    .executes(() => {
+      throw new Error(
+        "The OpenSSF Scorecard cannot run locally: there is no scorecard CLI " +
+          "in the toolchain. It runs in CI — the generated " +
+          ".github/workflows/scorecard.yml scores every push to master and " +
+          "a weekly schedule, publishes the result to scorecard.dev, and " +
+          "uploads the SARIF to the repository's Security tab.",
+      );
     });
 
   // CodeQL is the SAST lane: GitHub's hosted static analysis over the


### PR DESCRIPTION
## What & why

The README's OpenSSF Scorecard badge has shown 6.6, computed on 2026-08-06, for a month while the `Scorecard supply-chain` workflow ran green on every push. Today's run computed 8.7 and then logged, as a warning only, that it was unable to POST the results to the webapp: HTTP 400, `workflow verification failed: job has unallowed step: zuke-build/zuke`.

scorecard.dev verifies the workflow server-side before it accepts a published score. The job holding `ossf/scorecard-action` may consist only of `uses:` steps from a short allowlist: `actions/checkout`, `actions/create-github-app-token`, `actions/upload-artifact`, `github/codeql-action/upload-sarif`, `step-security/harden-runner`, and the scorecard action itself, with no `run:` step and no job-level `env`. Two changes had pushed the job outside it: #302 replaced harden-runner and checkout with the `zuke-build/zuke` composite action, and #295 replaced `upload-sarif` with a `./zuke scorecardSarif` run step. Every publish since then was refused.

This brings the job back within the allowlist without hand-writing YAML:

- The `scorecard` declaration in `build/workflows.ts` opts that one job out of the Zuke prelude by naming `step-security/harden-runner` and `actions/checkout` explicitly, which the generator renders as separate pinned steps, and uses `steps` to replace the target's run step with the `ossf/scorecard-action` and `github/codeql-action/upload-sarif` pair. This is the same shape the `codeql` job already uses. `scorecard.yml` is regenerated and matches the last workflow scorecard.dev accepted, minus the optional `upload-artifact` copy of the SARIF, which the Security tab upload covers.
- The `scorecardSarif` target is retired. Its CI caller is gone, so it becomes a `scorecard` target that, like `codeql`, fails locally with an explanation rather than pretending to run. The `uploadSarif` task in `@zuke/gh` is unaffected.
- `github/codeql-action/upload-sarif` joins `SEED_PINS`, at the release the committed `codeql.yml` already pins; the `init` and `analyze` seeds move to the same SHA so the three subpaths of one action agree. Dependabot keeps owning the pin from the generated file onward.
- `docs/graph.md` regenerated.

Verified locally: `format`, `lint`, `spell`, `coverage`, `apiDocsCheck`, `docLint`, `snippetsCheck`, `examplesCheck`, `hclSyncCheck`, `pluginSyncCheck`, `skillsCheck`, `graphDocCheck`, `prBodyLint`, `actionPinCheck`, and `lockCheck` all pass. The `security` target could not complete in the sandbox because zizmor's advisory lookup against the GitHub API is blocked there; zizmor run offline with the gate's persona and actionlint both report the regenerated `scorecard.yml` clean. The workflow's `Scorecard supply-chain` run on the merge commit is the real proof: its `Run Scorecard` step should no longer log `Unable to POST scorecard results to webapp`, and the badge should move to the current score on the first push to master after merge.

### Tests

- `tests/scorecard_workflow_test.ts` holds the committed `scorecard.yml` to the allowlist: only permitted actions and no `run:` step, no job-level `env`, `container` or `services`, a hosted Ubuntu runner, `id-token: write` on the scorecard job alone with no workflow-level write permission, and `publish_results` set with the upload reading the file the scorecard step wrote. It finds the job by its step rather than its id, the way the verifier does.
- `tests/_workflow.ts` is the shared reader for committed workflows, parsing a workflow, its jobs, their steps and the action a step uses, so this test and `tests/action_release_job_test.ts` share one implementation instead of each retyping it.
- `tests/action_pins_test.ts` gains a test that the `github/codeql-action/*` seeds pin one SHA.

## Related issues

Closes #514

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a
      [Conventional Commit](https://www.conventionalcommits.org/)
      (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell). Every target except `security`, whose GitHub advisory lookup is blocked in the sandbox; see above.
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour
      changed.
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`,
      `llms-full.txt`, package README `## API`). Not applicable: no package API changed.
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with
      type guards instead).
- [x] No dead code: unreachable branches and can't-fire fallbacks are removed,
      with types tightened so the impossible state is unrepresentable.
- [x] No duplicated logic: an existing helper is imported rather than retyped,
      and a near-copy differing by a constant or a message is parameterised into
      one implementation. A guard, escape, or credential resolution has exactly
      one implementation.
- [x] SOLID shapes respected: one domain per file, extension via the settings
      lambda (not a behaviour-switching flag), narrow parameter types, and
      dependencies on the injectable seam (`StateHost`, an injected `fetch`,
      `EnvReader`) rather than `Deno.*` or a global.
- [x] A new package was wired into all six places (see
      [AGENTS.md](../blob/master/AGENTS.md#good-open-source-practices-to-follow)),
      if applicable. Not applicable.
- [x] The code is written using AI assisted coding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tpd9Bj4X2gMXNbzJstvtN
