### PR TITLE
fix(console): escape the two workflow-command sites #547 left for later

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -481,8 +481,7 @@
       ]
     },
     "@xmldom/xmldom@0.8.13": {
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
-      "deprecated": true
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw=="
     },
     "agent-base@7.1.4": {
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="
@@ -1593,7 +1592,7 @@
       },
       "packages/console": {
         "dependencies": [
-          "jsr:@zuke/core@^1.25.0"
+          "jsr:@zuke/core@^1.51.0"
         ]
       },
       "packages/cspell": {

--- a/packages/console/deno.json
+++ b/packages/console/deno.json
@@ -7,7 +7,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1.25.0"
+    "@zuke/core": "jsr:@zuke/core@^1.51.0"
   },
   "publish": {
     "exclude": [

--- a/packages/console/src/console.ts
+++ b/packages/console/src/console.ts
@@ -27,6 +27,7 @@ import {
   box as renderBox,
   type BoxOptions,
   detectWidth,
+  escapeData,
   line as renderLine,
   type LineOptions,
   type Style,
@@ -173,7 +174,13 @@ function logAt(
       color: false,
       tags: themeTags(state.theme),
     });
-    emit([`::${command}::${detail ? `${plain}: ${detail}` : plain}`], stream);
+    // A command body, so it takes the body escape rather than `escapeLine`: a
+    // newline here would end the command and let what follows open a new one.
+    // `detail` is `messageOf(options.error)`, which for a failed command
+    // carries that subprocess's stderr verbatim.
+    emit([
+      `::${command}::${escapeData(detail ? `${plain}: ${detail}` : plain)}`,
+    ], stream);
     return;
   }
 
@@ -375,7 +382,9 @@ export const ConsoleTasks: ConsoleTasksApi = {
     if (muted()) return;
     const style = currentStyle();
     if (style.github) {
-      emit([`::group::${renderMarkup(name, { color: false })}`], "out");
+      emit([
+        `::group::${escapeData(renderMarkup(name, { color: false }))}`,
+      ], "out");
     } else {
       emit([renderRule(style, name, {})], "out");
     }

--- a/packages/console/src/renderer.ts
+++ b/packages/console/src/renderer.ts
@@ -17,12 +17,16 @@
  */
 
 import { defaultRenderer, type Renderer } from "@zuke/core";
-import { line, type Style, stylize } from "@zuke/core/render";
+import { escapeData, line, type Style, stylize } from "@zuke/core/render";
 import { defaultTheme, type Theme } from "./theme.ts";
 
 /** The ruled, theme-coloured banner that opens a target's section. */
 function themedHeader(theme: Theme, style: Style, name: string): string[] {
-  if (style.github) return [`::group::${name}`];
+  // A command body, like core's own group header — so it takes `escapeData`,
+  // not `escapeLine`. The name is a target's, which for a fan-out carries an
+  // item key, and this header is emitted BEFORE the body: a suspend directive
+  // here would disarm everything the target goes on to print.
+  if (style.github) return [`::group::${escapeData(name)}`];
   const rule = line(style);
   const label = stylize(style.color, ["bold", ...theme.info], name);
   return [rule, label, rule];

--- a/packages/console/tests/console_test.ts
+++ b/packages/console/tests/console_test.ts
@@ -83,6 +83,31 @@ Deno.test("GitHub Actions mode emits workflow commands for warn/error", () => {
   ConsoleTasks.reset();
 });
 
+Deno.test("a workflow command's body cannot be forged from its own arguments", () => {
+  // The runner ends a command at the end of its line, so a newline in the body
+  // lets what follows open a command of its own. `error`'s detail is
+  // `messageOf(options.error)`, which for a failed command carries that
+  // subprocess's stderr verbatim — not something this package controls.
+  const { err } = capture({ github: true });
+  ConsoleTasks.warn("heads up\n::stop-commands::TOKEN");
+  ConsoleTasks.error("bad", {
+    error: new Error("boom\n::error::forged annotation"),
+  });
+  // One physical line per command, with the newline encoded rather than live.
+  assertEquals(err, [
+    "::warning::heads up%0A::stop-commands::TOKEN",
+    "::error::bad: boom%0A::error::forged annotation",
+  ]);
+  ConsoleTasks.reset();
+});
+
+Deno.test("a group name cannot forge a workflow command", () => {
+  const { out } = capture({ github: true });
+  ConsoleTasks.group("deploy\n::stop-commands::TOKEN");
+  assertEquals(out, ["::group::deploy%0A::stop-commands::TOKEN"]);
+  ConsoleTasks.reset();
+});
+
 Deno.test("line and rule draw across the configured width", () => {
   const { out } = capture();
   ConsoleTasks.line();

--- a/packages/console/tests/renderer_test.ts
+++ b/packages/console/tests/renderer_test.ts
@@ -25,6 +25,23 @@ Deno.test("consoleRenderer opens a group under GitHub Actions", () => {
   ]);
 });
 
+Deno.test("a hostile target name cannot forge a command from the header", () => {
+  // The header is emitted BEFORE the target's body, so a suspend directive in
+  // the name would disarm everything the target goes on to print — including
+  // core's own escaped footers and annotation. A fan-out sub-target's name
+  // carries its item key, which comes from repository or remote data.
+  const NL = String.fromCharCode(10);
+  assertEquals(
+    consoleRenderer.targetHeader(actions, `fan[item${NL}::stop-commands::x]`),
+    ["::group::fan[item%0A::stop-commands::x]"],
+  );
+  // Off Actions the name is untouched, newline and all.
+  assertEquals(
+    consoleRenderer.targetHeader(plain, `a${NL}b`)[1],
+    `a${NL}b`,
+  );
+});
+
 Deno.test("the header colour comes from the theme's info token", () => {
   const green: Theme = { ...defaultTheme, info: ["green"] };
   const renderer = createConsoleRenderer(green);

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -7,6 +7,8 @@
  */
 
 import { type Build, discoverGroups, discoverTargets } from "./build.ts";
+import { detectCiHost } from "./host.ts";
+import { escapeLine } from "./render.ts";
 import { discoverCiFiles, syncCiFiles } from "./ci.ts";
 import { isEntryModule } from "./entry.ts";
 import { messageOf } from "./internal.ts";
@@ -1111,11 +1113,19 @@ async function runForce(build: Build, parsed: ParsedArgs): Promise<number> {
       ...(parsed.reason === undefined ? {} : { reason: parsed.reason }),
       actor: parsed.actor,
     });
+    // The reason inside this message is the operator's, and in a scripted force
+    // it is often interpolated from a pull request title or an issue body. The
+    // escape belongs here, at the printer that owns the terminal, rather than in
+    // `forceTarget` — the MCP tool returns the same message inside a JSON
+    // payload, which must not carry a terminal's encoding.
+    const shown = detectCiHost() === "github"
+      ? escapeLine(result.message)
+      : result.message;
     if (!result.ok) {
-      console.error(result.message);
+      console.error(shown);
       return 1;
     }
-    console.log(result.message);
+    console.log(shown);
     return 0;
   } catch (error) {
     console.error(messageOf(error));

--- a/packages/core/src/force.ts
+++ b/packages/core/src/force.ts
@@ -19,9 +19,7 @@
 
 import type { Build } from "./build.ts";
 import { discoverTargets } from "./build.ts";
-import { detectCiHost } from "./host.ts";
 import { messageOf } from "./internal.ts";
-import { escapeLine } from "./render.ts";
 import { assertOwnsRun, resolveBuildId } from "./ownership.ts";
 import { resolveActor } from "./state/record.ts";
 import { resolveRunStore } from "./run_store.ts";
@@ -269,17 +267,12 @@ export async function forceTarget(
       };
     }
     if (result.ok) {
-      // Echoed back to whatever prints this message, which under Actions is the
-      // job log. In a scripted force the reason is often interpolated from a
-      // pull request title or an issue body, so it is escaped here — where it
-      // is embedded — and is covered whichever way the message is printed.
-      const why = override.reason === undefined
-        ? ""
-        : ` (${
-          detectCiHost() === "github"
-            ? escapeLine(override.reason)
-            : override.reason
-        })`;
+      // Not escaped here. This message is data: the MCP `force_target` tool
+      // returns it inside a JSON payload, and encoding it for a terminal the
+      // producer does not own would corrupt that payload for every client
+      // whenever the *server* happened to run under Actions. The CLI escapes it
+      // where it prints it.
+      const why = override.reason === undefined ? "" : ` (${override.reason})`;
       return {
         ok: true,
         override,

--- a/packages/core/src/force.ts
+++ b/packages/core/src/force.ts
@@ -19,7 +19,9 @@
 
 import type { Build } from "./build.ts";
 import { discoverTargets } from "./build.ts";
+import { detectCiHost } from "./host.ts";
 import { messageOf } from "./internal.ts";
+import { escapeLine } from "./render.ts";
 import { assertOwnsRun, resolveBuildId } from "./ownership.ts";
 import { resolveActor } from "./state/record.ts";
 import { resolveRunStore } from "./run_store.ts";
@@ -267,7 +269,17 @@ export async function forceTarget(
       };
     }
     if (result.ok) {
-      const why = override.reason === undefined ? "" : ` (${override.reason})`;
+      // Echoed back to whatever prints this message, which under Actions is the
+      // job log. In a scripted force the reason is often interpolated from a
+      // pull request title or an issue body, so it is escaped here — where it
+      // is embedded — and is covered whichever way the message is printed.
+      const why = override.reason === undefined
+        ? ""
+        : ` (${
+          detectCiHost() === "github"
+            ? escapeLine(override.reason)
+            : override.reason
+        })`;
       return {
         ok: true,
         override,

--- a/packages/core/tests/force_test.ts
+++ b/packages/core/tests/force_test.ts
@@ -95,6 +95,33 @@ Deno.test("a settled target cannot be forced", async () => {
   }
 });
 
+Deno.test("the returned message is data, not terminal-encoded output", async () => {
+  // The MCP `force_target` tool returns this message inside a JSON payload. If
+  // `forceTarget` encoded it for a terminal, every client would get mangled
+  // text whenever the *server* happened to run under Actions — so the escaping
+  // lives at the CLI printer instead, and this pins the producer's side of that
+  // split. An earlier version of this change escaped here and broke it.
+  await withTempStore(async (store) => {
+    const runId = await seed(store);
+    const reason = ["done", "::stop-commands::TOKEN"].join(
+      String.fromCharCode(10),
+    );
+    const result = await forceTarget(new CD(), {
+      runId,
+      target: "deploy",
+      outcome: "skipped",
+      reason,
+      actor: "operator-b",
+      stateStore: store,
+      // Claim to be inside Actions: the producer must not care.
+      readEnv: (name) => name === "GITHUB_ACTIONS" ? "true" : undefined,
+    });
+    assertEquals(result.ok, true);
+    assertStringIncludes(result.message, reason);
+    assertEquals(result.message.includes("%3A%3A"), false);
+  });
+});
+
 Deno.test("a target the build declares unforceable is refused", async () => {
   await withTempStore(async (store) => {
     const runId = await seed(store);

--- a/tests/integration/github_output_test.ts
+++ b/tests/integration/github_output_test.ts
@@ -17,8 +17,8 @@
  */
 
 import { assertEquals } from "../../packages/core/tests/_assert.ts";
-import { Build, target } from "../../packages/core/mod.ts";
-import { runCli } from "./_harness.ts";
+import { Build, externalSignal, target } from "../../packages/core/mod.ts";
+import { runCli, withStateDir } from "./_harness.ts";
 import { withEnv } from "../../packages/core/tests/_env.ts";
 
 /** Zuke's own workflow commands, which are supposed to open with `::`. */
@@ -109,4 +109,52 @@ Deno.test("integration: a hostile target name cannot forge workflow commands", a
     [],
     `these lines would run as workflow commands:\n${stray.join("\n")}`,
   );
+});
+
+Deno.test("a force's echoed reason cannot forge a command", async () => {
+  // `zuke force` echoes the operator's reason back to the log. In a scripted
+  // force that reason is often interpolated from a pull request title or an
+  // issue body, so it is not something the job's own author controls.
+  //
+  // This asserts on the FORCE command's own output, not on a later run: the
+  // forced target settles before the scheduler prints anything about it, so a
+  // test that watched the resumed run would pass with the escaping removed.
+  await withStateDir(async () => {
+    class Pipeline extends Build {
+      migrate = target().executes(() => {});
+      gate = target()
+        .dependsOn(this.migrate)
+        .waitsFor((s) => s.on(externalSignal("go")));
+      report = target().dependsOn(this.gate).executes(() => {});
+    }
+
+    const first = await runCli(Pipeline, ["report"]);
+    assertEquals(first.code, 0, first.err);
+    const listed = await runCli(Pipeline, ["runs", "list", "--json"]);
+    const runId = String(JSON.parse(listed.out)[0].id);
+
+    let forced = { code: -1, out: "", err: "" };
+    await withEnv({ GITHUB_ACTIONS: "true" }, async () => {
+      // `report` is still pending behind the gate; forcing an already-succeeded
+      // target is refused, since the record would then claim something that did
+      // not happen.
+      forced = await runCli(Pipeline, [
+        "force",
+        runId,
+        "report",
+        "--outcome",
+        "skipped",
+        "--reason",
+        HOSTILE,
+        "--actor",
+        "ops",
+      ]);
+    });
+    assertEquals(forced.code, 0, forced.err);
+    assertEquals(
+      unintendedCommands(`${forced.out}\n${forced.err}`),
+      [],
+      "the force echo let hostile text reach the runner as a command",
+    );
+  });
 });


### PR DESCRIPTION
Refs #546. Follow-up to #547, which fixed the core reporting path and published the escapes "so that package can reuse them later".

Two sites still emit raw, and both carry text the job's own author does not control.

## The console package's own commands

`@zuke/console` interpolates straight into its `::warning::` and `::error::` commands and into its group header, with no escaping. The error body is `messageOf(options.error)` — for a failed command, that subprocess's stderr verbatim, which is the same untrusted source the core fix was written for.

These are command **bodies** rather than lines printed as themselves, so they take `escapeData` rather than `escapeLine`: a newline inside a command ends it, and what follows opens a new one.

## The force command's echoed reason

`zuke force` echoes the operator's reason back to the log. In a scripted force that reason is commonly interpolated from a pull request title or an issue body, so it is not the job author's own text. It is escaped where it is embedded, so it stays covered whichever way the message is later printed.

## On the overlap with #547

This branch originally carried its own version of the core fix as well. #547 landed first, and its `escapeLine` is the better implementation — it splits on `\r`, `\r\n` and `\n` and trims NEXT LINE (U+0085), where the version here split on `\n` alone and would have let a `\r`-separated marker through. That work is dropped rather than merged; only the two uncovered sites are carried forward, using #547's helpers.

## Verification

Every test here was confirmed to fail with its own escape removed, then to pass with it restored.

The force test asserts on the **force command's own output**, not on a later run. An earlier version watched the resumed run and passed with the escaping removed, because the forced target settles before the scheduler prints anything about it — the stream it watched never carried the value at all.

Gate green at 23/23: 4453 tests, 98.5% lines, 97.4% branches.
