### PR TITLE
fix(core): record a resume's parameter overrides in the audit trail

### DIFF
--- a/docs/state.md
+++ b/docs/state.md
@@ -67,7 +67,7 @@ Each run is stored as one JSON document:
     { "name": "build", "dependsOn": [] },
     { "name": "deploy", "dependsOn": ["build"] }
   ],
-  "params": { "env": "sit" }, // resolved, NON-secret parameters only
+  "params": { "env": "sit" }, // NON-secret values the run was LAUNCHED with
   "deadlineAt": "2026-07-17T…Z", // optional; from Build.deadline(), enforced by the reaper
   "intendedTerminal": "cancelled", // optional; set when a run enters `cancelling`
   "signals": {}, // external signals delivered to a .waitsFor() gate
@@ -107,6 +107,27 @@ The executor writes the record when it is created, on each target's start and
 finish, and when the run ends. So if the process is killed mid-run, the record
 on disk shows the target that was executing as `running`, with its `startedAt`
 stamped.
+
+`params` holds the values the run was **launched** with, and is never
+rewritten. A [resume](./orchestration.md#resuming-a-suspended-run) may supply
+different ones — re-supplying a rotated credential is the usual reason — and
+those take effect, so a resumed run can execute under two sets of values. One
+map cannot hold both, and this one keeps the launch's for a concrete reason: a
+cancellation resolves each compensation body's parameters from it, and the
+targets a compensation unwinds are the ones that ran *before* the suspension. A
+deploy that went to `sit` must be rolled back against `sit`, whatever a later
+resume was given.
+
+What the resume changed is recorded in the audit trail instead, naming the
+values and who supplied them:
+
+```
+Parameters:
+  env = sit
+
+Audit:
+  2026-07-17T09:12:03Z  resume  alice  ok  env=production
+```
 
 `buildId` is the run's **origin**: `ZUKE_BUILD_ID`, else `GITHUB_REPOSITORY`,
 resolved once when the run is created. It says which build a run belongs to when

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4065,6 +4065,13 @@ interface RunRecord
     The graph shape the run planned, in declaration order.
   params: Record<string, string>
     Resolved parameter values, keyed by name. Secrets are always omitted.
+
+    The values the run was launched with, and they are not rewritten. A
+    resume may supply different ones, in which case the run executes under two
+    sets and this field cannot hold both — so it keeps the launch's, which is
+    what the targets that ran before the suspension used, and what a
+    cancellation resolves each compensation body from. A resume that changed
+    anything records it in {@link RunRecord.events} instead.
   targets: Record<string, TargetRunState>
     Per-target progress, keyed by dotted target name.
   signals: Record<string, SignalRecord>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4119,6 +4119,13 @@ interface RunRecord
     The graph shape the run planned, in declaration order.
   params: Record<string, string>
     Resolved parameter values, keyed by name. Secrets are always omitted.
+
+    The values the run was launched with, and they are not rewritten. A
+    resume may supply different ones, in which case the run executes under two
+    sets and this field cannot hold both — so it keeps the launch's, which is
+    what the targets that ran before the suspension used, and what a
+    cancellation resolves each compensation body from. A resume that changed
+    anything records it in {@link RunRecord.events} instead.
   targets: Record<string, TargetRunState>
     Per-target progress, keyed by dotted target name.
   signals: Record<string, SignalRecord>

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -37,6 +37,7 @@ import {
   resolveRunParameters,
 } from "./execute_plan.ts";
 import { openRunState } from "./execute_state.ts";
+import { paramOverrideEvent, recordedParams } from "./state/record.ts";
 import type { HeldLease } from "./state/run_lease.ts";
 import { settleCancelledRun } from "./execute_cancel.ts";
 import { cancelledElsewhere } from "./cancel.ts";
@@ -419,6 +420,21 @@ export async function execute(
     };
     if (lease.lost.aborted) stopOwning();
     else lease.lost.addEventListener("abort", stopOwning, { once: true });
+  }
+
+  // A resume may have been given parameter values the launch did not supply,
+  // and they are what the bodies below will read. Record that in the audit
+  // trail — after the lease wiring above, so a process that has already lost
+  // the run writes nothing. `params` itself is deliberately left alone; see
+  // `paramOverrideEvent`.
+  if (options.resume !== undefined && writer !== undefined) {
+    const override = paramOverrideEvent(
+      options.resume.record.params,
+      recordedParams(params.values()),
+      actor,
+      new Date().toISOString(),
+    );
+    if (override !== undefined) await writer.appendEvent(override);
   }
 
   // Announce the run's initial durable state (`running`) to plugins — a no-op

