### PR TITLE
feat(core): export cliReporter, the console sink for a command surface

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -895,6 +895,34 @@ const ZUKE_ACTION: "zuke-build/zuke"
   The name a {@link CiPinResolver} is asked for the prelude action, so a
   repository that pins its own actions can pin this one the same way.
 
+const cliReporter: Reporter
+  The sink every command-surface module writes through, neutralised for a
+  GitHub Actions runner.
+
+  These commands echo arguments the invoker chose — a run id, a target name, a
+  force reason — and read values another process wrote into the shared state
+  store. Under Actions those commonly come from a workflow-dispatch input or an
+  issue body rather than from a person at a terminal, and a thrown message
+  quotes them straight back.
+
+  A sink rather than a guard at each of the sixty-odd writes, because none of
+  them should be exempt: unlike the run's reporter, none of these modules emits
+  a workflow command of its own, so there is no half to carve out. The MCP
+  command writes only diagnostics here — its protocol never goes through the
+  console — so escaping cannot corrupt it.
+
+  The decision is made per line, not once when this module loads. A top-level
+  constant would read the environment at import time, before an embedder or a
+  test has set it, and the escaping would then silently not apply.
+
+  Public so a companion command surface — `@zuke/cli` is one — can write
+  through the same sink instead of composing a copy of it. It is the sink for
+  a command's own diagnostics and output, not the `reporter` handed to
+  {@link execute}: the run's renderer writes `::group::` and `::endgroup::` of
+  its own and wraps only third-party text in {@link escapingReporter} beside
+  them, and a sink that neutralises every leading `::` would break that
+  grouping.
+
 const defaultRenderer: Renderer
   The built-in renderer: Zuke's ruled headers and summary table.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -949,6 +949,34 @@ const ZUKE_ACTION: "zuke-build/zuke"
   The name a {@link CiPinResolver} is asked for the prelude action, so a
   repository that pins its own actions can pin this one the same way.
 
+const cliReporter: Reporter
+  The sink every command-surface module writes through, neutralised for a
+  GitHub Actions runner.
+
+  These commands echo arguments the invoker chose — a run id, a target name, a
+  force reason — and read values another process wrote into the shared state
+  store. Under Actions those commonly come from a workflow-dispatch input or an
+  issue body rather than from a person at a terminal, and a thrown message
+  quotes them straight back.
+
+  A sink rather than a guard at each of the sixty-odd writes, because none of
+  them should be exempt: unlike the run's reporter, none of these modules emits
+  a workflow command of its own, so there is no half to carve out. The MCP
+  command writes only diagnostics here — its protocol never goes through the
+  console — so escaping cannot corrupt it.
+
+  The decision is made per line, not once when this module loads. A top-level
+  constant would read the environment at import time, before an embedder or a
+  test has set it, and the escaping would then silently not apply.
+
+  Public so a companion command surface — `@zuke/cli` is one — can write
+  through the same sink instead of composing a copy of it. It is the sink for
+  a command's own diagnostics and output, not the `reporter` handed to
+  {@link execute}: the run's renderer writes `::group::` and `::endgroup::` of
+  its own and wraps only third-party text in {@link escapingReporter} beside
+  them, and a sink that neutralises every leading `::` would break that
+  grouping.
+
 const defaultRenderer: Renderer
   The built-in renderer: Zuke's ruled headers and summary table.
 

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -103,6 +103,7 @@ export {
   type Reporter,
   type ResumeState,
 } from "./src/executor.ts";
