### PR TITLE
feat(core): the seams the credential and scope fixes need

### DIFF
--- a/docs/state-api.md
+++ b/docs/state-api.md
@@ -231,8 +231,14 @@ client validates every summary and does not re-sort.
   takeover, append-only events, and the `/builds` register/deregister CAS:
 
   ```sh
-  deno run -A jsr:@zuke/core/conformance --url http://localhost:8080 [--token …]
+  ZUKE_STATE_TOKEN=… ZUKE_REGISTRY_TOKEN=… \
+    deno run -A jsr:@zuke/core/conformance --url http://localhost:8080
   ```
+
+  Set the two variables only when your backend requires a bearer token. There is
+  no `--token` argument: passing one is refused, because a credential in argv is
+  readable by every local process and lands in the transcript of whatever
+  invoked the kit.
 
   It exits `0` when every scenario passes and `1` (naming the failures) when one
   does not. A backend that passes is compatible with `HttpStateStore` /

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5619,8 +5619,14 @@ lane runs them against the filesystem store, and a backend author runs them
 against a live service:
 
 ```sh
-deno run -A jsr:@zuke/core/conformance --url http://localhost:8080 [--token …]
+ZUKE_STATE_TOKEN=… ZUKE_REGISTRY_TOKEN=… \
+  deno run -A jsr:@zuke/core/conformance --url http://localhost:8080
 ```
+
+Both variables are optional — set them only when the backend requires a
+bearer token. There is no `--token` argument: passing one is refused, because
+a credential in argv is readable by every local process and lands in the
+transcript of whatever invoked the kit.
 
 Every scenario uses freshly-generated ids, so it is safe to run against a
 shared, persistent service; the lock-takeover scenario uses a short real TTL

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -138,13 +138,21 @@ async function cancelRun(build: Build, options: CancelOptions): Promise<CancelRe
   @throws
       if no state store is configured, or the run does not exist.
 
-function ciHost(): string
+function ciHost(env: (name: string) => string | undefined): string
   A short identifier for the detected CI host, or `"local"` when not on CI.
   Recognises GitHub Actions, GitLab CI, Azure Pipelines, Bitbucket Pipelines,
-  and the generic `CI` convention.
+  and — as the generic `"ci"` — the common markers other systems set, including
+  Jenkins, Buildkite, CircleCI, Travis and TeamCity.
 
   Prefer {@link detectCiHost} for new code: its values match {@link CiProvider}.
   This function is kept for compatibility and uses longer, host-specific names.
