### PR TITLE
fix(core): route every command-surface write through the escaping sink

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -7,8 +7,7 @@
  */
 
 import { type Build, discoverGroups, discoverTargets } from "./build.ts";
-import { detectCiHost } from "./host.ts";
-import { escapeLineIf } from "./render.ts";
+import { cliReporter } from "./reporter.ts";
 import { discoverCiFiles, syncCiFiles } from "./ci.ts";
 import { isEntryModule } from "./entry.ts";
 import { messageOf } from "./internal.ts";
@@ -75,32 +74,6 @@ import {
   type InstallOptions,
 } from "./completions_install.ts";
 import { describeBuildSurface } from "./describe.ts";
-
-/**
- * The CLI's own output, neutralised for a GitHub Actions runner.
- *
- * Every command here echoes arguments the invoker chose — a run id, a target
- * name, a force reason — and on Actions those commonly come from a
- * `workflow_dispatch` input or an issue body rather than from a person at a
- * terminal. The catch arms are the sharp end: they quote a thrown message
- * straight back, so they leak exactly what the success paths are careful about.
- *
- * A sink rather than a call-site guard because there are forty-odd writes here
- * and no reason for any of them to be exempt: unlike the run's reporter, this
- * module emits no workflow commands of its own, so there is no half to carve
- * out. The decision is made per line, not once at module load — a top-level
- * `const` would read the environment before an embedder or a test has set it,
- * and the escaping would then silently not apply.
- */
-const cli: Reporter = {
-  info: (line) => console.log(escapeLineIf(inActions(), line)),
-  error: (line) => console.error(escapeLineIf(inActions(), line)),
-};
-
-/** Whether this process is running on a GitHub Actions runner. */
-function inActions(): boolean {
-  return detectCiHost() === "github";
-}
 
 /** `completions` sub-action: print the script to stdout. */
 const PRINT_SUBCOMMAND = "print";
