### PR TITLE
feat(core): let a parameter declare its CLI flag

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -149,8 +149,42 @@ has resolved parameters (e.g. at construction time) throws.
 
 The flag and environment variable are derived from the property name:
 `environment` → `--environment` / `ENVIRONMENT`; a camelCase name like
-`targetEnv` → `--target-env` / `TARGET_ENV`. Override the environment variable
-with `.env("NAME")`.
+`targetEnv` → `--target-env` / `TARGET_ENV`. A nested group joins with the same
+separator, so `runs.limit` → `--runs-limit` / `RUNS_LIMIT`.
+
+The rule is one dash (or underscore) at **each lower-to-upper transition**. A
+run of capitals has no internal transition and so stays together — but a digit
+ends a run, which is where the rule surprises people:
+
+| Property name | Flag           | Environment variable |
+| ------------- | -------------- | -------------------- |
+| `apiURL`      | `--api-url`    | `API_URL`            |
+| `useHTTPS`    | `--use-https`  | `USE_HTTPS`          |
+| `skipE2E`     | `--skip-e2-e`  | `SKIP_E2_E`          |
+| `runE2E`      | `--run-e2-e`   | `RUN_E2_E`           |
+
+`skipE2E` gives `--skip-e2-e` because the `2` ends the run of capitals, making
+`2E` a transition of its own. Two ways out, and the first is often enough:
+
+- **Name it so the rule agrees with you.** `skipE2e` → `--skip-e2e`.
+- **Declare the flag.** `.flag("--skip-e2e")` sets the spelling explicitly, and
+  the leading dashes are optional.
+
+```ts
+class CI extends Build {
+  skipE2E = parameter("skip the E2E suite").flag("--skip-e2e").boolean();
+}
+```
+
+A declared flag **replaces** the derived one: only it is accepted on the
+command line, and it is what `--help`, `--list --json`, shell completions and a
+registered build's descriptor all show. It must be lowercase letters, digits
+and dashes starting with a letter, it may not be a built-in flag (see below),
+and no two parameters may claim the same one — each is a `ParameterError` when
+the build loads, naming the field.
+
+The environment variable is derived separately and is unaffected by a declared
+flag; override that half with `.env("NAME")`.
 
 ### Names a parameter may not use
 
@@ -173,8 +207,9 @@ naming the field:
 
 Only the rendered flag matters, so a longer or nested name is fine: `actorName`
 → `--actor-name` and a grouped `runs.limit` → `--runs-limit` both stay usable.
-Rename the field; there is no opt-out, because the alternative is a flag that
-silently belongs to something else.
+Rename the field, or declare a different flag with `.flag("--…")`. What is not
+available is keeping the colliding spelling, because the alternative is a flag
+that silently belongs to something else.
 
 ## Without the CLI
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "zuke",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build)."
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1658,6 +1658,8 @@ class Parameter<K extends ParamValue = ParamValue, T extends K | K[] | undefined
     The allowed string choices, if restricted with {@link Parameter.options}.
   readonly envName_?: string
     An explicit environment variable name override.
+  readonly flagName_?: string
+    An explicit CLI flag name override, without the leading dashes.
   readonly hasFallback_: boolean
     Whether the parameter has a declared default value.
   readonly secret_: boolean
@@ -1698,6 +1700,19 @@ class Parameter<K extends ParamValue = ParamValue, T extends K | K[] | undefined
     Require a value, making `value` non-optional (`K`); errors if unsupplied.
   env(name: string): Parameter<K, T>
     Override the environment variable read as a fallback for this parameter.
+  flag(name: string): Parameter<K, T>
+    Override the CLI flag this parameter is set by. The leading `--` is
+    optional, so `.flag("--skip-e2e")` and `.flag("skip-e2e")` are the same.
+
+    The declared spelling replaces the derived one: only it is accepted on
+    the command line, and it is what `--help`, the JSON build surface, shell
+    completions and the registry descriptor all show. Reach for this when the
+    name-to-flag rule produces something you would not have chosen — a name
+    containing an initialism that ends in a digit is the usual case, since the
+    digit ends the run of capitals and `skipE2E` derives `--skip-e2-e`.
+
+    The environment variable is derived separately and is unaffected; override
+    it with {@link env}.
   array(this: Parameter<E, E | undefined>): Parameter<E, E[]>
     Accept a comma-separated list (or a repeated flag), exposing `value` as an
     array. `--tags a,b` and `--tags a --tags b` both yield `["a", "b"]`; blank
@@ -2484,6 +2499,8 @@ interface AnyParameter
     The allowed string choices, if restricted with {@link Parameter.options}.
   readonly envName_?: string
     An explicit environment variable name override.
+  readonly flagName_?: string
+    An explicit CLI flag name override, without the leading dashes.
   readonly hasFallback_: boolean
     Whether the parameter has a declared default value.
   readonly secret_: boolean

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1712,6 +1712,8 @@ class Parameter<K extends ParamValue = ParamValue, T extends K | K[] | undefined
     The allowed string choices, if restricted with {@link Parameter.options}.
   readonly envName_?: string
     An explicit environment variable name override.
+  readonly flagName_?: string
+    An explicit CLI flag name override, without the leading dashes.
   readonly hasFallback_: boolean
     Whether the parameter has a declared default value.
   readonly secret_: boolean
@@ -1752,6 +1754,19 @@ class Parameter<K extends ParamValue = ParamValue, T extends K | K[] | undefined
     Require a value, making `value` non-optional (`K`); errors if unsupplied.
   env(name: string): Parameter<K, T>
     Override the environment variable read as a fallback for this parameter.