+
+  @param env
+      The environment reader, injectable so detection can be unit-tested
+      hermetically; defaults to the process environment. {@link detectCiHost} has
+      taken one since it was written, and this takes the same one so a caller that
+      wants "am I on CI?" does not have to reach for the host-specific function to
+      get a testable answer.
 
 function cicd(spec: CiFileSpec): CiFile
   Declare a CI file as a build field. Running the build regenerates it (and the
@@ -452,8 +460,15 @@ async function installTree(options: InstallTreeOptions): Promise<AbsolutePath>
   are marked executable on POSIX. With a {@link InstallTreeOptions.checksum} the
   archive is verified before unpacking and a matching prior install is reused.
 
-function isCI(): boolean
+function isCI(env: (name: string) => string | undefined): boolean
   Whether the build appears to be running in a CI environment.
+
+  Broader than `detectCiHost(env) !== "local"`, which answers only whether the
+  host is one of the four Zuke names: a system it has no specific support for is
+  still CI, and this says so.
+
+  @param env
+      The environment reader; defaults to the process environment.
 
 function listStoreLocks(store: StateStore): Promise<HeldLockEntry[]>
   The locks `store` holds, or a friendly failure when the backend cannot
@@ -3841,6 +3856,22 @@ interface RemediationContext
   error: unknown
     The failure being remediated. When a target fails through the shell this is
     a `CommandError` carrying the failed command and its captured `stderr`.
+  redact(text: string): string
+    Mask every resolved `secret` parameter in `text`.
+
+    A remediation that publishes anywhere — a pull-request comment, a job
+    summary, a file it writes — has to run its output through this first. What
+    it is publishing is typically a model's response to a prompt built from the
+    failure, and that prompt carries the failed command and its output, so a
+    secret the build holds can come back in the reply.
+
+    Zuke's own reporter and run record redact what they emit, but a
+    remediation that posts over the network is not going through either of them:
+    this is the only thing between such a value and a comment that cannot be
+    taken back.
+
+    Masks the same values {@link "./params.ts".parameter} marked secret, so a
+    credential the build never declared is not covered — declare it.
 
 interface RemediationResult
   The outcome of one {@link Remediation} attempt.
@@ -4975,6 +5006,21 @@ class Command implements PromiseLike<CommandOutput>
   killAfter(ms: number): this
     Kill the process if it runs longer than `ms` milliseconds, raising a
     {@link CommandTimeoutError}. Fires even under {@link noThrow}.
+  stdin(text: string): this
+    Write `text` to the child's standard input, then close it.
+
+    The reason this exists is credentials. A tool that takes a password or token
+    as an argument puts it in the process table, where any local user reading
+    `/proc` or running `ps` can see it, and in whatever transcript the command
+    line is echoed into. Tools that care offer a stdin form instead — `docker login --password-stdin` is the canonical one — and without this there was no
+    way to use it: the secret had nowhere to go but argv.
+
+    The text never reaches {@link Command.commandLine}, because it is not part
+    of the command line. That is the point, not a side effect.
+
+    Only affects the run paths. A {@link Command.spawn}ed long-running process
+    keeps its inherited stdin, since a service that reads from the terminal is a
+    different thing from a one-shot that takes a secret.
   maxCapturedBytes(bytes: number): this
     Cap how much of each captured stream is kept in memory, in bytes
     (default 8 MiB). Capture keeps the newest bytes: once the cap is reached the
@@ -5204,8 +5250,9 @@ abstract class ToolSettings
   the base provides the shared chainers and {@link run}.
 
   os_: typeof Deno.build.os
-    The platform identifier used by {@link run} to decide whether to retry a
-    missing binary through the `cmd /c` shim path (Windows only).
+    The platform identifier used when resolving a tool from `node_modules`,
+    which on Windows means looking for the `.cmd` shim rather than the bare
+    name.
 
     In production this is always `Deno.build.os`. It is exposed as a public
     field — rather than read from `Deno.build.os` inline — so that tests can
@@ -5214,11 +5261,29 @@ abstract class ToolSettings
 
     ```ts
     const s = new MyToolSettings();
-    s.os_ = "windows"; // exercise the cmd /c retry branch on any host
+    s.os_ = "windows"; // resolve as Windows would, on any host
     ```
 
     The trailing underscore signals an internal test seam: do not rely on this
     field in production code.
+  protected markSecret(value: string): void
+    Register `value` with the run's redactor, so every rendered form of this
+    command masks it.
+
+    For the credential a tool will only take as an argument. Prefer
+    {@link "./shell.ts".Command.stdin} wherever the tool offers a stdin form:
+    this masks the rendering, not the argv, so the value is still visible in
+    the process table to anyone on the same host. It is what to reach for when
+    there is no better option, not instead of the better option.
+
+    Protected because it is for a wrapper to call while building its own
+    settings — the wrapper is what knows which of its fields is a credential.
+    A build marks its own values by declaring them with
+    {@link "./params.ts".parameter} and `.secret()`, which is the same redactor.
+
+    Does nothing outside a run, where there is no redactor to register with —
+    a wrapper used standalone in a script still works, it simply has nothing
+    masking its output.
   abstract protected defaultTool(): string
     The binary to spawn when {@link toolPath} is not set.
   abstract protected buildArgs(): string[]
@@ -5573,9 +5638,21 @@ async function checkStateStore(make: StateStoreFactory, options: ConformanceOpti
   Run the state-store conformance scenarios against the store `make` builds.
 
 async function runConformanceCli(args: string[], deps: ConformanceCliDeps): Promise<number>
-  Run the conformance kit as a CLI: `--url <base>` (required) and `--token <bearer>` (optional) name the backend, then both suites run against it. Prints
-  a `PASS`/`FAIL` line per scenario and resolves to a process exit code — `0`
-  when every scenario passes, `1` when any fails or `--url` is missing.
+  Run the conformance kit as a CLI: `--url <base>` (required) names the backend
+  and both suites run against it. Prints a `PASS`/`FAIL` line per scenario and
+  resolves to a process exit code — `0` when every scenario passes, `1` when any
+  fails, `--url` is missing, or a credential was passed as an argument.
+
+  The bearer token comes from the environment, `ZUKE_STATE_TOKEN` and
+  `ZUKE_REGISTRY_TOKEN`, exactly as every other consumer of these stores reads
+  it. It used to be a `--token` argument, which put a credential that can forge
+  run records, the audit trail and lock exclusivity into the process table for
+  any local user to read, and into the transcript of whatever invoked it.
+
+  `--token` is now refused rather than ignored: an invocation that still
+  passes one would otherwise authenticate as anonymous and fail somewhere less
+  obvious, and the credential would already have been exposed by the time it
+  did.
 
 interface ConformanceCliDeps
   Injectable dependencies for {@link runConformanceCli} (tests override them).
@@ -5586,6 +5663,8 @@ interface ConformanceCliDeps
     Build the {@link BuildRegistry} for a url/token (default {@link HttpBuildRegistry}).
   log?: (line: string) => void
     Emit a line of output (default `console.log`).
+  readEnv?: (name: string) => string | undefined
+    Read an environment variable (default the process environment).
 
 interface ConformanceOptions
   Tuning options for the conformance scenarios.

--- a/packages/ai/tests/agent_fixer_test.ts
+++ b/packages/ai/tests/agent_fixer_test.ts
@@ -11,6 +11,7 @@ const CTX: RemediationContext = {
   target: "test",
   attempt: 1,
   error: new Error("boom: a test failed"),
+  redact: (text: string) => text,
 };
 
 /** A runner that records each AgentContext it receives. */
@@ -60,6 +61,7 @@ Deno.test("the failed command and stderr feed the prompt", async () => {
     target: "lint",
     attempt: 1,
     error: new CommandError("deno lint", 1, "error: unused variable x"),
+    redact: (text: string) => text,
   });
   assertEquals(r.calls[0].command, "deno lint");
   assertEquals(r.calls[0].prompt.includes("deno lint"), true);

--- a/packages/ai/tests/cost_controls_test.ts
+++ b/packages/ai/tests/cost_controls_test.ts
@@ -87,6 +87,7 @@ const CTX: RemediationContext = {
   target: "test",
   attempt: 1,
   error: new Error("boom: a test failed"),
+  redact: (text: string) => text,
 };
 
 const ONE_EDIT: Partial<Fix> = {

--- a/packages/ai/tests/fixer_test.ts
+++ b/packages/ai/tests/fixer_test.ts
@@ -75,6 +75,7 @@ const CTX: RemediationContext = {
   target: "test",
   attempt: 1,
   error: new Error("boom: a test failed"),
+  redact: (text: string) => text,
 };
 
 const ONE_EDIT: Partial<Fix> = {
@@ -257,6 +258,7 @@ Deno.test("CommandError context feeds the failed command and stderr to the promp
     target: "lint",
     attempt: 1,
     error: new CommandError("deno lint", 1, "error: unused variable x"),
+    redact: (text: string) => text,
   });
   assertEquals(calls[0].body.includes("deno lint"), true);
   assertEquals(calls[0].body.includes("unused variable x"), true);
@@ -626,6 +628,7 @@ Deno.test("a non-Error failure value is stringified into the prompt", async () =
     target: "t",
     attempt: 1,
     error: "raw string failure",
+    redact: (text: string) => text,
   });
   assertEquals(calls[0].body.includes("raw string failure"), true);
 });

--- a/packages/ai/tests/run_scope_test.ts
+++ b/packages/ai/tests/run_scope_test.ts
@@ -26,6 +26,7 @@ const CTX: RemediationContext = {
   target: "lint",
   attempt: 1,
   error: new Error("boom: a test failed"),
+  redact: (text: string) => text,
 };
 
 /** An env reader that looks like a GitHub Actions runner. */

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -192,13 +192,21 @@ async function cancelRun(build: Build, options: CancelOptions): Promise<CancelRe
   @throws
       if no state store is configured, or the run does not exist.
 
-function ciHost(): string
+function ciHost(env: (name: string) => string | undefined): string
   A short identifier for the detected CI host, or `"local"` when not on CI.
   Recognises GitHub Actions, GitLab CI, Azure Pipelines, Bitbucket Pipelines,
-  and the generic `CI` convention.
+  and — as the generic `"ci"` — the common markers other systems set, including
+  Jenkins, Buildkite, CircleCI, Travis and TeamCity.
 
   Prefer {@link detectCiHost} for new code: its values match {@link CiProvider}.
   This function is kept for compatibility and uses longer, host-specific names.
