### PR TITLE
fix(core): neutralise every line Zuke prints on an Actions runner, not only the renderer's

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5509,6 +5509,21 @@ function escapeLine(text: string): string
   Ordinary output is returned unchanged; only text that would have been
   executed as a command comes back visibly encoded.
 
+function escapeLineIf(github: boolean, text: string): string
+  {@link escapeLine}, applied only when something is parsing this process's
+  output for workflow commands.
+
+  The condition is not a security gate — the runner parses every line a step
+  writes, whatever this process believes about its own style. It is a
+  readability one: `escapeLine` leaves ordinary text alone, but a compiler
+  dump that legitimately begins a line with `::` would come back encoded, and
+  on a developer's terminal that is noise protecting against nothing.
+
+  It exists so the decision has one implementation. It was written out at more
+  than a dozen call sites, in three shapes that had already drifted apart — two
+  asking the style, one asking the environment — which is how a site gets added
+  without it.
+
 function escapeProperty(value: string): string
   Escape a value interpolated into a workflow command's property list
   (`::error title=<property>::`). Properties are comma-separated and

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -5563,6 +5563,21 @@ function escapeLine(text: string): string
   Ordinary output is returned unchanged; only text that would have been
   executed as a command comes back visibly encoded.
 
+function escapeLineIf(github: boolean, text: string): string
+  {@link escapeLine}, applied only when something is parsing this process's
+  output for workflow commands.
+
+  The condition is not a security gate — the runner parses every line a step
+  writes, whatever this process believes about its own style. It is a
+  readability one: `escapeLine` leaves ordinary text alone, but a compiler
+  dump that legitimately begins a line with `::` would come back encoded, and
+  on a developer's terminal that is noise protecting against nothing.
+
+  It exists so the decision has one implementation. It was written out at more
+  than a dozen call sites, in three shapes that had already drifted apart — two
+  asking the style, one asking the environment — which is how a site gets added
+  without it.
+
 function escapeProperty(value: string): string
   Escape a value interpolated into a workflow command's property list
   (`::error title=<property>::`). Properties are comma-separated and

--- a/packages/core/src/cancel.ts
+++ b/packages/core/src/cancel.ts
@@ -35,7 +35,13 @@
 import { type Build, discoverTargets, resolveOrderingEdges } from "./build.ts";
 import { buildRunPlan, type RunPlan } from "./run_plan.ts";
 import { defaultReadEnv, messageOf, runWithTimeout } from "./internal.ts";
-import { consoleReporter, type Reporter, silentReporter } from "./reporter.ts";
+import {
+  consoleReporter,
+  escapingReporter,
+  type Reporter,
+  silentReporter,
+} from "./reporter.ts";
+import { detectCiHost } from "./host.ts";
 import { type OrderingEdge, planGraph } from "./graph.ts";
 import { discoverParameters, resolveParameters } from "./params.ts";
 import { Redactor } from "./redact.ts";
@@ -777,8 +783,17 @@ export async function settleExternally(
   }
   const runId = options.runId;
   const actor = resolveActor(options.actor, readEnv);
-  const reporter = options.reporter ??
+  const sink = options.reporter ??
     (options.silent ? silentReporter : consoleReporter);
+  // Every line below carries text this process did not author: a run id or
+  // status another process wrote into the shared state store, an actor, a
+  // compensation name, the message of something that threw. On an Actions
+  // runner each is parsed for workflow commands, and this module composes no
+  // commands of its own — so the whole sink is neutralised, which covers the
+  // lines that exist and the ones added later.
+  const reporter = detectCiHost(readEnv) === "github"
+    ? escapingReporter(sink)
+    : sink;
   const now = () => new Date().toISOString();
 
   // A settlement runs *this* build's compensations against the record, so a run

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -8,7 +8,7 @@
 
 import { type Build, discoverGroups, discoverTargets } from "./build.ts";
 import { detectCiHost } from "./host.ts";
-import { escapeLine } from "./render.ts";
+import { escapeLineIf } from "./render.ts";
 import { discoverCiFiles, syncCiFiles } from "./ci.ts";
 import { isEntryModule } from "./entry.ts";
 import { messageOf } from "./internal.ts";
