### PR TITLE
chore: verify each example's committed pipeline files against the renderer

### DIFF
--- a/build/examples.ts
+++ b/build/examples.ts
@@ -3,9 +3,9 @@
 
 /**
  * The examples gate. Every `examples/<name>/zuke.ts` is a complete build a
- * reader is meant to copy, so each one is type-checked against the workspace
- * and asked to list its targets on every run — an example cannot rot when the
- * API moves.
+ * reader is meant to copy, so each one is type-checked against the workspace,
+ * asked to list its targets, and asked to verify any pipeline files it commits
+ * — an example cannot rot when the API moves.
  *
  * The examples import `jsr:@zuke/*`. From inside this repository those
  * specifiers resolve to the workspace members, so the check holds an example
@@ -31,35 +31,63 @@ export interface Example {
 export interface ExampleFailure {
   /** The example's directory. */
   dir: string;
-  /** Which step failed: the type-check, or listing the build's targets. */
-  step: "check" | "list";
+  /**
+   * Which step failed: the type-check, listing the build's targets, or
+   * verifying the pipeline files the example commits.
+   */
+  step: "check" | "list" | "pipeline";
   /** The tool's output. */
   detail: string;
 }
 
-/** The two steps the gate runs per example, injectable for unit tests. */
+/** One step's verdict: whether it passed, and the tool output to report. */
+export interface ExampleVerdict {
+  /** Whether the step passed. */
+  ok: boolean;
+  /** The tool's output, reported when the step failed. */
+  detail: string;
+}
+
+/** The three steps the gate runs per example, injectable for unit tests. */
 export interface ExampleRunner {
   /** Type-check the build file. */
   check: SnippetChecker;
   /** Run the build's `--list` from inside its directory. */
-  list: (dir: string) => Promise<{ ok: boolean; detail: string }>;
+  list: (dir: string) => Promise<ExampleVerdict>;
+  /** Run the build's `generate-ci --check` from inside its directory. */
+  pipeline: (dir: string) => Promise<ExampleVerdict>;
 }
 
-/** The default runner: `deno check` and `deno run … --list`, both frozen. */
+/**
+ * Run one example's build with `args`, from inside its own directory.
+ *
+ * An example that drives a Node app carries that app's package.json. Deno
+ * would discover it from the example's directory and, under --frozen, refuse
+ * to run because the root lockfile does not list it as a workspace member —
+ * but it is the app's manifest, not the build's, so opt out of package.json
+ * discovery for every step the gate runs.
+ */
+async function runExampleBuild(
+  dir: string,
+  args: string[],
+): Promise<ExampleVerdict> {
+  const out = await DenoTasks.run((s) =>
+    s.allowAll().frozen().script("zuke.ts").scriptArgs(...args).cwd(dir)
+      .env({ DENO_NO_PACKAGE_JSON: "1" }).quiet().noThrow()
+  );
+  return { ok: out.code === 0, detail: `${out.stderr}${out.stdout}`.trim() };
+}
+
+/**
+ * The default runner: `deno check`, then the build's own `--list` and
+ * `generate-ci --check`, all frozen. An example that declares no pipeline
+ * reports that and exits zero, so the last step is safe to run over every
+ * example rather than only the ones that commit workflow files.
+ */
 const denoRunner: ExampleRunner = {
   check: denoCheck,
-  list: async (dir) => {
-    // An example that drives a Node app carries that app's package.json. Deno
-    // would discover it from the example's directory and, under --frozen,
-    // refuse to run because the root lockfile does not list it as a workspace
-    // member — but it is the app's manifest, not the build's, so opt out of
-    // package.json discovery for the listing.
-    const out = await DenoTasks.run((s) =>
-      s.allowAll().frozen().script("zuke.ts").scriptArgs("--list").cwd(dir)
-        .env({ DENO_NO_PACKAGE_JSON: "1" }).quiet().noThrow()
-    );
-    return { ok: out.code === 0, detail: `${out.stderr}${out.stdout}`.trim() };
-  },
+  list: (dir) => runExampleBuild(dir, ["--list"]),
+  pipeline: (dir) => runExampleBuild(dir, ["generate-ci", "--check"]),
 };
 
 /**
@@ -82,10 +110,11 @@ export async function discoverExamples(
 }
 
 /**
- * Run the gate over `examples`: type-check each build file, then list its
- * targets from inside its directory. A build that fails to type-check is not
- * listed — the check output is the root cause, and the list would only repeat
- * it — so each example contributes at most one failure.
+ * Run the gate over `examples`: type-check each build file, list its targets
+ * from inside its directory, then verify the pipeline files it commits are
+ * what the current core renders. Each step runs only when the one before it
+ * passed — the first failure is the root cause and the rest would repeat it —
+ * so each example contributes at most one failure.
  */
 export async function checkExamples(
   examples: Example[],
@@ -105,16 +134,32 @@ export async function checkExamples(
     const listed = await runner.list(example.dir);
     if (!listed.ok) {
       failures.push({ dir: example.dir, step: "list", detail: listed.detail });
+      continue;
+    }
+    const pipeline = await runner.pipeline(example.dir);
+    if (!pipeline.ok) {
+      failures.push({
+        dir: example.dir,
+        step: "pipeline",
+        detail: pipeline.detail,
+      });
     }
   }
   return failures;
 }
 
