### PR TITLE
fix(core): keep a hostile target name inside its summary cell

### DIFF
--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -211,8 +211,10 @@ export function summaryBlock(
   now: Date = new Date(),
 ): string[] {
   const headers = { name: "Target", status: "Status", duration: "Duration" };
+  const shownName = new Map(reports.map((r) => [r, displayName(r.name)]));
+  const nameOf = (r: TargetReport): string => shownName.get(r) ?? r.name;
   const nameWidth = reports.reduce(
-    (w, r) => Math.max(w, r.name.length),
+    (w, r) => Math.max(w, nameOf(r).length),
     headers.name.length,
   );
   const statusWidth = Object.values(STATUS_LABEL).reduce(
@@ -259,8 +261,9 @@ export function summaryBlock(
     // A row starts at column 0, so a target name is the one thing here that
     // could open a command; the padding is computed from the raw name so the
     // columns stay aligned when nothing needed escaping.
-    const name = style.github ? escapeLine(r.name) : r.name;
-    return name + " ".repeat(Math.max(0, nameWidth - r.name.length)) + "  " +
+    const shown = nameOf(r);
+    const name = style.github ? escapeLine(shown) : shown;
+    return name + " ".repeat(Math.max(0, nameWidth - shown.length)) + "  " +
       status + "  " +
       duration.padStart(durationWidth) + notes;
   });
@@ -336,7 +339,11 @@ export function closingLine(
   }
   const failed = reports.filter((r) => r.status === "failed");
   const culprit = failed.length === 1
-    ? `'${style.github ? escapeLine(failed[0].name) : failed[0].name}' failed`
+    ? `'${
+      style.github
+        ? escapeLine(displayName(failed[0].name))
+        : displayName(failed[0].name)
+    }' failed`
     : failed.length > 1
     ? `${failed.length} targets failed`
     : "no target succeeded";
@@ -354,6 +361,20 @@ export function closingLine(
  * Render the GitHub Actions job-summary Markdown for a build — an aligned table
  * with a Total row and a verdict heading, mirroring the terminal summary.
  */
+/**
+ * A target's name as any renderer should print it: collapsed to one line.
+ *
+ * A name is not necessarily the build author's text — a fan-out sub-target's
+ * carries its item key, which comes from repository or remote data — and every
+ * renderer here puts it in a table. A newline breaks the row in each of them:
+ * the terminal table loses its alignment and gains a line that can imitate a
+ * Total row, and a Markdown row ends early, publishing what follows as document
+ * content. So it is collapsed once, here, rather than at each renderer.
+ */
+function displayName(name: string): string {
+  return singleLine(name);
+}
+
 /**
  * Render `value` as the contents of one Markdown table cell.
  *
@@ -378,9 +399,10 @@ export function closingLine(
  */
 function markdownCell(value: string): string {
   return singleLine(value)
-    .replaceAll("|", "\\|")
-    .replaceAll("<!--", "&lt;!--")
-    .replaceAll("-->", "--&gt;");
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll("|", "\\|");
 }
 
 export function jobSummaryMarkdown(

--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -14,6 +14,7 @@
  */
 
 import { messageOf } from "./internal.ts";
+import { singleLine } from "./summary_note.ts";
 import type { TargetStatus } from "./build.ts";
 import {
   escapeData,
@@ -353,6 +354,35 @@ export function closingLine(
  * Render the GitHub Actions job-summary Markdown for a build — an aligned table
  * with a Total row and a verdict heading, mirroring the terminal summary.
  */
+/**
+ * Render `value` as the contents of one Markdown table cell.
+ *
+ * Neither a target name nor a summary note is necessarily the build author's
+ * text: a wrapper hands over what a tool printed, and a fan-out sub-target's
+ * name carries its item key, which comes from repository or remote data. Three
+ * things in such a value would otherwise escape the cell:
+ *
+ * - a **newline** ends the row, so everything after it is published as document
+ *   content — a heading, a list, raw markup — rather than as a cell;
+ * - a **pipe** opens a column of its own, shifting every later cell;
+ * - an **HTML comment marker** comments out the rest of the table, so the rows
+ *   below it silently vanish from the rendered summary.
+ *
+ * The collapsing is {@link "./summary_note.ts".singleLine}, which a note
+ * already went through when it was recorded; applying it here as well is what
+ * covers the name, which went through nothing.
+ *
+ * Matches `@zuke/ai`'s own cell renderer deliberately, including in what it
+ * does *not* do: other markup is left as written, since a cell is rendered by
+ * GitHub's sanitiser and over-escaping would mangle ordinary names.
+ */
+function markdownCell(value: string): string {
+  return singleLine(value)
+    .replaceAll("|", "\\|")
+    .replaceAll("<!--", "&lt;!--")
+    .replaceAll("-->", "--&gt;");
+}
+
 export function jobSummaryMarkdown(
   reports: TargetReport[],
   totalMs: number,
@@ -365,13 +395,11 @@ export function jobSummaryMarkdown(
   // keeps the three-column table it always had.
   const withNotes = reports.some((r) => formatSummary(r.summary) !== "");
   const notesCell = (r: TargetReport) =>
-    withNotes ? ` ${formatSummary(r.summary).replaceAll("|", "\\|")} |` : "";
+    withNotes ? ` ${markdownCell(formatSummary(r.summary))} |` : "";
   const rows = reports.map((r) => {
     const ran = r.status === "passed" || r.status === "failed";
     const duration = ran ? formatDuration(r.ms) : "—";
-    // A pipe in a name would otherwise open a column of its own, the way the
-    // note cell already guards against.
-    const name = r.name.replaceAll("|", "\\|");
+    const name = markdownCell(r.name);
     return `| ${name} | ${ICON[r.status]} ${
       STATUS_LABEL[r.status]
     } | ${duration} |${notesCell(r)}`;

--- a/packages/core/src/summary_note.ts
+++ b/packages/core/src/summary_note.ts
@@ -42,14 +42,22 @@ export interface SummaryEntry {
 }
 
 /**
- * Collapse a reported key or value to a single line of printable text.
+ * Collapse a value to a single line of printable text, for anything that lands
+ * in a table cell.
  *
- * A note lands in a terminal table row and a Markdown table cell, and a wrapper
- * may hand over text a tool printed: a newline would start a new row and an
- * ANSI sequence would restyle the rest of the table, so both are removed here —
- * the one place — rather than at each renderer.
+ * A note or a target name lands in a terminal table row and a Markdown table
+ * cell, and neither is necessarily the build author's text: a wrapper hands
+ * over what a tool printed, and a fan-out sub-target's name carries its item
+ * key. A newline would start a new row — in Markdown, ending the row early and
+ * publishing whatever follows as document content — and an ANSI sequence would
+ * restyle the rest of the table. Both are removed here, the one place, rather
+ * than at each renderer.
+ *
+ * Exported within the package for that reason: the second caller is the job
+ * summary's target column, which had no such guard and let a newline in a name
+ * break the table and inject Markdown.
  */
-function singleLine(text: string): string {
+export function singleLine(text: string): string {
   return stripAnsi(text)
     // deno-lint-ignore no-control-regex
     .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "")

--- a/packages/core/src/summary_note.ts
+++ b/packages/core/src/summary_note.ts
@@ -50,12 +50,12 @@ export interface SummaryEntry {
  * over what a tool printed, and a fan-out sub-target's name carries its item
  * key. A newline would start a new row — in Markdown, ending the row early and
  * publishing whatever follows as document content — and an ANSI sequence would
- * restyle the rest of the table. Both are removed here, the one place, rather
- * than at each renderer.
+ * restyle the rest of the table.
  *
- * Exported within the package for that reason: the second caller is the job
- * summary's target column, which had no such guard and let a newline in a name
- * break the table and inject Markdown.
+ * This is the collapsing itself, not the whole guard. A note goes through it
+ * when it is recorded; a name goes through it in `report.ts`, which applies it
+ * for every renderer it owns. A Markdown cell needs more on top — escaping the
+ * markup that would otherwise close the table — and that lives with the cell.
  */
 export function singleLine(text: string): string {
   return stripAnsi(text)

--- a/packages/core/tests/report_test.ts
+++ b/packages/core/tests/report_test.ts
@@ -155,6 +155,57 @@ Deno.test("colour mode wraps headers, rows, and the closing line in ANSI codes",
   assertEquals(block[block.length - 1].includes("\x1b["), true);
 });
 
+Deno.test("a hostile target name cannot escape its job-summary cell", () => {
+  // A fan-out sub-target's name carries its item key, which comes from
+  // repository or remote data. Three ways a cell leaks without this guard.
+  const NL = String.fromCharCode(10);
+  const md = jobSummaryMarkdown(
+    [
+      {
+        name: [
+          "ok |",
+          "",
+          "## Injected heading",
+          "",
+          "<img src=x onerror=1>",
+        ].join(NL),
+        status: "passed",
+        ms: 100,
+      },
+      { name: "after", status: "passed", ms: 100 },
+    ],
+    200,
+    true,
+  );
+
+  // One row per target: the newline no longer ends the row early, so the
+  // heading below it is cell text rather than a document heading.
+  const rows = md.split(NL).filter((l) => l.startsWith("|"));
+  // header, separator, two target rows, Total.
+  assertEquals(rows.length, 5);
+  assertEquals(md.includes(`${NL}## Injected heading`), false);
+  // The pipe is escaped, so it does not open a column of its own.
+  assertEquals(md.includes("ok \\|"), true);
+  // The row that follows is still present and still a row of its own.
+  assertEquals(md.includes("| after | ✔ Succeeded | 0.1s |"), true);
+});
+
+Deno.test("a comment marker in a cell cannot hide the rows below it", () => {
+  // `<!--` would otherwise comment out the remainder of the table, so the rows
+  // after it vanish from the rendered summary without any error.
+  const md = jobSummaryMarkdown(
+    [
+      { name: "a<!--", status: "passed", ms: 100 },
+      { name: "b", status: "passed", ms: 100 },
+    ],
+    200,
+    true,
+  );
+  assertEquals(md.includes("<!--"), false);
+  assertEquals(md.includes("a&lt;!--"), true);
+  assertEquals(md.includes("| b | ✔ Succeeded | 0.1s |"), true);
+});
+
 Deno.test("jobSummaryMarkdown renders an aligned table with a bold Total row", () => {
   const reports = [
     { name: "a", status: "passed" as const, ms: 100 },

--- a/packages/core/tests/report_test.ts
+++ b/packages/core/tests/report_test.ts
@@ -155,20 +155,28 @@ Deno.test("colour mode wraps headers, rows, and the closing line in ANSI codes",
   assertEquals(block[block.length - 1].includes("\x1b["), true);
 });
 
-Deno.test("a hostile target name cannot escape its job-summary cell", () => {
-  // A fan-out sub-target's name carries its item key, which comes from
-  // repository or remote data. Three ways a cell leaks without this guard.
+Deno.test("markup in a name cannot close the job-summary table", () => {
+  // The escape that matters most, and the one a pipe-only guard misses:
+  // `</table>` is not a newline, a pipe or a comment marker, and GitHub's
+  // sanitiser allows it — it stops scripts, it does not keep text in a cell.
+  // Left raw, the table ends at that row and everything after is published as
+  // page content, including a forged heading.
+  const md = jobSummaryMarkdown(
+    [{ name: "</table><h1>All checks passed</h1>", status: "passed", ms: 100 }],
+    100,
+    true,
+  );
+  assertEquals(md.includes("</table>"), false);
+  assertEquals(md.includes("<h1>"), false);
+  assertEquals(md.includes("&lt;/table&gt;&lt;h1&gt;"), true);
+});
+
+Deno.test("a newline in a name cannot end its job-summary row", () => {
   const NL = String.fromCharCode(10);
   const md = jobSummaryMarkdown(
     [
       {
-        name: [
-          "ok |",
-          "",
-          "## Injected heading",
-          "",
-          "<img src=x onerror=1>",
-        ].join(NL),
+        name: ["a", "## Injected heading"].join(NL),
         status: "passed",
         ms: 100,
       },
@@ -177,33 +185,61 @@ Deno.test("a hostile target name cannot escape its job-summary cell", () => {
     200,
     true,
   );
-
-  // One row per target: the newline no longer ends the row early, so the
-  // heading below it is cell text rather than a document heading.
-  const rows = md.split(NL).filter((l) => l.startsWith("|"));
-  // header, separator, two target rows, Total.
-  assertEquals(rows.length, 5);
-  assertEquals(md.includes(`${NL}## Injected heading`), false);
-  // The pipe is escaped, so it does not open a column of its own.
-  assertEquals(md.includes("ok \\|"), true);
-  // The row that follows is still present and still a row of its own.
-  assertEquals(md.includes("| after | ✔ Succeeded | 0.1s |"), true);
+  // Asserted on the LINE, not on the substring: the heading text is expected to
+  // survive as cell content, and what must not happen is it starting a line of
+  // its own. Checking `includes("## Injected heading")` would pass either way.
+  const lines = md.split(NL);
+  assertEquals(lines.some((l) => l.startsWith("## Injected heading")), false);
+  assertEquals(lines.filter((l) => l.startsWith("|")).length, 5);
+  assertEquals(
+    md.includes("| a ## Injected heading | ✔ Succeeded | 0.1s |"),
+    true,
+  );
 });
 
-Deno.test("a comment marker in a cell cannot hide the rows below it", () => {
-  // `<!--` would otherwise comment out the remainder of the table, so the rows
-  // after it vanish from the rendered summary without any error.
+Deno.test("a pipe in a name cannot open a column of its own", () => {
   const md = jobSummaryMarkdown(
+    [{ name: "a | b", status: "passed", ms: 100 }],
+    100,
+    true,
+  );
+  // Three cells, not four: the row still has exactly its own columns.
+  const row = md.split(String.fromCharCode(10)).find((l) =>
+    l.startsWith("| a")
+  );
+  assertEquals(row?.split(" | ").length, 3);
+  assertEquals(md.includes("a \\| b"), true);
+});
+
+Deno.test("a newline in a name cannot forge a row in the terminal table", () => {
+  // The same value, the other renderer. Left raw it prints a line of its own,
+  // which can imitate a Total row, and destroys the column alignment because
+  // the width is measured on a string that is no longer one line.
+  const NL = String.fromCharCode(10);
+  const rows = summaryBlock(
+    { github: false, color: false, width: 60 },
     [
-      { name: "a<!--", status: "passed", ms: 100 },
-      { name: "b", status: "passed", ms: 100 },
+      {
+        name: ["ok", "== FAKE TOTAL ==", "Build succeeded"].join(NL),
+        status: "passed",
+        ms: 100,
+      },
+      { name: "after", status: "passed", ms: 100 },
     ],
     200,
     true,
+    new Date(0),
   );
-  assertEquals(md.includes("<!--"), false);
-  assertEquals(md.includes("a&lt;!--"), true);
-  assertEquals(md.includes("| b | ✔ Succeeded | 0.1s |"), true);
+  assertEquals(rows.some((l) => l.startsWith("== FAKE TOTAL ==")), false);
+  // Every rendered line is one line: nothing smuggled a break through.
+  assertEquals(rows.some((l) => l.includes(NL)), false);
+  // And the two target rows still align under the same column.
+  const target = rows.filter((l) => /^(ok|after)/.test(l));
+  assertEquals(target.length, 2);
+  assertEquals(
+    target[0].indexOf("Succeeded"),
+    target[1].indexOf("Succeeded"),
+  );
 });
 
 Deno.test("jobSummaryMarkdown renders an aligned table with a bold Total row", () => {


### PR DESCRIPTION
Closes #554.

## The defect

The job-summary table escaped a pipe in a target name and nothing else. A newline ends a Markdown row, so everything after it was published as document content rather than as a cell — a heading, a list, raw markup — and the row itself broke in half.

A fan-out sub-target's name carries its item key, which comes from repository or remote data, so this is not the build author's text.

Reproduced before the fix: an item key carrying a blank line, a heading and an `img` tag rendered all three into the published summary and split the row across five lines.

## What the adversarial pass changed, which is most of this PR

**The first attempt did not achieve its goal.** It guarded a newline, a pipe and an HTML comment marker, and deliberately left other markup alone on the grounds that a cell is rendered by GitHub's sanitiser. The sanitiser stops scripts; it does not keep text in a cell. A name of `</table><h1>All checks passed</h1>` ends the table at that row and publishes a forged heading as page content — the same defect the issue describes, reached by a token the guard did not cover. The reviewer confirmed it against GitHub's own renderer, not by reasoning about it.

The mistake behind it is worth naming: I matched `@zuke/ai`'s cell renderer because it was there, and treated a precedent as a proof. It is weaker than this needs to be. A cell of arbitrary text escapes its markup now.

**The commit documented a guard it had not written.** The collapsing helper's JSDoc said a name is collapsed for a terminal row and a Markdown cell alike, "the one place, rather than at each renderer" — and only the Markdown renderer called it. The terminal table still split a row across lines, printed a line that can imitate a Total row, and lost its column alignment, because the width was measured on a string that was no longer one line. Names are collapsed once in the module that owns all three renderers, so the sentence is true of each of them now.

**Most of the tests' assertions held against the pre-fix code.** They asserted the injected heading was present as a substring, which it is either way — what matters is whether it *starts a line*. That is the fourth test of mine in this stretch that asserted what its own fixture arranged, and the reviewer was asked to look for exactly it.

## Verification

Every guard was removed in turn, and each one fails a distinct, correctly-named test:

| Guard removed | Test that fails |
| --- | --- |
| Markup escaping | markup in a name cannot close the table |
| Name collapsing (renderers) | a newline cannot forge a row in the terminal table |
| Cell collapsing (Markdown) | a newline cannot end its job-summary row |
| Pipe escaping | a pipe cannot open a column of its own |

Gate green at 23/23: 4479 tests, 98.5% lines, 97.4% branches.

## Left alone deliberately

`@zuke/ai`'s own cell renderer has the weaker escaping this PR moves away from. It is a separate package with its own core floor, and #559 already tracks the floor work there; consolidating the two renderers belongs with that rather than here.
