### PR TITLE
feat(core): expose the resolved run plan to a body and a condition

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.49.0",
+      "version": "0.50.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -17,7 +17,7 @@ body, which is required before the target can run.
 | `.dependentFor(...targets)` | `(...t: Target[]) => this`                            | Reverse of `dependsOn`: run this _before_ those.                                                   |
 | `.inputs(...paths)`         | `(...p: PathLike[]) => this`                          | Cache inputs: skip the target when these are unchanged.                                            |
 | `.outputs(...paths)`        | `(...p: PathLike[]) => this`                          | Cache outputs: a hit also requires these to still exist.                                           |
-| `.onlyWhen(condition)`      | `(c: () => boolean \| Promise<boolean>) => this`      | Run only when the condition holds, else skip.                                                      |
+| `.onlyWhen(condition)`      | `(c: (ctx?) => boolean \| Promise<boolean>) => this`  | Run only when the condition holds, else skip. The condition may read `ctx.plan()`.                  |
 | `.requires(...params)`      | `(...p: Parameter[]) => this`                         | Fail the target unless these parameters are set.                                                   |
 | `.proceedAfterFailure()`    | `() => this`                                          | Keep the build going if this target fails.                                                         |
 | `.always()`                 | `() => this`                                          | Run even after the build has failed; waits for dependencies to settle, not succeed.                |

--- a/docs/run-context.md
+++ b/docs/run-context.md
@@ -30,6 +30,7 @@ class Deploy extends Build {
 | `stateOf`    | `(t) => …`          | The state handle of **another** target — read a dependency's published metadata (e.g. a wait's result). |
 | `outcomeOf`  | `(t) => …`          | What another target in this run **did** — `succeeded`, `failed`, `skipped`, … or `undefined` if it has none yet. |
 | `outcomes`   | `() => ReadonlyMap` | Every outcome settled so far, keyed by target name. |