@@ -1118,9 +1118,10 @@ async function runForce(build: Build, parsed: ParsedArgs): Promise<number> {
     // escape belongs here, at the printer that owns the terminal, rather than in
     // `forceTarget` — the MCP tool returns the same message inside a JSON
     // payload, which must not carry a terminal's encoding.
-    const shown = detectCiHost() === "github"
-      ? escapeLine(result.message)
-      : result.message;
+    const shown = escapeLineIf(
+      detectCiHost() === "github",
+      result.message,
+    );
     if (!result.ok) {
       console.error(shown);
       return 1;

--- a/packages/core/src/execute_output.ts
+++ b/packages/core/src/execute_output.ts
@@ -25,15 +25,7 @@ import { appendJobSummary } from "./job_summary.ts";
 import { maskPatterns, Redactor } from "./redact.ts";
 import { detectWidth, type Style, type TargetReport } from "./report.ts";
 import { defaultRenderer, type Renderer } from "./renderer.ts";
-
-/** Whether the build is running inside a GitHub Actions runner. */
-function inGitHubActions(): boolean {
-  try {
-    return Deno.env.get("GITHUB_ACTIONS") === "true";
-  } catch {
-    return false;
-  }
-}
+import { detectCiHost } from "./host.ts";
 
 /** Whether terminal colour should be used (TTY, and `NO_COLOR` unset). */
 function autoColor(): boolean {
@@ -97,7 +89,10 @@ export function composeOutput(opts: {
   // `execute` with `silent`/a custom reporter) from polluting the workflow
   // summary, while a normal CLI run still writes it.
   const writesToConsole = opts.reporter === undefined && !opts.silent;
-  const github = opts.github ?? inGitHubActions();
+  // The same question `detectCiHost` already answers, asked through it rather
+  // than through a second reader of GITHUB_ACTIONS — the private copy this
+  // replaces tested the identical variable for the identical value.
+  const github = opts.github ?? detectCiHost() === "github";
   const style = resolveStyle(github, opts.color, opts.reporter !== undefined);
   const renderer = opts.renderer ?? defaultRenderer;
   return {

--- a/packages/core/src/executor.ts
+++ b/packages/core/src/executor.ts
@@ -22,8 +22,7 @@
 
 import type { Build, BuildResult } from "./build.ts";
 import { defaultReadEnv, messageOf } from "./internal.ts";
-import { escapeLine } from "./render.ts";
-import type { Reporter } from "./reporter.ts";
+import { escapingReporter, type Reporter } from "./reporter.ts";
 export type { Reporter } from "./reporter.ts";
 import {
   composeOutput,
@@ -250,6 +249,16 @@ export async function execute(
     style,
     renderer,
   } = composeOutput(options);
+  // The sink for lines this module and its helpers compose themselves: a run id
+  // or status another process wrote into the shared state store, a failing
+  // service's stderr, a warning a remote cache server returned, a plugin's
+  // message. None of them is ever a workflow command, and every one carries text
+  // this process did not author — so the neutralising happens once here rather
+  // than at each of the fifteen places that write one, which is how the two this
+  // change fixes came to be missed. `reporter` stays unwrapped for the
+  // renderer's lines, which *are* commands: escaping `::endgroup::` would break
+  // the grouping it closes.
+  const messages = style.github ? escapingReporter(reporter) : reporter;
   const skip = new Set(options.skip ?? []);
 
   const readEnv = options.readEnv ?? defaultReadEnv;
@@ -271,8 +280,8 @@ export async function execute(
     emitActionsMasks(secrets, baseReporter);
   }
   if (paramErrors.length > 0) {
-    reporter.error("Invalid or missing parameters:");
-    for (const message of paramErrors) reporter.error(`  ${message}`);
+    messages.error("Invalid or missing parameters:");
+    for (const message of paramErrors) messages.error(`  ${message}`);
     return {
       ok: false,
       executed: [],
@@ -292,7 +301,7 @@ export async function execute(
   try {
     extraEdges = await resolveOrderingEdges(build, discovered);
   } catch (error) {
-    reporter.error(`Failed to resolve ordering edges: ${messageOf(error)}`);
+    messages.error(`Failed to resolve ordering edges: ${messageOf(error)}`);
     return { ok: false, executed: [], error };
   }
   const { order, predecessors } = planGraph(root, extraEdges);
@@ -300,7 +309,7 @@ export async function execute(
   // answer in every process a resumed run passes through, since it is derived
   // from the graph rather than from what has happened so far.
   const planView = buildRunPlan(order, predecessors);
-  reportDanglingEdges(extraEdges, order, discovered.values(), reporter);
+  reportDanglingEdges(extraEdges, order, discovered.values(), messages);
   // Evaluate up-front conditions for `whenSkipped("skip-dependencies")` targets
   // and skip them plus any dependencies that nothing else needs.
   for (const name of await conditionSkips(root, order, planView)) {
@@ -311,7 +320,7 @@ export async function execute(
   // targets still unblock their dependents (their prior outputs are assumed
   // current), so an affected target downstream of an unaffected one still runs.
   if (options.affected !== undefined) {
-    await applyAffectedSkips(options.affected, order, skip, reporter);
+    await applyAffectedSkips(options.affected, order, skip, messages);
   }
 
   const limit = resolveConcurrency(options.parallel);
@@ -331,7 +340,7 @@ export async function execute(
     build,
     options.remoteCache,
     readEnv,
-    reporter,
+    messages,
   );
   const overallStart = performance.now();
 
@@ -344,7 +353,7 @@ export async function execute(
     build,
     options.plugins ?? [],
     runInfo,
-    (message) => reporter.info(message),
+    (message) => messages.info(message),
     redactor,
   );
   await life.start();
@@ -392,7 +401,7 @@ export async function execute(
     plan: planView,
     signal: runController.signal,
     redactor,
-    reporter,
+    reporter: messages,
     readEnv,
     nowIso,
     onExternalCancel,
@@ -403,7 +412,7 @@ export async function execute(
     resume: options.resume,
   });
   if (!opened.ok) {
-    reporter.error(opened.error.message);
+    messages.error(opened.error.message);
     return { ok: false, executed: [], error: opened.error };
   }
   const { writer, env } = opened.state;
@@ -506,7 +515,7 @@ export async function execute(
       options.signal.removeEventListener("abort", onCancel);
     }
     if (services.size > 0) {
-      await services.stopAll((line) => reporter.info(line));
+      await services.stopAll((line) => messages.info(line));
     }
   }
   // A cancellation (Ctrl-C / an aborted `options.signal`, or another process
@@ -539,7 +548,7 @@ export async function execute(
         `which now owns the run. Nothing was rolled back — the compensations ` +
         `belong to whoever holds the run.`,
     );
-    reporter.error(lost.message);
+    messages.error(lost.message);
     result = { ok: false, executed: run.executed, error: lost, runId };
   } else if (cancelled) {
     result = {
@@ -553,7 +562,7 @@ export async function execute(
       // settles the record. We stop and leave the run `cancelling`, draining any
       // pending per-target writes so none races the process exit.
       await writer?.drain();
-      reporter.info(cancelledElsewhere(runId));
+      messages.info(cancelledElsewhere(runId));
     } else if (writer !== undefined) {
       const settlement = await settleCancelledRun({
         writer,
@@ -563,7 +572,7 @@ export async function execute(
         runId,
         actor,
         signals: env.signals,
-        reporter,
+        reporter: messages,
         redactor,
         nowIso,
         isExternallyCancelled: () => externallyCancelled,
@@ -589,7 +598,7 @@ export async function execute(
             `The rest of the rollback, and the run's outcome, belong to ` +
             `whoever holds it now.`,
         );
-        reporter.error(lost.message);
+        messages.error(lost.message);
         result = { ok: false, executed: run.executed, error: lost, runId };
       }
     }
@@ -613,7 +622,7 @@ export async function execute(
           `working on it (its record says ${writer.snapshot().status}), so ` +
           `this process's result is not the run's outcome.`,
       );
-      reporter.error(settled.message);
+      messages.error(settled.message);
       result = { ok: false, executed: run.executed, error: settled, runId };
     }
   }
@@ -652,9 +661,12 @@ export async function execute(
   // On suspension, point the operator at the saved run so it can be resumed.
   // A cancelled run never resumes, so it skips this even if it parked a wait.
   if (run.suspended && !cancelled) {
+    // The names go through the sink with the rest of the line; `runId` does
+    // too, which it did not before — on a resume it is whatever id the caller
+    // named, not the generated one.
     const waiting = run.reports.filter((r) => r.status === "waiting")
-      .map((r) => style.github ? escapeLine(r.name) : r.name);
-    reporter.info(
+      .map((r) => r.name);
+    messages.info(
       `Run ${runId} suspended — state saved; waiting on: ${
         waiting.join(", ")
       }.`,

--- a/packages/core/src/render.ts
+++ b/packages/core/src/render.ts
@@ -86,6 +86,25 @@ export function escapeLine(text: string): string {
     .join("");
 }
 
+/**
+ * {@link escapeLine}, applied only when something is parsing this process's
+ * output for workflow commands.
+ *
+ * The condition is not a security gate — the runner parses every line a step
+ * writes, whatever this process believes about its own style. It is a
+ * readability one: `escapeLine` leaves ordinary text alone, but a compiler
+ * dump that legitimately begins a line with `::` would come back encoded, and
+ * on a developer's terminal that is noise protecting against nothing.
+ *
+ * It exists so the decision has one implementation. It was written out at more
+ * than a dozen call sites, in three shapes that had already drifted apart — two
+ * asking the style, one asking the environment — which is how a site gets added
+ * without it.
+ */
+export function escapeLineIf(github: boolean, text: string): string {
+  return github ? escapeLine(text) : text;
+}
+
 /** ANSI select-graphic-rendition codes, keyed by style name. */
 export const SGR = {
   reset: "\x1b[0m",

--- a/packages/core/src/reporter.ts
+++ b/packages/core/src/reporter.ts
@@ -4,14 +4,16 @@
 /**
  * The executor's output sink — the {@link Reporter} interface plus the small set
  * of reporter wrappers the engine composes: the console/silent defaults, a
- * redacting wrapper (masks resolved secrets), a best-effort wrapper (a throwing
- * sink can never unwind the run), and a buffering wrapper (so a target's block
- * flushes atomically under concurrency).
+ * redacting wrapper (masks resolved secrets), an escaping wrapper (neutralises
+ * workflow commands in text this process did not author), a best-effort wrapper
+ * (a throwing sink can never unwind the run), and a buffering wrapper (so a
+ * target's block flushes atomically under concurrency).
  *
  * @module
  */
 
 import type { Redactor } from "./redact.ts";
+import { escapeLine } from "./render.ts";
 
 /** Sink for executor output, defaulting to the console. Overridable in tests. */
 export interface Reporter {
@@ -38,6 +40,31 @@ export function redactingReporter(
   return {
     info: (line) => inner.info(redactor.redact(line)),
     error: (line) => inner.error(redactor.redact(line)),
+  };
+}
+
+/**
+ * Wrap a reporter so every line is neutralised with {@link escapeLine} before it
+ * is written — for a sink whose lines are **never** workflow commands.
+ *
+ * On a GitHub Actions runner every line a step writes is parsed for commands, so
+ * text this process did not author can forge an annotation, collapse a
+ * `::group::` over real output, or issue `::stop-commands::` and silence the
+ * masking directives that follow. The text reaching these sinks is exactly that:
+ * a run id or an actor another run wrote into the shared state store, a message
+ * a failing subprocess printed, a warning a remote cache server returned.
+ *
+ * Use this only where the module behind it emits no workflow commands of its
+ * own. `escapeLine` encodes a leading `::`, so a sink that also carries
+ * `::endgroup::` would have its grouping broken by this wrapper; those lines
+ * have to be escaped where they are composed instead, which is what the
+ * renderer does. Applying it twice is harmless — `escapeLine` removes the
+ * sequence it encodes, so it is idempotent.
+ */
+export function escapingReporter(inner: Reporter): Reporter {
+  return {
+    info: (line) => inner.info(escapeLine(line)),
+    error: (line) => inner.error(escapeLine(line)),
   };
 }
 

--- a/packages/core/src/resume.ts
+++ b/packages/core/src/resume.ts
@@ -41,7 +41,12 @@ import type {
   WaitDisposition,
   WaitState,
 } from "./state/types.ts";
-import { consoleReporter, silentReporter } from "./reporter.ts";
+import {
+  consoleReporter,
+  escapingReporter,
+  silentReporter,
+} from "./reporter.ts";
+import { detectCiHost } from "./host.ts";
 
 /** Raised when a run has already been resumed by another process. */
 export class AlreadyResumedError extends Error {
@@ -573,8 +578,17 @@ export async function resumeCheck(
   // A per-run refusal (a degraded record above all) is the sweep's only
   // explanation of a non-zero result, so default the sink to the console the
   // same way execute() does instead of swallowing it when no reporter is given.
-  const reporter = options.reporter ??
+  const sink = options.reporter ??
     (options.silent === true ? silentReporter : consoleReporter);
+  // Every line below carries text this process did not author: a run id or
+  // status another process wrote into the shared state store, an actor, a
+  // compensation name, the message of something that threw. On an Actions
+  // runner each is parsed for workflow commands, and this module composes no
+  // commands of its own — so the whole sink is neutralised, which covers the
+  // lines that exist and the ones added later.
+  const reporter = detectCiHost(readEnv) === "github"
+    ? escapingReporter(sink)
+    : sink;
   const store = resolveRunStore(
     options.stateStore,
     build.stateStore(),

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -33,12 +33,8 @@ import {
   TargetSummary,
   withAmbientSummary,
 } from "./summary_note.ts";
-import {
-  escapeLine,
-  type Style,
-  type TargetReport,
-  targetWaitFooter,
-} from "./report.ts";
+import { type Style, type TargetReport, targetWaitFooter } from "./report.ts";
+import { escapeLineIf } from "./render.ts";
 import type { Renderer } from "./renderer.ts";
 import {
   cloneTarget,
@@ -375,7 +371,7 @@ async function driveEffects(
           messageOf(error),
         );
       } catch (settleError) {
-        const safe = (text: string) => style.github ? escapeLine(text) : text;
+        const safe = (text: string) => escapeLineIf(style.github, text);
         reporter.info(
           `effect "${safe(declared.name)}" on "${safe(name)}" failed, and ` +
             `recording that failed too: ${safe(messageOf(settleError))}`,
@@ -451,7 +447,7 @@ async function runTarget(
     // stream they are neutralised like any other text this process did not
     // author. The target name is ours, but a fan-out key is not, so it goes
     // through too.
-    const safe = (text: string) => style.github ? escapeLine(text) : text;
+    const safe = (text: string) => escapeLineIf(style.github, text);
     reporter.info(
       `${safe(name)}: forced ${forced.outcome} by ${safe(forced.actor)}` +
         (forced.reason === undefined ? "" : ` — ${safe(forced.reason)}`),
@@ -512,7 +508,7 @@ async function runTarget(
               // The echoed command line is built from argv the build composed,
               // which can carry a parameter value or a fan-out key.
               (line) =>
-                reporter.info(`  $ ${style.github ? escapeLine(line) : line}`),
+                reporter.info(`  $ ${escapeLineIf(style.github, line)}`),
               () => runBody(t, targetCtx),
             ),
         );
@@ -629,7 +625,15 @@ async function runTarget(
   // or a lock declared with no store — fails the target with the guidance.
   let lock: HeldLock | null;
   try {
-    lock = await acquireTargetLock(t, env, (line) => reporter.info(line));
+    lock = await acquireTargetLock(
+      t,
+      env,
+      // The notice names the run that holds the lock — its actor, id, start
+      // time and url — and every one of those was written into the shared
+      // state store by another run. Same provenance as the forced-override
+      // line above, which has been neutralised since #547; this one was not.
+      (line) => reporter.info(escapeLineIf(style.github, line)),
+    );
   } catch (error) {
     const ms = performance.now() - start;
     failTarget(reporter, renderer, style, name, ms, error);
@@ -716,10 +720,15 @@ async function runForEachTarget(
     failTarget(reporter, renderer, style, name, ms, error);
     return { status: "failed", ms, error };
   }
+  // `name` is a class field for a top-level fan-out, but a stage of a fan-out
+  // may itself declare one: dispatch is per-target and `cloneTarget` copies the
+  // spec, so this line can be reached with `parent[key].stage` — carrying an
+  // item key — as its name.
+  const shownName = escapeLineIf(style.github, name);
   reporter.info(
     items.length === 0
-      ? `${name}: fan-out over 0 items — nothing to run.`
-      : `${name}: fan-out over ${items.length} item(s).`,
+      ? `${shownName}: fan-out over 0 items — nothing to run.`
+      : `${shownName}: fan-out over ${items.length} item(s).`,
   );
   const run = await runScheduled(
     ctx,

--- a/packages/core/tests/cancel_test.ts
+++ b/packages/core/tests/cancel_test.ts
@@ -33,6 +33,14 @@ import { withTemp } from "./_temp.ts";
 import { runRecord, testPlan } from "./_fakes.ts";
 import { withTempStore } from "./_store.ts";
 
+/**
+ * The percent-encoded `::`, kept as its own constant so the encoded prefix
+ * never fuses with the word after it into a token no dictionary can know: the
+ * spell gate reads the encoding and the word that follows it as one. The same
+ * reason `report_test.ts` splits its literal.
+ */
+const ENC = "%3A%3A";
+
 /** A run record scaffold for driving {@link runCompensations} directly. */
 function craftRecord(
   rootTarget: string,
@@ -1908,4 +1916,61 @@ Deno.test("a compensation reads the run's plan, not an empty one", async () => {
     reporter: { info: () => {}, error: () => {} },
   });
   assertEquals(seen, ["build,deploy", "includes(deploy)=true"]);
+});
+
+Deno.test("a failing compensation cannot forge a command on an Actions runner", async () => {
+  // Every line `cancelRun` prints carries text this process did not author — a
+  // run id, an actor, a compensation's name, the message of something that
+  // threw. None of them is ever a workflow command, so the whole sink is
+  // neutralised rather than each of the eighteen writers.
+  //
+  // Hermetic: the Actions detection reads through the injected `readEnv`, so
+  // this proves the behaviour without touching the process environment.
+  const NL = String.fromCharCode(10);
+  await withTempStore(async (store) => {
+    const makeBuild = () => {
+      class Hostile extends Build {
+        deploy = target()
+          .executes(() => {})
+          .onCancel(() => this.rollback);
+        rollback = target().executes(() => {
+          throw new Error(["boom", "::stop-commands::deadbeef"].join(NL));
+        });
+        gate = target()
+          .dependsOn(this.deploy)
+          .waitsFor((s) => s.on(externalSignal("approved")));
+      }
+      const build = new Hostile();
+      discoverTargets(build);
+      return build;
+    };
+
+    const a = makeBuild();
+    assertEquals(
+      (await execute(a, a.gate, {
+        silent: true,
+        stateStore: store,
+      })).suspended,
+      true,
+    );
+    const runId = (await store.listRuns({}))[0].id;
+
+    const onActions = capturingReporter();
+    const result = await cancelRun(makeBuild(), {
+      runId,
+      stateStore: store,
+      reporter: onActions.reporter,
+      readEnv: (name) => name === "GITHUB_ACTIONS" ? "true" : undefined,
+    });
+    // The compensation really did fail — without this the assertions below
+    // would hold over a line that was never printed.
+    assertEquals(result.failures.length, 1);
+
+    const printed = onActions.errors.join(NL);
+    assertStringIncludes(printed, ENC + "stop-commands::deadbeef");
+    assertEquals(
+      printed.split(NL).some((l) => l.startsWith("::stop-commands::")),
+      false,
+    );
+  });
 });

--- a/packages/core/tests/escaping_sink_test.ts
+++ b/packages/core/tests/escaping_sink_test.ts
@@ -1,0 +1,197 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * The neutralising of text Zuke did not author, on the stream a GitHub Actions
+ * runner parses for workflow commands: the `escapeLineIf` decision, the
+ * `escapingReporter` sink the executor and the operator commands write through,
+ * and the two composed lines that were still going out raw.
+ *
+ * The runner acts on a line whose first non-blank characters are `::`, and on
+ * `##[` anywhere in a line. Every assertion below is about the *start of a
+ * line*, not about a substring: the injected text is expected to survive as
+ * text, and what must not happen is it opening a command. Asserting
+ * `includes("::stop-commands::")` would pass whether or not the fix is there.
+ */
+
+import { assertEquals, assertStringIncludes } from "./_assert.ts";
+import { escapeLineIf } from "../src/render.ts";
+import {
+  escapingReporter,
+  type Reporter,
+  silentReporter,
+} from "../src/reporter.ts";
+import { Build, discoverTargets } from "../src/build.ts";
+import { target } from "../src/target.ts";
+import { execute } from "../src/executor.ts";
+import type { Plugin } from "../src/plugin.ts";
+
+const NL = String.fromCharCode(10);
+
+/**
+ * The percent-encoded `::`, kept as its own constant so the encoded prefix
+ * never fuses with the word after it into a token no dictionary can know: the
+ * spell gate reads the encoding and the word that follows it as one. The same
+ * reason `report_test.ts` splits its literal.
+ */
+const ENC = "%3A%3A";
+
+/** A reporter that records every line, so a test can inspect the stream. */
+function capture(): { reporter: Reporter; info: string[]; error: string[] } {
+  const info: string[] = [];
+  const error: string[] = [];
+  return {
+    reporter: {
+      info: (l) => void info.push(l),
+      error: (l) => void error.push(l),
+    },
+    info,
+    error,
+  };
+}
+
+/** Every line of `lines`, split on newlines — what the runner actually reads. */
+function streamLines(lines: string[]): string[] {
+  return lines.flatMap((l) => l.split(NL));
+}
+
+Deno.test("escapeLineIf escapes only when something is parsing for commands", () => {
+  const forged = "::stop-commands::deadbeef";
+  assertEquals(escapeLineIf(false, forged), forged);
+  assertEquals(escapeLineIf(true, forged), ENC + "stop-commands::deadbeef");
+  // Ordinary text is untouched in both directions — the escape is not a filter.
+  assertEquals(escapeLineIf(true, "lint passed"), "lint passed");
+  assertEquals(escapeLineIf(false, "lint passed"), "lint passed");
+});
+
+Deno.test("escapingReporter neutralises a command and leaves prose alone", () => {
+  const sink = capture();
+  const wrapped = escapingReporter(sink.reporter);
+
+  wrapped.info("Run abc123 cancelled — 2 compensation(s) ran.");
+  wrapped.info("::error::forged annotation");
+  wrapped.info("   ::stop-commands::deadbeef"); // leading blanks are trimmed
+  wrapped.error("held by ##[group]x");
+
+  assertEquals(sink.info[0], "Run abc123 cancelled — 2 compensation(s) ran.");
+  assertEquals(sink.info[1], ENC + "error::forged annotation");
+  assertEquals(sink.info[2], "   " + ENC + "stop-commands::deadbeef");
+  assertEquals(sink.error[0], "held by %23%23[group]x");
+});
+
+Deno.test("escapingReporter is idempotent, so double-wrapping is harmless", () => {
+  const once = capture();
+  const twice = capture();
+  escapingReporter(once.reporter).info("::error::x");
+  escapingReporter(escapingReporter(twice.reporter)).info("::error::x");
+  assertEquals(twice.info, once.info);
+});
+
+/** A build whose only target succeeds — enough to produce a target block. */
+class Quiet extends Build {
+  work = target().executes(() => {});
+}
+
+/** Run `Quiet` and return everything written, split into runner-visible lines. */
+async function runQuiet(
+  opts: { github: boolean; plugins?: Plugin[] },
+): Promise<{ info: string[]; error: string[] }> {
+  const sink = capture();
+  const build = new Quiet();
+  const root = discoverTargets(build).get("work");
+  if (root === undefined) throw new Error("fixture target not found");
+  await execute(build, root, {
+    reporter: sink.reporter,
+    github: opts.github,
+    ...(opts.plugins === undefined ? {} : { plugins: opts.plugins }),
+  });
+  return { info: streamLines(sink.info), error: streamLines(sink.error) };
+}
+
+Deno.test("a plugin's message cannot forge a command through the executor's sink", async () => {
+  // A plugin that throws is reported through the lifecycle's `warn` channel,
+  // which embeds the thrown message verbatim — third-party text on a stream the
+  // runner parses.
+  const hostile: Plugin = {
+    name: "rogue",
+    onStart: () => {
+      throw new Error(["boom", "::stop-commands::deadbeef"].join(NL));
+    },
+  };
+
+  const actions = await runQuiet({ github: true, plugins: [hostile] });
+  // The whole set of command-opening lines, asserted exactly: the two the
+  // renderer authored and nothing else. Weaker forms pass vacuously — an
+  // allowlist by prefix would admit a forged `::group::`, and "no line starts
+  // with `::`" is false here for a legitimate reason.
+  assertEquals(
+    actions.info.filter((l) => l.startsWith("::")),
+    ["::group::work", "::endgroup::"],
+  );
+  // The text is still there — neutralised, not filtered.
+  assertStringIncludes(
+    actions.info.join(NL),
+    ENC + "stop-commands::deadbeef",
+  );
+
+  // Off a runner the same line is left readable: nothing is parsing it.
+  const local = await runQuiet({ github: false, plugins: [hostile] });
+  assertEquals(
+    local.info.some((l) => l.startsWith("::stop-commands::deadbeef")),
+    true,
+  );
+});
+
+Deno.test("the renderer's own workflow commands survive the executor's sink", async () => {
+  // The guard on the other side: wrapping the renderer's sink too would encode
+  // `::endgroup::` and break every target's grouping. This fails if the
+  // escaping reporter is put in front of `ctx.reporter` instead of beside it.
+  const actions = await runQuiet({ github: true });
+  assertEquals(actions.info.includes("::endgroup::"), true);
+  assertEquals(actions.info.some((l) => l.startsWith("::group::")), true);
+});
+
+/** A stage that is itself a fan-out, so its parent's name carries an item key. */
+const innerFanOut = target().forEach(
+  () => ["one"],
+  () => ({ work: target().executes(() => {}) }),
+);
+
+class NestedFanOut extends Build {
+  outer = target().forEach(
+    () => [["a", "::stop-commands::deadbeef"].join(NL)],
+    () => ({ stage: innerFanOut }),
+  );
+}
+
+Deno.test("a fan-out item key cannot forge a command through the count line", async () => {
+  // Reachability is the point: a top-level fan-out's name is a class field, but
+  // a *stage* may declare a fan-out of its own, and the nested one is named
+  // `outer[<key>].stage` — so the count line is composed from an item key.
+  const sink = capture();
+  const build = new NestedFanOut();
+  const root = discoverTargets(build).get("outer");
+  if (root === undefined) throw new Error("fixture target not found");
+  const result = await execute(build, root, {
+    reporter: sink.reporter,
+    github: true,
+  });
+  assertEquals(result.ok, true);
+
+  const lines = streamLines(sink.info);
+  const counts = lines.filter((l) => l.includes("fan-out over"));
+  // Two of them: the outer target's, and the nested one whose name carries the
+  // key. Asserted so a change that stops reaching the nested line fails here
+  // rather than passing vacuously.
+  assertEquals(counts.length, 2);
+  assertEquals(
+    counts.some((l) => l.includes(ENC + "stop-commands::deadbeef")),
+    true,
+  );
+  assertEquals(lines.some((l) => l.startsWith("::stop-commands::")), false);
+});
+
+Deno.test("silentReporter stays silent once wrapped", () => {
+  // The wrapper composes with the other reporters rather than replacing them.
+  escapingReporter(silentReporter).info("::error::x");
+});

--- a/packages/core/tests/resume_test.ts
+++ b/packages/core/tests/resume_test.ts
@@ -20,6 +20,15 @@ import type { RunRecord } from "../src/state/types.ts";
 import { externalSignal, resumeWhen } from "../src/wait.ts";
 import { withTemp } from "./_temp.ts";
 import { withTempStore } from "./_store.ts";
+import { runRecord } from "./_fakes.ts";
+
+/**
+ * The percent-encoded `::`, kept as its own constant so the encoded prefix
+ * never fuses with the word after it into a token no dictionary can know: the
+ * spell gate reads the encoding and the word that follows it as one. The same
+ * reason `report_test.ts` splits its literal.
+ */
+const ENC = "%3A%3A";
 
 Deno.test("deploy → wait → promote survives across processes, exactly once", async () => {
   await withTempStore(async (store) => {
@@ -1120,5 +1129,51 @@ Deno.test("a sweep skips a run another process holds, without counting it", asyn
     assertEquals(swept, { checked: 1, failed: 0 });
     // Left exactly as found — the holder is driving it.
     assertEquals((await store.getRun(runId))?.record.status, "suspended");
+  });
+});
+
+Deno.test("a record's root target cannot forge a command during a sweep", async () => {
+  // A sweep reads records another process wrote — on a store shared between
+  // builds, another *repository's* process. A record naming a root target this
+  // build does not declare makes `resumeRun` throw, and the sweep prints the
+  // message with the name inside it. On an Actions runner that line is parsed
+  // for workflow commands, so the whole sink is neutralised.
+  //
+  // Hermetic: the Actions detection reads through the injected `readEnv`.
+  const NL = String.fromCharCode(10);
+  const forged = ["ghost", "::stop-commands::deadbeef"].join(NL);
+  await withTempStore(async (store) => {
+    class Sweeper extends Build {
+      deploy = target().executes(() => {});
+    }
+    const build = new Sweeper();
+    discoverTargets(build);
+
+    const record: RunRecord = runRecord({
+      id: "run-hostile",
+      build: "Sweeper",
+      rootTarget: forged,
+      status: "suspended",
+      graph: [{ name: forged, dependsOn: [] }],
+      targets: { [forged]: { status: "waiting", meta: {} } },
+    });
+    await store.putRun(record, null);
+
+    const errors: string[] = [];
+    const result = await resumeCheck(build, {
+      stateStore: store,
+      reporter: { info: () => {}, error: (l) => void errors.push(l) },
+      readEnv: (name) => name === "GITHUB_ACTIONS" ? "true" : undefined,
+    });
+    // The sweep really did hit the error path — without this the assertions
+    // below would hold over an empty buffer.
+    assertEquals(result.failed, 1);
+    assertEquals(errors.length, 1);
+
+    assertEquals(errors[0].includes(ENC + "stop-commands::deadbeef"), true);
+    assertEquals(
+      errors[0].split(NL).some((l) => l.startsWith("::stop-commands::")),
+      false,
+    );
   });
 });

--- a/tests/integration/lock_wait_test.ts
+++ b/tests/integration/lock_wait_test.ts
@@ -23,6 +23,14 @@ import type { Reporter } from "../../packages/core/mod.ts";
 import { runCli, withStateDir } from "./_harness.ts";
 
 /**
+ * The percent-encoded `::`, kept as its own constant so the encoded prefix
+ * never fuses with the word after it into a token no dictionary can know: the
+ * spell gate reads the encoding and the word that follows it as one. The same
+ * reason `report_test.ts` splits its literal.
+ */
+const ENC = "%3A%3A";
+
+/**
  * The shared resource a lock usually guards — one dev environment, one
  * database, one port — plus the log of who was inside it when, which is what
  * the wait has to get right.
@@ -166,4 +174,69 @@ Deno.test("a waiter that runs out of time fails and says it waited", async () =>
     release();
     assertEquals((await holding).code, 0);
   });
+});
+
+Deno.test("a lock holder's actor cannot forge a command in the waiting notice", async () => {
+  // The waiting notice describes the run that holds the lock — its actor, id,
+  // start time and url — and every one of those was written into the shared
+  // state store by another run. On an Actions runner that lands on a stream
+  // parsed for workflow commands, so it is neutralised like the forced-override
+  // line beside it.
+  const NL = String.fromCharCode(10);
+  const forged = ["ci-bot", "::stop-commands::deadbeef"].join(NL);
+  const prevActor = Deno.env.get("ZUKE_ACTOR");
+  const prevActions = Deno.env.get("GITHUB_ACTIONS");
+  Deno.env.set("ZUKE_ACTOR", forged);
+  Deno.env.set("GITHUB_ACTIONS", "true");
+  try {
+    await withStateDir(async () => {
+      const { HolderBuild, release, held } = sharedResource();
+      class WaiterBuild extends Build {
+        stack = target()
+          .description("queue behind the hostile holder")
+          .lock((s) =>
+            s.lockKey("dev-env").withTtl("1h").waitUpTo("30s").pollEvery("10ms")
+          )
+          .executes(() => {});
+      }
+
+      const holderOutput = recordingReporter();
+      const holding = runCli(HolderBuild, ["stack"], {
+        reporter: holderOutput.reporter,
+      });
+      await held();
+
+      const waiterOutput = recordingReporter();
+      const waiting = runCli(WaiterBuild, ["stack"], {
+        reporter: waiterOutput.reporter,
+      });
+      // The notice is what carries the holder's actor, so waiting for it is
+      // also what makes the assertions below non-vacuous: without it they
+      // would hold over an empty buffer.
+      await waiterOutput.await(`Waiting for lock "dev-env"`);
+
+      release();
+      assertEquals((await holding).code, 0);
+      assertEquals((await waiting).code, 0);
+
+      const stream = waiterOutput.lines.join(NL).split(NL);
+      // The actor survives as text — it is neutralised, not filtered — but no
+      // line of it opens a command. Asserted on the line, not the substring:
+      // `includes("::stop-commands::")` is true either way, since the encoded
+      // form still ends in `-commands::`.
+      assertStringIncludes(
+        waiterOutput.lines.join(NL),
+        ENC + "stop-commands::deadbeef",
+      );
+      assertEquals(
+        stream.some((l) => l.startsWith("::stop-commands::")),
+        false,
+      );
+    });
+  } finally {
+    if (prevActor === undefined) Deno.env.delete("ZUKE_ACTOR");
+    else Deno.env.set("ZUKE_ACTOR", prevActor);
+    if (prevActions === undefined) Deno.env.delete("GITHUB_ACTIONS");
+    else Deno.env.set("GITHUB_ACTIONS", prevActions);
+  }
 });


### PR DESCRIPTION
## What & why

The Actions runner parses **every** line a step writes, whatever the process
believes about its own output style. So a line Zuke did not author can forge an
annotation, collapse a group over real output, or issue a stop-commands
directive that silences the `::add-mask::` calls after it.

#547 and #550 closed the sites the assessment named. All of them were composed
by the renderer. Around forty others were still going out raw:

| module | sites | what they interpolate |
| --- | --- | --- |
| `cancel.ts` | 18 | store-derived run id, actor, status, compensation names, thrown-error messages |
| `executor.ts` | 9 | remote-cache warnings, service-stop errors carrying subprocess stderr, plugin messages, parameter-validation text, store-open errors |
| `reap.ts` | 4 | run ids and per-run error messages from the store |
| `resume.ts` | 3 | record-derived text |
| `execute_cancel.ts` | 3 | run id, compensation summary |
| `scheduler.ts` | 2 | the lock waiting notice and the fan-out count line |
| `execute_plan.ts`, `execute_state.ts` | 3 | the `--since` base ref, state-store warnings |

Two sat beside code that had already been fixed, carrying the same provenance it
was fixed for:

- **The lock waiting notice.** It describes the run holding the lock — its
  actor, id, start time and url, all written into the shared state store by
  another run. Thirty lines earlier the forced-override line escapes the actor
  and reason from that same store, with a comment saying why. This one did not.
- **The fan-out count line.** It took the target name raw. A top-level fan-out's
  name is a class field, but a *stage* of a fan-out may declare a fan-out of its
  own — dispatch is per-target and the clone copies the spec — so the nested one
  is named after the outer item key. I verified that rather than reasoning about
  it: the new test has a nested fixture, and its forged key reaches the line.

## How

Fixing forty writers by hand leaves the forty-first, so the neutralising moves
to the sinks that never carry a workflow command. One wrapper in the executor
covers its own lines and those of the three modules it feeds; one each in
`cancel` and `resume` covers those and the reap that `resume` drives.

**The renderer's sink stays unwrapped, deliberately.** Encoding the end-group
directive would break the grouping it closes — the escape turns it into
`%3A%3Aendgroup::` — so those lines are escaped where they are composed, which
is what the renderer already does. A test pins that from the other side: it
asserts the exact set of command-opening lines, so wrapping the renderer's sink
turns it red.

The decision itself had drifted into three shapes — two asking the resolved
style, one asking the environment — plus a private reader of the very variable
the shared host detection already reads. All of them now go through one helper
and one detector, and the private reader tested the identical variable for the
identical value, so folding it changes nothing.

## Related issues

Closes #567

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a
      [Conventional Commit](https://www.conventionalcommits.org/)
      (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour
      changed.
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`,
      `llms-full.txt`, package README `## API`).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with
      type guards instead).
- [x] No dead code: unreachable branches and can't-fire fallbacks are removed,
      with types tightened so the impossible state is unrepresentable.
- [x] No duplicated logic: an existing helper is imported rather than retyped,
      and a near-copy differing by a constant or a message is parameterised into
      one implementation. A guard, escape, or credential resolution has exactly
      one implementation.
- [x] SOLID shapes respected: one domain per file, extension via the settings
      lambda (not a behaviour-switching flag), narrow parameter types, and
      dependencies on the injectable seam (`StateHost`, an injected `fetch`,
      `EnvReader`) rather than `Deno.*` or a global.
- [x] A new package was wired into all six places (see
      [AGENTS.md](../blob/master/AGENTS.md#good-open-source-practices-to-follow)),
      if applicable.
- [x] The code is written using AI assisted coding.

## Notes for the reviewer

**Why `fix` and not `feat`.** One new public export, `escapeLineIf` on the
`@zuke/core/render` entrypoint, which is additive. The escaping wrapper is not
public: `reporter.ts` is not an entrypoint and `mod.ts` does not re-export its
siblings either, so this grows the internal surface rather than the published
one.

**`report.ts` is untouched, on purpose.** Its three copied lambdas are the
remaining instances of the duplicated decision, and #565 is rewriting exactly
those lines. Deduping them here would be a conflict for no functional gain: the
renderer keeps escaping at composition either way. Worth a follow-up once #565
lands.

**Hermeticity.** The cancel and resume tests reach the Actions detection through
the injected environment reader, so they prove the behaviour without touching
the process environment. The lock test cannot — the notice comes from a real
holder across a real store — so it sets and restores the two variables, the way
`cli_test.ts` already does.

**Every new guard was mutation-tested.** Reverting the wrapper to a
pass-through; dropping either sink wrapper; wrapping the renderer's sink as
well; taking the raw name at each of the two residual sites. Each turns its test
red. The assertions are written on the *start of a line*, not on substrings —
the injected text is expected to survive as text, and checking that the output
contains the forged token would pass whether or not the fix is there.

**One correction found while writing.** A comment I drafted credited the
forced-override escaping to #550; it came from #547. Checked with `git log -L`
rather than left as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNN7wc1BczPDB7zEaQ9noH

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNN7wc1BczPDB7zEaQ9noH)_