### PR TITLE
fix(core): settle the targets a terminal run never reached

### DIFF
--- a/docs/state.md
+++ b/docs/state.md
@@ -103,6 +103,12 @@ no longer carries one. So a run that has reached a terminal status never has a
 target still claiming to be parked on a gate, and a reader can trust the two to
 agree.
 
+`pending` is bounded the same way. It earns its place on a **suspended** record,
+where it means "a resume will run this"; on a terminal one there is nothing left
+to run it, and no sweep will revisit it. So every terminal run settles the
+targets it never reached to `skipped`, whichever way it ended — failed, timed
+out, or cancelled. A terminal record therefore has no `pending` rows at all.
+
 The executor writes the record when it is created, on each target's start and
 finish, and when the run ends. So if the process is killed mid-run, the record
 on disk shows the target that was executing as `running`, with its `startedAt`

--- a/packages/core/src/cancel.ts
+++ b/packages/core/src/cancel.ts
@@ -52,7 +52,7 @@ import type { StateStore } from "./state/store.ts";
 import { resolveRunStore } from "./run_store.ts";
 import { acquireCancelLock } from "./state/cancel_lock.ts";
 import { resolveActor } from "./state/record.ts";
-import { settleWaitingTargets } from "./state/settle.ts";
+import { settleUnreachedTargets } from "./state/settle.ts";
 import {
   isTerminalRunStatus,
   type RunEvent,
@@ -1033,7 +1033,7 @@ async function finalizeCancelled(
     // `zuke runs show` would print it as still parked on a deadline nobody is
     // watching. Runs after the compensation walk, which treats a `waiting`
     // target as unproven and unwinds it.
-    settleWaitingTargets(next, at, expiredWait);
+    settleUnreachedTargets(next, at, expiredWait);
     for (const event of compensationEvents(outcome.attempts, actor, at)) {
       next.events.push(event);
     }

--- a/packages/core/src/resume.ts
+++ b/packages/core/src/resume.ts
@@ -33,7 +33,7 @@ import type { JsonValue, TargetBuilder } from "./target.ts";
 import type { StateStore } from "./state/store.ts";
 import { resolveRunStore } from "./run_store.ts";
 import { resolveActor } from "./state/record.ts";
-import { settleTargetRow, settleWaitingTargets } from "./state/settle.ts";
+import { settleTargetRow, settleUnreachedTargets } from "./state/settle.ts";
 import type {
   RunGraphNode,
   RunRecord,
@@ -477,7 +477,7 @@ async function failTimedOut(
     // passed is failed above. The others are never resumed — this run is about
     // to be terminal — so they settle too, the same rule the scheduler applies
     // when a run fails with gates still parked.
-    settleWaitingTargets(next, at);
+    settleUnreachedTargets(next, at);
     next.status = "failed";
     next.updatedAt = at;
     const result = await store.putRun(next, version);

--- a/packages/core/src/state/settle.ts
+++ b/packages/core/src/state/settle.ts
@@ -37,9 +37,16 @@ export function settleTargetRow(
 }
 
 /**
- * Settle every target still parked on a gate, for a run that has reached a
- * terminal status. `skipped` is the vocabulary the scheduler already uses when
- * a failed run leaves a gate nobody will ever resume.
+ * Settle every target a run that has reached a terminal status will never
+ * reach: the ones still parked on a gate, and the ones it never started.
+ * `skipped` is the vocabulary the scheduler already uses for both.
+ *
+ * `pending` earns its place on a **suspended** record, where it means "a resume
+ * will run this". On a terminal one it means nothing a reader can act on, and
+ * no sweep will ever revisit it — which is the scheduler's own stated reason
+ * for settling those rows when a run fails outright. Applying it here is what
+ * makes the three terminal paths agree: before this, a run that failed said
+ * `skipped` while a run that failed *by timing out* said `pending`.
  *
  * Both cancellation paths call this **after** their compensation walk, and that
  * order is load-bearing: the walk treats a `waiting` target as unproven and
@@ -51,13 +58,15 @@ export function settleTargetRow(
  * from one an operator cancelled by hand, and the terminal record would no
  * longer say a deadline was missed — which the `fail` disposition does record.
  */
-export function settleWaitingTargets(
+export function settleUnreachedTargets(
   record: RunRecord,
   at: string,
   expired?: { target: string; message: string },
 ): void {
   for (const row of Object.values(record.targets)) {
-    if (row.status === "waiting") settleTargetRow(row, "skipped", at);
+    if (row.status === "waiting" || row.status === "pending") {
+      settleTargetRow(row, "skipped", at);
+    }
   }
   if (expired === undefined) return;
   // Looked up, not matched by name while sweeping: the reason belongs to the

--- a/packages/core/src/state/writer.ts
+++ b/packages/core/src/state/writer.ts
@@ -35,7 +35,7 @@ import type {
 } from "./types.ts";
 import type { SummaryEntry } from "../summary_note.ts";
 import { recordStatusOf } from "./record.ts";
-import { settleTargetRow, settleWaitingTargets } from "./settle.ts";
+import { settleTargetRow, settleUnreachedTargets } from "./settle.ts";
 import { acquireCancelLock, type CancelLock } from "./cancel_lock.ts";
 import { messageOf } from "../internal.ts";
 
@@ -344,7 +344,7 @@ export class RunStateWriter {
       // The in-process half of the same sweep `finalizeCancelled` runs for an
       // out-of-process `zuke cancel`: a cancelled run has no live waiter, and
       // its compensation walk has already finished by the time this is called.
-      settleWaitingTargets(record, at);
+      settleUnreachedTargets(record, at);
     });
   }
 

--- a/packages/core/tests/cancel_test.ts
+++ b/packages/core/tests/cancel_test.ts
@@ -152,8 +152,9 @@ Deno.test("cancelRun settles the target its run was parked on", async () => {
     assertEquals(loaded?.record.targets.gate.status, "skipped");
     assertEquals(loaded?.record.targets.gate.waitingFor, undefined);
     assertEquals(typeof loaded?.record.targets.gate.endedAt, "string");
-    // A target the run never reached is untouched: it was never waiting.
-    assertEquals(loaded?.record.targets.promote?.status, "pending");
+    // A target the run never reached settles too: on a terminal record
+    // `pending` means nothing a reader can act on, and no sweep revisits it.
+    assertEquals(loaded?.record.targets.promote?.status, "skipped");
   });
 });
 

--- a/packages/core/tests/settle_test.ts
+++ b/packages/core/tests/settle_test.ts
@@ -8,7 +8,10 @@
  */
 
 import { assertEquals } from "./_assert.ts";
-import { settleTargetRow, settleWaitingTargets } from "../src/state/settle.ts";
+import {
+  settleTargetRow,
+  settleUnreachedTargets,
+} from "../src/state/settle.ts";
 import { runRecord } from "./_fakes.ts";
 import type { TargetRunState } from "../src/state/types.ts";
 
@@ -69,15 +72,16 @@ Deno.test("the sweep settles only the rows still parked on a gate", () => {
       later: { status: "pending", meta: {} },
     },
   });
-  settleWaitingTargets(record, "2026-09-08T10:30:00.000Z");
+  settleUnreachedTargets(record, "2026-09-08T10:30:00.000Z");
   assertEquals(record.targets.gate.status, "skipped");
   assertEquals(record.targets.gate.waitingFor, undefined);
   // A target that already settled keeps its own outcome and its own endedAt.
   assertEquals(record.targets.built.status, "succeeded");
   assertEquals(record.targets.built.endedAt, "2026-09-08T10:00:00.000Z");
-  // One the run never reached was never waiting, so it is left alone.
-  assertEquals(record.targets.later.status, "pending");
-  assertEquals(record.targets.later.endedAt, undefined);
+  // One the run never reached settles as well — a terminal run will not get
+  // to it, and the scheduler already says `skipped` for exactly this case.
+  assertEquals(record.targets.later.status, "skipped");
+  assertEquals(typeof record.targets.later.endedAt, "string");
 });
 
 Deno.test("the sweep records why, when a deadline is what cancelled the run", () => {
@@ -87,7 +91,7 @@ Deno.test("the sweep records why, when a deadline is what cancelled the run", ()
     status: "cancelled",
     targets: { gate: waitingRow(), other: waitingRow() },
   });
-  settleWaitingTargets(record, "2026-09-08T10:30:00.000Z", {
+  settleUnreachedTargets(record, "2026-09-08T10:30:00.000Z", {
     target: "gate",
     message: 'wait "gate" timed out (deadline 2026-09-08T11:00:00.000Z)',
   });

--- a/tests/integration/waiting_test.ts
+++ b/tests/integration/waiting_test.ts
@@ -437,3 +437,59 @@ Deno.test("a cancellation unwinds on the values its targets actually ran on", as
     assertEquals(log, ["deploy sit", "rollback sit"]);
   });
 });
