### PR TITLE
feat(cli): let zuke setup choose launchers that bootstrap a pinned Deno

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -390,14 +390,16 @@ can drift from it. `zuke.ts`'s `ci` target depends on: `format`
 (`deno fmt --check`), `lint` (`deno lint`), `spell` (cspell), `coverage`
 (type-check, then the test suite with the 95% coverage gate), `coverageUpload`
 (skips locally without a `CODECOV_TOKEN`), `apiDocsCheck`, `docLint`,
-`snippetsCheck`, `examplesCheck`, `hclSyncCheck`, `pluginSyncCheck`, `skillsCheck`,
+`snippetsCheck`, `examplesCheck`, `hclSyncCheck`, `pluginSyncCheck`,
+`launcherSyncCheck`, `skillsCheck`,
 `graphDocCheck`, `pluginVersionCheck`, `prBodyLint`, `actionPinCheck`,
 `security`, and `lockCheck`. Read `zuke.ts`'s `ci` target for the current,
 authoritative list — this is a snapshot, not a second source of truth.
 
 **The lock is part of the gate.** Every entrypoint that loads `zuke.ts` — both
-launchers and the root tasks — passes `--frozen`, so a run cannot quietly heal a
-stale `deno.lock` by writing the resolutions it is missing. That mattered: a
+launchers (once a `deno.lock` exists, which in this repository is always) and
+the root tasks — passes `--frozen`, so a run cannot quietly heal a stale
+`deno.lock` by writing the resolutions it is missing. That mattered: a
 green gate used to be able to mean "the lock resolves _now that we fixed it_"
 while CI, whose checkout has the committed lock, failed with "The lockfile is
 out of date". `deno task` resolves the workspace before running its command, so
@@ -422,7 +424,7 @@ tests/
 examples/                 # cloneable mini projects, type-checked and listed by `examplesCheck`
 zuke.ts                   # Zuke's own build (runnable example)
 build/                    # reusable helpers behind zuke.ts's targets (docs, publish, snippets, …)
-zuke, zuke.ps1            # bootstrap launchers (install Deno, run the build); zuke.json names the build class
+zuke, zuke.ps1            # bootstrap launchers (install Deno, run the build) — GENERATED from packages/cli/src/launcher.ts by `./zuke launcherSync`; zuke.json names the build class
 docs/                     # long-form guides (linked from the README)
 skills/                   # agent skills: zuke-write-build, zuke-setup
 plugins/zuke/             # Claude Code + Codex plugin wrapping the skills

