### PR TITLE
feat(core): neutralise workflow-command sequences in GitHub-mode output and redact the job summary

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5402,6 +5402,13 @@ function escapeLine(text: string): string
   `##[command]` form is recognised anywhere in a line, so it needs no newline
   to reach at all.
 
+  "Blank" is the runner's idea of it, not this language's. The two sets differ
+  by exactly one character in the direction that matters: NEXT LINE (U+0085),
+  which the runner trims and `\s` does not match. It is not a line terminator
+  for the reader the runner uses, so it travels inside a line and disappears
+  only when the command is parsed, which would let `::` reach the front of a
+  line that looked indented here. It is matched explicitly for that reason.
+
   Ordinary output is returned unchanged; only text that would have been
   executed as a command comes back visibly encoded.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5372,6 +5372,45 @@ function box(style: Style, content: string | readonly string[], options: BoxOpti
 function detectWidth(): number
   Read the terminal width if available, clamped to a sane range.
 
+function escapeData(value: string): string
+  Escape a value interpolated into the body of a GitHub Actions workflow
+  command (`::error::<data>`).
+
+  A workflow command is terminated by the end of its line, so a value carrying
+  a newline continues into what the runner parses as a fresh command. A
+  target's failure message embeds a subprocess's stderr verbatim, which is not
+  ours to trust: a tool that writes `::stop-commands::` on a line of its own
+  would otherwise suspend the runner's command processing, and one that writes
+  `::error::` would forge an annotation. Percent-encoding is the escape the
+  Actions spec defines for exactly this, and `%` is encoded first so the
+  encoding cannot be spoofed by a literal `%0A` in the input.
+
+function escapeLine(text: string): string
+  Neutralise workflow commands in text that is printed as itself on a stream
+  the GitHub Actions runner parses — a failure message, a target name, a
+  summary row — rather than interpolated into a command's body.
+
+  {@link escapeData} is the wrong tool there. It answers the same threat, but
+  by encoding every newline, which would fold a multi-line compiler dump into
+  one unreadable `%0A`-joined line: correct, and useless to the person reading
+  the log. This keeps the text as it was written and disarms only the two
+  sequences the runner acts on.
+
+  Both forms are covered, because the runner accepts both. A line whose first
+  non-blank characters are `::` opens a command, and leading whitespace is
+  trimmed before that test, so indenting the text defends nothing. The legacy
+  `##[command]` form is recognised anywhere in a line, so it needs no newline
+  to reach at all.
+
+  Ordinary output is returned unchanged; only text that would have been
+  executed as a command comes back visibly encoded.
+
+function escapeProperty(value: string): string
+  Escape a value interpolated into a workflow command's property list
+  (`::error title=<property>::`). Properties are comma-separated and
+  colon-terminated, so those two characters need encoding on top of what
+  {@link escapeData} handles.
+
 function formatDuration(ms: number): string
   Format a duration in milliseconds as `1.2s`.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -5426,6 +5426,45 @@ function box(style: Style, content: string | readonly string[], options: BoxOpti
 function detectWidth(): number
   Read the terminal width if available, clamped to a sane range.
 
+function escapeData(value: string): string
+  Escape a value interpolated into the body of a GitHub Actions workflow
+  command (`::error::<data>`).
+
+  A workflow command is terminated by the end of its line, so a value carrying
+  a newline continues into what the runner parses as a fresh command. A
+  target's failure message embeds a subprocess's stderr verbatim, which is not
+  ours to trust: a tool that writes `::stop-commands::` on a line of its own
+  would otherwise suspend the runner's command processing, and one that writes
+  `::error::` would forge an annotation. Percent-encoding is the escape the
+  Actions spec defines for exactly this, and `%` is encoded first so the
+  encoding cannot be spoofed by a literal `%0A` in the input.
+
+function escapeLine(text: string): string
+  Neutralise workflow commands in text that is printed as itself on a stream
+  the GitHub Actions runner parses — a failure message, a target name, a
+  summary row — rather than interpolated into a command's body.
+
+  {@link escapeData} is the wrong tool there. It answers the same threat, but
+  by encoding every newline, which would fold a multi-line compiler dump into
+  one unreadable `%0A`-joined line: correct, and useless to the person reading
+  the log. This keeps the text as it was written and disarms only the two
+  sequences the runner acts on.
+
+  Both forms are covered, because the runner accepts both. A line whose first
+  non-blank characters are `::` opens a command, and leading whitespace is
+  trimmed before that test, so indenting the text defends nothing. The legacy
+  `##[command]` form is recognised anywhere in a line, so it needs no newline
+  to reach at all.
+
+  Ordinary output is returned unchanged; only text that would have been
+  executed as a command comes back visibly encoded.
+
+function escapeProperty(value: string): string
+  Escape a value interpolated into a workflow command's property list
+  (`::error title=<property>::`). Properties are comma-separated and
+  colon-terminated, so those two characters need encoding on top of what
+  {@link escapeData} handles.
+
 function formatDuration(ms: number): string
   Format a duration in milliseconds as `1.2s`.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -5456,6 +5456,13 @@ function escapeLine(text: string): string
   `##[command]` form is recognised anywhere in a line, so it needs no newline
   to reach at all.
 
+  "Blank" is the runner's idea of it, not this language's. The two sets differ
+  by exactly one character in the direction that matters: NEXT LINE (U+0085),
+  which the runner trims and `\s` does not match. It is not a line terminator
+  for the reader the runner uses, so it travels inside a line and disappears
+  only when the command is parsed, which would let `::` reach the front of a
+  line that looked indented here. It is matched explicitly for that reason.
+
   Ordinary output is returned unchanged; only text that would have been
   executed as a command comes back visibly encoded.
 

--- a/packages/core/src/execute_output.ts
+++ b/packages/core/src/execute_output.ts
@@ -140,15 +140,28 @@ export function emitActionsMasks(
   }
 }
 
-/** Append the Markdown job-summary table to `GITHUB_STEP_SUMMARY`, if set. */
+/**
+ * Append the Markdown job-summary table to `GITHUB_STEP_SUMMARY`, if set.
+ *
+ * The Markdown goes through `redactor` first. Every other sink for a resolved
+ * `secret()` parameter is redacted — the console through the reporter, the run
+ * record as it is persisted — and this one was not, so a summary note carrying
+ * a secret read `[redacted]` on the terminal and in the record while the job
+ * summary published it in the clear, to everyone who can view the workflow run.
+ * The `::add-mask::` directives do not cover this: they mask the runner's log
+ * stream, not a file the build writes.
+ */
 export function writeJobSummary(
   renderer: Renderer,
   reports: TargetReport[],
   totalMs: number,
   ok: boolean,
+  redactor: Redactor,
 ): void {
   // Append, not overwrite: validations like the AI reviewers/fixer write their
   // own sections to this same file during the run, and overwriting would wipe
   // them. Best-effort — an unwritable summary must never fail the build.
-  appendJobSummary(renderer.jobSummaryMarkdown(reports, totalMs, ok));
+  appendJobSummary(
+    redactor.redact(renderer.jobSummaryMarkdown(reports, totalMs, ok)),
+  );
 }

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -659,7 +659,7 @@ export async function execute(
     );
   }
   if (style.github && writesToConsole) {
-    writeJobSummary(renderer, run.reports, totalMs, result.ok);
+    writeJobSummary(renderer, run.reports, totalMs, result.ok, redactor);
   }
   await life.finish(result);
   return result;

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -22,6 +22,7 @@
 
 import type { Build, BuildResult } from "./build.ts";
 import { defaultReadEnv, messageOf } from "./internal.ts";
