### PR TITLE
fix(core): report a held-back state write that a later conflict destroys

### DIFF
--- a/docs/state.md
+++ b/docs/state.md
@@ -339,10 +339,13 @@ freshly-read record on the next attempt; and when it gives up because the run
 vanished from the store, or because the store threw, the mutation is still held in
 memory for any later write to re-persist. Those paths warn and carry on.
 
-One path genuinely loses a write. If a **foreign writer** — an MCP audit append,
+Two paths genuinely lose a write. If a **foreign writer** — an MCP audit append,
 a concurrent `zuke cancel` — wins the compare-and-swap race often enough to
 exhaust the writer's retry budget, the last attempt's mutation is discarded along
-with the base it was applied to. The writer then sets **`degraded: true`** on the
+with the base it was applied to. And a mutation that was merely *held* in memory
+is lost the moment a conflict replaces the record it was waiting in: the write
+that was going to carry it is the one that just conflicted, and the freshly read
+base has never seen it. Either way the writer sets **`degraded: true`** on the
 record, and the next write that _does_ land persists the flag (the failing write,
 by definition, could not carry it). `zuke runs show` prints it. So `degraded`
 means exactly one thing: **a mutation was permanently lost.**

--- a/packages/core/src/state/writer.ts
+++ b/packages/core/src/state/writer.ts
@@ -132,6 +132,16 @@ export class RunStateWriter {
    * already sitting on the chain are neutralised too.
    */
   #disowned = false;
+  /**
+   * Whether a write has been dropped-but-retained since the last one that
+   * landed — a mutation living only in {@link "#record"}, waiting for a later
+   * write to carry it to the store.
+   *
+   * Tracked because the conflict path replaces that record wholesale, which
+   * takes any such mutation with it. Knowing one was pending is what turns a
+   * silent loss into a reported one.
+   */
+  #retainedPending = false;
   #chain: Promise<unknown> = Promise.resolve();
 
   private constructor(
@@ -682,6 +692,7 @@ export class RunStateWriter {
    * record with nothing missing.
    */
   #retainedWrite(message: string): void {
+    this.#retainedPending = true;
     this.#warn?.(message);
   }
 
@@ -698,6 +709,9 @@ export class RunStateWriter {
         const result = await this.#store.putRun(this.#record, this.#version);
         if (result.ok) {
           this.#version = result.version;
+          // Whatever was waiting in the record went to the store with this
+          // write, which is exactly what `#retainedWrite` promised.
+          this.#retainedPending = false;
           return true;
         }
         // Another writer moved the record on: re-read a FRESH base and re-apply
@@ -713,6 +727,19 @@ export class RunStateWriter {
               `mid-write; dropping one update`,
           );
           return false;
+        }
+        // A mutation dropped earlier was still living in the record we are
+        // about to replace, and the fresh base has never seen it: the write
+        // that was going to carry it is the one that just conflicted. That is
+        // a permanent loss, so it is reported as one rather than vanishing —
+        // `degraded` is what stops a later resume trusting the record.
+        if (this.#retainedPending) {
+          this.#lostWrite(
+            `state: an earlier update to run "${this.#record.id}" was held ` +
+              `back and is now lost — the write meant to carry it conflicted, ` +
+              `and the record it was waiting in has been replaced`,
+          );
+          this.#retainedPending = false;
         }
         // Adopt the fresh base, but carry a degraded flag across: whoever wrote
         // the record in the store never saw the write we already lost.
@@ -743,6 +770,7 @@ export class RunStateWriter {
           );
           if (reapply.ok) {
             this.#version = reapply.version;
+            this.#retainedPending = false;
           } else {
             // The canceller finalises the run from here, so no later write of
             // ours lands to carry this mutation: it is gone for good.

--- a/packages/core/tests/retained_write_test.ts
+++ b/packages/core/tests/retained_write_test.ts
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Unit tests for a **retained** write — one the store refused, whose mutation
+ * stays in the writer's in-memory record for a later write to carry.
+ *
+ * The contract that promise makes is only kept while that record survives. The
+ * conflict path replaces it wholesale with a freshly read base, which takes any
+ * waiting mutation with it, so the loss has to be reported the way every other
+ * permanent loss is: a warning, and `degraded` on the record, which is what
+ * stops a later resume trusting per-target progress that is missing a
+ * transition that really happened.
+ *
+ * @module
+ */
+
+import { assertEquals, assertStringIncludes } from "./_assert.ts";
+import { Redactor } from "../src/redact.ts";
+import { RunStateWriter } from "../src/state/writer.ts";
+import { MemStateStore, runRecord } from "./_fakes.ts";
+import type { TargetStateHandle } from "../src/target.ts";
+
+const NOW = "2026-09-09T12:00:00.000Z";
+
+/** A writer over `store`, adopted on a running one-target run. */
+async function adopted(store: MemStateStore): Promise<{
+  writer: RunStateWriter;
+  handle: TargetStateHandle;
+  warnings: string[];
+}> {
+  const record = runRecord({
+    id: "r1",
+    rootTarget: "deploy",
+    status: "running",
+    targets: { deploy: { status: "running", meta: {} } },
+  });
+  const put = await store.putRun(record, null);
+  assertEquals(put.ok, true);
+  if (!put.ok) throw new Error("unreachable: the first put cannot conflict");
+  const warnings: string[] = [];
+  const writer = RunStateWriter.adopt(
+    store,
+    structuredClone(record),
+    put.version,
+    () => NOW,
+    new Redactor(),
+    (message) => warnings.push(message),
+  );
+  return { writer, handle: writer.stateHandle("deploy"), warnings };
+}
+
+Deno.test("a retained write lost to the next write's conflict is reported", async () => {
+  const store = new MemStateStore();
+  const { writer, handle, warnings } = await adopted(store);
+
+  // Held back: the store errored, so the patch waits in the record for a later
+  // write to carry it.
+  store.failNextPut = true;
+  assertEquals(await handle.trySet({ a: "1" }), false);
+  assertEquals(writer.snapshot().degraded, undefined); // nothing lost yet
+
+  // The write that was going to carry it conflicts once, re-reads a fresh base
+  // — which has never seen `a` — and lands. `a` is gone for good.
+  store.forceConflicts = 1;
+  assertEquals(await handle.trySet({ b: "2" }), true);
+
+  assertEquals(store.record?.targets.deploy.meta, { b: "2" });
+  // The point of the fix: the record no longer claims to be complete.
+  assertEquals(writer.snapshot().degraded, true);
+  assertEquals(warnings.length, 2);
+  assertStringIncludes(warnings[1], "held back and is now lost");
+});
+
+Deno.test("a retained write carried by the next write is not reported lost", async () => {
+  const store = new MemStateStore();
+  const { writer, handle, warnings } = await adopted(store);
+
+  store.failNextPut = true;
+  assertEquals(await handle.trySet({ a: "1" }), false);
+
+  // This one lands with no conflict, so it persists the record the retained
+  // patch is still sitting in — exactly what being retained promised.
+  assertEquals(await handle.trySet({ b: "2" }), true);
+
+  assertEquals(store.record?.targets.deploy.meta, { a: "1", b: "2" });
+  // Nothing was lost, so nothing is marked: `degraded` means a mutation is
+  // missing, and a resume refuses a record carrying it.
+  assertEquals(writer.snapshot().degraded, undefined);
+  assertEquals(warnings.length, 1); // only the store error itself
+
+  // And the debt is settled, not merely paid once: a later conflict is an
+  // ordinary conflict again. Without clearing the flag, every conflict for the
+  // rest of the run would report a loss that already reached the store.
+  store.forceConflicts = 1;
+  assertEquals(await handle.trySet({ c: "3" }), true);
+  assertEquals(writer.snapshot().degraded, undefined);
+  assertEquals(warnings.length, 1);
+});
+
+Deno.test("an ordinary conflict with nothing retained reports no loss", async () => {
+  const store = new MemStateStore();
+  const { writer, handle, warnings } = await adopted(store);
+
+  // A conflict on its own is routine — the writer re-reads and re-applies —
+  // so it must not start marking records degraded.
+  store.forceConflicts = 1;
+  assertEquals(await handle.trySet({ a: "1" }), true);
+
+  assertEquals(store.record?.targets.deploy.meta, { a: "1" });
+  assertEquals(writer.snapshot().degraded, undefined);
+  assertEquals(warnings.length, 0);
+});


### PR DESCRIPTION
### The problem

A write the store refuses is **retained** rather than lost: the mutation stays in the writer's in-memory record, and `#retainedWrite` states the contract — "any later write that lands re-persists it. Nothing was lost, so the record is deliberately *not* marked `degraded`".

That promise is only kept while the record survives. The conflict path replaces it wholesale with a freshly read base, which takes any waiting mutation with it: the write meant to carry it is the one that just conflicted, and the new base has never seen it.

Nothing warned, and the record was not marked `degraded` — so a resume trusted a record missing a transition that really happened, which is precisely what `degraded` exists to prevent.

    store meta:   {"b":"2"}      <- "a" never reached the store
    degraded:     undefined      <- yet the record claims to be complete
    warnings:     []

### The shape

The writer tracks whether a mutation is waiting, and reports its loss the way every other permanent loss is reported: a warning naming what happened, and `degraded` on the record.

Recovering the mutation instead — replaying it onto the fresh base — was considered and rejected. It would mean re-applying a mutator to a base that may already carry its effect, since a store that errors may still have persisted the write. The same trade-off is already settled the other way one branch above, where a run that vanished mid-write drops its update rather than risk pushing an audit event twice; deciding it differently here would leave the two neighbouring paths disagreeing about the same hazard.

The flag clears whenever a write actually lands, so a run does not spend the rest of its life reporting a loss that already reached the store. That direction matters as much as the other: without it every later conflict would mark the record degraded and a resume would refuse a run with nothing missing.

### Testing

4 new tests: the loss reported, a retained write carried by a clean later write and therefore *not* reported, the debt clearing so a subsequent conflict is ordinary again, and an ordinary conflict with nothing retained staying silent. Both directions were mutation-checked — the first pass missed the clearing case, which is why the second and third tests exist.

`deno task ci`: 22/22 targets, 4368 tests, 98.4% lines and 97.4% branches against a 95% gate.

### Related issues

Closes #511

### Checklist

- [x] This PR closes a tracking issue.
- [x] The PR title is a Conventional Commit.
- [x] `deno task ci` passes locally.
- [x] Tests were added or updated; coverage stays at 95%+.
- [x] Docs updated in the same PR (the durable state guide's account of what `degraded` means).
- [x] No public API change, so no API doc regeneration is due.
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/`.
- [x] No agent-skill change, so no plugin version bump is due.