+/** How each step's failure reads in the gate's message. */
+const STEP_FAILURE: Record<ExampleFailure["step"], string> = {
+  check: "does not type-check",
+  list: "fails --list",
+  pipeline: "has stale pipeline files",
+};
+
 /** Render the failures as one actionable message, each example named first. */
 export function formatExampleFailures(failures: ExampleFailure[]): string {
   const blocks = failures.map((f) => {
     const detail = f.detail.split("\n").map((line) => `    ${line}`).join("\n");
-    const what = f.step === "check" ? "does not type-check" : "fails --list";
+    const what = STEP_FAILURE[f.step];
     return `  ${f.dir} ${what}:\n${detail}`;
   });
   return `${failures.length} example(s) failed the gate:\n${

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -96,7 +96,7 @@ flowchart TD
 | `syncWebsite` | Open and merge a website PR with refreshed llms.txt + api.json | — |
 | `docLint` | Fail on missing JSDoc or first-party private-type refs (deno doc --lint) | — |
 | `snippetsCheck` | Type-check the marked ts snippets in docs and skills | — |
-| `examplesCheck` | Type-check every example project and list its targets | — |
+| `examplesCheck` | Type-check every example, list its targets, verify its CI | — |
 | `hclGen` | Regenerate the Terraform/OpenTofu wrappers from one template | — |
 | `hclSyncCheck` | Verify the Terraform/OpenTofu wrappers match their template | — |
 | `pluginSync` | Sync plugins/zuke/skills/ from skills/ (real copies, not a symlink) | — |

--- a/tests/examples_check_test.ts
+++ b/tests/examples_check_test.ts
@@ -12,27 +12,27 @@ import {
 
 /** A runner that records the order of its calls and answers from a script. */
 function fakeRunner(
-  verdicts: { check?: Record<string, string>; list?: Record<string, string> },
+  verdicts: {
+    check?: Record<string, string>;
+    list?: Record<string, string>;
+    pipeline?: Record<string, string>;
+  },
 ): ExampleRunner & { calls: string[] } {
   const calls: string[] = [];
+  const step =
+    (name: string, scripted?: Record<string, string>) => (key: string) => {
+      calls.push(`${name} ${key}`);
+      const detail = scripted?.[key];
+      return Promise.resolve({
+        ok: detail === undefined,
+        detail: detail ?? "",
+      });
+    };
   return {
     calls,
-    check: (path) => {
-      calls.push(`check ${path}`);
-      const detail = verdicts.check?.[path];
-      return Promise.resolve({
-        ok: detail === undefined,
-        detail: detail ?? "",
-      });
-    },
-    list: (dir) => {
-      calls.push(`list ${dir}`);
-      const detail = verdicts.list?.[dir];
-      return Promise.resolve({
-        ok: detail === undefined,
-        detail: detail ?? "",
-      });
-    },
+    check: step("check", verdicts.check),
+    list: step("list", verdicts.list),
+    pipeline: step("pipeline", verdicts.pipeline),
   };
 }
 
@@ -75,14 +75,16 @@ Deno.test("discoverExamples refuses an empty match rather than passing vacuously
   assertEquals(message.includes("No example builds match"), true);
 });
 
-Deno.test("checkExamples type-checks then lists each example, in order", async () => {
+Deno.test("checkExamples runs all three steps per example, in order", async () => {
   const runner = fakeRunner({});
   assertEquals(await checkExamples(EXAMPLES, runner), []);
   assertEquals(runner.calls, [
     "check examples/a/zuke.ts",
     "list examples/a",
+    "pipeline examples/a",
     "check examples/b/zuke.ts",
     "list examples/b",
+    "pipeline examples/b",
   ]);
 });
 
@@ -95,6 +97,7 @@ Deno.test("a build that fails to type-check is reported once and not listed", as
     { dir: "examples/a", step: "check", detail: "TS2339: no such method" },
   ]);
   assertEquals(runner.calls.includes("list examples/a"), false);
+  assertEquals(runner.calls.includes("pipeline examples/a"), false);
   assertEquals(runner.calls.includes("list examples/b"), true);
 });
 
@@ -109,14 +112,35 @@ Deno.test("a build whose --list fails is reported with the list output", async (
       detail: "forward reference to this.test",
     },
   ]);
+  // The pipeline step would only repeat a build that does not run.
+  assertEquals(runner.calls.includes("pipeline examples/b"), false);
+});
+
+Deno.test("an example whose committed pipeline drifted is reported", async () => {
+  // The step this covers: an example commits the workflow files `cicd()`
+  // renders, and a change to the renderer leaves them stale. Type-checking and
+  // `--list` both still pass, so without this the gate is blind to it.
+  const runner = fakeRunner({
+    pipeline: {
+      "examples/a": "CI configuration is out of date: .gitlab-ci.yml.",
+    },
+  });
+  assertEquals(await checkExamples(EXAMPLES, runner), [
+    {
+      dir: "examples/a",
+      step: "pipeline",
+      detail: "CI configuration is out of date: .gitlab-ci.yml.",
+    },
+  ]);
 });
 
 Deno.test("formatExampleFailures names the example, the step, and the output", () => {
   const text = formatExampleFailures([
     { dir: "examples/a", step: "check", detail: "line one\nline two" },
     { dir: "examples/b", step: "list", detail: "boom" },
+    { dir: "examples/c", step: "pipeline", detail: "stale .gitlab-ci.yml" },
   ]);
-  assertEquals(text.startsWith("2 example(s) failed the gate:"), true);
+  assertEquals(text.startsWith("3 example(s) failed the gate:"), true);
   assertEquals(
     text.includes(
       "  examples/a does not type-check:\n    line one\n    line two",
@@ -124,6 +148,12 @@ Deno.test("formatExampleFailures names the example, the step, and the output", (
     true,
   );
   assertEquals(text.includes("  examples/b fails --list:\n    boom"), true);
+  assertEquals(
+    text.includes(
+      "  examples/c has stale pipeline files:\n    stale .gitlab-ci.yml",
+    ),
+    true,
+  );
   assertEquals(text.includes("it is what readers copy"), true);
 });
 

--- a/zuke.ts
+++ b/zuke.ts
@@ -459,19 +459,22 @@ class ZukeBuild extends Build {
     });
 
   examplesCheck = target()
-    .description("Type-check every example project and list its targets")
+    .description("Type-check every example, list its targets, verify its CI")
     .executes(async () => {
       // The examples import `jsr:@zuke/*`, which resolves to the workspace from
       // inside this repository — so each one is held to the real source, not a
       // published version that could lag behind it. A failing `--list` catches
-      // what a type-check cannot: a build that no longer constructs.
+      // what a type-check cannot: a build that no longer constructs. And
+      // `generate-ci --check` catches what neither can: an example that commits
+      // generated pipeline files the current renderer no longer produces.
       const examples = await discoverExamples();
       const failures = await checkExamples(examples);
       if (failures.length > 0) {
         throw new Error(formatExampleFailures(failures));
       }
       ConsoleTasks.info(
-        `${examples.length} example(s) type-check and list their targets.`,
+        `${examples.length} example(s) type-check, list their targets, and ` +
+          "carry up-to-date pipeline files.",
       );
     });
 


### PR DESCRIPTION
Hey! First PR here. I was reading through the new `examples/` after our chat
and noticed one thread left loose. Nothing urgent, and very happy to reshape or
close it if you would rather take it a different way.

Closes #520

## What I noticed

`examples/ci-only` commits the three pipeline files its CI fields render:
`.github/workflows/ci.yml`, `.gitlab-ci.yml` and `azure-pipelines.yml`. Its own
README teaches that a run verifies those committed copies and fails when they
have drifted.

Nothing verified them here. The examples gate type-checks each build and lists
its targets, so a change to the CI renderer in core leaves the committed files
stale while `examplesCheck` stays green. The example that teaches drift
detection was the one place drift went unchecked, and since the examples are
what readers clone, a stale file there is copied outward rather than only being
wrong in place.

Reproduced on `773daf0`: append a line to `examples/ci-only/.gitlab-ci.yml`,
run `./zuke examplesCheck`, and it succeeds.

## What this does

A third step on the examples runner, after the listing: the build's own
`generate-ci --check`, run from inside the example's directory. A build that
declares no pipeline reports that and exits zero, so the step is safe over
every example rather than only the ones that commit pipeline files, and no
per-example configuration is needed.

The failure carries the renderer's own message, so the gate names the example,
says its pipeline files are stale, names the file that drifted, and repeats the
command that regenerates it.

Each step still runs only when the one before it passed, so an example
contributes at most one failure and the pipeline step never repeats a build
that does not run.

The two spawns now share one helper. That keeps the `DENO_NO_PACKAGE_JSON`
opt-out the Node example needs from being applied to one step and forgotten on
the next.

`docs/graph.md` is regenerated because the target description changed.

## Verification

- `deno task ci` passes: 22/22 targets, 4347 tests, coverage 98.3 percent lines
  and 97.4 percent branches.
- The gate fails on a drifted `examples/ci-only/.gitlab-ci.yml` and passes once
  it is restored.
- Unit coverage in `tests/examples_check_test.ts`: the three-step order, the
  new failure being reported, the step being skipped when the listing already
  failed, and its wording in the summary.

Thanks for building this in the open. Reading the gate was genuinely a pleasure.
