### PR TITLE
chore(ai): raise the core floor to the release carrying the redaction

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1550,7 +1550,7 @@
     "members": {
       "packages/ai": {
         "dependencies": [
-          "jsr:@zuke/core@^1.51.0"
+          "jsr:@zuke/core@^1.52.0"
         ]
       },
       "packages/biome": {

--- a/packages/ai/deno.json
+++ b/packages/ai/deno.json
@@ -7,7 +7,7 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@zuke/core": "jsr:@zuke/core@^1.51.0"
+    "@zuke/core": "jsr:@zuke/core@^1.52.0"
   },
   "publish": {
     "exclude": [

--- a/packages/ai/src/report.ts
+++ b/packages/ai/src/report.ts
@@ -473,12 +473,9 @@ export function skipMarkdown(
  * has been exported since core 1.33.0, below the floor even then, so the copy
  * never had a reason to exist.
  *
- * One residual, stated rather than glossed: the redaction arrived in the core
- * release *after* this package's floor, so a consumer pinned at the floor
- * itself gets the delegation without the masking — no worse than the copy it
- * replaces, and correct as soon as they move up. Raising the floor is a
- * follow-up once that release is out, since a floor above the workspace's own
- * core version stops the repository resolving at all.
+ * The declared core floor is the release that carries that redaction, so a
+ * consumer installing the floor itself gets the masking rather than a version
+ * that silently lacks it.
  */
 export function writeStepSummary(markdown: string): void {
   appendJobSummary(markdown);


### PR DESCRIPTION
Closes #559.

The job summary is redacted inside `appendJobSummary`, and `@zuke/ai` delegates to it. But the declared floor was the release *before* that landed, so a consumer installing the floor itself got the delegation without the masking — the fix silently doing nothing for anyone pinned there.

It could not be raised in the original change: a floor above the workspace's own core version stops the repository resolving at all, which is what parked this as a follow-up. That release is out and the workspace is on it, so the floor now names the version whose behaviour this package actually depends on. The JSDoc paragraph describing the gap goes with it.

## Verified

- The floor version is published and exports `appendJobSummary`.
- It carries the redaction, which is the part that mattered and the reason for the bump.
- `coreFloorCheck` resolves against it.
- The lock is regenerated in the same change and its diff is the single specifier line.

## Worth carrying forward

`coreFloorCheck` cannot catch this class of mistake. It type-checks that the export exists at the declared floor — and `appendJobSummary` had been exported since well before either version, so the check was green the whole time the floor was wrong. What the floor needed to encode was a *behaviour*, which no type check sees.