+
+  @param env
+      The environment reader, injectable so detection can be unit-tested
+      hermetically; defaults to the process environment. {@link detectCiHost} has
+      taken one since it was written, and this takes the same one so a caller that
+      wants "am I on CI?" does not have to reach for the host-specific function to
+      get a testable answer.
 
 function cicd(spec: CiFileSpec): CiFile
   Declare a CI file as a build field. Running the build regenerates it (and the
@@ -506,8 +514,15 @@ async function installTree(options: InstallTreeOptions): Promise<AbsolutePath>
   are marked executable on POSIX. With a {@link InstallTreeOptions.checksum} the
   archive is verified before unpacking and a matching prior install is reused.
 
-function isCI(): boolean
+function isCI(env: (name: string) => string | undefined): boolean
   Whether the build appears to be running in a CI environment.
+
+  Broader than `detectCiHost(env) !== "local"`, which answers only whether the
+  host is one of the four Zuke names: a system it has no specific support for is
+  still CI, and this says so.
+
+  @param env
+      The environment reader; defaults to the process environment.
 
 function listStoreLocks(store: StateStore): Promise<HeldLockEntry[]>
   The locks `store` holds, or a friendly failure when the backend cannot
@@ -3895,6 +3910,22 @@ interface RemediationContext
   error: unknown
     The failure being remediated. When a target fails through the shell this is
     a `CommandError` carrying the failed command and its captured `stderr`.
+  redact(text: string): string
+    Mask every resolved `secret` parameter in `text`.
+
+    A remediation that publishes anywhere — a pull-request comment, a job
+    summary, a file it writes — has to run its output through this first. What
+    it is publishing is typically a model's response to a prompt built from the
+    failure, and that prompt carries the failed command and its output, so a
+    secret the build holds can come back in the reply.
+
+    Zuke's own reporter and run record redact what they emit, but a
+    remediation that posts over the network is not going through either of them:
+    this is the only thing between such a value and a comment that cannot be
+    taken back.
+
+    Masks the same values {@link "./params.ts".parameter} marked secret, so a
+    credential the build never declared is not covered — declare it.
 
 interface RemediationResult
   The outcome of one {@link Remediation} attempt.
@@ -5029,6 +5060,21 @@ class Command implements PromiseLike<CommandOutput>
   killAfter(ms: number): this
     Kill the process if it runs longer than `ms` milliseconds, raising a
     {@link CommandTimeoutError}. Fires even under {@link noThrow}.
+  stdin(text: string): this
+    Write `text` to the child's standard input, then close it.
+
+    The reason this exists is credentials. A tool that takes a password or token
+    as an argument puts it in the process table, where any local user reading
+    `/proc` or running `ps` can see it, and in whatever transcript the command
+    line is echoed into. Tools that care offer a stdin form instead — `docker login --password-stdin` is the canonical one — and without this there was no
+    way to use it: the secret had nowhere to go but argv.
+
+    The text never reaches {@link Command.commandLine}, because it is not part
+    of the command line. That is the point, not a side effect.
+
+    Only affects the run paths. A {@link Command.spawn}ed long-running process
+    keeps its inherited stdin, since a service that reads from the terminal is a
+    different thing from a one-shot that takes a secret.
   maxCapturedBytes(bytes: number): this
     Cap how much of each captured stream is kept in memory, in bytes
     (default 8 MiB). Capture keeps the newest bytes: once the cap is reached the
@@ -5258,8 +5304,9 @@ abstract class ToolSettings
   the base provides the shared chainers and {@link run}.
 
   os_: typeof Deno.build.os
-    The platform identifier used by {@link run} to decide whether to retry a
-    missing binary through the `cmd /c` shim path (Windows only).
+    The platform identifier used when resolving a tool from `node_modules`,
+    which on Windows means looking for the `.cmd` shim rather than the bare
+    name.
 
     In production this is always `Deno.build.os`. It is exposed as a public
     field — rather than read from `Deno.build.os` inline — so that tests can
@@ -5268,11 +5315,29 @@ abstract class ToolSettings
 
     ```ts
     const s = new MyToolSettings();
-    s.os_ = "windows"; // exercise the cmd /c retry branch on any host
+    s.os_ = "windows"; // resolve as Windows would, on any host
     ```
 
     The trailing underscore signals an internal test seam: do not rely on this
     field in production code.
+  protected markSecret(value: string): void
+    Register `value` with the run's redactor, so every rendered form of this
+    command masks it.
+
+    For the credential a tool will only take as an argument. Prefer
+    {@link "./shell.ts".Command.stdin} wherever the tool offers a stdin form:
+    this masks the rendering, not the argv, so the value is still visible in
+    the process table to anyone on the same host. It is what to reach for when
+    there is no better option, not instead of the better option.
+
+    Protected because it is for a wrapper to call while building its own
+    settings — the wrapper is what knows which of its fields is a credential.
+    A build marks its own values by declaring them with
+    {@link "./params.ts".parameter} and `.secret()`, which is the same redactor.
+
+    Does nothing outside a run, where there is no redactor to register with —
+    a wrapper used standalone in a script still works, it simply has nothing
+    masking its output.
   abstract protected defaultTool(): string
     The binary to spawn when {@link toolPath} is not set.
   abstract protected buildArgs(): string[]
@@ -5627,9 +5692,21 @@ async function checkStateStore(make: StateStoreFactory, options: ConformanceOpti
   Run the state-store conformance scenarios against the store `make` builds.
 
 async function runConformanceCli(args: string[], deps: ConformanceCliDeps): Promise<number>
-  Run the conformance kit as a CLI: `--url <base>` (required) and `--token <bearer>` (optional) name the backend, then both suites run against it. Prints
-  a `PASS`/`FAIL` line per scenario and resolves to a process exit code — `0`
-  when every scenario passes, `1` when any fails or `--url` is missing.
+  Run the conformance kit as a CLI: `--url <base>` (required) names the backend
+  and both suites run against it. Prints a `PASS`/`FAIL` line per scenario and
+  resolves to a process exit code — `0` when every scenario passes, `1` when any
+  fails, `--url` is missing, or a credential was passed as an argument.
+
+  The bearer token comes from the environment, `ZUKE_STATE_TOKEN` and
+  `ZUKE_REGISTRY_TOKEN`, exactly as every other consumer of these stores reads
+  it. It used to be a `--token` argument, which put a credential that can forge
+  run records, the audit trail and lock exclusivity into the process table for
+  any local user to read, and into the transcript of whatever invoked it.
+
+  `--token` is now refused rather than ignored: an invocation that still
+  passes one would otherwise authenticate as anonymous and fail somewhere less
+  obvious, and the credential would already have been exposed by the time it
+  did.
 
 interface ConformanceCliDeps
   Injectable dependencies for {@link runConformanceCli} (tests override them).
@@ -5640,6 +5717,8 @@ interface ConformanceCliDeps
     Build the {@link BuildRegistry} for a url/token (default {@link HttpBuildRegistry}).
   log?: (line: string) => void
     Emit a line of output (default `console.log`).
+  readEnv?: (name: string) => string | undefined
+    Read an environment variable (default the process environment).
 
 interface ConformanceOptions
   Tuning options for the conformance scenarios.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -5673,8 +5673,14 @@ lane runs them against the filesystem store, and a backend author runs them
 against a live service:
 
 ```sh
-deno run -A jsr:@zuke/core/conformance --url http://localhost:8080 [--token …]
+ZUKE_STATE_TOKEN=… ZUKE_REGISTRY_TOKEN=… \
+  deno run -A jsr:@zuke/core/conformance --url http://localhost:8080
 ```
+
+Both variables are optional — set them only when the backend requires a
+bearer token. There is no `--token` argument: passing one is refused, because
+a credential in argv is readable by every local process and lands in the
+transcript of whatever invoked the kit.
 
 Every scenario uses freshly-generated ids, so it is safe to run against a
 shared, persistent service; the lock-takeover scenario uses a short real TTL

--- a/packages/core/src/conformance.ts
+++ b/packages/core/src/conformance.ts
@@ -29,7 +29,7 @@
  */
 
 import type { RunEvent, RunRecord } from "./state/types.ts";
-import { delay, messageOf } from "./internal.ts";
+import { defaultReadEnv, delay, messageOf } from "./internal.ts";
 import type { StateStore } from "./state/store.ts";
 import type { LockHolder } from "./state/lock.ts";
 import { HttpStateStore } from "./state/http_store.ts";
@@ -521,25 +521,48 @@ export interface ConformanceCliDeps {
   makeBuildRegistry?: (url: string, token?: string) => BuildRegistry;
   /** Emit a line of output (default `console.log`). */
   log?: (line: string) => void;
+  /** Read an environment variable (default the process environment). */
+  readEnv?: (name: string) => string | undefined;
 }
 
 /**
- * Run the conformance kit as a CLI: `--url <base>` (required) and `--token
- * <bearer>` (optional) name the backend, then both suites run against it. Prints
- * a `PASS`/`FAIL` line per scenario and resolves to a process exit code — `0`
- * when every scenario passes, `1` when any fails or `--url` is missing.
+ * Run the conformance kit as a CLI: `--url <base>` (required) names the backend
+ * and both suites run against it. Prints a `PASS`/`FAIL` line per scenario and
+ * resolves to a process exit code — `0` when every scenario passes, `1` when any
+ * fails, `--url` is missing, or a credential was passed as an argument.
+ *
+ * **The bearer token comes from the environment**, `ZUKE_STATE_TOKEN` and
+ * `ZUKE_REGISTRY_TOKEN`, exactly as every other consumer of these stores reads
+ * it. It used to be a `--token` argument, which put a credential that can forge
+ * run records, the audit trail and lock exclusivity into the process table for
+ * any local user to read, and into the transcript of whatever invoked it.
+ *
+ * `--token` is now **refused** rather than ignored: an invocation that still
+ * passes one would otherwise authenticate as anonymous and fail somewhere less
+ * obvious, and the credential would already have been exposed by the time it
+ * did.
  */
 export async function runConformanceCli(
   args: string[],
   deps: ConformanceCliDeps = {},
 ): Promise<number> {
   const log = deps.log ?? ((line: string) => console.log(line));
+  const env = deps.readEnv ?? defaultReadEnv;
   const url = flag(args, "--url");
-  const token = flag(args, "--token");
+  if (args.includes("--token")) {
+    log(
+      "conformance: --token is no longer accepted — a credential passed as an " +
+        "argument is visible to every local process and in this command's own " +
+        "transcript. Set ZUKE_STATE_TOKEN and ZUKE_REGISTRY_TOKEN instead.",
+    );
+    return 1;
+  }
   if (url === undefined) {
     log("conformance: --url <base> is required.");
     return 1;
   }
+  const stateToken = env("ZUKE_STATE_TOKEN");
+  const registryToken = env("ZUKE_REGISTRY_TOKEN");
   const makeState = deps.makeStateStore ??
     ((u: string, t?: string) => new HttpStateStore({ url: u, token: t }));
   const makeRegistry = deps.makeBuildRegistry ??
@@ -547,8 +570,10 @@ export async function runConformanceCli(
 
   const results: ConformanceResult[] = [];
   try {
-    results.push(...await checkStateStore(() => makeState(url, token)));
-    results.push(...await checkBuildRegistry(() => makeRegistry(url, token)));
+    results.push(...await checkStateStore(() => makeState(url, stateToken)));
+    results.push(
+      ...await checkBuildRegistry(() => makeRegistry(url, registryToken)),
+    );
   } catch (error) {
     // A transport/protocol failure (e.g. a version mismatch) aborts the run.
     log(`conformance: aborted — ${messageOf(error)}`);

--- a/packages/core/src/conformance.ts
+++ b/packages/core/src/conformance.ts
@@ -14,8 +14,14 @@
  * against a live service:
  *
  * ```sh
- * deno run -A jsr:@zuke/core/conformance --url http://localhost:8080 [--token …]
+ * ZUKE_STATE_TOKEN=… ZUKE_REGISTRY_TOKEN=… \
+ *   deno run -A jsr:@zuke/core/conformance --url http://localhost:8080
  * ```
+ *
+ * Both variables are optional — set them only when the backend requires a
+ * bearer token. There is no `--token` argument: passing one is refused, because
+ * a credential in argv is readable by every local process and lands in the
+ * transcript of whatever invoked the kit.
  *
  * Every scenario uses freshly-generated ids, so it is safe to run against a
  * shared, persistent service; the lock-takeover scenario uses a short real TTL

--- a/packages/core/src/host.ts
+++ b/packages/core/src/host.ts
@@ -42,15 +42,55 @@ export function detectCiHost(
 }
 
 /**
+ * Environment variables that mean "some CI system is running this", beyond the
+ * four hosts {@link detectCiHost} names.
+ *
+ * A CI system Zuke has no specific support for is still CI, and treating it as a
+ * developer's machine is the dangerous direction: a fixer scoped to CI silently
+ * stops running, and one left at its default applies changes to what it believes
+ * is a working tree someone is editing. Jenkins is the case that matters most —
+ * it sets none of the four, and does not set `CI` either.
+ *
+ * Presence is what counts for all but `CI`, whose conventional "not CI" value is
+ * the string `false`.
+ */
+const GENERIC_CI_MARKERS = [
+  "CI",
+  "JENKINS_URL",
+  "BUILDKITE",
+  "CIRCLECI",
+  "TRAVIS",
+  "TEAMCITY_VERSION",
+];
+
+/** Whether any generic marker says this is CI. */
+function genericCi(env: (name: string) => string | undefined): boolean {
+  return GENERIC_CI_MARKERS.some((name) => {
+    const value = env(name);
+    if (value === undefined || value === "") return false;
+    return name !== "CI" || value !== "false";
+  });
+}
+
+/**
  * A short identifier for the detected CI host, or `"local"` when not on CI.
  * Recognises GitHub Actions, GitLab CI, Azure Pipelines, Bitbucket Pipelines,
- * and the generic `CI` convention.
+ * and — as the generic `"ci"` — the common markers other systems set, including
+ * Jenkins, Buildkite, CircleCI, Travis and TeamCity.
  *
  * Prefer {@link detectCiHost} for new code: its values match {@link CiProvider}.
  * This function is kept for compatibility and uses longer, host-specific names.
+ *
+ * @param env The environment reader, injectable so detection can be unit-tested
+ *   hermetically; defaults to the process environment. {@link detectCiHost} has
+ *   taken one since it was written, and this takes the same one so a caller that
+ *   wants "am I on CI?" does not have to reach for the host-specific function to
+ *   get a testable answer.
  */
-export function ciHost(): string {
-  switch (detectCiHost()) {
+export function ciHost(
+  env: (name: string) => string | undefined = defaultReadEnv,
+): string {
+  switch (detectCiHost(env)) {
     case "github":
       return "github-actions";
     case "gitlab":
@@ -59,16 +99,24 @@ export function ciHost(): string {
       return "azure-pipelines";
     case "bitbucket":
       return "bitbucket-pipelines";
-    case "local": {
-      const ci = defaultReadEnv("CI");
-      return ci !== undefined && ci !== "" && ci !== "false" ? "ci" : "local";
-    }
+    case "local":
+      return genericCi(env) ? "ci" : "local";
   }
 }
 
-/** Whether the build appears to be running in a CI environment. */
-export function isCI(): boolean {
-  return ciHost() !== "local";
+/**
+ * Whether the build appears to be running in a CI environment.
+ *
+ * Broader than `detectCiHost(env) !== "local"`, which answers only whether the
+ * host is one of the four Zuke names: a system it has no specific support for is
+ * still CI, and this says so.
+ *
+ * @param env The environment reader; defaults to the process environment.
+ */
+export function isCI(
+  env: (name: string) => string | undefined = defaultReadEnv,
+): boolean {
+  return ciHost(env) !== "local";
 }
 
 /**

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -13,6 +13,7 @@
  * @module
  */
 
+import { redactLine } from "./ambient_redactor.ts";
 import { delay, messageOf, runWithTimeout } from "./internal.ts";
 import { bufferReporter, type Reporter } from "./reporter.ts";
 import type { Lifecycle } from "./lifecycle.ts";
@@ -189,6 +190,11 @@ async function runBodyWithRecovery(
             target: name,
             attempt,
             error: lastError,
+            // The run's redactor, reached through the ambient scope the executor
+            // installed. Handed over rather than left for the remediation to
+            // find, because the one that most needs it lives in another package
+            // and cannot reach core's internals.
+            redact: redactLine,
           });
           if (result.retry) willRetry = true;
         } catch {

--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -184,6 +184,9 @@ export class Command implements PromiseLike<CommandOutput> {
   #capturing = false;
   #timeoutMs?: number;
   #signal?: AbortSignal;
+  /** Text to write to the child's stdin, or `undefined` to inherit it. */
+  #stdin: string | undefined;
+
   #maxCapturedBytes = DEFAULT_MAX_CAPTURED_BYTES;
   #result?: Promise<RunResult>;
 
@@ -222,6 +225,28 @@ export class Command implements PromiseLike<CommandOutput> {
    */
   killAfter(ms: number): this {
     this.#timeoutMs = ms;
+    return this;
+  }
+
+  /**
+   * Write `text` to the child's standard input, then close it.
+   *
+   * The reason this exists is credentials. A tool that takes a password or token
+   * as an argument puts it in the process table, where any local user reading
+   * `/proc` or running `ps` can see it, and in whatever transcript the command
+   * line is echoed into. Tools that care offer a stdin form instead — `docker
+   * login --password-stdin` is the canonical one — and without this there was no
+   * way to use it: the secret had nowhere to go but argv.
+   *
+   * The text never reaches {@link Command.commandLine}, because it is not part
+   * of the command line. That is the point, not a side effect.
+   *
+   * Only affects the run paths. A {@link Command.spawn}ed long-running process
+   * keeps its inherited stdin, since a service that reads from the terminal is a
+   * different thing from a one-shot that takes a secret.
+   */
+  stdin(text: string): this {
+    this.#stdin = text;
     return this;
   }
 
@@ -302,6 +327,10 @@ export class Command implements PromiseLike<CommandOutput> {
         args,
         cwd: this.#cwd,
         env: this.#env,
+        // Piped only when there is something to write: otherwise the child keeps
+        // the inherited stdin it has always had, so a tool that prompts still
+        // works.
+        stdin: this.#stdin === undefined ? "inherit" : "piped",
         stdout: "piped",
         stderr: "piped",
         // Cancellation (an explicit `.signal()`, else the executor's ambient run
@@ -327,9 +356,14 @@ export class Command implements PromiseLike<CommandOutput> {
       // Capture is bounded (per stream) so a runaway child cannot grow the buffer
       // until the run dies; the tee to the terminal above stays unbounded.
       const cap = this.#maxCapturedBytes;
+      // Written *concurrently* with the captures, not before them. A child that
+      // writes more than a pipe buffer holds before reading its input would
+      // block on its own output while this blocked on the write, and neither
+      // side would ever move.
       const [stdout, stderr] = await Promise.all([
         captureStream(child.stdout, streamStdout ? Deno.stdout : null, cap),
         captureStream(child.stderr, streamStderr ? Deno.stderr : null, cap),
+        this.#writeStdin(child),
       ]);
       const status = await child.status;
       if (timedOut && ms !== undefined) {
@@ -343,6 +377,25 @@ export class Command implements PromiseLike<CommandOutput> {
       };
     } finally {
       if (timer !== undefined) clearTimeout(timer);
+    }
+  }
+
+  /**
+   * Write the configured stdin text to `child` and close the stream, or do
+   * nothing when none was configured.
+   *
+   * Closing is what matters: a tool reading its credential from stdin waits for
+   * end-of-input, so leaving the stream open hangs the run rather than failing
+   * it. The close therefore happens even when the write does not.
+   */
+  async #writeStdin(child: Deno.ChildProcess): Promise<void> {
+    const text = this.#stdin;
+    if (text === undefined) return;
+    const writer = child.stdin.getWriter();
+    try {
+      await writer.write(new TextEncoder().encode(text));
+    } finally {
+      await writer.close().catch(() => {});
     }
   }
 

--- a/packages/core/src/target.ts
+++ b/packages/core/src/target.ts
@@ -538,6 +538,24 @@ export interface RemediationContext {
    * a `CommandError` carrying the failed command and its captured `stderr`.
    */
   error: unknown;
+  /**
+   * Mask every resolved `secret` parameter in `text`.
+   *
+   * A remediation that publishes anywhere — a pull-request comment, a job
+   * summary, a file it writes — has to run its output through this first. What
+   * it is publishing is typically a model's response to a prompt built from the
+   * failure, and that prompt carries the failed command and its output, so a
+   * secret the build holds can come back in the reply.
+   *
+   * Zuke's own reporter and run record redact what *they* emit, but a
+   * remediation that posts over the network is not going through either of them:
+   * this is the only thing between such a value and a comment that cannot be
+   * taken back.
+   *
+   * Masks the same values {@link "./params.ts".parameter} marked secret, so a
+   * credential the build never declared is not covered — declare it.
+   */
+  redact(text: string): string;
 }
 
 /** The outcome of one {@link Remediation} attempt. */

--- a/packages/core/src/tooling.ts
+++ b/packages/core/src/tooling.ts
@@ -24,6 +24,7 @@
 
 import { Command, CommandError, type CommandOutput } from "./shell.ts";
 import { checkMaxCapturedBytes } from "./capture.ts";
+import { ambientRedactor } from "./ambient_redactor.ts";
 import { type AbsolutePath, absolutePath, type PathLike } from "./path.ts";
 
 export type { PathLike };
@@ -200,8 +201,9 @@ export type Configure<S> = (settings: S) => S;
  */
 export abstract class ToolSettings {
   /**
-   * The platform identifier used by {@link run} to decide whether to retry a
-   * missing binary through the `cmd /c` shim path (Windows only).
+   * The platform identifier used when resolving a tool from `node_modules`,
+   * which on Windows means looking for the `.cmd` shim rather than the bare
+   * name.
    *
    * In production this is always `Deno.build.os`. It is exposed as a public
    * field — rather than read from `Deno.build.os` inline — so that tests can
@@ -210,13 +212,36 @@ export abstract class ToolSettings {
    *
    * ```ts
    * const s = new MyToolSettings();
-   * s.os_ = "windows"; // exercise the cmd /c retry branch on any host
+   * s.os_ = "windows"; // resolve as Windows would, on any host
    * ```
    *
    * The trailing underscore signals an internal test seam: do not rely on this
    * field in production code.
    */
   os_: typeof Deno.build.os = Deno.build.os;
+
+  /**
+   * Register `value` with the run's redactor, so every rendered form of this
+   * command masks it.
+   *
+   * For the credential a tool will only take as an argument. Prefer
+   * {@link "./shell.ts".Command.stdin} wherever the tool offers a stdin form:
+   * this masks the *rendering*, not the argv, so the value is still visible in
+   * the process table to anyone on the same host. It is what to reach for when
+   * there is no better option, not instead of the better option.
+   *
+   * Protected because it is for a wrapper to call while building its own
+   * settings — the wrapper is what knows which of its fields is a credential.
+   * A build marks its own values by declaring them with
+   * {@link "./params.ts".parameter} and `.secret()`, which is the same redactor.
+   *
+   * Does nothing outside a run, where there is no redactor to register with —
+   * a wrapper used standalone in a script still works, it simply has nothing
+   * masking its output.
+   */
+  protected markSecret(value: string): void {
+    ambientRedactor()?.add(value);
+  }
 
   #env: Record<string, string> = {};
   #cwd?: string;

--- a/packages/core/tests/conformance_test.ts
+++ b/packages/core/tests/conformance_test.ts
@@ -7,7 +7,11 @@
  * CLI runner — plus the wire protocol-version handshake on the HTTP client.
  */
 
-import { assertEquals, assertRejects } from "./_assert.ts";
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "./_assert.ts";
 import {
   checkBuildRegistry,
   checkStateStore,
@@ -189,4 +193,45 @@ Deno.test("the kit catches a registry that violates listBuilds ordering", async 
   // CAS/round-trip/deregister pass; only the ordering+filter scenario fails.
   assertEquals(results.find((r) => r.name.includes("newest first"))?.ok, false);
   assertEquals(results.find((r) => r.name.includes("CAS"))?.ok, true);
+});
+
+Deno.test("runConformanceCli refuses a token passed as an argument", async () => {
+  // Refused rather than ignored: an ignored --token would authenticate as
+  // anonymous and fail somewhere less obvious, and the credential would already
+  // be in the process table and the transcript by then.
+  const lines: string[] = [];
+  const code = await runConformanceCli(
+    ["--url", "https://state.example", "--token", "hunter2"],
+    { log: (l) => lines.push(l) },
+  );
+  assertEquals(code, 1);
+  const message = lines.join("\n");
+  assertStringIncludes(message, "--token is no longer accepted");
+  assertStringIncludes(message, "ZUKE_STATE_TOKEN");
+  // And the refusal itself does not echo the credential it is refusing.
+  assertEquals(message.includes("hunter2"), false);
+});
+
+Deno.test("runConformanceCli reads each token from its own variable", async () => {
+  // The two stores have separate credentials, and every other consumer of them
+  // already reads these names.
+  const seen: Record<string, string | undefined> = {};
+  await runConformanceCli(["--url", "https://backend.example"], {
+    log: () => {},
+    readEnv: (name) =>
+      name === "ZUKE_STATE_TOKEN"
+        ? "state-token"
+        : name === "ZUKE_REGISTRY_TOKEN"
+        ? "registry-token"
+        : undefined,
+    makeStateStore: (_url, token) => {
+      seen.state = token;
+      throw new Error("stop after capturing the token");
+    },
+    makeBuildRegistry: (_url, token) => {
+      seen.registry = token;
+      throw new Error("stop after capturing the token");
+    },
+  });
+  assertEquals(seen.state, "state-token");
 });

--- a/packages/core/tests/conformance_test.ts
+++ b/packages/core/tests/conformance_test.ts
@@ -214,24 +214,33 @@ Deno.test("runConformanceCli refuses a token passed as an argument", async () =>
 
 Deno.test("runConformanceCli reads each token from its own variable", async () => {
   // The two stores have separate credentials, and every other consumer of them
-  // already reads these names.
+  // already reads these names. Both factories return a working store so the run
+  // completes and *both* are actually reached — an earlier cut of this test
+  // threw from the state factory, which meant the registry token was captured
+  // but never exercised, and asserting it would have been asserting nothing.
+  const dir = await Deno.makeTempDir({ prefix: "zuke-conf-token-" });
   const seen: Record<string, string | undefined> = {};
-  await runConformanceCli(["--url", "https://backend.example"], {
-    log: () => {},
-    readEnv: (name) =>
-      name === "ZUKE_STATE_TOKEN"
-        ? "state-token"
-        : name === "ZUKE_REGISTRY_TOKEN"
-        ? "registry-token"
-        : undefined,
-    makeStateStore: (_url, token) => {
-      seen.state = token;
-      throw new Error("stop after capturing the token");
-    },
-    makeBuildRegistry: (_url, token) => {
-      seen.registry = token;
-      throw new Error("stop after capturing the token");
-    },
-  });
-  assertEquals(seen.state, "state-token");
+  try {
+    await runConformanceCli(["--url", "unused"], {
+      log: () => {},
+      readEnv: (name) =>
+        name === "ZUKE_STATE_TOKEN"
+          ? "state-token"
+          : name === "ZUKE_REGISTRY_TOKEN"
+          ? "registry-token"
+          : undefined,
+      makeStateStore: (_url, token) => {
+        seen.state = token;
+        return new FileSystemStateStore(`${dir}/a`, defaultStateHost);
+      },
+      makeBuildRegistry: (_url, token) => {
+        seen.registry = token;
+        return new FileSystemBuildRegistry(`${dir}/b`, defaultStateHost);
+      },
+    });
+    assertEquals(seen.state, "state-token");
+    assertEquals(seen.registry, "registry-token");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
 });

--- a/packages/core/tests/host_test.ts
+++ b/packages/core/tests/host_test.ts
@@ -104,3 +104,59 @@ Deno.test("operatingSystem normalises Deno's os names to a friendly union", () =
   const host = operatingSystem();
   assertEquals(["linux", "macos", "windows"].includes(host), true);
 });
+
+Deno.test("isCI recognises a CI system Zuke has no specific support for", () => {
+  // The dangerous direction is reading CI as local: a fixer scoped to CI stops
+  // running, and one at its default applies changes to what it believes is a
+  // working tree someone is editing. Jenkins is the case that matters — it sets
+  // none of the four hosts, and does not set `CI` either.
+  for (
+    const marker of [
+      "JENKINS_URL",
+      "BUILDKITE",
+      "CIRCLECI",
+      "TRAVIS",
+      "TEAMCITY_VERSION",
+    ]
+  ) {
+    const env = (name: string) => name === marker ? "set" : undefined;
+    assertEquals(isCI(env), true, `${marker} should read as CI`);
+    assertEquals(ciHost(env), "ci", `${marker} should read as generic CI`);
+    // The host-specific answer is unchanged: these are not one of the four.
+    assertEquals(detectCiHost(env), "local");
+  }
+});
+
+Deno.test("a developer's machine is still local", () => {
+  assertEquals(isCI(() => undefined), false);
+  assertEquals(ciHost(() => undefined), "local");
+});
+
+Deno.test("CI=false is not CI, but another marker set to false still is", () => {
+  // `CI` has a conventional "not CI" value; the others are presence-only, so a
+  // literal "false" in one of them is still a set marker.
+  assertEquals(isCI((name) => name === "CI" ? "false" : undefined), false);
+  assertEquals(isCI((name) => name === "CI" ? "" : undefined), false);
+  assertEquals(
+    isCI((name) => name === "BUILDKITE" ? "false" : undefined),
+    true,
+  );
+});
+
+Deno.test("a named host still wins over the generic markers", () => {
+  const env = (name: string) =>
+    name === "GITHUB_ACTIONS"
+      ? "true"
+      : name === "JENKINS_URL"
+      ? "x"
+      : undefined;
+  assertEquals(ciHost(env), "github-actions");
+  assertEquals(detectCiHost(env), "github");
+});
+
+Deno.test("ciHost and isCI default to the process environment", () => {
+  // The reader is an added optional parameter, so every existing call site keeps
+  // reading the real environment — the property that makes this non-breaking.
+  assertEquals(typeof ciHost(), "string");
+  assertEquals(typeof isCI(), "boolean");
+});

--- a/packages/core/tests/shell_test.ts
+++ b/packages/core/tests/shell_test.ts
@@ -362,3 +362,46 @@ Deno.test("under echo, .spawn() echoes and returns a no-op stub", async () => {
   assertEquals((await proc.status).code, 0);
   await proc.stop(); // no-op, does not throw
 });
+
+Deno.test("stdin writes to the child and closes the stream", async () => {
+  // A real subprocess, because the property is about a real pipe: the child has
+  // to see end-of-input, or a tool reading a credential from stdin hangs.
+  const out = await $`${Deno.execPath()} eval --no-lock ${
+    "const b=new Uint8Array(1024);let n=0,r;" +
+    "while((r=await Deno.stdin.read(b))!==null)n+=r;" +
+    "console.log('read',n)"
+  }`.stdin("hunter2").quiet().text();
+  assertEquals(out.trim(), "read 7");
+});
+
+Deno.test("a credential passed on stdin stays out of the command line", async () => {
+  // The whole reason the setter exists. argv is what `ps` and `/proc` expose,
+  // and what every rendered form of the command is built from.
+  const command = $`${Deno.execPath()} eval --no-lock ${"console.log(1)"}`
+    .stdin("s3cr3t").quiet();
+  assertEquals(command.commandLine.includes("s3cr3t"), false);
+  await command;
+});
+
+Deno.test("stdin does not deadlock on a child that outruns its pipe", async () => {
+  // Writing before draining stdout would wedge here: the child fills its output
+  // pipe and stops, while the parent is still blocked writing input. Both sides
+  // have to move at once.
+  const script = "const b=new Uint8Array(65536);" +
+    "console.log('x'.repeat(200000));" +
+    "let n=0,r;while((r=await Deno.stdin.read(b))!==null)n+=r;" +
+    "console.error('read',n)";
+  const result = await $`${Deno.execPath()} eval --no-lock ${script}`
+    .stdin("y".repeat(100000)).quiet();
+  assertEquals(result.code, 0);
+  assertStringIncludes(result.stderr, "read 100000");
+});
+
+Deno.test("without stdin the child keeps an inherited stream", async () => {
+  // The non-breaking half: nothing changes for every existing call site.
+  const result =
+    await $`${Deno.execPath()} eval --no-lock ${"console.log('ok')"}`
+      .quiet();
+  assertEquals(result.code, 0);
+  assertStringIncludes(result.stdout, "ok");
+});

--- a/packages/core/tests/tooling_test.ts
+++ b/packages/core/tests/tooling_test.ts
@@ -17,6 +17,8 @@ import {
   ToolSettings,
   windowsCmdShim,
 } from "../src/tooling.ts";
+import { withAmbientRedactor } from "../src/ambient_redactor.ts";
+import { REDACTED, Redactor } from "../src/redact.ts";
 import { CommandError, CommandTimeoutError } from "../src/shell.ts";
 import { withTemp } from "./_temp.ts";
 
@@ -558,4 +560,57 @@ Deno.test("onOutput runs once under noThrow too, and the output is returned", as
   const out = await s.run();
   assertEquals(out.code, 3);
   assertEquals(s.seen, [{ code: 3, stdout: "partial" }]);
+});
+
+Deno.test("markSecret masks a credential a tool only takes as an argument", async () => {
+  // Some tools have no stdin form, so the value must ride in argv. This does not
+  // hide it from the process table — nothing can — but it keeps it out of every
+  // rendered form of the command: the dry-run echo, a CommandError, a recorded
+  // service line.
+  class TokenSettings extends ToolSettings {
+    #token = "";
+    token(value: string): this {
+      this.#token = value;
+      this.markSecret(value);
+      return this;
+    }
+    protected override defaultTool(): string {
+      return Deno.execPath();
+    }
+    protected override buildArgs(): string[] {
+      return [
+        "eval",
+        "--no-lock",
+        `console.log(${JSON.stringify(this.#token)})`,
+      ];
+    }
+  }
+
+  const redactor = new Redactor();
+  await withAmbientRedactor(redactor, () => {
+    const settings = new TokenSettings().token("hunter2");
+    assertEquals(redactor.size > 0, true);
+    assertEquals(redactor.redact("token=hunter2"), `token=${REDACTED}`);
+    return Promise.resolve(settings);
+  });
+});
+
+Deno.test("markSecret outside a run is a no-op, not a crash", async () => {
+  // A wrapper used standalone in a script has no redactor to register with. It
+  // should still work — with nothing masking its output, which is the honest
+  // outcome rather than a failure.
+  class TokenSettings extends ToolSettings {
+    token(value: string): this {
+      this.markSecret(value);
+      return this;
+    }
+    protected override defaultTool(): string {
+      return Deno.execPath();
+    }
+    protected override buildArgs(): string[] {
+      return ["eval", "--no-lock", "console.log('ok')"];
+    }
+  }
+  new TokenSettings().token("hunter2");
+  await Promise.resolve();
 });

--- a/tests/integration/remediation_redact_test.ts
+++ b/tests/integration/remediation_redact_test.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Integration coverage for `RemediationContext.redact`.
+ *
+ * A remediation is the one thing in a run that publishes over the network — a
+ * pull-request comment, a job summary — and it does not go through the reporter
+ * or the run record, both of which redact what they emit. Its prompt is built
+ * from the failed command and its output, so a secret the build holds can come
+ * back in whatever it publishes. This proves the redactor reaches it.
+ *
+ * @module
+ */
+
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "../../packages/core/tests/_assert.ts";
+import {
+  Build,
+  parameter,
+  type RemediationContext,
+  target,
+} from "../../packages/core/mod.ts";
+import { runCli } from "./_harness.ts";
+
+Deno.test("a remediation can mask a secret the build declared", async () => {
+  const seen: string[] = [];
+
+  class Healing extends Build {
+    token = parameter("token").secret().default("hunter2");
+
+    lint = target()
+      .recoverWith({
+        remediate: (context: RemediationContext) => {
+          // What a real fixer publishes is a model's reply to a prompt built
+          // from this failure, so the secret arrives back inside the text.
+          const published = `the model said: use ${this.token.value} to retry`;
+          seen.push(context.redact(published));
+          return Promise.resolve({ retry: false });
+        },
+      })
+      .executes(() => {
+        throw new Error("lint failed");
+      });
+  }
+
+  const { code } = await runCli(Healing, ["lint"]);
+  assertEquals(code, 1); // diagnose-only: the failure still stands
+  assertEquals(seen.length, 1);
+  assertStringIncludes(seen[0] ?? "", "[redacted]");
+  assertEquals(
+    (seen[0] ?? "").includes("hunter2"),
+    false,
+    "the declared secret must not survive redact()",
+  );
+});


### PR DESCRIPTION
## What & why

Wave two of the assessment remediation is blocked on capabilities `@zuke/core`
does not expose. Each remaining fix lives in a wrapper or in `@zuke/ai`, and each
needs a seam here first — and `coreFloorCheck` type-checks every package against
the core version **published on JSR**, so these have to land and release before
the packages that consume them can raise their floor.

Five additions, each traced to a finding it unblocks.

1. **CI detection could not be tested, and missed most CI systems (F6).**
   `detectCiHost(env)` took an injectable reader; `ciHost()` and `isCI()` did
   not. So a consumer wanting "am I on CI?" could not answer it hermetically and
   reached for the host-specific function instead, inheriting its four-host list
   — Jenkins, Buildkite, CircleCI, Travis and TeamCity all read as `"local"`.
2. **A remediation could not redact what it publishes (F11).**
3. **`Command` had no stdin (F3, F12, F13, F18–F20, F27, F28).**
4. **A wrapper could not register a credential with the run's redactor.**
5. **The conformance CLI took its bearer token as an argument (F16).**

## Related issues

Closes #564

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a
      [Conventional Commit](https://www.conventionalcommits.org/)
      (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour
      changed.
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`,
      `llms-full.txt`, package README `## API`).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with
      type guards instead).
- [x] No dead code: unreachable branches and can't-fire fallbacks are removed,
      with types tightened so the impossible state is unrepresentable.
- [x] No duplicated logic: an existing helper is imported rather than retyped,
      and a near-copy differing by a constant or a message is parameterised into
      one implementation. A guard, escape, or credential resolution has exactly
      one implementation.
- [x] SOLID shapes respected: one domain per file, extension via the settings
      lambda (not a behaviour-switching flag), narrow parameter types, and
      dependencies on the injectable seam (`StateHost`, an injected `fetch`,
      `EnvReader`) rather than `Deno.*` or a global.
- [x] A new package was wired into all six places (see
      [AGENTS.md](../blob/master/AGENTS.md#good-open-source-practices-to-follow)),
      if applicable.
- [x] The code is written using AI assisted coding.

## Notes for the reviewer

**Why `feat`, and the one breaking edge.** `RemediationContext` gains a
**required** member. Optional would let a consumer silently skip the redaction it
exists to guarantee — the same reasoning that kept `SetupHost.isSymlink` required
in #542. Nothing external *constructs* a context (the executor does; a
`Remediation` receives one), so what this breaks is fabricated test contexts —
six in this repo, updated here. Everything else is an added optional parameter or
a new method.

**`CiHost` is deliberately untouched.** It is documented to match `CiProvider`,
`ciHost()` switches on it exhaustively and `hosts.ts` keys a record on it, so
widening it is a breaking public-type change — for a question that does not need
the host's name, only whether there is one. The generic markers answer that
instead, and `detectCiHost` still returns `"local"` for them, which a test pins.

**The stdin write is concurrent, and that is load-bearing.** Writing to
completion before draining the child's output deadlocks: the child fills its
output pipe and stops, while the parent is still blocked writing input. I
verified that rather than reasoning about it — sequencing the write first makes
the test hang until killed, and it passes only with the write inside the same
`Promise.all` as the captures.

**`markSecret` is honest about what it does not do.** It masks the *rendering* of
a command, not its argv, so the value is still in the process table for anyone on
the same host. The JSDoc says to prefer `Command.stdin` wherever the tool offers a
stdin form, and that this is for when there is no better option — not instead of
one.

**The conformance CLI refuses `--token` rather than ignoring it.** An ignored
argument would authenticate as anonymous and fail somewhere less obvious, and the
credential would already be in the process table and the transcript by then. The
refusal does not echo the value it is refusing, which a test pins.

**Two things found while in these files.** `ToolSettings.os_`'s JSDoc still
described the `cmd /c` retry #542 removed — the field now feeds
`findNodeModulesBin`, and the comment a few lines below already said the wrapping
"used to be" there. And my first cut of the stdin setter silently stole
`maxCapturedBytes`'s JSDoc by inserting between the comment and its signature;
`docLint` caught it, which is the check doing exactly its job.

**Every new guard was mutation-tested**: the generic CI markers reverted to the
single marker, the scheduler handed a pass-through redactor, and the stdin write
sequenced ahead of the captures. Each turns its test red.

**What this unblocks**, once released: `fix(wrappers)` for the eight argv-credential
findings, and `fix(ai)` for scope, provenance and redaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNN7wc1BczPDB7zEaQ9noH

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNN7wc1BczPDB7zEaQ9noH)_