### PR TITLE
ci: pin the secret scan's ruleset and correct what the gate claims to prevent

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ inputs:
     required: false
     default: "1"
   ref:
-    description: "Branch, tag or SHA to check out. Empty checks out what the event points at. Refused outright on an event whose content a contributor writes (`pull_request_target`, `issue_comment`, `workflow_run`, …) — see the refusal below."
+    description: "Branch, tag or SHA to check out. Leave it empty — the default — and the checkout follows the event, which on an event whose content a contributor writes (`pull_request_target`, `issue_comment`, `workflow_run`, …) is the base or default branch: code that is already trusted. Setting it is what those events refuse, because a ref chosen from a contributor's text would run with this repository's secrets — see the refusal below."
     required: false
     default: ""
   deno-version:

--- a/build/gitleaks_report.ts
+++ b/build/gitleaks_report.ts
@@ -163,8 +163,12 @@ export function gitleaksSummary(
       findings.length === 1 ? "" : "s"
     }`,
     "",
-    "Values are redacted: this names where a secret is, not what it is. To " +
-    "dismiss a false positive, add its fingerprint to the gitleaks allowlist.",
+    "Values are redacted: this names where a secret is, not what it is. If a " +
+    "finding is real, rotate the credential first — it is in the history, so " +
+    "removing the line does not withdraw it. If it is a false positive, say so " +
+    "on the pull request: scanner configuration is not carried in a feature " +
+    "branch, because a diff that narrows the scan is a change to the gate and " +
+    "is reviewed as one.",
     "",
     "| Rule | File | Line | Commit | Fingerprint |",
     "| --- | --- | --- | --- | --- |",

--- a/build/scanner_policy.ts
+++ b/build/scanner_policy.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Whether a pull request has changed a file that decides what the security
+ * scanners look for — and therefore what they can be told to miss.
+ *
+ * The scanners read their rules and their exclusions from the working tree, so
+ * a branch that adds one of these files chooses the configuration its own diff
+ * is scanned by. None of them exists in this repository, which is deliberate:
+ * the scanners run on their defaults, and the appearance of one is the event
+ * worth failing on.
+ *
+ * @module
+ */
+
+/**
+ * The files whose content configures a scanner's rules or its exclusions.
+ *
+ * Both spellings are listed where a tool accepts either, since a check that
+ * knew only one of them would be walked around by using the other.
+ */
+export const SCANNER_CONFIG_FILES: readonly string[] = [
+  ".gitleaks.toml",
+  ".gitleaksignore",
+  ".github/zizmor.yml",
+  ".github/zizmor.yaml",
+  ".github/actionlint.yaml",
+  ".github/actionlint.yml",
+];
+
+/**
+ * The scanner configuration files among `changed`, listed in the order of
+ * {@link SCANNER_CONFIG_FILES} so a refusal reads the same way twice.
+ *
+ * `changed` is the output of a `git diff --name-only`, so entries are
+ * repository-relative and one per line; blank lines and surrounding whitespace
+ * are ignored rather than treated as a path.
+ */
+export function changedScannerConfigs(
+  changed: readonly string[],
+): string[] {
+  const names = new Set(
+    changed.map((path) => path.trim()).filter((path) => path !== ""),
+  );
+  return SCANNER_CONFIG_FILES.filter((file) => names.has(file));
+}
+
+/**
+ * A refusal naming the scanner configuration a pull request changed, or `null`
+ * when it changed none.
+ *
+ * The message is deliberately explicit that this is not a complete defence. The
+ * gate runs the pull request's own `zuke.ts`, so a branch can delete the scanner
+ * call outright and no in-tree pinning can stop it. What this buys is that a
+ * configuration change becomes a named failure a reviewer sees, rather than a
+ * silent narrowing of what the scan covers — and that the scheduled and
+ * post-merge scans are protected from a file that merged unnoticed.
+ */
+export function scannerConfigDenial(
+  changed: readonly string[],
+): string | null {
+  const found = changedScannerConfigs(changed);
+  if (found.length === 0) return null;
+  const list = found.map((file) => `  - ${file}`).join("\n");
+  return `This pull request changes scanner configuration:\n${list}\n\n` +
+    `Those files decide what the secret and workflow scanners report, so a ` +
+    `change to them narrows the scan that is judging this very diff. None of ` +
+    `them exists on the default branch: the scanners run on their defaults ` +
+    `deliberately.\n\n` +
+    `If the change is legitimate — a rule the project genuinely wants — land ` +
+    `it on its own, so it is reviewed as a change to the gate rather than as ` +
+    `a detail of an unrelated pull request.`;
+}

--- a/build/workflows.ts
+++ b/build/workflows.ts
@@ -58,11 +58,18 @@ export interface WorkflowTargets {
 /**
  * The hosts `./zuke ci` legitimately reaches, for the one job that runs build
  * code while holding live secrets and a write-scoped token. Egress is blocked
- * rather than audited there: even if untrusted code in the gate read a token
- * from the environment, it could not POST it anywhere. Each entry is traceable
- * to something the build does — the Deno bootstrap, module resolution (JSR, plus
- * npm for the cspell tooling), the OpenAI API for the lint fixer, GitHub for the
- * fixer's comment and push, and Codecov's CDN, API, and upload bucket.
+ * rather than audited there, which bounds where those secrets could go — but
+ * not whether they could go anywhere. GitHub itself is on this list, and must
+ * be, because the lint fixer pushes and comments through it; a token read from
+ * this environment can be sent there, and on a public repository the job log is
+ * world-readable, so masking is defeated by any encoding. What blocking buys is
+ * that a *third-party* destination is not reachable, which is the realistic
+ * shape of a compromised build-time dependency.
+ *
+ * Each entry is traceable to something the build does — the Deno bootstrap,
+ * module resolution (JSR, plus npm for the cspell tooling), the OpenAI API for
+ * the lint fixer, GitHub for the fixer's comment and push, and Codecov's CDN,
+ * API, and upload bucket.
  */
 const GATE_ENDPOINTS = [
   "deno.land:443",
@@ -167,9 +174,11 @@ export function githubWorkflows(
           // job needs both scopes. On a fork PR the key is absent, the token is
           // read-only whatever is asked for, and the fixer skips.
           permissions: { contents: "write", "pull-requests": "write" },
-          // Runs build code while holding live secrets and a write-scoped token,
-          // so block egress rather than audit it: even if untrusted code in the
-          // gate read a token, it could not POST it anywhere.
+          // Runs build code while holding live secrets and a write-scoped
+          // token, so block egress rather than audit it. That bounds the
+          // destinations, not the exfiltration: GitHub is necessarily on the
+          // allowlist, so this stops a third party receiving a token, not
+          // GitHub receiving one. See GATE_ENDPOINTS.
           harden: { egress: "block", allowedEndpoints: GATE_ENDPOINTS },
           checkout: {
             // Keeps the token in git config so the fixer can push, and checks out

--- a/docs/assurance-case.md
+++ b/docs/assurance-case.md
@@ -36,6 +36,7 @@ Adversaries considered, and the assets they target:
 | Registry-level attacker              | Consumers of `@zuke/*`          | OIDC trusted publishing; Sigstore provenance per version; no long-lived registry tokens exist                                                       |
 | Network attacker (MITM) on bootstrap | Developer/CI machines           | Launcher downloads the pinned Deno release over HTTPS and verifies a per-platform SHA-256 baked into the launcher; `DENO_VERSION=latest` is refused |
 | Careless or compromised insider      | Repository history              | gitleaks scans full history on schedule and pushes; PR-scoped scans on every pull request; secret parameters are redacted from output               |
+| Contributor with write access (same-repo PR) | CI secrets, write token  | Not defended against, by design: the lint fixer pushes fixes and Codecov uploads from pull-request runs, so same-repo PRs carry `OPENAI_API_KEY`, `CODECOV_TOKEN` and a write-scoped token. Write access is held only by maintainers, whose own secrets these are; the residual is a compromised maintainer account yielding an OpenAI key and an upload-only Codecov token |
 
 Out of scope: vulnerabilities in GitHub, JSR, or Deno themselves (they are the
 trusted computing base — see the boundaries below), and denial of service
@@ -57,8 +58,13 @@ against public CI.
    job (OIDC) never holds a write-scoped repo token. A compromise of one job
    does not yield the other's authority.
 4. **CI jobs → network.** Every job that holds a write-scoped token runs with
-   egress _blocked_ to a named allowlist, so even code that reads a token has
-   nowhere unauthorized to send it.
+   egress _blocked_ to a named allowlist. That bounds **which third parties** a
+   job can reach; it does not stop a secret leaving. GitHub is on the
+   allowlist by necessity — the lint fixer pushes and comments through it — and
+   a public repository's job log is world-readable, so masking is defeated by
+   any encoding. The counter this boundary provides is against a compromised
+   build-time dependency phoning home, not against code that is already trusted
+   with the token.
 5. **Repository → third-party code.** Actions cross the boundary only at pinned
    commit SHAs; scanner binaries only with verified checksums
    (`build/scanners.ts`); modules only through the committed, frozen

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -222,7 +222,7 @@ only governs what runs after it.
 | `allowed-endpoints`   | `""`    | Space-separated `host:port` list permitted under `block`.                          |
 | `persist-credentials` | `false` | Leave the token in git config, for a later push.                                   |
 | `fetch-depth`         | `1`     | Commits to fetch. `0` is the full history, which a secret scan needs.              |
-| `ref`                 | `""`    | Branch, tag or SHA to check out. Empty follows the event. See the warning below.   |
+| `ref`                 | `""`    | Branch, tag or SHA to check out. Empty follows the event — the base or default branch on a secret-bearing one. See below. |
 | `deno-version`        | `""`    | Install this Deno. Usually unnecessary — the `./zuke` launcher bootstraps its own. |
 
 Running a target needs a committed `./zuke` launcher in the repository (that is
@@ -300,6 +300,16 @@ today would be silently wrong the moment the list grew.
 It is also **not keyed on `target`**: a `ref` checkout with no target is refused
 just the same, because a caller who omits it and writes `run: ./zuke ci` in
 their own next step reaches the identical outcome.
+
+**Leaving `ref` empty is the safe default, on those events too**, and the guard
+deliberately does not touch it. An empty `ref` is passed straight through to
+`actions/checkout`, which then follows `GITHUB_REF`/`GITHUB_SHA` — and on
+`pull_request_target` that pair is the **base** branch and its tip, not the
+contributor's head; on `issue_comment` and `workflow_run` it is the default
+branch. So the workspace holds code that is already trusted, which is what makes
+the standard base-checkout pattern possible at all. Refusing an empty `ref`
+would refuse every such job while protecting nothing: what a pwn-request needs
+is a `ref` pointing at the head, and that is the case the guard rejects.
 
 Zuke's own six workflows all start with the published action — the generated
 YAML opens with `uses: zuke-build/zuke@<sha>`, so the repository dogfoods the

--- a/tests/ci_secrets_test.ts
+++ b/tests/ci_secrets_test.ts
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Regression tests for which CI jobs hold which secrets.
+ *
+ * The repository accepts, deliberately, that a same-repo pull request runs with
+ * live secrets and a write-scoped token: the lint fixer pushes its fix to the
+ * branch and Codecov uploads from pull-request runs. `docs/assurance-case.md`
+ * names that adversary and that residual.
+ *
+ * What must not happen is the exposure widening by accident — a secret added to
+ * a job that had none, a `pull_request_target` trigger appearing, credentials
+ * persisted in a job that has no reason to push. None of those breaks a build,
+ * so nothing else would notice. These pin the current shape so a change to it
+ * has to be deliberate.
+ *
+ * They read the committed YAML rather than the declaration in
+ * `build/workflows.ts`, because that is what GitHub runs; the gate's
+ * `generate-ci --check` proves the two agree.
+ *
+ * @module
+ */
+
+import { assertEquals } from "../packages/core/tests/_assert.ts";
+import { isRecord, jobsOf, readWorkflow } from "./_workflow.ts";
+
+const CI = ".github/workflows/ci.yml";
+const AI_REVIEW = ".github/workflows/ai-review.yml";
+
+/** Every `secrets.NAME` a job's own text refers to, sorted and deduplicated. */
+function secretsOf(job: Record<string, unknown>): string[] {
+  const names = new Set<string>();
+  for (const match of JSON.stringify(job).matchAll(/secrets\.([A-Z0-9_]+)/g)) {
+    names.add(match[1]);
+  }
+  return [...names].sort();
+}
+
+/** Every job in a committed workflow, keyed by id. */
+function jobs(path: string): Map<string, Record<string, unknown>> {
+  return jobsOf(readWorkflow(path));
+}
+
+Deno.test("only the gate job in ci.yml holds secrets", async (t) => {
+  const found = new Map(
+    [...jobs(CI)].map(([id, job]) => [id, secretsOf(job)]),
+  );
+  await t.step("the gate holds exactly the three it needs", () => {
+    // OPENAI_API_KEY for the lint fixer, GITHUB_TOKEN for its push and comment,
+    // CODECOV_TOKEN for the coverage upload. A fourth arriving here is the
+    // change this test exists to catch.
+    assertEquals(found.get("ci"), [
+      "CODECOV_TOKEN",
+      "GITHUB_TOKEN",
+      "OPENAI_API_KEY",
+    ]);
+  });
+  await t.step("every other job holds none", () => {
+    for (const [id, secrets] of found) {
+      if (id === "ci") continue;
+      assertEquals(secrets, [], `${id} should hold no secrets`);
+    }
+  });
+});
+
+Deno.test("the ai-review job holds only what posting a review needs", () => {
+  const review = jobs(AI_REVIEW).get("review");
+  assertEquals(review === undefined, false);
+  assertEquals(secretsOf(review ?? {}), ["GITHUB_TOKEN", "OPENAI_API_KEY"]);
+});
+
+Deno.test("no workflow triggers on pull_request_target", async () => {
+  // The trigger that would run a fork's code with this repository's secrets.
+  // Nothing here uses it, and nothing should start to without the change being
+  // argued for.
+  for await (const entry of Deno.readDir(".github/workflows")) {
+    if (!entry.name.endsWith(".yml")) continue;
+    const workflow = readWorkflow(`.github/workflows/${entry.name}`);
+    // `on` is YAML 1.1 truthy, so a parser may key it as `true`.
+    const on = workflow.on ?? workflow[String(true)];
+    const triggers = isRecord(on) ? Object.keys(on) : [];
+    assertEquals(
+      triggers.includes("pull_request_target"),
+      false,
+      `${entry.name} triggers on pull_request_target`,
+    );
+  }
+});
+
+Deno.test("only the gate persists credentials, and only it needs to", () => {
+  // A persisted token is what lets the fixer push. Any other job keeping one in
+  // git config would be holding a push capability it never uses.
+  for (const [id, job] of jobs(CI)) {
+    const persists = JSON.stringify(job).includes(
+      '"persist-credentials":"true"',
+    );
+    assertEquals(
+      persists,
+      id === "ci",
+      `${id}: unexpected persist-credentials`,
+    );
+  }
+});
+
+Deno.test("the gate blocks egress and the review job does not", () => {
+  // Recorded rather than aspirational: the review job audits, which is why
+  // `docs/assurance-case.md` claims blocking only for jobs that hold a
+  // write-scoped token. If that changes, the prose has to change with it.
+  const gate = JSON.stringify(jobs(CI).get("ci") ?? {});
+  assertEquals(gate.includes('"egress-policy":"block"'), true);
+  const review = JSON.stringify(jobs(AI_REVIEW).get("review") ?? {});
+  assertEquals(review.includes('"egress-policy":"audit"'), true);
+});