+  flag(name: string): Parameter<K, T>
+    Override the CLI flag this parameter is set by. The leading `--` is
+    optional, so `.flag("--skip-e2e")` and `.flag("skip-e2e")` are the same.
+
+    The declared spelling replaces the derived one: only it is accepted on
+    the command line, and it is what `--help`, the JSON build surface, shell
+    completions and the registry descriptor all show. Reach for this when the
+    name-to-flag rule produces something you would not have chosen — a name
+    containing an initialism that ends in a digit is the usual case, since the
+    digit ends the run of capitals and `skipE2E` derives `--skip-e2-e`.
+
+    The environment variable is derived separately and is unaffected; override
+    it with {@link env}.
   array(this: Parameter<E, E | undefined>): Parameter<E, E[]>
     Accept a comma-separated list (or a repeated flag), exposing `value` as an
     array. `--tags a,b` and `--tags a --tags b` both yield `["a", "b"]`; blank
@@ -2538,6 +2553,8 @@ interface AnyParameter
     The allowed string choices, if restricted with {@link Parameter.options}.
   readonly envName_?: string
     An explicit environment variable name override.
+  readonly flagName_?: string
+    An explicit CLI flag name override, without the leading dashes.
   readonly hasFallback_: boolean
     Whether the parameter has a declared default value.
   readonly secret_: boolean

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -29,7 +29,7 @@ import {
 import {
   type AnyParameter,
   discoverParameters,
-  flagName,
+  flagOf,
   ParameterError,
 } from "./params.ts";
 import type { JsonValue, TargetBuilder } from "./target.ts";
@@ -786,7 +786,7 @@ function renderTargets(targets: Map<string, TargetBuilder>): string {
 /** Render the parameters section, or `""` when no parameters are declared. */
 function formatParameters(params: Map<string, AnyParameter>): string {
   if (params.size === 0) return "";
-  const flags = [...params.keys()].map(flagName);
+  const flags = [...params].map(([n, p]) => flagOf(n, p));
   const width = Math.max(...flags.map((f) => f.length));
   const lines = ["Parameters:"];
   for (const [name, p] of params) {
@@ -797,7 +797,7 @@ function formatParameters(params: Map<string, AnyParameter>): string {
     }
     const meta = bits.length > 0 ? `  (${bits.join("; ")})` : "";
     const desc = p.description_ ?? "";
-    lines.push(`  --${flagName(name).padEnd(width)}  ${desc}${meta}`);
+    lines.push(`  --${flagOf(name, p).padEnd(width)}  ${desc}${meta}`);
   }
   return lines.join("\n");
 }
@@ -1341,7 +1341,7 @@ async function runCommand(
   discoverGroups(build); // names group batches so the graph can label them
   const paramFlags: ParamFlag[] = [...params.entries()].map(([name, p]) => ({
     name,
-    flag: flagName(name),
+    flag: flagOf(name, p),
     boolean: p.kind_ === "boolean",
     array: p.array_,
   }));

--- a/packages/core/src/cli_spec.ts
+++ b/packages/core/src/cli_spec.ts
@@ -254,3 +254,17 @@ export const BUILTIN_FLAGS: readonly BuiltinFlag[] = [
 export const BUILTIN_FLAG_NAMES: readonly string[] = BUILTIN_FLAGS.map((flag) =>
   flag.name.slice(2)
 );
+
+/**
+ * What a usable flag name looks like: lowercase letters, digits and dashes,
+ * starting with a letter.
+ *
+ * Shape, not just membership, is what makes {@link BUILTIN_FLAG_NAMES} a
+ * sufficient check. The parser splits `--flag=value` at the first `=` and
+ * matches the prefix, so a "flag" of `actor=mallory` is not in the built-in
+ * list yet reaches the parser **as** `--actor` — landing a value on the
+ * built-in and forging the run's actor. Anything with an `=`, a space, a
+ * leading dash or a different case can mean something to the parser other than
+ * what it says, so it is refused wherever a flag is declared or read.
+ */
+export const VALID_FLAG_NAME = /^[a-z][a-z0-9-]*$/;

--- a/packages/core/src/completions.ts
+++ b/packages/core/src/completions.ts
@@ -20,7 +20,7 @@
  */
 
 import type { TargetBuilder } from "./target.ts";
-import { type AnyParameter, flagName } from "./params.ts";
+import { type AnyParameter, flagOf } from "./params.ts";
 import { BUILTIN_FLAGS, RESERVED_COMMANDS } from "./cli_spec.ts";
 
 /** The shells for which a completion script can be emitted. */
@@ -60,7 +60,7 @@ function paramCandidates(params: Map<string, AnyParameter>): Candidate[] {
   const out: Candidate[] = [];
   for (const [name, p] of params) {
     out.push({
-      name: `--${flagName(name)}`,
+      name: `--${flagOf(name, p)}`,
       description: oneLine(p.description_ ?? ""),
     });
   }

--- a/packages/core/src/describe.ts
+++ b/packages/core/src/describe.ts
@@ -11,7 +11,7 @@
  */
 
 import { type Build, discoverTargets } from "./build.ts";
-import { type AnyParameter, discoverParameters, flagName } from "./params.ts";
+import { type AnyParameter, discoverParameters, flagOf } from "./params.ts";
 import type { TargetBuilder } from "./target.ts";
 import {
   BUILTIN_FLAGS,
@@ -102,7 +102,7 @@ function targetInfo(name: string, t: TargetBuilder): CliTargetInfo {
 function parameterInfo(name: string, p: AnyParameter): CliParameterInfo {
   const info: CliParameterInfo = {
     name,
-    flag: flagName(name),
+    flag: flagOf(name, p),
     description: p.description_ ?? "",
     required: p.required_,
     kind: p.kind_,

--- a/packages/core/src/params.ts
+++ b/packages/core/src/params.ts
@@ -32,7 +32,7 @@
  * @module
  */
 
-import { BUILTIN_FLAG_NAMES } from "./cli_spec.ts";
+import { BUILTIN_FLAG_NAMES, VALID_FLAG_NAME } from "./cli_spec.ts";
 import { messageOf } from "./internal.ts";
 import { forEachField } from "./build.ts";
 import type { Redactor } from "./redact.ts";
@@ -142,6 +142,8 @@ export interface AnyParameter {
   readonly options_?: readonly string[];
   /** An explicit environment variable name override. */
   readonly envName_?: string;
+  /** An explicit CLI flag name override, without the leading dashes. */
+  readonly flagName_?: string;
   /** Whether the parameter has a declared default value. */
   readonly hasFallback_: boolean;
   /** Whether the value is sensitive and should be masked in CI output. */
@@ -171,6 +173,7 @@ interface ParamSpec<K extends ParamValue, T extends K | K[] | undefined> {
   required: boolean;
   options?: readonly string[];
   envName?: string;
+  flagName?: string;
   parse: (raw: string) => T;
   fallback: Fallback<T>;
   secret?: boolean;
@@ -203,6 +206,8 @@ export class Parameter<
   readonly options_?: readonly string[];
   /** An explicit environment variable name override. */
   readonly envName_?: string;
+  /** An explicit CLI flag name override, without the leading dashes. */
+  readonly flagName_?: string;
   /** Whether the parameter has a declared default value. */
   readonly hasFallback_: boolean;
   /** Whether the value is sensitive and should be masked in CI output. */
@@ -252,6 +257,7 @@ export class Parameter<
     this.required_ = spec.required;
     this.options_ = spec.options;
     this.envName_ = spec.envName;
+    this.flagName_ = spec.flagName;
     this.#parse = spec.parse;
     this.#fallback = spec.fallback;
     this.hasFallback_ = spec.fallback.has;
@@ -374,6 +380,27 @@ export class Parameter<
   }
 
   /**
+   * Override the CLI flag this parameter is set by. The leading `--` is
+   * optional, so `.flag("--skip-e2e")` and `.flag("skip-e2e")` are the same.
+   *
+   * The declared spelling **replaces** the derived one: only it is accepted on
+   * the command line, and it is what `--help`, the JSON build surface, shell
+   * completions and the registry descriptor all show. Reach for this when the
+   * name-to-flag rule produces something you would not have chosen — a name
+   * containing an initialism that ends in a digit is the usual case, since the
+   * digit ends the run of capitals and `skipE2E` derives `--skip-e2-e`.
+   *
+   * The environment variable is derived separately and is unaffected; override
+   * it with {@link env}.
+   */
+  flag(name: string): Parameter<K, T> {
+    return new Parameter<K, T>({
+      ...this.#spec,
+      flagName: name.replace(/^--/, ""),
+    });
+  }
+
+  /**
    * Accept a comma-separated list (or a repeated flag), exposing `value` as an
    * array. `--tags a,b` and `--tags a --tags b` both yield `["a", "b"]`; blank
    * entries are dropped, and an unsupplied *optional* list defaults to `[]`
@@ -454,6 +481,8 @@ export function parameter(
  */
 export function discoverParameters(build: object): Map<string, AnyParameter> {
   const params = new Map<string, AnyParameter>();
+  // Which parameter already claims each flag, so a collision names both.
+  const byFlag = new Map<string, string>();
   forEachField(build, (path, value) => {
     if (value instanceof Parameter) {
       if (RESERVED_PARAM_NAMES.has(path)) {
@@ -462,15 +491,38 @@ export function discoverParameters(build: object): Map<string, AnyParameter> {
             `(dryRun, confirm, operatorToken). Rename the parameter field.`,
         );
       }
-      const flag = flagName(path);
-      if (BUILTIN_FLAGS.has(flag)) {
+      const declared = value.flagName_;
+      if (declared !== undefined && !VALID_FLAG_NAME.test(declared)) {
         throw new ParameterError(
-          `Parameter "${path}" renders as "--${flag}", which is a built-in ` +
-            `Zuke CLI flag: the parser matches the built-in first, so the ` +
-            `flag would mean the built-in and not this parameter. Rename the ` +
-            `parameter field.`,
+          `Parameter "${path}" declares the flag "--${declared}", which is ` +
+            `not a valid flag name. Use lowercase letters, digits and ` +
+            `dashes, starting with a letter — for example "--skip-e2e".`,
         );
       }
+      const flag = flagOf(path, value);
+      if (BUILTIN_FLAGS.has(flag)) {
+        throw new ParameterError(
+          declared === undefined
+            ? `Parameter "${path}" renders as "--${flag}", which is a ` +
+              `built-in Zuke CLI flag: the parser matches the built-in ` +
+              `first, so the flag would mean the built-in and not this ` +
+              `parameter. Rename the parameter field, or declare a ` +
+              `different flag with .flag("--…").`
+            : `Parameter "${path}" declares the flag "--${flag}", which is ` +
+              `a built-in Zuke CLI flag: the parser matches the built-in ` +
+              `first, so the flag would mean the built-in and not this ` +
+              `parameter. Declare a different one.`,
+        );
+      }
+      const owner = byFlag.get(flag);
+      if (owner !== undefined) {
+        throw new ParameterError(
+          `Parameters "${owner}" and "${path}" both render as "--${flag}", ` +
+            `so a value on that flag is ambiguous. Rename one, or declare a ` +
+            `different flag with .flag("--…").`,
+        );
+      }
+      byFlag.set(flag, path);
       value.name_ = path;
       params.set(path, value);
     }
@@ -478,7 +530,28 @@ export function discoverParameters(build: object): Map<string, AnyParameter> {
   return params;
 }
 
-/** The CLI flag for a parameter: its property path in kebab-case. */
+/**
+ * The CLI flag a parameter is actually set by: the one it declared with
+ * {@link Parameter.flag}, else {@link flagName} of its property path.
+ *
+ * Every place a flag is rendered or matched goes through here — the parser,
+ * `--help`, the JSON surface, completions, the registry descriptor — so a
+ * declared flag cannot be honoured in one of them and derived in another.
+ */
+export function flagOf(name: string, param: AnyParameter): string {
+  return param.flagName_ ?? flagName(name);
+}
+
+/**
+ * The CLI flag derived from a parameter's property path: kebab-case, with a
+ * dash inserted at each lower-to-upper transition.
+ *
+ * The transition rule is worth knowing before naming a field. A run of
+ * capitals has no internal transition, so `apiURL` gives `--api-url` and
+ * `useHTTPS` gives `--use-https`. A digit ends such a run, so `skipE2E` gives
+ * `--skip-e2-e` — declare {@link Parameter.flag} when that is not the spelling
+ * you want.
+ */
 export function flagName(name: string): string {
   return name.replace(/([a-z0-9])([A-Z])/g, "$1-$2").replace(/\./g, "-")
     .toLowerCase();
@@ -523,7 +596,7 @@ export async function resolveParameters(
     let raw = name in cliValues ? cliValues[name] : readEnv(envName);
     // Prompt for a missing required value when an input source is available.
     if (raw === undefined && param.required_ && !param.hasFallback_ && prompt) {
-      const answer = prompt(flagName(name), param.description_);
+      const answer = prompt(flagOf(name, param), param.description_);
       if (answer !== undefined && answer !== "") raw = answer;
     }
     // Fall back to a secret source when nothing else supplied a value.
@@ -532,7 +605,7 @@ export async function resolveParameters(
         raw = await param.source_.resolve();
       } catch (error) {
         const message = messageOf(error);
-        errors.push(`--${flagName(name)}: ${message}`);
+        errors.push(`--${flagOf(name, param)}: ${message}`);
         continue;
       }
     }
@@ -545,11 +618,11 @@ export async function resolveParameters(
       param.resolve_(raw);
     } catch (error) {
       const message = messageOf(error);
-      errors.push(`--${flagName(name)}: ${message}`);
+      errors.push(`--${flagOf(name, param)}: ${message}`);
       continue;
     }
     if (raw === undefined && param.required_ && !param.hasFallback_) {
-      errors.push(`--${flagName(name)} is required (or set ${envName}).`);
+      errors.push(`--${flagOf(name, param)} is required (or set ${envName}).`);
     }
   }
   return errors;

--- a/packages/core/src/registry/descriptor.ts
+++ b/packages/core/src/registry/descriptor.ts
@@ -27,9 +27,8 @@ import type {
   CliParameterInfo,
   CliTargetInfo,
 } from "../describe.ts";
-import { BUILTIN_FLAG_NAMES } from "../cli_spec.ts";
+import { BUILTIN_FLAG_NAMES, VALID_FLAG_NAME } from "../cli_spec.ts";
 import { asObject, fields } from "../json_shape.ts";
-import { flagName } from "../params.ts";
 
 /** The field readers for a build descriptor's fields. */
 const { optionalStr, str, strArray } = fields("registry: descriptor field");
@@ -188,6 +187,52 @@ function paramKind(
 }
 
 /**
+ * Refuse a descriptor whose parameters collide — on their flag, or on their
+ * name.
+ *
+ * With the derived-flag rule gone, this is what stops one parameter shadowing
+ * another, and it has to cover both keys because the two are read by different
+ * consumers. The MCP registry server advertises a parameter by **name** and
+ * spawns it by **flag**, keying each through a last-wins map, so either
+ * duplicate hides a value from the caller who supplied it: two parameters
+ * named `env` with different flags advertise one `env` property and put the
+ * value on whichever flag came last, while two claiming `--env` land it on
+ * whichever the child's parser matched first.
+ *
+ * The removed rule enforced name uniqueness as a side effect — two entries
+ * with one name derived one flag — so dropping it needed both halves back, not
+ * just the flag half.
+ */
+function assertDistinctParameters(
+  parameters: CliParameterInfo[],
+): CliParameterInfo[] {
+  const byFlag = new Map<string, string>();
+  const names = new Set<string>();
+  for (const parameter of parameters) {
+    if (names.has(parameter.name)) {
+      throw new Error(
+        `registry: descriptor declares two parameters named ` +
+          `"${parameter.name}". A caller can only supply one of them, and ` +
+          `the value would reach whichever the registry read last, so the ` +
+          `descriptor is refused.`,
+      );
+    }
+    names.add(parameter.name);
+    const claimed = byFlag.get(parameter.flag);
+    if (claimed !== undefined) {
+      throw new Error(
+        `registry: descriptor parameters "${claimed}" and ` +
+          `"${parameter.name}" both claim the flag "--${parameter.flag}". A ` +
+          `spawned run would apply the caller's value to whichever the ` +
+          `child's parser matched first, so the descriptor is refused.`,
+      );
+    }
+    byFlag.set(parameter.flag, parameter.name);
+  }
+  return parameters;
+}
+
+/**
  * Validate one {@link CliParameterInfo}.
  *
  * A descriptor's `flag` is not taken on trust. The registry MCP server renders
@@ -196,8 +241,14 @@ function paramKind(
  * built-in would put the caller's value on that flag instead. With `--actor`
  * that overrides the `ZUKE_ACTOR` the runner exported for the resolved caller,
  * and the run is recorded under an actor the descriptor chose. A registry's
- * backend is a service Zuke does not control, so both shapes are refused here,
+ * backend is a service Zuke does not control, so that shape is refused here,
  * at the parse boundary every backend goes through.
+ *
+ * A flag that merely *differs* from what its `name` would derive is not
+ * refused. A build may declare its own spelling with
+ * {@link "../params.ts".Parameter.flag}, and the descriptor has to carry it or
+ * a spawned run could not set that parameter at all. What stands in its place
+ * is {@link assertDistinctParameters}, which stops one parameter shadowing another.
  */
 function parseParameterInfo(value: unknown): CliParameterInfo {
   const object = asObject(value);
@@ -208,12 +259,19 @@ function parseParameterInfo(value: unknown): CliParameterInfo {
   const boolean = bool(object, "boolean");
   // Pre-M12 descriptors carry no `name`; the flag is the best available key.
   const name = optionalStr(object, "name") ?? flag;
-  const derived = flagName(name);
-  if (flag !== derived) {
+  // Shape before membership, because membership alone is not a check. The
+  // child's parser splits `--flag=value` at the first `=` and matches the
+  // prefix, so a descriptor flag of `actor=mallory` is absent from the
+  // built-in list yet arrives as `--actor` — landing the caller's value on the
+  // built-in and recording the run under an actor the descriptor chose. The
+  // build side refuses the same shapes when a flag is declared; this is the
+  // same rule at the boundary where the flag comes from a service instead.
+  if (!VALID_FLAG_NAME.test(flag)) {
     throw new Error(
-      `registry: descriptor parameter "${name}" declares flag "--${flag}", ` +
-        `but its name renders as "--${derived}". A flag that does not follow ` +
-        `from its parameter's name is refused.`,
+      `registry: descriptor parameter "${name}" declares the flag ` +
+        `"--${flag}", which is not a valid flag name. A flag that the ` +
+        `child's parser would read as something other than it says — one ` +
+        `containing "=", a space or a leading dash — is refused.`,
     );
   }
   if (BUILTIN_FLAG_NAMES.includes(flag)) {
@@ -248,7 +306,9 @@ function parseCliDescription(value: unknown): CliDescription {
     commands: arrayOf(object, "commands", parseNamed),
     flags: arrayOf(object, "flags", parseNamed),
     targets: arrayOf(object, "targets", parseTargetInfo),
-    parameters: arrayOf(object, "parameters", parseParameterInfo),
+    parameters: assertDistinctParameters(
+      arrayOf(object, "parameters", parseParameterInfo),
+    ),
   };
 }
 

--- a/packages/core/tests/params_test.ts
+++ b/packages/core/tests/params_test.ts
@@ -10,6 +10,7 @@ import {
   discoverParameters,
   envVarName,
   flagName,
+  flagOf,
   Parameter,
   parameter,
   ParameterError,
@@ -597,4 +598,75 @@ Deno.test("a parameter exposes its default as a display string", () => {
   // An empty-list array default and an undefined optional carry no default.
   assertEquals(parameter().array().default_, undefined);
   assertEquals(parameter().default_, undefined);
+});
+
+Deno.test("a declared flag replaces the one the name would derive", () => {
+  class B extends Build {
+    // The digit ends the run of capitals, so the derived flag would be
+    // `--skip-e2-e`. This is the case `.flag()` exists for.
+    skipE2E = parameter("skip the E2E suite").flag("--skip-e2e").boolean();
+    plain = parameter("derived as usual");
+  }
+  const params = discoverParameters(new B());
+  assertEquals(flagOf("skipE2E", params.get("skipE2E")!), "skip-e2e");
+  assertEquals(flagName("skipE2E"), "skip-e2-e"); // the rule itself is unchanged
+  assertEquals(flagOf("plain", params.get("plain")!), "plain");
+});
+
+Deno.test("the leading dashes are optional when declaring a flag", () => {
+  // Two builds, not two fields of one: a single build declaring the same flag
+  // twice is refused, which is its own test below.
+  class WithDashes extends Build {
+    a = parameter("with dashes").flag("--skip-e2e");
+  }
+  class Without extends Build {
+    a = parameter("without").flag("skip-e2e");
+  }
+  // The stored value, not merely that the two agree — a strip that mapped both
+  // to the empty string would satisfy equality alone.
+  assertEquals(new WithDashes().a.flagName_, "skip-e2e");
+  assertEquals(new Without().a.flagName_, "skip-e2e");
+});
+
+Deno.test("a declared flag that is not a valid flag name is refused", () => {
+  for (const bad of ["skip e2e", "-skip", "skip=e2e", "2fast", "Skip", ""]) {
+    class B extends Build {
+      thing = parameter("bad").flag(bad);
+    }
+    assertThrows(
+      () => discoverParameters(new B()),
+      Error,
+      "not a valid flag name",
+    );
+  }
+});
+
+Deno.test("a declared flag naming a built-in is refused, naming the declaration", () => {
+  class B extends Build {
+    message = parameter("would hijack attribution").flag("--actor");
+  }
+  // The derived-name refusal would not have caught this: `message` renders as
+  // `--message`. The check has to read the flag the parameter actually claims.
+  const error = assertThrows(
+    () => discoverParameters(new B()),
+    Error,
+    "built-in Zuke CLI flag",
+  );
+  assertStringIncludes(String(error), "declares the flag");
+});
+
+Deno.test("two parameters claiming one flag are refused, naming both", () => {
+  class B extends Build {
+    // Field names deliberately absent from the rendered flag, so the message
+    // has to name them rather than merely echo `--stage`.
+    stage = parameter("first").flag("--stage");
+    tier = parameter("second").flag("--stage");
+  }
+  const error = assertThrows(
+    () => discoverParameters(new B()),
+    Error,
+    "both render as",
+  );
+  assertStringIncludes(String(error), '"stage"');
+  assertStringIncludes(String(error), '"tier"');
 });

--- a/packages/core/tests/registry_test.ts
+++ b/packages/core/tests/registry_test.ts
@@ -577,11 +577,13 @@ Deno.test("parseBuildDescriptor refuses a parameter flag that shadows a built-in
       },
     });
 
-  // A flag that does not follow from its name: the tampering shape.
+  // A flag that does not follow from its name is no longer refused for that
+  // alone — a build may declare its own spelling — but naming a built-in is
+  // still the tampering shape, and that is what this catches.
   assertThrows(
     () => parseBuildDescriptor(withParam({ name: "message", flag: "actor" })),
     Error,
-    "does not follow from its parameter's name",
+    "built-in Zuke CLI flag",
   );
   // A name that honestly renders as a built-in: a build registered before the
   // declaration itself was refused. Refused now on read, not silently honoured.
@@ -596,6 +598,28 @@ Deno.test("parseBuildDescriptor refuses a parameter flag that shadows a built-in
     Error,
     "built-in Zuke CLI flag",
   );
+  // A flag whose SHAPE lets it mean something else to the child's parser. The
+  // parser splits `--flag=value` at the first `=` and matches the prefix, so
+  // `actor=mallory` is absent from the built-in list yet arrives as `--actor`:
+  // the caller's value lands on the built-in and the run is recorded under an
+  // actor the descriptor chose, while the advertised parameter gets nothing.
+  // Membership alone never caught this; shape does.
+  assertThrows(
+    () =>
+      parseBuildDescriptor(
+        withParam({ name: "environment", flag: "actor=mallory" }),
+      ),
+    Error,
+    "not a valid flag name",
+  );
+  for (const bad of ["", "--actor", "actor ", "ACTOR", "a b", "-l", "a\nb"]) {
+    assertThrows(
+      () => parseBuildDescriptor(withParam({ name: "environment", flag: bad })),
+      Error,
+      "not a valid flag name",
+    );
+  }
+
   // A name merely near a built-in, and a grouped one, still parse.
   assertEquals(
     parseBuildDescriptor(withParam({ name: "actorName", flag: "actor-name" }))
@@ -610,16 +634,16 @@ Deno.test("parseBuildDescriptor refuses a parameter flag that shadows a built-in
 });
 
 Deno.test("any surface describeCli produces still parses, awkward names included", () => {
-  // The refusal above rejects a descriptor whose `flag` does not follow from
-  // its `name`. That is safe only while `describeCli` is the sole producer of
-  // the field and always derives it — including for a pre-M12 descriptor,
-  // where the name is recovered from the flag, so `flagName` must be
-  // idempotent. Pinned here rather than argued: a change to `flagName` that
-  // broke either property would fail this test rather than quietly start
-  // refusing descriptors a previous Zuke wrote.
+  // A pre-M12 descriptor carries no `name`, so the name is recovered from the
+  // flag — which means `flagName` must be idempotent, or a descriptor a
+  // previous Zuke wrote would come back with a different name than it went in
+  // with. Pinned here rather than argued.
   class Awkward extends Build {
     actorName = parameter("near a built-in");
     xmlHttpTimeout = parameter("consecutive capitals").number();
+    // The property the relaxed rule exists for: describeCli now emits a flag
+    // that does NOT derive from its name, and the read path must accept it.
+    skipE2E = parameter("declared flag").flag("--skip-e2e").boolean();
     runs = { keepLast: parameter("grouped"), limit: parameter("grouped") };
     deploy = target().executes(() => {});
   }
@@ -640,5 +664,64 @@ Deno.test("any surface describeCli produces still parses, awkward names included
   assertEquals(
     parseBuildDescriptor(legacy).surface.parameters.map((p) => p.flag),
     surface.parameters.map((p) => p.flag),
+  );
+});
+
+Deno.test("parseBuildDescriptor refuses two parameters claiming one flag", () => {
+  const withParams = (parameters: Record<string, unknown>[]) =>
+    JSON.stringify({
+      ...sampleDescriptor(),
+      surface: {
+        commands: [],
+        flags: [],
+        targets: [],
+        parameters: parameters.map((parameter) => ({
+          description: "",
+          required: false,
+          boolean: false,
+          array: false,
+          options: [],
+          ...parameter,
+        })),
+      },
+    });
+
+  // This is what stands in for the derived-flag rule: without it one parameter
+  // shadows another, and a caller's value lands on whichever the child's
+  // parser matched first — invisible to the caller either way.
+  assertThrows(
+    () =>
+      parseBuildDescriptor(withParams([
+        { name: "environment", flag: "env" },
+        { name: "tag", flag: "env" },
+      ])),
+    Error,
+    "both claim the flag",
+  );
+
+  // Two parameters sharing a NAME is the other half. The removed rule gave
+  // name uniqueness away for free — two entries with one name derived one flag
+  // — so dropping it reopened it. The MCP registry server advertises by name
+  // and spawns by flag through last-wins maps, so a descriptor naming `env`
+  // twice advertises one `env` property and puts the caller's value on
+  // whichever flag came last: `--deploy-token`, say.
+  assertThrows(
+    () =>
+      parseBuildDescriptor(withParams([
+        { name: "env", flag: "env" },
+        { name: "env", flag: "deploy-token" },
+      ])),
+    Error,
+    "two parameters named",
+  );
+
+  // A declared flag that simply differs from its name is fine: that is the
+  // whole point of letting a build choose its spelling.
+  assertEquals(
+    parseBuildDescriptor(withParams([
+      { name: "skipE2E", flag: "skip-e2e" },
+      { name: "tag", flag: "tag" },
+    ])).surface.parameters.map((p) => p.flag),
+    ["skip-e2e", "tag"],
   );
 });

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/.codex-plugin/plugin.json
+++ b/plugins/zuke/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/skills/zuke-write-build/SKILL.md
+++ b/plugins/zuke/skills/zuke-write-build/SKILL.md
@@ -212,6 +212,9 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   named so that it renders as a built-in CLI flag (`actor`, `actorKind`,
   `limit`, `target`, `output`, …) or as an MCP control key (`dryRun`,
   `confirm`, `operatorToken`) — the build refuses to load, naming the field.
+  The flag is one dash per lower-to-upper transition, and a **digit ends a run
+  of capitals**, so `skipE2E` gives `--skip-e2-e`; name it `skipE2e` or declare
+  `.flag("--skip-e2e")`, which replaces the derived spelling everywhere.
 - **Secrets from a manager:** `parameter(...).secret().from(source)` sources a
   value at run time (e.g. `execSecret(...)` shelling out to a secret CLI) and
   **redacts** it from all of Zuke's output. See the cheatsheet.

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -560,7 +560,17 @@ Secrets are masked in CI output. Read a resolved value with `this.x.value`.
 Kinds & modifiers: `.number()` → `number`, `.boolean()` → `boolean` (a flag,
 defaults to `false`), `.options("a", "b")` restricts a string, `.secret()`
 masks + redacts, `.default(v)`/`.required()` set optionality, `.env(NAME)`
-overrides the env var.
+overrides the env var, `.flag("--name")` overrides the CLI flag.
+
+Flag/env derivation: one dash (underscore) per lower-to-upper transition, so
+`targetEnv` gives `--target-env` / `TARGET_ENV` and `runs.limit` gives
+`--runs-limit`. A run of capitals stays together (`apiURL` gives `--api-url`),
+but a **digit ends the run** — `skipE2E` gives `--skip-e2-e`, not `--skip-e2e`.
+Either name it `skipE2e`, or declare `.flag("--skip-e2e")`. A declared flag
+replaces the derived one everywhere (parser, `--help`, JSON surface,
+completions, registry descriptor); it must be lowercase letters/digits/dashes
+starting with a letter, may not be a built-in, and no two parameters may claim
+the same one. The env var is derived separately and is unaffected.
 
 Lists: `.array()` (comma-separated or repeated flag) comes **last** and composes
 — `.options("a", "b").array()` validates each element, and `.number().array()`

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -212,6 +212,9 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   named so that it renders as a built-in CLI flag (`actor`, `actorKind`,
   `limit`, `target`, `output`, …) or as an MCP control key (`dryRun`,
   `confirm`, `operatorToken`) — the build refuses to load, naming the field.
+  The flag is one dash per lower-to-upper transition, and a **digit ends a run
+  of capitals**, so `skipE2E` gives `--skip-e2-e`; name it `skipE2e` or declare
+  `.flag("--skip-e2e")`, which replaces the derived spelling everywhere.
 - **Secrets from a manager:** `parameter(...).secret().from(source)` sources a
   value at run time (e.g. `execSecret(...)` shelling out to a secret CLI) and
   **redacts** it from all of Zuke's output. See the cheatsheet.

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -560,7 +560,17 @@ Secrets are masked in CI output. Read a resolved value with `this.x.value`.
 Kinds & modifiers: `.number()` → `number`, `.boolean()` → `boolean` (a flag,
 defaults to `false`), `.options("a", "b")` restricts a string, `.secret()`
 masks + redacts, `.default(v)`/`.required()` set optionality, `.env(NAME)`
-overrides the env var.
+overrides the env var, `.flag("--name")` overrides the CLI flag.
+
+Flag/env derivation: one dash (underscore) per lower-to-upper transition, so
+`targetEnv` gives `--target-env` / `TARGET_ENV` and `runs.limit` gives
+`--runs-limit`. A run of capitals stays together (`apiURL` gives `--api-url`),
+but a **digit ends the run** — `skipE2E` gives `--skip-e2-e`, not `--skip-e2e`.
+Either name it `skipE2e`, or declare `.flag("--skip-e2e")`. A declared flag
+replaces the derived one everywhere (parser, `--help`, JSON surface,
+completions, registry descriptor); it must be lowercase letters/digits/dashes
+starting with a letter, may not be a built-in, and no two parameters may claim
+the same one. The env var is derived separately and is unaffected.
 
 Lists: `.array()` (comma-separated or repeated flag) comes **last** and composes
 — `.options("a", "b").array()` validates each element, and `.number().array()`

--- a/tests/integration/params_test.ts
+++ b/tests/integration/params_test.ts
@@ -168,3 +168,60 @@ Deno.test("a parameter beside --actor keeps its own value and the run's actor", 
     assertEquals(bob.out.includes("deploy"), false);
   });
 });
+
+Deno.test("a declared flag is the one the CLI accepts, and the derived one is not", async () => {
+  const seen: boolean[] = [];
+  class Ship extends Build {
+    // `skipE2E` derives `--skip-e2-e`: the digit ends the run of capitals, so
+    // `2E` is a lower-to-upper transition. This is what `.flag()` is for.
+    skipE2E = parameter("skip the E2E suite").flag("--skip-e2e").boolean();
+    ship = target().executes(() => void seen.push(this.skipE2E.value));
+  }
+
+  const declared = await runCli(Ship, ["ship", "--skip-e2e"]);
+  assertEquals(declared.code, 0);
+  assertEquals(seen, [true]);
+
+  // The derived spelling is gone: the author chose, so only their spelling is
+  // accepted, and an unknown flag is an error rather than a silent no-op.
+  const derived = await runCli(Ship, ["ship", "--skip-e2-e"]);
+  assertEquals(derived.code, 1);
+  assertStringIncludes(derived.err + derived.out, "--skip-e2-e");
+});
+
+Deno.test("a declared flag is what --help and the JSON surface show", async () => {
+  class Ship extends Build {
+    skipE2E = parameter("skip the E2E suite").flag("--skip-e2e").boolean();
+    ship = target().executes(() => {});
+  }
+
+  const help = await runCli(Ship, ["--help"]);
+  assertEquals(help.code, 0);
+  assertStringIncludes(help.out, "--skip-e2e");
+  // The derived spelling must not appear anywhere a reader would copy it from.
+  assertEquals(help.out.includes("--skip-e2-e"), false);
+
+  const json = await runCli(Ship, ["--list", "--json"]);
+  assertEquals(json.code, 0);
+  assertStringIncludes(json.out, '"flag": "skip-e2e"');
+});
+
+Deno.test("the environment variable is unaffected by a declared flag", async () => {
+  const seen: boolean[] = [];
+  class Ship extends Build {
+    skipE2E = parameter("skip the E2E suite").flag("--skip-e2e").boolean();
+    ship = target().executes(() => void seen.push(this.skipE2E.value));
+  }
+  // The flag and the variable are derived separately, so overriding one leaves
+  // the other exactly where it was — `.env()` is the override for that half.
+  const prev = Deno.env.get("SKIP_E2_E");
+  Deno.env.set("SKIP_E2_E", "true");
+  try {
+    const run = await runCli(Ship, ["ship"]);
+    assertEquals(run.code, 0);
+    assertEquals(seen, [true]);
+  } finally {
+    if (prev === undefined) Deno.env.delete("SKIP_E2_E");
+    else Deno.env.set("SKIP_E2_E", prev);
+  }
+});


### PR DESCRIPTION
### The problem

A parameter's flag and environment variable are derived from its field name: one dash, or underscore, at each lower-to-upper transition. A run of capitals has no internal transition and stays together, so `apiURL` gives `--api-url`. A **digit ends a run**, which is where the rule surprises people:

    skipE2E   -->  --skip-e2-e   SKIP_E2_E
    runE2E    -->  --run-e2-e    RUN_E2_E

An author who wanted `--skip-e2e` had no way to ask for it, and the rule that produced the surprising spelling was documented nowhere. The environment variable already had an explicit override, so the flag was the asymmetric half.

This is item 14.3 of the maintainer proposal.

### The shape

A declared flag **replaces** the derived one, everywhere a flag is rendered or matched: the parser, `--help`, `--list --json`, shell completions, resolution errors, the interactive prompt, and a registered build's descriptor. A single accessor is the only way any of them asks, so a declared flag cannot be honoured in one place and derived in another.

Three refusals at load, each naming the field: a flag that is not a valid flag name, one that names a built-in, and two parameters claiming one flag. The second is worth noting because the old name-based check could not reach it — a parameter named `message` declaring `--actor` renders as `--message`.

The environment variable is derived separately and is unaffected.

### Re-basing the descriptor guard, and the two holes that opened

The change could not land without touching the guard added in #486, which refused any registry descriptor whose `flag` differed from what its `name` derives. A declared flag legitimately differs, and the descriptor has to carry it or a registry-spawned run could not set the parameter at all.

I argued that the rule was belt-and-braces the built-in check covers on its own. That was reasoning about the **threat** rather than about what the rule mechanically guaranteed, and it was wrong twice. Both were found by attacking this change before opening the PR, both are fixed here, and both have regression tests that were mutation-checked.

**A descriptor flag containing an equals sign forged the run's actor** (high). The child's parser splits a flag from its value at the first `=` and matches the prefix, so a flag of `actor=mallory` is absent from the built-in list yet arrives as `--actor`. A malicious registry advertises a plausible `environment` parameter, marks it required so a conforming MCP client fills it in, and the caller's own value overrides the actor the runner exported for the authenticated caller — the exact attribution forgery #486 existed to stop, reached through a parameter name that looks innocent. The removed rule had been supplying the missing shape guarantee incidentally, because a *derived* flag can never contain an equals sign. Shape is now checked before membership, by one regex shared between the two boundaries: where a build declares a flag, and where a descriptor is read.

**Two parameters sharing a name shadowed each other** (medium-high). The removed rule gave name uniqueness away for free, since two entries with one name derive one flag. The registry server advertises a parameter by name and spawns it by flag, each through a last-wins map, so a descriptor naming `env` twice advertises one `env` property and puts the caller's value on the other entry's flag. Both keys are checked now, in one place, for the reason each is read by a different consumer.

Also from the same review, three tests that were weaker than they looked: two assertions that passed on the rendered flag alone rather than on the field names the message is supposed to carry, an equality assertion that any collapsing transform would satisfy, and a round-trip fixture that never exercised the new property it was guarding.

### Testing

15 new tests. Unit coverage of the accessor, the dash-stripping, and each of the three load-time refusals; descriptor coverage of the shape rule, the built-in rule, both uniqueness rules, and a declared flag surviving the round trip; and integration tests driving real builds through the CLI for the declared flag being accepted, the derived one being rejected, `--help` and the JSON surface showing the declared spelling, and the environment variable being untouched.

`deno task ci`: 22/22 targets, 4357 tests, 98.4% lines and 97.4% branches against a 95% gate.

### Related issues

Closes #517

### Checklist

- [x] This PR closes a tracking issue.
- [x] The PR title is a Conventional Commit.
- [x] `deno task ci` passes locally.
- [x] Tests were added or updated; coverage stays at 95%+.
- [x] Docs updated in the same PR (the parameters guide).
- [x] Public API changes were regenerated with the API docs target.
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/`.
- [x] Agent skills updated and the plugin version bumped in all four manifests (0.47.0 to 0.48.0).
