### PR TITLE
chore(docs): document what a compensation and a remediation can read

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.50.0",
+      "version": "0.51.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -418,6 +418,23 @@ What a cancellation does:
   body gets a normal `ctx` whose `ctx.state` exposes **the original target's**
   metadata — the `deploy` above rolls back from exactly the `slot` it recorded.
   So persist what a rollback needs in `ctx.state` at the time you do the work.
+
+  Two details worth knowing before you need them, because a rollback is a bad
+  place to be surprised:
+
+  `ctx.target` names the **compensation** (`rollback`), while `ctx.state` holds
+  the **compensated** target's meta (`deploy`'s). Those are deliberately
+  different targets. `ctx.stateOf(ctx.target)` is the same handle as `ctx.state`,
+  as everywhere else — but `ctx.stateOf("deploy")`, asking for the compensated
+  target **by name**, reads **empty**. So does every other target. A compensation
+  runs off the durable graph rather than inside the run, so `ctx.state` is the
+  only state it is given; reach for it, not for `stateOf`.
+
+  Writes merge into that seeded meta and stay **in memory** — the run is ending,
+  so nothing a compensation records is persisted. What does still work is
+  `ctx.outcomeOf(...)`, which reads the durable record, so a rollback can ask
+  what actually happened to the run it is undoing. A compensation is not itself
+  a planned target, so it does not appear in `ctx.plan()`.
 - **A live run stops.** Cancelling a run another process is executing flips it
   to `cancelling`; the owner observes that on its next state write and aborts —
   its in-flight `$` commands get SIGTERM through the ambient signal, releasing

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -419,22 +419,33 @@ What a cancellation does:
   metadata — the `deploy` above rolls back from exactly the `slot` it recorded.
   So persist what a rollback needs in `ctx.state` at the time you do the work.
 
-  Two details worth knowing before you need them, because a rollback is a bad
-  place to be surprised:
+  The precise rule, because a rollback is a bad place to be surprised:
+  **`ctx.state` is seeded with the meta of the target the compensation step is
+  _for_** — and which target that is depends on how the step was created.
 
-  `ctx.target` names the **compensation** (`rollback`), while `ctx.state` holds
-  the **compensated** target's meta (`deploy`'s). Those are deliberately
-  different targets. `ctx.stateOf(ctx.target)` is the same handle as `ctx.state`,
-  as everywhere else — but `ctx.stateOf("deploy")`, asking for the compensated
-  target **by name**, reads **empty**. So does every other target. A compensation
-  runs off the durable graph rather than inside the run, so `ctx.state` is the
-  only state it is given; reach for it, not for `stateOf`.
+  With `.onCancel(...)`, the step is for the target being undone. So `ctx.target`
+  names the **compensation** (`rollback`) while `ctx.state` holds **`deploy`'s**
+  meta: deliberately two different targets.
+
+  With a timed-out wait's `.onTimeout(() => this.cleanup)`, the named target
+  compensates **itself** — the step is for `cleanup`, so `ctx.state` is
+  `cleanup`'s **own** meta. If `cleanup` never ran forward in the run, that is
+  `{}`. A body written for the `.onCancel` shape, reaching for the deployed
+  target's slot, finds nothing there.
+
+  One invariant spans both: **`ctx.stateOf(ctx.target)` is the same handle as
+  `ctx.state`, and every other name reads empty.** So under `.onCancel`,
+  `ctx.stateOf("deploy")` — asking for the compensated target by name — is
+  empty even though `ctx.state` is holding exactly that target's meta. A
+  compensation runs off the durable graph rather than inside the run: reach for
+  `ctx.state`, not for `stateOf`.
 
   Writes merge into that seeded meta and stay **in memory** — the run is ending,
-  so nothing a compensation records is persisted. What does still work is
-  `ctx.outcomeOf(...)`, which reads the durable record, so a rollback can ask
-  what actually happened to the run it is undoing. A compensation is not itself
-  a planned target, so it does not appear in `ctx.plan()`.
+  so nothing a compensation records is persisted, on either cancel path. What
+  does still work is `ctx.outcomeOf(...)`, which reads the durable record, so a
+  rollback can ask what actually happened to the run it is undoing; a target
+  that never ran reads `undefined`. `ctx.plan()` is the whole run's plan, so a
+  compensation appears in it exactly when it is also a target in the graph.
 - **A live run stops.** Cancelling a run another process is executing flips it
   to `cancelling`; the owner observes that on its next state write and aborts —
   its in-flight `$` commands get SIGTERM through the ambient signal, releasing