--- a/README.md
+++ b/README.md
@@ -135,11 +135,13 @@ Teams running Zuke in production:
 ## Install
 
 Zuke runs on [Deno](https://deno.com/) and is imported straight from
-[JSR](https://jsr.io/@zuke) — there is nothing else to install. The scaffolded
-`./zuke` launcher (and `zuke.ps1` on Windows) runs the build with the Deno on
-your `PATH`; for a checkout that needs **nothing** installed up front, copy
-Zuke's own [`zuke`](./zuke) / [`zuke.ps1`](./zuke.ps1), which bootstrap a
-pinned, checksum-verified Deno on first use.
+[JSR](https://jsr.io/@zuke) — there is nothing else to install. By default the
+scaffolded `./zuke` launcher (and `zuke.ps1` on Windows) bootstraps a pinned,
+checksum-verified Deno on first use, so a checkout needs **nothing** installed
+up front — it is the same script this repository runs on, [`zuke`](./zuke) /
+[`zuke.ps1`](./zuke.ps1). `zuke setup` asks; `--no-bootstrap-deno` scaffolds a
+launcher that uses the Deno on your `PATH` and fails closed without one, for a
+project that must never download a tool from its build entry point.
 
 ```sh
 deno install -A -g -n zuke jsr:@zuke/cli   # the CLI: setup, import, doc

--- a/build/launchers.ts
+++ b/build/launchers.ts
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Keeps the repository's own `./zuke` and `zuke.ps1` generated from the
+ * launcher template `zuke setup` scaffolds (`packages/cli/src/launcher.ts`),
+ * in its bootstrap variant. One template, one pin: a Deno bump is a change to
+ * `packages/cli/src/deno_pin.ts`, a `./zuke launcherSync`, and a commit —
+ * never a hand edit of a shell script that the CLI would then drift from.
+ * `launcherSyncCheck` fails the gate on any drift, the same
+ * generate-then-verify pattern as `build/plugin_sync.ts`.
+ *
+ * @module
+ */
+
+import { launcherBash, launcherPwsh } from "../packages/cli/src/launcher.ts";
+
+/** The bash launcher's file name at the repository root. */
+export const BASH_LAUNCHER = "zuke";
+
+/** The PowerShell launcher's file name at the repository root. */
+export const PWSH_LAUNCHER = "zuke.ps1";
+
+/** The permission bits the bash launcher needs to be run as `./zuke`. */
+const EXECUTABLE = 0o755;
+
+/** The variant the repository runs on: nothing installed up front. */
+const ROOT_VARIANT = { bootstrapDeno: true };
+
+/** The launchers as they should be committed, keyed by file name. */
+export function renderRootLaunchers(): ReadonlyMap<string, string> {
+  return new Map([
+    [BASH_LAUNCHER, launcherBash(ROOT_VARIANT)],
+    [PWSH_LAUNCHER, launcherPwsh(ROOT_VARIANT)],
+  ]);
+}
+
+/**
+ * Write both launchers into `dir`, returning the paths written.
+ *
+ * Each file is written to a sibling temp path and renamed into place rather
+ * than truncated and rewritten: `./zuke launcherSync` is itself started by the
+ * bash launcher, and bash reads a script incrementally, so overwriting the
+ * file it is executing could feed it garbage. A rename swaps the directory
+ * entry while bash keeps the old inode open.
+ */
+export async function syncRootLaunchers(dir = "."): Promise<string[]> {
+  const written: string[] = [];
+  for (const [name, content] of renderRootLaunchers()) {
+    const path = `${dir}/${name}`;
+    const staging = `${path}.tmp-${crypto.randomUUID()}`;
+    await Deno.writeTextFile(staging, content);
+    if (name === BASH_LAUNCHER && Deno.build.os !== "windows") {
+      await Deno.chmod(staging, EXECUTABLE);
+    }
+    await Deno.rename(staging, path);
+    written.push(path);
+  }
+  return written;
+}
+
+/**
+ * The launchers in `dir` that differ from the template, as
+ * `<file> (<reason>)` lines; empty when both are current. Line endings are
+ * normalised before comparing, so a Windows checkout that converted them
+ * does not report drift the generator did not cause.
+ */
+export async function checkRootLaunchers(dir = "."): Promise<string[]> {
+  const stale: string[] = [];
+  for (const [name, expected] of renderRootLaunchers()) {
+    const path = `${dir}/${name}`;
+    let actual: string;
+    try {
+      actual = await Deno.readTextFile(path);
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) throw error;
+      stale.push(`${path} (missing)`);
+      continue;
+    }
+    if (actual.replaceAll("\r\n", "\n") !== expected) {
+      stale.push(`${path} (content differs from the template)`);
+    }
+  }
+  return stale;
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -30,11 +30,17 @@ build's own [MCP server](./mcp.md) (`deno run -A zuke.ts mcp`) so an agent
 client picks the build up from the first commit; `--allow-run` registers it
 with execution enabled and implies `--mcp`. An existing `.mcp.json` is merged
 around its other servers, and an existing `zuke` entry is kept unless `--force`
-is set. `--launcher-name <name>` (for when a `zuke/` directory already occupies
-the launcher's name) applies to `setup` only; `import` additionally takes
-`--from <package.json|makefile>` to pin the source instead of auto-detecting
-it. Both finish by scaffolding the launchers and `deno.json`, so the very next
-command you run is your build's own CLI, `./zuke`.
+is set. Both also ask which launchers to write — `--bootstrap-deno` (the
+default, and what `--yes` takes) scaffolds launchers that install a pinned,
+checksum-verified Deno when none is on `PATH`, so a checkout needs nothing
+installed up front; `--no-bootstrap-deno` scaffolds launchers that require Deno
+on `PATH` and fail closed without it, for a project that must never download a
+tool from its build entry point. `--launcher-name <name>` (for when a `zuke/`
+directory already occupies the launcher's name) applies to `setup` only;
+`import` additionally takes `--from <package.json|makefile>` to pin the source
+instead of auto-detecting it. Both finish by scaffolding the launchers and
+`deno.json`, so the very next command you run is your build's own CLI,
+`./zuke`.
 
 ## Your build's CLI (`./zuke` / `deno run -A zuke.ts`)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,14 +25,18 @@ zuke setup                                  # in your project
 ```
 
 Without installing, the same wizard runs via `deno run -A jsr:@zuke/cli setup`
-(flags: `--dir <path>`, `--name <Class>`, `--force`, `--yes`, `--mcp`). Pass
-`--mcp` to also write a `.mcp.json` that registers the build's
-[MCP server](./mcp.md), so Claude Code, Codex or any stdio MCP client can list
-the targets and run one through typed calls from day one (`--allow-run` lets
-the agent execute targets, not just inspect them). If a `zuke/`
-directory already occupies the launcher's name, setup stops with an actionable
-error — pass `--launcher-name <name>` to write the launcher (and its `.ps1`)
-under a different name.
+(flags: `--dir <path>`, `--name <Class>`, `--force`, `--yes`, `--mcp`,
+`--bootstrap-deno` / `--no-bootstrap-deno`). Pass `--mcp` to also write a
+`.mcp.json` that registers the build's [MCP server](./mcp.md), so Claude Code,
+Codex or any stdio MCP client can list the targets and run one through typed
+calls from day one (`--allow-run` lets the agent execute targets, not just
+inspect them). The wizard asks which launchers you want: by default they
+bootstrap a pinned, checksum-verified Deno when none is on `PATH` — the same
+scripts this repository runs on — so a clone needs nothing installed first;
+`--no-bootstrap-deno` writes launchers that require Deno on `PATH` and fail
+closed without it. If a `zuke/` directory already occupies the launcher's name,
+setup stops with an actionable error — pass `--launcher-name <name>` to write
+the launcher (and its `.ps1`) under a different name.
 
 Already have a `@zuke/*` package's API in hand? `zuke doc <package>` prints it
 (`zuke doc core`, `zuke doc @scope/pkg`), running `deno doc` in an isolated

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -4,7 +4,7 @@
 
 The dependency graph of [`zuke.ts`](../zuke.ts) — Zuke building itself. An arrow points from a dependency to the target that depends on it, so a target runs after everything that points at it. This is the same graph `./zuke graph` prints as text and `./zuke graph --output=html` renders interactively.
 
-40 target(s), 26 dependency edge(s). Regenerate with `./zuke graphDoc`; the `graphDocCheck` target in the CI gate fails when this page drifts from the build.
+42 target(s), 27 dependency edge(s). Regenerate with `./zuke graphDoc`; the `graphDocCheck` target in the CI gate fails when this page drifts from the build.
 
 ```mermaid
 flowchart TD
@@ -29,51 +29,54 @@ flowchart TD
   t18["hclSyncCheck"]
   t19["pluginSync"]
   t20["pluginSyncCheck"]
-  t21["skillsCheck"]
-  t22["graphDoc"]
-  t23["graphDocCheck"]
-  t24["pluginVersionCheck"]
-  t25["prBodyLint"]
-  t26["coreFloorCheck"]
-  t27["lockCheck"]
-  t28["security"]
-  t29["actionPinCheck"]
-  t30["ci"]
-  t31["scorecardSarif"]
-  t32["codeql"]
-  t33["reviewBase"]
-  t34["review"]
-  t35["release"]
-  t36["actionRelease"]
-  t37["publishJsr"]
-  t38["publish"]
-  t39["default"]
+  t21["launcherSync"]
+  t22["launcherSyncCheck"]
+  t23["skillsCheck"]
+  t24["graphDoc"]
+  t25["graphDocCheck"]
+  t26["pluginVersionCheck"]
+  t27["prBodyLint"]
+  t28["coreFloorCheck"]
+  t29["lockCheck"]
+  t30["security"]
+  t31["actionPinCheck"]
+  t32["ci"]
+  t33["scorecardSarif"]
+  t34["codeql"]
+  t35["reviewBase"]
+  t36["review"]
+  t37["release"]
+  t38["actionRelease"]
+  t39["publishJsr"]
+  t40["publish"]
+  t41["default"]
   t1 --> t5
   t5 --> t6
   t6 --> t8
   t8 --> t9
-  t2 --> t30
-  t3 --> t30
-  t4 --> t30
-  t8 --> t30
-  t9 --> t30
-  t11 --> t30
-  t14 --> t30
-  t15 --> t30
-  t16 --> t30
-  t18 --> t30
-  t20 --> t30
-  t21 --> t30
-  t23 --> t30
-  t24 --> t30
-  t25 --> t30
-  t29 --> t30
-  t28 --> t30
-  t27 --> t30
-  t33 --> t34
-  t35 --> t38
-  t37 --> t38
-  t30 --> t39
+  t2 --> t32
+  t3 --> t32
+  t4 --> t32
+  t8 --> t32
+  t9 --> t32
+  t11 --> t32
+  t14 --> t32
+  t15 --> t32
+  t16 --> t32
+  t18 --> t32
+  t20 --> t32
+  t22 --> t32
+  t23 --> t32
+  t25 --> t32
+  t26 --> t32
+  t27 --> t32
+  t31 --> t32
+  t30 --> t32
+  t29 --> t32
+  t35 --> t36
+  t37 --> t40
+  t39 --> t40
+  t32 --> t41
 ```
 
 ## Targets
@@ -101,6 +104,8 @@ flowchart TD
 | `hclSyncCheck` | Verify the Terraform/OpenTofu wrappers match their template | — |
 | `pluginSync` | Sync plugins/zuke/skills/ from skills/ (real copies, not a symlink) | — |
 | `pluginSyncCheck` | Verify plugins/zuke/skills/ matches skills/ (no drift) | — |
+| `launcherSync` | Regenerate ./zuke and zuke.ps1 from @zuke/cli's launcher template | — |
+| `launcherSyncCheck` | Verify ./zuke and zuke.ps1 match @zuke/cli's launcher template | — |
 | `skillsCheck` | Validate skills/ against the Agent Skills spec (frontmatter, names) | — |
 | `graphDoc` | Regenerate docs/graph.md — this build's graph as a Mermaid page | — |
 | `graphDocCheck` | Verify docs/graph.md matches the current build graph | — |
@@ -110,7 +115,7 @@ flowchart TD
 | `lockCheck` | Verify the run did not rewrite deno.lock | — |
 | `security` | Run supply-chain security scanners (zuke/security) | — |
 | `actionPinCheck` | Verify the workflows only use inputs the released action has | — |
-| `ci` | Full pre-commit / CI gate | `format`, `lint`, `spell`, `coverage`, `coverageUpload`, `apiDocsCheck`, `docLint`, `snippetsCheck`, `examplesCheck`, `hclSyncCheck`, `pluginSyncCheck`, `skillsCheck`, `graphDocCheck`, `pluginVersionCheck`, `prBodyLint`, `actionPinCheck`, `security`, `lockCheck` |
+| `ci` | Full pre-commit / CI gate | `format`, `lint`, `spell`, `coverage`, `coverageUpload`, `apiDocsCheck`, `docLint`, `snippetsCheck`, `examplesCheck`, `hclSyncCheck`, `pluginSyncCheck`, `launcherSyncCheck`, `skillsCheck`, `graphDocCheck`, `pluginVersionCheck`, `prBodyLint`, `actionPinCheck`, `security`, `lockCheck` |
 | `scorecardSarif` | Upload the Scorecard SARIF to GitHub code scanning | — |
 | `codeql` | CodeQL static analysis (runs in CI via codeql.yml) | — |
 | `reviewBase` | Fetch the base branch the AI review diffs against | — |

--- a/docs/installing-tools.md
+++ b/docs/installing-tools.md
@@ -392,7 +392,10 @@ needs no "set up tool X" step:
   the pinned Deno release (`DEFAULT_DENO_VERSION`/`$DefaultDenoVersion`) as a
   zip and verify it against a hardcoded per-platform SHA-256 before unpacking it
   — the same pin-and-verify model as `installRelease` below, applied to Deno
-  itself. `DENO_VERSION` can still request a different release — an exact
+  itself. The pin lives in one place, `@zuke/cli`'s `deno_pin.ts`: the
+  launchers `zuke setup` scaffolds and this repository's own are rendered from
+  the same template (`./zuke launcherSync` regenerates them), so bumping Deno
+  is a change to that file, not to two shell scripts. `DENO_VERSION` can still request a different release — an exact
   release tag (`v2.9.0`), never `latest`, which has no fixed hash to pin — but
   the launcher then requires `DENO_SHA256` (the expected hash for the current
   platform) too; it never installs an unverified binary.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "zuke",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build)."
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8122,6 +8122,11 @@ interface SetupFlags
     Also write `.mcp.json`, registering the build's MCP server for agent clients.
   allowRun: boolean
     Register that server with `--allow-run`, so the agent may execute targets. Implies `mcp`.
+  bootstrapDeno?: boolean
+    Which launchers to scaffold: `true` (`--bootstrap-deno`) for ones that
+    install a pinned, checksum-verified Deno when none is on `PATH`, `false`
+    (`--no-bootstrap-deno`) for ones that require it and fail closed. Unset:
+    ask when interactive, else take the default (bootstrap).
 
 interface SetupHost
   Injected side effects, so {@link runSetup} is unit-testable.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -77,6 +77,11 @@ interface SetupFlags
     Also write `.mcp.json`, registering the build's MCP server for agent clients.
   allowRun: boolean
     Register that server with `--allow-run`, so the agent may execute targets. Implies `mcp`.
+  bootstrapDeno?: boolean
+    Which launchers to scaffold: `true` (`--bootstrap-deno`) for ones that
+    install a pinned, checksum-verified Deno when none is on `PATH`, `false`
+    (`--no-bootstrap-deno`) for ones that require it and fail closed. Unset:
+    ask when interactive, else take the default (bootstrap).
 
 interface SetupHost
   Injected side effects, so {@link runSetup} is unit-testable.

--- a/packages/cli/mod.ts
+++ b/packages/cli/mod.ts
@@ -27,6 +27,7 @@ import {
   type StarActions,
 } from "./src/star.ts";
 import { VERSION } from "./src/version.ts";
+import { DENO_PIN } from "./src/deno_pin.ts";
 
 export type { SetupHost } from "./src/setup.ts";
 export type { ImportSource } from "./src/import.ts";
@@ -74,6 +75,13 @@ export interface SetupFlags {
   mcp: boolean;
   /** Register that server with `--allow-run`, so the agent may execute targets. Implies `mcp`. */
   allowRun: boolean;
+  /**
+   * Which launchers to scaffold: `true` (`--bootstrap-deno`) for ones that
+   * install a pinned, checksum-verified Deno when none is on `PATH`, `false`
+   * (`--no-bootstrap-deno`) for ones that require it and fail closed. Unset:
+   * ask when interactive, else take the default (bootstrap).
+   */
+  bootstrapDeno?: boolean;
 }
 
 /** Parse the argument list following `zuke setup`. */
@@ -97,6 +105,10 @@ export function parseSetupFlags(args: string[]): SetupFlags {
       // implies --mcp rather than being silently ignored without it.
       flags.mcp = true;
       flags.allowRun = true;
+    } else if (arg === "--bootstrap-deno") {
+      flags.bootstrapDeno = true;
+    } else if (arg === "--no-bootstrap-deno") {
+      flags.bootstrapDeno = false;
     } else if (arg === "--name") {
       if (i + 1 < args.length) {
         i++;
@@ -126,6 +138,27 @@ export function parseSetupFlags(args: string[]): SetupFlags {
 /** The `.mcp.json` request the flags make, or `undefined` for none. */
 function mcpOption(flags: SetupFlags): McpSetupOptions | undefined {
   return flags.mcp ? { allowRun: flags.allowRun } : undefined;
+}
+
+/** The launcher question, naming the release a yes will pin. */
+const BOOTSTRAP_QUESTION =
+  `Launchers: bootstrap a pinned, checksum-verified Deno v${DENO_PIN.version} ` +
+  "when none is on PATH? [y/n]";
+
+/**
+ * Which launchers to scaffold. A flag decides outright; otherwise the wizard
+ * asks when it is interactive, and the default — bootstrap — stands under
+ * `--yes` or a non-TTY. Only an explicit "n…" opts out, so Enter keeps the
+ * default the question shows.
+ */
+function resolveBootstrapDeno(
+  flags: SetupFlags,
+  prompter: Prompter,
+  interactive: boolean,
+): boolean {
+  if (flags.bootstrapDeno !== undefined) return flags.bootstrapDeno;
+  if (!interactive) return true;
+  return !/^n/i.test(prompter.ask(BOOTSTRAP_QUESTION, "y").trim());
 }
 
 /** The one-line identity printed under the logo and atop `--help`. */
@@ -163,17 +196,21 @@ Setup options:
   --launcher-name <name>  Launcher base name when a zuke/ directory is in the way
   --mcp                   Also write .mcp.json registering the build's MCP server
   --allow-run             …with --allow-run, so an agent may execute targets (implies --mcp)
+  --bootstrap-deno        Launchers install a pinned, checksum-verified Deno when none is on PATH (default)
+  --no-bootstrap-deno     Launchers require Deno on PATH and fail closed without it
   --force, -f             Overwrite existing files
   --yes, -y               Accept defaults without prompting
 
 Import options:
-  --dir <path>     Directory to read from and scaffold into (default: .)
-  --name <Class>   Build class name for zuke.ts (default: MyBuild)
-  --from <source>  Force a source: package.json or makefile (default: auto-detect)
-  --mcp            Also write .mcp.json registering the build's MCP server
-  --allow-run      …with --allow-run, so an agent may execute targets (implies --mcp)
-  --force, -f      Overwrite existing files
-  --yes, -y        Accept defaults without prompting
+  --dir <path>            Directory to read from and scaffold into (default: .)
+  --name <Class>          Build class name for zuke.ts (default: MyBuild)
+  --from <source>         Force a source: package.json or makefile (default: auto-detect)
+  --mcp                   Also write .mcp.json registering the build's MCP server
+  --allow-run             …with --allow-run, so an agent may execute targets (implies --mcp)
+  --bootstrap-deno        Launchers install a pinned, checksum-verified Deno when none is on PATH (default)
+  --no-bootstrap-deno     Launchers require Deno on PATH and fail closed without it
+  --force, -f             Overwrite existing files
+  --yes, -y               Accept defaults without prompting
 
 Doc:
   zuke doc core           API of @zuke/core
@@ -201,12 +238,13 @@ async function commandSetup(
       force = prompter.confirm("Overwrite existing files if present?");
     }
   }
+  const bootstrapDeno = resolveBootstrapDeno(flags, prompter, interactive);
 
   const where = dir === "." ? "the current directory" : dir;
   host.log(`Scaffolding Zuke into ${where}:`);
   const launcherName = flags.launcherName;
   const result = await runSetup(
-    { dir, force, name, launcherName, mcp: mcpOption(flags) },
+    { dir, force, name, launcherName, mcp: mcpOption(flags), bootstrapDeno },
     host,
   );
   const written = result.files.filter((f) => f.status !== "skipped").length;
@@ -259,15 +297,24 @@ async function commandImport(
   const dir = flags.dir ?? ".";
 
   printBanner(host);
-  if (!flags.yes && prompter.interactive()) {
+  const interactive = !flags.yes && prompter.interactive();
+  if (interactive) {
     name = prompter.ask("Build class name", name);
     if (!force) {
       force = prompter.confirm("Overwrite existing files if present?");
     }
   }
+  const bootstrapDeno = resolveBootstrapDeno(flags, prompter, interactive);
 
   const result = await runImport(
-    { dir, force, name, from: flags.from, mcp: mcpOption(flags) },
+    {
+      dir,
+      force,
+      name,
+      from: flags.from,
+      mcp: mcpOption(flags),
+      bootstrapDeno,
+    },
     host,
   );
   if (result.source === null) {

--- a/packages/cli/src/deno_pin.ts
+++ b/packages/cli/src/deno_pin.ts
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * The Deno release the bootstrapping launchers install, and the SHA-256 of
+ * each platform's release asset they verify it against.
+ *
+ * This is the one place the pin lives. The repository's own `./zuke` and
+ * `zuke.ps1` are generated from the launcher template that reads it (see
+ * `build/launchers.ts`), and `zuke setup` stamps the same template into every
+ * project that opts into the bootstrap — so bumping Deno is a change here, a
+ * `./zuke launcherSync`, and a commit, never a hand edit of a shell file.
+ *
+ * Bump the version and the checksums *together*: pull the new asset digests
+ * from the release page (GitHub reports each asset's `digest`), or from
+ * `gh release view <tag> --repo denoland/deno --json assets`, and cross-check
+ * by downloading and hashing the artifact.
+ *
+ * @module
+ */
+
+/**
+ * A Deno release asset's target triple, as it appears in the asset name
+ * (`deno-<target>.zip`).
+ */
+export type DenoTarget =
+  | "x86_64-unknown-linux-gnu"
+  | "aarch64-unknown-linux-gnu"
+  | "x86_64-apple-darwin"
+  | "aarch64-apple-darwin"
+  | "x86_64-pc-windows-msvc"
+  | "aarch64-pc-windows-msvc";
+
+/** The pinned Deno release and the checksum of each platform's asset. */
+export interface DenoPin {
+  /** The release version without its `v` prefix, e.g. `"2.8.3"`. */
+  readonly version: string;
+  /** Lowercase hex SHA-256 of `deno-<target>.zip` for each supported target. */
+  readonly checksums: Readonly<Record<DenoTarget, string>>;
+}
+
+/* cspell:disable */
+
+/** The Deno release the launchers bootstrap, with its verified checksums. */
+export const DENO_PIN: DenoPin = {
+  version: "2.8.3",
+  checksums: {
+    "x86_64-unknown-linux-gnu":
+      "30455b845ffa6082209c3590269c910ad3b7efdf28c9879afd4006c47ae54197",
+    "aarch64-unknown-linux-gnu":
+      "d4589cc1ffcbf1995c92a0127d932aaf832ac70cfdcc6d5b7bf38043cf303575",
+    "x86_64-apple-darwin":
+      "4254ec12123cfcf88b87703d7acf092a1ea024bdf9be8dd3cd9d4474761cb74e",
+    "aarch64-apple-darwin":
+      "88b350be928fdba0e5d8142ff7c101a17133426371e3cf5ed0e0f74e62476f6c",
+    "x86_64-pc-windows-msvc":
+      "7fdd1f42e6b0855421ecf27bb406e2492ade1087c85e30ebf0deab6280ea743c",
+    "aarch64-pc-windows-msvc":
+      "243f478ac577ade1bbd980ecf510607a10ed8cc977b462083ada48e5f6580de1",
+  },
+};
+
+/* cspell:enable */
+
+/** The release tag the pin downloads, e.g. `v2.8.3`. */
+export function denoReleaseTag(pin: DenoPin): string {
+  return `v${pin.version}`;
+}
+
+/** The targets the POSIX launcher can bootstrap (Linux and macOS). */
+export const POSIX_TARGETS: readonly DenoTarget[] = [
+  "x86_64-unknown-linux-gnu",
+  "aarch64-unknown-linux-gnu",
+  "x86_64-apple-darwin",
+  "aarch64-apple-darwin",
+];
+
+/** The targets the PowerShell launcher can bootstrap (Windows). */
+export const WINDOWS_TARGETS: readonly DenoTarget[] = [
+  "x86_64-pc-windows-msvc",
+  "aarch64-pc-windows-msvc",
+];

--- a/packages/cli/src/import.ts
+++ b/packages/cli/src/import.ts
@@ -439,6 +439,8 @@ export interface ImportOptions {
   from?: ImportSource;
   /** Also register the build's MCP server in `.mcp.json` (see {@link "./setup.ts".SetupOptions.mcp}). */
   mcp?: McpSetupOptions;
+  /** Which launchers to scaffold (see {@link "./setup.ts".SetupOptions.bootstrapDeno}). */
+  bootstrapDeno?: boolean;
 }
 
 /** The outcome of {@link runImport}. */
@@ -487,6 +489,7 @@ export async function runImport(
       name: options.name,
       buildContent: generateBuild(options.name, tasks),
       mcp: options.mcp,
+      bootstrapDeno: options.bootstrapDeno,
     }, host);
     return { ...setup, source: candidate.source, taskCount: tasks.length };
   }

--- a/packages/cli/src/launcher.ts
+++ b/packages/cli/src/launcher.ts
@@ -1,0 +1,490 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * The `./zuke` (bash) and `zuke.ps1` (PowerShell) launcher scripts, rendered
+ * from one template in two variants:
+ *
+ * - **bootstrap** — when no Deno is on `PATH`, download the pinned release
+ *   from {@link "./deno_pin.ts"}, verify it against the per-platform SHA-256,
+ *   unpack it into `DENO_INSTALL` (default `~/.deno`), and run the build with
+ *   it. A checkout needs nothing installed up front. The launcher never runs
+ *   an install script and never installs an unverified binary: an overriding
+ *   `DENO_VERSION` must be an exact release tag and must come with the matching
+ *   `DENO_SHA256`, and `latest` is rejected because a moving target has no
+ *   hash to pin.
+ * - **plain** — require Deno on `PATH`, and when it is missing print the one
+ *   command to run and exit 1. For a project that must never download a
+ *   tool from its build entry point (a locked-down CI image, a policy against
+ *   downloads), so it fails closed instead.
+ *
+ * Both variants pass `--frozen` only once a `deno.lock` exists: a freshly
+ * scaffolded project has none, and `deno run --frozen` against a missing
+ * lockfile fails outright ("The lockfile is out of date") instead of writing
+ * one. So the first run resolves and records the graph, and every run after
+ * that verifies it and fails loudly if it changed. The unfrozen branch says so
+ * on stderr — the same branch is taken if a `deno.lock` is later removed, which
+ * drops integrity verification, so it must not run unverified in silence.
+ *
+ * Zuke's own `./zuke` and `zuke.ps1` are the bootstrap variant, generated
+ * from here by `./zuke launcherSync` and verified by `launcherSyncCheck`, so
+ * the scripts `zuke setup` stamps into a project are the ones this repository
+ * runs on every CI job.
+ *
+ * @module
+ */
+
+import {
+  DENO_PIN,
+  type DenoPin,
+  denoReleaseTag,
+  POSIX_TARGETS,
+  WINDOWS_TARGETS,
+} from "./deno_pin.ts";
+
+/** Which launcher variant to render. */
+export interface LauncherOptions {
+  /**
+   * Bootstrap a pinned, checksum-verified Deno when none is on `PATH`
+   * (`true`), or require one and fail closed when it is missing (`false`).
+   */
+  bootstrapDeno: boolean;
+}
+
+/** The URL the plain launchers point at when Deno is missing. */
+export const DENO_INSTALL_DOCS =
+  "https://docs.deno.com/runtime/getting_started/installation/";
+
+/** The MIT notice every generated launcher opens with (after its shebang). */
+const LICENSE_HEADER = `# Copyright (c) 2026 the Zuke contributors
+# SPDX-License-Identifier: MIT`;
+
+/* cspell:disable */
+
+/**
+ * The `DENO_VERSION` / `DENO_SHA256` / `DENO_INSTALL` contract, as the comment
+ * block both bootstrap launchers carry. `dash` is the hyphen the script's
+ * encoding is comfortable with (PowerShell sources are kept ASCII).
+ */
+function bootstrapEnvDocs(pin: DenoPin, dash: string): string {
+  return `# Honoured environment variables:
+#   DENO_INSTALL   where Deno is installed/looked for (default: ~/.deno)
+#   DENO_VERSION   which Deno to install on bootstrap. Defaults to a pinned,
+#                  known-good version (see below) for reproducible and more
+#                  predictable installs. An override must name an exact release
+#                  tag (e.g. ${
+    denoReleaseTag(pin)
+  }) ${dash} "latest" is rejected, because a moving
+#                  target has no checksum to pin ${dash} and is only installed if
+#                  DENO_SHA256 also supplies the matching per-platform checksum
+#                  (see below); this launcher never downloads an unverified
+#                  binary.
+#   DENO_SHA256    required alongside a DENO_VERSION override: the expected
+#                  SHA-256 of the release zip for the *current* platform (see
+#                  the asset name printed on a checksum mismatch).`;
+}
+
+/** The provenance comment above the pinned checksums. */
+function checksumProvenance(pin: DenoPin, versionVar: string): string {
+  return `# SHA-256 of each \`deno-<target>.zip\` release asset, from
+# https://github.com/denoland/deno/releases/tag/${
+    denoReleaseTag(pin)
+  } (GitHub's own reported
+# asset \`digest\`, cross-checked by downloading and hashing the artifact).
+# Bump *together* with ${versionVar}: this file is generated from
+# @zuke/cli's deno_pin.ts, so change the pin there and regenerate.`;
+}
+
+/** The bash launcher's Deno resolution: the bootstrap, or the fail-closed check. */
+function bashResolveDeno(options: LauncherOptions, pin: DenoPin): string {
+  if (!options.bootstrapDeno) {
+    return `if ! command -v deno >/dev/null 2>&1; then
+  echo "zuke: Deno not found on PATH. Install it, then re-run this launcher:" >&2
+  echo "      ${DENO_INSTALL_DOCS}" >&2
+  exit 1
+fi
+deno_bin="$(command -v deno)"`;
+  }
+  return `deno_install="\${DENO_INSTALL:-$HOME/.deno}"
+
+if command -v deno >/dev/null 2>&1; then
+  deno_bin="$(command -v deno)"
+elif [ -x "$deno_install/bin/deno" ]; then
+  deno_bin="$deno_install/bin/deno"
+else
+  echo "zuke: Deno not found — installing it now..." >&2
+  for cmd in curl unzip; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+      echo "zuke: $cmd is required to bootstrap Deno; install Deno manually:" >&2
+      echo "      ${DENO_INSTALL_DOCS}" >&2
+      exit 1
+    fi
+  done
+
+  deno_version="\${DENO_VERSION:-$DEFAULT_DENO_VERSION}"
+  case "$deno_version" in
+    latest)
+      # There is no \`latest\` release tag to download, and a moving target has no
+      # checksum to pin — so name the release you want instead.
+      echo "zuke: DENO_VERSION=latest is not supported: this launcher verifies the" >&2
+      echo "      download against a pinned SHA-256, and \\"latest\\" has no fixed hash." >&2
+      echo "      Set DENO_VERSION to an exact release tag (e.g. ${
+    denoReleaseTag(pin)
+  }) plus DENO_SHA256" >&2
+      echo "      with that release's deno-<target>.zip hash, or unset DENO_VERSION to" >&2
+      echo "      install the verified default $DEFAULT_DENO_VERSION." >&2
+      exit 1
+      ;;
+    v*) ;;
+    *) deno_version="v$deno_version" ;;
+  esac
+
+  # Map uname's OS/arch spelling to Deno's release asset target triple.
+  case "$(uname -s)" in
+    Linux) os_part="unknown-linux-gnu" ;;
+    Darwin) os_part="apple-darwin" ;;
+    *)
+      echo "zuke: unsupported OS for the checksum-verified bootstrap: $(uname -s)." >&2
+      echo "      Install Deno manually: ${DENO_INSTALL_DOCS}" >&2
+      exit 1
+      ;;
+  esac
+  case "$(uname -m)" in
+    x86_64 | amd64) arch_part="x86_64" ;;
+    arm64 | aarch64) arch_part="aarch64" ;;
+    *)
+      echo "zuke: unsupported architecture for the checksum-verified bootstrap: $(uname -m)." >&2
+      echo "      Install Deno manually: ${DENO_INSTALL_DOCS}" >&2
+      exit 1
+      ;;
+  esac
+  target="\${arch_part}-\${os_part}"
+
+  if [ "$deno_version" = "$DEFAULT_DENO_VERSION" ]; then
+    expected_sha256="$(deno_checksum_for "$target")" || {
+      echo "zuke: no pinned checksum for $target — this platform isn't covered yet." >&2
+      exit 1
+    }
+  elif [ -n "\${DENO_SHA256:-}" ]; then
+    # An explicit override: the caller vouches for this version/platform pair
+    # by supplying its own checksum, so the download is still verified.
+    expected_sha256="$DENO_SHA256"
+  else
+    echo "zuke: DENO_VERSION=$deno_version overrides the pinned $DEFAULT_DENO_VERSION," >&2
+    echo "      but no checksum is pinned for it. Set DENO_SHA256 to the expected" >&2
+    echo "      SHA-256 of deno-$target.zip for that release, or unset DENO_VERSION" >&2
+    echo "      to use the verified default." >&2
+    exit 1
+  fi
+
+  asset="deno-\${target}.zip"
+  download_url="https://github.com/denoland/deno/releases/download/\${deno_version}/\${asset}"
+  work_dir="$(mktemp -d)"
+  trap 'rm -rf "$work_dir"' EXIT
+  archive="$work_dir/$asset"
+
+  # The download fetches over the network, which is occasionally flaky (e.g. a
+  # transient 5xx from the CDN). Retry a few times with backoff so a blip
+  # doesn't fail the whole run.
+  download_deno() {
+    curl -fsSL -o "$archive" "$download_url"
+  }
+  attempt=1
+  max_attempts=4
+  until download_deno; do
+    if [ "$attempt" -ge "$max_attempts" ]; then
+      echo "zuke: failed to download Deno after $max_attempts attempts." >&2
+      exit 1
+    fi
+    delay=$((attempt * 3))
+    echo "zuke: Deno download failed (attempt $attempt/$max_attempts); retrying in \${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+  done
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual_sha256="$(sha256sum "$archive" | awk '{print $1}')"
+  elif command -v shasum >/dev/null 2>&1; then
+    actual_sha256="$(shasum -a 256 "$archive" | awk '{print $1}')"
+  else
+    echo "zuke: neither sha256sum nor shasum is available to verify the download." >&2
+    exit 1
+  fi
+  if [ "$actual_sha256" != "$expected_sha256" ]; then
+    echo "zuke: checksum mismatch for $asset:" >&2
+    echo "      expected $expected_sha256" >&2
+    echo "      got      $actual_sha256" >&2
+    exit 1
+  fi
+
+  mkdir -p "$deno_install/bin"
+  unzip -oq "$archive" -d "$deno_install/bin"
+  chmod +x "$deno_install/bin/deno"
+  deno_bin="$deno_install/bin/deno"
+fi
+
+# Put this Deno on PATH so CLIs the build provisions with \`deno install\` — whose
+# generated launchers invoke \`deno\` by name — can find it even when Deno was
+# bootstrapped to a non-PATH location (e.g. ~/.deno/bin).
+export PATH="$(dirname "$deno_bin"):$PATH"`;
+}
+
+/** The bash launcher's pin block: the version and the per-platform checksums. */
+function bashPin(pin: DenoPin): string {
+  const arms = POSIX_TARGETS.map((target) =>
+    `    ${target})\n      echo "${pin.checksums[target]}" ;;`
+  ).join("\n");
+  return `# Pinned default so the bootstrap installs a known version rather than whatever
+# "latest" happens to be.
+DEFAULT_DENO_VERSION="${denoReleaseTag(pin)}"
+
+# --- Pinned per-platform checksums for DEFAULT_DENO_VERSION -----------------
+${checksumProvenance(pin, "DEFAULT_DENO_VERSION")}
+deno_checksum_for() {
+  case "$1" in
+${arms}
+    *)
+      return 1 ;;
+  esac
+}
+# -----------------------------------------------------------------------------
+`;
+}
+
+/**
+ * The bash launcher (`./zuke`). Runs `zuke.ts` with the Deno on `PATH`, or
+ * with the one it bootstraps first (see the module docs for the variants).
+ */
+export function launcherBash(
+  options: LauncherOptions,
+  pin: DenoPin = DENO_PIN,
+): string {
+  const purpose = options.bootstrapDeno
+    ? `# Zuke bootstrap launcher — a \`./build.sh\`-style entry point for Deno.
+#
+#   ./zuke               # run the default target
+#   ./zuke <target>      # run one target and its prerequisites
+#   ./zuke --list        # list every target
+#
+# Ensures Deno is available (installing it on first use if missing), then runs
+# the project's build file (zuke.ts). No global install required.
+#
+${bootstrapEnvDocs(pin, "—")}`
+    : `# Zuke launcher — runs the project's build file (zuke.ts) with the Deno on PATH.
+#
+#   ./zuke               # run the default target
+#   ./zuke <target>      # run one target and its prerequisites
+#   ./zuke --list        # list every target
+#
+# Requires Deno: ${DENO_INSTALL_DOCS}`;
+  const pinBlock = options.bootstrapDeno ? `\n${bashPin(pin)}` : "";
+  return `#!/usr/bin/env bash
+${LICENSE_HEADER}
+#
+${purpose}
+set -euo pipefail
+${pinBlock}
+dir="$(cd "$(dirname "\${BASH_SOURCE[0]}")" && pwd)"
+cd "$dir"
+
+${bashResolveDeno(options, pin)}
+
+# The first run has no lockfile to verify against, so let Deno write one; from
+# then on --frozen fails the build if the module graph changed. Say so when
+# skipping, so a deleted lockfile downgrades verification visibly instead of
+# silently.
+if [ -f deno.lock ]; then
+  exec "$deno_bin" run -A --frozen zuke.ts "$@"
+else
+  echo "zuke: no deno.lock here yet — running without lockfile verification so Deno can write one." >&2
+  exec "$deno_bin" run -A zuke.ts "$@"
+fi
+`;
+}
+
+/** The PowerShell launcher's Deno resolution: the bootstrap, or the fail-closed check. */
+function pwshResolveDeno(options: LauncherOptions, pin: DenoPin): string {
+  if (!options.bootstrapDeno) {
+    return `$found = Get-Command deno -CommandType Application -ErrorAction SilentlyContinue
+if (-not $found) {
+  Write-Error "zuke: Deno not found on PATH. Install it, then re-run this launcher: ${DENO_INSTALL_DOCS}"
+  exit 1
+}
+$deno = $found.Source`;
+  }
+  return `if (-not $env:DENO_INSTALL) {
+  $env:DENO_INSTALL = Join-Path $HOME ".deno"
+}
+
+function Resolve-Deno {
+  $onPath = Get-Command deno -CommandType Application -ErrorAction SilentlyContinue
+  if ($onPath) { return $onPath.Source }
+  $local = Join-Path $env:DENO_INSTALL "bin\\deno.exe"
+  if (Test-Path $local) { return $local }
+  return $null
+}
+
+$deno = Resolve-Deno
+if (-not $deno) {
+  Write-Host "zuke: Deno not found - installing it now..."
+
+  $denoVersion = if ($env:DENO_VERSION) { $env:DENO_VERSION } else { $DefaultDenoVersion }
+  if ($denoVersion -eq "latest") {
+    # There is no \`latest\` release tag to download, and a moving target has no
+    # checksum to pin - so name the release you want instead.
+    throw "zuke: DENO_VERSION=latest is not supported: this launcher verifies the " +
+      "download against a pinned SHA-256, and ""latest"" has no fixed hash. Set " +
+      "DENO_VERSION to an exact release tag (e.g. ${
+    denoReleaseTag(pin)
+  }) plus DENO_SHA256 with that " +
+      "release's deno-<target>.zip hash, or unset DENO_VERSION to install the " +
+      "verified default $DefaultDenoVersion."
+  }
+  $vTag = if ($denoVersion.StartsWith("v")) { $denoVersion } else { "v$denoVersion" }
+  $bareVersion = $vTag.Substring(1)
+
+  # .ToString() forces a plain string comparison in the switch below,
+  # independent of how PowerShell would otherwise coerce the enum/string types.
+  $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+  $target = switch ($arch) {
+    "X64" { "x86_64-pc-windows-msvc" }
+    "Arm64" { "aarch64-pc-windows-msvc" }
+    default {
+      throw "zuke: unsupported architecture for the checksum-verified bootstrap: $arch. " +
+        "Install Deno manually: ${DENO_INSTALL_DOCS}"
+    }
+  }
+
+  if ($bareVersion -eq $DefaultDenoVersion -and $DenoChecksums.ContainsKey($target)) {
+    $expectedSha256 = $DenoChecksums[$target]
+  } elseif ($env:DENO_SHA256) {
+    # An explicit override: the caller vouches for this version/platform pair
+    # by supplying its own checksum, so the download is still verified.
+    $expectedSha256 = $env:DENO_SHA256
+  } else {
+    throw "zuke: DENO_VERSION=$denoVersion overrides the pinned $DefaultDenoVersion, " +
+      "but no checksum is pinned for it. Set DENO_SHA256 to the expected SHA-256 " +
+      "of deno-$target.zip for that release, or unset DENO_VERSION to use the " +
+      "verified default."
+  }
+
+  $asset = "deno-$target.zip"
+  $downloadUrl = "https://github.com/denoland/deno/releases/download/$vTag/$asset"
+  $workDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
+  New-Item -ItemType Directory -Path $workDir | Out-Null
+  $archive = Join-Path $workDir $asset
+  try {
+    # The download fetches over the network, which is occasionally flaky (e.g.
+    # a transient 5xx from the CDN). Retry a few times with backoff so a blip
+    # doesn't fail the whole run.
+    $maxAttempts = 4
+    for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+      try {
+        Invoke-WebRequest -Uri $downloadUrl -OutFile $archive
+        break
+      } catch {
+        if ($attempt -ge $maxAttempts) {
+          throw "zuke: failed to download Deno after $maxAttempts attempts: $_"
+        }
+        $delay = $attempt * 3
+        Write-Host "zuke: Deno download failed (attempt $attempt/$maxAttempts); retrying in \${delay}s..."
+        Start-Sleep -Seconds $delay
+      }
+    }
+
+    $actualSha256 = (Get-FileHash -Path $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actualSha256 -ne $expectedSha256.ToLowerInvariant()) {
+      throw "zuke: checksum mismatch for \${asset}: expected $expectedSha256, got $actualSha256"
+    }
+
+    $binDir = Join-Path $env:DENO_INSTALL "bin"
+    New-Item -ItemType Directory -Force -Path $binDir | Out-Null
+    Expand-Archive -Path $archive -DestinationPath $binDir -Force
+  } finally {
+    Remove-Item -Recurse -Force $workDir -ErrorAction SilentlyContinue
+  }
+
+  $deno = Join-Path $env:DENO_INSTALL "bin\\deno.exe"
+}
+
+# Put this Deno on PATH so CLIs the build provisions with \`deno install\` - whose
+# generated launchers invoke \`deno\` by name - can find it even when Deno was
+# bootstrapped to a non-PATH location.
+$env:PATH = (Split-Path -Parent $deno) + [IO.Path]::PathSeparator + $env:PATH`;
+}
+
+/** The PowerShell launcher's pin block: the version and the per-platform checksums. */
+function pwshPin(pin: DenoPin): string {
+  const width = Math.max(...WINDOWS_TARGETS.map((t) => t.length)) + 2;
+  const entries = WINDOWS_TARGETS.map((target) =>
+    `  ${`"${target}"`.padEnd(width)} = "${pin.checksums[target]}"`
+  ).join("\n");
+  return `# Pinned default so the bootstrap installs a known version rather than whatever
+# "latest" happens to be.
+$DefaultDenoVersion = "${pin.version}"
+
+# --- Pinned per-platform checksums for $DefaultDenoVersion ------------------
+${checksumProvenance(pin, "$DefaultDenoVersion")}
+$DenoChecksums = @{
+${entries}
+}
+# -----------------------------------------------------------------------------
+`;
+}
+
+/**
+ * The PowerShell launcher (`.\zuke.ps1`). Mirrors {@link launcherBash},
+ * variant for variant, including the conditional `--frozen`.
+ */
+export function launcherPwsh(
+  options: LauncherOptions,
+  pin: DenoPin = DENO_PIN,
+): string {
+  const purpose = options.bootstrapDeno
+    ? `# Zuke bootstrap launcher (PowerShell) - a \`.\\build.ps1\`-style entry point.
+#
+#   .\\zuke.ps1               # run the default target
+#   .\\zuke.ps1 <target>      # run one target and its prerequisites
+#   .\\zuke.ps1 --list        # list every target
+#
+# Ensures Deno is available (installing it on first use if missing), then runs
+# the project's build file (zuke.ts). No global install required.
+#
+${bootstrapEnvDocs(pin, "-")}`
+    : `# Zuke launcher (PowerShell) - runs the project's build file (zuke.ts) with the Deno on PATH.
+#
+#   .\\zuke.ps1               # run the default target
+#   .\\zuke.ps1 <target>      # run one target and its prerequisites
+#   .\\zuke.ps1 --list        # list every target
+#
+# Requires Deno: ${DENO_INSTALL_DOCS}`;
+  const pinBlock = options.bootstrapDeno ? `\n${pwshPin(pin)}` : "";
+  return `#!/usr/bin/env pwsh
+${LICENSE_HEADER}
+#
+${purpose}
+
+$ErrorActionPreference = "Stop"
+${pinBlock}
+$dir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $dir
+
+${pwshResolveDeno(options, pin)}
+
+# The first run has no lockfile to verify against, so let Deno write one; from
+# then on --frozen fails the build if the module graph changed. Say so when
+# skipping, so a deleted lockfile downgrades verification visibly instead of
+# silently.
+$denoArgs = @("run", "-A")
+if (Test-Path (Join-Path $dir "deno.lock")) {
+  $denoArgs += "--frozen"
+} else {
+  Write-Warning "zuke: no deno.lock here yet - running without lockfile verification so Deno can write one."
+}
+$denoArgs += (Join-Path $dir "zuke.ts")
+& $deno @denoArgs @args
+exit $LASTEXITCODE
+`;
+}
+
+/* cspell:enable */

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -3,8 +3,8 @@
 
 /**
  * The scaffolding engine behind `zuke setup`. It writes a starter `zuke.ts`,
- * the `./zuke` bootstrap launchers, and a `deno.json` task into a target
- * directory.
+ * the `./zuke` launchers (see {@link "./launcher.ts"} for the two variants),
+ * and a `deno.json` task into a target directory.
  *
  * All filesystem and console effects go through an injectable {@link SetupHost}
  * so the logic stays pure and unit-testable; {@link defaultHost} is the real
@@ -17,6 +17,7 @@ import {
   parseMcpConfig,
 } from "./mcp_config.ts";
 import { isRecord } from "./records.ts";
+import { launcherBash, launcherPwsh } from "./launcher.ts";
 
 // Re-exported so the merge guard keeps its historical home for importers.
 export { isRecord };
@@ -52,89 +53,6 @@ await run(${name});
 export function starterConfig(name: string): string {
   return `${JSON.stringify({ name }, null, 2)}\n`;
 }
-
-/**
- * The URL the launchers point at when Deno is missing. They deliberately do not
- * install it themselves: piping an install script straight into a shell
- * downloads and executes code with no integrity check, and a scaffolded
- * launcher has no pinned per-platform checksum to verify against (Zuke's own
- * `./zuke` carries one because it pins the Deno version it bootstraps). Telling
- * the user which one command to run keeps the scaffold honest about that.
- */
-const DENO_INSTALL_DOCS =
-  "https://docs.deno.com/runtime/getting_started/installation/";
-
-/* cspell:disable */
-
-/**
- * The bash launcher (`./zuke`). Runs `zuke.ts` with the Deno on `PATH`.
- *
- * `--frozen` is passed only when a `deno.lock` is already there: a freshly
- * scaffolded project has none, and `deno run --frozen` against a missing
- * lockfile fails outright ("The lockfile is out of date") instead of writing
- * one. So the first run resolves and records the graph, and every run after
- * that verifies it and fails loudly if it changed.
- *
- * The unfrozen branch prints a notice to stderr. The same branch is taken if a
- * `deno.lock` is later removed, which drops integrity verification, so it says
- * so rather than running unverified in silence.
- */
-export function launcherBash(): string {
-  return `#!/usr/bin/env bash
-# Zuke launcher — runs zuke.ts with Deno.
-set -euo pipefail
-dir="$(cd "$(dirname "\${BASH_SOURCE[0]}")" && pwd)"
-cd "$dir"
-if ! command -v deno >/dev/null 2>&1; then
-  echo "zuke: Deno not found on PATH. Install it, then re-run this launcher:" >&2
-  echo "      ${DENO_INSTALL_DOCS}" >&2
-  exit 1
-fi
-# The first run has no lockfile to verify against, so let Deno write one; from
-# then on --frozen fails the build if the module graph changed. Say so when
-# skipping, so a deleted lockfile downgrades verification visibly instead of
-# silently.
-if [ -f deno.lock ]; then
-  deno run -A --frozen zuke.ts "$@"
-else
-  echo "zuke: no deno.lock here yet — running without lockfile verification so Deno can write one." >&2
-  deno run -A zuke.ts "$@"
-fi
-`;
-}
-
-/**
- * The PowerShell launcher (`.\\zuke.ps1`). Mirrors {@link launcherBash},
- * including its conditional `--frozen`.
- */
-export function launcherPwsh(): string {
-  return `#!/usr/bin/env pwsh
-# Zuke launcher — runs zuke.ts with Deno.
-$ErrorActionPreference = "Stop"
-$dir = Split-Path -Parent $MyInvocation.MyCommand.Path
-Set-Location $dir
-$found = Get-Command deno -ErrorAction SilentlyContinue
-if (-not $found) {
-  Write-Error "zuke: Deno not found on PATH. Install it, then re-run this launcher: ${DENO_INSTALL_DOCS}"
-  exit 1
-}
-# The first run has no lockfile to verify against, so let Deno write one; from
-# then on --frozen fails the build if the module graph changed. Say so when
-# skipping, so a deleted lockfile downgrades verification visibly instead of
-# silently.
-$denoArgs = @("run", "-A")
-if (Test-Path (Join-Path $dir "deno.lock")) {
-  $denoArgs += "--frozen"
-} else {
-  Write-Warning "zuke: no deno.lock here yet - running without lockfile verification so Deno can write one."
-}
-$denoArgs += (Join-Path $dir "zuke.ts")
-& $found.Source @denoArgs @args
-exit $LASTEXITCODE
-`;
-}
-
-/* cspell:enable */
 
 /**
  * The task names `setup` writes into `deno.json`, with their commands.
@@ -259,6 +177,12 @@ export interface SetupOptions {
    */
   buildContent?: string;
   /**
+   * Scaffold launchers that bootstrap a pinned, checksum-verified Deno when
+   * none is on `PATH` (the default), or plain ones that require Deno and fail
+   * closed when it is missing (`false`). See {@link "./launcher.ts"}.
+   */
+  bootstrapDeno?: boolean;
+  /**
    * Also write an `.mcp.json` registering the build's MCP server (`--mcp`), so
    * an agent client picks the build up from the first commit. `allowRun`
    * adds `--allow-run`, letting the agent execute targets rather than only
@@ -354,14 +278,20 @@ export async function runSetup(
   const files: FileResult[] = [];
   const launcher = options.launcherName ?? DEFAULT_LAUNCHER;
   assertLauncherName(launcher);
+  const variant = { bootstrapDeno: options.bootstrapDeno ?? true };
 
   const scaffold: readonly ScaffoldFile[] = [
     {
       name: "zuke.ts",
       content: options.buildContent ?? starterBuild(options.name),
     },
-    { name: launcher, content: launcherBash(), mode: 0o755, launcher: true },
-    { name: `${launcher}.ps1`, content: launcherPwsh(), launcher: true },
+    {
+      name: launcher,
+      content: launcherBash(variant),
+      mode: 0o755,
+      launcher: true,
+    },
+    { name: `${launcher}.ps1`, content: launcherPwsh(variant), launcher: true },
     { name: "zuke.json", content: starterConfig(options.name) },
   ];
 

--- a/packages/cli/tests/_fakes.ts
+++ b/packages/cli/tests/_fakes.ts
@@ -62,6 +62,8 @@ export class FakeHost implements SetupHost {
 export class FakePrompter implements Prompter {
   /** Every question passed to {@link confirm}, in order. */
   readonly confirms: string[] = [];
+  /** Every question passed to {@link ask}, in order. */
+  readonly asks: string[] = [];
 
   constructor(
     private readonly tty: boolean,
@@ -70,13 +72,22 @@ export class FakePrompter implements Prompter {
     /** The answer to the star prompt (kept apart from `yes`, so tests of the
      * other confirms don't accidentally opt in to starring). */
     private readonly star: boolean = false,
+    /** The answer to the launcher question; `""` takes its default. Kept
+     * apart from `answer`, which is the build class name. */
+    private readonly bootstrap: string = "",
   ) {}
 
   interactive(): boolean {
     return this.tty;
   }
 
-  ask(_question: string, fallback: string): string {
+  ask(question: string, fallback: string): string {
+    this.asks.push(question);
+    // Match the launcher question narrowly, as `confirm` does for the star
+    // one, so the class-name answer never leaks into a yes/no question.
+    if (question.includes("bootstrap a pinned")) {
+      return this.bootstrap === "" ? fallback : this.bootstrap;
+    }
     return this.answer === "" ? fallback : this.answer;
   }
 

--- a/packages/cli/tests/cli_test.ts
+++ b/packages/cli/tests/cli_test.ts
@@ -9,6 +9,7 @@ import {
   resolveDocSpec,
 } from "../mod.ts";
 import { VERSION } from "../src/version.ts";
+import { DENO_PIN } from "../src/deno_pin.ts";
 import { FakeHost, FakePrompter, FakeStarActions } from "./_fakes.ts";
 import { withTemp } from "../../core/tests/_temp.ts";
 import { ConsoleTasks, ZUKE_LOGO } from "@zuke/console";
@@ -62,6 +63,116 @@ Deno.test("parseSetupFlags reads every flag form", () => {
     mcp: true,
     allowRun: true,
   });
+  // Unset means "ask, or take the default"; either flag decides outright, and
+  // the last one wins.
+  assertEquals(parseSetupFlags([]).bootstrapDeno, undefined);
+  assertEquals(parseSetupFlags(["--bootstrap-deno"]).bootstrapDeno, true);
+  assertEquals(parseSetupFlags(["--no-bootstrap-deno"]).bootstrapDeno, false);
+  assertEquals(
+    parseSetupFlags(["--bootstrap-deno", "--no-bootstrap-deno"]).bootstrapDeno,
+    false,
+  );
+});
+
+Deno.test("main setup --yes scaffolds the bootstrapping launchers by default", async () => {
+  const host = new FakeHost();
+  const prompter = new FakePrompter(true);
+  assertEquals(await main(["setup", "--yes"], host, prompter), 0);
+  assertEquals(host.files.get("zuke")?.includes("DEFAULT_DENO_VERSION"), true);
+  assertEquals(host.files.get("zuke.ps1")?.includes("$DenoChecksums"), true);
+  // --yes means no questions, the launcher one included.
+  assertEquals(prompter.asks, []);
+});
+
+Deno.test("main setup --no-bootstrap-deno scaffolds the plain launchers", async () => {
+  const host = new FakeHost();
+  const code = await main(
+    ["setup", "--yes", "--no-bootstrap-deno"],
+    host,
+    new FakePrompter(false),
+  );
+  assertEquals(code, 0);
+  assertEquals(
+    host.files.get("zuke")?.includes("Deno not found on PATH"),
+    true,
+  );
+  assertEquals(host.files.get("zuke")?.includes("DEFAULT_DENO_VERSION"), false);
+  assertEquals(
+    host.files.get("zuke.ps1")?.includes("Deno not found on PATH"),
+    true,
+  );
+});
+
+Deno.test("main setup (interactive) asks about the launcher and honours a no", async () => {
+  const host = new FakeHost();
+  const prompter = new FakePrompter(true, "", true, false, "n");
+  assertEquals(await main(["setup"], host, prompter), 0);
+  const question = prompter.asks.find((q) => q.includes("bootstrap a pinned"));
+  assertEquals(question !== undefined, true);
+  // The question names the release a yes will pin, so the choice is informed.
+  assertEquals(question?.includes(`Deno v${DENO_PIN.version}`), true);
+  assertEquals(
+    host.files.get("zuke")?.includes("Deno not found on PATH"),
+    true,
+  );
+});
+
+Deno.test("main setup (interactive) takes Enter as the default: bootstrap", async () => {
+  const host = new FakeHost();
+  const prompter = new FakePrompter(true, "", true);
+  assertEquals(await main(["setup"], host, prompter), 0);
+  assertEquals(
+    prompter.asks.some((q) => q.includes("bootstrap a pinned")),
+    true,
+  );
+  assertEquals(host.files.get("zuke")?.includes("DEFAULT_DENO_VERSION"), true);
+});
+
+Deno.test("main setup (interactive) does not ask when a flag already answered", async () => {
+  const host = new FakeHost();
+  const prompter = new FakePrompter(true, "", true, false, "n");
+  const code = await main(["setup", "--bootstrap-deno"], host, prompter);
+  assertEquals(code, 0);
+  assertEquals(
+    prompter.asks.some((q) => q.includes("bootstrap a pinned")),
+    false,
+  );
+  // The flag wins over the scripted "n" the prompt would have returned.
+  assertEquals(host.files.get("zuke")?.includes("DEFAULT_DENO_VERSION"), true);
+});
+
+Deno.test("main import honours the launcher flags and question too", async () => {
+  const flagged = new FakeHost({ Makefile: "build:\n\techo hi\n" });
+  const code = await main(
+    ["import", "--yes", "--no-bootstrap-deno"],
+    flagged,
+    new FakePrompter(false),
+  );
+  assertEquals(code, 0);
+  assertEquals(
+    flagged.files.get("zuke")?.includes("Deno not found on PATH"),
+    true,
+  );
+
+  const asked = new FakeHost({ Makefile: "build:\n\techo hi\n" });
+  const prompter = new FakePrompter(true, "", true, false, "no");
+  assertEquals(await main(["import"], asked, prompter), 0);
+  assertEquals(
+    prompter.asks.some((q) => q.includes("bootstrap a pinned")),
+    true,
+  );
+  assertEquals(
+    asked.files.get("zuke")?.includes("Deno not found on PATH"),
+    true,
+  );
+});
+
+Deno.test("main --help documents both launcher flags", async () => {
+  const host = new FakeHost();
+  assertEquals(await main(["--help"], host), 0);
+  const help = host.logs.join("\n");
+  assertEquals(help.includes("--bootstrap-deno"), true);
+  assertEquals(help.includes("--no-bootstrap-deno"), true);
 });
 
 Deno.test("main setup --mcp writes .mcp.json and import --allow-run passes it through", async () => {

--- a/packages/cli/tests/launcher_test.ts
+++ b/packages/cli/tests/launcher_test.ts
@@ -1,0 +1,204 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../core/tests/_assert.ts";
+import {
+  DENO_INSTALL_DOCS,
+  launcherBash,
+  launcherPwsh,
+} from "../src/launcher.ts";
+import {
+  DENO_PIN,
+  type DenoPin,
+  denoReleaseTag,
+  POSIX_TARGETS,
+  WINDOWS_TARGETS,
+} from "../src/deno_pin.ts";
+
+const BOOTSTRAP = { bootstrapDeno: true };
+const PLAIN = { bootstrapDeno: false };
+
+/** A well-formed lowercase 64-character hex SHA-256. */
+const SHA256_RE = /^[0-9a-f]{64}$/;
+
+/** A pin with recognisable, obviously fake values. */
+const FAKE_PIN: DenoPin = {
+  version: "9.9.9",
+  checksums: {
+    "x86_64-unknown-linux-gnu": "a".repeat(64),
+    "aarch64-unknown-linux-gnu": "b".repeat(64),
+    "x86_64-apple-darwin": "c".repeat(64),
+    "aarch64-apple-darwin": "d".repeat(64),
+    "x86_64-pc-windows-msvc": "e".repeat(64),
+    "aarch64-pc-windows-msvc": "f".repeat(64),
+  },
+};
+
+Deno.test("the pin carries a well-formed checksum for every target", () => {
+  assertEquals(denoReleaseTag(DENO_PIN), `v${DENO_PIN.version}`);
+  assertEquals(/^\d+\.\d+\.\d+$/.test(DENO_PIN.version), true);
+  const targets = Object.keys(DENO_PIN.checksums).sort();
+  // The two launchers between them cover every pinned target, exactly once.
+  assertEquals(targets, [...POSIX_TARGETS, ...WINDOWS_TARGETS].sort());
+  for (const [target, hash] of Object.entries(DENO_PIN.checksums)) {
+    assertEquals(SHA256_RE.test(hash), true, `${target}: "${hash}"`);
+  }
+});
+
+Deno.test("both variants carry a shebang, the license header, and run zuke.ts", () => {
+  for (const options of [BOOTSTRAP, PLAIN]) {
+    const bash = launcherBash(options);
+    assertEquals(bash.startsWith("#!/usr/bin/env bash\n# Copyright"), true);
+    assertStringIncludes(bash, "# SPDX-License-Identifier: MIT");
+    assertStringIncludes(bash, "run -A zuke.ts");
+    const pwsh = launcherPwsh(options);
+    assertEquals(pwsh.startsWith("#!/usr/bin/env pwsh\n# Copyright"), true);
+    assertStringIncludes(pwsh, "# SPDX-License-Identifier: MIT");
+    assertStringIncludes(pwsh, "zuke.ts");
+  }
+});
+
+Deno.test("the plain launchers fail closed when Deno is missing", () => {
+  // No install script, no download: report the missing Deno and point at the
+  // one command to run. This is the variant for a project that must never
+  // fetch a tool from its build entry point.
+  for (const script of [launcherBash(PLAIN), launcherPwsh(PLAIN)]) {
+    assertEquals(script.includes("deno.land/install"), false);
+    assertEquals(script.includes("| sh"), false);
+    assertEquals(script.includes("Invoke-Expression"), false);
+    assertEquals(script.includes("Invoke-WebRequest"), false);
+    assertEquals(script.includes("curl"), false);
+    assertEquals(script.includes("DEFAULT_DENO_VERSION"), false);
+    assertEquals(script.includes("DefaultDenoVersion"), false);
+    assertStringIncludes(script, "Deno not found on PATH");
+    assertStringIncludes(script, DENO_INSTALL_DOCS);
+  }
+});
+
+Deno.test("the bootstrap bash launcher pins the release and every POSIX checksum", () => {
+  const bash = launcherBash(BOOTSTRAP);
+  assertStringIncludes(
+    bash,
+    `DEFAULT_DENO_VERSION="${denoReleaseTag(DENO_PIN)}"`,
+  );
+  for (const target of POSIX_TARGETS) {
+    assertStringIncludes(
+      bash,
+      `    ${target})\n      echo "${DENO_PIN.checksums[target]}" ;;`,
+    );
+  }
+  for (const target of WINDOWS_TARGETS) {
+    assertEquals(bash.includes(DENO_PIN.checksums[target]), false);
+  }
+  // Download from the release page, verify, never run an install script.
+  assertStringIncludes(
+    bash,
+    "https://github.com/denoland/deno/releases/download/",
+  );
+  assertEquals(bash.includes("deno.land/install"), false);
+  assertEquals(bash.includes("| sh"), false);
+  assertStringIncludes(bash, "DENO_VERSION=latest is not supported");
+  assertStringIncludes(bash, `if [ "$actual_sha256" != "$expected_sha256" ]`);
+  // The bootstrapped Deno goes on PATH for the tools the build provisions.
+  assertStringIncludes(bash, 'export PATH="$(dirname "$deno_bin"):$PATH"');
+});
+
+Deno.test("the bootstrap PowerShell launcher pins the release and every Windows checksum", () => {
+  const pwsh = launcherPwsh(BOOTSTRAP);
+  assertStringIncludes(pwsh, `$DefaultDenoVersion = "${DENO_PIN.version}"`);
+  for (const target of WINDOWS_TARGETS) {
+    assertStringIncludes(
+      pwsh,
+      `"${target}"`,
+    );
+    assertStringIncludes(pwsh, `= "${DENO_PIN.checksums[target]}"`);
+  }
+  for (const target of POSIX_TARGETS) {
+    assertEquals(pwsh.includes(DENO_PIN.checksums[target]), false);
+  }
+  assertEquals(pwsh.includes("deno.land/install"), false);
+  assertEquals(pwsh.includes("Invoke-Expression"), false);
+  assertStringIncludes(pwsh, `if ($denoVersion -eq "latest")`);
+  assertStringIncludes(pwsh, "DENO_VERSION=latest is not supported");
+  assertStringIncludes(pwsh, "Get-FileHash -Path $archive -Algorithm SHA256");
+  // PowerShell sources are kept ASCII: no em dash anywhere in the script.
+  assertEquals(pwsh.includes("—"), false);
+});
+
+Deno.test("the launchers render whatever pin they are given", () => {
+  // The pin is a parameter, so a Deno bump is a data change and the rendered
+  // scripts follow it — no hash or version is baked into the template text.
+  const bash = launcherBash(BOOTSTRAP, FAKE_PIN);
+  assertStringIncludes(bash, 'DEFAULT_DENO_VERSION="v9.9.9"');
+  assertStringIncludes(bash, `echo "${"a".repeat(64)}" ;;`);
+  assertStringIncludes(bash, "(e.g. v9.9.9)");
+  assertEquals(bash.includes(DENO_PIN.version), false);
+  const pwsh = launcherPwsh(BOOTSTRAP, FAKE_PIN);
+  assertStringIncludes(pwsh, '$DefaultDenoVersion = "9.9.9"');
+  assertStringIncludes(pwsh, `= "${"f".repeat(64)}"`);
+  assertEquals(pwsh.includes(DENO_PIN.version), false);
+});
+
+Deno.test("launchers pass --frozen only once a deno.lock exists", () => {
+  // A fresh scaffold has no lockfile, and `deno run --frozen` against a
+  // missing one fails outright rather than writing it — so an unconditional
+  // --frozen breaks the very first `./zuke` the CLI tells the user to run.
+  // Every --frozen must therefore sit behind a lockfile check, with a
+  // plain (lock-writing) invocation as the other branch.
+  for (const options of [BOOTSTRAP, PLAIN]) {
+    const bash = launcherBash(options);
+    const check = bash.indexOf("if [ -f deno.lock ]; then");
+    assertEquals(check > 0, true);
+    const tail = bash.slice(check);
+    assertEquals(tail.split("run -A --frozen zuke.ts").length - 1, 1);
+    assertEquals(tail.split(`run -A zuke.ts "$@"`).length - 1, 1);
+    // The frozen branch comes first, the lock-writing branch after the `else`.
+    assertEquals(tail.indexOf("--frozen") < tail.indexOf("else\n"), true);
+    assertEquals(
+      tail.indexOf("else\n") < tail.indexOf(`run -A zuke.ts "$@"`),
+      true,
+    );
+    // No invocation outside that check passes --frozen.
+    assertEquals(bash.split("--frozen zuke.ts").length - 1, 1);
+
+    const pwsh = launcherPwsh(options);
+    assertStringIncludes(pwsh, `Test-Path (Join-Path $dir "deno.lock")`);
+    assertEquals(pwsh.split(`$denoArgs += "--frozen"`).length - 1, 1);
+    // --frozen is only ever appended inside that check, never in the base argv.
+    assertStringIncludes(pwsh, `@("run", "-A")`);
+  }
+});
+
+Deno.test("the unfrozen branch says so, so a deleted lockfile is not silent", () => {
+  // Skipping --frozen is correct on a fresh scaffold, but the same branch is
+  // taken if someone removes deno.lock later — which drops integrity
+  // verification. Both launchers must announce that on stderr rather than
+  // quietly running unverified.
+  for (const options of [BOOTSTRAP, PLAIN]) {
+    const bash = launcherBash(options);
+    const notice = bash.indexOf("without lockfile verification");
+    assertEquals(notice > 0, true);
+    // On stderr, and only in the branch that skips --frozen.
+    assertEquals(notice > bash.indexOf("if [ -f deno.lock ]; then"), true);
+    assertEquals(notice > bash.lastIndexOf("else\n"), true);
+    assertStringIncludes(bash.slice(notice), ">&2");
+
+    const pwsh = launcherPwsh(options);
+    assertStringIncludes(pwsh, "without lockfile verification");
+    assertStringIncludes(pwsh, "Write-Warning");
+  }
+});
+
+Deno.test("the bash launcher execs Deno so the script is not read after it starts", () => {
+  // `./zuke launcherSync` rewrites the very file bash is executing. `exec`
+  // replaces the shell with Deno before that target runs, so there is no
+  // shell left to read a half-rewritten script.
+  for (const options of [BOOTSTRAP, PLAIN]) {
+    const bash = launcherBash(options);
+    assertStringIncludes(bash, `exec "$deno_bin" run -A --frozen zuke.ts "$@"`);
+    assertStringIncludes(bash, `exec "$deno_bin" run -A zuke.ts "$@"`);
+  }
+});

--- a/packages/cli/tests/setup_test.ts
+++ b/packages/cli/tests/setup_test.ts
@@ -9,8 +9,6 @@ import {
 import {
   defaultHost,
   isRecord,
-  launcherBash,
-  launcherPwsh,
   mergeDenoJson,
   runSetup,
   starterBuild,
@@ -40,77 +38,6 @@ Deno.test("starterConfig records the build name as JSON", () => {
   const parsed: unknown = JSON.parse(starterConfig("Acme"));
   assertEquals(isRecord(parsed) && parsed.name === "Acme", true);
   assertEquals(starterConfig("Acme").endsWith("\n"), true);
-});
-
-Deno.test("launchers carry a shebang and run zuke.ts", () => {
-  const bash = launcherBash();
-  assertEquals(bash.startsWith("#!/usr/bin/env bash"), true);
-  assertEquals(bash.includes("run -A zuke.ts"), true);
-  const pwsh = launcherPwsh();
-  assertEquals(pwsh.startsWith("#!/usr/bin/env pwsh"), true);
-  assertEquals(pwsh.includes("zuke.ts"), true);
-});
-
-Deno.test("scaffolded launchers never pipe an unverified install script", () => {
-  // A launcher that pipes `deno.land/install.sh` into a shell downloads and
-  // executes code with nothing verifying it, in every project `zuke setup`
-  // scaffolds. Missing Deno must be reported, not silently installed.
-  for (const script of [launcherBash(), launcherPwsh()]) {
-    assertEquals(script.includes("deno.land/install"), false);
-    assertEquals(script.includes("| sh"), false);
-    assertEquals(script.includes("Invoke-Expression"), false);
-    assertEquals(script.includes("Deno not found on PATH"), true);
-    assertStringIncludes(
-      script,
-      "https://docs.deno.com/runtime/getting_started/installation/",
-    );
-  }
-});
-
-Deno.test("launchers pass --frozen only once a deno.lock exists", () => {
-  // A fresh scaffold has no lockfile, and `deno run --frozen` against a
-  // missing one fails outright rather than writing it — so an unconditional
-  // --frozen breaks the very first `./zuke` the CLI tells the user to run.
-  // Every --frozen must therefore sit behind a lockfile check, with a
-  // plain (lock-writing) invocation as the other branch.
-  const bash = launcherBash();
-  assertEquals(bash.includes("if [ -f deno.lock ]; then"), true);
-  assertEquals(bash.split("run -A --frozen zuke.ts").length - 1, 1);
-  assertEquals(bash.split(`run -A zuke.ts "$@"`).length - 1, 1);
-  // The frozen branch comes first, the bootstrap branch after the `else`.
-  assertEquals(bash.indexOf("--frozen") < bash.indexOf("else\n"), true);
-  assertEquals(
-    bash.indexOf("else\n") < bash.indexOf(`run -A zuke.ts "$@"`),
-    true,
-  );
-
-  const pwsh = launcherPwsh();
-  assertEquals(pwsh.includes(`Test-Path (Join-Path $dir "deno.lock")`), true);
-  assertEquals(pwsh.split(`$denoArgs += "--frozen"`).length - 1, 1);
-  // --frozen is only ever appended inside that check, never in the base argv.
-  assertEquals(pwsh.includes(`@("run", "-A")`), true);
-});
-
-Deno.test("the unfrozen branch says so, so a deleted lockfile is not silent", () => {
-  // Skipping --frozen is correct on a fresh scaffold, but the same branch is
-  // taken if someone removes deno.lock later — which drops integrity
-  // verification. Both launchers must announce that on stderr rather than
-  // quietly running unverified.
-  const bash = launcherBash();
-  assertEquals(bash.includes("without lockfile verification"), true);
-  // On stderr, and only in the branch that skips --frozen.
-  assertEquals(
-    bash.indexOf("without lockfile verification") > bash.indexOf("else\n"),
-    true,
-  );
-  assertEquals(
-    bash.slice(bash.indexOf("without lockfile verification")).includes(">&2"),
-    true,
-  );
-
-  const pwsh = launcherPwsh();
-  assertEquals(pwsh.includes("without lockfile verification"), true);
-  assertEquals(pwsh.includes("Write-Warning"), true);
 });
 
 Deno.test("mergeDenoJson seeds tasks from scratch", () => {
@@ -169,6 +96,37 @@ Deno.test("runSetup scaffolds an empty project", async () => {
   assertEquals(host.files.has("deno.json"), true);
   assertEquals(host.files.get(".gitignore")?.includes(".zuke/"), true);
   assertEquals(host.chmods[0], ["zuke", 0o755]);
+});
+
+Deno.test("runSetup scaffolds the bootstrapping launchers by default", async () => {
+  // Nothing installed up front is the default: the launchers carry the pinned
+  // Deno release and its checksums, and the PowerShell one mirrors the bash.
+  const host = new FakeHost();
+  await runSetup({ dir: ".", force: false, name: "Acme" }, host);
+  const bash = host.files.get("zuke") ?? "";
+  const pwsh = host.files.get("zuke.ps1") ?? "";
+  assertStringIncludes(bash, "DEFAULT_DENO_VERSION=");
+  assertStringIncludes(bash, "deno_checksum_for()");
+  assertStringIncludes(pwsh, "$DefaultDenoVersion =");
+  assertStringIncludes(pwsh, "$DenoChecksums = @{");
+  assertEquals(bash.includes("Deno not found on PATH"), false);
+  assertEquals(pwsh.includes("Deno not found on PATH"), false);
+});
+
+Deno.test("runSetup scaffolds the plain launchers when bootstrapDeno is false", async () => {
+  const host = new FakeHost();
+  await runSetup(
+    { dir: ".", force: false, name: "Acme", bootstrapDeno: false },
+    host,
+  );
+  const bash = host.files.get("zuke") ?? "";
+  const pwsh = host.files.get("zuke.ps1") ?? "";
+  assertStringIncludes(bash, "Deno not found on PATH");
+  assertStringIncludes(pwsh, "Deno not found on PATH");
+  assertEquals(bash.includes("DEFAULT_DENO_VERSION"), false);
+  assertEquals(pwsh.includes("DefaultDenoVersion"), false);
+  // Still executable, still a launcher: the variant changes nothing else.
+  assertEquals(host.chmods, [["zuke", 0o755]]);
 });
 
 Deno.test("runSetup writes the launcher under a custom --launcher-name", async () => {

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/.codex-plugin/plugin.json
+++ b/plugins/zuke/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/skills/zuke-setup/SKILL.md
+++ b/plugins/zuke/skills/zuke-setup/SKILL.md
@@ -27,7 +27,9 @@ deno run -A jsr:@zuke/cli setup
 ```
 
 `setup` flags: `--dir <path>`, `--name <ClassName>`, `--force` (overwrite
-existing files), `--yes` (non-interactive), `--mcp` (also write `.mcp.json`
+existing files), `--yes` (non-interactive), `--bootstrap-deno` /
+`--no-bootstrap-deno` (which launchers to write — see below; the wizard asks
+when interactive, and `--yes` takes the default, bootstrap), `--mcp` (also write `.mcp.json`
 registering the build's MCP server, so this agent — and any other stdio MCP
 client — can list and run the targets through typed calls; `--allow-run`
 registers it with execution enabled and implies `--mcp`), `--launcher-name
@@ -68,7 +70,8 @@ is a bug, not a shortcut. An `&&` chain becomes sequential steps, a
 shell-specific to translate (pipes, redirects, env assignments) is preserved
 behind a `// TODO` so the file still compiles. It scaffolds the launchers and
 `deno.json` exactly like `setup`, and takes the same `--dir`, `--name`,
-`--force`, `--yes`, `--mcp` and `--allow-run` flags. Afterwards, use the **zuke-write-build** skill to
+`--force`, `--yes`, `--bootstrap-deno` / `--no-bootstrap-deno`, `--mcp` and
+`--allow-run` flags. Afterwards, use the **zuke-write-build** skill to
 finish replacing any remaining generated `CmdTasks.exec` calls with typed
 `*Tasks` wrappers.
 
@@ -76,10 +79,14 @@ finish replacing any remaining generated `CmdTasks.exec` calls with typed
 
 - **`zuke.ts`** — a starter build class with a sample target and a `default`.
 - **`./zuke`** + **`./zuke.ps1`** — launchers that locate the project and run
-  `zuke.ts` with the Deno on `PATH`. If Deno is missing they point at the
-  official install docs and exit rather than piping an install script into a
-  shell, which would download and execute code unverified. They pass `--frozen`
-  once a `deno.lock` exists, so the first run writes the lockfile and every run
+  `zuke.ts`. By default (`--bootstrap-deno`) they use the Deno on `PATH` and,
+  when there is none, download the pinned release Zuke itself runs on, verify
+  it against a per-platform SHA-256, and install it under `~/.deno` — never an
+  install script, never an unverified binary — so a clone needs nothing
+  installed first. With `--no-bootstrap-deno` they require Deno on `PATH` and
+  exit with the install docs URL when it is missing, for a project that must
+  never download a tool from its build entry point. Both pass `--frozen` once
+  a `deno.lock` exists, so the first run writes the lockfile and every run
   after verifies it.
 - **`deno.json`** — merged to add a `zuke` task, plus `fmt`/`lint`/`test` if
   absent. The merge is all-or-nothing: if a `zuke` task is already declared the

--- a/skills/zuke-setup/SKILL.md
+++ b/skills/zuke-setup/SKILL.md
@@ -27,7 +27,9 @@ deno run -A jsr:@zuke/cli setup
 ```
 
 `setup` flags: `--dir <path>`, `--name <ClassName>`, `--force` (overwrite
-existing files), `--yes` (non-interactive), `--mcp` (also write `.mcp.json`
+existing files), `--yes` (non-interactive), `--bootstrap-deno` /
+`--no-bootstrap-deno` (which launchers to write — see below; the wizard asks
+when interactive, and `--yes` takes the default, bootstrap), `--mcp` (also write `.mcp.json`
 registering the build's MCP server, so this agent — and any other stdio MCP
 client — can list and run the targets through typed calls; `--allow-run`
 registers it with execution enabled and implies `--mcp`), `--launcher-name
@@ -68,7 +70,8 @@ is a bug, not a shortcut. An `&&` chain becomes sequential steps, a
 shell-specific to translate (pipes, redirects, env assignments) is preserved
 behind a `// TODO` so the file still compiles. It scaffolds the launchers and
 `deno.json` exactly like `setup`, and takes the same `--dir`, `--name`,
-`--force`, `--yes`, `--mcp` and `--allow-run` flags. Afterwards, use the **zuke-write-build** skill to
+`--force`, `--yes`, `--bootstrap-deno` / `--no-bootstrap-deno`, `--mcp` and
+`--allow-run` flags. Afterwards, use the **zuke-write-build** skill to
 finish replacing any remaining generated `CmdTasks.exec` calls with typed
 `*Tasks` wrappers.
 
@@ -76,10 +79,14 @@ finish replacing any remaining generated `CmdTasks.exec` calls with typed
 
 - **`zuke.ts`** — a starter build class with a sample target and a `default`.
 - **`./zuke`** + **`./zuke.ps1`** — launchers that locate the project and run
-  `zuke.ts` with the Deno on `PATH`. If Deno is missing they point at the
-  official install docs and exit rather than piping an install script into a
-  shell, which would download and execute code unverified. They pass `--frozen`
-  once a `deno.lock` exists, so the first run writes the lockfile and every run
+  `zuke.ts`. By default (`--bootstrap-deno`) they use the Deno on `PATH` and,
+  when there is none, download the pinned release Zuke itself runs on, verify
+  it against a per-platform SHA-256, and install it under `~/.deno` — never an
+  install script, never an unverified binary — so a clone needs nothing
+  installed first. With `--no-bootstrap-deno` they require Deno on `PATH` and
+  exit with the install docs URL when it is missing, for a project that must
+  never download a tool from its build entry point. Both pass `--frozen` once
+  a `deno.lock` exists, so the first run writes the lockfile and every run
   after verifies it.
 - **`deno.json`** — merged to add a `zuke` task, plus `fmt`/`lint`/`test` if
   absent. The merge is all-or-nothing: if a `zuke` task is already declared the

--- a/tests/launcher_bootstrap_test.ts
+++ b/tests/launcher_bootstrap_test.ts
@@ -122,25 +122,33 @@ Deno.test("the PowerShell launcher rejects DENO_VERSION=latest", async () => {
   );
 });
 
-Deno.test("a scaffolded launcher fails closed when Deno is missing", async () => {
-  // `zuke setup` stamps its own launchers into every new project, so they must
-  // not reintroduce the unverified `curl | sh` bootstrap either. Scaffold for
-  // real and run the generated script with no Deno on PATH: it must explain
-  // itself and exit non-zero rather than download anything.
-  if (Deno.build.os === "windows") return; // the generated bash launcher
+/**
+ * Whether a bare `/usr/bin:/bin` PATH would still find a Deno, which would make
+ * a "no Deno on PATH" check meaningless.
+ */
+async function bareDenoOnPath(): Promise<boolean> {
   for (const path of ["/usr/bin/deno", "/bin/deno"]) {
     try {
       await Deno.lstat(path);
-      return; // a Deno on the bare PATH would make the check meaningless
+      return true;
     } catch {
-      // expected: nothing to skip for
+      // expected: nothing there
     }
   }
+  return false;
+}
+
+Deno.test("a scaffolded plain launcher fails closed when Deno is missing", async () => {
+  // `zuke setup --no-bootstrap-deno` stamps a launcher that must not download
+  // anything. Scaffold for real and run the generated script with no Deno on
+  // PATH: it must explain itself and exit non-zero.
+  if (Deno.build.os === "windows") return; // the generated bash launcher
+  if (await bareDenoOnPath()) return;
   await withTemp(async (dir) => {
-    await runSetup({ dir, force: false, name: "Scaffolded" }, {
-      ...defaultHost,
-      log: () => {},
-    });
+    await runSetup(
+      { dir, force: false, name: "Scaffolded", bootstrapDeno: false },
+      { ...defaultHost, log: () => {} },
+    );
     const { code, stderr } = await new Deno.Command("/bin/bash", {
       args: [`${dir}/zuke`, "--help"],
       clearEnv: true,
@@ -153,6 +161,50 @@ Deno.test("a scaffolded launcher fails closed when Deno is missing", async () =>
       true,
       `expected the scaffolded launcher to report missing Deno; got: ${err}`,
     );
+    assertEquals(
+      err.includes("installing it now"),
+      false,
+      "the plain launcher must never try to install Deno",
+    );
+  }, { prefix: "zuke-scaffold-" });
+});
+
+Deno.test("a scaffolded bootstrap launcher verifies before it downloads", async () => {
+  // The default scaffold bootstraps Deno. Run the generated script with no
+  // Deno on PATH and DENO_VERSION=latest: it must take the bootstrap branch
+  // and refuse a version it cannot pin *before* any network call — the same
+  // hermetic path the repository's own launcher is held to above.
+  if (Deno.build.os === "windows") return; // the generated bash launcher
+  if (await bareDenoOnPath()) return;
+  await withTemp(async (dir) => {
+    await runSetup({ dir, force: false, name: "Scaffolded" }, {
+      ...defaultHost,
+      log: () => {},
+    });
+    const { code, stderr } = await new Deno.Command("/bin/bash", {
+      args: [`${dir}/zuke`, "--help"],
+      clearEnv: true,
+      env: {
+        PATH: "/usr/bin:/bin",
+        HOME: dir,
+        DENO_INSTALL: `${dir}/deno`,
+        DENO_VERSION: "latest",
+        DENO_SHA256: "deadbeef",
+      },
+    }).output();
+    const err = new TextDecoder().decode(stderr);
+    assertEquals(code, 1, `expected a fail-fast exit; stderr: ${err}`);
+    assertEquals(
+      err.includes("installing it now"),
+      true,
+      `expected the scaffolded launcher to take the bootstrap branch; got: ${err}`,
+    );
+    assertEquals(
+      err.includes("DENO_VERSION=latest is not supported"),
+      true,
+      `expected a friendly rejection of DENO_VERSION=latest; got: ${err}`,
+    );
+    assertEquals(err.includes("vlatest"), false);
   }, { prefix: "zuke-scaffold-" });
 });
 

--- a/tests/launcher_sync_test.ts
+++ b/tests/launcher_sync_test.ts
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Tests for the launcher sync (`build/launchers.ts`): the committed `./zuke`
+ * and `zuke.ps1` must be exactly what `@zuke/cli`'s launcher template renders
+ * in its bootstrap variant, so the scripts `zuke setup` stamps into a project
+ * are the ones this repository runs on every CI job.
+ *
+ * @module
+ */
+
+import { assertEquals } from "../packages/core/tests/_assert.ts";
+import {
+  BASH_LAUNCHER,
+  checkRootLaunchers,
+  PWSH_LAUNCHER,
+  renderRootLaunchers,
+  syncRootLaunchers,
+} from "../build/launchers.ts";
+import { withTemp } from "../packages/core/tests/_temp.ts";
+
+Deno.test("the committed launchers match the CLI's template", async () => {
+  assertEquals(await checkRootLaunchers(), []);
+});
+
+Deno.test("the rendered launchers are the bootstrap variant", () => {
+  const files = renderRootLaunchers();
+  assertEquals([...files.keys()], [BASH_LAUNCHER, PWSH_LAUNCHER]);
+  assertEquals(files.get(BASH_LAUNCHER)?.includes("deno_checksum_for()"), true);
+  assertEquals(files.get(PWSH_LAUNCHER)?.includes("$DenoChecksums"), true);
+});
+
+Deno.test("syncRootLaunchers round-trips through generate then check", async () => {
+  await withTemp(async (dir) => {
+    // Never sync into the repository root from a test: write only into the
+    // temp dir, and assert that so re-introducing the default fails here.
+    const written = await syncRootLaunchers(dir);
+    assertEquals(written, [
+      `${dir}/${BASH_LAUNCHER}`,
+      `${dir}/${PWSH_LAUNCHER}`,
+    ]);
+    assertEquals(written.every((path) => path.startsWith(`${dir}/`)), true);
+    assertEquals(await checkRootLaunchers(dir), []);
+    if (Deno.build.os !== "windows") {
+      const mode = (await Deno.stat(`${dir}/${BASH_LAUNCHER}`)).mode ?? 0;
+      assertEquals(mode & 0o111, 0o111, "./zuke must be executable");
+    }
+    // No staging file is left behind by the rename.
+    const leftovers: string[] = [];
+    for await (const entry of Deno.readDir(dir)) leftovers.push(entry.name);
+    assertEquals(leftovers.sort(), [BASH_LAUNCHER, PWSH_LAUNCHER]);
+  });
+});
+
+Deno.test("checkRootLaunchers reports a missing and a drifted launcher", async () => {
+  await withTemp(async (dir) => {
+    assertEquals(await checkRootLaunchers(dir), [
+      `${dir}/${BASH_LAUNCHER} (missing)`,
+      `${dir}/${PWSH_LAUNCHER} (missing)`,
+    ]);
+    await syncRootLaunchers(dir);
+    await Deno.writeTextFile(`${dir}/${BASH_LAUNCHER}`, "#!/bin/sh\nexit 1\n");
+    assertEquals(await checkRootLaunchers(dir), [
+      `${dir}/${BASH_LAUNCHER} (content differs from the template)`,
+    ]);
+  });
+});
+
+Deno.test("checkRootLaunchers tolerates CRLF from a Windows checkout", async () => {
+  await withTemp(async (dir) => {
+    await syncRootLaunchers(dir);
+    for (const name of [BASH_LAUNCHER, PWSH_LAUNCHER]) {
+      const path = `${dir}/${name}`;
+      const lf = await Deno.readTextFile(path);
+      await Deno.writeTextFile(path, lf.replaceAll("\n", "\r\n"));
+    }
+    assertEquals(await checkRootLaunchers(dir), []);
+  });
+});
+
+Deno.test("checkRootLaunchers rethrows an error that is not a missing file", async () => {
+  await withTemp(async (dir) => {
+    // A directory where the launcher should be is neither missing nor
+    // readable as text; that is a real error, not drift to report.
+    await Deno.mkdir(`${dir}/${BASH_LAUNCHER}`);
+    let thrown: unknown;
+    try {
+      await checkRootLaunchers(dir);
+    } catch (error) {
+      thrown = error;
+    }
+    assertEquals(thrown instanceof Error, true);
+  });
+});

--- a/zuke
+++ b/zuke
@@ -4,9 +4,9 @@
 #
 # Zuke bootstrap launcher — a `./build.sh`-style entry point for Deno.
 #
-#   ./zuke ci          # run the full gate
-#   ./zuke test        # type-check + tests
-#   ./zuke --list      # list every target
+#   ./zuke               # run the default target
+#   ./zuke <target>      # run one target and its prerequisites
+#   ./zuke --list        # list every target
 #
 # Ensures Deno is available (installing it on first use if missing), then runs
 # the project's build file (zuke.ts). No global install required.
@@ -14,29 +14,28 @@
 # Honoured environment variables:
 #   DENO_INSTALL   where Deno is installed/looked for (default: ~/.deno)
 #   DENO_VERSION   which Deno to install on bootstrap. Defaults to a pinned,
-#                  known-good version (see DEFAULT_DENO_VERSION) for reproducible
-#                  and more predictable installs. An override must name an exact
-#                  release tag (e.g. v2.8.3) — "latest" is rejected, because a
-#                  moving target has no checksum to pin — and is only installed
-#                  if DENO_SHA256 also supplies the matching per-platform
-#                  checksum (see below); this launcher never downloads an
-#                  unverified binary.
+#                  known-good version (see below) for reproducible and more
+#                  predictable installs. An override must name an exact release
+#                  tag (e.g. v2.8.3) — "latest" is rejected, because a moving
+#                  target has no checksum to pin — and is only installed if
+#                  DENO_SHA256 also supplies the matching per-platform checksum
+#                  (see below); this launcher never downloads an unverified
+#                  binary.
 #   DENO_SHA256    required alongside a DENO_VERSION override: the expected
 #                  SHA-256 of the release zip for the *current* platform (see
 #                  the asset name printed on a checksum mismatch).
 set -euo pipefail
 
 # Pinned default so the bootstrap installs a known version rather than whatever
-# "latest" happens to be. Bump deliberately; keep in sync with zuke.ps1.
+# "latest" happens to be.
 DEFAULT_DENO_VERSION="v2.8.3"
 
 # --- Pinned per-platform checksums for DEFAULT_DENO_VERSION -----------------
 # SHA-256 of each `deno-<target>.zip` release asset, from
 # https://github.com/denoland/deno/releases/tag/v2.8.3 (GitHub's own reported
 # asset `digest`, cross-checked by downloading and hashing the artifact).
-# Bump *together* with DEFAULT_DENO_VERSION — pull the new asset digests from
-# that release's page (or `gh release view <tag> --repo denoland/deno --json
-# assets`) before changing the version above.
+# Bump *together* with DEFAULT_DENO_VERSION: this file is generated from
+# @zuke/cli's deno_pin.ts, so change the pin there and regenerate.
 deno_checksum_for() {
   case "$1" in
     x86_64-unknown-linux-gnu)
@@ -53,8 +52,8 @@ deno_checksum_for() {
 }
 # -----------------------------------------------------------------------------
 
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "$script_dir"
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$dir"
 
 deno_install="${DENO_INSTALL:-$HOME/.deno}"
 
@@ -177,10 +176,13 @@ fi
 # bootstrapped to a non-PATH location (e.g. ~/.deno/bin).
 export PATH="$(dirname "$deno_bin"):$PATH"
 
-# `--frozen` so this invocation cannot rewrite `deno.lock`. Loading zuke.ts
-# resolves the whole workspace, and an unfrozen `deno run` silently writes any
-# resolution the committed lock is missing — which made a green gate mean
-# "the lock resolves *after* we fixed it" rather than "the committed lock
-# resolves". Regenerating the lock is a deliberate act: `deno install`, then
-# commit and review the diff (docs/versioning.md).
-exec "$deno_bin" run -A --frozen zuke.ts "$@"
+# The first run has no lockfile to verify against, so let Deno write one; from
+# then on --frozen fails the build if the module graph changed. Say so when
+# skipping, so a deleted lockfile downgrades verification visibly instead of
+# silently.
+if [ -f deno.lock ]; then
+  exec "$deno_bin" run -A --frozen zuke.ts "$@"
+else
+  echo "zuke: no deno.lock here yet — running without lockfile verification so Deno can write one." >&2
+  exec "$deno_bin" run -A zuke.ts "$@"
+fi

--- a/zuke.ps1
+++ b/zuke.ps1
@@ -2,11 +2,11 @@
 # Copyright (c) 2026 the Zuke contributors
 # SPDX-License-Identifier: MIT
 #
-# Zuke bootstrap launcher (PowerShell) — a `.\build.ps1`-style entry point.
+# Zuke bootstrap launcher (PowerShell) - a `.\build.ps1`-style entry point.
 #
-#   .\zuke.ps1 ci          # run the full gate
-#   .\zuke.ps1 test        # type-check + tests
-#   .\zuke.ps1 --list      # list every target
+#   .\zuke.ps1               # run the default target
+#   .\zuke.ps1 <target>      # run one target and its prerequisites
+#   .\zuke.ps1 --list        # list every target
 #
 # Ensures Deno is available (installing it on first use if missing), then runs
 # the project's build file (zuke.ts). No global install required.
@@ -14,13 +14,13 @@
 # Honoured environment variables:
 #   DENO_INSTALL   where Deno is installed/looked for (default: ~/.deno)
 #   DENO_VERSION   which Deno to install on bootstrap. Defaults to a pinned,
-#                  known-good version ($DefaultDenoVersion) for reproducible and
-#                  more predictable installs. An override must name an exact
-#                  release tag (e.g. v2.8.3) - "latest" is rejected, because a
-#                  moving target has no checksum to pin - and is only installed
-#                  if DENO_SHA256 also supplies the matching per-platform
-#                  checksum (see below); this launcher never downloads an
-#                  unverified binary.
+#                  known-good version (see below) for reproducible and more
+#                  predictable installs. An override must name an exact release
+#                  tag (e.g. v2.8.3) - "latest" is rejected, because a moving
+#                  target has no checksum to pin - and is only installed if
+#                  DENO_SHA256 also supplies the matching per-platform checksum
+#                  (see below); this launcher never downloads an unverified
+#                  binary.
 #   DENO_SHA256    required alongside a DENO_VERSION override: the expected
 #                  SHA-256 of the release zip for the *current* platform (see
 #                  the asset name printed on a checksum mismatch).
@@ -28,24 +28,23 @@
 $ErrorActionPreference = "Stop"
 
 # Pinned default so the bootstrap installs a known version rather than whatever
-# "latest" happens to be. Bump deliberately; keep in sync with the zuke script.
+# "latest" happens to be.
 $DefaultDenoVersion = "2.8.3"
 
 # --- Pinned per-platform checksums for $DefaultDenoVersion ------------------
 # SHA-256 of each `deno-<target>.zip` release asset, from
 # https://github.com/denoland/deno/releases/tag/v2.8.3 (GitHub's own reported
 # asset `digest`, cross-checked by downloading and hashing the artifact).
-# Bump *together* with $DefaultDenoVersion - pull the new asset digests from
-# that release's page (or `gh release view <tag> --repo denoland/deno --json
-# assets`) before changing the version above.
+# Bump *together* with $DefaultDenoVersion: this file is generated from
+# @zuke/cli's deno_pin.ts, so change the pin there and regenerate.
 $DenoChecksums = @{
   "x86_64-pc-windows-msvc"  = "7fdd1f42e6b0855421ecf27bb406e2492ade1087c85e30ebf0deab6280ea743c"
   "aarch64-pc-windows-msvc" = "243f478ac577ade1bbd980ecf510607a10ed8cc977b462083ada48e5f6580de1"
 }
 # -----------------------------------------------------------------------------
 
-$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
-Set-Location $scriptDir
+$dir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $dir
 
 if (-not $env:DENO_INSTALL) {
   $env:DENO_INSTALL = Join-Path $HOME ".deno"
@@ -140,12 +139,21 @@ if (-not $deno) {
   $deno = Join-Path $env:DENO_INSTALL "bin\deno.exe"
 }
 
-# Put this Deno on PATH so CLIs the build provisions with `deno install` — whose
-# generated launchers invoke `deno` by name — can find it even when Deno was
+# Put this Deno on PATH so CLIs the build provisions with `deno install` - whose
+# generated launchers invoke `deno` by name - can find it even when Deno was
 # bootstrapped to a non-PATH location.
 $env:PATH = (Split-Path -Parent $deno) + [IO.Path]::PathSeparator + $env:PATH
 
-# --frozen so this invocation cannot rewrite deno.lock; see the comment in the
-# POSIX launcher. Regenerate deliberately with `deno install`, then commit it.
-& $deno run -A --frozen (Join-Path $scriptDir "zuke.ts") @args
+# The first run has no lockfile to verify against, so let Deno write one; from
+# then on --frozen fails the build if the module graph changed. Say so when
+# skipping, so a deleted lockfile downgrades verification visibly instead of
+# silently.
+$denoArgs = @("run", "-A")
+if (Test-Path (Join-Path $dir "deno.lock")) {
+  $denoArgs += "--frozen"
+} else {
+  Write-Warning "zuke: no deno.lock here yet - running without lockfile verification so Deno can write one."
+}
+$denoArgs += (Join-Path $dir "zuke.ts")
+& $deno @denoArgs @args
 exit $LASTEXITCODE

--- a/zuke.ts
+++ b/zuke.ts
@@ -106,6 +106,7 @@ import {
   checkPluginSkillsSync,
   syncPluginSkills,
 } from "./build/plugin_sync.ts";
+import { checkRootLaunchers, syncRootLaunchers } from "./build/launchers.ts";
 import { checkSkillTree } from "./build/skill_check.ts";
 import {
   buildGeminiArchive,
@@ -526,6 +527,33 @@ class ZukeBuild extends Build {
       ConsoleTasks.info("plugins/zuke/skills/ is in sync with skills/.");
     });
 
+  launcherSync = target()
+    .description(
+      "Regenerate ./zuke and zuke.ps1 from @zuke/cli's launcher template",
+    )
+    .executes(async () => {
+      const written = await syncRootLaunchers();
+      ConsoleTasks.info(`Wrote ${written.join(", ")}.`);
+    });
+
+  launcherSyncCheck = target()
+    .description(
+      "Verify ./zuke and zuke.ps1 match @zuke/cli's launcher template",
+    )
+    .executes(async () => {
+      const stale = await checkRootLaunchers();
+      if (stale.length > 0) {
+        throw new Error(
+          `The launchers have drifted from the template:\n  ${
+            stale.join("\n  ")
+          }\n` +
+            "Run `./zuke launcherSync` and commit the result (edit " +
+            "packages/cli/src/launcher.ts or deno_pin.ts, never the scripts).",
+        );
+      }
+      ConsoleTasks.info("./zuke and zuke.ps1 are in sync with the template.");
+    });
+
   skillsCheck = target()
     .description(
       "Validate skills/ against the Agent Skills spec (frontmatter, names)",
@@ -802,6 +830,7 @@ class ZukeBuild extends Build {
       this.examplesCheck,
       this.hclSyncCheck,
       this.pluginSyncCheck,
+      this.launcherSyncCheck,
       this.skillsCheck,
       this.graphDocCheck,
       this.pluginVersionCheck,


### PR DESCRIPTION
## What & why

`zuke setup` and `zuke import` now ask which launchers to scaffold:

1. **Bootstrap** (the default, and what `--yes` takes): when no Deno is on `PATH`, `./zuke` / `zuke.ps1` download the pinned release, verify it against a per-platform SHA-256, install it under `~/.deno`, and run the build. A clone needs nothing installed first. The launcher never runs an install script and never installs an unverified binary; `DENO_VERSION` overrides need a matching `DENO_SHA256`, and `latest` is rejected.
2. **Plain** (`--no-bootstrap-deno`): today's behaviour. The launchers require Deno on `PATH` and fail closed with the install docs URL, for a project that must never download a tool from its build entry point.

`--bootstrap-deno` answers the question up front for non-interactive runs.

Until now the repository's own launchers bootstrapped Deno while the ones the CLI scaffolded did not, because the scaffold "had no pinned checksum to verify against". This closes that gap with one implementation, not two copies: the launcher text lives in `packages/cli/src/launcher.ts`, the pinned version and six checksums in `packages/cli/src/deno_pin.ts`, and the repo's own `zuke` / `zuke.ps1` are **generated** from that template by the new `launcherSync` target. `launcherSyncCheck` joins the `ci` gate so they cannot drift. The scripts `zuke setup` stamps into a project are therefore exactly the ones this repository runs on every CI job, and a Deno bump is a change to one TypeScript file plus a regeneration.

The regenerated root launchers differ from the previous ones only in comments, a variable name, and passing `--frozen` conditionally once `deno.lock` exists (which the scaffold already did, and which is always the case here). The bootstrap logic is byte-identical, and the regenerated `./zuke` was exercised end to end: with Deno hidden from `PATH` it downloaded, verified and ran Deno 2.8.3.

## Related issues

Closes #512

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a
      [Conventional Commit](https://www.conventionalcommits.org/)
      (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell). The one target run without the network is `security`: zizmor's advisories lookup needs an authenticated GitHub API call; gitleaks passed.
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches): 98.3% lines / 97.4% branches. Unit: `packages/cli/tests/launcher_test.ts` (both variants, the pin, `--frozen` handling), `cli_test.ts` (flags, the prompt, `--yes` default, `import` pass-through), `setup_test.ts`. Hermetic launcher runs: `tests/launcher_bootstrap_test.ts` now exercises the scaffolded bootstrap variant too. Sync: `tests/launcher_sync_test.ts` holds the committed launchers to the template.
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour
      changed: README install note, `docs/cli.md`, `docs/getting-started.md`, `docs/installing-tools.md`, `zuke --help`, `AGENTS.md`, and `skills/zuke-setup/SKILL.md` (plugin version 0.49.0).
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`,
      `llms-full.txt`, package README `## API`).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with
      type guards instead).
- [x] No dead code: unreachable branches and can't-fire fallbacks are removed,
      with types tightened so the impossible state is unrepresentable.
- [x] No duplicated logic: an existing helper is imported rather than retyped,
      and a near-copy differing by a constant or a message is parameterised into
      one implementation. A guard, escape, or credential resolution has exactly
      one implementation.
- [x] SOLID shapes respected: one domain per file, extension via the settings
      lambda (not a behaviour-switching flag), narrow parameter types, and
      dependencies on the injectable seam (`StateHost`, an injected `fetch`,
      `EnvReader`) rather than `Deno.*` or a global.
- [ ] A new package was wired into all six places (see
      [AGENTS.md](../blob/master/AGENTS.md#good-open-source-practices-to-follow)),
      if applicable. Not applicable: no new package.
- [x] The code is written using AI assisted coding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4FJS8vNxvbAc9pjW86eCq