### PR TITLE
chore(cli): use core's exported cliReporter as the console sink

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1571,7 +1571,7 @@
       "packages/cli": {
         "dependencies": [
           "jsr:@zuke/console@^1.1.0",
-          "jsr:@zuke/core@^1.53.0",
+          "jsr:@zuke/core@^1.54.0",
           "jsr:@zuke/gh@^1.6.0"
         ]
       },

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -8,7 +8,7 @@
   },
   "imports": {
     "@zuke/console": "jsr:@zuke/console@^1.1.0",
-    "@zuke/core": "jsr:@zuke/core@^1.53.0",
+    "@zuke/core": "jsr:@zuke/core@^1.54.0",
     "@zuke/gh": "jsr:@zuke/gh@^1.6.0"
   },
   "publish": {

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -12,16 +12,13 @@
  * command straight from argv, a `--dir` or `--from` the user typed, a path or
  * an error message from the filesystem or a failed spawn, and what a
  * subprocess it ran said — so every line goes out through here and is
- * neutralised with `escapeLineIf` when something is parsing for commands. Off a runner nothing scans the stream and the line
- * goes out byte for byte.
+ * neutralised when something is parsing for commands. Off a runner nothing
+ * scans the stream and the line goes out byte for byte.
  *
- * This composes the two pieces `@zuke/core` publishes for exactly this —
- * `escapeLineIf` on `@zuke/core/render` and `detectCiHost` — rather than
- * core's own `cliReporter`, which is internal to that package: exporting it
- * would need a core release this package's floor cannot reach in the same
- * change; #581 tracks folding this onto the export once the floor can move.
- * The decision is made per line, not once at import, so an embedder or a
- * test that sets the environment after loading this module is honoured.
+ * The sink is `@zuke/core`'s own `cliReporter`, the one every core command
+ * writes through, so the escaping has exactly one implementation. It decides
+ * per line, not once at import, so an embedder or a test that sets the
+ * environment after loading this module is honoured.
  *
  * `tests/output_test.ts` scans this package's source and fails on any other
  * console write, so the guard cannot quietly come undone by a new
@@ -30,15 +27,14 @@
  * @module
  */
 
-import { detectCiHost, type Reporter } from "@zuke/core";
+import { cliReporter, detectCiHost, type Reporter } from "@zuke/core";
 import { escapeLineIf } from "@zuke/core/render";
 
 /**
  * `line` as it may reach an Actions runner: neutralised while one is parsing
- * the output, untouched anywhere else. The sink applies this to every write;
- * it is exported for the one write the sink cannot own — the text Deno's
- * `prompt` puts on the terminal, which carries a default the user typed on
- * the command line.
+ * the output, untouched anywhere else — the same decision the sink makes,
+ * for the one write the sink cannot own: the text Deno's `prompt` puts on the
+ * terminal, which carries a default the user typed on the command line.
  */
 export function neutralise(line: string): string {
   return escapeLineIf(detectCiHost() === "github", line);
@@ -48,7 +44,4 @@ export function neutralise(line: string): string {
  * The CLI's console sink: `info` is stdout, `error` is stderr, and each line
  * is neutralised on an Actions runner before it is written.
  */
-export const output: Reporter = {
-  info: (line) => console.log(neutralise(line)),
-  error: (line) => console.error(neutralise(line)),
-};
+export const output: Reporter = cliReporter;

--- a/packages/cli/tests/output_test.ts
+++ b/packages/cli/tests/output_test.ts
@@ -12,7 +12,8 @@ import { assertEquals } from "../../core/tests/_assert.ts";
 import { withEnv } from "../../core/tests/_env.ts";
 import { capture } from "../../core/tests/_console.ts";
 import { consoleWriters, ENC } from "../../core/tests/_escaping.ts";
-import { output } from "../src/output.ts";
+import { neutralise, output } from "../src/output.ts";
+import { cliReporter } from "@zuke/core";
 
 Deno.test("output neutralises a workflow command on an Actions runner, on both streams", async () => {
   const { out, err } = await capture(async () => {
@@ -33,6 +34,26 @@ Deno.test("output neutralises a workflow command on an Actions runner, on both s
     "held by %23%23[group]x",
     "Unknown command: ::stop-commands::forged",
   ]);
+});
+
+Deno.test("output is core's own sink, and neutralise makes the same decision", async () => {
+  // The escaping has one implementation: the sink is `cliReporter` itself,
+  // not a composition that could drift from it, and the prompt's step agrees
+  // with it line for line in both environments.
+  assertEquals(output === cliReporter, true);
+  await withEnv({ GITHUB_ACTIONS: "true" }, () => {
+    assertEquals(
+      neutralise("::stop-commands::forged"),
+      ENC + "stop-commands::forged",
+    );
+    assertEquals(neutralise("held by ##[group]x"), "held by %23%23[group]x");
+  });
+  await withEnv({ GITHUB_ACTIONS: undefined }, () => {
+    assertEquals(
+      neutralise("::stop-commands::forged"),
+      "::stop-commands::forged",
+    );
+  });
 });
 
 Deno.test("output leaves every line alone off a runner", async () => {


### PR DESCRIPTION
## What & why

The second and last step of #581. `packages/cli/src/output.ts`, the package's only console writer since #582, was a four-line copy of `@zuke/core`'s `cliReporter`, composed from `escapeLineIf` and `detectCiHost` because the reporter itself was internal. #584 exported it and core 1.54.0 carries the export, so:

- `@zuke/cli`'s core floor rises to `^1.54.0` in `packages/cli/deno.json`, with `deno.lock` updated (the one dependency line) and `./zuke coreFloorCheck` passing against JSR.
- `output` is now `cliReporter` itself, not a composition that could drift from it — the escaping has exactly one implementation, as AGENTS.md guideline 12 asks.
- `neutralise` stays for the one write no sink can own: the text Deno's `prompt` puts on the terminal, carrying the `--name` default. Its JSDoc says so; it makes the same per-line decision as the sink.
- `packages/cli/tests/output_test.ts` pins the fold: `output === cliReporter`, and `neutralise` agrees with the sink on and off a runner. The existing sink tests and the source-level scan are unchanged and green.

No behaviour changes; no public API changes (both modules are internal), so the API references are untouched.

## Related issues

Closes #581

## Checklist

- [x] This PR closes a tracking issue (`Closes #<n>` above).
- [x] The PR title is a
      [Conventional Commit](https://www.conventionalcommits.org/)
      (`type(scope): summary`).
- [x] `deno task ci` passes locally (lint, fmt, type-check, tests, spell). Every target except `security`, whose zizmor advisory lookup cannot reach the GitHub API from the sandbox; it runs on CI.
- [x] Tests were added or updated; coverage stays at 95%+ (lines and branches): 98.3% lines, 97.4% branches.
- [x] Docs updated in the same PR (`README.md`, JSDoc, `docs/`) when behaviour
      changed. The module JSDoc now names core's reporter as the sink; no behaviour changed.
- [x] Public API changes were regenerated with `./zuke apiDocs` (`llms.txt`,
      `llms-full.txt`, package README `## API`). No public API changed; `apiDocsCheck` passes.
- [x] No `any`, no `as` casts or `!` non-null assertions in `src/` (narrow with
      type guards instead).
- [x] No dead code: unreachable branches and can't-fire fallbacks are removed,
      with types tightened so the impossible state is unrepresentable.
- [x] No duplicated logic: an existing helper is imported rather than retyped,
      and a near-copy differing by a constant or a message is parameterised into
      one implementation. A guard, escape, or credential resolution has exactly
      one implementation. This PR removes the last copy.
- [x] SOLID shapes respected: one domain per file, extension via the settings
      lambda (not a behaviour-switching flag), narrow parameter types, and
      dependencies on the injectable seam (`StateHost`, an injected `fetch`,
      `EnvReader`) rather than `Deno.*` or a global.
- [ ] A new package was wired into all six places (see
      [AGENTS.md](../blob/master/AGENTS.md#good-open-source-practices-to-follow)),
      if applicable. Not applicable.
- [x] The code is written using AI assisted coding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016X4VGLpngSHWRSiVFX6eAx

---
_Generated by [Claude Code](https://claude.ai/code/session_016X4VGLpngSHWRSiVFX6eAx)_