+export { cliReporter } from "./src/reporter.ts";
 export {
   AlreadyResumedError,
   resumeCheck,

--- a/packages/core/src/reporter.ts
+++ b/packages/core/src/reporter.ts
@@ -88,6 +88,14 @@ export function escapingReporter(inner: Reporter): Reporter {
  * The decision is made per line, not once when this module loads. A top-level
  * constant would read the environment at import time, before an embedder or a
  * test has set it, and the escaping would then silently not apply.
+ *
+ * Public so a companion command surface — `@zuke/cli` is one — can write
+ * through the same sink instead of composing a copy of it. It is the sink for
+ * a command's own diagnostics and output, **not** the `reporter` handed to
+ * {@link execute}: the run's renderer writes `::group::` and `::endgroup::` of
+ * its own and wraps only third-party text in {@link escapingReporter} beside
+ * them, and a sink that neutralises every leading `::` would break that
+ * grouping.
  */
 export const cliReporter: Reporter = {
   info: (line) => console.log(escapeLineIf(onActionsRunner(), line)),

--- a/packages/core/tests/escaping_sink_test.ts
+++ b/packages/core/tests/escaping_sink_test.ts
@@ -15,6 +15,8 @@
  */
 
 import { assertEquals, assertStringIncludes } from "./_assert.ts";
+import { cliReporter } from "../mod.ts";
+import { capture as captureConsole } from "./_console.ts";
 import { escapeLineIf } from "../src/render.ts";
 import { printJson } from "../src/reporter.ts";
 import { withEnv } from "./_env.ts";
@@ -184,6 +186,26 @@ Deno.test("a fan-out item key cannot forge a command through the count line", as
     true,
   );
   assertEquals(lines.some((l) => l.startsWith("::stop-commands::")), false);
+});
+
+Deno.test("cliReporter is public, and neutralises each line only on a runner", async () => {
+  // Imported from `mod.ts`, so this pins the export a companion command
+  // surface (`@zuke/cli`) writes through rather than composing a copy. The
+  // decision is per line: the environment changes between the two writes on
+  // each stream, after the module has long been loaded.
+  const { out, err } = await captureConsole(async () => {
+    await withEnv({ GITHUB_ACTIONS: "true" }, () => {
+      cliReporter.info("::stop-commands::forged");
+      cliReporter.error("held by ##[group]x");
+    });
+    await withEnv({ GITHUB_ACTIONS: undefined }, () => {
+      cliReporter.info("::stop-commands::forged");
+      cliReporter.error("held by ##[group]x");
+    });
+    return 0;
+  });
+  assertEquals(out, [ENC + "stop-commands::forged", "::stop-commands::forged"]);
+  assertEquals(err, ["held by %23%23[group]x", "held by ##[group]x"]);
 });
 
 Deno.test("silentReporter stays silent once wrapped", () => {


### PR DESCRIPTION
## What & why

`cliReporter` in `packages/core/src/reporter.ts` is the sink every `@zuke/core` command writes through: a line goes to stdout or stderr and, while a GitHub Actions runner is parsing the output, is neutralised with `escapeLineIf` so text Zuke did not author cannot open a workflow command. It was internal — `mod.ts` exported only the `Reporter` type.

`@zuke/cli` needed the same sink for #575 and could not reach it, so `packages/cli/src/output.ts` composes the two public pieces (`escapeLineIf` on `@zuke/core/render` and `detectCiHost`) into a four-line copy. That copy cannot be folded back in one change: a floor above the workspace's own core version stops the repository resolving, so the export and the CLI's floor bump have to be two releases apart. This PR is the first step; #581 is the second, once the release carrying this export is on JSR.

**The change:**
- `cliReporter` is exported from `packages/core/mod.ts`.
- Its JSDoc says what it is for — a command surface's own diagnostics and output — and what it is not: the `reporter` handed to `execute`. The run's renderer writes `::group::` and `::endgroup::` of its own and wraps only third-party text in `escapingReporter` beside them, so a sink that neutralises every leading `::` would break that grouping.
- A test in `packages/core/tests/escaping_sink_test.ts` imports the sink from `mod.ts`, pinning the export, and asserts the per-line decision on both streams: escaped with `GITHUB_ACTIONS=true`, untouched with it unset, the environment changing between writes after the module was loaded.
- `llms-full.txt` and the core README's API block are regenerated with `./zuke apiDocs`; `docLint` is clean.

No behaviour changes for existing consumers; `printJson` stays internal, since no consumer needs it. The integration layer is the existing suites that drive the core commands writing through this sink; the change adds no new flow to exercise.

## Related issues

Closes #583. First of the two steps in #581.

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a
      [Conventional Commit](https://www.conventionalcommits.org/)
      (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell). Every target except `security`, whose zizmor advisory lookup cannot reach the GitHub API from the sandbox; it runs on CI.
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches): 98.3% lines, 97.4% branches.
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour
      changed. The JSDoc carries the scope note; no behaviour changed.
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`,
      `llms-full.txt`, package README `## API`).
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with
      type guards instead).
- [x] No dead code: unreachable branches and can't-fire fallbacks are removed,
      with types tightened so the impossible state is unrepresentable.
- [x] No duplicated logic: an existing helper is imported rather than retyped,
      and a near-copy differing by a constant or a message is parameterised into
      one implementation. A guard, escape, or credential resolution has exactly
      one implementation. This is the export that lets the CLI's copy be removed under #581.
- [x] SOLID shapes respected: one domain per file, extension via the settings
      lambda (not a behaviour-switching flag), narrow parameter types, and
      dependencies on the injectable seam (`StateHost`, an injected `fetch`,
      `EnvReader`) rather than `Deno.*` or a global.
- [ ] A new package was wired into all six places (see
      [AGENTS.md](../blob/master/AGENTS.md#good-open-source-practices-to-follow)),
      if applicable. Not applicable.
- [x] The code is written using AI assisted coding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016X4VGLpngSHWRSiVFX6eAx

---
_Generated by [Claude Code](https://claude.ai/code/session_016X4VGLpngSHWRSiVFX6eAx)_