+
+Deno.test("every terminal path says the same thing about a target it never reached", async () => {
+  // Three ways a run ends without reaching `after`. They used to disagree: a
+  // run that failed outright said `skipped`, while one that failed by timing
+  // out said `pending`, and so did a cancelled one — the same situation
+  // described two different ways under the same terminal status.
+  const statuses = async (
+    build: new () => Build,
+    drive: (dir: string, id: string) => Promise<void>,
+  ): Promise<string> => {
+    let line = "";
+    await withStateDir(async (dir) => {
+      await runCli(build, ["after"]);
+      const id = await onlyRunId(dir);
+      await drive(dir, id);
+      const store = new FileSystemStateStore(dir, defaultStateHost);
+      const record = (await store.getRun(id))?.record;
+      line = `${record?.status} after=${record?.targets["after"].status}`;
+    });
+    return line;
+  };
+
+  class Fails extends Build {
+    boom = target().executes(() => {
+      throw new Error("boom");
+    });
+    after = target().dependsOn(this.boom).executes(() => {});
+  }
+  class TimesOut extends Build {
+    gate = target().waitsFor((s) => s.on(externalSignal("never")).timeout(0));
+    after = target().dependsOn(this.gate).executes(() => {});
+  }
+  class Cancelled extends Build {
+    gate = target().waitsFor((s) =>
+      s.on(externalSignal("never")).timeout("1h")
+    );
+    after = target().dependsOn(this.gate).executes(() => {});
+  }
+
+  assertEquals(
+    await statuses(Fails, () => Promise.resolve()),
+    "failed after=skipped",
+  );
+  assertEquals(
+    await statuses(TimesOut, async (_dir, _id) => {
+      await runCli(TimesOut, ["resume", "--check"]);
+    }),
+    "failed after=skipped",
+  );
+  assertEquals(
+    await statuses(Cancelled, async (_dir, id) => {
+      await runCli(Cancelled, ["cancel", id]);
+    }),
+    "cancelled after=skipped",
+  );
+});