--- a/tests/scanner_policy_test.ts
+++ b/tests/scanner_policy_test.ts
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../packages/core/tests/_assert.ts";
+import {
+  changedScannerConfigs,
+  SCANNER_CONFIG_FILES,
+  scannerConfigDenial,
+} from "../build/scanner_policy.ts";
+
+Deno.test("an ordinary diff changes no scanner configuration", () => {
+  assertEquals(
+    scannerConfigDenial([
+      "packages/core/src/executor.ts",
+      "docs/caching.md",
+      "README.md",
+    ]),
+    null,
+  );
+});
+
+Deno.test("adding a gitleaks config is refused, and named", () => {
+  const denial = scannerConfigDenial(["src/app.ts", ".gitleaks.toml"]);
+  assertEquals(denial === null, false);
+  assertStringIncludes(denial ?? "", ".gitleaks.toml");
+});
+
+Deno.test("an ignore file is refused as well as a rule file", () => {
+  // The two weaken a scan by different routes — one changes the rules, the
+  // other exempts a finding — so covering only the rules would miss half.
+  assertEquals(scannerConfigDenial([".gitleaksignore"]) === null, false);
+});
+
+Deno.test("every listed config is actually refused", () => {
+  // Guards the list against an entry that is present but unreachable, e.g. one
+  // whose spelling drifts from the constant.
+  for (const file of SCANNER_CONFIG_FILES) {
+    assertEquals(
+      scannerConfigDenial([file]) === null,
+      false,
+      `${file} is listed but not refused`,
+    );
+  }
+});
+
+Deno.test("both spellings a tool accepts are refused", () => {
+  // A check that knew only `.yml` would be walked around with `.yaml`.
+  for (
+    const pair of [
+      [".github/zizmor.yml", ".github/zizmor.yaml"],
+      [".github/actionlint.yaml", ".github/actionlint.yml"],
+    ]
+  ) {
+    for (const file of pair) {
+      assertEquals(scannerConfigDenial([file]) === null, false, file);
+    }
+  }
+});
+
+Deno.test("several changed configs are all named, in list order", () => {
+  const denial = scannerConfigDenial([
+    ".gitleaksignore",
+    "src/app.ts",
+    ".gitleaks.toml",
+  ]) ?? "";
+  // Listed in the constant's order, not the diff's, so the message reads the
+  // same way whichever order git happens to print.
+  assertEquals(
+    denial.indexOf(".gitleaks.toml") < denial.indexOf(".gitleaksignore"),
+    true,
+  );
+});
+
+Deno.test("blank and padded lines are not treated as paths", () => {
+  // `git diff --name-only` output is split on newlines, so the trailing empty
+  // line is always there; a naive check would see it as a filename.
+  assertEquals(scannerConfigDenial(["", "  ", "src/app.ts", ""]), null);
+  assertEquals(changedScannerConfigs([" .gitleaks.toml "]), [".gitleaks.toml"]);
+});
+
+Deno.test("a path that merely contains a config name is not refused", () => {
+  // The scanners read these at fixed locations; a file of a similar name
+  // elsewhere configures nothing, and refusing it would be a false positive a
+  // contributor cannot act on.
+  assertEquals(
+    scannerConfigDenial([
+      "docs/.gitleaks.toml",
+      "vendor/x/.gitleaksignore",
+      "examples/app/.github/zizmor.yml",
+    ]),
+    null,
+  );
+});