--- a/packages/core/src/state/record.ts
+++ b/packages/core/src/state/record.ts
@@ -16,6 +16,7 @@
 import type { TargetStatus } from "../build.ts";
 import type { AnyParameter } from "../params.ts";
 import type { TargetBuilder } from "../target.ts";
+import type { RunEvent } from "./types.ts";
 import {
   ACTOR_KINDS,
   type ActorKind,
@@ -132,20 +133,37 @@ export interface RunRecordInput {
  * snapshot in declaration order, resolved non-secret parameters, and every
  * planned target seeded `pending`.
  */
+/**
+ * The parameters a run record carries: every resolved, **non-secret** value,
+ * keyed by property name.
+ *
+ * The exclusion is the record's whole promise about secrets — it holds none by
+ * construction — so this projection is the only way parameters reach a record,
+ * whether the record is being created or updated by a resume that supplied
+ * different values. An unset parameter is omitted rather than stored empty:
+ * absent means "never supplied", which an empty string would not.
+ */
+export function recordedParams(
+  params: Iterable<AnyParameter>,
+): Record<string, string> {
+  const recorded: Record<string, string> = {};
+  for (const parameter of params) {
+    if (parameter.secret_ || !parameter.isSet_()) continue;
+    const value = parameter.stringValue_();
+    if (parameter.name_ !== undefined && value !== undefined) {
+      recorded[parameter.name_] = value;
+    }
+  }
+  return recorded;
+}
+
 export function buildRunRecord(input: RunRecordInput): RunRecord {
   const graph = input.order.map((t) => ({
     name: t.name_ ?? "",
     dependsOn: dependencyNames(t),
   }));
 
-  const params: Record<string, string> = {};
-  for (const parameter of input.params) {
-    if (parameter.secret_ || !parameter.isSet_()) continue;
-    const value = parameter.stringValue_();
-    if (parameter.name_ !== undefined && value !== undefined) {
-      params[parameter.name_] = value;
-    }
-  }
+  const params = recordedParams(input.params);
 
   const targets: Record<string, TargetRunState> = {};
   for (const t of input.order) {
@@ -191,4 +209,47 @@ function dependencyNames(target: TargetBuilder): string[] {
     if (dependency.name_ !== undefined) names.push(dependency.name_);
   }
   return names;
+}
+
+/**
+ * The audit event recording that a resume ran with parameter values the launch
+ * did not supply — or `undefined` when it supplied the same ones.
+ *
+ * The values themselves are deliberately **not** written back over
+ * {@link RunRecord.params}. That field is not display-only: a cancellation
+ * resolves each compensation body's parameters from it, so a run that deployed
+ * to `sit` and was resumed with `prod` would have its rollback undo the `sit`
+ * deploy against `prod`. A resumed run genuinely executes under two sets of
+ * values, and one map cannot hold both — so `params` keeps the launch's, which
+ * is what the targets a compensation unwinds actually ran on, and the override
+ * is reported here instead. Nothing is overwritten, so a later resume still
+ * merges from the launch's values rather than inheriting an earlier resumer's,
+ * and a parameter the resumer's build no longer declares is not erased.
+ *
+ * `after` must already have been through {@link recordedParams}, so secrets are
+ * excluded before they reach an event that is stored and displayed.
+ */
+export function paramOverrideEvent(
+  before: Record<string, string>,
+  after: Record<string, string>,
+  actor: string,
+  at: string,
+): RunEvent | undefined {
+  const changed: Record<string, string> = {};
+  for (const [name, value] of Object.entries(after)) {
+    if (before[name] !== value) changed[name] = value;
+  }
+  if (Object.keys(changed).length === 0) return undefined;
+  return {
+    at,
+    tool: "resume",
+    actor,
+    outcome: "ok",
+    args: changed,
+    // Rendered into `detail` as well as carried in `args`, because
+    // `zuke runs show` prints the detail and not the arguments — and a line
+    // saying only that an override happened, without saying to what, would
+    // leave a reader no better off than the misreport this replaces.
+    detail: Object.entries(changed).map(([n, v]) => `${n}=${v}`).join(" "),
+  };
 }

--- a/packages/core/src/state/types.ts
+++ b/packages/core/src/state/types.ts
@@ -289,7 +289,16 @@ export interface RunRecord {
   updatedAt: string;
   /** The graph shape the run planned, in declaration order. */
   graph: RunGraphNode[];
-  /** Resolved parameter values, keyed by name. Secrets are always omitted. */
+  /**
+   * Resolved parameter values, keyed by name. Secrets are always omitted.
+   *
+   * The values the run was **launched** with, and they are not rewritten. A
+   * resume may supply different ones, in which case the run executes under two
+   * sets and this field cannot hold both — so it keeps the launch's, which is
+   * what the targets that ran before the suspension used, and what a
+   * cancellation resolves each compensation body from. A resume that changed
+   * anything records it in {@link RunRecord.events} instead.
+   */
   params: Record<string, string>;
   /** Per-target progress, keyed by dotted target name. */
   targets: Record<string, TargetRunState>;

--- a/packages/core/tests/state_test.ts
+++ b/packages/core/tests/state_test.ts
@@ -23,6 +23,9 @@ import {
 } from "../src/state/store.ts";
 import { FileSystemStateStore } from "../src/state/fs_store.ts";
 import { HttpStateStore } from "../src/state/http_store.ts";
+import { paramOverrideEvent, recordedParams } from "../src/state/record.ts";
+
+const NOW_ISO = "2026-09-09T08:12:00.000Z";
 import { envStateStore, resolveStateStore } from "../src/state/resolve.ts";
 import { HttpError } from "../src/http.ts";
 import {
@@ -1978,4 +1981,56 @@ Deno.test("initiatorOf falls back to the actor when no initiator was recorded", 
   const resumed: RunRecord = { ...record, actor: "sweep-bot" };
   assertEquals(initiatorOf(resumed), "engineer-a");
   assertEquals(toSummary(resumed).initiator?.actor, "engineer-a");
+});
+
+Deno.test("recordedParams keeps resolved non-secret values and drops the rest", () => {
+  class B extends Build {
+    env = parameter("environment");
+    token = parameter("deploy token").secret();
+    tags = parameter("labels").array();
+    unset = parameter("never supplied");
+  }
+  const build = new B();
+  const params = discoverParameters(build);
+  build.env.resolve_("prod");
+  build.token.resolve_("deploy-token-value");
+  build.tags.resolve_("a,b");
+
+  const recorded = recordedParams(params.values());
+  // A secret is excluded by construction — this projection is the only way a
+  // parameter reaches a record, so the record holds none.
+  assertEquals(recorded, { env: "prod", tags: "a,b" });
+  assertEquals("token" in recorded, false);
+  // Absent means never supplied, which an empty string would not.
+  assertEquals("unset" in recorded, false);
+});
+
+Deno.test("paramOverrideEvent names only what the resume changed", () => {
+  const event = paramOverrideEvent(
+    { env: "sit", region: "eu" },
+    { env: "production", region: "eu" },
+    "alice",
+    "2026-09-09T08:12:00.000Z",
+  );
+  assertEquals(event?.tool, "resume");
+  assertEquals(event?.actor, "alice");
+  // Only the changed key: a resume re-supplying the same value is not an
+  // override, and listing it would bury the one that is.
+  assertEquals(event?.args, { env: "production" });
+  // `runs show` prints the detail and not the arguments, so the values have to
+  // be in it or a reader learns only that something changed.
+  assertEquals(event?.detail, "env=production");
+});
+
+Deno.test("paramOverrideEvent is undefined when the resume changed nothing", () => {
+  assertEquals(
+    paramOverrideEvent({ env: "sit" }, { env: "sit" }, "alice", NOW_ISO),
+    undefined,
+  );
+  // A parameter the resumer's build no longer sets is not an override either:
+  // nothing was supplied, so there is nothing to report.
+  assertEquals(
+    paramOverrideEvent({ env: "sit" }, {}, "alice", NOW_ISO),
+    undefined,
+  );
 });

--- a/tests/integration/waiting_test.ts
+++ b/tests/integration/waiting_test.ts
@@ -19,6 +19,7 @@ import {
   defaultStateHost,
   externalSignal,
   FileSystemStateStore,
+  parameter,
   resumeWhen,
   service,
   target,
@@ -315,4 +316,124 @@ Deno.test("a service starts, gates its dependent on readiness, and is stopped", 
   assertEquals(log, ["smoke"]);
   assertEquals(probes >= 2, true); // the dependent waited for readiness
   assertEquals(stopped, true); // the service was torn down after the run
+});
+
+Deno.test("a resume that overrides a parameter records it in the audit trail", async () => {
+  await withStateDir(async (dir) => {
+    const deployed: string[] = [];
+    class B extends Build {
+      env = parameter("environment");
+      token = parameter("deploy token").secret();
+      gate = target().waitsFor((s) => s.on(externalSignal("go")));
+      ship = target().dependsOn(this.gate).executes(() =>
+        void deployed.push(this.env.value ?? "?")
+      );
+    }
+    const first = await runCli(B, [
+      "ship",
+      "--env",
+      "sit",
+      "--token",
+      "launch-secret",
+    ]);
+    assertEquals(first.code, 0);
+    const id = await onlyRunId(dir);
+
+    const resumed = await runCli(B, [
+      "resume",
+      id,
+      "--signal",
+      "go",
+      "--env",
+      "production",
+      "--token",
+      "rotated-secret",
+    ]);
+    assertEquals(resumed.code, 0);
+    assertEquals(deployed, ["production"]);
+
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    const record = (await store.getRun(id))?.record;
+
+    // `params` keeps the launch's values: a cancellation resolves each
+    // compensation from them, and the targets a compensation unwinds are the
+    // ones that ran before the gate — on `sit`.
+    assertEquals(record?.params, { env: "sit" });
+
+    // The override is reported instead, naming the value and who supplied it.
+    const event = record?.events.find((e) => e.tool === "resume");
+    assertEquals(event?.args, { env: "production" });
+    assertEquals(event?.outcome, "ok");
+
+    // Neither secret reaches the record, on either pass.
+    const raw = JSON.stringify(record);
+    assertEquals(raw.includes("rotated-secret"), false);
+    assertEquals(raw.includes("launch-secret"), false);
+
+    // And a reader sees both halves: what the run launched with, and what the
+    // resume changed. The audit line prints the detail, not the arguments.
+    const shown = await runCli(B, ["runs", "show", id]);
+    assertStringIncludes(shown.out, "env = sit");
+    assertStringIncludes(shown.out, "env=production");
+  });
+});
+
+Deno.test("a resume that overrides nothing records no event", async () => {
+  await withStateDir(async (dir) => {
+    class B extends Build {
+      env = parameter("environment");
+      gate = target().waitsFor((s) => s.on(externalSignal("go")));
+      ship = target().dependsOn(this.gate).executes(() => {});
+    }
+    assertEquals((await runCli(B, ["ship", "--env", "sit"])).code, 0);
+    const id = await onlyRunId(dir);
+
+    // The env var supplies the same value the launch did, so nothing differs
+    // and an ordinary resume leaves no audit noise behind.
+    const prev = Deno.env.get("ENV");
+    Deno.env.set("ENV", "sit");
+    try {
+      assertEquals((await runCli(B, ["resume", id, "--signal", "go"])).code, 0);
+    } finally {
+      if (prev === undefined) Deno.env.delete("ENV");
+      else Deno.env.set("ENV", prev);
+    }
+    const store = new FileSystemStateStore(dir, defaultStateHost);
+    const record = (await store.getRun(id))?.record;
+    assertEquals(record?.params, { env: "sit" });
+    assertEquals(record?.events.some((e) => e.tool === "resume"), false);
+  });
+});
+
+Deno.test("a cancellation unwinds on the values its targets actually ran on", async () => {
+  await withStateDir(async (dir) => {
+    const log: string[] = [];
+    class B extends Build {
+      env = parameter("environment");
+      deploy = target()
+        .executes(() => void log.push(`deploy ${this.env.value}`))
+        .onCancel(() => this.rollback);
+      rollback = target().executes(() =>
+        void log.push(`rollback ${this.env.value}`)
+      );
+      gate = target().dependsOn(this.deploy).waitsFor((s) =>
+        s.on(externalSignal("go"))
+      );
+      ship = target().dependsOn(this.gate).executes(() => {});
+    }
+    assertEquals((await runCli(B, ["ship", "--env", "sit"])).code, 0);
+    const id = await onlyRunId(dir);
+
+    // The deploy happened before the gate, on `sit`. Writing the resumer's
+    // values over `record.params` would make this rollback undo it against
+    // `prod` — a compensation acting on an environment its target never
+    // touched, which is worse than the misreport it would have fixed.
+    // Resumed with a different value but no signal, so the gate re-suspends
+    // and the run is still cancellable — the deploy/gate/cancel shape a
+    // compensation exists for.
+    await runCli(B, ["resume", id, "--env", "prod"]);
+    assertEquals(await runStatus(dir, id), "suspended");
+    await runCli(B, ["cancel", id]);
+    assertEquals(log, ["deploy sit", "rollback sit"]);
+  });
 });


### PR DESCRIPTION
### The problem

A resume may supply parameter values the launch did not, and they take effect — the merge is deliberate, since a resume runs in a fresh process and secrets are absent from the record by design, so re-supplying a rotated credential is a real need. But nothing recorded that it happened. The record kept reporting the launch's values while the bodies ran on the resumer's:

    body deployed to: ["production"]

    $ zuke runs show <run-id>
    Parameters:
      env = sit

Same class as the `actor` and `initiator` work in #476: the record is the durable account of a run, so it has to say what the run did.

Found while checking item 14.4 of the maintainer proposal, which turned out to be already fixed — a resume rejects unknown flags exactly as a launch does, on every shape tried. This is what the same probe found next door.

### The fix that was wrong, and why it is worth stating

The obvious change is to write the resumer's values back over `record.params`. That is what this branch did first, and it is wrong.

`record.params` is not display-only. A cancellation resolves each compensation body's parameters from it, so the write-back changed what a rollback **does**:

    before:  [ "deploy sit",  "rollback sit"  ]
    after:   [ "deploy sit",  "rollback prod" ]

A deploy that went to `sit` rolled back against `prod` — a compensation acting on an environment its target never touched, which is worse than the misreport it set out to fix. A resumed run genuinely executes under two sets of values and one map cannot hold both, so writing back does not remove the inaccuracy; it moves it onto the deploy → gate → cancel path, which is the path compensations exist for. It also made a one-off override sticky for every later resume, and erased a parameter the resumer's build no longer declares.

### The shape

`params` keeps the launch's values — what the targets a compensation unwinds actually ran on — and the override is recorded as an audit event naming the values and who supplied them:

    Parameters:
      env = sit

    Audit:
      2026-07-17T09:12:03Z  resume  alice  ok  env=production

Nothing is overwritten, so a later resume still merges from the launch's values rather than inheriting an earlier resumer's, and the original is never lost. Only what actually differs is listed: a resume re-supplying the same value is not an override, and listing it would bury one that is. The values are rendered into the event's `detail` as well as carried in its `args`, because `zuke runs show` prints the detail and not the arguments — an event saying only that something changed would leave a reader no better off.

The secret filter `buildRunRecord` already applies is extracted rather than re-implemented, so a rotated credential supplied on resume reaches neither `params` nor the event. Verified in both directions.

The event is appended after the lease-loss wiring, so a process that has already lost the run writes nothing.

### What the adversarial review found

One reviewer attacked the first version across secrecy, ordering and the readers of `record.params`. Every finding was reproduced against the running code, including a side-by-side against the base commit. The compensation regression above is its headline, and it is what redesigned the change. Two more came from the same choice and are answered by the same redesign: the sticky override, and the full replace erasing a parameter that dropped out of the projection. A fourth, that the write landed before the lease-loss guard, is why the event is appended where it is.

### Testing

7 new tests. Unit coverage of the projection — resolved non-secret values kept, secrets and unset parameters dropped — and of the event builder, including that it reports only what changed and is absent when nothing did. Integration tests driving real builds through the CLI for the audit trail and both secrets staying out, for an ordinary resume leaving no event behind, and for a cancellation still unwinding on the values its targets ran on. Each of the three moving pieces was mutation-checked.

`deno task ci`: 22/22 targets, 4364 tests, 98.4% lines and 97.4% branches against a 95% gate.

### Related issues

Closes #522

### Checklist

- [x] This PR closes a tracking issue.
- [x] The PR title is a Conventional Commit.
- [x] `deno task ci` passes locally.
- [x] Tests were added or updated; coverage stays at 95%+.
- [x] Docs updated in the same PR (the durable state guide, the record's JSDoc).
- [x] Public API changes were regenerated with the API docs target.
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/`.
- [x] No agent-skill change, so no plugin version bump is due.
