### PR TITLE
chore(core): fold the last copies of the Actions escape decision onto escapeLineIf

### DIFF
--- a/packages/core/src/report.ts
+++ b/packages/core/src/report.ts
@@ -19,6 +19,7 @@ import type { TargetStatus } from "./build.ts";
 import {
   escapeData,
   escapeLine,
+  escapeLineIf,
   escapeProperty,
   formatDuration,
   line,
@@ -120,7 +121,7 @@ export function targetPassFooter(
   // A fan-out sub-target's name carries the item key, which comes from repo or
   // remote data, so on the runner's stream it is neutralised like any other
   // untrusted text.
-  const safe = style.github ? escapeLine(name) : name;
+  const safe = escapeLineIf(style.github, name);
   const line = `${icon} ${safe} ${tail}`;
   return style.github ? [line, "::endgroup::"] : [line];
 }
@@ -184,7 +185,7 @@ export function targetWaitFooter(
   // The trigger describes what is being waited on, which for a workflow gate
   // names a repository and a workflow file, so it is no more ours than the
   // target name beside it.
-  const safe = (text: string) => style.github ? escapeLine(text) : text;
+  const safe = (text: string) => escapeLineIf(style.github, text);
   const note = paint(style.color, SGR.dim, `waiting for ${safe(trigger)}`);
   const line = `${icon} ${safe(name)} ${note}`;
   return style.github ? [line, "::endgroup::"] : [line];
@@ -194,7 +195,7 @@ export function targetWaitFooter(
 export function targetDryRunFooter(style: Style, name: string): string[] {
   const icon = paint(style.color, SGR.cyan, ICON.passed);
   const note = paint(style.color, SGR.dim, "(dry run — not executed)");
-  const line = `${icon} ${style.github ? escapeLine(name) : name} ${note}`;
+  const line = `${icon} ${escapeLineIf(style.github, name)} ${note}`;
   return style.github ? [line, "::endgroup::"] : [line];
 }
 
@@ -254,7 +255,7 @@ export function summaryBlock(
     // they are the same untrusted class as the name. They need no newline to
     // matter: the legacy bracketed command form is recognised mid-line.
     const raw = formatSummary(r.summary);
-    const note = style.github ? escapeLine(raw) : raw;
+    const note = escapeLineIf(style.github, raw);
     const notes = note === ""
       ? ""
       : "  " + paint(style.color, SGR.dim, `// ${note}`);
@@ -262,7 +263,7 @@ export function summaryBlock(
     // could open a command; the padding is computed from the raw name so the
     // columns stay aligned when nothing needed escaping.
     const shown = nameOf(r);
-    const name = style.github ? escapeLine(shown) : shown;
+    const name = escapeLineIf(style.github, shown);
     return name + " ".repeat(Math.max(0, nameWidth - shown.length)) + "  " +
       status + "  " +
       duration.padStart(durationWidth) + notes;
@@ -339,11 +340,7 @@ export function closingLine(
   }
   const failed = reports.filter((r) => r.status === "failed");
   const culprit = failed.length === 1
-    ? `'${
-      style.github
-        ? escapeLine(displayName(failed[0].name))
-        : displayName(failed[0].name)
-    }' failed`
+    ? `'${escapeLineIf(style.github, displayName(failed[0].name))}' failed`
     : failed.length > 1
     ? `${failed.length} targets failed`
     : "no target succeeded";

--- a/packages/core/tests/report_test.ts
+++ b/packages/core/tests/report_test.ts
@@ -573,3 +573,95 @@ Deno.test("a pipe in a target name cannot add a column to the job summary", () =
   // rather than opening columns of their own.
   assertEquals(row.split(/(?<!\\)\|/).length, 5);
 });
+
+Deno.test("a summary row's target name cannot open a workflow command", () => {
+  // A row starts at column 0 with the name, so a name beginning `::` needs no
+  // newline to reach the front of a line the runner parses — and `displayName`
+  // trims, so indenting it does not help either. The legacy bracketed form is
+  // recognised anywhere in a line, so it needs no position at all.
+  //
+  // This escape has been in `summaryBlock` since #547 and nothing pinned it:
+  // removing it left all 4523 tests green, which is how it was found.
+  const rows = summaryBlock(
+    GITHUB,
+    [
+      { name: "  ::error::forged", status: "failed", ms: 100 },
+      { name: "a ##[group]x", status: "passed", ms: 100 },
+    ],
+    200,
+    false,
+    NOW,
+  );
+  // Asserted on the line, not the substring: the text is meant to survive, and
+  // what must not happen is it starting one. `includes("::error::")` is true
+  // either way, since the encoded form still ends in `error::`.
+  assertEquals(rows.some((l) => l.startsWith("::")), false);
+  assertEquals(rows.some((l) => l.includes("##[")), false);
+  assertStringIncludes(rows.join("\n"), "%3A%3A" + "error::forged");
+  assertStringIncludes(rows.join("\n"), "a %23%23[group]x");
+
+  // Off a runner the name is left as written — nothing is parsing it there.
+  const plain = summaryBlock(
+    PLAIN,
+    [{ name: "  ::error::forged", status: "failed", ms: 100 }],
+    100,
+    false,
+    NOW,
+  );
+  assertEquals(plain.some((l) => l.startsWith("::error::forged")), true);
+});
+
+Deno.test("the build-failed line's culprit name cannot open a workflow command", () => {
+  // The single-culprit name is the one target name `closingLine` interpolates.
+  // It lands mid-line, after the icon and the opening quote, so the reachable
+  // form here is the legacy bracketed one — recognised anywhere in a line
+  // rather than only at its start. Escaping the name in isolation also encodes
+  // a leading `::`, which is conservative rather than load-bearing, and is
+  // asserted as the behaviour it is.
+  const bracketed = closingLine(
+    GITHUB,
+    [{ name: "deploy ##[group]x", status: "failed", ms: 100 }],
+    100,
+    false,
+    NOW,
+  );
+  assertEquals(bracketed.includes("##["), false);
+  assertStringIncludes(bracketed, "deploy %23%23[group]x");
+
+  const colons = closingLine(
+    GITHUB,
+    [{ name: "::error::forged", status: "failed", ms: 100 }],
+    100,
+    false,
+    NOW,
+  );
+  assertStringIncludes(colons, "%3A%3A" + "error::forged");
+
+  // Two or more failures name a count instead of a target, so there is nothing
+  // to escape — pinned so a future change cannot start interpolating a name
+  // there without a test noticing.
+  const many = closingLine(
+    GITHUB,
+    [
+      { name: "::error::forged", status: "failed", ms: 100 },
+      { name: "##[group]x", status: "failed", ms: 100 },
+    ],
+    200,
+    false,
+    NOW,
+  );
+  assertStringIncludes(many, "2 targets failed");
+  assertEquals(many.includes("forged"), false);
+
+  // Off a runner the name is left as written.
+  assertStringIncludes(
+    closingLine(
+      PLAIN,
+      [{ name: "deploy ##[group]x", status: "failed", ms: 100 }],
+      100,
+      false,
+      NOW,
+    ),
+    "deploy ##[group]x",
+  );
+});


### PR DESCRIPTION
## What & why

The last piece of #567. #569 gave the "should this line be escaped for the
Actions runner?" decision one implementation and folded every copy onto it
except the ones in `report.ts`, which were skipped because #565 was rewriting
the same lines. #565 has landed, so they are free.

Six sites wrote the decision out by hand — one of them a five-line ternary that
resolved the same name twice. They now call the helper. The replacement is the
same expression by definition, so there is no behaviour change.

Three other escapes in the file are deliberately different and untouched:
`targetFailFooter` escapes unconditionally inside a branch that is already
GitHub-only, and `targetHeader` uses the body escape because the name goes into
a command's payload rather than onto a line of its own. The
`::endgroup::`-appending ternaries are a different decision again — close the
group, not escape the text — and are also left alone.

## What the tidying surfaced

This is the part worth reviewing. Mutating each of the six in turn, against the
**whole** suite rather than just this file's tests, found two that nothing
covered:

| site | what it escapes |
| --- | --- |
| `summaryBlock` | the target name in a row |
| `closingLine` | the culprit name on the build-failed line |

Both escapes have been there since #547. Removing either left all 4523 tests
green. A guard that can be deleted silently is a guard that will be, so both now
have one, and the audit is in the acceptance criteria of #573 rather than being
a thing I happened to do.

The two tests are written against what actually reaches each site, which differs:

- A summary **row** starts at column 0 with the name, and #565's collapsing
  trims it, so a leading marker needs no newline and gains nothing from being
  indented. Both that and the legacy bracketed form are asserted.
- The **build-failed line** puts its name mid-line, after an icon and a quote,
  so the genuinely reachable form there is the bracketed one, which the runner
  recognises anywhere in a line. Escaping the name in isolation also encodes a
  leading colon pair; that is conservative rather than load-bearing, and is
  asserted as the behaviour it is rather than dressed up as a defence.
- The multi-failure branch names a count instead of a target, so it has nothing
  to escape. Pinned anyway, so a later change cannot start interpolating a name
  there unnoticed.

Assertions are on the start of a line, not on substrings: the text is meant to
survive, and checking that the output still contains the payload would pass
whether or not the escape is there.

## Related issues

Closes #573

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a
      [Conventional Commit](https://www.conventionalcommits.org/)
      (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell).
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches).
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour
      changed.
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`,
      `llms-full.txt`, package README `## API`).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with
      type guards instead).
- [x] No dead code: unreachable branches and can't-fire fallbacks are removed,
      with types tightened so the impossible state is unrepresentable.
- [x] No duplicated logic: an existing helper is imported rather than retyped,
      and a near-copy differing by a constant or a message is parameterised into
      one implementation. A guard, escape, or credential resolution has exactly
      one implementation.
- [x] SOLID shapes respected: one domain per file, extension via the settings
      lambda (not a behaviour-switching flag), narrow parameter types, and
      dependencies on the injectable seam (`StateHost`, an injected `fetch`,
      `EnvReader`) rather than `Deno.*` or a global.
- [x] A new package was wired into all six places (see
      [AGENTS.md](../blob/master/AGENTS.md#good-open-source-practices-to-follow)),
      if applicable.
- [x] The code is written using AI assisted coding.

## Notes for the reviewer

**Why `chore`.** No behaviour changes and no public API moves, so nothing should
release for it. The two new tests are the substance.

**`escapeLineIf` is not added to this file's re-export block.** `escapeLine` and
its neighbours are re-exported here for historical reasons; adding a second
import path for the new one would make the situation worse rather than better,
so it keeps the single path through `render.ts` that #569 gave it.

**The mutation audit is reproducible.** Each of the six was reverted to the raw
value in turn and the suite re-run. Four were already red; the two named above
were not, and are red now. The one non-source edit is splitting two encoded
literals in the test so the spell gate does not read the percent-encoding and
the word after it as a single token — the same split `report_test.ts` already
uses a few lines above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNN7wc1BczPDB7zEaQ9noH

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNN7wc1BczPDB7zEaQ9noH)_