### PR TITLE
fix(core): correct the lock-refresh advice zuke outdated prints

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "zuke",
       "source": "./plugins/zuke",
       "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build).",
-      "version": "0.54.0",
+      "version": "0.55.0",
       "author": {
         "name": "Zuke",
         "email": "contact@zuke.build",

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@
   execution.
 - [Paths (`absolutePath`)](./paths.md) — the fluent path type.
 - [Packages](./packages.md) — the full package matrix with JSR badges.
-- Recipes — the three things a small project wants first:
+- Recipes — the things a small project wants first:
   [replace your shell scripts](./recipes/replace-shell-scripts.md) with the `$`
   shell, [generate your CI](./recipes/generate-ci.md) and stop editing YAML,
   [know when your dependencies fall behind](./recipes/keep-dependencies-current.md),

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@
 - Recipes — the three things a small project wants first:
   [replace your shell scripts](./recipes/replace-shell-scripts.md) with the `$`
   shell, [generate your CI](./recipes/generate-ci.md) and stop editing YAML,
+  [know when your dependencies fall behind](./recipes/keep-dependencies-current.md),
   and [release a small library](./recipes/release-a-library.md) as one chain
   of targets.
 - [Examples](../examples/README.md) — five cloneable mini projects: a Deno

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -230,7 +230,7 @@ that are behind:
 @zuke/git     1.5.0  →  1.11.0
 @zuke/gcloud  1.1.0  →  1.3.0
 
-2 packages are behind. Refresh the lock with a plain `deno cache --reload` …
+2 packages are behind. Delete these entries from the lock (or the lock file) and re-run …
 ```
 
 It exists for the case nothing else covers. A build whose specifiers are
@@ -267,11 +267,18 @@ It needs the network, which is why it is a command you run rather than a line in
 `--list` or the run summary: those stay offline and instant. `outdated` is a
 reserved command name.
 
-Two things about refreshing the lock afterwards, because the obvious move is
-wrong. In a repo that also has a `package.json`, `deno cache` resolves the whole
-npm tree and writes an `npm` section a jsr-only lock never had. And
-`--reload=jsr:` re-resolves from cached registry metadata, handing back the same
-stale versions — only a bare `--reload` actually re-resolves.
+Refreshing the lock afterwards is where the obvious moves all fail. Measured on
+deno 2.9.5 against a stale entry for an inline `jsr:` specifier — the case this
+command exists for — neither reload flavour changes the locked version:
+`--reload=jsr:` re-resolves from cached registry metadata, and a bare `--reload`
+re-downloads the sources behind the resolution while leaving the resolution
+itself alone. `deno outdated --update` does re-resolve, but it reads manifests,
+so it cannot see a specifier written inline rather than in an imports map.
+
+What works is removing the stale entries from `deno.lock` (or deleting the lock)
+and re-running, which resolves them afresh. One caveat when you delete the whole
+file: in a repo that also has a `package.json`, `deno cache` resolves the whole
+npm tree and writes an `npm` section a jsr-only lock never had.
 
 ## Parallel execution
 

--- a/docs/recipes/keep-dependencies-current.md
+++ b/docs/recipes/keep-dependencies-current.md
@@ -107,12 +107,17 @@ jobs:
 
 **Two UTC crons for one schedule, and a guard job.** GitHub only understands UTC
 cron, so a schedule in a daylight-saving zone contributes one UTC cron per
-distinct offset — `0 4` for winter, `0 3` for summer here. Both fire year-round,
-which would run the job twice a year at the wrong local hour, so Zuke generates
-the `zuke-schedule-guard` job to check the real local time and let the run
-proceed only in the intended one. A fixed-offset zone, or plain UTC, needs
-neither. Schedules are honoured on GitHub and Azure; GitLab and Bitbucket
-configure them in the provider UI, so the field is ignored there.
+distinct offset — `0 4` for winter, `0 3` for summer here. Both fire on **every**
+occurrence, so a bare pair of crons would run this job twice a week, once of them
+at the wrong local hour. Zuke generates the `zuke-schedule-guard` job to compare
+the real local time against the schedule and let the run proceed only on the
+matching one. A fixed-offset zone, or plain UTC, needs no guard.
+
+The guard is only generated for **GitHub**. On **Azure**, a daylight-saving zone
+is a hard error at generation time — write the cron in UTC, or use a
+fixed-offset zone, for that provider. **GitLab** and **Bitbucket** configure
+schedules in the provider UI rather than in-file, so the field is ignored there.
+See [schedules](../schedules.md) for the full matrix.
 
 **Egress.** The default hardening policy is `audit`, which reports egress rather
 than blocking it. If you tighten a job to `egress-policy: block`, this one needs
@@ -121,9 +126,14 @@ whole purpose is to talk to the registry.
 
 ## What `--exit-code` treats as a failure
 
-Without the flag, `outdated` is a report and always exits `0`. With it, the
+Without the flag, `outdated` is a report: being behind exits `0`. With it, the
 command exits `1` when a package is **behind** *or* when a package **could not
 be checked** — a private scope, a rename, a runner behind a proxy.
+
+One case fails either way: with **no lock file** there are no resolved versions
+to compare, and `outdated` reports that as an error and exits `1` with or
+without the flag. If the scheduled job runs before anything has written a lock,
+it goes red for that reason rather than for staleness.
 
 That second half is the point of the gate. A run that reached nothing at all
 would otherwise print that every package is at its latest release, which is the
@@ -139,11 +149,24 @@ The output names each package and the version it is behind:
 @zuke/gcloud  1.1.0  →  1.3.0
 ```
 
-Refreshing the lock has one trap worth knowing: `--reload=jsr:` re-resolves from
-cached registry metadata and hands back the same stale versions. Only a bare
-`deno cache --reload` actually re-resolves. And in a repository that also has a
-`package.json`, `deno cache` resolves the whole npm tree and writes an `npm`
-section a jsr-only lock never had.
+Refreshing the lock is the part that catches people out, because the obvious
+commands do nothing. Measured against deno 2.9.5, on a stale entry for an inline
+`jsr:` specifier:
+
+| Command | Effect on the locked version |
+| --- | --- |
+| `deno cache --reload=jsr:` | unchanged — re-resolves from cached registry metadata |
+| `deno cache --reload` | unchanged — re-downloads sources, keeps the locked resolution |
+| `deno outdated --update` | unchanged — it reads manifests, and an inline specifier is in no manifest |
+| delete the lock, then re-cache | **re-resolved** |
+
+That last row is the one that works. `deno outdated --update` *is* the right tool
+when the dependency is declared in a `deno.json` imports map — but then you would
+not have needed `zuke outdated` to find it, which is the whole point of this
+command.
+
+And in a repository that also has a `package.json`, `deno cache` resolves the
+whole npm tree and writes an `npm` section a jsr-only lock never had.
 
 Review the lock diff and commit it in the same change, exactly as you would for
 a deliberate dependency bump — the lock is part of the gate.

--- a/docs/recipes/keep-dependencies-current.md
+++ b/docs/recipes/keep-dependencies-current.md
@@ -1,0 +1,154 @@
+# Recipe: know when your dependencies fall behind
+
+A build that pins its tools inline — `jsr:@zuke/git@^1` in `zuke.ts` and its
+helper modules, rather than in a `deno.json` imports map — has no manifest for
+`deno outdated` to read. The lock keeps resolving the versions recorded when the
+build was written, and `--frozen` is perfectly content with that, because a
+stale-but-valid lock is exactly what `--frozen` is for.
+
+Nothing fails. The build stays green for months while a wrapper it depends on
+grows the typed command the build is still hand-rolling. `zuke outdated` is the
+signal that nothing else gives you; this recipe wires it up so it arrives on its
+own schedule instead of when someone remembers to look.
+
+## Do not put it in the gate
+
+The obvious move is a line in the `ci` target. Resist it, for two reasons.
+
+`outdated` needs the **network**, and the gate is deliberately hermetic — that
+is what makes it reproducible and fast. And a dependency publishing a release
+would turn a red X on a pull request that has nothing to do with it, blocking an
+author who cannot fix the cause and did not create it. Freshness is a property
+of the repository over time, not of a change.
+
+So it gets its own pipeline, on a schedule.
+
+## The wiring
+
+<!-- check -->
+
+```ts
+import { Build, cicd, run, target } from "jsr:@zuke/core";
+import { DenoTasks } from "jsr:@zuke/deno";
+
+class MyBuild extends Build {
+  // The ordinary gate: hermetic, on every push and pull request.
+  ci = cicd({
+    pipeline: {
+      name: "CI",
+      triggers: { push: ["main"], pullRequest: ["main"] },
+    },
+  });
+
+  // Freshness, on its own file and its own cadence.
+  freshness = cicd({
+    path: ".github/workflows/freshness.yml",
+    pipeline: {
+      name: "Dependency freshness",
+      triggers: {
+        // 06:00 Monday, in a real timezone (see below).
+        schedule: [{ cron: "0 6 * * 1", tz: "Europe/Sofia" }],
+        // So anyone can ask the question on demand.
+        manual: true,
+      },
+      jobs: [{
+        id: "outdated",
+        name: "Are we current?",
+        // `outdated` is a reserved command rather than a target, so the job
+        // names it directly instead of invoking a target.
+        steps: [{ name: "Check", run: "./zuke outdated --exit-code" }],
+      }],
+    },
+  });
+
+  test = target().executes(() => DenoTasks.test((s) => s.allowAll()));
+}
+
+await run(MyBuild);
+```
+
+```sh
+./zuke generate-ci           # writes both workflow files
+./zuke generate-ci --check   # the gate: fails if a committed file drifted
+./zuke outdated              # ask right now, as a report
+```
+
+## What gets generated
+
+The freshness workflow, as written by `generate-ci`:
+
+```yaml
+name: Dependency freshness
+"on":
+  workflow_dispatch: {}
+  schedule:
+    - cron: "0 4 * * 1"
+    - cron: "0 3 * * 1"
+permissions:
+  contents: read
+jobs:
+  outdated:
+    name: "Are we current?"
+    runs-on: ubuntu-latest
+    needs:
+      - zuke-schedule-guard
+    if: "${{ needs.zuke-schedule-guard.outputs.run == 'true' }}"
+    steps:
+      - name: Harden and check out with Zuke
+        uses: zuke-build/zuke@… # pinned
+        with:
+          egress-policy: audit
+          persist-credentials: "false"
+      - name: Check
+        run: ./zuke outdated --exit-code
+  zuke-schedule-guard:
+    # …resolves the local time and sets run=true only in the intended hour
+```
+
+**Two UTC crons for one schedule, and a guard job.** GitHub only understands UTC
+cron, so a schedule in a daylight-saving zone contributes one UTC cron per
+distinct offset — `0 4` for winter, `0 3` for summer here. Both fire year-round,
+which would run the job twice a year at the wrong local hour, so Zuke generates
+the `zuke-schedule-guard` job to check the real local time and let the run
+proceed only in the intended one. A fixed-offset zone, or plain UTC, needs
+neither. Schedules are honoured on GitHub and Azure; GitLab and Bitbucket
+configure them in the provider UI, so the field is ignored there.
+
+**Egress.** The default hardening policy is `audit`, which reports egress rather
+than blocking it. If you tighten a job to `egress-policy: block`, this one needs
+`jsr.io:443` on its allowed endpoints — it is the one job in the repository whose
+whole purpose is to talk to the registry.
+
+## What `--exit-code` treats as a failure
+
+Without the flag, `outdated` is a report and always exits `0`. With it, the
+command exits `1` when a package is **behind** *or* when a package **could not
+be checked** — a private scope, a rename, a runner behind a proxy.
+
+That second half is the point of the gate. A run that reached nothing at all
+would otherwise print that every package is at its latest release, which is the
+confident wrong answer this command exists to prevent. A gate asking "are we
+current?" has not been told yes by a run that never got an answer.
+
+## When it fires
+
+The output names each package and the version it is behind:
+
+```text
+@zuke/git     1.5.0  →  1.11.0
+@zuke/gcloud  1.1.0  →  1.3.0
+```
+
+Refreshing the lock has one trap worth knowing: `--reload=jsr:` re-resolves from
+cached registry metadata and hands back the same stale versions. Only a bare
+`deno cache --reload` actually re-resolves. And in a repository that also has a
+`package.json`, `deno cache` resolves the whole npm tree and writes an `npm`
+section a jsr-only lock never had.
+
+Review the lock diff and commit it in the same change, exactly as you would for
+a deliberate dependency bump — the lock is part of the gate.
+
+## See also
+
+- [`zuke outdated`](../cli.md#zuke-outdated) — the full command reference.
+- [Generate your CI](./generate-ci.md) — the `cicd` builder this recipe extends.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "zuke",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "description": "Agent skills for Zuke — scaffold Zuke into a project (zuke-setup) and write or edit a zuke.ts build (zuke-write-build)."
 }

--- a/packages/core/src/outdated.ts
+++ b/packages/core/src/outdated.ts
@@ -255,9 +255,15 @@ export function formatOutdated(report: OutdatedReport): string {
       : `${behind.length} packages are`;
     lines.push(
       "",
-      `${count} behind. Refresh the lock with a plain \`deno cache --reload\` ` +
-        "— `--reload=jsr:` re-resolves from cached registry metadata and hands " +
-        "back the same versions.",
+      // Neither `--reload` flavour re-resolves: both keep the locked version
+      // and only revisit the sources behind it. `deno outdated --update` reads
+      // manifests, so it cannot see an inline `jsr:` specifier — which is the
+      // case this command exists for. Removing the entry is what makes the next
+      // run resolve it afresh.
+      `${count} behind. Delete these entries from the lock (or the lock file) ` +
+        "and re-run to resolve them afresh — neither `deno cache --reload` nor " +
+        "`--reload=jsr:` changes a locked version, and `deno outdated --update` " +
+        "only sees dependencies declared in an imports map.",
     );
   } else if (unchecked.length === 0) {
     return "Every JSR package the lock resolves is at its latest release.";

--- a/packages/core/tests/outdated_test.ts
+++ b/packages/core/tests/outdated_test.ts
@@ -289,9 +289,19 @@ Deno.test("formatOutdated aligns the report and says how to refresh", () => {
   });
   assertEquals(one.includes("@zuke/git  1.5.0  →  1.11.0"), true);
   assertEquals(one.includes("1 package is behind"), true);
-  // The refresh hint is the part that is not obvious: --reload=jsr: hands back
-  // the same versions from cached registry metadata.
-  assertEquals(one.includes("--reload=jsr:"), true);
+  // The refresh hint is the part users act on, so it is pinned here rather than
+  // left to drift. It used to tell them to run `deno cache --reload`, which
+  // re-downloads sources and leaves the locked version exactly where it was —
+  // so the report repeated itself and the advice looked like a no-op. What
+  // actually re-resolves is removing the entry.
+  assertEquals(one.includes("Delete these entries from the lock"), true);
+  // And it must not send them back to either reload, or to `deno outdated`,
+  // as the fix: none of them changes a locked version for an inline specifier.
+  assertEquals(/(?<!neither )`deno cache --reload`/.test(one), false);
+  assertEquals(
+    one.includes("only sees dependencies declared in an imports map"),
+    true,
+  );
 
   const two = formatOutdated({
     behind: [

--- a/plugins/zuke/.claude-plugin/plugin.json
+++ b/plugins/zuke/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/.codex-plugin/plugin.json
+++ b/plugins/zuke/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zuke",
-  "version": "0.54.0",
+  "version": "0.55.0",
   "description": "Agent skills for Zuke, the code-first build automation system for Deno/TypeScript. Bundles zuke-setup (scaffold Zuke into a project) and zuke-write-build (author or edit a zuke.ts build).",
   "author": {
     "name": "Zuke",

--- a/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
+++ b/plugins/zuke/skills/zuke-write-build/references/cheatsheet.md
@@ -1295,6 +1295,10 @@ Copy the closest one instead of composing from primitives; each is a full
 ./zuke register [--json]      # record this build in the build registry (idempotent)
 ./zuke doc jsr:@zuke/deno     # print a package's API (deno doc) from an isolated empty dir
 ./zuke outdated [--exit-code]  # jsr packages the lock resolves behind their latest (network)
+                               # --exit-code exits 1 when behind OR uncheckable.
+                               # Wire it as a SCHEDULED pipeline, never in the ci
+                               # gate: it needs the network, and a dependency's
+                               # release would redden unrelated PRs.
 ./zuke mcp --registry --allow-run  # serve the registry: registered builds as tools, spawned
 ./zuke mcp --registry --max-concurrent-runs 4  # cap concurrent run-tool spawns (default 4)
 ```

--- a/skills/zuke-write-build/references/cheatsheet.md
+++ b/skills/zuke-write-build/references/cheatsheet.md
@@ -1295,6 +1295,10 @@ Copy the closest one instead of composing from primitives; each is a full
 ./zuke register [--json]      # record this build in the build registry (idempotent)
 ./zuke doc jsr:@zuke/deno     # print a package's API (deno doc) from an isolated empty dir
 ./zuke outdated [--exit-code]  # jsr packages the lock resolves behind their latest (network)
+                               # --exit-code exits 1 when behind OR uncheckable.
+                               # Wire it as a SCHEDULED pipeline, never in the ci
+                               # gate: it needs the network, and a dependency's
+                               # release would redden unrelated PRs.
 ./zuke mcp --registry --allow-run  # serve the registry: registered builds as tools, spawned
 ./zuke mcp --registry --max-concurrent-runs 4  # cap concurrent run-tool spawns (default 4)
 ```


### PR DESCRIPTION
Closes #539. Closes #541.

## The recipe

`docs/cli.md` explains what `zuke outdated` compares and what `--exit-code` means. What it never said is **where the command belongs**, and the obvious placement is wrong: it needs the network while the gate is deliberately hermetic, and wiring it into the gate turns a pull request red the moment a dependency publishes — a failure the author cannot act on and did not cause. Freshness is a property of the repository over time, not of a change. The recipe puts it in its own scheduled pipeline, generated by the same builder as every other workflow.

Everything it asserts was produced by running the recipe's own build rather than read off the types, which is how it turned up something the API surface does not show: a schedule in a daylight-saving zone compiles to one UTC cron per offset plus a generated guard job that compares the real local time, because both crons fire on every occurrence.

## The bug the review found

While attacking the recipe's claims, a reviewer falsified one the recipe had inherited from the command reference — and from the command itself.

`zuke outdated` printed, to every user, that the way to refresh the lock is a plain `deno cache --reload`. It is not. Measured on deno 2.9.5 against a stale entry for an inline `jsr:` specifier, which is the case this command exists for:

| Command | Effect on the locked version |
| --- | --- |
| `deno cache --reload=jsr:` | unchanged — re-resolves from cached registry metadata |
| `deno cache --reload` | unchanged — re-downloads sources, keeps the resolution |
| `deno outdated --update` | unchanged — reads manifests, and an inline specifier is in none |
| remove the entries, re-run | **re-resolved** |

So a user followed the advice, saw nothing change, re-ran the report and got the same answer. The message now says what works, and names the three things that do not, because those are exactly what someone reaches for next. Verified end to end against this repository's own stale dependency, which the corrected advice moves from 1.1.1 to 1.2.0.

The same claim was in the command reference twice and in the new recipe. All of them now agree with the measurement, and a unit test pins the runtime advice string so the docs cannot drift from what users actually see.

## What else the review corrected in the recipe

- **"Both crons fire twice a year at the wrong hour."** Wrong — they fire on every scheduled occurrence, so a bare pair would run the job twice a week. The reviewer proved it by running the generated guard script against a faked clock at all four instants.
- **"Schedules are honoured on GitHub and Azure."** Not for the recipe's own example: Azure treats a daylight-saving zone as a hard error at generation time. `docs/schedules.md` already said so, so the recipe contradicted an existing page. It now defers to that page's matrix.
- **"Without the flag it always exits 0."** False with no lock file, which is precisely what a freshly added scheduled job may hit. That case exits non-zero either way and is now called out.
- A count in the recipe index that the new entry made wrong.

Verified as accurate and left alone: the generated YAML matches the recipe's own build byte for byte, the winter/summer cron labelling, the `audit` default for egress, and the link targets.

## Testing

Gate green at 23/23: 4407 tests, 98.5% lines, 97.4% branches. The recipe's build snippet is covered by `snippetsCheck` like every other recipe, and the corrected runtime advice is pinned by a unit test.