+import { escapeLine } from "./render.ts";
 import type { Reporter } from "./reporter.ts";
 export type { Reporter } from "./reporter.ts";
 import {
@@ -651,7 +652,7 @@ export async function execute(
   // A cancelled run never resumes, so it skips this even if it parked a wait.
   if (run.suspended && !cancelled) {
     const waiting = run.reports.filter((r) => r.status === "waiting")
-      .map((r) => r.name);
+      .map((r) => style.github ? escapeLine(r.name) : r.name);
     reporter.info(
       `Run ${runId} suspended — state saved; waiting on: ${
         waiting.join(", ")

--- a/packages/core/src/render.ts
+++ b/packages/core/src/render.ts
@@ -15,6 +15,67 @@
  * @module
  */
 
+/**
+ * Escape a value interpolated into the body of a GitHub Actions workflow
+ * command (`::error::<data>`).
+ *
+ * A workflow command is terminated by the end of its line, so a value carrying
+ * a newline continues into what the runner parses as a *fresh* command. A
+ * target's failure message embeds a subprocess's stderr verbatim, which is not
+ * ours to trust: a tool that writes `::stop-commands::` on a line of its own
+ * would otherwise suspend the runner's command processing, and one that writes
+ * `::error::` would forge an annotation. Percent-encoding is the escape the
+ * Actions spec defines for exactly this, and `%` is encoded first so the
+ * encoding cannot be spoofed by a literal `%0A` in the input.
+ */
+export function escapeData(value: string): string {
+  return value
+    .replaceAll("%", "%25")
+    .replaceAll("\r", "%0D")
+    .replaceAll("\n", "%0A");
+}
+
+/**
+ * Escape a value interpolated into a workflow command's **property** list
+ * (`::error title=<property>::`). Properties are comma-separated and
+ * colon-terminated, so those two characters need encoding on top of what
+ * {@link escapeData} handles.
+ */
+export function escapeProperty(value: string): string {
+  return escapeData(value).replaceAll(":", "%3A").replaceAll(",", "%2C");
+}
+
+/**
+ * Neutralise workflow commands in text that is *printed as itself* on a stream
+ * the GitHub Actions runner parses — a failure message, a target name, a
+ * summary row — rather than interpolated into a command's body.
+ *
+ * {@link escapeData} is the wrong tool there. It answers the same threat, but
+ * by encoding every newline, which would fold a multi-line compiler dump into
+ * one unreadable `%0A`-joined line: correct, and useless to the person reading
+ * the log. This keeps the text as it was written and disarms only the two
+ * sequences the runner acts on.
+ *
+ * Both forms are covered, because the runner accepts both. A line whose first
+ * non-blank characters are `::` opens a command, and leading whitespace is
+ * trimmed before that test, so indenting the text defends nothing. The legacy
+ * `##[command]` form is recognised *anywhere* in a line, so it needs no newline
+ * to reach at all.
+ *
+ * Ordinary output is returned unchanged; only text that would have been
+ * executed as a command comes back visibly encoded.
+ */
+export function escapeLine(text: string): string {
+  return text
+    .split(/(\r\n|\r|\n)/)
+    .map((part) =>
+      /^(?:\r\n|\r|\n)$/.test(part)
+        ? part
+        : part.replace(/^(\s*)::/, "$1%3A%3A").replaceAll("##[", "%23%23[")
+    )
+    .join("");
+}
+
 /** ANSI select-graphic-rendition codes, keyed by style name. */
 export const SGR = {
   reset: "\x1b[0m",

--- a/packages/core/src/render.ts
+++ b/packages/core/src/render.ts
@@ -62,6 +62,13 @@ export function escapeProperty(value: string): string {
  * `##[command]` form is recognised *anywhere* in a line, so it needs no newline
  * to reach at all.
  *
+ * "Blank" is the runner's idea of it, not this language's. The two sets differ
+ * by exactly one character in the direction that matters: NEXT LINE (U+0085),
+ * which the runner trims and `\s` does not match. It is not a line terminator
+ * for the reader the runner uses, so it travels inside a line and disappears
+ * only when the command is parsed, which would let `::` reach the front of a
+ * line that looked indented here. It is matched explicitly for that reason.
+ *
  * Ordinary output is returned unchanged; only text that would have been
  * executed as a command comes back visibly encoded.
  */
@@ -71,7 +78,10 @@ export function escapeLine(text: string): string {
     .map((part) =>
       /^(?:\r\n|\r|\n)$/.test(part)
         ? part
-        : part.replace(/^(\s*)::/, "$1%3A%3A").replaceAll("##[", "%23%23[")
+        : part.replace(/^([\s\u0085]*)::/, "$1%3A%3A").replaceAll(
+          "##[",
+          "%23%23[",
+        )
     )
     .join("");
 }

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -15,10 +15,26 @@
 
 import { messageOf } from "./internal.ts";
 import type { TargetStatus } from "./build.ts";
-import { formatDuration, line, paint, SGR, type Style } from "./render.ts";
+import {
+  escapeData,
+  escapeLine,
+  escapeProperty,
+  formatDuration,
+  line,
+  paint,
+  SGR,
+  type Style,
+} from "./render.ts";
 import type { SummaryEntry } from "./summary_note.ts";
 
-export { detectWidth, formatDuration, type Style } from "./render.ts";
+export {
+  detectWidth,
+  escapeData,
+  escapeLine,
+  escapeProperty,
+  formatDuration,
+  type Style,
+} from "./render.ts";
 
 /** Per-status icon shown in headers, footers, and summary rows. */
 export const ICON: Record<TargetStatus, string> = {
@@ -76,36 +92,6 @@ export function formatSummary(
 }
 
 /**
- * Escape a value interpolated into the body of a GitHub Actions workflow
- * command (`::error::<data>`).
- *
- * A workflow command is terminated by the end of its line, so a value carrying
- * a newline continues into what the runner parses as a *fresh* command. A
- * target's failure message embeds a subprocess's stderr verbatim, which is not
- * ours to trust: a tool that writes `::stop-commands::` on a line of its own
- * would otherwise suspend the runner's command processing, and one that writes
- * `::error::` would forge an annotation. Percent-encoding is the escape the
- * Actions spec defines for exactly this, and `%` is encoded first so the
- * encoding cannot be spoofed by a literal `%0A` in the input.
- */
-export function escapeData(value: string): string {
-  return value
-    .replaceAll("%", "%25")
-    .replaceAll("\r", "%0D")
-    .replaceAll("\n", "%0A");
-}
-
-/**
- * Escape a value interpolated into a workflow command's **property** list
- * (`::error title=<property>::`). Properties are comma-separated and
- * colon-terminated, so those two characters need encoding on top of what
- * {@link escapeData} handles.
- */
-export function escapeProperty(value: string): string {
-  return escapeData(value).replaceAll(":", "%3A").replaceAll(",", "%2C");
-}
-
-/**
  * The ruled header that opens a target's section in the terminal. Two `═` rules
  * frame the target name (bold cyan), so the stream is easy to scan into blocks.
  * In GitHub Actions, a `::group::` command is used instead — the collapsible
@@ -130,7 +116,11 @@ export function targetPassFooter(
     SGR.dim,
     `succeeded in ${formatDuration(ms)}`,
   );
-  const line = `${icon} ${name} ${tail}`;
+  // A fan-out sub-target's name carries the item key, which comes from repo or
+  // remote data, so on the runner's stream it is neutralised like any other
+  // untrusted text.
+  const safe = style.github ? escapeLine(name) : name;
+  const line = `${icon} ${safe} ${tail}`;
   return style.github ? [line, "::endgroup::"] : [line];
 }
 
@@ -146,18 +136,36 @@ export function targetFailFooter(
   error: unknown,
 ): { info: string[]; error: string[] } {
   const message = messageOf(error);
-  const line = paint(
-    style.color,
-    SGR.red,
-    `${ICON.failed} ${name} failed in ${formatDuration(ms)}`,
-  );
-  const detail = paint(style.color, SGR.red, `  ${message}`);
-  if (!style.github) return { info: [], error: [line, detail] };
+  if (!style.github) {
+    return {
+      info: [],
+      error: [
+        paint(
+          style.color,
+          SGR.red,
+          `${ICON.failed} ${name} failed in ${formatDuration(ms)}`,
+        ),
+        paint(style.color, SGR.red, `  ${message}`),
+      ],
+    };
+  }
+  // Both of these are printed as themselves on a stream the runner parses for
+  // commands. The message embeds a failed subprocess's stderr verbatim, which
+  // is the very content escapeData's contract names as untrusted, and the name
+  // can carry a fan-out item key. Escaping only the annotation below would have
+  // left the detail line able to suspend command processing — and it is emitted
+  // *first*, so it would have disarmed the annotation that follows it.
+  const safeName = escapeLine(name);
+  const safeMessage = escapeLine(message);
   return {
     info: ["::endgroup::"],
     error: [
-      line,
-      detail,
+      paint(
+        style.color,
+        SGR.red,
+        `${ICON.failed} ${safeName} failed in ${formatDuration(ms)}`,
+      ),
+      paint(style.color, SGR.red, `  ${safeMessage}`),
       `::error title=${escapeProperty(name)}::${
         escapeData(`${name} failed: ${message}`)
       }`,
@@ -173,7 +181,7 @@ export function targetWaitFooter(
 ): string[] {
   const icon = paint(style.color, SGR.magenta, ICON.waiting);
   const note = paint(style.color, SGR.dim, `waiting for ${trigger}`);
-  const line = `${icon} ${name} ${note}`;
+  const line = `${icon} ${style.github ? escapeLine(name) : name} ${note}`;
   return style.github ? [line, "::endgroup::"] : [line];
 }
 
@@ -181,7 +189,7 @@ export function targetWaitFooter(
 export function targetDryRunFooter(style: Style, name: string): string[] {
   const icon = paint(style.color, SGR.cyan, ICON.passed);
   const note = paint(style.color, SGR.dim, "(dry run — not executed)");
-  const line = `${icon} ${name} ${note}`;
+  const line = `${icon} ${style.github ? escapeLine(name) : name} ${note}`;
   return style.github ? [line, "::endgroup::"] : [line];
 }
 
@@ -239,7 +247,11 @@ export function summaryBlock(
     const notes = note === ""
       ? ""
       : "  " + paint(style.color, SGR.dim, `// ${note}`);
-    return r.name.padEnd(nameWidth) + "  " +
+    // A row starts at column 0, so a target name is the one thing here that
+    // could open a command; the padding is computed from the raw name so the
+    // columns stay aligned when nothing needed escaping.
+    const name = style.github ? escapeLine(r.name) : r.name;
+    return name + " ".repeat(Math.max(0, nameWidth - r.name.length)) + "  " +
       status + "  " +
       duration.padStart(durationWidth) + notes;
   });
@@ -315,7 +327,7 @@ export function closingLine(
   }
   const failed = reports.filter((r) => r.status === "failed");
   const culprit = failed.length === 1
-    ? `'${failed[0].name}' failed`
+    ? `'${style.github ? escapeLine(failed[0].name) : failed[0].name}' failed`
     : failed.length > 1
     ? `${failed.length} targets failed`
     : "no target succeeded";

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -180,8 +180,12 @@ export function targetWaitFooter(
   trigger: string,
 ): string[] {
   const icon = paint(style.color, SGR.magenta, ICON.waiting);
-  const note = paint(style.color, SGR.dim, `waiting for ${trigger}`);
-  const line = `${icon} ${style.github ? escapeLine(name) : name} ${note}`;
+  // The trigger describes what is being waited on, which for a workflow gate
+  // names a repository and a workflow file, so it is no more ours than the
+  // target name beside it.
+  const safe = (text: string) => style.github ? escapeLine(text) : text;
+  const note = paint(style.color, SGR.dim, `waiting for ${safe(trigger)}`);
+  const line = `${icon} ${safe(name)} ${note}`;
   return style.github ? [line, "::endgroup::"] : [line];
 }
 
@@ -243,7 +247,11 @@ export function summaryBlock(
     // so the status and timing columns stay the thing the eye lands on. They
     // are not part of the table's width: a long note overhangs the rules
     // rather than pushing every duration to the right.
-    const note = formatSummary(r.summary);
+    // Notes are parsed out of a tool's own output by the wrapper packages, so
+    // they are the same untrusted class as the name. They need no newline to
+    // matter: the legacy bracketed command form is recognised mid-line.
+    const raw = formatSummary(r.summary);
+    const note = style.github ? escapeLine(raw) : raw;
     const notes = note === ""
       ? ""
       : "  " + paint(style.color, SGR.dim, `// ${note}`);
@@ -361,7 +369,10 @@ export function jobSummaryMarkdown(
   const rows = reports.map((r) => {
     const ran = r.status === "passed" || r.status === "failed";
     const duration = ran ? formatDuration(r.ms) : "—";
-    return `| ${r.name} | ${ICON[r.status]} ${
+    // A pipe in a name would otherwise open a column of its own, the way the
+    // note cell already guards against.
+    const name = r.name.replaceAll("|", "\\|");
+    return `| ${name} | ${ICON[r.status]} ${
       STATUS_LABEL[r.status]
     } | ${duration} |${notesCell(r)}`;
   });

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -329,6 +329,7 @@ async function driveEffects(
   ctx: TargetContext,
   env: RunEnv,
   reporter: Reporter,
+  style: Style,
 ): Promise<void> {
   if (t.effects_.length === 0) return;
   const writer = env.writer;
@@ -368,9 +369,10 @@ async function driveEffects(
           messageOf(error),
         );
       } catch (settleError) {
+        const safe = (text: string) => style.github ? escapeLine(text) : text;
         reporter.info(
-          `effect "${declared.name}" on "${name}" failed, and recording that ` +
-            `failed too: ${messageOf(settleError)}`,
+          `effect "${safe(declared.name)}" on "${safe(name)}" failed, and ` +
+            `recording that failed too: ${safe(messageOf(settleError))}`,
         );
       }
       throw error;
@@ -501,7 +503,10 @@ async function runTarget(
           summary,
           () =>
             withAmbientEcho(
-              (line) => reporter.info(`  $ ${line}`),
+              // The echoed command line is built from argv the build composed,
+              // which can carry a parameter value or a fan-out key.
+              (line) =>
+                reporter.info(`  $ ${style.github ? escapeLine(line) : line}`),
               () => runBody(t, targetCtx),
             ),
         );
@@ -578,6 +583,7 @@ async function runTarget(
               targetContextFor(name, env, dryRun, summary),
               env,
               reporter,
+              style,
             ),
         );
       } catch (error) {
@@ -628,7 +634,7 @@ async function runTarget(
     await withAmbientSummary(summary, async () => {
       for (const v of t.validateBefore_) await v.validate({ target: name });
       await runBodyWithRecovery(t, name, globalRecovery, targetCtx);
-      await driveEffects(t, name, targetCtx, env, reporter);
+      await driveEffects(t, name, targetCtx, env, reporter, style);
       for (const v of t.validateAfter_) await v.validate({ target: name });
     });
     const ms = performance.now() - start;

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -32,7 +32,12 @@ import {
   TargetSummary,
   withAmbientSummary,
 } from "./summary_note.ts";
-import { type Style, type TargetReport, targetWaitFooter } from "./report.ts";
+import {
+  escapeLine,
+  type Style,
+  type TargetReport,
+  targetWaitFooter,
+} from "./report.ts";
 import type { Renderer } from "./renderer.ts";
 import {
   cloneTarget,
@@ -434,9 +439,14 @@ async function runTarget(
   // started yet.
   const forced = env.writer?.snapshot().overrides?.[name];
   if (forced !== undefined) {
+    // The actor and reason come from the shared state store, so on the runner's
+    // stream they are neutralised like any other text this process did not
+    // author. The target name is ours, but a fan-out key is not, so it goes
+    // through too.
+    const safe = (text: string) => style.github ? escapeLine(text) : text;
     reporter.info(
-      `${name}: forced ${forced.outcome} by ${forced.actor}` +
-        (forced.reason === undefined ? "" : ` — ${forced.reason}`),
+      `${safe(name)}: forced ${forced.outcome} by ${safe(forced.actor)}` +
+        (forced.reason === undefined ? "" : ` — ${safe(forced.reason)}`),
     );
     return {
       status: forced.outcome === "skipped" ? "skipped" : "passed",

--- a/packages/core/tests/executor_test.ts
+++ b/packages/core/tests/executor_test.ts
@@ -3293,3 +3293,32 @@ Deno.test("summary: a target's notes land in the run record and in a dependent's
     assertEquals(loaded?.record.targets.gate.summary, undefined);
   });
 });
+
+Deno.test("a secret in a summary note is redacted in the job summary too", async () => {
+  // Every other sink for a resolved secret() parameter is redacted — the
+  // console through the reporter, the run record as it is persisted — and this
+  // one was not, so the value read [redacted] on the terminal while the job
+  // summary published it to everyone who can view the workflow run. The
+  // ::add-mask:: directives do not cover it: they mask the runner's log stream,
+  // not a file the build writes.
+  class B extends Build {
+    token = parameter("deploy token").secret().default("s3cr3t-value");
+    deploy = target().executes(() => {
+      // The shape this bites in practice: an identifier built from the secret.
+      reportSummary({ Endpoint: `https://api.example/${this.token.value}` });
+    });
+  }
+  const build = new B();
+  discoverTargets(build);
+  const tmp = await Deno.makeTempFile();
+  try {
+    await withEnv("GITHUB_STEP_SUMMARY", tmp, async () => {
+      await silence(() => execute(build, build.deploy, { github: true }));
+    });
+    const md = await Deno.readTextFile(tmp);
+    assertEquals(md.includes("s3cr3t-value"), false);
+    assertEquals(md.includes("[redacted]"), true);
+  } finally {
+    await Deno.remove(tmp);
+  }
+});

--- a/packages/core/tests/report_test.ts
+++ b/packages/core/tests/report_test.ts
@@ -316,3 +316,118 @@ Deno.test("jobSummaryMarkdown escapes a pipe in a note so it cannot add a cell",
   );
   assertStringIncludes(md, "| t | ✔ Succeeded | 0.0s | Ratio: a \\| b |");
 });
+
+// --- workflow-command neutralisation on the runner's stream -----------------
+
+/** Every physical line of `lines`, as the Actions runner would split them. */
+function physicalLines(lines: readonly string[]): string[] {
+  return lines.flatMap((l) => l.split(/\r\n|\r|\n/));
+}
+
+/**
+ * Zuke's own workflow commands, which are supposed to open with `::`. Their
+ * bodies are percent-encoded, so untrusted text cannot break out of them.
+ */
+const OWN_COMMAND = /^::(?:endgroup::|group::|error title=)/;
+
+/**
+ * Whether any physical line would be taken by the runner as a command that
+ * Zuke did not intend to emit — the runner trims leading whitespace before
+ * testing for `::`, and recognises the legacy `##[...]` form anywhere.
+ */
+function hasCommandLine(lines: readonly string[]): boolean {
+  return physicalLines(lines).some((l) => {
+    const trimmed = l.trimStart();
+    if (OWN_COMMAND.test(trimmed)) return false;
+    return trimmed.startsWith("::") || l.includes("##[");
+  });
+}
+
+Deno.test("a failure message cannot open a workflow command", () => {
+  // A CommandError embeds the failed subprocess's stderr verbatim, so this is
+  // attacker-influenced whenever a tool echoes repository content. Both runner
+  // syntaxes are covered: a `::` line (leading whitespace is trimmed before the
+  // test, so indenting defends nothing) and the legacy `##[...]` form, which is
+  // recognised anywhere in a line and needs no newline at all.
+  const hostile = [
+    "Command failed (exit 1): lint",
+    "::stop-commands::deadbeef",
+    "   ::error::forged",
+    "trailing ##[error]forged",
+  ].join("\n");
+  const { info, error } = targetFailFooter(
+    GITHUB,
+    "lint",
+    5,
+    new Error(hostile),
+  );
+
+  assertEquals(hasCommandLine(error.slice(0, 2)), false);
+  // The text is still there and still readable — only the two sequences the
+  // runner acts on are encoded.
+  // The leading `::` is encoded, so the line no longer opens a command; the
+  // rest of the text is untouched.
+  assertStringIncludes(error[1], "%3A%3A" + "stop-commands::deadbeef");
+  assertStringIncludes(error[1], "%23%23[error]forged");
+  assertStringIncludes(error[1], "Command failed (exit 1): lint");
+  // Zuke's own commands still work: the annotation and the group close.
+  assertStringIncludes(error[2], "::error title=lint::");
+  assertEquals(info, ["::endgroup::"]);
+});
+
+Deno.test("plain mode leaves a failure message exactly as it was", () => {
+  // Nothing parses a terminal, so encoding there would only hurt legibility.
+  const hostile = "boom\n::stop-commands::x\n##[error]y";
+  const { error } = targetFailFooter(PLAIN, "lint", 5, new Error(hostile));
+  assertStringIncludes(error[1], "::stop-commands::x");
+  assertStringIncludes(error[1], "##[error]y");
+});
+
+Deno.test("a target name cannot open a workflow command in any footer", () => {
+  // A fan-out sub-target's name embeds its item key, which is derived from
+  // repository or remote data.
+  const name = "build[a\n::stop-commands::x].compile";
+  assertEquals(hasCommandLine(targetPassFooter(GITHUB, name, 1)), false);
+  assertEquals(hasCommandLine(targetDryRunFooter(GITHUB, name)), false);
+  const { error } = targetFailFooter(GITHUB, name, 1, new Error("x"));
+  assertEquals(hasCommandLine(error.slice(0, 2)), false);
+
+  // The group header is one of Zuke's own commands, so it opens with `::` by
+  // design. What matters there is that the name cannot break out of it: it is
+  // percent-encoded into the command body, leaving a single physical line.
+  const header = targetHeader(GITHUB, name);
+  assertEquals(header.length, 1);
+  assertEquals(physicalLines(header).length, 1);
+  assertStringIncludes(header[0], "%0A" + "::stop-commands::x");
+});
+
+Deno.test("a hostile target name cannot open a command from the summary", () => {
+  const reports = [
+    { name: "ok", status: "passed", ms: 1 },
+    { name: "b\n::stop-commands::x", status: "failed", ms: 2 },
+  ] as const;
+  const block = summaryBlock(GITHUB, [...reports], 3, false);
+  assertEquals(hasCommandLine(block), false);
+  // The closing line names the culprit, so it carries the name too.
+  assertEquals(
+    hasCommandLine([closingLine(GITHUB, [...reports], 3, false, new Date())]),
+    false,
+  );
+});
+
+Deno.test("ordinary output is returned unchanged", () => {
+  // The escape must be invisible to every build that is not under attack.
+  const plain = summaryBlock(
+    PLAIN,
+    [{ name: "lint", status: "passed", ms: 1 }],
+    1,
+    true,
+  );
+  const github = summaryBlock(
+    GITHUB,
+    [{ name: "lint", status: "passed", ms: 1 }],
+    1,
+    true,
+  );
+  assertEquals(github.filter((l) => l !== "::endgroup::"), plain);
+});

--- a/packages/core/tests/report_test.ts
+++ b/packages/core/tests/report_test.ts
@@ -12,6 +12,8 @@ import {
   targetFailFooter,
   targetHeader,
   targetPassFooter,
+  type TargetReport,
+  targetWaitFooter,
 } from "../src/report.ts";
 
 /** Plain (no colour, terminal mode), with a stable width for assertions. */
@@ -337,11 +339,17 @@ const OWN_COMMAND = /^::(?:endgroup::|group::|error title=)/;
  */
 function hasCommandLine(lines: readonly string[]): boolean {
   return physicalLines(lines).some((l) => {
-    const trimmed = l.trimStart();
+    // Trim what the *runner* considers blank, which includes NEXT LINE and so
+    // is wider than this language's `trimStart`. Using the narrower set would
+    // give the oracle the same blind spot as the code it checks.
+    const trimmed = l.replace(/^[\s\u0085]*/, "");
     if (OWN_COMMAND.test(trimmed)) return false;
     return trimmed.startsWith("::") || l.includes("##[");
   });
 }
+
+/** NEXT LINE: whitespace to the runner, not matched by this language's `\s`. */
+const NEL = String.fromCharCode(0x85);
 
 Deno.test("a failure message cannot open a workflow command", () => {
   // A CommandError embeds the failed subprocess's stderr verbatim, so this is
@@ -430,4 +438,51 @@ Deno.test("ordinary output is returned unchanged", () => {
     true,
   );
   assertEquals(github.filter((l) => l !== "::endgroup::"), plain);
+});
+
+Deno.test("a line the runner un-blanks cannot open a command", () => {
+  // NEXT LINE is trimmed by the runner before it tests for `::`, and is not
+  // matched by this language's `\s`. A line that looks indented here therefore
+  // starts with `::` by the time the runner reads it.
+  const { error } = targetFailFooter(
+    GITHUB,
+    "lint",
+    1,
+    new Error(`boom\n${NEL}::stop-commands::x`),
+  );
+  assertEquals(hasCommandLine(error.slice(0, 2)), false);
+});
+
+Deno.test("a summary note cannot open a command", () => {
+  // Notes are parsed out of a tool's own output by the wrapper packages, and
+  // the legacy bracketed form needs no newline to be recognised.
+  const reports: TargetReport[] = [{
+    name: "lint",
+    status: "passed",
+    ms: 1,
+    summary: [{ key: "Files", value: "##[add-mask]hunter2" }],
+  }];
+  assertEquals(hasCommandLine(summaryBlock(GITHUB, reports, 1, true)), false);
+});
+
+Deno.test("a wait footer's trigger cannot open a command", () => {
+  // The trigger names what is being waited on — for a workflow gate, a
+  // repository and a workflow file.
+  assertEquals(
+    hasCommandLine(targetWaitFooter(GITHUB, "e2e", "gh:acme/app##[error]x")),
+    false,
+  );
+});
+
+Deno.test("a pipe in a target name cannot add a column to the job summary", () => {
+  // The note cell already guarded against this; the name cell did not.
+  const md = jobSummaryMarkdown(
+    [{ name: "deploy|extra|cells", status: "passed", ms: 1 }],
+    1,
+    true,
+  );
+  const row = md.split("\n").find((l) => l.includes("deploy")) ?? "";
+  // Leading, name, result, time, trailing — the pipes in the name are escaped
+  // rather than opening columns of their own.
+  assertEquals(row.split(/(?<!\\)\|/).length, 5);
 });

--- a/tests/integration/github_output_test.ts
+++ b/tests/integration/github_output_test.ts
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Integration: under GitHub Actions styling, nothing a build prints can be
+ * mistaken by the runner for a workflow command it did not intend to emit.
+ *
+ * The runner reads every line of a step's stdout and stderr, and acts on two
+ * syntaxes: a line whose first non-blank characters are `::`, and the legacy
+ * `##[command]` form, which it recognises anywhere in a line. A build carries
+ * text it did not author into both streams — a failed tool's stderr, a fan-out
+ * key derived from repository data — so this drives a real build through the
+ * CLI and asserts the whole stream, rather than trusting a unit test of one
+ * formatter to have covered every emission site.
+ *
+ * @module
+ */
+
+import { assertEquals } from "../../packages/core/tests/_assert.ts";
+import { Build, target } from "../../packages/core/mod.ts";
+import { runCli } from "./_harness.ts";
+import { withEnv } from "../../packages/core/tests/_env.ts";
+
+/** Zuke's own workflow commands, which are supposed to open with `::`. */
+const OWN_COMMAND = /^::(?:endgroup::|group::|error title=|add-mask::)/;
+
+/** Physical lines the runner would parse, minus Zuke's own commands. */
+function unintendedCommands(stream: string): string[] {
+  return stream
+    .split(/\r\n|\r|\n/)
+    .filter((l) => {
+      const trimmed = l.trimStart();
+      if (OWN_COMMAND.test(trimmed)) return false;
+      return trimmed.startsWith("::") || l.includes("##[");
+    });
+}
+
+/** What a tool prints when it echoes hostile repository content back at us. */
+const HOSTILE = [
+  "lint failed on src/x.ts",
+  "::stop-commands::deadbeef",
+  "   ::error::forged annotation",
+  "note: ##[error]forged too",
+].join("\n");
+
+Deno.test("integration: a failing target's output cannot forge workflow commands", async () => {
+  class CI extends Build {
+    lint = target().executes(() => {
+      // Stands in for a captured tool failure: the message embeds the tool's
+      // stderr, which quoted the file it was linting.
+      throw new Error(HOSTILE);
+    });
+  }
+
+  let r = { code: 0, out: "", err: "" };
+  await withEnv({ GITHUB_ACTIONS: "true" }, async () => {
+    r = await runCli(CI, ["lint"]);
+  });
+  assertEquals(r.code, 1);
+
+  const stray = unintendedCommands(r.out + "\n" + r.err);
+  assertEquals(
+    stray,
+    [],
+    `these lines would run as workflow commands:\n${stray.join("\n")}`,
+  );
+
+  // The text is still legible — neutralised, not deleted.
+  assertEquals((r.out + r.err).includes("lint failed on src/x.ts"), true);
+  assertEquals(
+    (r.out + r.err).includes("%3A%3A" + "stop-commands::deadbeef"),
+    true,
+  );
+});
+
+Deno.test("integration: a hostile target name cannot forge workflow commands", async () => {
+  // A fan-out sub-target's name embeds its item key, which comes from
+  // repository or remote data. The name reaches the group header, the pass
+  // footer, the summary row and the closing line.
+  class CI extends Build {
+    ["deploy[a\n::stop-commands::x]"] = target().executes(() => {});
+  }
+
+  let r = { code: 0, out: "", err: "" };
+  await withEnv({ GITHUB_ACTIONS: "true" }, async () => {
+    r = await runCli(CI, ["deploy[a\n::stop-commands::x]"]);
+  });
+  assertEquals(r.code, 0, r.err);
+
+  const stray = unintendedCommands(r.out + "\n" + r.err);
+  assertEquals(
+    stray,
+    [],
+    `these lines would run as workflow commands:\n${stray.join("\n")}`,
+  );
+});

--- a/tests/integration/github_output_test.ts
+++ b/tests/integration/github_output_test.ts
@@ -24,22 +24,38 @@ import { withEnv } from "../../packages/core/tests/_env.ts";
 /** Zuke's own workflow commands, which are supposed to open with `::`. */
 const OWN_COMMAND = /^::(?:endgroup::|group::|error title=|add-mask::)/;
 
+/**
+ * Trim what the *runner* considers blank before it tests for a command, which
+ * is not the same set this language trims: NEXT LINE (U+0085) is whitespace to
+ * the runner and not to `String.prototype.trimStart`. Using the language's
+ * idea here would give the oracle the same blind spot as the code it checks.
+ */
+function runnerTrimStart(line: string): string {
+  return line.replace(/^[\s\u0085]*/, "");
+}
+
 /** Physical lines the runner would parse, minus Zuke's own commands. */
 function unintendedCommands(stream: string): string[] {
   return stream
     .split(/\r\n|\r|\n/)
     .filter((l) => {
-      const trimmed = l.trimStart();
+      const trimmed = runnerTrimStart(l);
       if (OWN_COMMAND.test(trimmed)) return false;
       return trimmed.startsWith("::") || l.includes("##[");
     });
 }
+
+/** NEXT LINE: trimmed by the runner, not matched by this language's `\s`. */
+const NEL = String.fromCharCode(0x85);
 
 /** What a tool prints when it echoes hostile repository content back at us. */
 const HOSTILE = [
   "lint failed on src/x.ts",
   "::stop-commands::deadbeef",
   "   ::error::forged annotation",
+  // NEXT LINE is whitespace to the runner but not to this language, so it is
+  // trimmed at parse time and the `::` lands at the front of the line.
+  `${NEL}::error::forged past a language-specific trim`,
   "note: ##[error]forged too",
 ].join("\n");
 


### PR DESCRIPTION
## What & why

Two findings from the whole-repository security assessment, both on the path
between a build and the GitHub Actions runner.

**Build output could forge workflow commands.** The runner reads every line a
step writes, on stdout and stderr alike, and acts on two syntaxes: a line whose
first non-blank characters are `::`, and the legacy `##[command]` form, which it
recognises *anywhere* in a line. The escapes that answer this already existed,
and their own documentation named the threat — a subprocess's stderr carrying
`::stop-commands::` — but they were applied only to the synthesized `::error::`
annotation and the `::group::` header.

Everything else went out raw: the failure footer's detail line, which is the
error message and therefore embeds a failed subprocess's stderr verbatim; the
pass, wait, dry-run, summary and closing lines, which embed a target name that
for a fan-out sub-target carries an item key derived from repository data; the
forced-override line, whose actor and reason come from the shared state store.

Ordering made the first one worse. The detail precedes the annotation, so a
`::stop-commands::` in a tool's stderr disarmed the very annotation the escaping
protects, and the `::endgroup::` after it.

Two details ruled out the obvious defences. The runner trims leading whitespace
before deciding a line opens a command, so the two-space indent on the detail
line was never a mitigation. And the existing escape is the wrong tool for text
printed as itself: it encodes every newline, folding a multi-line compiler dump
into one unreadable `%0A`-joined line. So this adds a third escape beside the
other two, which disarms only the sequences the runner acts on and returns
everything else byte-identical.

**The job summary bypassed the secret redactor.** Every other sink for a
resolved `secret()` parameter was covered — the console through the reporter, the
run record as it is persisted — so a summary note carrying one read `[redacted]`
on the terminal and in the record while the job summary published it in the clear
to everyone who can view the workflow run. The `::add-mask::` directives do not
help: they mask the runner's log stream, not a file the build writes. This
contradicted the guarantee in `docs/secrets.md`, that a secret never surfaces in
Zuke's own output, a summary included.

The escapes move to `render.ts`, the published `./render` entrypoint already
shared with `@zuke/console`, so that package can reuse them rather than growing a
second copy that drifts.

## Related issues

Closes #546

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a
      [Conventional Commit](https://www.conventionalcommits.org/)
      (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour
      changed.
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`,
      `llms-full.txt`, package README `## API`).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with
      type guards instead).
- [x] No dead code: unreachable branches and can't-fire fallbacks are removed,
      with types tightened so the impossible state is unrepresentable.
- [x] No duplicated logic: an existing helper is imported rather than retyped,
      and a near-copy differing by a constant or a message is parameterised into
      one implementation. A guard, escape, or credential resolution has exactly
      one implementation.
- [x] SOLID shapes respected: one domain per file, extension via the settings
      lambda (not a behaviour-switching flag), narrow parameter types, and
      dependencies on the injectable seam (`StateHost`, an injected `fetch`,
      `EnvReader`) rather than `Deno.*` or a global.
- [x] A new package was wired into all six places (see
      [AGENTS.md](../blob/master/AGENTS.md#good-open-source-practices-to-follow)),
      if applicable.
- [x] The code is written using AI assisted coding.

## Notes for the reviewer

**Why `feat`.** Three new exports on the published `./render` entrypoint, so a
minor rather than a patch.

**The adversarial pass found a bypass in my own fix, and it is the interesting
part of this PR.** "Blank" is the runner's idea of it, not JavaScript's, and the
two sets differ by exactly one character in the direction that matters: NEXT LINE
(U+0085). The runner trims it before testing for `::`; `\s` does not match it. It
is not a line terminator for the reader the runner uses, so it travels inside a
line and disappears only at parse time, carrying the colons to the front of a
line that looked safely indented. Worse, the integration oracle I had written to
guard all of this trimmed with the same narrow rule, so it shared the blind spot
and reported success. Both now trim what the runner trims, and the test was
confirmed to fail against the previous pattern.

**Two sites were simply forgotten**, which is the predictable cost of escaping at
each call site rather than at the boundary: summary notes, which the wrapper
packages parse out of a tool's own output, and the suspended-run waiting list —
plus the wait trigger, the effect-settle failure and the dry-run echo. All are
covered now.

**The boundary refactor is the durable answer and is not in this PR.** Escaping
once in the reporter, with Zuke's own commands exempt, would make a forgotten
site impossible rather than merely caught. Doing it soundly needs the reporter to
distinguish a command from content by type rather than by pattern — a
prefix-match exemption is forgeable by text that starts with the same prefix —
which is a wider change than this fix should carry. What guards it meanwhile is
the integration test, which drives a real build and asserts over its whole
output stream, so a new emission site that forgets the escape fails rather than
passing unnoticed.

**Every new test was confirmed to fail without its fix**, rather than assumed to
pin anything: the redaction test, the escaping test, and the whitespace one
against the previous pattern.

**Plain output is unchanged.** Nothing parses a terminal, so encoding there would
only cost legibility; the escape is gated on GitHub styling throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNN7wc1BczPDB7zEaQ9noH

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNN7wc1BczPDB7zEaQ9noH)_