### PR TITLE
fix(core): apply the retained-write check to the effect path too

### DIFF
--- a/packages/core/src/state/writer.ts
+++ b/packages/core/src/state/writer.ts
@@ -620,7 +620,7 @@ export class RunStateWriter {
         throw error;
       }
       if (result.ok) {
-        this.#version = result.version;
+        this.#persisted(result.version);
         return;
       }
       // Another writer moved the record on. Re-read a fresh base and re-apply on
@@ -639,10 +639,7 @@ export class RunStateWriter {
             `recording an effect; refusing to run it without a durable intent`,
         );
       }
-      const degraded = this.#record.degraded;
-      this.#record = fresh.record;
-      this.#record.degraded ||= degraded;
-      this.#version = fresh.version;
+      this.#adoptFreshBase(fresh);
       if (fresh.record.status !== "running") {
         this.#onExternalCancel?.();
         throw new RunNotActiveError(fresh.record.id, fresh.record.status);
@@ -696,6 +693,51 @@ export class RunStateWriter {
     this.#warn?.(message);
   }
 
+  /**
+   * Adopt a freshly read record as the new base after a conflict.
+   *
+   * Both persist paths — the best-effort one and the strict one an effect
+   * uses — have to do exactly this, and having it twice is how they drifted:
+   * the retained-write check was added to one copy and not the other, so an
+   * effect's conflict went on destroying a waiting mutation silently. One
+   * implementation, so the next thing either path learns, both learn.
+   */
+  #adoptFreshBase(fresh: { record: RunRecord; version: string }): void {
+    // A mutation dropped earlier was still living in the record about to be
+    // replaced, and the fresh base has never seen it: the write that was going
+    // to carry it is the one that just conflicted. That is a permanent loss,
+    // so it is reported as one — `degraded` is what stops a later resume
+    // trusting the record.
+    if (this.#retainedPending) {
+      this.#lostWrite(
+        `state: an earlier update to run "${this.#record.id}" was held ` +
+          `back and is now lost — the write meant to carry it conflicted, ` +
+          `and the record it was waiting in has been replaced`,
+      );
+      this.#retainedPending = false;
+    }
+    // Carry the degraded flag across: whoever wrote the record in the store
+    // never saw the write we already lost.
+    const degraded = this.#record.degraded;
+    this.#record = fresh.record;
+    this.#record.degraded ||= degraded;
+    this.#version = fresh.version;
+  }
+
+  /**
+   * Note that a write reached the store: adopt its version, and clear any
+   * retained mutation, which that write has just carried.
+   *
+   * Both persist paths land writes, and both have to clear — a flag left armed
+   * after the mutation reached the store makes the *next* conflict report a
+   * loss that never happened, and a spuriously degraded record is one a resume
+   * refuses.
+   */
+  #persisted(version: string): void {
+    this.#version = version;
+    this.#retainedPending = false;
+  }
+
   /** Apply `mutator` and CAS-write, re-reading and retrying on conflict. */
   async #applyAndPersist(
     mutator: (record: RunRecord) => void,
@@ -708,10 +750,7 @@ export class RunStateWriter {
         this.#record.updatedAt = this.#now();
         const result = await this.#store.putRun(this.#record, this.#version);
         if (result.ok) {
-          this.#version = result.version;
-          // Whatever was waiting in the record went to the store with this
-          // write, which is exactly what `#retainedWrite` promised.
-          this.#retainedPending = false;
+          this.#persisted(result.version);
           return true;
         }
         // Another writer moved the record on: re-read a FRESH base and re-apply
@@ -728,25 +767,7 @@ export class RunStateWriter {
           );
           return false;
         }
-        // A mutation dropped earlier was still living in the record we are
-        // about to replace, and the fresh base has never seen it: the write
-        // that was going to carry it is the one that just conflicted. That is
-        // a permanent loss, so it is reported as one rather than vanishing —
-        // `degraded` is what stops a later resume trusting the record.
-        if (this.#retainedPending) {
-          this.#lostWrite(
-            `state: an earlier update to run "${this.#record.id}" was held ` +
-              `back and is now lost — the write meant to carry it conflicted, ` +
-              `and the record it was waiting in has been replaced`,
-          );
-          this.#retainedPending = false;
-        }
-        // Adopt the fresh base, but carry a degraded flag across: whoever wrote
-        // the record in the store never saw the write we already lost.
-        const degraded = this.#record.degraded;
-        this.#record = fresh.record;
-        this.#record.degraded ||= degraded;
-        this.#version = fresh.version;
+        this.#adoptFreshBase(fresh);
         // Another process has taken the run's outcome: a `zuke cancel`, or a
         // sweep settling a run it found abandoned or past its deadline. Re-apply
         // our (target-level) change onto its record — so a just-settled