--- a/zuke.ts
+++ b/zuke.ts
@@ -119,6 +119,7 @@ import {
   resolveBaseRef,
 } from "./build/plugin_version_check.ts";
 import { actionPin } from "./build/action_pins.ts";
+import { scannerConfigDenial } from "./build/scanner_policy.ts";
 import { actionlintTool, gitleaksTool, zizmorTool } from "./build/scanners.ts";
 import { githubWorkflows } from "./build/workflows.ts";
 
@@ -128,6 +129,19 @@ import { githubWorkflows } from "./build/workflows.ts";
  * because a local `./zuke security` writes it too.
  */
 const GITLEAKS_REPORT = "gitleaks-report.json";
+
+/**
+ * The ruleset `./zuke security` scans with: gitleaks' own defaults, extended by
+ * nothing.
+ *
+ * Written to a file the build controls and passed with `--config`, rather than
+ * left to gitleaks' own lookup, which reads `<source>/.gitleaks.toml`. That
+ * lookup is the hole: a config file that merged unnoticed would narrow every
+ * later scan — including the scheduled full-history one, which no pull-request
+ * diff can see. Refusing a diff that *changes* such a file (see the `security`
+ * target) covers the branch; this covers the branch that already landed.
+ */
+const GITLEAKS_CONFIG = ["[extend]", "useDefault = true", ""].join("\n");
 
 /**
  * The files the `check` target type-checks: the globs of the root `check` task
@@ -737,20 +751,57 @@ class ZukeBuild extends Build {
       // under review; a push to the default branch and the weekly schedule still
       // walk the whole history, so nothing stops being covered.
       const prBase = Deno.env.get("GITHUB_BASE_REF");
+      // On a pull request, refuse a diff that changes what the scanners look
+      // for. They read their rules from the working tree, so a branch that adds
+      // a config chooses the scan that judges it. This is visibility, not a
+      // seal: the gate runs the branch's own `zuke.ts` and could simply drop
+      // the scanner call — but a config change now has to be argued for rather
+      // than merged as a detail of something else.
+      if (prBase !== undefined && prBase !== "") {
+        const diff = await GitTasks.run((s) =>
+          s.command(
+            "diff",
+            "--name-only",
+            `origin/${prBase}...HEAD`,
+          ).noThrow()
+        );
+        if (diff.code !== 0) {
+          // Fail closed. A missing `origin/<base>` — a shallow checkout, a
+          // renamed branch — makes the diff empty, and an empty diff is
+          // indistinguishable from "changed nothing". Reporting nothing here
+          // would turn the check off exactly when it could not run, which is
+          // the failure mode `pluginVersionCheck` already learned the hard way.
+          failures.push(
+            `scanner config (could not diff against origin/${prBase}; ` +
+              `the check needs the base ref, so a shallow checkout disables ` +
+              `it silently)`,
+          );
+        } else {
+          const denial = scannerConfigDenial(diff.text().split("\n"));
+          if (denial !== null) failures.push(`scanner config\n${denial}`);
+        }
+      }
       // The report stays redacted — it carries the file, line, rule and
       // fingerprint of each finding but not the secret itself, which is what
       // makes a failure diagnosable from the uploaded artifact instead of only
       // from a bare count in the log.
-      await gate(
-        "gitleaks",
-        SecurityTasks.gitleaks((s) => {
-          const settings = s.toolPath(scanner("gitleaks")).source(".").redact()
-            .reportFormat("json").reportPath(GITLEAKS_REPORT).noThrow();
-          return prBase === undefined || prBase === ""
-            ? settings
-            : settings.logOpts(`origin/${prBase}..HEAD`);
-        }),
-      );
+      const gitleaksConfig = await Deno.makeTempFile({ suffix: ".toml" });
+      try {
+        await FileTasks.writeText(gitleaksConfig, GITLEAKS_CONFIG);
+        await gate(
+          "gitleaks",
+          SecurityTasks.gitleaks((s) => {
+            const settings = s.toolPath(scanner("gitleaks")).source(".")
+              .config(gitleaksConfig).redact()
+              .reportFormat("json").reportPath(GITLEAKS_REPORT).noThrow();
+            return prBase === undefined || prBase === ""
+              ? settings
+              : settings.logOpts(`origin/${prBase}..HEAD`);
+          }),
+        );
+      } finally {
+        await Deno.remove(gitleaksConfig).catch(() => {});
+      }
       // osv-scanner is omitted here: it has no extractor for Deno's lockfile.
       // The @zuke/security wrapper still ships it for projects with npm/cargo/
       // go/etc. lockfiles it does understand.


### PR DESCRIPTION
## What & why

The last three findings from the whole-repository security assessment that
concern this repository's own CI rather than a published package. One is a real
gap, one is a pair of false claims we were making in prose, and one is
**refuted** — recording that is part of the work.

**A pull request could choose the rules it was scanned by.** gitleaks resolves
configuration from the working tree, so a branch adding a config or an ignore
file narrows the scan judging that very branch — and the job summary invited it,
telling contributors to add a fingerprint to the allowlist. The scan now runs
against a ruleset the build writes, and a diff that changes any scanner
configuration is refused by name.

**Blocked egress does not mean a token cannot leave.** Two comments in
`build/workflows.ts` and trust boundary 4 in `docs/assurance-case.md` said it
did. GitHub is necessarily on the allowlist — the lint fixer pushes and comments
through it — and a public repository's job log is world-readable, so masking
falls to any encoding.

**The composite action's checkout guard was reported as unsafe and is not.** An
empty `ref` resolves to the base or default branch on every secret-bearing event.

## Related issues

Closes #561

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a
      [Conventional Commit](https://www.conventionalcommits.org/)
      (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour
      changed.
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`,
      `llms-full.txt`, package README `## API`).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with
      type guards instead).
- [x] No dead code: unreachable branches and can't-fire fallbacks are removed,
      with types tightened so the impossible state is unrepresentable.
- [x] No duplicated logic: an existing helper is imported rather than retyped,
      and a near-copy differing by a constant or a message is parameterised into
      one implementation. A guard, escape, or credential resolution has exactly
      one implementation.
- [x] SOLID shapes respected: one domain per file, extension via the settings
      lambda (not a behaviour-switching flag), narrow parameter types, and
      dependencies on the injectable seam (`StateHost`, an injected `fetch`,
      `EnvReader`) rather than `Deno.*` or a global.
- [x] A new package was wired into all six places (see
      [AGENTS.md](../blob/master/AGENTS.md#good-open-source-practices-to-follow)),
      if applicable.
- [x] The code is written using AI assisted coding.

## Notes for the reviewer

**Why `ci` and nothing releasable.** No package changes, so nothing bumps. The
scanner-config decision is a pure function in `build/`, unit-tested, rather than
inline in the target.

**The new refusal is honest about its own limits, and the message says so.** The
gate executes the pull request's own `zuke.ts`, so a branch can delete the
scanner call and no in-tree pinning stops it. What this buys is that narrowing a
scan has to be argued for rather than merged as a detail of an unrelated change.
The pinned ruleset covers the other half — a config that landed unnoticed would
otherwise weaken every later scan, including the scheduled full-history one that
no pull-request diff can see.

**It fails closed, which was a defect in my first cut.** A missing
`origin/<base>` makes the diff empty, and an empty diff is indistinguishable from
a clean one, so a shallow checkout would have disabled the check exactly when it
could not run. That is the failure mode `pluginVersionCheck` already learned the
hard way, so it reports rather than passes.

**The gitleaks config was verified against the pinned version's own source**
rather than from memory: v8.30.1's `ViperConfig.Extend` carries `UseDefault`, and
setting it calls `extendDefault`, which loads the embedded ruleset. I could not
run the `security` target here — it needs the provisioned scanners and an
authenticated API call — so CI is its first real execution, and that is the one
thing in this PR I have reasoned about rather than watched run.

**Every workflow assertion was mutation-tested.** Each of the three properties
was broken in the committed YAML in turn to confirm the test fails: a secret
added to a job that should hold none, a `pull_request_target` trigger added, and
credentials persisted in a second job. The first attempt at the trigger mutation
passed — my mutation script had matched `on:` inside `integration:` rather than
the top-level key — which is worth recording, because a mutation that does not
mutate looks exactly like a test that works.

**What is deliberately not changed.** The secret exposure itself stays: same-repo
pull requests carry `OPENAI_API_KEY`, `CODECOV_TOKEN` and a write-scoped token
because the lint fixer pushes and Codecov uploads from those runs, and removing
the secrets removes both features. What was missing is that the threat model
named only the fork-PR adversary and never the writer these secrets are actually
exposed to; that row now exists with its residual.

**Two follow-ups this PR cannot carry.** `.gitleaksignore` is still read from the
source directory, because pinning it needs `--gitleaks-ignore-path`, which the
wrapper does not expose — a `feat(security)` change to a published package that a
`ci:`-titled PR would never release. The same applies to an egress option on
`AiReviewWorkflowSpec`, where `packages/ai/src/workflow.ts` hard-codes `audit`.
Until then the diff refusal is what covers the ignore file.

**On the refuted finding.** The report assumed the default checkout on
`pull_request_target` is `refs/pull/<n>/merge`; that describes `pull_request`,
where forks get no secrets anyway. Dropping the `inputs.ref != ''` conjunct would
refuse every `pull_request_target` job including the safe base-checkout pattern.
`tests/action_manifest_test.ts` already pinned the design — what was missing was
prose saying what an empty ref does, which is what made the report plausible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNN7wc1BczPDB7zEaQ9noH

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNN7wc1BczPDB7zEaQ9noH)_