--- a/docs/self-healing.md
+++ b/docs/self-healing.md
@@ -43,6 +43,20 @@ await run(CI);
 Any object with a `remediate` method qualifies, so `recoverWith` is not
 AI-specific (a deterministic "run `deno fmt`, then retry" remediation is valid).
 
+### What a remediation is given
+
+A remediation receives a `RemediationContext` carrying exactly three things: the
+failed target's name, the 1-based `attempt` number, and the `error` itself. When
+the target failed through the shell, that error is a `CommandError` carrying the
+failed command and its captured `stderr` — which is where a fixer gets what it
+needs to diagnose.
+
+There is **no state handle**. Unlike a target body or a compensation, a
+remediation cannot read the target's durable metadata, and that is deliberate
+rather than an omission: the failure carries the command and its output, which
+is what a fix is derived from. If a remediation needs a value the body computed,
+close over it in the build class rather than looking for it on the context.
+
 ### Per-target or global
 
 Attach a fixer to one target with `.recoverWith(...)`, or override

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "zuke",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build)."
 }

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/.codex-plugin/plugin.json
+++ b/plugins/zuke/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -442,11 +442,15 @@ class CD extends Build {
 
 - The compensation body's `ctx.state` exposes **the original target's**
   persisted metadata (persist what a rollback needs in `ctx.state` when you do
-  the work). Note `ctx.target` names the **compensation** while `ctx.state`
-  holds the **compensated** target's meta, and `ctx.stateOf("<compensated>")`
-  reads **empty** — `ctx.state` is the only state a compensation gets. Its
-  writes stay in memory (the run is ending). `ctx.outcomeOf(...)` does work; a
-  compensation is not in `ctx.plan()`.
+  the work). `ctx.state` is seeded with the meta of the target the step is
+  **for**: under `.onCancel` that is the compensated target (so `ctx.target`
+  names the compensation but `ctx.state` holds `deploy`'s meta), while a
+  timed-out `.onTimeout(() => this.cleanup)` makes `cleanup` compensate
+  **itself** — its own meta, `{}` if it never ran forward. One rule spans both:
+  `ctx.stateOf(ctx.target)` is `ctx.state`, every other name reads **empty**
+  (so `stateOf("deploy")` is empty under `.onCancel`). Writes stay in memory.
+  `ctx.outcomeOf(...)` works; `ctx.plan()` is the whole run's plan, so a
+  compensation is in it only when it is also a graph target.
 - Cancel with `zuke cancel <id>`, `Ctrl-C`/`SIGTERM`, or the MCP `cancel_run`
   tool (all run the same walk). A live run aborts on its next state write.
 - A compensation that throws is recorded but does **not** stop the walk (cleanup

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -39,7 +39,7 @@ that declares only `.effect(...)` each legitimately have no `.executes(...)`.
 | `.unlisted()`                                                                                            | Hide from `--list`/`--help`; still runnable by name.                                                                                                      |
 | `.dryRunnable()`                                                                                         | Run this body under `--dry-run` with `$` in echo mode (prints argv, no spawn); others stay skipped.                                                       |
 | `.validateBefore(...v)` / `.validateAfter(...v)`                                                         | Run `Validation` checks around the body; a throw fails the target.                                                                                        |
-| `.recoverWith(...r)` / `.recoverAttempts(n)`                                                             | Run `Remediation`s if the body fails (self-healing); re-run when one asks to. See AI section.                                                             |
+| `.recoverWith(...r)` / `.recoverAttempts(n)`                                                             | Run `Remediation`s if the body fails (self-healing); re-run when one asks to. A remediation gets the target name, attempt and error — **no state handle**. |
 | `.partOf(group)`                                                                                         | Join a parallel batch (see `group()`).                                                                                                                    |
 | `.produces(...p)` / `.consumes(...t)`                                                                    | Declare and consume artifact paths.                                                                                                                       |
 | `.readOnly()`                                                                                            | Advertise the target as query-only over MCP (`readOnlyHint` instead of `destructiveHint`).                                                                |
@@ -442,7 +442,11 @@ class CD extends Build {
 
 - The compensation body's `ctx.state` exposes **the original target's**
   persisted metadata (persist what a rollback needs in `ctx.state` when you do
-  the work).
+  the work). Note `ctx.target` names the **compensation** while `ctx.state`
+  holds the **compensated** target's meta, and `ctx.stateOf("<compensated>")`
+  reads **empty** — `ctx.state` is the only state a compensation gets. Its
+  writes stay in memory (the run is ending). `ctx.outcomeOf(...)` does work; a
+  compensation is not in `ctx.plan()`.
 - Cancel with `zuke cancel <id>`, `Ctrl-C`/`SIGTERM`, or the MCP `cancel_run`
   tool (all run the same walk). A live run aborts on its next state write.
 - A compensation that throws is recorded but does **not** stop the walk (cleanup

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -442,11 +442,15 @@ class CD extends Build {
 
 - The compensation body's `ctx.state` exposes **the original target's**
   persisted metadata (persist what a rollback needs in `ctx.state` when you do
-  the work). Note `ctx.target` names the **compensation** while `ctx.state`
-  holds the **compensated** target's meta, and `ctx.stateOf("<compensated>")`
-  reads **empty** — `ctx.state` is the only state a compensation gets. Its
-  writes stay in memory (the run is ending). `ctx.outcomeOf(...)` does work; a
-  compensation is not in `ctx.plan()`.
+  the work). `ctx.state` is seeded with the meta of the target the step is
+  **for**: under `.onCancel` that is the compensated target (so `ctx.target`
+  names the compensation but `ctx.state` holds `deploy`'s meta), while a
+  timed-out `.onTimeout(() => this.cleanup)` makes `cleanup` compensate
+  **itself** — its own meta, `{}` if it never ran forward. One rule spans both:
+  `ctx.stateOf(ctx.target)` is `ctx.state`, every other name reads **empty**
+  (so `stateOf("deploy")` is empty under `.onCancel`). Writes stay in memory.
+  `ctx.outcomeOf(...)` works; `ctx.plan()` is the whole run's plan, so a
+  compensation is in it only when it is also a graph target.
 - Cancel with `zuke cancel <id>`, `Ctrl-C`/`SIGTERM`, or the MCP `cancel_run`
   tool (all run the same walk). A live run aborts on its next state write.
 - A compensation that throws is recorded but does **not** stop the walk (cleanup

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -39,7 +39,7 @@ that declares only `.effect(...)` each legitimately have no `.executes(...)`.
 | `.unlisted()`                                                                                            | Hide from `--list`/`--help`; still runnable by name.                                                                                                      |
 | `.dryRunnable()`                                                                                         | Run this body under `--dry-run` with `$` in echo mode (prints argv, no spawn); others stay skipped.                                                       |
 | `.validateBefore(...v)` / `.validateAfter(...v)`                                                         | Run `Validation` checks around the body; a throw fails the target.                                                                                        |
-| `.recoverWith(...r)` / `.recoverAttempts(n)`                                                             | Run `Remediation`s if the body fails (self-healing); re-run when one asks to. See AI section.                                                             |
+| `.recoverWith(...r)` / `.recoverAttempts(n)`                                                             | Run `Remediation`s if the body fails (self-healing); re-run when one asks to. A remediation gets the target name, attempt and error — **no state handle**. |
 | `.partOf(group)`                                                                                         | Join a parallel batch (see `group()`).                                                                                                                    |
 | `.produces(...p)` / `.consumes(...t)`                                                                    | Declare and consume artifact paths.                                                                                                                       |
 | `.readOnly()`                                                                                            | Advertise the target as query-only over MCP (`readOnlyHint` instead of `destructiveHint`).                                                                |
@@ -442,7 +442,11 @@ class CD extends Build {
 
 - The compensation body's `ctx.state` exposes **the original target's**
   persisted metadata (persist what a rollback needs in `ctx.state` when you do
-  the work).
+  the work). Note `ctx.target` names the **compensation** while `ctx.state`
+  holds the **compensated** target's meta, and `ctx.stateOf("<compensated>")`
+  reads **empty** — `ctx.state` is the only state a compensation gets. Its
+  writes stay in memory (the run is ending). `ctx.outcomeOf(...)` does work; a
+  compensation is not in `ctx.plan()`.
 - Cancel with `zuke cancel <id>`, `Ctrl-C`/`SIGTERM`, or the MCP `cancel_run`
   tool (all run the same walk). A live run aborts on its next state write.
 - A compensation that throws is recorded but does **not** stop the walk (cleanup

--- a/tests/integration/cancel_test.ts
+++ b/tests/integration/cancel_test.ts
@@ -233,7 +233,9 @@ Deno.test("a compensation's context reads its target's meta, and nothing else's"
         seen.push(`selfIdentity=${ctx.stateOf(ctx.target) === ctx.state}`);
         // Outcomes come from the durable record, so these do work.
         seen.push(`outcomeOf(deploy)=${ctx.outcomeOf("deploy")?.status}`);
-        // A compensation is not a planned target.
+        // `rollback` is not a node in THIS graph, so it is not in the plan.
+        // That is a fact about this fixture, not about compensations — the
+        // test below covers a compensation that is also a graph target.
         seen.push(`inPlan=${ctx.plan().includes("rollback")}`);
         // Writes merge into the seeded meta, in memory only.
         await ctx.state.set({ undone: "yes" });
@@ -262,6 +264,78 @@ Deno.test("a compensation's context reads its target's meta, and nothing else's"
       "outcomeOf(deploy)=succeeded",
       "inPlan=false",
       'afterSet={"slot":"sit-7","undone":"yes"}',
+    ]);
+  });
+});
+
+Deno.test("a compensation that is also a graph target is in the run's plan", async () => {
+  // The companion to the test above, whose fixture declares its compensation
+  // off the graph. `ctx.plan()` is the whole run's plan and nothing filters a
+  // compensation out of it, so "a compensation is not in the plan" would be a
+  // property of that fixture rather than of compensations.
+  await withStateDir(async () => {
+    const seen: string[] = [];
+    const controller = new AbortController();
+    class CD extends Build {
+      rollback = target().executes((ctx) => {
+        seen.push(`${ctx.target} inPlan=${ctx.plan().includes("rollback")}`);
+      });
+      deploy = target()
+        .dependsOn(this.rollback)
+        .executes(async (ctx) => {
+          await ctx.state.set({ slot: "sit-7" });
+          controller.abort();
+        })
+        .onCancel(() => this.rollback);
+      promote = target().dependsOn(this.deploy).executes(() => {});
+    }
+    await runCli(CD, ["promote"], { signal: controller.signal });
+    // Once running forward as an ordinary target, once as the compensation —
+    // in the plan both times.
+    assertEquals(seen, [
+      "rollback inPlan=true",
+      "rollback inPlan=true",
+    ]);
+  });
+});
+
+Deno.test("a timed-out wait's compensation target compensates itself", async () => {
+  // The other way a compensation is reached. `.onTimeout(() => this.cleanup)`
+  // builds the step FOR `cleanup`, so `ctx.state` is cleanup's own meta — not
+  // the deployed target's. A rollback written for the `.onCancel` shape, going
+  // after deploy's slot, finds nothing here.
+  await withStateDir(async () => {
+    const seen: string[] = [];
+    class B extends Build {
+      cleanup = target().executes((ctx) => {
+        seen.push(`target=${ctx.target}`);
+        // Its OWN meta, empty because it never ran forward...
+        seen.push(`state=${JSON.stringify(ctx.state.get())}`);
+        // ...and emphatically not the deployed target's.
+        seen.push(
+          `stateOf(deploy)=${JSON.stringify(ctx.stateOf("deploy").get())}`,
+        );
+        // The one invariant that holds on both compensation paths.
+        seen.push(`selfIdentity=${ctx.stateOf(ctx.target) === ctx.state}`);
+      });
+      deploy = target().executes((ctx) => ctx.state.set({ slot: "sit-7" }));
+      gate = target()
+        .dependsOn(this.deploy)
+        .waitsFor((s) =>
+          s.on(externalSignal("approved")).timeout(0).onTimeout(() =>
+            this.cleanup
+          )
+        );
+      promote = target().dependsOn(this.gate).executes(() => {});
+    }
+    assertEquals((await runCli(B, ["promote"])).code, 0);
+    // The sweep finds the missed deadline and runs the named target.
+    assertEquals((await runCli(B, ["resume", "--check"])).code, 1);
+    assertEquals(seen, [
+      "target=cleanup",
+      "state={}",
+      "stateOf(deploy)={}",
+      "selfIdentity=true",
     ]);
   });
 });

--- a/tests/integration/cancel_test.ts
+++ b/tests/integration/cancel_test.ts
@@ -208,3 +208,60 @@ Deno.test("zuke cancel with a missing run id fails with usage", async () => {
     assertStringIncludes(bad.err, "Usage: zuke cancel");
   });
 });