@@ -769,8 +790,9 @@ export class RunStateWriter {
             this.#version,
           );
           if (reapply.ok) {
+            // Not `#persisted`: `#adoptFreshBase` above already settled any
+            // retained mutation, so there is never one left to clear here.
             this.#version = reapply.version;
-            this.#retainedPending = false;
           } else {
             // The canceller finalises the run from here, so no later write of
             // ours lands to carry this mutation: it is gone for good.

--- a/packages/core/tests/retained_write_test.ts
+++ b/packages/core/tests/retained_write_test.ts
@@ -111,3 +111,44 @@ Deno.test("an ordinary conflict with nothing retained reports no loss", async ()
   assertEquals(writer.snapshot().degraded, undefined);
   assertEquals(warnings.length, 0);
 });
+
+Deno.test("an effect write that lands carries the retained mutation and clears the debt", async () => {
+  const store = new MemStateStore();
+  const { writer, handle, warnings } = await adopted(store);
+
+  store.failNextPut = true;
+  assertEquals(await handle.trySet({ a: "1" }), false);
+
+  // An effect writes strictly, through a different persist path — but it
+  // CAS-writes the very record the retained patch is sitting in, so landing
+  // carries it to the store exactly as an ordinary write would.
+  assertEquals(await writer.beginEffect("deploy", "post"), "run");
+  assertEquals(store.record?.targets.deploy.meta, { a: "1" });
+
+  // So a later conflict must not report a loss: the mutation is durably in
+  // the store, and a spuriously degraded record is one a resume refuses.
+  store.forceConflicts = 1;
+  assertEquals(await handle.trySet({ b: "2" }), true);
+  assertEquals(writer.snapshot().degraded, undefined);
+  assertEquals(warnings.length, 1); // only the store error itself
+});
+
+Deno.test("a retained write lost to an effect write's conflict is reported", async () => {
+  const store = new MemStateStore();
+  const { writer, handle, warnings } = await adopted(store);
+
+  store.failNextPut = true;
+  assertEquals(await handle.trySet({ a: "1" }), false);
+
+  // The strict path replaces the in-memory record on a conflict just as the
+  // best-effort one does, so it destroys a waiting mutation the same way and
+  // has to report it the same way. Having the check on only one of the two is
+  // how this went unnoticed.
+  store.forceConflicts = 1;
+  assertEquals(await writer.beginEffect("deploy", "post"), "run");
+
+  assertEquals(store.record?.targets.deploy.meta, {});
+  assertEquals(writer.snapshot().degraded, true);
+  assertEquals(warnings.length, 2);
+  assertStringIncludes(warnings[1], "held back and is now lost");
+});


### PR DESCRIPTION
### The problem

#527 taught the writer to report a **retained** write — one held in memory after the store refused it — that a later conflict destroys. It guarded only the best-effort persist path. The strict path an effect writes through does the same two things and got neither guard, so #511 is still live one function away, and a second defect came with it.

**A retained mutation is still destroyed silently by an effect's conflict.** The strict path replaces the in-memory record on a conflict exactly as the best-effort one does, with no check and no report.

**A landed effect write leaves the flag armed.** The strict path writes the very record the retained mutation is sitting in, so landing carries it to the store — but it never cleared the flag, so the next conflict reported a loss for a mutation that was durably persisted.

The false positive is the more expensive of the two: `zuke resume` refuses a degraded record and `resume --check` counts it as failed, so a spurious flag strands a run with nothing missing. Any build that touches an effect after one transient store error was exposed.

### The shape

The cause is duplication, not oversight. Adopting a fresh base after a conflict, and noting that a write landed, each existed as two copies; #527 taught one copy of each and left the other. That is exactly the drift guideline 12 describes — "the copies drift, and the drift is where the bugs live" — so the fix is the shared unit rather than a second copy of the check.

Both paths now adopt a fresh base through one implementation, and note a landed write through another. The next thing either path learns, both learn.

The clear inside the settled-elsewhere re-apply is gone with them: adopting the fresh base settles any retained mutation first, so that line could never observe one. It was confirmed unreachable before removal, not assumed.

### How this was found, and why it is a separate PR

An adversarial review of #527 reported after #527 had already merged. Both defects were on master by then, so this is a follow-up rather than a fix to an open branch. The review is the standing practice for every PR here; on #527 I ran it late — after opening the PR rather than before — which is the only reason the findings arrived behind the merge.

### Testing

2 new tests beside the three from #527: an effect write that lands carries the retained mutation and clears the debt, so a later conflict stays silent; and a retained write destroyed by an effect write's conflict is reported. Both mutation-checked — reverting either half of the fix fails one of them.

`deno task ci`: 23/23 targets, 98.4% lines and 97.4% branches against a 95% gate.

### Related issues

Closes #530

### Checklist

- [x] This PR closes a tracking issue.
- [x] The PR title is a Conventional Commit.
- [x] `deno task ci` passes locally.
- [x] Tests were added or updated; coverage stays at 95%+.
- [x] No doc change is due: the behaviour documented for `degraded` is what this restores on the second path.
- [x] No public API change, so no API doc regeneration is due.
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/`.
- [x] No agent-skill change, so no plugin version bump is due.