@@ -862,18 +835,18 @@ export async function syncCiConfig(
   const files = discoverCiFiles(build);
   if (files.length === 0) {
     if (!options.quietWhenEmpty) {
-      cli.info("No CI configuration is declared on this build.");
+      cliReporter.info("No CI configuration is declared on this build.");
     }
     return 0;
   }
   const results = await syncCiFiles(files, { check: options.check });
   const stale: string[] = [];
   for (const { path, status } of results) {
-    if (status === "written") cli.info(`Generated ${path}`);
+    if (status === "written") cliReporter.info(`Generated ${path}`);
     else if (status === "stale") stale.push(path);
   }
   if (stale.length > 0) {
-    cli.error(
+    cliReporter.error(
       `CI configuration is out of date: ${stale.join(", ")}.\n` +
         `Run \`zuke generate-ci\` and commit the result.`,
     );
@@ -941,19 +914,23 @@ async function installCompletionScript(
       params,
       options.installOptions,
     );
-    cli.info(`Installed ${result.shell} completion to ${result.scriptPath}`);
+    cliReporter.info(
+      `Installed ${result.shell} completion to ${result.scriptPath}`,
+    );
     if (result.rcPath === undefined) {
-      cli.info("Open a new shell (or restart fish) to load it.");
+      cliReporter.info("Open a new shell (or restart fish) to load it.");
     } else if (result.alreadySourced) {
-      cli.info(`${result.rcPath} already sources it — nothing to change.`);
+      cliReporter.info(
+        `${result.rcPath} already sources it — nothing to change.`,
+      );
     } else {
-      cli.info(
+      cliReporter.info(
         `Added a source line to ${result.rcPath}; open a new shell to use it.`,
       );
     }
     return 0;
   } catch (error) {
-    cli.error(messageOf(error));
+    cliReporter.error(messageOf(error));
     return 1;
   }
 }
@@ -1007,11 +984,13 @@ async function runResume(
         resumeDegraded: parsed.resumeDegraded,
         plugins,
       });
-      cli.info(`Checked ${checked} suspended run(s); ${failed} failed.`);
+      cliReporter.info(
+        `Checked ${checked} suspended run(s); ${failed} failed.`,
+      );
       return failed > 0 ? 1 : 0;
     }
     if (parsed.resumeRunId === undefined) {
-      cli.error(
+      cliReporter.error(
         "Usage: zuke resume <run-id> [--signal <name>] [--data <json>]  |  " +
           "zuke resume --check [<run-id>]",
       );
@@ -1029,7 +1008,7 @@ async function runResume(
     });
     return result.ok ? 0 : 1;
   } catch (error) {
-    cli.error(messageOf(error));
+    cliReporter.error(messageOf(error));
     // A lost resume race (AlreadyResumedError) and any other failure both exit
     // non-zero; the message tells the operator what happened.
     return 1;
@@ -1063,7 +1042,7 @@ async function runMcp(build: Build, parsed: ParsedArgs): Promise<number> {
     try {
       http = parseHttpAddress(parsed.httpAddr);
     } catch (error) {
-      cli.error(messageOf(error));
+      cliReporter.error(messageOf(error));
       return 1;
     }
   }
@@ -1083,7 +1062,7 @@ async function runMcp(build: Build, parsed: ParsedArgs): Promise<number> {
 /** Run the `cancel` command: cancel a run and run its compensations. */
 async function runCancel(build: Build, parsed: ParsedArgs): Promise<number> {
   if (parsed.cancelRunId === undefined) {
-    cli.error("Usage: zuke cancel <run-id> [--actor <name>]");
+    cliReporter.error("Usage: zuke cancel <run-id> [--actor <name>]");
     return 1;
   }
   try {
@@ -1095,7 +1074,7 @@ async function runCancel(build: Build, parsed: ParsedArgs): Promise<number> {
     // a compensation that threw surfaces non-zero so the operator notices.
     return result.failures.length > 0 ? 1 : 0;
   } catch (error) {
-    cli.error(messageOf(error));
+    cliReporter.error(messageOf(error));
     return 1;
   }
 }
@@ -1109,7 +1088,7 @@ async function runCancel(build: Build, parsed: ParsedArgs): Promise<number> {
  */
 async function runForce(build: Build, parsed: ParsedArgs): Promise<number> {
   if (parsed.forceExtra !== undefined) {
-    cli.error(
+    cliReporter.error(
       `force: unexpected argument "${parsed.forceExtra}". ` +
         `Usage: zuke force <run-id> <target> --outcome skipped|succeeded ` +
         `[--reason <why>] [--actor <name>]`,
@@ -1117,7 +1096,7 @@ async function runForce(build: Build, parsed: ParsedArgs): Promise<number> {
     return 1;
   }
   if (parsed.forceRunId === undefined || parsed.forceTarget === undefined) {
-    cli.error(
+    cliReporter.error(
       "Usage: zuke force <run-id> <target> --outcome skipped|succeeded " +
         "[--reason <why>] [--actor <name>]",
     );
@@ -1125,7 +1104,7 @@ async function runForce(build: Build, parsed: ParsedArgs): Promise<number> {
   }
   const outcome = FORCED_OUTCOMES.find((o) => o === parsed.outcome);
   if (outcome === undefined) {
-    cli.error(
+    cliReporter.error(
       `force: --outcome must be one of: ${FORCED_OUTCOMES.join(", ")}` +
         (parsed.outcome === undefined ? "." : ` (got "${parsed.outcome}").`),
     );
@@ -1145,13 +1124,13 @@ async function runForce(build: Build, parsed: ParsedArgs): Promise<number> {
     // unencoded, because the MCP tool hands the same message back inside a JSON
     // payload that must not carry a terminal's encoding. The printer decides.
     if (!result.ok) {
-      cli.error(result.message);
+      cliReporter.error(result.message);
       return 1;
     }
-    cli.info(result.message);
+    cliReporter.info(result.message);
     return 0;
   } catch (error) {
-    cli.error(messageOf(error));
+    cliReporter.error(messageOf(error));
     return 1;
   }
 }
@@ -1164,7 +1143,7 @@ async function runRegister(build: Build, parsed: ParsedArgs): Promise<number> {
       json: parsed.json,
     });
   } catch (error) {
-    cli.error(messageOf(error));
+    cliReporter.error(messageOf(error));
     return 1;
   }
 }
@@ -1226,7 +1205,7 @@ async function runDoc(
 ): Promise<number> {
   let spec = parsed.docSpec;
   if (spec === undefined) {
-    cli.error(
+    cliReporter.error(
       "Usage: zuke doc <spec>   (e.g. zuke doc jsr:@zuke/deno, or ./mod.ts)",
     );
     return 1;
@@ -1237,7 +1216,7 @@ async function runDoc(
   try {
     return await runner(spec);
   } catch (error) {
-    cli.error(messageOf(error));
+    cliReporter.error(messageOf(error));
     return 1;
   }
 }
@@ -1259,7 +1238,7 @@ async function runOutdated(
 ): Promise<number> {
   try {
     const report = await findOutdated(options);
-    cli.info(formatOutdated(report));
+    cliReporter.info(formatOutdated(report));
     // A package that could not be checked counts as a failure under
     // --exit-code: a gate asking "are we current?" has not been told yes, and
     // an offline runner passing quietly is the silence this command exists to
@@ -1267,7 +1246,7 @@ async function runOutdated(
     const unresolved = report.behind.length + report.unchecked.length;
     return parsed.exitCode && unresolved > 0 ? 1 : 0;
   } catch (error) {
-    cli.error(messageOf(error));
+    cliReporter.error(messageOf(error));
     return 1;
   }
 }
@@ -1277,7 +1256,7 @@ async function runRuns(build: Build, parsed: ParsedArgs): Promise<number> {
   const query: RunQuery = {};
   if (parsed.runStatus !== undefined) {
     if (!isRunStatus(parsed.runStatus)) {
-      cli.error(
+      cliReporter.error(
         `runs: unknown --status "${parsed.runStatus}" ` +
           `(one of: ${RUN_STATUS_NAMES.join(", ")}).`,
       );
@@ -1290,7 +1269,7 @@ async function runRuns(build: Build, parsed: ParsedArgs): Promise<number> {
   if (parsed.runLimit !== undefined) {
     const limit = parsePositiveInt(parsed.runLimit);
     if (limit === undefined) {
-      cli.error(
+      cliReporter.error(
         `runs: --limit must be a positive integer (got "${parsed.runLimit}").`,
       );
       return 1;
@@ -1303,7 +1282,7 @@ async function runRuns(build: Build, parsed: ParsedArgs): Promise<number> {
     try {
       keepMs = parseDuration(parsed.keep);
     } catch (error) {
-      cli.error(`runs: --keep is ${messageOf(error)}`);
+      cliReporter.error(`runs: --keep is ${messageOf(error)}`);
       return 1;
     }
   }
@@ -1311,7 +1290,7 @@ async function runRuns(build: Build, parsed: ParsedArgs): Promise<number> {
   if (parsed.keepLast !== undefined) {
     keepLast = parsePositiveInt(parsed.keepLast);
     if (keepLast === undefined) {
-      cli.error(
+      cliReporter.error(
         `runs: --keep-last must be a positive integer (got "${parsed.keepLast}").`,
       );
       return 1;
@@ -1346,7 +1325,7 @@ export async function main(
     return await runCommand(BuildClass, args, options);
   } catch (error) {
     if (error instanceof InsecureBackendUrlError) {
-      cli.error(error.message);
+      cliReporter.error(error.message);
       return 1;
     }
     throw error;
@@ -1373,7 +1352,7 @@ async function runCommand(
     // come before `--help`, because the help text lists the parameters that
     // discovery is what produces.
     if (error instanceof ParameterError) {
-      cli.error(error.message);
+      cliReporter.error(error.message);
       return 1;
     }
     throw error;
@@ -1391,12 +1370,12 @@ async function runCommand(
   } catch (error) {
     // parseArgs only ever throws Error; messageOf narrows `unknown` without a
     // second branch here that no input can reach.
-    cli.error(messageOf(error));
+    cliReporter.error(messageOf(error));
     return 1;
   }
 
   if (parsed.help) {
-    cli.info(formatHelp(targets, params));
+    cliReporter.info(formatHelp(targets, params));
     return 0;
   }
 
@@ -1404,7 +1383,7 @@ async function runCommand(
     validateGraph(targets);
   } catch (error) {
     if (error instanceof GraphError) {
-      cli.error(error.message);
+      cliReporter.error(error.message);
       return 1;
     }
     throw error;
@@ -1415,18 +1394,18 @@ async function runCommand(
   // written descriptor).
   if (parsed.json && !parsed.runs && !parsed.register) {
     const surface = describeBuildSurface(targets, params);
-    cli.info(JSON.stringify(surface, null, 2));
+    cliReporter.info(JSON.stringify(surface, null, 2));
     return 0;
   }
   if (parsed.list) {
-    cli.info(formatList(targets, params));
+    cliReporter.info(formatList(targets, params));
     return 0;
   }
   if (parsed.graph) {
     if (parsed.output === "html") {
       return await graphCommand(targets, { open: parsed.open }, graphHost);
     }
-    cli.info(formatGraph(targets));
+    cliReporter.info(formatGraph(targets));
     return 0;
   }
   if (parsed.completions) {
@@ -1436,13 +1415,13 @@ async function runCommand(
       action === PRINT_SUBCOMMAND;
     if (!validAction || shell === undefined || !isCompletionShell(shell)) {
       const shells = COMPLETION_SHELLS.join("|");
-      cli.error(`Usage: zuke completions <install|print> <${shells}>`);
+      cliReporter.error(`Usage: zuke completions <install|print> <${shells}>`);
       return 1;
     }
     if (action === INSTALL_SUBCOMMAND) {
       return await installCompletionScript(shell, targets, params, options);
     }
-    cli.info(formatCompletions(shell, targets, params));
+    cliReporter.info(formatCompletions(shell, targets, params));
     return 0;
   }
   if (parsed.generateCi) {
@@ -1478,7 +1457,7 @@ async function runCommand(
     if (targets.has(DEFAULT_TARGET)) {
       name = DEFAULT_TARGET;
     } else {
-      cli.info(formatList(targets, params));
+      cliReporter.info(formatList(targets, params));
       return 0;
     }
   }
@@ -1491,8 +1470,8 @@ async function runCommand(
     const hint = suggestion === undefined
       ? ""
       : ` Did you mean "${suggestion}"?`;
-    cli.error(`Unknown target: ${name}.${hint}\n`);
-    cli.error(formatList(targets, params));
+    cliReporter.error(`Unknown target: ${name}.${hint}\n`);
+    cliReporter.error(formatList(targets, params));
     return 1;
   }
 
@@ -1504,7 +1483,7 @@ async function runCommand(
   // union rather than a string the type system has to be told about.
   const actorKind = ACTOR_KINDS.find((kind) => kind === parsed.actorKind);
   if (parsed.actorKind !== undefined && actorKind === undefined) {
-    cli.error(
+    cliReporter.error(
       `--actor-kind must be one of: ${ACTOR_KINDS.join(", ")} ` +
         `(got "${parsed.actorKind}").`,
     );

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -7,7 +7,7 @@
  */
 
 import { type Build, discoverGroups, discoverTargets } from "./build.ts";
-import { cliReporter } from "./reporter.ts";
+import { cliReporter, printJson } from "./reporter.ts";
 import { discoverCiFiles, syncCiFiles } from "./ci.ts";
 import { isEntryModule } from "./entry.ts";
 import { messageOf } from "./internal.ts";
@@ -1394,7 +1394,7 @@ async function runCommand(
   // written descriptor).
   if (parsed.json && !parsed.runs && !parsed.register) {
     const surface = describeBuildSurface(targets, params);
-    cliReporter.info(JSON.stringify(surface, null, 2));
+    printJson(surface);
     return 0;
   }
   if (parsed.list) {

--- a/packages/core/src/conformance.ts
+++ b/packages/core/src/conformance.ts
@@ -42,6 +42,7 @@ import { HttpStateStore } from "./state/http_store.ts";
 import type { BuildDescriptor } from "./registry/descriptor.ts";
 import type { BuildRegistry } from "./registry/registry.ts";
 import { HttpBuildRegistry } from "./registry/http_registry.ts";
+import { cliReporter } from "./reporter.ts";
 
 /** The outcome of one conformance scenario. */
 export interface ConformanceResult {
@@ -552,7 +553,7 @@ export async function runConformanceCli(
   args: string[],
   deps: ConformanceCliDeps = {},
 ): Promise<number> {
-  const log = deps.log ?? ((line: string) => console.log(line));
+  const log = deps.log ?? ((line: string) => cliReporter.info(line));
   const env = deps.readEnv ?? defaultReadEnv;
   const url = flag(args, "--url");
   if (args.includes("--token")) {

--- a/packages/core/src/graph_view.ts
+++ b/packages/core/src/graph_view.ts
@@ -17,6 +17,7 @@ import { ARTIFACT_DIR, findConfigDir, pathExists } from "./config.ts";
 import { absolutePath } from "./path.ts";
 import type { TargetBuilder } from "./target.ts";
 import { browserCommand } from "./browser.ts";
+import { cliReporter } from "./reporter.ts";
 
 /** Spawn a detached command (binary + args); used to launch a browser. */
 export type Spawn = (cmd: string, args: string[]) => Promise<void>;
@@ -67,7 +68,7 @@ export const defaultGraphHost: GraphHost = {
   mkdir: (path) => Deno.mkdir(path, { recursive: true }),
   writeText: (path, content) => Deno.writeTextFile(path, content),
   open: (path) => openInBrowser(path),
-  log: (message) => console.log(message),
+  log: (message) => cliReporter.info(message),
 };
 
 /** Options controlling {@link graphCommand}. */

--- a/packages/core/src/mcp/command.ts
+++ b/packages/core/src/mcp/command.ts
@@ -35,6 +35,7 @@ import {
 } from "./auth.ts";
 import { McpServer, type McpServerOptions } from "./server.ts";
 import { RegistryMcpServer, type RegistryRunner } from "./registry_server.ts";
+import { cliReporter } from "../reporter.ts";
 
 /** A thing that answers MCP messages — either server flavour drives a transport. */
 interface McpHandler {
@@ -157,7 +158,7 @@ export async function serveMcp(
   const declared = build.mcpAuth();
   const hook = build.mcpIdentity();
   if (declared !== undefined && hook !== undefined) {
-    console.error(
+    cliReporter.error(
       "zuke mcp: this build declares both mcpAuth() and mcpIdentity() — keep " +
         "one: mcpAuth() is the general seam, and mcpIdentity() is sugar for a " +
         "header-trusting authenticator.",
@@ -174,7 +175,7 @@ export async function serveMcp(
     try {
       metadataDocument(protectedResource);
     } catch (error) {
-      console.error(`zuke mcp: ${messageOf(error)}`);
+      cliReporter.error(`zuke mcp: ${messageOf(error)}`);
       return 1;
     }
   }
@@ -234,7 +235,7 @@ export async function serveMcp(
   if (!options.quiet) {
     const mode = options.allowRun ? "run enabled" : "read-only";
     const source = registry !== undefined ? "registry, " : "";
-    console.error(
+    cliReporter.error(
       `zuke mcp: serving on stdio (${source}${mode}). Press Ctrl-C to stop.`,
     );
   }
@@ -267,7 +268,7 @@ async function serveMcpHttp(
   const token = options.token ?? readEnv("ZUKE_MCP_TOKEN");
   const hasToken = token !== undefined && token !== "";
   if (!isLoopbackHost(address.host) && !hasToken && !authenticates) {
-    console.error(
+    cliReporter.error(
       `zuke mcp: refusing to bind ${address.host}:${address.port} without ` +
         `authentication. A non-loopback MCP endpoint must be authenticated — ` +
         `set ZUKE_MCP_TOKEN, declare mcpAuth() on the build, or bind 127.0.0.1 ` +
@@ -288,7 +289,7 @@ async function serveMcpHttp(
       : hasToken
       ? "bearer token required"
       : "no auth (loopback only)";
-    console.error(
+    cliReporter.error(
       `zuke mcp: serving on http://${address.host}:${address.port} ` +
         `(${source}${mode}, ${auth}). Press Ctrl-C to stop.`,
     );

--- a/packages/core/src/registry/register.ts
+++ b/packages/core/src/registry/register.ts
@@ -26,6 +26,7 @@ import { resolveActor } from "../state/record.ts";
 import type { BuildDescriptor, BuildLocation } from "./descriptor.ts";
 import type { BuildRegistry } from "./registry.ts";
 import { resolveBuildRegistry } from "./resolve.ts";
+import { cliReporter } from "../reporter.ts";
 
 /** How many times a conflicting registration CAS is re-read and retried. */
 const MAX_RETRIES = 10;
@@ -146,7 +147,7 @@ export async function registerCommand(
   const readEnv = options.readEnv ?? defaultReadEnv;
   const registry = resolveRegisterRegistry(options.registry, build, readEnv);
   if (registry === undefined) {
-    console.error(
+    cliReporter.error(
       "register: no build registry is configured. Set ZUKE_REGISTRY_DIR / " +
         "ZUKE_REGISTRY_URL, or override registry() on the build.",
     );
@@ -166,9 +167,9 @@ export async function registerCommand(
   }, now);
 
   if (options.json) {
-    console.log(JSON.stringify(descriptor, null, 2));
+    cliReporter.info(JSON.stringify(descriptor, null, 2));
   } else {
-    console.log(
+    cliReporter.info(
       `Registered build "${descriptor.id}" ` +
         `(${descriptor.surface.targets.length} target(s)) to the registry.`,
     );

--- a/packages/core/src/registry/register.ts
+++ b/packages/core/src/registry/register.ts
@@ -26,7 +26,7 @@ import { resolveActor } from "../state/record.ts";
 import type { BuildDescriptor, BuildLocation } from "./descriptor.ts";
 import type { BuildRegistry } from "./registry.ts";
 import { resolveBuildRegistry } from "./resolve.ts";
-import { cliReporter } from "../reporter.ts";
+import { cliReporter, printJson } from "../reporter.ts";
 
 /** How many times a conflicting registration CAS is re-read and retried. */
 const MAX_RETRIES = 10;
@@ -167,7 +167,7 @@ export async function registerCommand(
   }, now);
 
   if (options.json) {
-    cliReporter.info(JSON.stringify(descriptor, null, 2));
+    printJson(descriptor);
   } else {
     cliReporter.info(
       `Registered build "${descriptor.id}" ` +

--- a/packages/core/src/reporter.ts
+++ b/packages/core/src/reporter.ts
@@ -118,8 +118,11 @@ export function printJson(value: unknown): void {
   // diffing it against a golden file, or checksumming it, sees no change at all.
   // On a runner the bytes differ and the parsed value does not, which is the
   // only combination that is both safe and faithful.
+  // Only the marker itself, not every `#`: escaping the first character of each
+  // occurrence is enough to stop the runner matching it, and leaves every other
+  // hash in the payload exactly as written.
   console.log(
-    onActionsRunner() ? json.replaceAll("#", "\\u0023") : json,
+    onActionsRunner() ? json.replaceAll("##[", "\\u0023#[") : json,
   );
 }
 

--- a/packages/core/src/reporter.ts
+++ b/packages/core/src/reporter.ts
@@ -13,7 +13,8 @@
  */
 
 import type { Redactor } from "./redact.ts";
-import { escapeLine } from "./render.ts";
+import { detectCiHost } from "./host.ts";
+import { escapeLine, escapeLineIf } from "./render.ts";
 
 /** Sink for executor output, defaulting to the console. Overridable in tests. */
 export interface Reporter {
@@ -66,6 +67,36 @@ export function escapingReporter(inner: Reporter): Reporter {
     info: (line) => inner.info(escapeLine(line)),
     error: (line) => inner.error(escapeLine(line)),
   };
+}
+
+/**
+ * The sink every command-surface module writes through, neutralised for a
+ * GitHub Actions runner.
+ *
+ * These commands echo arguments the invoker chose — a run id, a target name, a
+ * force reason — and read values another process wrote into the shared state
+ * store. Under Actions those commonly come from a workflow-dispatch input or an
+ * issue body rather than from a person at a terminal, and a thrown message
+ * quotes them straight back.
+ *
+ * A sink rather than a guard at each of the sixty-odd writes, because none of
+ * them should be exempt: unlike the run's reporter, none of these modules emits
+ * a workflow command of its own, so there is no half to carve out. The MCP
+ * command writes only diagnostics here — its protocol never goes through the
+ * console — so escaping cannot corrupt it.
+ *
+ * The decision is made per line, not once when this module loads. A top-level
+ * constant would read the environment at import time, before an embedder or a
+ * test has set it, and the escaping would then silently not apply.
+ */
+export const cliReporter: Reporter = {
+  info: (line) => console.log(escapeLineIf(onActionsRunner(), line)),
+  error: (line) => console.error(escapeLineIf(onActionsRunner(), line)),
+};
+
+/** Whether this process is running on a GitHub Actions runner. */
+function onActionsRunner(): boolean {
+  return detectCiHost() === "github";
 }
 
 /**

--- a/packages/core/src/reporter.ts
+++ b/packages/core/src/reporter.ts
@@ -94,6 +94,27 @@ export const cliReporter: Reporter = {
   error: (line) => console.error(escapeLineIf(onActionsRunner(), line)),
 };
 
+/**
+ * Print `value` as JSON that is safe on a runner **and** parses to exactly what
+ * it would print anywhere else.
+ *
+ * Machine-readable output cannot go through {@link cliReporter}: `escapeLine`
+ * percent-encodes a legacy `##[` marker wherever it appears, so a consumer doing
+ * `zuke runs list --json | jq -r '.[0].actor'` would silently read a different
+ * string on Actions than it reads locally. Escaping the transport corrupts the
+ * payload.
+ *
+ * Escaping it as JSON instead costs nothing: `\u0023` **is** `#` to every
+ * parser, so the value round-trips byte for byte, while the raw bytes on the
+ * stream can no longer contain the marker. The other half of `escapeLine` needs
+ * no answer here — an indented `JSON.stringify` never begins a physical line
+ * with `::`, because a newline inside a string is written as `\n` rather than
+ * breaking the line.
+ */
+export function printJson(value: unknown): void {
+  console.log(JSON.stringify(value, null, 2).replaceAll("#", "\\u0023"));
+}
+
 /** Whether this process is running on a GitHub Actions runner. */
 function onActionsRunner(): boolean {
   return detectCiHost() === "github";

--- a/packages/core/src/reporter.ts
+++ b/packages/core/src/reporter.ts
@@ -112,7 +112,15 @@ export const cliReporter: Reporter = {
  * breaking the line.
  */
 export function printJson(value: unknown): void {
-  console.log(JSON.stringify(value, null, 2).replaceAll("#", "\\u0023"));
+  const json = JSON.stringify(value, null, 2);
+  // Only where something is parsing for commands. Off a runner nothing scans
+  // this output, so it goes out byte for byte as it always has — a consumer
+  // diffing it against a golden file, or checksumming it, sees no change at all.
+  // On a runner the bytes differ and the parsed value does not, which is the
+  // only combination that is both safe and faithful.
+  console.log(
+    onActionsRunner() ? json.replaceAll("#", "\\u0023") : json,
+  );
 }
 
 /** Whether this process is running on a GitHub Actions runner. */

--- a/packages/core/src/runs.ts
+++ b/packages/core/src/runs.ts
@@ -25,6 +25,7 @@ import {
 } from "./state/types.ts";
 import { formatDuration, table } from "./render.ts";
 import { formatSummary } from "./report.ts";
+import { cliReporter } from "./reporter.ts";
 
 /** Inputs for {@link runsCommand}. */
 export interface RunsOptions {
@@ -118,7 +119,7 @@ export async function runsCommand(
     readEnv,
   );
   if (store === undefined) {
-    console.error(
+    cliReporter.error(
       "runs: no state store is configured. Set ZUKE_STATE_DIR / " +
         "ZUKE_STATE_URL, override stateStore(), or run a build with --state first.",
     );
@@ -143,14 +144,14 @@ export async function runsCommand(
       .slice(0, query.limit ?? listed.length);
     if (options.counts) {
       const counts = aggregateRunCounts(summaries);
-      console.log(
+      cliReporter.info(
         options.json
           ? JSON.stringify(counts, null, 2)
           : formatRunCounts(counts),
       );
       return 0;
     }
-    console.log(
+    cliReporter.info(
       options.json
         ? JSON.stringify(summaries, null, 2)
         : formatRunList(summaries),
@@ -159,15 +160,15 @@ export async function runsCommand(
   }
   if (action === "show") {
     if (options.runId === undefined) {
-      console.error("Usage: zuke runs show <run-id>");
+      cliReporter.error("Usage: zuke runs show <run-id>");
       return 1;
     }
     const loaded = await store.getRun(options.runId);
     if (loaded === null) {
-      console.error(`runs: no run "${options.runId}" found in the store.`);
+      cliReporter.error(`runs: no run "${options.runId}" found in the store.`);
       return 1;
     }
-    console.log(
+    cliReporter.info(
       options.json
         ? JSON.stringify(loaded.record, null, 2)
         : formatRunDetail(loaded.record),
@@ -175,7 +176,7 @@ export async function runsCommand(
     return 0;
   }
   if (action === "prune") return await pruneRuns(store, options);
-  console.error("Usage: zuke runs <list|show|prune> [<run-id>]");
+  cliReporter.error("Usage: zuke runs <list|show|prune> [<run-id>]");
   return 1;
 }
 
@@ -190,7 +191,7 @@ async function pruneRuns(
   options: RunsOptions,
 ): Promise<number> {
   if (options.keepMs === undefined && options.keepLast === undefined) {
-    console.error(
+    cliReporter.error(
       "Usage: zuke runs prune [--keep <duration>] [--keep-last <n>]\n" +
         "  Give at least one retention rule — prune never deletes everything by default.",
     );
@@ -206,7 +207,7 @@ async function pruneRuns(
     now(),
   );
   if (options.dryRun) {
-    console.log(
+    cliReporter.info(
       options.json
         ? JSON.stringify({ wouldPrune: ids }, null, 2)
         : `Would prune ${ids.length} run(s)${idList(ids)}.`,
@@ -214,7 +215,7 @@ async function pruneRuns(
     return 0;
   }
   for (const id of ids) await store.deleteRun(id);
-  console.log(
+  cliReporter.info(
     options.json
       ? JSON.stringify({ pruned: ids }, null, 2)
       : `Pruned ${ids.length} run(s)${idList(ids)}.`,

--- a/packages/core/src/runs.ts
+++ b/packages/core/src/runs.ts
@@ -25,7 +25,7 @@ import {
 } from "./state/types.ts";
 import { formatDuration, table } from "./render.ts";
 import { formatSummary } from "./report.ts";
-import { cliReporter } from "./reporter.ts";
+import { cliReporter, printJson } from "./reporter.ts";
 
 /** Inputs for {@link runsCommand}. */
 export interface RunsOptions {
@@ -144,18 +144,12 @@ export async function runsCommand(
       .slice(0, query.limit ?? listed.length);
     if (options.counts) {
       const counts = aggregateRunCounts(summaries);
-      cliReporter.info(
-        options.json
-          ? JSON.stringify(counts, null, 2)
-          : formatRunCounts(counts),
-      );
+      if (options.json) printJson(counts);
+      else cliReporter.info(formatRunCounts(counts));
       return 0;
     }
-    cliReporter.info(
-      options.json
-        ? JSON.stringify(summaries, null, 2)
-        : formatRunList(summaries),
-    );
+    if (options.json) printJson(summaries);
+    else cliReporter.info(formatRunList(summaries));
     return 0;
   }
   if (action === "show") {
@@ -168,11 +162,8 @@ export async function runsCommand(
       cliReporter.error(`runs: no run "${options.runId}" found in the store.`);
       return 1;
     }
-    cliReporter.info(
-      options.json
-        ? JSON.stringify(loaded.record, null, 2)
-        : formatRunDetail(loaded.record),
-    );
+    if (options.json) printJson(loaded.record);
+    else cliReporter.info(formatRunDetail(loaded.record));
     return 0;
   }
   if (action === "prune") return await pruneRuns(store, options);
@@ -207,19 +198,13 @@ async function pruneRuns(
     now(),
   );
   if (options.dryRun) {
-    cliReporter.info(
-      options.json
-        ? JSON.stringify({ wouldPrune: ids }, null, 2)
-        : `Would prune ${ids.length} run(s)${idList(ids)}.`,
-    );
+    if (options.json) printJson({ wouldPrune: ids });
+    else cliReporter.info(`Would prune ${ids.length} run(s)${idList(ids)}.`);
     return 0;
   }
   for (const id of ids) await store.deleteRun(id);
-  cliReporter.info(
-    options.json
-      ? JSON.stringify({ pruned: ids }, null, 2)
-      : `Pruned ${ids.length} run(s)${idList(ids)}.`,
-  );
+  if (options.json) printJson({ pruned: ids });
+  else cliReporter.info(`Pruned ${ids.length} run(s)${idList(ids)}.`);
   return 0;
 }
 

--- a/packages/core/tests/escaping_sink_test.ts
+++ b/packages/core/tests/escaping_sink_test.ts
@@ -16,6 +16,8 @@
 
 import { assertEquals, assertStringIncludes } from "./_assert.ts";
 import { escapeLineIf } from "../src/render.ts";
+import { printJson } from "../src/reporter.ts";
+import { withEnv } from "./_env.ts";
 import {
   escapingReporter,
   type Reporter,
@@ -210,6 +212,8 @@ Deno.test("no module writes to the console except the sink itself", async () => 
   //
   // Comments are stripped first: a JSDoc example showing a plugin author how to
   // write one is documentation, not a write.
+  // Keyed by path from `src/`, not by file name: a nested module sharing a
+  // basename with an allowed one would otherwise be exempt by accident.
   const allowed = new Set([
     // The sink itself, the one place allowed to reach the real console.
     "reporter.ts",
@@ -229,12 +233,13 @@ Deno.test("no module writes to the console except the sink itself", async () => 
         await walk(child);
         continue;
       }
-      if (!entry.name.endsWith(".ts") || allowed.has(entry.name)) continue;
+      const relative = child.href.slice(root.href.length);
+      if (!entry.name.endsWith(".ts") || allowed.has(relative)) continue;
       const code = (await Deno.readTextFile(child))
         .replace(/\/\*[\s\S]*?\*\//g, "")
         .replace(/\/\/[^\n]*/g, "");
       if (/\bconsole\.(log|error|warn|info|debug)\s*\(/.test(code)) {
-        offenders.push(entry.name);
+        offenders.push(relative);
       }
     }
   };
@@ -247,4 +252,35 @@ Deno.test("no module writes to the console except the sink itself", async () => 
       offenders.join(", ")
     }`,
   );
+});
+
+Deno.test("printJson encodes the marker wherever it appears in a payload", async () => {
+  // `replaceAll` runs over the whole serialised document, so field position is
+  // not a factor — but that is the kind of claim worth demonstrating rather
+  // than asserting, since a reader cannot tell from the call site whether it
+  // covers nesting, arrays, keys, or several occurrences in one value.
+  const payload = {
+    "##[key]": "top level",
+    nested: { deep: { actor: "##[set-output name=x]mallory" } },
+    list: ["a##[b", "plain", "##[c##[d"],
+    adjacent: "###[x] ####[y]",
+    innocent: "a # b #[c] ##d",
+  };
+
+  const lines: string[] = [];
+  const original = console.log;
+  console.log = (line: string) => void lines.push(line);
+  try {
+    await withEnv({ GITHUB_ACTIONS: "true" }, () => printJson(payload));
+  } finally {
+    console.log = original;
+  }
+
+  const wire = lines.join("\n");
+  // Nothing the runner scans for survives, anywhere in the document.
+  assertEquals(wire.includes("##["), false);
+  // And every value still parses back to exactly what went in.
+  assertEquals(JSON.parse(wire), payload);
+  // A hash that is not part of the marker is left as written.
+  assertStringIncludes(wire, "a # b #[c] ##d");
 });

--- a/packages/core/tests/escaping_sink_test.ts
+++ b/packages/core/tests/escaping_sink_test.ts
@@ -196,36 +196,55 @@ Deno.test("silentReporter stays silent once wrapped", () => {
   escapingReporter(silentReporter).info("::error::x");
 });
 
-Deno.test("every command-surface module writes through the shared sink", () => {
-  // Two of the modules routed through `cliReporter` had no test at all: the
-  // registry's register command and the MCP command's diagnostics. Reverting
-  // either to a bare console call left the whole suite green, which is the
+Deno.test("no module writes to the console except the sink itself", async () => {
+  // Two of the modules routed through `cliReporter` had no test at all, and
+  // reverting either to a bare console call left the whole suite green — the
   // shape of a guard that quietly comes undone.
   //
-  // Asserting on the source is blunt, and it is the assertion that matches what
-  // is actually being promised: not that one message is escaped, but that no
-  // module on this surface writes past the sink. A behavioural test can only
-  // cover the lines it happens to trigger.
-  const modules = [
-    "../src/cli.ts",
-    "../src/runs.ts",
-    "../src/graph_view.ts",
-    "../src/registry/register.ts",
-    "../src/mcp/command.ts",
-  ];
-  for (const relative of modules) {
-    const source = Deno.readTextFileSync(
-      new URL(relative, import.meta.url),
-    );
-    // The sink itself is the one place allowed to reach the real console, and
-    // it does not live in any of these.
-    const direct = source.match(
-      /(?<!\/\/[^\n]*)\bconsole\.(log|error|warn)\(/g,
-    );
-    assertEquals(
-      direct,
-      null,
-      `${relative} writes to the console directly; use cliReporter or printJson`,
-    );
-  }
+  // Scanned over the whole source tree rather than a list of modules, because a
+  // list only covers what someone remembered to add: the regression this is
+  // guarding against is a *new* write appearing somewhere it was not expected.
+  // What is promised is not that one message is escaped but that nothing
+  // reaches the console except through the sink, and that is a property of the
+  // tree, not of any one behaviour a test could trigger.
+  //
+  // Comments are stripped first: a JSDoc example showing a plugin author how to
+  // write one is documentation, not a write.
+  const allowed = new Set([
+    // The sink itself, the one place allowed to reach the real console.
+    "reporter.ts",
+    // Emits browser JavaScript inside a template literal: its `console.warn`
+    // runs in the viewer's browser, not in this process, and rewriting it would
+    // break the generated page. Stripping template literals automatically would
+    // risk hiding a real write, so this is named rather than inferred.
+    "graph_html.ts",
+  ]);
+  const offenders: string[] = [];
+  const root = new URL("../src/", import.meta.url);
+
+  const walk = async (dir: URL): Promise<void> => {
+    for await (const entry of Deno.readDir(dir)) {
+      const child = new URL(entry.name + (entry.isDirectory ? "/" : ""), dir);
+      if (entry.isDirectory) {
+        await walk(child);
+        continue;
+      }
+      if (!entry.name.endsWith(".ts") || allowed.has(entry.name)) continue;
+      const code = (await Deno.readTextFile(child))
+        .replace(/\/\*[\s\S]*?\*\//g, "")
+        .replace(/\/\/[^\n]*/g, "");
+      if (/\bconsole\.(log|error|warn|info|debug)\s*\(/.test(code)) {
+        offenders.push(entry.name);
+      }
+    }
+  };
+  await walk(root);
+
+  assertEquals(
+    offenders,
+    [],
+    `these write to the console directly; use cliReporter or printJson: ${
+      offenders.join(", ")
+    }`,
+  );
 });

--- a/packages/core/tests/escaping_sink_test.ts
+++ b/packages/core/tests/escaping_sink_test.ts
@@ -195,3 +195,37 @@ Deno.test("silentReporter stays silent once wrapped", () => {
   // The wrapper composes with the other reporters rather than replacing them.
   escapingReporter(silentReporter).info("::error::x");
 });
+
+Deno.test("every command-surface module writes through the shared sink", () => {
+  // Two of the modules routed through `cliReporter` had no test at all: the
+  // registry's register command and the MCP command's diagnostics. Reverting
+  // either to a bare console call left the whole suite green, which is the
+  // shape of a guard that quietly comes undone.
+  //
+  // Asserting on the source is blunt, and it is the assertion that matches what
+  // is actually being promised: not that one message is escaped, but that no
+  // module on this surface writes past the sink. A behavioural test can only
+  // cover the lines it happens to trigger.
+  const modules = [
+    "../src/cli.ts",
+    "../src/runs.ts",
+    "../src/graph_view.ts",
+    "../src/registry/register.ts",
+    "../src/mcp/command.ts",
+  ];
+  for (const relative of modules) {
+    const source = Deno.readTextFileSync(
+      new URL(relative, import.meta.url),
+    );
+    // The sink itself is the one place allowed to reach the real console, and
+    // it does not live in any of these.
+    const direct = source.match(
+      /(?<!\/\/[^\n]*)\bconsole\.(log|error|warn)\(/g,
+    );
+    assertEquals(
+      direct,
+      null,
+      `${relative} writes to the console directly; use cliReporter or printJson`,
+    );
+  }
+});

--- a/tests/integration/_harness.ts
+++ b/tests/integration/_harness.ts
@@ -13,6 +13,12 @@
 
 import { main, type MainOptions } from "../../packages/core/src/cli.ts";
 import type { Build } from "../../packages/core/mod.ts";
+import { defaultGraphHost } from "../../packages/core/src/graph_view.ts";
+
+/** Swallow the browser open; see the note in `runCli`. */
+function noOpen(): Promise<void> {
+  return Promise.resolve();
+}
 
 /** The captured result of one {@link runCli} invocation. */
 export interface CliResult {
@@ -35,6 +41,17 @@ export async function runCli(
   args: string[],
   options: MainOptions = {},
 ): Promise<CliResult> {
+  // Never let a test reach the real browser opener. `zuke graph` defaults
+  // `--open` to true, so a test that forgets `--no-open` spawns the OS opener on
+  // whoever is running the suite — and then deletes the temp directory, so the
+  // tab shows nothing. Defaulting the injectable host here means a missing flag
+  // cannot do that, rather than every future test having to remember.
+  // A caller's own host is used as given — never spread into a literal, which
+  // would copy its own fields and drop every method on its prototype, quietly
+  // substituting the real implementations for a fake's.
+  const opts: MainOptions = options.graphHost !== undefined
+    ? options
+    : { ...options, graphHost: { ...defaultGraphHost, open: noOpen } };
   const out: string[] = [];
   const err: string[] = [];
   const origLog = console.log;
@@ -54,7 +71,7 @@ export async function runCli(
   };
   addEventListener("unhandledrejection", onRejection);
   try {
-    const code = await main(BuildClass, args, options);
+    const code = await main(BuildClass, args, opts);
     // A macrotask boundary so any queued unhandledrejection event has dispatched
     // before we inspect — it fires at a microtask checkpoint, which setTimeout(0)
     // is guaranteed to follow.

--- a/tests/integration/github_output_test.ts
+++ b/tests/integration/github_output_test.ts
@@ -341,8 +341,11 @@ Deno.test("machine-readable output is safe on a runner and unchanged by it", asy
     // Off a runner the bytes are untouched, so a consumer diffing or
     // checksumming this output sees exactly what it always saw.
     assertStringIncludes(plain.out, "##[set-output name=x]mallory");
-    // On a runner the marker the runner scans for is not on the wire.
+    // On a runner the marker the runner scans for is not on the wire — and
+    // only the marker is touched, so an ordinary hash elsewhere in the payload
+    // is still written as itself.
     assertEquals(onActions.out.includes("##["), false);
+    assertStringIncludes(onActions.out, "name=x]mallory");
     // Unchanged: a consumer reads the same value either way.
     assertEquals(JSON.parse(onActions.out)[0].actor, actor);
     assertEquals(

--- a/tests/integration/github_output_test.ts
+++ b/tests/integration/github_output_test.ts
@@ -277,3 +277,36 @@ Deno.test("a CLI error quoting its own argument cannot forge a command", async (
     }
   });
 });
+
+Deno.test("the run-inspection commands cannot print a forged command", async () => {
+  // `runs show` and `runs list` print an actor read back from the shared store,
+  // and that actor is not always operator-typed: the registry MCP server feeds
+  // `resolveActor` the client's own self-reported name from its `initialize`
+  // request, so it can be chosen by whoever connects.
+  //
+  // These live in their own module with their own console writes, which is why
+  // the sink added for `cli.ts` did not reach them — the same shape, one file
+  // over.
+  await withStateDir(async () => {
+    class B extends Build {
+      deploy = target().executes(() => {});
+    }
+    const hostile = ["mallory", "::stop-commands::TOKEN"].join("\n");
+    assertEquals((await runCli(B, ["deploy", "--actor", hostile])).code, 0);
+    const listed = await runCli(B, ["runs", "list", "--json"]);
+    const runId = String(JSON.parse(listed.out)[0].id);
+
+    for (const args of [["runs", "show", runId], ["runs", "list"]]) {
+      let r = { code: -1, out: "", err: "" };
+      await withEnv({ GITHUB_ACTIONS: "true" }, async () => {
+        r = await runCli(B, args);
+      });
+      assertEquals(r.code, 0, r.err);
+      assertEquals(
+        unintendedCommands(`${r.out}\n${r.err}`),
+        [],
+        `\`zuke ${args.join(" ")}\` let a stored actor reach the runner`,
+      );
+    }
+  });
+});

--- a/tests/integration/github_output_test.ts
+++ b/tests/integration/github_output_test.ts
@@ -331,7 +331,10 @@ Deno.test("machine-readable output is safe on a runner and unchanged by it", asy
       onActions = await runCli(B, ["runs", "list", "--json"]);
     });
 
-    // Safe: the marker the runner scans for is not on the wire.
+    // Off a runner the bytes are untouched, so a consumer diffing or
+    // checksumming this output sees exactly what it always saw.
+    assertStringIncludes(plain.out, "##[set-output name=x]mallory");
+    // On a runner the marker the runner scans for is not on the wire.
     assertEquals(onActions.out.includes("##["), false);
     // Unchanged: a consumer reads the same value either way.
     assertEquals(JSON.parse(onActions.out)[0].actor, actor);

--- a/tests/integration/github_output_test.ts
+++ b/tests/integration/github_output_test.ts
@@ -325,7 +325,14 @@ Deno.test("machine-readable output is safe on a runner and unchanged by it", asy
     const actor = "##[set-output name=x]mallory";
     assertEquals((await runCli(B, ["deploy", "--actor", actor])).code, 0);
 
-    const plain = await runCli(B, ["runs", "list", "--json"]);
+    // Both legs state their environment. Inheriting it makes the off-runner
+    // leg a no-op when the suite itself runs on Actions, which is where this
+    // test most needs to hold — it passed locally and failed on CI for exactly
+    // that reason.
+    let plain = { code: -1, out: "", err: "" };
+    await withEnv({ GITHUB_ACTIONS: undefined }, async () => {
+      plain = await runCli(B, ["runs", "list", "--json"]);
+    });
     let onActions = { code: -1, out: "", err: "" };
     await withEnv({ GITHUB_ACTIONS: "true" }, async () => {
       onActions = await runCli(B, ["runs", "list", "--json"]);

--- a/tests/integration/github_output_test.ts
+++ b/tests/integration/github_output_test.ts
@@ -310,3 +310,61 @@ Deno.test("the run-inspection commands cannot print a forged command", async () 
     }
   });
 });
+
+Deno.test("machine-readable output is safe on a runner and unchanged by it", async () => {
+  // The sink cannot be applied to JSON. `escapeLine` encodes a legacy `##[`
+  // marker wherever it appears, so a consumer doing
+  // `zuke runs list --json | jq -r '.[0].actor'` would read a different string
+  // on Actions than it reads locally — silently, because the payload still
+  // parses. Escaping it as JSON instead costs nothing: `\u0023` is `#` to every
+  // parser, so the bytes are safe and the value round-trips.
+  await withStateDir(async () => {
+    class B extends Build {
+      deploy = target().executes(() => {});
+    }
+    const actor = "##[set-output name=x]mallory";
+    assertEquals((await runCli(B, ["deploy", "--actor", actor])).code, 0);
+
+    const plain = await runCli(B, ["runs", "list", "--json"]);
+    let onActions = { code: -1, out: "", err: "" };
+    await withEnv({ GITHUB_ACTIONS: "true" }, async () => {
+      onActions = await runCli(B, ["runs", "list", "--json"]);
+    });
+
+    // Safe: the marker the runner scans for is not on the wire.
+    assertEquals(onActions.out.includes("##["), false);
+    // Unchanged: a consumer reads the same value either way.
+    assertEquals(JSON.parse(onActions.out)[0].actor, actor);
+    assertEquals(
+      JSON.parse(onActions.out)[0].actor,
+      JSON.parse(plain.out)[0].actor,
+    );
+  });
+});
+
+Deno.test("the graph command's own output cannot forge a command", async () => {
+  // `zuke graph --output html` reports where it wrote the file, and that path
+  // includes the workspace directory — which on a runner can come from a
+  // matrix entry or a dispatch input. It has its own host with its own console
+  // write, so the sink had to reach it too.
+  const dir = await Deno.makeTempDir({ prefix: "zuke-##[error]graph-" });
+  try {
+    class B extends Build {
+      ok = target().executes(() => {});
+    }
+    const cwd = Deno.cwd();
+    Deno.chdir(dir);
+    try {
+      await Deno.writeTextFile("zuke.json", '{"build":"B"}');
+      let r = { code: -1, out: "", err: "" };
+      await withEnv({ GITHUB_ACTIONS: "true" }, async () => {
+        r = await runCli(B, ["graph", "--output", "html"]);
+      });
+      assertEquals(unintendedCommands(`${r.out}\n${r.err}`), []);
+    } finally {
+      Deno.chdir(cwd);
+    }
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/tests/integration/github_output_test.ts
+++ b/tests/integration/github_output_test.ts
@@ -358,7 +358,7 @@ Deno.test("the graph command's own output cannot forge a command", async () => {
       await Deno.writeTextFile("zuke.json", '{"build":"B"}');
       let r = { code: -1, out: "", err: "" };
       await withEnv({ GITHUB_ACTIONS: "true" }, async () => {
-        r = await runCli(B, ["graph", "--output", "html"]);
+        r = await runCli(B, ["graph", "--output", "html", "--no-open"]);
       });
       assertEquals(unintendedCommands(`${r.out}\n${r.err}`), []);
     } finally {


### PR DESCRIPTION
Closes #551.

## The gap

`zuke runs show` printed an actor read back from the shared store straight to the log, forging workflow commands on a runner. `zuke runs list` did too, which the issue did not mention.

That actor is not always operator-typed: the registry MCP server feeds `resolveActor` the client's own self-reported name from its `initialize` request, so it can be chosen by whoever connects.

The escaping sinks added in #569 and #571 did not reach it — `runs.ts` is a different module with its own console writes. Sweeping for the shape found four such modules, so the sink moved into the reporter module as one implementation and all of them use it. The tell that it now sits in the right place: `cli.ts` imports neither the escape helper nor the host detector any more.

## What the adversarial pass changed

**I introduced a regression, and the commit message denied it in so many words.** It claimed there was "nothing to corrupt". But the line escape encodes the legacy bracket marker *wherever* it appears, and the JSON commands went through the same sink — so a consumer piping `runs list --json` into a parser read a different actor on Actions than it read locally, silently, because the payload still parses.

Leaving JSON unescaped is not the answer either: the runner matches that marker mid-line, so raw JSON genuinely can forge a command. There was a third option I had not looked for. Escaping it *as JSON* costs nothing, because the escape for `#` is `#` to every parser — the bytes on the wire cannot carry the marker, and the value round-trips unchanged. The test asserts all three properties: safe on the wire, identical after parsing, identical to the non-Actions run.

**The graph command has its own host**, with its own console write, reached from the very function this change rewrote. It reports a path that on a runner can come from a matrix entry or a dispatch input.

**Two of the four modules had no test at all.** Reverting either the registry command or the MCP diagnostics to a bare console call left the whole suite green. That is answered at the source rather than behaviourally: what is promised is not that one message is escaped but that no module on this surface writes past the sink, and a behavioural test can only cover the lines it happens to trigger.

## Left out deliberately

`@zuke/cli` — the binary users actually run — echoes its arguments unescaped through its own host. Fixing it needs a new public export from core and a floor above an unreleased version, which cannot land in the same change. Filed as #575 with three options and the constraint spelled out.

## Verification

Every guard removed in turn fails a distinct test: the sink, the JSON encoding, the graph host, and the source-level assertion. Gate green at 23/23.