+
+Deno.test("a compensation's context reads its target's meta, and nothing else's", async () => {
+  // Pins the contract documented in docs/orchestration.md. The trap it exists
+  // to stop: `ctx.state` holds the COMPENSATED target's meta while `ctx.target`
+  // names the compensation, and asking for that same target through `stateOf`
+  // reads empty — so a rollback written the obvious way silently does nothing.
+  await withStateDir(async () => {
+    const seen: string[] = [];
+    const controller = new AbortController();
+    class CD extends Build {
+      rollback = target().executes(async (ctx) => {
+        seen.push(`target=${ctx.target}`);
+        // The compensated target's meta, reached through `state`...
+        seen.push(`state=${JSON.stringify(ctx.state.get())}`);
+        // ...and not through its name.
+        seen.push(
+          `stateOf(deploy)=${JSON.stringify(ctx.stateOf("deploy").get())}`,
+        );
+        seen.push(
+          `stateOf(other)=${JSON.stringify(ctx.stateOf("other").get())}`,
+        );
+        // The documented self-identity still holds for the compensation itself.
+        seen.push(`selfIdentity=${ctx.stateOf(ctx.target) === ctx.state}`);
+        // Outcomes come from the durable record, so these do work.
+        seen.push(`outcomeOf(deploy)=${ctx.outcomeOf("deploy")?.status}`);
+        // A compensation is not a planned target.
+        seen.push(`inPlan=${ctx.plan().includes("rollback")}`);
+        // Writes merge into the seeded meta, in memory only.
+        await ctx.state.set({ undone: "yes" });
+        seen.push(`afterSet=${JSON.stringify(ctx.state.get())}`);
+      });
+      other = target().executes((ctx) => ctx.state.set({ from: "other" }));
+      deploy = target()
+        .dependsOn(this.other)
+        .executes(async (ctx) => {
+          await ctx.state.set({ slot: "sit-7" });
+          controller.abort();
+        })
+        .onCancel(() => this.rollback);
+      promote = target().dependsOn(this.deploy).executes(() => {});
+    }
+    const { code } = await runCli(CD, ["promote"], {
+      signal: controller.signal,
+    });
+    assertEquals(code, 1);
+    assertEquals(seen, [
+      "target=rollback",
+      'state={"slot":"sit-7"}',
+      "stateOf(deploy)={}",
+      "stateOf(other)={}",
+      "selfIdentity=true",
+      "outcomeOf(deploy)=succeeded",
+      "inPlan=false",
+      'afterSet={"slot":"sit-7","undone":"yes"}',
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #535.

## The trap

The compensation bullet in `docs/orchestration.md` said a compensation's state handle exposes the original target's metadata. True, and one sentence short of what sits behind it.

A probe against the real engine: the context's `target` names the **compensation**, while its state handle carries the **compensated** target's meta. Those are two different targets. And asking for that compensated target **by name** through `stateOf` reads **empty** — as does every other target — even though the state handle is holding exactly that target's data. A reader who knows `stateOf` from ordinary bodies reaches for it, gets an empty object, and concludes the state was lost. In a rollback, which is the least forgiving place to learn otherwise.

Writes merge into the seeded meta but stay in memory: the run is ending, and nothing a compensation records is persisted, on either cancel path. Outcomes do still work, reading the durable record, so a rollback can ask what actually happened to the run it is undoing.

## The half that has no state at all

`RemediationContext`, what a `recoverWith` remediation receives, carries the target name, the attempt number and the error. There is no state handle.

That is deliberate rather than an omission, and the investigation behind this PR is why it stays that way: both real implementations in the AI package use exactly those three fields, and neither works around the absence, because the failure itself carries the failed command and its captured output. Adding an accessor no consumer wants is the dead flexibility guideline 10 warns about. It is now written down so nobody hunts for something that was never there.

## What the adversarial pass changed

The first commit here documented the rule from one code path. A reviewer ran the paths it had not, and falsified two claims:

**The state rule was wrong for timed-out waits.** What the handle is seeded with is the meta of the target the compensation step is *for*. Under `onCancel` that is the target being undone. But a timed-out wait's `onTimeout` names a target that compensates **itself**, seeded with its own meta — empty when it never ran forward. A body written from the old sentence, reaching for the deployed target's slot, finds nothing. That is precisely the silent no-op this documentation exists to prevent, reached by the sibling path the same page points at a few lines later.

What actually spans both paths is narrower, and is now the documented invariant: `stateOf` of the context's own target is the state handle, and every other name reads empty. Each path's seeding is spelled out beneath it.

**The plan claim was a property of the test's fixture.** The first commit said a compensation never appears in the run plan, and its test agreed — because that fixture declared the compensation off the graph. The plan is the whole run's plan and nothing filters a compensation out, so one that is also a graph target *is* in it. The test now says which fact is the fixture's, and a second test covers the on-graph case with the opposite result.

Verified as accurate and left alone: the in-memory write behaviour on both cancel paths, the self-identity invariant including for an anonymous inline compensation, outcome access from a process that never executed the run, and the remediation contract.

## Testing

Three integration tests pin the documented behaviour so it cannot drift from the engine: the `onCancel` contract line by line, a compensation that is also a graph target, and the `onTimeout` path where a target compensates itself. Gate green at 23/23: 4407 tests, 98.5% lines, 97.4% branches.
