### PR TITLE
chore(core): remove the wall-clock assumption from the lock wait test

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -14,7 +14,7 @@ import { forceTarget } from "./force.ts";
 import { isCI } from "./host.ts";
 import { GraphError, validateGraph } from "./graph.ts";
 import { InsecureBackendUrlError } from "./http.ts";
-import { execute } from "./executor.ts";
+import { execute, type Reporter } from "./executor.ts";
 import type { Renderer } from "./renderer.ts";
 import {
   defaultGraphHost,
@@ -872,6 +872,13 @@ export interface MainOptions {
   /** Renderer for the build's banners and summary (see {@link RunOptions}). */
   renderer?: Renderer;
   /**
+   * Where the run narrates its progress — the lock-wait notice, cancellation
+   * lines, and the like. Injected in tests, which need to observe those lines
+   * **while** a run is still going: `main` otherwise writes to the console, and
+   * two concurrent runs cannot be told apart there.
+   */
+  reporter?: Reporter;
+  /**
    * Cancel a running **build** when this signal aborts (its compensations run and
    * the record is marked cancelled). Applies only to a target run; other
    * commands ignore it. Tests inject one directly; {@link run} does not use it —
@@ -1505,6 +1512,7 @@ async function runCommand(
       actorKind,
       plugins: options.plugins,
       renderer: options.renderer,
+      ...(options.reporter === undefined ? {} : { reporter: options.reporter }),
       signal: cleanupSignals ? controller.signal : options.signal,
     });
     return result.ok ? 0 : 1;

--- a/tests/integration/lock_wait_test.ts
+++ b/tests/integration/lock_wait_test.ts
@@ -1,66 +1,124 @@
 // Copyright (c) 2026 the Zuke contributors
 // SPDX-License-Identifier: MIT
 
+/**
+ * Integration: waiting for a held lock (`.waitUpTo(...)`), driven through the
+ * real CLI with two runs overlapping in one process.
+ *
+ * There is deliberately **no wall-clock assumption** here. A test that sleeps
+ * "long enough" for another run to reach a point is a test that rots on a
+ * loaded machine, so each step waits on the event itself: the holder announces
+ * itself through a shared log, and the waiter announces itself through the
+ * reporter the harness injects. The only duration in the file is the
+ * `waitUpTo` of the run that is *supposed* to run out of time, and it expires
+ * because the lock is genuinely held, not because a timer won a race.
+ */
+
 import {
   assertEquals,
   assertStringIncludes,
 } from "../../packages/core/tests/_assert.ts";
 import { Build, target } from "../../packages/core/mod.ts";
+import type { Reporter } from "../../packages/core/mod.ts";
 import { runCli, withStateDir } from "./_harness.ts";
 
-// The shared resource stands in for the ones a lock is usually guarding: one
-// dev environment, one database, one port. `order` records who was inside it
-// when, which is what the wait has to get right.
-const order: string[] = [];
+/**
+ * The shared resource a lock usually guards — one dev environment, one
+ * database, one port — plus the log of who was inside it when, which is what
+ * the wait has to get right.
+ *
+ * Built per test rather than shared at module level: two tests sharing one
+ * `release` means a failure in the first can leave the second's holder
+ * unresolved, so one real failure reports as two and neither names itself.
+ */
+function sharedResource() {
+  const order: string[] = [];
+  let release: () => void = () => {};
 
-/** Released by the test once the first run has taken the lock. */
-let release: () => void = () => {};
+  class HolderBuild extends Build {
+    stack = target()
+      .description("hold the shared resource until the test lets go")
+      .lock((s) => s.lockKey("dev-env").withTtl("1h"))
+      .executes(async () => {
+        // `release` is assigned before the log entry the test polls for, so
+        // observing "holder in" guarantees `release` points at this run.
+        await new Promise<void>((resolve) => {
+          release = resolve;
+          order.push("holder in");
+        });
+        order.push("holder out");
+      });
+  }
 
-class HolderBuild extends Build {
-  stack = target()
-    .description("hold the shared resource until the test lets go")
-    .lock((s) => s.lockKey("dev-env").withTtl("1h"))
-    .executes(async () => {
-      order.push("holder in");
-      await new Promise<void>((resolve) => (release = resolve));
-      order.push("holder out");
-    });
+  return {
+    order,
+    HolderBuild,
+    release: () => release(),
+    /** Resolves once the holder's body is inside, holding the lock. */
+    async held(): Promise<void> {
+      while (!order.includes("holder in")) {
+        await new Promise((r) => setTimeout(r, 5));
+      }
+    },
+  };
 }
 
-class WaiterBuild extends Build {
-  stack = target()
-    .description("queue for the shared resource rather than failing")
-    .lock((s) =>
-      s.lockKey("dev-env").withTtl("1h").waitUpTo("30s").pollEvery("10ms")
-    )
-    .executes(() => {
-      order.push("waiter in");
-    });
-}
-
-class ImpatientBuild extends Build {
-  stack = target()
-    .description("give up quickly rather than queue")
-    .lock((s) =>
-      s.lockKey("dev-env").withTtl("1h").waitUpTo("50ms").pollEvery("10ms")
-    )
-    .executes(() => {
-      order.push("impatient in");
-    });
+/** A reporter that records every line, plus a way to wait for one to appear. */
+function recordingReporter(): {
+  reporter: Reporter;
+  lines: string[];
+  await(fragment: string): Promise<void>;
+} {
+  const lines: string[] = [];
+  const push = (line: string) => void lines.push(line);
+  return {
+    lines,
+    reporter: { info: push, error: push },
+    async await(fragment: string): Promise<void> {
+      // The deadline is a failure mode, not a synchronisation point: the test
+      // proceeds the instant the line appears, and the only thing this bounds
+      // is how long a *broken* run takes to say so. An unbounded poll would
+      // hang CI instead of reporting, which is the one way this could be worse
+      // than the sleep it replaces.
+      const deadline = Date.now() + 30_000;
+      while (!lines.some((line) => line.includes(fragment))) {
+        if (Date.now() > deadline) {
+          throw new Error(
+            `waited 30s for a run to report ${JSON.stringify(fragment)}; ` +
+              `it reported: ${JSON.stringify(lines)}`,
+          );
+        }
+        await new Promise((r) => setTimeout(r, 5));
+      }
+    },
+  };
 }
 
 Deno.test("a second run waits for the lock and proceeds when the first finishes", async () => {
   await withStateDir(async () => {
-    order.length = 0;
-    const holding = runCli(HolderBuild, ["stack"]);
-    // Let the holder's target reach its body and take the lock.
-    while (!order.includes("holder in")) {
-      await new Promise((r) => setTimeout(r, 5));
+    const { order, HolderBuild, release, held } = sharedResource();
+    class WaiterBuild extends Build {
+      stack = target()
+        .description("queue for the shared resource rather than failing")
+        .lock((s) =>
+          s.lockKey("dev-env").withTtl("1h").waitUpTo("30s").pollEvery("10ms")
+        )
+        .executes(() => void order.push("waiter in"));
     }
 
-    const waiting = runCli(WaiterBuild, ["stack"]);
-    // The waiter must still be queueing: it cannot have run yet.
-    await new Promise((r) => setTimeout(r, 50));
+    const holding = runCli(HolderBuild, ["stack"]);
+    await held();
+
+    const waiterOutput = recordingReporter();
+    const waiting = runCli(WaiterBuild, ["stack"], {
+      reporter: waiterOutput.reporter,
+    });
+
+    // Wait for the waiter to say it is queueing, rather than sleeping and
+    // hoping. This is also what makes the release below meaningful: without
+    // it the holder could let go before the waiter ever reached the lock, and
+    // the test would pass having exercised no waiting at all.
+    await waiterOutput.await(`Waiting for lock "dev-env"`);
     assertEquals(order.includes("waiter in"), false);
 
     release();
@@ -70,19 +128,36 @@ Deno.test("a second run waits for the lock and proceeds when the first finishes"
     assertEquals(first.code, 0, first.err);
     assertEquals(second.code, 0, second.err);
     assertEquals(order, ["holder in", "holder out", "waiter in"]);
-    // While it waited, the run said whose lock it was waiting on.
-    assertStringIncludes(second.out, `Waiting for lock "dev-env"`);
+    // The waiter did not merely finish second — it queued, and said so. The
+    // ordering above would hold even if the holder had let go before the
+    // waiter ever reached the lock, so this is what proves the wait happened.
+    // Its own reporter, not the console: two overlapping runs share the
+    // console, and the holder's lines would land in the waiter's buffer.
+    assertStringIncludes(
+      waiterOutput.lines.join("\n"),
+      `Waiting for lock "dev-env"`,
+    );
   });
 });
 
 Deno.test("a waiter that runs out of time fails and says it waited", async () => {
   await withStateDir(async () => {
-    order.length = 0;
-    const holding = runCli(HolderBuild, ["stack"]);
-    while (!order.includes("holder in")) {
-      await new Promise((r) => setTimeout(r, 5));
+    const { order, HolderBuild, release, held } = sharedResource();
+    class ImpatientBuild extends Build {
+      stack = target()
+        .description("give up quickly rather than queue")
+        .lock((s) =>
+          s.lockKey("dev-env").withTtl("1h").waitUpTo("50ms").pollEvery("10ms")
+        )
+        .executes(() => void order.push("impatient in"));
     }
 
+    const holding = runCli(HolderBuild, ["stack"]);
+    await held();
+
+    // The lock is held for the whole of this run, so the wait expires for a
+    // reason the test controls rather than a race it hopes to win. The 50ms in
+    // the message is the *configured* wait, not a measured one.
     const impatient = await runCli(ImpatientBuild, ["stack"]);
     assertEquals(impatient.code, 1);
     assertStringIncludes(impatient.err, "still held after waiting 50ms");


### PR DESCRIPTION
### The problem

`tests/integration/lock_wait_test.ts` failed twice during long working sessions and was green on every rerun. It could not be reproduced — 40 isolated runs and 6 whole-directory runs all passed — so #492 was filed as an observation plus a code reading rather than a diagnosis.

The code reading found one wall-clock assumption, and it is the shape that rots: the test started the waiting run, slept for a fixed 50ms, and then asserted the waiter had not entered the shared resource yet.

The assertion is sound — the waiter genuinely cannot enter while the lock is held — but the 50ms was chosen to be "long enough", with nothing tying it to the event it waited for.

Worth recording what is **not** the cause, since it is the obvious suspect: the message about still being held after a 50ms wait is built from the **configured** wait, not a measured one, so it is deterministic regardless of scheduling.

### The shape

The test waits on the event now. The waiter announces itself through a reporter the harness injects, so the test proceeds the instant the queue notice appears rather than after a fixed guess.

The poll is bounded, and the bound is a **failure mode, not a synchronisation point**: the test never waits for it in the good case, and all it decides is how long a broken run takes to say so. An unbounded poll would hang CI rather than report, which is the one way this could have come out worse than the sleep it replaces.

Three things fell out of writing it:

**The notice is now asserted, not merely awaited.** The ordering assertion alone would hold even if the holder let go before the waiter ever reached the lock — the test could pass having exercised no waiting at all. It reads the waiter's **own** buffer, because `runCli` patches `console.log` globally: with two runs overlapping, the second one's patch is installed over the first's, so the holder's lines land in the waiter's captured output and the original assertion was passing on a shared buffer.

**The shared resource is per test.** `order` and `release` were module-level and reset between tests, which works only because tests in a file run sequentially — and means a failure in the first can leave the second's holder unresolved, so one real failure reports as two and neither names itself.

**The release callback is assigned before the log entry the test polls for**, so observing the holder guarantees the callback points at that run rather than a previous one.

### The one production change

`MainOptions` gains an optional `reporter`, alongside the five seams it already carries that are documented "injected in tests". Nothing observable changes without one: `main` still writes to the console. It is what makes a concurrent run's output separable at all, which is the part the old test could not do.

### Testing

The file is the test. 30 consecutive runs pass. Removing the injected reporter makes the wait poll to its deadline and fail with what the run actually reported — the seam is load-bearing rather than decorative.

`deno task ci`: 22/22 targets, 98.4% lines and 97.4% branches against a 95% gate.

### Related issues

Closes #492

### Checklist

- [x] This PR closes a tracking issue.
- [x] The PR title is a Conventional Commit.
- [x] `deno task ci` passes locally.
- [x] Tests were updated; coverage stays at 95%+.
- [x] Public API changes were regenerated with the API docs target.
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/`.
- [x] No agent-skill change, so no plugin version bump is due.
