### PR TITLE
fix(cli): route every console write through an escaping sink

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1571,7 +1571,7 @@
       "packages/cli": {
         "dependencies": [
           "jsr:@zuke/console@^1.1.0",
-          "jsr:@zuke/core@^1.40.0",
+          "jsr:@zuke/core@^1.53.0",
           "jsr:@zuke/gh@^1.6.0"
         ]
       },

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -8,7 +8,7 @@
   },
   "imports": {
     "@zuke/console": "jsr:@zuke/console@^1.1.0",
-    "@zuke/core": "jsr:@zuke/core@^1.40.0",
+    "@zuke/core": "jsr:@zuke/core@^1.53.0",
     "@zuke/gh": "jsr:@zuke/gh@^1.6.0"
   },
   "publish": {

--- a/packages/cli/mod.ts
+++ b/packages/cli/mod.ts
@@ -42,7 +42,7 @@ import {
   runningNotice,
 } from "./src/dispatch.ts";
 import { absolutePath } from "@zuke/core";
-import { output } from "./src/output.ts";
+import { neutralise, output } from "./src/output.ts";
 
 export type { SetupHost } from "./src/setup.ts";
 export type { ImportSource } from "./src/import.ts";
@@ -72,8 +72,13 @@ export const defaultPrompter: Prompter = {
     return Deno.stdin.isTerminal();
   },
   ask(question: string, fallback: string): string {
-    const answer = prompt(question, fallback);
-    return answer ?? fallback;
+    // The default is shown in the question rather than prefilled: `prompt`
+    // writes its text to the terminal itself, past the package's sink, and the
+    // default is what the user typed on the command line (`--name`). Shown
+    // neutralised, so the line cannot open a workflow command on a runner;
+    // the value itself stays what was typed.
+    const answer = prompt(neutralise(`${question} [${fallback}]`));
+    return answer === null || answer === "" ? fallback : answer;
   },
   confirm(question: string): boolean {
     return confirm(question);
@@ -366,19 +371,33 @@ async function commandImport(
  */
 export type DocRunner = (denoArgs: string[]) => Promise<number>;
 
-/** The default {@link DocRunner}: spawn `deno doc …` in an isolated temp dir. */
+/**
+ * The default {@link DocRunner}: spawn `deno doc …` in an isolated temp dir,
+ * relaying what it printed through the package's sink. The child's output is
+ * not inherited: it repeats the arguments the user passed (`deno doc` names a
+ * `--filter` it could not find) and prints a third-party package's own text,
+ * neither of which may reach an Actions runner raw.
+ */
 const defaultDocRunner: DocRunner = async (denoArgs) => {
   // Run from a throwaway directory so the surrounding repo's deno.json /
   // node_modules / tsconfig don't drag @types/node resolution noise into the
   // output — the whole point of `zuke doc` inside a Node project.
   const cwd = await Deno.makeTempDir({ prefix: "zuke-doc-" });
   try {
-    const { code } = await new Deno.Command(Deno.execPath(), {
+    const { code, stdout, stderr } = await new Deno.Command(Deno.execPath(), {
       args: denoArgs,
       cwd,
-      stdout: "inherit",
-      stderr: "inherit",
+      stdout: "piped",
+      stderr: "piped",
     }).output();
+    const relay = (bytes: Uint8Array, write: (line: string) => void) => {
+      const text = new TextDecoder().decode(bytes);
+      // The console adds the line's own newline; keep the text otherwise as
+      // the child wrote it, blank lines included.
+      if (text !== "") write(text.endsWith("\n") ? text.slice(0, -1) : text);
+    };
+    relay(stdout, output.info);
+    relay(stderr, output.error);
     return code;
   } finally {
     await Deno.remove(cwd, { recursive: true });

--- a/packages/cli/mod.ts
+++ b/packages/cli/mod.ts
@@ -42,6 +42,7 @@ import {
   runningNotice,
 } from "./src/dispatch.ts";
 import { absolutePath } from "@zuke/core";
+import { output } from "./src/output.ts";
 
 export type { SetupHost } from "./src/setup.ts";
 export type { ImportSource } from "./src/import.ts";
@@ -435,9 +436,11 @@ async function forwardToBuild(
   probe: BuildProbe,
   runner: BuildRunner,
 ): Promise<number | null> {
-  // Plain stderr writes, not `ConsoleTasks`: `ZUKE_LOG_LEVEL` is a knob for
-  // the build's output, and neither a security refusal nor the launchers'
-  // unverified-lockfile notice may be silenced by it.
+  // The CLI's own stderr sink, not `ConsoleTasks`: `ZUKE_LOG_LEVEL` is a knob
+  // for the build's output, and neither a security refusal nor the launchers'
+  // unverified-lockfile notice may be silenced by it. The sink neutralises the
+  // line on an Actions runner — the root and the error message below carry
+  // text from the filesystem and from a failed spawn, not from Zuke.
   try {
     const cwd = Deno.cwd();
     const location = await locateBuild(cwd, probe);
@@ -445,12 +448,12 @@ async function forwardToBuild(
     // Discovery ran something the caller never named: say which, unless it
     // is the build right here, where `./zuke` would have been the same act.
     if (location.root !== absolutePath(cwd).path) {
-      console.error(runningNotice(location.root));
+      output.error(runningNotice(location.root));
     }
-    if (!location.frozen) console.error(NO_LOCK_NOTICE);
+    if (!location.frozen) output.error(NO_LOCK_NOTICE);
     return await runner(location.root, buildRunArgs(location, args));
   } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
+    output.error(error instanceof Error ? error.message : String(error));
     return 1;
   }
 }

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * The one place `@zuke/cli` writes to the console.
+ *
+ * A GitHub Actions runner parses the job's output for workflow commands: a
+ * line whose first non-blank characters are `::` is executed (`::error::`
+ * forges an annotation, `::stop-commands::` silences every command that
+ * follows, including Zuke's own `::add-mask::`), and `##[` anywhere in a line
+ * is the legacy form. The CLI echoes text it did not author — an unknown
+ * command straight from argv, a `--dir` or `--from` the user typed, a path or
+ * an error message from the filesystem or a failed spawn — so every line goes
+ * out through here and is neutralised with `escapeLineIf` when something is
+ * parsing for commands. Off a runner nothing scans the stream and the line
+ * goes out byte for byte.
+ *
+ * This composes the two pieces `@zuke/core` publishes for exactly this —
+ * `escapeLineIf` on `@zuke/core/render` and `detectCiHost` — rather than
+ * core's own `cliReporter`, which is internal to that package: exporting it
+ * would need a core release this package's floor cannot reach in the same
+ * change. The decision is made per line, not once at import, so an embedder
+ * or a test that sets the environment after loading this module is honoured.
+ *
+ * `tests/escaping_sink_test.ts` in `@zuke/core` scans this package's source
+ * and fails on any other console write, so the guard cannot quietly come
+ * undone by a new `console.log` elsewhere.
+ *
+ * @module
+ */
+
+import { detectCiHost, type Reporter } from "@zuke/core";
+import { escapeLineIf } from "@zuke/core/render";
+
+/** Whether this process is running on a GitHub Actions runner, right now. */
+function onActionsRunner(): boolean {
+  return detectCiHost() === "github";
+}
+
+/**
+ * The CLI's console sink: `info` is stdout, `error` is stderr, and each line
+ * is neutralised on an Actions runner before it is written.
+ */
+export const output: Reporter = {
+  info: (line) => console.log(escapeLineIf(onActionsRunner(), line)),
+  error: (line) => console.error(escapeLineIf(onActionsRunner(), line)),
+};

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -10,21 +10,22 @@
  * follows, including Zuke's own `::add-mask::`), and `##[` anywhere in a line
  * is the legacy form. The CLI echoes text it did not author — an unknown
  * command straight from argv, a `--dir` or `--from` the user typed, a path or
- * an error message from the filesystem or a failed spawn — so every line goes
- * out through here and is neutralised with `escapeLineIf` when something is
- * parsing for commands. Off a runner nothing scans the stream and the line
+ * an error message from the filesystem or a failed spawn, and what a
+ * subprocess it ran said — so every line goes out through here and is
+ * neutralised with `escapeLineIf` when something is parsing for commands. Off a runner nothing scans the stream and the line
  * goes out byte for byte.
  *
  * This composes the two pieces `@zuke/core` publishes for exactly this —
  * `escapeLineIf` on `@zuke/core/render` and `detectCiHost` — rather than
  * core's own `cliReporter`, which is internal to that package: exporting it
  * would need a core release this package's floor cannot reach in the same
- * change. The decision is made per line, not once at import, so an embedder
- * or a test that sets the environment after loading this module is honoured.
+ * change; #581 tracks folding this onto the export once the floor can move.
+ * The decision is made per line, not once at import, so an embedder or a
+ * test that sets the environment after loading this module is honoured.
  *
- * `tests/escaping_sink_test.ts` in `@zuke/core` scans this package's source
- * and fails on any other console write, so the guard cannot quietly come
- * undone by a new `console.log` elsewhere.
+ * `tests/output_test.ts` scans this package's source and fails on any other
+ * console write, so the guard cannot quietly come undone by a new
+ * `console.log` elsewhere.
  *
  * @module
  */
@@ -32,9 +33,15 @@
 import { detectCiHost, type Reporter } from "@zuke/core";
 import { escapeLineIf } from "@zuke/core/render";
 
-/** Whether this process is running on a GitHub Actions runner, right now. */
-function onActionsRunner(): boolean {
-  return detectCiHost() === "github";
+/**
+ * `line` as it may reach an Actions runner: neutralised while one is parsing
+ * the output, untouched anywhere else. The sink applies this to every write;
+ * it is exported for the one write the sink cannot own — the text Deno's
+ * `prompt` puts on the terminal, which carries a default the user typed on
+ * the command line.
+ */
+export function neutralise(line: string): string {
+  return escapeLineIf(detectCiHost() === "github", line);
 }
 
 /**
@@ -42,6 +49,6 @@ function onActionsRunner(): boolean {
  * is neutralised on an Actions runner before it is written.
  */
 export const output: Reporter = {
-  info: (line) => console.log(escapeLineIf(onActionsRunner(), line)),
-  error: (line) => console.error(escapeLineIf(onActionsRunner(), line)),
+  info: (line) => console.log(neutralise(line)),
+  error: (line) => console.error(neutralise(line)),
 };

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -19,41 +19,11 @@ import {
 import { isRecord } from "./records.ts";
 import { launcherBash, launcherPwsh } from "./launcher.ts";
 import { exists, lstatOrNull } from "./fs.ts";
+import { output } from "./output.ts";
+import { starterBuild, starterConfig } from "./starter.ts";
 
 // Re-exported so the merge guard keeps its historical home for importers.
 export { isRecord };
-
-/** The starter `zuke.ts`, with the build class named `name`. */
-export function starterBuild(name: string): string {
-  return `import { Build, run, target } from "jsr:@zuke/core@^1";
-
-/** Your project's build. Run a target with \`./zuke <target>\`. */
-class ${name} extends Build {
-  hello = target()
-    .description("A sample target — replace me with real work")
-    .executes(() => {
-      console.log("Hello from Zuke!");
-    });
-
-  // Convention: \`default\` runs when no target is named.
-  default = target()
-    .description("Default target")
-    .dependsOn(this.hello)
-    .executes(() => {});
-}
-
-await run(${name});
-`;
-}
-
-/**
- * The starter `zuke.json` config. Its presence at the repository root is what
- * `@zuke/core`'s `repoRoot()` walks up to find; the recorded `name` is the
- * build class for reference.
- */
-export function starterConfig(name: string): string {
-  return `${JSON.stringify({ name }, null, 2)}\n`;
-}
 
 /**
  * The task names `setup` writes into `deno.json`, with their commands.
@@ -189,7 +159,7 @@ export const defaultHost: SetupHost = {
     return Deno.chmod(path, mode);
   },
   log(message: string): void {
-    console.log(message);
+    output.info(message);
   },
 };
 

--- a/packages/cli/src/starter.ts
+++ b/packages/cli/src/starter.ts
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * The files `zuke setup` scaffolds from a template: the starter build and the
+ * repository-root marker. Kept apart from the scaffolder because the build
+ * template is source code for the user's project — its `console.log` runs in
+ * their build, not in this process — and the suite's check that nothing in
+ * this package writes to the console except its sink names this module as the
+ * one file that may look as if it does.
+ *
+ * @module
+ */
+
+/** The starter `zuke.ts`, with the build class named `name`. */
+export function starterBuild(name: string): string {
+  return `import { Build, run, target } from "jsr:@zuke/core@^1";
+
+/** Your project's build. Run a target with \`./zuke <target>\`. */
+class ${name} extends Build {
+  hello = target()
+    .description("A sample target — replace me with real work")
+    .executes(() => {
+      console.log("Hello from Zuke!");
+    });
+
+  // Convention: \`default\` runs when no target is named.
+  default = target()
+    .description("Default target")
+    .dependsOn(this.hello)
+    .executes(() => {});
+}
+
+await run(${name});
+`;
+}
+
+/**
+ * The starter `zuke.json` config. Its presence at the repository root is what
+ * `@zuke/core`'s `repoRoot()` walks up to find; the recorded `name` is the
+ * build class for reference.
+ */
+export function starterConfig(name: string): string {
+  return `${JSON.stringify({ name }, null, 2)}\n`;
+}

--- a/packages/cli/tests/cli_test.ts
+++ b/packages/cli/tests/cli_test.ts
@@ -13,6 +13,8 @@ import { VERSION } from "../src/version.ts";
 import { DENO_PIN } from "../src/deno_pin.ts";
 import { FakeHost, FakePrompter, FakeStarActions } from "./_fakes.ts";
 import { withTemp } from "../../core/tests/_temp.ts";
+import { withEnv } from "../../core/tests/_env.ts";
+import { defaultHost } from "../src/setup.ts";
 import { ConsoleTasks, ZUKE_LOGO } from "@zuke/console";
 import { absolutePath } from "@zuke/core";
 
@@ -815,4 +817,96 @@ Deno.test("main refuses to forward into a build owned by another user", async ()
   assertEquals(host.logs, []);
   assertEquals(err.length, 1);
   assertEquals(err[0].includes("refusing to run the build at"), true);
+});
+
+/**
+ * The percent-encoded `::`, kept as its own constant so the encoded prefix
+ * never fuses with the word after it into a token no dictionary can know.
+ */
+const ENC = "%3A%3A";
+
+/** Run `fn` with stdout captured, returning the lines written. */
+async function capturingOut(fn: () => Promise<void>): Promise<string[]> {
+  const out: string[] = [];
+  const original = console.log;
+  console.log = (...parts: unknown[]) => void out.push(parts.join(" "));
+  try {
+    await fn();
+  } finally {
+    console.log = original;
+  }
+  return out;
+}
+
+Deno.test("an unknown command cannot forge a workflow command through the real host", async () => {
+  // The bug: `Unknown command: <argv>` went out through a bare `console.log`.
+  // The runner acts on a line whose first non-blank characters are `::`, and
+  // an argument can carry a newline, so the second physical line of the
+  // message opened a command. Through the real `defaultHost`, with nothing
+  // above the cwd to forward to, asserted over every physical line the runner
+  // would read.
+  const { runner } = neverRun();
+  let code = 0;
+  const out = await capturingOut(() =>
+    withEnv({ GITHUB_ACTIONS: "true" }, async () => {
+      code = await main(
+        [["typo", "::stop-commands::forged"].join("\n")],
+        defaultHost,
+        defaultPrompter,
+        undefined,
+        undefined,
+        runner,
+        probeAt([]),
+      );
+    })
+  );
+  assertEquals(code, 1);
+  const lines = out.flatMap((l) => l.split("\n"));
+  assertEquals(lines.some((l) => l.trimStart().startsWith("::")), false);
+  // Neutralised, not filtered: the text is still there to read.
+  assertEquals(
+    lines.some((l) => l.startsWith(ENC + "stop-commands::forged")),
+    true,
+  );
+});
+
+Deno.test("a forwarding failure cannot forge a workflow command on stderr", async () => {
+  // The catch arm is the sharp end: a spawn failure's message is Deno's, and a
+  // refusal names a path from the filesystem — neither is Zuke's text. A
+  // message carrying a newline puts the runner's `::` at the start of a line.
+  const hostile = ["spawn failed", "::stop-commands::forged"].join("\n");
+  let code = 0;
+  const err = await capturingErr(() =>
+    withEnv({ GITHUB_ACTIONS: "true" }, async () => {
+      code = await main(
+        ["ci"],
+        new FakeHost(),
+        defaultPrompter,
+        undefined,
+        undefined,
+        () => Promise.reject(new Error(hostile)),
+        probeAt(["zuke.json", "deno.lock"]),
+      );
+    })
+  );
+  assertEquals(code, 1);
+  const lines = err.flatMap((l) => l.split("\n"));
+  assertEquals(lines.some((l) => l.trimStart().startsWith("::")), false);
+  assertEquals(lines.includes(ENC + "stop-commands::forged"), true);
+
+  // Off a runner the same message is left readable: nothing is parsing it.
+  const local = await capturingErr(() =>
+    withEnv({ GITHUB_ACTIONS: undefined }, async () => {
+      await main(
+        ["ci"],
+        new FakeHost(),
+        defaultPrompter,
+        undefined,
+        undefined,
+        () => Promise.reject(new Error(hostile)),
+        probeAt(["zuke.json", "deno.lock"]),
+      );
+    })
+  );
+  assertEquals(local.join("\n").includes("::stop-commands::forged"), true);
 });

--- a/packages/cli/tests/cli_test.ts
+++ b/packages/cli/tests/cli_test.ts
@@ -14,6 +14,8 @@ import { DENO_PIN } from "../src/deno_pin.ts";
 import { FakeHost, FakePrompter, FakeStarActions } from "./_fakes.ts";
 import { withTemp } from "../../core/tests/_temp.ts";
 import { withEnv } from "../../core/tests/_env.ts";
+import { capture } from "../../core/tests/_console.ts";
+import { ENC } from "../../core/tests/_escaping.ts";
 import { defaultHost } from "../src/setup.ts";
 import { ConsoleTasks, ZUKE_LOGO } from "@zuke/console";
 import { absolutePath } from "@zuke/core";
@@ -313,6 +315,41 @@ Deno.test("main doc runs a real `deno doc` via the default runner (end-to-end)",
   });
 });
 
+Deno.test("main doc relays the real runner's output through the sink, escaped on a runner", async () => {
+  // `deno doc` repeats a `--filter` it cannot find on stderr. Inherited, that
+  // line reached an Actions runner raw; relayed through the sink, the legacy
+  // marker in it is neutralised. Off a runner the same line is left as the
+  // child wrote it.
+  await withTemp(async (dir) => {
+    const fixture = `${dir}/doc_fixture.ts`;
+    await Deno.writeTextFile(
+      fixture,
+      '/** A documented greeting. */\nexport const hello = "hi";\n',
+    );
+    const filter = "##[add-mask]forged";
+    const onRunner = await capture(async () => {
+      let exit = 0;
+      await withEnv({ GITHUB_ACTIONS: "true" }, async () => {
+        exit = await main(["doc", fixture, "--filter", filter], new FakeHost());
+      });
+      return exit;
+    });
+    assertEquals(onRunner.code === 0, false);
+    const wire = onRunner.err.join("\n");
+    assertEquals(wire.includes("##["), false);
+    assertEquals(wire.includes("%23%23[add-mask]forged"), true);
+
+    const local = await capture(async () => {
+      let exit = 0;
+      await withEnv({ GITHUB_ACTIONS: undefined }, async () => {
+        exit = await main(["doc", fixture, "--filter", filter], new FakeHost());
+      });
+      return exit;
+    });
+    assertEquals(local.err.join("\n").includes(filter), true);
+  });
+});
+
 Deno.test("main doc propagates a non-zero exit from the real runner", async () => {
   const host = new FakeHost();
   // A missing file → `deno doc` exits non-zero. No injected runner, so the real
@@ -487,6 +524,9 @@ Deno.test("defaultPrompter wraps prompt/confirm", () => {
   try {
     globalThis.prompt = () => "typed";
     assertEquals(defaultPrompter.ask("q", "fallback"), "typed");
+    // An empty answer and an end of input both mean "the default".
+    globalThis.prompt = () => "";
+    assertEquals(defaultPrompter.ask("q", "fallback"), "fallback");
     globalThis.prompt = () => null;
     assertEquals(defaultPrompter.ask("q", "fallback"), "fallback");
     globalThis.confirm = () => true;
@@ -495,6 +535,37 @@ Deno.test("defaultPrompter wraps prompt/confirm", () => {
     globalThis.prompt = realPrompt;
     globalThis.confirm = realConfirm;
   }
+});
+
+Deno.test("defaultPrompter shows the default in the question, neutralised on a runner", async () => {
+  // `prompt` writes to the terminal past the package's sink, and the default
+  // it shows is `--name` from the command line. It is shown in the question
+  // rather than prefilled, escaped like every other line, and the value the
+  // caller gets back is still exactly what was typed.
+  const realPrompt = globalThis.prompt;
+  const shown: string[] = [];
+  try {
+    globalThis.prompt = (message?: string) => {
+      shown.push(message ?? "");
+      return "";
+    };
+    await withEnv({ GITHUB_ACTIONS: "true" }, () => {
+      assertEquals(
+        defaultPrompter.ask("Build class name", "::stop-commands::forged"),
+        "::stop-commands::forged",
+      );
+    });
+    await withEnv({ GITHUB_ACTIONS: undefined }, () => {
+      defaultPrompter.ask("Build class name", "Acme");
+    });
+  } finally {
+    globalThis.prompt = realPrompt;
+  }
+  assertEquals(shown, [
+    "Build class name [::stop-commands::forged]",
+    "Build class name [Acme]",
+  ]);
+  assertEquals(shown[0].includes(ENC), false); // no line opens with `::`
 });
 
 /** The path of `name` at the real cwd, where `main` starts its walk. */
@@ -819,25 +890,6 @@ Deno.test("main refuses to forward into a build owned by another user", async ()
   assertEquals(err[0].includes("refusing to run the build at"), true);
 });
 
-/**
- * The percent-encoded `::`, kept as its own constant so the encoded prefix
- * never fuses with the word after it into a token no dictionary can know.
- */
-const ENC = "%3A%3A";
-
-/** Run `fn` with stdout captured, returning the lines written. */
-async function capturingOut(fn: () => Promise<void>): Promise<string[]> {
-  const out: string[] = [];
-  const original = console.log;
-  console.log = (...parts: unknown[]) => void out.push(parts.join(" "));
-  try {
-    await fn();
-  } finally {
-    console.log = original;
-  }
-  return out;
-}
-
 Deno.test("an unknown command cannot forge a workflow command through the real host", async () => {
   // The bug: `Unknown command: <argv>` went out through a bare `console.log`.
   // The runner acts on a line whose first non-blank characters are `::`, and
@@ -846,10 +898,10 @@ Deno.test("an unknown command cannot forge a workflow command through the real h
   // above the cwd to forward to, asserted over every physical line the runner
   // would read.
   const { runner } = neverRun();
-  let code = 0;
-  const out = await capturingOut(() =>
-    withEnv({ GITHUB_ACTIONS: "true" }, async () => {
-      code = await main(
+  const { code, out } = await capture(async () => {
+    let exit = 0;
+    await withEnv({ GITHUB_ACTIONS: "true" }, async () => {
+      exit = await main(
         [["typo", "::stop-commands::forged"].join("\n")],
         defaultHost,
         defaultPrompter,
@@ -858,8 +910,9 @@ Deno.test("an unknown command cannot forge a workflow command through the real h
         runner,
         probeAt([]),
       );
-    })
-  );
+    });
+    return exit;
+  });
   assertEquals(code, 1);
   const lines = out.flatMap((l) => l.split("\n"));
   assertEquals(lines.some((l) => l.trimStart().startsWith("::")), false);

--- a/packages/cli/tests/output_test.ts
+++ b/packages/cli/tests/output_test.ts
@@ -10,42 +10,20 @@
 
 import { assertEquals } from "../../core/tests/_assert.ts";
 import { withEnv } from "../../core/tests/_env.ts";
+import { capture } from "../../core/tests/_console.ts";
+import { consoleWriters, ENC } from "../../core/tests/_escaping.ts";
 import { output } from "../src/output.ts";
 
-/**
- * The percent-encoded `::`, kept as its own constant so the encoded prefix
- * never fuses with the word after it into a token no dictionary can know.
- */
-const ENC = "%3A%3A";
-
-/** Run `fn` with both console streams captured, returning what was written. */
-async function captured(
-  fn: () => void | Promise<void>,
-): Promise<{ out: string[]; err: string[] }> {
-  const out: string[] = [];
-  const err: string[] = [];
-  const log = console.log;
-  const error = console.error;
-  console.log = (...parts: unknown[]) => void out.push(parts.join(" "));
-  console.error = (...parts: unknown[]) => void err.push(parts.join(" "));
-  try {
-    await fn();
-  } finally {
-    console.log = log;
-    console.error = error;
-  }
-  return { out, err };
-}
-
 Deno.test("output neutralises a workflow command on an Actions runner, on both streams", async () => {
-  const { out, err } = await captured(() =>
-    withEnv({ GITHUB_ACTIONS: "true" }, () => {
+  const { out, err } = await capture(async () => {
+    await withEnv({ GITHUB_ACTIONS: "true" }, () => {
       output.info("::stop-commands::forged");
       output.info("   ::error::forged annotation");
       output.error("held by ##[group]x");
       output.error("Unknown command: ::stop-commands::forged");
-    })
-  );
+    });
+    return 0;
+  });
   assertEquals(out, [
     ENC + "stop-commands::forged",
     "   " + ENC + "error::forged annotation",
@@ -60,12 +38,13 @@ Deno.test("output neutralises a workflow command on an Actions runner, on both s
 Deno.test("output leaves every line alone off a runner", async () => {
   // Explicitly unset: the suite itself runs under Actions, where the variable
   // is inherited and the sink would otherwise escape for the wrong reason.
-  const { out, err } = await captured(() =>
-    withEnv({ GITHUB_ACTIONS: undefined }, () => {
+  const { out, err } = await capture(async () => {
+    await withEnv({ GITHUB_ACTIONS: undefined }, () => {
       output.info("::stop-commands::forged");
       output.error("held by ##[group]x");
-    })
-  );
+    });
+    return 0;
+  });
   assertEquals(out, ["::stop-commands::forged"]);
   assertEquals(err, ["held by ##[group]x"]);
 });
@@ -73,13 +52,42 @@ Deno.test("output leaves every line alone off a runner", async () => {
 Deno.test("output decides per line, not once at import", async () => {
   // The module was loaded before this test set the environment; a decision
   // captured at import time would escape neither line, or both.
-  const { out } = await captured(async () => {
+  const { out } = await capture(async () => {
     await withEnv({ GITHUB_ACTIONS: undefined }, () => {
       output.info("::group::one");
     });
     await withEnv({ GITHUB_ACTIONS: "true" }, () => {
       output.info("::group::two");
     });
+    return 0;
   });
   assertEquals(out, ["::group::one", ENC + "group::two"]);
+});
+
+Deno.test("no module of @zuke/cli writes to the console except its sink", async () => {
+  // The bug behind #575 was a bare `console.log` in the package's host, and
+  // reverting the sink to one leaves every behavioural test above green only
+  // as long as its inputs happen to reach that write. This holds the property
+  // itself: a new direct write anywhere in the package fails here rather than
+  // being noticed on a runner later. The package root, not `src/` alone,
+  // because `mod.ts` lives there; the tests are scanned with it, and they
+  // capture the console by assignment rather than writing to it.
+  const allowed = new Set([
+    // The sink itself.
+    "src/output.ts",
+    // The scaffolded starter build, inside a template literal: its
+    // `console.log` runs in the user's project, not in this process.
+    "src/starter.ts",
+  ]);
+  const offenders = await consoleWriters(
+    new URL("../", import.meta.url),
+    allowed,
+  );
+  assertEquals(
+    offenders,
+    [],
+    `these write to the console directly; use the sink in src/output.ts: ${
+      offenders.join(", ")
+    }`,
+  );
 });

--- a/packages/cli/tests/output_test.ts
+++ b/packages/cli/tests/output_test.ts
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * The CLI's console sink: every line is neutralised on a GitHub Actions
+ * runner and left alone anywhere else. The assertions are about the *start of
+ * a line* — what the runner acts on — not about a substring: the text must
+ * survive as text, and what must not happen is it opening a command.
+ */
+
+import { assertEquals } from "../../core/tests/_assert.ts";
+import { withEnv } from "../../core/tests/_env.ts";
+import { output } from "../src/output.ts";
+
+/**
+ * The percent-encoded `::`, kept as its own constant so the encoded prefix
+ * never fuses with the word after it into a token no dictionary can know.
+ */
+const ENC = "%3A%3A";
+
+/** Run `fn` with both console streams captured, returning what was written. */
+async function captured(
+  fn: () => void | Promise<void>,
+): Promise<{ out: string[]; err: string[] }> {
+  const out: string[] = [];
+  const err: string[] = [];
+  const log = console.log;
+  const error = console.error;
+  console.log = (...parts: unknown[]) => void out.push(parts.join(" "));
+  console.error = (...parts: unknown[]) => void err.push(parts.join(" "));
+  try {
+    await fn();
+  } finally {
+    console.log = log;
+    console.error = error;
+  }
+  return { out, err };
+}
+
+Deno.test("output neutralises a workflow command on an Actions runner, on both streams", async () => {
+  const { out, err } = await captured(() =>
+    withEnv({ GITHUB_ACTIONS: "true" }, () => {
+      output.info("::stop-commands::forged");
+      output.info("   ::error::forged annotation");
+      output.error("held by ##[group]x");
+      output.error("Unknown command: ::stop-commands::forged");
+    })
+  );
+  assertEquals(out, [
+    ENC + "stop-commands::forged",
+    "   " + ENC + "error::forged annotation",
+  ]);
+  // A `::` that does not open the line is not a command, and stays readable.
+  assertEquals(err, [
+    "held by %23%23[group]x",
+    "Unknown command: ::stop-commands::forged",
+  ]);
+});
+
+Deno.test("output leaves every line alone off a runner", async () => {
+  // Explicitly unset: the suite itself runs under Actions, where the variable
+  // is inherited and the sink would otherwise escape for the wrong reason.
+  const { out, err } = await captured(() =>
+    withEnv({ GITHUB_ACTIONS: undefined }, () => {
+      output.info("::stop-commands::forged");
+      output.error("held by ##[group]x");
+    })
+  );
+  assertEquals(out, ["::stop-commands::forged"]);
+  assertEquals(err, ["held by ##[group]x"]);
+});
+
+Deno.test("output decides per line, not once at import", async () => {
+  // The module was loaded before this test set the environment; a decision
+  // captured at import time would escape neither line, or both.
+  const { out } = await captured(async () => {
+    await withEnv({ GITHUB_ACTIONS: undefined }, () => {
+      output.info("::group::one");
+    });
+    await withEnv({ GITHUB_ACTIONS: "true" }, () => {
+      output.info("::group::two");
+    });
+  });
+  assertEquals(out, ["::group::one", ENC + "group::two"]);
+});

--- a/packages/cli/tests/output_test.ts
+++ b/packages/cli/tests/output_test.ts
@@ -69,9 +69,10 @@ Deno.test("no module of @zuke/cli writes to the console except its sink", async 
   // reverting the sink to one leaves every behavioural test above green only
   // as long as its inputs happen to reach that write. This holds the property
   // itself: a new direct write anywhere in the package fails here rather than
-  // being noticed on a runner later. The package root, not `src/` alone,
-  // because `mod.ts` lives there; the tests are scanned with it, and they
-  // capture the console by assignment rather than writing to it.
+  // being noticed on a runner later. Scanned from the package root, because
+  // `mod.ts` lives there, and narrowed to what the package publishes:
+  // `deno.json` keeps `tests/` out of it, and a test printing a diagnostic is
+  // not a write the sink was meant to own.
   const allowed = new Set([
     // The sink itself.
     "src/output.ts",
@@ -79,10 +80,10 @@ Deno.test("no module of @zuke/cli writes to the console except its sink", async 
     // `console.log` runs in the user's project, not in this process.
     "src/starter.ts",
   ]);
-  const offenders = await consoleWriters(
+  const offenders = (await consoleWriters(
     new URL("../", import.meta.url),
     allowed,
-  );
+  )).filter((path) => !path.startsWith("tests/"));
   assertEquals(
     offenders,
     [],

--- a/packages/cli/tests/setup_test.ts
+++ b/packages/cli/tests/setup_test.ts
@@ -11,10 +11,9 @@ import {
   isRecord,
   mergeDenoJson,
   runSetup,
-  starterBuild,
-  starterConfig,
   zukeTaskState,
 } from "../src/setup.ts";
+import { starterBuild, starterConfig } from "../src/starter.ts";
 import { FakeHost } from "./_fakes.ts";
 import { withTemp } from "../../core/tests/_temp.ts";
 

--- a/packages/core/tests/_escaping.ts
+++ b/packages/core/tests/_escaping.ts
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 the Zuke contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Helpers for the tests of the escaping a GitHub Actions runner needs: the
+ * encoded form of the marker it acts on, and the source-level scan that holds
+ * a package to writing through one sink.
+ *
+ * @module
+ */
+
+/**
+ * The percent-encoded `::`, kept as its own constant so the encoded prefix
+ * never fuses with the word after it into a token no dictionary can know: the
+ * spell gate reads the encoding and the word that follows it as one.
+ */
+export const ENC = "%3A%3A";
+
+/**
+ * Every `.ts` file under `root` (recursively) that calls the console directly
+ * — any method, by name or by computed key — as paths relative to `root`,
+ * skipping the ones in `allowed`. Comments are
+ * stripped first: a JSDoc example showing a plugin author how to write one is
+ * documentation, not a write. Keyed by path from `root`, not by file name: a
+ * nested module sharing a basename with an allowed one would otherwise be
+ * exempt by accident.
+ *
+ * Scanned as source rather than exercised, because what a package promises is
+ * not that one message is escaped but that nothing reaches the console except
+ * through its sink — a property of the tree, not of any one behaviour a test
+ * could trigger, and the regression it guards against is a *new* write
+ * appearing somewhere no test was expecting one. It is a lint, not a
+ * boundary: an aliased `console`, a raw `Deno.stdout` write, or a `prompt`
+ * pass it, so those stay the reviewer's to look for.
+ */
+export async function consoleWriters(
+  root: URL,
+  allowed: ReadonlySet<string>,
+): Promise<string[]> {
+  const offenders: string[] = [];
+  const walk = async (dir: URL): Promise<void> => {
+    for await (const entry of Deno.readDir(dir)) {
+      const child = new URL(entry.name + (entry.isDirectory ? "/" : ""), dir);
+      if (entry.isDirectory) {
+        await walk(child);
+        continue;
+      }
+      const relative = child.href.slice(root.href.length);
+      if (!entry.name.endsWith(".ts") || allowed.has(relative)) continue;
+      const code = (await Deno.readTextFile(child))
+        .replace(/\/\*[\s\S]*?\*\//g, "")
+        .replace(/\/\/[^\n]*/g, "");
+      if (/\bconsole\s*(?:\.\s*\w+|\[[^\]]*\])\s*\(/.test(code)) {
+        offenders.push(relative);
+      }
+    }
+  };
+  await walk(root);
+  return offenders;
+}

--- a/packages/core/tests/escaping_sink_test.ts
+++ b/packages/core/tests/escaping_sink_test.ts
@@ -18,6 +18,7 @@ import { assertEquals, assertStringIncludes } from "./_assert.ts";
 import { escapeLineIf } from "../src/render.ts";
 import { printJson } from "../src/reporter.ts";
 import { withEnv } from "./_env.ts";
+import { consoleWriters, ENC } from "./_escaping.ts";
 import {
   escapingReporter,
   type Reporter,
@@ -29,14 +30,6 @@ import { execute } from "../src/executor.ts";
 import type { Plugin } from "../src/plugin.ts";
 
 const NL = String.fromCharCode(10);
-
-/**
- * The percent-encoded `::`, kept as its own constant so the encoded prefix
- * never fuses with the word after it into a token no dictionary can know: the
- * spell gate reads the encoding and the word that follows it as one. The same
- * reason `report_test.ts` splits its literal.
- */
-const ENC = "%3A%3A";
 
 /** A reporter that records every line, so a test can inspect the stream. */
 function capture(): { reporter: Reporter; info: string[]; error: string[] } {
@@ -198,51 +191,13 @@ Deno.test("silentReporter stays silent once wrapped", () => {
   escapingReporter(silentReporter).info("::error::x");
 });
 
-/**
- * Every `.ts` file under `root` (recursively) that calls the console directly,
- * as paths relative to `root`, skipping the ones in `allowed`. Comments are
- * stripped first: a JSDoc example showing a plugin author how to write one is
- * documentation, not a write. Keyed by path from `root`, not by file name: a
- * nested module sharing a basename with an allowed one would otherwise be
- * exempt by accident.
- */
-async function consoleWriters(
-  root: URL,
-  allowed: ReadonlySet<string>,
-): Promise<string[]> {
-  const offenders: string[] = [];
-  const walk = async (dir: URL): Promise<void> => {
-    for await (const entry of Deno.readDir(dir)) {
-      const child = new URL(entry.name + (entry.isDirectory ? "/" : ""), dir);
-      if (entry.isDirectory) {
-        await walk(child);
-        continue;
-      }
-      const relative = child.href.slice(root.href.length);
-      if (!entry.name.endsWith(".ts") || allowed.has(relative)) continue;
-      const code = (await Deno.readTextFile(child))
-        .replace(/\/\*[\s\S]*?\*\//g, "")
-        .replace(/\/\/[^\n]*/g, "");
-      if (/\bconsole\.(log|error|warn|info|debug)\s*\(/.test(code)) {
-        offenders.push(relative);
-      }
-    }
-  };
-  await walk(root);
-  return offenders;
-}
-
 Deno.test("no module writes to the console except the sink itself", async () => {
   // Two of the modules routed through `cliReporter` had no test at all, and
   // reverting either to a bare console call left the whole suite green — the
   // shape of a guard that quietly comes undone.
   //
   // Scanned over the whole source tree rather than a list of modules, because a
-  // list only covers what someone remembered to add: the regression this is
-  // guarding against is a *new* write appearing somewhere it was not expected.
-  // What is promised is not that one message is escaped but that nothing
-  // reaches the console except through the sink, and that is a property of the
-  // tree, not of any one behaviour a test could trigger.
+  // list only covers what someone remembered to add — see `consoleWriters`.
   const allowed = new Set([
     // The sink itself, the one place allowed to reach the real console.
     "reporter.ts",
@@ -260,35 +215,6 @@ Deno.test("no module writes to the console except the sink itself", async () => 
     offenders,
     [],
     `these write to the console directly; use cliReporter or printJson: ${
-      offenders.join(", ")
-    }`,
-  );
-});
-
-Deno.test("no module of @zuke/cli writes to the console except its sink", async () => {
-  // The second command surface, and the binary users actually run: `zuke`
-  // echoes its arguments (an unknown command, a `--dir`, a `--from`), paths and
-  // error messages, and did so through a bare `console.log` in its host —
-  // `Unknown command: ::stop-commands::x` on a runner was a command. The
-  // package's writes now all go through `src/output.ts`, and this is what
-  // keeps it that way: a new direct write anywhere in the package fails here
-  // rather than being noticed later. Scanned as source, so no dependency on
-  // the package is introduced.
-  const allowed = new Set([
-    // The sink itself.
-    "src/output.ts",
-    // The scaffolded starter build, inside a template literal: its
-    // `console.log` runs in the user's project, not in this process.
-    "src/starter.ts",
-  ]);
-  const root = new URL("../../cli/", import.meta.url);
-  const offenders = (await consoleWriters(root, allowed))
-    // The package's tests capture the console on purpose.
-    .filter((path) => !path.startsWith("tests/"));
-  assertEquals(
-    offenders,
-    [],
-    `these write to the console directly; use the sink in src/output.ts: ${
       offenders.join(", ")
     }`,
   );

--- a/packages/core/tests/escaping_sink_test.ts
+++ b/packages/core/tests/escaping_sink_test.ts
@@ -198,34 +198,19 @@ Deno.test("silentReporter stays silent once wrapped", () => {
   escapingReporter(silentReporter).info("::error::x");
 });
 
-Deno.test("no module writes to the console except the sink itself", async () => {
-  // Two of the modules routed through `cliReporter` had no test at all, and
-  // reverting either to a bare console call left the whole suite green — the
-  // shape of a guard that quietly comes undone.
-  //
-  // Scanned over the whole source tree rather than a list of modules, because a
-  // list only covers what someone remembered to add: the regression this is
-  // guarding against is a *new* write appearing somewhere it was not expected.
-  // What is promised is not that one message is escaped but that nothing
-  // reaches the console except through the sink, and that is a property of the
-  // tree, not of any one behaviour a test could trigger.
-  //
-  // Comments are stripped first: a JSDoc example showing a plugin author how to
-  // write one is documentation, not a write.
-  // Keyed by path from `src/`, not by file name: a nested module sharing a
-  // basename with an allowed one would otherwise be exempt by accident.
-  const allowed = new Set([
-    // The sink itself, the one place allowed to reach the real console.
-    "reporter.ts",
-    // Emits browser JavaScript inside a template literal: its `console.warn`
-    // runs in the viewer's browser, not in this process, and rewriting it would
-    // break the generated page. Stripping template literals automatically would
-    // risk hiding a real write, so this is named rather than inferred.
-    "graph_html.ts",
-  ]);
+/**
+ * Every `.ts` file under `root` (recursively) that calls the console directly,
+ * as paths relative to `root`, skipping the ones in `allowed`. Comments are
+ * stripped first: a JSDoc example showing a plugin author how to write one is
+ * documentation, not a write. Keyed by path from `root`, not by file name: a
+ * nested module sharing a basename with an allowed one would otherwise be
+ * exempt by accident.
+ */
+async function consoleWriters(
+  root: URL,
+  allowed: ReadonlySet<string>,
+): Promise<string[]> {
   const offenders: string[] = [];
-  const root = new URL("../src/", import.meta.url);
-
   const walk = async (dir: URL): Promise<void> => {
     for await (const entry of Deno.readDir(dir)) {
       const child = new URL(entry.name + (entry.isDirectory ? "/" : ""), dir);
@@ -244,11 +229,66 @@ Deno.test("no module writes to the console except the sink itself", async () => 
     }
   };
   await walk(root);
+  return offenders;
+}
 
+Deno.test("no module writes to the console except the sink itself", async () => {
+  // Two of the modules routed through `cliReporter` had no test at all, and
+  // reverting either to a bare console call left the whole suite green — the
+  // shape of a guard that quietly comes undone.
+  //
+  // Scanned over the whole source tree rather than a list of modules, because a
+  // list only covers what someone remembered to add: the regression this is
+  // guarding against is a *new* write appearing somewhere it was not expected.
+  // What is promised is not that one message is escaped but that nothing
+  // reaches the console except through the sink, and that is a property of the
+  // tree, not of any one behaviour a test could trigger.
+  const allowed = new Set([
+    // The sink itself, the one place allowed to reach the real console.
+    "reporter.ts",
+    // Emits browser JavaScript inside a template literal: its `console.warn`
+    // runs in the viewer's browser, not in this process, and rewriting it would
+    // break the generated page. Stripping template literals automatically would
+    // risk hiding a real write, so this is named rather than inferred.
+    "graph_html.ts",
+  ]);
+  const offenders = await consoleWriters(
+    new URL("../src/", import.meta.url),
+    allowed,
+  );
   assertEquals(
     offenders,
     [],
     `these write to the console directly; use cliReporter or printJson: ${
+      offenders.join(", ")
+    }`,
+  );
+});
+
+Deno.test("no module of @zuke/cli writes to the console except its sink", async () => {
+  // The second command surface, and the binary users actually run: `zuke`
+  // echoes its arguments (an unknown command, a `--dir`, a `--from`), paths and
+  // error messages, and did so through a bare `console.log` in its host —
+  // `Unknown command: ::stop-commands::x` on a runner was a command. The
+  // package's writes now all go through `src/output.ts`, and this is what
+  // keeps it that way: a new direct write anywhere in the package fails here
+  // rather than being noticed later. Scanned as source, so no dependency on
+  // the package is introduced.
+  const allowed = new Set([
+    // The sink itself.
+    "src/output.ts",
+    // The scaffolded starter build, inside a template literal: its
+    // `console.log` runs in the user's project, not in this process.
+    "src/starter.ts",
+  ]);
+  const root = new URL("../../cli/", import.meta.url);
+  const offenders = (await consoleWriters(root, allowed))
+    // The package's tests capture the console on purpose.
+    .filter((path) => !path.startsWith("tests/"));
+  assertEquals(
+    offenders,
+    [],
+    `these write to the console directly; use the sink in src/output.ts: ${
       offenders.join(", ")
     }`,
   );

--- a/tests/integration/global_cli_test.ts
+++ b/tests/integration/global_cli_test.ts
@@ -18,6 +18,8 @@ import { defaultBuildProbe } from "../../packages/cli/src/dispatch.ts";
 import { defaultHost, type SetupHost } from "../../packages/cli/src/setup.ts";
 import { withTemp } from "../../packages/core/tests/_temp.ts";
 import { withEnv } from "../../packages/core/tests/_env.ts";
+import { capture } from "../../packages/core/tests/_console.ts";
+import { ENC } from "../../packages/core/tests/_escaping.ts";
 
 /**
  * The real, filesystem-probing host — the walk up to `zuke.json` must see the
@@ -142,12 +144,6 @@ Deno.test("zuke <target> outside any project is an unknown command, not a spawn"
   }, { prefix: "zuke-global-cli-" });
 });
 
-/**
- * The percent-encoded `::`, kept as its own constant so the encoded prefix
- * never fuses with the word after it into a token no dictionary can know.
- */
-const ENC = "%3A%3A";
-
 Deno.test("zuke <argv> cannot forge a workflow command on an Actions runner", async () => {
   // The whole path, as the binary runs it: the real host writing through the
   // package's sink, the real probe (confined to the temp dir, so there is no
@@ -157,12 +153,10 @@ Deno.test("zuke <argv> cannot forge a workflow command on an Actions runner", as
   // line is asserted, since the runner reads lines, not messages.
   await withTemp(async (dir) => {
     await inDir(dir, async () => {
-      const out: string[] = [];
-      const original = console.log;
-      console.log = (...parts: unknown[]) => void out.push(parts.join(" "));
-      try {
+      const { code, out } = await capture(async () => {
+        let exit = 0;
         await withEnv({ GITHUB_ACTIONS: "true" }, async () => {
-          const code = await main(
+          exit = await main(
             [["typo", "::stop-commands::forged"].join("\n")],
             defaultHost,
             undefined,
@@ -171,11 +165,10 @@ Deno.test("zuke <argv> cannot forge a workflow command on an Actions runner", as
             () => Promise.reject(new Error("must not spawn")),
             confinedTo(dir),
           );
-          assertEquals(code, 1);
         });
-      } finally {
-        console.log = original;
-      }
+        return exit;
+      });
+      assertEquals(code, 1);
       const lines = out.flatMap((l) => l.split("\n"));
       assertEquals(lines.some((l) => l.trimStart().startsWith("::")), false);
       assertEquals(

--- a/tests/integration/global_cli_test.ts
+++ b/tests/integration/global_cli_test.ts
@@ -17,6 +17,7 @@ import { type BuildProbe, main } from "../../packages/cli/mod.ts";
 import { defaultBuildProbe } from "../../packages/cli/src/dispatch.ts";
 import { defaultHost, type SetupHost } from "../../packages/cli/src/setup.ts";
 import { withTemp } from "../../packages/core/tests/_temp.ts";
+import { withEnv } from "../../packages/core/tests/_env.ts";
 
 /**
  * The real, filesystem-probing host — the walk up to `zuke.json` must see the
@@ -137,6 +138,50 @@ Deno.test("zuke <target> outside any project is an unknown command, not a spawn"
       );
       assertEquals(code, 1);
       assertEquals(host.logs[0].includes("no zuke.json was found"), true);
+    });
+  }, { prefix: "zuke-global-cli-" });
+});
+
+/**
+ * The percent-encoded `::`, kept as its own constant so the encoded prefix
+ * never fuses with the word after it into a token no dictionary can know.
+ */
+const ENC = "%3A%3A";
+
+Deno.test("zuke <argv> cannot forge a workflow command on an Actions runner", async () => {
+  // The whole path, as the binary runs it: the real host writing through the
+  // package's sink, the real probe (confined to the temp dir, so there is no
+  // build to forward to), and the runner's environment. The unknown-command
+  // message echoed argv raw, and an argument carrying a newline put `::` at
+  // the start of a physical line, which the runner executes; every physical
+  // line is asserted, since the runner reads lines, not messages.
+  await withTemp(async (dir) => {
+    await inDir(dir, async () => {
+      const out: string[] = [];
+      const original = console.log;
+      console.log = (...parts: unknown[]) => void out.push(parts.join(" "));
+      try {
+        await withEnv({ GITHUB_ACTIONS: "true" }, async () => {
+          const code = await main(
+            [["typo", "::stop-commands::forged"].join("\n")],
+            defaultHost,
+            undefined,
+            undefined,
+            undefined,
+            () => Promise.reject(new Error("must not spawn")),
+            confinedTo(dir),
+          );
+          assertEquals(code, 1);
+        });
+      } finally {
+        console.log = original;
+      }
+      const lines = out.flatMap((l) => l.split("\n"));
+      assertEquals(lines.some((l) => l.trimStart().startsWith("::")), false);
+      assertEquals(
+        lines.some((l) => l.startsWith(ENC + "stop-commands::forged")),
+        true,
+      );
     });
   }, { prefix: "zuke-global-cli-" });
 });


### PR DESCRIPTION
## What & why

A GitHub Actions runner parses the job's output for workflow commands: a line whose first non-blank characters are `::` is executed (`::error::` forges an annotation, `::stop-commands::` silences every command that follows, Zuke's own `::add-mask::` included), and `##[` anywhere in a line is the legacy form. The `zuke` command echoed text it did not author through a bare `console.log`: the unknown-command message repeats argv, the scaffold and import paths repeat what the user typed, and the forwarding path prints a filesystem path or a failed spawn's message. An argument carrying a newline put a forged command at the start of a physical line, which the runner acted on.

**One sink.** `packages/cli/src/output.ts` is now the package's only console writer. It composes the two pieces `@zuke/core` already publishes — `escapeLineIf` on `@zuke/core/render` and `detectCiHost` — deciding per line, so a line is neutralised while a runner is parsing the output and left byte for byte anywhere else. Core's own `cliReporter` is internal, and exporting it needs a core release this package's floor cannot reach in the same change (the constraint #559 and #575 both ran into); #581 records folding the sink onto that export once the floor can move.

**Every write routed through it:**
- `defaultHost.log` in `setup.ts`, which every `setup` and `import` progress line and the unknown-command message go through
- the three stderr writes in `forwardToBuild` (the running notice, the no-lockfile notice, and the refusal or spawn failure)
- the `deno doc` subprocess in `commandDoc`, whose stdio was inherited: `deno doc` repeats a `--filter` it cannot find on stderr, so the child's output is now piped and relayed through the sink
- the interactive prompt's default, which Deno's `prompt` writes to the terminal past the sink as an editable prefill of `--name`: the default is now shown in the question text, neutralised, and the value returned stays exactly what was typed (an empty answer or end of input means the default)

**Floor.** `@zuke/cli` now declares `@zuke/core@^1.53.0`, the release carrying both helpers (`escapeLineIf` landed in #569, listed under 1.53.0 in core's changelog; `detectCiHost` has been exported since 1.47.0). `deno.lock` records it, and `./zuke coreFloorCheck` passes against JSR.

**Guard in the suite.** The source-level console scan from `packages/core/tests/escaping_sink_test.ts` moved into a shared test helper, `packages/core/tests/_escaping.ts`, alongside the encoded-marker constant; core's scan uses it unchanged, and `packages/cli/tests/output_test.ts` runs it over the CLI package, so a new direct write anywhere in `@zuke/cli` fails the package's own suite. The scan now matches every console method and a computed key. Its JSDoc says what it is: a lint, not a boundary — an aliased `console`, a raw `Deno.stdout` write, or a `prompt` pass it.

The starter build template moved from `setup.ts` to `packages/cli/src/starter.ts`: its `console.log` is source for the user's project, and naming that one module in the scan's allowlist keeps `setup.ts` scanned.

**Tests.** Unit tests for the sink (both streams, on and off a runner, per-line decision); routing tests through the real host with a newline-carrying argument, through the forwarding catch arm with a hostile spawn error, through the real `deno doc` runner with a hostile `--filter`, and through the prompter; an integration test in `tests/integration/global_cli_test.ts` driving the real entry point under `GITHUB_ACTIONS=true` with the real host and a confined probe. Every assertion is about the start of a physical line, and the "off a runner" cases unset the variable explicitly because the suite itself runs under Actions.

**Adversarial review.** Two independent reviewers attacked the change; every finding was verified against the code. Confirmed and fixed in the second commit: the inherited `deno doc` stderr, the prefilled prompt default, three copies of a console-capture helper where `packages/core/tests/_console.ts` already had one, a dead `tests/` filter in the scan, and the scan's regex gaps. Refuted: `\r`-only endings and leading-whitespace variants (handled by `escapeLine`), ANSI before `::` (the runner does not strip it, so it is not a command), `##[` split across writes, non-string arguments, uncaught throws carrying argv, `ConsoleTasks` (its sink is redirected to `host.log` for the banner), and the forwarded build's own output (the user's program, escaped by core's executor). Accepted as a documented limit: escaping fails open if `zuke` was installed without env permission, which matches core's reporter and the documented `-A` install.

## Related issues

Closes #575

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a
      [Conventional Commit](https://www.conventionalcommits.org/)
      (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell). Every target except `security`, whose zizmor advisory lookup cannot reach the GitHub API from the sandbox; it runs on CI.
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches): 98.3% lines, 97.4% branches.
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour
      changed. No user-facing behaviour changed except that hostile text in the CLI's own messages is percent-encoded on Actions, the policy core already applies; the two new modules are internal and documented in their JSDoc.
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`,
      `llms-full.txt`, package README `## API`). No public API changed; `apiDocsCheck` passes.
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with
      type guards instead).
- [x] No dead code: unreachable branches and can't-fire fallbacks are removed,
      with types tightened so the impossible state is unrepresentable.
- [x] No duplicated logic: an existing helper is imported rather than retyped,
      and a near-copy differing by a constant or a message is parameterised into
      one implementation. A guard, escape, or credential resolution has exactly
      one implementation. The escaping has one implementation, core's `escapeLine`; the sink composes it. Its four-line composition mirrors core's internal `cliReporter`, with #581 tracking the fold.
- [x] SOLID shapes respected: one domain per file, extension via the settings
      lambda (not a behaviour-switching flag), narrow parameter types, and
      dependencies on the injectable seam (`StateHost`, an injected `fetch`,
      `EnvReader`) rather than `Deno.*` or a global.
- [ ] A new package was wired into all six places (see
      [AGENTS.md](../blob/master/AGENTS.md#good-open-source-practices-to-follow)),
      if applicable. Not applicable.
- [x] The code is written using AI assisted coding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016X4VGLpngSHWRSiVFX6eAx

---
_Generated by [Claude Code](https://claude.ai/code/session_016X4VGLpngSHWRSiVFX6eAx)_