+| `plan`       | `() => RunPlan`     | The run's **planned shape** — which targets it set out to run, and how they relate. See [Reading the run's shape](#reading-the-runs-shape--ctxplan). |
 | `signals`    | `ReadonlyMap`       | Payloads of external signals received so far (see [waits](./orchestration.md)). |
 | `dryRun`     | `boolean`           | `true` when the run is a dry run (bodies don't execute in a dry run). |
 | `reportSummary` | `(pairs) => void` | Put `key: value` notes on **this target's row** of the Build Summary — see [Notes on the summary row](#notes-on-the-summary-row). |
@@ -155,6 +156,79 @@ them after each target's duration (`✔ test  succeeded  128.1s  // Tests: 4094
 record, and a target that reads a dependency's outcome sees them as
 `ctx.outcomeOf("test")?.summary` — after a resume too, since the record is
 what a resumed run reads.
+
+## Reading the run's shape — `ctx.plan()`
+
+`ctx.plan()` answers what the run *set out to do*: which targets it planned, in
+execution order, and which targets must finish before a given one starts. It is
+the seam for a body whose work depends on what else was asked for.
+
+<!-- check -->
+
+```ts
+import { Build, target } from "jsr:@zuke/core";
+
+class Ci extends Build {
+  build = target().executes((ctx) => {
+    // Only worth signing the artifact if this run is going to deploy it.
+    if (ctx.plan().includes("deploy")) console.log("signing");
+  });
+  deploy = target().dependsOn(this.build).executes(() => {});
+}
+```
+
+`zuke build` prints nothing; `zuke deploy` signs. Same body, same build — the
+plan describes **this run**, not the class.
+
+A condition reads the same view, so a target can gate on the graph rather than
+only on the environment:
+
+<!-- check -->
+
+```ts
+import { Build, target } from "jsr:@zuke/core";
+
+class Ci extends Build {
+  unit = target().executes(() => {});
+  coverage = target()
+    .dependsOn(this.unit)
+    .onlyWhen((ctx) => ctx.plan().includes("unit"))
+    .executes(() => {});
+}
+```
+
+Receiving the context is optional: an existing `.onlyWhen(() => …)` keeps
+working, since a zero-argument function is assignable to the one-parameter type.
+
+A condition gets a **narrower** context than a body — `target` and `plan()` only.
+A `.whenSkipped("skip-dependencies")` condition is evaluated *before* the run
+starts, to decide what the run prunes, and at that point the run's identity, its
+state handles, and its cancellation signal do not exist yet.
+
+### The plan is not the outcome
+
+This is the distinction to keep straight:
+
+- **`ctx.plan()`** says what the run **planned**. It is fixed for the whole run,
+  and identical in every process a resumed run passes through.
+- **`ctx.outcomeOf(name)`** says what **became** of a target, once it settled.
+
+A planned target can still be skipped — by a condition, by `--affected`, or by
+an operator's forced outcome — and a run that fails early never reaches its
+later targets at all. So `plan().includes("deploy")` means "`deploy` is part of
+this run", never "`deploy` will execute". Ask `outcomeOf` for that.
+
+There is a concrete reason the plan refuses to answer "will it run". A
+`whenSkipped("skip-dependencies")` condition is evaluated **twice**: once up
+front, to decide what the run prunes, and again when the scheduler reaches the
+target. A "will it run" view would answer differently at those two moments — and
+at the first one it would be circular, since that very condition is one of the
+things deciding the answer. Reporting the planned graph gives one answer
+everywhere.
+
+`dependenciesOf` returns an empty list both for a target with no predecessors
+and for a name that is not in the plan at all; use `includes` to tell those
+apart.
 
 ## Reading what the rest of the run did
 

--- a/docs/run-context.md
+++ b/docs/run-context.md
@@ -181,7 +181,9 @@ class Ci extends Build {
 plan describes **this run**, not the class.
 
 A condition reads the same view, so a target can gate on the graph rather than
-only on the environment:
+only on the environment. Gate on a target you do **not** depend on — a hard
+dependency is in the plan whenever its dependent is, so gating on one is a
+condition that can never be false:
 
 <!-- check -->
 
@@ -190,10 +192,12 @@ import { Build, target } from "jsr:@zuke/core";
 
 class Ci extends Build {
   unit = target().executes(() => {});
+  // Only worth publishing coverage when the run is also going to deploy.
   coverage = target()
     .dependsOn(this.unit)
-    .onlyWhen((ctx) => ctx.plan().includes("unit"))
+    .onlyWhen((ctx) => ctx.plan().includes("deploy"))
     .executes(() => {});
+  deploy = target().dependsOn(this.unit).executes(() => {});
 }
 ```
 
@@ -209,8 +213,7 @@ state handles, and its cancellation signal do not exist yet.
 
 This is the distinction to keep straight:
 
-- **`ctx.plan()`** says what the run **planned**. It is fixed for the whole run,
-  and identical in every process a resumed run passes through.
+- **`ctx.plan()`** says what the run **planned**, as this process resolved it.
 - **`ctx.outcomeOf(name)`** says what **became** of a target, once it settled.
 
 A planned target can still be skipped — by a condition, by `--affected`, or by
@@ -229,6 +232,32 @@ everywhere.
 `dependenciesOf` returns an empty list both for a target with no predecessors
 and for a name that is not in the plan at all; use `includes` to tell those
 apart.
+
+### Fan-out sub-targets are not in the plan
+
+A `.forEach()` fan-out expands into its sub-targets **while the run executes**,
+after the graph has been planned. So `fan[us].prep` has a summary row, a run
+record entry and an outcome — but `plan().includes("fan[us].prep")` is `false`,
+and only the `fan` target that produced it is in `targets`. This is the one
+place the plan reports *less* than the outcomes do; ask `outcomeOf` about a
+fan-out's sub-targets.
+
+### The plan does not cross processes
+
+Within one process the plan is fixed: two bodies agree, and both evaluations of
+a `skip-dependencies` condition agree. A **second** process re-resolves the graph
+from the build class it was handed, so it can legitimately differ:
+
+- a resume runs against today's build class, which may have changed since the run
+  was suspended — `--force-graph` exists precisely for that case;
+- a lazy `orderWith` provider may answer differently, and `zuke cancel` degrades
+  to the base topological order when the provider is unreachable, rather than
+  abandoning the rollback.
+
+So a compensation's `ctx.plan()` is this canceller's reading of the graph, not a
+recording of what the original run planned. Anything a later process must agree
+with belongs in durable state (see [Durable run state](./state.md)), which is
+what crosses the boundary.
 
 ## Reading what the rest of the run did
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "zuke",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build)."
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4026,8 +4026,8 @@ interface RunOptions
     custom {@link Renderer}) to restyle a build's output.
 
 interface RunPlan
-  The resolved shape of this run: the targets it plans, in order, and the
-  dependencies between them.
+  The resolved shape of this run: the class-field targets it plans, in order,
+  and the dependencies between them.
 
   This describes the plan, not the outcome. A target is in the plan because
   the graph put it there; it may still be skipped by a condition, by
@@ -4036,12 +4036,30 @@ interface RunPlan
   run set out to do, and `ctx.outcomeOf(...)` what actually became of a target
   once it settled.
 
-  The plan is fixed for the whole run: every body and every condition, in every
-  process a resumed run passes through, reads the same answer.
+  Two things the plan is not.
+
+  It is not every target that will appear in the run record. A `.forEach()`
+  fan-out expands into its sub-targets while the run executes, long after the
+  graph is planned, so `fan[us].prep` has an outcome and a summary row but is
+  absent from the plan — only the `fan` target that produced it is in
+  there. For a fan-out, `outcomeOf` sees more than `includes` does.
+
+  It is not a promise that holds across processes. The plan is the graph as
+  this process resolved it, and it is fixed for the whole of this process: two
+  bodies, and both evaluations of a condition, always agree. A second process —
+  a resume, or a `zuke cancel` running compensations — re-resolves the graph
+  from the build class it was given, so it can legitimately differ: the class
+  may have changed since the run was suspended (which is what `--force-graph`
+  is for), and a lazy `orderWith` provider may answer differently or, if it is
+  unreachable, be degraded to the base topological order.
 
   readonly targets: readonly string[]
     Every planned target's dotted name, in the run's deterministic execution
-    order — the same order the build summary lists.
+    order.
+
+    The build summary can list more rows than this: a `.forEach()` fan-out's
+    sub-targets are created during execution and get their own rows, but are
+    not part of the planned graph.
   includes(target: string): boolean
     Whether `target` is part of this run's planned set.
 
@@ -4050,9 +4068,10 @@ interface RunPlan
     for?". An unknown name is `false`, never an error, so probing for an
     optional target does not need a guard.
   dependenciesOf(target: string): readonly string[]
-    The targets that must complete before `target` may start: its declared
-    dependencies plus the soft `before`/`after` edges that apply within this
-    run's set.
+    The targets that must complete before `target` may start: everything the
+    planner treats as a predecessor — declared `dependsOn` dependencies, the
+    targets this one `triggers`, and the soft `before`/`after`, `extraEdges`
+    and `orderWith` edges that apply within this run's set.
 
     Empty for a target with no predecessors and for a name that is not in
     the plan — use {@link RunPlan.includes} to tell those apart.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3107,6 +3107,27 @@ interface CompensationFailure
   error: string
     The failure message.
 
+interface ConditionContext
+  The context a condition receives.
+
+  Deliberately narrower than a {@link TargetContext}. A condition on a
+  `.whenSkipped("skip-dependencies")` target is evaluated before the run
+  starts, to decide what the run prunes — at which point the run's identity,
+  its durable state handles, and its cancellation signal do not exist yet. This
+  type carries only what is available at every moment a condition can be
+  called.
+
+  readonly target: string
+    Dotted name of the target this condition gates.
+  plan(): RunPlan
+    The resolved shape of this run — which targets it plans, and how they
+    relate. Lets a condition gate on the graph ("only when `deploy` was asked
+    for") rather than only on the environment.
+
+    Reports the plan, not the outcome, which matters most here: a condition can
+    be one of the things deciding what runs, so the plan deliberately does not
+    claim to know what will execute. See {@link "./run_plan.ts".RunPlan}.
+
 interface CopyOptions
   Options for {@link FileTasksApi.copy}.
 
@@ -4004,6 +4025,38 @@ interface RunOptions
     Zuke's built-in look; inject `consoleRenderer` from `@zuke/console` (or a
     custom {@link Renderer}) to restyle a build's output.
 
+interface RunPlan
+  The resolved shape of this run: the targets it plans, in order, and the
+  dependencies between them.
+
+  This describes the plan, not the outcome. A target is in the plan because
+  the graph put it there; it may still be skipped by a condition, by
+  `--affected`, or by an operator's forced outcome, and a run that fails early
+  never reaches its later targets at all. Ask {@link RunPlan.includes} what the
+  run set out to do, and `ctx.outcomeOf(...)` what actually became of a target
+  once it settled.
+
+  The plan is fixed for the whole run: every body and every condition, in every
+  process a resumed run passes through, reads the same answer.
+
+  readonly targets: readonly string[]
+    Every planned target's dotted name, in the run's deterministic execution
+    order — the same order the build summary lists.
+  includes(target: string): boolean
+    Whether `target` is part of this run's planned set.
+
+    The question a body asks to decide whether its work is needed by something
+    else in the run — "am I building for a `deploy` that was actually asked
+    for?". An unknown name is `false`, never an error, so probing for an
+    optional target does not need a guard.
+  dependenciesOf(target: string): readonly string[]
+    The targets that must complete before `target` may start: its declared
+    dependencies plus the soft `before`/`after` edges that apply within this
+    run's set.
+
+    Empty for a target with no predecessors and for a name that is not in
+    the plan — use {@link RunPlan.includes} to tell those apart.
+
 interface RunQuery
   Filters for {@link "./store.ts".StateStore.listRuns}; all fields are optional.
 
@@ -4338,6 +4391,12 @@ interface TargetContext
     Every outcome this run has settled so far, keyed by dotted target name — a
     snapshot, not a live view. Targets that have not settled are absent rather
     than present with a placeholder status.
+  plan(): RunPlan
+    The resolved shape of this run — which targets it plans, and how they
+    relate. The seam for a body whose work depends on what else was asked
+    for: a build that signs its artifact only when `deploy` is in the run.
+
+    Reports the plan, not the outcome — see {@link "./run_plan.ts".RunPlan}.
   reportSummary(pairs: SummaryPairs): void
     Report `key: value` notes into this target's row of the end-of-build
     summary — where a count or a version belongs once the body is done:
@@ -4641,8 +4700,12 @@ type CiSyncStatus = "written" | "unchanged" | "stale"
 type CiUses = string | CiActionRef
   A step's `uses:` value — a bare reference, or one carrying its version.
 
-type Condition = () => boolean | Promise<boolean>
+type Condition = (ctx: ConditionContext) => boolean | Promise<boolean>
   A predicate gating whether a target runs; may be synchronous or async.
+
+  Receiving the context is optional — a zero-argument
+  `.onlyWhen(() => …)` stays valid, since a zero-argument function is
+  assignable to this one-parameter type.
 
 type DownloadFn = (url: string, dest: PathLike) => Promise<void>
   A download function: fetch `url` into the file at `dest`.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -3161,6 +3161,27 @@ interface CompensationFailure
   error: string
     The failure message.
 
+interface ConditionContext
+  The context a condition receives.
+
+  Deliberately narrower than a {@link TargetContext}. A condition on a
+  `.whenSkipped("skip-dependencies")` target is evaluated before the run
+  starts, to decide what the run prunes — at which point the run's identity,
+  its durable state handles, and its cancellation signal do not exist yet. This
+  type carries only what is available at every moment a condition can be
+  called.
+
+  readonly target: string
+    Dotted name of the target this condition gates.
+  plan(): RunPlan
+    The resolved shape of this run — which targets it plans, and how they
+    relate. Lets a condition gate on the graph ("only when `deploy` was asked
+    for") rather than only on the environment.
+
+    Reports the plan, not the outcome, which matters most here: a condition can
+    be one of the things deciding what runs, so the plan deliberately does not
+    claim to know what will execute. See {@link "./run_plan.ts".RunPlan}.
+
 interface CopyOptions
   Options for {@link FileTasksApi.copy}.
 
@@ -4058,6 +4079,38 @@ interface RunOptions
     Zuke's built-in look; inject `consoleRenderer` from `@zuke/console` (or a
     custom {@link Renderer}) to restyle a build's output.
 
+interface RunPlan
+  The resolved shape of this run: the targets it plans, in order, and the
+  dependencies between them.
+
+  This describes the plan, not the outcome. A target is in the plan because
+  the graph put it there; it may still be skipped by a condition, by
+  `--affected`, or by an operator's forced outcome, and a run that fails early
+  never reaches its later targets at all. Ask {@link RunPlan.includes} what the
+  run set out to do, and `ctx.outcomeOf(...)` what actually became of a target
+  once it settled.
+
+  The plan is fixed for the whole run: every body and every condition, in every
+  process a resumed run passes through, reads the same answer.
+
+  readonly targets: readonly string[]
+    Every planned target's dotted name, in the run's deterministic execution
+    order — the same order the build summary lists.
+  includes(target: string): boolean
+    Whether `target` is part of this run's planned set.
+
+    The question a body asks to decide whether its work is needed by something
+    else in the run — "am I building for a `deploy` that was actually asked
+    for?". An unknown name is `false`, never an error, so probing for an
+    optional target does not need a guard.
+  dependenciesOf(target: string): readonly string[]
+    The targets that must complete before `target` may start: its declared
+    dependencies plus the soft `before`/`after` edges that apply within this
+    run's set.
+
+    Empty for a target with no predecessors and for a name that is not in
+    the plan — use {@link RunPlan.includes} to tell those apart.
+
 interface RunQuery
   Filters for {@link "./store.ts".StateStore.listRuns}; all fields are optional.
 
@@ -4392,6 +4445,12 @@ interface TargetContext
     Every outcome this run has settled so far, keyed by dotted target name — a
     snapshot, not a live view. Targets that have not settled are absent rather
     than present with a placeholder status.
+  plan(): RunPlan
+    The resolved shape of this run — which targets it plans, and how they
+    relate. The seam for a body whose work depends on what else was asked
+    for: a build that signs its artifact only when `deploy` is in the run.
+
+    Reports the plan, not the outcome — see {@link "./run_plan.ts".RunPlan}.
   reportSummary(pairs: SummaryPairs): void
     Report `key: value` notes into this target's row of the end-of-build
     summary — where a count or a version belongs once the body is done:
@@ -4695,8 +4754,12 @@ type CiSyncStatus = "written" | "unchanged" | "stale"
 type CiUses = string | CiActionRef
   A step's `uses:` value — a bare reference, or one carrying its version.
 
-type Condition = () => boolean | Promise<boolean>
+type Condition = (ctx: ConditionContext) => boolean | Promise<boolean>
   A predicate gating whether a target runs; may be synchronous or async.
+
+  Receiving the context is optional — a zero-argument
+  `.onlyWhen(() => …)` stays valid, since a zero-argument function is
+  assignable to this one-parameter type.
 
 type DownloadFn = (url: string, dest: PathLike) => Promise<void>
   A download function: fetch `url` into the file at `dest`.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4080,8 +4080,8 @@ interface RunOptions
     custom {@link Renderer}) to restyle a build's output.
 
 interface RunPlan
-  The resolved shape of this run: the targets it plans, in order, and the
-  dependencies between them.
+  The resolved shape of this run: the class-field targets it plans, in order,
+  and the dependencies between them.
 
   This describes the plan, not the outcome. A target is in the plan because
   the graph put it there; it may still be skipped by a condition, by
@@ -4090,12 +4090,30 @@ interface RunPlan
   run set out to do, and `ctx.outcomeOf(...)` what actually became of a target
   once it settled.
 
-  The plan is fixed for the whole run: every body and every condition, in every
-  process a resumed run passes through, reads the same answer.
+  Two things the plan is not.
+
+  It is not every target that will appear in the run record. A `.forEach()`
+  fan-out expands into its sub-targets while the run executes, long after the
+  graph is planned, so `fan[us].prep` has an outcome and a summary row but is
+  absent from the plan — only the `fan` target that produced it is in
+  there. For a fan-out, `outcomeOf` sees more than `includes` does.
+
+  It is not a promise that holds across processes. The plan is the graph as
+  this process resolved it, and it is fixed for the whole of this process: two
+  bodies, and both evaluations of a condition, always agree. A second process —
+  a resume, or a `zuke cancel` running compensations — re-resolves the graph
+  from the build class it was given, so it can legitimately differ: the class
+  may have changed since the run was suspended (which is what `--force-graph`
+  is for), and a lazy `orderWith` provider may answer differently or, if it is
+  unreachable, be degraded to the base topological order.
 
   readonly targets: readonly string[]
     Every planned target's dotted name, in the run's deterministic execution
-    order — the same order the build summary lists.
+    order.
+
+    The build summary can list more rows than this: a `.forEach()` fan-out's
+    sub-targets are created during execution and get their own rows, but are
+    not part of the planned graph.
   includes(target: string): boolean
     Whether `target` is part of this run's planned set.
 
@@ -4104,9 +4122,10 @@ interface RunPlan
     for?". An unknown name is `false`, never an error, so probing for an
     optional target does not need a guard.
   dependenciesOf(target: string): readonly string[]
-    The targets that must complete before `target` may start: its declared
-    dependencies plus the soft `before`/`after` edges that apply within this
-    run's set.
+    The targets that must complete before `target` may start: everything the
+    planner treats as a predecessor — declared `dependsOn` dependencies, the
+    targets this one `triggers`, and the soft `before`/`after`, `extraEdges`
+    and `orderWith` edges that apply within this run's set.
 
     Empty for a target with no predecessors and for a name that is not in
     the plan — use {@link RunPlan.includes} to tell those apart.

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -45,6 +45,7 @@ export {
 } from "./src/host.ts";
 export {
   type Condition,
+  type ConditionContext,
   type DeclaredEffect,
   type EffectContext,
   type EffectFn,
@@ -404,3 +405,4 @@ export {
   ZUKE_ACTION,
 } from "./src/ci.ts";
 export { type ScheduleEntry } from "./src/ci_schedule.ts";
+export { type RunPlan } from "./src/run_plan.ts";

--- a/packages/core/src/cancel.ts
+++ b/packages/core/src/cancel.ts
@@ -33,6 +33,7 @@
  */
 
 import { type Build, discoverTargets, resolveOrderingEdges } from "./build.ts";
+import { buildRunPlan, type RunPlan } from "./run_plan.ts";
 import { defaultReadEnv, messageOf, runWithTimeout } from "./internal.ts";
 import { consoleReporter, type Reporter, silentReporter } from "./reporter.ts";
 import { type OrderingEdge, planGraph } from "./graph.ts";
@@ -175,6 +176,12 @@ export interface CompensationOutcome {
 export interface CompensationDeps {
   /** The run id, stamped on every compensation's {@link TargetContext}. */
   runId: string;
+  /**
+   * The run's resolved plan, read by a compensation body via `ctx.plan()` —
+   * the same graph the walk is ordered by, so a compensation sees the run it
+   * is unwinding rather than an empty one.
+   */
+  plan: RunPlan;
   /** The run's received signals, exposed to compensation bodies via `ctx.signals`. */
   signals: ReadonlyMap<string, SignalRecord>;
   /** Where the walk narrates its progress. */
@@ -365,6 +372,7 @@ export async function runCompensations(
     const ctx: TargetContext = {
       runId: deps.runId,
       target: compName,
+      plan: () => deps.plan,
       signal: NEVER_ABORTED,
       state: ownState,
       // A compensation runs off the durable graph, so only its own seeded state
@@ -914,9 +922,10 @@ export async function settleExternally(
             `compensating in base topological order.`,
         );
       }
-      const order = planGraph(root, edges).order;
+      const { order, predecessors } = planGraph(root, edges);
       outcome = await runCompensations(order, record, {
         runId,
+        plan: buildRunPlan(order, predecessors),
         signals: new Map(Object.entries(record.signals)),
         reporter,
         redactor,

--- a/packages/core/src/cancel.ts
+++ b/packages/core/src/cancel.ts
@@ -178,8 +178,13 @@ export interface CompensationDeps {
   runId: string;
   /**
    * The run's resolved plan, read by a compensation body via `ctx.plan()` —
-   * the same graph the walk is ordered by, so a compensation sees the run it
-   * is unwinding rather than an empty one.
+   * the same graph this walk is ordered by.
+   *
+   * Resolved by **this** process, which for an out-of-process `zuke cancel` is
+   * not the process that ran the build: if the build class has changed since,
+   * or the lazy `orderWith` provider answers differently (or is unreachable, so
+   * the walk degrades to base topological order), this plan can differ from the
+   * one the original run's bodies read.
    */
   plan: RunPlan;
   /** The run's received signals, exposed to compensation bodies via `ctx.signals`. */

--- a/packages/core/src/execute_cancel.ts
+++ b/packages/core/src/execute_cancel.ts
@@ -15,6 +15,7 @@
  */
 
 import type { TargetBuilder } from "./target.ts";
+import type { RunPlan } from "./run_plan.ts";
 import type { Reporter } from "./reporter.ts";
 import type { Redactor } from "./redact.ts";
 import type { Lifecycle } from "./lifecycle.ts";
@@ -58,6 +59,8 @@ export async function settleCancelledRun(opts: {
   isExternallyCancelled: () => boolean;
   /** Whether this process has lost the run's lease (see {@link "../cancel.ts".CompensationDeps.stop}). */
   isLeaseLost?: () => boolean;
+  /** The run's resolved shape, read by a compensation via `ctx.plan()`. */
+  plan: RunPlan;
 }): Promise<CancelSettlement> {
   const { writer, life, order, runId, actor, reporter } = opts;
   // Hold the per-run cancel lock while we compensate, so a concurrent
@@ -98,6 +101,7 @@ export async function settleCancelledRun(opts: {
         // settle.
         const comp = await runCompensations(order, writer.snapshot(), {
           runId,
+          plan: opts.plan,
           signals: opts.signals,
           reporter,
           redactor: opts.redactor,

--- a/packages/core/src/execute_plan.ts
+++ b/packages/core/src/execute_plan.ts
@@ -15,6 +15,7 @@
 
 import type { Build } from "./build.ts";
 import type { TargetBuilder } from "./target.ts";
+import type { RunPlan } from "./run_plan.ts";
 import type { OrderingEdge } from "./graph.ts";
 import type { Reporter } from "./reporter.ts";
 import type { Redactor } from "./redact.ts";
@@ -128,13 +129,15 @@ export function reportDanglingEdges(
 export async function conditionSkips(
   root: TargetBuilder,
   order: TargetBuilder[],
+  plan: RunPlan,
 ): Promise<Set<string>> {
   const pruned = new Set<TargetBuilder>();
   for (const t of order) {
     if (!t.skipDependencies_ || t.onlyWhen_.length === 0) continue;
     let run = true;
+    const ctx = { target: t.name_ ?? "<unnamed>", plan: () => plan };
     for (const condition of t.onlyWhen_) {
-      if (!(await condition())) {
+      if (!(await condition(ctx))) {
         run = false;
         break;
       }

--- a/packages/core/src/execute_state.ts
+++ b/packages/core/src/execute_state.ts
@@ -16,6 +16,7 @@
 
 import type { Build } from "./build.ts";
 import type { TargetBuilder } from "./target.ts";
+import type { RunPlan } from "./run_plan.ts";
 import type { Reporter } from "./reporter.ts";
 import type { Redactor } from "./redact.ts";
 import type { AnyParameter } from "./params.ts";
@@ -184,6 +185,8 @@ export async function openRunState(opts: {
   build: Build;
   root: TargetBuilder;
   order: TargetBuilder[];
+  /** The run's resolved shape, handed to every body via `ctx.plan()`. */
+  plan: RunPlan;
   /**
    * The run's resolved parameters, copied into the record. An array rather than
    * an `Iterable` on purpose: a `MapIterator` is one-shot, so a second read
@@ -344,6 +347,7 @@ export async function openRunState(opts: {
   const initiator = writer?.snapshot().initiator;
   const env: RunEnv = {
     runId: opts.runId,
+    plan: opts.plan,
     signal: opts.signal,
     writer,
     store: stateStore,

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -29,6 +29,7 @@ import {
   emitActionsMasks,
   writeJobSummary,
 } from "./execute_output.ts";
+import { buildRunPlan } from "./run_plan.ts";
 import {
   applyAffectedSkips,
   conditionSkips,
@@ -294,10 +295,16 @@ export async function execute(
     return { ok: false, executed: [], error };
   }
   const { order, predecessors } = planGraph(root, extraEdges);
+  // The run's shape, fixed here and read by every body and condition — the same
+  // answer in every process a resumed run passes through, since it is derived
+  // from the graph rather than from what has happened so far.
+  const planView = buildRunPlan(order, predecessors);
   reportDanglingEdges(extraEdges, order, discovered.values(), reporter);
   // Evaluate up-front conditions for `whenSkipped("skip-dependencies")` targets
   // and skip them plus any dependencies that nothing else needs.
-  for (const name of await conditionSkips(root, order)) skip.add(name);
+  for (const name of await conditionSkips(root, order, planView)) {
+    skip.add(name);
+  }
 
   // With `--affected`, skip every planned target a change cannot reach. Skipped
   // targets still unblock their dependents (their prior outputs are assumed
@@ -380,6 +387,7 @@ export async function execute(
     params: [...params.values()],
     runId,
     dryRun,
+    plan: planView,
     signal: runController.signal,
     redactor,
     reporter,
@@ -549,6 +557,7 @@ export async function execute(
         writer,
         life,
         order,
+        plan: planView,
         runId,
         actor,
         signals: env.signals,

--- a/packages/core/src/run_plan.ts
+++ b/packages/core/src/run_plan.ts
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * The resolved shape of a run — which targets it plans and how they relate —
+ * as read by a target body and by a condition.
+ *
+ * @module
+ */
+
+import type { TargetBuilder } from "./target.ts";
+
+/**
+ * The resolved shape of this run: the targets it plans, in order, and the
+ * dependencies between them.
+ *
+ * **This describes the plan, not the outcome.** A target is in the plan because
+ * the graph put it there; it may still be skipped by a condition, by
+ * `--affected`, or by an operator's forced outcome, and a run that fails early
+ * never reaches its later targets at all. Ask {@link RunPlan.includes} what the
+ * run set out to do, and `ctx.outcomeOf(...)` what actually became of a target
+ * once it settled.
+ *
+ * The plan is fixed for the whole run: every body and every condition, in every
+ * process a resumed run passes through, reads the same answer.
+ */
+export interface RunPlan {
+  /**
+   * Every planned target's dotted name, in the run's deterministic execution
+   * order — the same order the build summary lists.
+   */
+  readonly targets: readonly string[];
+  /**
+   * Whether `target` is part of this run's planned set.
+   *
+   * The question a body asks to decide whether its work is needed by something
+   * else in the run — "am I building for a `deploy` that was actually asked
+   * for?". An unknown name is `false`, never an error, so probing for an
+   * optional target does not need a guard.
+   */
+  includes(target: string): boolean;
+  /**
+   * The targets that must complete before `target` may start: its declared
+   * dependencies plus the soft `before`/`after` edges that apply within this
+   * run's set.
+   *
+   * Empty for a target with no predecessors **and** for a name that is not in
+   * the plan — use {@link RunPlan.includes} to tell those apart.
+   */
+  dependenciesOf(target: string): readonly string[];
+}
+
+/**
+ * Build the immutable {@link RunPlan} for a planned graph.
+ *
+ * Internal to the engine: the plan is constructed once per run, from
+ * `planGraph`'s output, and handed to every body and condition.
+ *
+ * @param order the planned targets, in execution order.
+ * @param predecessors each target's direct predecessors.
+ * @returns a plan reporting those targets by dotted name.
+ */
+export function buildRunPlan(
+  order: readonly TargetBuilder[],
+  predecessors: ReadonlyMap<TargetBuilder, TargetBuilder[]>,
+): RunPlan {
+  const nameOf = (t: TargetBuilder): string => t.name_ ?? "<unnamed>";
+  const targets = order.map(nameOf);
+  const planned = new Set(targets);
+  const deps = new Map<string, readonly string[]>();
+  for (const t of order) {
+    deps.set(nameOf(t), (predecessors.get(t) ?? []).map(nameOf));
+  }
+  return {
+    targets,
+    includes: (target) => planned.has(target),
+    dependenciesOf: (target) => deps.get(target) ?? [],
+  };
+}

--- a/packages/core/src/run_plan.ts
+++ b/packages/core/src/run_plan.ts
@@ -11,8 +11,8 @@
 import type { TargetBuilder } from "./target.ts";
 
 /**
- * The resolved shape of this run: the targets it plans, in order, and the
- * dependencies between them.
+ * The resolved shape of this run: the class-field targets it plans, in order,
+ * and the dependencies between them.
  *
  * **This describes the plan, not the outcome.** A target is in the plan because
  * the graph put it there; it may still be skipped by a condition, by
@@ -21,13 +21,31 @@ import type { TargetBuilder } from "./target.ts";
  * run set out to do, and `ctx.outcomeOf(...)` what actually became of a target
  * once it settled.
  *
- * The plan is fixed for the whole run: every body and every condition, in every
- * process a resumed run passes through, reads the same answer.
+ * **Two things the plan is not.**
+ *
+ * It is not every target that will appear in the run record. A `.forEach()`
+ * fan-out expands into its sub-targets while the run executes, long after the
+ * graph is planned, so `fan[us].prep` has an outcome and a summary row but is
+ * **absent** from the plan — only the `fan` target that produced it is in
+ * there. For a fan-out, `outcomeOf` sees more than `includes` does.
+ *
+ * It is not a promise that holds across processes. The plan is the graph **as
+ * this process resolved it**, and it is fixed for the whole of this process: two
+ * bodies, and both evaluations of a condition, always agree. A second process —
+ * a resume, or a `zuke cancel` running compensations — re-resolves the graph
+ * from the build class it was given, so it can legitimately differ: the class
+ * may have changed since the run was suspended (which is what `--force-graph`
+ * is for), and a lazy `orderWith` provider may answer differently or, if it is
+ * unreachable, be degraded to the base topological order.
  */
 export interface RunPlan {
   /**
    * Every planned target's dotted name, in the run's deterministic execution
-   * order — the same order the build summary lists.
+   * order.
+   *
+   * The build summary can list **more** rows than this: a `.forEach()` fan-out's
+   * sub-targets are created during execution and get their own rows, but are
+   * not part of the planned graph.
    */
   readonly targets: readonly string[];
   /**
@@ -40,9 +58,10 @@ export interface RunPlan {
    */
   includes(target: string): boolean;
   /**
-   * The targets that must complete before `target` may start: its declared
-   * dependencies plus the soft `before`/`after` edges that apply within this
-   * run's set.
+   * The targets that must complete before `target` may start: everything the
+   * planner treats as a predecessor — declared `dependsOn` dependencies, the
+   * targets this one `triggers`, and the soft `before`/`after`, `extraEdges`
+   * and `orderWith` edges that apply within this run's set.
    *
    * Empty for a target with no predecessors **and** for a name that is not in
    * the plan — use {@link RunPlan.includes} to tell those apart.
@@ -65,15 +84,25 @@ export function buildRunPlan(
   predecessors: ReadonlyMap<TargetBuilder, TargetBuilder[]>,
 ): RunPlan {
   const nameOf = (t: TargetBuilder): string => t.name_ ?? "<unnamed>";
-  const targets = order.map(nameOf);
+  // Frozen, not copied per call: one plan is shared by every body in the run,
+  // and bodies run concurrently. `readonly` is erased at runtime, so without
+  // this a body that sorts the array it was handed — or any JavaScript consumer,
+  // where `readonly` does not exist at all — silently reorders or truncates what
+  // every other body reads. Freezing turns that into a loud TypeError instead.
+  const targets = Object.freeze(order.map(nameOf));
   const planned = new Set(targets);
+  // Read from the map's own entries rather than looking each target up by key:
+  // `planGraph` seeds an entry for every node in the planned set, so a lookup
+  // would be total and its `undefined` arm unreachable. Iterating leaves no arm
+  // to be wrong about.
   const deps = new Map<string, readonly string[]>();
-  for (const t of order) {
-    deps.set(nameOf(t), (predecessors.get(t) ?? []).map(nameOf));
+  for (const [t, predecessorsOf] of predecessors) {
+    deps.set(nameOf(t), Object.freeze(predecessorsOf.map(nameOf)));
   }
+  const none: readonly string[] = Object.freeze([]);
   return {
     targets,
     includes: (target) => planned.has(target),
-    dependenciesOf: (target) => deps.get(target) ?? [],
+    dependenciesOf: (target) => deps.get(target) ?? none,
   };
 }

--- a/packages/core/src/run_support.ts
+++ b/packages/core/src/run_support.ts
@@ -17,6 +17,7 @@ import type { TargetOutcomeView } from "./target.ts";
 import type { TargetReport } from "./report.ts";
 import type { SummaryEntry } from "./summary_note.ts";
 import type { RunStateWriter } from "./state/writer.ts";
+import type { RunPlan } from "./run_plan.ts";
 import type { StateStore } from "./state/store.ts";
 import type {
   RunInitiator,
@@ -70,6 +71,8 @@ export interface RunOutcome {
 export interface RunEnv {
   /** The run's stable identity (across a resume). */
   runId: string;
+  /** The resolved shape of the run, read by bodies via `ctx.plan()`. */
+  plan: RunPlan;
   /** The cancellation signal handed to every target context. */
   signal: AbortSignal;
   /** The durable-state writer that records transitions, if any. */

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -265,6 +265,7 @@ function targetContextFor(
     runId: env.runId,
     ...(env.initiator === undefined ? {} : { initiator: env.initiator }),
     target: name,
+    plan: () => env.plan,
     signal: env.signal,
     state: ownState,
     stateOf: (t) => t === name ? ownState : stateHandleFor(env, t),
@@ -443,8 +444,9 @@ async function runTarget(
     };
   }
 
+  const conditionCtx = { target: name, plan: () => env.plan };
   for (const condition of t.onlyWhen_) {
-    if (!(await condition())) return { status: "skipped", ms: 0 };
+    if (!(await condition(conditionCtx))) return { status: "skipped", ms: 0 };
   }
 
   const missing = t.requires_.filter((p) => !p.isSet_());
@@ -473,6 +475,7 @@ async function runTarget(
       const targetCtx: TargetContext = {
         runId: env.runId,
         target: name,
+        plan: () => env.plan,
         signal: env.signal,
         state: echoState,
         stateOf: (t2) => echo(t2),

--- a/packages/core/src/target.ts
+++ b/packages/core/src/target.ts
@@ -31,6 +31,7 @@
  */
 
 import type { PathLike } from "./path.ts";
+import type { RunPlan } from "./run_plan.ts";
 import type { AnyParameter } from "./params.ts";
 import type { Configure } from "./tooling.ts";
 import { type LockHolder, lockKey } from "./state/lock.ts";
@@ -403,6 +404,14 @@ export interface TargetContext {
   /** True when the run is a dry run (bodies do not execute under a dry run). */
   readonly dryRun: boolean;
   /**
+   * The resolved shape of this run — which targets it plans, and how they
+   * relate. The seam for a body whose work depends on what *else* was asked
+   * for: a build that signs its artifact only when `deploy` is in the run.
+   *
+   * Reports the plan, not the outcome — see {@link "./run_plan.ts".RunPlan}.
+   */
+  plan(): RunPlan;
+  /**
    * Report `key: value` notes into **this target's row** of the end-of-build
    * summary — where a count or a version belongs once the body is done:
    *
@@ -462,8 +471,41 @@ export interface DeclaredEffect {
   fn: EffectFn;
 }
 
-/** A predicate gating whether a target runs; may be synchronous or async. */
-export type Condition = () => boolean | Promise<boolean>;
+/**
+ * The context a condition receives.
+ *
+ * Deliberately narrower than a {@link TargetContext}. A condition on a
+ * `.whenSkipped("skip-dependencies")` target is evaluated **before** the run
+ * starts, to decide what the run prunes — at which point the run's identity,
+ * its durable state handles, and its cancellation signal do not exist yet. This
+ * type carries only what is available at every moment a condition can be
+ * called.
+ */
+export interface ConditionContext {
+  /** Dotted name of the target this condition gates. */
+  readonly target: string;
+  /**
+   * The resolved shape of this run — which targets it plans, and how they
+   * relate. Lets a condition gate on the graph ("only when `deploy` was asked
+   * for") rather than only on the environment.
+   *
+   * Reports the plan, not the outcome, which matters most here: a condition can
+   * be one of the things *deciding* what runs, so the plan deliberately does not
+   * claim to know what will execute. See {@link "./run_plan.ts".RunPlan}.
+   */
+  plan(): RunPlan;
+}
+
+/**
+ * A predicate gating whether a target runs; may be synchronous or async.
+ *
+ * Receiving the context is optional — a zero-argument
+ * `.onlyWhen(() => …)` stays valid, since a zero-argument function is
+ * assignable to this one-parameter type.
+ */
+export type Condition = (
+  ctx: ConditionContext,
+) => boolean | Promise<boolean>;
 
 /** Context passed to a {@link Validation} when it runs. */
 export interface ValidationContext {

--- a/packages/core/tests/_fakes.ts
+++ b/packages/core/tests/_fakes.ts
@@ -6,6 +6,7 @@
 import type { GraphHost } from "../src/graph_view.ts";
 import type { StateHost, StateStore } from "../src/state/store.ts";
 import type { RunRecord } from "../src/state/types.ts";
+import type { RunPlan } from "../src/run_plan.ts";
 import type { RemoteCacheStore } from "../src/remote_cache.ts";
 
 /**
@@ -228,5 +229,22 @@ export function runRecord(over: Partial<RunRecord> = {}): RunRecord {
     signals: {},
     events: [],
     ...over,
+  };
+}
+
+/**
+ * A {@link RunPlan} over `targets`, each with no dependencies — the plan a unit
+ * test hands an engine seam that requires one but is not exercising it.
+ *
+ * Pass names when the test asserts on the plan; the default empty plan says
+ * "this run planned nothing", which is the honest reading for a seam driven
+ * with no graph behind it.
+ */
+export function testPlan(targets: readonly string[] = []): RunPlan {
+  const planned = new Set(targets);
+  return {
+    targets: [...targets],
+    includes: (t) => planned.has(t),
+    dependenciesOf: () => [],
   };
 }

--- a/packages/core/tests/_fakes.ts
+++ b/packages/core/tests/_fakes.ts
@@ -233,18 +233,12 @@ export function runRecord(over: Partial<RunRecord> = {}): RunRecord {
 }
 
 /**
- * A {@link RunPlan} over `targets`, each with no dependencies — the plan a unit
- * test hands an engine seam that requires one but is not exercising it.
+ * The empty {@link RunPlan} — the plan a unit test hands an engine seam that
+ * requires one but is not exercising it. It says "this run planned nothing",
+ * which is the honest reading for a seam driven with no graph behind it.
  *
- * Pass names when the test asserts on the plan; the default empty plan says
- * "this run planned nothing", which is the honest reading for a seam driven
- * with no graph behind it.
+ * A test that asserts on a real plan builds one with `buildRunPlan` instead.
  */
-export function testPlan(targets: readonly string[] = []): RunPlan {
-  const planned = new Set(targets);
-  return {
-    targets: [...targets],
-    includes: (t) => planned.has(t),
-    dependenciesOf: () => [],
-  };
+export function testPlan(): RunPlan {
+  return { targets: [], includes: () => false, dependenciesOf: () => [] };
 }

--- a/packages/core/tests/cancel_test.ts
+++ b/packages/core/tests/cancel_test.ts
@@ -17,6 +17,8 @@ import {
 } from "../src/cancel.ts";
 import { resumeRun } from "../src/resume.ts";
 import type { OrderingEdge } from "../src/graph.ts";
+import { planGraph } from "../src/graph.ts";
+import { buildRunPlan } from "../src/run_plan.ts";
 import { FileSystemStateStore } from "../src/state/fs_store.ts";
 import {
   defaultStateHost,
@@ -1873,4 +1875,37 @@ Deno.test("without a redactor, a compensation failure message is kept verbatim",
   });
   assertEquals(outcome.failures.length, 1);
   assertEquals(outcome.failures[0].error, "exact diagnostic text");
+});
+
+Deno.test("a compensation reads the run's plan, not an empty one", async () => {
+  // `CompensationDeps.plan` promises a compensation body sees the graph this
+  // walk is ordered by. Every other cancel test passes the empty `testPlan()`,
+  // so nothing asserted the wiring: handing `runCompensations` an empty plan
+  // used to leave the whole suite green.
+  const seen: string[] = [];
+  class B extends Build {
+    rollback = target().executes((ctx) => {
+      seen.push([...ctx.plan().targets].sort().join(","));
+      seen.push(`includes(deploy)=${ctx.plan().includes("deploy")}`);
+    });
+    build = target().executes(() => {});
+    deploy = target()
+      .dependsOn(this.build)
+      .executes(() => {})
+      .onCancel(() => this.rollback);
+  }
+  const build = new B();
+  discoverTargets(build);
+  const { order, predecessors } = planGraph(build.deploy);
+  const record = craftRecord("deploy", {
+    build: { status: "succeeded", meta: {} },
+    deploy: { status: "succeeded", meta: {} },
+  });
+  await runCompensations(order, record, {
+    runId: "run",
+    plan: buildRunPlan(order, predecessors),
+    signals: new Map(),
+    reporter: { info: () => {}, error: () => {} },
+  });
+  assertEquals(seen, ["build,deploy", "includes(deploy)=true"]);
 });

--- a/packages/core/tests/cancel_test.ts
+++ b/packages/core/tests/cancel_test.ts
@@ -28,7 +28,7 @@ import type { RunRecord } from "../src/state/types.ts";
 import type { Reporter } from "../src/executor.ts";
 import { externalSignal } from "../src/wait.ts";
 import { withTemp } from "./_temp.ts";
-import { runRecord } from "./_fakes.ts";
+import { runRecord, testPlan } from "./_fakes.ts";
 import { withTempStore } from "./_store.ts";
 
 /** A run record scaffold for driving {@link runCompensations} directly. */
@@ -834,6 +834,7 @@ Deno.test("an in-flight (running) fan-out item is compensated; a stage with no o
   });
   const outcome = await runCompensations([build.deployBatch], record, {
     runId: "run",
+    plan: testPlan(),
     signals: new Map(),
     reporter: { info: () => {}, error: () => {} },
   });
@@ -862,6 +863,7 @@ Deno.test("a pending fan-out item (never started) is not compensated", async () 
   });
   const outcome = await runCompensations([build.deployBatch], record, {
     runId: "run",
+    plan: testPlan(),
     signals: new Map(),
     reporter: { info: () => {}, error: () => {} },
   });
@@ -890,6 +892,7 @@ Deno.test("a non-deterministic forEach list reports an unmatched recorded item",
   const { reporter, errors } = capturingReporter();
   const outcome = await runCompensations([build.deployBatch], record, {
     runId: "run",
+    plan: testPlan(),
     signals: new Map(),
     reporter,
   });
@@ -922,6 +925,7 @@ Deno.test("a forEach item list that throws at cancel is recorded, not fatal", as
   const { reporter } = capturingReporter();
   const outcome = await runCompensations([build.deployBatch], record, {
     runId: "run",
+    plan: testPlan(),
     signals: new Map(),
     reporter,
   });
@@ -957,6 +961,7 @@ Deno.test("an item .onCancel() thunk that throws or returns undefined is skipped
   const { reporter } = capturingReporter();
   const outcome = await runCompensations([build.deployBatch], record, {
     runId: "run",
+    plan: testPlan(),
     signals: new Map(),
     reporter,
   });
@@ -1012,6 +1017,7 @@ Deno.test("cancel runs a nested fan-out item's onCancel without false-warning", 
   const { reporter, errors } = capturingReporter();
   const outcome = await runCompensations([build.deployBatch], record, {
     runId: "run",
+    plan: testPlan(),
     signals: new Map(),
     reporter,
   });
@@ -1049,6 +1055,7 @@ Deno.test("a declared target reused as a fan-out stage keeps its own name at can
     record,
     {
       runId: "run",
+      plan: testPlan(),
       signals: new Map(),
       reporter: capturingReporter().reporter,
     },
@@ -1082,6 +1089,7 @@ Deno.test("a fan-out parent's own onCancel runs after its item compensations", a
   });
   await runCompensations([build.deployBatch], record, {
     runId: "run",
+    plan: testPlan(),
     signals: new Map(),
     reporter: { info: () => {}, error: () => {} },
   });
@@ -1357,6 +1365,7 @@ Deno.test("a degraded record compensates targets whose settlement was lost", asy
     record,
     {
       runId: "run",
+      plan: testPlan(),
       signals: new Map(),
       reporter: { info: (l) => void info.push(l), error: () => {} },
     },
@@ -1384,6 +1393,7 @@ Deno.test("a healthy record still skips a pending target's compensation", async 
   });
   const outcome = await runCompensations([build.deploy], record, {
     runId: "run",
+    plan: testPlan(),
     signals: new Map(),
     reporter: { info: () => {}, error: () => {} },
   });
@@ -1418,6 +1428,7 @@ Deno.test("a degraded record compensates a pending fan-out item", async () => {
   };
   const outcome = await runCompensations([build.deployBatch], record, {
     runId: "run",
+    plan: testPlan(),
     signals: new Map(),
     reporter: { info: () => {}, error: () => {} },
   });
@@ -1855,6 +1866,7 @@ Deno.test("without a redactor, a compensation failure message is kept verbatim",
   });
   const outcome = await runCompensations([build.deploy], record, {
     runId: "run",
+    plan: testPlan(),
     signals: new Map(),
     reporter: { info: () => {}, error: () => {} },
     // no redactor

--- a/packages/core/tests/execute_cancel_test.ts
+++ b/packages/core/tests/execute_cancel_test.ts
@@ -10,6 +10,7 @@
  * @module
  */
 
+import { testPlan } from "./_fakes.ts";
 import { assertEquals } from "./_assert.ts";
 import { Build, discoverTargets } from "../src/build.ts";
 import { target } from "../src/target.ts";
@@ -69,6 +70,7 @@ Deno.test("the settlement stops when the cancel changes hands during the drain",
 
     const settlement = await settleCancelledRun({
       writer,
+      plan: testPlan(),
       life: makeLifecycle(
         build,
         [],

--- a/packages/core/tests/execute_plan_test.ts
+++ b/packages/core/tests/execute_plan_test.ts
@@ -10,6 +10,7 @@
  * @module
  */
 
+import { testPlan } from "./_fakes.ts";
 import { assertEquals } from "./_assert.ts";
 import { Build, discoverTargets } from "../src/build.ts";
 import { target } from "../src/target.ts";
@@ -139,7 +140,7 @@ Deno.test("conditionSkips keeps triggered targets and tolerates an unbound depen
     b.optional,
     b.fire,
     b.root,
-  ]);
+  ], testPlan());
   // The pruned target and the dependency only it needed are skipped; the
   // target reachable through `triggers` survives (the walk follows trigger
   // edges, not just dependencies); the unbound forward reference is ignored.

--- a/packages/core/tests/lock_test.ts
+++ b/packages/core/tests/lock_test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 the Zuke contributors
 // SPDX-License-Identifier: MIT
 
+import { testPlan } from "./_fakes.ts";
 import {
   assertEquals,
   assertRejects,
@@ -66,6 +67,7 @@ class FakeStore implements StateStore {
 function envWith(store: StateStore, signal?: AbortSignal): RunEnv {
   return {
     runId: "run-2",
+    plan: testPlan(),
     signal: signal ?? new AbortController().signal,
     store,
     actor: "bob",

--- a/packages/core/tests/run_plan_test.ts
+++ b/packages/core/tests/run_plan_test.ts
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Unit tests for {@link buildRunPlan} — the view of a run's resolved shape that
+ * every target body and every condition reads through `ctx.plan()`.
+ *
+ * @module
+ */
+
+import { assertEquals } from "./_assert.ts";
+import { Build, discoverTargets } from "../src/build.ts";
+import { target } from "../src/target.ts";
+import { planGraph } from "../src/graph.ts";
+import { buildRunPlan } from "../src/run_plan.ts";
+
+/** A diamond: `base` under both `left` and `right`, both under `top`. */
+class Diamond extends Build {
+  base = target().executes(() => {});
+  left = target().dependsOn(this.base).executes(() => {});
+  right = target().dependsOn(this.base).executes(() => {});
+  top = target().dependsOn(this.left, this.right).executes(() => {});
+}
+
+/** The plan for `Diamond` rooted at the named target. */
+function planFor(root: "top" | "left"): ReturnType<typeof buildRunPlan> {
+  const b = new Diamond();
+  const targets = discoverTargets(b);
+  const node = targets.get(root);
+  if (node === undefined) throw new Error(`no target "${root}"`);
+  const { order, predecessors } = planGraph(node);
+  return buildRunPlan(order, predecessors);
+}
+
+Deno.test("the plan lists every reached target, dependencies before dependents", () => {
+  // Sibling order is the graph's business (and deliberately not pinned by the
+  // graph suite either); what the plan owes a reader is the full set and a
+  // valid topological order.
+  const targets = planFor("top").targets;
+  assertEquals([...targets].sort(), ["base", "left", "right", "top"]);
+  assertEquals(targets[0], "base");
+  assertEquals(targets[3], "top");
+});
+
+Deno.test("includes reports the planned set, and is false for an unknown name", () => {
+  const plan = planFor("top");
+  assertEquals(plan.includes("base"), true);
+  assertEquals(plan.includes("top"), true);
+  // Probing for an optional target must not need a guard.
+  assertEquals(plan.includes("nope"), false);
+});
+
+Deno.test("the plan covers only what the root reaches", () => {
+  // Rooted at `left`, the run never planned `right` or `top` — so a body
+  // deciding whether its work is needed gets the answer for *this* run, not for
+  // everything the build could do.
+  const plan = planFor("left");
+  assertEquals(plan.targets, ["base", "left"]);
+  assertEquals(plan.includes("right"), false);
+  assertEquals(plan.includes("top"), false);
+});
+
+Deno.test("dependenciesOf reports a target's direct predecessors", () => {
+  const plan = planFor("top");
+  assertEquals([...plan.dependenciesOf("top")].sort(), ["left", "right"]);
+  assertEquals(plan.dependenciesOf("left"), ["base"]);
+  // A root of the graph has none, and so does a name that is not in the plan —
+  // which is why `includes` is the way to tell those two apart.
+  assertEquals(plan.dependenciesOf("base"), []);
+  assertEquals(plan.dependenciesOf("nope"), []);
+});
+
+Deno.test("the plan honours soft ordering edges", () => {
+  // `before`/`after` are part of what determines when a target may start, so a
+  // plan that reported only hard dependencies would understate the constraint.
+  class B extends Build {
+    a = target().executes(() => {});
+    b = target().after(this.a).executes(() => {});
+    root = target().dependsOn(this.a, this.b).executes(() => {});
+  }
+  const instance = new B();
+  const targets = discoverTargets(instance);
+  const root = targets.get("root");
+  if (root === undefined) throw new Error("no root");
+  const { order, predecessors } = planGraph(root);
+  const plan = buildRunPlan(order, predecessors);
+  assertEquals(plan.targets, ["a", "b", "root"]);
+  assertEquals(plan.dependenciesOf("b"), ["a"]);
+});
+
+Deno.test("the plan is deterministic across builds of the same graph", () => {
+  // Every body and condition in a run reads one plan, and a resumed run rebuilds
+  // it in another process — so two plans of the same graph must not disagree.
+  assertEquals(planFor("top").targets, planFor("top").targets);
+  assertEquals(
+    planFor("top").dependenciesOf("top"),
+    planFor("top").dependenciesOf("top"),
+  );
+});

--- a/packages/core/tests/run_plan_test.ts
+++ b/packages/core/tests/run_plan_test.ts
@@ -88,12 +88,14 @@ Deno.test("the plan honours soft ordering edges", () => {
   assertEquals(plan.dependenciesOf("b"), ["a"]);
 });
 
-Deno.test("the plan is deterministic across builds of the same graph", () => {
-  // Every body and condition in a run reads one plan, and a resumed run rebuilds
-  // it in another process — so two plans of the same graph must not disagree.
-  assertEquals(planFor("top").targets, planFor("top").targets);
-  assertEquals(
-    planFor("top").dependenciesOf("top"),
-    planFor("top").dependenciesOf("top"),
-  );
+Deno.test("the plan's arrays are frozen, so one body cannot corrupt another", () => {
+  // One plan object is shared by every body in a run, and bodies run
+  // concurrently. `readonly` is erased at runtime and does not exist at all for
+  // a JavaScript consumer, so without freezing, a body that sorts the array it
+  // was handed silently reorders what every other body reads.
+  const plan = planFor("top");
+  assertEquals(Object.isFrozen(plan.targets), true);
+  assertEquals(Object.isFrozen(plan.dependenciesOf("top")), true);
+  // The shared empty answer for an unknown name is frozen too.
+  assertEquals(Object.isFrozen(plan.dependenciesOf("nope")), true);
 });

--- a/packages/core/tests/scheduler_test.ts
+++ b/packages/core/tests/scheduler_test.ts
@@ -29,7 +29,7 @@ import { execute } from "../src/executor.ts";
 import { resumeRun } from "../src/resume.ts";
 import { externalSignal } from "../src/wait.ts";
 import { withTemp } from "./_temp.ts";
-import { runRecord } from "./_fakes.ts";
+import { runRecord, testPlan } from "./_fakes.ts";
 import { withTempStore } from "./_store.ts";
 
 const NOW = "2026-08-10T12:00:00.000Z";
@@ -42,6 +42,7 @@ function contextFor(
   const lines: string[] = [];
   const env: RunEnv = {
     runId: "run-1",
+    plan: testPlan(),
     signal: new AbortController().signal,
     actor: "tester",
     signals: new Map(),

--- a/packages/core/tests/target_test.ts
+++ b/packages/core/tests/target_test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 the Zuke contributors
 // SPDX-License-Identifier: MIT
 
+import { testPlan } from "./_fakes.ts";
 import { assertEquals, assertThrows } from "./_assert.ts";
 import { Build, discoverGroups, discoverTargets } from "../src/build.ts";
 import { Group, group, target, TargetBuilder } from "../src/target.ts";
@@ -106,9 +107,10 @@ Deno.test("inputs, outputs, and onlyWhen record their configuration", () => {
   assertEquals(t.inputs_, ["src", "deno.json"]);
   assertEquals(t.outputs_, ["dist"]);
   assertEquals(t.onlyWhen_.length, 1);
-  assertEquals(t.onlyWhen_[0](), false);
+  const conditionCtx = { target: "t", plan: () => testPlan() };
+  assertEquals(t.onlyWhen_[0](conditionCtx), false);
   allow = true;
-  assertEquals(t.onlyWhen_[0](), true);
+  assertEquals(t.onlyWhen_[0](conditionCtx), true);
 });
 
 Deno.test("cacheKey, produces, consumes, always, whenSkipped record config", () => {

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/.codex-plugin/plugin.json
+++ b/plugins/zuke/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/skills/zuke-write-build/SKILL.md
+++ b/plugins/zuke/skills/zuke-write-build/SKILL.md
@@ -120,7 +120,10 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   `.executes((ctx) => …)` — with `ctx.runId`, `ctx.initiator` (who asked for the
   run, unchanged by a resume), `ctx.target`, `ctx.signal` (an
   `AbortSignal` fired when the run is cancelled; a plain `` $`…` `` in the body
-  is `SIGTERM`'d automatically), `ctx.state`, `ctx.dryRun`, and
+  is `SIGTERM`'d automatically), `ctx.state`, `ctx.dryRun`, `ctx.plan()` (the
+  run's planned shape — `targets`, `includes(name)`, `dependenciesOf(name)` — so
+  a body can ask whether `deploy` was part of what was asked for; it reports the
+  plan, never what will actually execute, which is `ctx.outcomeOf(name)`), and
   `ctx.reportSummary({ … })` (`key: value` notes on the target's own row of
   the Build Summary; every test-runner wrapper — `DenoTasks.test`,
   `VitestTasks.run`, `JestTasks.run`, `BunTasks.test`, `NodeTasks.test`,

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -24,7 +24,7 @@ that declares only `.effect(...)` each legitimately have no `.executes(...)`.
 | `.dependentFor(...t)`                                                                                    | Reverse of `dependsOn`: make this a prerequisite of others.                                                                                               |
 | `.inputs(...p)` / `.outputs(...p)`                                                                       | Incremental cache: skip when inputs unchanged and outputs exist.                                                                                          |
 | `.cacheKey(fn)`                                                                                          | Add a non-file value (version, git sha, param) to the cache fingerprint.                                                                                  |
-| `.onlyWhen(cond)`                                                                                        | Run only when the (possibly async) predicate holds, else skip.                                                                                            |
+| `.onlyWhen(cond)`                                                                                        | Run only when the (possibly async) predicate holds, else skip. The predicate may take a context: `(ctx) => ctx.plan().includes("deploy")`.                 |
 | `.whenSkipped("skip-dependencies")`                                                                      | When `onlyWhen` skips this target, also skip deps no other planned target needs. Condition is evaluated up front, so it must not read run-produced state. |
 | `.requires(...params)`                                                                                   | Fail unless the listed parameters resolved to a value.                                                                                                    |
 | `.retry(times, delayMs?)`                                                                                | Retry the body on failure.                                                                                                                                |
@@ -156,6 +156,9 @@ deploy = target().executes(async (ctx) => {
   ctx.outcomeOf("checks")?.status; // one target's settled outcome, or undefined
   ctx.outcomeOf("test")?.summary; // its Build Summary notes (durable, e.g. Tests/Passed)
   ctx.outcomes(); // every outcome settled SO FAR, keyed by dotted name
+  ctx.plan().targets; // every target THIS run planned, in execution order
+  ctx.plan().includes("deploy"); // was `deploy` part of what was asked for?
+  ctx.plan().dependenciesOf("test"); // what must finish before `test` starts
   ctx.reportSummary({ Version: "3.6.2" }); // a note on THIS row of the Build Summary
 });
 ```

--- a/skills/zuke-write-build/SKILL.md
+++ b/skills/zuke-write-build/SKILL.md
@@ -120,7 +120,10 @@ it cannot answer "does one exist for this tool?"; only the catalogue
   `.executes((ctx) => …)` — with `ctx.runId`, `ctx.initiator` (who asked for the
   run, unchanged by a resume), `ctx.target`, `ctx.signal` (an
   `AbortSignal` fired when the run is cancelled; a plain `` $`…` `` in the body
-  is `SIGTERM`'d automatically), `ctx.state`, `ctx.dryRun`, and
+  is `SIGTERM`'d automatically), `ctx.state`, `ctx.dryRun`, `ctx.plan()` (the
+  run's planned shape — `targets`, `includes(name)`, `dependenciesOf(name)` — so
+  a body can ask whether `deploy` was part of what was asked for; it reports the
+  plan, never what will actually execute, which is `ctx.outcomeOf(name)`), and
   `ctx.reportSummary({ … })` (`key: value` notes on the target's own row of
   the Build Summary; every test-runner wrapper — `DenoTasks.test`,
   `VitestTasks.run`, `JestTasks.run`, `BunTasks.test`, `NodeTasks.test`,

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -24,7 +24,7 @@ that declares only `.effect(...)` each legitimately have no `.executes(...)`.
 | `.dependentFor(...t)`                                                                                    | Reverse of `dependsOn`: make this a prerequisite of others.                                                                                               |
 | `.inputs(...p)` / `.outputs(...p)`                                                                       | Incremental cache: skip when inputs unchanged and outputs exist.                                                                                          |
 | `.cacheKey(fn)`                                                                                          | Add a non-file value (version, git sha, param) to the cache fingerprint.                                                                                  |
-| `.onlyWhen(cond)`                                                                                        | Run only when the (possibly async) predicate holds, else skip.                                                                                            |
+| `.onlyWhen(cond)`                                                                                        | Run only when the (possibly async) predicate holds, else skip. The predicate may take a context: `(ctx) => ctx.plan().includes("deploy")`.                 |
 | `.whenSkipped("skip-dependencies")`                                                                      | When `onlyWhen` skips this target, also skip deps no other planned target needs. Condition is evaluated up front, so it must not read run-produced state. |
 | `.requires(...params)`                                                                                   | Fail unless the listed parameters resolved to a value.                                                                                                    |
 | `.retry(times, delayMs?)`                                                                                | Retry the body on failure.                                                                                                                                |
@@ -156,6 +156,9 @@ deploy = target().executes(async (ctx) => {
   ctx.outcomeOf("checks")?.status; // one target's settled outcome, or undefined
   ctx.outcomeOf("test")?.summary; // its Build Summary notes (durable, e.g. Tests/Passed)
   ctx.outcomes(); // every outcome settled SO FAR, keyed by dotted name
+  ctx.plan().targets; // every target THIS run planned, in execution order
+  ctx.plan().includes("deploy"); // was `deploy` part of what was asked for?
+  ctx.plan().dependenciesOf("test"); // what must finish before `test` starts
   ctx.reportSummary({ Version: "3.6.2" }); // a note on THIS row of the Build Summary
 });
 ```

--- a/tests/integration/run_plan_test.ts
+++ b/tests/integration/run_plan_test.ts
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Integration tests for `ctx.plan()` — the resolved run shape, read through a
+ * real build driven by the CLI.
+ *
+ * The unit tests cover the view itself; these prove the engine hands the same
+ * plan to every place that can read one, including the two different moments a
+ * condition is evaluated.
+ *
+ * @module
+ */
+
+import { assertEquals } from "../../packages/core/tests/_assert.ts";
+import { Build, target } from "../../packages/core/mod.ts";
+import { runCli } from "./_harness.ts";
+
+Deno.test("a body reads the run's planned targets and their dependencies", async () => {
+  const seen: string[] = [];
+  class B extends Build {
+    lint = target().executes(() => {});
+    unit = target().dependsOn(this.lint).executes(() => {});
+    report = target().dependsOn(this.unit).executes((ctx) => {
+      seen.push(`targets=${[...ctx.plan().targets].sort().join(",")}`);
+      seen.push(`deps(unit)=${ctx.plan().dependenciesOf("unit").join(",")}`);
+      seen.push(`includes(lint)=${ctx.plan().includes("lint")}`);
+    });
+  }
+  const { code, err } = await runCli(B, ["report"]);
+  assertEquals(code, 0, err);
+  assertEquals(seen, [
+    "targets=lint,report,unit",
+    "deps(unit)=lint",
+    "includes(lint)=true",
+  ]);
+});
+
+Deno.test("the plan covers only what this run's root reaches", async () => {
+  // The question a body actually asks — "was `deploy` asked for?" — has to be
+  // answered for *this* run, not for everything the build could do.
+  const seen: string[] = [];
+  class B extends Build {
+    build = target().executes((ctx) => {
+      seen.push(`deploy=${ctx.plan().includes("deploy")}`);
+    });
+    deploy = target().dependsOn(this.build).executes(() => {});
+  }
+
+  const first = await runCli(B, ["build"]);
+  assertEquals(first.code, 0, first.err);
+  const second = await runCli(B, ["deploy"]);
+  assertEquals(second.code, 0, second.err);
+
+  // Same body, same build, two runs — and the answer differs, because the plan
+  // describes the run rather than the class.
+  assertEquals(seen, ["deploy=false", "deploy=true"]);
+});
+
+Deno.test("a condition reads the same plan its target's body does", async () => {
+  const fromCondition: string[] = [];
+  const fromBody: string[] = [];
+  class B extends Build {
+    setup = target().executes(() => {});
+    gated = target()
+      .dependsOn(this.setup)
+      .onlyWhen((ctx) => {
+        fromCondition.push([...ctx.plan().targets].sort().join(","));
+        return ctx.plan().includes("setup");
+      })
+      .executes((ctx) => {
+        fromBody.push([...ctx.plan().targets].sort().join(","));
+      });
+  }
+  const { code, err } = await runCli(B, ["gated"]);
+  assertEquals(code, 0, err);
+  assertEquals(fromCondition, ["gated,setup"]);
+  assertEquals(fromBody, ["gated,setup"]);
+});
+
+Deno.test("a skip-dependencies condition sees one plan at both evaluations", async () => {
+  // The reason the plan reports graph facts and not "will this run": a
+  // `whenSkipped("skip-dependencies")` condition is evaluated once up front to
+  // decide what the run prunes, and again when the scheduler reaches the
+  // target. A view of what *will* run would answer differently each time — and
+  // at the first call it would be circular, since this condition is one of the
+  // things deciding it.
+  const seen: string[] = [];
+  class B extends Build {
+    helper = target().executes(() => {});
+    gated = target()
+      .dependsOn(this.helper)
+      .whenSkipped("skip-dependencies")
+      .onlyWhen((ctx) => {
+        seen.push([...ctx.plan().targets].sort().join(","));
+        return true;
+      })
+      .executes(() => {});
+  }
+  const { code, err } = await runCli(B, ["gated"]);
+  assertEquals(code, 0, err);
+  // Evaluated twice, and the two calls agree.
+  assertEquals(seen.length, 2);
+  assertEquals(seen[0], "gated,helper");
+  assertEquals(seen[1], "gated,helper");
+});
+
+Deno.test("a zero-argument condition still compiles and runs", async () => {
+  // The compatibility promise: widening the callback's parameter list must not
+  // disturb the conditions every existing build already declares.
+  let ran = false;
+  class B extends Build {
+    only = target()
+      .onlyWhen(() => true)
+      .executes(() => {
+        ran = true;
+      });
+  }
+  const { code, err } = await runCli(B, ["only"]);
+  assertEquals(code, 0, err);
+  assertEquals(ran, true);
+});

--- a/tests/integration/run_plan_test.ts
+++ b/tests/integration/run_plan_test.ts
@@ -13,8 +13,14 @@
  */
 
 import { assertEquals } from "../../packages/core/tests/_assert.ts";
-import { Build, target } from "../../packages/core/mod.ts";
-import { runCli } from "./_harness.ts";
+import {
+  Build,
+  defaultStateHost,
+  externalSignal,
+  FileSystemStateStore,
+  target,
+} from "../../packages/core/mod.ts";
+import { runCli, withStateDir } from "./_harness.ts";
 
 Deno.test("a body reads the run's planned targets and their dependencies", async () => {
   const seen: string[] = [];
@@ -119,4 +125,103 @@ Deno.test("a zero-argument condition still compiles and runs", async () => {
   const { code, err } = await runCli(B, ["only"]);
   assertEquals(code, 0, err);
   assertEquals(ran, true);
+});
+
+Deno.test("a fan-out's sub-targets are not in the plan, though they have outcomes", async () => {
+  // The one place the plan reports LESS than the outcomes do. `.forEach()`
+  // expands while the run executes, after the graph is planned — so a
+  // sub-target has a summary row and an outcome, but was never in the plan.
+  // Documented in docs/run-context.md; pinned here so it cannot drift into a
+  // claim the code does not keep.
+  const seen: string[] = [];
+  class B extends Build {
+    fan = target().forEach(
+      () => ["us"],
+      () => ({ prep: target().executes(() => {}) }),
+    );
+    top = target().dependsOn(this.fan).executes((ctx) => {
+      const sub = "fan[us].prep";
+      seen.push(`outcome=${ctx.outcomeOf(sub)?.status}`);
+      seen.push(`includes=${ctx.plan().includes(sub)}`);
+      seen.push(`targets=${[...ctx.plan().targets].sort().join(",")}`);
+    });
+  }
+  const { code, err } = await runCli(B, ["top"]);
+  assertEquals(code, 0, err);
+  assertEquals(seen, [
+    // It ran, and the record knows it...
+    "outcome=succeeded",
+    // ...but the plan never had it, and says so rather than guessing.
+    "includes=false",
+    // Only the fan-out target that produced it is planned.
+    "targets=fan,top",
+  ]);
+});
+
+Deno.test("a compensation run by `zuke cancel` reads the run's plan", async () => {
+  // The wiring a unit test cannot reach: `cancelRun` re-plans the graph in the
+  // cancelling process and hands that plan to the walk. Driving
+  // `runCompensations` directly with a plan the test built proves nothing about
+  // it — replacing cancel.ts's plan with an empty one left that green.
+  await withStateDir(async () => {
+    const log: string[] = [];
+    class CD extends Build {
+      rollback = target().executes((ctx) => {
+        log.push(`plan:${[...ctx.plan().targets].sort().join(",")}`);
+        log.push(`includes(deploy):${ctx.plan().includes("deploy")}`);
+      });
+      deploy = target()
+        .executes((ctx) => ctx.state.set({ slot: "sit-7" }))
+        .onCancel(() => this.rollback);
+      gate = target()
+        .dependsOn(this.deploy)
+        .waitsFor((s) => s.on(externalSignal("approved")));
+      promote = target().dependsOn(this.gate).executes(() => {});
+    }
+
+    const first = await runCli(CD, ["promote"]);
+    assertEquals(first.code, 0, first.err);
+    const store = new FileSystemStateStore(
+      Deno.env.get("ZUKE_STATE_DIR") ?? "",
+      defaultStateHost,
+    );
+    const runs = await store.listRuns({});
+    assertEquals(runs.length, 1);
+
+    const cancelled = await runCli(CD, [
+      "cancel",
+      runs[0].id,
+      "--actor",
+      "ops",
+    ]);
+    assertEquals(cancelled.code, 0, cancelled.err);
+    // The compensation saw the real graph, not an empty plan.
+    assertEquals(log, ["plan:deploy,gate,promote", "includes(deploy):true"]);
+  });
+});
+
+Deno.test("a compensation run by an in-process cancel reads the run's plan", async () => {
+  // The other cancel path: Ctrl-C / an aborted signal settles the run in the
+  // executing process, through `settleCancelledRun` rather than `cancelRun`.
+  // It is wired separately, so it needs its own proof.
+  await withStateDir(async () => {
+    const log: string[] = [];
+    const controller = new AbortController();
+    class B extends Build {
+      rollback = target().executes((ctx) => {
+        log.push(`plan:${[...ctx.plan().targets].sort().join(",")}`);
+      });
+      deploy = target()
+        .executes(() => {
+          controller.abort();
+        })
+        .onCancel(() => this.rollback);
+      promote = target().dependsOn(this.deploy).executes(() => {});
+    }
+    const { code } = await runCli(B, ["promote"], {
+      signal: controller.signal,
+    });
+    assertEquals(code, 1);
+    assertEquals(log, ["plan:deploy,promote"]);
+  });
 });


### PR DESCRIPTION
Closes #532.

## What this adds

A target body and a condition could read plenty about a run — its id, its initiator, another target's state, another target's outcome — but nothing about the shape of the run itself. There was no way to ask whether `deploy` was part of what was asked for, or what a target depends on, without re-deriving the graph by hand and drifting from the planner.

This adds a `RunPlan` view, built once per run from the graph, reachable as a `plan` accessor on the context of a target body, a compensation, and a condition. It reports three things: the planned targets in execution order, whether a name is in the planned set, and a target's direct predecessors.

## Why it reports the graph and not "will this run"

The obvious accessor to write would be a `willRun` accessor. It cannot be written honestly.

A condition on a `whenSkipped("skip-dependencies")` target is evaluated **twice** — once up front to decide what the run prunes, and again when the scheduler reaches the target. A probe confirmed both calls happen for one declared condition. So "will it run" would have two truthful answers at two different moments, and at the earlier one it would be circular: whether the target runs is still being decided by the very condition asking.

Reporting the planned graph gives one answer at every call site. What actually became of a target stays where it already lived, on the context's `outcomeOf` accessor.

## Two things the plan deliberately does not claim

**It does not cross processes.** Within one process it is fixed — two bodies agree, and both evaluations of a condition agree. A second process re-resolves the graph from the build class it was handed, so it can legitimately differ: a resume runs against today's class, `--force-graph` exists precisely for that case, and a lazy ordering provider may answer differently or be degraded to base order when unreachable. The first draft of this change asserted the opposite in three places and enforced it nowhere.

**It does not include fan-out sub-targets.** A `forEach` fan-out expands while the run executes, after the graph is planned, so a sub-target has an outcome and a summary row but was never in the plan. This is the one place the plan reports less than the outcomes do, and it is now documented and pinned by a test.

## Compatibility

Widening the condition callback's parameter list keeps every existing zero-argument condition compiling, which is how conditions are written. There is one edge it does not cover, stated plainly rather than glossed: a consumer who **calls** a `Condition` value itself, or assigns one to a zero-argument type, needs a change. That requires reaching for the internal `onlyWhen` field, a trailing-underscore internal-by-convention field, or building a registry typed with the exported alias. Shipping as a minor, consistent with the four previous features that added required members to the target context.

## Review

Three adversarial reviewers attacked this before the PR was opened, on separate lenses: semantic honesty across every execution path, public-API compatibility, and shared mutable state plus the repo's own guidelines. Every finding was reproduced against real code before being accepted, and one claim of dead code was checked twice after a contaminated first measurement.

They found a real defect and a pattern of overclaiming. The defect: one plan object is shared by every concurrently-running body, and the readonly modifier is erased at runtime, so a body that sorted the array it was handed silently reordered what every other body read. A JavaScript consumer needed no cast at all. The arrays are frozen now, so the attempt raises a loud TypeError.

They also found that both cancel paths hand the compensation walk a plan and neither was covered — replacing either with an empty plan left the whole suite green. A unit test cannot reach that wiring, because driving the walk directly supplies its own plan, so both are now covered through the real entry points and each was mutation-checked.

Refuted and left alone: condition skips, `--affected`, forced outcomes, dry runs and groups do not disturb the plan; the two condition evaluations do agree; and the second inline context literal is not a guideline 12 duplication.

## Testing

Unit tests for the view, integration tests through the CLI for a body, a condition, both evaluations of a `skip-dependencies` condition, a zero-argument condition, the fan-out exclusion, and both cancel paths. Gate green at 23/23: 4404 tests, 98.5% lines, 97.4% branches.