### PR DESCRIPTION
### The problem

Three ways a run can end without reaching a target, and three different answers about that target:

    run fails outright  ->  failed     after=skipped
    gate times out      ->  failed     after=pending
    run is cancelled    ->  cancelled  after=pending

The first two carry the **same terminal status** and describe the same situation differently, which is the part that makes this a defect rather than a matter of taste.

### The shape

The rule already exists, written down in the scheduler where the first case is handled: `pending` earns its place on a **suspended** record, where it means "a resume will run this". On a terminal record there is nothing left to run it, and no sweep will revisit it — so it lingers as a row no reader can act on.

The sweep the cancellation and timeout paths already run for parked gates now settles unstarted targets as well, so every terminal record says `skipped` for a target the run never reached, whichever way it ended. A terminal record has no `pending` rows at all.

The helper is renamed to `settleUnreachedTargets`, because "parked on a gate" and "never started" are now both what it covers.

### Why not the other direction

Leaving `pending` everywhere and teaching readers to interpret it was the alternative. It loses on two counts: the scheduler would have to stop doing what it already does, undoing a fix made deliberately, and `pending` would then mean two different things depending on whether the run is suspended or terminal — which is exactly the ambiguity a reader cannot resolve from the record alone.

Compensation behaviour is untouched: the walk treats `running` and `waiting` as unproven, never `pending`, so nothing about which cleanups run changes.

### Testing

One integration test drives all three terminal paths through the real CLI and asserts they agree — it is the test that would have caught the disagreement in the first place. Two existing assertions that pinned the old behaviour were updated to the new rule rather than deleted. Mutation-checked: narrowing the sweep back to `waiting` alone fails two tests.

`deno task ci`: 22/22 targets, 4369 tests, 98.4% lines and 97.4% branches against a 95% gate.

### Related issues

Closes #505

### Checklist

- [x] This PR closes a tracking issue.
- [x] The PR title is a Conventional Commit.
- [x] `deno task ci` passes locally.
- [x] Tests were added or updated; coverage stays at 95%+.
- [x] Docs updated in the same PR (the durable state guide's account of target statuses).
- [x] No public API change, so no API doc regeneration is due.
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/`.
- [x] No agent-skill change, so no plugin version bump is due.
